### PR TITLE
Fix agent CI evidence flow

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -1007,6 +1007,32 @@ class RunContributorTests(unittest.TestCase):
             ["Screenshot of NewWorkspaceSheet from the exact commit under review"],
         )
 
+    def test_validate_evidence_accounting_accepts_pending_ci_entries(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [pending-ci] swift test --filter NewWorkspaceSheetTests -- self-hosted macOS CI will run this command\n"
+            "- [pending-ci] Screenshot of NewWorkspaceSheet from the exact commit under review -- self-hosted macOS CI will capture this\n\n"
+            "## Validation\n"
+            "- blocked on evidence: macOS-only evidence is deferred to CI\n"
+        )
+        accounting, errors = run_contributor.validate_evidence_accounting(
+            body,
+            [
+                "swift test --filter NewWorkspaceSheetTests",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            accounting["pending_ci_items"],
+            [
+                "swift test --filter NewWorkspaceSheetTests",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+
     def test_validate_evidence_accounting_rejects_missing_requested_item(self) -> None:
         body = (
             "## Summary\n"
@@ -1066,6 +1092,88 @@ class RunContributorTests(unittest.TestCase):
         )
         self.assertIsNotNone(gate_error)
         self.assertIn("request_changes", gate_error)
+
+    def test_extract_test_commands_preserves_explicit_swift_test_commands(self) -> None:
+        commands = run_contributor._extract_test_commands(
+            [
+                "swift test --filter WorkspaceProviders",
+                "swift test --filter NewWorkspaceSheetTests",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ]
+        )
+        self.assertEqual(
+            commands,
+            [
+                "swift test --filter WorkspaceProviders",
+                "swift test --filter NewWorkspaceSheetTests",
+            ],
+        )
+
+    def test_needs_macos_evidence_for_screenshot_only_requests(self) -> None:
+        self.assertTrue(
+            run_contributor._needs_macos_evidence(
+                ["Screenshot of NewWorkspaceSheet from the exact commit under review"]
+            )
+        )
+
+    def test_reconcile_pending_ci_evidence_marks_successful_items_complete(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [pending-ci] swift build -- self-hosted macOS CI will run this command\n"
+            "- [pending-ci] swift test --filter WorkspaceProviders -- self-hosted macOS CI will run this command\n"
+            "- [pending-ci] Screenshot of NewWorkspaceSheet from the exact commit under review -- self-hosted macOS CI will capture this\n\n"
+            "## Validation\n"
+            "- blocked on evidence: macOS-only evidence is deferred to CI\n"
+        )
+        reconciled = run_contributor.reconcile_pending_ci_evidence(
+            body,
+            build_succeeded=True,
+            tests_succeeded=True,
+            smoke_succeeded=True,
+        )
+        accounting, errors = run_contributor.validate_evidence_accounting(
+            reconciled,
+            [
+                "swift build",
+                "swift test --filter WorkspaceProviders",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(accounting["pending_ci_items"], [])
+        self.assertEqual(accounting["blocked_items"], [])
+        self.assertEqual(
+            accounting["complete_items"],
+            [
+                "swift build",
+                "swift test --filter WorkspaceProviders",
+                "Screenshot of NewWorkspaceSheet from the exact commit under review",
+            ],
+        )
+
+    def test_reconcile_pending_ci_evidence_marks_failed_tests_blocked(self) -> None:
+        body = (
+            "## Summary\n"
+            "- Updated the status severity mapping\n\n"
+            "## Evidence Status\n"
+            "- [pending-ci] swift test --filter WorkspaceProviders -- self-hosted macOS CI will run this command\n\n"
+            "## Validation\n"
+            "- blocked on evidence: macOS-only evidence is deferred to CI\n"
+        )
+        reconciled = run_contributor.reconcile_pending_ci_evidence(
+            body,
+            build_succeeded=True,
+            tests_succeeded=False,
+            smoke_succeeded=True,
+        )
+        accounting, errors = run_contributor.validate_evidence_accounting(
+            reconciled,
+            ["swift test --filter WorkspaceProviders"],
+        )
+        self.assertEqual(accounting["blocked_items"], ["swift test --filter WorkspaceProviders"])
+        self.assertEqual(errors, [])
 
     def test_format_pr_list_for_context_includes_evidence_summary(self) -> None:
         issue_body = run_planner.compose_issue_body_with_metadata(

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -666,6 +666,100 @@ def review_evidence_gate_error(verdict: str, accounting: dict[str, object], erro
     return None
 
 
+def _normalize_evidence_item(item: str) -> str:
+    return item.strip().strip("`").strip()
+
+
+def _evidence_item_kind(item: str) -> str:
+    normalized = _normalize_evidence_item(item).casefold()
+    if normalized.startswith("swift test"):
+        return "test"
+    if normalized.startswith("swift build"):
+        return "build"
+    if "screenshot" in normalized or "screen recording" in normalized:
+        return "screenshot"
+    return "other"
+
+
+def _needs_macos_evidence(requested_evidence: list[str]) -> bool:
+    """Return True if requested evidence includes macOS-only proof."""
+    return any(_evidence_item_kind(item) != "other" for item in requested_evidence)
+
+
+def _needs_screenshot_evidence(requested_evidence: list[str]) -> bool:
+    return any(_evidence_item_kind(item) == "screenshot" for item in requested_evidence)
+
+
+def _extract_test_commands(requested_evidence: list[str]) -> list[str]:
+    return [
+        _normalize_evidence_item(item)
+        for item in requested_evidence
+        if _evidence_item_kind(item) == "test"
+    ]
+
+
+def _pending_ci_resolution(
+    item: str,
+    *,
+    build_succeeded: bool,
+    tests_succeeded: bool,
+    smoke_succeeded: bool,
+) -> tuple[str, str]:
+    kind = _evidence_item_kind(item)
+    normalized = _normalize_evidence_item(item)
+
+    if kind == "build":
+        if build_succeeded:
+            return "complete", "`swift build` succeeded on self-hosted macOS CI"
+        return "blocked", "self-hosted macOS CI `swift build` failed; see workflow logs"
+    if kind == "test":
+        if tests_succeeded:
+            return "complete", f"`{normalized}` succeeded on self-hosted macOS CI"
+        return "blocked", f"self-hosted macOS CI `{normalized}` failed; see test-output.txt"
+    if kind == "screenshot":
+        if smoke_succeeded:
+            return "complete", "captured on self-hosted macOS CI; see workflow artifacts"
+        return "blocked", "self-hosted macOS CI screenshot capture failed; see dev-smoke-output.txt"
+    return "blocked", "self-hosted macOS CI cannot reconcile this evidence item automatically"
+
+
+def reconcile_pending_ci_evidence(
+    body: str,
+    *,
+    build_succeeded: bool,
+    tests_succeeded: bool,
+    smoke_succeeded: bool,
+) -> str:
+    """Resolve pending-ci evidence lines after the macOS evidence job finishes."""
+    lines = body.splitlines()
+    updated: list[str] = []
+    in_evidence_status = False
+
+    for line in lines:
+        if line.startswith("## "):
+            in_evidence_status = line.strip() == "## Evidence Status"
+            updated.append(line)
+            continue
+        if in_evidence_status:
+            match = EVIDENCE_STATUS_LINE_RE.match(line)
+            if match and match.group("status") == "pending-ci":
+                item = match.group("item").strip()
+                status, detail = _pending_ci_resolution(
+                    item,
+                    build_succeeded=build_succeeded,
+                    tests_succeeded=tests_succeeded,
+                    smoke_succeeded=smoke_succeeded,
+                )
+                updated.append(f"- [{status}] {item} -- {detail}")
+                continue
+        updated.append(line)
+
+    reconciled = "\n".join(updated)
+    if body.endswith("\n"):
+        reconciled += "\n"
+    return reconciled
+
+
 def latest_issue_claim(issue_number: int, comments: dict[str, object]) -> dict[str, str] | None:
     nodes = comments.get("nodes", []) if isinstance(comments, dict) else []
     claims: list[dict[str, str]] = []
@@ -1717,37 +1811,11 @@ def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -
         )
 
 
-def _changed_files_in_head(env: dict[str, str]) -> list[str]:
-    """Return files changed in the most recent commit."""
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
-        capture_output=True, text=True, timeout=GITHUB_API_TIMEOUT, cwd=REPO_ROOT,
-        env=env,
-    )
-    if result.returncode != 0:
-        return []
-    return [f for f in result.stdout.strip().splitlines() if f]
-
-
-def _needs_macos_evidence(changed: list[str]) -> bool:
-    """Return True if any changed file requires a macOS build to validate."""
-    macos_prefixes = ("Sources/", "Tests/", "Package.swift")
-    return any(f.startswith(macos_prefixes) for f in changed)
-
-
-def _extract_test_filter(requested_evidence: list[str]) -> str:
-    """Extract a swift test filter from requested evidence items, if any."""
-    for item in requested_evidence:
-        for token in item.split():
-            if "Test" in token and not token.startswith("http"):
-                return token.rstrip(".,;:)")
-    return ""
-
-
 def _write_github_outputs(
     needs_evidence: bool,
+    needs_screenshot_evidence: bool,
     branch: str,
-    test_filter: str,
+    test_commands: list[str],
 ) -> None:
     """Write outputs to $GITHUB_OUTPUT for downstream workflow jobs."""
     output_file = os.environ.get("GITHUB_OUTPUT", "")
@@ -1756,9 +1824,16 @@ def _write_github_outputs(
         return
     with open(output_file, "a") as f:
         f.write(f"needs_macos_evidence={str(needs_evidence).lower()}\n")
+        f.write(f"needs_screenshot_evidence={str(needs_screenshot_evidence).lower()}\n")
         f.write(f"pr_branch={branch}\n")
-        f.write(f"test_filter={test_filter}\n")
-    log(f"Emitted outputs: needs_macos_evidence={needs_evidence}, pr_branch={branch}, test_filter={test_filter}")
+        f.write(f"test_commands_json={json.dumps(test_commands, separators=(',', ':'))}\n")
+    log(
+        "Emitted outputs: "
+        f"needs_macos_evidence={needs_evidence}, "
+        f"needs_screenshot_evidence={needs_screenshot_evidence}, "
+        f"pr_branch={branch}, "
+        f"test_commands={test_commands}"
+    )
 
 
 def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int:
@@ -1966,10 +2041,15 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 env=env,
             )
 
-            changed = _changed_files_in_head(env)
-            evidence_needed = _needs_macos_evidence(changed)
-            test_filter = _extract_test_filter(requested_evidence)
-            _write_github_outputs(evidence_needed, branch, test_filter)
+            evidence_needed = _needs_macos_evidence(requested_evidence)
+            screenshot_evidence_needed = _needs_screenshot_evidence(requested_evidence)
+            test_commands = _extract_test_commands(requested_evidence)
+            _write_github_outputs(
+                evidence_needed,
+                screenshot_evidence_needed,
+                branch,
+                test_commands,
+            )
 
             if own_pr is not None:
                 run_checked(

--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -33,8 +33,9 @@ jobs:
     timeout-minutes: 30
     outputs:
       needs_macos_evidence: ${{ steps.contributor.outputs.needs_macos_evidence }}
+      needs_screenshot_evidence: ${{ steps.contributor.outputs.needs_screenshot_evidence }}
       pr_branch: ${{ steps.contributor.outputs.pr_branch }}
-      test_filter: ${{ steps.contributor.outputs.test_filter }}
+      test_commands_json: ${{ steps.contributor.outputs.test_commands_json }}
     steps:
       - name: Generate app token
         id: app-token
@@ -77,27 +78,114 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.run.outputs.pr_branch }}
           fetch-depth: 50
       - name: Build GhosttyKit
+        id: ghosttykit
+        continue-on-error: true
         run: ./scripts/build-ghosttykit.sh
       - name: Build app
+        id: build
+        continue-on-error: true
         run: swift build
-      - name: Run targeted tests
-        if: needs.run.outputs.test_filter != ''
-        run: swift test --filter '${{ needs.run.outputs.test_filter }}' 2>&1 | tee test-output.txt || true
-      - name: Run all tests (no filter specified)
-        if: needs.run.outputs.test_filter == ''
-        run: swift test 2>&1 | tee test-output.txt || true
+      - name: Run requested tests
+        id: tests
+        if: needs.run.outputs.test_commands_json != '[]'
+        continue-on-error: true
+        shell: bash
+        env:
+          TEST_COMMANDS_JSON: ${{ needs.run.outputs.test_commands_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > .ci-test-commands.txt
+          import json
+          import os
+
+          for command in json.loads(os.environ["TEST_COMMANDS_JSON"]):
+              print(command)
+          PY
+
+          : > test-output.txt
+          while IFS= read -r command; do
+            echo "$ $command" | tee -a test-output.txt
+            bash -lc "set -o pipefail; $command 2>&1 | tee -a test-output.txt"
+          done < .ci-test-commands.txt
       - name: Capture evidence
-        run: ./scripts/dev-smoke.sh --no-build 2>&1 | head -100 || true
+        id: smoke
+        if: needs.run.outputs.needs_screenshot_evidence == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          ./scripts/dev-smoke.sh --no-build 2>&1 | tee dev-smoke-output.txt
+      - name: Reconcile pending-ci evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BRANCH: ${{ needs.run.outputs.pr_branch }}
+          BUILD_SUCCEEDED: ${{ steps.ghosttykit.outcome == 'success' && steps.build.outcome == 'success' }}
+          TESTS_SUCCEEDED: ${{ needs.run.outputs.test_commands_json == '[]' || steps.tests.outcome == 'success' }}
+          SMOKE_SUCCEEDED: ${{ needs.run.outputs.needs_screenshot_evidence != 'true' || steps.smoke.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --json number --jq '.[0].number')
+          gh pr view "$PR_NUMBER" --json body --jq '.body' > pr-body.md
+          python3 - <<'PY'
+          import importlib.util
+          import os
+          from pathlib import Path
+
+          module_path = Path(".agents/skills/cofounder-contributor/scripts/run-contributor.py")
+          spec = importlib.util.spec_from_file_location("run_contributor", module_path)
+          module = importlib.util.module_from_spec(spec)
+          assert spec.loader is not None
+          spec.loader.exec_module(module)
+
+          body_path = Path("pr-body.md")
+          reconciled = module.reconcile_pending_ci_evidence(
+              body_path.read_text(),
+              build_succeeded=os.environ["BUILD_SUCCEEDED"] == "true",
+              tests_succeeded=os.environ["TESTS_SUCCEEDED"] == "true",
+              smoke_succeeded=os.environ["SMOKE_SUCCEEDED"] == "true",
+          )
+          body_path.write_text(reconciled)
+          PY
+          gh pr edit "$PR_NUMBER" --body-file pr-body.md
       - name: Upload evidence artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: evidence-${{ github.run_id }}
           path: |
             output/
             test-output.txt
+            dev-smoke-output.txt
+      - name: Fail on evidence errors
+        if: always()
+        shell: bash
+        env:
+          GHOSTTYKIT_OUTCOME: ${{ steps.ghosttykit.outcome }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          TESTS_OUTCOME: ${{ steps.tests.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          TEST_COMMANDS_JSON: ${{ needs.run.outputs.test_commands_json }}
+          NEEDS_SCREENSHOT_EVIDENCE: ${{ needs.run.outputs.needs_screenshot_evidence }}
+        run: |
+          set -euo pipefail
+          if [ "$GHOSTTYKIT_OUTCOME" != "success" ] || [ "$BUILD_OUTCOME" != "success" ]; then
+            echo "Build evidence failed"
+            exit 1
+          fi
+          if [ "$TEST_COMMANDS_JSON" != "[]" ] && [ "$TESTS_OUTCOME" != "success" ]; then
+            echo "Requested test evidence failed"
+            exit 1
+          fi
+          if [ "$NEEDS_SCREENSHOT_EVIDENCE" = "true" ] && [ "$SMOKE_OUTCOME" != "success" ]; then
+            echo "Screenshot evidence failed"
+            exit 1
+          fi

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -33,8 +33,9 @@ jobs:
     timeout-minutes: 30
     outputs:
       needs_macos_evidence: ${{ steps.contributor.outputs.needs_macos_evidence }}
+      needs_screenshot_evidence: ${{ steps.contributor.outputs.needs_screenshot_evidence }}
       pr_branch: ${{ steps.contributor.outputs.pr_branch }}
-      test_filter: ${{ steps.contributor.outputs.test_filter }}
+      test_commands_json: ${{ steps.contributor.outputs.test_commands_json }}
     steps:
       - name: Generate app token
         id: app-token
@@ -77,27 +78,114 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.run.outputs.pr_branch }}
           fetch-depth: 50
       - name: Build GhosttyKit
+        id: ghosttykit
+        continue-on-error: true
         run: ./scripts/build-ghosttykit.sh
       - name: Build app
+        id: build
+        continue-on-error: true
         run: swift build
-      - name: Run targeted tests
-        if: needs.run.outputs.test_filter != ''
-        run: swift test --filter '${{ needs.run.outputs.test_filter }}' 2>&1 | tee test-output.txt || true
-      - name: Run all tests (no filter specified)
-        if: needs.run.outputs.test_filter == ''
-        run: swift test 2>&1 | tee test-output.txt || true
+      - name: Run requested tests
+        id: tests
+        if: needs.run.outputs.test_commands_json != '[]'
+        continue-on-error: true
+        shell: bash
+        env:
+          TEST_COMMANDS_JSON: ${{ needs.run.outputs.test_commands_json }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' > .ci-test-commands.txt
+          import json
+          import os
+
+          for command in json.loads(os.environ["TEST_COMMANDS_JSON"]):
+              print(command)
+          PY
+
+          : > test-output.txt
+          while IFS= read -r command; do
+            echo "$ $command" | tee -a test-output.txt
+            bash -lc "set -o pipefail; $command 2>&1 | tee -a test-output.txt"
+          done < .ci-test-commands.txt
       - name: Capture evidence
-        run: ./scripts/dev-smoke.sh --no-build 2>&1 | head -100 || true
+        id: smoke
+        if: needs.run.outputs.needs_screenshot_evidence == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          ./scripts/dev-smoke.sh --no-build 2>&1 | tee dev-smoke-output.txt
+      - name: Reconcile pending-ci evidence
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BRANCH: ${{ needs.run.outputs.pr_branch }}
+          BUILD_SUCCEEDED: ${{ steps.ghosttykit.outcome == 'success' && steps.build.outcome == 'success' }}
+          TESTS_SUCCEEDED: ${{ needs.run.outputs.test_commands_json == '[]' || steps.tests.outcome == 'success' }}
+          SMOKE_SUCCEEDED: ${{ needs.run.outputs.needs_screenshot_evidence != 'true' || steps.smoke.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --json number --jq '.[0].number')
+          gh pr view "$PR_NUMBER" --json body --jq '.body' > pr-body.md
+          python3 - <<'PY'
+          import importlib.util
+          import os
+          from pathlib import Path
+
+          module_path = Path(".agents/skills/cofounder-contributor/scripts/run-contributor.py")
+          spec = importlib.util.spec_from_file_location("run_contributor", module_path)
+          module = importlib.util.module_from_spec(spec)
+          assert spec.loader is not None
+          spec.loader.exec_module(module)
+
+          body_path = Path("pr-body.md")
+          reconciled = module.reconcile_pending_ci_evidence(
+              body_path.read_text(),
+              build_succeeded=os.environ["BUILD_SUCCEEDED"] == "true",
+              tests_succeeded=os.environ["TESTS_SUCCEEDED"] == "true",
+              smoke_succeeded=os.environ["SMOKE_SUCCEEDED"] == "true",
+          )
+          body_path.write_text(reconciled)
+          PY
+          gh pr edit "$PR_NUMBER" --body-file pr-body.md
       - name: Upload evidence artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: evidence-${{ github.run_id }}
           path: |
             output/
             test-output.txt
+            dev-smoke-output.txt
+      - name: Fail on evidence errors
+        if: always()
+        shell: bash
+        env:
+          GHOSTTYKIT_OUTCOME: ${{ steps.ghosttykit.outcome }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          TESTS_OUTCOME: ${{ steps.tests.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          TEST_COMMANDS_JSON: ${{ needs.run.outputs.test_commands_json }}
+          NEEDS_SCREENSHOT_EVIDENCE: ${{ needs.run.outputs.needs_screenshot_evidence }}
+        run: |
+          set -euo pipefail
+          if [ "$GHOSTTYKIT_OUTCOME" != "success" ] || [ "$BUILD_OUTCOME" != "success" ]; then
+            echo "Build evidence failed"
+            exit 1
+          fi
+          if [ "$TEST_COMMANDS_JSON" != "[]" ] && [ "$TESTS_OUTCOME" != "success" ]; then
+            echo "Requested test evidence failed"
+            exit 1
+          fi
+          if [ "$NEEDS_SCREENSHOT_EVIDENCE" = "true" ] && [ "$SMOKE_OUTCOME" != "success" ]; then
+            echo "Screenshot evidence failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Fix the new macOS evidence workflow so `[pending-ci]` entries can resolve after CI and targeted test evidence runs the exact requested `swift test` commands.

## Changes

- derive macOS evidence needs from `requested_evidence` instead of the latest commit's file paths
- emit exact `swift test ...` commands for the workflow instead of trying to guess a filter token
- add PR-body reconciliation so the evidence job rewrites `[pending-ci]` entries to `[complete]` or `[blocked]`
- make the evidence jobs fail explicitly when build, test, or screenshot capture evidence fails
- add regression coverage for pending-ci accounting, test-command extraction, screenshot-only evidence, and reconciliation behavior

## Validation

- `python3 -m py_compile .agents/skills/cofounder-contributor/scripts/run-contributor.py`
- `uv run --script .agents/scripts/test_run_planner.py`
- YAML parse for `.github/workflows/agent-april.yml`
- YAML parse for `.github/workflows/agent-plat.yml`
