### PR TITLE
Refactor new workspace backend requests

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
     @State private var repoForNewWorkspaceFromLanding: Repo?
     @State private var webSourceCreationTarget: WebSourceCreationTarget?
     @State private var landingErrorMessage: String?
-    @State private var isRemoteBackendAvailableForLanding = false
+    @State private var isDaytonaBackendAvailableForLanding = false
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
     @StateObject private var webSurfaceStore = WebSurfaceStore()
     @StateObject private var terminalFocusCoordinator = TerminalFocusCoordinator()
@@ -368,7 +368,7 @@ struct ContentView: View {
                 syncOpenInEditorShortcutRouting()
             }
             .task {
-                isRemoteBackendAvailableForLanding = await remoteBackend.isAvailable()
+                isDaytonaBackendAvailableForLanding = await remoteBackend.isAvailable()
                 await syncCloudWorkspaceStatuses()
             }
             .onDisappear {
@@ -459,11 +459,11 @@ struct ContentView: View {
             .sheet(item: $repoForNewWorkspaceFromLanding) { repo in
                 NewWorkspaceSheet(
                     repo: repo,
-                    isRemoteBackendAvailable: isRemoteBackendAvailableForLanding,
+                    isDaytonaBackendAvailable: isDaytonaBackendAvailableForLanding,
                     isCreateDisabled: false
-                ) { name, backend in
+                ) { request in
                     Task { @MainActor in
-                        await createWorkspaceFromLanding(repo: repo, name: name, backend: backend)
+                        await createWorkspaceFromLanding(repo: repo, request: request)
                     }
                 }
             }
@@ -937,20 +937,18 @@ struct ContentView: View {
     }
 
     @MainActor
-    private func createWorkspaceFromLanding(repo: Repo, name: String, backend: WorkspaceBackendChoice) async {
+    private func createWorkspaceFromLanding(repo: Repo, request: NewWorkspaceRequest) async {
         let controller = SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
             remoteBackend: remoteBackend
         )
         do {
-            let workspace: Workspace
-            switch backend {
-            case .local:
-                workspace = try await controller.createWorkspace(from: repo, name: name, progress: { _ in })
-            case .remoteVM:
-                workspace = try await controller.createRemoteWorkspace(from: repo, name: name)
-            }
+            let workspace = try await controller.createWorkspace(
+                from: repo,
+                request: request,
+                progress: nil
+            )
             abandonPendingRemoteConnection(reason: "workspace_created")
             handleWorkspaceSelection(workspace)
         } catch {

--- a/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceRequest.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceRequest.swift
@@ -1,0 +1,179 @@
+import Foundation
+import WorkspaceManagerCore
+
+enum WorkspaceBackendChoice: String, CaseIterable, Identifiable, Sendable {
+    case local
+    case daytona
+    case sshHost
+    case kubernetesPod
+    case sshCompose
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .local:
+            return "Local"
+        case .daytona:
+            return "Daytona"
+        case .sshHost:
+            return "SSH Host"
+        case .kubernetesPod:
+            return "Kubernetes Pod"
+        case .sshCompose:
+            return "SSH + Compose"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .local:
+            return "laptopcomputer"
+        case .daytona:
+            return "cloud"
+        case .sshHost:
+            return "terminal"
+        case .kubernetesPod:
+            return "shippingbox"
+        case .sshCompose:
+            return "square.stack.3d.forward.dottedline"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .local:
+            return "Copy the repository into a new local workspace directory."
+        case .daytona:
+            return "Create a Daytona-managed remote sandbox for the repository."
+        case .sshHost:
+            return "Connect the workspace to an existing SSH host."
+        case .kubernetesPod:
+            return "Target an existing pod or launch from a Kubernetes image template."
+        case .sshCompose:
+            return "Connect over SSH and attach to a Docker Compose service."
+        }
+    }
+
+    var usesSSHConfiguration: Bool {
+        switch self {
+        case .sshHost, .sshCompose:
+            return true
+        case .local, .daytona, .kubernetesPod:
+            return false
+        }
+    }
+
+    var usesKubernetesConfiguration: Bool {
+        self == .kubernetesPod
+    }
+
+    var usesComposeConfiguration: Bool {
+        self == .sshCompose
+    }
+
+    var requiresDaytonaAvailability: Bool {
+        self == .daytona
+    }
+
+    var supportsCreationFlow: Bool {
+        switch self {
+        case .local, .daytona:
+            return true
+        case .sshHost, .kubernetesPod, .sshCompose:
+            return false
+        }
+    }
+}
+
+enum SSHAuthenticationChoice: String, CaseIterable, Identifiable, Sendable {
+    case agent = "ssh-agent"
+    case key = "private-key"
+    case password
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .agent:
+            return "SSH Agent"
+        case .key:
+            return "Private Key"
+        case .password:
+            return "Password"
+        }
+    }
+}
+
+enum ComposeStartupStrategy: String, CaseIterable, Identifiable, Sendable {
+    case execExisting
+    case upThenExec
+    case runOneOff
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .execExisting:
+            return "Exec Existing"
+        case .upThenExec:
+            return "Up Then Exec"
+        case .runOneOff:
+            return "Run One-off"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .execExisting:
+            return "Attach to an already-running service container."
+        case .upThenExec:
+            return "Start the service first, then open a shell inside it."
+        case .runOneOff:
+            return "Launch a one-off container session for the service."
+        }
+    }
+}
+
+struct KubernetesPodWorkspaceRequest: Equatable, Sendable {
+    var context: String
+    var namespace: String?
+    var pod: String?
+    var container: String?
+    var imageTemplate: String?
+}
+
+struct SSHComposeWorkspaceRequest: Equatable, Sendable {
+    var ssh: SSHWorkspaceMetadata
+    var composeFiles: [String]
+    var service: String
+    var startupStrategy: ComposeStartupStrategy
+}
+
+struct NewWorkspaceRequest: Equatable, Sendable {
+    enum Backend: Equatable, Sendable {
+        case local
+        case daytona
+        case sshHost(SSHWorkspaceMetadata)
+        case kubernetesPod(KubernetesPodWorkspaceRequest)
+        case sshCompose(SSHComposeWorkspaceRequest)
+    }
+
+    let name: String
+    let backend: Backend
+
+    var backendChoice: WorkspaceBackendChoice {
+        switch backend {
+        case .local:
+            return .local
+        case .daytona:
+            return .daytona
+        case .sshHost:
+            return .sshHost
+        case .kubernetesPod:
+            return .kubernetesPod
+        case .sshCompose:
+            return .sshCompose
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceSheet.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceSheet.swift
@@ -8,41 +8,32 @@
 import SwiftUI
 import WorkspaceManagerCore
 
-enum WorkspaceBackendChoice: String, CaseIterable, Identifiable {
-    case local
-    case remoteVM
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .local: return "Local"
-        case .remoteVM: return "Remote VM"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .local: return "laptopcomputer"
-        case .remoteVM: return "cloud"
-        }
-    }
-}
-
 struct NewWorkspaceSheet: View {
     let repo: Repo
-    let isRemoteBackendAvailable: Bool
+    let isDaytonaBackendAvailable: Bool
     let isCreateDisabled: Bool
-    let onCreate: (String, WorkspaceBackendChoice) -> Void
+    let onCreate: (NewWorkspaceRequest) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @State private var name = ""
     @State private var backend: WorkspaceBackendChoice = .local
     @State private var isCreating = false
 
-    var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
+    @State private var sshHost = ""
+    @State private var sshUser = ""
+    @State private var sshPort = 22
+    @State private var sshAuthentication: SSHAuthenticationChoice = .agent
+    @State private var sshWorkingDirectory = ""
+
+    @State private var kubernetesContext = ""
+    @State private var kubernetesNamespace = ""
+    @State private var kubernetesPod = ""
+    @State private var kubernetesContainer = ""
+    @State private var kubernetesImageTemplate = ""
+
+    @State private var composeFilesRaw = ""
+    @State private var composeService = ""
+    @State private var composeStartupStrategy: ComposeStartupStrategy = .upThenExec
 
     private var suggestedName: String {
         let existingNames = Set(repo.workspaces.map { $0.name.lowercased() })
@@ -55,61 +46,155 @@ struct NewWorkspaceSheet: View {
         return candidate
     }
 
-    private var descriptionText: String {
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var parsedComposeFiles: [String] {
+        composeFilesRaw
+            .split { $0 == "," || $0.isNewline }
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private var requestValidationMessage: String? {
+        guard !trimmedName.isEmpty else {
+            return "Enter a workspace name."
+        }
+
         switch backend {
         case .local:
-            return "A copy of the repository will be created in a new directory."
-        case .remoteVM:
-            return "A remote Linux sandbox will be created in the cloud."
+            return nil
+        case .daytona:
+            return isDaytonaBackendAvailable ? nil : "Daytona is not available on this system."
+        case .sshHost:
+            return trimmed(sshHost).isEmpty ? "Enter an SSH host." : nil
+        case .kubernetesPod:
+            guard !trimmed(kubernetesContext).isEmpty else {
+                return "Enter a Kubernetes context."
+            }
+            if trimmed(kubernetesPod).isEmpty && trimmed(kubernetesImageTemplate).isEmpty {
+                return "Enter a pod or an image template."
+            }
+            return nil
+        case .sshCompose:
+            if trimmed(sshHost).isEmpty {
+                return "Enter an SSH host."
+            }
+            if parsedComposeFiles.isEmpty {
+                return "Enter at least one Compose file path."
+            }
+            return trimmed(composeService).isEmpty ? "Enter a Compose service." : nil
         }
+    }
+
+    private var createRequest: NewWorkspaceRequest? {
+        guard requestValidationMessage == nil else { return nil }
+
+        switch backend {
+        case .local:
+            return NewWorkspaceRequest(name: trimmedName, backend: .local)
+        case .daytona:
+            return NewWorkspaceRequest(name: trimmedName, backend: .daytona)
+        case .sshHost:
+            return NewWorkspaceRequest(
+                name: trimmedName,
+                backend: .sshHost(sshMetadata)
+            )
+        case .kubernetesPod:
+            return NewWorkspaceRequest(
+                name: trimmedName,
+                backend: .kubernetesPod(
+                    KubernetesPodWorkspaceRequest(
+                        context: trimmed(kubernetesContext),
+                        namespace: trimmedOrNil(kubernetesNamespace),
+                        pod: trimmedOrNil(kubernetesPod),
+                        container: trimmedOrNil(kubernetesContainer),
+                        imageTemplate: trimmedOrNil(kubernetesImageTemplate)
+                    )
+                )
+            )
+        case .sshCompose:
+            return NewWorkspaceRequest(
+                name: trimmedName,
+                backend: .sshCompose(
+                    SSHComposeWorkspaceRequest(
+                        ssh: sshMetadata,
+                        composeFiles: parsedComposeFiles,
+                        service: trimmed(composeService),
+                        startupStrategy: composeStartupStrategy
+                    )
+                )
+            )
+        }
+    }
+
+    private var sshMetadata: SSHWorkspaceMetadata {
+        SSHWorkspaceMetadata(
+            host: trimmed(sshHost),
+            user: trimmedOrNil(sshUser),
+            port: sshPort,
+            authMode: sshAuthentication.rawValue,
+            workingDir: trimmedOrNil(sshWorkingDirectory)
+        )
+    }
+
+    private var descriptionText: String {
+        let note: String
+        if backend.requiresDaytonaAvailability && !isDaytonaBackendAvailable {
+            note = " Daytona is currently unavailable."
+        } else if !backend.supportsCreationFlow {
+            note = " Configuration is captured now, but backend provisioning is not implemented yet."
+        } else {
+            note = ""
+        }
+        return backend.summary + note
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(spacing: 10) {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.secondary.opacity(0.08))
-                    .frame(width: 44, height: 44)
-                    .overlay {
-                        Image(systemName: backend == .remoteVM ? "cloud.fill" : "plus.rectangle.on.folder.fill")
-                            .font(.system(size: 18, weight: .semibold))
-                            .foregroundStyle(.primary)
-                    }
-
-                Text("New Workspace")
-                    .font(.title3)
-                    .fontWeight(.semibold)
-
-                Text("from \(repo.name)")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.top, 20)
-            .padding(.bottom, 16)
+            header
 
             Divider()
 
             Form {
-                TextField("Workspace Name", text: $name)
-                    .textFieldStyle(.roundedBorder)
+                Section("Workspace") {
+                    TextField("Workspace Name", text: $name)
 
-                if isRemoteBackendAvailable {
                     Picker("Environment", selection: $backend) {
                         ForEach(WorkspaceBackendChoice.allCases) { choice in
                             Label(choice.label, systemImage: choice.icon)
                                 .tag(choice)
                         }
                     }
-                    .pickerStyle(.segmented)
+
+                    Text(descriptionText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Text(descriptionText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if backend.usesSSHConfiguration {
+                    sshSection
+                }
+
+                if backend.usesKubernetesConfiguration {
+                    kubernetesSection
+                }
+
+                if backend.usesComposeConfiguration {
+                    composeSection
+                }
+
+                if let requestValidationMessage {
+                    Section {
+                        Text(requestValidationMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
             }
             .formStyle(.grouped)
-            .scrollDisabled(true)
 
             Divider()
 
@@ -122,21 +207,119 @@ struct NewWorkspaceSheet: View {
                 Spacer()
 
                 Button("Create") {
+                    guard let createRequest else { return }
                     isCreating = true
-                    onCreate(name.trimmingCharacters(in: .whitespacesAndNewlines), backend)
+                    onCreate(createRequest)
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(!isValid || isCreating || isCreateDisabled)
+                .disabled(createRequest == nil || isCreating || isCreateDisabled)
             }
             .padding()
         }
-        .frame(width: 360)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(width: 480, height: 560)
         .onAppear {
             if name.isEmpty {
                 name = suggestedName
             }
         }
+        .onChange(of: isDaytonaBackendAvailable) { _, isAvailable in
+            if !isAvailable && backend == .daytona {
+                backend = .local
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.secondary.opacity(0.08))
+                .frame(width: 44, height: 44)
+                .overlay {
+                    Image(systemName: backend.icon)
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(.primary)
+                }
+
+            Text("New Workspace")
+                .font(.title3)
+                .fontWeight(.semibold)
+
+            Text("from \(repo.name)")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, 20)
+        .padding(.bottom, 16)
+    }
+
+    private var sshSection: some View {
+        Section("SSH") {
+            TextField("Host", text: $sshHost)
+            TextField("User", text: $sshUser)
+            TextField("Port", value: $sshPort, format: .number)
+
+            Picker("Authentication", selection: $sshAuthentication) {
+                ForEach(SSHAuthenticationChoice.allCases) { choice in
+                    Text(choice.label)
+                        .tag(choice)
+                }
+            }
+
+            TextField("Working Directory", text: $sshWorkingDirectory)
+        }
+    }
+
+    private var kubernetesSection: some View {
+        Section("Kubernetes") {
+            TextField("Context", text: $kubernetesContext)
+            TextField("Namespace", text: $kubernetesNamespace)
+            TextField("Pod", text: $kubernetesPod)
+            TextField("Container", text: $kubernetesContainer)
+            TextField("Image Template", text: $kubernetesImageTemplate)
+        }
+    }
+
+    private var composeSection: some View {
+        Section("Compose") {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Compose File Paths")
+                    .font(.callout)
+                TextEditor(text: $composeFilesRaw)
+                    .font(.body.monospaced())
+                    .frame(minHeight: 64, maxHeight: 96)
+                    .padding(4)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.secondary.opacity(0.2))
+                    }
+                Text("Separate multiple paths with commas or new lines.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            TextField("Service", text: $composeService)
+
+            Picker("Startup Strategy", selection: $composeStartupStrategy) {
+                ForEach(ComposeStartupStrategy.allCases) { strategy in
+                    Text(strategy.label)
+                        .tag(strategy)
+                }
+            }
+
+            Text(composeStartupStrategy.summary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func trimmed(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func trimmedOrNil(_ value: String) -> String? {
+        let trimmedValue = trimmed(value)
+        return trimmedValue.isEmpty ? nil : trimmedValue
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -42,7 +42,7 @@ struct SidebarView: View {
 
     @State private var isAddingRepo = false
     @State private var repoForNewWorkspace: Repo?
-    @State private var isRemoteBackendAvailable = false
+    @State private var isDaytonaBackendAvailable = false
 
     // Error alert state
     @State private var errorMessage: String?
@@ -125,16 +125,11 @@ struct SidebarView: View {
             .sheet(item: $repoForNewWorkspace) { repo in
                 NewWorkspaceSheet(
                     repo: repo,
-                    isRemoteBackendAvailable: isRemoteBackendAvailable,
+                    isDaytonaBackendAvailable: isDaytonaBackendAvailable,
                     isCreateDisabled: isCreatingWorkspace(for: repo.id)
-                ) { name, backend in
+                ) { request in
                     Task { @MainActor in
-                        switch backend {
-                        case .local:
-                            await createWorkspace(from: repo, name: name)
-                        case .remoteVM:
-                            await createRemoteWorkspace(from: repo, name: name)
-                        }
+                        await createWorkspace(from: repo, request: request)
                     }
                 }
             }
@@ -191,7 +186,7 @@ struct SidebarView: View {
                 }
             }
             .task {
-                isRemoteBackendAvailable = await remoteBackend.isAvailable()
+                isDaytonaBackendAvailable = await remoteBackend.isAvailable()
             }
     }
 
@@ -583,21 +578,46 @@ struct SidebarView: View {
     }
 
     @MainActor
-    private func createWorkspace(from repo: Repo, name: String) async {
+    private func createWorkspace(from repo: Repo, request: NewWorkspaceRequest) async {
         let repoID = repo.id
         guard !isCreatingWorkspace(for: repoID) else { return }
         expandedRepoIDs.insert(repoID)
-        updateLocalCreationStatus(repoID: repoID, phase: .preparing)
+        switch request.backendChoice {
+        case .local:
+            updateLocalCreationStatus(repoID: repoID, phase: .preparing)
+        case .daytona:
+            workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
+                message: "Creating Daytona workspace..."
+            )
+        case .sshHost:
+            workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
+                message: "Preparing SSH host workspace..."
+            )
+        case .kubernetesPod:
+            workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
+                message: "Preparing Kubernetes pod workspace..."
+            )
+        case .sshCompose:
+            workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
+                message: "Preparing SSH Compose workspace..."
+            )
+        }
 
         do {
-            let workspace = try await workspaceController.createWorkspace(
-                from: repo,
-                name: name,
-                progress: { phase in
+            let progress: WorkspaceCreationProgressHandler?
+            if request.backendChoice == .local {
+                progress = { phase in
                     await MainActor.run {
                         updateLocalCreationStatus(repoID: repoID, phase: phase)
                     }
                 }
+            } else {
+                progress = nil
+            }
+            let workspace = try await workspaceController.createWorkspace(
+                from: repo,
+                request: request,
+                progress: progress
             )
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             onWorkspaceCreated()
@@ -605,27 +625,6 @@ struct SidebarView: View {
         } catch {
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             errorMessage = "Failed to create workspace: \(error.localizedDescription)"
-            showingError = true
-        }
-    }
-
-    @MainActor
-    private func createRemoteWorkspace(from repo: Repo, name: String) async {
-        let repoID = repo.id
-        guard !isCreatingWorkspace(for: repoID) else { return }
-        workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
-            message: "Creating cloud workspace..."
-        )
-        expandedRepoIDs.insert(repoID)
-
-        do {
-            let workspace = try await workspaceController.createRemoteWorkspace(from: repo, name: name)
-            workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
-            onWorkspaceCreated()
-            selectedWorkspace = workspace
-        } catch {
-            workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
-            errorMessage = "Failed to create remote workspace: \(error.localizedDescription)"
             showingError = true
         }
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -90,6 +90,25 @@ struct SidebarWorkspaceController {
 
     func createWorkspace(
         from repo: Repo,
+        request: NewWorkspaceRequest,
+        progress: WorkspaceCreationProgressHandler? = nil
+    ) async throws -> Workspace {
+        switch request.backend {
+        case .local:
+            return try await createLocalWorkspace(from: repo, name: request.name, progress: progress)
+        case .daytona:
+            return try await createDaytonaWorkspace(from: repo, name: request.name)
+        case .sshHost:
+            throw ControllerError.message("SSH host workspaces are not supported yet.")
+        case .kubernetesPod:
+            throw ControllerError.message("Kubernetes pod workspaces are not supported yet.")
+        case .sshCompose:
+            throw ControllerError.message("SSH Compose workspaces are not supported yet.")
+        }
+    }
+
+    private func createLocalWorkspace(
+        from repo: Repo,
         name: String,
         progress: WorkspaceCreationProgressHandler? = nil
     ) async throws -> Workspace {
@@ -117,13 +136,17 @@ struct SidebarWorkspaceController {
         }
     }
 
-    func createRemoteWorkspace(from repo: Repo, name: String) async throws -> Workspace {
+    private func createDaytonaWorkspace(from repo: Repo, name: String) async throws -> Workspace {
+        guard await remoteBackend.isAvailable() else {
+            throw BackendError.notAvailable("Daytona")
+        }
+
         let info = try await remoteBackend.createSandbox(name: name, cloneURL: repo.remoteURL)
         let workspace = Workspace(
             name: name,
             path: FileManager.default.temporaryDirectory,
             sourceRepo: repo,
-            backendIdentifier: remoteBackend.identifier,
+            backendIdentifier: WorkspaceBackendChoice.daytona.rawValue,
             remoteId: info.sandboxId
         )
         modelContext.insert(workspace)


### PR DESCRIPTION
## Summary
- replace the simple workspace backend choice with a richer typed request model
- add per-backend new-workspace form sections for SSH, Kubernetes, and Compose settings
- route sidebar and landing workspace creation through `NewWorkspaceRequest` instead of `(name, backend)`
- keep local and Daytona provisioning wired up, with explicit not-yet-supported errors for SSH/Kubernetes/Compose backends

## Testing
- ./scripts/build-ghosttykit.sh
- swift build
- swift test