### PR TITLE
Require PR evidence accounting for agent work

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -977,6 +978,148 @@ class RunContributorTests(unittest.TestCase):
         )
         self.assertEqual(issue_number, 116)
         self.assertEqual(agent, "april-clearwater")
+
+    def test_validate_evidence_accounting_accepts_complete_and_blocked_entries(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [complete] swift test --filter NewWorkspaceSheetTests -- `swift test --filter NewWorkspaceSheetTests`\n"
+            "- [blocked] Screenshot of NewWorkspaceSheet from the exact commit under review -- Linux runner cannot launch the macOS app\n\n"
+            "## Validation\n"
+            "- `swift test --filter NewWorkspaceSheetTests`\n"
+            "- blocked on evidence: Linux runner cannot capture the requested macOS screenshot\n"
+        )
+        accounting, errors = run_contributor.validate_evidence_accounting(
+            body,
+            [
+                "swift test --filter NewWorkspaceSheetTests",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            accounting["complete_items"],
+            ["swift test --filter NewWorkspaceSheetTests"],
+        )
+        self.assertEqual(
+            accounting["blocked_items"],
+            ["Screenshot of NewWorkspaceSheet from the exact commit under review"],
+        )
+
+    def test_validate_evidence_accounting_rejects_missing_requested_item(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [complete] swift test --filter NewWorkspaceSheetTests -- `swift test --filter NewWorkspaceSheetTests`\n\n"
+            "## Validation\n"
+            "- `swift test --filter NewWorkspaceSheetTests`\n"
+        )
+        _, errors = run_contributor.validate_evidence_accounting(
+            body,
+            [
+                "swift test --filter NewWorkspaceSheetTests",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("missing:", errors[0])
+        self.assertIn(
+            "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            errors[0],
+        )
+
+    def test_validate_evidence_accounting_requires_blocked_on_evidence_language(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [blocked] Screenshot of NewWorkspaceSheet from the exact commit under review -- Linux runner cannot launch the macOS app\n\n"
+            "## Validation\n"
+            "- `swift test --filter NewWorkspaceSheetTests`\n"
+        )
+        _, errors = run_contributor.validate_evidence_accounting(
+            body,
+            ["Screenshot of NewWorkspaceSheet from the exact commit under review"],
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("blocked on evidence", errors[0])
+
+    def test_review_evidence_gate_requires_request_changes_for_blocked_evidence(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [blocked] Screenshot of NewWorkspaceSheet from the exact commit under review -- Linux runner cannot launch the macOS app\n\n"
+            "## Validation\n"
+            "- blocked on evidence: Linux runner cannot capture the requested macOS screenshot\n"
+        )
+        accounting, errors = run_contributor.validate_evidence_accounting(
+            body,
+            ["Screenshot of NewWorkspaceSheet from the exact commit under review"],
+        )
+        gate_error = run_contributor.review_evidence_gate_error(
+            "approve_with_followups",
+            accounting,
+            errors,
+        )
+        self.assertIsNotNone(gate_error)
+        self.assertIn("request_changes", gate_error)
+
+    def test_format_pr_list_for_context_includes_evidence_summary(self) -> None:
+        issue_body = run_planner.compose_issue_body_with_metadata(
+            "## Context\nBody",
+            "https://github.com/fairchild/workspaces/discussions/110",
+            110,
+            "fix-status-color",
+            priority=1,
+            blocked_by=[],
+            requested_evidence=[
+                "swift test --filter NewWorkspaceSheetTests",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+        pr_body = (
+            "*April Clearwater, Application Lead*\n\n"
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [complete] swift test --filter NewWorkspaceSheetTests -- `swift test --filter NewWorkspaceSheetTests`\n"
+            "- [blocked] Screenshot of NewWorkspaceSheet from the exact commit under review -- Linux runner cannot launch the macOS app\n\n"
+            "## Validation\n"
+            "- `swift test --filter NewWorkspaceSheetTests`\n"
+            "- blocked on evidence: Linux runner cannot capture the requested macOS screenshot\n\n"
+            "Closes #116\n\n"
+            "<!-- contributor:issue=116;agent=april-clearwater -->"
+        )
+        payload = json.loads(
+            run_contributor.format_pr_list_for_context(
+                [
+                    {
+                        "number": 119,
+                        "title": "Fix environment status color semantics in NewWorkspaceSheet",
+                        "author": {"login": "app/april-clearwater"},
+                        "isDraft": False,
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "headRefName": "codex/april-clearwater-issue-116-fix-status",
+                        "url": "https://github.com/fairchild/workspaces/pull/119",
+                        "body": pr_body,
+                    }
+                ],
+                [
+                    {
+                        "number": 116,
+                        "body": issue_body,
+                    }
+                ],
+            )
+        )
+        self.assertEqual(payload[0]["linkedIssue"], 116)
+        self.assertEqual(payload[0]["evidenceSummary"]["requested"], 2)
+        self.assertEqual(payload[0]["evidenceSummary"]["complete"], 1)
+        self.assertEqual(payload[0]["evidenceSummary"]["blocked"], 1)
+        self.assertEqual(payload[0]["evidenceSummary"]["missing"], 0)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cofounder-contributor/SKILL.md
+++ b/.agents/skills/cofounder-contributor/SKILL.md
@@ -56,3 +56,4 @@ uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
 - Produce exactly one action.
 - Keep the final output valid YAML frontmatter with no preamble.
 - Deduplicate new ideas before posting them.
+- Treat issue `requested_evidence` as required PR accounting: execution PRs must include `## Evidence Status`, and approval reviews cannot pass while requested evidence is missing or blocked.

--- a/.agents/skills/cofounder-contributor/references/april-clearwater.md
+++ b/.agents/skills/cofounder-contributor/references/april-clearwater.md
@@ -63,7 +63,11 @@ If you choose this action, you must have already edited the code during this run
 - If the issue already has your open PR, check out that PR branch before editing.
 - Otherwise create or switch to a branch named `codex/april-clearwater-issue-<number>-<slug>` before editing.
 - Run the most relevant validation you can from the issue's requested evidence.
-- If you cannot gather a requested artifact in this environment, say `blocked on evidence` in the Validation section.
+- `## Evidence Status` is required in the PR body.
+- Mirror every issue `requested_evidence` item using the exact issue text and one of these forms:
+  - `- [complete] <requested_evidence item> -- <artifact, command, link, or short proof note>`
+  - `- [blocked] <requested_evidence item> -- <concrete reason it could not be produced>`
+- If any evidence item is blocked, say `blocked on evidence` in the Validation section.
 
 ```
 ---
@@ -78,6 +82,10 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 - High-level explanation of what changed
 - Key files touched and why
 
+## Evidence Status
+- [complete] Exact requested evidence item text -- proof note
+- [blocked] Exact requested evidence item text -- why it could not be produced here
+
 ## Validation
 - `swift test ...`
 - `blocked on evidence: <reason>` if needed
@@ -88,7 +96,13 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 
 ### Review a PR
 
-Lead with your decision, then explain. Use GitHub suggestion blocks for small fixes. For larger changes, open a PR against the author's branch.
+Lead with your decision, then explain. Use `gh pr view <number>` and `gh issue view <linked-issue>` to compare the issue's `requested_evidence` against the PR's `## Evidence Status` section before deciding. Use GitHub suggestion blocks for small fixes. For larger changes, open a PR against the author's branch.
+
+Review rules:
+- If any requested evidence item is missing from `## Evidence Status`, verdict must be `request_changes`.
+- If all evidence items are accounted for but one or more are `[blocked]`, you may still review the code, but verdict must stay `request_changes`.
+- Only use `approve` or `approve_with_followups` when the evidence contract is fully accounted for and unblocked.
+- Separate code-quality feedback from evidence-gate feedback in your review body.
 
 ```
 ---
@@ -98,9 +112,13 @@ pr_number: 42
 verdict: approve | approve_with_followups | request_changes
 ---
 
-**Verdict: Approve with follow-ups** (or Approve / Request changes: <reason>)
+**Verdict: Request changes: screenshot evidence still blocked** (or Approve / Approve with follow-ups / Request changes: <reason>)
 
+## Code Review
 What's good, what needs attention, specific file/line references.
+
+## Evidence Gate
+- Requested evidence status, missing items, or blocked items that keep the PR from approval.
 
 For small fixes, use GitHub code suggestions:
 ` ```suggestion

--- a/.agents/skills/cofounder-contributor/references/plat-ironwood.md
+++ b/.agents/skills/cofounder-contributor/references/plat-ironwood.md
@@ -63,7 +63,11 @@ If you choose this action, you must have already edited the code during this run
 - If the issue already has your open PR, check out that PR branch before editing.
 - Otherwise create or switch to a branch named `codex/plat-ironwood-issue-<number>-<slug>` before editing.
 - Run the most relevant validation you can from the issue's requested evidence.
-- If you cannot gather a requested artifact in this environment, say `blocked on evidence` in the Validation section.
+- `## Evidence Status` is required in the PR body.
+- Mirror every issue `requested_evidence` item using the exact issue text and one of these forms:
+  - `- [complete] <requested_evidence item> -- <artifact, command, link, or short proof note>`
+  - `- [blocked] <requested_evidence item> -- <concrete reason it could not be produced>`
+- If any evidence item is blocked, say `blocked on evidence` in the Validation section.
 
 ```
 ---
@@ -78,6 +82,10 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 - High-level explanation of what changed
 - Key files touched and why
 
+## Evidence Status
+- [complete] Exact requested evidence item text -- proof note
+- [blocked] Exact requested evidence item text -- why it could not be produced here
+
 ## Validation
 - `swift test ...`
 - `blocked on evidence: <reason>` if needed
@@ -88,7 +96,13 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 
 ### Review a PR
 
-Lead with your decision, then explain. Use GitHub suggestion blocks for small fixes. For larger changes, open a PR against the author's branch.
+Lead with your decision, then explain. Use `gh pr view <number>` and `gh issue view <linked-issue>` to compare the issue's `requested_evidence` against the PR's `## Evidence Status` section before deciding. Use GitHub suggestion blocks for small fixes. For larger changes, open a PR against the author's branch.
+
+Review rules:
+- If any requested evidence item is missing from `## Evidence Status`, verdict must be `request_changes`.
+- If all evidence items are accounted for but one or more are `[blocked]`, you may still review the code, but verdict must stay `request_changes`.
+- Only use `approve` or `approve_with_followups` when the evidence contract is fully accounted for and unblocked.
+- Separate code-quality feedback from evidence-gate feedback in your review body.
 
 ```
 ---
@@ -98,9 +112,13 @@ pr_number: 42
 verdict: approve | approve_with_followups | request_changes
 ---
 
-**Verdict: Approve with follow-ups** (or Approve / Request changes: <reason>)
+**Verdict: Request changes: screenshot evidence still blocked** (or Approve / Approve with follow-ups / Request changes: <reason>)
 
+## Code Review
 What's good, what needs attention, specific file/line references.
+
+## Evidence Gate
+- Requested evidence status, missing items, or blocked items that keep the PR from approval.
 
 For small fixes, use GitHub code suggestions:
 ` ```suggestion

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -21,7 +21,9 @@ from pathlib import Path
 CLAUDE_TASK = (
     "Check what needs attention: open PRs to review, then your own open PRs "
     "or claimed issues to advance, then execution-approved issues to pick up, "
-    "then discussions to participate in or propose. Output your response "
+    "then discussions to participate in or propose. When you execute an issue, "
+    "the PR body must account for every requested evidence item in `## Evidence Status`. "
+    "When you review a PR, approvals are only allowed if requested evidence is fully accounted for and unblocked. Output your response "
     "using YAML frontmatter as specified in your prompt."
 )
 CLAUDE_TASK_CLI = (
@@ -30,7 +32,9 @@ CLAUDE_TASK_CLI = (
     "commits were pushed since). Then review other open PRs, then continue "
     "your own open PRs or claimed issues, then claim an execution-approved "
     "ready issue if one exists, then participate in discussions — comment on "
-    "an existing one or propose a new idea. CRITICAL: Your final output MUST "
+    "an existing one or propose a new idea. CRITICAL: execution PRs must mirror "
+    "every requested evidence item in `## Evidence Status`, and reviews must not "
+    "approve PRs with missing or blocked requested evidence. Your final output MUST "
     "be valid YAML frontmatter exactly as specified in your prompt — start "
     "with `---` on the very first line, then metadata fields, then closing "
     "`---`, then your markdown body. Do NOT write any text before the "
@@ -463,6 +467,9 @@ PR_MARKER_RE = re.compile(
 CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
+EVIDENCE_STATUS_LINE_RE = re.compile(
+    r"^- \[(?P<status>complete|blocked)\] (?P<item>.+?) -- (?P<detail>.+)$"
+)
 EXECUTION_PRIORITY_RE = re.compile(r"(?m)^- Priority:\s*(?P<priority>\d+)\s*$")
 AGENT_READY_LABEL = "agent:ready"
 AGENT_READY_LABEL_COLOR = "5319e7"
@@ -503,6 +510,10 @@ def markdown_section(body: str, heading: str) -> str:
     return match.group(1).strip()
 
 
+def has_markdown_section(body: str, heading: str) -> bool:
+    return re.search(rf"(?m)^## {re.escape(heading)}\s*$", body) is not None
+
+
 def extract_issue_discussion_number(body: str) -> int | None:
     match = TASK_ISSUE_MARKER_RE.search(body)
     if not match:
@@ -530,6 +541,112 @@ def extract_requested_evidence(body: str) -> list[str]:
         for line in evidence_section.splitlines()
         if line.strip().startswith("- ") and line[2:].strip().lower() != "none"
     ]
+
+
+def extract_evidence_status_entries(body: str) -> dict[str, object]:
+    section_present = has_markdown_section(body, "Evidence Status")
+    evidence_section = markdown_section(body, "Evidence Status")
+    entries: dict[str, dict[str, str]] = {}
+    invalid_lines: list[str] = []
+    duplicate_items: list[str] = []
+
+    for raw_line in evidence_section.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if not line.startswith("- "):
+            invalid_lines.append(line)
+            continue
+        match = EVIDENCE_STATUS_LINE_RE.match(line)
+        if not match:
+            invalid_lines.append(line)
+            continue
+        item = match.group("item").strip()
+        if item in entries:
+            duplicate_items.append(item)
+            continue
+        entries[item] = {
+            "status": match.group("status"),
+            "detail": match.group("detail").strip(),
+        }
+
+    return {
+        "section_present": section_present,
+        "entries": entries,
+        "invalid_lines": invalid_lines,
+        "duplicate_items": duplicate_items,
+    }
+
+
+def evaluate_evidence_accounting(body: str, requested_evidence: list[str]) -> dict[str, object]:
+    parsed = extract_evidence_status_entries(body)
+    entries = parsed["entries"]
+    missing_items = [item for item in requested_evidence if item not in entries]
+    blocked_items = [
+        item
+        for item in requested_evidence
+        if item in entries and entries[item]["status"] == "blocked"
+    ]
+    complete_items = [
+        item
+        for item in requested_evidence
+        if item in entries and entries[item]["status"] == "complete"
+    ]
+    unexpected_items = [item for item in entries if item not in requested_evidence]
+    return {
+        **parsed,
+        "missing_items": missing_items,
+        "blocked_items": blocked_items,
+        "complete_items": complete_items,
+        "unexpected_items": unexpected_items,
+        "blocked_on_evidence": "blocked on evidence" in body.casefold(),
+    }
+
+
+def validate_evidence_accounting(body: str, requested_evidence: list[str]) -> tuple[dict[str, object], list[str]]:
+    accounting = evaluate_evidence_accounting(body, requested_evidence)
+    errors: list[str] = []
+    if not accounting["section_present"]:
+        errors.append("missing required '## Evidence Status' section")
+    invalid_lines = accounting["invalid_lines"]
+    if invalid_lines:
+        preview = "; ".join(str(line) for line in invalid_lines[:3])
+        errors.append(
+            "malformed Evidence Status entries; expected "
+            "'- [complete|blocked] <requested_evidence item> -- <proof note>' "
+            f"(examples: {preview})"
+        )
+    duplicate_items = accounting["duplicate_items"]
+    if duplicate_items:
+        preview = ", ".join(str(item) for item in duplicate_items[:3])
+        errors.append(f"duplicate Evidence Status entries for: {preview}")
+    missing_items = accounting["missing_items"]
+    if missing_items:
+        preview = "; ".join(str(item) for item in missing_items[:3])
+        errors.append(
+            "PR body must account for every requested evidence item exactly; "
+            f"missing: {preview}"
+        )
+    if accounting["blocked_items"] and not accounting["blocked_on_evidence"]:
+        errors.append(
+            "blocked evidence entries require 'blocked on evidence' language in the Validation section"
+        )
+    return accounting, errors
+
+
+def review_evidence_gate_error(verdict: str, accounting: dict[str, object], errors: list[str]) -> str | None:
+    if verdict == "request_changes":
+        return None
+    if errors:
+        return "; ".join(errors)
+    blocked_items = accounting["blocked_items"]
+    if blocked_items:
+        preview = "; ".join(str(item) for item in blocked_items[:3])
+        return (
+            "requested evidence is still blocked and review must stay in request_changes; "
+            f"blocked: {preview}"
+        )
+    return None
 
 
 def latest_issue_claim(issue_number: int, comments: dict[str, object]) -> dict[str, str] | None:
@@ -866,9 +983,20 @@ def format_issue_list_for_context(issues: list[dict[str, object]]) -> str:
     return json.dumps(payload, indent=2, ensure_ascii=False)
 
 
-def format_pr_list_for_context(pull_requests: list[dict[str, object]]) -> str:
-    payload = [
-        {
+def format_pr_list_for_context(
+    pull_requests: list[dict[str, object]],
+    issues: list[dict[str, object]],
+) -> str:
+    issue_map = {
+        int(issue["number"]): issue
+        for issue in issues
+        if issue.get("number") is not None
+    }
+    payload: list[dict[str, object]] = []
+    for pr in pull_requests:
+        pr_body = str(pr.get("body", ""))
+        issue_number, _ = extract_pr_issue_reference(pr_body)
+        entry: dict[str, object] = {
             "number": pr.get("number"),
             "title": pr.get("title"),
             "author": (pr.get("author") or {}).get("login", ""),
@@ -877,8 +1005,19 @@ def format_pr_list_for_context(pull_requests: list[dict[str, object]]) -> str:
             "headRefName": pr.get("headRefName"),
             "url": pr.get("url"),
         }
-        for pr in pull_requests
-    ]
+        if issue_number is not None:
+            issue_body = str(issue_map.get(issue_number, {}).get("body", ""))
+            requested_evidence = extract_requested_evidence(issue_body)
+            accounting = evaluate_evidence_accounting(pr_body, requested_evidence)
+            entry["linkedIssue"] = issue_number
+            entry["evidenceSummary"] = {
+                "requested": len(requested_evidence),
+                "complete": len(accounting["complete_items"]),
+                "blocked": len(accounting["blocked_items"]),
+                "missing": len(accounting["missing_items"]),
+                "malformed": len(accounting["invalid_lines"]),
+            }
+        payload.append(entry)
     return json.dumps(payload, indent=2, ensure_ascii=False)
 
 
@@ -1156,7 +1295,7 @@ def gather_context(
     )
     engagement_summary = format_engagement_candidates(engagement_candidates)
     open_issues = format_issue_list_for_context(work_state["issues"])
-    open_prs = format_pr_list_for_context(work_state["pull_requests"])
+    open_prs = format_pr_list_for_context(work_state["pull_requests"], work_state["issues"])
 
     backlog_state = gather_backlog_state()
     history = gather_agent_history(persona, owner, name, env)
@@ -1378,10 +1517,6 @@ def compose_pr_body(
     )
 
 
-def compose_pr_update_comment(persona: str, summary_body: str) -> str:
-    return f"*{persona}*\n\n{summary_body.strip()}"
-
-
 def set_git_identity(env: dict[str, str], persona: str, bot_login: str) -> None:
     user_name = bot_login or short_persona_name(persona)
     user_email = f"{persona_slug(persona)}@users.noreply.github.com"
@@ -1469,6 +1604,32 @@ def find_issue_execution_state(
         "stale_claim": stale_claim,
         "own_pr": own_pr,
         "other_pr": other_pr,
+    }
+
+
+def find_pr_review_state(pr_number: int, env: dict[str, str]) -> dict[str, object] | None:
+    owner, name = repo_owner_name(env)
+    work_state = fetch_work_state(owner, name, env)
+    pr = next((item for item in work_state["pull_requests"] if int(item["number"]) == pr_number), None)
+    if pr is None:
+        return None
+
+    issue_number, _ = extract_pr_issue_reference(str(pr.get("body", "")))
+    issue = None
+    requested_evidence: list[str] = []
+    if issue_number is not None:
+        issue = next((item for item in work_state["issues"] if int(item["number"]) == issue_number), None)
+        if issue is not None:
+            requested_evidence = extract_requested_evidence(str(issue.get("body", "")))
+
+    accounting, errors = validate_evidence_accounting(str(pr.get("body", "")), requested_evidence)
+    return {
+        "pr": pr,
+        "issue_number": issue_number,
+        "issue": issue,
+        "requested_evidence": requested_evidence,
+        "evidence_accounting": accounting,
+        "evidence_errors": errors,
     }
 
 
@@ -1593,6 +1754,20 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
     try:
         if action == "review_pr":
             verdict = str(data.get("verdict", "")).lower()
+            pr_number = int(data["pr_number"])
+            review_state = find_pr_review_state(pr_number, env)
+            if review_state is not None:
+                evidence_gate_error = review_evidence_gate_error(
+                    verdict,
+                    review_state["evidence_accounting"],
+                    review_state["evidence_errors"],
+                )
+                if evidence_gate_error is not None:
+                    print(
+                        f"error: PR #{pr_number} cannot be reviewed with verdict '{verdict}': {evidence_gate_error}",
+                        file=sys.stderr,
+                    )
+                    return 1
             review_flag = {
                 "approve": "--approve",
                 "approve_with_followups": "--approve",
@@ -1662,6 +1837,18 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 )
                 return 1
 
+            summary_body = str(data.get("body", "")).strip()
+            requested_evidence = list(state.get("requested_evidence", []))
+            _, evidence_errors = validate_evidence_accounting(summary_body, requested_evidence)
+            if evidence_errors:
+                print(
+                    "error: PR body evidence accounting is incomplete: "
+                    + "; ".join(evidence_errors),
+                    file=sys.stderr,
+                )
+                return 1
+            pr_body = compose_pr_body(issue_number, persona, summary_body)
+
             branch = current_branch(env)
             if own_pr is not None:
                 expected_branch = str(own_pr.get("headRefName", ""))
@@ -1718,16 +1905,17 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 env=env,
             )
 
-            summary_body = str(data.get("body", "")).strip()
             if own_pr is not None:
                 run_checked(
                     [
                         "gh",
                         "pr",
-                        "comment",
+                        "edit",
                         str(own_pr["number"]),
+                        "--title",
+                        str(data["pr_title"]).strip(),
                         "--body",
-                        compose_pr_update_comment(persona, summary_body),
+                        pr_body,
                     ],
                     timeout=GITHUB_API_TIMEOUT,
                     cwd=REPO_ROOT,
@@ -1735,7 +1923,6 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 )
                 return 0
 
-            pr_body = compose_pr_body(issue_number, persona, summary_body)
             run_checked(
                 [
                     "gh",

--- a/.agents/skills/peter-planner/SKILL.md
+++ b/.agents/skills/peter-planner/SKILL.md
@@ -47,3 +47,4 @@ uv run .agents/skills/peter-planner/scripts/run-planner.py --discussion-number 4
 - Keep issue scope to one focused session per issue.
 - When 3+ issues are needed, derive the milestone name from the discussion title.
 - Preserve planner markers so retries reuse existing artifacts instead of leaking duplicates.
+- Treat `requested_evidence` as the required PR evidence contract for each issue, not optional guidance.

--- a/.agents/skills/peter-planner/references/peter-planner.md
+++ b/.agents/skills/peter-planner/references/peter-planner.md
@@ -38,7 +38,16 @@ Use `blocked_by` as the single dependency field:
 - Use real GitHub issue numbers only when the blocker already exists outside this new plan
 - Use `[]` when the issue is ready immediately
 
-`requested_evidence` should describe the concrete proof the coding agent should attach to the PR or issue update, such as test commands, screenshots, artifact paths, or before/after perf data.
+`requested_evidence` is the required-by-default PR evidence contract for that issue. It should describe the concrete proof the coding agent must account for in the PR's `## Evidence Status` section, such as test commands, screenshots, artifact paths, or before/after perf data.
+
+Evidence planning rules:
+- Keep `requested_evidence` short and concrete. Usually 2-4 items is enough.
+- Derive it from the repo evidence bar plus the discussion context.
+- For UI or visual work, request screenshots from the exact commit under review. Add before/after only when visual correction is the point of the issue.
+- For behavior or logic work, request the targeted test command or exact verification command.
+- For workflow or automation work, request the successful run URL plus the relevant log or artifact proof.
+- For performance-sensitive work, request before/after measurements on the same workload.
+- Avoid vague items like `verify manually` unless the repo genuinely has no stronger proof path.
 
 ## Scoping Rules
 
@@ -67,8 +76,8 @@ labels: [enhancement]
 priority: 1
 blocked_by: []
 requested_evidence:
-  - "Relevant swift test command(s)"
-  - "Any screenshots, logs, or perf comparisons the PR should include"
+  - "Relevant swift test command(s) the PR must account for"
+  - "Any screenshots, logs, or perf comparisons the PR must account for in Evidence Status"
 ---
 
 ## Context

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -441,6 +441,8 @@ def compose_summary_comment(
     lines.extend(
         [
             "",
+            "Each issue's `Requested Evidence` section is a required PR accounting contract. The executor PR must mirror those items in `## Evidence Status`.",
+            "",
             "React with 👍 on this comment when you're ready for April or Plat to start execution.",
         ]
     )

--- a/docs/development/agent-owner-protocol.md
+++ b/docs/development/agent-owner-protocol.md
@@ -103,6 +103,7 @@ You merge the PR yourself when it is ready.
 3. Then they review other open PRs.
 4. Then they continue their own open PRs or claimed issues.
 5. Then they claim the highest-priority ready approved issue and open or update one PR per issue.
+6. Their PR body must account for every issue `Requested Evidence` item in `## Evidence Status`, marking each one as `complete` or `blocked`.
 
 ### Merge
 
@@ -134,6 +135,7 @@ Good examples:
 - `plan it, but keep this to one PR`
 - `plan it, but the UI work should wait until after the isolation fix`
 - `plan it, but require screenshots in the requested evidence`
+- `plan it, but keep requested evidence to one screenshot and one targeted test`
 
 ### Best place to give execution direction
 
@@ -144,6 +146,7 @@ Good examples:
 - `Request changes: keep the enum in the controller, not the view`
 - `Please add a test that covers the degraded status`
 - `Blocked on evidence until the PR includes a screenshot from the reviewed commit`
+- `Keep this PR in request-changes until the Evidence Status section is fully complete`
 
 ### Best place to stop or narrow work
 
@@ -183,14 +186,17 @@ Good examples:
 - Use normal code review.
 - Request changes with exact guidance.
 - Keep the feedback on the PR, not in a new side discussion.
+- If requested evidence is still missing or blocked, treat the PR as not ready unless you intentionally decide to merge anyway.
 
 ## Current Limitations
 
 - The execution approval signal is per planned discussion, not per issue.
 - Removing 👍 stops new issue pickup for that discussion, but you should still comment directly on any already-open PR you want paused or redirected.
 - Claim ownership is tracked by labels, claim comments, and GitHub issue assignments. Agents assign themselves when claiming an issue and are unassigned when claims expire.
+- `Requested Evidence` is a required-by-default PR evidence contract; the current status of each item lives in the PR body's `## Evidence Status` section.
 - The workflows are wired for execution, but the installed GitHub Apps still need `contents: write` in GitHub App settings for branch push and PR creation to work.
 - Agents do not merge PRs.
+- Evidence waivers are manual today. If you choose to merge despite blocked evidence, do it explicitly in the PR conversation and on your own judgment.
 
 ## Suggested Default Protocol
 

--- a/docs/development/agent-team.md
+++ b/docs/development/agent-team.md
@@ -201,7 +201,7 @@ Agents propose ideas and review each other's work. Human approves. Planner creat
 Add persistent memory so agents build context across sessions — what shipped, what worked, what didn't. They stop re-proposing similar ideas and develop a sense of project trajectory.
 
 ### Phase 3: Execute
-Approved and planned issues get picked up by April and Plat after the owner reacts 👍 on Peter's summary comment. They create branches, write code, open PRs, and keep open PRs moving to closure. Human reviews PRs and remains the only merge authority.
+Approved and planned issues get picked up by April and Plat after the owner reacts 👍 on Peter's summary comment. They create branches, write code, open PRs, and keep open PRs moving to closure. Peter defines the requested evidence for each issue, and the PR body must account for that evidence before review can clear. Human reviews PRs and remains the only merge authority.
 
 The `$drive` skill remains the manual bridge for milestone-wide execution, but the standing contributor workflows can now autonomously pick up a single approved issue at their scheduled wake-up.
 


### PR DESCRIPTION
## Summary

Make Peter's `requested_evidence` a required PR evidence contract instead of soft guidance.

This change makes the PR body the live accounting surface for evidence:
- Peter plans concrete `requested_evidence` as the required proof bar for each issue.
- April and Plat must mirror every requested evidence item into `## Evidence Status` using `complete` or `blocked` entries.
- Contributor runtime rejects `execute_issue` output when the PR body does not fully account for the issue evidence list.
- Contributor reviews may still review code while evidence is blocked, but they cannot approve or approve-with-followups until requested evidence is fully accounted for and unblocked.
- Owner/operator docs now describe the new evidence workflow and manual waiver model.

## Verification

- `uv run .agents/scripts/test_run_planner.py`
