### PR TITLE
Restore native GitHub App reviews

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -557,68 +557,6 @@ class RunContributorTests(unittest.TestCase):
         )
         self.assertEqual(env["OPENAI_API_KEY"], "fallback-key")
 
-    def test_fallback_review_env_prefers_dedicated_review_token(self) -> None:
-        env = run_contributor.fallback_review_env(
-            {
-                "GH_TOKEN": "app-token",
-                "GH_REVIEW_TOKEN": "review-token",
-                "GITHUB_TOKEN": "stale-token",
-            }
-        )
-        self.assertEqual(env["GH_TOKEN"], "review-token")
-        self.assertEqual(env["GITHUB_TOKEN"], "review-token")
-
-    def test_fallback_review_env_returns_original_env_without_dedicated_review_token(self) -> None:
-        env = {"GH_TOKEN": "app-token"}
-        self.assertIs(run_contributor.fallback_review_env(env), env)
-
-    def test_should_retry_review_with_fallback_only_on_integration_error(self) -> None:
-        env = {
-            "GH_TOKEN": "app-token",
-            "GH_REVIEW_TOKEN": "review-token",
-        }
-        failing = subprocess.CompletedProcess(
-            args=["gh", "pr", "review"],
-            returncode=1,
-            stdout="",
-            stderr="GraphQL: Resource not accessible by integration (addPullRequestReview)",
-        )
-        self.assertTrue(run_contributor.should_retry_review_with_fallback(failing, env))
-
-        non_retry = subprocess.CompletedProcess(
-            args=["gh", "pr", "review"],
-            returncode=1,
-            stdout="",
-            stderr="pull request review body is invalid",
-        )
-        self.assertFalse(run_contributor.should_retry_review_with_fallback(non_retry, env))
-
-    def test_should_retry_review_with_fallback_skips_successful_reviews(self) -> None:
-        env = {
-            "GH_TOKEN": "app-token",
-            "GH_REVIEW_TOKEN": "review-token",
-        }
-        success = subprocess.CompletedProcess(
-            args=["gh", "pr", "review"],
-            returncode=0,
-            stdout="",
-            stderr="",
-        )
-        self.assertFalse(run_contributor.should_retry_review_with_fallback(success, env))
-
-    def test_should_retry_review_with_fallback_skips_when_tokens_match(self) -> None:
-        env = {
-            "GH_TOKEN": "same-token",
-            "GH_REVIEW_TOKEN": "same-token",
-        }
-        failing = subprocess.CompletedProcess(
-            args=["gh", "pr", "review"],
-            returncode=1,
-            stdout="",
-            stderr="GraphQL: Resource not accessible by integration (addPullRequestReview)",
-        )
-        self.assertFalse(run_contributor.should_retry_review_with_fallback(failing, env))
-
     def test_planner_normalize_provider_env_falls_back_to_codespaces_key(self) -> None:
         env = run_planner.normalize_provider_env(
             {
@@ -1291,7 +1229,7 @@ class RunContributorTests(unittest.TestCase):
         self.assertEqual(payload[0]["evidenceSummary"]["blocked"], 1)
         self.assertEqual(payload[0]["evidenceSummary"]["missing"], 0)
 
-    def test_route_action_review_prefers_app_token_when_successful(self) -> None:
+    def test_route_action_review_uses_app_token(self) -> None:
         validated_json = json.dumps(
             {
                 "action": "review_pr",
@@ -1303,67 +1241,22 @@ class RunContributorTests(unittest.TestCase):
         )
         env = {
             "GH_TOKEN": "app-token",
-            "GH_REVIEW_TOKEN": "review-token",
         }
 
         with (
             mock.patch.object(run_contributor, "find_pr_review_state", return_value=None),
-            mock.patch.object(run_contributor, "run_result") as run_result,
+            mock.patch.object(run_contributor, "run_checked") as run_checked,
             mock.patch.object(run_contributor, "_update_mergeable_label") as update_mergeable_label,
         ):
-            run_result.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+            run_checked.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
             result = run_contributor.route_action(validated_json, False, env)
 
         self.assertEqual(result, 0)
-        _, kwargs = run_result.call_args
+        _, kwargs = run_checked.call_args
         self.assertEqual(kwargs["env"]["GH_TOKEN"], "app-token")
         mergeable_args, _ = update_mergeable_label.call_args
         self.assertEqual(mergeable_args[2]["GH_TOKEN"], "app-token")
-
-    def test_route_action_review_retries_with_dedicated_review_token(self) -> None:
-        validated_json = json.dumps(
-            {
-                "action": "review_pr",
-                "persona": "Plat Ironwood",
-                "pr_number": 119,
-                "verdict": "request_changes",
-                "body": "## Findings\n- Missing evidence status",
-            }
-        )
-        env = {
-            "GH_TOKEN": "app-token",
-            "GH_REVIEW_TOKEN": "review-token",
-        }
-        app_failure = subprocess.CompletedProcess(
-            args=["gh", "pr", "review"],
-            returncode=1,
-            stdout="",
-            stderr="GraphQL: Resource not accessible by integration (addPullRequestReview)",
-        )
-        fallback_success = subprocess.CompletedProcess(
-            args=["gh", "pr", "review"],
-            returncode=0,
-            stdout="",
-            stderr="",
-        )
-
-        with (
-            mock.patch.object(run_contributor, "find_pr_review_state", return_value=None),
-            mock.patch.object(run_contributor, "run_result", side_effect=[app_failure, fallback_success]) as run_result,
-            mock.patch.object(run_contributor, "_update_mergeable_label") as update_mergeable_label,
-        ):
-            result = run_contributor.route_action(validated_json, False, env)
-
-        self.assertEqual(result, 0)
-        self.assertEqual(run_result.call_count, 2)
-        first_kwargs = run_result.call_args_list[0].kwargs
-        second_kwargs = run_result.call_args_list[1].kwargs
-        self.assertEqual(first_kwargs["env"]["GH_TOKEN"], "app-token")
-        self.assertEqual(second_kwargs["env"]["GH_TOKEN"], "review-token")
-        self.assertEqual(second_kwargs["env"]["GITHUB_TOKEN"], "review-token")
-        mergeable_args, _ = update_mergeable_label.call_args
-        self.assertEqual(mergeable_args[2]["GH_TOKEN"], "review-token")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -81,70 +81,6 @@ def normalize_provider_env(env: dict[str, str]) -> dict[str, str]:
     return normalized
 
 
-def fallback_review_env(env: dict[str, str]) -> dict[str, str]:
-    """Build the workflow-token fallback env for PR reviews."""
-    review_token = env.get("GH_REVIEW_TOKEN", "").strip()
-    if not review_token:
-        return env
-    scoped = dict(env)
-    scoped["GH_TOKEN"] = review_token
-    scoped["GITHUB_TOKEN"] = review_token
-    return scoped
-
-
-def should_retry_review_with_fallback(
-    result: subprocess.CompletedProcess[str],
-    env: dict[str, str],
-) -> bool:
-    review_token = env.get("GH_REVIEW_TOKEN", "").strip()
-    if not review_token or review_token == env.get("GH_TOKEN", "").strip():
-        return False
-    if result.returncode == 0:
-        return False
-    combined = "\n".join(
-        part.strip()
-        for part in (result.stdout, result.stderr)
-        if part and part.strip()
-    )
-    return (
-        "Resource not accessible by integration" in combined
-        and "addPullRequestReview" in combined
-    )
-
-
-def submit_pr_review(
-    cmd: list[str],
-    env: dict[str, str],
-) -> dict[str, str] | None:
-    result = run_result(
-        cmd,
-        timeout=GITHUB_API_TIMEOUT,
-        cwd=REPO_ROOT,
-        env=env,
-    )
-    used_env = env
-    if result.returncode != 0 and should_retry_review_with_fallback(result, env):
-        fallback_env = fallback_review_env(env)
-        if fallback_env is not env:
-            log("App-token review failed; retrying with workflow review token")
-            result = run_result(
-                cmd,
-                timeout=GITHUB_API_TIMEOUT,
-                cwd=REPO_ROOT,
-                env=fallback_env,
-            )
-            used_env = fallback_env
-    if result.returncode != 0:
-        command = " ".join(cmd)
-        print(f"error: command failed: {command}", file=sys.stderr)
-        if result.stderr.strip():
-            print(result.stderr.strip(), file=sys.stderr)
-        elif result.stdout.strip():
-            print(result.stdout.strip(), file=sys.stderr)
-        return None
-    return used_env
-
-
 def log(message: str) -> None:
     print(f"[run-contributor] {message}", file=sys.stderr)
 
@@ -178,30 +114,6 @@ def run_checked(
             print(result.stderr.strip(), file=sys.stderr)
         sys.exit(result.returncode or 1)
     return result
-
-
-def run_result(
-    cmd: list[str],
-    *,
-    timeout: int,
-    cwd: Path | None = None,
-    env: dict[str, str] | None = None,
-    input: str | None = None,
-) -> subprocess.CompletedProcess[str]:
-    try:
-        return subprocess.run(
-            cmd,
-            input=input,
-            capture_output=True,
-            text=True,
-            env=env,
-            cwd=cwd,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as exc:
-        command = " ".join(cmd)
-        print(f"error: command timed out after {exc.timeout}s: {command}", file=sys.stderr)
-        sys.exit(1)
 
 
 def run_optional(
@@ -2006,10 +1918,13 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 "--body-file",
                 body_file,
             ]
-            reviewer_env = submit_pr_review(review_cmd, env)
-            if reviewer_env is None:
-                return 1
-            _update_mergeable_label(int(data["pr_number"]), verdict, reviewer_env)
+            run_checked(
+                review_cmd,
+                timeout=GITHUB_API_TIMEOUT,
+                cwd=REPO_ROOT,
+                env=env,
+            )
+            _update_mergeable_label(int(data["pr_number"]), verdict, env)
             return 0
         if action == "execute_issue":
             persona = str(data.get("persona", ""))

--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -102,7 +102,6 @@ jobs:
           AGENT_MESSAGE: ${{ inputs.message }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REVIEW_TOKEN: ${{ github.token }}
           GH_APP_SLUG: april-clearwater
 
   # Evidence fallback: only runs when the main job ran on ubuntu (Lume was

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -69,7 +69,6 @@ jobs:
           AGENT_MESSAGE: ${{ inputs.message }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_REVIEW_TOKEN: ${{ github.token }}
           GH_APP_SLUG: workspace-agents
 
   evidence:

--- a/.github/workflows/app-review-smoke.yml
+++ b/.github/workflows/app-review-smoke.yml
@@ -1,0 +1,188 @@
+name: GitHub App Review Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_slug:
+        description: "GitHub App slug to use for the review"
+        type: choice
+        required: true
+        options:
+          - april-clearwater
+          - workspace-agents
+      pr_number:
+        description: "Pull request number to review"
+        type: number
+        required: true
+      review_event:
+        description: "Review event to submit"
+        type: choice
+        required: true
+        options:
+          - COMMENT
+          - REQUEST_CHANGES
+          - APPROVE
+      body:
+        description: "Review body text"
+        type: string
+        required: true
+
+permissions:
+  # This workflow validates GitHub App review capability. These permissions only
+  # apply to GITHUB_TOKEN and are intentionally minimal.
+  contents: read
+
+concurrency:
+  group: app-review-smoke-${{ inputs.app_slug }}-${{ inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate April app token
+        if: inputs.app_slug == 'april-clearwater'
+        id: april-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APRIL_APP_ID }}
+          private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
+
+      - name: Generate Workspace Agents app token
+        if: inputs.app_slug == 'workspace-agents'
+        id: workspace-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
+          private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}
+
+      - name: Resolve selected app token
+        id: resolve
+        env:
+          APP_SLUG: ${{ inputs.app_slug }}
+          APRIL_TOKEN: ${{ steps.april-token.outputs.token }}
+          WORKSPACE_TOKEN: ${{ steps.workspace-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          case "$APP_SLUG" in
+            april-clearwater)
+              token="$APRIL_TOKEN"
+              expected_login="april-clearwater[bot]"
+              ;;
+            workspace-agents)
+              token="$WORKSPACE_TOKEN"
+              expected_login="workspace-agents[bot]"
+              ;;
+            *)
+              echo "Unsupported app slug: $APP_SLUG" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$token" ]; then
+            echo "No app token was generated for $APP_SLUG" >&2
+            exit 1
+          fi
+
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+          echo "expected_login=$expected_login" >> "$GITHUB_OUTPUT"
+
+      - name: Submit app-native review
+        env:
+          GH_TOKEN: ${{ steps.resolve.outputs.token }}
+          APP_SLUG: ${{ inputs.app_slug }}
+          EXPECTED_LOGIN: ${{ steps.resolve.outputs.expected_login }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REVIEW_EVENT: ${{ inputs.review_event }}
+          REVIEW_BODY: ${{ inputs.body }}
+        run: |
+          set -euo pipefail
+          unset GITHUB_TOKEN || true
+
+          case "$REVIEW_EVENT" in
+            COMMENT)
+              review_flag="--comment"
+              expected_state="COMMENTED"
+              ;;
+            REQUEST_CHANGES)
+              review_flag="--request-changes"
+              expected_state="CHANGES_REQUESTED"
+              ;;
+            APPROVE)
+              review_flag="--approve"
+              expected_state="APPROVED"
+              ;;
+            *)
+              echo "Unsupported review event: $REVIEW_EVENT" >&2
+              exit 1
+              ;;
+          esac
+
+          viewer=$(gh api graphql -f query='query { viewer { login } }' --jq '.data.viewer.login')
+          echo "viewer=$viewer"
+
+          if [ "$viewer" != "$EXPECTED_LOGIN" ]; then
+            echo "Unexpected authenticated identity: expected $EXPECTED_LOGIN, got $viewer" >&2
+            exit 1
+          fi
+
+          marker="[app-review-smoke] run ${GITHUB_RUN_ID} attempt ${GITHUB_RUN_ATTEMPT}"
+          body_file=$(mktemp)
+          printf '%s\n\n%s\n' "$REVIEW_BODY" "$marker" > "$body_file"
+
+          set +e
+          output=$(gh pr review "$PR_NUMBER" "$review_flag" --body-file "$body_file" --repo "$GITHUB_REPOSITORY" 2>&1)
+          status=$?
+          set -e
+
+          printf '%s\n' "$output"
+
+          if [[ "$output" == *"Resource not accessible by integration"* || "$output" == *"addPullRequestReview"* ]]; then
+            echo "GitHub App review failed with an integration permissions error." >&2
+            exit 1
+          fi
+
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
+
+          reviews_json=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews")
+          review_author=$(printf '%s' "$reviews_json" | jq -r --arg marker "$marker" 'map(select((.body // "") | contains($marker))) | last | .user.login // empty')
+          review_state=$(printf '%s' "$reviews_json" | jq -r --arg marker "$marker" 'map(select((.body // "") | contains($marker))) | last | .state // empty')
+
+          if [ -z "$review_author" ] || [ -z "$review_state" ]; then
+            echo "Unable to find the smoke review after submission." >&2
+            exit 1
+          fi
+
+          echo "review_author=$review_author"
+          echo "review_state=$review_state"
+
+          if [ "$review_author" != "$EXPECTED_LOGIN" ]; then
+            echo "Unexpected review author: expected $EXPECTED_LOGIN, got $review_author" >&2
+            exit 1
+          fi
+
+          if [ "$review_author" = "github-actions[bot]" ]; then
+            echo "Review was authored by github-actions[bot], not the GitHub App bot." >&2
+            exit 1
+          fi
+
+          if [ "$review_state" != "$expected_state" ]; then
+            echo "Unexpected review state: expected $expected_state, got $review_state" >&2
+            exit 1
+          fi
+
+          {
+            echo "### GitHub App Review Smoke"
+            echo ""
+            echo "- app: \`$APP_SLUG\`"
+            echo "- viewer: \`$viewer\`"
+            echo "- review author: \`$review_author\`"
+            echo "- review state: \`$review_state\`"
+            echo "- pull request: \`#$PR_NUMBER\`"
+            echo "- marker: \`$marker\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/development/agent-owner-protocol.md
+++ b/docs/development/agent-owner-protocol.md
@@ -188,13 +188,20 @@ Good examples:
 - Keep the feedback on the PR, not in a new side discussion.
 - If requested evidence is still missing or blocked, treat the PR as not ready unless you intentionally decide to merge anyway.
 
+## If Native App Reviews Break
+
+- Workflow `permissions:` only affect the built-in `GITHUB_TOKEN`. They do not grant pull request review authority to GitHub App installation tokens.
+- Update the affected GitHub App in GitHub settings so the repository permissions include `pull_requests: write`, `contents: write`, `issues: write`, `discussions: write`, and `metadata: read`.
+- After saving the permission change, re-approve the app installation for `fairchild/workspaces`. Existing installations do not pick up new permissions until you do.
+- Run the manual `GitHub App Review Smoke` workflow against a disposable PR before relying on app-native reviews again.
+
 ## Current Limitations
 
 - The execution approval signal is per planned discussion, not per issue.
 - Removing 👍 stops new issue pickup for that discussion, but you should still comment directly on any already-open PR you want paused or redirected.
 - Claim ownership is tracked by labels, claim comments, and GitHub issue assignments. Agents assign themselves when claiming an issue and are unassigned when claims expire.
 - `Requested Evidence` is a required-by-default PR evidence contract; the current status of each item lives in the PR body's `## Evidence Status` section.
-- The workflows are wired for execution, but the installed GitHub Apps still need `contents: write` in GitHub App settings for branch push and PR creation to work.
+- GitHub App permission changes and installation reapproval are manual GitHub web UI steps today.
 - Agents do not merge PRs.
 - Evidence waivers are manual today. If you choose to merge despite blocked evidence, do it explicitly in the PR conversation and on your own judgment.
 


### PR DESCRIPTION
## Summary
- remove the workflow-token review fallback and restore app-token-only review submission
- add a smoke workflow for future deterministic GitHub App review verification
- document that GitHub App installation permissions, not workflow `permissions:`, control app-native review capability

## Validation
- uv run python .agents/scripts/test_run_planner.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/app-review-smoke.yml")'
- gh api /repos/fairchild/workspaces/actions/permissions/workflow

## Evidence Status
- [complete] `april-clearwater` request-changes smoke on PR #125 -- run 23228140828 succeeded and review marker `[smoke-april-request-20260318-1]` was authored by `april-clearwater[bot]`
- [complete] `workspace-agents` request-changes smoke on PR #125 -- run 23228169914 succeeded and review marker `[smoke-plat-request-20260318-1]` was authored by `workspace-agents[bot]`
- [complete] unit tests for contributor runtime updates -- `uv run python .agents/scripts/test_run_planner.py` passed locally with 46 tests
- [complete] workflow syntax sanity for `.github/workflows/app-review-smoke.yml` -- Ruby YAML load passed locally
