### PR TITLE
Gate public agent workflows to trusted actors

### DIFF
--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -124,6 +124,7 @@ jobs:
           case "$permission" in
             admin|maintain|write)
               echo "trusted=true" >> "$GITHUB_OUTPUT"
+              echo "Actor $ACTOR trusted (permission: $permission)"
               ;;
             *)
               echo "trusted=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,6 +46,7 @@ jobs:
           case "$permission" in
             admin|maintain|write)
               echo "trusted=true" >> "$GITHUB_OUTPUT"
+              echo "Actor $ACTOR trusted (permission: $permission)"
               ;;
             *)
               echo "trusted=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- add a hosted trust check to `agent-mention.yml` that only treats repo users with `write`, `maintain`, or `admin` permission as trusted
- gate the April, Plat, Peter, and Claude mention flows on that trust result so public commenters can no longer reach secret-backed or self-hosted jobs
- keep the detection path on GitHub-hosted runners with read-only permissions

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/agent-mention.yml"); YAML.load_file(".github/workflows/claude.yml"); puts "yaml ok"'`
- `git diff --check`
