### PR TITLE
feat(web): chat API route and GitHub Discussion bridge

### DIFF
--- a/web/src/app/api/chat/messages/route.ts
+++ b/web/src/app/api/chat/messages/route.ts
@@ -1,0 +1,131 @@
+import crypto from "node:crypto";
+import { pushChatMessage, getMixedTimeline } from "@/lib/chat";
+import { getSession } from "@/lib/auth-server";
+import {
+	getGitHubToken,
+	createDiscussion,
+	addDiscussionComment,
+} from "@/lib/github";
+import type { ChatMessage } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+interface PostBody {
+	repo: string;
+	agentName?: string;
+	message: string;
+	parentDiscussionId?: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) {
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+	}
+
+	const body = (await request.json()) as PostBody;
+	if (!body.repo || !body.message) {
+		return Response.json(
+			{ error: "repo and message are required" },
+			{ status: 400 },
+		);
+	}
+
+	const [owner, repo] = body.repo.split("/");
+	if (!owner || !repo) {
+		return Response.json(
+			{ error: "repo must be owner/name format" },
+			{ status: 400 },
+		);
+	}
+
+	const token = await getGitHubToken(session.user.id);
+	if (!token) {
+		return Response.json(
+			{ error: "GitHub token not found" },
+			{ status: 403 },
+		);
+	}
+
+	const messageId = crypto.randomUUID();
+	const timestamp = new Date().toISOString();
+	let discussionId: string | null = null;
+	let discussionUrl: string | null = null;
+
+	const agentTarget = body.agentName ?? parseAgentMention(body.message);
+	const title = agentTarget
+		? `@${agentTarget}: ${body.message.slice(0, 100)}`
+		: body.message.slice(0, 100);
+
+	try {
+		if (body.parentDiscussionId) {
+			const comment = await addDiscussionComment(
+				token,
+				body.parentDiscussionId,
+				body.message,
+			);
+			discussionId = body.parentDiscussionId;
+			discussionUrl = comment.url;
+		} else {
+			const discussion = await createDiscussion(
+				token,
+				owner,
+				repo,
+				title,
+				body.message,
+			);
+			discussionId = discussion.id;
+			discussionUrl = discussion.url;
+		}
+	} catch (err) {
+		console.error("[chat] GitHub Discussion error:", err);
+		// Still persist the chat message even if Discussion creation fails
+	}
+
+	const chatMessage: ChatMessage = {
+		id: messageId,
+		repo: body.repo,
+		author: session.user.name ?? session.user.email ?? "you",
+		authorType: "user",
+		content: body.message,
+		agentTarget: agentTarget ?? null,
+		discussionId,
+		discussionUrl,
+		timestamp,
+	};
+
+	await pushChatMessage(chatMessage);
+
+	return Response.json({
+		messageId,
+		discussionId,
+		discussionUrl,
+	});
+}
+
+export async function GET(request: Request): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) {
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+	}
+
+	const { searchParams } = new URL(request.url);
+	const repo = searchParams.get("repo");
+	if (!repo) {
+		return Response.json(
+			{ error: "repo query parameter is required" },
+			{ status: 400 },
+		);
+	}
+
+	const limit = Math.min(Number(searchParams.get("limit") ?? 50), 200);
+	const since = searchParams.get("since") ?? undefined;
+
+	const timeline = await getMixedTimeline(repo, limit, since);
+	return Response.json(timeline);
+}
+
+function parseAgentMention(message: string): string | null {
+	const match = message.match(/^@(\w[\w-]*)/);
+	return match ? match[1] : null;
+}

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
+import { pushChatMessage } from "@/lib/chat";
 import { pushEvent } from "@/lib/events";
-import type { WebhookEvent, WebhookEventType } from "@/lib/types";
+import type { ChatMessage, WebhookEvent, WebhookEventType } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -108,5 +109,59 @@ export async function POST(request: Request): Promise<Response> {
 
 	await pushEvent(event);
 
+	// Bridge discussion/discussion_comment webhooks into chat_messages
+	if (eventType === "discussion" || eventType === "discussion_comment") {
+		const chatMsg = extractDiscussionChatMessage(eventType, payload, repo ?? "unknown");
+		if (chatMsg) {
+			await pushChatMessage(chatMsg);
+		}
+	}
+
 	return Response.json({ ok: true });
+}
+
+function extractDiscussionChatMessage(
+	eventType: string,
+	payload: Record<string, unknown>,
+	repo: string,
+): ChatMessage | null {
+	if (eventType === "discussion_comment") {
+		const comment = payload.comment as Record<string, unknown> | undefined;
+		const discussion = payload.discussion as Record<string, unknown> | undefined;
+		if (!comment?.body) return null;
+		const user = comment.user as Record<string, unknown> | undefined;
+		const isBot = String(user?.type ?? "").toLowerCase() === "bot";
+		return {
+			id: `ghdc-${comment.id ?? crypto.randomUUID()}`,
+			repo,
+			author: String(user?.login ?? "unknown"),
+			authorType: isBot ? "bot" : "user",
+			content: String(comment.body),
+			agentTarget: null,
+			discussionId: String(discussion?.node_id ?? ""),
+			discussionUrl: String(comment.html_url ?? discussion?.html_url ?? ""),
+			timestamp: String(comment.created_at ?? new Date().toISOString()),
+		};
+	}
+
+	if (eventType === "discussion") {
+		const discussion = payload.discussion as Record<string, unknown> | undefined;
+		const action = String(payload.action ?? "");
+		if (action !== "created" || !discussion?.body) return null;
+		const user = discussion.user as Record<string, unknown> | undefined;
+		const isBot = String(user?.type ?? "").toLowerCase() === "bot";
+		return {
+			id: `ghd-${discussion.id ?? crypto.randomUUID()}`,
+			repo,
+			author: String(user?.login ?? "unknown"),
+			authorType: isBot ? "bot" : "user",
+			content: String(discussion.body),
+			agentTarget: null,
+			discussionId: String(discussion.node_id ?? ""),
+			discussionUrl: String(discussion.html_url ?? ""),
+			timestamp: String(discussion.created_at ?? new Date().toISOString()),
+		};
+	}
+
+	return null;
 }

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -1,0 +1,167 @@
+import { getDb } from "./db";
+import type {
+	AuthorType,
+	ChatMessage,
+	TimelineEntry,
+	WebhookEventType,
+} from "./types";
+
+let migrated = false;
+
+async function ensureChatTable(): Promise<void> {
+	if (migrated) return;
+	const db = getDb();
+	await db.schema
+		.createTable("chat_messages")
+		.ifNotExists()
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("repo", "text", (c) => c.notNull())
+		.addColumn("author", "text", (c) => c.notNull())
+		.addColumn("author_type", "text", (c) => c.notNull())
+		.addColumn("content", "text", (c) => c.notNull())
+		.addColumn("agent_target", "text")
+		.addColumn("discussion_id", "text")
+		.addColumn("discussion_url", "text")
+		.addColumn("timestamp", "text", (c) => c.notNull())
+		.execute();
+	await db.schema
+		.createIndex("idx_chat_messages_repo_ts")
+		.ifNotExists()
+		.on("chat_messages")
+		.columns(["repo", "timestamp desc"])
+		.execute();
+	migrated = true;
+}
+
+export async function pushChatMessage(msg: ChatMessage): Promise<void> {
+	await ensureChatTable();
+	const db = getDb();
+	await db
+		.insertInto("chat_messages")
+		.values({
+			id: msg.id,
+			repo: msg.repo,
+			author: msg.author,
+			author_type: msg.authorType,
+			content: msg.content,
+			agent_target: msg.agentTarget,
+			discussion_id: msg.discussionId,
+			discussion_url: msg.discussionUrl,
+			timestamp: msg.timestamp,
+		})
+		.onConflict((oc) => oc.doNothing())
+		.execute();
+}
+
+export async function getChatMessages(
+	repo: string,
+	limit = 50,
+	since?: string,
+): Promise<ChatMessage[]> {
+	await ensureChatTable();
+	const db = getDb();
+	let query = db
+		.selectFrom("chat_messages")
+		.selectAll()
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(limit);
+	if (since) {
+		query = query.where("timestamp", ">", since);
+	}
+	const rows = await query.execute();
+	return rows.map((r) => ({
+		id: r.id,
+		repo: r.repo,
+		author: r.author,
+		authorType: r.author_type as AuthorType,
+		content: r.content,
+		agentTarget: r.agent_target,
+		discussionId: r.discussion_id,
+		discussionUrl: r.discussion_url,
+		timestamp: r.timestamp,
+	}));
+}
+
+export async function getMixedTimeline(
+	repo: string,
+	limit = 50,
+	since?: string,
+): Promise<TimelineEntry[]> {
+	await ensureChatTable();
+	const db = getDb();
+
+	let eventsQuery = db
+		.selectFrom("webhook_events")
+		.select([
+			"id",
+			"type",
+			"action",
+			"summary",
+			"repo",
+			"timestamp",
+		])
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(limit);
+
+	let chatQuery = db
+		.selectFrom("chat_messages")
+		.select([
+			"id",
+			"repo",
+			"author",
+			"author_type",
+			"content",
+			"agent_target",
+			"discussion_id",
+			"discussion_url",
+			"timestamp",
+		])
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(limit);
+
+	if (since) {
+		eventsQuery = eventsQuery.where("timestamp", ">", since);
+		chatQuery = chatQuery.where("timestamp", ">", since);
+	}
+
+	const [events, messages] = await Promise.all([
+		eventsQuery.execute(),
+		chatQuery.execute(),
+	]);
+
+	const timeline: TimelineEntry[] = [
+		...events.map(
+			(e) =>
+				({
+					kind: "event" as const,
+					id: e.id,
+					type: e.type as WebhookEventType,
+					action: e.action,
+					summary: e.summary,
+					repo: e.repo,
+					timestamp: e.timestamp,
+				}),
+		),
+		...messages.map(
+			(m) =>
+				({
+					kind: "chat" as const,
+					id: m.id,
+					repo: m.repo,
+					author: m.author,
+					authorType: m.author_type as AuthorType,
+					content: m.content,
+					agentTarget: m.agent_target,
+					discussionId: m.discussion_id,
+					discussionUrl: m.discussion_url,
+					timestamp: m.timestamp,
+				}),
+		),
+	];
+
+	timeline.sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1));
+	return timeline.slice(0, limit);
+}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -11,8 +11,21 @@ export interface EventsTable {
 	timestamp: string;
 }
 
+export interface ChatMessagesTable {
+	id: string;
+	repo: string;
+	author: string;
+	author_type: string;
+	content: string;
+	agent_target: string | null;
+	discussion_id: string | null;
+	discussion_url: string | null;
+	timestamp: string;
+}
+
 interface Database {
 	webhook_events: EventsTable;
+	chat_messages: ChatMessagesTable;
 }
 
 let _turso: Client | undefined;

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -196,6 +196,138 @@ export function fetchOpenPRCount(
 	});
 }
 
+// --- Discussions (GraphQL) ---
+
+const GITHUB_GRAPHQL = "https://api.github.com/graphql";
+
+async function ghGraphQL<T>(
+	token: string,
+	query: string,
+	variables: Record<string, unknown>,
+): Promise<T> {
+	const res = await fetch(GITHUB_GRAPHQL, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	if (!res.ok) {
+		throw new GitHubApiError(res.status, await res.text());
+	}
+	const json = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
+	if (json.errors?.length) {
+		throw new GitHubApiError(422, json.errors.map((e) => e.message).join("; "));
+	}
+	return json.data as T;
+}
+
+export async function getDiscussionCategoryId(
+	token: string,
+	owner: string,
+	repo: string,
+	categoryName = "General",
+): Promise<{ repoId: string; categoryId: string }> {
+	const key = `disc-cat:${owner}/${repo}:${categoryName}`;
+	return cached(key, FIFTEEN_MIN, async () => {
+		const data = await ghGraphQL<{
+			repository: {
+				id: string;
+				discussionCategories: {
+					nodes: Array<{ id: string; name: string }>;
+				};
+			};
+		}>(
+			token,
+			`query($owner: String!, $repo: String!) {
+				repository(owner: $owner, name: $repo) {
+					id
+					discussionCategories(first: 25) {
+						nodes { id name }
+					}
+				}
+			}`,
+			{ owner, repo },
+		);
+		const cat = data.repository.discussionCategories.nodes.find(
+			(c) => c.name === categoryName,
+		);
+		if (!cat) {
+			throw new GitHubApiError(
+				404,
+				`Discussion category "${categoryName}" not found in ${owner}/${repo}`,
+			);
+		}
+		return { repoId: data.repository.id, categoryId: cat.id };
+	});
+}
+
+export interface CreatedDiscussion {
+	id: string;
+	url: string;
+	number: number;
+}
+
+export async function createDiscussion(
+	token: string,
+	owner: string,
+	repo: string,
+	title: string,
+	body: string,
+	categoryName = "General",
+): Promise<CreatedDiscussion> {
+	const { repoId, categoryId } = await getDiscussionCategoryId(
+		token,
+		owner,
+		repo,
+		categoryName,
+	);
+	const data = await ghGraphQL<{
+		createDiscussion: {
+			discussion: { id: string; url: string; number: number };
+		};
+	}>(
+		token,
+		`mutation($input: CreateDiscussionInput!) {
+			createDiscussion(input: $input) {
+				discussion { id url number }
+			}
+		}`,
+		{
+			input: {
+				repositoryId: repoId,
+				categoryId,
+				title,
+				body,
+			},
+		},
+	);
+	const d = data.createDiscussion.discussion;
+	return { id: d.id, url: d.url, number: d.number };
+}
+
+export async function addDiscussionComment(
+	token: string,
+	discussionId: string,
+	body: string,
+): Promise<{ id: string; url: string }> {
+	const data = await ghGraphQL<{
+		addDiscussionComment: {
+			comment: { id: string; url: string };
+		};
+	}>(
+		token,
+		`mutation($input: AddDiscussionCommentInput!) {
+			addDiscussionComment(input: $input) {
+				comment { id url }
+			}
+		}`,
+		{ input: { discussionId, body } },
+	);
+	return data.addDiscussionComment.comment;
+}
+
 // --- Agents dir check ---
 
 export async function checkAgentsDir(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -139,6 +139,28 @@ export const PIPELINE_LABELS: Record<PipelineColumn, string> = {
 	mergeable: "Mergeable",
 };
 
+// --- Chat ---
+
+export type AuthorType = "user" | "agent" | "bot";
+
+export interface ChatMessage {
+	id: string;
+	repo: string;
+	author: string;
+	authorType: AuthorType;
+	content: string;
+	agentTarget: string | null;
+	discussionId: string | null;
+	discussionUrl: string | null;
+	timestamp: string;
+}
+
+export type TimelineEntryKind = "event" | "chat";
+
+export type TimelineEntry =
+	| (WebhookEvent & { kind: "event" })
+	| (ChatMessage & { kind: "chat" });
+
 export const PIPELINE_GITHUB_LABELS: Record<PipelineColumn, string> = {
 	ready: "agent:ready",
 	claimed: "agent:claimed",


### PR DESCRIPTION
## Summary
- **POST `/api/chat/messages`** — Auth-guarded. Persists chat messages to Turso `chat_messages` table, creates GitHub Discussions (or replies to existing threads via `parentDiscussionId`). Parses `@agent` mentions.
- **GET `/api/chat/messages`** — Auth-guarded. Returns mixed timeline of webhook events + chat messages for a repo, with `?repo=`, `&limit=`, `&since=` params.
- **Webhook bridge** — Incoming `discussion` and `discussion_comment` webhooks are automatically stored as chat messages, detecting bot vs user authors.
- **GitHub GraphQL helpers** — `createDiscussion()`, `addDiscussionComment()`, `getDiscussionCategoryId()` for the Discussion bridge.

Closes #226

## Test plan
- [ ] POST `/api/chat/messages` with `{ repo, message }` creates a Turso row and GitHub Discussion
- [ ] POST with `parentDiscussionId` adds a comment to existing Discussion
- [ ] GET `/api/chat/messages?repo=owner/name` returns mixed timeline sorted by timestamp
- [ ] `discussion_comment` webhook creates a chat_messages row
- [ ] Auth returns 401 for unauthenticated requests
- [ ] `pnpm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)