### PR TITLE
fix: disable scheduled agent runs until hardening is complete

### DIFF
--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   check-runner:
+    if: github.event_name != 'schedule' || vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'
     # Prefer the Lume macOS VM when it's online; fall back to ubuntu-latest.
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/agent-oliver.yml
+++ b/.github/workflows/agent-oliver.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   run:
+    if: github.event_name != 'schedule' || vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -28,6 +28,7 @@ concurrency:
 
 jobs:
   run:
+    if: github.event_name != 'schedule' || vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'
     # Contributor automation is CLI-only; keep it on the broadly available hosted lane.
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

- Gate April, Plat, and Oliver cron jobs on `vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'`
- `workflow_dispatch` (manual) runs remain available
- Repo variable `AGENT_SCHEDULED_RUNS_ENABLED` created and set to `false`

## Context

Follow-up to #256. Scheduled agent cron runs fetch full raw GitHub payloads (issue bodies, PR comments, discussion text) into Claude prompts. A crafted issue or comment doesn't need an `@mention` — the next scheduled wake-up encounters it organically. Disabling scheduled runs eliminates this attack surface until the deeper prompt injection hardening is in place.

## Re-enabling

```bash
gh api -X PATCH repos/fairchild/workspaces/actions/variables/AGENT_SCHEDULED_RUNS_ENABLED -f value=true
```

## Test plan

- [ ] Confirm variable is false: `gh api repos/fairchild/workspaces/actions/variables --jq '.variables[] | select(.name=="AGENT_SCHEDULED_RUNS_ENABLED")'`
- [ ] Next scheduled cron run should show as skipped in Actions tab
- [ ] Manual dispatch still works: trigger April via workflow_dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)