### PR TITLE
fix: unified AGENT_AUTOMATIONS_ENABLED kill switch

### DIFF
--- a/.github/workflows/agent-april.yml
+++ b/.github/workflows/agent-april.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   check-runner:
-    if: github.event_name != 'schedule' || vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.AGENT_AUTOMATIONS_ENABLED == 'true'
     # Prefer the Lume macOS VM when it's online; fall back to ubuntu-latest.
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/agent-carl.yml
+++ b/.github/workflows/agent-carl.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   run:
+    if: github.event_name == 'workflow_dispatch' || vars.AGENT_AUTOMATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/agent-executor.yml
+++ b/.github/workflows/agent-executor.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   claim:
-    if: github.event.label.name == 'safe-to-run-agent' && vars.MENTION_AUTOMATIONS_ENABLED == 'true'
+    if: github.event.label.name == 'safe-to-run-agent' && vars.AGENT_AUTOMATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   triage:
     if: >-
-      vars.MENTION_AUTOMATIONS_ENABLED == 'true' &&
+      vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
       !endsWith(github.event.sender.login, '[bot]') && (
         ((github.event_name == 'issue_comment') && (
           contains(github.event.comment.body || '', '@april') ||

--- a/.github/workflows/agent-oliver.yml
+++ b/.github/workflows/agent-oliver.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   run:
-    if: github.event_name != 'schedule' || vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.AGENT_AUTOMATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/agent-plat.yml
+++ b/.github/workflows/agent-plat.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   run:
-    if: github.event_name != 'schedule' || vars.AGENT_SCHEDULED_RUNS_ENABLED == 'true'
+    if: github.event_name == 'workflow_dispatch' || vars.AGENT_AUTOMATIONS_ENABLED == 'true'
     # Contributor automation is CLI-only; keep it on the broadly available hosted lane.
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

Consolidate two separate variables into one `AGENT_AUTOMATIONS_ENABLED` kill switch that gates **all** automated agent execution:

| Workflow | Trigger | Gated |
|----------|---------|-------|
| agent-april.yml | cron | yes |
| agent-plat.yml | cron | yes |
| agent-oliver.yml | cron | yes |
| agent-carl.yml | cron | **yes (newly added)** |
| agent-mention.yml | issue_comment, pr_review | yes |
| agent-executor.yml | label approval | yes |
| agent-peter.yml | discussion_comment | already owner-gated |

Manual `workflow_dispatch` is **always available** regardless of kill switch state.

## Variable changes

- Created: `AGENT_AUTOMATIONS_ENABLED: false`
- Deleted: `MENTION_AUTOMATIONS_ENABLED` (superseded)
- Deleted: `AGENT_SCHEDULED_RUNS_ENABLED` (superseded)

## Re-enabling

```bash
gh api -X PATCH repos/fairchild/workspaces/actions/variables/AGENT_AUTOMATIONS_ENABLED -f value=true
```

## Disabling

```bash
gh api -X PATCH repos/fairchild/workspaces/actions/variables/AGENT_AUTOMATIONS_ENABLED -f value=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)