### PR TITLE
Enable agents to produce macOS evidence via CI job

### DIFF
--- a/.agents/skills/cofounder-contributor/references/april-clearwater.md
+++ b/.agents/skills/cofounder-contributor/references/april-clearwater.md
@@ -67,7 +67,9 @@ If you choose this action, you must have already edited the code during this run
 - Mirror every issue `requested_evidence` item using the exact issue text and one of these forms:
   - `- [complete] <requested_evidence item> -- <artifact, command, link, or short proof note>`
   - `- [blocked] <requested_evidence item> -- <concrete reason it could not be produced>`
-- If any evidence item is blocked, say `blocked on evidence` in the Validation section.
+  - `- [pending-ci] <requested_evidence item> -- <what the CI evidence job will produce>`
+- Use `[pending-ci]` for evidence that requires macOS (builds, tests, screenshots) — the CI evidence job on the self-hosted Mac runner will produce it automatically.
+- If any evidence item is blocked or pending-ci, say `blocked on evidence` in the Validation section.
 
 ```
 ---
@@ -85,6 +87,7 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 ## Evidence Status
 - [complete] Exact requested evidence item text -- proof note
 - [blocked] Exact requested evidence item text -- why it could not be produced here
+- [pending-ci] Exact requested evidence item text -- CI evidence job will run swift test / capture screenshots
 
 ## Validation
 - `swift test ...`

--- a/.agents/skills/cofounder-contributor/references/plat-ironwood.md
+++ b/.agents/skills/cofounder-contributor/references/plat-ironwood.md
@@ -67,7 +67,9 @@ If you choose this action, you must have already edited the code during this run
 - Mirror every issue `requested_evidence` item using the exact issue text and one of these forms:
   - `- [complete] <requested_evidence item> -- <artifact, command, link, or short proof note>`
   - `- [blocked] <requested_evidence item> -- <concrete reason it could not be produced>`
-- If any evidence item is blocked, say `blocked on evidence` in the Validation section.
+  - `- [pending-ci] <requested_evidence item> -- <what the CI evidence job will produce>`
+- Use `[pending-ci]` for evidence that requires macOS (builds, tests, screenshots) — the CI evidence job on the self-hosted Mac runner will produce it automatically.
+- If any evidence item is blocked or pending-ci, say `blocked on evidence` in the Validation section.
 
 ```
 ---
@@ -85,6 +87,7 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 ## Evidence Status
 - [complete] Exact requested evidence item text -- proof note
 - [blocked] Exact requested evidence item text -- why it could not be produced here
+- [pending-ci] Exact requested evidence item text -- CI evidence job will run swift test / capture screenshots
 
 ## Validation
 - `swift test ...`

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -468,7 +468,7 @@ CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
 EVIDENCE_STATUS_LINE_RE = re.compile(
-    r"^- \[(?P<status>complete|blocked)\] (?P<item>.+?) -- (?P<detail>.+)$"
+    r"^- \[(?P<status>complete|blocked|pending-ci)\] (?P<item>.+?) -- (?P<detail>.+)$"
 )
 EXECUTION_PRIORITY_RE = re.compile(r"(?m)^- Priority:\s*(?P<priority>\d+)\s*$")
 AGENT_READY_LABEL = "agent:ready"
@@ -587,6 +587,11 @@ def evaluate_evidence_accounting(body: str, requested_evidence: list[str]) -> di
         for item in requested_evidence
         if item in entries and entries[item]["status"] == "blocked"
     ]
+    pending_ci_items = [
+        item
+        for item in requested_evidence
+        if item in entries and entries[item]["status"] == "pending-ci"
+    ]
     complete_items = [
         item
         for item in requested_evidence
@@ -597,6 +602,7 @@ def evaluate_evidence_accounting(body: str, requested_evidence: list[str]) -> di
         **parsed,
         "missing_items": missing_items,
         "blocked_items": blocked_items,
+        "pending_ci_items": pending_ci_items,
         "complete_items": complete_items,
         "unexpected_items": unexpected_items,
         "blocked_on_evidence": "blocked on evidence" in body.casefold(),
@@ -613,7 +619,7 @@ def validate_evidence_accounting(body: str, requested_evidence: list[str]) -> tu
         preview = "; ".join(str(line) for line in invalid_lines[:3])
         errors.append(
             "malformed Evidence Status entries; expected "
-            "'- [complete|blocked] <requested_evidence item> -- <proof note>' "
+            "'- [complete|blocked|pending-ci] <requested_evidence item> -- <proof note>' "
             f"(examples: {preview})"
         )
     duplicate_items = accounting["duplicate_items"]
@@ -631,6 +637,10 @@ def validate_evidence_accounting(body: str, requested_evidence: list[str]) -> tu
         errors.append(
             "blocked evidence entries require 'blocked on evidence' language in the Validation section"
         )
+    if accounting["pending_ci_items"] and not accounting["blocked_on_evidence"]:
+        errors.append(
+            "pending-ci evidence entries require 'blocked on evidence' language in the Validation section"
+        )
     return accounting, errors
 
 
@@ -645,6 +655,13 @@ def review_evidence_gate_error(verdict: str, accounting: dict[str, object], erro
         return (
             "requested evidence is still blocked and review must stay in request_changes; "
             f"blocked: {preview}"
+        )
+    pending_ci_items = accounting.get("pending_ci_items", [])
+    if pending_ci_items:
+        preview = "; ".join(str(item) for item in pending_ci_items[:3])
+        return (
+            "requested evidence is pending CI and review must stay in request_changes; "
+            f"pending-ci: {preview}"
         )
     return None
 
@@ -1700,6 +1717,50 @@ def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -
         )
 
 
+def _changed_files_in_head(env: dict[str, str]) -> list[str]:
+    """Return files changed in the most recent commit."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
+        capture_output=True, text=True, timeout=GITHUB_API_TIMEOUT, cwd=REPO_ROOT,
+        env=env,
+    )
+    if result.returncode != 0:
+        return []
+    return [f for f in result.stdout.strip().splitlines() if f]
+
+
+def _needs_macos_evidence(changed: list[str]) -> bool:
+    """Return True if any changed file requires a macOS build to validate."""
+    macos_prefixes = ("Sources/", "Tests/", "Package.swift")
+    return any(f.startswith(macos_prefixes) for f in changed)
+
+
+def _extract_test_filter(requested_evidence: list[str]) -> str:
+    """Extract a swift test filter from requested evidence items, if any."""
+    for item in requested_evidence:
+        for token in item.split():
+            if "Test" in token and not token.startswith("http"):
+                return token.rstrip(".,;:)")
+    return ""
+
+
+def _write_github_outputs(
+    needs_evidence: bool,
+    branch: str,
+    test_filter: str,
+) -> None:
+    """Write outputs to $GITHUB_OUTPUT for downstream workflow jobs."""
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if not output_file:
+        log("GITHUB_OUTPUT not set; skipping output emission")
+        return
+    with open(output_file, "a") as f:
+        f.write(f"needs_macos_evidence={str(needs_evidence).lower()}\n")
+        f.write(f"pr_branch={branch}\n")
+        f.write(f"test_filter={test_filter}\n")
+    log(f"Emitted outputs: needs_macos_evidence={needs_evidence}, pr_branch={branch}, test_filter={test_filter}")
+
+
 def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int:
     data = json.loads(validated_json)
     action = data["action"]
@@ -1904,6 +1965,11 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 cwd=REPO_ROOT,
                 env=env,
             )
+
+            changed = _changed_files_in_head(env)
+            evidence_needed = _needs_macos_evidence(changed)
+            test_filter = _extract_test_filter(requested_evidence)
+            _write_github_outputs(evidence_needed, branch, test_filter)
 
             if own_pr is not None:
                 run_checked(

--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -31,6 +31,10 @@ jobs:
     # Contributor automation is CLI-only; keep it on the broadly available hosted lane.
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      needs_macos_evidence: ${{ steps.contributor.outputs.needs_macos_evidence }}
+      pr_branch: ${{ steps.contributor.outputs.pr_branch }}
+      test_filter: ${{ steps.contributor.outputs.test_filter }}
     steps:
       - name: Generate app token
         id: app-token
@@ -48,6 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Run contributor
+        id: contributor
         run: |
           ARGS=(--prompt-file .agents/skills/cofounder-contributor/references/april-clearwater.md)
           ARGS+=(--mode cli)
@@ -64,3 +69,35 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: april-clearwater
+
+  evidence:
+    needs: run
+    if: needs.run.outputs.needs_macos_evidence == 'true'
+    runs-on: [self-hosted, tart-ui]
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.run.outputs.pr_branch }}
+          fetch-depth: 50
+      - name: Build GhosttyKit
+        run: ./scripts/build-ghosttykit.sh
+      - name: Build app
+        run: swift build
+      - name: Run targeted tests
+        if: needs.run.outputs.test_filter != ''
+        run: swift test --filter '${{ needs.run.outputs.test_filter }}' 2>&1 | tee test-output.txt || true
+      - name: Run all tests (no filter specified)
+        if: needs.run.outputs.test_filter == ''
+        run: swift test 2>&1 | tee test-output.txt || true
+      - name: Capture evidence
+        run: ./scripts/dev-smoke.sh --no-build 2>&1 | head -100 || true
+      - name: Upload evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-${{ github.run_id }}
+          path: |
+            output/
+            test-output.txt

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -31,6 +31,10 @@ jobs:
     # Contributor automation is CLI-only; keep it on the broadly available hosted lane.
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      needs_macos_evidence: ${{ steps.contributor.outputs.needs_macos_evidence }}
+      pr_branch: ${{ steps.contributor.outputs.pr_branch }}
+      test_filter: ${{ steps.contributor.outputs.test_filter }}
     steps:
       - name: Generate app token
         id: app-token
@@ -48,6 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Run contributor
+        id: contributor
         run: |
           ARGS=(--prompt-file .agents/skills/cofounder-contributor/references/plat-ironwood.md)
           ARGS+=(--mode cli)
@@ -64,3 +69,35 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: workspace-agents
+
+  evidence:
+    needs: run
+    if: needs.run.outputs.needs_macos_evidence == 'true'
+    runs-on: [self-hosted, tart-ui]
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.run.outputs.pr_branch }}
+          fetch-depth: 50
+      - name: Build GhosttyKit
+        run: ./scripts/build-ghosttykit.sh
+      - name: Build app
+        run: swift build
+      - name: Run targeted tests
+        if: needs.run.outputs.test_filter != ''
+        run: swift test --filter '${{ needs.run.outputs.test_filter }}' 2>&1 | tee test-output.txt || true
+      - name: Run all tests (no filter specified)
+        if: needs.run.outputs.test_filter == ''
+        run: swift test 2>&1 | tee test-output.txt || true
+      - name: Capture evidence
+        run: ./scripts/dev-smoke.sh --no-build 2>&1 | head -100 || true
+      - name: Upload evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-${{ github.run_id }}
+          path: |
+            output/
+            test-output.txt


### PR DESCRIPTION
## Summary

Add support for evidence status `[pending-ci]` and a conditional macOS evidence job so agents can produce build/test/screenshot evidence on the self-hosted Mac runner. Agents can now mark macOS-only requested evidence items as pending on CI, push the PR, and the evidence job automatically builds GhosttyKit, runs swift tests, captures screenshots, and uploads artifacts.

## Validation

- [x] `swift build` — no Swift changes
- [x] `swift test` — no test changes  
- [x] YAML validation — both workflows pass `yaml.safe_load`
- [x] Python validation — syntax checked with `ast.parse`

## Evidence

- [x] Not a UI-affecting change

## Changes

**run-contributor.py** — Added `[pending-ci]` status to evidence regex, validation logic, and review gate. Added GitHub output functions to emit `needs_macos_evidence`, `pr_branch`, and `test_filter` when `execute_issue` completes.

**agent-april.yml / agent-plat.yml** — Added `outputs:` to `run` job and `id: contributor` to capture outputs. Added conditional `evidence` job that runs on `[self-hosted, tart-ui]` when `needs_macos_evidence == 'true'`, builds the app, runs tests, captures evidence via `dev-smoke.sh`, and uploads artifacts.

**april-clearwater.md / plat-ironwood.md** — Updated execution examples and guidance to document `[pending-ci]` status for evidence items that require macOS (swift tests, screenshots). Explains that CI evidence job on self-hosted runner handles these automatically.

This unblocks the first execution loop (#116): April can now create a PR with `[pending-ci]` evidence entries, the evidence job runs on the Mac runner to produce proof, and Plat can review with complete evidence without gaps.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>