### PR TITLE
Wire R2 evidence URLs into April workflow

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -747,15 +747,22 @@ def _extract_test_commands(requested_evidence: list[str]) -> list[str]:
     ]
 
 
+def _format_uploaded_evidence_links(uploaded_urls: list[tuple[str, str]]) -> str:
+    return ", ".join(f"[{label}]({url})" for label, url in uploaded_urls)
+
+
 def _pending_ci_resolution(
     item: str,
     *,
     build_succeeded: bool,
     tests_succeeded: bool,
     smoke_succeeded: bool,
+    screenshot_upload_succeeded: bool = False,
+    screenshot_urls: list[tuple[str, str]] | None = None,
 ) -> tuple[str, str]:
     kind = _evidence_item_kind(item)
     normalized = _normalize_evidence_item(item)
+    uploaded_screenshot_urls = screenshot_urls or []
 
     if kind == "build":
         if build_succeeded:
@@ -767,7 +774,12 @@ def _pending_ci_resolution(
         return "blocked", f"self-hosted macOS CI `{normalized}` failed; see test-output.txt"
     if kind == "screenshot":
         if smoke_succeeded:
-            return "complete", "captured on self-hosted macOS CI; see workflow artifacts"
+            if screenshot_upload_succeeded and uploaded_screenshot_urls:
+                links = _format_uploaded_evidence_links(uploaded_screenshot_urls)
+                return "complete", f"captured on self-hosted macOS CI: {links}"
+            if screenshot_upload_succeeded:
+                return "blocked", "self-hosted macOS CI captured screenshots but no R2 URLs were recorded; see workflow artifacts"
+            return "blocked", "self-hosted macOS CI captured screenshots but R2 upload failed; see workflow artifacts"
         return "blocked", "self-hosted macOS CI screenshot capture failed; see dev-smoke-output.txt"
     return "blocked", "self-hosted macOS CI cannot reconcile this evidence item automatically"
 
@@ -778,6 +790,8 @@ def reconcile_pending_ci_evidence(
     build_succeeded: bool,
     tests_succeeded: bool,
     smoke_succeeded: bool,
+    screenshot_upload_succeeded: bool = False,
+    screenshot_urls: list[tuple[str, str]] | None = None,
 ) -> str:
     """Resolve pending-ci evidence lines after the macOS evidence job finishes."""
     lines = body.splitlines()
@@ -798,6 +812,8 @@ def reconcile_pending_ci_evidence(
                     build_succeeded=build_succeeded,
                     tests_succeeded=tests_succeeded,
                     smoke_succeeded=smoke_succeeded,
+                    screenshot_upload_succeeded=screenshot_upload_succeeded,
+                    screenshot_urls=screenshot_urls,
                 )
                 updated.append(f"- [{status}] {item} -- {detail}")
                 continue

--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           ref: ${{ needs.run.outputs.pr_branch }}
           fetch-depth: 50
+      - uses: astral-sh/setup-uv@v7
       - name: Build GhosttyKit
         id: ghosttykit
         continue-on-error: true
@@ -165,32 +166,61 @@ jobs:
         run: |
           set -o pipefail
           ./scripts/dev-smoke.sh --no-build 2>&1 | tee dev-smoke-output.txt
-      - name: Upload evidence to R2
-        if: hashFiles('output/**/*.png') != ''
+      - name: Resolve PR number
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BRANCH: ${{ needs.run.outputs.pr_branch }}
         run: |
-          for f in output/**/*.png; do
-            [ -f "$f" ] || continue
-            SLUG=$(basename "$f" .png)
-            uv run scripts/upload-evidence.py "$f" \
-              --repo workspaces \
-              --pr "${{ needs.run.outputs.pr_branch }}" \
-              --name "$SLUG" \
-              --breadcrumb || true
-          done
+          set -euo pipefail
+          PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "Could not resolve a PR number for branch: $PR_BRANCH" >&2
+            exit 1
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+      - name: Upload screenshot evidence to R2
+        id: upload
+        if: steps.smoke.outcome == 'success' && needs.run.outputs.needs_screenshot_evidence == 'true'
+        shell: bash
         env:
           EVIDENCE_UPLOAD_TOKEN: ${{ secrets.EVIDENCE_UPLOAD_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          files=(output/**/*.png)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No PNG evidence files found under output/" >&2
+            exit 1
+          fi
+
+          : > uploaded-screenshot-urls.tsv
+          count=0
+          for f in "${files[@]}"; do
+            slug=$(basename "$f" .png)
+            url=$(uv run scripts/upload-evidence.py "$f" \
+              --repo workspaces \
+              --pr "$PR_NUMBER" \
+              --name "$slug" \
+              --breadcrumb)
+            printf '%s\t%s\n' "$slug" "$url" >> uploaded-screenshot-urls.tsv
+            count=$((count + 1))
+          done
+          echo "count=$count" >> "$GITHUB_OUTPUT"
       - name: Reconcile pending-ci evidence
         if: always()
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_BRANCH: ${{ needs.run.outputs.pr_branch }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           BUILD_SUCCEEDED: ${{ steps.ghosttykit.outcome == 'success' && steps.build.outcome == 'success' }}
           TESTS_SUCCEEDED: ${{ needs.run.outputs.test_commands_json == '[]' || steps.tests.outcome == 'success' }}
           SMOKE_SUCCEEDED: ${{ needs.run.outputs.needs_screenshot_evidence != 'true' || steps.smoke.outcome == 'success' }}
+          SCREENSHOT_UPLOAD_SUCCEEDED: ${{ needs.run.outputs.needs_screenshot_evidence != 'true' || steps.upload.outcome == 'success' }}
         run: |
           set -euo pipefail
-          PR_NUMBER=$(gh pr list --head "$PR_BRANCH" --json number --jq '.[0].number')
           gh pr view "$PR_NUMBER" --json body --jq '.body' > pr-body.md
           python3 - <<'PY'
           import importlib.util
@@ -204,11 +234,22 @@ jobs:
           spec.loader.exec_module(module)
 
           body_path = Path("pr-body.md")
+          uploaded_urls: list[tuple[str, str]] = []
+          uploaded_urls_path = Path("uploaded-screenshot-urls.tsv")
+          if uploaded_urls_path.exists():
+              for line in uploaded_urls_path.read_text().splitlines():
+                  if not line.strip():
+                      continue
+                  label, url = line.split("\t", 1)
+                  uploaded_urls.append((label, url))
+
           reconciled = module.reconcile_pending_ci_evidence(
               body_path.read_text(),
               build_succeeded=os.environ["BUILD_SUCCEEDED"] == "true",
               tests_succeeded=os.environ["TESTS_SUCCEEDED"] == "true",
               smoke_succeeded=os.environ["SMOKE_SUCCEEDED"] == "true",
+              screenshot_upload_succeeded=os.environ["SCREENSHOT_UPLOAD_SUCCEEDED"] == "true",
+              screenshot_urls=uploaded_urls,
           )
           body_path.write_text(reconciled)
           PY
@@ -230,6 +271,8 @@ jobs:
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           TESTS_OUTCOME: ${{ steps.tests.outcome }}
           SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.upload.outcome }}
+          UPLOADED_SCREENSHOT_COUNT: ${{ steps.upload.outputs.count }}
           TEST_COMMANDS_JSON: ${{ needs.run.outputs.test_commands_json }}
           NEEDS_SCREENSHOT_EVIDENCE: ${{ needs.run.outputs.needs_screenshot_evidence }}
         run: |
@@ -242,7 +285,13 @@ jobs:
             echo "Requested test evidence failed"
             exit 1
           fi
-          if [ "$NEEDS_SCREENSHOT_EVIDENCE" = "true" ] && [ "$SMOKE_OUTCOME" != "success" ]; then
-            echo "Screenshot evidence failed"
-            exit 1
+          if [ "$NEEDS_SCREENSHOT_EVIDENCE" = "true" ]; then
+            if [ "$SMOKE_OUTCOME" != "success" ]; then
+              echo "Screenshot evidence failed"
+              exit 1
+            fi
+            if [ "$UPLOAD_OUTCOME" != "success" ] || [ "${UPLOADED_SCREENSHOT_COUNT:-0}" -lt 1 ]; then
+              echo "Screenshot evidence upload failed"
+              exit 1
+            fi
           fi

--- a/scripts/test_run_contributor.py
+++ b/scripts/test_run_contributor.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Stdlib tests for run-contributor evidence reconciliation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / ".agents" / "skills" / "cofounder-contributor" / "scripts" / "run-contributor.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+run_contributor = load_module("run_contributor", SCRIPT_PATH)
+
+
+class RunContributorEvidenceTests(unittest.TestCase):
+    maxDiff = None
+
+    def test_reconcile_pending_ci_evidence_includes_uploaded_screenshot_links(self) -> None:
+        body = "\n".join(
+            [
+                "## Evidence Status",
+                "- [pending-ci] Post-setup screenshot -- CI evidence job will capture screenshot",
+                "",
+                "## Validation",
+                "- blocked on evidence",
+            ]
+        )
+
+        reconciled = run_contributor.reconcile_pending_ci_evidence(
+            body,
+            build_succeeded=True,
+            tests_succeeded=True,
+            smoke_succeeded=True,
+            screenshot_upload_succeeded=True,
+            screenshot_urls=[
+                ("01-launch", "https://evidence.example/workspaces/pr-42/01-launch.png"),
+                ("02-final", "https://evidence.example/workspaces/pr-42/02-final.png"),
+            ],
+        )
+
+        self.assertIn(
+            "- [complete] Post-setup screenshot -- captured on self-hosted macOS CI: "
+            "[01-launch](https://evidence.example/workspaces/pr-42/01-launch.png), "
+            "[02-final](https://evidence.example/workspaces/pr-42/02-final.png)",
+            reconciled,
+        )
+
+    def test_reconcile_pending_ci_evidence_blocks_missing_screenshot_upload(self) -> None:
+        body = "## Evidence Status\n- [pending-ci] Final screenshot -- CI evidence job will capture screenshot\n"
+
+        reconciled = run_contributor.reconcile_pending_ci_evidence(
+            body,
+            build_succeeded=True,
+            tests_succeeded=True,
+            smoke_succeeded=True,
+            screenshot_upload_succeeded=False,
+            screenshot_urls=[],
+        )
+
+        self.assertEqual(
+            reconciled,
+            "## Evidence Status\n"
+            "- [blocked] Final screenshot -- self-hosted macOS CI captured screenshots but R2 upload failed; "
+            "see workflow artifacts\n",
+        )
+
+    def test_reconcile_pending_ci_evidence_blocks_missing_uploaded_urls(self) -> None:
+        body = "## Evidence Status\n- [pending-ci] Final screenshot -- CI evidence job will capture screenshot\n"
+
+        reconciled = run_contributor.reconcile_pending_ci_evidence(
+            body,
+            build_succeeded=True,
+            tests_succeeded=True,
+            smoke_succeeded=True,
+            screenshot_upload_succeeded=True,
+            screenshot_urls=[],
+        )
+
+        self.assertEqual(
+            reconciled,
+            "## Evidence Status\n"
+            "- [blocked] Final screenshot -- self-hosted macOS CI captured screenshots but no R2 URLs were recorded; "
+            "see workflow artifacts\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- resolve the actual PR number before uploading evidence to R2
- capture uploaded screenshot URLs and thread them back into `## Evidence Status`
- fail the evidence job when required screenshot uploads do not succeed

## Validation
- `uv run --script scripts/test_run_contributor.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-april.yml"); puts "agent-april.yml: ok"'`
- `git diff --check`
- not run: full GitHub Actions evidence workflow against the live R2 worker

## Notes
- This branch is the base for PR #135.
