### PR TITLE
chore: move CI to self-hosted lume-macos runner

### DIFF
--- a/.github/workflows/ci-fallback.yml
+++ b/.github/workflows/ci-fallback.yml
@@ -12,9 +12,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'failure' ||
       github.event.workflow_run.conclusion == 'timed_out'
-    # Keep the fallback lane on GitHub-hosted macOS so it is still available
-    # when the self-hosted lanes are busy, offline, or being reconfigured.
-    runs-on: macos-17
+    runs-on: [self-hosted, lume-macos]
     timeout-minutes: 90
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    # Generic build/lint/test runs on GitHub-hosted macOS so routine CI never
-    # depends on the interactive desktop or the dedicated self-hosted lanes.
-    runs-on: macos-17
+    runs-on: [self-hosted, lume-macos]
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- Move `ci.yml` and `ci-fallback.yml` from GitHub-hosted `macos-17` to `[self-hosted, lume-macos]`
- `macos-17` runners are rarely available, causing CI to stall and release preflight gates to time out
- Runner allocation: `lume-macos` for CI, `signing-host` for release/notarize, `tart-ui` for perf/UI automation

## Test plan

- [ ] CI triggers on lume-macos runner after merge
- [ ] Release preflight passes with CI check on the release SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)