### PR TITLE
docs: clarify signing-host release lane and CI scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,16 +109,16 @@ workspaces/
 
 ## CI Runner Lanes
 
-Generic lint/build/test CI runs on GitHub-hosted macOS (`macos-17`). Self-hosted jobs must use explicit lanes: `[self-hosted, tart-ui]` for UI/perf automation and `[self-hosted, signing-host]` for release/signing/notarization. The `Perf Validation` workflow runs separately from the main CI workflow via `workflow_dispatch`, a nightly schedule, and scoped `codex/**` pushes so app-launching checks stay off the default path.
+Generic lint/build/test CI runs on GitHub-hosted macOS (`macos-17`) and is path-scoped to product, test, build, and release inputs so docs, backlog, skill, and changelog-only pushes do not consume the hosted macOS queue. Self-hosted jobs must use explicit lanes: `[self-hosted, tart-ui]` for UI/perf automation and `[self-hosted, signing-host]` for release/signing/notarization. The `Perf Validation` workflow runs separately from the main CI workflow via `workflow_dispatch`, a nightly schedule, and scoped `codex/**` pushes so app-launching checks stay off the default path.
 
-For this repo, the currently registered self-hosted runners are:
+For this repo, the default self-hosted runner layout is:
 
 | Runner | Labels | Location |
 |--------|--------|----------|
-| `blue-workspaces` | `self-hosted-macos` | `~/.local/share/actions-runner-workspaces` |
+| `blue-workspaces` | `self-hosted-macos`, optionally `signing-host` when it is serving as the release lane | `~/.local/share/actions-runner-workspaces` |
 | `workspaces-tart-ui` | `tart-ui` | Tart guest `~/.local/share/actions-runner-tart-ui` |
 
-The release workflow also expects a separate runner advertising the `signing-host` label before dispatch.
+The release workflow requires at least one online runner advertising the `signing-host` label before dispatch. That label is operational state in GitHub, not something stored in the repo. If `blue-workspaces` is not carrying the release lane, move `signing-host` to whichever signing-capable runner should own releases. See [docs/development/signing-runner-setup.md](./docs/development/signing-runner-setup.md).
 
 ### Focus stealing prevention
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -234,7 +234,10 @@ The recommended method for production releases.
    - Trigger: `workflow_dispatch`
    - In GitHub: Actions > `Release` > `Run workflow`
    - Ref: `main` or an existing release tag (`v*`, `workspaces-v*`)
-   - Runner lane: `[self-hosted, signing-host]` (the signing runner must advertise the `signing-host` label before dispatch)
+   - Runner lane: `[self-hosted, signing-host]`
+     - At least one online runner must advertise the `signing-host` label before dispatch.
+     - The release lane can be an existing signing-capable host; it does not need to be a separate machine, but it must be intentionally designated for release duties.
+     - See [docs/development/signing-runner-setup.md](./docs/development/signing-runner-setup.md) for label assignment and verification commands.
    - Guardrails:
      - Manual releases fail if started from a non-`main` branch.
      - Release commit must be reachable from `origin/main`.

--- a/docs/development/signing-runner-setup.md
+++ b/docs/development/signing-runner-setup.md
@@ -1,0 +1,86 @@
+# Signing Runner Setup
+
+Use this runbook to provision or relabel the dedicated `[self-hosted, signing-host]` lane required by the `Release` workflow.
+
+## Why this exists
+
+The release workflow intentionally does not run on a generic self-hosted runner. It targets `[self-hosted, signing-host]` so signing and notarization stay isolated from routine desktop CI and Tart UI automation.
+
+`signing-host` is a mutable GitHub runner label, not repo state. If no online runner advertises it, `Release` jobs will remain queued even when self-hosted runners are otherwise healthy.
+
+## Prerequisites
+
+- GitHub CLI authenticated with permission to inspect and update Actions runners for `fairchild/workspaces`
+- A signing-capable macOS host with Xcode command line tools available
+- The chosen host intentionally approved for release duties
+
+## 1. Inspect the current runner inventory
+
+```bash
+gh api repos/fairchild/workspaces/actions/runners \
+  --jq '.runners[] | {id, name, status, busy, labels: [.labels[].name]}'
+```
+
+Confirm there is at least one online runner you want to use for release work.
+
+## 2. Assign the `signing-host` label
+
+Pick the runner by name and add the label in GitHub:
+
+```bash
+RUNNER_NAME=blue-workspaces
+RUNNER_ID="$(
+  gh api repos/fairchild/workspaces/actions/runners \
+    --jq ".runners[] | select(.name == \"${RUNNER_NAME}\") | .id"
+)"
+
+gh api --method POST \
+  "repos/fairchild/workspaces/actions/runners/${RUNNER_ID}/labels" \
+  --raw-field 'labels[]=signing-host'
+```
+
+Notes:
+
+- Keep the workflow contract explicit. Do not relax `.github/workflows/release.yml` back to bare `self-hosted`.
+- If a different machine should own releases, apply `signing-host` there instead of overloading the interactive desktop runner.
+
+## 3. Verify the label is live
+
+```bash
+gh api repos/fairchild/workspaces/actions/runners \
+  --jq '.runners[] | {name, status, labels: [.labels[].name]}'
+```
+
+Confirm at least one online runner now includes `signing-host`.
+
+## 4. Verify release scheduling
+
+Dispatch or observe a `Release` workflow run and confirm the job lands on the expected lane:
+
+```bash
+gh workflow run release.yml --ref main
+gh run list --workflow Release --limit 1
+gh api repos/fairchild/workspaces/actions/runs/<run-id>/jobs \
+  --jq '.jobs[] | {name, status, labels, runner_name}'
+```
+
+The job should report labels including `self-hosted` and `signing-host`, and `runner_name` should resolve to the designated signing runner instead of remaining empty while queued.
+
+If repository release credentials are intentionally unavailable in the current environment, stop after the job is claimed by the correct runner.
+
+## 5. Move or remove the label
+
+If release duties move to a different host:
+
+```bash
+gh api --method DELETE \
+  repos/fairchild/workspaces/actions/runners/<runner-id>/labels/signing-host
+```
+
+Then add `signing-host` to the new designated runner and re-run the verification steps above.
+
+## References
+
+- [RELEASING.md](../../RELEASING.md)
+- [.github/workflows/release.yml](../../.github/workflows/release.yml)
+- [docs/development/tart-runner-setup.md](./tart-runner-setup.md)


### PR DESCRIPTION
## Summary
- document that generic macOS CI is path-scoped to build-affecting inputs
- clarify that `Release` requires an online `[self-hosted, signing-host]` lane rather than a bare self-hosted runner
- add a dedicated signing runner setup runbook with GitHub label assignment and verification commands

## Context
The queue investigation showed two separate issues:
- routine `CI` churn on `main` was coming from GitHub-hosted `macos-17` jobs, not self-hosted runner health
- `Release` jobs were unschedulable until a runner advertised the `signing-host` label

The direct `ci.yml` trigger scoping fix is already on `main`; this PR backfills the missing repo documentation so the workflow contract matches the operational setup.

## Verification
- `git diff --check`
- confirmed the release lane was claimed by `blue-workspaces` once `signing-host` was assigned
