### PR TITLE
fix: prefer engagement before new agent proposals

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from unittest import mock
 from pathlib import Path
 
@@ -540,6 +541,86 @@ class RunContributorTests(unittest.TestCase):
         self.assertIn("Revised take", threads[0]["agent_item"]["body"])
         self.assertEqual(len(threads[0]["replies"]), 1)
         self.assertIn("Looks good now", threads[0]["replies"][0]["body"])
+
+    def test_find_discussions_needing_engagement_prefers_recent_other_agent_thread(self) -> None:
+        now = datetime(2026, 3, 16, 0, 0, tzinfo=timezone.utc)
+        discussions = [
+            {
+                "number": 111,
+                "title": "[idea] Split release workflow",
+                "body": "*Proposed by Plat Ironwood, Platform Lead*\n\nIdea body",
+                "createdAt": "2026-03-15T20:46:59Z",
+                "comments": {
+                    "nodes": [],
+                    "totalCount": 0,
+                },
+            },
+            {
+                "number": 109,
+                "title": "[idea] Fix remote workspace identity",
+                "body": "*Proposed by April Clearwater, Application Lead*\n\nIdea body",
+                "createdAt": "2026-03-15T16:25:01Z",
+                "comments": {
+                    "nodes": [],
+                    "totalCount": 0,
+                },
+            },
+        ]
+        candidates = run_contributor.find_discussions_needing_engagement(
+            discussions,
+            owner_login="fairchild",
+            persona="April Clearwater",
+            now=now,
+        )
+        self.assertEqual(candidates[0]["number"], 111)
+        self.assertIn("Plat Ironwood opened this", candidates[0]["reasons"][0])
+
+    def test_find_discussions_needing_engagement_marks_low_comment_and_missing_owner_reply(self) -> None:
+        now = datetime(2026, 3, 16, 0, 0, tzinfo=timezone.utc)
+        discussions = [
+            {
+                "number": 110,
+                "title": "[idea] Fix environment status color semantics",
+                "body": "*Proposed by April Clearwater, Application Lead*\n\nIdea body",
+                "createdAt": "2026-03-15T16:49:20Z",
+                "comments": {
+                    "nodes": [
+                        {
+                            "body": "One comment",
+                            "author": {"login": "workspace-agents"},
+                            "createdAt": "2026-03-15T18:00:00Z",
+                        }
+                    ],
+                    "totalCount": 1,
+                },
+            }
+        ]
+        candidates = run_contributor.find_discussions_needing_engagement(
+            discussions,
+            owner_login="fairchild",
+            persona="April Clearwater",
+            now=now,
+        )
+        self.assertEqual(candidates[0]["number"], 110)
+        self.assertIn("only 1 comment", candidates[0]["reasons"])
+        self.assertIn("no owner reply yet", candidates[0]["reasons"])
+
+    def test_maybe_block_new_proposal_returns_top_candidate(self) -> None:
+        validated_json = '{"action":"propose","title":"[idea] New thread"}'
+        candidates = [
+            {
+                "number": 111,
+                "title": "[idea] Split release workflow",
+                "reasons": ["0 comments", "no owner reply yet"],
+            }
+        ]
+        blocked = run_contributor.maybe_block_new_proposal(validated_json, candidates)
+        self.assertEqual(blocked["number"], 111)
+
+    def test_maybe_block_new_proposal_ignores_comment_action(self) -> None:
+        validated_json = '{"action":"comment","discussion_number":111}'
+        blocked = run_contributor.maybe_block_new_proposal(validated_json, [{"number": 111}])
+        self.assertIsNone(blocked)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cofounder-contributor/references/april-clearwater.md
+++ b/.agents/skills/cofounder-contributor/references/april-clearwater.md
@@ -22,7 +22,13 @@ Work through this list in order. If an item applies, do it.
 
 3. **Discussions** — Always participate. Discussions are where ideas form, get refined, and get endorsed. Read open discussions and their comments, then either:
    - **Comment on an existing discussion** — agree, push back, refine, ask a question, or build on someone's point. Respond to what others have said. If you endorse an idea, say why. If you disagree, say what you'd do instead.
-   - **Propose a new idea** — if no existing discussion needs your voice, start one. Scope to 1-3 sessions of work. Do NOT duplicate existing open discussions, open issues, or active backlog items. Good proposals spot opportunities others haven't noticed — patterns in recent commits, UX friction you'd want fixed, technical debt that's about to bite.
+   - **Propose a new idea** — only if no existing discussion needs your voice. Scope to 1-3 sessions of work. Do NOT duplicate existing open discussions, open issues, or active backlog items. Good proposals spot opportunities others haven't noticed — patterns in recent commits, UX friction you'd want fixed, technical debt that's about to bite.
+
+Before proposing anything new, prefer depth over breadth:
+- If any open `[idea]` discussion has 0 or 1 comments, comment on an existing thread instead of opening a new one.
+- If any open `[idea]` discussion has no owner reply yet, comment on an existing thread instead of opening a new one.
+- If Plat opened a new `[idea]` discussion in the last 72 hours, default to replying there unless you have strong evidence it is off-track.
+- Only propose a new idea when there are no unattended `[idea]` threads left to deepen.
 
 Do NOT comment on issues. Issues are execution artifacts — they get worked when someone picks them up. Your value is in shaping direction through discussion, not writing implementation plans nobody asked for.
 

--- a/.agents/skills/cofounder-contributor/references/plat-ironwood.md
+++ b/.agents/skills/cofounder-contributor/references/plat-ironwood.md
@@ -22,7 +22,13 @@ Work through this list in order. If an item applies, do it.
 
 3. **Discussions** — Always participate. Discussions are where ideas form, get refined, and get endorsed. Read open discussions and their comments, then either:
    - **Comment on an existing discussion** — agree, push back, refine, ask a question, or build on someone's point. Respond to what others have said. If you endorse an idea, say why. If you disagree, say what you'd do instead.
-   - **Propose a new idea** — if no existing discussion needs your voice, start one. Scope to 1-3 sessions of work. Do NOT duplicate existing open discussions, open issues, or active backlog items. Good proposals spot opportunities others haven't noticed — patterns in recent commits, CI gaps, infrastructure risks, testing blind spots.
+   - **Propose a new idea** — only if no existing discussion needs your voice. Scope to 1-3 sessions of work. Do NOT duplicate existing open discussions, open issues, or active backlog items. Good proposals spot opportunities others haven't noticed — patterns in recent commits, CI gaps, infrastructure risks, testing blind spots.
+
+Before proposing anything new, prefer depth over breadth:
+- If any open `[idea]` discussion has 0 or 1 comments, comment on an existing thread instead of opening a new one.
+- If any open `[idea]` discussion has no owner reply yet, comment on an existing thread instead of opening a new one.
+- If April opened a new `[idea]` discussion in the last 72 hours, default to replying there unless you have strong evidence it is off-track.
+- Only propose a new idea when there are no unattended `[idea]` threads left to deepen.
 
 Do NOT comment on issues. Issues are execution artifacts — they get worked when someone picks them up. Your value is in shaping direction through discussion, not writing implementation plans nobody asked for.
 

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -41,6 +43,8 @@ VALIDATOR_SCRIPT = SKILL_ROOT / "scripts" / "validate-agent-output.py"
 GITHUB_API_TIMEOUT = 30
 CLAUDE_TIMEOUT = 300
 VALIDATION_TIMEOUT = 30
+ENGAGEMENT_RECENT_HOURS = 72
+LOW_COMMENT_THRESHOLD = 1
 
 
 def parse_args() -> argparse.Namespace:
@@ -459,7 +463,174 @@ def detect_bot_login(env: dict[str, str]) -> str:
     return login
 
 
-def gather_context(env: dict[str, str], persona: str = "", bot_login: str = "") -> str:
+def _parse_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _normalize_login(login: str) -> str:
+    return login.removesuffix("[bot]").strip().casefold()
+
+
+def _extract_proposed_persona(body: str) -> str:
+    match = re.search(r"\*Proposed by ([^*\n]+)\*", body)
+    if not match:
+        return ""
+    return match.group(1).split(",", 1)[0].strip()
+
+
+def _is_idea_discussion(title: str) -> bool:
+    return "[idea]" in title.casefold()
+
+
+def format_open_discussions(discussions: list[dict[str, object]]) -> str:
+    lines: list[str] = []
+    for disc in discussions:
+        comments = disc.get("comments", {})
+        comment_nodes = comments.get("nodes", []) if isinstance(comments, dict) else []
+        comment_count = comments.get("totalCount", len(comment_nodes)) if isinstance(comments, dict) else 0
+        category = disc.get("category", {})
+        category_name = category.get("name", "Unknown") if isinstance(category, dict) else "Unknown"
+        line = (
+            f"#{disc.get('number')} [{category_name}] {disc.get('title')} "
+            f"({comment_count} comments)"
+        )
+        previews: list[str] = []
+        for comment in comment_nodes[:2]:
+            author = (comment.get("author") or {}).get("login", "unknown")
+            body = str(comment.get("body", "")).replace("\n", " ")[:200]
+            previews.append(f"  -> {author}: {body}")
+        if previews:
+            line = f"{line}\n" + "\n".join(previews)
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def find_discussions_needing_engagement(
+    discussions: list[dict[str, object]],
+    *,
+    owner_login: str,
+    persona: str,
+    now: datetime | None = None,
+) -> list[dict[str, object]]:
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    owner = _normalize_login(owner_login)
+    current_persona = persona.casefold()
+    candidates: list[dict[str, object]] = []
+
+    for disc in discussions:
+        title = str(disc.get("title", ""))
+        if not _is_idea_discussion(title):
+            continue
+
+        body = str(disc.get("body", ""))
+        comments = disc.get("comments", {})
+        comment_nodes = comments.get("nodes", []) if isinstance(comments, dict) else []
+        comment_count = comments.get("totalCount", len(comment_nodes)) if isinstance(comments, dict) else 0
+        proposed_by = _extract_proposed_persona(body)
+        created_at = _parse_timestamp(str(disc.get("createdAt", "")))
+        age = now - created_at if created_at is not None else None
+        owner_replied = any(
+            _normalize_login((comment.get("author") or {}).get("login", "")) == owner
+            for comment in comment_nodes
+        )
+        other_agent_recent = bool(
+            proposed_by
+            and proposed_by.casefold() != current_persona
+            and age is not None
+            and age <= timedelta(hours=ENGAGEMENT_RECENT_HOURS)
+        )
+
+        reasons: list[str] = []
+        if other_agent_recent:
+            age_hours = max(1, int(age.total_seconds() // 3600)) if age is not None else ENGAGEMENT_RECENT_HOURS
+            reasons.append(f"{proposed_by} opened this {age_hours}h ago")
+        if comment_count == 0:
+            reasons.append("0 comments")
+        elif comment_count <= LOW_COMMENT_THRESHOLD:
+            reasons.append("only 1 comment")
+        if not owner_replied:
+            reasons.append("no owner reply yet")
+
+        if not reasons:
+            continue
+
+        if other_agent_recent:
+            priority = 0
+        elif comment_count <= LOW_COMMENT_THRESHOLD:
+            priority = 1
+        else:
+            priority = 2
+
+        sort_timestamp = created_at.timestamp() if created_at is not None else 0.0
+        candidates.append(
+            {
+                "number": disc.get("number"),
+                "title": title,
+                "proposed_by": proposed_by,
+                "comment_count": comment_count,
+                "owner_replied": owner_replied,
+                "reasons": reasons,
+                "priority": priority,
+                "sort_timestamp": sort_timestamp,
+            }
+        )
+
+    candidates.sort(
+        key=lambda item: (
+            int(item["priority"]),
+            int(item["comment_count"]),
+            -float(item["sort_timestamp"]),
+        )
+    )
+    return candidates
+
+
+def format_engagement_candidates(candidates: list[dict[str, object]]) -> str:
+    if not candidates:
+        return ""
+
+    lines = ["PRIORITY — discussions needing engagement before new proposals:\n"]
+    for candidate in candidates[:5]:
+        reasons = ", ".join(str(reason) for reason in candidate["reasons"])
+        lines.append(
+            f"  Discussion #{candidate['number']} — {candidate['title']}\n"
+            f"    Reasons: {reasons}"
+        )
+    return "\n".join(lines)
+
+
+def build_engagement_retry_message(candidate: dict[str, object]) -> str:
+    reasons = ", ".join(str(reason) for reason in candidate["reasons"])
+    return (
+        "Do not propose a new discussion. Comment on the existing discussion "
+        f"#{candidate['number']} instead and help move that thread forward. "
+        f"It needs engagement because: {reasons}. Respond to the existing thesis, "
+        "refine the scope, or ask one concrete question that advances the thread."
+    )
+
+
+def maybe_block_new_proposal(
+    validated_json: str,
+    engagement_candidates: list[dict[str, object]],
+) -> dict[str, object] | None:
+    data = json.loads(validated_json)
+    if data.get("action") != "propose" or not engagement_candidates:
+        return None
+    return engagement_candidates[0]
+
+
+def gather_context(
+    env: dict[str, str],
+    persona: str = "",
+    bot_login: str = "",
+) -> tuple[str, list[dict[str, object]]]:
     log("Gathering context")
     owner, name = repo_owner_name(env)
 
@@ -473,13 +644,13 @@ def gather_context(env: dict[str, str], persona: str = "", bot_login: str = "") 
     discussions_query = """
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
-    discussions(first: 30, states: OPEN) {
+    discussions(first: 30, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes {
-        number title
+        number title body createdAt updatedAt
         category { name }
         author { login }
         comments(first: 5) {
-          nodes { body author { login } }
+          nodes { body author { login } createdAt }
           totalCount
         }
       }
@@ -487,7 +658,7 @@ query($owner: String!, $name: String!) {
   }
 }
 """
-    discussions = run_optional(
+    discussions_raw = run_optional(
         [
             "gh",
             "api",
@@ -498,20 +669,29 @@ query($owner: String!, $name: String!) {
             f"owner={owner}",
             "-f",
             f"name={name}",
-            "--jq",
-            (
-                '.data.repository.discussions.nodes[] | '
-                '"#\\(.number) [\\(.category.name)] \\(.title) '
-                '(\\(.comments.totalCount) comments)'
-                '\\(.comments.nodes[:2] | map("\\n  -> \\(.author.login): '
-                '\\(.body[:200] | gsub(\\"\\n\\";\\" \\"))") | join(""))"'
-            ),
         ],
         timeout=GITHUB_API_TIMEOUT,
         cwd=REPO_ROOT,
         env=env,
         default="",
     ).rstrip()
+    try:
+        discussions_data = json.loads(discussions_raw) if discussions_raw else {}
+    except json.JSONDecodeError:
+        discussions_data = {}
+    discussion_nodes = (
+        discussions_data.get("data", {})
+        .get("repository", {})
+        .get("discussions", {})
+        .get("nodes", [])
+    )
+    discussions = format_open_discussions(discussion_nodes)
+    engagement_candidates = find_discussions_needing_engagement(
+        discussion_nodes,
+        owner_login=owner,
+        persona=persona,
+    )
+    engagement_summary = format_engagement_candidates(engagement_candidates)
 
     open_issues = run_optional(
         [
@@ -556,6 +736,8 @@ query($owner: String!, $name: String!) {
     sections = []
     if pending_reviews:
         sections.append(pending_reviews)
+    if engagement_summary:
+        sections.append(engagement_summary)
     sections.extend([
         f"Recent commits (last 2 weeks):\n{recent_commits}",
         f"Open discussions:\n{discussions}",
@@ -565,7 +747,7 @@ query($owner: String!, $name: String!) {
     ])
     if history:
         sections.append(history)
-    return "\n\n".join(sections)
+    return "\n\n".join(sections), engagement_candidates
 
 
 def run_claude(
@@ -737,7 +919,7 @@ def main() -> int:
     bot_login = detect_bot_login(env)
     if bot_login:
         log(f"Authenticated as {bot_login}")
-    context = gather_context(env, persona=persona, bot_login=bot_login)
+    context, engagement_candidates = gather_context(env, persona=persona, bot_login=bot_login)
     raw_output = run_claude(prompt_file, context, env, mode=args.mode, message=args.message)
     exit_code, validated_json, error_text = validate_output(raw_output, env)
 
@@ -748,6 +930,35 @@ def main() -> int:
         print("--- Raw output ---", file=sys.stderr)
         print(raw_output, file=sys.stderr)
         return 1
+
+    if not args.message:
+        blocked_candidate = maybe_block_new_proposal(validated_json, engagement_candidates)
+        if blocked_candidate is not None:
+            log(
+                "Blocking new proposal because existing discussions need engagement: "
+                f"#{blocked_candidate['number']}"
+            )
+            retry_message = build_engagement_retry_message(blocked_candidate)
+            raw_output = run_claude(
+                prompt_file,
+                context,
+                env,
+                mode=args.mode,
+                message=retry_message,
+            )
+            exit_code, validated_json, error_text = validate_output(raw_output, env)
+            if exit_code != 0 or validated_json is None:
+                print("--- Raw output ---", file=sys.stderr)
+                print(raw_output, file=sys.stderr)
+                return 1
+            if json.loads(validated_json).get("action") == "propose":
+                print(
+                    "error: contributor proposed a new idea despite engagement policy",
+                    file=sys.stderr,
+                )
+                print("--- Raw output ---", file=sys.stderr)
+                print(raw_output, file=sys.stderr)
+                return 1
 
     result = route_action(validated_json, args.dry_run, env)
     if result == 0:


### PR DESCRIPTION
## Summary
- rank open idea discussions that need engagement before proposing new ones
- block new proposal actions in the contributor runtime and retry as a directed comment
- align April and Plat prompts with the same engagement-first policy
- add contributor helper tests for engagement ranking and proposal blocking

## Verification
- uv run .agents/scripts/test_run_planner.py