### PR TITLE
Add app launcher flow for workspaces CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,18 +70,21 @@ Replace your installed app in `/Applications` with your current local build:
 ./scripts/install-local.sh
 ```
 
+This also links `workspaces` into the first writable directory already on your `PATH` unless you pass `--no-cli-link`.
+
 Useful options:
 
 ```bash
 ./scripts/install-local.sh --no-build --no-open
 ./scripts/install-local.sh --signed
 ./scripts/install-local.sh --dest ~/Applications/WorkspaceManager.app
+./scripts/install-local.sh --cli-link ~/.local/bin/workspaces
 ```
 
 ## CLI Development
 
 ```bash
-swift run WorkspaceManagerCLI help
+swift run workspaces help
 ```
 
 ## Project Structure

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     products: [
         .executable(name: "WorkspaceManager", targets: ["WorkspaceManager"]),
+        .executable(name: "workspaces", targets: ["WorkspaceManagerCLI"]),
         .executable(name: "WorkspaceManagerCLI", targets: ["WorkspaceManagerCLI"]),
     ],
     dependencies: [],

--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@
 ### CLI (source builds)
 
 ```bash
-swift run WorkspaceManagerCLI help
-swift run WorkspaceManagerCLI repo add ~/code/my-repo
-swift run WorkspaceManagerCLI ws new my-repo feature-auth
-swift run WorkspaceManagerCLI open my-repo/feature-auth --cmd "claude"
+swift run workspaces
+swift run workspaces .
+swift run workspaces repo add ~/code/my-repo
+swift run workspaces ws new my-repo feature-auth
+swift run workspaces open my-repo/feature-auth --cmd "claude"
 ```
 
 ## Configuration

--- a/Sources/WorkspaceManager/App/WorkspaceDeepLink.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceDeepLink.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct WorkspaceDeepLink: Equatable {
     let cwd: String
+    let repoRoot: String?
     let sessionID: String?
     let source: String?
 
@@ -24,6 +25,14 @@ struct WorkspaceDeepLink: Equatable {
         guard normalizedCWD.hasPrefix("/") else { return nil }
 
         cwd = normalizedCWD
+        if let rawRepoRoot = queryItems.first(where: { $0.name == "repo_root" })?.value,
+            !rawRepoRoot.isEmpty
+        {
+            let normalizedRepoRoot = Self.normalizePath(rawRepoRoot)
+            repoRoot = normalizedRepoRoot.hasPrefix("/") ? normalizedRepoRoot : nil
+        } else {
+            repoRoot = nil
+        }
         sessionID = queryItems.first(where: { $0.name == "session_id" })?.value
         source = queryItems.first(where: { $0.name == "source" })?.value
     }

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleDisplayName</key>
     <string>Workspaces</string>
 
-    <!-- Custom URL scheme for focusing an existing workspace -->
+    <!-- Custom URL scheme for focusing an existing directory, repo, or workspace -->
     <key>CFBundleURLTypes</key>
     <array>
         <dict>

--- a/Sources/WorkspaceManager/Services/CommandLineToolService.swift
+++ b/Sources/WorkspaceManager/Services/CommandLineToolService.swift
@@ -1,0 +1,522 @@
+import Darwin
+import Foundation
+
+enum CommandLineToolAvailability: Equatable {
+    case installed
+    case notInstalled
+    case unavailable
+}
+
+enum CommandLineToolPrimaryAction: Equatable {
+    case install
+    case repair
+
+    var title: String {
+        switch self {
+        case .install:
+            return "Install"
+        case .repair:
+            return "Repair"
+        }
+    }
+}
+
+enum CommandLineToolStatusReason: Equatable {
+    case active
+    case missing
+    case missingFromPath
+    case brokenSymlink
+    case differentTarget(existingTargetPath: String?)
+    case conflictingFile
+    case shadowedByOtherCommand(path: String)
+    case missingBundledCommand
+    case noWritableInstallLocation
+}
+
+struct CommandLineToolStatus: Equatable {
+    let availability: CommandLineToolAvailability
+    let reason: CommandLineToolStatusReason
+    let commandPath: String?
+    let sourcePath: String?
+    let setupCommand: String?
+    let primaryAction: CommandLineToolPrimaryAction?
+}
+
+enum CommandLineToolInstallError: LocalizedError, Equatable {
+    case missingBundledCommand
+    case noWritableInstallLocation
+    case conflictingFile(path: String)
+    case installFailed(reason: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingBundledCommand:
+            return "This build does not include the bundled workspaces launcher."
+        case .noWritableInstallLocation:
+            return "No writable install location was found for the workspaces command."
+        case .conflictingFile(let path):
+            return "A different file already exists at \(path). Move or rename it before installing."
+        case .installFailed(let reason):
+            return "Failed to install the workspaces command: \(reason)"
+        }
+    }
+}
+
+struct CommandLineToolService {
+    private static let commandName = "workspaces"
+
+    private let fileManager: FileManager
+    private let environment: [String: String]
+    private let sourceCommandURL: URL?
+    private let preferredInstallDirectories: [URL]
+
+    init(
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        sourceCommandURL: URL? = nil,
+        preferredInstallDirectories: [URL]? = nil,
+        homeDirectoryURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.environment = environment
+        let resolvedSourceCommandURL =
+            sourceCommandURL
+            ?? CommandLineToolService.defaultSourceCommandURL(fileManager: fileManager)
+        self.sourceCommandURL = resolvedSourceCommandURL?.standardizedFileURL.resolvingSymlinksInPath()
+
+        let resolvedHomeDirectory =
+            homeDirectoryURL?.standardizedFileURL
+            ?? fileManager.homeDirectoryForCurrentUser.standardizedFileURL
+        self.preferredInstallDirectories =
+            preferredInstallDirectories?.map { $0.standardizedFileURL }
+            ?? Self.defaultPreferredInstallDirectories(homeDirectoryURL: resolvedHomeDirectory)
+    }
+
+    func status() -> CommandLineToolStatus {
+        guard let sourceCommandURL, fileManager.isExecutableFile(atPath: sourceCommandURL.path) else {
+            return CommandLineToolStatus(
+                availability: .unavailable,
+                reason: .missingBundledCommand,
+                commandPath: nil,
+                sourcePath: sourceCommandURL?.path,
+                setupCommand: nil,
+                primaryAction: nil
+            )
+        }
+
+        let sourcePath = normalizePath(sourceCommandURL)
+        let pathDirectories = resolvedPathDirectories()
+
+        if let activeCommandPath = activeCommandPath(
+            pathDirectories: pathDirectories,
+            sourcePath: sourcePath
+        ) {
+            return CommandLineToolStatus(
+                availability: .installed,
+                reason: .active,
+                commandPath: activeCommandPath,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: nil,
+                primaryAction: nil
+            )
+        }
+
+        let candidateDirectories = candidateDirectories(pathDirectories: pathDirectories)
+        let preferredCommandURL =
+            managedCommandURL(
+                sourcePath: sourcePath,
+                candidateDirectories: candidateDirectories
+            )
+            ?? resolvedInstallCommandURL(pathDirectories: pathDirectories)
+
+        guard let preferredCommandURL else {
+            return CommandLineToolStatus(
+                availability: .unavailable,
+                reason: .noWritableInstallLocation,
+                commandPath: nil,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: nil,
+                primaryAction: nil
+            )
+        }
+
+        let shadowingCommandPath = shadowingCommandPath(
+            pathDirectories: pathDirectories,
+            sourcePath: sourcePath
+        )
+        let commandPath = preferredCommandURL.path
+        let directoryOnPath = pathDirectories.contains {
+            sameDirectory($0, preferredCommandURL.deletingLastPathComponent())
+        }
+        let shouldPrependPath = shadowingCommandPath != nil || !directoryOnPath
+        let setupCommand = makeSetupCommand(
+            sourceCommandURL: sourceCommandURL,
+            installCommandURL: preferredCommandURL,
+            prependToPath: shouldPrependPath
+        )
+
+        let preferredEntry = pathEntry(at: preferredCommandURL)
+
+        if let shadowingCommandPath {
+            if shadowingCommandPath == commandPath {
+                switch preferredEntry {
+                case .otherSymlink(let existingTargetPath):
+                    return CommandLineToolStatus(
+                        availability: .notInstalled,
+                        reason: .differentTarget(existingTargetPath: existingTargetPath),
+                        commandPath: commandPath,
+                        sourcePath: sourceCommandURL.path,
+                        setupCommand: setupCommand,
+                        primaryAction: .repair
+                    )
+                case .brokenSymlink:
+                    return CommandLineToolStatus(
+                        availability: .notInstalled,
+                        reason: .brokenSymlink,
+                        commandPath: commandPath,
+                        sourcePath: sourceCommandURL.path,
+                        setupCommand: setupCommand,
+                        primaryAction: .repair
+                    )
+                case .file:
+                    return CommandLineToolStatus(
+                        availability: .notInstalled,
+                        reason: .conflictingFile,
+                        commandPath: commandPath,
+                        sourcePath: sourceCommandURL.path,
+                        setupCommand: setupCommand,
+                        primaryAction: nil
+                    )
+                case .missing:
+                    break
+                }
+            }
+
+            let existingManagedCommand = preferredEntry.resolvesTo(path: sourcePath)
+            return CommandLineToolStatus(
+                availability: .notInstalled,
+                reason: .shadowedByOtherCommand(path: shadowingCommandPath),
+                commandPath: commandPath,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: setupCommand,
+                primaryAction: existingManagedCommand ? nil : .install
+            )
+        }
+
+        switch preferredEntry {
+        case .missing:
+            return CommandLineToolStatus(
+                availability: .notInstalled,
+                reason: .missing,
+                commandPath: commandPath,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: setupCommand,
+                primaryAction: .install
+            )
+        case .otherSymlink(let existingTargetPath):
+            if existingTargetPath == sourcePath {
+                return CommandLineToolStatus(
+                    availability: .notInstalled,
+                    reason: .missingFromPath,
+                    commandPath: commandPath,
+                    sourcePath: sourceCommandURL.path,
+                    setupCommand: setupCommand,
+                    primaryAction: nil
+                )
+            }
+            return CommandLineToolStatus(
+                availability: .notInstalled,
+                reason: .differentTarget(existingTargetPath: existingTargetPath),
+                commandPath: commandPath,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: setupCommand,
+                primaryAction: .repair
+            )
+        case .brokenSymlink:
+            return CommandLineToolStatus(
+                availability: .notInstalled,
+                reason: .brokenSymlink,
+                commandPath: commandPath,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: setupCommand,
+                primaryAction: .repair
+            )
+        case .file:
+            return CommandLineToolStatus(
+                availability: .notInstalled,
+                reason: .conflictingFile,
+                commandPath: commandPath,
+                sourcePath: sourceCommandURL.path,
+                setupCommand: setupCommand,
+                primaryAction: nil
+            )
+        }
+    }
+
+    func installOrRepair() throws -> CommandLineToolStatus {
+        let currentStatus = status()
+
+        guard let sourcePath = currentStatus.sourcePath,
+            let commandPath = currentStatus.commandPath
+        else {
+            switch currentStatus.reason {
+            case .missingBundledCommand:
+                throw CommandLineToolInstallError.missingBundledCommand
+            case .noWritableInstallLocation:
+                throw CommandLineToolInstallError.noWritableInstallLocation
+            default:
+                throw CommandLineToolInstallError.installFailed(reason: "Missing install metadata.")
+            }
+        }
+
+        let sourceCommandURL = URL(fileURLWithPath: sourcePath)
+        let installCommandURL = URL(fileURLWithPath: commandPath)
+
+        if !fileManager.isExecutableFile(atPath: sourceCommandURL.path) {
+            throw CommandLineToolInstallError.missingBundledCommand
+        }
+
+        try fileManager.createDirectory(
+            at: installCommandURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        switch pathEntry(at: installCommandURL) {
+        case .file:
+            throw CommandLineToolInstallError.conflictingFile(path: installCommandURL.path)
+        case .otherSymlink, .brokenSymlink:
+            do {
+                try fileManager.removeItem(at: installCommandURL)
+            } catch {
+                throw CommandLineToolInstallError.installFailed(reason: error.localizedDescription)
+            }
+        case .missing:
+            break
+        }
+
+        do {
+            try fileManager.createSymbolicLink(
+                at: installCommandURL,
+                withDestinationURL: sourceCommandURL
+            )
+        } catch {
+            throw CommandLineToolInstallError.installFailed(reason: error.localizedDescription)
+        }
+
+        return status()
+    }
+
+    private func activeCommandPath(pathDirectories: [URL], sourcePath: String) -> String? {
+        for directory in pathDirectories {
+            let candidate = directory.appendingPathComponent(Self.commandName, isDirectory: false)
+            if pathEntry(at: candidate).resolvesTo(path: sourcePath) {
+                return candidate.path
+            }
+            if pathEntry(at: candidate).isPresent {
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    private func shadowingCommandPath(pathDirectories: [URL], sourcePath: String) -> String? {
+        for directory in pathDirectories {
+            let candidate = directory.appendingPathComponent(Self.commandName, isDirectory: false)
+            let entry = pathEntry(at: candidate)
+            if entry.resolvesTo(path: sourcePath) {
+                return nil
+            }
+            if entry.isPresent {
+                return candidate.path
+            }
+        }
+
+        return nil
+    }
+
+    private func managedCommandURL(sourcePath: String, candidateDirectories: [URL]) -> URL? {
+        candidateDirectories
+            .map { $0.appendingPathComponent(Self.commandName, isDirectory: false) }
+            .first { pathEntry(at: $0).resolvesTo(path: sourcePath) }
+    }
+
+    private func resolvedInstallCommandURL(pathDirectories: [URL]) -> URL? {
+        let installDirectory = candidateDirectories(pathDirectories: pathDirectories)
+            .first(where: isWritableInstallDirectory)
+        return installDirectory?.appendingPathComponent(Self.commandName, isDirectory: false)
+    }
+
+    private func candidateDirectories(pathDirectories: [URL]) -> [URL] {
+        let combined = preferredInstallDirectories + pathDirectories
+        var seen = Set<String>()
+        var result: [URL] = []
+
+        for directory in combined {
+            let normalizedPath = directory.standardizedFileURL.path
+            guard seen.insert(normalizedPath).inserted else { continue }
+            result.append(directory)
+        }
+
+        return result
+    }
+
+    private func resolvedPathDirectories() -> [URL] {
+        let rawPath = environment["PATH"] ?? ""
+        return
+            rawPath
+            .split(separator: ":")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+            .map {
+                URL(
+                    fileURLWithPath: NSString(string: $0).expandingTildeInPath,
+                    isDirectory: true
+                )
+                .standardizedFileURL
+            }
+    }
+
+    private func isWritableInstallDirectory(_ directory: URL) -> Bool {
+        guard let existingAncestor = nearestExistingAncestor(of: directory) else {
+            return false
+        }
+
+        var isDirectory = ObjCBool(false)
+        guard fileManager.fileExists(atPath: existingAncestor.path, isDirectory: &isDirectory), isDirectory.boolValue
+        else {
+            return false
+        }
+
+        return fileManager.isWritableFile(atPath: existingAncestor.path)
+    }
+
+    private func nearestExistingAncestor(of directory: URL) -> URL? {
+        var current = directory.standardizedFileURL
+
+        while true {
+            if fileManager.fileExists(atPath: current.path) {
+                return current
+            }
+
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                return nil
+            }
+            current = parent
+        }
+    }
+
+    private func sameDirectory(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.standardizedFileURL.path == rhs.standardizedFileURL.path
+    }
+
+    private func normalizePath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private func makeSetupCommand(
+        sourceCommandURL: URL,
+        installCommandURL: URL,
+        prependToPath: Bool
+    ) -> String {
+        let installDirectory = installCommandURL.deletingLastPathComponent()
+        let installDirectoryQuoted = shellQuote(installDirectory.path)
+        let sourceCommandQuoted = shellQuote(sourceCommandURL.path)
+        let installCommandQuoted = shellQuote(installCommandURL.path)
+
+        var command = "mkdir -p \(installDirectoryQuoted) && ln -sfn \(sourceCommandQuoted) \(installCommandQuoted)"
+        if prependToPath {
+            command += " && export PATH=\(installDirectoryQuoted):\"$PATH\""
+        }
+        return command
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+
+    private func pathEntry(at url: URL) -> PathEntry {
+        var fileStatus = stat()
+        if lstat(url.path, &fileStatus) != 0 {
+            return .missing
+        }
+
+        let fileType = fileStatus.st_mode & S_IFMT
+        guard fileType == S_IFLNK else {
+            return .file
+        }
+
+        guard let rawDestination = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+            return .brokenSymlink
+        }
+
+        let destinationURL = URL(
+            fileURLWithPath: rawDestination,
+            relativeTo: url.deletingLastPathComponent()
+        )
+        .standardizedFileURL
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            return .otherSymlink(existingTargetPath: normalizePath(destinationURL))
+        }
+
+        return .brokenSymlink
+    }
+
+    private static func defaultPreferredInstallDirectories(homeDirectoryURL: URL) -> [URL] {
+        [
+            URL(fileURLWithPath: "/opt/homebrew/bin", isDirectory: true),
+            URL(fileURLWithPath: "/usr/local/bin", isDirectory: true),
+            homeDirectoryURL
+                .appendingPathComponent(".local", isDirectory: true)
+                .appendingPathComponent("bin", isDirectory: true),
+            homeDirectoryURL.appendingPathComponent("bin", isDirectory: true),
+        ]
+    }
+
+    private static func defaultSourceCommandURL(fileManager: FileManager) -> URL? {
+        let bundleURL = Bundle.main.bundleURL
+        let executableURL = Bundle.main.executableURL
+
+        let candidates = [
+            bundleURL.pathExtension == "app"
+                ? bundleURL
+                    .appendingPathComponent("Contents", isDirectory: true)
+                    .appendingPathComponent("MacOS", isDirectory: true)
+                    .appendingPathComponent(commandName, isDirectory: false)
+                : nil,
+            executableURL?
+                .deletingLastPathComponent()
+                .appendingPathComponent(commandName, isDirectory: false),
+        ]
+        .compactMap { $0 }
+
+        return candidates.first(where: { fileManager.isExecutableFile(atPath: $0.path) })
+    }
+
+    private enum PathEntry {
+        case missing
+        case otherSymlink(existingTargetPath: String?)
+        case brokenSymlink
+        case file
+
+        var isPresent: Bool {
+            switch self {
+            case .missing:
+                return false
+            case .otherSymlink, .brokenSymlink, .file:
+                return true
+            }
+        }
+
+        func resolvesTo(path sourcePath: String) -> Bool {
+            switch self {
+            case .otherSymlink(let existingTargetPath):
+                return existingTargetPath == sourcePath
+            case .missing, .brokenSymlink, .file:
+                return false
+            }
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Services/LaunchRepositoryService.swift
+++ b/Sources/WorkspaceManager/Services/LaunchRepositoryService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftData
+import WorkspaceManagerCore
+
+@MainActor
+struct LaunchRepositoryService {
+    let modelContext: ModelContext
+
+    func trackedRepo(matchingNormalizedPath normalizedPath: String) -> Repo? {
+        let descriptor = FetchDescriptor<Repo>()
+        guard let fetchedRepos = try? modelContext.fetch(descriptor) else {
+            return nil
+        }
+
+        return fetchedRepos.first { normalizePath($0.localURL) == normalizedPath }
+    }
+
+    func existingOrImportedRepo(at repoRootPath: String) -> Repo? {
+        let repoURL = URL(fileURLWithPath: repoRootPath, isDirectory: true)
+        let normalizedPath = normalizePath(repoURL)
+
+        if let existing = trackedRepo(matchingNormalizedPath: normalizedPath) {
+            return existing
+        }
+
+        guard isGitRepository(at: repoURL) else {
+            return nil
+        }
+
+        let repo = Repo(name: repoURL.lastPathComponent, localPath: repoURL)
+        modelContext.insert(repo)
+
+        do {
+            try modelContext.save()
+            return repo
+        } catch {
+            modelContext.rollback()
+            return nil
+        }
+    }
+
+    private func isGitRepository(at url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.appendingPathComponent(".git").path)
+    }
+
+    private func normalizePath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -44,6 +44,10 @@ struct ContentView: View {
     private let presentationController = MainWindowPresentationController()
     private let splitRoutingController = SplitRoutingController()
 
+    private var launchRepositoryService: LaunchRepositoryService {
+        LaunchRepositoryService(modelContext: modelContext)
+    }
+
     private var sessionPresentation: HostTerminalSessionPresentation {
         hostTerminalState.sessionPresentation
     }
@@ -575,7 +579,53 @@ struct ContentView: View {
             )
 
             abandonPendingRemoteConnection(reason: "deep_link_selected")
-            handleWorkspaceSelection(workspace)
+            handleWorkspaceSelection(
+                workspace,
+                preferredDirectory: URL(fileURLWithPath: request.cwd, isDirectory: true)
+            )
+            deepLinkState.clearPendingRequest()
+            viewState.didResolveInitialSurface = true
+            focusWorkspaceWindow()
+            return false
+
+        case .selectDeepLinkedRepo(let request, let repo):
+            NSLog(
+                "[DeepLink] Matched repo '%@' for cwd '%@' (session_id=%@ source=%@)",
+                repo.name,
+                request.cwd,
+                request.sessionID ?? "",
+                request.source ?? ""
+            )
+
+            abandonPendingRemoteConnection(reason: "deep_link_selected")
+            handleRepoTerminalSelection(
+                repo,
+                preferredDirectory: URL(fileURLWithPath: request.cwd, isDirectory: true)
+            )
+            deepLinkState.clearPendingRequest()
+            viewState.didResolveInitialSurface = true
+            focusWorkspaceWindow()
+            return false
+
+        case .importDeepLinkedRepo(let request, let repoRoot):
+            guard let repo = launchRepositoryService.existingOrImportedRepo(at: repoRoot) else {
+                NSLog("[DeepLink] Failed to import repo for cwd '%@' repo_root='%@'", request.cwd, repoRoot)
+                deepLinkState.clearPendingRequest()
+                return true
+            }
+
+            NSLog(
+                "[DeepLink] Imported repo '%@' for cwd '%@' (repo_root=%@)",
+                repo.name,
+                request.cwd,
+                repoRoot
+            )
+
+            abandonPendingRemoteConnection(reason: "deep_link_repo_imported")
+            handleRepoTerminalSelection(
+                repo,
+                preferredDirectory: URL(fileURLWithPath: request.cwd, isDirectory: true)
+            )
             deepLinkState.clearPendingRequest()
             viewState.didResolveInitialSurface = true
             focusWorkspaceWindow()
@@ -741,14 +791,23 @@ struct ContentView: View {
 
     @MainActor
     private func handleRepoTerminalSelection(_ repo: Repo) {
+        handleRepoTerminalSelection(repo, preferredDirectory: nil)
+    }
+
+    @MainActor
+    private func handleRepoTerminalSelection(_ repo: Repo, preferredDirectory: URL?) {
         let repoDirectory = repo.localURL.standardizedFileURL.resolvingSymlinksInPath()
+        let launchDirectory = preferredSessionDirectory(
+            preferredDirectory,
+            inside: repoDirectory
+        )
 
         abandonPendingRemoteConnection(reason: "repo_terminal_selected")
         markAccessed(repo: repo)
         applyNavigationDestination(.repoTerminal(repo))
         let session = activateHostSession(
             key: .repoPath(repoDirectory.path),
-            directory: repoDirectory
+            directory: launchDirectory
         )
         terminalFocusCoordinator.beginRepoClickMeasurement(
             sessionID: session.id,
@@ -784,6 +843,11 @@ struct ContentView: View {
 
     @MainActor
     private func handleWorkspaceSelection(_ workspace: Workspace) {
+        handleWorkspaceSelection(workspace, preferredDirectory: nil)
+    }
+
+    @MainActor
+    private func handleWorkspaceSelection(_ workspace: Workspace, preferredDirectory: URL?) {
         terminalFocusCoordinator.cancelPendingRepoClickMeasurement(reason: "workspace_selected")
 
         if workspace.isRemote, let sandboxId = workspace.remoteId {
@@ -793,9 +857,13 @@ struct ContentView: View {
             markAccessed(workspace: workspace)
             applyNavigationDestination(.workspaceTerminal(workspace))
             let workspaceDirectory = workspace.workspaceURL.standardizedFileURL.resolvingSymlinksInPath()
+            let launchDirectory = preferredSessionDirectory(
+                preferredDirectory,
+                inside: workspaceDirectory
+            )
             let session = activateHostSession(
                 key: .hostPath(workspaceDirectory.path),
-                directory: workspaceDirectory
+                directory: launchDirectory
             )
             terminalFocusCoordinator.requestMainTerminalFocus(
                 targetSessionID: session.id,
@@ -1413,6 +1481,26 @@ struct ContentView: View {
             guard let terminal = TerminalFocusManager.shared.focusedTerminal else { return }
             TerminalFocusManager.shared.requestFocus(for: terminal)
         }
+    }
+
+    private func preferredSessionDirectory(_ preferredDirectory: URL?, inside root: URL) -> URL {
+        guard let preferredDirectory else { return root }
+
+        let normalizedRoot = root.standardizedFileURL.resolvingSymlinksInPath()
+        let normalizedPreferred = preferredDirectory.standardizedFileURL.resolvingSymlinksInPath()
+        guard path(normalizedPreferred.path, isInside: normalizedRoot.path) else {
+            return normalizedRoot
+        }
+
+        var isDirectory = ObjCBool(false)
+        guard
+            FileManager.default.fileExists(atPath: normalizedPreferred.path, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            return normalizedRoot
+        }
+
+        return normalizedPreferred
     }
 
     private func path(_ path: String, isInside root: String) -> Bool {

--- a/Sources/WorkspaceManager/Views/MainWindow/MainSelectionCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainSelectionCoordinator.swift
@@ -42,6 +42,37 @@ struct MainSelectionCoordinator {
         return bestMatch?.workspace
     }
 
+    func bestRepoMatch(
+        for cwd: String,
+        repoRoot: String?,
+        repos: [Repo],
+        normalizePath: (String) -> String,
+        pathIsInside: (String, String) -> Bool
+    ) -> Repo? {
+        if let repoRoot {
+            let normalizedRepoRoot = normalizePath(repoRoot)
+            if let exact = repos.first(where: { normalizePath($0.localPath) == normalizedRepoRoot }) {
+                return exact
+            }
+        }
+
+        let normalizedCWD = normalizePath(cwd)
+        let matches = repos.compactMap { repo -> (repo: Repo, matchLength: Int)? in
+            let repoPath = normalizePath(repo.localPath)
+            guard pathIsInside(normalizedCWD, repoPath) else { return nil }
+            return (repo, repoPath.count)
+        }
+
+        let bestMatch = matches.sorted { lhs, rhs in
+            if lhs.matchLength == rhs.matchLength {
+                return lhs.repo.lastAccessedAt > rhs.repo.lastAccessedAt
+            }
+            return lhs.matchLength > rhs.matchLength
+        }.first
+
+        return bestMatch?.repo
+    }
+
     func syncedWorkspaceSelection(
         for activeSession: HostTerminalSession?,
         repos: [Repo],

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowBootstrapController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowBootstrapController.swift
@@ -6,7 +6,9 @@ struct MainWindowBootstrapController {
         case none
         case waitForRepos(WorkspaceDeepLink)
         case clearNoMatch(WorkspaceDeepLink)
-        case select(request: WorkspaceDeepLink, workspace: Workspace)
+        case selectWorkspace(request: WorkspaceDeepLink, workspace: Workspace)
+        case selectRepo(request: WorkspaceDeepLink, repo: Repo)
+        case importRepo(request: WorkspaceDeepLink, repoRoot: String)
     }
 
     enum PreviewBootstrapDecision {
@@ -49,7 +51,21 @@ struct MainWindowBootstrapController {
             normalizePath: normalizePath,
             pathIsInside: pathIsInside
         ) {
-            return .select(request: pendingRequest, workspace: workspace)
+            return .selectWorkspace(request: pendingRequest, workspace: workspace)
+        }
+
+        if let repo = selectionCoordinator.bestRepoMatch(
+            for: pendingRequest.cwd,
+            repoRoot: pendingRequest.repoRoot,
+            repos: repos,
+            normalizePath: normalizePath,
+            pathIsInside: pathIsInside
+        ) {
+            return .selectRepo(request: pendingRequest, repo: repo)
+        }
+
+        if let repoRoot = pendingRequest.repoRoot {
+            return .importRepo(request: pendingRequest, repoRoot: repoRoot)
         }
 
         return repos.isEmpty ? .waitForRepos(pendingRequest) : .clearNoMatch(pendingRequest)

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowSurfaceResolutionController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowSurfaceResolutionController.swift
@@ -20,6 +20,8 @@ enum MainWindowSurfaceResolutionAction {
     case waitForRepos
     case clearDeepLinkNoMatch(WorkspaceDeepLink)
     case selectDeepLinkedWorkspace(WorkspaceDeepLink, Workspace)
+    case selectDeepLinkedRepo(WorkspaceDeepLink, Repo)
+    case importDeepLinkedRepo(WorkspaceDeepLink, String)
     case perfAutoSelect(Repo)
     case recordMissingPreviewBootstrap(UIFixturePreviewBootstrapConfiguration)
     case applyPreviewBootstrap(UIFixturePreviewBootstrapConfiguration, Repo, CodePreviewSelection)
@@ -46,8 +48,12 @@ struct MainWindowSurfaceResolutionController {
             return .waitForRepos
         case .clearNoMatch(let request):
             return .clearDeepLinkNoMatch(request)
-        case .select(let request, let workspace):
+        case .selectWorkspace(let request, let workspace):
             return .selectDeepLinkedWorkspace(request, workspace)
+        case .selectRepo(let request, let repo):
+            return .selectDeepLinkedRepo(request, repo)
+        case .importRepo(let request, let repoRoot):
+            return .importDeepLinkedRepo(request, repoRoot)
         }
 
         guard !context.didResolveInitialSurface else { return .none }

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -5,6 +5,7 @@
 //  App settings including configurable workspace location
 //
 
+import AppKit
 import SwiftUI
 import WorkspaceManagerCore
 
@@ -16,7 +17,17 @@ struct SettingsView: View {
     private var notificationsEnabled: Bool = NotificationConstants.defaultEnabled
 
     @State private var showFolderPicker = false
+    @State private var commandLineToolStatus: CommandLineToolStatus
+    @State private var commandLineToolFeedback: String?
+    @State private var commandLineToolFeedbackIsError = false
     @ObservedObject private var notificationCoordinator = NotificationCoordinator.shared
+
+    private let commandLineToolService: CommandLineToolService
+
+    init(commandLineToolService: CommandLineToolService = CommandLineToolService()) {
+        self.commandLineToolService = commandLineToolService
+        _commandLineToolStatus = State(initialValue: commandLineToolService.status())
+    }
 
     private var defaultPath: String {
         FileManager.default.homeDirectoryForCurrentUser
@@ -74,6 +85,66 @@ struct SettingsView: View {
                 }
             } header: {
                 Text("General")
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Use Workspaces from Terminal")
+                        .font(.headline)
+
+                    HStack(spacing: 8) {
+                        Image(systemName: commandLineToolStatusSymbolName)
+                            .foregroundStyle(commandLineToolStatusColor)
+                        Text(commandLineToolStatusTitle)
+                            .font(.callout.weight(.medium))
+                    }
+
+                    if let commandPath = commandLineToolStatus.commandPath {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Command Path")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            Text(commandPath)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                                .lineLimit(2)
+                                .truncationMode(.middle)
+                        }
+                        .padding(8)
+                        .background(Color(nsColor: .textBackgroundColor))
+                        .clipShape(.rect(cornerRadius: 6))
+                    }
+
+                    Text(commandLineToolStatusDetail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 10) {
+                        if let primaryAction = commandLineToolStatus.primaryAction {
+                            Button(primaryAction.title) {
+                                installCommandLineTool()
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+
+                        if commandLineToolStatus.setupCommand != nil {
+                            Button("Copy Setup Command") {
+                                copyCommandLineToolSetupCommand()
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+
+                    if let commandLineToolFeedback {
+                        Text(commandLineToolFeedback)
+                            .font(.caption)
+                            .foregroundStyle(commandLineToolFeedbackIsError ? .red : .green)
+                    }
+                }
+            } header: {
+                Text("Command Line Tool")
             }
 
             Section {
@@ -162,8 +233,9 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 500, height: 450)
+        .frame(width: 520, height: 540)
         .onAppear {
+            refreshCommandLineToolStatus()
             notificationCoordinator.loadStoredAuth()
         }
         .fileImporter(
@@ -184,6 +256,70 @@ struct SettingsView: View {
             case .failure(let error):
                 print("Folder picker error: \(error)")
             }
+        }
+    }
+
+    private var commandLineToolStatusTitle: String {
+        switch commandLineToolStatus.availability {
+        case .installed:
+            return "Installed"
+        case .notInstalled:
+            return "Not Installed"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+
+    private var commandLineToolStatusSymbolName: String {
+        switch commandLineToolStatus.availability {
+        case .installed:
+            return "checkmark.circle.fill"
+        case .notInstalled:
+            return "arrow.down.circle"
+        case .unavailable:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var commandLineToolStatusColor: Color {
+        switch commandLineToolStatus.availability {
+        case .installed:
+            return .green
+        case .notInstalled:
+            return .orange
+        case .unavailable:
+            return .red
+        }
+    }
+
+    private var commandLineToolStatusDetail: String {
+        let commandPath = commandLineToolStatus.commandPath ?? "the selected install location"
+
+        switch commandLineToolStatus.reason {
+        case .active:
+            return "The `workspaces` command is ready to open Workspaces from Terminal."
+        case .missing:
+            return "Install the `workspaces` command at \(commandPath) so `workspaces .` opens the current folder."
+        case .missingFromPath:
+            return
+                "The launcher is already linked at \(commandPath), but Terminal may not see that directory yet. Use the copied setup command to prepend it to PATH."
+        case .brokenSymlink:
+            return "The command link exists at \(commandPath), but it no longer points to this app."
+        case .differentTarget(let existingTargetPath):
+            if let existingTargetPath {
+                return "The command at \(commandPath) points to \(existingTargetPath) instead of this app."
+            }
+            return "The command at \(commandPath) points somewhere else and should be repaired."
+        case .conflictingFile:
+            return
+                "A different file already exists at \(commandPath). Move or rename it before installing this launcher."
+        case .shadowedByOtherCommand(let path):
+            return
+                "Another `workspaces` command at \(path) is taking precedence in PATH. Install here, then use the copied setup command to make this location win."
+        case .missingBundledCommand:
+            return "This app build does not include the bundled `workspaces` launcher."
+        case .noWritableInstallLocation:
+            return "No writable install location was found for the `workspaces` command."
         }
     }
 
@@ -255,6 +391,34 @@ struct SettingsView: View {
                 Task { await notificationCoordinator.startDeviceFlow() }
             }
         }
+    }
+
+    private func refreshCommandLineToolStatus() {
+        commandLineToolStatus = commandLineToolService.status()
+    }
+
+    private func installCommandLineTool() {
+        do {
+            commandLineToolStatus = try commandLineToolService.installOrRepair()
+            commandLineToolFeedbackIsError = false
+            if let commandPath = commandLineToolStatus.commandPath {
+                commandLineToolFeedback = "Linked `workspaces` at \(commandPath)."
+            } else {
+                commandLineToolFeedback = "Updated the `workspaces` command."
+            }
+        } catch {
+            commandLineToolFeedbackIsError = true
+            commandLineToolFeedback = error.localizedDescription
+            refreshCommandLineToolStatus()
+        }
+    }
+
+    private func copyCommandLineToolSetupCommand() {
+        guard let setupCommand = commandLineToolStatus.setupCommand else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(setupCommand, forType: .string)
+        commandLineToolFeedbackIsError = false
+        commandLineToolFeedback = "Copied the setup command."
     }
 
     private static var versionString: String {

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -3,6 +3,7 @@
 //  WorkspaceManagerCLI
 //
 
+import AppKit
 import Darwin
 import Foundation
 import WorkspaceManagerCore
@@ -22,14 +23,32 @@ struct WorkspaceManagerCLI {
 }
 
 private final class CLIApp {
+    private static let appBundleIdentifier = "com.cloudcompute.workspaces"
+    private static let reservedCommands: Set<String> = [
+        "help",
+        "--help",
+        "-h",
+        "repo",
+        "ws",
+        "open",
+        "run",
+        "resume",
+        "status",
+        "recent",
+        "doctor",
+    ]
+
     private let stateStore = CLIStateStore()
     private let workspaceService: WorkspaceService = .shared
     private let gitService: GitService = .shared
 
     func run(arguments: [String]) async throws -> Int32 {
         guard let command = arguments.first else {
-            printHelp()
-            return 0
+            return try launchApp(request: nil)
+        }
+
+        if let launchRequest = try appLaunchRequest(for: arguments) {
+            return try launchApp(request: launchRequest)
         }
 
         var state = try stateStore.load()
@@ -58,6 +77,73 @@ private final class CLIApp {
         default:
             throw CLIError("Unknown command '\(command)'. Run 'workspaces help'.")
         }
+    }
+
+    private func appLaunchRequest(for arguments: [String]) throws -> AppLaunchRequest? {
+        guard arguments.count == 1 else { return nil }
+        guard let rawArgument = arguments.first else { return nil }
+        guard !Self.reservedCommands.contains(rawArgument) else { return nil }
+        guard looksLikePath(rawArgument) || fileSystemEntryExists(at: rawArgument) else { return nil }
+
+        let resolvedURL = normalizePath(rawArgument)
+        var isDirectory = ObjCBool(false)
+        let exists = FileManager.default.fileExists(atPath: resolvedURL.path, isDirectory: &isDirectory)
+        guard exists else {
+            throw CLIError("Path not found: \(rawArgument)")
+        }
+
+        let launchDirectory =
+            isDirectory.boolValue
+            ? resolvedURL
+            : resolvedURL.deletingLastPathComponent()
+        return try AppLaunchRequest(launchDirectory: launchDirectory)
+    }
+
+    private func looksLikePath(_ argument: String) -> Bool {
+        argument == "."
+            || argument == ".."
+            || argument.hasPrefix("./")
+            || argument.hasPrefix("../")
+            || argument.hasPrefix("/")
+            || argument.hasPrefix("~")
+    }
+
+    private func fileSystemEntryExists(at rawPath: String) -> Bool {
+        FileManager.default.fileExists(atPath: normalizePath(rawPath).path)
+    }
+
+    private func launchApp(request: AppLaunchRequest?) throws -> Int32 {
+        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: Self.appBundleIdentifier)
+        else {
+            throw CLIError(
+                "Could not find the Workspaces app. Install it first so the 'workspaces' launcher can hand off to the GUI."
+            )
+        }
+
+        if let request {
+            let deepLinkURL = request.deepLinkURL
+            guard NSWorkspace.shared.open(deepLinkURL) else {
+                throw CLIError("Failed to open Workspaces for path: \(request.launchDirectory.path)")
+            }
+            return 0
+        }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var openError: Error?
+        NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
+            openError = error
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        if let openError {
+            throw CLIError("Failed to launch Workspaces: \(openError.localizedDescription)")
+        }
+
+        return 0
     }
 
     private func runRepo(arguments: [String], state: inout CLIState) async throws -> Int32 {
@@ -655,6 +741,44 @@ private struct WorkspaceLocalConfig {
     var archiveHook: String?
 }
 
+private struct AppLaunchRequest {
+    let launchDirectory: URL
+    let repoRoot: URL?
+
+    init(launchDirectory: URL) throws {
+        var isDirectory = ObjCBool(false)
+        guard
+            FileManager.default.fileExists(atPath: launchDirectory.path, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            throw CLIError("Path is not a directory: \(launchDirectory.path)")
+        }
+
+        let normalizedDirectory = launchDirectory.standardizedFileURL.resolvingSymlinksInPath()
+        self.launchDirectory = normalizedDirectory
+        repoRoot = resolveGitTopLevel(for: normalizedDirectory)
+    }
+
+    var deepLinkURL: URL {
+        var components = URLComponents()
+        components.scheme = "workspaces"
+        components.host = "focus"
+        components.queryItems = [
+            URLQueryItem(name: "cwd", value: launchDirectory.path),
+            URLQueryItem(name: "source", value: "cli"),
+        ]
+
+        if let repoRoot {
+            components.queryItems?.append(URLQueryItem(name: "repo_root", value: repoRoot.path))
+        }
+
+        guard let url = components.url else {
+            preconditionFailure("Failed to build Workspaces deep link URL.")
+        }
+        return url
+    }
+}
+
 // MARK: - Helpers
 
 private struct CLIError: LocalizedError {
@@ -678,6 +802,41 @@ private func validateGitRepository(at url: URL) throws {
     guard FileManager.default.fileExists(atPath: gitDir) else {
         throw CLIError("Not a git repository: \(url.path)")
     }
+}
+
+private func resolveGitTopLevel(for directory: URL) -> URL? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = ["-C", directory.path, "rev-parse", "--show-toplevel"]
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    do {
+        try process.run()
+    } catch {
+        return nil
+    }
+
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        return nil
+    }
+
+    let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    guard
+        let output = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+        !output.isEmpty
+    else {
+        return nil
+    }
+
+    return URL(fileURLWithPath: output, isDirectory: true)
+        .standardizedFileURL
+        .resolvingSymlinksInPath()
 }
 
 private func resolveExecutable(_ name: String) throws -> String {
@@ -772,6 +931,9 @@ private func printHelp() {
         WorkspaceManager CLI
 
         Usage:
+          workspaces
+          workspaces .
+          workspaces /path/to/repo
           workspaces repo add <path>
           workspaces repo list
           workspaces ws new <repo> <name>
@@ -785,6 +947,10 @@ private func printHelp() {
           workspaces recent
           workspaces doctor
           workspaces help
+
+        Launch behavior:
+          - no args: open the Workspaces app
+          - path arg: open the app and focus the matching workspace or repo
 
         Workspace selectors:
           - UUID

--- a/Tests/WorkspaceManagerAppTests/CommandLineToolServiceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/CommandLineToolServiceTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("CommandLineToolService", .serialized)
+struct CommandLineToolServiceTests {
+    @Test("Status is installed when PATH resolves to the bundled launcher")
+    func installedWhenPathResolvesToBundledLauncher() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        try fileManager.createDirectory(at: fixture.primaryBin, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: fixture.primaryBin.appendingPathComponent("workspaces", isDirectory: false),
+            withDestinationURL: fixture.sourceCommandURL
+        )
+
+        let service = makeService(
+            fileManager: fileManager,
+            sourceCommandURL: fixture.sourceCommandURL,
+            preferredInstallDirectories: [fixture.primaryBin],
+            pathDirectories: [fixture.primaryBin]
+        )
+
+        let status = service.status()
+
+        #expect(status.availability == .installed)
+        #expect(status.reason == .active)
+        #expect(status.commandPath == fixture.primaryBin.appendingPathComponent("workspaces").path)
+        #expect(status.primaryAction == nil)
+    }
+
+    @Test("Missing command offers install at the preferred location")
+    func missingCommandOffersInstall() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        try fileManager.createDirectory(at: fixture.primaryBin, withIntermediateDirectories: true)
+
+        let service = makeService(
+            fileManager: fileManager,
+            sourceCommandURL: fixture.sourceCommandURL,
+            preferredInstallDirectories: [fixture.primaryBin],
+            pathDirectories: [fixture.primaryBin]
+        )
+
+        let status = service.status()
+
+        #expect(status.availability == .notInstalled)
+        #expect(status.reason == .missing)
+        #expect(status.primaryAction == .install)
+        #expect(status.commandPath == fixture.primaryBin.appendingPathComponent("workspaces").path)
+        #expect(status.setupCommand?.contains("export PATH=") == false)
+    }
+
+    @Test("Different target offers repair")
+    func differentTargetOffersRepair() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        try fileManager.createDirectory(at: fixture.primaryBin, withIntermediateDirectories: true)
+        let otherCommandURL = try makeExecutable(
+            at: fixture.root
+                .appendingPathComponent("Other.app", isDirectory: true)
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent("workspaces", isDirectory: false),
+            fileManager: fileManager
+        )
+        try fileManager.createSymbolicLink(
+            at: fixture.primaryBin.appendingPathComponent("workspaces", isDirectory: false),
+            withDestinationURL: otherCommandURL
+        )
+
+        let service = makeService(
+            fileManager: fileManager,
+            sourceCommandURL: fixture.sourceCommandURL,
+            preferredInstallDirectories: [fixture.primaryBin],
+            pathDirectories: [fixture.primaryBin]
+        )
+
+        let status = service.status()
+
+        #expect(status.availability == .notInstalled)
+        #expect(
+            status.reason
+                == .differentTarget(
+                    existingTargetPath: otherCommandURL.standardizedFileURL.resolvingSymlinksInPath().path)
+        )
+        #expect(status.primaryAction == .repair)
+    }
+
+    @Test("Managed launcher outside PATH asks for PATH update")
+    func managedLauncherOutsidePathAsksForPathUpdate() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        try fileManager.createDirectory(at: fixture.primaryBin, withIntermediateDirectories: true)
+        try fileManager.createSymbolicLink(
+            at: fixture.primaryBin.appendingPathComponent("workspaces", isDirectory: false),
+            withDestinationURL: fixture.sourceCommandURL
+        )
+
+        let service = makeService(
+            fileManager: fileManager,
+            sourceCommandURL: fixture.sourceCommandURL,
+            preferredInstallDirectories: [fixture.primaryBin],
+            pathDirectories: [fixture.secondaryBin]
+        )
+
+        let status = service.status()
+
+        #expect(status.availability == .notInstalled)
+        #expect(status.reason == .missingFromPath)
+        #expect(status.primaryAction == nil)
+        #expect(status.setupCommand?.contains("export PATH=") == true)
+    }
+
+    @Test("Shadowed launcher keeps the linked path and suggests prepending PATH")
+    func shadowedLauncherSuggestsPrependingPath() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        try fileManager.createDirectory(at: fixture.primaryBin, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: fixture.secondaryBin, withIntermediateDirectories: true)
+        _ = try makeExecutable(
+            at: fixture.primaryBin.appendingPathComponent("workspaces", isDirectory: false),
+            fileManager: fileManager
+        )
+        try fileManager.createSymbolicLink(
+            at: fixture.secondaryBin.appendingPathComponent("workspaces", isDirectory: false),
+            withDestinationURL: fixture.sourceCommandURL
+        )
+
+        let service = makeService(
+            fileManager: fileManager,
+            sourceCommandURL: fixture.sourceCommandURL,
+            preferredInstallDirectories: [fixture.secondaryBin],
+            pathDirectories: [fixture.primaryBin, fixture.secondaryBin]
+        )
+
+        let status = service.status()
+
+        #expect(status.availability == .notInstalled)
+        #expect(
+            status.reason == .shadowedByOtherCommand(path: fixture.primaryBin.appendingPathComponent("workspaces").path)
+        )
+        #expect(status.commandPath == fixture.secondaryBin.appendingPathComponent("workspaces").path)
+        #expect(status.primaryAction == nil)
+        #expect(status.setupCommand?.contains("export PATH=") == true)
+    }
+
+    @Test("Install creates the symlink and returns installed state")
+    func installCreatesSymlink() throws {
+        let fileManager = FileManager.default
+        let fixture = try makeFixture(fileManager: fileManager)
+        defer { try? fileManager.removeItem(at: fixture.root) }
+
+        try fileManager.createDirectory(at: fixture.primaryBin, withIntermediateDirectories: true)
+
+        let service = makeService(
+            fileManager: fileManager,
+            sourceCommandURL: fixture.sourceCommandURL,
+            preferredInstallDirectories: [fixture.primaryBin],
+            pathDirectories: [fixture.primaryBin]
+        )
+
+        let status = try service.installOrRepair()
+
+        #expect(status.availability == .installed)
+        #expect(status.commandPath == fixture.primaryBin.appendingPathComponent("workspaces").path)
+        #expect(
+            fixture.primaryBin
+                .appendingPathComponent("workspaces", isDirectory: false)
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+                .path
+                == fixture.sourceCommandURL.standardizedFileURL.resolvingSymlinksInPath().path
+        )
+    }
+
+    private func makeService(
+        fileManager: FileManager,
+        sourceCommandURL: URL,
+        preferredInstallDirectories: [URL],
+        pathDirectories: [URL]
+    ) -> CommandLineToolService {
+        CommandLineToolService(
+            fileManager: fileManager,
+            environment: [
+                "PATH": pathDirectories.map(\.path).joined(separator: ":"),
+                "HOME": pathDirectories.first?.deletingLastPathComponent().path
+                    ?? fileManager.homeDirectoryForCurrentUser.path,
+            ],
+            sourceCommandURL: sourceCommandURL,
+            preferredInstallDirectories: preferredInstallDirectories,
+            homeDirectoryURL: fileManager.homeDirectoryForCurrentUser
+        )
+    }
+
+    private func makeFixture(fileManager: FileManager) throws -> Fixture {
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("wm-cli-service-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let sourceCommandURL = try makeExecutable(
+            at:
+                root
+                .appendingPathComponent("WorkspaceManager.app", isDirectory: true)
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent("workspaces", isDirectory: false),
+            fileManager: fileManager
+        )
+
+        return Fixture(
+            root: root,
+            sourceCommandURL: sourceCommandURL,
+            primaryBin: root.appendingPathComponent("primary-bin", isDirectory: true),
+            secondaryBin: root.appendingPathComponent("secondary-bin", isDirectory: true)
+        )
+    }
+
+    private func makeExecutable(at url: URL, fileManager: FileManager) throws -> URL {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    private struct Fixture {
+        let root: URL
+        let sourceCommandURL: URL
+        let primaryBin: URL
+        let secondaryBin: URL
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainSelectionCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainSelectionCoordinatorTests.swift
@@ -45,4 +45,30 @@ struct MainSelectionCoordinatorTests {
 
         #expect(resolved?.id == source.id)
     }
+
+    @Test("Best repo match prefers explicit repo root and longest path")
+    func bestRepoMatchPrefersExplicitRepoRoot() {
+        let firstRepo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let secondRepo = Repo(name: "nested", localPath: URL(fileURLWithPath: "/tmp/alpha/nested"))
+
+        let resolved = coordinator.bestRepoMatch(
+            for: "/tmp/alpha/nested/Sources/App",
+            repoRoot: "/tmp/alpha/nested",
+            repos: [firstRepo, secondRepo],
+            normalizePath: normalizePath,
+            pathIsInside: path(_:isInside:)
+        )
+
+        #expect(resolved?.id == secondRepo.id)
+    }
+
+    private func normalizePath(_ rawPath: String) -> String {
+        URL(fileURLWithPath: rawPath).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private func path(_ path: String, isInside root: String) -> Bool {
+        if path == root { return true }
+        guard root != "/" else { return true }
+        return path.hasPrefix(root + "/")
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/MainWindowBootstrapControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowBootstrapControllerTests.swift
@@ -45,11 +45,58 @@ struct MainWindowBootstrapControllerTests {
         )
 
         switch decision {
-        case .select(let pendingRequest, let matchedWorkspace):
+        case .selectWorkspace(let pendingRequest, let matchedWorkspace):
             #expect(pendingRequest == request)
             #expect(matchedWorkspace.id == workspace.id)
         default:
             Issue.record("Expected deep link decision to select workspace")
+        }
+    }
+
+    @Test("Deep link selects matching repo when cwd is inside repo root")
+    func deepLinkSelectsMatchingRepo() {
+        let repo = Repo(name: "app", localPath: URL(fileURLWithPath: "/tmp/app"))
+        let request = makeDeepLink(
+            cwd: "/tmp/app/Sources/App",
+            repoRoot: "/tmp/app"
+        )
+
+        let decision = controller.deepLinkDecision(
+            pendingRequest: request,
+            repos: [repo],
+            normalizePath: normalizePath,
+            pathIsInside: path(_:isInside:)
+        )
+
+        switch decision {
+        case .selectRepo(let pendingRequest, let matchedRepo):
+            #expect(pendingRequest == request)
+            #expect(matchedRepo.id == repo.id)
+        default:
+            Issue.record("Expected deep link decision to select repo")
+        }
+    }
+
+    @Test("Deep link requests repo import when repo root is not tracked")
+    func deepLinkRequestsRepoImportForUntrackedRepo() {
+        let request = makeDeepLink(
+            cwd: "/tmp/app/Sources/App",
+            repoRoot: "/tmp/app"
+        )
+
+        let decision = controller.deepLinkDecision(
+            pendingRequest: request,
+            repos: [],
+            normalizePath: normalizePath,
+            pathIsInside: path(_:isInside:)
+        )
+
+        switch decision {
+        case .importRepo(let pendingRequest, let repoRoot):
+            #expect(pendingRequest == request)
+            #expect(repoRoot == "/tmp/app")
+        default:
+            Issue.record("Expected deep link decision to request repo import")
         }
     }
 
@@ -415,9 +462,11 @@ struct MainWindowBootstrapControllerTests {
         return Repo(name: name, localPath: repoURL)
     }
 
-    private func makeDeepLink(cwd: String) -> WorkspaceDeepLink {
+    private func makeDeepLink(cwd: String, repoRoot: String? = nil) -> WorkspaceDeepLink {
         let encodedCWD = cwd.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-        let url = URL(string: "workspaces://focus?cwd=\(encodedCWD)")!
+        let encodedRepoRoot = repoRoot?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let repoRootQuery = encodedRepoRoot.map { "&repo_root=\($0)" } ?? ""
+        let url = URL(string: "workspaces://focus?cwd=\(encodedCWD)\(repoRootQuery)")!
         return WorkspaceDeepLink(url: url)!
     }
 

--- a/Tests/WorkspaceManagerAppTests/MainWindowSurfaceResolutionControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowSurfaceResolutionControllerTests.swift
@@ -45,6 +45,71 @@ struct MainWindowSurfaceResolutionControllerTests {
         }
     }
 
+    @Test("Repo deep link resolution selects repo terminal when workspace does not match")
+    func repoDeepLinkSelectsRepo() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let deepLink = makeDeepLink(
+            cwd: "/tmp/alpha/Sources/App",
+            repoRoot: "/tmp/alpha"
+        )
+
+        let action = controller.nextAction(
+            context: MainWindowSurfaceResolutionContext(
+                environment: [:],
+                didRunPerfAutoSelection: false,
+                didApplyFixturePreviewBootstrap: false,
+                didApplyFixtureWebBootstrap: false,
+                didResolveInitialSurface: false,
+                pendingRequest: deepLink,
+                lastSurfaceRawValue: "",
+                previewConfiguration: nil,
+                webConfiguration: nil,
+                repos: [repo],
+                webSources: []
+            )
+        )
+
+        switch action {
+        case .selectDeepLinkedRepo(let request, let selectedRepo):
+            #expect(request == deepLink)
+            #expect(selectedRepo.id == repo.id)
+        default:
+            Issue.record("Expected repo deep link to select the repo")
+        }
+    }
+
+    @Test("Repo deep link requests repo import when repo is untracked")
+    func repoDeepLinkRequestsImport() {
+        let deepLink = makeDeepLink(
+            cwd: "/tmp/alpha/Sources/App",
+            repoRoot: "/tmp/alpha"
+        )
+
+        let action = controller.nextAction(
+            context: MainWindowSurfaceResolutionContext(
+                environment: [:],
+                didRunPerfAutoSelection: false,
+                didApplyFixturePreviewBootstrap: false,
+                didApplyFixtureWebBootstrap: false,
+                didResolveInitialSurface: false,
+                pendingRequest: deepLink,
+                lastSurfaceRawValue: "",
+                previewConfiguration: nil,
+                webConfiguration: nil,
+                repos: [],
+                webSources: []
+            )
+        )
+
+        switch action {
+        case .importDeepLinkedRepo(let request, let repoRoot):
+            #expect(request == deepLink)
+            #expect(repoRoot == "/tmp/alpha")
+        default:
+            Issue.record("Expected repo deep link to request repo import")
+        }
+    }
+
     @Test("Resolved initial surface blocks later launch-resolution actions")
     func resolvedInitialSurfaceBlocksLaterActions() {
         let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
@@ -160,9 +225,11 @@ struct MainWindowSurfaceResolutionControllerTests {
         return Repo(name: name, localPath: repoURL)
     }
 
-    private func makeDeepLink(cwd: String) -> WorkspaceDeepLink {
+    private func makeDeepLink(cwd: String, repoRoot: String? = nil) -> WorkspaceDeepLink {
         let encodedCWD = cwd.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-        let url = URL(string: "workspaces://focus?cwd=\(encodedCWD)")!
+        let encodedRepoRoot = repoRoot?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let repoRootQuery = encodedRepoRoot.map { "&repo_root=\($0)" } ?? ""
+        let url = URL(string: "workspaces://focus?cwd=\(encodedCWD)\(repoRootQuery)")!
         return WorkspaceDeepLink(url: url)!
     }
 }

--- a/Tests/WorkspaceManagerAppTests/WorkspaceDeepLinkTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceDeepLinkTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("WorkspaceDeepLink")
+struct WorkspaceDeepLinkTests {
+    @Test("Parses cwd and repo root from focus URL")
+    func parsesCWDAndRepoRoot() {
+        let url = URL(
+            string:
+                "workspaces://focus?cwd=%2Ftmp%2Fproject%2FSources&repo_root=%2Ftmp%2Fproject&source=cli"
+        )!
+
+        let deepLink = WorkspaceDeepLink(url: url)
+
+        #expect(deepLink?.cwd == "/tmp/project/Sources")
+        #expect(deepLink?.repoRoot == "/tmp/project")
+        #expect(deepLink?.source == "cli")
+    }
+}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -215,6 +215,12 @@ mkdir -p "$APP_BUNDLE/Contents/Resources"
 cp ".build/release/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/"
 log_success "Copied executable"
 
+CLI_NAME="workspaces"
+if [[ -f ".build/release/$CLI_NAME" ]]; then
+    cp ".build/release/$CLI_NAME" "$APP_BUNDLE/Contents/MacOS/"
+    log_success "Copied CLI launcher"
+fi
+
 # Copy Info.plist
 INFO_PLIST="Sources/WorkspaceManager/Resources/Info.plist"
 if [[ -f "$INFO_PLIST" ]]; then

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -29,12 +29,15 @@ NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 APP_NAME="WorkspaceManager"
+CLI_NAME="workspaces"
 SOURCE_APP="$PROJECT_DIR/build/$APP_NAME.app"
 DEST_APP="/Applications/$APP_NAME.app"
 
 BUILD_SIGNED=false
 SKIP_BUILD=false
 OPEN_AFTER_INSTALL=true
+LINK_CLI=true
+CLI_LINK_PATH=""
 
 usage() {
     cat <<USAGE
@@ -44,6 +47,9 @@ Options:
   --signed        Build with signing (uses scripts/build-release.sh)
   --no-build      Skip build and install existing build/WorkspaceManager.app
   --no-open       Do not relaunch app after install
+  --no-cli-link   Do not update the `workspaces` CLI symlink
+  --cli-link <path>
+                  Override CLI symlink path (default: first writable PATH dir)
   --dest <path>   Install destination app bundle path
   --help, -h      Show this help
 USAGE
@@ -65,6 +71,49 @@ log_error() {
     echo -e "${RED}ERR${NC} $1"
 }
 
+resolve_default_cli_link_path() {
+    local dir
+    for dir in /opt/homebrew/bin /usr/local/bin "$HOME/.local/bin" "$HOME/bin"; do
+        local parent
+        parent="$(dirname "$dir")"
+        if [[ -d "$dir" && -w "$dir" ]]; then
+            printf "%s/%s\n" "$dir" "$CLI_NAME"
+            return 0
+        fi
+        if [[ ! -d "$dir" && -d "$parent" && -w "$parent" ]]; then
+            printf "%s/%s\n" "$dir" "$CLI_NAME"
+            return 0
+        fi
+    done
+
+    local original_ifs="$IFS"
+    IFS=':'
+    for dir in $PATH; do
+        [[ -n "$dir" ]] || continue
+        if [[ -d "$dir" && -w "$dir" ]]; then
+            printf "%s/%s\n" "$dir" "$CLI_NAME"
+            IFS="$original_ifs"
+            return 0
+        fi
+    done
+    IFS="$original_ifs"
+
+    return 1
+}
+
+expand_home_prefix() {
+    local path="$1"
+    if [[ "$path" == "~" ]]; then
+        printf "%s\n" "$HOME"
+        return
+    fi
+    if [[ "$path" == "~/"* ]]; then
+        printf "%s\n" "$HOME/${path#~/}"
+        return
+    fi
+    printf "%s\n" "$path"
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --signed)
@@ -78,6 +127,18 @@ while [[ $# -gt 0 ]]; do
         --no-open)
             OPEN_AFTER_INSTALL=false
             shift
+            ;;
+        --no-cli-link)
+            LINK_CLI=false
+            shift
+            ;;
+        --cli-link)
+            if [[ $# -lt 2 ]]; then
+                log_error "--cli-link requires a value"
+                exit 1
+            fi
+            CLI_LINK_PATH="$2"
+            shift 2
             ;;
         --dest)
             if [[ $# -lt 2 ]]; then
@@ -167,6 +228,35 @@ fi
 if [[ "$OPEN_AFTER_INSTALL" == true ]]; then
     log_step "Launching installed app"
     open "$DEST_APP"
+fi
+
+if [[ "$LINK_CLI" == true ]]; then
+    CLI_SOURCE="$DEST_APP/Contents/MacOS/$CLI_NAME"
+    if [[ -x "$CLI_SOURCE" ]]; then
+        if [[ -z "$CLI_LINK_PATH" ]]; then
+            if ! CLI_LINK_PATH="$(resolve_default_cli_link_path)"; then
+                log_warning "No writable PATH directory found for CLI link; use $CLI_SOURCE directly"
+                CLI_LINK_PATH=""
+            fi
+        fi
+
+        if [[ -n "$CLI_LINK_PATH" ]]; then
+            CLI_LINK_PATH="$(expand_home_prefix "$CLI_LINK_PATH")"
+            CLI_LINK_DIR="$(dirname "$CLI_LINK_PATH")"
+            mkdir -p "$CLI_LINK_DIR"
+            CLI_LINK_DIR="$(cd "$CLI_LINK_DIR" && pwd)"
+            CLI_LINK_PATH="$CLI_LINK_DIR/$(basename "$CLI_LINK_PATH")"
+
+            if [[ -e "$CLI_LINK_PATH" && ! -L "$CLI_LINK_PATH" ]]; then
+                log_warning "Skipping CLI link because a non-symlink file exists at $CLI_LINK_PATH"
+            else
+                ln -sfn "$CLI_SOURCE" "$CLI_LINK_PATH"
+                log_success "Linked CLI: $CLI_LINK_PATH"
+            fi
+        fi
+    else
+        log_warning "CLI launcher not found in app bundle; skipping CLI link"
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- make `workspaces` launch or activate the app by default, with path handoff for repo/workspace focus
- import untracked repos on CLI deep-link handoff and package/link the bundled `workspaces` launcher in release and local installs
- add a Settings > Command Line Tool section to show install state, repair/install the launcher, and copy a setup command

## Testing
- swift build
- swift test --filter CommandLineToolService
- swift test
- built the app bundle and visually verified the Settings command-line-tool section locally
- verified end-to-end CLI handoff by launching the app with an isolated data dir and running `workspaces /tmp/...`
