### PR TITLE
fix: improve crash safety and reliability

### DIFF
--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -44,7 +44,7 @@
 
     <!-- Build number (increment on each build, used for updates) -->
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
 
     <!-- ============================================================
          BUNDLE CONFIGURATION

--- a/Sources/WorkspaceManager/Views/MainWindow/NotificationCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NotificationCoordinator.swift
@@ -103,9 +103,17 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         refreshTask = nil
         currentRemoteURL = nil
 
-        try? KeychainHelper.delete(key: NotificationConstants.keychainJWTKey)
-        try? KeychainHelper.delete(key: NotificationConstants.keychainLoginKey)
-        try? KeychainHelper.delete(key: NotificationConstants.keychainGitHubTokenKey)
+        for key in [
+            NotificationConstants.keychainJWTKey,
+            NotificationConstants.keychainLoginKey,
+            NotificationConstants.keychainGitHubTokenKey,
+        ] {
+            do {
+                try KeychainHelper.delete(key: key)
+            } catch {
+                log.warning("Failed to delete keychain item \(key): \(error.localizedDescription)")
+            }
+        }
 
         Task { await eventStreamService.disconnect() }
         eventListenerTask?.cancel()
@@ -165,15 +173,17 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
     private func startStream(
         remoteURL: String, resetActivity: Bool
     ) async {
-        guard
-            let jwt = try? KeychainHelper.loadString(
-                key: NotificationConstants.keychainJWTKey
-            ),
-            let githubToken = try? KeychainHelper.loadString(
-                key: NotificationConstants.keychainGitHubTokenKey
-            ),
-            let owner = Self.parseOwner(from: remoteURL)
-        else {
+        var jwt: String?
+        var githubToken: String?
+        do {
+            jwt = try KeychainHelper.loadString(key: NotificationConstants.keychainJWTKey)
+            githubToken = try KeychainHelper.loadString(key: NotificationConstants.keychainGitHubTokenKey)
+        } catch {
+            log.error("Failed to load credentials from keychain: \(error.localizedDescription)")
+            jwt = nil
+            githubToken = nil
+        }
+        guard let jwt, let githubToken, let owner = Self.parseOwner(from: remoteURL) else {
             await eventStreamService.disconnect()
             isStreamConnected = false
             return

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -149,6 +149,17 @@ struct SettingsView: View {
             } header: {
                 Text("Notifications")
             }
+
+            Section {
+                HStack {
+                    Text("Version")
+                    Spacer()
+                    Text(Self.versionString)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("About")
+            }
         }
         .formStyle(.grouped)
         .frame(width: 500, height: 450)
@@ -244,6 +255,12 @@ struct SettingsView: View {
                 Task { await notificationCoordinator.startDeviceFlow() }
             }
         }
+    }
+
+    private static var versionString: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "\(version) (\(build))"
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/EventStreamService.swift
+++ b/Sources/WorkspaceManagerCore/Services/EventStreamService.swift
@@ -83,7 +83,10 @@ public actor EventStreamService: EventStreamServiceProtocol {
             let jwt = currentJWT
         else { return }
 
-        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            log.error("Failed to parse base URL for WebSocket")
+            return
+        }
         components.scheme = baseURL.scheme == "http" ? "ws" : "wss"
         components.path = "/ws/\(owner)"
 
@@ -141,9 +144,13 @@ public actor EventStreamService: EventStreamServiceProtocol {
                     _lastDisconnectReason = .transportError
                     log.warning("WebSocket disconnected: \(error.localizedDescription)")
                     await scheduleReconnect()
-                } else {
+                } else if Self.isAuthError(error) {
                     _lastDisconnectReason = .authFailure
-                    log.error("WebSocket connection rejected: \(error.localizedDescription)")
+                    log.error("WebSocket auth rejected: \(error.localizedDescription)")
+                } else {
+                    _lastDisconnectReason = .transportError
+                    log.warning("WebSocket connection failed (will retry): \(error.localizedDescription)")
+                    await scheduleReconnect()
                 }
                 return
             }
@@ -208,6 +215,20 @@ public actor EventStreamService: EventStreamServiceProtocol {
             guard !Task.isCancelled, let task else { return }
             task.sendPing { _ in }
         }
+    }
+
+    private static func isAuthError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        // URLSession WebSocket reports HTTP 401/403 as POSIXError or URLError
+        // with specific codes; network timeouts use different domains/codes.
+        if nsError.domain == NSURLErrorDomain {
+            // Explicit server rejection codes (not timeouts or connectivity)
+            return [
+                NSURLErrorUserAuthenticationRequired,  // -1013
+                NSURLErrorUserCancelledAuthentication,  // -1012
+            ].contains(nsError.code)
+        }
+        return false
     }
 
     private func scheduleReconnect() async {

--- a/Sources/WorkspaceManagerCore/Services/GitHubDeviceAuth.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitHubDeviceAuth.swift
@@ -78,7 +78,9 @@ public actor GitHubDeviceAuth: GitHubDeviceAuthProtocol {
         request.httpBody = try JSONEncoder().encode(body)
 
         let (data, response) = try await session.data(for: request)
-        let httpResponse = response as! HTTPURLResponse
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw DeviceAuthError.requestFailed(-1)
+        }
 
         guard httpResponse.statusCode == 200 else {
             log.error("Device code request failed: \(httpResponse.statusCode)")

--- a/Sources/WorkspaceManagerCore/Services/KeychainHelper.swift
+++ b/Sources/WorkspaceManagerCore/Services/KeychainHelper.swift
@@ -1,24 +1,38 @@
 import Foundation
 import Security
 
-public enum KeychainError: Error {
+public enum KeychainError: LocalizedError {
     case saveFailed(OSStatus)
     case loadFailed(OSStatus)
     case deleteFailed(OSStatus)
     case unexpectedData
+
+    public var errorDescription: String? {
+        switch self {
+        case .saveFailed(let status):
+            "Keychain save failed (OSStatus \(status))"
+        case .loadFailed(let status):
+            "Keychain load failed (OSStatus \(status))"
+        case .deleteFailed(let status):
+            "Keychain delete failed (OSStatus \(status))"
+        case .unexpectedData:
+            "Keychain returned unexpected data"
+        }
+    }
 }
 
 public enum KeychainHelper {
     private static let service = "com.cloudcompute.workspaces"
 
     public static func save(key: String, data: Data) throws {
-        // Delete existing item first to avoid duplicates
-        let deleteQuery: [String: Any] = [
+        let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
         ]
-        SecItemDelete(deleteQuery as CFDictionary)
+
+        // Try deleting any existing item first
+        SecItemDelete(baseQuery as CFDictionary)
 
         let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -29,6 +43,20 @@ public enum KeychainHelper {
         ]
 
         let status = SecItemAdd(addQuery as CFDictionary, nil)
+
+        if status == errSecDuplicateItem {
+            // Delete failed silently (e.g. item owned by different signing identity).
+            // Fall back to update-in-place.
+            let updateStatus = SecItemUpdate(
+                baseQuery as CFDictionary,
+                [kSecValueData as String: data] as CFDictionary
+            )
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.saveFailed(updateStatus)
+            }
+            return
+        }
+
         guard status == errSecSuccess else {
             throw KeychainError.saveFailed(status)
         }

--- a/Sources/WorkspaceManagerCore/Services/NotificationSessionService.swift
+++ b/Sources/WorkspaceManagerCore/Services/NotificationSessionService.swift
@@ -47,7 +47,9 @@ public actor NotificationSessionService: NotificationSessionServiceProtocol {
         request.httpBody = try JSONEncoder().encode(["github_token": githubToken])
 
         let (data, response) = try await session.data(for: request)
-        let httpResponse = response as! HTTPURLResponse
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NotificationSessionError.invalidResponse
+        }
 
         guard httpResponse.statusCode == 200 else {
             let body = String(data: data, encoding: .utf8) ?? "(no body)"

--- a/Tests/WorkspaceManagerTests/EventStreamServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/EventStreamServiceTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("EventStreamService")
+struct EventStreamServiceTests {
+
+    @Test("initial state is disconnected")
+    func initialState() async {
+        let service = EventStreamService(
+            baseURL: URL(string: "https://test.example.com")!
+        )
+        let connected = await service.isConnected
+        let reason = await service.lastDisconnectReason
+        #expect(connected == false)
+        #expect(reason == .none)
+    }
+
+    @Test("disconnect is idempotent")
+    func disconnectIdempotent() async {
+        let service = EventStreamService(
+            baseURL: URL(string: "https://test.example.com")!
+        )
+        await service.disconnect()
+        await service.disconnect()
+        let connected = await service.isConnected
+        #expect(connected == false)
+    }
+
+    @Test("events stream is created lazily")
+    func eventsStreamCreated() async {
+        let service = EventStreamService(
+            baseURL: URL(string: "https://test.example.com")!
+        )
+        let stream = await service.events
+        // Stream should be non-nil (it's always returned)
+        // Verify we can iterate (will be empty since not connected)
+        let task = Task<WebhookEvent?, Never> {
+            for await event in stream {
+                return event
+            }
+            return nil
+        }
+        // Finish the stream by disconnecting
+        await service.disconnect()
+        let result = await task.value
+        #expect(result == nil)
+    }
+
+    @Test("WebhookEvent decodes wire format correctly")
+    func webhookEventDecoding() throws {
+        let json = """
+            {
+                "id": "evt_123",
+                "type": "push",
+                "action": "created",
+                "summary": "Push to main",
+                "repo": "octocat/hello-world",
+                "timestamp": "2026-03-09T00:00:00Z"
+            }
+            """
+        let data = Data(json.utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let event = try decoder.decode(WebhookEvent.self, from: data)
+
+        #expect(event.id == "evt_123")
+        #expect(event.type == "push")
+        #expect(event.action == "created")
+        #expect(event.summary == "Push to main")
+        #expect(event.repo == "octocat/hello-world")
+    }
+}

--- a/Tests/WorkspaceManagerTests/KeychainHelperTests.swift
+++ b/Tests/WorkspaceManagerTests/KeychainHelperTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("KeychainHelper", .serialized)
+struct KeychainHelperTests {
+    // Use a unique key prefix per test run to avoid polluting the real keychain
+    private static let testPrefix = "test-\(UUID().uuidString.prefix(8))"
+
+    private func testKey(_ name: String) -> String {
+        "\(Self.testPrefix)-\(name)"
+    }
+
+    @Test("save and load roundtrip")
+    func saveLoadRoundtrip() throws {
+        let key = testKey("roundtrip")
+        defer { try? KeychainHelper.delete(key: key) }
+
+        try KeychainHelper.saveString(key: key, value: "hello-world")
+        let loaded = try KeychainHelper.loadString(key: key)
+        #expect(loaded == "hello-world")
+    }
+
+    @Test("load missing key returns nil")
+    func loadMissing() throws {
+        let key = testKey("missing")
+        let result = try KeychainHelper.loadString(key: key)
+        #expect(result == nil)
+    }
+
+    @Test("save overwrites existing value")
+    func saveOverwrite() throws {
+        let key = testKey("overwrite")
+        defer { try? KeychainHelper.delete(key: key) }
+
+        try KeychainHelper.saveString(key: key, value: "first")
+        try KeychainHelper.saveString(key: key, value: "second")
+        let loaded = try KeychainHelper.loadString(key: key)
+        #expect(loaded == "second")
+    }
+
+    @Test("delete removes item")
+    func deleteRemoves() throws {
+        let key = testKey("delete")
+
+        try KeychainHelper.saveString(key: key, value: "to-delete")
+        try KeychainHelper.delete(key: key)
+        let loaded = try KeychainHelper.loadString(key: key)
+        #expect(loaded == nil)
+    }
+
+    @Test("delete nonexistent key does not throw")
+    func deleteIdempotent() throws {
+        let key = testKey("nonexistent")
+        try KeychainHelper.delete(key: key)
+    }
+
+    @Test("save and load binary data")
+    func binaryRoundtrip() throws {
+        let key = testKey("binary")
+        defer { try? KeychainHelper.delete(key: key) }
+
+        let data = Data([0x00, 0xFF, 0x42, 0x13])
+        try KeychainHelper.save(key: key, data: data)
+        let loaded = try KeychainHelper.load(key: key)
+        #expect(loaded == data)
+    }
+
+    @Test("KeychainError provides descriptive messages")
+    func errorDescriptions() {
+        let save = KeychainError.saveFailed(-25299)
+        #expect(save.errorDescription?.contains("-25299") == true)
+
+        let load = KeychainError.loadFailed(-25300)
+        #expect(load.errorDescription?.contains("load") == true)
+
+        let unexpected = KeychainError.unexpectedData
+        #expect(unexpected.errorDescription?.contains("unexpected") == true)
+    }
+}


### PR DESCRIPTION
## Summary
- **Crash prevention**: Replace 3 force casts with safe alternatives in HTTP response handling and URL construction
- **Error visibility**: Log previously-silent keychain failures to improve debuggability
- **Connection resilience**: Fix WebSocket reconnection to distinguish network timeouts from auth failures
- **User clarity**: Add version display in Settings → About

## Improvements
**Tier 1 (Crash Safety)**
- GitHubDeviceAuth, NotificationSessionService: Use `as?` instead of `as!` for HTTPURLResponse
- EventStreamService: Use `guard let` for URLComponents initialization

**Tier 2 (Reliability)**  
- NotificationCoordinator: Log all keychain delete failures during sign-out
- EventStreamService: Add `isAuthError()` classifier to retry on transport errors, not auth rejections

**Tier 3 (Test Coverage)**
- KeychainHelperTests: 7 new tests (roundtrip, overwrite, delete, binary, error messages)
- EventStreamServiceTests: 4 new tests (init state, disconnect, stream creation, event decoding)

Tests: 255/41 suites (up from 244/39). Build: clean, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)