### PR TITLE
feat(web): collapsible dashboard sections

### DIFF
--- a/web/src/app/dashboard/components/main-panel.module.css
+++ b/web/src/app/dashboard/components/main-panel.module.css
@@ -97,8 +97,35 @@
 .section {
 	display: flex;
 	align-items: center;
-	padding-top: 0.5rem;
+	gap: 0.375rem;
+	padding: 0.375rem 0;
+	margin: 0;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: inherit;
+	font: inherit;
+	width: 100%;
+	text-align: left;
 	animation: fadeIn 0.5s ease-out 0.1s both;
+}
+
+.section:hover .sectionLabel {
+	color: var(--text-secondary);
+}
+
+.section:hover .sectionChevron {
+	color: var(--text-secondary);
+}
+
+.sectionChevron {
+	font-size: 0.5rem;
+	color: var(--text-tertiary);
+	transition: transform 0.15s ease, color 0.15s ease;
+}
+
+.sectionChevronCollapsed {
+	transform: rotate(-90deg);
 }
 
 .sectionLabel {
@@ -107,6 +134,7 @@
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
 	color: var(--text-tertiary);
+	transition: color 0.15s ease;
 }
 
 /* ── Agent grid ── */

--- a/web/src/app/dashboard/components/main-panel.tsx
+++ b/web/src/app/dashboard/components/main-panel.tsx
@@ -1,7 +1,43 @@
 import type { AgentDiscoveryResponse } from "@/lib/types";
+import { useCallback, useState } from "react";
 import { AgentCard } from "./agent-card";
 import styles from "./main-panel.module.css";
 import { PipelineBoard } from "./pipeline";
+
+const STORAGE_KEY = "spaces:collapsed-sections";
+
+function getCollapsedSections(): Set<string> {
+	if (typeof window === "undefined") return new Set();
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		return stored ? new Set(JSON.parse(stored)) : new Set();
+	} catch {
+		return new Set();
+	}
+}
+
+function useCollapsible(section: string) {
+	const [collapsed, setCollapsed] = useState(() =>
+		getCollapsedSections().has(section),
+	);
+
+	const toggle = useCallback(() => {
+		setCollapsed((prev) => {
+			const next = !prev;
+			try {
+				const sections = getCollapsedSections();
+				if (next) sections.add(section);
+				else sections.delete(section);
+				localStorage.setItem(STORAGE_KEY, JSON.stringify([...sections]));
+			} catch {
+				// localStorage unavailable
+			}
+			return next;
+		});
+	}, [section]);
+
+	return { collapsed, toggle };
+}
 
 interface MainPanelProps {
 	agentData: AgentDiscoveryResponse | null;
@@ -86,6 +122,9 @@ export function MainPanel({
 	if (!agentData) return null;
 
 	const { stats, agents, pipeline } = agentData;
+	const statsSection = useCollapsible("stats");
+	const agentsSection = useCollapsible("agents");
+	const pipelineSection = useCollapsible("pipeline");
 
 	return (
 		<div className={styles.panel}>
@@ -93,29 +132,57 @@ export function MainPanel({
 				{selectedRepo.owner}/{selectedRepo.repo}
 			</h2>
 
-			<div className={styles.grid}>
-				<StatCard label="Agents" value={stats.agentCount} accent />
-				<StatCard label="Skills" value={stats.skillCount} />
-				<StatCard label="Open PRs" value={stats.openPRs} />
-				<StatCard label="Ready Issues" value={stats.readyIssues} />
-			</div>
+			<SectionHeader
+				label="Overview"
+				collapsed={statsSection.collapsed}
+				onToggle={statsSection.toggle}
+			/>
+			{!statsSection.collapsed && (
+				<div className={styles.grid}>
+					<StatCard label="Agents" value={stats.agentCount} accent />
+					<StatCard label="Skills" value={stats.skillCount} />
+					<StatCard label="Open PRs" value={stats.openPRs} />
+					<StatCard label="Ready Issues" value={stats.readyIssues} />
+				</div>
+			)}
 
-			<div className={styles.section}>
-				<span className={styles.sectionLabel}>Agent Team</span>
-			</div>
+			<SectionHeader
+				label="Agent Team"
+				collapsed={agentsSection.collapsed}
+				onToggle={agentsSection.toggle}
+			/>
+			{!agentsSection.collapsed && (
+				<div className={styles.agentGrid}>
+					{agents.map((agent) => (
+						<AgentCard key={agent.name} agent={agent} />
+					))}
+				</div>
+			)}
 
-			<div className={styles.agentGrid}>
-				{agents.map((agent) => (
-					<AgentCard key={agent.name} agent={agent} />
-				))}
-			</div>
-
-			<div className={styles.section}>
-				<span className={styles.sectionLabel}>Issue Pipeline</span>
-			</div>
-
-			<PipelineBoard pipeline={pipeline} />
+			<SectionHeader
+				label="Issue Pipeline"
+				collapsed={pipelineSection.collapsed}
+				onToggle={pipelineSection.toggle}
+			/>
+			{!pipelineSection.collapsed && <PipelineBoard pipeline={pipeline} />}
 		</div>
+	);
+}
+
+function SectionHeader({
+	label,
+	collapsed,
+	onToggle,
+}: { label: string; collapsed: boolean; onToggle: () => void }) {
+	return (
+		<button type="button" className={styles.section} onClick={onToggle}>
+			<span
+				className={`${styles.sectionChevron} ${collapsed ? styles.sectionChevronCollapsed : ""}`}
+			>
+				&#9662;
+			</span>
+			<span className={styles.sectionLabel}>{label}</span>
+		</button>
 	);
 }
 


### PR DESCRIPTION
## Summary

- Dashboard sections (Overview, Agent Team, Issue Pipeline) are now collapsible via click on the section header
- Chevron indicator rotates to show collapsed/expanded state
- User preferences persist in `localStorage` across sessions
- All sections expanded by default

## Test plan

- [ ] Click section headers to toggle collapse
- [ ] Refresh page — collapsed state persists
- [ ] Clear localStorage — all sections re-expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)