### PR TITLE
Fix stale SwiftBar runner plugin installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,8 +149,8 @@ brew install --cask swiftbar
 # 2. Configure SwiftBar to use a plugin folder (e.g. ~/swiftbar)
 #    Open SwiftBar preferences and set the plugin folder
 
-# 3. Symlink the menu bar plugin
-ln -s "$(pwd)/scripts/runner-ci-menubar.5s.sh" ~/swiftbar/
+# 3. Install the menu bar plugin
+./scripts/install-runner-ci-menubar.sh ~/swiftbar
 
 # 4. Install runner activity hooks (writes to all runners' .env files)
 ./scripts/install-runner-hooks.sh
@@ -177,7 +177,8 @@ ln -s "$(pwd)/scripts/runner-ci-menubar.5s.sh" ~/swiftbar/
 | Script | Purpose |
 |--------|---------|
 | `runner-status.sh` | CLI status of all runners, WorkspaceManager processes, recent jobs |
-| `runner-ci-menubar.5s.sh` | SwiftBar plugin (symlink into plugin folder) |
+| `runner-ci-menubar.5s.sh` | SwiftBar plugin (installed into plugin folder) |
+| `install-runner-ci-menubar.sh` | Installs the SwiftBar plugin as a durable local copy |
 | `runner-notify-start.sh` | Runner hook: logs job start to activity log |
 | `runner-notify-complete.sh` | Runner hook: logs job completion to activity log |
 | `install-runner-hooks.sh` | Installs hooks on all runners (copies scripts, updates .env) |

--- a/scripts/install-runner-ci-menubar.sh
+++ b/scripts/install-runner-ci-menubar.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Install the SwiftBar runner status plugin into the configured plugin folder.
+#
+# Usage:
+#   ./scripts/install-runner-ci-menubar.sh
+#   ./scripts/install-runner-ci-menubar.sh ~/swiftbar
+#   SWIFTBAR_PLUGIN_DIR=~/swiftbar ./scripts/install-runner-ci-menubar.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_NAME="runner-ci-menubar.5s.sh"
+PLUGIN_DIR_ARG="${1:-}"
+
+expand_home_prefix() {
+    local path="$1"
+    if [[ "$path" == "~" ]]; then
+        printf '%s\n' "$HOME"
+        return
+    fi
+    if [[ "$path" == "~/"* ]]; then
+        printf '%s\n' "$HOME/${path#~/}"
+        return
+    fi
+    printf '%s\n' "$path"
+}
+
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/install-runner-ci-menubar.sh [plugin-dir]
+
+Installs the SwiftBar runner status plugin as a real file so it keeps working
+even if the current checkout or worktree moves.
+
+Resolution order for plugin-dir:
+  1. First positional argument
+  2. SWIFTBAR_PLUGIN_DIR
+  3. ~/Library/Application Support/SwiftBar/Plugins
+  4. ~/swiftbar
+USAGE
+}
+
+resolve_plugin_dir() {
+    if [[ -n "$PLUGIN_DIR_ARG" ]]; then
+        expand_home_prefix "$PLUGIN_DIR_ARG"
+        return
+    fi
+
+    if [[ -n "${SWIFTBAR_PLUGIN_DIR:-}" ]]; then
+        expand_home_prefix "$SWIFTBAR_PLUGIN_DIR"
+        return
+    fi
+
+    local official_dir="$HOME/Library/Application Support/SwiftBar/Plugins"
+    if [[ -d "$official_dir" ]]; then
+        printf '%s\n' "$official_dir"
+        return
+    fi
+
+    local legacy_dir="$HOME/swiftbar"
+    if [[ -d "$legacy_dir" ]]; then
+        printf '%s\n' "$legacy_dir"
+        return
+    fi
+
+    return 1
+}
+
+if [[ "$PLUGIN_DIR_ARG" == "--help" || "$PLUGIN_DIR_ARG" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+PLUGIN_DIR="$(resolve_plugin_dir)" || {
+    echo "Could not determine the SwiftBar plugin folder." >&2
+    echo "Pass it explicitly, for example: ./scripts/install-runner-ci-menubar.sh ~/swiftbar" >&2
+    exit 1
+}
+
+PLUGIN_DIR="$(expand_home_prefix "$PLUGIN_DIR")"
+SIDECAR_DIR="$PLUGIN_DIR/.runner-ci-menubar"
+PLUGIN_DEST="$PLUGIN_DIR/$PLUGIN_NAME"
+STATUS_DEST="$SIDECAR_DIR/runner-status.sh"
+
+mkdir -p "$PLUGIN_DIR" "$SIDECAR_DIR"
+rm -f "$PLUGIN_DEST"
+install -m 755 "$SCRIPT_DIR/runner-ci-menubar.5s.sh" "$PLUGIN_DEST"
+install -m 755 "$SCRIPT_DIR/runner-status.sh" "$STATUS_DEST"
+
+cat <<EOF
+Installed SwiftBar plugin:
+  Plugin: $PLUGIN_DEST
+  Helper: $STATUS_DEST
+
+If SwiftBar is already pointing at $PLUGIN_DIR, refresh the plugin or reopen SwiftBar.
+EOF

--- a/scripts/runner-ci-menubar.5s.sh
+++ b/scripts/runner-ci-menubar.5s.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # SwiftBar/xbar plugin: shows self-hosted GitHub Actions runner status in the menu bar.
-# Install: symlink or copy to ~/Library/Application Support/SwiftBar/plugins/
+# Install: run scripts/install-runner-ci-menubar.sh
 # Refresh: every 5 seconds (from filename)
+
+set -euo pipefail
 
 RUNNER_DIRS=(
     "$HOME/.local/share/actions-runner-workspaces"
@@ -9,6 +11,50 @@ RUNNER_DIRS=(
     "$HOME/.local/share/actions-runner-code-cadence"
 )
 LOG="$HOME/.local/share/runner-activity.log"
+
+resolve_real_script() {
+    local source="$1"
+    if [[ ! -L "$source" ]]; then
+        printf '%s\n' "$source"
+        return
+    fi
+
+    local target=""
+    target="$(readlink "$source" 2>/dev/null || true)"
+    if [[ -z "$target" ]]; then
+        printf '%s\n' "$source"
+        return
+    fi
+
+    if [[ "$target" == /* ]]; then
+        printf '%s\n' "$target"
+        return
+    fi
+
+    printf '%s\n' "$(cd "$(dirname "$source")" && cd "$(dirname "$target")" && pwd)/$(basename "$target")"
+}
+
+resolve_status_script() {
+    local plugin_dir=""
+    plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    local installed_sidecar="$plugin_dir/.runner-ci-menubar/runner-status.sh"
+    if [[ -x "$installed_sidecar" ]]; then
+        printf '%s\n' "$installed_sidecar"
+        return
+    fi
+
+    local real_script=""
+    real_script="$(resolve_real_script "$0")"
+    local repo_sidecar=""
+    repo_sidecar="$(cd "$(dirname "$real_script")" && pwd)/runner-status.sh"
+    if [[ -x "$repo_sidecar" ]]; then
+        printf '%s\n' "$repo_sidecar"
+        return
+    fi
+
+    return 1
+}
 
 total=0
 running=0
@@ -70,5 +116,9 @@ fi
 
 echo "---"
 echo "Refresh | refresh=true"
-REAL_SCRIPT="$(readlink "$0" 2>/dev/null || echo "$0")"
-echo "Open runner-status.sh | bash='$(cd "$(dirname "$REAL_SCRIPT")/.." 2>/dev/null && pwd)/scripts/runner-status.sh' terminal=true"
+STATUS_SCRIPT="$(resolve_status_script || true)"
+if [[ -n "$STATUS_SCRIPT" ]]; then
+    echo "Open runner-status.sh | bash='$STATUS_SCRIPT' terminal=true"
+else
+    echo "runner-status.sh not installed | color=#888888"
+fi


### PR DESCRIPTION
## Summary
- replace the brittle SwiftBar symlink setup with an installer that copies the plugin into the configured plugin directory
- install `runner-status.sh` alongside the plugin so the menu item keeps working after repo moves or worktree cleanup
- update the CI visibility docs to use the installer instead of a symlink

## Root cause
SwiftBar was configured to execute a plugin symlinked from a transient checkout. Once that checkout disappeared, the plugin path in `~/swiftbar` pointed to a missing file and SwiftBar showed `/bin/bash: ... No such file or directory`.

## Verification
- `bash -n scripts/runner-ci-menubar.5s.sh scripts/install-runner-ci-menubar.sh scripts/runner-status.sh`
- `./scripts/install-runner-ci-menubar.sh ~/swiftbar`
- `bash /Users/fairchild/swiftbar/runner-ci-menubar.5s.sh`
- `swift-format lint` via the repo pre-commit hook during `git commit`