### PR TITLE
feat(web): chat platform — AI streaming, Slack, dispatch, status cards, chat UI

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,9 +11,14 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.80.0",
+		"@chat-adapter/github": "^4.23.0",
+		"@chat-adapter/slack": "^4.23.0",
+		"@chat-adapter/state-memory": "^4.23.0",
 		"@libsql/client": "^0.17.2",
 		"@vercel/analytics": "^2.0.1",
 		"better-auth": "^1.5.6",
+		"chat": "^4.23.0",
 		"kysely": "^0.28.14",
 		"next": "^15",
 		"react": "^19",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.80.0
+        version: 0.80.0(zod@4.3.6)
+      '@chat-adapter/github':
+        specifier: ^4.23.0
+        version: 4.23.0
+      '@chat-adapter/slack':
+        specifier: ^4.23.0
+        version: 4.23.0
+      '@chat-adapter/state-memory':
+        specifier: ^4.23.0
+        version: 4.23.0
       '@libsql/client':
         specifier: ^0.17.2
         version: 0.17.2
@@ -17,6 +29,9 @@ importers:
       better-auth:
         specifier: ^1.5.6
         version: 1.5.6(@opentelemetry/api@1.9.0)(next@15.5.14(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      chat:
+        specifier: ^4.23.0
+        version: 4.23.0
       kysely:
         specifier: ^0.28.14
         version: 0.28.14
@@ -47,6 +62,19 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@better-auth/core@1.5.6':
     resolution: {integrity: sha512-Ez9DZdIMFyxHremmoLz1emFPGNQomDC1jqqBPnZ6Ci+6TiGN3R9w/Y03cJn6I8r1ycKgOzeVMZtJ/erOZ27Gsw==}
@@ -175,6 +203,18 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@chat-adapter/github@4.23.0':
+    resolution: {integrity: sha512-H8pXdWj+EVj4tqFpeE3FCLV7wSDWwNhtX3x1ZwxEWfCAr06w+NPeeQAEzjgnR4hlr5EREpgUXcXxuS9sV9YVjw==}
+
+  '@chat-adapter/shared@4.23.0':
+    resolution: {integrity: sha512-IDHgrAi3Y8Qptl1kd8zmM6jxWX+lu0cq/uZiURv8jONufWHrVwVr19pN0YK52ASnRlLZkcaNYXoa+mLFGQ2tlw==}
+
+  '@chat-adapter/slack@4.23.0':
+    resolution: {integrity: sha512-J5Ml/Ug8Zdb3zVIcbMhkei9U9aTeY+uqpzuuzcHkwdJC6FDFhwj5TSiuocckctqW9tMCqzFl4h4gU5q9f6KSGA==}
+
+  '@chat-adapter/state-memory@4.23.0':
+    resolution: {integrity: sha512-IlAVV4MGpjdassiI4haNAzWdFl66xFAfqM5DnWAGZdndkQj0LNMigcxhOgyS++yQUUWWvT1yRKwCswenCvxWVw==}
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
@@ -435,6 +475,82 @@ packages:
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
 
+  '@octokit/auth-app@8.2.0':
+    resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.3':
+    resolution: {integrity: sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.2':
+    resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -443,11 +559,32 @@ packages:
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.20.1':
+    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.15.0':
+    resolution: {integrity: sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -459,6 +596,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -491,6 +634,21 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   better-auth@1.5.6:
     resolution: {integrity: sha512-QSpJTqaT1XVfWRQe/fm3PgeuwOIlz1nWX/Dx7nsHStJ382bLzmDbQk2u7IT0IJ6wS5SRxfqEE1Ev9TXontgyAQ==}
@@ -562,11 +720,28 @@ packages:
       zod:
         optional: true
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  chat@4.23.0:
+    resolution: {integrity: sha512-Gmw8yyDrrH9Vxs+TfxF7FoTENrCzJV4T0FiAh7APGcQPhMMYAhrpq66PKj8azhkUSEyaen8ujbneogoJWiY8vg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
@@ -578,8 +753,28 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -589,19 +784,116 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   kysely@0.28.14:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
@@ -611,6 +903,144 @@ packages:
     resolution: {integrity: sha512-wKqx9FgtPcKHdPfR/Kfm0gejsnbuf8zV+ESPmltFvsq5uXwdeN9fsWn611DmqrdXj1e94NkARcMA2f1syiAqOg==}
     cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -660,6 +1090,22 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -670,6 +1116,10 @@ packages:
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -678,6 +1128,22 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
@@ -714,8 +1180,18 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -727,6 +1203,33 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -753,7 +1256,18 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@babel/runtime@7.29.2': {}
 
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
     dependencies:
@@ -839,6 +1353,36 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@chat-adapter/github@4.23.0':
+    dependencies:
+      '@chat-adapter/shared': 4.23.0
+      '@octokit/auth-app': 8.2.0
+      '@octokit/rest': 22.0.1
+      chat: 4.23.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@chat-adapter/shared@4.23.0':
+    dependencies:
+      chat: 4.23.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@chat-adapter/slack@4.23.0':
+    dependencies:
+      '@chat-adapter/shared': 4.23.0
+      '@slack/web-api': 7.15.0
+      chat: 4.23.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@chat-adapter/state-memory@4.23.0':
+    dependencies:
+      chat: 4.23.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@emnapi/runtime@1.9.1':
     dependencies:
@@ -1036,15 +1580,154 @@ snapshots:
 
   '@noble/hashes@2.0.1': {}
 
+  '@octokit/auth-app@8.2.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.8':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@slack/types@2.20.1': {}
+
+  '@slack/web-api@7.15.0':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.20.1
+      '@types/node': 22.19.15
+      '@types/retry': 0.12.0
+      axios: 1.14.0
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
 
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@22.19.15':
     dependencies:
@@ -1058,6 +1741,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.15
@@ -1066,6 +1753,22 @@ snapshots:
     optionalDependencies:
       next: 15.5.14(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.14.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  bail@2.0.2: {}
+
+  before-after-hook@4.0.0: {}
 
   better-auth@1.5.6(@opentelemetry/api@1.9.0)(next@15.5.14(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -1103,9 +1806,34 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   caniuse-lite@1.0.30001781: {}
 
+  ccount@2.0.1: {}
+
+  character-entities@2.0.2: {}
+
+  chat@4.23.0:
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   client-only@0.0.1: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   cross-fetch@4.1.0:
     dependencies:
@@ -1117,25 +1845,127 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   defu@6.1.4: {}
+
+  delayed-stream@1.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.0.2: {}
 
   detect-libc@2.1.2:
     optional: true
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  escape-string-regexp@5.0.0: {}
+
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
+  extend@3.0.2: {}
+
+  fast-content-type-parse@3.0.0: {}
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
 
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  is-electron@2.2.2: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-stream@2.0.1: {}
+
   jose@6.2.2: {}
 
   js-base64@3.7.8: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
+  json-with-bigint@3.5.8: {}
 
   kysely@0.28.14: {}
 
@@ -1153,6 +1983,313 @@ snapshots:
       '@libsql/linux-x64-gnu': 0.5.28
       '@libsql/linux-x64-musl': 0.5.28
       '@libsql/win32-x64-msvc': 0.5.28
+
+  longest-streak@3.1.0: {}
+
+  markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
@@ -1194,6 +2331,22 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
   picocolors@1.1.1: {}
 
   postcss@8.4.31:
@@ -1204,12 +2357,44 @@ snapshots:
 
   promise-limit@2.7.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
 
   react@19.2.4: {}
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remend@1.3.0: {}
+
+  retry@0.13.1: {}
 
   rou3@0.7.12: {}
 
@@ -1259,13 +2444,62 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
+  toad-cache@3.7.0: {}
+
   tr46@0.0.3: {}
+
+  trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   web-streams-polyfill@3.3.3: {}
 
@@ -1279,3 +2513,5 @@ snapshots:
   ws@8.20.0: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/web/src/app/api/chat/dispatch/route.ts
+++ b/web/src/app/api/chat/dispatch/route.ts
@@ -1,0 +1,150 @@
+import crypto from "node:crypto";
+import { getSession } from "@/lib/auth-server";
+import { pushChatMessage } from "@/lib/chat";
+import { createDiscussion, getGitHubToken } from "@/lib/github";
+import type { ChatMessage, DispatchMetadata } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+interface DispatchBody {
+	repo: string;
+	agentName: string;
+	task: string;
+	issueRef?: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) {
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+	}
+
+	const body = (await request.json()) as DispatchBody;
+	if (!body.repo || !body.agentName || !body.task) {
+		return Response.json(
+			{ error: "repo, agentName, and task are required" },
+			{ status: 400 },
+		);
+	}
+
+	const [owner, repo] = body.repo.split("/");
+	if (!owner || !repo) {
+		return Response.json(
+			{ error: "repo must be owner/name format" },
+			{ status: 400 },
+		);
+	}
+
+	const token = await getGitHubToken(session.user.id);
+	if (!token) {
+		return Response.json({ error: "GitHub token not found" }, { status: 403 });
+	}
+
+	const taskId = crypto.randomUUID().slice(0, 8);
+	const timestamp = new Date().toISOString();
+	const issueRef = body.issueRef ?? parseIssueRef(body.task);
+
+	const title = `@${body.agentName}: ${body.task.slice(0, 100)}`;
+	const discussionBody = formatDispatchBody(
+		body.agentName,
+		body.task,
+		issueRef,
+		taskId,
+	);
+
+	let discussionId: string | null = null;
+	let discussionUrl: string | null = null;
+
+	try {
+		const discussion = await createDiscussion(
+			token,
+			owner,
+			repo,
+			title,
+			discussionBody,
+		);
+		discussionId = discussion.id;
+		discussionUrl = discussion.url;
+	} catch (err) {
+		console.error("[dispatch] GitHub Discussion error:", err);
+		return Response.json(
+			{ error: "Failed to create GitHub Discussion" },
+			{ status: 502 },
+		);
+	}
+
+	const userMessageId = crypto.randomUUID();
+	const userMessage: ChatMessage = {
+		id: userMessageId,
+		repo: body.repo,
+		author: session.user.name ?? session.user.email ?? "you",
+		authorType: "user",
+		content: `@${body.agentName} ${body.task}`,
+		agentTarget: body.agentName,
+		discussionId,
+		discussionUrl,
+		timestamp,
+	};
+	await pushChatMessage(userMessage);
+
+	const dispatchMetadata: DispatchMetadata = {
+		type: "dispatch",
+		taskId,
+		agent: body.agentName,
+		task: body.task,
+		issueRef,
+		repo: body.repo,
+		discussionUrl: discussionUrl ?? "",
+		status: "pending",
+		branch: null,
+		prUrl: null,
+	};
+
+	const botMessageId = crypto.randomUUID();
+	const botMessage: ChatMessage = {
+		id: botMessageId,
+		repo: body.repo,
+		author: "spaces-bot",
+		authorType: "bot",
+		content: JSON.stringify(dispatchMetadata),
+		agentTarget: body.agentName,
+		discussionId,
+		discussionUrl,
+		timestamp: new Date(Date.now() + 1).toISOString(),
+	};
+	await pushChatMessage(botMessage);
+
+	return Response.json({
+		taskId,
+		messageId: userMessageId,
+		discussionId,
+		discussionUrl,
+	});
+}
+
+function parseIssueRef(task: string): string | null {
+	const match = task.match(/#(\d+)/);
+	return match ? `#${match[1]}` : null;
+}
+
+function formatDispatchBody(
+	agent: string,
+	task: string,
+	issueRef: string | null,
+	taskId: string,
+): string {
+	const lines = [
+		`**Agent:** @${agent}`,
+		`**Task:** ${task}`,
+		`**Task ID:** \`${taskId}\``,
+	];
+	if (issueRef) {
+		lines.push(`**Issue:** ${issueRef}`);
+	}
+	lines.push(
+		"",
+		"---",
+		"*Dispatched from [Spaces](https://spaces.cloudcompute.com) chat*",
+	);
+	return lines.join("\n");
+}

--- a/web/src/app/api/chat/messages/route.ts
+++ b/web/src/app/api/chat/messages/route.ts
@@ -1,0 +1,203 @@
+import crypto from "node:crypto";
+import { getSession } from "@/lib/auth-server";
+import { getMixedTimeline, pushChatMessage } from "@/lib/chat";
+import { getEventStats } from "@/lib/events";
+import {
+	addDiscussionComment,
+	createDiscussion,
+	getGitHubToken,
+} from "@/lib/github";
+import type { ChatMessage } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+interface PostBody {
+	repo: string;
+	agentName?: string;
+	message: string;
+	parentDiscussionId?: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) {
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+	}
+
+	const body = (await request.json()) as PostBody;
+	if (!body.repo || !body.message) {
+		return Response.json(
+			{ error: "repo and message are required" },
+			{ status: 400 },
+		);
+	}
+
+	const [owner, repo] = body.repo.split("/");
+	if (!owner || !repo) {
+		return Response.json(
+			{ error: "repo must be owner/name format" },
+			{ status: 400 },
+		);
+	}
+
+	const token = await getGitHubToken(session.user.id);
+	if (!token) {
+		return Response.json({ error: "GitHub token not found" }, { status: 403 });
+	}
+
+	const messageId = crypto.randomUUID();
+	const timestamp = new Date().toISOString();
+	let discussionId: string | null = null;
+	let discussionUrl: string | null = null;
+
+	const agentTarget = body.agentName ?? parseAgentMention(body.message);
+
+	// Bot commands: @spaces status, @spaces pipeline, @<agent> status
+	const botResponse = await handleBotCommand(
+		agentTarget,
+		body.message,
+		body.repo,
+		session.user.name ?? session.user.email ?? "you",
+	);
+	if (botResponse) {
+		return Response.json(botResponse);
+	}
+
+	const title = agentTarget
+		? `@${agentTarget}: ${body.message.slice(0, 100)}`
+		: body.message.slice(0, 100);
+
+	try {
+		if (body.parentDiscussionId) {
+			const comment = await addDiscussionComment(
+				token,
+				body.parentDiscussionId,
+				body.message,
+			);
+			discussionId = body.parentDiscussionId;
+			discussionUrl = comment.url;
+		} else {
+			const discussion = await createDiscussion(
+				token,
+				owner,
+				repo,
+				title,
+				body.message,
+			);
+			discussionId = discussion.id;
+			discussionUrl = discussion.url;
+		}
+	} catch (err) {
+		console.error("[chat] GitHub Discussion error:", err);
+		// Still persist the chat message even if Discussion creation fails
+	}
+
+	const chatMessage: ChatMessage = {
+		id: messageId,
+		repo: body.repo,
+		author: session.user.name ?? session.user.email ?? "you",
+		authorType: "user",
+		content: body.message,
+		agentTarget: agentTarget ?? null,
+		discussionId,
+		discussionUrl,
+		timestamp,
+	};
+
+	await pushChatMessage(chatMessage);
+
+	return Response.json({
+		messageId,
+		discussionId,
+		discussionUrl,
+	});
+}
+
+export async function GET(request: Request): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) {
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+	}
+
+	const { searchParams } = new URL(request.url);
+	const repo = searchParams.get("repo");
+	if (!repo) {
+		return Response.json(
+			{ error: "repo query parameter is required" },
+			{ status: 400 },
+		);
+	}
+
+	const limit = Math.min(Number(searchParams.get("limit") ?? 50), 200);
+	const since = searchParams.get("since") ?? undefined;
+
+	const timeline = await getMixedTimeline(repo, limit, since);
+	return Response.json(timeline);
+}
+
+function parseAgentMention(message: string): string | null {
+	const match = message.match(/^@(\w[\w-]*)/);
+	return match ? match[1] : null;
+}
+
+function stripMention(message: string): string {
+	return message.replace(/^@\w[\w-]*\s*/, "").trim();
+}
+
+async function handleBotCommand(
+	target: string | null,
+	message: string,
+	repo: string,
+	author: string,
+): Promise<{ messageId: string; botMessageId: string } | null> {
+	if (!target) return null;
+	const command = stripMention(message).toLowerCase();
+
+	let responseContent: string | null = null;
+
+	if (target === "spaces" && /^status$/i.test(command)) {
+		const stats = await getEventStats();
+		const repoList =
+			stats.repos.length > 0
+				? stats.repos.map((r) => `- ${r}`).join("\n")
+				: "No repos tracked yet.";
+		responseContent = `**Active repos:**\n${repoList}\n\nEvents today: ${stats.eventsToday}`;
+	} else if (target === "spaces" && /^pipeline$/i.test(command)) {
+		responseContent =
+			"Pipeline summary is available on the Dashboard tab. Select a repo to view its issue pipeline.";
+	} else if (target !== "spaces" && /^status$/i.test(command)) {
+		responseContent = `Checking status for **@${target}**... No active dispatches found. Use \`@${target} <task>\` to dispatch work.`;
+	} else {
+		return null;
+	}
+
+	const timestamp = new Date().toISOString();
+
+	const userMsg: ChatMessage = {
+		id: crypto.randomUUID(),
+		repo,
+		author,
+		authorType: "user",
+		content: message,
+		agentTarget: target,
+		discussionId: null,
+		discussionUrl: null,
+		timestamp,
+	};
+	await pushChatMessage(userMsg);
+
+	const botMsg: ChatMessage = {
+		id: crypto.randomUUID(),
+		repo,
+		author: "spaces-bot",
+		authorType: "bot",
+		content: responseContent,
+		agentTarget: null,
+		discussionId: null,
+		discussionUrl: null,
+		timestamp: new Date(Date.now() + 1).toISOString(),
+	};
+	await pushChatMessage(botMsg);
+
+	return { messageId: userMsg.id, botMessageId: botMsg.id };
+}

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -1,6 +1,16 @@
 import crypto from "node:crypto";
+import {
+	getChatMessageByDiscussionId,
+	pushChatMessage,
+	updateChatMessageContent,
+} from "@/lib/chat";
 import { pushEvent } from "@/lib/events";
-import type { WebhookEvent, WebhookEventType } from "@/lib/types";
+import type {
+	ChatMessage,
+	DispatchMetadata,
+	WebhookEvent,
+	WebhookEventType,
+} from "@/lib/types";
 
 export const dynamic = "force-dynamic";
 
@@ -104,10 +114,210 @@ export async function POST(request: Request): Promise<Response> {
 		summary: summarize(eventType, action, payload),
 		repo: repo ?? "unknown",
 		timestamp: new Date().toISOString(),
-		payload: body,
 	};
 
 	await pushEvent(event);
 
+	// Bridge discussion/discussion_comment webhooks into chat_messages
+	if (eventType === "discussion" || eventType === "discussion_comment") {
+		const chatMsg = extractDiscussionChatMessage(
+			eventType,
+			payload,
+			repo ?? "unknown",
+		);
+		if (chatMsg) {
+			await pushChatMessage(chatMsg);
+		}
+	}
+
+	// Update dispatch cards when PR/CI events link back to a Discussion
+	if (
+		eventType === "pull_request" ||
+		eventType === "check_run" ||
+		eventType === "workflow_run"
+	) {
+		await updateDispatchFromWebhook(eventType, action, payload);
+	}
+
 	return Response.json({ ok: true });
+}
+
+function extractDiscussionChatMessage(
+	eventType: string,
+	payload: Record<string, unknown>,
+	repo: string,
+): ChatMessage | null {
+	if (eventType === "discussion_comment") {
+		const comment = payload.comment as Record<string, unknown> | undefined;
+		const discussion = payload.discussion as
+			| Record<string, unknown>
+			| undefined;
+		if (!comment?.body) return null;
+		const user = comment.user as Record<string, unknown> | undefined;
+		const isBot = String(user?.type ?? "").toLowerCase() === "bot";
+		return {
+			id: `ghdc-${comment.id ?? crypto.randomUUID()}`,
+			repo,
+			author: String(user?.login ?? "unknown"),
+			authorType: isBot ? "bot" : "user",
+			content: String(comment.body),
+			agentTarget: null,
+			discussionId: String(discussion?.node_id ?? ""),
+			discussionUrl: String(comment.html_url ?? discussion?.html_url ?? ""),
+			timestamp: String(comment.created_at ?? new Date().toISOString()),
+		};
+	}
+
+	if (eventType === "discussion") {
+		const discussion = payload.discussion as
+			| Record<string, unknown>
+			| undefined;
+		const action = String(payload.action ?? "");
+		if (action !== "created" || !discussion?.body) return null;
+		const user = discussion.user as Record<string, unknown> | undefined;
+		const isBot = String(user?.type ?? "").toLowerCase() === "bot";
+		return {
+			id: `ghd-${discussion.id ?? crypto.randomUUID()}`,
+			repo,
+			author: String(user?.login ?? "unknown"),
+			authorType: isBot ? "bot" : "user",
+			content: String(discussion.body),
+			agentTarget: null,
+			discussionId: String(discussion.node_id ?? ""),
+			discussionUrl: String(discussion.html_url ?? ""),
+			timestamp: String(discussion.created_at ?? new Date().toISOString()),
+		};
+	}
+
+	return null;
+}
+
+function parseDispatchMetadata(content: string): DispatchMetadata | null {
+	try {
+		const parsed = JSON.parse(content);
+		if (parsed?.type === "dispatch") return parsed as DispatchMetadata;
+	} catch {
+		// Not JSON or not dispatch metadata
+	}
+	return null;
+}
+
+function extractDiscussionUrlFromBody(body: string): string | null {
+	// Match GitHub Discussion URLs in PR body
+	const match = body.match(
+		/https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/discussions\/\d+/,
+	);
+	return match ? match[0] : null;
+}
+
+async function updateDispatchFromWebhook(
+	eventType: string,
+	action: string,
+	payload: Record<string, unknown>,
+): Promise<void> {
+	try {
+		if (eventType === "pull_request") {
+			const pr = payload.pull_request as Record<string, unknown> | undefined;
+			if (!pr?.body) return;
+
+			const discussionUrl = extractDiscussionUrlFromBody(String(pr.body));
+			if (!discussionUrl) return;
+
+			// Find the dispatch card by searching for a bot message linking to this Discussion
+			const nodeId = pr.node_id as string | undefined;
+			// We need the discussion node_id, but we have the URL. Search by content.
+			// Instead, find the bot message whose content JSON references this Discussion URL.
+			const { getDb } = await import("@/lib/db");
+			const db = getDb();
+			const rows = await db
+				.selectFrom("chat_messages")
+				.select(["id", "content"])
+				.where("author_type", "=", "bot")
+				.where("content", "like", "%dispatch%")
+				.orderBy("timestamp", "desc")
+				.limit(50)
+				.execute();
+
+			for (const row of rows) {
+				const meta = parseDispatchMetadata(row.content);
+				if (!meta || !meta.discussionUrl) continue;
+				if (
+					!discussionUrl.includes(meta.discussionUrl) &&
+					!meta.discussionUrl.includes(discussionUrl)
+				)
+					continue;
+
+				const updated: DispatchMetadata = {
+					...meta,
+					status:
+						action === "closed" && (pr.merged as boolean)
+							? "complete"
+							: "pr_opened",
+					branch: String(
+						(pr.head && (pr.head as Record<string, unknown>).ref) ||
+							meta.branch ||
+							"",
+					),
+					prUrl: String(pr.html_url ?? meta.prUrl ?? ""),
+				};
+				await updateChatMessageContent(row.id, JSON.stringify(updated));
+				return;
+			}
+		}
+
+		if (eventType === "check_run" || eventType === "workflow_run") {
+			const run = (payload.check_run ?? payload.workflow_run) as
+				| Record<string, unknown>
+				| undefined;
+			if (!run) return;
+			const conclusion = String(run.conclusion ?? "");
+			if (!conclusion) return;
+
+			const prs = run.pull_requests as
+				| Array<Record<string, unknown>>
+				| undefined;
+			if (!prs?.length) return;
+
+			const prUrl = String(prs[0].url ?? "").replace(
+				"api.github.com/repos",
+				"github.com",
+			);
+
+			const { getDb } = await import("@/lib/db");
+			const db = getDb();
+			const rows = await db
+				.selectFrom("chat_messages")
+				.select(["id", "content"])
+				.where("author_type", "=", "bot")
+				.where("content", "like", "%dispatch%")
+				.orderBy("timestamp", "desc")
+				.limit(50)
+				.execute();
+
+			for (const row of rows) {
+				const meta = parseDispatchMetadata(row.content);
+				if (!meta?.prUrl) continue;
+				if (
+					!meta.prUrl.includes(String(prs[0].number ?? "")) &&
+					prUrl !== meta.prUrl
+				)
+					continue;
+				if (meta.status === "complete" || meta.status === "failed") continue;
+
+				const updated: DispatchMetadata = {
+					...meta,
+					status:
+						conclusion === "success"
+							? "ci_passed"
+							: conclusion === "failure"
+								? "failed"
+								: meta.status,
+				};
+				await updateChatMessageContent(row.id, JSON.stringify(updated));
+				return;
+			}
+		}
+	} catch (err) {
+		console.error("[webhooks] dispatch update error:", err);
+	}
 }

--- a/web/src/app/api/workspaces/sync/route.ts
+++ b/web/src/app/api/workspaces/sync/route.ts
@@ -1,6 +1,10 @@
 import { getSession } from "@/lib/auth-server";
-import type { Workspace, WorkspaceStatus } from "@/lib/types";
-import { getWorkspaces, syncWorkspaces } from "@/lib/workspaces";
+import type { Workspace } from "@/lib/types";
+import {
+	type SyncWorkspaceInput,
+	getWorkspaces,
+	syncWorkspaces,
+} from "@/lib/workspaces";
 
 const SYNC_API_KEY = process.env.WORKSPACE_SYNC_API_KEY;
 
@@ -64,8 +68,8 @@ export async function POST(request: Request): Promise<Response> {
 		}
 	}
 
-	syncWorkspaces(userId, workspaces as Workspace[]);
-	return Response.json({ ok: true, count: workspaces.length });
+	const count = await syncWorkspaces(workspaces as SyncWorkspaceInput[]);
+	return Response.json({ ok: true, count });
 }
 
 export async function GET(): Promise<Response> {
@@ -73,11 +77,7 @@ export async function GET(): Promise<Response> {
 	if (!session)
 		return Response.json({ error: "unauthorized" }, { status: 401 });
 
-	// User-specific state first, fall back to API-key-synced default
-	const state = getWorkspaces(session.user.id) ?? getWorkspaces("default");
+	const workspaces = await getWorkspaces();
 
-	return Response.json({
-		workspaces: state?.workspaces ?? [],
-		syncedAt: state?.syncedAt ?? null,
-	});
+	return Response.json({ workspaces });
 }

--- a/web/src/app/dashboard/components/chat-panel.module.css
+++ b/web/src/app/dashboard/components/chat-panel.module.css
@@ -1,0 +1,31 @@
+.panel {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+}
+
+.noRepo {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	gap: 0.75rem;
+	padding: 2rem;
+	text-align: center;
+}
+
+.noRepoIcon {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 1.25rem;
+	color: var(--text-tertiary);
+}
+
+.noRepoText {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-tertiary);
+	max-width: 260px;
+	line-height: 1.5;
+}

--- a/web/src/app/dashboard/components/chat-panel.tsx
+++ b/web/src/app/dashboard/components/chat-panel.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Agent, TimelineEntry } from "@/lib/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import styles from "./chat-panel.module.css";
+import { ComposeBar } from "./compose-bar";
+import { MessageList } from "./message-list";
+
+const POLL_INTERVAL = 5_000;
+
+interface ChatPanelProps {
+	selectedRepo: { owner: string; repo: string } | null;
+	agents: Agent[];
+	onNewMessage?: () => void;
+}
+
+export function ChatPanel({
+	selectedRepo,
+	agents,
+	onNewMessage,
+}: ChatPanelProps) {
+	const [entries, setEntries] = useState<TimelineEntry[]>([]);
+	const [loading, setLoading] = useState(false);
+	const lastCountRef = useRef(0);
+
+	const repo = selectedRepo
+		? `${selectedRepo.owner}/${selectedRepo.repo}`
+		: null;
+
+	const fetchTimeline = useCallback(async () => {
+		if (!repo) return;
+		try {
+			const res = await fetch(
+				`/api/chat/messages?repo=${encodeURIComponent(repo)}&limit=100`,
+			);
+			if (res.ok) {
+				const data: TimelineEntry[] = await res.json();
+				setEntries(data);
+				if (data.length > lastCountRef.current && lastCountRef.current > 0) {
+					onNewMessage?.();
+				}
+				lastCountRef.current = data.length;
+			}
+		} catch {
+			// retry on next poll
+		}
+	}, [repo, onNewMessage]);
+
+	useEffect(() => {
+		setEntries([]);
+		lastCountRef.current = 0;
+		if (!repo) return;
+
+		setLoading(true);
+		fetchTimeline().finally(() => setLoading(false));
+
+		const id = setInterval(fetchTimeline, POLL_INTERVAL);
+		return () => clearInterval(id);
+	}, [repo, fetchTimeline]);
+
+	const handleSend = useCallback(
+		async (message: string, agentName?: string) => {
+			if (!repo) return;
+			const res = await fetch("/api/chat/messages", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ repo, message, agentName }),
+			});
+			if (res.ok) {
+				// Immediately refetch to show the new message
+				await fetchTimeline();
+			}
+		},
+		[repo, fetchTimeline],
+	);
+
+	if (!selectedRepo) {
+		return (
+			<div className={styles.noRepo}>
+				<span className={styles.noRepoIcon}>&gt;_</span>
+				<span className={styles.noRepoText}>
+					Select a repository from the sidebar to start chatting with agents.
+				</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className={styles.panel}>
+			<MessageList entries={entries} loading={loading} />
+			<ComposeBar repo={repo as string} agents={agents} onSend={handleSend} />
+		</div>
+	);
+}

--- a/web/src/app/dashboard/components/compose-bar.module.css
+++ b/web/src/app/dashboard/components/compose-bar.module.css
@@ -1,0 +1,127 @@
+.container {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	border-top: 1px solid var(--border-subtle);
+	background: var(--bg-surface);
+	flex-shrink: 0;
+}
+
+.agentChipBar {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.375rem 0.75rem 0;
+}
+
+.agentChip {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.1875rem 0.5rem;
+	border-radius: 3px;
+	background: rgba(166, 255, 223, 0.12);
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	font-weight: 600;
+	color: var(--accent);
+	cursor: default;
+	animation: fadeIn 0.15s ease-out;
+}
+
+.agentChipRemove {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 14px;
+	height: 14px;
+	border: none;
+	background: none;
+	color: var(--accent-muted);
+	font-size: 0.75rem;
+	cursor: pointer;
+	border-radius: 2px;
+	transition: color 0.1s ease, background 0.1s ease;
+	padding: 0;
+	line-height: 1;
+}
+
+.agentChipRemove:hover {
+	color: var(--accent);
+	background: rgba(166, 255, 223, 0.12);
+}
+
+.inputRow {
+	display: flex;
+	align-items: flex-end;
+	gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+}
+
+.input {
+	flex: 1;
+	min-height: 36px;
+	max-height: 120px;
+	resize: none;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	line-height: 1.5;
+	padding: 0.5rem 0.625rem;
+	outline: none;
+	transition: border-color 0.15s ease;
+}
+
+.input::placeholder {
+	color: var(--text-tertiary);
+}
+
+.input:focus {
+	border-color: var(--accent-muted);
+}
+
+.sendBtn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 36px;
+	padding: 0 0.75rem;
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	background: var(--bg-elevated);
+	color: var(--text-secondary);
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	cursor: pointer;
+	transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+	flex-shrink: 0;
+}
+
+.sendBtn:hover:not(:disabled) {
+	color: var(--accent);
+	border-color: var(--accent-muted);
+}
+
+.sendBtn:disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
+.sendBtnActive {
+	color: var(--accent);
+	border-color: var(--accent-muted);
+	background: var(--accent-dim);
+}
+
+.hint {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	color: var(--text-tertiary);
+	padding: 0 0.75rem 0.375rem;
+}

--- a/web/src/app/dashboard/components/compose-bar.tsx
+++ b/web/src/app/dashboard/components/compose-bar.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { Agent } from "@/lib/types";
+import { useCallback, useRef, useState } from "react";
+import styles from "./compose-bar.module.css";
+import { MentionAutocomplete } from "./mention-autocomplete";
+
+interface ComposeBarProps {
+	repo: string;
+	agents: Agent[];
+	onSend: (message: string, agentName?: string) => Promise<void>;
+	disabled?: boolean;
+}
+
+export function ComposeBar({
+	repo,
+	agents,
+	onSend,
+	disabled,
+}: ComposeBarProps) {
+	const [text, setText] = useState("");
+	const [agentTarget, setAgentTarget] = useState<string | null>(null);
+	const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+	const [sending, setSending] = useState(false);
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	const handleInput = useCallback((value: string) => {
+		setText(value);
+
+		// Detect @mention at current cursor position
+		const textarea = inputRef.current;
+		if (!textarea) return;
+		const cursor = textarea.selectionStart;
+		const before = value.slice(0, cursor);
+		const match = before.match(/@(\w*)$/);
+
+		if (match) {
+			setMentionQuery(match[1]);
+		} else {
+			setMentionQuery(null);
+		}
+	}, []);
+
+	const selectAgent = useCallback(
+		(agent: Agent) => {
+			setAgentTarget(agent.name);
+			setMentionQuery(null);
+
+			// Replace @query with @agentName in text
+			const textarea = inputRef.current;
+			if (!textarea) return;
+			const cursor = textarea.selectionStart;
+			const before = text.slice(0, cursor);
+			const after = text.slice(cursor);
+			const replaced = before.replace(/@\w*$/, `@${agent.name} `);
+			setText(replaced + after);
+
+			requestAnimationFrame(() => {
+				textarea.focus();
+				const pos = replaced.length;
+				textarea.setSelectionRange(pos, pos);
+			});
+		},
+		[text],
+	);
+
+	const clearAgent = useCallback(() => {
+		setAgentTarget(null);
+		inputRef.current?.focus();
+	}, []);
+
+	const dismissMention = useCallback(() => {
+		setMentionQuery(null);
+	}, []);
+
+	const handleSend = useCallback(async () => {
+		const trimmed = text.trim();
+		if (!trimmed || sending) return;
+
+		setSending(true);
+		try {
+			await onSend(trimmed, agentTarget ?? undefined);
+			setText("");
+			setAgentTarget(null);
+			inputRef.current?.focus();
+		} finally {
+			setSending(false);
+		}
+	}, [text, agentTarget, sending, onSend]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			// Let autocomplete handle arrow/enter/tab/escape when open
+			if (mentionQuery !== null) return;
+
+			if (e.key === "Enter" && !e.shiftKey) {
+				e.preventDefault();
+				handleSend();
+			}
+		},
+		[mentionQuery, handleSend],
+	);
+
+	const canSend = text.trim().length > 0 && !sending && !disabled;
+
+	return (
+		<div className={styles.container}>
+			{mentionQuery !== null && (
+				<MentionAutocomplete
+					query={mentionQuery}
+					agents={agents}
+					onSelect={selectAgent}
+					onDismiss={dismissMention}
+				/>
+			)}
+
+			{agentTarget && (
+				<div className={styles.agentChipBar}>
+					<span className={styles.agentChip}>
+						@{agentTarget}
+						<button
+							type="button"
+							className={styles.agentChipRemove}
+							onClick={clearAgent}
+							aria-label="Remove agent target"
+						>
+							×
+						</button>
+					</span>
+				</div>
+			)}
+
+			<div className={styles.inputRow}>
+				<textarea
+					ref={inputRef}
+					className={styles.input}
+					value={text}
+					onChange={(e) => handleInput(e.target.value)}
+					onKeyDown={handleKeyDown}
+					placeholder={
+						agentTarget
+							? `Message @${agentTarget}...`
+							: "Type a message or @mention an agent..."
+					}
+					rows={1}
+					disabled={disabled || sending}
+				/>
+				<button
+					type="button"
+					className={`${styles.sendBtn} ${canSend ? styles.sendBtnActive : ""}`}
+					onClick={handleSend}
+					disabled={!canSend}
+				>
+					{sending ? "..." : "Send"}
+				</button>
+			</div>
+
+			<span className={styles.hint}>
+				Enter to send · Shift+Enter for newline · @ to mention agent
+			</span>
+		</div>
+	);
+}

--- a/web/src/app/dashboard/components/dashboard-shell.tsx
+++ b/web/src/app/dashboard/components/dashboard-shell.tsx
@@ -1,17 +1,69 @@
 "use client";
 
 import type { AgentDiscoveryResponse, SelectedRepo } from "@/lib/types";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import styles from "../page.module.css";
 import { ActivityFeed } from "./activity-feed";
+import { ChatPanel } from "./chat-panel";
 import { MainPanel } from "./main-panel";
 import { Sidebar } from "./sidebar";
 
-interface DashboardShellProps {
-	selectedRepo: { owner: string; repo: string } | null;
+type TabId = "dashboard" | "chat";
+
+const TABS: { id: TabId; label: string }[] = [
+	{ id: "dashboard", label: "Dashboard" },
+	{ id: "chat", label: "Chat" },
+];
+
+function isValidTab(value: string | undefined): value is TabId {
+	return value === "dashboard" || value === "chat";
 }
 
-export function DashboardShell({ selectedRepo }: DashboardShellProps) {
+interface DashboardShellProps {
+	selectedRepo: { owner: string; repo: string } | null;
+	initialTab?: string;
+}
+
+export function DashboardShell({
+	selectedRepo,
+	initialTab,
+}: DashboardShellProps) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+
+	const activeTab: TabId = isValidTab(searchParams.get("tab") ?? undefined)
+		? (searchParams.get("tab") as TabId)
+		: isValidTab(initialTab)
+			? initialTab
+			: "dashboard";
+
+	const [unreadChat, setUnreadChat] = useState(false);
+
+	const setTab = useCallback(
+		(tab: TabId) => {
+			const params = new URLSearchParams(searchParams.toString());
+			if (tab === "dashboard") {
+				params.delete("tab");
+			} else {
+				params.set("tab", tab);
+			}
+			const qs = params.toString();
+			router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+		},
+		[pathname, router, searchParams],
+	);
+
+	// Clear unread badge when switching to chat
+	useEffect(() => {
+		if (activeTab === "chat") setUnreadChat(false);
+	}, [activeTab]);
+
+	const handleNewChatMessage = useCallback(() => {
+		if (activeTab !== "chat") setUnreadChat(true);
+	}, [activeTab]);
+
 	const [repos, setRepos] = useState<SelectedRepo[]>([]);
 	const [agentData, setAgentData] = useState<AgentDiscoveryResponse | null>(
 		null,
@@ -67,12 +119,35 @@ export function DashboardShell({ selectedRepo }: DashboardShellProps) {
 				<Sidebar repos={repos} selectedRepo={selectedRepo} />
 			</aside>
 			<main className={styles.center}>
-				<MainPanel
-					agentData={agentData}
-					selectedRepo={selectedRepo}
-					loading={loading}
-					error={error}
-				/>
+				<nav className={styles.tabBar}>
+					{TABS.map(({ id, label }) => (
+						<button
+							key={id}
+							type="button"
+							className={`${styles.tab} ${activeTab === id ? styles.tabActive : ""}`}
+							onClick={() => setTab(id)}
+						>
+							{label}
+							{id === "chat" && unreadChat && (
+								<span className={styles.unreadBadge} />
+							)}
+						</button>
+					))}
+				</nav>
+				{activeTab === "dashboard" ? (
+					<MainPanel
+						agentData={agentData}
+						selectedRepo={selectedRepo}
+						loading={loading}
+						error={error}
+					/>
+				) : (
+					<ChatPanel
+						selectedRepo={selectedRepo}
+						agents={agentData?.agents ?? []}
+						onNewMessage={handleNewChatMessage}
+					/>
+				)}
 			</main>
 			<aside className={styles.right}>
 				<ActivityFeed

--- a/web/src/app/dashboard/components/dispatch-card.module.css
+++ b/web/src/app/dashboard/components/dispatch-card.module.css
@@ -1,0 +1,168 @@
+.card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	padding: 0.75rem 1rem;
+	border: 1px solid var(--border-subtle);
+	border-left: 3px solid var(--accent);
+	border-radius: 8px;
+	background: var(--bg-surface);
+	margin: 0.25rem 0;
+}
+
+/* ── Header ── */
+
+.header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 0.5rem;
+}
+
+.identity {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 0;
+}
+
+.agent {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--accent);
+}
+
+.task {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-primary);
+	line-height: 1.4;
+}
+
+/* ── Status ── */
+
+.statusArea {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	flex-shrink: 0;
+}
+
+.statusDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+}
+
+.statusLabel {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	padding: 0.125rem 0.375rem;
+	border-radius: 3px;
+}
+
+.statusPending {
+	color: var(--text-tertiary);
+	background: transparent;
+}
+
+.statusPending.statusDot {
+	background: var(--text-tertiary);
+}
+
+.statusRunning {
+	color: var(--accent);
+	background: var(--accent-dim);
+}
+
+.statusRunning.statusDot {
+	background: var(--accent);
+	animation: pulse 2s ease-in-out infinite;
+}
+
+.statusPr {
+	color: #c4a1ff;
+	background: rgba(196, 161, 255, 0.1);
+}
+
+.statusPr.statusDot {
+	background: #c4a1ff;
+}
+
+.statusPassed {
+	color: var(--accent);
+	background: var(--accent-dim);
+}
+
+.statusPassed.statusDot {
+	background: var(--accent);
+}
+
+.statusComplete {
+	color: var(--accent);
+	background: var(--accent-dim);
+}
+
+.statusComplete.statusDot {
+	background: var(--accent);
+}
+
+.statusFailed {
+	color: #f85149;
+	background: rgba(248, 81, 73, 0.08);
+}
+
+.statusFailed.statusDot {
+	background: #f85149;
+}
+
+/* ── Fields ── */
+
+.fields {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+
+.field {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+.fieldLabel {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	color: var(--text-tertiary);
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+}
+
+.fieldValue {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-secondary);
+}
+
+/* ── Links ── */
+
+.links {
+	display: flex;
+	gap: 0.75rem;
+}
+
+.link {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--accent);
+	text-decoration: none;
+	transition: opacity 0.15s ease;
+}
+
+.link:hover {
+	text-decoration: underline;
+	opacity: 0.8;
+}

--- a/web/src/app/dashboard/components/dispatch-card.tsx
+++ b/web/src/app/dashboard/components/dispatch-card.tsx
@@ -1,0 +1,93 @@
+import type { DispatchMetadata, DispatchStatus } from "@/lib/types";
+import styles from "./dispatch-card.module.css";
+
+const STATUS_CONFIG: Record<
+	DispatchStatus,
+	{ label: string; className: string }
+> = {
+	pending: { label: "Pending", className: styles.statusPending },
+	running: { label: "Running", className: styles.statusRunning },
+	pr_opened: { label: "PR Opened", className: styles.statusPr },
+	ci_passed: { label: "CI Passed", className: styles.statusPassed },
+	complete: { label: "Complete", className: styles.statusComplete },
+	failed: { label: "Failed", className: styles.statusFailed },
+};
+
+interface DispatchCardProps {
+	metadata: DispatchMetadata;
+}
+
+export function DispatchCard({ metadata }: DispatchCardProps) {
+	const statusInfo = STATUS_CONFIG[metadata.status] ?? STATUS_CONFIG.pending;
+
+	return (
+		<div className={styles.card}>
+			<div className={styles.header}>
+				<div className={styles.identity}>
+					<span className={styles.agent}>@{metadata.agent}</span>
+					<span className={styles.task}>{metadata.task}</span>
+				</div>
+				<div className={styles.statusArea}>
+					<span className={`${styles.statusDot} ${statusInfo.className}`} />
+					<span className={`${styles.statusLabel} ${statusInfo.className}`}>
+						{statusInfo.label}
+					</span>
+				</div>
+			</div>
+
+			<div className={styles.fields}>
+				<span className={styles.field}>
+					<span className={styles.fieldLabel}>Task</span>
+					<span className={styles.fieldValue}>{metadata.taskId}</span>
+				</span>
+				{metadata.branch && (
+					<span className={styles.field}>
+						<span className={styles.fieldLabel}>Branch</span>
+						<span className={styles.fieldValue}>{metadata.branch}</span>
+					</span>
+				)}
+				{metadata.issueRef && (
+					<span className={styles.field}>
+						<span className={styles.fieldLabel}>Issue</span>
+						<span className={styles.fieldValue}>{metadata.issueRef}</span>
+					</span>
+				)}
+			</div>
+
+			<div className={styles.links}>
+				{metadata.discussionUrl && (
+					<a
+						href={metadata.discussionUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={styles.link}
+					>
+						Discussion
+					</a>
+				)}
+				{metadata.prUrl && (
+					<a
+						href={metadata.prUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={styles.link}
+					>
+						Pull Request
+					</a>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export function tryParseDispatchMetadata(
+	content: string,
+): DispatchMetadata | null {
+	try {
+		const parsed = JSON.parse(content);
+		if (parsed?.type === "dispatch") return parsed as DispatchMetadata;
+	} catch {
+		// Not dispatch metadata
+	}
+	return null;
+}

--- a/web/src/app/dashboard/components/dispatch-dialog.module.css
+++ b/web/src/app/dashboard/components/dispatch-dialog.module.css
@@ -1,0 +1,138 @@
+.backdrop {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.6);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 100;
+	animation: fadeIn 0.15s ease-out;
+}
+
+.dialog {
+	width: 100%;
+	max-width: 440px;
+	background: var(--bg-elevated);
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	padding: 1.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+	animation: slideUp 0.2s ease-out;
+}
+
+.title {
+	font-family: var(--font-display), "Georgia", serif;
+	font-size: 1.25rem;
+	font-weight: 400;
+	font-style: italic;
+	color: var(--text-primary);
+	letter-spacing: -0.02em;
+	margin: 0;
+}
+
+/* ── Body fields ── */
+
+.body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.625rem;
+}
+
+.field {
+	display: flex;
+	align-items: baseline;
+	gap: 0.75rem;
+}
+
+.fieldLabel {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--text-tertiary);
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	min-width: 3.5rem;
+	flex-shrink: 0;
+}
+
+.fieldValue {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	color: var(--text-primary);
+	line-height: 1.4;
+	word-break: break-word;
+}
+
+.hint {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-tertiary);
+	line-height: 1.5;
+	margin: 0;
+}
+
+/* ── Actions ── */
+
+.actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.75rem;
+}
+
+.cancelBtn {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	padding: 0.5rem 1rem;
+	border-radius: 6px;
+	border: 1px solid var(--border);
+	background: transparent;
+	color: var(--text-secondary);
+	cursor: pointer;
+	transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.cancelBtn:hover:not(:disabled) {
+	color: var(--text-primary);
+	border-color: var(--text-tertiary);
+}
+
+.confirmBtn {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	padding: 0.5rem 1.25rem;
+	border-radius: 6px;
+	border: none;
+	background: var(--accent);
+	color: #0e1117;
+	font-weight: 600;
+	cursor: pointer;
+	transition: opacity 0.15s ease;
+}
+
+.confirmBtn:hover:not(:disabled) {
+	opacity: 0.85;
+}
+
+.confirmBtn:disabled,
+.cancelBtn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+/* ── Animations ── */
+
+@keyframes slideUp {
+	from {
+		opacity: 0;
+		transform: translateY(12px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}

--- a/web/src/app/dashboard/components/dispatch-dialog.tsx
+++ b/web/src/app/dashboard/components/dispatch-dialog.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import styles from "./dispatch-dialog.module.css";
+
+interface DispatchDialogProps {
+	agent: string;
+	task: string;
+	repo: string;
+	issueRef: string | null;
+	onConfirm: () => void;
+	onCancel: () => void;
+	sending: boolean;
+}
+
+export function DispatchDialog({
+	agent,
+	task,
+	repo,
+	issueRef,
+	onConfirm,
+	onCancel,
+	sending,
+}: DispatchDialogProps) {
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent) => {
+			if (e.key === "Escape" && !sending) onCancel();
+		},
+		[onCancel, sending],
+	);
+
+	useEffect(() => {
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [handleKeyDown]);
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: Escape key handled via document listener
+		<div className={styles.backdrop} onClick={sending ? undefined : onCancel}>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled on backdrop */}
+			<div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+				<h3 className={styles.title}>Dispatch to @{agent}</h3>
+
+				<div className={styles.body}>
+					<div className={styles.field}>
+						<span className={styles.fieldLabel}>Agent</span>
+						<span className={styles.fieldValue}>@{agent}</span>
+					</div>
+					<div className={styles.field}>
+						<span className={styles.fieldLabel}>Repo</span>
+						<span className={styles.fieldValue}>{repo}</span>
+					</div>
+					<div className={styles.field}>
+						<span className={styles.fieldLabel}>Task</span>
+						<span className={styles.fieldValue}>{task}</span>
+					</div>
+					{issueRef && (
+						<div className={styles.field}>
+							<span className={styles.fieldLabel}>Issue</span>
+							<span className={styles.fieldValue}>{issueRef}</span>
+						</div>
+					)}
+				</div>
+
+				<p className={styles.hint}>
+					This will create a GitHub Discussion for the agent to pick up.
+				</p>
+
+				<div className={styles.actions}>
+					<button
+						type="button"
+						className={styles.cancelBtn}
+						onClick={onCancel}
+						disabled={sending}
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						className={styles.confirmBtn}
+						onClick={onConfirm}
+						disabled={sending}
+					>
+						{sending ? "Dispatching..." : "Dispatch"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/web/src/app/dashboard/components/mention-autocomplete.module.css
+++ b/web/src/app/dashboard/components/mention-autocomplete.module.css
@@ -1,0 +1,89 @@
+.overlay {
+	position: absolute;
+	bottom: 100%;
+	left: 0;
+	right: 0;
+	max-height: 200px;
+	overflow-y: auto;
+	background: var(--bg-elevated);
+	border: 1px solid var(--border);
+	border-radius: 6px 6px 0 0;
+	box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+	z-index: 10;
+	animation: slideUp 0.15s ease-out;
+}
+
+@keyframes slideUp {
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	padding: 0.25rem 0;
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	cursor: pointer;
+	transition: background 0.1s ease;
+}
+
+.item:hover,
+.itemActive {
+	background: var(--accent-dim);
+}
+
+.itemDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--text-tertiary);
+	flex-shrink: 0;
+}
+
+.itemDotActive {
+	background: var(--accent);
+	animation: pulse 2s ease-in-out infinite;
+}
+
+.itemInfo {
+	display: flex;
+	flex-direction: column;
+	gap: 0.0625rem;
+	min-width: 0;
+}
+
+.itemName {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.itemRole {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.625rem;
+	color: var(--text-secondary);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.empty {
+	padding: 0.75rem;
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-tertiary);
+	text-align: center;
+}

--- a/web/src/app/dashboard/components/mention-autocomplete.tsx
+++ b/web/src/app/dashboard/components/mention-autocomplete.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { Agent } from "@/lib/types";
+import { useEffect, useRef, useState } from "react";
+import styles from "./mention-autocomplete.module.css";
+
+interface MentionAutocompleteProps {
+	query: string;
+	agents: Agent[];
+	onSelect: (agent: Agent) => void;
+	onDismiss: () => void;
+}
+
+export function MentionAutocomplete({
+	query,
+	agents,
+	onSelect,
+	onDismiss,
+}: MentionAutocompleteProps) {
+	const [activeIndex, setActiveIndex] = useState(0);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	const filtered = agents.filter((a) =>
+		a.name.toLowerCase().startsWith(query.toLowerCase()),
+	);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset on filter change
+	useEffect(() => {
+		setActiveIndex(0);
+	}, [query]);
+
+	useEffect(() => {
+		const handleKey = (e: KeyboardEvent) => {
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+			} else if (e.key === "ArrowUp") {
+				e.preventDefault();
+				setActiveIndex((i) => Math.max(i - 1, 0));
+			} else if (e.key === "Enter" || e.key === "Tab") {
+				e.preventDefault();
+				if (filtered[activeIndex]) onSelect(filtered[activeIndex]);
+			} else if (e.key === "Escape") {
+				e.preventDefault();
+				onDismiss();
+			}
+		};
+		window.addEventListener("keydown", handleKey);
+		return () => window.removeEventListener("keydown", handleKey);
+	}, [activeIndex, filtered, onSelect, onDismiss]);
+
+	useEffect(() => {
+		const el = listRef.current?.children[activeIndex] as
+			| HTMLElement
+			| undefined;
+		el?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	if (filtered.length === 0) {
+		return (
+			<div className={styles.overlay}>
+				<div className={styles.empty}>No matching agents</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className={styles.overlay}>
+			<div className={styles.list} ref={listRef}>
+				{filtered.map((agent, i) => (
+					<div
+						key={agent.name}
+						className={`${styles.item} ${i === activeIndex ? styles.itemActive : ""}`}
+						onMouseDown={(e) => {
+							e.preventDefault();
+							onSelect(agent);
+						}}
+						onMouseEnter={() => setActiveIndex(i)}
+					>
+						<span
+							className={`${styles.itemDot} ${agent.status === "active" ? styles.itemDotActive : ""}`}
+						/>
+						<div className={styles.itemInfo}>
+							<span className={styles.itemName}>@{agent.name}</span>
+							{agent.role && (
+								<span className={styles.itemRole}>{agent.role}</span>
+							)}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/web/src/app/dashboard/components/message-list.module.css
+++ b/web/src/app/dashboard/components/message-list.module.css
@@ -1,0 +1,140 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 0.5rem 0;
+}
+
+.timeline {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+/* ── Plain chat message (no agent target) ── */
+
+.message {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	padding: 0.625rem 1rem;
+	transition: background 0.15s ease;
+	animation: fadeIn 0.3s ease-out both;
+}
+
+.message:hover {
+	background: var(--accent-dim);
+}
+
+.messageHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+}
+
+.messageAuthor {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.messageAuthorAgent {
+	color: var(--accent);
+}
+
+.messageAuthorBot {
+	color: #7eb8ff;
+}
+
+.messageTime {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	color: var(--text-tertiary);
+	flex-shrink: 0;
+}
+
+.messageContent {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	color: var(--text-primary);
+	line-height: 1.5;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.messageDiscussionLink {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	color: var(--text-tertiary);
+	text-decoration: none;
+	transition: color 0.15s ease;
+}
+
+.messageDiscussionLink:hover {
+	color: var(--accent);
+}
+
+/* ── Empty state ── */
+
+.empty {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	flex: 1;
+	gap: 0.75rem;
+	padding: 2rem;
+	text-align: center;
+}
+
+.emptyIcon {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 1.25rem;
+	color: var(--text-tertiary);
+}
+
+.emptyText {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-tertiary);
+	max-width: 260px;
+	line-height: 1.5;
+}
+
+/* ── Day separator ── */
+
+.daySeparator {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.5rem 1rem;
+	margin: 0.25rem 0;
+}
+
+.daySeparator::before,
+.daySeparator::after {
+	content: "";
+	flex: 1;
+	height: 1px;
+	background: var(--border-subtle);
+}
+
+.dayLabel {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	color: var(--text-tertiary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	flex-shrink: 0;
+}
+
+/* ── Scroll anchor ── */
+
+.anchor {
+	height: 0;
+	flex-shrink: 0;
+}

--- a/web/src/app/dashboard/components/message-list.tsx
+++ b/web/src/app/dashboard/components/message-list.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import type { DispatchMetadata, TimelineEntry } from "@/lib/types";
+import { useEffect, useRef } from "react";
+import { DispatchCard, tryParseDispatchMetadata } from "./dispatch-card";
+import styles from "./message-list.module.css";
+import { StatusCard } from "./status-card";
+import { formatTime } from "./timeline-utils";
+
+interface MessageListProps {
+	entries: TimelineEntry[];
+	loading: boolean;
+}
+
+function dayKey(timestamp: string): string {
+	return new Date(timestamp).toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function shouldShowDay(entries: TimelineEntry[], index: number): boolean {
+	if (index === 0) return true;
+	const prev = entries[index - 1];
+	const curr = entries[index];
+	return dayKey(prev.timestamp) !== dayKey(curr.timestamp);
+}
+
+export function MessageList({ entries, loading }: MessageListProps) {
+	const anchorRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const wasAtBottom = useRef(true);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		const handleScroll = () => {
+			wasAtBottom.current =
+				el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+		};
+		el.addEventListener("scroll", handleScroll, { passive: true });
+		return () => el.removeEventListener("scroll", handleScroll);
+	}, []);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new entries
+	useEffect(() => {
+		if (wasAtBottom.current) {
+			anchorRef.current?.scrollIntoView({ behavior: "smooth" });
+		}
+	}, [entries.length]);
+
+	if (!loading && entries.length === 0) {
+		return (
+			<div className={styles.empty}>
+				<span className={styles.emptyIcon}>&gt;_</span>
+				<span className={styles.emptyText}>
+					No messages yet. Use the compose bar below to dispatch an agent or
+					start a conversation.
+				</span>
+			</div>
+		);
+	}
+
+	return (
+		<div className={styles.container} ref={containerRef}>
+			<div className={styles.timeline}>
+				{entries.map((entry, i) => (
+					<div key={entry.id}>
+						{shouldShowDay(entries, i) && (
+							<div className={styles.daySeparator}>
+								<span className={styles.dayLabel}>
+									{dayKey(entry.timestamp)}
+								</span>
+							</div>
+						)}
+						{entry.kind === "event" ? (
+							<StatusCard event={entry} />
+						) : entry.agentTarget && tryParseDispatchMetadata(entry.content) ? (
+							<DispatchCard
+								metadata={
+									tryParseDispatchMetadata(entry.content) as DispatchMetadata
+								}
+							/>
+						) : (
+							<ChatMessageRow message={entry} />
+						)}
+					</div>
+				))}
+			</div>
+			<div ref={anchorRef} className={styles.anchor} />
+		</div>
+	);
+}
+
+function ChatMessageRow({
+	message,
+}: { message: TimelineEntry & { kind: "chat" } }) {
+	const authorClass =
+		message.authorType === "agent"
+			? styles.messageAuthorAgent
+			: message.authorType === "bot"
+				? styles.messageAuthorBot
+				: "";
+
+	return (
+		<div className={styles.message}>
+			<div className={styles.messageHeader}>
+				<span className={`${styles.messageAuthor} ${authorClass}`}>
+					{message.author}
+				</span>
+				<span className={styles.messageTime}>
+					{formatTime(message.timestamp)}
+				</span>
+			</div>
+			<span className={styles.messageContent}>{message.content}</span>
+			{message.discussionUrl && (
+				<a
+					href={message.discussionUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className={styles.messageDiscussionLink}
+				>
+					view discussion →
+				</a>
+			)}
+		</div>
+	);
+}

--- a/web/src/app/dashboard/components/status-card.module.css
+++ b/web/src/app/dashboard/components/status-card.module.css
@@ -1,0 +1,101 @@
+.card {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+	padding: 0.5rem 1rem;
+	animation: fadeIn 0.3s ease-out both;
+}
+
+.indicator {
+	width: 1px;
+	align-self: stretch;
+	flex-shrink: 0;
+}
+
+.indicatorCi {
+	background: var(--accent);
+}
+
+.indicatorPr {
+	background: #c4a1ff;
+}
+
+.indicatorPush {
+	background: #ffd07e;
+}
+
+.indicatorDiscussion {
+	background: #7eb8ff;
+}
+
+.indicatorIssue {
+	background: #ff9e7e;
+}
+
+.body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 0;
+	flex: 1;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+}
+
+.badge {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	padding: 0.0625rem 0.3125rem;
+	border-radius: 2px;
+	flex-shrink: 0;
+}
+
+.badgeCi {
+	color: var(--accent);
+	background: var(--accent-dim);
+}
+
+.badgePr {
+	color: #c4a1ff;
+	background: rgba(196, 161, 255, 0.1);
+}
+
+.badgePush {
+	color: #ffd07e;
+	background: rgba(255, 208, 126, 0.1);
+}
+
+.badgeDiscussion {
+	color: #7eb8ff;
+	background: rgba(126, 184, 255, 0.1);
+}
+
+.badgeIssue {
+	color: #ff9e7e;
+	background: rgba(255, 158, 126, 0.1);
+}
+
+.time {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.5625rem;
+	color: var(--text-tertiary);
+	flex-shrink: 0;
+}
+
+.summary {
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.6875rem;
+	color: var(--text-secondary);
+	line-height: 1.4;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/web/src/app/dashboard/components/status-card.tsx
+++ b/web/src/app/dashboard/components/status-card.tsx
@@ -1,0 +1,68 @@
+import type { WebhookEvent, WebhookEventType } from "@/lib/types";
+import styles from "./status-card.module.css";
+import { formatTime } from "./timeline-utils";
+
+const TYPE_LABEL: Record<WebhookEventType, string> = {
+	pull_request: "PR",
+	check_run: "CI",
+	check_suite: "CI",
+	discussion: "DISC",
+	discussion_comment: "DISC",
+	push: "PUSH",
+	issues: "ISSUE",
+	issue_comment: "ISSUE",
+	workflow_run: "CI",
+};
+
+type ColorKey = "ci" | "pr" | "push" | "discussion" | "issue";
+
+const TYPE_COLOR: Record<WebhookEventType, ColorKey> = {
+	pull_request: "pr",
+	check_run: "ci",
+	check_suite: "ci",
+	discussion: "discussion",
+	discussion_comment: "discussion",
+	push: "push",
+	issues: "issue",
+	issue_comment: "issue",
+	workflow_run: "ci",
+};
+
+const INDICATOR: Record<ColorKey, string> = {
+	ci: styles.indicatorCi,
+	pr: styles.indicatorPr,
+	push: styles.indicatorPush,
+	discussion: styles.indicatorDiscussion,
+	issue: styles.indicatorIssue,
+};
+
+const BADGE: Record<ColorKey, string> = {
+	ci: styles.badgeCi,
+	pr: styles.badgePr,
+	push: styles.badgePush,
+	discussion: styles.badgeDiscussion,
+	issue: styles.badgeIssue,
+};
+
+interface StatusCardProps {
+	event: WebhookEvent;
+}
+
+export function StatusCard({ event }: StatusCardProps) {
+	const color = TYPE_COLOR[event.type];
+
+	return (
+		<div className={styles.card}>
+			<div className={`${styles.indicator} ${INDICATOR[color]}`} />
+			<div className={styles.body}>
+				<div className={styles.row}>
+					<span className={`${styles.badge} ${BADGE[color]}`}>
+						{TYPE_LABEL[event.type]}
+					</span>
+					<span className={styles.time}>{formatTime(event.timestamp)}</span>
+				</div>
+				<span className={styles.summary}>{event.summary}</span>
+			</div>
+		</div>
+	);
+}

--- a/web/src/app/dashboard/components/timeline-utils.ts
+++ b/web/src/app/dashboard/components/timeline-utils.ts
@@ -1,0 +1,9 @@
+export function formatTime(timestamp: string): string {
+	const diff = Date.now() - new Date(timestamp).getTime();
+	const mins = Math.floor(diff / 60000);
+	if (mins < 1) return "now";
+	if (mins < 60) return `${mins}m`;
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return `${hours}h`;
+	return `${Math.floor(hours / 24)}d`;
+}

--- a/web/src/lib/ai.ts
+++ b/web/src/lib/ai.ts
@@ -1,0 +1,53 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { AiMessage } from "chat";
+
+let _client: Anthropic | undefined;
+
+function getClient(): Anthropic {
+	if (!_client) {
+		_client = new Anthropic();
+	}
+	return _client;
+}
+
+const SYSTEM_PROMPT = `You are spaces-bot, an AI assistant embedded in GitHub Discussions for the Workspaces project.
+You help developers with workspace state, codebase questions, PR context, and CI status.
+Keep responses concise, use markdown, and stay relevant to the thread context.
+If you don't have enough context to answer, say so briefly.`;
+
+export async function* streamResponse(
+	messages: AiMessage[],
+	systemPrompt = SYSTEM_PROMPT,
+): AsyncGenerator<string> {
+	const client = getClient();
+
+	const stream = client.messages.stream({
+		model: "claude-sonnet-4-6",
+		max_tokens: 1024,
+		system: systemPrompt,
+		messages: messages.map((m) => ({
+			role: m.role,
+			content:
+				typeof m.content === "string"
+					? m.content
+					: m.content.map((p) => {
+							if (p.type === "text")
+								return { type: "text" as const, text: p.text };
+							return { type: "text" as const, text: "[attachment]" };
+						}),
+		})),
+	});
+
+	for await (const event of stream) {
+		if (
+			event.type === "content_block_delta" &&
+			event.delta.type === "text_delta"
+		) {
+			yield event.delta.text;
+		}
+	}
+}
+
+export function isAiConfigured(): boolean {
+	return !!process.env.ANTHROPIC_API_KEY;
+}

--- a/web/src/lib/bot.ts
+++ b/web/src/lib/bot.ts
@@ -1,0 +1,116 @@
+import { createGitHubAdapter } from "@chat-adapter/github";
+import { type SlackAdapter, createSlackAdapter } from "@chat-adapter/slack";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, toAiMessages } from "chat";
+import type { Message, Thread } from "chat";
+import { isAiConfigured, streamResponse } from "./ai";
+import { getEventStats } from "./events";
+import { formatWorkspaceStatusCard, getWorkspaces } from "./workspaces";
+
+let _bot: Chat | undefined;
+
+function buildAdapters(): Record<
+	string,
+	ReturnType<typeof createGitHubAdapter> | SlackAdapter
+> {
+	const appId = process.env.GITHUB_APP_ID ?? "";
+	const privateKey = (process.env.GITHUB_PRIVATE_KEY ?? "").replace(
+		/\\n/g,
+		"\n",
+	);
+
+	const adapters: Record<
+		string,
+		ReturnType<typeof createGitHubAdapter> | SlackAdapter
+	> = {
+		github: createGitHubAdapter({
+			appId,
+			privateKey,
+			webhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
+		}),
+	};
+
+	if (process.env.SLACK_BOT_TOKEN) {
+		adapters.slack = createSlackAdapter({
+			botToken: process.env.SLACK_BOT_TOKEN,
+			signingSecret: process.env.SLACK_SIGNING_SECRET,
+		});
+	}
+
+	return adapters;
+}
+
+export function getBot(): Chat {
+	if (!_bot) {
+		_bot = new Chat({
+			userName: process.env.CHAT_BOT_USERNAME ?? "spaces-bot",
+			adapters: buildAdapters(),
+			state: createMemoryState(),
+			fallbackStreamingPlaceholderText: null,
+			streamingUpdateIntervalMs: 1000,
+		});
+
+		_bot.onNewMessage(/status/i, async (thread) => {
+			const [stats, workspaces] = await Promise.all([
+				getEventStats(),
+				getWorkspaces("default"),
+			]);
+			const repoList =
+				stats.repos.length > 0
+					? stats.repos.map((r) => `- ${r}`).join("\n")
+					: "No repos tracked yet.";
+			const card = formatWorkspaceStatusCard(workspaces);
+			await thread.post(
+				`**Active repos:**\n${repoList}\n\nEvents today: ${stats.eventsToday}\n\n${card}`,
+			);
+		});
+
+		_bot.onNewMention(async (thread, message) => {
+			await handleAiResponse(thread, message);
+			await thread.subscribe();
+		});
+
+		_bot.onSubscribedMessage(async (thread, message) => {
+			await handleAiResponse(thread, message);
+		});
+	}
+	return _bot;
+}
+
+async function handleAiResponse(
+	thread: Thread,
+	message: Message,
+): Promise<void> {
+	if (!isAiConfigured()) {
+		const [stats, workspaces] = await Promise.all([
+			getEventStats(),
+			getWorkspaces("default"),
+		]);
+		const card = formatWorkspaceStatusCard(workspaces);
+		await thread.post(
+			`Tracking ${stats.repos.length} repo(s) with ${stats.eventsToday} event(s) today.\n\n${card}`,
+		);
+		return;
+	}
+
+	await thread.refresh();
+	const history = await toAiMessages(thread.recentMessages, {
+		includeNames: true,
+	});
+
+	if (history.length === 0) {
+		history.push({ role: "user", content: message.text });
+	}
+
+	const stream = streamResponse(history);
+	await thread.post(stream);
+}
+
+export function getSlackAdapter(): SlackAdapter | null {
+	const bot = getBot();
+	try {
+		return bot.getAdapter("slack") as SlackAdapter;
+	} catch {
+		return null;
+	}
+}

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -1,0 +1,194 @@
+import { getDb } from "./db";
+import type {
+	AuthorType,
+	ChatMessage,
+	TimelineEntry,
+	WebhookEventType,
+} from "./types";
+
+let migrated = false;
+
+async function ensureChatTable(): Promise<void> {
+	if (migrated) return;
+	const db = getDb();
+	await db.schema
+		.createTable("chat_messages")
+		.ifNotExists()
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("repo", "text", (c) => c.notNull())
+		.addColumn("author", "text", (c) => c.notNull())
+		.addColumn("author_type", "text", (c) => c.notNull())
+		.addColumn("content", "text", (c) => c.notNull())
+		.addColumn("agent_target", "text")
+		.addColumn("discussion_id", "text")
+		.addColumn("discussion_url", "text")
+		.addColumn("timestamp", "text", (c) => c.notNull())
+		.execute();
+	await db.schema
+		.createIndex("idx_chat_messages_repo_ts")
+		.ifNotExists()
+		.on("chat_messages")
+		.columns(["repo", "timestamp desc"])
+		.execute();
+	migrated = true;
+}
+
+export async function pushChatMessage(msg: ChatMessage): Promise<void> {
+	await ensureChatTable();
+	const db = getDb();
+	await db
+		.insertInto("chat_messages")
+		.values({
+			id: msg.id,
+			repo: msg.repo,
+			author: msg.author,
+			author_type: msg.authorType,
+			content: msg.content,
+			agent_target: msg.agentTarget,
+			discussion_id: msg.discussionId,
+			discussion_url: msg.discussionUrl,
+			timestamp: msg.timestamp,
+		})
+		.onConflict((oc) => oc.doNothing())
+		.execute();
+}
+
+export async function getChatMessages(
+	repo: string,
+	limit = 50,
+	since?: string,
+): Promise<ChatMessage[]> {
+	await ensureChatTable();
+	const db = getDb();
+	let query = db
+		.selectFrom("chat_messages")
+		.selectAll()
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(limit);
+	if (since) {
+		query = query.where("timestamp", ">", since);
+	}
+	const rows = await query.execute();
+	return rows.map((r) => ({
+		id: r.id,
+		repo: r.repo,
+		author: r.author,
+		authorType: r.author_type as AuthorType,
+		content: r.content,
+		agentTarget: r.agent_target,
+		discussionId: r.discussion_id,
+		discussionUrl: r.discussion_url,
+		timestamp: r.timestamp,
+	}));
+}
+
+export async function updateChatMessageContent(
+	id: string,
+	content: string,
+): Promise<void> {
+	await ensureChatTable();
+	const db = getDb();
+	await db
+		.updateTable("chat_messages")
+		.set({ content })
+		.where("id", "=", id)
+		.execute();
+}
+
+export async function getChatMessageByDiscussionId(
+	discussionId: string,
+): Promise<ChatMessage | null> {
+	await ensureChatTable();
+	const db = getDb();
+	const row = await db
+		.selectFrom("chat_messages")
+		.selectAll()
+		.where("discussion_id", "=", discussionId)
+		.where("author_type", "=", "bot")
+		.orderBy("timestamp", "desc")
+		.limit(1)
+		.executeTakeFirst();
+	if (!row) return null;
+	return {
+		id: row.id,
+		repo: row.repo,
+		author: row.author,
+		authorType: row.author_type as AuthorType,
+		content: row.content,
+		agentTarget: row.agent_target,
+		discussionId: row.discussion_id,
+		discussionUrl: row.discussion_url,
+		timestamp: row.timestamp,
+	};
+}
+
+export async function getMixedTimeline(
+	repo: string,
+	limit = 50,
+	since?: string,
+): Promise<TimelineEntry[]> {
+	await ensureChatTable();
+	const db = getDb();
+
+	let eventsQuery = db
+		.selectFrom("webhook_events")
+		.select(["id", "type", "action", "summary", "repo", "timestamp"])
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(limit);
+
+	let chatQuery = db
+		.selectFrom("chat_messages")
+		.select([
+			"id",
+			"repo",
+			"author",
+			"author_type",
+			"content",
+			"agent_target",
+			"discussion_id",
+			"discussion_url",
+			"timestamp",
+		])
+		.where("repo", "=", repo)
+		.orderBy("timestamp", "desc")
+		.limit(limit);
+
+	if (since) {
+		eventsQuery = eventsQuery.where("timestamp", ">", since);
+		chatQuery = chatQuery.where("timestamp", ">", since);
+	}
+
+	const [events, messages] = await Promise.all([
+		eventsQuery.execute(),
+		chatQuery.execute(),
+	]);
+
+	const timeline: TimelineEntry[] = [
+		...events.map((e) => ({
+			kind: "event" as const,
+			id: e.id,
+			type: e.type as WebhookEventType,
+			action: e.action,
+			summary: e.summary,
+			repo: e.repo,
+			timestamp: e.timestamp,
+		})),
+		...messages.map((m) => ({
+			kind: "chat" as const,
+			id: m.id,
+			repo: m.repo,
+			author: m.author,
+			authorType: m.author_type as AuthorType,
+			content: m.content,
+			agentTarget: m.agent_target,
+			discussionId: m.discussion_id,
+			discussionUrl: m.discussion_url,
+			timestamp: m.timestamp,
+		})),
+	];
+
+	timeline.sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1));
+	return timeline.slice(0, limit);
+}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,5 +1,3 @@
-import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
 import { type Client, createClient } from "@libsql/client";
 import { Kysely } from "kysely";
 import { LibsqlDialect } from "./libsql-dialect";
@@ -14,8 +12,36 @@ export interface EventsTable {
 	payload: string;
 }
 
+export interface ChatMessagesTable {
+	id: string;
+	repo: string;
+	author: string;
+	author_type: string;
+	content: string;
+	agent_target: string | null;
+	discussion_id: string | null;
+	discussion_url: string | null;
+	timestamp: string;
+}
+
+export interface WorkspacesTable {
+	id: string;
+	name: string;
+	path: string;
+	repo_id: string | null;
+	repo_name: string | null;
+	created_at: string;
+	last_accessed_at: string;
+	status: string;
+	git_branch: string | null;
+	backend_identifier: string;
+	synced_at: string;
+}
+
 interface Database {
 	webhook_events: EventsTable;
+	chat_messages: ChatMessagesTable;
+	workspaces: WorkspacesTable;
 }
 
 let _turso: Client | undefined;
@@ -24,11 +50,10 @@ let _db: Kysely<Database> | undefined;
 
 export function getTurso(): Client {
 	if (!_turso) {
-		const url = process.env.TURSO_DATABASE_URL ?? "file:data/auth.db";
-		if (url.startsWith("file:")) {
-			mkdirSync(dirname(url.slice(5)), { recursive: true });
-		}
-		_turso = createClient({ url, authToken: process.env.TURSO_AUTH_TOKEN });
+		_turso = createClient({
+			url: process.env.TURSO_DATABASE_URL ?? "file:data/auth.db",
+			authToken: process.env.TURSO_AUTH_TOKEN,
+		});
 	}
 	return _turso;
 }

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -196,6 +196,141 @@ export function fetchOpenPRCount(
 	});
 }
 
+// --- Discussions (GraphQL) ---
+
+const GITHUB_GRAPHQL = "https://api.github.com/graphql";
+
+async function ghGraphQL<T>(
+	token: string,
+	query: string,
+	variables: Record<string, unknown>,
+): Promise<T> {
+	const res = await fetch(GITHUB_GRAPHQL, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ query, variables }),
+	});
+	if (!res.ok) {
+		throw new GitHubApiError(res.status, await res.text());
+	}
+	const json = (await res.json()) as {
+		data?: T;
+		errors?: Array<{ message: string }>;
+	};
+	if (json.errors?.length) {
+		throw new GitHubApiError(422, json.errors.map((e) => e.message).join("; "));
+	}
+	return json.data as T;
+}
+
+export async function getDiscussionCategoryId(
+	token: string,
+	owner: string,
+	repo: string,
+	categoryName = "General",
+): Promise<{ repoId: string; categoryId: string }> {
+	const key = `disc-cat:${owner}/${repo}:${categoryName}`;
+	return cached(key, FIFTEEN_MIN, async () => {
+		const data = await ghGraphQL<{
+			repository: {
+				id: string;
+				discussionCategories: {
+					nodes: Array<{ id: string; name: string }>;
+				};
+			};
+		}>(
+			token,
+			`query($owner: String!, $repo: String!) {
+				repository(owner: $owner, name: $repo) {
+					id
+					discussionCategories(first: 25) {
+						nodes { id name }
+					}
+				}
+			}`,
+			{ owner, repo },
+		);
+		const cat = data.repository.discussionCategories.nodes.find(
+			(c) => c.name === categoryName,
+		);
+		if (!cat) {
+			throw new GitHubApiError(
+				404,
+				`Discussion category "${categoryName}" not found in ${owner}/${repo}`,
+			);
+		}
+		return { repoId: data.repository.id, categoryId: cat.id };
+	});
+}
+
+export interface CreatedDiscussion {
+	id: string;
+	url: string;
+	number: number;
+}
+
+export async function createDiscussion(
+	token: string,
+	owner: string,
+	repo: string,
+	title: string,
+	body: string,
+	categoryName = "General",
+): Promise<CreatedDiscussion> {
+	const { repoId, categoryId } = await getDiscussionCategoryId(
+		token,
+		owner,
+		repo,
+		categoryName,
+	);
+	const data = await ghGraphQL<{
+		createDiscussion: {
+			discussion: { id: string; url: string; number: number };
+		};
+	}>(
+		token,
+		`mutation($input: CreateDiscussionInput!) {
+			createDiscussion(input: $input) {
+				discussion { id url number }
+			}
+		}`,
+		{
+			input: {
+				repositoryId: repoId,
+				categoryId,
+				title,
+				body,
+			},
+		},
+	);
+	const d = data.createDiscussion.discussion;
+	return { id: d.id, url: d.url, number: d.number };
+}
+
+export async function addDiscussionComment(
+	token: string,
+	discussionId: string,
+	body: string,
+): Promise<{ id: string; url: string }> {
+	const data = await ghGraphQL<{
+		addDiscussionComment: {
+			comment: { id: string; url: string };
+		};
+	}>(
+		token,
+		`mutation($input: AddDiscussionCommentInput!) {
+			addDiscussionComment(input: $input) {
+				comment { id url }
+			}
+		}`,
+		{ input: { discussionId, body } },
+	);
+	return data.addDiscussionComment.comment;
+}
+
 // --- Agents dir check ---
 
 export async function checkAgentsDir(

--- a/web/src/lib/slack-notifications.ts
+++ b/web/src/lib/slack-notifications.ts
@@ -1,0 +1,45 @@
+import { getSlackAdapter } from "./bot";
+
+/**
+ * Slack channel ID for posting workspace notifications.
+ * Set SLACK_NOTIFICATION_CHANNEL to a channel ID (e.g., C0123456789).
+ */
+function getNotificationChannel(): string | null {
+	return process.env.SLACK_NOTIFICATION_CHANNEL ?? null;
+}
+
+/** Post a message to the notification channel. No-op if Slack is not configured. */
+async function postToChannel(text: string): Promise<void> {
+	const adapter = getSlackAdapter();
+	const channel = getNotificationChannel();
+	if (!adapter || !channel) return;
+
+	const channelId = `slack:${channel}`;
+	await adapter.postChannelMessage(channelId, text);
+}
+
+/** Notify on CI build / workflow failure. */
+export async function notifyBuildFailure(
+	repo: string,
+	name: string,
+	conclusion: string,
+	url: string,
+): Promise<void> {
+	if (conclusion !== "failure") return;
+	await postToChannel(
+		`🔴 *Build failed* in \`${repo}\`\n*${name}* — <${url}|View run>`,
+	);
+}
+
+/** Notify when a PR review is requested. */
+export async function notifyReviewRequested(
+	repo: string,
+	prNumber: number,
+	prTitle: string,
+	reviewer: string,
+	url: string,
+): Promise<void> {
+	await postToChannel(
+		`👀 *Review requested* in \`${repo}\`\n<${url}|#${prNumber}: ${prTitle}> — reviewer: *${reviewer}*`,
+	);
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -140,6 +140,51 @@ export const PIPELINE_LABELS: Record<PipelineColumn, string> = {
 	mergeable: "Mergeable",
 };
 
+// --- Chat ---
+
+export type AuthorType = "user" | "agent" | "bot";
+
+export interface ChatMessage {
+	id: string;
+	repo: string;
+	author: string;
+	authorType: AuthorType;
+	content: string;
+	agentTarget: string | null;
+	discussionId: string | null;
+	discussionUrl: string | null;
+	timestamp: string;
+}
+
+// --- Dispatch ---
+
+export type DispatchStatus =
+	| "pending"
+	| "running"
+	| "pr_opened"
+	| "ci_passed"
+	| "complete"
+	| "failed";
+
+export interface DispatchMetadata {
+	type: "dispatch";
+	taskId: string;
+	agent: string;
+	task: string;
+	issueRef: string | null;
+	repo: string;
+	discussionUrl: string;
+	status: DispatchStatus;
+	branch: string | null;
+	prUrl: string | null;
+}
+
+export type TimelineEntryKind = "event" | "chat";
+
+export type TimelineEntry =
+	| (WebhookEvent & { kind: "event" })
+	| (ChatMessage & { kind: "chat" });
+
 export const PIPELINE_GITHUB_LABELS: Record<PipelineColumn, string> = {
 	ready: "agent:ready",
 	claimed: "agent:claimed",

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -1,20 +1,146 @@
-import type { Workspace } from "./types";
+import { getDb } from "./db";
+import type { Workspace, WorkspaceStatus } from "./types";
 
-export interface SyncState {
-	workspaces: Workspace[];
-	syncedAt: string;
+let migrated = false;
+
+async function ensureWorkspacesTable(): Promise<void> {
+	if (migrated) return;
+	const db = getDb();
+	await db.schema
+		.createTable("workspaces")
+		.ifNotExists()
+		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("name", "text", (c) => c.notNull())
+		.addColumn("path", "text", (c) => c.notNull())
+		.addColumn("repo_id", "text")
+		.addColumn("repo_name", "text")
+		.addColumn("created_at", "text", (c) => c.notNull())
+		.addColumn("last_accessed_at", "text", (c) => c.notNull())
+		.addColumn("status", "text", (c) => c.notNull().defaultTo("stopped"))
+		.addColumn("git_branch", "text")
+		.addColumn("backend_identifier", "text", (c) =>
+			c.notNull().defaultTo("local"),
+		)
+		.addColumn("synced_at", "text", (c) => c.notNull())
+		.execute();
+	migrated = true;
 }
 
-/** In-memory store keyed by user ID. Native app syncs replace the full list. */
-const store = new Map<string, SyncState>();
+export interface SyncWorkspaceInput {
+	id: string;
+	name: string;
+	path: string;
+	repoId?: string | null;
+	repoName?: string | null;
+	createdAt: string;
+	lastAccessedAt: string;
+	status: WorkspaceStatus;
+	gitBranch?: string | null;
+	backendIdentifier: string;
+}
 
-export function syncWorkspaces(userId: string, workspaces: Workspace[]): void {
-	store.set(userId, {
-		workspaces,
-		syncedAt: new Date().toISOString(),
+export async function syncWorkspaces(
+	workspaces: SyncWorkspaceInput[],
+): Promise<number> {
+	await ensureWorkspacesTable();
+	const db = getDb();
+	const now = new Date().toISOString();
+	let count = 0;
+
+	for (const ws of workspaces) {
+		await db
+			.insertInto("workspaces")
+			.values({
+				id: ws.id,
+				name: ws.name,
+				path: ws.path,
+				repo_id: ws.repoId ?? null,
+				repo_name: ws.repoName ?? null,
+				created_at: ws.createdAt,
+				last_accessed_at: ws.lastAccessedAt,
+				status: ws.status,
+				git_branch: ws.gitBranch ?? null,
+				backend_identifier: ws.backendIdentifier,
+				synced_at: now,
+			})
+			.onConflict((oc) =>
+				oc.column("id").doUpdateSet({
+					name: ws.name,
+					path: ws.path,
+					repo_id: ws.repoId ?? null,
+					repo_name: ws.repoName ?? null,
+					last_accessed_at: ws.lastAccessedAt,
+					status: ws.status,
+					git_branch: ws.gitBranch ?? null,
+					backend_identifier: ws.backendIdentifier,
+					synced_at: now,
+				}),
+			)
+			.execute();
+		count++;
+	}
+
+	return count;
+}
+
+export async function getWorkspaces(
+	repo?: string | null,
+): Promise<Workspace[]> {
+	await ensureWorkspacesTable();
+	const db = getDb();
+	let query = db
+		.selectFrom("workspaces")
+		.selectAll()
+		.orderBy("last_accessed_at", "desc");
+	if (repo) {
+		query = query.where("repo_name", "=", repo);
+	}
+	const rows = await query.execute();
+	return rows.map((r) => ({
+		id: r.id,
+		name: r.name,
+		path: r.path,
+		repoId: r.repo_id,
+		repoName: r.repo_name,
+		createdAt: r.created_at,
+		lastAccessedAt: r.last_accessed_at,
+		status: r.status as WorkspaceStatus,
+		gitBranch: r.git_branch,
+		backendIdentifier: r.backend_identifier,
+	}));
+}
+
+function relativeTime(iso: string): string {
+	const diff = Date.now() - new Date(iso).getTime();
+	const mins = Math.floor(diff / 60_000);
+	if (mins < 1) return "just now";
+	if (mins < 60) return `${mins}m ago`;
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}
+
+const STATUS_EMOJI: Record<WorkspaceStatus, string> = {
+	active: "🟢",
+	provisioning: "🟡",
+	stopped: "🔴",
+	archived: "⚪",
+};
+
+export function formatWorkspaceStatusCard(workspaces: Workspace[]): string {
+	if (workspaces.length === 0) {
+		return "No workspaces tracked yet.";
+	}
+
+	const header =
+		"| Workspace | Status | Branch | Last Activity |\n| --- | --- | --- | --- |";
+	const rows = workspaces.map((ws) => {
+		const emoji = STATUS_EMOJI[ws.status] ?? "⚪";
+		const branch = ws.gitBranch ?? "—";
+		const activity = relativeTime(ws.lastAccessedAt);
+		return `| ${ws.name} | ${emoji} ${ws.status} | \`${branch}\` | ${activity} |`;
 	});
-}
 
-export function getWorkspaces(userId: string): SyncState | null {
-	return store.get(userId) ?? null;
+	return `**Workspace Status**\n\n${header}\n${rows.join("\n")}`;
 }

--- a/web/web/src/app/api/chat/dispatch/route.ts
+++ b/web/web/src/app/api/chat/dispatch/route.ts
@@ -1,0 +1,150 @@
+import crypto from "node:crypto";
+import { getSession } from "@/lib/auth-server";
+import { pushChatMessage } from "@/lib/chat";
+import { createDiscussion, getGitHubToken } from "@/lib/github";
+import type { ChatMessage, DispatchMetadata } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+interface DispatchBody {
+	repo: string;
+	agentName: string;
+	task: string;
+	issueRef?: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) {
+		return Response.json({ error: "unauthorized" }, { status: 401 });
+	}
+
+	const body = (await request.json()) as DispatchBody;
+	if (!body.repo || !body.agentName || !body.task) {
+		return Response.json(
+			{ error: "repo, agentName, and task are required" },
+			{ status: 400 },
+		);
+	}
+
+	const [owner, repo] = body.repo.split("/");
+	if (!owner || !repo) {
+		return Response.json(
+			{ error: "repo must be owner/name format" },
+			{ status: 400 },
+		);
+	}
+
+	const token = await getGitHubToken(session.user.id);
+	if (!token) {
+		return Response.json({ error: "GitHub token not found" }, { status: 403 });
+	}
+
+	const taskId = crypto.randomUUID().slice(0, 8);
+	const timestamp = new Date().toISOString();
+	const issueRef = body.issueRef ?? parseIssueRef(body.task);
+
+	const title = `@${body.agentName}: ${body.task.slice(0, 100)}`;
+	const discussionBody = formatDispatchBody(
+		body.agentName,
+		body.task,
+		issueRef,
+		taskId,
+	);
+
+	let discussionId: string | null = null;
+	let discussionUrl: string | null = null;
+
+	try {
+		const discussion = await createDiscussion(
+			token,
+			owner,
+			repo,
+			title,
+			discussionBody,
+		);
+		discussionId = discussion.id;
+		discussionUrl = discussion.url;
+	} catch (err) {
+		console.error("[dispatch] GitHub Discussion error:", err);
+		return Response.json(
+			{ error: "Failed to create GitHub Discussion" },
+			{ status: 502 },
+		);
+	}
+
+	const userMessageId = crypto.randomUUID();
+	const userMessage: ChatMessage = {
+		id: userMessageId,
+		repo: body.repo,
+		author: session.user.name ?? session.user.email ?? "you",
+		authorType: "user",
+		content: `@${body.agentName} ${body.task}`,
+		agentTarget: body.agentName,
+		discussionId,
+		discussionUrl,
+		timestamp,
+	};
+	await pushChatMessage(userMessage);
+
+	const dispatchMetadata: DispatchMetadata = {
+		type: "dispatch",
+		taskId,
+		agent: body.agentName,
+		task: body.task,
+		issueRef,
+		repo: body.repo,
+		discussionUrl: discussionUrl ?? "",
+		status: "pending",
+		branch: null,
+		prUrl: null,
+	};
+
+	const botMessageId = crypto.randomUUID();
+	const botMessage: ChatMessage = {
+		id: botMessageId,
+		repo: body.repo,
+		author: "spaces-bot",
+		authorType: "bot",
+		content: JSON.stringify(dispatchMetadata),
+		agentTarget: body.agentName,
+		discussionId,
+		discussionUrl,
+		timestamp: new Date(Date.now() + 1).toISOString(),
+	};
+	await pushChatMessage(botMessage);
+
+	return Response.json({
+		taskId,
+		messageId: userMessageId,
+		discussionId,
+		discussionUrl,
+	});
+}
+
+function parseIssueRef(task: string): string | null {
+	const match = task.match(/#(\d+)/);
+	return match ? `#${match[1]}` : null;
+}
+
+function formatDispatchBody(
+	agent: string,
+	task: string,
+	issueRef: string | null,
+	taskId: string,
+): string {
+	const lines = [
+		`**Agent:** @${agent}`,
+		`**Task:** ${task}`,
+		`**Task ID:** \`${taskId}\``,
+	];
+	if (issueRef) {
+		lines.push(`**Issue:** ${issueRef}`);
+	}
+	lines.push(
+		"",
+		"---",
+		"*Dispatched from [Spaces](https://spaces.cloudcompute.com) chat*",
+	);
+	return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
Integrates six chat platform features that were developed on separate branches but all modify overlapping files. Combined into one PR to avoid serial merge conflicts.

### Features
- **Chat API** (#232): message persistence, Discussion bridge, webhook handler
- **AI streaming** (#181): Anthropic SDK streaming in GitHub comments  
- **Slack adapter** (#182): team notifications via Chat SDK
- **Status cards** (#180): workspace status grid via @mention
- **Agent dispatch** (#227): @mention dispatch with confirmation dialog, progress tracking
- **Chat UI** (#225): message list, compose bar, mention autocomplete, timeline

### Verification
- [x] `pnpm biome check .` passes
- [x] `pnpm typecheck` passes
- [ ] Web CI passes

Closes #180, #181, #182, #225, #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)