### PR TITLE
fix: use data protection keychain to prevent recurring security popups

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/KeychainHelper.swift
+++ b/Sources/WorkspaceManagerCore/Services/KeychainHelper.swift
@@ -24,23 +24,37 @@ public enum KeychainError: LocalizedError {
 public enum KeychainHelper {
     private static let service = "com.cloudcompute.workspaces"
 
-    public static func save(key: String, data: Data) throws {
-        let baseQuery: [String: Any] = [
+    /// Use the data protection keychain (macOS 10.15+) to avoid per-application ACL
+    /// prompts when different binaries (app vs test runner) access the same items.
+    /// Disabled in tests where the SPM test runner lacks signing entitlements.
+    static var useDataProtection = true
+
+    private static func query(key: String, extras: [String: Any] = [:]) -> [String: Any] {
+        var q: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: key,
         ]
+        if useDataProtection {
+            q[kSecUseDataProtectionKeychain as String] = true
+        }
+        for (k, v) in extras { q[k] = v }
+        return q
+    }
+
+    public static func save(key: String, data: Data) throws {
+        let baseQuery = query(key: key)
 
         // Try deleting any existing item first
         SecItemDelete(baseQuery as CFDictionary)
 
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-        ]
+        let addQuery = query(
+            key: key,
+            extras: [
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            ]
+        )
 
         let status = SecItemAdd(addQuery as CFDictionary, nil)
 
@@ -63,16 +77,16 @@ public enum KeychainHelper {
     }
 
     public static func load(key: String) throws -> Data? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
+        let q = query(
+            key: key,
+            extras: [
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne,
+            ]
+        )
 
         var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        let status = SecItemCopyMatching(q as CFDictionary, &result)
 
         switch status {
         case errSecSuccess:
@@ -88,13 +102,9 @@ public enum KeychainHelper {
     }
 
     public static func delete(key: String) throws {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: key,
-        ]
+        let q = query(key: key)
 
-        let status = SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(q as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw KeychainError.deleteFailed(status)
         }

--- a/Tests/WorkspaceManagerTests/KeychainHelperTests.swift
+++ b/Tests/WorkspaceManagerTests/KeychainHelperTests.swift
@@ -8,6 +8,12 @@ struct KeychainHelperTests {
     // Use a unique key prefix per test run to avoid polluting the real keychain
     private static let testPrefix = "test-\(UUID().uuidString.prefix(8))"
 
+    init() {
+        // SPM test runner lacks keychain-access-groups entitlements required
+        // for the data protection keychain; fall back to legacy keychain.
+        KeychainHelper.useDataProtection = false
+    }
+
     private func testKey(_ name: String) -> String {
         "\(Self.testPrefix)-\(name)"
     }


### PR DESCRIPTION
## Summary

- Switch `KeychainHelper` from the legacy file-based keychain to the **data protection keychain** (`kSecUseDataProtectionKeychain`), which uses user-level access instead of per-application ACLs — eliminates the recurring "swiftpm-testing-helper wants to use confidential information" password prompt
- Extract a shared `query()` helper to centralize keychain query construction
- Tests disable the flag (SPM test runner lacks `keychain-access-groups` entitlements) and use the legacy keychain with unique per-run keys

**Trade-off:** Existing credentials in the legacy keychain won't be found — one-time re-auth via GitHub Device Flow required.

## Test plan

- [x] `swift test` — all 301 tests pass with no keychain popup
- [ ] `swift build && ./scripts/launch-dev.sh --no-build` — app launches, notification auth flow works (re-auth required once)
- [ ] Run `swift test` a second time — still no popup (confirms persistence across rebuilds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)