### PR TITLE
fix: workspace creation hang diagnostics and debounced save guard

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -9,6 +9,12 @@ import AppKit
 import SwiftData
 import SwiftUI
 import WorkspaceManagerCore
+import os.log
+
+private let creationLog = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceCreation"
+)
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
@@ -1255,6 +1261,9 @@ struct ContentView: View {
         guestOS: WorkspaceGuestOS?,
         skipSetup: Bool
     ) async throws {
+        creationLog.info(
+            "createWorkspaceFromLanding: repo=\(repo.name) provider=\(providerID) skipSetup=\(skipSetup)"
+        )
         let controller = SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
@@ -1269,6 +1278,7 @@ struct ContentView: View {
             progress: { _ in },
             onPersisted: nil
         )
+        creationLog.info("createWorkspaceFromLanding: workspace created successfully")
 
         if skipSetup {
             abandonPendingRemoteConnection(reason: "workspace_created")
@@ -1388,7 +1398,16 @@ struct ContentView: View {
             do {
                 try modelContext.save()
             } catch {
-                modelContext.rollback()
+                if modelContext.insertedModelsArray.isEmpty {
+                    creationLog.warning(
+                        "saveAccessTimestampChanges: save failed, rolling back (no pending inserts)"
+                    )
+                    modelContext.rollback()
+                } else {
+                    creationLog.error(
+                        "saveAccessTimestampChanges: save failed with \(modelContext.insertedModelsArray.count) pending inserts — skipping rollback to preserve workspace creation"
+                    )
+                }
             }
         }
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -8,6 +8,12 @@
 import SwiftData
 import SwiftUI
 import WorkspaceManagerCore
+import os.log
+
+private let creationLog = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceCreation"
+)
 
 struct WorkspaceActionState {
     let workspaceID: UUID
@@ -721,6 +727,23 @@ struct SidebarView: View {
             message: initialCreationMessage(for: providerID)
         )
 
+        creationLog.info(
+            "createWorkspaceAfterSetup: starting repo=\(repo.name) provider=\(providerID)"
+        )
+
+        let watchdog = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(30))
+            guard !Task.isCancelled else { return }
+            let currentPhase = workspaceCreationStatusByRepoID[repoID]?.message ?? "unknown"
+            creationLog.error(
+                "createWorkspaceAfterSetup: WATCHDOG — creation stalled for 30s at phase=\(currentPhase)"
+            )
+            workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
+                message: "Creation is taking longer than expected..."
+            )
+        }
+        defer { watchdog.cancel() }
+
         do {
             let workspace = try await workspaceController.createWorkspace(
                 from: repo,
@@ -729,6 +752,7 @@ struct SidebarView: View {
                 providerID: providerID,
                 guestOS: guestOS,
                 progress: { phase in
+                    creationLog.debug("createWorkspaceAfterSetup: progress phase=\(phase)")
                     await MainActor.run {
                         workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(message: phase)
                     }
@@ -738,6 +762,7 @@ struct SidebarView: View {
                     await hostLumeSmokeAutomation.noteWorkspacePersisted(record)
                 }
             )
+            creationLog.info("createWorkspaceAfterSetup: workspace created, updating selection")
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             onWorkspaceCreated()
             selectedWorkspace = workspace
@@ -745,6 +770,9 @@ struct SidebarView: View {
                 HostLumeSmokeWorkspaceRecord(workspace: workspace)
             )
         } catch {
+            creationLog.error(
+                "createWorkspaceAfterSetup: failed: \(error.localizedDescription)"
+            )
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             let providerName = providerDisplayName(for: providerID)
             errorMessage = "Failed to create \(providerName) workspace: \(error.localizedDescription)"

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -6,6 +6,12 @@
 import Foundation
 import SwiftData
 @preconcurrency import WorkspaceManagerCore
+import os.log
+
+private let log = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceCreation"
+)
 
 @MainActor
 struct SidebarWorkspaceController {
@@ -83,6 +89,10 @@ struct SidebarWorkspaceController {
             includeOnDiskDirectories: provider.descriptor.usesHostWorkspaceFiles
         )
 
+        log.info(
+            "createWorkspace: starting provider=\(providerID) repo=\(repo.name) name=\(reservation.resolvedName)"
+        )
+
         var persistedWorkspace: Workspace?
         let request = WorkspaceProviderCreationRequest(
             repoName: repo.name,
@@ -93,11 +103,13 @@ struct SidebarWorkspaceController {
         )
 
         do {
+            log.info("createWorkspace: calling provider.createWorkspace")
             let finalResult = try await provider.createWorkspace(
                 request: request,
                 workspaceService: workspaceService,
                 progress: progress,
                 persist: { partialResult in
+                    log.info("createWorkspace: persist handler called, hopping to MainActor")
                     try await MainActor.run {
                         try upsertWorkspace(
                             from: partialResult,
@@ -105,15 +117,18 @@ struct SidebarWorkspaceController {
                             existingWorkspace: &persistedWorkspace
                         )
                     }
+                    log.info("createWorkspace: persist handler upsert complete")
                     await onPersisted?(HostLumeSmokeWorkspaceRecord(result: partialResult))
                 }
             )
 
+            log.info("createWorkspace: provider returned, calling final upsertWorkspace")
             try upsertWorkspace(
                 from: finalResult,
                 repo: repo,
                 existingWorkspace: &persistedWorkspace
             )
+            log.info("createWorkspace: final upsert complete")
             await onPersisted?(HostLumeSmokeWorkspaceRecord(result: finalResult))
 
             guard let persistedWorkspace else {
@@ -121,6 +136,7 @@ struct SidebarWorkspaceController {
             }
 
             await Self.nameReservationStore.release(reservation)
+            log.info("createWorkspace: success, returning workspace")
             return persistedWorkspace
         } catch {
             if let persistedWorkspace {
@@ -273,8 +289,11 @@ struct SidebarWorkspaceController {
 
     private func saveModelContext(action: String) throws {
         do {
+            log.debug("saveModelContext: \(action)")
             try modelContext.save()
+            log.debug("saveModelContext: \(action) succeeded")
         } catch {
+            log.error("saveModelContext: \(action) failed: \(error.localizedDescription)")
             modelContext.rollback()
             throw ControllerError.message("Failed to \(action): \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary

- Add `os.Logger` tracing to the workspace creation flow so the exact hang point is visible via `log stream --predicate 'subsystem == "com.cloudcompute.workspaces" AND category == "WorkspaceCreation"'`
- Guard the debounced `saveAccessTimestampChanges` rollback: skip `modelContext.rollback()` when pending inserts exist, preventing silent discard of in-flight workspace creation
- Add a 30-second watchdog in `createWorkspaceAfterSetup` that logs an error and updates the UI when creation stalls (replaces indefinite "Finishing workspace...")

## Context

After Milestone 6 (PRs #162-#165), a hang was observed during local workspace creation — the UI showed "Finishing workspace..." indefinitely and required force quit. No crash report was generated. NSLog doesn't flow to unified log in debug builds, making the hang point invisible.

The debounced save from PR #164 creates a MainActor Task that calls `modelContext.save()` with a `rollback()` on failure. This rollback could discard ALL pending changes in the context — including a workspace that was just inserted by `upsertWorkspace()` in `SidebarWorkspaceController`.

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (390 tests, 0 failures)
- [ ] Launch dev build, create a local workspace, verify logs show full lifecycle via `log stream`
- [ ] Verify watchdog fires after 30s if creation is artificially delayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)