### PR TITLE
Upgrade create-github-app-token workflows to v3

### DIFF
--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APRIL_APP_ID }}
           private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
@@ -70,7 +70,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APRIL_APP_ID }}
           private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APRIL_APP_ID }}
           private-key: ${{ secrets.APRIL_PRIVATE_KEY }}

--- a/.github/workflows/agent-peter.yml
+++ b/.github/workflows/agent-peter.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
           private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
           private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
           private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}

--- a/.github/workflows/app-review-smoke.yml
+++ b/.github/workflows/app-review-smoke.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate April app token
         if: inputs.app_slug == 'april-clearwater'
         id: april-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APRIL_APP_ID }}
           private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
@@ -52,7 +52,7 @@ jobs:
       - name: Generate Workspace Agents app token
         if: inputs.app_slug == 'workspace-agents'
         id: workspace-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
           private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- upgrade every workflow use of `actions/create-github-app-token` from `@v2` to `@v3`
- remove the Node.js 20 deprecation warning path without adding a workflow-level Node 24 override
- keep all existing workflow structure, inputs, and token wiring unchanged

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `git diff --check`
  - `rg -n "actions/create-github-app-token@v2" .github/workflows` returned no matches after the update
  - `gh workflow run agent-april.yml --ref codex/node24-create-github-app-token-v3 -f dry_run=true -f message="Node 24 warning validation run"`
  - validation run: https://github.com/fairchild/workspaces/actions/runs/23372000722

## Performance

- [x] Not a performance-sensitive change
- [ ] Baseline metrics were provided with the task
- [ ] Baseline metrics were gathered before changes
- [ ] Post-change metrics were gathered at the end of the work
- [ ] Before/after/delta is included below
- [ ] Any meaningful change, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Not applicable

Performance comparison notes:

- Not applicable

## Evidence

- [x] Not a UI-affecting change
- [ ] UI-affecting change with PR-attached evidence from the exact commit under review

Evidence links:

- Not applicable

## Blockers

- [x] None
- [ ] Blocked on evidence
