### PR TITLE
docs: note Peter discussion token requirements

### DIFF
--- a/.github/workflows/agent-peter.yml
+++ b/.github/workflows/agent-peter.yml
@@ -40,6 +40,9 @@ jobs:
 
       - name: Run planner
         run: |
+          # GITHUB_TOKEN can comment on discussions with discussions:write, but it
+          # still cannot retitle discussions here. Prefer the explicit repo secret
+          # when it exists so Peter can apply [idea][endorsed] reliably.
           if [ -n "${PETER_DISCUSSION_TOKEN}" ]; then
             export GH_TOKEN="${PETER_DISCUSSION_TOKEN}"
           fi

--- a/docs/development/agent-team.md
+++ b/docs/development/agent-team.md
@@ -116,6 +116,7 @@ Peter Planner stays separate because it is event-driven and uses a different pla
 - **Shell safety** — event context passed via env vars, body content via temp files
 - **Catalog-backed labels** — Peter can only use repo-managed labels from `.agents/config/peter-planner.toml`, with alias normalization for common CI/platform terms
 - **Idempotent planning markers** — planner comments, milestone descriptions, and issue bodies carry machine markers so retries reuse existing artifacts instead of leaking duplicates
+- **Discussion token override** — `permissions.discussions: write` is enough for comments, issues, and milestones, but GitHub's built-in Actions token still cannot retitle discussions via `updateDiscussion` in this repo. `agent-peter.yml` therefore prefers the repo secret `PETER_DISCUSSION_TOKEN` when present, and the repo's default Actions workflow permission should stay at `write`
 
 ## Vision: Autonomous Development
 


### PR DESCRIPTION
## Summary
- document that Peter needs `PETER_DISCUSSION_TOKEN` to retitle discussions reliably
- note that the repo Actions default workflow permission should remain `write`
- add the same caveat inline in the Peter workflow for future maintainers