### PR TITLE
security: pin remaining floating action, add explicit permissions, harden tests

### DIFF
--- a/.github/workflows/_evidence.yml
+++ b/.github/workflows/_evidence.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Download evidence artifacts
         if: always()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name }}-${{ github.run_id }}
           path: evidence-artifacts

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -13,6 +13,9 @@ on:
       - ".github/workflows/ci-agents.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-agents-${{ github.ref }}
   cancel-in-progress: true
@@ -25,7 +28,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Run frontmatter parser tests
         run: uv run .agents/scripts/test_parse_frontmatter.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ on:
       - "scripts/verify-release-bundle.sh"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -11,6 +11,9 @@ on:
       - "web/**"
       - ".github/workflows/web-ci.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Lint, Typecheck & Build

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -110,6 +110,49 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("types: [labeled]", on_block)
         self.assertIn("safe-to-run-agent", workflow)
 
+    def test_all_actions_pinned_to_sha(self) -> None:
+        """Every `uses:` reference to a third-party action must be pinned to a full SHA."""
+        workflows_dir = REPO_ROOT / ".github/workflows"
+        floating_refs: list[str] = []
+        tag_pattern = re.compile(
+            r"^\s*uses:\s+(?!\./)(\S+)@([a-z0-9]{40})\b",
+        )
+        uses_pattern = re.compile(r"^\s*uses:\s+(?!\./)(\S+)@(\S+)")
+        for wf in sorted(workflows_dir.glob("*.yml")):
+            for i, line in enumerate(wf.read_text().splitlines(), 1):
+                m = uses_pattern.match(line)
+                if not m:
+                    continue
+                ref = m.group(2)
+                if not re.fullmatch(r"[0-9a-f]{40}", ref):
+                    floating_refs.append(f"{wf.name}:{i}  {m.group(1)}@{ref}")
+        self.assertEqual(
+            floating_refs,
+            [],
+            "Actions with floating (non-SHA) refs found:\n" + "\n".join(floating_refs),
+        )
+
+    def test_ci_workflows_have_explicit_permissions(self) -> None:
+        """CI workflows should declare explicit top-level permissions to limit default token scope."""
+        for name in ("ci.yml", "ci-agents.yml", "web-ci.yml"):
+            workflow = (REPO_ROOT / ".github/workflows" / name).read_text()
+            self.assertIn(
+                "\npermissions:\n",
+                workflow,
+                f"{name} must declare explicit top-level permissions",
+            )
+
+    def test_no_pull_request_target_trigger(self) -> None:
+        """No workflow should use pull_request_target, which runs with write access on untrusted PRs."""
+        workflows_dir = REPO_ROOT / ".github/workflows"
+        for wf in sorted(workflows_dir.glob("*.yml")):
+            content = wf.read_text()
+            self.assertNotIn(
+                "pull_request_target",
+                content,
+                f"{wf.name} must not use pull_request_target trigger",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Pin actions/download-artifact to SHA in _evidence.yml (last unpinned action)
- Standardize setup-uv to v7 in ci-agents.yml (was v6)
- Add explicit `permissions: contents: read` to ci.yml, ci-agents.yml, web-ci.yml
- Add regression tests: all-actions-pinned-to-SHA, CI permissions blocks,
  no pull_request_target trigger

https://claude.ai/code/session_019LGpVn2L3NhhK92bxqaUXP