### PR TITLE
feat(web): webhook status indicator + collapsible sections

### DIFF
--- a/web/src/app/api/repos/[owner]/[repo]/webhook-status/route.ts
+++ b/web/src/app/api/repos/[owner]/[repo]/webhook-status/route.ts
@@ -1,0 +1,17 @@
+import { getSession } from "@/lib/auth-server";
+import { getLastEventTime } from "@/lib/events";
+
+export async function GET(
+	_request: Request,
+	{ params }: { params: Promise<{ owner: string; repo: string }> },
+): Promise<Response> {
+	const session = await getSession();
+	if (!session)
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+
+	const { owner, repo } = await params;
+	const fullName = `${owner}/${repo}`;
+	const lastEvent = await getLastEventTime(fullName);
+
+	return Response.json({ lastEvent, connected: lastEvent !== null });
+}

--- a/web/src/app/dashboard/components/main-panel.module.css
+++ b/web/src/app/dashboard/components/main-panel.module.css
@@ -49,6 +49,50 @@
 	animation: fadeIn 0.4s ease-out both;
 }
 
+/* ── Webhook status ── */
+
+.webhookStatus {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	animation: fadeIn 0.4s ease-out 0.05s both;
+}
+
+.webhookDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.webhookConnected {
+	background: var(--accent);
+	box-shadow: 0 0 4px rgba(166, 255, 223, 0.4);
+}
+
+.webhookDisconnected {
+	background: #f85149;
+	box-shadow: 0 0 4px rgba(248, 81, 73, 0.4);
+}
+
+.webhookText {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-tertiary);
+}
+
+.webhookConfigure {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--accent);
+	text-decoration: none;
+	margin-left: 0.25rem;
+}
+
+.webhookConfigure:hover {
+	text-decoration: underline;
+}
+
 /* ── Stats grid ── */
 
 .grid {

--- a/web/src/app/dashboard/components/main-panel.tsx
+++ b/web/src/app/dashboard/components/main-panel.tsx
@@ -1,5 +1,5 @@
 import type { AgentDiscoveryResponse } from "@/lib/types";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { AgentCard } from "./agent-card";
 import styles from "./main-panel.module.css";
 import { PipelineBoard } from "./pipeline";
@@ -107,6 +107,7 @@ export function MainPanel({
 				<h2 className={styles.repoTitle}>
 					{selectedRepo.owner}/{selectedRepo.repo}
 				</h2>
+				<WebhookStatus owner={selectedRepo.owner} repo={selectedRepo.repo} />
 				<div className={styles.noAgents}>
 					<span className={styles.noAgentsIcon}>&gt;_</span>
 					<span className={styles.noAgentsTitle}>No agent setup detected</span>
@@ -131,6 +132,7 @@ export function MainPanel({
 			<h2 className={styles.repoTitle}>
 				{selectedRepo.owner}/{selectedRepo.repo}
 			</h2>
+			<WebhookStatus owner={selectedRepo.owner} repo={selectedRepo.repo} />
 
 			<SectionHeader
 				label="Overview"
@@ -199,6 +201,57 @@ function StatCard({
 				{value}
 			</span>
 			<span className={styles.statLabel}>{label}</span>
+		</div>
+	);
+}
+
+function formatTimeAgo(timestamp: string): string {
+	const diff = Date.now() - new Date(timestamp).getTime();
+	const mins = Math.floor(diff / 60000);
+	if (mins < 1) return "just now";
+	if (mins < 60) return `${mins}m ago`;
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return `${hours}h ago`;
+	return `${Math.floor(hours / 24)}d ago`;
+}
+
+function WebhookStatus({ owner, repo }: { owner: string; repo: string }) {
+	const [status, setStatus] = useState<{
+		lastEvent: string | null;
+		connected: boolean;
+	} | null>(null);
+
+	useEffect(() => {
+		fetch(`/api/repos/${owner}/${repo}/webhook-status`)
+			.then((r) => (r.ok ? r.json() : null))
+			.then(setStatus)
+			.catch(() => {});
+	}, [owner, repo]);
+
+	if (!status) return null;
+
+	const appSettingsUrl = "https://github.com/settings/installations";
+
+	return (
+		<div className={styles.webhookStatus}>
+			<span
+				className={`${styles.webhookDot} ${status.connected ? styles.webhookConnected : styles.webhookDisconnected}`}
+			/>
+			<span className={styles.webhookText}>
+				{status.connected && status.lastEvent
+					? `Last event ${formatTimeAgo(status.lastEvent)}`
+					: "No webhook events received"}
+			</span>
+			{!status.connected && (
+				<a
+					href={appSettingsUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className={styles.webhookConfigure}
+				>
+					Configure
+				</a>
+			)}
 		</div>
 	);
 }

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -73,6 +73,19 @@ export async function getEvents(
 	}));
 }
 
+export async function getLastEventTime(repo: string): Promise<string | null> {
+	await ensureEventsTable();
+	const db = getDb();
+	const row = await db
+		.selectFrom("webhook_events")
+		.select("timestamp")
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(1)
+		.executeTakeFirst();
+	return row?.timestamp ?? null;
+}
+
 export interface EventStats {
 	eventsToday: number;
 	repos: string[];


### PR DESCRIPTION
## Summary

- **Webhook status indicator**: Green dot + "Last event Xm ago" when events are flowing, red dot + "No webhook events received" with "Configure" link when not connected
- **Collapsible sections**: Overview, Agent Team, and Issue Pipeline sections toggle on click. State persists in localStorage.
- **New API**: `GET /api/repos/{owner}/{repo}/webhook-status` returns `{ lastEvent, connected }`

## Test plan

- [ ] Select a repo with webhook events — green dot shows with timestamp
- [ ] Select a repo without events — red dot shows with "Configure" link
- [ ] "Configure" opens GitHub App installation settings
- [ ] Click section headers to collapse/expand
- [ ] Refresh — collapsed state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)