### PR TITLE
fix: wire mention kill switch and harden evidence store

### DIFF
--- a/.github/workflows/agent-executor.yml
+++ b/.github/workflows/agent-executor.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   claim:
-    if: github.event.label.name == 'safe-to-run-agent'
+    if: github.event.label.name == 'safe-to-run-agent' && vars.MENTION_AUTOMATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   triage:
     if: >-
+      vars.MENTION_AUTOMATIONS_ENABLED == 'true' &&
       !endsWith(github.event.sender.login, '[bot]') && (
         ((github.event_name == 'issue_comment') && (
           contains(github.event.comment.body || '', '@april') ||

--- a/infra/cloudflare-evidence-store/src/index.ts
+++ b/infra/cloudflare-evidence-store/src/index.ts
@@ -3,6 +3,19 @@ interface Env {
   EVIDENCE_UPLOAD_TOKEN: string;
 }
 
+const encoder = new TextEncoder();
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  let result = 0;
+  for (let i = 0; i < aBytes.length; i++) {
+    result |= aBytes[i] ^ bBytes[i];
+  }
+  return result === 0;
+}
+
 const CONTENT_TYPES: Record<string, string> = {
   png: "image/png",
   jpg: "image/jpeg",
@@ -45,7 +58,7 @@ export default {
 
     if (request.method === "PUT" && path) {
       const auth = request.headers.get("Authorization");
-      if (auth !== `Bearer ${env.EVIDENCE_UPLOAD_TOKEN}`) {
+      if (!auth || !timingSafeEqual(auth, `Bearer ${env.EVIDENCE_UPLOAD_TOKEN}`)) {
         return new Response("unauthorized", { status: 401 });
       }
 
@@ -65,8 +78,8 @@ export default {
       return new Response(null, {
         headers: {
           "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, PUT, OPTIONS",
-          "Access-Control-Allow-Headers": "Authorization, Content-Type",
+          "Access-Control-Allow-Methods": "GET, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type",
         },
       });
     }


### PR DESCRIPTION
## Summary

- **Wire `MENTION_AUTOMATIONS_ENABLED` kill switch** — the repo variable was already set to `false` but neither `agent-mention.yml` nor `agent-executor.yml` checked it. Both workflows now gate on `vars.MENTION_AUTOMATIONS_ENABLED == 'true'`, making the public mention→agent execution pipeline actually disabled.
- **Timing-safe token comparison** — evidence store bearer token auth used `!==` (vulnerable to timing side-channel). Now uses constant-time `timingSafeEqual`, matching the pattern already used in the webhook relay's `github-verify.ts`.
- **Restrict CORS on evidence store** — preflight responses no longer advertise `PUT` or `Authorization` headers. Uploads come from CI runners, not browsers.

## Context

Security review identified the public mention→agent execution pipeline as the highest-risk surface. Any GitHub user can craft a malicious `@april`/`@plat` mention; after triage, the contributor runtime re-fetches the full raw GitHub payload (bypassing the 280-char sanitization) and passes it into the Claude prompt. The `MENTION_AUTOMATIONS_ENABLED: false` variable existed as an intended kill switch but had no effect until this PR.

## Test plan

- [ ] Confirm `MENTION_AUTOMATIONS_ENABLED` is `false`: `gh api repos/fairchild/workspaces/actions/variables --jq '.variables[] | select(.name=="MENTION_AUTOMATIONS_ENABLED")'`
- [ ] Verify mention triage workflow skips when variable is false (check Actions tab after a test comment)
- [ ] Verify evidence store still accepts uploads after deploy (existing `EVIDENCE_UPLOAD_TOKEN` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)