### PR TITLE
feat: add release quality gate before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
             exit 1
           fi
 
+      - name: Release preflight — verify CI passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/release-preflight.sh "${GITHUB_SHA}" "${GITHUB_REPOSITORY}"
+
       - name: Validate release secrets
         env:
           APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Release preflight — verify CI checks passed on the release SHA before
+# signing and publishing proceeds.
+#
+# Usage:
+#   ./scripts/release-preflight.sh <sha> [repo]
+#   ./scripts/release-preflight.sh --dry-run <sha> [repo]
+#
+# Checks:
+#   - build-and-test (CI) must have passed on <sha>       → hard gate
+#   - perf-validation passing is advisory                 → warning only
+#
+# Exit codes:
+#   0  all required checks passed
+#   1  a required check failed or was not found
+
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+    shift
+fi
+
+SHA="${1:?Usage: release-preflight.sh [--dry-run] <sha> [repo]}"
+REPO="${2:-${GITHUB_REPOSITORY:-fairchild/workspaces}}"
+
+echo "=== Release Preflight ==="
+echo "SHA:  $SHA"
+echo "Repo: $REPO"
+echo ""
+
+# Check a workflow's conclusion for a given SHA.
+# Returns: "success", "failure", "neutral", "cancelled", "skipped",
+#          "timed_out", "action_required", or "not_found"
+check_workflow() {
+    local workflow_name="$1"
+    local conclusion
+    conclusion=$(gh api \
+        "repos/$REPO/commits/$SHA/check-runs" \
+        --jq ".check_runs[] | select(.name == \"$workflow_name\") | .conclusion" \
+        2>/dev/null | head -1)
+    echo "${conclusion:-not_found}"
+}
+
+EXIT_CODE=0
+
+# --- Required: build-and-test (CI) ---
+echo -n "CI (build-and-test): "
+CI_RESULT=$(check_workflow "build-and-test")
+case "$CI_RESULT" in
+    success)
+        echo "PASS"
+        ;;
+    not_found)
+        echo "NOT FOUND"
+        echo "  Warning: CI may not have run if no build-affecting files changed."
+        echo "  Verify manually that no source changes were introduced since last CI run."
+        if [[ "$DRY_RUN" == true ]]; then
+            echo "  (dry-run: continuing)"
+        else
+            EXIT_CODE=1
+        fi
+        ;;
+    *)
+        echo "FAIL ($CI_RESULT)"
+        EXIT_CODE=1
+        ;;
+esac
+
+# --- Advisory: perf-validation ---
+echo -n "Perf validation: "
+PERF_RESULT=$(check_workflow "capture")
+case "$PERF_RESULT" in
+    success)
+        echo "PASS"
+        ;;
+    not_found)
+        echo "NOT FOUND (advisory — perf may not have run on this SHA)"
+        ;;
+    *)
+        echo "WARN ($PERF_RESULT) — perf regression detected but not blocking release"
+        ;;
+esac
+
+echo ""
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+    echo "Preflight passed."
+else
+    echo "Preflight FAILED — required checks did not pass on $SHA."
+    echo "Do not publish this release until CI is green."
+fi
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary
- Adds `scripts/release-preflight.sh` that verifies CI (`build-and-test`) passed on the release SHA before signing/publishing
- Perf-validation is checked as advisory — failure warns but does not block
- Preflight runs early in `release.yml` (before secrets validation or build), so a failed gate wastes no compute
- Supports `--dry-run` for local pre-tag validation

Closes [#98](https://github.com/fairchild/workspaces/issues/98)

## Test plan
- [ ] Run `./scripts/release-preflight.sh --dry-run <sha>` locally against a SHA with passing CI
- [ ] Run against a SHA with failing/missing CI — should exit 1
- [ ] Verify perf-validation missing produces a warning, not a hard failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)