### PR TITLE
feat: add exportable local diagnostics for startup regressions

### DIFF
--- a/Sources/WorkspaceManager/Diagnostics/PerformanceSignposts.swift
+++ b/Sources/WorkspaceManager/Diagnostics/PerformanceSignposts.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import OSLog
+import WorkspaceManagerCore
 
 enum PerformanceSignposts {
     #if DEBUG
@@ -81,6 +82,7 @@ enum PerformanceSignposts {
             durationMs,
             trigger
         )
+        recordDiagnostic(metric: "launch_to_first_prompt", durationMs: durationMs, labels: ["trigger": trigger])
     }
 
     static func beginRepoHydration(rootPath: String) {
@@ -111,6 +113,11 @@ enum PerformanceSignposts {
             durationMs,
             discoveredCount,
             importedCount
+        )
+        recordDiagnostic(
+            metric: "repo_hydration",
+            durationMs: durationMs,
+            labels: ["discovered": "\(discoveredCount)", "imported": "\(importedCount)"]
         )
     }
 
@@ -461,5 +468,15 @@ enum PerformanceSignposts {
         let components = duration.components
         return Double(components.seconds) * 1_000
             + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+
+    private static func recordDiagnostic(metric: String, durationMs: Double, labels: [String: String]) {
+        Task.detached {
+            await StartupDiagnosticsStore.shared.record(
+                metric: metric,
+                durationMs: durationMs,
+                labels: labels
+            )
+        }
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
@@ -230,12 +230,22 @@ struct WorkspaceEnvironmentOptionsController {
         }
 
         let unavailableCount = resolvedAvailability.values.filter { !$0.isAvailable }.count
+        let durationMs = Date().timeIntervalSince(refreshStartedAt) * 1000
         NSLog(
             "[Perf] metric=workspace_provider_availability_refresh duration_ms=%.2f trigger=%@ providers=%ld unavailable_count=%ld",
-            Date().timeIntervalSince(refreshStartedAt) * 1000,
+            durationMs,
             trigger,
             registry.providers.count,
             unavailableCount
+        )
+        await StartupDiagnosticsStore.shared.record(
+            metric: "workspace_provider_availability_refresh",
+            durationMs: durationMs,
+            labels: [
+                "trigger": trigger,
+                "providers": "\(registry.providers.count)",
+                "unavailable_count": "\(unavailableCount)",
+            ]
         )
 
         return resolvedAvailability
@@ -259,13 +269,24 @@ struct WorkspaceEnvironmentOptionsController {
             } else {
                 "success"
             }
+        let durationMs = Date().timeIntervalSince(refreshStartedAt) * 1000
         NSLog(
             "[Perf] metric=lume_runtime_snapshot_refresh duration_ms=%.2f trigger=%@ outcome=%@ state=%@ base_vm_status=%@",
-            Date().timeIntervalSince(refreshStartedAt) * 1000,
+            durationMs,
             trigger,
             outcome,
             snapshot?.state.rawValue ?? "pending",
             snapshot?.baseVM?.status.rawValue ?? "none"
+        )
+        await StartupDiagnosticsStore.shared.record(
+            metric: "lume_runtime_snapshot_refresh",
+            durationMs: durationMs,
+            labels: [
+                "trigger": trigger,
+                "outcome": outcome,
+                "state": snapshot?.state.rawValue ?? "pending",
+                "base_vm_status": snapshot?.baseVM?.status.rawValue ?? "none",
+            ]
         )
         return snapshot
     }

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -27,6 +27,8 @@ struct SettingsView: View {
     @State private var runtimeActionLabel: String?
     @State private var runtimeErrorMessage: String?
     @State private var isRunningRuntimeAction = false
+    @State private var diagnosticsFeedback: String?
+    @State private var diagnosticsFeedbackIsError = false
 
     private let commandLineToolService: CommandLineToolService
 
@@ -369,6 +371,29 @@ struct SettingsView: View {
             }
 
             Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Startup Diagnostics")
+                        .font(.headline)
+
+                    Text("Export recent startup performance events as a JSON file for troubleshooting.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Button("Export Startup Diagnostics") {
+                        exportDiagnostics()
+                    }
+
+                    if let diagnosticsFeedback {
+                        Text(diagnosticsFeedback)
+                            .font(.caption)
+                            .foregroundStyle(diagnosticsFeedbackIsError ? .red : .secondary)
+                    }
+                }
+            } header: {
+                Text("Diagnostics")
+            }
+
+            Section {
                 HStack {
                     Text("Version")
                     Spacer()
@@ -695,6 +720,35 @@ struct SettingsView: View {
         NSPasteboard.general.setString(setupCommand, forType: .string)
         commandLineToolFeedbackIsError = false
         commandLineToolFeedback = "Copied the setup command."
+    }
+
+    private func exportDiagnostics() {
+        Task { @MainActor in
+            let bundle = await StartupDiagnosticsStore.shared.export()
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+
+            do {
+                let data = try encoder.encode(bundle)
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime]
+                let timestamp = formatter.string(from: Date())
+                    .replacingOccurrences(of: ":", with: "-")
+                let filename = "workspaces-diagnostics-\(timestamp).json"
+                let desktopURL = FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent("Desktop")
+                    .appendingPathComponent(filename)
+
+                try data.write(to: desktopURL, options: .atomic)
+                diagnosticsFeedbackIsError = false
+                diagnosticsFeedback = "Saved to Desktop"
+            } catch {
+                diagnosticsFeedbackIsError = true
+                diagnosticsFeedback = error.localizedDescription
+            }
+        }
     }
 
     private static var versionString: String {

--- a/Sources/WorkspaceManagerCore/Services/StartupDiagnosticsStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/StartupDiagnosticsStore.swift
@@ -1,0 +1,130 @@
+//
+//  StartupDiagnosticsStore.swift
+//  WorkspaceManager
+//
+//  In-memory accumulator for startup diagnostic events. Events are recorded
+//  during launch and provider-availability checks, then exported on demand
+//  as a self-contained JSON bundle. No disk I/O happens on the hot path.
+//
+
+import Foundation
+
+public actor StartupDiagnosticsStore {
+    public static let shared = StartupDiagnosticsStore()
+
+    public struct DiagnosticEvent: Codable, Sendable, Equatable {
+        public let timestamp: Date
+        public let metric: String
+        public let durationMs: Double
+        public let labels: [String: String]
+
+        public init(timestamp: Date, metric: String, durationMs: Double, labels: [String: String]) {
+            self.timestamp = timestamp
+            self.metric = metric
+            self.durationMs = durationMs
+            self.labels = labels
+        }
+    }
+
+    public struct DiagnosticsBundle: Codable, Sendable, Equatable {
+        public let schemaVersion: Int
+        public let appVersion: String
+        public let buildNumber: String
+        public let osVersion: String
+        public let architecture: String
+        public let capturedAt: Date
+        public let events: [DiagnosticEvent]
+
+        public init(
+            schemaVersion: Int = 1,
+            appVersion: String,
+            buildNumber: String,
+            osVersion: String,
+            architecture: String,
+            capturedAt: Date,
+            events: [DiagnosticEvent]
+        ) {
+            self.schemaVersion = schemaVersion
+            self.appVersion = appVersion
+            self.buildNumber = buildNumber
+            self.osVersion = osVersion
+            self.architecture = architecture
+            self.capturedAt = capturedAt
+            self.events = events
+        }
+    }
+
+    private var events: [DiagnosticEvent] = []
+    private let maxEvents: Int
+
+    public init(maxEvents: Int = 200) {
+        self.maxEvents = maxEvents
+    }
+
+    public func record(_ event: DiagnosticEvent) {
+        events.append(event)
+        if events.count > maxEvents {
+            events.removeFirst()
+        }
+    }
+
+    public func record(
+        metric: String,
+        durationMs: Double,
+        labels: [String: String] = [:]
+    ) {
+        record(
+            DiagnosticEvent(
+                timestamp: Date(),
+                metric: metric,
+                durationMs: durationMs,
+                labels: labels
+            )
+        )
+    }
+
+    public var eventCount: Int {
+        events.count
+    }
+
+    public func allEvents() -> [DiagnosticEvent] {
+        events
+    }
+
+    public func export(
+        appVersion: String? = nil,
+        buildNumber: String? = nil
+    ) -> DiagnosticsBundle {
+        let resolvedAppVersion =
+            appVersion
+            ?? Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            ?? "unknown"
+        let resolvedBuildNumber =
+            buildNumber
+            ?? Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+            ?? "unknown"
+
+        return DiagnosticsBundle(
+            appVersion: resolvedAppVersion,
+            buildNumber: resolvedBuildNumber,
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            architecture: currentArchitecture(),
+            capturedAt: Date(),
+            events: events
+        )
+    }
+
+    public func clear() {
+        events.removeAll()
+    }
+
+    private func currentArchitecture() -> String {
+        #if arch(arm64)
+            return "arm64"
+        #elseif arch(x86_64)
+            return "x86_64"
+        #else
+            return "unknown"
+        #endif
+    }
+}

--- a/Tests/WorkspaceManagerTests/StartupDiagnosticsStoreTests.swift
+++ b/Tests/WorkspaceManagerTests/StartupDiagnosticsStoreTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("StartupDiagnosticsStore")
+struct StartupDiagnosticsStoreTests {
+
+    @Test("Records events and returns them in order")
+    func recordEventsInOrder() async {
+        let store = StartupDiagnosticsStore()
+
+        await store.record(
+            metric: "launch_to_first_prompt",
+            durationMs: 120.5,
+            labels: ["trigger": "terminal_focus"]
+        )
+        await store.record(
+            metric: "repo_hydration",
+            durationMs: 340.2,
+            labels: ["discovered": "12", "imported": "3"]
+        )
+
+        let events = await store.allEvents()
+        #expect(events.count == 2)
+        #expect(events[0].metric == "launch_to_first_prompt")
+        #expect(events[0].durationMs == 120.5)
+        #expect(events[0].labels["trigger"] == "terminal_focus")
+        #expect(events[1].metric == "repo_hydration")
+        #expect(events[1].durationMs == 340.2)
+    }
+
+    @Test("Ring buffer caps at maxEvents")
+    func ringBufferCaps() async {
+        let store = StartupDiagnosticsStore(maxEvents: 5)
+
+        for i in 0..<8 {
+            await store.record(
+                metric: "event_\(i)",
+                durationMs: Double(i),
+                labels: [:]
+            )
+        }
+
+        let events = await store.allEvents()
+        #expect(events.count == 5)
+        #expect(events[0].metric == "event_3")
+        #expect(events[4].metric == "event_7")
+    }
+
+    @Test("Event count reflects current buffer size")
+    func eventCountReflectsBufferSize() async {
+        let store = StartupDiagnosticsStore(maxEvents: 3)
+
+        #expect(await store.eventCount == 0)
+
+        await store.record(metric: "a", durationMs: 1, labels: [:])
+        #expect(await store.eventCount == 1)
+
+        await store.record(metric: "b", durationMs: 2, labels: [:])
+        await store.record(metric: "c", durationMs: 3, labels: [:])
+        await store.record(metric: "d", durationMs: 4, labels: [:])
+        #expect(await store.eventCount == 3)
+    }
+
+    @Test("Clear removes all events")
+    func clearRemovesAllEvents() async {
+        let store = StartupDiagnosticsStore()
+
+        await store.record(metric: "x", durationMs: 1, labels: [:])
+        await store.record(metric: "y", durationMs: 2, labels: [:])
+        await store.clear()
+
+        #expect(await store.eventCount == 0)
+        #expect(await store.allEvents().isEmpty)
+    }
+
+    @Test("Export produces a valid bundle with metadata")
+    func exportProducesValidBundle() async {
+        let store = StartupDiagnosticsStore()
+
+        await store.record(
+            metric: "test_metric",
+            durationMs: 99.9,
+            labels: ["key": "value"]
+        )
+
+        let bundle = await store.export(appVersion: "1.2.3", buildNumber: "42")
+
+        #expect(bundle.schemaVersion == 1)
+        #expect(bundle.appVersion == "1.2.3")
+        #expect(bundle.buildNumber == "42")
+        #expect(!bundle.osVersion.isEmpty)
+        #expect(!bundle.architecture.isEmpty)
+        #expect(bundle.events.count == 1)
+        #expect(bundle.events[0].metric == "test_metric")
+    }
+
+    @Test("DiagnosticEvent Codable roundtrip preserves all fields")
+    func diagnosticEventCodableRoundtrip() throws {
+        let event = StartupDiagnosticsStore.DiagnosticEvent(
+            timestamp: Date(timeIntervalSinceReferenceDate: 700_000_000),
+            metric: "launch_to_first_prompt",
+            durationMs: 523.45,
+            labels: ["trigger": "terminal_focus", "outcome": "success"]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(StartupDiagnosticsStore.DiagnosticEvent.self, from: data)
+
+        #expect(decoded.metric == event.metric)
+        #expect(decoded.durationMs == event.durationMs)
+        #expect(decoded.labels == event.labels)
+    }
+
+    @Test("DiagnosticsBundle Codable roundtrip preserves all fields")
+    func diagnosticsBundleCodableRoundtrip() throws {
+        let event = StartupDiagnosticsStore.DiagnosticEvent(
+            timestamp: Date(timeIntervalSinceReferenceDate: 700_000_000),
+            metric: "repo_hydration",
+            durationMs: 210.0,
+            labels: ["discovered": "5", "imported": "2"]
+        )
+
+        let bundle = StartupDiagnosticsStore.DiagnosticsBundle(
+            appVersion: "2.0.0",
+            buildNumber: "100",
+            osVersion: "macOS 15.3",
+            architecture: "arm64",
+            capturedAt: Date(timeIntervalSinceReferenceDate: 700_000_001),
+            events: [event]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(bundle)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(StartupDiagnosticsStore.DiagnosticsBundle.self, from: data)
+
+        #expect(decoded.schemaVersion == bundle.schemaVersion)
+        #expect(decoded.appVersion == bundle.appVersion)
+        #expect(decoded.buildNumber == bundle.buildNumber)
+        #expect(decoded.osVersion == bundle.osVersion)
+        #expect(decoded.architecture == bundle.architecture)
+        #expect(decoded.events.count == 1)
+        #expect(decoded.events[0].metric == "repo_hydration")
+        #expect(decoded.events[0].durationMs == 210.0)
+        #expect(decoded.events[0].labels == ["discovered": "5", "imported": "2"])
+    }
+
+    @Test("Export with empty events produces valid JSON")
+    func exportWithEmptyEventsProducesValidJSON() async throws {
+        let store = StartupDiagnosticsStore()
+        let bundle = await store.export(appVersion: "1.0.0", buildNumber: "1")
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(bundle)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(StartupDiagnosticsStore.DiagnosticsBundle.self, from: data)
+
+        #expect(decoded.events.isEmpty)
+        #expect(decoded.appVersion == "1.0.0")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `StartupDiagnosticsStore` actor in `WorkspaceManagerCore/Services/` that accumulates structured perf events in a capped ring buffer (200 events max), with no disk I/O on the hot path
- Hook `record()` calls into existing `[Perf]` NSLog emit sites: `WorkspaceEnvironmentOptionsController` (provider availability + Lume snapshot refresh) and `PerformanceSignposts` (launch-to-first-prompt, repo hydration)
- Add "Diagnostics" section to Settings view with an "Export Startup Diagnostics" button that writes a pretty-printed JSON bundle to `~/Desktop/workspaces-diagnostics-<timestamp>.json` with inline feedback
- Add comprehensive tests: Codable roundtrips for `DiagnosticEvent` and `DiagnosticsBundle`, ring-buffer cap behavior, clear, export with metadata

Closes #97

### Bundle format

```json
{
  "schemaVersion": 1,
  "appVersion": "1.2.3",
  "buildNumber": "42",
  "osVersion": "macOS 15.3",
  "architecture": "arm64",
  "capturedAt": "2026-03-20T12:00:00Z",
  "events": [
    {
      "timestamp": "2026-03-20T12:00:00Z",
      "metric": "launch_to_first_prompt",
      "durationMs": 523.45,
      "labels": { "trigger": "terminal_focus" }
    }
  ]
}
```

### File changes

| File | Change |
|------|--------|
| `Sources/WorkspaceManagerCore/Services/StartupDiagnosticsStore.swift` | New actor with `DiagnosticEvent`, `DiagnosticsBundle`, ring buffer, export |
| `Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift` | Record perf events after NSLog calls |
| `Sources/WorkspaceManager/Diagnostics/PerformanceSignposts.swift` | Record launch and hydration events via `Task.detached` |
| `Sources/WorkspaceManager/Views/SettingsView.swift` | Add Diagnostics section with export button |
| `Tests/WorkspaceManagerTests/StartupDiagnosticsStoreTests.swift` | New test suite |

## Test plan

- [ ] Verify `StartupDiagnosticsStore` tests pass (`swift test --filter StartupDiagnosticsStoreTests`)
- [ ] Launch the app, navigate Settings, confirm "Diagnostics" section appears below "VM Runtime"
- [ ] Click "Export Startup Diagnostics", confirm JSON file appears on Desktop
- [ ] Open the JSON file and verify it contains `schemaVersion`, `appVersion`, `osVersion`, `architecture`, `events` array
- [ ] Verify perf events are recorded during startup (events array is non-empty after app launch)
- [ ] Verify "Saved to Desktop" feedback appears inline after export
- [ ] Confirm no disk I/O during startup (events only written on explicit export)

Generated with [Claude Code](https://claude.com/claude-code)