### PR TITLE
fix: add auth guard to ideation workflow

### DIFF
--- a/.github/workflows/agent-ideation.yml
+++ b/.github/workflows/agent-ideation.yml
@@ -49,6 +49,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check auth
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not set. Add it in Settings → Secrets → Actions."
+            exit 1
+          fi
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
       - name: Run Claude Code ideation
         run: |
           npx @anthropic-ai/claude-code --print \


### PR DESCRIPTION
## Summary
- Adds early check for `CLAUDE_CODE_OAUTH_TOKEN` secret before running Claude Code
- Fails fast with a clear `::error::` annotation instead of cryptic exit code 1

Fixes the failure from #37's first run where the secret wasn't configured yet.

## Test plan
- [ ] Merge and trigger `workflow_dispatch` with `dry_run: true`
- [ ] Verify the auth check passes (token is now set)
- [ ] Verify Claude Code produces a parseable proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)