### PR TITLE
fix(web): show tab bar on desktop for Dashboard/Chat switching

### DIFF
--- a/web/src/app/dashboard/page.module.css
+++ b/web/src/app/dashboard/page.module.css
@@ -22,10 +22,47 @@
 	background: var(--bg-surface);
 }
 
-/* ── Tab bar (hidden on desktop) ── */
+/* ── Tab bar ── */
 
 .tabBar {
-	display: none;
+	display: flex;
+	align-items: center;
+	gap: 0;
+	border-bottom: 1px solid var(--border-subtle);
+	background: var(--bg-surface);
+	flex-shrink: 0;
+}
+
+.tab {
+	padding: 0.5rem 1rem;
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	cursor: pointer;
+	color: var(--text-tertiary);
+	font-family: var(--font-mono), ui-monospace, monospace;
+	font-size: 0.75rem;
+	letter-spacing: 0.04em;
+	transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.tab:hover {
+	color: var(--text-secondary);
+}
+
+.tabActive {
+	color: var(--accent);
+	border-bottom-color: var(--accent);
+}
+
+.unreadBadge {
+	display: inline-block;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--accent);
+	margin-left: 0.375rem;
+	vertical-align: middle;
 }
 
 /* ── Responsive: collapse right pane ── */
@@ -38,60 +75,29 @@
 	}
 }
 
-/* ── Responsive: mobile tab bar ── */
+/* ── Responsive: mobile ── */
 @media (max-width: 640px) {
 	.columns {
 		grid-template-columns: 1fr;
 	}
 
-	/* Hide ALL panels by default on mobile */
 	.panel {
 		display: none;
 		border: none;
 	}
 
-	/* Only the active tab's panel is visible */
 	.mobileVisible {
 		display: block;
 	}
 
 	.tabBar {
-		display: flex;
-		align-items: center;
 		justify-content: space-around;
-		height: 56px;
+		border-bottom: none;
 		border-top: 1px solid var(--border-subtle);
-		background: var(--bg-surface);
-		flex-shrink: 0;
 		padding-bottom: env(safe-area-inset-bottom, 0);
 	}
 
 	.tab {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 0.25rem;
-		padding: 0.375rem 1rem;
-		background: none;
-		border: none;
-		cursor: pointer;
-		color: var(--text-tertiary);
-		font-family: var(--font-mono), ui-monospace, monospace;
-		font-size: 0.625rem;
-		letter-spacing: 0.04em;
-		transition: color 0.15s ease;
-	}
-
-	.tab:hover {
-		color: var(--text-secondary);
-	}
-
-	.tabActive {
-		color: var(--accent);
-	}
-
-	.tabIcon {
-		width: 20px;
-		height: 20px;
+		border-bottom: none;
 	}
 }


### PR DESCRIPTION
## Summary
- The Dashboard/Chat tab bar was hidden with `display: none` on desktop — users couldn't switch to the Chat tab
- Tab bar is now visible on all viewports with an underline active indicator
- Mobile layout preserved with bottom-bar style

## Test plan
- [ ] Tab bar visible on desktop at top of center panel
- [ ] Clicking Dashboard/Chat switches content
- [ ] Active tab has accent underline
- [ ] Mobile layout still uses bottom bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)