### PR TITLE
Require PR evidence for UI and performance-sensitive work

### DIFF
--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -49,6 +49,7 @@ Read these repo sources before acting:
 - If the milestone already has a good plan, audit it against the latest repo and GitHub state and reuse only what is still true.
 - If reality drifted, rewrite the plan before touching code.
 - Decide PR shape as part of the plan: one PR, one PR per issue, or a stacked series.
+- If the work is performance-sensitive and no usable baseline metrics were supplied with the task, add an early baseline-capture step to the plan before making code changes.
 
 ### 3. Execute issues one at a time
 
@@ -62,12 +63,20 @@ Read these repo sources before acting:
 - Run the smallest relevant local checks first.
 - When workflows, CI, runners, or UI automation change, validate on the real lane for this repo, including Tart when applicable.
 - Present evidence in issue and PR updates instead of only saying that something worked.
+- For UI-affecting work, treat visual evidence as a delivery gate: attach proof from the exact commit under review to the PR itself before asking for review or calling it ready.
+- Minimum UI evidence: at least one rendered screenshot or equivalent visual artifact, the exact verification commands used, and a linked log or artifact path. If the behavior is interactive, include a second screenshot or short recording.
+- For performance-sensitive work, include before/after metrics in the PR from the same or clearly described workload and environment, and note the delta instead of only reporting the final number.
+- If baseline metrics were not provided up front, gather them before changing code whenever feasible so the final PR can compare the merged result against a real pre-change baseline.
+- If the comparison is not like-for-like, say so explicitly. If a metric is missing, regresses meaningfully, or crosses a target boundary, call that out directly instead of burying it.
+- If visual evidence cannot be produced, mark the work `blocked on evidence`, explain why in the PR and issue, and do not merge unless the user explicitly accepts shipping without that proof.
 
 ### 5. Manage PRs and review
 
 - If issues are independent, prefer separate issue-sized PRs.
 - If later issues build directly on earlier branches, use stacked PRs and say where each PR sits in the stack.
 - If one consolidated PR is the better plan, explain that explicitly in issue updates and the PR summary.
+- Before requesting review, confirm the PR description or comments include the required evidence links for any UI-affecting work.
+- Before requesting review on performance-sensitive work, confirm the PR includes baseline metrics, final metrics, and a short comparison note describing any meaningful change or explaining why the numbers are not directly comparable.
 - Request review with stack context, then address review comments one by one through code changes, direct explanation, or a tracked backlog item.
 
 ### 6. Close out the milestone
@@ -88,5 +97,7 @@ Read these repo sources before acting:
 - Always plan first. No `/drive` execution starts with coding.
 - Always work from latest GitHub state, even if the milestone already contains a plan.
 - Never assume issues are still open, PRs are absent, or runner state is unchanged.
+- Never treat local-only screenshots or logs as sufficient PR evidence for UI-affecting work.
+- Never treat a final perf number without a baseline or comparison note as sufficient performance evidence for performance-sensitive work.
 - Keep milestone, issue, and PR comments aligned so another agent can resume without rediscovering the whole story.
 - When execution uncovers work that should not block the milestone, capture it in `backlog/` rather than hiding it in a PR comment.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] `swift build`
+- [ ] `swift test`
+- [ ] Other checks run:
+
+## Performance
+
+- [ ] Not a performance-sensitive change
+- [ ] Baseline metrics were provided with the task
+- [ ] Baseline metrics were gathered before changes
+- [ ] Post-change metrics were gathered at the end of the work
+- [ ] Before/after/delta is included below
+- [ ] Any meaningful change, missing metric, target crossing, or non-comparable context is called out below
+
+Performance evidence for performance-sensitive work should include:
+
+- the metric source and exact commands used
+- before and after values
+- the workload and environment context
+- a short note about the delta and whether the comparison is like-for-like
+
+Performance evidence:
+
+- 
+
+Performance comparison notes:
+
+- 
+
+## Evidence
+
+- [ ] Not a UI-affecting change
+- [ ] UI-affecting change with PR-attached evidence from the exact commit under review
+
+Visual evidence for UI-affecting work must include:
+
+- at least one rendered screenshot or equivalent visual artifact in this PR
+- the exact verification commands used
+- a linked log or artifact path
+- if interaction changed, a second screenshot or short recording that proves the result
+
+Evidence links:
+
+- 
+
+## Blockers
+
+- [ ] None
+- [ ] Blocked on evidence
+
+If blocked on evidence, explain why here. Do not merge UI-affecting work without explicit approval to ship without visual proof.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,13 @@ Verify your work visually, then present evidence to the user. Don't just say it 
 - **Self-verify**: Use Tart VMs (`/tart-gui-automation`) to build, launch, and screenshot the app in an isolated environment.
 - **Present evidence**: Open HTML artifacts in the browser (`open <path>`), render screenshots inline in chat, and show test output. The user should see the proof without asking twice.
 - **Tests are evidence too**: Run `swift test` and show the summary. Green tests are necessary but not sufficient — visual confirmation of UI changes is expected.
+- **Treat visual proof as a merge gate for UI work**: For changes that affect UI, terminal behavior, keyboard handling, sidebar behavior, windowing, launch flow, or visual appearance, do not request review, call the PR ready, or merge until the PR itself contains visual evidence from the exact commit under review.
+- **Minimum PR evidence for UI work**: Include at least one rendered screenshot or equivalent visual artifact in the PR description or comments, the exact verification commands used, and a linked log or artifact path. If the change affects interaction, include a second screenshot or short recording that proves the result.
+- **Capture performance baselines early when work is performance-sensitive**: For changes that could affect launch time, terminal responsiveness, repo loading, focus restoration, rendering cost, or other user-visible performance, gather baseline metrics before making changes unless equivalent baseline data is already provided as input to the task.
+- **Compare before and after on the same footing**: Re-run the same performance measurement at the end of the work with the same or clearly described workload, environment, and metric source, then include before/after/delta in the PR discussion.
+- **Call out meaningful performance changes explicitly**: If a like-for-like comparison shows a meaningful delta, a target boundary crossing, or missing metrics, say so directly in the PR and final summary. If the comparison is not like-for-like, state that it is not directly comparable rather than implying confidence.
+- **Blocked evidence is an explicit state**: If you cannot produce visual evidence, say so clearly in the PR and in chat as `blocked on evidence`, explain why, and do not merge unless the user explicitly approves shipping without that proof.
+- **Do not rely on local-only proof**: Local screenshots, logs, and perf results are useful during development, but they are not sufficient close-out evidence unless they are attached to or clearly linked from the PR discussion.
 
 ## High-Signal Lessons
 


### PR DESCRIPTION
## Summary

- make visual evidence a hard PR/merge gate for UI-affecting work in `AGENTS.md`
- require early baseline capture and before/after/delta notes for performance-sensitive work in `AGENTS.md` and the `drive` skill
- add a PR template with explicit `Validation`, `Performance`, `Evidence`, and `Blockers` sections

## Validation

- not run; docs/template-only change
