### PR TITLE
fix(web): exclude e2e from vitest/biome, add evidence hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(gh pr create*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '⚠️  Evidence check: Have you uploaded evidence with ./scripts/evidence.sh before creating this PR? Evidence is a merge gate — see AGENTS.md § Evidence-Driven Development.'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/web/biome.jsonc
+++ b/web/biome.jsonc
@@ -13,6 +13,12 @@
 		"parser": { "cssModules": true }
 	},
 	"files": {
-		"ignore": [".next/", "node_modules/"]
+		"ignore": [
+			".next/",
+			"node_modules/",
+			"e2e/",
+			"playwright-report/",
+			"test-results/"
+		]
 	}
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		environment: "node",
+		exclude: ["e2e/**", "node_modules/**"],
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Summary
- Exclude `e2e/`, `playwright-report/`, `test-results/` from biome checks (Playwright tests use different conventions)
- Exclude `e2e/**` from vitest so Playwright specs don't fail when run under `pnpm test`
- Add `.claude/settings.json` with `PreToolUse` hook that reminds agents to capture evidence before `gh pr create`

## Evidence

**biome check:** 92 files, no issues
```
Checked 92 files in 40ms. No fixes applied.
```

**vitest:** 9/9 passed (e2e correctly excluded)
```
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  107ms
```

## Test plan
- [x] `pnpm biome check .` — clean
- [x] `pnpm vitest run` — 9 passed, no Playwright failures
- [x] `pnpm typecheck` — only pre-existing errors from untracked agent-runtime files

🤖 Generated with [Claude Code](https://claude.com/claude-code)