### PR TITLE
Hide activity tab when notifications are disabled

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -28,7 +28,7 @@ struct RightPaneTabPolicy {
         if visibleTabs.contains(selectedTab) {
             return selectedTab
         }
-        return visibleTabs.first ?? .files
+        return visibleTabs[0]
     }
 }
 

--- a/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
@@ -37,22 +37,50 @@ struct RightPaneTabPolicyTests {
         #expect(policy.normalizedSelection(for: .activity) == .files)
     }
 
-    @Test("Re-enabling notifications preserves the normalized non-activity selection")
-    func reenablingNotificationsPreservesNormalizedSelection() {
+    @Test("Repo tabs exclude activity regardless of notification setting")
+    func repoTabsExcludeActivityRegardlessOfNotificationSetting() {
+        let disabledPolicy = RightPaneTabPolicy(
+            supportsFilesystemInspection: true,
+            showActivity: false,
+            notificationsEnabled: false
+        )
+        let enabledPolicy = RightPaneTabPolicy(
+            supportsFilesystemInspection: true,
+            showActivity: false,
+            notificationsEnabled: true
+        )
+
+        #expect(disabledPolicy.visibleTabs == [.files, .changes])
+        #expect(enabledPolicy.visibleTabs == [.files, .changes])
+    }
+
+    @Test("Disabled notifications preserve non-activity tab selections")
+    func disabledNotificationsPreserveNonActivitySelections() {
+        let disabledPolicy = RightPaneTabPolicy(
+            supportsFilesystemInspection: true,
+            showActivity: true,
+            notificationsEnabled: false
+        )
+
+        #expect(disabledPolicy.normalizedSelection(for: .files) == .files)
+        #expect(disabledPolicy.normalizedSelection(for: .changes) == .changes)
+    }
+
+    @Test("Re-enabling notifications keeps a previously normalized files selection")
+    func reenablingNotificationsKeepsNormalizedFilesSelection() {
         let disabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
             showActivity: true,
             notificationsEnabled: false
         )
         let normalizedSelection = disabledPolicy.normalizedSelection(for: .activity)
-
-        let enabledPolicy = RightPaneTabPolicy(
+        let reenabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
             showActivity: true,
             notificationsEnabled: true
         )
 
         #expect(normalizedSelection == .files)
-        #expect(enabledPolicy.normalizedSelection(for: normalizedSelection) == .files)
+        #expect(reenabledPolicy.normalizedSelection(for: normalizedSelection) == .files)
     }
 }


### PR DESCRIPTION
## Summary
- hide the right-pane Activity tab when notifications are disabled
- normalize an active Activity selection back to Files when the setting turns off
- add focused tab policy tests for visibility and fallback behavior

## Verification
- swift test --filter RightPaneTabPolicyTests
- swift test
- ./scripts/build-ghosttykit.sh
- ./scripts/dev-smoke.sh --no-build --no-activate --clean-data --trust-mise

@claude please review this PR.