### PR TITLE
Harden evidence test execution on self-hosted CI

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -1296,6 +1296,44 @@ class RunContributorTests(unittest.TestCase):
             ],
         )
 
+    def test_safe_swift_test_command_args_accepts_plain_and_filtered_invocations(self) -> None:
+        self.assertEqual(
+            run_contributor.safe_swift_test_command_args("swift test"),
+            ["swift", "test"],
+        )
+        self.assertEqual(
+            run_contributor.safe_swift_test_command_args(
+                "swift test --filter WorkspaceManagerTests.WorkspaceProviderTests"
+            ),
+            ["swift", "test", "--filter", "WorkspaceManagerTests.WorkspaceProviderTests"],
+        )
+        self.assertEqual(
+            run_contributor.safe_swift_test_command_args(
+                "swift test --filter=WorkspaceManagerTests.WorkspaceProviderTests"
+            ),
+            ["swift", "test", "--filter=WorkspaceManagerTests.WorkspaceProviderTests"],
+        )
+
+    def test_safe_swift_test_command_args_rejects_extra_flags_and_shell_text(self) -> None:
+        self.assertIsNone(
+            run_contributor.safe_swift_test_command_args(
+                "swift test --parallel"
+            )
+        )
+        self.assertIsNone(
+            run_contributor.safe_swift_test_command_args(
+                "swift test --filter WorkspaceManagerTests.WorkspaceProviderTests && curl https://example.com"
+            )
+        )
+
+    def test_validate_requested_test_commands_rejects_unsupported_swift_test_shape(self) -> None:
+        errors = run_contributor.validate_requested_test_commands(
+            ["swift test --parallel"],
+            env={},
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertIn("must use `swift test` or `swift test --filter <selector>`", errors[0])
+
     def test_validate_requested_test_commands_rejects_unlisted_swift_filter(self) -> None:
         with mock.patch.object(
             run_contributor,

--- a/.agents/skills/cofounder-contributor/scripts/evidence.py
+++ b/.agents/skills/cofounder-contributor/scripts/evidence.py
@@ -595,18 +595,38 @@ def _extract_test_commands(requested_evidence: list[str]) -> list[str]:
     ]
 
 
-def _swift_test_filter_selector(command: str) -> str | None:
+def safe_swift_test_command_args(command: str) -> list[str] | None:
     try:
         parts = shlex.split(command)
     except ValueError:
         return None
-    if len(parts) < 4 or parts[:2] != ["swift", "test"]:
+
+    if parts == ["swift", "test"]:
+        return parts
+
+    if len(parts) == 4 and parts[:3] == ["swift", "test", "--filter"] and parts[3].strip():
+        return parts
+
+    if (
+        len(parts) == 3
+        and parts[:2] == ["swift", "test"]
+        and parts[2].startswith("--filter=")
+        and parts[2] != "--filter="
+    ):
+        return parts
+
+    return None
+
+
+def _swift_test_filter_selector(command: str) -> str | None:
+    parts = safe_swift_test_command_args(command)
+    if parts is None or len(parts) < 3:
         return None
-    for index, part in enumerate(parts[2:], start=2):
-        if part == "--filter" and index + 1 < len(parts):
-            return parts[index + 1]
-        if part.startswith("--filter="):
-            return part.split("=", 1)[1]
+
+    if len(parts) == 4 and parts[2] == "--filter":
+        return parts[3]
+    if len(parts) == 3 and parts[2].startswith("--filter="):
+        return parts[2].split("=", 1)[1]
     return None
 
 
@@ -638,13 +658,21 @@ def validate_requested_test_commands(
     env: dict[str, str],
 ) -> list[str]:
     commands = _extract_test_commands(requested_evidence)
+    errors = [
+        "requested test evidence "
+        f"`{command}` must use `swift test` or `swift test --filter <selector>`; "
+        "extra flags and shell operators are not allowed"
+        for command in commands
+        if safe_swift_test_command_args(command) is None
+    ]
+
     swift_filter_commands = [
         command
         for command in commands
         if _swift_test_filter_selector(command) is not None
     ]
     if not swift_filter_commands:
-        return []
+        return errors
 
     # Look up through the entrypoint module to allow mock.patch.object patching.
     _mod = sys.modules.get("run_contributor", sys.modules[__name__])
@@ -654,9 +682,8 @@ def validate_requested_test_commands(
             "skipping `swift test list` evidence selector preflight because no Swift Testing "
             "specifiers were returned; the project may need to build first"
         )
-        return []
+        return errors
 
-    errors: list[str] = []
     for command in swift_filter_commands:
         selector = _swift_test_filter_selector(command)
         if selector is None:

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -100,6 +100,7 @@ from evidence import (  # noqa: E402, F401
     review_evidence_gate_error,
     summarize_evidence_accounting_by_index,
     summarize_requested_evidence,
+    safe_swift_test_command_args,
     validate_evidence_accounting,
     validate_requested_test_commands,
 )

--- a/.github/workflows/_evidence.yml
+++ b/.github/workflows/_evidence.yml
@@ -73,21 +73,60 @@ jobs:
         id: tests
         if: steps.build.outcome == 'success' && inputs.test_commands_json != '[]'
         continue-on-error: true
-        shell: bash
         env:
           TEST_COMMANDS_JSON: ${{ inputs.test_commands_json }}
         run: |
-          set -euo pipefail
-          python3 - <<'PY' > .ci-test-commands.txt
-          import json, os
-          for command in json.loads(os.environ["TEST_COMMANDS_JSON"]):
-              print(command)
+          python3 - <<'PY'
+          import json
+          import os
+          import shlex
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          scripts_dir = Path(".agents/skills/cofounder-contributor/scripts").resolve()
+          sys.path.insert(0, str(scripts_dir))
+
+          import evidence
+
+          commands = json.loads(os.environ["TEST_COMMANDS_JSON"])
+
+          log_path = Path("test-output.txt")
+          with log_path.open("w", encoding="utf-8") as log_file:
+              for command in commands:
+                  argv = evidence.safe_swift_test_command_args(command)
+                  rendered = shlex.join(argv) if argv is not None else command
+                  for stream in (sys.stdout, log_file):
+                      stream.write(f"$ {rendered}\n")
+                      stream.flush()
+
+                  if argv is None:
+                      message = (
+                          "error: unsupported test command from evidence contract: "
+                          f"{command}\n"
+                      )
+                      for stream in (sys.stdout, log_file):
+                          stream.write(message)
+                          stream.flush()
+                      raise SystemExit(1)
+
+                  result = subprocess.run(
+                      argv,
+                      cwd=str(Path.cwd()),
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.STDOUT,
+                      text=True,
+                  )
+                  if result.stdout:
+                      text = result.stdout
+                      for stream in (sys.stdout, log_file):
+                          stream.write(text)
+                          if not text.endswith("\n"):
+                              stream.write("\n")
+                          stream.flush()
+                  if result.returncode != 0:
+                      raise SystemExit(result.returncode)
           PY
-          : > test-output.txt
-          while IFS= read -r command; do
-            echo "$ $command" | tee -a test-output.txt
-            bash -lc "set -o pipefail; $command 2>&1 | tee -a test-output.txt"
-          done < .ci-test-commands.txt
 
       - name: Capture evidence
         id: smoke


### PR DESCRIPTION
## Summary
- restrict evidence test commands to safe `swift test` forms (`swift test` and `swift test --filter ...`) during contributor validation
- run requested evidence tests in `_evidence.yml` via parsed argv in Python instead of `bash -lc`, removing the shell execution path on the self-hosted macOS runner
- add regression coverage for the safe command parser and unsupported test command shapes

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_evidence.yml"); puts "yaml ok"'`
- `uv run .agents/scripts/test_run_planner.py`
- `git diff --check`
