### PR TITLE
perf: async hydration for New Workspace transitions (#152)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceSheet.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NewWorkspaceSheet.swift
@@ -30,6 +30,7 @@ struct WorkspaceEnvironmentSheetOption: Identifiable {
     let providerID: String
     let guestOS: WorkspaceGuestOS?
     let isAvailable: Bool
+    let isLoading: Bool
     let statusText: String?
     let statusSeverity: EnvironmentStatusSeverity?
     let availabilityReason: String?
@@ -324,11 +325,16 @@ private struct EnvironmentSelectionRow: View {
                         Text(option.title)
                             .font(.body.weight(.semibold))
 
+                        if option.isLoading {
+                            ProgressView()
+                                .controlSize(.mini)
+                        }
+
                         if let statusText = option.statusText {
                             Text(statusText)
                                 .font(.caption2.weight(.medium))
                                 .foregroundStyle(statusColor)
-                        } else if !option.isAvailable {
+                        } else if !option.isAvailable && !option.isLoading {
                             Text("Unavailable")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
@@ -151,14 +151,35 @@ struct WorkspaceEnvironmentOptionsController {
             registry: registry
         )
 
-        let deferredProviders = registry.providers.filter { $0.descriptor.sheetStatusPolicy == .deferred }
+        let deferredProviders = registry.providers.filter {
+            $0.descriptor.sheetStatusPolicy == .deferred
+        }
         let deferredRegistry = WorkspaceProviderRegistry(providers: deferredProviders)
-        let deferredAvailabilityByID = await refreshProviderAvailability(
+        let needsLumeSnapshot =
+            registry.provider(for: LumeWorkspaceProvider.identifier) != nil
+        let capturedExistingAvailability = resolvedState.providerAvailabilityByID
+        let capturedExistingSnapshot = resolvedState.lumeRuntimeSnapshot
+
+        // Run provider availability and Lume snapshot refresh in parallel
+        // instead of sequentially — avoids stacking two 5s timeout windows.
+        async let availabilityResult = refreshProviderAvailability(
             registry: deferredRegistry,
-            existingAvailabilityByID: resolvedState.providerAvailabilityByID,
+            existingAvailabilityByID: capturedExistingAvailability,
             trigger: trigger,
             timeoutNanoseconds: timeoutNanoseconds
         )
+        async let snapshotResult: LumeRuntimeSnapshot? =
+            needsLumeSnapshot
+            ? refreshLumeRuntimeSnapshot(
+                runtimeService: runtimeService,
+                existingSnapshot: capturedExistingSnapshot,
+                trigger: trigger,
+                timeoutNanoseconds: timeoutNanoseconds
+            )
+            : nil
+
+        let deferredAvailabilityByID = await availabilityResult
+        let lumeSnapshot = await snapshotResult
 
         for provider in registry.providers {
             let descriptor = provider.descriptor
@@ -180,17 +201,11 @@ struct WorkspaceEnvironmentOptionsController {
             resolvedState = resolvedState.updating(providerState)
         }
 
-        if registry.provider(for: LumeWorkspaceProvider.identifier) != nil {
-            let snapshot = await refreshLumeRuntimeSnapshot(
-                runtimeService: runtimeService,
-                existingSnapshot: resolvedState.lumeRuntimeSnapshot,
-                trigger: trigger,
-                timeoutNanoseconds: timeoutNanoseconds
-            )
+        if needsLumeSnapshot {
             let descriptor = LumeWorkspaceProvider.providerDescriptor
             let providerState = resolvedState.providerState(for: descriptor).replacing(
                 isRefreshing: false,
-                detail: .lume(snapshot: snapshot)
+                detail: .lume(snapshot: lumeSnapshot)
             )
             resolvedState = resolvedState.updating(providerState)
         }
@@ -389,6 +404,7 @@ struct WorkspaceEnvironmentOptionsController {
             providerID: LocalWorkspaceProvider.identifier,
             guestOS: nil,
             isAvailable: availability.isAvailable,
+            isLoading: false,
             statusText: nil,
             statusSeverity: nil,
             availabilityReason: availability.reason
@@ -415,6 +431,7 @@ struct WorkspaceEnvironmentOptionsController {
             providerID: DaytonaWorkspaceProvider.identifier,
             guestOS: .linux,
             isAvailable: availability.isAvailable,
+            isLoading: providerState.isRefreshing,
             statusText: providerState.isRefreshing && providerState.availability == nil
                 ? "Checking cloud runtime" : nil,
             statusSeverity: nil,
@@ -449,6 +466,7 @@ struct WorkspaceEnvironmentOptionsController {
             providerID: LumeWorkspaceProvider.identifier,
             guestOS: .macOS,
             isAvailable: isAvailable,
+            isLoading: providerState.isRefreshing,
             statusText: macOSRuntimeStatusText(providerState: providerState),
             statusSeverity: macOSRuntimeStatusSeverity(snapshot: snapshot),
             availabilityReason: availabilityReason
@@ -469,6 +487,7 @@ struct WorkspaceEnvironmentOptionsController {
             providerID: LumeWorkspaceProvider.identifier,
             guestOS: .linux,
             isAvailable: availability.isAvailable,
+            isLoading: providerState.isRefreshing,
             statusText: lumeRuntimeStatusText(providerState: providerState),
             statusSeverity: lumeRuntimeStatusSeverity(snapshot: snapshot),
             availabilityReason: availability.reason
@@ -486,6 +505,7 @@ struct WorkspaceEnvironmentOptionsController {
             repo: repo,
             sheetState: sheetState
         )
+        let providerState = sheetState.providerState(for: descriptor)
 
         return WorkspaceEnvironmentSheetOption(
             title: genericEnvironmentTitle(for: descriptor, guestOS: guestOS),
@@ -495,6 +515,7 @@ struct WorkspaceEnvironmentOptionsController {
             providerID: descriptor.id,
             guestOS: guestOS,
             isAvailable: availability.isAvailable,
+            isLoading: providerState.isRefreshing,
             statusText: nil,
             statusSeverity: nil,
             availabilityReason: availability.reason

--- a/Tests/WorkspaceManagerAppTests/NewWorkspaceSheetTests.swift
+++ b/Tests/WorkspaceManagerAppTests/NewWorkspaceSheetTests.swift
@@ -82,6 +82,7 @@ struct NewWorkspaceSheetTests {
         providerID: String,
         guestOS: WorkspaceGuestOS?,
         isAvailable: Bool = true,
+        isLoading: Bool = false,
         statusText: String? = nil,
         statusSeverity: EnvironmentStatusSeverity? = nil
     ) -> WorkspaceEnvironmentSheetOption {
@@ -93,6 +94,7 @@ struct NewWorkspaceSheetTests {
             providerID: providerID,
             guestOS: guestOS,
             isAvailable: isAvailable,
+            isLoading: isLoading,
             statusText: statusText,
             statusSeverity: statusSeverity,
             availabilityReason: isAvailable ? nil : "Unavailable"


### PR DESCRIPTION
## Summary

- **Parallelize provider availability and Lume snapshot refresh** in `refreshSheetState` using `async let` — previously these ran sequentially, stacking two 5s timeout windows. Worst-case sheet hydration time is now roughly halved.
- **Add per-provider loading indicators** (inline `ProgressView` spinner) on each `EnvironmentSelectionRow` so users see which specific providers are still hydrating, rather than relying solely on the global "Checking workspace environments" banner.
- **New `isLoading` field** on `WorkspaceEnvironmentSheetOption` drives the per-row spinner, derived from each provider's `isRefreshing` state.

Closes #152

## Changes

| File | What |
|------|------|
| `WorkspaceEnvironmentOptionsController.swift` | `async let` for parallel availability + snapshot refresh |
| `NewWorkspaceSheet.swift` | `isLoading` field, per-row `ProgressView` spinner |
| `NewWorkspaceSheetTests.swift` | Updated `makeOption` helper for `isLoading` |

## Test plan

- [x] `swift build` passes
- [x] `swift test --filter "WorkspaceEnvironmentOptionsController|NewWorkspaceSheet"` — 20/20 tests pass
- [ ] Full `swift test` (CI)
- [ ] Visual verification: open New Workspace sheet and confirm per-provider spinners appear during hydration


🤖 Generated with [Claude Code](https://claude.com/claude-code)