### PR TITLE
fix: remove stale snapshot cache from setup flow

### DIFF
--- a/Sources/WorkspaceManager/App/UIFixtureLumeEnvironment.swift
+++ b/Sources/WorkspaceManager/App/UIFixtureLumeEnvironment.swift
@@ -333,10 +333,6 @@ actor UIFixtureLumeWorkspaceProvider: WorkspaceProviderProtocol {
     private let workspacesRoot: URL
     private let stepDelayNanoseconds: UInt64 = 450_000_000
     private var statusesByRemoteID: [String: WorkspaceStatus] = [:]
-    /// Snapshot captured during `setupRequirement(for:)` — reused by
-    /// `performSetup(progress:)` to avoid a redundant daemon probe.
-    private var cachedSetupSnapshot: LumeRuntimeSnapshot?
-
     nonisolated let descriptor = WorkspaceProviderDescriptor(
         id: LumeWorkspaceProvider.identifier,
         displayName: "Lume VM",
@@ -543,7 +539,6 @@ extension UIFixtureLumeWorkspaceProvider: WorkspaceProviderSetupCapable {
         for action: WorkspaceProviderSetupAction
     ) async throws -> WorkspaceProviderSetupRequirement? {
         let snapshot = await runtimeService.snapshot()
-        cachedSetupSnapshot = snapshot
 
         switch snapshot.state {
         case .ready:
@@ -611,15 +606,7 @@ extension UIFixtureLumeWorkspaceProvider: WorkspaceProviderSetupCapable {
     }
 
     func performSetup(progress: WorkspaceProviderSetupProgressHandler?) async throws {
-        // Consume the snapshot captured in setupRequirement(for:) to avoid a
-        // redundant daemon probe in the normal confirm-and-continue flow.
-        let snapshot: LumeRuntimeSnapshot
-        if let cached = cachedSetupSnapshot {
-            snapshot = cached
-            cachedSetupSnapshot = nil
-        } else {
-            snapshot = await runtimeService.snapshot()
-        }
+        let snapshot = await runtimeService.snapshot()
         let progressHandler: LumeRuntimeProgressHandler = { step in
             await progress?(
                 WorkspaceProviderSetupProgress(

--- a/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
@@ -79,11 +79,6 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
     private let daemonInfoLogPath = "/tmp/lume_daemon.log"
     private let daemonErrorLogPath = "/tmp/lume_daemon.error.log"
 
-    /// Snapshot captured during `setupRequirement(for:)` so that the
-    /// immediately following `performSetup(progress:)` call can reuse it
-    /// without issuing a second probe to the Lume daemon.
-    private var cachedSetupSnapshot: LumeRuntimeSnapshot?
-
     public init(
         baseURL: URL = URL(string: "http://localhost:7777/lume/")!,
         urlSession: URLSession = .shared,
@@ -1296,7 +1291,6 @@ extension LumeWorkspaceProvider: WorkspaceProviderSetupCapable {
         for action: WorkspaceProviderSetupAction
     ) async throws -> WorkspaceProviderSetupRequirement? {
         let snapshot = await runtimeService.snapshot()
-        cachedSetupSnapshot = snapshot
 
         switch snapshot.state {
         case .ready:
@@ -1364,17 +1358,7 @@ extension LumeWorkspaceProvider: WorkspaceProviderSetupCapable {
     }
 
     public func performSetup(progress: WorkspaceProviderSetupProgressHandler?) async throws {
-        // Consume the snapshot from setupRequirement(for:) if available — avoids
-        // a second round-trip to the Lume daemon when called as part of the normal
-        // confirm-and-continue flow. Fall back to a fresh probe otherwise (e.g.
-        // when performSetup is called directly in tests or repair paths).
-        let setupSnapshot: LumeRuntimeSnapshot
-        if let cached = cachedSetupSnapshot {
-            setupSnapshot = cached
-            cachedSetupSnapshot = nil
-        } else {
-            setupSnapshot = await runtimeService.snapshot()
-        }
+        let setupSnapshot = await runtimeService.snapshot()
         let progressHandler: LumeRuntimeProgressHandler = { step in
             await progress?(
                 WorkspaceProviderSetupProgress(

--- a/Tests/WorkspaceManagerTests/WorkspaceProviderTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceProviderTests.swift
@@ -191,35 +191,28 @@ struct WorkspaceProviderTests {
         )
     }
 
-    @Test("setupRequirement followed by performSetup issues only one snapshot probe")
-    func setupRequirementCachesSnapshotForPerformSetup() async throws {
-        let runtimeService = SpyLumeRuntimeService(state: .setupRequired)
+    @Test("performSetup sees fresh state even when runtime changes after setupRequirement")
+    func performSetupAlwaysTakesFreshSnapshot() async throws {
+        // Start as repairRequired, then transition to ready before performSetup runs.
+        let runtimeService = SpyLumeRuntimeService(state: .repairRequired)
         let provider = LumeWorkspaceProvider(
             baseURL: URL(string: "http://localhost:7777/lume/")!,
             runtimeService: runtimeService
         )
 
-        // Simulate the full confirm-and-continue flow: setupRequirement then performSetup.
-        _ = try await provider.setupRequirement(for: .createWorkspace(name: "vm", guestOS: .macOS))
-        try? await provider.performSetup(progress: nil)
-
-        let callCount = await runtimeService.snapshotCallCount
-        #expect(callCount == 1, "Expected exactly one snapshot() probe; got \(callCount)")
-    }
-
-    @Test("performSetup without prior setupRequirement still probes snapshot")
-    func performSetupWithoutCacheFallsBackToFreshProbe() async throws {
-        let runtimeService = SpyLumeRuntimeService(state: .setupRequired)
-        let provider = LumeWorkspaceProvider(
-            baseURL: URL(string: "http://localhost:7777/lume/")!,
-            runtimeService: runtimeService
+        let requirement = try await provider.setupRequirement(
+            for: .createWorkspace(name: "vm", guestOS: .macOS)
         )
+        #expect(requirement != nil, "repairRequired should produce a confirmation")
 
-        // Call performSetup directly — no prior setupRequirement.
+        // Runtime self-heals between setupRequirement and performSetup.
+        await runtimeService.setState(.ready)
+
+        // performSetup must re-probe and see .ready — not act on stale .repairRequired.
         try? await provider.performSetup(progress: nil)
 
         let callCount = await runtimeService.snapshotCallCount
-        #expect(callCount == 1, "Expected exactly one snapshot() probe from performSetup fallback; got \(callCount)")
+        #expect(callCount == 2, "performSetup must take its own fresh snapshot")
     }
 
     @Test("Lume bridged reachability extracts interface and matching ARP IP")
@@ -250,16 +243,20 @@ struct WorkspaceProviderTests {
 /// stubs install/verify/repair to return without error.
 private actor SpyLumeRuntimeService: LumeRuntimeServiceProtocol {
     private(set) var snapshotCallCount = 0
-    private let fixedState: LumeRuntimeState
+    private var currentState: LumeRuntimeState
 
     init(state: LumeRuntimeState) {
-        self.fixedState = state
+        self.currentState = state
+    }
+
+    func setState(_ state: LumeRuntimeState) {
+        currentState = state
     }
 
     func snapshot() async -> LumeRuntimeSnapshot {
         snapshotCallCount += 1
         return LumeRuntimeSnapshot(
-            state: fixedState,
+            state: currentState,
             executablePath: nil,
             launchAgentPath: "/tmp/lume.plist",
             launchAgentInstalled: false,
@@ -309,7 +306,7 @@ private actor SpyLumeRuntimeService: LumeRuntimeServiceProtocol {
     /// Returns a snapshot value without incrementing the call counter.
     private func stubbedSnapshot() -> LumeRuntimeSnapshot {
         LumeRuntimeSnapshot(
-            state: fixedState,
+            state: currentState,
             executablePath: nil,
             launchAgentPath: "/tmp/lume.plist",
             launchAgentInstalled: false,


### PR DESCRIPTION
## Summary

- Removes the `cachedSetupSnapshot` optimization from PR #142 that cached the Lume runtime snapshot between `setupRequirement()` and `performSetup()`. If the runtime state changed during the confirmation dialog (e.g. `repairRequired` → `ready`), `performSetup` would act on stale state and unnecessarily reinstall.
- `performSetup()` now always takes a fresh `snapshot()` probe, matching pre-#142 behavior.
- Replaces the call-count optimization tests with a state-transition safety test that proves `performSetup` sees live state even when the runtime changes after `setupRequirement`.

## Validation

- [x] `swift build`
- [x] `swift test --filter WorkspaceProviderTests` — 12 tests pass including new state-transition test

## Performance

- [x] Not a performance-sensitive change

One extra lightweight daemon probe per setup flow — correctness over saving one HTTP round-trip.

## Evidence

- [x] Not a UI-affecting change

## Blockers

- [x] None