### PR TITLE
Address PR 47 launcher flow review follow-ups

### DIFF
--- a/Sources/WorkspaceManager/App/WorkspaceDeepLink.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceDeepLink.swift
@@ -21,12 +21,14 @@ struct WorkspaceDeepLink: Equatable {
             return nil
         }
 
+        guard Self.isAbsolutePathInput(rawCWD) else { return nil }
         let normalizedCWD = Self.normalizePath(rawCWD)
         guard normalizedCWD.hasPrefix("/") else { return nil }
 
         cwd = normalizedCWD
         if let rawRepoRoot = queryItems.first(where: { $0.name == "repo_root" })?.value,
-            !rawRepoRoot.isEmpty
+            !rawRepoRoot.isEmpty,
+            Self.isAbsolutePathInput(rawRepoRoot)
         {
             let normalizedRepoRoot = Self.normalizePath(rawRepoRoot)
             repoRoot = normalizedRepoRoot.hasPrefix("/") ? normalizedRepoRoot : nil
@@ -40,6 +42,10 @@ struct WorkspaceDeepLink: Equatable {
     private static func normalizePath(_ path: String) -> String {
         let expanded = NSString(string: path).expandingTildeInPath
         return URL(fileURLWithPath: expanded).standardizedFileURL.path
+    }
+
+    private static func isAbsolutePathInput(_ path: String) -> Bool {
+        path.hasPrefix("/") || path.hasPrefix("~")
     }
 }
 

--- a/Sources/WorkspaceManager/Services/CommandLineToolService.swift
+++ b/Sources/WorkspaceManager/Services/CommandLineToolService.swift
@@ -465,6 +465,7 @@ struct CommandLineToolService {
     }
 
     private static func defaultPreferredInstallDirectories(homeDirectoryURL: URL) -> [URL] {
+        // Keep this order in sync with scripts/install-local.sh.
         [
             URL(fileURLWithPath: "/opt/homebrew/bin", isDirectory: true),
             URL(fileURLWithPath: "/usr/local/bin", isDirectory: true),

--- a/Sources/WorkspaceManager/Services/LaunchRepositoryService.swift
+++ b/Sources/WorkspaceManager/Services/LaunchRepositoryService.swift
@@ -1,14 +1,21 @@
 import Foundation
+import OSLog
 import SwiftData
 import WorkspaceManagerCore
 
 @MainActor
 struct LaunchRepositoryService {
+    private static let log = Logger(
+        subsystem: "com.cloudcompute.workspaces",
+        category: "LaunchRepositoryService"
+    )
+
     let modelContext: ModelContext
 
     func trackedRepo(matchingNormalizedPath normalizedPath: String) -> Repo? {
         let descriptor = FetchDescriptor<Repo>()
         guard let fetchedRepos = try? modelContext.fetch(descriptor) else {
+            Self.log.error("Failed to fetch tracked repos while resolving path \(normalizedPath, privacy: .public)")
             return nil
         }
 
@@ -35,6 +42,9 @@ struct LaunchRepositoryService {
             return repo
         } catch {
             modelContext.rollback()
+            Self.log.error(
+                "Failed to save imported repo at \(repoRootPath, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
             return nil
         }
     }

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
     private var notificationsEnabled: Bool = NotificationConstants.defaultEnabled
 
     @State private var showFolderPicker = false
-    @State private var commandLineToolStatus: CommandLineToolStatus
+    @State private var commandLineToolStatus: CommandLineToolStatus?
     @State private var commandLineToolFeedback: String?
     @State private var commandLineToolFeedbackIsError = false
     @ObservedObject private var notificationCoordinator = NotificationCoordinator.shared
@@ -26,7 +26,7 @@ struct SettingsView: View {
 
     init(commandLineToolService: CommandLineToolService = CommandLineToolService()) {
         self.commandLineToolService = commandLineToolService
-        _commandLineToolStatus = State(initialValue: commandLineToolService.status())
+        _commandLineToolStatus = State(initialValue: nil)
     }
 
     private var defaultPath: String {
@@ -92,48 +92,58 @@ struct SettingsView: View {
                     Text("Use Workspaces from Terminal")
                         .font(.headline)
 
-                    HStack(spacing: 8) {
-                        Image(systemName: commandLineToolStatusSymbolName)
-                            .foregroundStyle(commandLineToolStatusColor)
-                        Text(commandLineToolStatusTitle)
-                            .font(.callout.weight(.medium))
-                    }
-
-                    if let commandPath = commandLineToolStatus.commandPath {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Command Path")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-
-                            Text(commandPath)
-                                .font(.system(.body, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
-                                .lineLimit(2)
-                                .truncationMode(.middle)
-                        }
-                        .padding(8)
-                        .background(Color(nsColor: .textBackgroundColor))
-                        .clipShape(.rect(cornerRadius: 6))
-                    }
-
-                    Text(commandLineToolStatusDetail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    HStack(spacing: 10) {
-                        if let primaryAction = commandLineToolStatus.primaryAction {
-                            Button(primaryAction.title) {
-                                installCommandLineTool()
-                            }
-                            .buttonStyle(.borderedProminent)
+                    if let commandLineToolStatus {
+                        HStack(spacing: 8) {
+                            Image(systemName: commandLineToolStatusSymbolName(for: commandLineToolStatus))
+                                .foregroundStyle(commandLineToolStatusColor(for: commandLineToolStatus))
+                            Text(commandLineToolStatusTitle(for: commandLineToolStatus))
+                                .font(.callout.weight(.medium))
                         }
 
-                        if commandLineToolStatus.setupCommand != nil {
-                            Button("Copy Setup Command") {
-                                copyCommandLineToolSetupCommand()
+                        if let commandPath = commandLineToolStatus.commandPath {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Command Path")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+
+                                Text(commandPath)
+                                    .font(.system(.body, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+                                    .lineLimit(2)
+                                    .truncationMode(.middle)
                             }
-                            .buttonStyle(.bordered)
+                            .padding(8)
+                            .background(Color(nsColor: .textBackgroundColor))
+                            .clipShape(.rect(cornerRadius: 6))
+                        }
+
+                        Text(commandLineToolStatusDetail(for: commandLineToolStatus))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        HStack(spacing: 10) {
+                            if let primaryAction = commandLineToolStatus.primaryAction {
+                                Button(primaryAction.title) {
+                                    installCommandLineTool()
+                                }
+                                .buttonStyle(.borderedProminent)
+                            }
+
+                            if commandLineToolStatus.setupCommand != nil {
+                                Button("Copy Setup Command") {
+                                    copyCommandLineToolSetupCommand()
+                                }
+                                .buttonStyle(.bordered)
+                            }
+                        }
+                    } else {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Checking installation status…")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
                         }
                     }
 
@@ -259,8 +269,8 @@ struct SettingsView: View {
         }
     }
 
-    private var commandLineToolStatusTitle: String {
-        switch commandLineToolStatus.availability {
+    private func commandLineToolStatusTitle(for status: CommandLineToolStatus) -> String {
+        switch status.availability {
         case .installed:
             return "Installed"
         case .notInstalled:
@@ -270,8 +280,8 @@ struct SettingsView: View {
         }
     }
 
-    private var commandLineToolStatusSymbolName: String {
-        switch commandLineToolStatus.availability {
+    private func commandLineToolStatusSymbolName(for status: CommandLineToolStatus) -> String {
+        switch status.availability {
         case .installed:
             return "checkmark.circle.fill"
         case .notInstalled:
@@ -281,8 +291,8 @@ struct SettingsView: View {
         }
     }
 
-    private var commandLineToolStatusColor: Color {
-        switch commandLineToolStatus.availability {
+    private func commandLineToolStatusColor(for status: CommandLineToolStatus) -> Color {
+        switch status.availability {
         case .installed:
             return .green
         case .notInstalled:
@@ -292,10 +302,10 @@ struct SettingsView: View {
         }
     }
 
-    private var commandLineToolStatusDetail: String {
-        let commandPath = commandLineToolStatus.commandPath ?? "the selected install location"
+    private func commandLineToolStatusDetail(for status: CommandLineToolStatus) -> String {
+        let commandPath = status.commandPath ?? "the selected install location"
 
-        switch commandLineToolStatus.reason {
+        switch status.reason {
         case .active:
             return "The `workspaces` command is ready to open Workspaces from Terminal."
         case .missing:
@@ -394,14 +404,21 @@ struct SettingsView: View {
     }
 
     private func refreshCommandLineToolStatus() {
-        commandLineToolStatus = commandLineToolService.status()
+        let service = commandLineToolService
+        DispatchQueue.global(qos: .userInitiated).async {
+            let status = service.status()
+            DispatchQueue.main.async {
+                commandLineToolStatus = status
+            }
+        }
     }
 
     private func installCommandLineTool() {
         do {
-            commandLineToolStatus = try commandLineToolService.installOrRepair()
+            let status = try commandLineToolService.installOrRepair()
+            commandLineToolStatus = status
             commandLineToolFeedbackIsError = false
-            if let commandPath = commandLineToolStatus.commandPath {
+            if let commandPath = status.commandPath {
                 commandLineToolFeedback = "Linked `workspaces` at \(commandPath)."
             } else {
                 commandLineToolFeedback = "Updated the `workspaces` command."
@@ -414,7 +431,7 @@ struct SettingsView: View {
     }
 
     private func copyCommandLineToolSetupCommand() {
-        guard let setupCommand = commandLineToolStatus.setupCommand else { return }
+        guard let setupCommand = commandLineToolStatus?.setupCommand else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(setupCommand, forType: .string)
         commandLineToolFeedbackIsError = false

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -44,11 +44,11 @@ private final class CLIApp {
 
     func run(arguments: [String]) async throws -> Int32 {
         guard let command = arguments.first else {
-            return try launchApp(request: nil)
+            return try await launchApp(request: nil)
         }
 
         if let launchRequest = try appLaunchRequest(for: arguments) {
-            return try launchApp(request: launchRequest)
+            return try await launchApp(request: launchRequest)
         }
 
         var state = try stateStore.load()
@@ -82,6 +82,8 @@ private final class CLIApp {
     private func appLaunchRequest(for arguments: [String]) throws -> AppLaunchRequest? {
         guard arguments.count == 1 else { return nil }
         guard let rawArgument = arguments.first else { return nil }
+        // Reserved verbs win over path-like arguments so `workspaces doctor`
+        // always dispatches to the subcommand even if a sibling folder exists.
         guard !Self.reservedCommands.contains(rawArgument) else { return nil }
         guard looksLikePath(rawArgument) || fileSystemEntryExists(at: rawArgument) else { return nil }
 
@@ -112,7 +114,7 @@ private final class CLIApp {
         FileManager.default.fileExists(atPath: normalizePath(rawPath).path)
     }
 
-    private func launchApp(request: AppLaunchRequest?) throws -> Int32 {
+    private func launchApp(request: AppLaunchRequest?) async throws -> Int32 {
         guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: Self.appBundleIdentifier)
         else {
             throw CLIError(
@@ -131,17 +133,7 @@ private final class CLIApp {
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.activates = true
 
-        let semaphore = DispatchSemaphore(value: 0)
-        var openError: Error?
-        NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
-            openError = error
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        if let openError {
-            throw CLIError("Failed to launch Workspaces: \(openError.localizedDescription)")
-        }
+        try await openApplication(at: appURL, configuration: configuration)
 
         return 0
     }
@@ -360,7 +352,7 @@ private final class CLIApp {
             print(execution.stdout, terminator: execution.stdout.hasSuffix("\n") ? "" : "\n")
         }
         if !execution.stderr.isEmpty {
-            writeStderr(execution.stderr, appendNewlineIfNeeded: true)
+            writeStderr(execution.stderr)
         }
 
         markWorkspaceAccess(workspaceID: workspace.id, command: commandString, state: &state)
@@ -760,22 +752,12 @@ private struct AppLaunchRequest {
     }
 
     var deepLinkURL: URL {
-        var components = URLComponents()
-        components.scheme = "workspaces"
-        components.host = "focus"
-        components.queryItems = [
-            URLQueryItem(name: "cwd", value: launchDirectory.path),
-            URLQueryItem(name: "source", value: "cli"),
-        ]
-
-        if let repoRoot {
-            components.queryItems?.append(URLQueryItem(name: "repo_root", value: repoRoot.path))
-        }
-
-        guard let url = components.url else {
-            preconditionFailure("Failed to build Workspaces deep link URL.")
-        }
-        return url
+        WorkspacesFocusLink(
+            cwd: launchDirectory.path,
+            repoRoot: repoRoot?.path,
+            source: "cli"
+        )
+        .url
     }
 }
 
@@ -837,6 +819,19 @@ private func resolveGitTopLevel(for directory: URL) -> URL? {
     return URL(fileURLWithPath: output, isDirectory: true)
         .standardizedFileURL
         .resolvingSymlinksInPath()
+}
+
+private func openApplication(at appURL: URL, configuration: NSWorkspace.OpenConfiguration) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
+            if let error {
+                continuation.resume(throwing: CLIError("Failed to launch Workspaces: \(error.localizedDescription)"))
+                return
+            }
+
+            continuation.resume()
+        }
+    }
 }
 
 private func resolveExecutable(_ name: String) throws -> String {
@@ -912,12 +907,9 @@ private func parseTomlString<S: StringProtocol>(_ rawValue: S) -> String {
     return trimmed
 }
 
-private func writeStderr(_ message: String, appendNewlineIfNeeded: Bool = false) {
+private func writeStderr(_ message: String) {
     var final = message
-    if appendNewlineIfNeeded, !final.hasSuffix("\n") {
-        final += "\n"
-    }
-    if !appendNewlineIfNeeded {
+    if !final.hasSuffix("\n") {
         final += "\n"
     }
     if let data = final.data(using: .utf8) {

--- a/Sources/WorkspaceManagerCore/Models/WorkspacesFocusLink.swift
+++ b/Sources/WorkspaceManagerCore/Models/WorkspacesFocusLink.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct WorkspacesFocusLink: Equatable, Sendable {
+    public let cwd: String
+    public let repoRoot: String?
+    public let source: String?
+
+    public init(cwd: String, repoRoot: String? = nil, source: String? = nil) {
+        self.cwd = cwd
+        self.repoRoot = repoRoot
+        self.source = source
+    }
+
+    public var url: URL {
+        var components = URLComponents()
+        components.scheme = "workspaces"
+        components.host = "focus"
+
+        var queryItems = [URLQueryItem(name: "cwd", value: cwd)]
+        if let repoRoot {
+            queryItems.append(URLQueryItem(name: "repo_root", value: repoRoot))
+        }
+        if let source {
+            queryItems.append(URLQueryItem(name: "source", value: source))
+        }
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            preconditionFailure("Failed to build Workspaces focus URL.")
+        }
+        return url
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/LaunchRepositoryServiceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/LaunchRepositoryServiceTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SwiftData
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("LaunchRepositoryService", .serialized)
+struct LaunchRepositoryServiceTests {
+    @Test("Returns an existing tracked repo without importing a duplicate")
+    func returnsExistingTrackedRepo() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let root = try makeTemporaryDirectory(prefix: "wm-launch-repo-existing")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let repoURL = root.appendingPathComponent("alpha", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+
+        let repo = Repo(name: "alpha", localPath: repoURL)
+        context.insert(repo)
+        try context.save()
+
+        let service = LaunchRepositoryService(modelContext: context)
+        let resolved = service.existingOrImportedRepo(at: repoURL.path)
+        let repos = try context.fetch(FetchDescriptor<Repo>())
+
+        #expect(resolved?.id == repo.id)
+        #expect(repos.count == 1)
+    }
+
+    @Test("Imports an untracked git repo")
+    func importsUntrackedGitRepo() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let repoURL = try makeGitRepository(prefix: "wm-launch-repo-import")
+        defer { try? FileManager.default.removeItem(at: repoURL.deletingLastPathComponent()) }
+
+        let service = LaunchRepositoryService(modelContext: context)
+        let resolved = service.existingOrImportedRepo(at: repoURL.path)
+        let repos = try context.fetch(FetchDescriptor<Repo>())
+
+        #expect(resolved?.localURL.path == repoURL.path)
+        #expect(resolved?.name == repoURL.lastPathComponent)
+        #expect(repos.count == 1)
+    }
+
+    @Test("Returns nil for a non-git directory")
+    func returnsNilForNonGitDirectory() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let root = try makeTemporaryDirectory(prefix: "wm-launch-repo-non-git")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let repoURL = root.appendingPathComponent("plain-folder", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+
+        let service = LaunchRepositoryService(modelContext: context)
+        let resolved = service.existingOrImportedRepo(at: repoURL.path)
+        let repos = try context.fetch(FetchDescriptor<Repo>())
+
+        #expect(resolved == nil)
+        #expect(repos.isEmpty)
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    private func makeTemporaryDirectory(prefix: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeGitRepository(prefix: String) throws -> URL {
+        let root = try makeTemporaryDirectory(prefix: prefix)
+        let repoURL = root.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+        try runGit(["init"], at: repoURL)
+        return repoURL
+    }
+
+    private func runGit(_ arguments: [String], at directory: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + arguments
+        process.currentDirectoryURL = directory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            throw NSError(
+                domain: "LaunchRepositoryServiceTests",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed"]
+            )
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/WorkspaceDeepLinkTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceDeepLinkTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WorkspaceManagerCore
 
 @testable import WorkspaceManager
 
@@ -13,6 +14,58 @@ struct WorkspaceDeepLinkTests {
         )!
 
         let deepLink = WorkspaceDeepLink(url: url)
+
+        #expect(deepLink?.cwd == "/tmp/project/Sources")
+        #expect(deepLink?.repoRoot == "/tmp/project")
+        #expect(deepLink?.source == "cli")
+    }
+
+    @Test("Rejects links with relative cwd")
+    func rejectsRelativeCWD() {
+        let url = URL(string: "workspaces://focus?cwd=../etc")!
+
+        #expect(WorkspaceDeepLink(url: url) == nil)
+    }
+
+    @Test("Rejects links with missing cwd")
+    func rejectsMissingCWD() {
+        let url = URL(string: "workspaces://focus?repo_root=%2Ftmp%2Fproject")!
+
+        #expect(WorkspaceDeepLink(url: url) == nil)
+    }
+
+    @Test("Rejects unsupported scheme and host")
+    func rejectsUnsupportedSchemeAndHost() {
+        let wrongScheme = URL(string: "https://focus?cwd=%2Ftmp%2Fproject")!
+        let wrongHost = URL(string: "workspaces://open?cwd=%2Ftmp%2Fproject")!
+
+        #expect(WorkspaceDeepLink(url: wrongScheme) == nil)
+        #expect(WorkspaceDeepLink(url: wrongHost) == nil)
+    }
+
+    @Test("Expands tilde cwd")
+    func expandsTildeCWD() {
+        let url = URL(string: "workspaces://focus?cwd=~%2Fproject")!
+        let expectedPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("project", isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+
+        let deepLink = WorkspaceDeepLink(url: url)
+
+        #expect(deepLink?.cwd == expectedPath)
+    }
+
+    @Test("Focus link builder round-trips through parser")
+    func focusLinkBuilderRoundTripsThroughParser() {
+        let focusLink = WorkspacesFocusLink(
+            cwd: "/tmp/project/Sources",
+            repoRoot: "/tmp/project",
+            source: "cli"
+        )
+
+        let deepLink = WorkspaceDeepLink(url: focusLink.url)
 
         #expect(deepLink?.cwd == "/tmp/project/Sources")
         #expect(deepLink?.repoRoot == "/tmp/project")

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -73,6 +73,8 @@ log_error() {
 
 resolve_default_cli_link_path() {
     local dir
+    # Keep this preference order in sync with
+    # Sources/WorkspaceManager/Services/CommandLineToolService.swift.
     for dir in /opt/homebrew/bin /usr/local/bin "$HOME/.local/bin" "$HOME/bin"; do
         local parent
         parent="$(dirname "$dir")"
@@ -202,7 +204,6 @@ fi
 
 TMP_DEST="${DEST_APP}.tmp.$$"
 rm -rf "$TMP_DEST"
-rm -rf "$DEST_APP"
 
 if ! ditto "$SOURCE_APP" "$TMP_DEST"; then
     log_error "Failed to copy app bundle to temporary destination"
@@ -210,6 +211,7 @@ if ! ditto "$SOURCE_APP" "$TMP_DEST"; then
     exit 1
 fi
 
+rm -rf "$DEST_APP"
 mv "$TMP_DEST" "$DEST_APP"
 log_success "Installed: $DEST_APP"
 


### PR DESCRIPTION
Follow-up for the merged review on #47:
- https://github.com/fairchild/workspaces/pull/47#issuecomment-4036534965

## Summary
- make the app install swap safer by copying to the temp bundle before removing the existing destination
- remove the CLI semaphore wait by awaiting `NSWorkspace.openApplication`, add launch/import logging, and move deep-link URL building into a shared helper
- load command-line tool status asynchronously in Settings and add deeper deep-link and repo-import coverage

## Testing
- bash -n scripts/install-local.sh
- swift build
- swift test --filter WorkspaceDeepLink
- swift test
