### PR TITLE
Show progress before New Workspace finishes probing

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
 
     @State private var viewState = MainWindowViewState()
     @State private var repoForNewWorkspaceFromLanding: Repo?
+    @State private var isPreparingLandingNewWorkspaceSheet = false
     @State private var webSourceCreationTarget: WebSourceCreationTarget?
     @State private var landingErrorMessage: String?
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
@@ -601,6 +602,7 @@ struct ContentView: View {
                 NewWorkspaceSheet(
                     repo: repo,
                     environmentOptions: environmentOptions(for: repo),
+                    isPreparingEnvironmentOptions: isPreparingLandingNewWorkspaceSheet,
                     isCreateDisabled: false
                 ) { name, nameSource, providerID, guestOS in
                     Task { @MainActor in
@@ -679,7 +681,6 @@ struct ContentView: View {
                 attemptID: attemptID,
                 outcome: "success"
             )
-            return
         }
 
         workspaceEnvironmentSheetState = workspaceEnvironmentOptionsController.prepareSheetStateForPresentation(
@@ -687,6 +688,7 @@ struct ContentView: View {
             registry: workspaceProviderRegistry
         )
         repoForNewWorkspaceFromLanding = repo
+        isPreparingLandingNewWorkspaceSheet = true
         InvestigationDiagnostics.emitSheet(
             phase: "landing_sheet_context_set",
             fields: [
@@ -700,6 +702,9 @@ struct ContentView: View {
         )
 
         Task { @MainActor in
+            defer {
+                isPreparingLandingNewWorkspaceSheet = false
+            }
             await refreshLandingWorkspaceEnvironmentState(trigger: "landing_sheet_open")
             InvestigationDiagnostics.emitSheet(
                 phase: "landing_environment_refresh_completed",

--- a/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceSheet.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceSheet.swift
@@ -49,6 +49,7 @@ struct WorkspaceEnvironmentSheetOption: Identifiable {
 struct NewWorkspaceSheet: View {
     let repo: Repo
     let environmentOptions: [WorkspaceEnvironmentSheetOption]
+    let isPreparingEnvironmentOptions: Bool
     let isCreateDisabled: Bool
     let onCreate: (String, WorkspaceNameSource, String, WorkspaceGuestOS?) -> Void
 
@@ -133,6 +134,11 @@ struct NewWorkspaceSheet: View {
             .padding(.bottom, 16)
 
             Divider()
+
+            if isPreparingEnvironmentOptions {
+                preparationBanner
+                Divider()
+            }
 
             Form {
                 TextField("Workspace Name", text: $name)
@@ -221,6 +227,32 @@ struct NewWorkspaceSheet: View {
         .onChange(of: name) { _, newValue in
             updateNameSource(for: newValue)
         }
+    }
+
+    private var preparationBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Checking workspace environments...")
+                    .font(.callout.weight(.semibold))
+
+                Text(
+                    "Provider availability and VM runtime details are still loading. "
+                        + "You can keep typing while the options update."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+        .background(Color.secondary.opacity(0.06))
     }
 
     private var iconName: String {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -68,6 +68,7 @@ struct SidebarView: View {
     @State private var workspaceAction: WorkspaceActionState?
     @State private var workspaceCreationStatusByRepoID: [UUID: WorkspaceCreationStatus] = [:]
     @State private var repoLastAccessedSnapshotByID: [UUID: Date] = [:]
+    @State private var isPreparingNewWorkspaceSheet = false
 
     private var isUIFixtureMode: Bool {
         ProcessInfo.processInfo.environment["WORKSPACES_UI_FIXTURE"] == "1"
@@ -145,6 +146,7 @@ struct SidebarView: View {
                 NewWorkspaceSheet(
                     repo: context.repo,
                     environmentOptions: environmentOptions(for: context.repo),
+                    isPreparingEnvironmentOptions: isPreparingNewWorkspaceSheet,
                     isCreateDisabled: isCreatingWorkspace(for: context.repo.id)
                 ) { name, nameSource, providerID, guestOS in
                     Task { @MainActor in
@@ -1006,6 +1008,7 @@ struct SidebarView: View {
         )
 
         newWorkspaceSheetContext = NewWorkspaceSheetContext(repo: repo)
+        isPreparingNewWorkspaceSheet = true
         InvestigationDiagnostics.emitSheet(
             phase: "sidebar_sheet_context_set",
             fields: [
@@ -1019,6 +1022,9 @@ struct SidebarView: View {
         )
 
         Task { @MainActor in
+            defer {
+                isPreparingNewWorkspaceSheet = false
+            }
             await refreshWorkspaceEnvironmentState(trigger: "sidebar_sheet_open")
             InvestigationDiagnostics.emitSheet(
                 phase: "sidebar_environment_refresh_completed",


### PR DESCRIPTION
## Summary
- open the New Workspace sheet immediately from both sidebar and landing entry points
- show an in-sheet progress banner while provider/runtime probing is still running
- avoid recreating the sidebar sheet during refresh so typed names do not reset

Closes #100

## Validation
- `./scripts/build-ghosttykit.sh`
- `swift test --filter NewWorkspaceSheetTests`
- `swift build`
- `WORKSPACES_UI_FIXTURE_LUME_STEP_DELAY_MS=4000 ./scripts/lume-e2e-capture.sh`
- blocked on GitHub-visible evidence

## Evidence Status
- [complete] `swift build` -- passed locally on March 20, 2026
- [complete] `swift test --filter NewWorkspaceSheetTests` -- passed locally on March 20, 2026
- [blocked] Screenshot of the New Workspace sheet showing visible progress during a slow environment probe -- local capture is ready at `/Users/fairchild/.codex/worktrees/1285/workspaces/output/lume-e2e/20260319-072617/01-new-workspace-sheet.png`; blocked on GitHub-visible evidence
- [blocked] Screenshot of the post-probe New Workspace state after the environment details resolve -- local capture is ready at `/Users/fairchild/.codex/worktrees/1285/workspaces/output/lume-e2e/20260319-072617/02-macos-vm-selected.png`; blocked on GitHub-visible evidence

## Notes
- Rebased on latest `main` on March 20, 2026 to clear merge conflicts after #136, #137, and #138 landed.
