### PR TITLE
ci: review PR files from pull refs

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -794,6 +794,46 @@ class RunContributorTests(unittest.TestCase):
             run_contributor.contributor_tools_for_selection("execute_ready_issue"),
         )
 
+    def test_run_claude_uses_override_cwd_when_provided(self) -> None:
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+        prompt = (
+            REPO_ROOT
+            / ".agents"
+            / "skills"
+            / "cofounder-contributor"
+            / "references"
+            / "april-clearwater.md"
+        )
+        override = Path("/tmp/model-workspace")
+        with mock.patch.object(run_contributor, "run_checked", return_value=completed) as run_checked:
+            run_contributor.run_claude(
+                prompt,
+                "task",
+                {},
+                mode="cli",
+                tools=run_contributor.READ_ONLY_MODEL_TOOLS,
+                cwd=override,
+            )
+        self.assertEqual(run_checked.call_args.kwargs["cwd"], override)
+
+    def test_contributor_model_cwd_only_uses_override_for_review_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            override = Path(tmpdir)
+            self.assertEqual(
+                run_contributor.contributor_model_cwd(
+                    "review_pr",
+                    {"CONTRIBUTOR_MODEL_CWD": str(override)},
+                ),
+                override,
+            )
+            self.assertEqual(
+                run_contributor.contributor_model_cwd(
+                    "execute_ready_issue",
+                    {"CONTRIBUTOR_MODEL_CWD": str(override)},
+                ),
+                run_contributor.REPO_ROOT,
+            )
+
     def test_build_action_phase_inputs_keeps_prompt_injection_in_untrusted_payloads(self) -> None:
         fixture = load_fixture("contributor-prompt-injection.json")
         choice = run_contributor.SelectionChoice(selection_kind="review_pr", number=200, reason="review open pr")
@@ -2649,6 +2689,23 @@ class RunContributorTests(unittest.TestCase):
             accounting["complete_items"],
             ["swift build", "swift test --filter RunPlannerTests"],
         )
+
+    def test_agent_review_workflows_checkout_pr_head_into_model_workspace(self) -> None:
+        april_workflow = (REPO_ROOT / ".github" / "workflows" / "agent-april.yml").read_text(encoding="utf-8")
+        plat_workflow = (REPO_ROOT / ".github" / "workflows" / "agent-plat.yml").read_text(encoding="utf-8")
+        executor_workflow = (REPO_ROOT / ".github" / "workflows" / "agent-executor.yml").read_text(encoding="utf-8")
+
+        self.assertIn("path: model-workspace", april_workflow)
+        self.assertIn("CONTRIBUTOR_MODEL_CWD", april_workflow)
+        self.assertIn("refs/pull/${{ steps.resolve-pr.outputs.pr_number }}/head", april_workflow)
+
+        self.assertIn("path: model-workspace", plat_workflow)
+        self.assertIn("CONTRIBUTOR_MODEL_CWD", plat_workflow)
+        self.assertIn("refs/pull/${{ steps.resolve-pr.outputs.pr_number }}/head", plat_workflow)
+
+        self.assertIn("path: model-workspace", executor_workflow)
+        self.assertIn("CONTRIBUTOR_MODEL_CWD", executor_workflow)
+        self.assertIn("refs/pull/${{ steps.target-workspace.outputs.pr_number }}/head", executor_workflow)
 
     def test_contributor_and_evidence_workflows_disable_persisted_credentials(self) -> None:
         workflow_paths = [

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -579,6 +579,19 @@ def run_claude(
     return run_checked(cmd, timeout=effective_timeout, cwd=cwd or REPO_ROOT, env=env).stdout
 
 
+def contributor_model_cwd(selection_kind: str, env: dict[str, str]) -> Path:
+    if selection_kind not in {"review_followup_pr", "review_pr"}:
+        return REPO_ROOT
+    override = env.get("CONTRIBUTOR_MODEL_CWD", "").strip()
+    if not override:
+        return REPO_ROOT
+    candidate = Path(override).expanduser()
+    if candidate.is_dir():
+        return candidate
+    log(f"CONTRIBUTOR_MODEL_CWD does not exist: {candidate}; falling back to repo root")
+    return REPO_ROOT
+
+
 def build_reviewable_pr_candidates(
     pull_requests: list[dict[str, object]],
     issues: list[dict[str, object]],
@@ -1183,7 +1196,7 @@ def main() -> int:
             env,
             message=args.message,
         )
-        claude_cwd = REPO_ROOT
+        claude_cwd = contributor_model_cwd(choice.selection_kind, env)
         if selection_uses_isolated_workspace(choice.selection_kind):
             scratch_workspace = create_scratch_workspace(env)
             claude_cwd = scratch_workspace.scratch_dir

--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -79,6 +79,27 @@ jobs:
           fetch-depth: 50
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
+      - name: Resolve directed PR workspace
+        id: resolve-pr
+        if: inputs.message != ''
+        env:
+          AGENT_MESSAGE: ${{ inputs.message }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$AGENT_MESSAGE" =~ [Pp][Rr][[:space:]]#([0-9]+) ]]; then
+            echo "pr_number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "model_cwd=$GITHUB_WORKSPACE/model-workspace" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Checkout directed PR workspace
+        if: steps.resolve-pr.outputs.pr_number != ''
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: refs/pull/${{ steps.resolve-pr.outputs.pr_number }}/head
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - name: Sync execution state
         run: uv run .agents/skills/cofounder-contributor/scripts/sync-execution-state.py
@@ -102,6 +123,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: april-clearwater
+          CONTRIBUTOR_MODEL_CWD: ${{ steps.resolve-pr.outputs.model_cwd }}
 
   evidence:
     needs: [check-runner, run]

--- a/.github/workflows/agent-executor.yml
+++ b/.github/workflows/agent-executor.yml
@@ -98,6 +98,25 @@ jobs:
         with:
           fetch-depth: 50
           token: ${{ steps.app-token.outputs.token }}
+      - name: Resolve target workspace
+        id: target-workspace
+        if: needs.claim.outputs.target_type == 'pull_request'
+        env:
+          TARGET_NUMBER: ${{ needs.claim.outputs.target_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "pr_number=$TARGET_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "model_cwd=$GITHUB_WORKSPACE/model-workspace" >> "$GITHUB_OUTPUT"
+      - name: Checkout target PR workspace
+        if: steps.target-workspace.outputs.pr_number != ''
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: refs/pull/${{ steps.target-workspace.outputs.pr_number }}/head
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - name: Build approved request prompt
         env:
@@ -114,6 +133,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: april-clearwater
+          CONTRIBUTOR_MODEL_CWD: ${{ steps.target-workspace.outputs.model_cwd }}
           EVIDENCE_UPLOAD_TOKEN: ${{ secrets.EVIDENCE_UPLOAD_TOKEN }}
 
   april-evidence:
@@ -155,6 +175,25 @@ jobs:
         with:
           fetch-depth: 50
           token: ${{ steps.app-token.outputs.token }}
+      - name: Resolve target workspace
+        id: target-workspace
+        if: needs.claim.outputs.target_type == 'pull_request'
+        env:
+          TARGET_NUMBER: ${{ needs.claim.outputs.target_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "pr_number=$TARGET_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "model_cwd=$GITHUB_WORKSPACE/model-workspace" >> "$GITHUB_OUTPUT"
+      - name: Checkout target PR workspace
+        if: steps.target-workspace.outputs.pr_number != ''
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: refs/pull/${{ steps.target-workspace.outputs.pr_number }}/head
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - name: Build approved request prompt
         env:
@@ -171,6 +210,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: workspace-agents
+          CONTRIBUTOR_MODEL_CWD: ${{ steps.target-workspace.outputs.model_cwd }}
 
   plat-evidence:
     needs: [claim, plat]

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - name: Triage public mention
         env:

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -48,6 +48,27 @@ jobs:
           fetch-depth: 50
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
+      - name: Resolve directed PR workspace
+        id: resolve-pr
+        if: inputs.message != ''
+        env:
+          AGENT_MESSAGE: ${{ inputs.message }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$AGENT_MESSAGE" =~ [Pp][Rr][[:space:]]#([0-9]+) ]]; then
+            echo "pr_number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "model_cwd=$GITHUB_WORKSPACE/model-workspace" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Checkout directed PR workspace
+        if: steps.resolve-pr.outputs.pr_number != ''
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: refs/pull/${{ steps.resolve-pr.outputs.pr_number }}/head
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
       - name: Sync execution state
         run: uv run .agents/skills/cofounder-contributor/scripts/sync-execution-state.py
@@ -71,6 +92,7 @@ jobs:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_APP_SLUG: workspace-agents
+          CONTRIBUTOR_MODEL_CWD: ${{ steps.resolve-pr.outputs.model_cwd }}
 
   evidence:
     needs: run


### PR DESCRIPTION
## Summary
- checkout PR heads into `model-workspace` for directed April/Plat review runs
- extend the approval-gated executor to do the same for approved PR review requests
- keep contributor reviews on the checked-out PR workspace when `CONTRIBUTOR_MODEL_CWD` is provided and harden mention triage checkout creds

## Validation
- `uv run python .agents/scripts/test_run_planner.py`
- `uv run python -m py_compile .agents/skills/cofounder-contributor/scripts/run-contributor.py .agents/scripts/test_run_planner.py`
- `ruby -e 'require "yaml"; %w[.github/workflows/agent-april.yml .github/workflows/agent-plat.yml .github/workflows/agent-executor.yml .github/workflows/agent-mention.yml].each { |p| YAML.safe_load(File.read(p), permitted_classes: [], aliases: true) }'`
- `git diff --check`