### PR TITLE
feat: agent frontmatter output + CLI agentic loop

### DIFF
--- a/.agents/prompts/april-clearwater.md
+++ b/.agents/prompts/april-clearwater.md
@@ -36,46 +36,63 @@ You also receive pre-gathered context appended to your system prompt: recent com
 
 ## Output Format
 
-Output a single JSON block wrapped in ```json fences. No preamble, no commentary outside the fences.
+Output YAML frontmatter followed by your markdown body. No preamble before the `---`.
 
 Choose ONE action based on your priority assessment:
 
 ### Propose a new idea
-```json
-{
-  "action": "propose",
-  "title": "[idea] <concise title, under 80 chars>",
-  "body": "## Thesis\n<problem or opportunity and why now>\n\n## Proposal\n<what to build or change, with file references>\n\n## Evidence\n<what in the codebase supports this>\n\n## Scope\n<small/medium/large, what the first PR contains>\n\n## Open Questions\n<1-3 questions for the human>",
-  "persona": "April Clearwater, Application Lead"
-}
+```
+---
+action: propose
+persona: April Clearwater, Application Lead
+title: "[idea] Concise title, under 80 chars"
+---
+
+## Thesis
+Problem or opportunity and why now
+
+## Proposal
+What to build or change, with file references
+
+## Evidence
+What in the codebase supports this
+
+## Scope
+small/medium/large, what the first PR contains
+
+## Open Questions
+1-3 questions for the human
 ```
 
 ### Comment on a discussion
-```json
-{
-  "action": "comment",
-  "discussion_number": 44,
-  "body": "<your comment — substantive, not just +1>",
-  "persona": "April Clearwater, Application Lead"
-}
+```
+---
+action: comment
+persona: April Clearwater, Application Lead
+discussion_number: 44
+---
+
+Your substantive comment here...
 ```
 
 ### Review a PR
-```json
-{
-  "action": "review_pr",
-  "pr_number": 42,
-  "body": "<code review with specific file/line references>",
-  "persona": "April Clearwater, Application Lead"
-}
+```
+---
+action: review_pr
+persona: April Clearwater, Application Lead
+pr_number: 42
+---
+
+Code review with specific file/line references...
 ```
 
 ### Advance an issue
-```json
-{
-  "action": "advance_issue",
-  "issue_number": 15,
-  "body": "<concrete suggestions to move this toward completion>",
-  "persona": "April Clearwater, Application Lead"
-}
+```
+---
+action: advance_issue
+persona: April Clearwater, Application Lead
+issue_number: 15
+---
+
+Concrete suggestions to move this toward completion...
 ```

--- a/.agents/prompts/peter-planner.md
+++ b/.agents/prompts/peter-planner.md
@@ -35,22 +35,39 @@ When 3+ issues are needed, derive `milestone_name` directly from the discussion 
 
 ## Output Format
 
-Output a single JSON block wrapped in ```json fences. No preamble, no commentary outside the fences.
+Output multi-document YAML frontmatter. First document is the plan header, each subsequent document is an issue. No preamble before the first `---`.
 
-```json
-{
-  "action": "plan",
-  "discussion_number": 44,
-  "milestone_name": null,
-  "issues": [
-    {
-      "title": "<clear, actionable issue title>",
-      "body": "## Context\n<link to discussion, brief summary>\n\n## What to do\n<specific changes with file references>\n\n## Acceptance criteria\n- [ ] <testable criterion>\n- [ ] <testable criterion>",
-      "labels": ["enhancement"],
-      "priority": 1
-    }
-  ]
-}
+```
+---
+action: plan
+discussion_number: 44
+milestone_name: null
+---
+
+---
+title: "Clear, actionable issue title"
+labels: [enhancement]
+priority: 1
+---
+
+## Context
+Link to discussion, brief summary
+
+## What to do
+Specific changes with file references
+
+## Acceptance criteria
+- [ ] Testable criterion
+- [ ] Testable criterion
+
+---
+title: "Second issue title"
+labels: [enhancement, "area: ui"]
+priority: 2
+---
+
+## Context
+...
 ```
 
 Set `milestone_name` to a short descriptive name when creating 3+ issues. Leave `null` for 1-2 issues.

--- a/.agents/prompts/plat-ironwood.md
+++ b/.agents/prompts/plat-ironwood.md
@@ -36,46 +36,63 @@ You also receive pre-gathered context appended to your system prompt: recent com
 
 ## Output Format
 
-Output a single JSON block wrapped in ```json fences. No preamble, no commentary outside the fences.
+Output YAML frontmatter followed by your markdown body. No preamble before the `---`.
 
 Choose ONE action based on your priority assessment:
 
 ### Propose a new idea
-```json
-{
-  "action": "propose",
-  "title": "[idea] <concise title, under 80 chars>",
-  "body": "## Thesis\n<problem or opportunity and why now>\n\n## Proposal\n<what to build or change, with file references>\n\n## Evidence\n<what in the codebase supports this>\n\n## Scope\n<small/medium/large, what the first PR contains>\n\n## Open Questions\n<1-3 questions for the human>",
-  "persona": "Plat Ironwood, Platform Lead"
-}
+```
+---
+action: propose
+persona: Plat Ironwood, Platform Lead
+title: "[idea] Concise title, under 80 chars"
+---
+
+## Thesis
+Problem or opportunity and why now
+
+## Proposal
+What to build or change, with file references
+
+## Evidence
+What in the codebase supports this
+
+## Scope
+small/medium/large, what the first PR contains
+
+## Open Questions
+1-3 questions for the human
 ```
 
 ### Comment on a discussion
-```json
-{
-  "action": "comment",
-  "discussion_number": 44,
-  "body": "<your comment — substantive, not just +1>",
-  "persona": "Plat Ironwood, Platform Lead"
-}
+```
+---
+action: comment
+persona: Plat Ironwood, Platform Lead
+discussion_number: 44
+---
+
+Your substantive comment here...
 ```
 
 ### Review a PR
-```json
-{
-  "action": "review_pr",
-  "pr_number": 42,
-  "body": "<code review with specific file/line references>",
-  "persona": "Plat Ironwood, Platform Lead"
-}
+```
+---
+action: review_pr
+persona: Plat Ironwood, Platform Lead
+pr_number: 42
+---
+
+Code review with specific file/line references...
 ```
 
 ### Advance an issue
-```json
-{
-  "action": "advance_issue",
-  "issue_number": 15,
-  "body": "<concrete suggestions to move this toward completion>",
-  "persona": "Plat Ironwood, Platform Lead"
-}
+```
+---
+action: advance_issue
+persona: Plat Ironwood, Platform Lead
+issue_number: 15
+---
+
+Concrete suggestions to move this toward completion...
 ```

--- a/.agents/scripts/parse-frontmatter.py
+++ b/.agents/scripts/parse-frontmatter.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Parse YAML frontmatter from agent output.
+
+Handles a subset of YAML: strings (bare/quoted), integers, booleans,
+null, and inline lists.  No external dependencies.
+
+Functions:
+    parse_frontmatter(text) -> (metadata, body)
+    parse_multi_document(text) -> [(metadata, body), ...]
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+Value = str | int | bool | None | list[str]
+
+
+def _parse_yaml_value(raw: str) -> Value:
+    """Parse a single YAML value from the supported subset."""
+    value = raw.strip()
+    if not value:
+        return ""
+    if value == "null":
+        return None
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    if re.fullmatch(r"-?\d+", value):
+        return int(value)
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    if value.startswith("[") and value.endswith("]"):
+        return _parse_inline_list(value[1:-1])
+    return value
+
+
+def _parse_inline_list(content: str) -> list[str]:
+    """Parse inline list content: ``enhancement, "area: ui"``."""
+    items: list[str] = []
+    current: list[str] = []
+    in_quotes = False
+    quote_char: str | None = None
+
+    for char in content:
+        if in_quotes:
+            if char == quote_char:
+                in_quotes = False
+                items.append("".join(current))
+                current = []
+            else:
+                current.append(char)
+        elif char in ('"', "'"):
+            in_quotes = True
+            quote_char = char
+            current = []
+        elif char == ",":
+            token = "".join(current).strip()
+            if token:
+                items.append(token)
+            current = []
+        else:
+            current.append(char)
+
+    token = "".join(current).strip()
+    if token:
+        items.append(token)
+    return items
+
+
+def _parse_yaml_subset(text: str) -> dict[str, Any]:
+    """Parse simple ``key: value`` YAML lines into a dict."""
+    result: dict[str, Any] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = re.match(r"^([\w][\w_]*)\s*:\s*(.*)", stripped)
+        if not match:
+            raise ValueError(f"invalid YAML line: {stripped!r}")
+        result[match.group(1)] = _parse_yaml_value(match.group(2))
+    return result
+
+
+def _is_frontmatter_boundary(lines: list[str], index: int) -> bool:
+    """Check if ``lines[index]`` (a ``---`` line) opens a new frontmatter block.
+
+    Requires at least one ``key: value`` line before the next ``---`` closer.
+    """
+    has_yaml = False
+    for j in range(index + 1, len(lines)):
+        stripped = lines[j].strip()
+        if stripped == "---":
+            return has_yaml
+        if not stripped:
+            continue
+        if not re.match(r"^[\w][\w_]*\s*:", stripped):
+            return False
+        has_yaml = True
+    return False
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Parse a single frontmatter document.
+
+    Returns ``(metadata_dict, body_string)``.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("---"):
+        raise ValueError("text does not start with frontmatter delimiter")
+
+    lines = stripped.split("\n")
+    closing = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            closing = i
+            break
+
+    if closing is None:
+        raise ValueError("no closing frontmatter delimiter found")
+
+    yaml_text = "\n".join(lines[1:closing])
+    body = "\n".join(lines[closing + 1 :]).strip()
+    metadata = _parse_yaml_subset(yaml_text)
+    return metadata, body
+
+
+def parse_multi_document(text: str) -> list[tuple[dict[str, Any], str]]:
+    """Parse multiple frontmatter documents.
+
+    Each document is a ``---``-delimited YAML block optionally followed by
+    a markdown body.  Code-fenced ``---`` lines are not treated as
+    delimiters.
+
+    Returns a list of ``(metadata_dict, body_string)`` tuples.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("---"):
+        raise ValueError("text does not start with frontmatter delimiter")
+
+    lines = stripped.split("\n")
+    documents: list[tuple[dict[str, Any], str]] = []
+
+    state = "seeking"  # seeking | in_yaml | in_body
+    yaml_lines: list[str] = []
+    body_lines: list[str] = []
+    yaml_text: str | None = None
+    in_code_fence = False
+
+    for i, line in enumerate(lines):
+        line_stripped = line.strip()
+
+        if state == "seeking":
+            if line_stripped == "---":
+                state = "in_yaml"
+                yaml_lines = []
+            continue
+
+        if state == "in_yaml":
+            if line_stripped == "---":
+                yaml_text = "\n".join(yaml_lines)
+                state = "in_body"
+                body_lines = []
+                in_code_fence = False
+            else:
+                yaml_lines.append(line)
+            continue
+
+        if state == "in_body":
+            if line_stripped.startswith("```"):
+                in_code_fence = not in_code_fence
+                body_lines.append(line)
+                continue
+
+            if not in_code_fence and line_stripped == "---":
+                if _is_frontmatter_boundary(lines, i):
+                    assert yaml_text is not None
+                    documents.append(
+                        (_parse_yaml_subset(yaml_text), "\n".join(body_lines).strip())
+                    )
+                    yaml_text = None
+                    state = "in_yaml"
+                    yaml_lines = []
+                    continue
+
+            body_lines.append(line)
+            continue
+
+    # Finalize last document
+    if yaml_text is not None:
+        documents.append(
+            (_parse_yaml_subset(yaml_text), "\n".join(body_lines).strip())
+        )
+
+    if not documents:
+        raise ValueError("no frontmatter blocks found")
+
+    return documents

--- a/.agents/scripts/run-contributor.py
+++ b/.agents/scripts/run-contributor.py
@@ -18,8 +18,14 @@ from pathlib import Path
 
 CLAUDE_TASK = (
     "Check what needs attention first (open PRs, in-progress issues, recent discussion "
-    "comments), then propose a new idea only if nothing else needs you. Output ONLY the "
-    "JSON block as specified in your prompt."
+    "comments), then propose a new idea only if nothing else needs you. Output your "
+    "response using YAML frontmatter as specified in your prompt."
+)
+CLAUDE_TASK_CLI = (
+    "You are running as an automated contributor. Check what needs attention "
+    "(open PRs, in-progress issues, recent discussion comments), then act on "
+    "the highest-priority item. Output your response using YAML frontmatter "
+    "as specified in your prompt."
 )
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GH_DISCUSS_SCRIPT = REPO_ROOT / ".agents" / "skills" / "gh-discuss" / "scripts" / "gh-discuss.py"
@@ -35,6 +41,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--prompt-file", required=True, type=Path)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--mode", choices=["cli", "print"], default="cli")
     return parser.parse_args()
 
 
@@ -241,23 +248,29 @@ query($owner: String!, $name: String!) {
     )
 
 
-def run_claude(prompt_file: Path, context: str, env: dict[str, str]) -> str:
-    log(f"Running Claude Code with {prompt_file}")
-    return run_checked(
-        [
-            "npx",
-            "@anthropic-ai/claude-code",
-            "--print",
-            "--system-prompt",
-            prompt_file.read_text(),
-            "--append-system-prompt",
-            context,
-            CLAUDE_TASK,
-        ],
-        timeout=CLAUDE_TIMEOUT,
-        cwd=REPO_ROOT,
-        env=env,
-    ).stdout
+def run_claude(prompt_file: Path, context: str, env: dict[str, str], *, mode: str = "cli") -> str:
+    log(f"Running Claude Code with {prompt_file} (mode={mode})")
+    task = CLAUDE_TASK_CLI if mode == "cli" else CLAUDE_TASK
+    cmd = [
+        "npx",
+        "--yes",
+        "@anthropic-ai/claude-code",
+        "--print",
+        "--system-prompt",
+        prompt_file.read_text(),
+        "--append-system-prompt",
+        context,
+    ]
+    timeout = CLAUDE_TIMEOUT
+    if mode == "cli":
+        cmd.extend([
+            "--permission-mode", "bypassPermissions",
+            "--tools", "Read,Grep,Glob,Bash(git:*),Bash(gh:*),Bash(uv:*)",
+            "--max-budget-usd", "1.00",
+        ])
+        timeout = 600
+    cmd.append(task)
+    return run_checked(cmd, timeout=timeout, cwd=REPO_ROOT, env=env).stdout
 
 
 def validate_output(raw_output: str, env: dict[str, str]) -> tuple[int, str | None, str]:
@@ -396,7 +409,7 @@ def main() -> int:
     env = dict(os.environ)
 
     context = gather_context(env)
-    raw_output = run_claude(prompt_file, context, env)
+    raw_output = run_claude(prompt_file, context, env, mode=args.mode)
     exit_code, validated_json, error_text = validate_output(raw_output, env)
 
     if exit_code == 2 and error_text.startswith("duplicate:"):

--- a/.agents/scripts/run-planner.py
+++ b/.agents/scripts/run-planner.py
@@ -22,7 +22,12 @@ from typing import Any
 
 PLANNER_TASK = (
     "Read this approved discussion and break it into actionable GitHub Issues. "
-    "Output ONLY the JSON block as specified in your prompt."
+    "Output your response using YAML frontmatter as specified in your prompt."
+)
+PLANNER_TASK_CLI = (
+    "You are running as an automated planner. Read this approved discussion and "
+    "break it into actionable GitHub Issues. Output your response using YAML "
+    "frontmatter as specified in your prompt."
 )
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -141,6 +146,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="Use saved planner output instead of invoking Claude Code",
     )
+    parser.add_argument("--mode", choices=["cli", "print"], default="cli")
     return parser.parse_args()
 
 
@@ -643,6 +649,8 @@ def run_claude(
     discussion: dict[str, Any],
     catalog: LabelCatalog,
     env: dict[str, str],
+    *,
+    mode: str = "cli",
 ) -> str:
     label_summary = "\n".join(f"- {label}" for label in catalog.labels)
     prompt_context = (
@@ -651,22 +659,27 @@ def run_claude(
         "Allowed labels:\n"
         f"{label_summary}"
     )
-    return run_checked(
-        [
-            "npx",
-            "--yes",
-            "@anthropic-ai/claude-code",
-            "--print",
-            "--system-prompt",
-            PROMPT_FILE.read_text(encoding="utf-8"),
-            "--append-system-prompt",
-            prompt_context,
-            PLANNER_TASK,
-        ],
-        timeout=CLAUDE_TIMEOUT,
-        cwd=REPO_ROOT,
-        env=env,
-    ).stdout
+    task = PLANNER_TASK_CLI if mode == "cli" else PLANNER_TASK
+    cmd = [
+        "npx",
+        "--yes",
+        "@anthropic-ai/claude-code",
+        "--print",
+        "--system-prompt",
+        PROMPT_FILE.read_text(encoding="utf-8"),
+        "--append-system-prompt",
+        prompt_context,
+    ]
+    timeout = CLAUDE_TIMEOUT
+    if mode == "cli":
+        cmd.extend([
+            "--permission-mode", "bypassPermissions",
+            "--tools", "Bash(gh:*)",
+            "--max-budget-usd", "0.50",
+        ])
+        timeout = 600
+    cmd.append(task)
+    return run_checked(cmd, timeout=timeout, cwd=REPO_ROOT, env=env).stdout
 
 
 def load_plan_output(
@@ -682,8 +695,9 @@ def load_plan_output(
         log(f"Using planner output fixture from {plan_file}")
         return plan_file.read_text(encoding="utf-8")
 
-    log(f"Running Claude Code with timeout={CLAUDE_TIMEOUT}s")
-    return run_claude(discussion, catalog, env)
+    mode = getattr(args, "mode", "cli")
+    log(f"Running Claude Code (mode={mode})")
+    return run_claude(discussion, catalog, env, mode=mode)
 
 
 def fetch_issue_marker_map(

--- a/.agents/scripts/test_parse_frontmatter.py
+++ b/.agents/scripts/test_parse_frontmatter.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for the YAML frontmatter parser."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fm = load_module("parse_frontmatter", REPO_ROOT / ".agents" / "scripts" / "parse-frontmatter.py")
+
+
+class ParseFrontmatterTests(unittest.TestCase):
+    def test_simple_frontmatter(self) -> None:
+        text = "---\naction: comment\ndiscussion_number: 44\n---\n\nHello world"
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(metadata, {"action": "comment", "discussion_number": 44})
+        self.assertEqual(body, "Hello world")
+
+    def test_all_value_types(self) -> None:
+        text = (
+            "---\n"
+            "str_bare: hello\n"
+            'str_quoted: "hello: world"\n'
+            "num: 42\n"
+            "neg_num: -7\n"
+            "bool_t: true\n"
+            "bool_f: false\n"
+            "null_v: null\n"
+            'list_v: [a, "b: c"]\n'
+            "---\n\n"
+            "Body"
+        )
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["str_bare"], "hello")
+        self.assertEqual(metadata["str_quoted"], "hello: world")
+        self.assertEqual(metadata["num"], 42)
+        self.assertEqual(metadata["neg_num"], -7)
+        self.assertIs(metadata["bool_t"], True)
+        self.assertIs(metadata["bool_f"], False)
+        self.assertIsNone(metadata["null_v"])
+        self.assertEqual(metadata["list_v"], ["a", "b: c"])
+        self.assertEqual(body, "Body")
+
+    def test_empty_body(self) -> None:
+        text = "---\naction: plan\n---"
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["action"], "plan")
+        self.assertEqual(body, "")
+
+    def test_empty_body_trailing_newline(self) -> None:
+        text = "---\naction: plan\n---\n"
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(body, "")
+
+    def test_quoted_string_with_colons(self) -> None:
+        text = '---\npersona: "April Clearwater, Application Lead"\n---\n\nBody'
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["persona"], "April Clearwater, Application Lead")
+
+    def test_single_quoted_string(self) -> None:
+        text = "---\ntitle: 'hello world'\n---\n"
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["title"], "hello world")
+
+    def test_bare_string_with_spaces(self) -> None:
+        text = "---\npersona: April Clearwater, Application Lead\n---\n"
+        metadata, body = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["persona"], "April Clearwater, Application Lead")
+
+    def test_no_frontmatter_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            fm.parse_frontmatter("just plain text")
+
+    def test_no_closing_delimiter_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            fm.parse_frontmatter("---\nkey: value\nno closing")
+
+    def test_empty_inline_list(self) -> None:
+        text = "---\nlabels: []\n---\n"
+        metadata, _ = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["labels"], [])
+
+    def test_single_item_inline_list(self) -> None:
+        text = "---\nlabels: [enhancement]\n---\n"
+        metadata, _ = fm.parse_frontmatter(text)
+        self.assertEqual(metadata["labels"], ["enhancement"])
+
+
+class ParseMultiDocumentTests(unittest.TestCase):
+    def test_peter_planner_format(self) -> None:
+        text = (
+            "---\n"
+            "action: plan\n"
+            "discussion_number: 44\n"
+            "milestone_name: null\n"
+            "---\n"
+            "\n"
+            "---\n"
+            'title: "First issue title"\n'
+            "labels: [enhancement]\n"
+            "priority: 1\n"
+            "---\n"
+            "\n"
+            "## Context\n"
+            "Body one\n"
+            "\n"
+            "---\n"
+            'title: "Second issue title"\n'
+            'labels: [enhancement, "area: ui"]\n'
+            "priority: 2\n"
+            "---\n"
+            "\n"
+            "## Context\n"
+            "Body two"
+        )
+        docs = fm.parse_multi_document(text)
+        self.assertEqual(len(docs), 3)
+
+        header, header_body = docs[0]
+        self.assertEqual(header["action"], "plan")
+        self.assertEqual(header["discussion_number"], 44)
+        self.assertIsNone(header["milestone_name"])
+        self.assertEqual(header_body, "")
+
+        issue1_meta, issue1_body = docs[1]
+        self.assertEqual(issue1_meta["title"], "First issue title")
+        self.assertEqual(issue1_meta["labels"], ["enhancement"])
+        self.assertEqual(issue1_meta["priority"], 1)
+        self.assertIn("Body one", issue1_body)
+
+        issue2_meta, issue2_body = docs[2]
+        self.assertEqual(issue2_meta["title"], "Second issue title")
+        self.assertEqual(issue2_meta["labels"], ["enhancement", "area: ui"])
+        self.assertEqual(issue2_meta["priority"], 2)
+        self.assertIn("Body two", issue2_body)
+
+    def test_single_document_via_multi(self) -> None:
+        text = "---\naction: comment\n---\n\nBody text"
+        docs = fm.parse_multi_document(text)
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0][0]["action"], "comment")
+        self.assertEqual(docs[0][1], "Body text")
+
+    def test_body_with_hr_in_code_fence(self) -> None:
+        text = (
+            "---\n"
+            "action: plan\n"
+            "---\n"
+            "\n"
+            "---\n"
+            "title: Issue\n"
+            "---\n"
+            "\n"
+            "```markdown\n"
+            "---\n"
+            "```\n"
+            "\n"
+            "After fence"
+        )
+        docs = fm.parse_multi_document(text)
+        self.assertEqual(len(docs), 2)
+        self.assertIn("---", docs[1][1])
+        self.assertIn("After fence", docs[1][1])
+
+    def test_body_with_standalone_hr(self) -> None:
+        """A bare --- in the body (not followed by YAML) is kept as body text."""
+        text = (
+            "---\n"
+            "title: Issue\n"
+            "---\n"
+            "\n"
+            "Before\n"
+            "\n"
+            "---\n"
+            "\n"
+            "After"
+        )
+        docs = fm.parse_multi_document(text)
+        self.assertEqual(len(docs), 1)
+        self.assertIn("Before", docs[0][1])
+        self.assertIn("---", docs[0][1])
+        self.assertIn("After", docs[0][1])
+
+    def test_no_frontmatter_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            fm.parse_multi_document("plain text with no delimiters")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -301,7 +301,22 @@ class RunPlannerTests(unittest.TestCase):
 
     def test_load_plan_output_uses_fixture_file_without_claude(self) -> None:
         discussion = self.make_discussion()
-        fixture = '{"action":"plan","discussion_number":43,"milestone_name":null,"issues":[{"title":"Audit runners","body":"## Context\\nBody","labels":["ci"],"priority":1}]}'
+        fixture = (
+            "---\n"
+            "action: plan\n"
+            "discussion_number: 43\n"
+            "milestone_name: null\n"
+            "---\n"
+            "\n"
+            "---\n"
+            "title: Audit runners\n"
+            "labels: [ci]\n"
+            "priority: 1\n"
+            "---\n"
+            "\n"
+            "## Context\n"
+            "Body"
+        )
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             handle.write(fixture)
             fixture_path = Path(handle.name)
@@ -309,6 +324,7 @@ class RunPlannerTests(unittest.TestCase):
             discussion_number=43,
             dry_run=True,
             plan_file=fixture_path,
+            mode="cli",
         )
         try:
             with mock.patch.object(run_planner, "run_claude", side_effect=AssertionError("should not run")):

--- a/.agents/scripts/validate-agent-output.py
+++ b/.agents/scripts/validate-agent-output.py
@@ -3,21 +3,37 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Validate and extract JSON output from agent responses.
+"""Validate and extract structured output from agent responses.
 
-Reads agent output from stdin, extracts JSON from ```json fences,
-validates required fields, optionally checks for duplicate discussions.
+Reads agent output from stdin, extracts data from YAML frontmatter
+(preferred) or ```json fences (fallback), validates required fields,
+optionally checks for duplicate discussions.
 
 Usage:
     cat response.txt | ./validate-agent-output.py [--check-dedup]
 """
 
+import importlib.util
 import json
 import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
+
+
+def _load_frontmatter_parser():
+    spec = importlib.util.spec_from_file_location(
+        "parse_frontmatter",
+        Path(__file__).parent / "parse-frontmatter.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+_fm = _load_frontmatter_parser()
 
 REQUIRED_FIELDS: dict[str, list[str]] = {
     "propose": ["title", "body", "persona"],
@@ -37,6 +53,32 @@ def extract_json(text: str) -> dict:
     match = re.search(r"```json\s*\n(.*?)\n\s*```", text, re.DOTALL)
     raw = match.group(1) if match else text.strip()
     return json.loads(raw)
+
+
+def extract_structured(text: str) -> dict:
+    """Extract structured data from YAML frontmatter or ```json fences."""
+    stripped = text.strip()
+    if stripped.startswith("---"):
+        try:
+            documents = _fm.parse_multi_document(stripped)
+            if len(documents) > 1 and documents[0][0].get("action") == "plan":
+                header, _ = documents[0]
+                issues = []
+                for metadata, body in documents[1:]:
+                    issue = dict(metadata)
+                    issue["body"] = body
+                    issues.append(issue)
+                result = dict(header)
+                result["issues"] = issues
+                return result
+            metadata, body = documents[0]
+            if body:
+                metadata["body"] = body
+            return metadata
+        except (ValueError, IndexError):
+            pass
+
+    return extract_json(stripped)
 
 
 def normalize_title(title: str) -> str:
@@ -134,9 +176,9 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        data = extract_json(text)
-    except (json.JSONDecodeError, AttributeError) as e:
-        print(f"error: failed to parse JSON: {e}", file=sys.stderr)
+        data = extract_structured(text)
+    except (json.JSONDecodeError, ValueError, AttributeError) as e:
+        print(f"error: failed to parse output: {e}", file=sys.stderr)
         print(f"raw input (first 500 chars): {text[:500]}", file=sys.stderr)
         sys.exit(1)
 

--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Run contributor
         run: |
           ARGS=(--prompt-file .agents/prompts/april-clearwater.md)
+          ARGS+=(--mode cli)
           if [ "$DRY_RUN" = "true" ]; then
             ARGS+=(--dry-run)
           fi

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Run contributor
         run: |
           ARGS=(--prompt-file .agents/prompts/plat-ironwood.md)
+          ARGS+=(--mode cli)
           if [ "$DRY_RUN" = "true" ]; then
             ARGS+=(--dry-run)
           fi


### PR DESCRIPTION
## Summary

- **YAML frontmatter output** replaces JSON for all three agents (April, Plat, Peter), eliminating JSON escaping failures when markdown body contains unescaped quotes
- **CLI agentic loop mode** (`--mode cli`, now default) gives agents real tool access (Read, Grep, Glob, scoped Bash) with budget caps instead of blind single-turn `--print`
- **Frontmatter parser** (`parse-frontmatter.py`) is stdlib-only, handles multi-document format for Peter Planner, and the validator falls back to JSON for backward compat

### Files changed (11)

| File | Change |
|------|--------|
| `parse-frontmatter.py` | New stdlib YAML frontmatter parser |
| `test_parse_frontmatter.py` | 16 tests for parser |
| `validate-agent-output.py` | Frontmatter-first parsing, JSON fallback |
| `run-contributor.py` | `--mode cli\|print`, tools/budget/permissions |
| `run-planner.py` | `--mode cli\|print`, remove timeout helper |
| `test_run_planner.py` | Updated fixtures, removed dead test |
| `april-clearwater.md` | YAML frontmatter output format |
| `plat-ironwood.md` | YAML frontmatter output format |
| `peter-planner.md` | Multi-document YAML frontmatter |
| `agent-april.yml` | `--mode cli` |
| `agent-plat.yml` | `--mode cli` |

### Conflict resolution

Rebased onto main after #101 (required timeouts). Merged upstream's `GITHUB_API_TIMEOUT`/`CLAUDE_TIMEOUT`/`VALIDATION_TIMEOUT` constants with mode-conditional logic — print mode uses `CLAUDE_TIMEOUT` (300s), CLI mode overrides to 600s safety net alongside `--max-budget-usd`.

## Test plan

- [x] `uv run .agents/scripts/test_parse_frontmatter.py` — 16 tests pass
- [x] `uv run .agents/scripts/test_run_planner.py` — 12 tests pass
- [x] Validator accepts single frontmatter, multi-doc frontmatter, and JSON fallback
- [ ] Dry-run workflow dispatch with `dry_run: true` for April and Plat
- [ ] Verify `--print` + `--tools` enables multi-turn tool use in CLI mode (plan open question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)