### PR TITLE
Fix duplicate notification activity events

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/NotificationCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NotificationCoordinator.swift
@@ -8,6 +8,33 @@ private let log = Logger(
     category: "NotificationCoordinator"
 )
 
+protocol NotificationCredentialStoreProtocol: Sendable {
+    func loadString(key: String) throws -> String
+    func saveString(key: String, value: String) throws
+    func delete(key: String) throws
+}
+
+enum NotificationCredentialStoreError: Error {
+    case missingValue(String)
+}
+
+struct KeychainNotificationCredentialStore: NotificationCredentialStoreProtocol {
+    func loadString(key: String) throws -> String {
+        guard let value = try KeychainHelper.loadString(key: key) else {
+            throw NotificationCredentialStoreError.missingValue(key)
+        }
+        return value
+    }
+
+    func saveString(key: String, value: String) throws {
+        try KeychainHelper.saveString(key: key, value: value)
+    }
+
+    func delete(key: String) throws {
+        try KeychainHelper.delete(key: key)
+    }
+}
+
 @MainActor
 final class NotificationCoordinator: NotificationCoordinatorProtocol, ObservableObject {
     static let shared = NotificationCoordinator()
@@ -26,24 +53,31 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
     private var refreshTask: Task<Void, Never>?
     private var jwtRefreshTask: Task<Bool, Never>?
     private var currentRemoteURL: String?
+    private var seenEventIDs: Set<String> = []
+    private let credentialStore: any NotificationCredentialStoreProtocol
+    private let userDefaults: UserDefaults
     private static let maxEvents = 100
     private static let refreshMargin: TimeInterval = 15 * 60
 
     init(
         eventStreamService: any EventStreamServiceProtocol = EventStreamService(),
         sessionService: any NotificationSessionServiceProtocol = NotificationSessionService(),
+        credentialStore: any NotificationCredentialStoreProtocol = KeychainNotificationCredentialStore(),
+        userDefaults: UserDefaults = .standard,
         makeDeviceAuth: @escaping @Sendable () -> any GitHubDeviceAuthProtocol = {
             GitHubDeviceAuth(clientID: NotificationConstants.gitHubAppClientID)
         }
     ) {
         self.eventStreamService = eventStreamService
         self.sessionService = sessionService
+        self.credentialStore = credentialStore
+        self.userDefaults = userDefaults
         self.makeDeviceAuth = makeDeviceAuth
     }
 
     func loadStoredAuth() {
         guard
-            let login = try? KeychainHelper.loadString(
+            let login = try? credentialStore.loadString(
                 key: NotificationConstants.keychainLoginKey)
         else {
             return
@@ -112,7 +146,7 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
             NotificationConstants.keychainGitHubTokenKey,
         ] {
             do {
-                try KeychainHelper.delete(key: key)
+                try credentialStore.delete(key: key)
             } catch {
                 log.warning("Failed to delete keychain item \(key): \(error.localizedDescription)")
             }
@@ -124,13 +158,12 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         connectionPollingTask?.cancel()
         connectionPollingTask = nil
         isStreamConnected = false
-        events = []
-        unseenEventCount = 0
+        clearActivity()
         authState = .signedOut
     }
 
     func connectStream(remoteURL: String) async {
-        let enabled = UserDefaults.standard.bool(forKey: NotificationConstants.enabledKey)
+        let enabled = userDefaults.bool(forKey: NotificationConstants.enabledKey)
         guard enabled else { return }
 
         currentRemoteURL = remoteURL
@@ -154,8 +187,7 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         connectionPollingTask = nil
         currentRemoteURL = nil
         isStreamConnected = false
-        events = []
-        unseenEventCount = 0
+        clearActivity()
     }
 
     func markActivitySeen() {
@@ -166,11 +198,22 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
 
     private func handleEvent(_ event: WebhookEvent) {
         isStreamConnected = true
+        guard seenEventIDs.insert(event.id).inserted else { return }
         events.insert(event, at: 0)
         if events.count > Self.maxEvents {
-            events.removeLast(events.count - Self.maxEvents)
+            let overflowCount = events.count - Self.maxEvents
+            for event in events.suffix(overflowCount) {
+                seenEventIDs.remove(event.id)
+            }
+            events.removeLast(overflowCount)
         }
         unseenEventCount += 1
+    }
+
+    private func clearActivity() {
+        events = []
+        seenEventIDs.removeAll()
+        unseenEventCount = 0
     }
 
     private func startStream(
@@ -179,8 +222,8 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         var jwt: String?
         var githubToken: String?
         do {
-            jwt = try KeychainHelper.loadString(key: NotificationConstants.keychainJWTKey)
-            githubToken = try KeychainHelper.loadString(key: NotificationConstants.keychainGitHubTokenKey)
+            jwt = try credentialStore.loadString(key: NotificationConstants.keychainJWTKey)
+            githubToken = try credentialStore.loadString(key: NotificationConstants.keychainGitHubTokenKey)
         } catch {
             log.error("Failed to load credentials from keychain: \(error.localizedDescription)")
             jwt = nil
@@ -193,8 +236,7 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         }
 
         if resetActivity {
-            events = []
-            unseenEventCount = 0
+            clearActivity()
         }
 
         isStreamConnected = false
@@ -240,7 +282,7 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
 
         let task = Task<Bool, Never> { @MainActor in
             guard
-                let githubToken = try? KeychainHelper.loadString(
+                let githubToken = try? credentialStore.loadString(
                     key: NotificationConstants.keychainGitHubTokenKey)
             else {
                 log.warning("No stored GitHub token — cannot refresh JWT")
@@ -276,7 +318,7 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
             return
         }
 
-        let enabled = UserDefaults.standard.bool(
+        let enabled = userDefaults.bool(
             forKey: NotificationConstants.enabledKey
         )
         guard enabled, let remoteURL = currentRemoteURL else { return }
@@ -315,15 +357,15 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         githubToken: String, jwt: String, login: String
     ) throws {
         do {
-            try KeychainHelper.saveString(
+            try credentialStore.saveString(
                 key: NotificationConstants.keychainGitHubTokenKey,
                 value: githubToken
             )
             try updateSessionCredentials(jwt: jwt, login: login)
         } catch {
-            try? KeychainHelper.delete(key: NotificationConstants.keychainGitHubTokenKey)
-            try? KeychainHelper.delete(key: NotificationConstants.keychainJWTKey)
-            try? KeychainHelper.delete(key: NotificationConstants.keychainLoginKey)
+            try? credentialStore.delete(key: NotificationConstants.keychainGitHubTokenKey)
+            try? credentialStore.delete(key: NotificationConstants.keychainJWTKey)
+            try? credentialStore.delete(key: NotificationConstants.keychainLoginKey)
             throw error
         }
     }
@@ -332,17 +374,17 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         jwt: String, login: String
     ) throws {
         do {
-            try KeychainHelper.saveString(
+            try credentialStore.saveString(
                 key: NotificationConstants.keychainJWTKey,
                 value: jwt
             )
-            try KeychainHelper.saveString(
+            try credentialStore.saveString(
                 key: NotificationConstants.keychainLoginKey,
                 value: login
             )
         } catch {
-            try? KeychainHelper.delete(key: NotificationConstants.keychainJWTKey)
-            try? KeychainHelper.delete(key: NotificationConstants.keychainLoginKey)
+            try? credentialStore.delete(key: NotificationConstants.keychainJWTKey)
+            try? credentialStore.delete(key: NotificationConstants.keychainLoginKey)
             throw error
         }
     }
@@ -356,7 +398,7 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
 
     private func jwtExpiry() -> Date? {
         guard
-            let jwt = try? KeychainHelper.loadString(
+            let jwt = try? credentialStore.loadString(
                 key: NotificationConstants.keychainJWTKey)
         else { return nil }
         return Self.parseJWTExpiry(jwt)

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -487,8 +487,10 @@ struct ActivityTabView: View {
                     }
                     .buttonStyle(.borderedProminent)
 
-                    SettingsLink {
-                        Text("Open Settings")
+                    if !notificationsEnabled {
+                        SettingsLink {
+                            Text("Open Settings")
+                        }
                     }
                 }
             }
@@ -555,8 +557,10 @@ struct ActivityTabView: View {
                     }
                     .buttonStyle(.borderedProminent)
 
-                    SettingsLink {
-                        Text("Open Settings")
+                    if !notificationsEnabled {
+                        SettingsLink {
+                            Text("Open Settings")
+                        }
                     }
                 }
             }

--- a/Tests/WorkspaceManagerAppTests/NotificationCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/NotificationCoordinatorTests.swift
@@ -12,7 +12,7 @@ actor MockEventStreamService: EventStreamServiceProtocol {
     private var continuation: AsyncStream<WebhookEvent>.Continuation?
     private var _events: AsyncStream<WebhookEvent>?
 
-    var connectCalls: [(owner: String, jwt: String)] = []
+    var connectCalls: [(owner: String, jwt: String, githubToken: String?)] = []
     var disconnectCallCount = 0
 
     var isConnected: Bool { _isConnected }
@@ -27,7 +27,7 @@ actor MockEventStreamService: EventStreamServiceProtocol {
     }
 
     func connect(owner: String, jwt: String, githubToken: String?) {
-        connectCalls.append((owner: owner, jwt: jwt))
+        connectCalls.append((owner: owner, jwt: jwt, githubToken: githubToken))
         _isConnected = true
         _lastDisconnectReason = .none
         _ = events
@@ -48,6 +48,39 @@ actor MockEventStreamService: EventStreamServiceProtocol {
     func setLastDisconnectReason(_ reason: StreamDisconnectReason) {
         _lastDisconnectReason = reason
     }
+
+    func emit(_ event: WebhookEvent) {
+        continuation?.yield(event)
+    }
+}
+
+final class MockNotificationCredentialStore: NotificationCredentialStoreProtocol, @unchecked Sendable {
+    private var values: [String: String]
+    private(set) var deletedKeys: [String] = []
+
+    init(values: [String: String] = [:]) {
+        self.values = values
+    }
+
+    func loadString(key: String) throws -> String {
+        guard let value = values[key] else {
+            throw TestStoreError.missingValue(key)
+        }
+        return value
+    }
+
+    func saveString(key: String, value: String) throws {
+        values[key] = value
+    }
+
+    func delete(key: String) throws {
+        values.removeValue(forKey: key)
+        deletedKeys.append(key)
+    }
+}
+
+enum TestStoreError: Error {
+    case missingValue(String)
 }
 
 // MARK: - Tests
@@ -55,6 +88,43 @@ actor MockEventStreamService: EventStreamServiceProtocol {
 @MainActor
 @Suite("NotificationCoordinator")
 struct NotificationCoordinatorTests {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "NotificationCoordinatorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(false, forKey: NotificationConstants.enabledKey)
+        return defaults
+    }
+
+    private func makeCoordinator(
+        eventStreamService: MockEventStreamService = MockEventStreamService(),
+        credentialStore: MockNotificationCredentialStore = MockNotificationCredentialStore(),
+        userDefaults: UserDefaults? = nil
+    ) -> NotificationCoordinator {
+        NotificationCoordinator(
+            eventStreamService: eventStreamService,
+            credentialStore: credentialStore,
+            userDefaults: userDefaults ?? makeDefaults()
+        )
+    }
+
+    private func makeEvent(
+        id: String,
+        summary: String,
+        timestamp: TimeInterval
+    ) -> WebhookEvent {
+        WebhookEvent(
+            id: id,
+            type: "pull_request",
+            action: "opened",
+            summary: summary,
+            repo: "test-org/repo-a",
+            timestamp: Date(timeIntervalSince1970: timestamp)
+        )
+    }
+
+    private func flushEventDelivery() async {
+        try? await Task.sleep(for: .milliseconds(20))
+    }
 
     // MARK: - parseJWTExpiry
 
@@ -126,8 +196,7 @@ struct NotificationCoordinatorTests {
 
     @Test("Coordinator starts in signedOut state with empty events")
     func initialState() {
-        let mock = MockEventStreamService()
-        let coordinator = NotificationCoordinator(eventStreamService: mock)
+        let coordinator = makeCoordinator()
 
         #expect(coordinator.authState == .signedOut)
         #expect(coordinator.isStreamConnected == false)
@@ -137,8 +206,7 @@ struct NotificationCoordinatorTests {
 
     @Test("markActivitySeen resets unseen count")
     func markActivitySeen() {
-        let mock = MockEventStreamService()
-        let coordinator = NotificationCoordinator(eventStreamService: mock)
+        let coordinator = makeCoordinator()
 
         coordinator.markActivitySeen()
         #expect(coordinator.unseenEventCount == 0)
@@ -146,8 +214,14 @@ struct NotificationCoordinatorTests {
 
     @Test("signOut resets all state")
     func signOutResetsState() {
-        let mock = MockEventStreamService()
-        let coordinator = NotificationCoordinator(eventStreamService: mock)
+        let credentials = MockNotificationCredentialStore(
+            values: [
+                NotificationConstants.keychainJWTKey: "jwt",
+                NotificationConstants.keychainLoginKey: "login",
+                NotificationConstants.keychainGitHubTokenKey: "ghp",
+            ]
+        )
+        let coordinator = makeCoordinator(credentialStore: credentials)
 
         coordinator.signOut()
 
@@ -155,5 +229,144 @@ struct NotificationCoordinatorTests {
         #expect(coordinator.isStreamConnected == false)
         #expect(coordinator.events.isEmpty)
         #expect(coordinator.unseenEventCount == 0)
+        let deletedKeys = Set(credentials.deletedKeys)
+        let expectedKeys = Set([
+            NotificationConstants.keychainJWTKey,
+            NotificationConstants.keychainLoginKey,
+            NotificationConstants.keychainGitHubTokenKey,
+        ])
+        #expect(deletedKeys == expectedKeys)
+    }
+
+    @Test("loadStoredAuth restores signed-in state from injected credentials")
+    func loadStoredAuthRestoresSignedInState() {
+        let coordinator = makeCoordinator(
+            credentialStore: MockNotificationCredentialStore(
+                values: [NotificationConstants.keychainLoginKey: "local-test-user"]
+            )
+        )
+
+        coordinator.loadStoredAuth()
+
+        #expect(coordinator.authState == .signedIn(login: "local-test-user"))
+    }
+
+    @Test("connectStream does nothing when notifications are disabled")
+    func connectStreamDisabledDoesNothing() async {
+        let eventStream = MockEventStreamService()
+        let coordinator = makeCoordinator(
+            eventStreamService: eventStream,
+            credentialStore: MockNotificationCredentialStore(
+                values: [
+                    NotificationConstants.keychainJWTKey: "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig",
+                    NotificationConstants.keychainGitHubTokenKey: "ghp_test_token",
+                ]
+            ),
+            userDefaults: makeDefaults()
+        )
+
+        await coordinator.connectStream(remoteURL: "https://github.com/test-org/repo-a.git")
+
+        let calls = await eventStream.connectCalls
+        #expect(calls.isEmpty)
+    }
+
+    @Test("connectStream uses injected credentials when notifications are enabled")
+    func connectStreamUsesStoredCredentials() async {
+        let eventStream = MockEventStreamService()
+        let credentials = MockNotificationCredentialStore(
+            values: [
+                NotificationConstants.keychainJWTKey: "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig",
+                NotificationConstants.keychainGitHubTokenKey: "ghp_test_token",
+            ]
+        )
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: NotificationConstants.enabledKey)
+        let coordinator = makeCoordinator(
+            eventStreamService: eventStream,
+            credentialStore: credentials,
+            userDefaults: defaults
+        )
+
+        await coordinator.connectStream(remoteURL: "https://github.com/test-org/repo-a.git")
+
+        let calls = await eventStream.connectCalls
+        #expect(calls.count == 1)
+        #expect(calls[0].owner == "test-org")
+        #expect(calls[0].jwt == "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig")
+        #expect(calls[0].githubToken == "ghp_test_token")
+    }
+
+    @Test("replayed event IDs are ignored without inflating unseen count")
+    func replayedEventsIgnored() async {
+        let eventStream = MockEventStreamService()
+        let credentials = MockNotificationCredentialStore(
+            values: [
+                NotificationConstants.keychainJWTKey: "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig",
+                NotificationConstants.keychainGitHubTokenKey: "ghp_test_token",
+            ]
+        )
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: NotificationConstants.enabledKey)
+        let coordinator = makeCoordinator(
+            eventStreamService: eventStream,
+            credentialStore: credentials,
+            userDefaults: defaults
+        )
+
+        await coordinator.connectStream(remoteURL: "https://github.com/test-org/repo-a.git")
+
+        let first = makeEvent(id: "evt-1", summary: "PR #1 opened", timestamp: 1_710_000_000)
+        let second = makeEvent(id: "evt-2", summary: "PR #2 opened", timestamp: 1_710_000_100)
+
+        await eventStream.emit(first)
+        await eventStream.emit(second)
+        await flushEventDelivery()
+
+        #expect(coordinator.events.map(\.id) == ["evt-2", "evt-1"])
+        #expect(coordinator.unseenEventCount == 2)
+
+        await eventStream.emit(first)
+        await eventStream.emit(second)
+        await flushEventDelivery()
+
+        #expect(coordinator.events.map(\.id) == ["evt-2", "evt-1"])
+        #expect(coordinator.unseenEventCount == 2)
+    }
+
+    @Test("disconnect clears dedupe state so fresh sessions can show the same event again")
+    func disconnectClearsDedupeState() async {
+        let eventStream = MockEventStreamService()
+        let credentials = MockNotificationCredentialStore(
+            values: [
+                NotificationConstants.keychainJWTKey: "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig",
+                NotificationConstants.keychainGitHubTokenKey: "ghp_test_token",
+            ]
+        )
+        let defaults = makeDefaults()
+        defaults.set(true, forKey: NotificationConstants.enabledKey)
+        let coordinator = makeCoordinator(
+            eventStreamService: eventStream,
+            credentialStore: credentials,
+            userDefaults: defaults
+        )
+
+        await coordinator.connectStream(remoteURL: "https://github.com/test-org/repo-a.git")
+
+        let event = makeEvent(id: "evt-1", summary: "PR #1 opened", timestamp: 1_710_000_000)
+        await eventStream.emit(event)
+        await flushEventDelivery()
+
+        #expect(coordinator.events.map(\.id) == ["evt-1"])
+
+        await coordinator.disconnectStream()
+        #expect(coordinator.events.isEmpty)
+        #expect(coordinator.unseenEventCount == 0)
+
+        await coordinator.connectStream(remoteURL: "https://github.com/test-org/repo-a.git")
+        await eventStream.emit(event)
+        await flushEventDelivery()
+
+        #expect(coordinator.events.map(\.id) == ["evt-1"])
     }
 }

--- a/docs/development/notifications.md
+++ b/docs/development/notifications.md
@@ -140,7 +140,7 @@ bun run --bun wrangler deploy --env preview # preview
 | `src/webhook-relay.ts` | `WebhookRelay` Durable Object — SQLite event storage, WebSocket lifecycle, broadcast |
 | `src/github-verify.ts` | Crypto — HMAC-SHA256 signature verification, JWT sign/verify, timing-safe compare |
 | `src/log.ts` | Structured JSON logging helper (`{ level, msg, ts, ...context }`) |
-| `test/e2e.ts` | E2E test harness — orchestrates mock + wrangler dev + 6 test scenarios |
+| `test/e2e.ts` | E2E test harness — orchestrates mock + wrangler dev + 11 behavior-level scenarios |
 | `test/mock-github.ts` | Mock GitHub API server with token-dependent behavior |
 
 ### Durable Object Lifecycle
@@ -164,17 +164,21 @@ CREATE TABLE events (
   summary      TEXT NOT NULL,          -- Human-readable summary
   repo         TEXT NOT NULL,          -- Full repo name (owner/repo)
   payload      TEXT,                   -- Full GitHub webhook payload (JSON)
+  idempotency_key TEXT NOT NULL,       -- Canonical payload hash; suppresses duplicate deliveries
   delivery_id  TEXT,                   -- X-GitHub-Delivery header (for tracing)
   sender       TEXT,                   -- GitHub login of the actor
   clients_sent INTEGER NOT NULL DEFAULT 0,  -- WebSocket clients that received the broadcast
   created_at   INTEGER NOT NULL        -- Unix timestamp (ms)
 );
 CREATE INDEX idx_events_created ON events(created_at);
+CREATE UNIQUE INDEX idx_events_idempotency_key ON events(idempotency_key);
 ```
 
 **Retention**: Events older than 7 days are pruned on each webhook insert.
 
-**Migration**: Schema is forward-migrated via `PRAGMA table_info` introspection — new columns are added idempotently on DO construction.
+**Idempotency**: duplicate webhook payloads are ignored using a canonical payload hash, so retries and repeated deliveries do not appear twice in catch-up or live broadcasts.
+
+**Migration**: Schema is forward-migrated via `PRAGMA table_info` introspection — new columns are added idempotently on DO construction, legacy rows are backfilled with idempotency keys, and existing duplicates are pruned before the unique index is enforced.
 
 ### Structured Logging
 
@@ -198,6 +202,8 @@ All logs are JSON with a consistent shape: `{ level, msg, ts, ...context }`.
 | msg | When | Context |
 |-----|------|---------|
 | `do_event_stored` | Event inserted + broadcast | event_id, delivery_id, event_type, action, sender, repo, clients_sent, total_clients |
+| `do_event_duplicate_ignored` | Duplicate payload dropped | delivery_id, event_type, action, repo |
+| `do_event_duplicates_pruned` | Legacy duplicates removed during migration | count |
 | `do_ws_connected` | New WebSocket accepted | catchup_count, total_clients |
 | `do_ws_closed` | WebSocket disconnected | code, remaining_clients |
 | `do_ws_error` | WebSocket error | detail |
@@ -237,14 +243,14 @@ The notification pipeline can be tested entirely locally without hitting product
 ```bash
 cd infra/cloudflare-webhook-relay
 bun install          # first time only
-bun run test:e2e     # runs mock GitHub API + wrangler dev + 6 test scenarios
+bun run test:e2e     # runs mock GitHub API + wrangler dev + 11 behavior-level scenarios
 ```
 
 The harness automatically:
 - Kills stale processes from previous runs on ports 8787/8788
 - Starts a mock GitHub API on port 8788
 - Starts `wrangler dev` on port 8787 (reads `.dev.vars` for secrets)
-- Runs 6 tests: health, auth session, no-install rejection, WebSocket catchup, webhook broadcast, per-client repo filtering
+- Runs 11 behavior-level tests covering health, auth, catchup, live broadcast, duplicate suppression, payload-order invariance, distinct-event preservation, restart persistence, legacy duplicate cleanup, and per-client repo filtering
 - Cleans up all processes on exit
 
 ### How It Works

--- a/infra/cloudflare-webhook-relay/src/webhook-relay.ts
+++ b/infra/cloudflare-webhook-relay/src/webhook-relay.ts
@@ -15,6 +15,7 @@ interface StoredEvent {
   summary: string;
   repo: string;
   payload: string | null;
+  idempotency_key: string;
   delivery_id: string | null;
   sender: string | null;
   clients_sent: number;
@@ -25,8 +26,30 @@ interface ClientAttachment {
   allowedRepos: string[];
 }
 
+function canonicalJSONString(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJSONString(entry)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJSONString(entry)}`).join(",")}}`;
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
 export class WebhookRelay extends DurableObject<Env> {
   private sql: SqlStorage;
+  private schemaReadyPromise: Promise<void> | null = null;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -40,6 +63,7 @@ export class WebhookRelay extends DurableObject<Env> {
         summary TEXT NOT NULL,
         repo TEXT NOT NULL,
         payload TEXT,
+        idempotency_key TEXT NOT NULL,
         delivery_id TEXT,
         sender TEXT,
         clients_sent INTEGER NOT NULL DEFAULT 0,
@@ -70,9 +94,131 @@ export class WebhookRelay extends DurableObject<Env> {
     if (!cols.has("repo")) {
       this.sql.exec(`ALTER TABLE events ADD COLUMN repo TEXT NOT NULL DEFAULT ''`);
     }
+    if (!cols.has("idempotency_key")) {
+      this.sql.exec(`ALTER TABLE events ADD COLUMN idempotency_key TEXT`);
+    }
+  }
+
+  private ensureSchemaReady(): Promise<void> {
+    if (this.schemaReadyPromise == null) {
+      this.schemaReadyPromise = this.ctx.blockConcurrencyWhile(async () => {
+        await this.backfillIdempotencyKeys();
+        this.pruneDuplicateEvents();
+        this.sql.exec(
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_events_idempotency_key ON events(idempotency_key)`
+        );
+      }).catch((error) => {
+        this.schemaReadyPromise = null;
+        throw error;
+      });
+    }
+
+    return this.schemaReadyPromise;
+  }
+
+  private async backfillIdempotencyKeys(): Promise<void> {
+    const rows = this.sql.exec(
+      `SELECT id, type, action, summary, repo, payload, sender
+       FROM events
+       WHERE idempotency_key IS NULL OR idempotency_key = ''`
+    );
+
+    for (const row of rows) {
+      const eventID = row.id as string;
+      const key = await this.buildStoredEventIdempotencyKey({
+        type: row.type as string,
+        action: row.action as string,
+        summary: row.summary as string,
+        repo: row.repo as string,
+        payload: row.payload as string | null,
+        sender: row.sender as string | null,
+      });
+      this.sql.exec(`UPDATE events SET idempotency_key = ? WHERE id = ?`, key, eventID);
+    }
+  }
+
+  private pruneDuplicateEvents(): void {
+    const countCursor = this.sql.exec(
+      `SELECT COUNT(*) AS cnt
+       FROM events AS older
+       WHERE EXISTS (
+         SELECT 1
+         FROM events AS newer
+         WHERE newer.idempotency_key = older.idempotency_key
+           AND (
+             newer.created_at > older.created_at
+             OR (newer.created_at = older.created_at AND newer.id > older.id)
+           )
+       )`
+    );
+
+    let duplicates = 0;
+    for (const row of countCursor) {
+      duplicates = row.cnt as number;
+    }
+
+    if (duplicates == 0) {
+      return;
+    }
+
+    this.sql.exec(
+      `DELETE FROM events
+       WHERE id IN (
+         SELECT older.id
+         FROM events AS older
+         WHERE EXISTS (
+           SELECT 1
+           FROM events AS newer
+           WHERE newer.idempotency_key = older.idempotency_key
+             AND (
+               newer.created_at > older.created_at
+               OR (newer.created_at = older.created_at AND newer.id > older.id)
+             )
+         )
+       )`
+    );
+
+    log.info("do_event_duplicates_pruned", { count: duplicates });
+  }
+
+  private async buildIdempotencyKey(
+    eventType: string,
+    body: Record<string, unknown>
+  ): Promise<string> {
+    const canonical = canonicalJSONString({ eventType, body });
+    return `msg:${await sha256Hex(canonical)}`;
+  }
+
+  private async buildStoredEventIdempotencyKey(row: {
+    type: string;
+    action: string;
+    summary: string;
+    repo: string;
+    payload: string | null;
+    sender: string | null;
+  }): Promise<string> {
+    if (row.payload) {
+      try {
+        const payload = JSON.parse(row.payload) as Record<string, unknown>;
+        return this.buildIdempotencyKey(row.type, payload);
+      } catch {
+        // Fall through to a legacy deterministic key when payload is malformed.
+      }
+    }
+
+    const canonical = canonicalJSONString({
+      eventType: row.type,
+      action: row.action,
+      summary: row.summary,
+      repo: row.repo,
+      sender: row.sender,
+    });
+    return `legacy:${await sha256Hex(canonical)}`;
   }
 
   async fetch(request: Request): Promise<Response> {
+    await this.ensureSchemaReady();
+
     if (request.method === "GET" && request.headers.get("Upgrade") === "websocket") {
       return this.handleWebSocketUpgrade(request);
     }
@@ -108,11 +254,13 @@ export class WebhookRelay extends DurableObject<Env> {
   private async handleWebhookPost(request: Request): Promise<Response> {
     const eventType = request.headers.get("X-GitHub-Event") ?? "unknown";
     const deliveryId = request.headers.get("X-GitHub-Delivery") ?? null;
-    const body = await request.json<Record<string, unknown>>();
+    const payloadText = await request.text();
+    const body = JSON.parse(payloadText) as Record<string, unknown>;
     const action = (body.action as string) ?? "";
     const sender = (body.sender as Record<string, unknown>)?.login as string ?? null;
     const repo = (body.repository as Record<string, unknown>)?.full_name as string ?? "unknown";
     const summary = this.buildSummary(eventType, action, body);
+    const idempotencyKey = await this.buildIdempotencyKey(eventType, body);
 
     const event: StoredEvent = {
       id: crypto.randomUUID(),
@@ -120,7 +268,8 @@ export class WebhookRelay extends DurableObject<Env> {
       action,
       summary,
       repo,
-      payload: JSON.stringify(body),
+      payload: payloadText,
+      idempotency_key: idempotencyKey,
       delivery_id: deliveryId,
       sender,
       clients_sent: 0,
@@ -128,11 +277,34 @@ export class WebhookRelay extends DurableObject<Env> {
     };
 
     this.sql.exec(
-      `INSERT INTO events (id, type, action, summary, repo, payload, delivery_id, sender, clients_sent, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR IGNORE INTO events (
+         id, type, action, summary, repo, payload, idempotency_key, delivery_id, sender, clients_sent, created_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       event.id, event.type, event.action, event.summary, event.repo,
-      event.payload, event.delivery_id, event.sender, event.clients_sent, event.created_at
+      event.payload, event.idempotency_key, event.delivery_id, event.sender, event.clients_sent, event.created_at
     );
+
+    let storedEventID: string | null = null;
+    for (
+      const row of this.sql.exec(
+        `SELECT id FROM events WHERE idempotency_key = ? LIMIT 1`,
+        event.idempotency_key
+      )
+    ) {
+      storedEventID = row.id as string;
+      break;
+    }
+
+    if (storedEventID !== event.id) {
+      log.info("do_event_duplicate_ignored", {
+        delivery_id: deliveryId,
+        event_type: eventType,
+        action,
+        repo,
+      });
+      return new Response("OK", { status: 200 });
+    }
 
     this.pruneOldEvents();
 

--- a/infra/cloudflare-webhook-relay/test/e2e.ts
+++ b/infra/cloudflare-webhook-relay/test/e2e.ts
@@ -6,7 +6,7 @@
  */
 
 import { signJWT } from "../src/github-verify";
-import { writeFileSync, existsSync } from "fs";
+import { writeFileSync, existsSync, rmSync } from "fs";
 import { resolve } from "path";
 
 const WORKER_PORT = 8787;
@@ -16,6 +16,7 @@ const WEBHOOK_SECRET = "test-webhook-secret-e2e";
 const JWT_SECRET = "test-jwt-secret-e2e";
 
 const projectDir = resolve(import.meta.dir, "..");
+const stateDir = resolve(projectDir, ".wrangler/state");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -112,6 +113,99 @@ function assert(condition: boolean, msg: string) {
   if (!condition) throw new Error(msg);
 }
 
+async function postWebhook(
+  payload: string,
+  deliveryId: string,
+  eventType = "pull_request"
+): Promise<Response> {
+  const signature = await hmacSign(WEBHOOK_SECRET, payload);
+  return fetch(`${WORKER_URL}/webhook`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-GitHub-Event": eventType,
+      "X-GitHub-Delivery": deliveryId,
+      "X-Hub-Signature-256": signature,
+    },
+    body: payload,
+  });
+}
+
+function payloadForPR(
+  number: number,
+  title: string,
+  action: string,
+  repo = "test-org/repo-a",
+  sender = "test-user"
+): string {
+  return JSON.stringify({
+    action,
+    repository: { full_name: repo },
+    pull_request: { number, title },
+    sender: { login: sender },
+  });
+}
+
+async function expectNoExtraWebSocketMessage(
+  bws: BufferedWS,
+  timeoutMs = 750
+): Promise<void> {
+  try {
+    await bws.nextMessage(timeoutMs);
+    throw new Error("Unexpected extra WebSocket message");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message !== "WebSocket message timeout") {
+      throw err;
+    }
+  }
+}
+
+async function readCatchupEvents(
+  owner: string,
+  jwt: string,
+  githubToken: string
+): Promise<Array<{ summary: string; repo: string }>> {
+  const bws = await connectWebSocket(owner, jwt, githubToken);
+  try {
+    const msg = await bws.nextMessage() as {
+      type: string;
+      events: Array<{ summary: string; repo: string }>;
+    };
+    assert(msg.type === "catchup", `Expected catchup, got ${msg.type}`);
+    return msg.events;
+  } finally {
+    bws.close();
+  }
+}
+
+async function durableObjectSQLitePath(): Promise<string> {
+  const proc = Bun.spawn(
+    ["find", resolve(stateDir, "v3/do"), "-name", "*.sqlite"],
+    { stdout: "pipe", stderr: "ignore" }
+  );
+  const output = (await new Response(proc.stdout).text()).trim();
+  const paths = output.split("\n").filter(Boolean);
+  assert(paths.length === 1, `Expected 1 Durable Object sqlite file, found ${paths.length}`);
+  return paths[0];
+}
+
+async function runSQLite(sqlitePath: string, sql: string): Promise<string> {
+  const proc = Bun.spawn(["sqlite3", sqlitePath, sql], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`sqlite3 failed: ${stderr || stdout}`.trim());
+  }
+  return stdout;
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
@@ -125,56 +219,99 @@ if (!existsSync(devVarsPath)) {
   );
 }
 
-// Kill stale processes from previous runs
-async function killStaleProcesses() {
-  for (const port of [WORKER_PORT, MOCK_PORT]) {
-    try {
-      const proc = Bun.spawn(["lsof", "-ti", `:${port}`], { stdout: "pipe", stderr: "ignore" });
-      const text = await new Response(proc.stdout).text();
-      const pids = text.trim().split("\n").filter(Boolean);
-      for (const pid of pids) {
-        try { process.kill(Number(pid), 9); } catch {}
-      }
-    } catch {}
-  }
-  if ((await Bun.spawn(["lsof", "-ti", `:${WORKER_PORT}`, "-ti", `:${MOCK_PORT}`], { stdout: "pipe", stderr: "ignore" }).exited) === 0) {
-    await Bun.sleep(1000);
-  }
-}
+let mockProc: ReturnType<typeof Bun.spawn> | null = null;
+let wranglerProc: ReturnType<typeof Bun.spawn> | null = null;
 
-await killStaleProcesses();
-
-console.log("Starting mock GitHub API...");
-const mockProc = Bun.spawn(["bun", "run", resolve(projectDir, "test/mock-github.ts")], {
-  stdout: "inherit",
-  stderr: "inherit",
-});
-
-console.log("Starting wrangler dev...");
-const wranglerBin = resolve(projectDir, "node_modules/.bin/wrangler");
-const wranglerProc = Bun.spawn(
-  [wranglerBin, "dev", "--port", String(WORKER_PORT)],
-  {
-    cwd: projectDir,
-    stdout: "inherit",
-    stderr: "inherit",
-  }
-);
-
-async function cleanup() {
-  mockProc.kill();
-  wranglerProc.kill();
-  // Kill workerd grandchild processes spawned by wrangler
+async function killProcessesOnPort(port: number): Promise<void> {
   try {
-    const proc = Bun.spawn(["lsof", "-ti", `:${WORKER_PORT}`], { stdout: "pipe", stderr: "ignore" });
+    const proc = Bun.spawn(["lsof", "-ti", `:${port}`], { stdout: "pipe", stderr: "ignore" });
     const text = await new Response(proc.stdout).text();
-    for (const pid of text.trim().split("\n").filter(Boolean)) {
+    const pids = text.trim().split("\n").filter(Boolean);
+    for (const pid of pids) {
       try { process.kill(Number(pid), 9); } catch {}
     }
   } catch {}
 }
 
-// Poll for worker readiness
+async function portHasListener(port: number): Promise<boolean> {
+  const proc = Bun.spawn(["lsof", "-ti", `:${port}`], { stdout: "pipe", stderr: "ignore" });
+  const text = await new Response(proc.stdout).text();
+  return text.trim().length > 0;
+}
+
+async function waitForPortToClear(port: number, maxWaitMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    if (!(await portHasListener(port))) {
+      return;
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`Port ${port} did not clear`);
+}
+
+async function stopWorker(): Promise<void> {
+  if (wranglerProc) {
+    wranglerProc.kill();
+    await wranglerProc.exited;
+    wranglerProc = null;
+  }
+  await killProcessesOnPort(WORKER_PORT);
+  await waitForPortToClear(WORKER_PORT);
+}
+
+async function stopMock(): Promise<void> {
+  if (mockProc) {
+    mockProc.kill();
+    await mockProc.exited;
+    mockProc = null;
+  }
+  await killProcessesOnPort(MOCK_PORT);
+  await waitForPortToClear(MOCK_PORT);
+}
+
+async function startMock(): Promise<void> {
+  if (mockProc) return;
+  console.log("Starting mock GitHub API...");
+  mockProc = Bun.spawn(["bun", "run", resolve(projectDir, "test/mock-github.ts")], {
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const start = Date.now();
+  while (Date.now() - start < 5000) {
+    if (await portHasListener(MOCK_PORT)) {
+      return;
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error("Mock GitHub API did not become ready");
+}
+
+async function startWorker(): Promise<void> {
+  if (wranglerProc) return;
+  console.log("Starting wrangler dev...");
+  const wranglerBin = resolve(projectDir, "node_modules/.bin/wrangler");
+  wranglerProc = Bun.spawn(
+    [wranglerBin, "dev", "--port", String(WORKER_PORT)],
+    {
+      cwd: projectDir,
+      stdout: "inherit",
+      stderr: "inherit",
+    }
+  );
+  await waitForWorker();
+}
+
+async function restartWorker(): Promise<void> {
+  await stopWorker();
+  await startWorker();
+}
+
+async function cleanup() {
+  await stopWorker();
+  await stopMock();
+}
+
 async function waitForWorker(maxWaitMs = 30000) {
   const start = Date.now();
   while (Date.now() - start < maxWaitMs) {
@@ -192,7 +329,12 @@ async function waitForWorker(maxWaitMs = 30000) {
 // ---------------------------------------------------------------------------
 
 try {
-  await waitForWorker();
+  await stopWorker();
+  await stopMock();
+  rmSync(stateDir, { recursive: true, force: true });
+
+  await startMock();
+  await startWorker();
   console.log("\nRunning e2e tests...\n");
 
   // Test 1: Health check
@@ -244,25 +386,8 @@ try {
       // Consume catchup
       await bws.nextMessage();
 
-      // Send webhook
-      const payload = JSON.stringify({
-        action: "opened",
-        repository: { full_name: "test-org/repo-a" },
-        pull_request: { number: 42, title: "Test PR" },
-        sender: { login: "test-user" },
-      });
-      const signature = await hmacSign(WEBHOOK_SECRET, payload);
-
-      const resp = await fetch(`${WORKER_URL}/webhook`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-GitHub-Event": "pull_request",
-          "X-GitHub-Delivery": "test-delivery-1",
-          "X-Hub-Signature-256": signature,
-        },
-        body: payload,
-      });
+      const payload = payloadForPR(42, "Test PR", "opened");
+      const resp = await postWebhook(payload, "test-delivery-1");
       assert(resp.status === 200, `Webhook POST returned ${resp.status}`);
 
       const msg = await bws.nextMessage() as { type: string; event: { repo: string } };
@@ -273,7 +398,173 @@ try {
     }
   });
 
-  // Test 6: Per-client repo filtering
+  // Test 6: Duplicate webhook delivery is ignored
+  await test("Duplicate webhook payload only appears once", async () => {
+    const jwt = await makeJWT();
+    const payload = payloadForPR(4242, "Duplicate PR", "opened");
+
+    const liveWS = await connectWebSocket("test-org", jwt, "ghp_test_token");
+    try {
+      await liveWS.nextMessage();
+
+      for (const deliveryId of ["test-delivery-duplicate-1", "test-delivery-duplicate-2"]) {
+        const resp = await postWebhook(payload, deliveryId);
+        assert(resp.status === 200, `Webhook POST returned ${resp.status}`);
+      }
+
+      const msg = await liveWS.nextMessage() as { type: string; event: { summary: string } };
+      assert(msg.type === "event", `Expected event, got ${msg.type}`);
+      assert(msg.event.summary.includes("Duplicate PR"), "Expected live duplicate test event");
+      await expectNoExtraWebSocketMessage(liveWS);
+    } finally {
+      liveWS.close();
+    }
+
+    const events = await readCatchupEvents("test-org", jwt, "ghp_test_token");
+    const duplicateEntries = events.filter((event) => event.summary.includes("Duplicate PR"));
+    assert(duplicateEntries.length === 1, `Expected 1 duplicate-test event in catchup, got ${duplicateEntries.length}`);
+  });
+
+  // Test 7: Equivalent payloads with different key order are deduped
+  await test("Semantically equivalent payloads only appear once", async () => {
+    const jwt = await makeJWT();
+    const payloadA = payloadForPR(4343, "Key Order PR", "opened");
+    const payloadB = JSON.stringify({
+      sender: { login: "test-user" },
+      pull_request: { title: "Key Order PR", number: 4343 },
+      repository: { full_name: "test-org/repo-a" },
+      action: "opened",
+    });
+
+    const liveWS = await connectWebSocket("test-org", jwt, "ghp_test_token");
+    try {
+      await liveWS.nextMessage();
+
+      const respA = await postWebhook(payloadA, "key-order-delivery-1");
+      assert(respA.status === 200, `Webhook POST returned ${respA.status}`);
+      const respB = await postWebhook(payloadB, "key-order-delivery-2");
+      assert(respB.status === 200, `Webhook POST returned ${respB.status}`);
+
+      const msg = await liveWS.nextMessage() as { type: string; event: { summary: string } };
+      assert(msg.type === "event", `Expected event, got ${msg.type}`);
+      assert(msg.event.summary.includes("Key Order PR"), "Expected key-order test event");
+      await expectNoExtraWebSocketMessage(liveWS);
+    } finally {
+      liveWS.close();
+    }
+
+    const events = await readCatchupEvents("test-org", jwt, "ghp_test_token");
+    const matching = events.filter((event) => event.summary.includes("Key Order PR"));
+    assert(matching.length === 1, `Expected 1 key-order event in catchup, got ${matching.length}`);
+  });
+
+  // Test 8: Distinct lifecycle events for the same PR are preserved
+  await test("Distinct events for the same PR are not over-deduped", async () => {
+    const jwt = await makeJWT();
+    const openedPayload = payloadForPR(5151, "Lifecycle PR", "opened");
+    const closedPayload = payloadForPR(5151, "Lifecycle PR", "closed");
+
+    const liveWS = await connectWebSocket("test-org", jwt, "ghp_test_token");
+    try {
+      await liveWS.nextMessage();
+
+      const openedResp = await postWebhook(openedPayload, "lifecycle-delivery-1");
+      assert(openedResp.status === 200, `Webhook POST returned ${openedResp.status}`);
+      const closedResp = await postWebhook(closedPayload, "lifecycle-delivery-2");
+      assert(closedResp.status === 200, `Webhook POST returned ${closedResp.status}`);
+
+      const first = await liveWS.nextMessage() as { type: string; event: { summary: string } };
+      const second = await liveWS.nextMessage() as { type: string; event: { summary: string } };
+      assert(first.type === "event", `Expected first event, got ${first.type}`);
+      assert(second.type === "event", `Expected second event, got ${second.type}`);
+      assert(first.event.summary.includes("Lifecycle PR"), "Expected lifecycle opened event");
+      assert(second.event.summary.includes("Lifecycle PR"), "Expected lifecycle closed event");
+      assert(first.event.summary !== second.event.summary, "Expected distinct lifecycle summaries");
+    } finally {
+      liveWS.close();
+    }
+
+    const events = await readCatchupEvents("test-org", jwt, "ghp_test_token");
+    const matching = events.filter((event) => event.summary.includes("Lifecycle PR"));
+    assert(matching.length === 2, `Expected 2 lifecycle events in catchup, got ${matching.length}`);
+  });
+
+  // Test 9: Duplicate suppression survives worker restart
+  await test("Duplicate suppression survives worker restart", async () => {
+    const jwt = await makeJWT();
+    const payload = payloadForPR(6262, "Restart Stable PR", "opened");
+
+    const firstResp = await postWebhook(payload, "restart-stable-delivery-1");
+    assert(firstResp.status === 200, `Webhook POST returned ${firstResp.status}`);
+
+    await restartWorker();
+
+    const afterRestart = await readCatchupEvents("test-org", jwt, "ghp_test_token");
+    const initialMatches = afterRestart.filter((event) => event.summary.includes("Restart Stable PR"));
+    assert(initialMatches.length === 1, `Expected 1 restarted event in catchup, got ${initialMatches.length}`);
+
+    const liveWS = await connectWebSocket("test-org", jwt, "ghp_test_token");
+    try {
+      await liveWS.nextMessage();
+
+      const duplicateResp = await postWebhook(payload, "restart-stable-delivery-2");
+      assert(duplicateResp.status === 200, `Webhook POST returned ${duplicateResp.status}`);
+      await expectNoExtraWebSocketMessage(liveWS);
+    } finally {
+      liveWS.close();
+    }
+
+    const finalEvents = await readCatchupEvents("test-org", jwt, "ghp_test_token");
+    const finalMatches = finalEvents.filter((event) => event.summary.includes("Restart Stable PR"));
+    assert(finalMatches.length === 1, `Expected 1 restarted event after duplicate resend, got ${finalMatches.length}`);
+  });
+
+  // Test 10: Startup cleanup prunes legacy duplicate rows
+  await test("Startup cleanup collapses legacy duplicate rows before catchup", async () => {
+    const jwt = await makeJWT();
+    const payload = payloadForPR(7373, "Legacy Cleanup PR", "opened");
+    const seedResp = await postWebhook(payload, "legacy-cleanup-delivery-1");
+    assert(seedResp.status === 200, `Webhook POST returned ${seedResp.status}`);
+
+    await stopWorker();
+
+    const sqlitePath = await durableObjectSQLitePath();
+    await runSQLite(
+      sqlitePath,
+      `
+        DROP INDEX IF EXISTS idx_events_idempotency_key;
+        UPDATE events
+        SET idempotency_key = ''
+        WHERE summary LIKE '%Legacy Cleanup PR%';
+        INSERT INTO events (
+          id, type, action, summary, repo, payload, idempotency_key, delivery_id, sender, clients_sent, created_at
+        )
+        SELECT
+          lower(hex(randomblob(16))),
+          type,
+          action,
+          summary,
+          repo,
+          payload,
+          '',
+          'legacy-cleanup-duplicate',
+          sender,
+          clients_sent,
+          created_at - 1
+        FROM events
+        WHERE summary LIKE '%Legacy Cleanup PR%'
+        LIMIT 1;
+      `
+    );
+
+    await startWorker();
+
+    const events = await readCatchupEvents("test-org", jwt, "ghp_test_token");
+    const matching = events.filter((event) => event.summary.includes("Legacy Cleanup PR"));
+    assert(matching.length === 1, `Expected 1 legacy-cleanup event in catchup, got ${matching.length}`);
+  });
+
+  // Test 11: Per-client repo filtering
   await test("Repo filtering: ghp_repo_b_only only receives repo-b events", async () => {
     const jwt = await makeJWT();
     const bws = await connectWebSocket("test-org", jwt, "ghp_repo_b_only");
@@ -282,42 +573,14 @@ try {
       await bws.nextMessage();
 
       // Send repo-a event (should be filtered out)
-      const payloadA = JSON.stringify({
-        action: "opened",
-        repository: { full_name: "test-org/repo-a" },
-        pull_request: { number: 99, title: "Filtered PR" },
-        sender: { login: "test-user" },
-      });
-      const sigA = await hmacSign(WEBHOOK_SECRET, payloadA);
-      await fetch(`${WORKER_URL}/webhook`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-GitHub-Event": "pull_request",
-          "X-GitHub-Delivery": "test-delivery-2",
-          "X-Hub-Signature-256": sigA,
-        },
-        body: payloadA,
-      });
+      const payloadA = payloadForPR(99, "Filtered PR", "opened");
+      const respA = await postWebhook(payloadA, "test-delivery-2");
+      assert(respA.status === 200, `Webhook POST returned ${respA.status}`);
 
       // Send repo-b event (should be received)
-      const payloadB = JSON.stringify({
-        action: "closed",
-        repository: { full_name: "test-org/repo-b" },
-        pull_request: { number: 100, title: "Visible PR" },
-        sender: { login: "test-user" },
-      });
-      const sigB = await hmacSign(WEBHOOK_SECRET, payloadB);
-      await fetch(`${WORKER_URL}/webhook`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-GitHub-Event": "pull_request",
-          "X-GitHub-Delivery": "test-delivery-3",
-          "X-Hub-Signature-256": sigB,
-        },
-        body: payloadB,
-      });
+      const payloadB = payloadForPR(100, "Visible PR", "closed", "test-org/repo-b");
+      const respB = await postWebhook(payloadB, "test-delivery-3");
+      assert(respB.status === 200, `Webhook POST returned ${respB.status}`);
 
       const msg = await bws.nextMessage() as { type: string; event: { repo: string } };
       assert(msg.type === "event", `Expected event, got ${msg.type}`);


### PR DESCRIPTION
## Summary
- make webhook delivery idempotent in the local notification relay so duplicate GitHub payloads are stored and broadcast once
- dedupe replayed notification events in the app by `WebhookEvent.id`, while keeping distinct lifecycle events for the same PR
- keep `Open Settings` hidden in the Activity panel when notifications are already enabled

## Testing
- Previously verified in this session before fetch/rebase: `swift test` (`306 tests in 50 suites`)
- Previously verified in this session before fetch/rebase: `cd infra/cloudflare-webhook-relay && bun run test:e2e` (`11 passed, 0 failed`)
- Not rerun after fetch/rebase per request