### PR TITLE
Add a kill switch for mention-driven automations

### DIFF
--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -25,6 +25,7 @@ jobs:
       issues: read
       pull-requests: read
     if: >-
+      vars.MENTION_AUTOMATIONS_ENABLED != 'false' &&
       !endsWith(github.event.sender.login, '[bot]') && (
         contains(github.event.comment.body || github.event.review.body || '', '@april') ||
         contains(github.event.comment.body || github.event.review.body || '', '@plat') ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   gate:
     if: |
+      vars.MENTION_AUTOMATIONS_ENABLED != 'false' &&
       !endsWith(github.event.sender.login, '[bot]') && (
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
## Summary

- add a repo variable kill switch for mention-triggered workflows
- gate `agent-mention.yml` and `claude.yml` on `vars.MENTION_AUTOMATIONS_ENABLED != false

## Toggle

- disable: `gh variable set MENTION_AUTOMATIONS_ENABLED --body false`
- enable: `gh variable set MENTION_AUTOMATIONS_ENABLED --body true`
- default behavior remains enabled when the variable is unset
