### PR TITLE
feat: instrument workspace-switch focus metrics (#149)

### DIFF
--- a/Sources/WorkspaceManager/Diagnostics/PerformanceSignposts.swift
+++ b/Sources/WorkspaceManager/Diagnostics/PerformanceSignposts.swift
@@ -12,6 +12,7 @@ enum PerformanceSignposts {
     #if DEBUG
         typealias NewWorkspaceSheetMetricObserver = (_ phase: String, _ fields: [String: String]) -> Void
         typealias OpenInEditorMetricObserver = (_ phase: String, _ fields: [String: String]) -> Void
+        typealias WorkspaceClickMetricObserver = (_ phase: String, _ fields: [String: String]) -> Void
     #endif
 
     private struct ActiveInterval {
@@ -43,9 +44,11 @@ enum PerformanceSignposts {
     nonisolated(unsafe) private static var webFirstLoadSourceID: UUID?
     nonisolated(unsafe) private static var newWorkspaceSheetInterval: ActiveNewWorkspaceSheetInterval?
     nonisolated(unsafe) private static var openInEditorIntervals: [UUID: ActiveInterval] = [:]
+    nonisolated(unsafe) private static var workspaceClickIntervals: [UUID: ActiveInterval] = [:]
     #if DEBUG
         nonisolated(unsafe) private static var newWorkspaceSheetMetricObserver: NewWorkspaceSheetMetricObserver?
         nonisolated(unsafe) private static var openInEditorMetricObserver: OpenInEditorMetricObserver?
+        nonisolated(unsafe) private static var workspaceClickMetricObserver: WorkspaceClickMetricObserver?
     #endif
 
     static func beginLaunchToFirstPromptIfNeeded() {
@@ -158,6 +161,75 @@ enum PerformanceSignposts {
 
     static func cancelRepoClickToFocusedInputIfNeeded(sessionID: UUID, reason: String) {
         endRepoClickToFocusedInputIfNeeded(sessionID: sessionID, outcome: reason)
+    }
+
+    static func beginWorkspaceClickToFocusedInput(sessionID: UUID, workspacePath: String) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let existing = workspaceClickIntervals.removeValue(forKey: sessionID) {
+            signposter.endInterval("WorkspaceClickToFocusedInput", existing.state)
+            let durationMs = milliseconds(since: existing.startedAt)
+            let fields = [
+                "metric": "workspace_click_to_focus",
+                "status": "completed",
+                "session": sessionID.uuidString,
+                "outcome": "superseded",
+                "duration_ms": String(format: "%.2f", durationMs),
+            ]
+            emitPerfLog(
+                "[Perf] metric=workspace_click_to_focus duration_ms=%.2f session=%@ outcome=superseded",
+                durationMs,
+                sessionID.uuidString
+            )
+            emitWorkspaceClickMetricEvent(phase: "completed", fields: fields)
+        }
+
+        let state = signposter.beginInterval("WorkspaceClickToFocusedInput")
+        workspaceClickIntervals[sessionID] = ActiveInterval(state: state, startedAt: clock.now)
+        let fields = [
+            "metric": "workspace_click_to_focus",
+            "status": "started",
+            "session": sessionID.uuidString,
+            "path": workspacePath,
+        ]
+        emitPerfLog(
+            "[Perf] metric=workspace_click_to_focus status=started session=%@ path=%@",
+            sessionID.uuidString,
+            workspacePath
+        )
+        emitWorkspaceClickMetricEvent(phase: "started", fields: fields)
+    }
+
+    static func endWorkspaceClickToFocusedInputIfNeeded(sessionID: UUID, outcome: String) {
+        let interval: ActiveInterval?
+
+        lock.lock()
+        interval = workspaceClickIntervals.removeValue(forKey: sessionID)
+        lock.unlock()
+
+        guard let interval else { return }
+
+        signposter.endInterval("WorkspaceClickToFocusedInput", interval.state)
+        let durationMs = milliseconds(since: interval.startedAt)
+        let fields = [
+            "metric": "workspace_click_to_focus",
+            "status": "completed",
+            "session": sessionID.uuidString,
+            "outcome": outcome,
+            "duration_ms": String(format: "%.2f", durationMs),
+        ]
+        emitPerfLog(
+            "[Perf] metric=workspace_click_to_focus duration_ms=%.2f session=%@ outcome=%@",
+            durationMs,
+            sessionID.uuidString,
+            outcome
+        )
+        emitWorkspaceClickMetricEvent(phase: "completed", fields: fields)
+    }
+
+    static func cancelWorkspaceClickToFocusedInputIfNeeded(sessionID: UUID, reason: String) {
+        endWorkspaceClickToFocusedInputIfNeeded(sessionID: sessionID, outcome: reason)
     }
 
     static func beginWebViewInitializationIfNeeded() {
@@ -422,6 +494,12 @@ enum PerformanceSignposts {
             openInEditorMetricObserver = observer
             lock.unlock()
         }
+
+        static func setWorkspaceClickMetricObserver(_ observer: WorkspaceClickMetricObserver?) {
+            lock.lock()
+            workspaceClickMetricObserver = observer
+            lock.unlock()
+        }
     #endif
 
     private static func emitPerfLog(_ format: StaticString, _ args: CVarArg...) {
@@ -448,6 +526,19 @@ enum PerformanceSignposts {
             let observer: OpenInEditorMetricObserver?
             lock.lock()
             observer = openInEditorMetricObserver
+            lock.unlock()
+            observer?(phase, fields)
+        #else
+            _ = phase
+            _ = fields
+        #endif
+    }
+
+    private static func emitWorkspaceClickMetricEvent(phase: String, fields: [String: String]) {
+        #if DEBUG
+            let observer: WorkspaceClickMetricObserver?
+            lock.lock()
+            observer = workspaceClickMetricObserver
             lock.unlock()
             observer?(phase, fields)
         #else

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1074,10 +1074,20 @@ struct ContentView: View {
                 key: .hostPath(workspaceDirectory.path),
                 directory: launchDirectory
             )
+            terminalFocusCoordinator.beginWorkspaceClickMeasurement(
+                sessionID: session.id,
+                workspacePath: workspaceDirectory.path
+            )
             terminalFocusCoordinator.requestMainTerminalFocus(
                 targetSessionID: session.id,
                 surfaceStore: hostTerminalState.surfaceStore,
-                activeSessionID: hostTerminalState.activeSessionID
+                activeSessionID: hostTerminalState.activeSessionID,
+                onTargetFocused: {
+                    terminalFocusCoordinator.completeWorkspaceClickMeasurement(
+                        sessionID: session.id,
+                        outcome: "focused"
+                    )
+                }
             )
         }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
@@ -13,6 +13,7 @@ final class TerminalFocusCoordinator: ObservableObject {
 
     private weak var attachedSurfaceStore: HostTerminalSurfaceStore?
     private var pendingRepoFocusMeasurementSessionID: UUID?
+    private var pendingWorkspaceFocusMeasurementSessionID: UUID?
     private var pendingFocusRequest: PendingFocusRequest?
 
     init() {
@@ -130,6 +131,41 @@ final class TerminalFocusCoordinator: ObservableObject {
         )
     }
 
+    func beginWorkspaceClickMeasurement(sessionID: UUID, workspacePath: String) {
+        if let pendingSessionID = pendingWorkspaceFocusMeasurementSessionID,
+            pendingSessionID != sessionID
+        {
+            PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+                sessionID: pendingSessionID,
+                reason: "replaced_by_new_workspace_click"
+            )
+        }
+
+        pendingWorkspaceFocusMeasurementSessionID = sessionID
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: sessionID,
+            workspacePath: workspacePath
+        )
+    }
+
+    func completeWorkspaceClickMeasurement(sessionID: UUID, outcome: String) {
+        guard pendingWorkspaceFocusMeasurementSessionID == sessionID else { return }
+        pendingWorkspaceFocusMeasurementSessionID = nil
+        PerformanceSignposts.endWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: sessionID,
+            outcome: outcome
+        )
+    }
+
+    func cancelPendingWorkspaceClickMeasurement(reason: String) {
+        guard let sessionID = pendingWorkspaceFocusMeasurementSessionID else { return }
+        pendingWorkspaceFocusMeasurementSessionID = nil
+        PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: sessionID,
+            reason: reason
+        )
+    }
+
     func cancelPendingFocusRequest(reason: String) {
         guard let pendingFocusRequest else { return }
         self.pendingFocusRequest = nil
@@ -142,6 +178,9 @@ final class TerminalFocusCoordinator: ObservableObject {
         )
         if pendingRepoFocusMeasurementSessionID == pendingFocusRequest.sessionID {
             cancelPendingRepoClickMeasurement(reason: reason)
+        }
+        if pendingWorkspaceFocusMeasurementSessionID == pendingFocusRequest.sessionID {
+            cancelPendingWorkspaceClickMeasurement(reason: reason)
         }
     }
 
@@ -164,8 +203,19 @@ final class TerminalFocusCoordinator: ObservableObject {
         }
 
         InvestigationDiagnostics.emitFocus(
+            phase: "focus_surface_resolution",
+            fields: focusFields.merging(["sub_span": "focus_surface_resolution"]) { _, new in new }
+        )
+        InvestigationDiagnostics.emitFocus(
             phase: "coordinator_target_terminal_resolved",
             fields: focusFields
+        )
+        InvestigationDiagnostics.emitFocus(
+            phase: "focus_request_to_first_responder",
+            fields: focusFields.merging([
+                "sub_span": "focus_request_to_first_responder",
+                "status": "started",
+            ]) { _, new in new }
         )
         TerminalFocusManager.shared.requestFocus(
             for: terminal,
@@ -174,6 +224,13 @@ final class TerminalFocusCoordinator: ObservableObject {
                 guard let self else { return }
                 guard self.pendingFocusRequest?.sessionID == pendingFocusRequest.sessionID else { return }
                 self.pendingFocusRequest = nil
+                InvestigationDiagnostics.emitFocus(
+                    phase: "focus_request_to_first_responder",
+                    fields: focusFields.merging([
+                        "sub_span": "focus_request_to_first_responder",
+                        "status": "completed",
+                    ]) { _, new in new }
+                )
                 InvestigationDiagnostics.emitFocus(
                     phase: "coordinator_target_focused",
                     fields: focusFields

--- a/Tests/WorkspaceManagerTests/PerformanceSignpostsTests.swift
+++ b/Tests/WorkspaceManagerTests/PerformanceSignpostsTests.swift
@@ -1,0 +1,167 @@
+//
+//  PerformanceSignpostsTests.swift
+//  WorkspaceManagerTests
+//
+//  Tests for workspace_click_to_focus metric lifecycle.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("PerformanceSignposts workspace_click_to_focus", .serialized)
+struct WorkspaceClickToFocusSignpostTests {
+    init() {
+        PerformanceSignposts.setWorkspaceClickMetricObserver(nil)
+    }
+
+    @Test("begin emits started event")
+    func beginEmitsStarted() async {
+        var captured: [(phase: String, fields: [String: String])] = []
+        PerformanceSignposts.setWorkspaceClickMetricObserver { phase, fields in
+            captured.append((phase, fields))
+        }
+        defer { PerformanceSignposts.setWorkspaceClickMetricObserver(nil) }
+
+        let sessionID = UUID()
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: sessionID,
+            workspacePath: "/tmp/test-workspace"
+        )
+        // Clean up the interval
+        PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: sessionID,
+            reason: "test_cleanup"
+        )
+
+        let startedEvents = captured.filter { $0.fields["status"] == "started" }
+        #expect(startedEvents.count == 1)
+        #expect(startedEvents.first?.fields["metric"] == "workspace_click_to_focus")
+        #expect(startedEvents.first?.fields["session"] == sessionID.uuidString)
+    }
+
+    @Test("end emits completed event with duration")
+    func endEmitsCompleted() async {
+        var captured: [(phase: String, fields: [String: String])] = []
+        PerformanceSignposts.setWorkspaceClickMetricObserver { phase, fields in
+            captured.append((phase, fields))
+        }
+        defer { PerformanceSignposts.setWorkspaceClickMetricObserver(nil) }
+
+        let sessionID = UUID()
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: sessionID,
+            workspacePath: "/tmp/test-workspace"
+        )
+        PerformanceSignposts.endWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: sessionID,
+            outcome: "focused"
+        )
+
+        let completedEvents = captured.filter {
+            $0.fields["status"] == "completed" && $0.fields["outcome"] == "focused"
+        }
+        #expect(completedEvents.count == 1)
+        #expect(completedEvents.first?.fields["duration_ms"] != nil)
+    }
+
+    @Test("end without begin is a no-op")
+    func endWithoutBeginIsNoOp() async {
+        var captured: [(phase: String, fields: [String: String])] = []
+        PerformanceSignposts.setWorkspaceClickMetricObserver { phase, fields in
+            captured.append((phase, fields))
+        }
+        defer { PerformanceSignposts.setWorkspaceClickMetricObserver(nil) }
+
+        PerformanceSignposts.endWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: UUID(),
+            outcome: "focused"
+        )
+
+        #expect(captured.isEmpty)
+    }
+
+    @Test("supersede closes previous interval")
+    func supersedeClosesPrevious() async {
+        var captured: [(phase: String, fields: [String: String])] = []
+        PerformanceSignposts.setWorkspaceClickMetricObserver { phase, fields in
+            captured.append((phase, fields))
+        }
+        defer { PerformanceSignposts.setWorkspaceClickMetricObserver(nil) }
+
+        let firstSession = UUID()
+        let secondSession = UUID()
+
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: firstSession,
+            workspacePath: "/tmp/workspace-a"
+        )
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: secondSession,
+            workspacePath: "/tmp/workspace-b"
+        )
+        // Clean up second interval
+        PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: secondSession,
+            reason: "test_cleanup"
+        )
+
+        let supersededEvents = captured.filter { $0.fields["outcome"] == "superseded" }
+        #expect(supersededEvents.count == 1)
+        #expect(supersededEvents.first?.fields["session"] == firstSession.uuidString)
+    }
+
+    @Test("cancel closes interval with reason")
+    func cancelClosesWithReason() async {
+        var captured: [(phase: String, fields: [String: String])] = []
+        PerformanceSignposts.setWorkspaceClickMetricObserver { phase, fields in
+            captured.append((phase, fields))
+        }
+        defer { PerformanceSignposts.setWorkspaceClickMetricObserver(nil) }
+
+        let sessionID = UUID()
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: sessionID,
+            workspacePath: "/tmp/test-workspace"
+        )
+        PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: sessionID,
+            reason: "workspace_selected"
+        )
+
+        let cancelledEvents = captured.filter { $0.fields["outcome"] == "workspace_selected" }
+        #expect(cancelledEvents.count == 1)
+        #expect(cancelledEvents.first?.fields["session"] == sessionID.uuidString)
+    }
+
+    @Test("cancel with wrong session is a no-op")
+    func cancelWrongSessionNoOp() async {
+        var captured: [(phase: String, fields: [String: String])] = []
+        PerformanceSignposts.setWorkspaceClickMetricObserver { phase, fields in
+            captured.append((phase, fields))
+        }
+        defer { PerformanceSignposts.setWorkspaceClickMetricObserver(nil) }
+
+        let activeSession = UUID()
+        PerformanceSignposts.beginWorkspaceClickToFocusedInput(
+            sessionID: activeSession,
+            workspacePath: "/tmp/test-workspace"
+        )
+        // Try to cancel a different session
+        PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: UUID(),
+            reason: "wrong_session"
+        )
+
+        // Only the started event should exist, no completed/cancelled
+        let completedEvents = captured.filter { $0.fields["status"] == "completed" }
+        #expect(completedEvents.isEmpty)
+
+        // Clean up
+        PerformanceSignposts.cancelWorkspaceClickToFocusedInputIfNeeded(
+            sessionID: activeSession,
+            reason: "test_cleanup"
+        )
+    }
+}

--- a/docs/performance/metrics-reference.md
+++ b/docs/performance/metrics-reference.md
@@ -98,6 +98,51 @@ sequenceDiagram
     Content->>Perf: endRepoClickToFocusedInputIfNeeded(outcome)
 ```
 
+### `workspace_click_to_focus`
+
+What it measures:
+- Time from selecting a workspace row to terminal focus being restored for that workspace session.
+
+Start event:
+- `PerformanceSignposts.beginWorkspaceClickToFocusedInput(sessionID:workspacePath:)` in `handleWorkspaceSelection`.
+
+End event:
+- `PerformanceSignposts.endWorkspaceClickToFocusedInputIfNeeded(...)` when focus callback confirms terminal became first responder.
+
+Why it matters:
+- It reflects interaction responsiveness when switching between workspaces, analogous to `repo_click_to_focus` for repo switches.
+
+Sub-spans (emitted via `InvestigationDiagnostics.emitFocus`):
+- `focus_surface_resolution` — from `requestMainTerminalFocus` call to terminal resolved from `surfaceStore.terminal(for:)`
+- `focus_request_to_first_responder` — from `TerminalFocusManager.requestFocus()` call to `makeFirstResponder` success
+
+Notes:
+- Mirrors the `repo_click_to_focus` pattern exactly. Outcome `focused` means focus was successfully restored.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Sidebar as "SidebarView"
+    participant Content as "ContentView"
+    participant Session as "HostTerminalStateStore"
+    participant Perf as "PerformanceSignposts"
+    participant Coord as "TerminalFocusCoordinator"
+    participant Focus as "TerminalFocusManager"
+    participant Term as "GhosttySurfaceView"
+
+    User->>Sidebar: click workspace row
+    Sidebar->>Content: onWorkspaceSelected(workspace)
+    Content->>Session: activateSession(workspacePath)
+    Content->>Perf: beginWorkspaceClickToFocusedInput(sessionID, path)
+    Content->>Coord: requestMainTerminalFocus(targetSession)
+    Note over Coord: sub-span: focus_surface_resolution
+    Coord->>Focus: requestFocus(for: terminal)
+    Note over Focus: sub-span: focus_request_to_first_responder
+    Focus->>Term: makeFirstResponder(terminal)
+    Focus-->>Content: onFocused callback
+    Content->>Perf: endWorkspaceClickToFocusedInputIfNeeded(outcome)
+```
+
 ### `new_workspace_sheet_ready`
 
 What it measures:

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -174,6 +174,7 @@ metric_order = [
     "launch_to_first_prompt",
     "repo_hydration",
     "repo_click_to_focus",
+    "workspace_click_to_focus",
 ]
 metrics = {name: [] for name in metric_order}
 discovered_values = []
@@ -325,9 +326,11 @@ fieldnames = [
     "launch_to_first_prompt_median_ms",
     "repo_hydration_median_ms",
     "repo_click_to_focus_median_ms",
+    "workspace_click_to_focus_median_ms",
     "launch_to_first_prompt_mean_ms",
     "repo_hydration_mean_ms",
     "repo_click_to_focus_mean_ms",
+    "workspace_click_to_focus_mean_ms",
     "activation_to_first_prompt_median_ms",
 ]
 
@@ -344,9 +347,11 @@ record_row = {
     "launch_to_first_prompt_median_ms": summary["launch_to_first_prompt"]["median"] if summary["launch_to_first_prompt"] else "",
     "repo_hydration_median_ms": summary["repo_hydration"]["median"] if summary["repo_hydration"] else "",
     "repo_click_to_focus_median_ms": summary["repo_click_to_focus"]["median"] if summary["repo_click_to_focus"] else "",
+    "workspace_click_to_focus_median_ms": summary["workspace_click_to_focus"]["median"] if summary["workspace_click_to_focus"] else "",
     "launch_to_first_prompt_mean_ms": summary["launch_to_first_prompt"]["mean"] if summary["launch_to_first_prompt"] else "",
     "repo_hydration_mean_ms": summary["repo_hydration"]["mean"] if summary["repo_hydration"] else "",
     "repo_click_to_focus_mean_ms": summary["repo_click_to_focus"]["mean"] if summary["repo_click_to_focus"] else "",
+    "workspace_click_to_focus_mean_ms": summary["workspace_click_to_focus"]["mean"] if summary["workspace_click_to_focus"] else "",
     "activation_to_first_prompt_median_ms": summary["metadata"]["activation_to_first_prompt_median_ms"] or "",
 }
 
@@ -474,17 +479,19 @@ else:
 dashboard_lines.append("")
 dashboard_lines.append("## Trend (Last 10 Runs)")
 dashboard_lines.append("")
-dashboard_lines.append("| Timestamp | Launch (ms) | Hydration (ms) | Click-to-Focus (ms) |")
-dashboard_lines.append("|---|---:|---:|---:|")
+dashboard_lines.append("| Timestamp | Launch (ms) | Hydration (ms) | Repo Click-to-Focus (ms) | Workspace Click-to-Focus (ms) |")
+dashboard_lines.append("|---|---:|---:|---:|---:|")
 for row in window:
     launch_value = parse_float(row.get("launch_to_first_prompt_median_ms"))
     hydration_value = parse_float(row.get("repo_hydration_median_ms"))
     click_value = parse_float(row.get("repo_click_to_focus_median_ms"))
+    ws_click_value = parse_float(row.get("workspace_click_to_focus_median_ms"))
     dashboard_lines.append(
         f"| {row['timestamp']} | "
         f"{fmt_ms(launch_value)} | "
         f"{fmt_ms(hydration_value)} | "
-        f"{fmt_ms(click_value)} |"
+        f"{fmt_ms(click_value)} | "
+        f"{fmt_ms(ws_click_value)} |"
     )
 
 dashboard_lines.append("")
@@ -515,6 +522,7 @@ dashboard_lines.append("")
 dashboard_lines.append("- `launch_to_first_prompt`: launch init -> first terminal focus success (ready to type)")
 dashboard_lines.append("- `repo_hydration`: auto-discovery/import pass for `~/code` repos")
 dashboard_lines.append("- `repo_click_to_focus`: repo row click -> focused terminal session restore")
+dashboard_lines.append("- `workspace_click_to_focus`: workspace row click -> focused terminal session restore")
 dashboard_lines.append("- Detailed flow diagrams: `./metrics-reference.md`")
 
 dashboard_path.write_text("\n".join(dashboard_lines) + "\n")


### PR DESCRIPTION
## Summary

- Add `workspace_click_to_focus` metric to `PerformanceSignposts` (mirrors `repoClickIntervals` pattern with begin/end/cancel/supersede lifecycle)
- Add `focus_surface_resolution` and `focus_request_to_first_responder` sub-span diagnostics in `TerminalFocusCoordinator`
- Wire measurement into `ContentView.handleWorkspaceSelection`
- Update `perf-baseline.sh` to parse and report the new metric
- Update `metrics-reference.md` with flow documentation
- Add `PerformanceSignpostsTests` for metric lifecycle (6 tests)

Closes #149

## Metric Name Contract

These names are used by downstream milestone 6 issues (#150, #151, #152):
- `workspace_click_to_focus` — workspace row click → terminal first-responder success
- Sub-spans: `focus_surface_resolution`, `focus_request_to_first_responder`

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (231 tests/suites green)
- [ ] `./scripts/perf-baseline.sh 3 5 --launch-mode no-activate` reports `workspace_click_to_focus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)