### PR TITLE
docs: link lume milestone to backlog

### DIFF
--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -235,8 +235,9 @@ Default execution policy:
 
 Current GitHub state (2026-03-12):
 
-- the current open milestone is `Core reliability and maintainability` (#1)
-- it is the first roadmap-aligned execution milestone and should stay limited to the current `P0` theme
+- the active milestone is `Core reliability and maintainability` (#1)
+- the queued next milestone is `Lume runtime hardening` (#5)
+- the active milestone should stay limited to the current `P0` theme
 - roadmap ordering still wins over milestone drift; if the milestone scope widens, bring it back to the `P0` set
 
 Theme-to-milestone map:
@@ -244,7 +245,7 @@ Theme-to-milestone map:
 | Roadmap theme | Milestone posture |
 |------|----------|
 | Core reliability and maintainability | Current execution milestone |
-| Lume runtime hardening | Next-up standalone milestone after the current core-reliability milestone |
+| Lume runtime hardening | Queued standalone milestone after the current core-reliability milestone |
 | Notification catch-up and reconnect correctness | Standalone milestone after Lume unless activity work becomes urgent sooner |
 | Terminal multiplexing direction | Milestone only after an explicit product decision to invest here |
 | Strategic isolation backend direction | Backlog/research until promoted by a fresh approved discussion |

--- a/backlog/lume-runtime-architecture-followups_followup.md
+++ b/backlog/lume-runtime-architecture-followups_followup.md
@@ -4,6 +4,7 @@ category: followup
 topic: lume-runtime
 priority: 2
 description: Post-merge cleanup for Lume runtime decomposition, transport unification, launcher hardening, and stronger VM/error typing.
+milestone: 5
 ---
 
 # Lume Runtime Architecture Follow-Ups
@@ -109,6 +110,14 @@ LumeWorkspaceProvider
 **Acceptance criteria:**
 - [ ] Docs no longer describe duplicated transport internals or Python-based detachment
 - [ ] PR reviewers can trace runtime/provider responsibilities to small focused types
+
+## GitHub
+
+- Milestone: [#5 Lume runtime hardening](https://github.com/fairchild/workspaces/milestone/5)
+- Related issues:
+  - [#87 Extract shared Lume transport and runner helpers](https://github.com/fairchild/workspaces/issues/87)
+  - [#88 Replace Python detachment and normalize Lume VM typing](https://github.com/fairchild/workspaces/issues/88)
+  - [#89 Refresh Lume runtime docs after the architecture cleanup](https://github.com/fairchild/workspaces/issues/89)
 
 ## Verification Commands
 


### PR DESCRIPTION
## Summary
- add milestone and related issue links to the Lume backlog follow-up doc
- refresh the roadmap milestone state to reflect the queued Lume milestone

## Testing
- pre-commit `swift-format lint`