### PR TITLE
Sync Ghostty theme with macOS system appearance

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
@@ -52,6 +52,7 @@ final class GhosttyAppManager: NSObject {
     private(set) var app: ghostty_app_t?
     private var config: ghostty_config_t?
     private var initialized = false
+    private var currentColorScheme: ghostty_color_scheme_e?
 
     private override init() {
         super.init()
@@ -130,6 +131,16 @@ final class GhosttyAppManager: NSObject {
     func setFocus(_ focused: Bool) {
         guard let app else { return }
         ghostty_app_set_focus(app, focused)
+    }
+
+    func applyColorScheme(_ colorScheme: ghostty_color_scheme_e) {
+        guard let app else { return }
+        if let currentColorScheme, GhosttyAppearanceSync.isEqual(currentColorScheme, colorScheme) {
+            return
+        }
+
+        ghostty_app_set_color_scheme(app, colorScheme)
+        currentColorScheme = colorScheme
     }
 
     @objc private func keyboardSelectionDidChange(_ notification: Notification) {

--- a/Sources/WorkspaceManager/Terminal/GhosttyAppearanceSync.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyAppearanceSync.swift
@@ -1,0 +1,30 @@
+//
+//  GhosttyAppearanceSync.swift
+//  WorkspaceManager
+//
+
+import AppKit
+import GhosttyKit
+
+enum GhosttyAppearanceSync {
+    static func colorScheme(for appearance: NSAppearance?) -> ghostty_color_scheme_e {
+        let resolvedAppearance = appearance ?? NSAppearance(named: .aqua)
+        let bestMatch = resolvedAppearance?.bestMatch(from: [.darkAqua, .aqua])
+        if bestMatch == .darkAqua {
+            return GHOSTTY_COLOR_SCHEME_DARK
+        }
+        return GHOSTTY_COLOR_SCHEME_LIGHT
+    }
+
+    static func isEqual(_ lhs: ghostty_color_scheme_e, _ rhs: ghostty_color_scheme_e) -> Bool {
+        lhs.rawValue == rhs.rawValue
+    }
+
+    static func isDark(_ colorScheme: ghostty_color_scheme_e) -> Bool {
+        isEqual(colorScheme, GHOSTTY_COLOR_SCHEME_DARK)
+    }
+
+    static func isLight(_ colorScheme: ghostty_color_scheme_e) -> Bool {
+        isEqual(colorScheme, GHOSTTY_COLOR_SCHEME_LIGHT)
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -17,6 +17,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
     private var markedText = NSMutableAttributedString()
     private var focused = false
     private var lastPerformKeyEvent: TimeInterval?
+    private var currentColorScheme: ghostty_color_scheme_e?
 
     private(set) var surface: ghostty_surface_t?
     private(set) var terminalTitle: String = ""
@@ -54,10 +55,16 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
             TerminalFocusManager.shared.registerWindow(window)
             setupEventMonitor()
             updateScaleAndSize()
+            applySystemColorSchemeIfNeeded(force: true)
             TerminalFocusManager.shared.requestFocus(for: self)
         } else {
             removeEventMonitor()
         }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applySystemColorSchemeIfNeeded(force: true)
     }
 
     override func becomeFirstResponder() -> Bool {
@@ -223,6 +230,7 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
 
         surface = createdSurface
         updateScaleAndSize()
+        applySystemColorSchemeIfNeeded(force: true)
     }
 
     private func updateScaleAndSize() {
@@ -693,5 +701,23 @@ final class GhosttySurfaceView: NSView, NSTextInputClient {
         action.withCString { pointer in
             ghostty_surface_binding_action(surface, pointer, UInt(action.utf8.count))
         }
+    }
+
+    private func applySystemColorSchemeIfNeeded(force: Bool = false) {
+        let appearance = window?.effectiveAppearance ?? effectiveAppearance
+        let resolvedColorScheme = GhosttyAppearanceSync.colorScheme(for: appearance)
+
+        if !force,
+            let currentColorScheme,
+            GhosttyAppearanceSync.isEqual(currentColorScheme, resolvedColorScheme)
+        {
+            return
+        }
+
+        if let surface {
+            ghostty_surface_set_color_scheme(surface, resolvedColorScheme)
+        }
+        GhosttyAppManager.shared.applyColorScheme(resolvedColorScheme)
+        currentColorScheme = resolvedColorScheme
     }
 }

--- a/Tests/WorkspaceManagerAppTests/GhosttyAppearanceSyncTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyAppearanceSyncTests.swift
@@ -1,0 +1,32 @@
+//
+//  GhosttyAppearanceSyncTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import AppKit
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyAppearanceSync")
+struct GhosttyAppearanceSyncTests {
+    @Test("Maps dark appearances to Ghostty dark scheme")
+    func mapsDarkAppearance() throws {
+        let appearance = try #require(NSAppearance(named: .darkAqua))
+        let scheme = GhosttyAppearanceSync.colorScheme(for: appearance)
+        #expect(GhosttyAppearanceSync.isDark(scheme))
+    }
+
+    @Test("Maps light appearances to Ghostty light scheme")
+    func mapsLightAppearance() throws {
+        let appearance = try #require(NSAppearance(named: .aqua))
+        let scheme = GhosttyAppearanceSync.colorScheme(for: appearance)
+        #expect(GhosttyAppearanceSync.isLight(scheme))
+    }
+
+    @Test("Nil appearance defaults to Ghostty light scheme")
+    func nilAppearanceDefaultsToLight() {
+        let scheme = GhosttyAppearanceSync.colorScheme(for: nil)
+        #expect(GhosttyAppearanceSync.isLight(scheme))
+    }
+}


### PR DESCRIPTION
## Summary
- add `GhosttyAppearanceSync` to map AppKit appearance to Ghostty color-scheme enums
- apply the mapped scheme in `GhosttySurfaceView` when a surface is created, when it attaches to a window, and when effective appearance changes
- add app-level deduped color-scheme application in `GhosttyAppManager` via `ghostty_app_set_color_scheme`
- add focused unit tests for dark/light/nil appearance mapping

## Testing
- `./scripts/build-ghosttykit.sh`
- `swift build`
- `swift test`
- `swift test --filter ShortcutRoutingPolicy`
- `./scripts/launch-dev.sh --no-build --no-activate`

## Notes
- Launch logs confirmed the debug binary path. In this environment the process exits shortly after launch, so I could not complete interactive Light/Dark toggle verification from this session.
