### PR TITLE
feat(web): clickable event details with GitHub source links

### DIFF
--- a/web/src/app/api/events/[id]/route.ts
+++ b/web/src/app/api/events/[id]/route.ts
@@ -1,0 +1,13 @@
+import { getEvent } from "@/lib/events";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+	const { id } = await params;
+	const event = await getEvent(id);
+	if (!event) return new Response(null, { status: 404 });
+	return Response.json(event);
+}

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -104,6 +104,7 @@ export async function POST(request: Request): Promise<Response> {
 		summary: summarize(eventType, action, payload),
 		repo: repo ?? "unknown",
 		timestamp: new Date().toISOString(),
+		payload: body,
 	};
 
 	await pushEvent(event);

--- a/web/src/app/dashboard/components/activity-feed.module.css
+++ b/web/src/app/dashboard/components/activity-feed.module.css
@@ -38,11 +38,22 @@
 	flex-direction: column;
 	gap: 0.25rem;
 	padding: 0.625rem 1rem;
+	border: none;
 	border-bottom: 1px solid var(--border-subtle);
+	background: transparent;
+	width: 100%;
+	text-align: left;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
 	transition: background 0.15s ease;
 }
 
 .event:hover {
+	background: var(--accent-dim);
+}
+
+.eventExpanded {
 	background: var(--accent-dim);
 }
 

--- a/web/src/app/dashboard/components/activity-feed.tsx
+++ b/web/src/app/dashboard/components/activity-feed.tsx
@@ -3,6 +3,7 @@
 import type { WebhookEvent, WebhookEventType } from "@/lib/types";
 import { useCallback, useEffect, useState } from "react";
 import styles from "./activity-feed.module.css";
+import { EventDetail } from "./event-detail";
 
 const EVENT_COLORS: Record<WebhookEventType, string> = {
 	pull_request: styles.eventPr,
@@ -40,18 +41,43 @@ function formatTime(timestamp: string): string {
 	return `${Math.floor(hours / 24)}d ago`;
 }
 
-function EventRow({ event }: { event: WebhookEvent }) {
+function EventRow({
+	event,
+	isExpanded,
+	showRepo,
+	onToggle,
+}: {
+	event: WebhookEvent;
+	isExpanded: boolean;
+	showRepo: boolean;
+	onToggle: () => void;
+}) {
 	return (
-		<div className={styles.event}>
-			<div className={styles.eventHeader}>
-				<span className={`${styles.eventBadge} ${EVENT_COLORS[event.type]}`}>
-					{EVENT_LABELS[event.type]}
-				</span>
-				<span className={styles.eventTime}>{formatTime(event.timestamp)}</span>
-			</div>
-			<span className={styles.eventSummary}>{event.summary}</span>
-			<span className={styles.eventRepo}>{event.repo}</span>
-		</div>
+		<>
+			<button
+				type="button"
+				className={`${styles.event} ${isExpanded ? styles.eventExpanded : ""}`}
+				onClick={onToggle}
+			>
+				<div className={styles.eventHeader}>
+					<span
+						className={`${styles.eventBadge} ${EVENT_COLORS[event.type]}`}
+					>
+						{EVENT_LABELS[event.type]}
+					</span>
+					<span className={styles.eventTime}>
+						{formatTime(event.timestamp)}
+					</span>
+				</div>
+				<span className={styles.eventSummary}>{event.summary}</span>
+				{showRepo && (
+					<span className={styles.eventRepo}>{event.repo}</span>
+				)}
+			</button>
+			{isExpanded && (
+				<EventDetail eventId={event.id} eventType={event.type} />
+			)}
+		</>
 	);
 }
 
@@ -63,6 +89,7 @@ interface ActivityFeedProps {
 
 export function ActivityFeed({ filterRepo }: ActivityFeedProps) {
 	const [events, setEvents] = useState<WebhookEvent[]>([]);
+	const [expandedId, setExpandedId] = useState<string | null>(null);
 
 	const fetchEvents = useCallback(async () => {
 		try {
@@ -82,6 +109,11 @@ export function ActivityFeed({ filterRepo }: ActivityFeedProps) {
 		return () => clearInterval(id);
 	}, [fetchEvents]);
 
+	// Collapse when repo filter changes
+	useEffect(() => {
+		setExpandedId(null);
+	}, [filterRepo]);
+
 	return (
 		<div className={styles.feed}>
 			<div className={styles.header}>
@@ -100,7 +132,17 @@ export function ActivityFeed({ filterRepo }: ActivityFeedProps) {
 			) : (
 				<div className={styles.list}>
 					{events.map((event) => (
-						<EventRow key={event.id} event={event} />
+						<EventRow
+							key={event.id}
+							event={event}
+							isExpanded={expandedId === event.id}
+							showRepo={!filterRepo}
+							onToggle={() =>
+								setExpandedId((prev) =>
+									prev === event.id ? null : event.id,
+								)
+							}
+						/>
 					))}
 				</div>
 			)}

--- a/web/src/app/dashboard/components/event-detail.module.css
+++ b/web/src/app/dashboard/components/event-detail.module.css
@@ -1,0 +1,152 @@
+.detail {
+	padding: 0.75rem 1rem;
+	background: var(--bg-primary);
+	border: 1px solid var(--border-subtle);
+	border-radius: 6px;
+	margin: 0.25rem 0.75rem 0.5rem;
+}
+
+.skeleton {
+	composes: detail;
+	height: 60px;
+	animation: pulse 1.5s ease-in-out infinite;
+	background: var(--bg-elevated);
+}
+
+.sender {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-secondary);
+}
+
+.detailTitle {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 0.375rem;
+	line-height: 1.4;
+}
+
+.body {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-tertiary);
+	line-height: 1.5;
+	margin-bottom: 0.5rem;
+}
+
+.badges {
+	display: flex;
+	gap: 0.375rem;
+	margin-bottom: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.badge {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	padding: 0.125rem 0.375rem;
+	border-radius: 10px;
+	border: 1px solid var(--border-subtle);
+	color: var(--text-tertiary);
+}
+
+.commitList {
+	margin-bottom: 0.5rem;
+}
+
+.commit {
+	display: flex;
+	gap: 0.5rem;
+	padding: 0.25rem 0;
+	border-left: 2px solid var(--border-subtle);
+	padding-left: 0.625rem;
+	margin-bottom: 0.25rem;
+}
+
+.commitSha {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--accent);
+	flex-shrink: 0;
+}
+
+.commitMsg {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-primary);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.conclusion {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	margin-bottom: 0.5rem;
+}
+
+.conclusionDot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.conclusionSuccess {
+	background: #3fb950;
+}
+
+.conclusionFailure {
+	background: #f85149;
+}
+
+.conclusionNeutral {
+	background: #8b949e;
+}
+
+.conclusionText {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-secondary);
+}
+
+.branchName {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--text-tertiary);
+	margin-bottom: 0.5rem;
+}
+
+.sourceLink {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--accent);
+	text-decoration: none;
+	transition: opacity 0.15s ease;
+}
+
+.sourceLink:hover {
+	opacity: 0.8;
+}
+
+.fallback {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--text-tertiary);
+	font-style: italic;
+}
+
+@keyframes pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.5; }
+}

--- a/web/src/app/dashboard/components/event-detail.tsx
+++ b/web/src/app/dashboard/components/event-detail.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import {
+	type CIDetail,
+	type DiscussionDetail,
+	type IssueDetail,
+	type PRDetail,
+	type PushDetail,
+	extractCIDetail,
+	extractDiscussionDetail,
+	extractIssueDetail,
+	extractPRDetail,
+	extractPushDetail,
+	getSourceUrl,
+} from "@/lib/event-source";
+import type { WebhookEvent, WebhookEventType } from "@/lib/types";
+import { useEffect, useState } from "react";
+import styles from "./event-detail.module.css";
+
+interface EventDetailProps {
+	eventId: string;
+	eventType: WebhookEventType;
+}
+
+export function EventDetail({ eventId, eventType }: EventDetailProps) {
+	const [event, setEvent] = useState<WebhookEvent | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+		fetch(`/api/events/${eventId}`)
+			.then((r) => (r.ok ? r.json() : null))
+			.then((data) => {
+				if (!cancelled) {
+					setEvent(data);
+					setLoading(false);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [eventId]);
+
+	if (loading) return <div className={styles.skeleton} />;
+	if (!event) return null;
+
+	let payload: Record<string, unknown> = {};
+	try {
+		payload = JSON.parse(event.payload ?? "{}");
+	} catch {
+		/* invalid payload */
+	}
+
+	const isEmpty = Object.keys(payload).length === 0;
+	const sourceUrl = isEmpty ? null : getSourceUrl(eventType, payload);
+
+	if (isEmpty) {
+		return (
+			<div className={styles.detail}>
+				<span className={styles.fallback}>
+					Full details not available for this event
+				</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className={styles.detail}>
+			<TypeContent type={eventType} payload={payload} />
+			{sourceUrl && (
+				<a
+					href={sourceUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className={styles.sourceLink}
+				>
+					View on GitHub →
+				</a>
+			)}
+		</div>
+	);
+}
+
+function TypeContent({
+	type,
+	payload,
+}: { type: WebhookEventType; payload: Record<string, unknown> }) {
+	switch (type) {
+		case "pull_request": {
+			const pr = extractPRDetail(payload);
+			if (!pr) return null;
+			return <PRContent detail={pr} />;
+		}
+		case "push": {
+			const push = extractPushDetail(payload);
+			if (!push) return null;
+			return <PushContent detail={push} />;
+		}
+		case "check_run":
+		case "check_suite":
+		case "workflow_run": {
+			const ci = extractCIDetail(payload);
+			if (!ci) return null;
+			return <CIContent detail={ci} />;
+		}
+		case "issues":
+		case "issue_comment": {
+			const issue = extractIssueDetail(payload);
+			if (!issue) return null;
+			return <IssueContent detail={issue} />;
+		}
+		case "discussion":
+		case "discussion_comment": {
+			const disc = extractDiscussionDetail(payload);
+			if (!disc) return null;
+			return <DiscussionContent detail={disc} />;
+		}
+		default:
+			return null;
+	}
+}
+
+function PRContent({ detail }: { detail: PRDetail }) {
+	return (
+		<>
+			{detail.sender && (
+				<div className={styles.sender}>{detail.sender}</div>
+			)}
+			<div className={styles.detailTitle}>{detail.title}</div>
+			{detail.body && <div className={styles.body}>{detail.body}</div>}
+			<div className={styles.badges}>
+				<span className={styles.badge}>+{detail.additions}</span>
+				<span className={styles.badge}>-{detail.deletions}</span>
+				<span className={styles.badge}>
+					{detail.changedFiles} file{detail.changedFiles !== 1 ? "s" : ""}
+				</span>
+			</div>
+		</>
+	);
+}
+
+function PushContent({ detail }: { detail: PushDetail }) {
+	return (
+		<>
+			<div className={styles.branchName}>Branch: {detail.branch}</div>
+			<div className={styles.commitList}>
+				{detail.commits.map((c) => (
+					<div key={c.sha} className={styles.commit}>
+						<span className={styles.commitSha}>{c.sha}</span>
+						<span className={styles.commitMsg}>{c.message}</span>
+					</div>
+				))}
+			</div>
+		</>
+	);
+}
+
+function CIContent({ detail }: { detail: CIDetail }) {
+	const dotClass =
+		detail.conclusion === "success"
+			? styles.conclusionSuccess
+			: detail.conclusion === "failure"
+				? styles.conclusionFailure
+				: styles.conclusionNeutral;
+
+	return (
+		<>
+			<div className={styles.conclusion}>
+				<span className={`${styles.conclusionDot} ${dotClass}`} />
+				<span className={styles.conclusionText}>
+					{detail.name}: {detail.conclusion}
+				</span>
+			</div>
+			{detail.branch && (
+				<div className={styles.branchName}>Branch: {detail.branch}</div>
+			)}
+		</>
+	);
+}
+
+function IssueContent({ detail }: { detail: IssueDetail }) {
+	return (
+		<>
+			{detail.sender && (
+				<div className={styles.sender}>{detail.sender}</div>
+			)}
+			<div className={styles.detailTitle}>{detail.title}</div>
+			{detail.body && <div className={styles.body}>{detail.body}</div>}
+			{detail.labels.length > 0 && (
+				<div className={styles.badges}>
+					{detail.labels.map((l) => (
+						<span key={l} className={styles.badge}>
+							{l}
+						</span>
+					))}
+				</div>
+			)}
+		</>
+	);
+}
+
+function DiscussionContent({ detail }: { detail: DiscussionDetail }) {
+	return (
+		<>
+			{detail.sender && (
+				<div className={styles.sender}>{detail.sender}</div>
+			)}
+			<div className={styles.detailTitle}>{detail.title}</div>
+			{detail.body && <div className={styles.body}>{detail.body}</div>}
+		</>
+	);
+}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -9,6 +9,7 @@ export interface EventsTable {
 	summary: string;
 	repo: string;
 	timestamp: string;
+	payload: string;
 }
 
 interface Database {

--- a/web/src/lib/event-source.ts
+++ b/web/src/lib/event-source.ts
@@ -1,0 +1,141 @@
+import type { WebhookEventType } from "./types";
+
+type Payload = Record<string, unknown>;
+type Nested = Record<string, unknown> | undefined;
+
+function str(val: unknown): string {
+	return typeof val === "string" ? val : "";
+}
+
+function num(val: unknown): number {
+	return typeof val === "number" ? val : 0;
+}
+
+export function getSourceUrl(type: WebhookEventType, p: Payload): string | null {
+	switch (type) {
+		case "pull_request":
+			return str((p.pull_request as Nested)?.html_url) || null;
+		case "issues":
+			return str((p.issue as Nested)?.html_url) || null;
+		case "issue_comment":
+			return str((p.comment as Nested)?.html_url) || null;
+		case "push":
+			return str(p.compare) || null;
+		case "check_run":
+			return str((p.check_run as Nested)?.html_url) || null;
+		case "check_suite": {
+			const url = str((p.check_suite as Nested)?.url);
+			if (url) {
+				const repo = p.repository as Nested;
+				return str(repo?.html_url)
+					? `${str(repo?.html_url)}/actions`
+					: null;
+			}
+			return null;
+		}
+		case "workflow_run":
+			return str((p.workflow_run as Nested)?.html_url) || null;
+		case "discussion":
+			return str((p.discussion as Nested)?.html_url) || null;
+		case "discussion_comment":
+			return str((p.comment as Nested)?.html_url) || null;
+		default:
+			return null;
+	}
+}
+
+export interface PRDetail {
+	sender: string;
+	title: string;
+	body: string;
+	additions: number;
+	deletions: number;
+	changedFiles: number;
+}
+
+export function extractPRDetail(p: Payload): PRDetail | null {
+	const pr = p.pull_request as Nested;
+	if (!pr) return null;
+	return {
+		sender: str((p.sender as Nested)?.login),
+		title: str(pr.title),
+		body: str(pr.body).slice(0, 200),
+		additions: num(pr.additions),
+		deletions: num(pr.deletions),
+		changedFiles: num(pr.changed_files),
+	};
+}
+
+export interface PushDetail {
+	branch: string;
+	commits: { sha: string; message: string }[];
+}
+
+export function extractPushDetail(p: Payload): PushDetail | null {
+	const commits = p.commits as Array<Record<string, unknown>> | undefined;
+	if (!commits) return null;
+	return {
+		branch: str(p.ref).replace("refs/heads/", ""),
+		commits: commits.slice(0, 5).map((c) => ({
+			sha: str(c.id).slice(0, 7),
+			message: str(c.message).split("\n")[0],
+		})),
+	};
+}
+
+export interface CIDetail {
+	name: string;
+	conclusion: string;
+	branch: string;
+}
+
+export function extractCIDetail(p: Payload): CIDetail | null {
+	const run = (p.workflow_run ?? p.check_run ?? p.check_suite) as Nested;
+	if (!run) return null;
+	const branch =
+		str(run.head_branch) ||
+		str((run.head_sha as Nested)?.ref) ||
+		"";
+	return {
+		name: str(run.name),
+		conclusion: str(run.conclusion || run.status),
+		branch,
+	};
+}
+
+export interface IssueDetail {
+	sender: string;
+	title: string;
+	body: string;
+	labels: string[];
+}
+
+export function extractIssueDetail(p: Payload): IssueDetail | null {
+	const issue = p.issue as Nested;
+	if (!issue) return null;
+	const labels = Array.isArray(issue.labels)
+		? (issue.labels as Array<Record<string, unknown>>).map((l) => str(l.name))
+		: [];
+	return {
+		sender: str((p.sender as Nested)?.login),
+		title: str(issue.title),
+		body: str(issue.body).slice(0, 200),
+		labels,
+	};
+}
+
+export interface DiscussionDetail {
+	sender: string;
+	title: string;
+	body: string;
+}
+
+export function extractDiscussionDetail(p: Payload): DiscussionDetail | null {
+	const disc = p.discussion as Nested;
+	if (!disc) return null;
+	return {
+		sender: str((p.sender as Nested)?.login),
+		title: str(disc.title),
+		body: str(disc.body).slice(0, 200),
+	};
+}

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -15,7 +15,17 @@ async function ensureEventsTable(): Promise<void> {
 		.addColumn("summary", "text", (c) => c.notNull().defaultTo(""))
 		.addColumn("repo", "text", (c) => c.notNull().defaultTo("unknown"))
 		.addColumn("timestamp", "text", (c) => c.notNull())
+		.addColumn("payload", "text", (c) => c.notNull().defaultTo("{}"))
 		.execute();
+	// Ensure payload column exists on tables created before this migration
+	try {
+		await db.schema
+			.alterTable("webhook_events")
+			.addColumn("payload", "text", (c) => c.notNull().defaultTo("{}"))
+			.execute();
+	} catch {
+		/* column already exists */
+	}
 	await db.schema
 		.createIndex("idx_webhook_events_timestamp")
 		.ifNotExists()
@@ -43,6 +53,7 @@ export async function pushEvent(event: WebhookEvent): Promise<void> {
 			summary: event.summary,
 			repo: event.repo,
 			timestamp: event.timestamp,
+			payload: event.payload ?? "{}",
 		})
 		.onConflict((oc) => oc.doNothing())
 		.execute();
@@ -56,7 +67,7 @@ export async function getEvents(
 	const db = getDb();
 	let query = db
 		.selectFrom("webhook_events")
-		.selectAll()
+		.select(["id", "type", "action", "summary", "repo", "timestamp"])
 		.orderBy("timestamp", "desc")
 		.limit(limit);
 	if (repo) {
@@ -71,6 +82,26 @@ export async function getEvents(
 		repo: r.repo,
 		timestamp: r.timestamp,
 	}));
+}
+
+export async function getEvent(id: string): Promise<WebhookEvent | null> {
+	await ensureEventsTable();
+	const db = getDb();
+	const row = await db
+		.selectFrom("webhook_events")
+		.selectAll()
+		.where("id", "=", id)
+		.executeTakeFirst();
+	if (!row) return null;
+	return {
+		id: row.id,
+		type: row.type as WebhookEventType,
+		action: row.action,
+		summary: row.summary,
+		repo: row.repo,
+		timestamp: row.timestamp,
+		payload: row.payload,
+	};
 }
 
 export async function getLastEventTime(repo: string): Promise<string | null> {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,7 @@ export interface WebhookEvent {
 	summary: string;
 	repo: string;
 	timestamp: string;
+	payload?: string;
 }
 
 export type WebhookEventType =


### PR DESCRIPTION
## Summary
- Store full raw GitHub webhook payload in a new `payload` DB column (with ALTER TABLE migration for existing databases)
- Add `GET /api/events/[id]` endpoint for lazy-loading individual event payloads
- Clicking an event row in the activity feed expands it inline with type-aware detail:
  - **PR**: sender, title, body excerpt, +/- diff stats, file count
  - **Push**: branch name, commit list with SHAs and messages
  - **CI/Workflow**: name, conclusion with color indicator, branch
  - **Issue**: sender, title, body excerpt, labels
  - **Discussion**: sender, title, body excerpt
- Each expanded detail includes a "View on GitHub →" link to the original resource
- Repo name conditionally shown in event rows (visible in global feed, hidden when repo-scoped)

## Test plan
- [ ] Trigger webhooks via `pnpm run simulate` or real GitHub events
- [ ] Click an event row — expands with loading skeleton, then type-specific detail
- [ ] "View on GitHub →" opens correct GitHub page (PR, compare, workflow run, etc.)
- [ ] Click same row again — collapses
- [ ] Click different row — previous collapses, new one expands
- [ ] Global feed (`/dashboard`) shows repo name on each event
- [ ] Repo-scoped feed (`/dashboard/owner/repo`) hides redundant repo name
- [ ] Pre-migration events (no payload) show graceful "Full details not available" fallback
- [ ] `npx tsc --noEmit` passes (excluding pre-existing vercel/analytics issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)