### PR TITLE
Split remote backend protocols by capability

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -368,7 +368,12 @@ struct ContentView: View {
                 syncOpenInEditorShortcutRouting()
             }
             .task {
-                isRemoteBackendAvailableForLanding = await remoteBackend.isAvailable()
+                let supportsRemoteCreate = remoteBackend.runtimeCapabilities.supportsCreate
+                if supportsRemoteCreate {
+                    isRemoteBackendAvailableForLanding = await remoteBackend.healthCheck()
+                } else {
+                    isRemoteBackendAvailableForLanding = false
+                }
                 await syncCloudWorkspaceStatuses()
             }
             .onDisappear {
@@ -852,19 +857,31 @@ struct ContentView: View {
         }
 
         let backend = remoteBackend
+        let capabilities = backend.runtimeCapabilities
         let needsStart = workspace.status == .stopped || workspace.status == .archived
 
         Task {
             do {
-                let info: RemoteSandboxInfo
+                if needsStart && !capabilities.supportsStartStop {
+                    throw RemoteBackendCapabilityError.unsupportedOperation(
+                        backendIdentifier: backend.identifier,
+                        operation: "starting and resuming remote workspaces"
+                    )
+                }
+
                 if needsStart {
                     NSLog("[RemoteBackend] Starting sandbox %@ (was %@)", sandboxId, workspace.status.rawValue)
-                    info = try await backend.startSandbox(sandboxId: sandboxId)
+                }
+
+                let info = try await backend.openSession(
+                    sandboxId: sandboxId,
+                    workspaceStatus: workspace.status
+                )
+
+                if needsStart {
                     await MainActor.run {
                         workspace.status = .active
                     }
-                } else {
-                    info = try await backend.getSSHCommand(sandboxId: sandboxId)
                 }
 
                 await MainActor.run {
@@ -949,6 +966,12 @@ struct ContentView: View {
             case .local:
                 workspace = try await controller.createWorkspace(from: repo, name: name, progress: { _ in })
             case .remoteVM:
+                guard remoteBackend.runtimeCapabilities.supportsCreate else {
+                    throw RemoteBackendCapabilityError.unsupportedOperation(
+                        backendIdentifier: remoteBackend.identifier,
+                        operation: "creating remote workspaces"
+                    )
+                }
                 workspace = try await controller.createRemoteWorkspace(from: repo, name: name)
             }
             abandonPendingRemoteConnection(reason: "workspace_created")
@@ -961,6 +984,15 @@ struct ContentView: View {
     @MainActor
     private func archiveWorkspaceFromLanding(_ workspace: Workspace) async {
         if workspace.isRemote {
+            guard remoteBackend.runtimeCapabilities.supportsArchive else {
+                landingErrorMessage =
+                    RemoteBackendCapabilityError.unsupportedOperation(
+                        backendIdentifier: remoteBackend.identifier,
+                        operation: "archiving remote workspaces"
+                    ).localizedDescription
+                return
+            }
+
             let controller = SidebarWorkspaceController(
                 modelContext: modelContext,
                 workspaceService: workspaceService,
@@ -1108,9 +1140,18 @@ struct ContentView: View {
         guard !cloudWorkspaces.isEmpty else { return }
 
         let backend = remoteBackend
+        guard backend.runtimeCapabilities.supportsList else { return }
+        guard let listableBackend = backend as? any Listable else {
+            NSLog(
+                "[RemoteBackend] Backend %@ advertised list support but does not conform to Listable",
+                backend.identifier
+            )
+            return
+        }
+
         let statuses: [RemoteSandboxStatus]
         do {
-            statuses = try await backend.listSandboxes()
+            statuses = try await listableBackend.listSandboxes()
         } catch {
             NSLog("[RemoteBackend] Failed to sync sandbox statuses: %@", error.localizedDescription)
             return

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -85,6 +85,10 @@ struct SidebarView: View {
         SidebarRepoSortMode(rawValue: repoSortModeRawValue) ?? .alphabetical
     }
 
+    private var remoteCapabilities: RuntimeCapabilities {
+        remoteBackend.runtimeCapabilities
+    }
+
     private var sortedRepos: [Repo] {
         repoSortController.sortedRepos(
             repos,
@@ -191,7 +195,11 @@ struct SidebarView: View {
                 }
             }
             .task {
-                isRemoteBackendAvailable = await remoteBackend.isAvailable()
+                if remoteCapabilities.supportsCreate {
+                    isRemoteBackendAvailable = await remoteBackend.healthCheck()
+                } else {
+                    isRemoteBackendAvailable = false
+                }
             }
     }
 
@@ -613,6 +621,16 @@ struct SidebarView: View {
     private func createRemoteWorkspace(from repo: Repo, name: String) async {
         let repoID = repo.id
         guard !isCreatingWorkspace(for: repoID) else { return }
+        guard remoteCapabilities.supportsCreate else {
+            errorMessage =
+                RemoteBackendCapabilityError.unsupportedOperation(
+                    backendIdentifier: remoteBackend.identifier,
+                    operation: "creating remote workspaces"
+                ).localizedDescription
+            showingError = true
+            return
+        }
+
         workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
             message: "Creating cloud workspace..."
         )
@@ -652,24 +670,36 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func remoteWorkspaceActions(_ workspace: Workspace) -> some View {
+        let capabilities = remoteCapabilities
+
         switch workspace.status {
         case .active:
-            Button("Stop") {
-                performStop(workspace)
+            if capabilities.supportsStartStop {
+                Button("Stop") {
+                    performStop(workspace)
+                }
             }
-            Button("Archive") {
-                performArchive(workspace)
+            if capabilities.supportsArchive {
+                Button("Archive") {
+                    performArchive(workspace)
+                }
             }
         case .stopped:
-            Button("Start") {
-                performStart(workspace)
+            if capabilities.supportsStartStop {
+                Button("Start") {
+                    performStart(workspace)
+                }
             }
-            Button("Archive") {
-                performArchive(workspace)
+            if capabilities.supportsArchive {
+                Button("Archive") {
+                    performArchive(workspace)
+                }
             }
         case .archived:
-            Button("Start") {
-                performStart(workspace)
+            if capabilities.supportsStartStop {
+                Button("Start") {
+                    performStart(workspace)
+                }
             }
         }
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -60,17 +60,25 @@ struct SidebarWorkspaceController {
 
     nonisolated static func remoteWorkspacePersistenceFailureMessage(
         existingMessage: String?,
-        sandboxId: String,
-        cleanupError: Error
+        cleanupMessage: String
     ) -> String {
-        let cleanupMessage =
-            "Cleanup also failed for remote sandbox '\(sandboxId)': \(cleanupError.localizedDescription)"
-
         if let existingMessage, !existingMessage.isEmpty {
             return "\(existingMessage)\n\n\(cleanupMessage)"
         }
 
         return cleanupMessage
+    }
+
+    nonisolated static func remoteWorkspacePersistenceFailureMessage(
+        existingMessage: String?,
+        sandboxId: String,
+        cleanupError: Error
+    ) -> String {
+        remoteWorkspacePersistenceFailureMessage(
+            existingMessage: existingMessage,
+            cleanupMessage:
+                "Cleanup also failed for remote sandbox '\(sandboxId)': \(cleanupError.localizedDescription)"
+        )
     }
 
     nonisolated static func localCreationMessage(for phase: WorkspaceCreationPhase) -> String {
@@ -86,6 +94,54 @@ struct SidebarWorkspaceController {
         case .finished:
             return "Finishing workspace..."
         }
+    }
+
+    private func unsupportedOperationMessage(_ operation: String) -> String {
+        RemoteBackendCapabilityError.unsupportedOperation(
+            backendIdentifier: remoteBackend.identifier,
+            operation: operation
+        ).localizedDescription
+    }
+
+    private func provisioningBackend(
+        requiresCreate: Bool = false,
+        requiresDelete: Bool = false,
+        operation: String
+    ) throws -> any ProvisionCapable {
+        let capabilities = remoteBackend.runtimeCapabilities
+
+        guard
+            (!requiresCreate || capabilities.supportsCreate)
+                && (!requiresDelete || capabilities.supportsDelete)
+        else {
+            throw ControllerError.message(unsupportedOperationMessage(operation))
+        }
+
+        guard let backend = remoteBackend as? any ProvisionCapable else {
+            throw ControllerError.message(unsupportedOperationMessage(operation))
+        }
+
+        return backend
+    }
+
+    private func startStopBackend(operation: String) throws -> any StartStopCapable {
+        guard remoteBackend.runtimeCapabilities.supportsStartStop,
+            let backend = remoteBackend as? any StartStopCapable
+        else {
+            throw ControllerError.message(unsupportedOperationMessage(operation))
+        }
+
+        return backend
+    }
+
+    private func archivableBackend(operation: String) throws -> any Archivable {
+        guard remoteBackend.runtimeCapabilities.supportsArchive,
+            let backend = remoteBackend as? any Archivable
+        else {
+            throw ControllerError.message(unsupportedOperationMessage(operation))
+        }
+
+        return backend
     }
 
     func createWorkspace(
@@ -118,7 +174,11 @@ struct SidebarWorkspaceController {
     }
 
     func createRemoteWorkspace(from repo: Repo, name: String) async throws -> Workspace {
-        let info = try await remoteBackend.createSandbox(name: name, cloneURL: repo.remoteURL)
+        let backend = try provisioningBackend(
+            requiresCreate: true,
+            operation: "creating remote workspaces"
+        )
+        let info = try await backend.createSandbox(name: name, cloneURL: repo.remoteURL)
         let workspace = Workspace(
             name: name,
             path: FileManager.default.temporaryDirectory,
@@ -132,22 +192,36 @@ struct SidebarWorkspaceController {
             try saveModelContext(action: "save remote workspace")
             return workspace
         } catch {
-            if let cleanupError = await Self.cleanupRemoteSandboxAfterFailedPersistence(
-                sandboxId: info.sandboxId,
-                deleteSandbox: { sandboxId in
-                    try await remoteBackend.deleteSandbox(sandboxId: sandboxId)
+            if remoteBackend.runtimeCapabilities.supportsDelete {
+                if let cleanupError = await Self.cleanupRemoteSandboxAfterFailedPersistence(
+                    sandboxId: info.sandboxId,
+                    deleteSandbox: { sandboxId in
+                        try await backend.deleteSandbox(sandboxId: sandboxId)
+                    }
+                ) {
+                    NSLog(
+                        "[RemoteBackend] Failed to clean up sandbox %@ after persistence failure: %@",
+                        info.sandboxId,
+                        cleanupError.localizedDescription
+                    )
+                    throw ControllerError.message(
+                        Self.remoteWorkspacePersistenceFailureMessage(
+                            existingMessage: error.localizedDescription,
+                            cleanupMessage:
+                                "Cleanup also failed for remote sandbox '\(info.sandboxId)': \(cleanupError.localizedDescription)"
+                        )
+                    )
                 }
-            ) {
+            } else {
                 NSLog(
-                    "[RemoteBackend] Failed to clean up sandbox %@ after persistence failure: %@",
-                    info.sandboxId,
-                    cleanupError.localizedDescription
+                    "[RemoteBackend] Skipping sandbox cleanup after persistence failure because %@ does not support delete",
+                    remoteBackend.identifier
                 )
                 throw ControllerError.message(
                     Self.remoteWorkspacePersistenceFailureMessage(
                         existingMessage: error.localizedDescription,
-                        sandboxId: info.sandboxId,
-                        cleanupError: cleanupError
+                        cleanupMessage:
+                            "Cleanup was skipped for remote sandbox '\(info.sandboxId)' because backend '\(remoteBackend.identifier)' does not support deletion."
                     )
                 )
             }
@@ -159,10 +233,20 @@ struct SidebarWorkspaceController {
         let workspaceURL = workspace.workspaceURL
 
         if workspace.isRemote, let sandboxId = workspace.remoteId {
-            do {
-                try await remoteBackend.deleteSandbox(sandboxId: sandboxId)
-            } catch {
-                NSLog("[RemoteBackend] Failed to delete sandbox %@: %@", sandboxId, error.localizedDescription)
+            if remoteBackend.runtimeCapabilities.supportsDelete,
+                let backend = remoteBackend as? any ProvisionCapable
+            {
+                do {
+                    try await backend.deleteSandbox(sandboxId: sandboxId)
+                } catch {
+                    NSLog("[RemoteBackend] Failed to delete sandbox %@: %@", sandboxId, error.localizedDescription)
+                }
+            } else {
+                NSLog(
+                    "[RemoteBackend] Backend %@ does not support deleting sandbox %@; removing local record only",
+                    remoteBackend.identifier,
+                    sandboxId
+                )
             }
         } else {
             try await workspaceService.deleteWorkspace(at: workspaceURL, deleteFiles: deleteFiles)
@@ -174,21 +258,24 @@ struct SidebarWorkspaceController {
 
     func stop(_ workspace: Workspace) async throws {
         guard let sandboxId = workspace.remoteId else { return }
-        try await remoteBackend.stopSandbox(sandboxId: sandboxId)
+        let backend = try startStopBackend(operation: "stopping remote workspaces")
+        try await backend.stopSandbox(sandboxId: sandboxId)
         workspace.status = .stopped
         try saveModelContext(action: "stop sandbox")
     }
 
     func start(_ workspace: Workspace) async throws {
         guard let sandboxId = workspace.remoteId else { return }
-        _ = try await remoteBackend.startSandbox(sandboxId: sandboxId)
+        let backend = try startStopBackend(operation: "starting remote workspaces")
+        _ = try await backend.startSandbox(sandboxId: sandboxId)
         workspace.status = .active
         try saveModelContext(action: "start sandbox")
     }
 
     func archive(_ workspace: Workspace) async throws {
         guard let sandboxId = workspace.remoteId else { return }
-        try await remoteBackend.archiveSandbox(sandboxId: sandboxId)
+        let backend = try archivableBackend(operation: "archiving remote workspaces")
+        try await backend.archiveSandbox(sandboxId: sandboxId)
         workspace.status = .archived
         try saveModelContext(action: "archive sandbox")
     }

--- a/Sources/WorkspaceManagerCore/Services/DaytonaBackend.swift
+++ b/Sources/WorkspaceManagerCore/Services/DaytonaBackend.swift
@@ -22,10 +22,19 @@ public struct RemoteSandboxStatus: Decodable, Sendable {
     public let state: String
 }
 
-public actor DaytonaBackend: RemoteBackendProtocol {
+public actor DaytonaBackend: ProvisionCapable, StartStopCapable, Archivable, Listable {
     public static let shared = DaytonaBackend()
 
     public nonisolated var identifier: String { "daytona" }
+    public nonisolated var runtimeCapabilities: RuntimeCapabilities {
+        RuntimeCapabilities(
+            supportsCreate: true,
+            supportsDelete: true,
+            supportsStartStop: true,
+            supportsArchive: true,
+            supportsList: true
+        )
+    }
 
     private let scriptPath: String
 
@@ -50,7 +59,7 @@ public actor DaytonaBackend: RemoteBackendProtocol {
             } ?? "scripts/daytona-sandbox-manager.py"
     }
 
-    public func isAvailable() async -> Bool {
+    public func healthCheck() async -> Bool {
         guard ProcessInfo.processInfo.environment["DAYTONA_API_KEY"] != nil else {
             return false
         }
@@ -58,6 +67,18 @@ public actor DaytonaBackend: RemoteBackendProtocol {
     }
 
     // MARK: - Sandbox Lifecycle
+
+    public func openSession(
+        sandboxId: String,
+        workspaceStatus: WorkspaceStatus
+    ) async throws -> RemoteSandboxInfo {
+        switch workspaceStatus {
+        case .active:
+            return try await resolveCommand(sandboxId: sandboxId)
+        case .stopped, .archived:
+            return try await startSandbox(sandboxId: sandboxId)
+        }
+    }
 
     public func createSandbox(name: String, cloneURL: String? = nil) async throws -> RemoteSandboxInfo {
         var args = ["create", "--name", name]
@@ -67,7 +88,7 @@ public actor DaytonaBackend: RemoteBackendProtocol {
         return try await runCommand(args)
     }
 
-    public func getSSHCommand(sandboxId: String) async throws -> RemoteSandboxInfo {
+    public func resolveCommand(sandboxId: String) async throws -> RemoteSandboxInfo {
         try await runCommand(["ssh-command", "--sandbox-id", sandboxId])
     }
 

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -137,15 +137,91 @@ public protocol NotificationCoordinatorProtocol: AnyObject {
     func markActivitySeen()
 }
 
+public struct RuntimeCapabilities: Sendable, Equatable {
+    public let supportsCreate: Bool
+    public let supportsDelete: Bool
+    public let supportsStartStop: Bool
+    public let supportsArchive: Bool
+    public let supportsList: Bool
+    public let supportsCompose: Bool
+    public let supportsPortForwarding: Bool
+
+    public init(
+        supportsCreate: Bool = false,
+        supportsDelete: Bool = false,
+        supportsStartStop: Bool = false,
+        supportsArchive: Bool = false,
+        supportsList: Bool = false,
+        supportsCompose: Bool = false,
+        supportsPortForwarding: Bool = false
+    ) {
+        self.supportsCreate = supportsCreate
+        self.supportsDelete = supportsDelete
+        self.supportsStartStop = supportsStartStop
+        self.supportsArchive = supportsArchive
+        self.supportsList = supportsList
+        self.supportsCompose = supportsCompose
+        self.supportsPortForwarding = supportsPortForwarding
+    }
+}
+
+public enum RemoteBackendCapabilityError: LocalizedError, Sendable {
+    case unsupportedOperation(backendIdentifier: String, operation: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedOperation(let backendIdentifier, let operation):
+            return "Remote backend '\(backendIdentifier)' does not support \(operation)."
+        }
+    }
+}
+
 public protocol RemoteBackendProtocol: Sendable {
     var identifier: String { get }
-    func isAvailable() async -> Bool
+    var runtimeCapabilities: RuntimeCapabilities { get }
 
-    func createSandbox(name: String, cloneURL: String?) async throws -> RemoteSandboxInfo
-    func getSSHCommand(sandboxId: String) async throws -> RemoteSandboxInfo
+    func openSession(sandboxId: String, workspaceStatus: WorkspaceStatus) async throws -> RemoteSandboxInfo
+    func resolveCommand(sandboxId: String) async throws -> RemoteSandboxInfo
+    func healthCheck() async -> Bool
+}
+
+extension RemoteBackendProtocol {
+    public func openSession(
+        sandboxId: String,
+        workspaceStatus: WorkspaceStatus
+    ) async throws -> RemoteSandboxInfo {
+        switch workspaceStatus {
+        case .active:
+            return try await resolveCommand(sandboxId: sandboxId)
+        case .stopped, .archived:
+            guard runtimeCapabilities.supportsStartStop,
+                let backend = self as? any StartStopCapable
+            else {
+                throw RemoteBackendCapabilityError.unsupportedOperation(
+                    backendIdentifier: identifier,
+                    operation: "starting and resuming remote workspaces"
+                )
+            }
+
+            return try await backend.startSandbox(sandboxId: sandboxId)
+        }
+    }
+}
+
+public protocol StartStopCapable: RemoteBackendProtocol {
     func stopSandbox(sandboxId: String) async throws
     func startSandbox(sandboxId: String) async throws -> RemoteSandboxInfo
+}
+
+public protocol Archivable: RemoteBackendProtocol {
     func archiveSandbox(sandboxId: String) async throws
-    func deleteSandbox(sandboxId: String) async throws
+}
+
+public protocol Listable: RemoteBackendProtocol {
     func listSandboxes() async throws -> [RemoteSandboxStatus]
+}
+
+public protocol ProvisionCapable: RemoteBackendProtocol {
+    func createSandbox(name: String, cloneURL: String?) async throws -> RemoteSandboxInfo
+    func deleteSandbox(sandboxId: String) async throws
 }


### PR DESCRIPTION
## Summary
- split the remote backend API into a core session contract plus optional capability protocols
- add runtime capability flags and unsupported-operation errors so remote flows can branch explicitly
- update DaytonaBackend, landing flows, and sidebar actions to use health checks and capability-gated behavior

## Testing
- ./scripts/build-ghosttykit.sh
- swift build
- swift test --no-parallel
- git diff --check

## Runtime Verification
- ./scripts/launch-dev.sh --no-build
- app reached startup and repo hydration, but exited before ./scripts/capture-window.sh could capture a stable window in this environment
