### PR TITLE
test(web): Playwright auth fixture with DEV_BYPASS_AUTH

### DIFF
--- a/web/e2e/fast/landing.spec.ts
+++ b/web/e2e/fast/landing.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("Landing page @fast", () => {
+test.describe("Landing page", () => {
 	test("loads with Spaces branding", async ({ page }) => {
 		await page.goto("/");
 		await expect(page.getByText("Spaces", { exact: true }).first()).toBeVisible();

--- a/web/e2e/fast/unauth-api.spec.ts
+++ b/web/e2e/fast/unauth-api.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("Unauthenticated API responses @fast", () => {
+test.describe("Unauthenticated API responses", () => {
 	test("POST /api/workspaces/sync without auth returns unauthorized", async ({
 		request,
 	}) => {

--- a/web/e2e/fast/unauth-redirect.spec.ts
+++ b/web/e2e/fast/unauth-redirect.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test.describe("Auth redirect @fast", () => {
+test.describe("Auth redirect", () => {
 	test("GET /dashboard without auth redirects to sign-in", async ({
 		page,
 	}) => {

--- a/web/e2e/full/chat.spec.ts
+++ b/web/e2e/full/chat.spec.ts
@@ -1,32 +1,45 @@
-import { test } from "@playwright/test";
-
-// TODO: Set up auth fixture for authenticated tests
-// See e2e/full/dashboard.spec.ts for strategy options
+import { expect, test } from "@playwright/test";
 
 test.describe("Chat (authenticated)", () => {
-	test.skip("tab switching updates URL", async ({ page }) => {
-		// TODO: Sign in via auth fixture
-		// 1. Navigate to /dashboard/owner/repo
-		// 2. Verify Dashboard tab is active
-		// 3. Click Chat tab
-		// 4. Verify URL contains ?tab=chat
-		// 5. Verify Chat tab has active styling
-		// 6. Click Dashboard tab
-		// 7. Verify URL no longer contains ?tab=chat
+	test("tab switching updates URL", async ({ page }) => {
+		await page.goto("/dashboard");
+		await expect(page.getByRole("button", { name: "Dashboard" })).toBeVisible();
+
+		// Switch to Chat
+		await page.getByRole("button", { name: "Chat" }).click();
+		await expect(page).toHaveURL(/tab=chat/);
+
+		// Switch back to Dashboard
+		await page.getByRole("button", { name: "Dashboard" }).click();
+		await expect(page).not.toHaveURL(/tab=chat/);
+	});
+
+	test("chat tab shows compose bar", async ({ page }) => {
+		await page.goto("/dashboard?tab=chat");
+		await expect(
+			page.getByPlaceholder("Type a message or @mention an agent"),
+		).toBeVisible();
+		await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+	});
+
+	test("compose bar shows helper text", async ({ page }) => {
+		await page.goto("/dashboard?tab=chat");
+		await expect(page.getByText("Enter to send")).toBeVisible();
+		await expect(page.getByText("@ to mention agent")).toBeVisible();
 	});
 
 	test.skip("sticky tab bar stays visible while scrolling", async ({
 		page,
 	}) => {
-		// TODO: Sign in via auth fixture
+		// TODO: Needs seeded timeline entries to create scrollable content
 		// 1. Navigate to chat tab with long timeline
 		// 2. Scroll down significantly
-		// 3. Verify tab bar is still visible (position: sticky)
+		// 3. Verify tab bar is still in viewport
 	});
 
 	test.skip("timeline shows day separators", async ({ page }) => {
-		// TODO: Sign in via auth fixture
-		// 1. Navigate to chat tab with messages spanning multiple days
+		// TODO: Needs seeded chat messages spanning multiple days
+		// 1. Navigate to chat tab
 		// 2. Verify .daySeparator elements exist
 		// 3. Verify separator text matches "Mon DD" format
 	});
@@ -34,13 +47,11 @@ test.describe("Chat (authenticated)", () => {
 	test.skip("compose bar @ mention triggers autocomplete", async ({
 		page,
 	}) => {
-		// TODO: Sign in via auth fixture
-		// 1. Navigate to chat tab
-		// 2. Click compose bar textarea
-		// 3. Type "@"
-		// 4. Verify autocomplete dropdown appears with agent names
-		// 5. Type partial agent name to filter
-		// 6. Select an agent
-		// 7. Verify agent chip appears and text is updated
+		// TODO: Needs seeded agents via repo with .agents/ directory
+		// 1. Click compose bar textarea
+		// 2. Type "@"
+		// 3. Verify autocomplete dropdown appears
+		// 4. Select an agent
+		// 5. Verify agent chip appears
 	});
 });

--- a/web/e2e/full/dashboard.spec.ts
+++ b/web/e2e/full/dashboard.spec.ts
@@ -1,25 +1,28 @@
-import { test } from "@playwright/test";
-
-// TODO: Set up auth fixture for authenticated tests
-// Strategy options:
-// 1. Use Playwright's storageState with a pre-authenticated session cookie
-// 2. Create a test-only API endpoint that issues a session
-// 3. Mock the auth middleware in test mode
-// See: https://playwright.dev/docs/auth
+import { expect, test } from "@playwright/test";
 
 test.describe("Dashboard (authenticated)", () => {
-	test.skip("shows repo detail after sign-in", async ({ page }) => {
-		// TODO: Sign in via auth fixture
+	test("loads dashboard page with tab bar", async ({ page }) => {
+		await page.goto("/dashboard");
+		await expect(page.getByRole("button", { name: "Dashboard" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Chat" })).toBeVisible();
+	});
+
+	test("shows sidebar with Add repos button", async ({ page }) => {
+		await page.goto("/dashboard");
+		await expect(page.getByText("Add repos")).toBeVisible();
+	});
+
+	test.skip("shows repo detail after selecting a repo", async ({ page }) => {
+		// TODO: Needs seeded repos in the database
 		// 1. Navigate to /dashboard
-		// 2. Verify sidebar shows repos
-		// 3. Click a repo
-		// 4. Verify agent overview cards render (agents, skills, PRs, issues)
+		// 2. Click a repo in sidebar
+		// 3. Verify agent overview cards render (agents, skills, PRs, issues)
 	});
 
 	test.skip("activity feed shows webhook events with type badges", async ({
 		page,
 	}) => {
-		// TODO: Sign in via auth fixture
+		// TODO: Needs seeded webhook events in the database
 		// 1. Navigate to /dashboard/owner/repo
 		// 2. Verify activity feed panel is visible on desktop
 		// 3. Verify event cards show CI/PR/PUSH/ISSUE badges

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
 		"test": "vitest run",
 		"test:unit": "vitest run",
 		"test:e2e": "playwright test",
-		"test:e2e:fast": "playwright test --grep @fast"
+		"test:e2e:fast": "playwright test --project fast",
+		"test:e2e:full": "playwright test --project full"
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.80.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -13,7 +13,13 @@ export default defineConfig({
 	},
 	projects: [
 		{
-			name: "chromium",
+			name: "fast",
+			testMatch: "fast/**",
+			use: { ...devices["Desktop Chrome"] },
+		},
+		{
+			name: "full",
+			testMatch: "full/**",
 			use: { ...devices["Desktop Chrome"] },
 		},
 	],
@@ -22,5 +28,8 @@ export default defineConfig({
 		url: "http://localhost:3000",
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,
+		env: {
+			DEV_BYPASS_AUTH: "1",
+		},
 	},
 });

--- a/web/src/lib/auth-server.ts
+++ b/web/src/lib/auth-server.ts
@@ -1,6 +1,26 @@
 import { headers } from "next/headers";
 
 export async function getSession() {
+	if (
+		process.env.NODE_ENV === "development" &&
+		process.env.DEV_BYPASS_AUTH === "1"
+	) {
+		return {
+			user: {
+				id: "dev-user",
+				name: "Dev User",
+				email: "dev@localhost",
+				image: null,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				emailVerified: false,
+			},
+			session: {
+				id: "dev-session",
+				expiresAt: new Date(Date.now() + 86400000),
+			},
+		};
+	}
 	const { auth } = await import("./auth");
 	return auth.api.getSession({ headers: await headers() });
 }


### PR DESCRIPTION
## Summary
- Extend `getSession()` to return a mock dev session when `DEV_BYPASS_AUTH=1`, enabling authenticated E2E tests without real OAuth
- Split Playwright config into `fast` and `full` projects (replaces `@fast` grep tag)
- Implement 5 new authenticated E2E tests: dashboard loads, tab switching, compose bar visibility, helper text
- 4 data-dependent tests remain as TODO (need seeded repos/events)

## How it works
- Middleware already bypasses auth redirect when `DEV_BYPASS_AUTH=1` (development only)
- Now `getSession()` also returns a mock user in the same conditions
- Playwright's `webServer.env` sets `DEV_BYPASS_AUTH=1` so `pnpm dev` starts with auth bypass
- CI unchanged: fast tests still run against production build without bypass

## Scripts
- `pnpm test:e2e:fast` — unauthenticated tests (CI)
- `pnpm test:e2e:full` — authenticated tests (local dev)
- `pnpm test:e2e` — all tests

## Test plan
- [ ] CI passes (fast tests unaffected)
- [ ] `DEV_BYPASS_AUTH=1 pnpm dev` + `pnpm test:e2e:full` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)