### PR TITLE
Make Peter planner issues agent actionable

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -35,7 +35,7 @@ run_planner = load_module(
 )
 validator = load_module(
     "validate_agent_output",
-    REPO_ROOT / ".agents" / "skills" / "cofounder-contributor" / "scripts" / "validate-agent-output.py",
+    REPO_ROOT / ".agents" / "skills" / "peter-planner" / "scripts" / "validate-agent-output.py",
 )
 run_contributor = load_module(
     "run_contributor",
@@ -84,8 +84,69 @@ class ValidateAgentOutputTests(unittest.TestCase):
                     "discussion_number": 43,
                     "milestone_name": None,
                     "issues": [
-                        {"title": "One", "body": "A", "labels": ["enhancement"]},
-                        {"title": "one", "body": "B", "labels": ["enhancement"]},
+                        {
+                            "title": "One",
+                            "body": "A",
+                            "labels": ["enhancement"],
+                            "priority": 1,
+                            "blocked_by": [],
+                            "requested_evidence": ["swift test"],
+                        },
+                        {
+                            "title": "one",
+                            "body": "B",
+                            "labels": ["enhancement"],
+                            "priority": 2,
+                            "blocked_by": [],
+                            "requested_evidence": ["swift test"],
+                        },
+                    ],
+                }
+            )
+
+    def test_plan_requires_requested_evidence(self) -> None:
+        with self.assertRaises(validator.ValidationError):
+            validator.validate_data(
+                {
+                    "action": "plan",
+                    "discussion_number": 43,
+                    "milestone_name": None,
+                    "issues": [
+                        {
+                            "title": "One",
+                            "body": "A",
+                            "labels": ["enhancement"],
+                            "priority": 1,
+                            "blocked_by": [],
+                        }
+                    ],
+                }
+            )
+
+    def test_plan_rejects_duplicate_priorities(self) -> None:
+        with self.assertRaises(validator.ValidationError):
+            validator.validate_data(
+                {
+                    "action": "plan",
+                    "discussion_number": 43,
+                    "milestone_name": None,
+                    "issues": [
+                        {
+                            "title": "One",
+                            "body": "A",
+                            "labels": ["enhancement"],
+                            "priority": 1,
+                            "blocked_by": [],
+                            "requested_evidence": ["swift test"],
+                        },
+                        {
+                            "title": "Two",
+                            "body": "B",
+                            "labels": ["enhancement"],
+                            "priority": 1,
+                            "blocked_by": [],
+                            "requested_evidence": ["swift test"],
+                        },
                     ],
                 }
             )
@@ -102,8 +163,9 @@ class RunPlannerTests(unittest.TestCase):
             "comments": {"nodes": comments or []},
         }
 
-    def make_plan(self, issue_titles: list[str], discussion=None):
+    def make_plan(self, issue_titles: list[str], discussion=None, blocked_by_map=None):
         discussion = discussion or self.make_discussion()
+        blocked_by_map = blocked_by_map or {}
         return run_planner.normalize_plan(
             {
                 "action": "plan",
@@ -115,6 +177,8 @@ class RunPlannerTests(unittest.TestCase):
                         "body": f"## Context\n{title}",
                         "labels": ["ci"] if index == 0 else ["ui"],
                         "priority": index + 1,
+                        "blocked_by": blocked_by_map.get(index + 1, []),
+                        "requested_evidence": [f"Evidence for {title}"],
                     }
                     for index, title in enumerate(issue_titles)
                 ],
@@ -138,6 +202,54 @@ class RunPlannerTests(unittest.TestCase):
             "Isolate intrusive CI jobs onto a Tart VM runner lane",
         )
 
+    def test_normalize_plan_preserves_blocked_by_and_requested_evidence(self) -> None:
+        discussion = self.make_discussion()
+        plan = self.make_plan(
+            ["One", "Two"],
+            discussion=discussion,
+            blocked_by_map={2: [1]},
+        )
+        self.assertEqual(plan.issues[1].blocked_by, [1])
+        self.assertEqual(plan.issues[1].requested_evidence, ["Evidence for Two"])
+
+    def test_resolve_blocked_by_numbers_maps_plan_priorities(self) -> None:
+        discussion = self.make_discussion()
+        plan = self.make_plan(
+            ["One", "Two"],
+            discussion=discussion,
+            blocked_by_map={2: [1]},
+        )
+        blocked = run_planner.resolve_blocked_by_numbers(
+            plan.issues[1],
+            resolved_by_priority={1: 101},
+            plan_priorities={1, 2},
+        )
+        self.assertEqual(blocked, [101])
+
+    def test_normalize_plan_rejects_same_or_later_plan_blockers(self) -> None:
+        discussion = self.make_discussion()
+        with self.assertRaises(run_planner.PlannerError):
+            self.make_plan(
+                ["One", "Two"],
+                discussion=discussion,
+                blocked_by_map={1: [2]},
+            )
+
+    def test_compose_issue_body_renders_blocked_by_and_requested_evidence(self) -> None:
+        body = run_planner.compose_issue_body_with_metadata(
+            "## Context\nBody",
+            "https://github.com/fairchild/workspaces/discussions/43",
+            43,
+            "audit-runners",
+            blocked_by=[101],
+            requested_evidence=["swift test --filter WorkspaceProviders"],
+        )
+        self.assertIn("- Ship this issue as one PR.", body)
+        self.assertIn("## Blocked By", body)
+        self.assertIn("- #101", body)
+        self.assertIn("## Requested Evidence", body)
+        self.assertIn("swift test --filter WorkspaceProviders", body)
+
     def test_build_execution_state_reuses_marked_issue_and_milestone(self) -> None:
         discussion = self.make_discussion(
             comments=[
@@ -158,21 +270,42 @@ class RunPlannerTests(unittest.TestCase):
             {
                 "number": 101,
                 "title": plan.issues[0].title,
-                "body": plan.issues[0].body_with_marker,
+                "body": run_planner.compose_issue_body_with_metadata(
+                    plan.issues[0].body,
+                    discussion["url"],
+                    discussion["number"],
+                    plan.issues[0].slug,
+                    blocked_by=plan.issues[0].blocked_by,
+                    requested_evidence=plan.issues[0].requested_evidence,
+                ),
                 "url": "https://github.com/fairchild/workspaces/issues/101",
                 "labels": [],
             },
             {
                 "number": 102,
                 "title": plan.issues[1].title,
-                "body": plan.issues[1].body_with_marker,
+                "body": run_planner.compose_issue_body_with_metadata(
+                    plan.issues[1].body,
+                    discussion["url"],
+                    discussion["number"],
+                    plan.issues[1].slug,
+                    blocked_by=plan.issues[1].blocked_by,
+                    requested_evidence=plan.issues[1].requested_evidence,
+                ),
                 "url": "https://github.com/fairchild/workspaces/issues/102",
                 "labels": [],
             },
             {
                 "number": 103,
                 "title": plan.issues[2].title,
-                "body": plan.issues[2].body_with_marker,
+                "body": run_planner.compose_issue_body_with_metadata(
+                    plan.issues[2].body,
+                    discussion["url"],
+                    discussion["number"],
+                    plan.issues[2].slug,
+                    blocked_by=plan.issues[2].blocked_by,
+                    requested_evidence=plan.issues[2].requested_evidence,
+                ),
                 "url": "https://github.com/fairchild/workspaces/issues/103",
                 "labels": [],
             },
@@ -253,7 +386,14 @@ class RunPlannerTests(unittest.TestCase):
             {
                 "number": 101,
                 "title": plan.issues[0].title,
-                "body": plan.issues[0].body_with_marker,
+                "body": run_planner.compose_issue_body_with_metadata(
+                    plan.issues[0].body,
+                    discussion["url"],
+                    discussion["number"],
+                    plan.issues[0].slug,
+                    blocked_by=plan.issues[0].blocked_by,
+                    requested_evidence=plan.issues[0].requested_evidence,
+                ),
                 "url": "https://github.com/fairchild/workspaces/issues/101",
                 "labels": [],
             }

--- a/.agents/skills/peter-planner/references/peter-planner.md
+++ b/.agents/skills/peter-planner/references/peter-planner.md
@@ -7,9 +7,10 @@ You are Peter Planner. Your job is to convert approved ideas from GitHub Discuss
 You receive a discussion thread containing an approved idea and any human modifications or feedback. Your job:
 
 1. Read the full thread — original proposal, all comments, and especially the human's approval message (which may contain modifications or scope adjustments).
-2. Break the work into issues sized for one focused session each.
-3. Each issue must have clear acceptance criteria and reference relevant source files.
-4. Link every issue back to the originating discussion.
+2. Break the work into issues that should each ship as one reviewable PR.
+3. Keep issue bodies high-level and implementation-guiding, not micro-prescriptive. If one PR needs a few tightly coupled substeps, keep them in one issue and use a short checklist in the body instead of splitting it into extra issues.
+4. Each issue must have clear acceptance criteria, reference relevant source files, and include machine-readable execution metadata so coding agents can tell whether the issue is ready.
+5. Link every issue back to the originating discussion.
 
 ## Label Rules
 
@@ -24,13 +25,29 @@ Use only these labels:
 
 Do not invent new labels. `priority` is for sort order only, not labeling.
 
+## Execution Metadata
+
+For every planned issue include:
+
+- `priority`: unique integer sort order within the plan
+- `blocked_by`: list of integers
+- `requested_evidence`: list of strings
+
+Use `blocked_by` as the single dependency field:
+- Use issue priorities from this same plan when one planned issue depends on another planned issue
+- Use real GitHub issue numbers only when the blocker already exists outside this new plan
+- Use `[]` when the issue is ready immediately
+
+`requested_evidence` should describe the concrete proof the coding agent should attach to the PR or issue update, such as test commands, screenshots, artifact paths, or before/after perf data.
+
 ## Scoping Rules
 
-- **Small idea** (1 session) → 1 issue
-- **Medium idea** (2-3 sessions) → 2-3 issues with explicit priority order
-- **Larger scope** (3+ sessions) → create a milestone, then issues within it, prioritized
+- **Small idea** (1 reviewable PR) → 1 issue
+- **Medium idea** (2-3 reviewable PRs) → 2-3 issues with explicit priority order
+- **Larger scope** (3+ reviewable PRs) → create a milestone, then issues within it, prioritized
 
 Always respect scope guidance from the original proposal and any human modifications.
+Prefer fewer, higher-signal issues when substeps are tightly coupled enough to ship together in one PR.
 When 3+ issues are needed, derive `milestone_name` directly from the discussion title without inventing a synonym.
 
 ## Output Format
@@ -48,13 +65,21 @@ milestone_name: null
 title: "Clear, actionable issue title"
 labels: [enhancement]
 priority: 1
+blocked_by: []
+requested_evidence:
+  - "Relevant swift test command(s)"
+  - "Any screenshots, logs, or perf comparisons the PR should include"
 ---
 
 ## Context
 Link to discussion, brief summary
 
 ## What to do
-Specific changes with file references
+High-level changes with file references. Keep this focused on direction, not every edit.
+
+## Suggested Checklist
+- [ ] Optional tightly-coupled subtask
+- [ ] Optional tightly-coupled subtask
 
 ## Acceptance criteria
 - [ ] Testable criterion
@@ -64,6 +89,10 @@ Specific changes with file references
 title: "Second issue title"
 labels: [enhancement, "area: ui"]
 priority: 2
+blocked_by: [1]
+requested_evidence:
+  - "Screenshot from the exact commit under review"
+  - "Targeted test command covering the changed surface"
 ---
 
 ## Context

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -103,7 +103,8 @@ class NormalizedIssue:
     labels: list[str]
     priority: int
     slug: str
-    body_with_marker: str
+    blocked_by: list[int]
+    requested_evidence: list[str]
 
 
 @dataclass(frozen=True)
@@ -441,12 +442,45 @@ def compose_summary_comment(
 
 
 def compose_issue_body(body: str, discussion_url: str, discussion_number: int, slug: str) -> str:
-    return (
-        f"{body.rstrip()}\n\n"
-        "---\n"
-        f"*Planned from [discussion #{discussion_number}]({discussion_url}) by Peter Planner.*\n"
-        f"{issue_marker(discussion_number, slug)}"
+    return compose_issue_body_with_metadata(
+        body,
+        discussion_url,
+        discussion_number,
+        slug,
+        blocked_by=[],
+        requested_evidence=[],
     )
+
+
+def compose_issue_body_with_metadata(
+    body: str,
+    discussion_url: str,
+    discussion_number: int,
+    slug: str,
+    *,
+    blocked_by: list[int],
+    requested_evidence: list[str],
+) -> str:
+    lines = [body.rstrip(), "", "## Execution", "- Ship this issue as one PR."]
+    lines.extend(["", "## Blocked By"])
+    if blocked_by:
+        lines.extend(f"- #{number}" for number in blocked_by)
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Requested Evidence"])
+    if requested_evidence:
+        lines.extend(f"- {item}" for item in requested_evidence)
+    else:
+        lines.append("- Follow the repo evidence bar for the touched surfaces.")
+    lines.extend(
+        [
+            "",
+            "---",
+            f"*Planned from [discussion #{discussion_number}]({discussion_url}) by Peter Planner.*",
+            issue_marker(discussion_number, slug),
+        ]
+    )
+    return "\n".join(lines)
 
 
 def compose_milestone_description(discussion_url: str, discussion_number: int) -> str:
@@ -484,6 +518,69 @@ def normalize_labels(raw_labels: list[str] | None, catalog: LabelCatalog) -> lis
     return unique_preserving_order(labels)
 
 
+def normalize_blocked_by(raw_blocked_by: list[Any] | None, issue_title: str) -> list[int]:
+    if raw_blocked_by is None:
+        return []
+    if not isinstance(raw_blocked_by, list):
+        raise PlannerError(f"issue '{issue_title}' has invalid blocked_by field")
+    normalized: list[int] = []
+    for item in raw_blocked_by:
+        if not isinstance(item, int) or item <= 0:
+            raise PlannerError(
+                f"issue '{issue_title}' blocked_by values must be positive integers"
+            )
+        normalized.append(item)
+    return unique_preserving_order(normalized)
+
+
+def normalize_requested_evidence(
+    raw_requested_evidence: list[Any] | None,
+    issue_title: str,
+) -> list[str]:
+    if raw_requested_evidence is None or not isinstance(raw_requested_evidence, list):
+        raise PlannerError(f"issue '{issue_title}' is missing requested_evidence")
+    normalized: list[str] = []
+    for item in raw_requested_evidence:
+        if not isinstance(item, str) or not item.strip():
+            raise PlannerError(
+                f"issue '{issue_title}' requested_evidence entries must be non-empty strings"
+            )
+        normalized.append(item.strip())
+    if not normalized:
+        raise PlannerError(f"issue '{issue_title}' must request at least one evidence item")
+    return unique_preserving_order(normalized)
+
+
+def validate_plan_dependencies(issues: list[NormalizedIssue]) -> None:
+    priorities = {issue.priority for issue in issues}
+    if len(priorities) != len(issues):
+        raise PlannerError("planner returned duplicate issue priorities")
+    for issue in issues:
+        for blocker in issue.blocked_by:
+            if blocker in priorities and blocker >= issue.priority:
+                raise PlannerError(
+                    f"issue '{issue.title}' cannot be blocked by same-or-later plan priority {blocker}"
+                )
+
+
+def resolve_blocked_by_numbers(
+    issue_plan: NormalizedIssue,
+    resolved_by_priority: dict[int, int],
+    plan_priorities: set[int],
+) -> list[int]:
+    blocked_numbers: list[int] = []
+    for blocker in issue_plan.blocked_by:
+        if blocker in resolved_by_priority:
+            blocked_numbers.append(resolved_by_priority[blocker])
+            continue
+        if blocker in plan_priorities:
+            raise PlannerError(
+                f"issue '{issue_plan.title}' references unresolved plan priority {blocker}"
+            )
+        blocked_numbers.append(blocker)
+    return unique_preserving_order(blocked_numbers)
+
+
 def normalize_plan(
     data: dict[str, Any],
     discussion: dict[str, Any],
@@ -508,14 +605,14 @@ def normalize_plan(
                 labels=normalize_labels(item.get("labels"), catalog),
                 priority=int(item.get("priority", 99)),
                 slug=slug,
-                body_with_marker=compose_issue_body(
-                    body,
-                    discussion["url"],
-                    int(discussion["number"]),
-                    slug,
+                blocked_by=normalize_blocked_by(item.get("blocked_by"), title),
+                requested_evidence=normalize_requested_evidence(
+                    item.get("requested_evidence"),
+                    title,
                 ),
             )
         )
+    validate_plan_dependencies(normalized_issues)
 
     return NormalizedPlan(
         discussion_number=int(discussion["number"]),
@@ -542,7 +639,8 @@ def serialize_plan(plan: NormalizedPlan) -> dict[str, Any]:
                 "labels": issue.labels,
                 "priority": issue.priority,
                 "slug": issue.slug,
-                "body_with_marker": issue.body_with_marker,
+                "blocked_by": issue.blocked_by,
+                "requested_evidence": issue.requested_evidence,
             }
             for issue in plan.issues
         ],
@@ -974,10 +1072,22 @@ def ensure_issue(
     issue_plan: NormalizedIssue,
     existing_issue: dict[str, Any] | None,
     milestone_name: str | None,
+    discussion_url: str,
+    discussion_number: int,
+    blocked_by_numbers: list[int],
     env: dict[str, str],
 ) -> dict[str, Any]:
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
-        handle.write(issue_plan.body_with_marker)
+        handle.write(
+            compose_issue_body_with_metadata(
+                issue_plan.body,
+                discussion_url=discussion_url,
+                discussion_number=discussion_number,
+                slug=issue_plan.slug,
+                blocked_by=blocked_by_numbers,
+                requested_evidence=issue_plan.requested_evidence,
+            )
+        )
         body_file = handle.name
 
     try:
@@ -1160,10 +1270,26 @@ def main() -> int:
         add_discussion_comment(discussion["id"], compose_ack_comment(number, env), env)
 
     milestone = create_or_reuse_milestone(repo, number, normalized, execution, env)
-    resolved_issues = [
-        ensure_issue(item.issue, item.existing_issue, normalized.milestone_name, env)
-        for item in execution.issues
-    ]
+    plan_priorities = {issue.priority for issue in normalized.issues}
+    resolved_by_priority: dict[int, int] = {}
+    resolved_issues: list[dict[str, Any]] = []
+    for item in execution.issues:
+        blocked_by_numbers = resolve_blocked_by_numbers(
+            item.issue,
+            resolved_by_priority,
+            plan_priorities,
+        )
+        resolved_issue = ensure_issue(
+            item.issue,
+            item.existing_issue,
+            normalized.milestone_name,
+            normalized.discussion_url,
+            normalized.discussion_number,
+            blocked_by_numbers,
+            env,
+        )
+        resolved_by_priority[item.issue.priority] = int(resolved_issue["number"])
+        resolved_issues.append(resolved_issue)
     if not resolved_issues:
         raise PlannerError(f"planner produced zero issues for discussion #{number}")
 

--- a/.agents/skills/peter-planner/scripts/validate-agent-output.py
+++ b/.agents/skills/peter-planner/scripts/validate-agent-output.py
@@ -148,6 +148,7 @@ def validate_plan(data: dict[str, Any]) -> None:
         raise ValidationError("field 'issues' must be a non-empty list")
 
     seen_titles: set[str] = set()
+    seen_priorities: set[int] = set()
     for index, issue in enumerate(issues, start=1):
         if not isinstance(issue, dict):
             raise ValidationError(f"issue #{index} must be an object")
@@ -160,11 +161,33 @@ def validate_plan(data: dict[str, Any]) -> None:
             raise ValidationError(f"duplicate issue title in plan: '{title}'")
         seen_titles.add(title_key)
 
+        priority = issue.get("priority")
+        if not isinstance(priority, int) or priority <= 0:
+            raise ValidationError(f"field 'issues[{index}].priority' must be a positive integer")
+        if priority in seen_priorities:
+            raise ValidationError(f"duplicate issue priority in plan: '{priority}'")
+        seen_priorities.add(priority)
+
         labels = issue.get("labels")
-        if labels is None:
-            continue
-        if not isinstance(labels, list) or any(not isinstance(label, str) or not label.strip() for label in labels):
+        if labels is not None and (
+            not isinstance(labels, list)
+            or any(not isinstance(label, str) or not label.strip() for label in labels)
+        ):
             raise ValidationError(f"field 'issues[{index}].labels' must be a list of non-empty strings")
+
+        blocked_by = issue.get("blocked_by", [])
+        if not isinstance(blocked_by, list) or any(not isinstance(value, int) or value <= 0 for value in blocked_by):
+            raise ValidationError(f"field 'issues[{index}].blocked_by' must be a list of positive integers")
+
+        requested_evidence = issue.get("requested_evidence")
+        if (
+            not isinstance(requested_evidence, list)
+            or not requested_evidence
+            or any(not isinstance(value, str) or not value.strip() for value in requested_evidence)
+        ):
+            raise ValidationError(
+                f"field 'issues[{index}].requested_evidence' must be a non-empty list of strings"
+            )
 
 
 def validate_data(data: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- update Peter's planning prompt so each issue maps to one reviewable PR and carries `blocked_by` plus `requested_evidence`
- teach the planner runtime to validate and resolve `blocked_by` dependencies and render execution metadata into created issue bodies
- expand planner tests to cover the new schema and dependency rules

## Testing
- uv run .agents/scripts/test_run_planner.py