### PR TITLE
fix: sanitize pipe chars and resolve symlink in runner scripts

### DIFF
--- a/scripts/runner-ci-menubar.5s.sh
+++ b/scripts/runner-ci-menubar.5s.sh
@@ -70,4 +70,5 @@ fi
 
 echo "---"
 echo "Refresh | refresh=true"
-echo "Open runner-status.sh | bash='$(cd "$(dirname "$0")/.." 2>/dev/null && pwd)/scripts/runner-status.sh' terminal=true"
+REAL_SCRIPT="$(readlink "$0" 2>/dev/null || echo "$0")"
+echo "Open runner-status.sh | bash='$(cd "$(dirname "$REAL_SCRIPT")/.." 2>/dev/null && pwd)/scripts/runner-status.sh' terminal=true"

--- a/scripts/runner-notify-complete.sh
+++ b/scripts/runner-notify-complete.sh
@@ -6,7 +6,7 @@
 # All work is wrapped in a subshell with || true, and we exit 0 unconditionally.
 
 (
-    sanitize() { printf '%s' "$1" | tr -d '"\\'; }
+    sanitize() { printf '%s' "$1" | tr -d '"\\|'; }
 
     repo="$(sanitize "${GITHUB_REPOSITORY##*/}")"
     job="$(sanitize "${GITHUB_JOB:-unknown}")"

--- a/scripts/runner-notify-start.sh
+++ b/scripts/runner-notify-start.sh
@@ -6,7 +6,7 @@
 # All work is wrapped in a subshell with || true, and we exit 0 unconditionally.
 
 (
-    sanitize() { printf '%s' "$1" | tr -d '"\\'; }
+    sanitize() { printf '%s' "$1" | tr -d '"\\|'; }
 
     repo="$(sanitize "${GITHUB_REPOSITORY##*/}")"
     job="$(sanitize "${GITHUB_JOB:-unknown}")"


### PR DESCRIPTION
## Summary

- Strip `|` in `sanitize()` (runner hook scripts) to prevent SwiftBar protocol injection via crafted branch names
- Resolve symlink via `readlink` in menubar plugin so "Open runner-status.sh" works when installed as a symlink per CONTRIBUTING.md setup instructions

## Context

Found during code review of #73. A crafted branch name containing `|` (e.g. `feat/x|bash=/tmp/evil.sh`) could inject SwiftBar protocol attributes into the menu bar plugin's output, since `|` is SwiftBar's attribute delimiter. The menubar plugin's "Open" action also resolved to the wrong path when installed via symlink because bash doesn't resolve symlinks in `$0`.

## Test plan

- [x] `sanitize()` now strips `|` alongside `"` and `\`
- [ ] Verify menubar "Open runner-status.sh" action works when plugin is symlinked into ~/swiftbar/

🤖 Generated with [Claude Code](https://claude.com/claude-code)