### PR TITLE
fix: run contributor agents on ubuntu hosted runners

### DIFF
--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -28,7 +28,8 @@ concurrency:
 
 jobs:
   run:
-    runs-on: macos-17
+    # Contributor automation is CLI-only; keep it on the broadly available hosted lane.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Generate app token

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -28,7 +28,8 @@ concurrency:
 
 jobs:
   run:
-    runs-on: macos-17
+    # Contributor automation is CLI-only; keep it on the broadly available hosted lane.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Generate app token


### PR DESCRIPTION
## Summary
- move the April and Plat contributor workflows back to `ubuntu-latest`
- keep the contributor execution-flow changes from `4e1aa34`
- document inline why these workflows should stay on the broadly available hosted lane

## Why
The contributor workflows are CLI-only and do not require a macOS runner. The queue regression started when `4e1aa34` changed them from `ubuntu-latest` to `macos-17`.

GitHub job metadata for the stuck runs showed no runner assignment:
- April run `23136875648` queued with job label `macos-17` and `runner_id=0`
- later April scheduled run `23148870025` stayed `pending` because the workflow concurrency group was blocked behind that queued run

The last successful April runs before the regression were on `ubuntu-latest`, so this change restores the previously healthy hosted lane.

## Validation
- `ruby -e 'require "yaml"; [".github/workflows/agent-april.yml", ".github/workflows/agent-plat.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
- `git diff --check -- .github/workflows/agent-april.yml .github/workflows/agent-plat.yml`
