### PR TITLE
Optimize Workspaces UI latency and expand perf diagnostics

### DIFF
--- a/.agents/skills/workspaces-optimization/SKILL.md
+++ b/.agents/skills/workspaces-optimization/SKILL.md
@@ -21,17 +21,24 @@ The workflow supports two environments:
 
 ## Quick Start
 
+Collect the standard installed-app bundle on a target machine that also has a repo checkout:
+
+```bash
+./.agents/skills/workspaces-optimization/scripts/collect_installed_perf_bundle.py \
+  --slow-repo /path/to/slow/repo
+```
+
 Summarize an exported diagnostic report:
 
 ```bash
-uv run --script .agents/skills/workspaces-optimization/scripts/summarize_diagnostic_report.py \
+./.agents/skills/workspaces-optimization/scripts/summarize_diagnostic_report.py \
   /path/to/workspaces-report.zip
 ```
 
 Collect host-side shell and process evidence on a slow machine:
 
 ```bash
-uv run --script .agents/skills/workspaces-optimization/scripts/host_perf_probe.py \
+./.agents/skills/workspaces-optimization/scripts/host_perf_probe.py \
   --cwd /path/to/slow/repo \
   --sample-running
 ```
@@ -39,7 +46,7 @@ uv run --script .agents/skills/workspaces-optimization/scripts/host_perf_probe.p
 Capture active-lag samples for both the app and child shell processes:
 
 ```bash
-uv run --script .agents/skills/workspaces-optimization/scripts/capture_active_lag_samples.py \
+./.agents/skills/workspaces-optimization/scripts/capture_active_lag_samples.py \
   --countdown 5 \
   --sample-seconds 8
 ```
@@ -53,7 +60,7 @@ Launch an installed build with focused diagnostics enabled:
 Summarize the resulting `[Perf]` log:
 
 ```bash
-uv run --script .agents/skills/workspaces-optimization/scripts/summarize_perf_log.py \
+./.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py \
   /tmp/workspaces-installed-diagnostics-YYYYMMDD-HHMMSS.log
 ```
 
@@ -69,6 +76,7 @@ Run the repo's repeated launch baseline when you have a checkout and can use the
 ### 1. Classify the environment
 
 - If the user provides a diagnostic zip, run `summarize_diagnostic_report.py` first.
+- If the machine has both the installed app and a repo checkout, prefer `collect_installed_perf_bundle.py` so the operator can run one command and return one zip bundle.
 - If the machine only has the installed app, run `host_perf_probe.py` in the slow repo and use the installed app for manual repro.
 - If you have a repo checkout and want an instrumented installed build run, use `./scripts/launch-installed-diagnostics.sh` with either `--clean-shell` or `--login-shell`.
 - If you have the repo checkout and can build locally, use the repo perf scripts after the host probe so you have both target-machine and debug-build evidence.
@@ -174,6 +182,16 @@ Use after `launch-installed-diagnostics.sh` or any captured app log with `[Perf]
 - groups metrics by `metric` and `phase`
 - summarizes numeric fields such as `duration_ms`, `event_age_ms`, and `handler_duration_ms`
 - emits quick findings about terminal surface creation and input-path timing
+
+### `collect_installed_perf_bundle.py`
+
+Use on target machines that have both the installed app and a checkout of this repo.
+
+- runs clean-shell, login-shell, and optional input-diagnostics launch phases
+- summarizes each log automatically
+- runs the host probe
+- runs active-lag sampling with a guided countdown
+- writes `manifest.json`, `README.txt`, and a zip archive for easy handoff
 
 ## Guardrails
 

--- a/.agents/skills/workspaces-optimization/scripts/collect_installed_perf_bundle.py
+++ b/.agents/skills/workspaces-optimization/scripts/collect_installed_perf_bundle.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Collect a bundled set of installed-app performance diagnostics for Workspaces.
+
+This wrapper is intended for target machines that have both:
+
+- an installed WorkspaceManager app
+- a checkout of the workspaces repo so the helper scripts are available
+
+It guides the operator through a repeatable sequence and writes one output
+directory plus a zip archive that can be shared back for analysis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import signal
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_APP = Path("/Applications/WorkspaceManager.app/Contents/MacOS/WorkspaceManager")
+
+
+def repo_root_from_self() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = repo_root_from_self()
+    default_output = Path.home() / "Desktop" / f"workspaces-installed-perf-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+
+    parser = argparse.ArgumentParser(
+        description="Collect a bundled installed-app performance investigation for Workspaces."
+    )
+    parser.add_argument(
+        "--slow-repo",
+        type=Path,
+        required=True,
+        help="Path to the repo that feels slow in Workspaces.",
+    )
+    parser.add_argument(
+        "--wm-repo",
+        type=Path,
+        default=repo_root,
+        help="Path to the workspaces repo checkout that contains the helper scripts.",
+    )
+    parser.add_argument(
+        "--app",
+        type=Path,
+        default=DEFAULT_APP,
+        help="Installed WorkspaceManager binary path.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=default_output,
+        help="Directory for collected artifacts. Default: ~/Desktop/workspaces-installed-perf-<timestamp>",
+    )
+    parser.add_argument(
+        "--countdown",
+        type=int,
+        default=5,
+        help="Countdown before active-lag sampling starts. Default: 5.",
+    )
+    parser.add_argument(
+        "--sample-seconds",
+        type=int,
+        default=8,
+        help="Duration for active-lag samples. Default: 8.",
+    )
+    parser.add_argument(
+        "--host-probe-runs",
+        type=int,
+        default=3,
+        help="Number of shell timing runs per directory in the host probe. Default: 3.",
+    )
+    parser.add_argument(
+        "--skip-input-run",
+        action="store_true",
+        help="Skip the short input-diagnostics phase.",
+    )
+    parser.add_argument(
+        "--skip-active-lag",
+        action="store_true",
+        help="Skip the active-lag sample capture phase.",
+    )
+    parser.add_argument(
+        "--no-zip",
+        action="store_true",
+        help="Do not create a zip archive at the end.",
+    )
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Print the collection plan and exit without launching anything.",
+    )
+    return parser.parse_args()
+
+
+def check_paths(args: argparse.Namespace) -> dict[str, Path]:
+    wm_repo = args.wm_repo.expanduser().resolve()
+    slow_repo = args.slow_repo.expanduser().resolve()
+    app = args.app.expanduser().resolve()
+    output_dir = args.output_dir.expanduser().resolve()
+
+    if not wm_repo.is_dir():
+        raise SystemExit(f"Workspaces repo checkout not found: {wm_repo}")
+    if not slow_repo.is_dir():
+        raise SystemExit(f"Slow repo not found: {slow_repo}")
+    if not app.exists() or not app.is_file():
+        raise SystemExit(f"Installed app binary not found: {app}")
+
+    launcher = wm_repo / "scripts" / "launch-installed-diagnostics.sh"
+    summarize_perf = wm_repo / ".agents" / "skills" / "workspaces-optimization" / "scripts" / "summarize_perf_log.py"
+    host_probe = wm_repo / ".agents" / "skills" / "workspaces-optimization" / "scripts" / "host_perf_probe.py"
+    active_lag = wm_repo / ".agents" / "skills" / "workspaces-optimization" / "scripts" / "capture_active_lag_samples.py"
+
+    for required in [launcher, summarize_perf, host_probe, active_lag]:
+        if not required.exists():
+            raise SystemExit(f"Required helper script not found: {required}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return {
+        "wm_repo": wm_repo,
+        "slow_repo": slow_repo,
+        "app": app,
+        "output_dir": output_dir,
+        "launcher": launcher,
+        "summarize_perf": summarize_perf,
+        "host_probe": host_probe,
+        "active_lag": active_lag,
+    }
+
+
+def print_header(title: str) -> None:
+    border = "=" * len(title)
+    print(f"\n{title}\n{border}")
+
+
+def prompt(message: str) -> str:
+    try:
+        return input(message)
+    except EOFError:
+        return ""
+
+
+def wait_for_enter(message: str) -> None:
+    prompt(message)
+
+
+def kill_workspaces() -> None:
+    subprocess.run(["pkill", "-x", "WorkspaceManager"], capture_output=True, text=True, check=False)
+    time.sleep(1)
+
+
+def newest_workspace_manager_pid() -> int | None:
+    result = subprocess.run(["pgrep", "-x", "WorkspaceManager"], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return None
+    pids = [line.strip() for line in result.stdout.splitlines() if line.strip().isdigit()]
+    if not pids:
+        return None
+    return int(pids[-1])
+
+
+def terminate_launcher(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    process.send_signal(signal.SIGINT)
+    try:
+        process.wait(timeout=5)
+        return
+    except subprocess.TimeoutExpired:
+        process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def wait_for_launcher_exit(process: subprocess.Popen[Any]) -> None:
+    while True:
+        wait_for_enter("Quit Workspaces, then press Enter to continue.")
+        if process.poll() is None:
+            print("WorkspaceManager is still running. Quit it first, then press Enter again.")
+            continue
+        break
+
+
+def summarize_log(wm_repo: Path, summarize_perf: Path, log_file: Path, base_name: str) -> None:
+    text_path = log_file.parent / f"{base_name}-summary.txt"
+    json_path = log_file.parent / f"{base_name}-summary.json"
+
+    with text_path.open("w", encoding="utf-8") as handle:
+        result = subprocess.run(
+            [str(summarize_perf), str(log_file)],
+            cwd=str(wm_repo),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"Failed to summarize perf log: {log_file}")
+
+    with json_path.open("w", encoding="utf-8") as handle:
+        result = subprocess.run(
+            [str(summarize_perf), "--json", str(log_file)],
+            cwd=str(wm_repo),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"Failed to write perf JSON summary: {log_file}")
+
+
+def launch_phase(
+    *,
+    paths: dict[str, Path],
+    output_dir: Path,
+    phase_name: str,
+    shell_mode: str,
+    with_input_diagnostics: bool,
+    instructions: list[str],
+    notes: list[dict[str, str]],
+) -> None:
+    kill_workspaces()
+    log_file = output_dir / f"{phase_name}.log"
+
+    command = [
+        str(paths["launcher"]),
+        "--app",
+        str(paths["app"]),
+        "--log-file",
+        str(log_file),
+        f"--{shell_mode}-shell",
+    ]
+    if with_input_diagnostics:
+        command.append("--with-input-diagnostics")
+
+    print_header(f"Phase: {phase_name}")
+    print(f"Launching Workspaces with {shell_mode} shell mode.")
+    for line in instructions:
+        print(f"- {line}")
+
+    process = subprocess.Popen(
+        command,
+        cwd=str(paths["wm_repo"]),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    time.sleep(2)
+    if process.poll() is not None:
+        raise SystemExit(f"Workspaces exited immediately during {phase_name}. Check {log_file}.")
+
+    wait_for_launcher_exit(process)
+    process.wait(timeout=5)
+    summarize_log(paths["wm_repo"], paths["summarize_perf"], log_file, phase_name)
+    note = prompt(f"Short note for {phase_name} (optional): ").strip()
+    if note:
+        notes.append({"phase": phase_name, "note": note})
+    print(f"Wrote {log_file}")
+    print(f"Wrote {output_dir / f'{phase_name}-summary.txt'}")
+
+
+def run_host_probe(paths: dict[str, Path], output_dir: Path, host_probe_runs: int) -> None:
+    print_header("Phase: host-probe")
+    print("- Running shell timing and process snapshot collection.")
+    host_probe_dir = output_dir / "host-probe"
+    command = [
+        str(paths["host_probe"]),
+        "--cwd",
+        str(paths["slow_repo"]),
+        "--cwd",
+        str(Path.home()),
+        "--runs",
+        str(host_probe_runs),
+        "--output-dir",
+        str(host_probe_dir),
+    ]
+    result = subprocess.run(command, cwd=str(paths["wm_repo"]), text=True, check=False)
+    if result.returncode != 0:
+        raise SystemExit("Host probe failed.")
+    print(f"Wrote {host_probe_dir}")
+
+
+def run_active_lag_capture(
+    *,
+    paths: dict[str, Path],
+    output_dir: Path,
+    countdown: int,
+    sample_seconds: int,
+    notes: list[dict[str, str]],
+) -> None:
+    kill_workspaces()
+    log_file = output_dir / "lag-run.log"
+    active_lag_dir = output_dir / "active-lag"
+
+    print_header("Phase: active-lag")
+    print("- Workspaces will launch with normal login-shell behavior.")
+    print("- Open the slow repo and get it into the visibly laggy state.")
+    print("- Do not quit the app before the sampler runs.")
+
+    launcher = subprocess.Popen(
+        [
+            str(paths["launcher"]),
+            "--app",
+            str(paths["app"]),
+            "--log-file",
+            str(log_file),
+            "--login-shell",
+        ],
+        cwd=str(paths["wm_repo"]),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    time.sleep(2)
+    if launcher.poll() is not None:
+        raise SystemExit(f"Workspaces exited immediately during active-lag capture. Check {log_file}.")
+
+    wait_for_enter("When Workspaces is open and actively lagging, press Enter to start the sample countdown.")
+    pid = newest_workspace_manager_pid()
+    if pid is None:
+        terminate_launcher(launcher)
+        raise SystemExit("Could not find a running WorkspaceManager PID for active-lag capture.")
+
+    result = subprocess.run(
+        [
+            str(paths["active_lag"]),
+            "--pid",
+            str(pid),
+            "--countdown",
+            str(countdown),
+            "--sample-seconds",
+            str(sample_seconds),
+            "--output-dir",
+            str(active_lag_dir),
+        ],
+        cwd=str(paths["wm_repo"]),
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        terminate_launcher(launcher)
+        raise SystemExit("Active-lag sample capture failed.")
+
+    wait_for_launcher_exit(launcher)
+    launcher.wait(timeout=5)
+    summarize_log(paths["wm_repo"], paths["summarize_perf"], log_file, "lag-run")
+    note = prompt("Short note for active-lag run (optional): ").strip()
+    if note:
+        notes.append({"phase": "active-lag", "note": note})
+    print(f"Wrote {active_lag_dir}")
+
+
+def write_manifest(
+    *,
+    output_dir: Path,
+    paths: dict[str, Path],
+    args: argparse.Namespace,
+    notes: list[dict[str, str]],
+) -> None:
+    manifest = {
+        "collected_at": datetime.now().astimezone().isoformat(),
+        "wm_repo": str(paths["wm_repo"]),
+        "slow_repo": str(paths["slow_repo"]),
+        "app": str(paths["app"]),
+        "output_dir": str(output_dir),
+        "host_probe_runs": args.host_probe_runs,
+        "countdown": args.countdown,
+        "sample_seconds": args.sample_seconds,
+        "skip_input_run": args.skip_input_run,
+        "skip_active_lag": args.skip_active_lag,
+        "notes": notes,
+    }
+    (output_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    lines = [
+        "Workspaces installed performance bundle",
+        f"Collected at: {manifest['collected_at']}",
+        f"Workspaces repo: {paths['wm_repo']}",
+        f"Slow repo: {paths['slow_repo']}",
+        f"Installed app: {paths['app']}",
+        "",
+        "Files to send back:",
+        f"- {output_dir / 'clean-shell.log'}",
+        f"- {output_dir / 'clean-shell-summary.txt'}",
+        f"- {output_dir / 'login-shell.log'}",
+        f"- {output_dir / 'login-shell-summary.txt'}",
+    ]
+    if not args.skip_input_run:
+        lines.extend(
+            [
+                f"- {output_dir / 'input.log'}",
+                f"- {output_dir / 'input-summary.txt'}",
+            ]
+        )
+    lines.append(f"- {output_dir / 'host-probe'}")
+    if not args.skip_active_lag:
+        lines.extend(
+            [
+                f"- {output_dir / 'lag-run.log'}",
+                f"- {output_dir / 'lag-run-summary.txt'}",
+                f"- {output_dir / 'active-lag'}",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "Operator notes:",
+        ]
+    )
+    if notes:
+        for note in notes:
+            lines.append(f"- {note['phase']}: {note['note']}")
+    else:
+        lines.append("- none")
+
+    (output_dir / "README.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def make_zip(output_dir: Path) -> Path:
+    archive = shutil.make_archive(str(output_dir), "zip", root_dir=str(output_dir.parent), base_dir=output_dir.name)
+    return Path(archive)
+
+
+def print_plan(paths: dict[str, Path], args: argparse.Namespace) -> None:
+    print("Collection plan")
+    print(f"- Workspaces repo: {paths['wm_repo']}")
+    print(f"- Slow repo: {paths['slow_repo']}")
+    print(f"- Installed app: {paths['app']}")
+    print(f"- Output dir: {paths['output_dir']}")
+    print("- Phases:")
+    print("  1. clean-shell launch + perf summary")
+    print("  2. login-shell launch + perf summary")
+    if not args.skip_input_run:
+        print("  3. login-shell input diagnostics + perf summary")
+    print("  4. host shell/process probe")
+    if not args.skip_active_lag:
+        print("  5. active-lag samples + perf summary")
+    print("  6. write manifest and zip bundle")
+
+
+def main() -> int:
+    global args
+    args = parse_args()
+    paths = check_paths(args)
+    output_dir = paths["output_dir"]
+
+    if args.plan_only:
+        print_plan(paths, args)
+        return 0
+
+    notes: list[dict[str, str]] = []
+    print_header("Workspaces Performance Bundle")
+    print(f"Output directory: {output_dir}")
+    print("Each launch phase writes its own log and summary, then the script zips the bundle at the end.")
+
+    launch_phase(
+        paths=paths,
+        output_dir=output_dir,
+        phase_name="clean-shell",
+        shell_mode="clean",
+        with_input_diagnostics=False,
+        instructions=[
+            "Open the same slow repo in Workspaces.",
+            "Type in the terminal for 10-20 seconds.",
+            "Quit Workspaces when you are done.",
+        ],
+        notes=notes,
+    )
+
+    launch_phase(
+        paths=paths,
+        output_dir=output_dir,
+        phase_name="login-shell",
+        shell_mode="login",
+        with_input_diagnostics=False,
+        instructions=[
+            "Open the same slow repo again.",
+            "Repeat the same typing and terminal actions as the clean-shell run.",
+            "Quit Workspaces when you are done.",
+        ],
+        notes=notes,
+    )
+
+    if not args.skip_input_run:
+        launch_phase(
+            paths=paths,
+            output_dir=output_dir,
+            phase_name="input",
+            shell_mode="login",
+            with_input_diagnostics=True,
+            instructions=[
+                "This is a short capture run only.",
+                "Type for about 10-15 seconds in the terminal.",
+                "Quit Workspaces when you are done.",
+            ],
+            notes=notes,
+        )
+
+    run_host_probe(paths, output_dir, args.host_probe_runs)
+
+    if not args.skip_active_lag:
+        run_active_lag_capture(
+            paths=paths,
+            output_dir=output_dir,
+            countdown=args.countdown,
+            sample_seconds=args.sample_seconds,
+            notes=notes,
+        )
+
+    clean_observation = prompt("Did the clean-shell run still feel slow? [yes/no/notes] ").strip()
+    if clean_observation:
+        notes.append({"phase": "observation", "note": f"clean-shell subjective: {clean_observation}"})
+    terminal_observation = prompt("Did Terminal.app also feel slow in the same repo? [yes/no/unknown/notes] ").strip()
+    if terminal_observation:
+        notes.append({"phase": "observation", "note": f"Terminal.app subjective: {terminal_observation}"})
+
+    write_manifest(output_dir=output_dir, paths=paths, args=args, notes=notes)
+    if args.no_zip:
+        print(f"Collection complete: {output_dir}")
+        return 0
+
+    zip_path = make_zip(output_dir)
+    print(f"Collection complete: {output_dir}")
+    print(f"Zip archive: {zip_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -14,16 +14,7 @@ import WorkspaceManagerCore
 @main
 struct WorkspaceManagerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @FocusedValue(\.newWorkspaceAction) private var newWorkspaceAction
-    @FocusedValue(\.toggleSidebarAction) private var toggleSidebarAction
-    @FocusedValue(\.toggleInspectorAction) private var toggleInspectorAction
-    @FocusedValue(\.toggleTerminalPanelAction) private var toggleTerminalPanelAction
-    @FocusedValue(\.openInEditorAction) private var openInEditorAction
-    @FocusedValue(\.openInBrowserAction) private var openInBrowserAction
-    @FocusedValue(\.reloadWebSourceAction) private var reloadWebSourceAction
-    @FocusedValue(\.openDesktopAction) private var openDesktopAction
-    @FocusedValue(\.revealInFinderAction) private var revealInFinderAction
-    @FocusedValue(\.copyPathAction) private var copyPathAction
+    @StateObject private var appCommandState = AppCommandState()
     private let appRuntimeDependencies = AppRuntimeDependencies.resolved()
 
     var sharedModelContainer: ModelContainer = {
@@ -50,10 +41,16 @@ struct WorkspaceManagerApp: App {
 
     var body: some Scene {
         WindowGroup {
-            MainWindowRootView(appRuntimeDependencies: appRuntimeDependencies)
-                .environment(\.lumeRuntimeService, appRuntimeDependencies.lumeRuntimeService)
-                .environment(\.workspaceProviderRegistry, appRuntimeDependencies.workspaceProviderRegistry)
-                .frame(minWidth: 1000, minHeight: 700)
+            MainWindowRootView(
+                appRuntimeDependencies: appRuntimeDependencies,
+                appCommandState: appCommandState
+            )
+            .environment(\.lumeRuntimeService, appRuntimeDependencies.lumeRuntimeService)
+            .environment(
+                \.workspaceProviderRegistry,
+                appRuntimeDependencies.workspaceProviderRegistry
+            )
+            .frame(minWidth: 1000, minHeight: 700)
         }
         .modelContainer(sharedModelContainer)
         .defaultSize(width: 1400, height: 900)
@@ -63,76 +60,80 @@ struct WorkspaceManagerApp: App {
         .commands {
             CommandGroup(after: .newItem) {
                 Button("New Workspace...") {
-                    newWorkspaceAction?()
+                    appCommandState.newWorkspaceAction?()
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.newWorkspace.keyEquivalent,
                     modifiers: AppChromeShortcut.newWorkspace.eventModifiers
                 )
+                .disabled(appCommandState.newWorkspaceAction == nil)
 
                 Button("Open in...") {
-                    openInEditorAction?()
+                    appCommandState.mainWindowActions.openInEditor?()
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.openInEditor.keyEquivalent,
                     modifiers: AppChromeShortcut.openInEditor.eventModifiers
                 )
-                .disabled(openInEditorAction == nil)
+                .disabled(appCommandState.mainWindowActions.openInEditor == nil)
 
                 Button("Toggle Sidebar") {
-                    toggleSidebarAction?()
+                    appCommandState.mainWindowActions.toggleSidebar?()
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.toggleSidebar.keyEquivalent,
                     modifiers: AppChromeShortcut.toggleSidebar.eventModifiers
                 )
+                .disabled(appCommandState.mainWindowActions.toggleSidebar == nil)
 
                 Button("Toggle Inspector") {
-                    toggleInspectorAction?()
+                    appCommandState.mainWindowActions.toggleInspector?()
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.toggleInspector.keyEquivalent,
                     modifiers: AppChromeShortcut.toggleInspector.eventModifiers
                 )
+                .disabled(appCommandState.mainWindowActions.toggleInspector == nil)
 
                 Button("Toggle Terminal Panel") {
-                    toggleTerminalPanelAction?()
+                    appCommandState.mainWindowActions.toggleTerminalPanel?()
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.toggleTerminalPanel.keyEquivalent,
                     modifiers: AppChromeShortcut.toggleTerminalPanel.eventModifiers
                 )
+                .disabled(appCommandState.mainWindowActions.toggleTerminalPanel == nil)
             }
 
             SidebarCommands()
 
             CommandMenu("Selection") {
                 Button("Open in Browser") {
-                    openInBrowserAction?()
+                    appCommandState.mainWindowActions.openInBrowser?()
                 }
-                .disabled(openInBrowserAction == nil)
+                .disabled(appCommandState.mainWindowActions.openInBrowser == nil)
 
                 Button("Reload Web Source") {
-                    reloadWebSourceAction?()
+                    appCommandState.mainWindowActions.reloadWebSource?()
                 }
-                .disabled(reloadWebSourceAction == nil)
+                .disabled(appCommandState.mainWindowActions.reloadWebSource == nil)
 
                 Divider()
 
                 Button("Open Desktop") {
-                    openDesktopAction?()
+                    appCommandState.mainWindowActions.openDesktop?()
                 }
-                .disabled(openDesktopAction == nil)
+                .disabled(appCommandState.mainWindowActions.openDesktop == nil)
 
                 Button("Reveal in Finder") {
-                    revealInFinderAction?()
+                    appCommandState.mainWindowActions.revealInFinder?()
                 }
-                .disabled(revealInFinderAction == nil)
+                .disabled(appCommandState.mainWindowActions.revealInFinder == nil)
 
                 Button("Copy Path") {
-                    copyPathAction?()
+                    appCommandState.mainWindowActions.copyPath?()
                 }
-                .disabled(copyPathAction == nil)
+                .disabled(appCommandState.mainWindowActions.copyPath == nil)
             }
 
             CommandGroup(after: .help) {
@@ -304,14 +305,19 @@ private func seedUIFixtureDataIfNeeded(in context: ModelContext) {
 
 private struct MainWindowRootView: View {
     private let appRuntimeDependencies: AppRuntimeDependencies
+    @ObservedObject private var appCommandState: AppCommandState
     @State private var deepLinkState = WorkspaceDeepLinkState()
     @SceneStorage(MainWindowLastSurface.storageKey) private var lastSurfaceRawValue = ""
     @StateObject private var hostTerminalState = HostTerminalStateStore()
     @StateObject private var workspaceProviderSetupCoordinator = WorkspaceProviderSetupCoordinator()
     @StateObject private var hostLumeSmokeAutomation: HostLumeSmokeAutomationController
 
-    init(appRuntimeDependencies: AppRuntimeDependencies) {
+    init(
+        appRuntimeDependencies: AppRuntimeDependencies,
+        appCommandState: AppCommandState
+    ) {
         self.appRuntimeDependencies = appRuntimeDependencies
+        self._appCommandState = ObservedObject(wrappedValue: appCommandState)
         _hostLumeSmokeAutomation = StateObject(
             wrappedValue: HostLumeSmokeAutomationController()
         )
@@ -321,6 +327,7 @@ private struct MainWindowRootView: View {
         ContentView(
             deepLinkState: $deepLinkState,
             lastSurfaceRawValue: $lastSurfaceRawValue,
+            appCommandState: appCommandState,
             hostTerminalState: hostTerminalState,
             workspaceProviderSetupCoordinator: workspaceProviderSetupCoordinator,
             hostLumeSmokeAutomation: hostLumeSmokeAutomation
@@ -568,96 +575,24 @@ extension EnvironmentValues {
     }
 }
 
-// MARK: - Focused Scene Values
+struct MainWindowFocusedActions {
+    typealias Action = @MainActor () -> Void
 
-private struct NewWorkspaceActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
+    var toggleSidebar: Action? = nil
+    var toggleInspector: Action? = nil
+    var toggleTerminalPanel: Action? = nil
+    var openInEditor: Action? = nil
+    var openInBrowser: Action? = nil
+    var reloadWebSource: Action? = nil
+    var openDesktop: Action? = nil
+    var revealInFinder: Action? = nil
+    var copyPath: Action? = nil
+
+    static let empty = MainWindowFocusedActions()
 }
 
-private struct ToggleSidebarActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct ToggleInspectorActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct ToggleTerminalPanelActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct OpenInEditorActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct OpenInBrowserActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct ReloadWebSourceActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct OpenDesktopActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct RevealInFinderActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-private struct CopyPathActionKey: FocusedValueKey {
-    typealias Value = @MainActor () -> Void
-}
-
-extension FocusedValues {
-    var newWorkspaceAction: (@MainActor () -> Void)? {
-        get { self[NewWorkspaceActionKey.self] }
-        set { self[NewWorkspaceActionKey.self] = newValue }
-    }
-
-    var toggleSidebarAction: (@MainActor () -> Void)? {
-        get { self[ToggleSidebarActionKey.self] }
-        set { self[ToggleSidebarActionKey.self] = newValue }
-    }
-
-    var toggleInspectorAction: (@MainActor () -> Void)? {
-        get { self[ToggleInspectorActionKey.self] }
-        set { self[ToggleInspectorActionKey.self] = newValue }
-    }
-
-    var toggleTerminalPanelAction: (@MainActor () -> Void)? {
-        get { self[ToggleTerminalPanelActionKey.self] }
-        set { self[ToggleTerminalPanelActionKey.self] = newValue }
-    }
-
-    var openInEditorAction: (@MainActor () -> Void)? {
-        get { self[OpenInEditorActionKey.self] }
-        set { self[OpenInEditorActionKey.self] = newValue }
-    }
-
-    var openInBrowserAction: (@MainActor () -> Void)? {
-        get { self[OpenInBrowserActionKey.self] }
-        set { self[OpenInBrowserActionKey.self] = newValue }
-    }
-
-    var reloadWebSourceAction: (@MainActor () -> Void)? {
-        get { self[ReloadWebSourceActionKey.self] }
-        set { self[ReloadWebSourceActionKey.self] = newValue }
-    }
-
-    var openDesktopAction: (@MainActor () -> Void)? {
-        get { self[OpenDesktopActionKey.self] }
-        set { self[OpenDesktopActionKey.self] = newValue }
-    }
-
-    var revealInFinderAction: (@MainActor () -> Void)? {
-        get { self[RevealInFinderActionKey.self] }
-        set { self[RevealInFinderActionKey.self] = newValue }
-    }
-
-    var copyPathAction: (@MainActor () -> Void)? {
-        get { self[CopyPathActionKey.self] }
-        set { self[CopyPathActionKey.self] = newValue }
-    }
+@MainActor
+final class AppCommandState: ObservableObject {
+    @Published var newWorkspaceAction: (@MainActor () -> Void)?
+    @Published var mainWindowActions = MainWindowFocusedActions.empty
 }

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -19,6 +19,11 @@ struct WorkspaceManagerApp: App {
     @FocusedValue(\.toggleInspectorAction) private var toggleInspectorAction
     @FocusedValue(\.toggleTerminalPanelAction) private var toggleTerminalPanelAction
     @FocusedValue(\.openInEditorAction) private var openInEditorAction
+    @FocusedValue(\.openInBrowserAction) private var openInBrowserAction
+    @FocusedValue(\.reloadWebSourceAction) private var reloadWebSourceAction
+    @FocusedValue(\.openDesktopAction) private var openDesktopAction
+    @FocusedValue(\.revealInFinderAction) private var revealInFinderAction
+    @FocusedValue(\.copyPathAction) private var copyPathAction
     private let appRuntimeDependencies = AppRuntimeDependencies.resolved()
 
     var sharedModelContainer: ModelContainer = {
@@ -100,6 +105,35 @@ struct WorkspaceManagerApp: App {
             }
 
             SidebarCommands()
+
+            CommandMenu("Selection") {
+                Button("Open in Browser") {
+                    openInBrowserAction?()
+                }
+                .disabled(openInBrowserAction == nil)
+
+                Button("Reload Web Source") {
+                    reloadWebSourceAction?()
+                }
+                .disabled(reloadWebSourceAction == nil)
+
+                Divider()
+
+                Button("Open Desktop") {
+                    openDesktopAction?()
+                }
+                .disabled(openDesktopAction == nil)
+
+                Button("Reveal in Finder") {
+                    revealInFinderAction?()
+                }
+                .disabled(revealInFinderAction == nil)
+
+                Button("Copy Path") {
+                    copyPathAction?()
+                }
+                .disabled(copyPathAction == nil)
+            }
 
             CommandGroup(after: .help) {
                 Button("Export Diagnostic Report...") {
@@ -556,6 +590,26 @@ private struct OpenInEditorActionKey: FocusedValueKey {
     typealias Value = @MainActor () -> Void
 }
 
+private struct OpenInBrowserActionKey: FocusedValueKey {
+    typealias Value = @MainActor () -> Void
+}
+
+private struct ReloadWebSourceActionKey: FocusedValueKey {
+    typealias Value = @MainActor () -> Void
+}
+
+private struct OpenDesktopActionKey: FocusedValueKey {
+    typealias Value = @MainActor () -> Void
+}
+
+private struct RevealInFinderActionKey: FocusedValueKey {
+    typealias Value = @MainActor () -> Void
+}
+
+private struct CopyPathActionKey: FocusedValueKey {
+    typealias Value = @MainActor () -> Void
+}
+
 extension FocusedValues {
     var newWorkspaceAction: (@MainActor () -> Void)? {
         get { self[NewWorkspaceActionKey.self] }
@@ -580,5 +634,30 @@ extension FocusedValues {
     var openInEditorAction: (@MainActor () -> Void)? {
         get { self[OpenInEditorActionKey.self] }
         set { self[OpenInEditorActionKey.self] = newValue }
+    }
+
+    var openInBrowserAction: (@MainActor () -> Void)? {
+        get { self[OpenInBrowserActionKey.self] }
+        set { self[OpenInBrowserActionKey.self] = newValue }
+    }
+
+    var reloadWebSourceAction: (@MainActor () -> Void)? {
+        get { self[ReloadWebSourceActionKey.self] }
+        set { self[ReloadWebSourceActionKey.self] = newValue }
+    }
+
+    var openDesktopAction: (@MainActor () -> Void)? {
+        get { self[OpenDesktopActionKey.self] }
+        set { self[OpenDesktopActionKey.self] = newValue }
+    }
+
+    var revealInFinderAction: (@MainActor () -> Void)? {
+        get { self[RevealInFinderActionKey.self] }
+        set { self[RevealInFinderActionKey.self] = newValue }
+    }
+
+    var copyPathAction: (@MainActor () -> Void)? {
+        get { self[CopyPathActionKey.self] }
+        set { self[CopyPathActionKey.self] = newValue }
     }
 }

--- a/Sources/WorkspaceManager/Diagnostics/PerformanceExperimentFlags.swift
+++ b/Sources/WorkspaceManager/Diagnostics/PerformanceExperimentFlags.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum PerformanceExperimentFlags {
+    static let minimalToolbar =
+        ProcessInfo.processInfo.environment["WORKSPACES_PERF_MINIMAL_TOOLBAR"] == "1"
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
@@ -47,6 +47,12 @@ final class GhosttyAppManager: NSObject {
     func initializeIfNeeded() {
         guard !initialized else { return }
 
+        if let resourcesDirectory = GhosttyResourcesLocator.configureProcessEnvironment() {
+            NSLog("[GhosttyAppManager] using Ghostty resources dir: %@", resourcesDirectory.path)
+        } else {
+            NSLog("[GhosttyAppManager] Ghostty resources dir unavailable")
+        }
+
         let initResult = ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv)
         guard initResult == GHOSTTY_SUCCESS else {
             NSLog("[GhosttyAppManager] ghostty_init failed: %d", initResult)

--- a/Sources/WorkspaceManager/Terminal/GhosttyResourcesLocator.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyResourcesLocator.swift
@@ -1,0 +1,88 @@
+//
+//  GhosttyResourcesLocator.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+enum GhosttyResourcesLocator {
+    static let environmentVariableName = "GHOSTTY_RESOURCES_DIR"
+
+    static func bundledResourcesDirectory(
+        resourcesURL: URL?,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        guard let resourcesURL else { return nil }
+
+        let ghosttyDirectory = resourcesURL.appendingPathComponent("ghostty", isDirectory: true)
+        guard isUsableResourcesDirectory(ghosttyDirectory, fileManager: fileManager) else {
+            return nil
+        }
+
+        return ghosttyDirectory
+    }
+
+    static func resolvedResourcesDirectory(
+        existingEnvironmentValue: String?,
+        resourcesURL: URL?,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        if let existingDirectory = normalizedDirectoryURL(path: existingEnvironmentValue),
+            isUsableResourcesDirectory(existingDirectory, fileManager: fileManager)
+        {
+            return existingDirectory
+        }
+
+        return bundledResourcesDirectory(resourcesURL: resourcesURL, fileManager: fileManager)
+    }
+
+    @discardableResult
+    static func configureProcessEnvironment(
+        bundle: Bundle = .main,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let existingValue = environment[environmentVariableName]
+        guard
+            let directory = resolvedResourcesDirectory(
+                existingEnvironmentValue: existingValue,
+                resourcesURL: bundle.resourceURL,
+                fileManager: fileManager
+            )
+        else {
+            return nil
+        }
+
+        if normalizedDirectoryURL(path: existingValue)?.path != directory.path {
+            setenv(environmentVariableName, directory.path, 1)
+        }
+
+        return directory
+    }
+
+    private static func normalizedDirectoryURL(path: String?) -> URL? {
+        guard let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !trimmed.isEmpty
+        else {
+            return nil
+        }
+
+        return URL(fileURLWithPath: trimmed, isDirectory: true)
+    }
+
+    private static func isUsableResourcesDirectory(
+        _ directory: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        guard fileManager.fileExists(atPath: directory.path) else {
+            return false
+        }
+
+        let terminfoParent = directory.deletingLastPathComponent()
+        let terminfoSentinel = terminfoParent.appendingPathComponent(
+            "terminfo/78/xterm-ghostty",
+            isDirectory: false
+        )
+        return fileManager.fileExists(atPath: terminfoSentinel.path)
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -16,10 +16,23 @@ private let creationLog = Logger(
     category: "WorkspaceCreation"
 )
 
+private struct MainWindowCommandAvailabilitySnapshot: Equatable {
+    let canToggleSidebar: Bool
+    let canToggleInspector: Bool
+    let canToggleTerminalPanel: Bool
+    let canOpenInEditor: Bool
+    let canOpenInBrowser: Bool
+    let canReloadWebSource: Bool
+    let canOpenDesktop: Bool
+    let canRevealInFinder: Bool
+    let canCopyPath: Bool
+}
+
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Binding var deepLinkState: WorkspaceDeepLinkState
     @Binding var lastSurfaceRawValue: String
+    @ObservedObject var appCommandState: AppCommandState
     @ObservedObject var hostTerminalState: HostTerminalStateStore
     @ObservedObject var workspaceProviderSetupCoordinator: WorkspaceProviderSetupCoordinator
     @ObservedObject var hostLumeSmokeAutomation: HostLumeSmokeAutomationController
@@ -239,9 +252,7 @@ struct ContentView: View {
             selectedWorkspaceSupportsDesktop,
             workspace.status != .provisioning
         else { return nil }
-        return { @MainActor in
-            openDesktop(for: workspace)
-        }
+        return openDesktopForCurrentSelection
     }
 
     private var revealInFinderFocusedAction: (@MainActor () -> Void)? {
@@ -252,6 +263,34 @@ struct ContentView: View {
     private var copyPathFocusedAction: (@MainActor () -> Void)? {
         guard openInEditorTarget != nil else { return nil }
         return copyWorkspacePath
+    }
+
+    private var mainWindowFocusedActions: MainWindowFocusedActions {
+        MainWindowFocusedActions(
+            toggleSidebar: toggleSidebarVisibility,
+            toggleInspector: toggleInspectorVisibility,
+            toggleTerminalPanel: toggleTerminalPanelVisibility,
+            openInEditor: openInEditorFocusedAction,
+            openInBrowser: openInBrowserFocusedAction,
+            reloadWebSource: reloadWebSourceFocusedAction,
+            openDesktop: openDesktopFocusedAction,
+            revealInFinder: revealInFinderFocusedAction,
+            copyPath: copyPathFocusedAction
+        )
+    }
+
+    private var mainWindowCommandAvailabilitySnapshot: MainWindowCommandAvailabilitySnapshot {
+        MainWindowCommandAvailabilitySnapshot(
+            canToggleSidebar: true,
+            canToggleInspector: true,
+            canToggleTerminalPanel: true,
+            canOpenInEditor: openInEditorFocusedAction != nil,
+            canOpenInBrowser: openInBrowserFocusedAction != nil,
+            canReloadWebSource: reloadWebSourceFocusedAction != nil,
+            canOpenDesktop: openDesktopFocusedAction != nil,
+            canRevealInFinder: revealInFinderFocusedAction != nil,
+            canCopyPath: copyPathFocusedAction != nil
+        )
     }
 
     private var selectedWorkspaceProviderDescriptor: WorkspaceProviderDescriptor? {
@@ -356,6 +395,7 @@ struct ContentView: View {
     private var baseSplitView: some View {
         NavigationSplitView(columnVisibility: $viewState.columnVisibility) {
             SidebarView(
+                appCommandState: appCommandState,
                 repos: repos,
                 webSources: webSources,
                 selectedRepo: selectedRepoForSidebar,
@@ -486,15 +526,6 @@ struct ContentView: View {
 
     private var splitViewWithFocusAndAlerts: some View {
         splitViewWithLifecycleHandlers
-            .focusedSceneValue(\.toggleSidebarAction, toggleSidebarVisibility)
-            .focusedSceneValue(\.toggleInspectorAction, toggleInspectorVisibility)
-            .focusedSceneValue(\.toggleTerminalPanelAction, toggleTerminalPanelVisibility)
-            .focusedSceneValue(\.openInEditorAction, openInEditorFocusedAction)
-            .focusedSceneValue(\.openInBrowserAction, openInBrowserFocusedAction)
-            .focusedSceneValue(\.reloadWebSourceAction, reloadWebSourceFocusedAction)
-            .focusedSceneValue(\.openDesktopAction, openDesktopFocusedAction)
-            .focusedSceneValue(\.revealInFinderAction, revealInFinderFocusedAction)
-            .focusedSceneValue(\.copyPathAction, copyPathFocusedAction)
             .alert(
                 "Could Not Open Editor",
                 isPresented: isShowingOpenInEditorError
@@ -608,6 +639,15 @@ struct ContentView: View {
 
     var body: some View {
         splitViewWithFocusAndAlerts
+            .task {
+                syncAppCommands()
+            }
+            .onChange(of: mainWindowCommandAvailabilitySnapshot) { _, _ in
+                syncAppCommands()
+            }
+            .onDisappear {
+                clearAppCommands()
+            }
             .sheet(item: $repoForNewWorkspaceFromLanding) { repo in
                 NewWorkspaceSheet(
                     repo: repo,
@@ -1558,6 +1598,18 @@ struct ContentView: View {
     }
 
     @MainActor
+    private func openDesktopForCurrentSelection() {
+        guard let workspace = currentSelectedWorkspace,
+            selectedWorkspaceSupportsDesktop,
+            workspace.status != .provisioning
+        else {
+            return
+        }
+
+        openDesktop(for: workspace)
+    }
+
+    @MainActor
     private func openDesktopAfterSetup(
         _ workspace: Workspace,
         provider: any WorkspaceProviderProtocol
@@ -1722,6 +1774,16 @@ struct ContentView: View {
     private func clearCodePreview() {
         viewState.selectedCodePreview = nil
         viewState.isTerminalPanelVisible = true
+    }
+
+    @MainActor
+    private func syncAppCommands() {
+        appCommandState.mainWindowActions = mainWindowFocusedActions
+    }
+
+    @MainActor
+    private func clearAppCommands() {
+        appCommandState.mainWindowActions = .empty
     }
 
     private func persistLastSurface(_ surface: MainWindowLastSurface) {
@@ -2091,6 +2153,7 @@ struct WorkspaceConnectingOverlay: View {
 private struct ContentViewPreviewHost: View {
     @State private var deepLinkState = WorkspaceDeepLinkState()
     @State private var lastSurfaceRawValue = ""
+    @StateObject private var appCommandState = AppCommandState()
     @StateObject private var hostTerminalState = HostTerminalStateStore()
     @StateObject private var workspaceProviderSetupCoordinator = WorkspaceProviderSetupCoordinator()
     @StateObject private var hostLumeSmokeAutomation = HostLumeSmokeAutomationController(
@@ -2101,6 +2164,7 @@ private struct ContentViewPreviewHost: View {
         ContentView(
             deepLinkState: $deepLinkState,
             lastSurfaceRawValue: $lastSurfaceRawValue,
+            appCommandState: appCommandState,
             hostTerminalState: hostTerminalState,
             workspaceProviderSetupCoordinator: workspaceProviderSetupCoordinator,
             hostLumeSmokeAutomation: hostLumeSmokeAutomation

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -224,6 +224,36 @@ struct ContentView: View {
         return openInDefaultEditor
     }
 
+    private var openInBrowserFocusedAction: (@MainActor () -> Void)? {
+        guard currentSelectedWebSource?.baseURL != nil else { return nil }
+        return openSelectedWebSourceInBrowser
+    }
+
+    private var reloadWebSourceFocusedAction: (@MainActor () -> Void)? {
+        guard currentSelectedWebSource != nil else { return nil }
+        return reloadSelectedWebSource
+    }
+
+    private var openDesktopFocusedAction: (@MainActor () -> Void)? {
+        guard let workspace = currentSelectedWorkspace,
+            selectedWorkspaceSupportsDesktop,
+            workspace.status != .provisioning
+        else { return nil }
+        return { @MainActor in
+            openDesktop(for: workspace)
+        }
+    }
+
+    private var revealInFinderFocusedAction: (@MainActor () -> Void)? {
+        guard openInEditorTarget != nil else { return nil }
+        return revealInFinder
+    }
+
+    private var copyPathFocusedAction: (@MainActor () -> Void)? {
+        guard openInEditorTarget != nil else { return nil }
+        return copyWorkspacePath
+    }
+
     private var selectedWorkspaceProviderDescriptor: WorkspaceProviderDescriptor? {
         guard let workspace = currentSelectedWorkspace else { return nil }
         return workspaceProviderRegistry.provider(for: workspace)?.descriptor
@@ -351,66 +381,30 @@ struct ContentView: View {
     }
 
     private var splitViewWithToolbar: some View {
-        baseSplitView
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    AppBuildIdentityBadge(identity: buildIdentity)
-                }
-
-                ToolbarItemGroup(placement: .automatic) {
-                    if let selectedWebSource = currentSelectedWebSource {
-                        Button {
-                            openSelectedWebSourceInBrowser()
-                        } label: {
-                            Image(systemName: "safari")
+        Group {
+            if PerformanceExperimentFlags.minimalToolbar {
+                baseSplitView
+            } else {
+                baseSplitView
+                    .toolbar {
+                        ToolbarItem(placement: .principal) {
+                            AppBuildIdentityBadge(identity: buildIdentity)
                         }
-                        .help("Open in Browser")
-                        .disabled(selectedWebSource.baseURL == nil)
 
-                        Button {
-                            reloadSelectedWebSource()
-                        } label: {
-                            Image(systemName: "arrow.clockwise")
-                        }
-                        .help("Reload")
-                        .disabled(selectedWebSource.baseURL == nil)
-                    } else if let workspace = currentSelectedWorkspace {
-                        if selectedWorkspaceSupportsDesktop {
+                        ToolbarItemGroup(placement: .primaryAction) {
                             Button {
-                                openDesktop(for: workspace)
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    viewState.isRightPaneVisible.toggle()
+                                }
                             } label: {
-                                Image(systemName: "desktopcomputer")
+                                Image(systemName: "sidebar.trailing")
                             }
-                            .help("Open Desktop")
-                            .disabled(workspace.status == .provisioning)
-                        }
-
-                        if let defaultEditor = defaultEditorDescriptor {
-                            WorkspaceEditorToolbarButton(
-                                workspaceName: workspace.name,
-                                editorOptions: availableEditors,
-                                defaultEditor: defaultEditor,
-                                onOpenInDefaultEditor: openInDefaultEditor,
-                                onOpenInEditor: openInSelectedEditor,
-                                onRevealInFinder: revealInFinder,
-                                onCopyPath: copyWorkspacePath
-                            )
+                            .help(viewState.isRightPaneVisible ? "Hide Inspector" : "Show Inspector")
+                            .disabled(!hasInspectorTarget)
                         }
                     }
-                }
-
-                ToolbarItemGroup(placement: .primaryAction) {
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            viewState.isRightPaneVisible.toggle()
-                        }
-                    } label: {
-                        Image(systemName: "sidebar.trailing")
-                    }
-                    .help(viewState.isRightPaneVisible ? "Hide Inspector" : "Show Inspector")
-                    .disabled(!hasInspectorTarget)
-                }
             }
+        }
     }
 
     private var splitViewWithLifecycleHandlers: some View {
@@ -496,6 +490,11 @@ struct ContentView: View {
             .focusedSceneValue(\.toggleInspectorAction, toggleInspectorVisibility)
             .focusedSceneValue(\.toggleTerminalPanelAction, toggleTerminalPanelVisibility)
             .focusedSceneValue(\.openInEditorAction, openInEditorFocusedAction)
+            .focusedSceneValue(\.openInBrowserAction, openInBrowserFocusedAction)
+            .focusedSceneValue(\.reloadWebSourceAction, reloadWebSourceFocusedAction)
+            .focusedSceneValue(\.openDesktopAction, openDesktopFocusedAction)
+            .focusedSceneValue(\.revealInFinderAction, revealInFinderFocusedAction)
+            .focusedSceneValue(\.copyPathAction, copyPathFocusedAction)
             .alert(
                 "Could Not Open Editor",
                 isPresented: isShowingOpenInEditorError

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -147,26 +147,32 @@ struct RepoRow: View {
     }
 
     var body: some View {
+        let repoName = repo.name
         let workspaceCount = repo.workspaces.count
         let showsVisibleQuickActions = showsQuickActions && isHovering
+        let accessibilityDescription =
+            "\(repoName), \(workspaceCount) workspace\(workspaceCount == 1 ? "" : "s"), \(sessionActivity.accessibilityDescription)"
+            + (SidebarSessionActivity.showsPaneCountBadge(for: paneCount) ? ", \(paneCount) panes" : "")
+            + ", \(isExpanded ? "expanded" : "collapsed")"
 
         HStack(spacing: 10) {
             Button(action: onToggleExpansion) {
                 repoFolderIcon
             }
             .buttonStyle(.plain)
-            .help(isExpanded ? "Collapse \(repo.name)" : "Expand \(repo.name)")
+            .help(isExpanded ? "Collapse \(repoName)" : "Expand \(repoName)")
 
             Button(action: onSelectRepo) {
-                repoLabelContent(workspaceCount: workspaceCount)
+                repoLabelContent(repoName: repoName, workspaceCount: workspaceCount)
             }
             .buttonStyle(.plain)
 
             if showsQuickActions {
-                repoActionMenu
-                    .opacity(showsVisibleQuickActions ? 1 : 0)
-                    .allowsHitTesting(showsVisibleQuickActions)
-                    .accessibilityHidden(!showsVisibleQuickActions)
+                if showsVisibleQuickActions {
+                    repoActionMenu
+                } else {
+                    repoActionMenuPlaceholder
+                }
             }
         }
         .padding(.vertical, 2)
@@ -176,16 +182,10 @@ struct RepoRow: View {
                 .fill(isSelected ? Color.accentColor.opacity(0.1) : .clear)
         )
         .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.12)) {
-                isHovering = hovering
-            }
+            isHovering = hovering
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(
-            "\(repo.name), \(repo.workspaces.count) workspace\(repo.workspaces.count == 1 ? "" : "s"), \(sessionActivity.accessibilityDescription)"
-                + (SidebarSessionActivity.showsPaneCountBadge(for: paneCount) ? ", \(paneCount) panes" : "")
-                + ", \(isExpanded ? "expanded" : "collapsed")"
-        )
+        .accessibilityLabel(accessibilityDescription)
     }
 
     private var repoFolderIcon: some View {
@@ -199,9 +199,9 @@ struct RepoRow: View {
             .contentTransition(.symbolEffect(.replace))
     }
 
-    private func repoLabelContent(workspaceCount: Int) -> some View {
+    private func repoLabelContent(repoName: String, workspaceCount: Int) -> some View {
         HStack(spacing: 10) {
-            Text(repo.name)
+            Text(repoName)
                 .font(.callout.weight(isSelected || sessionActivity.isActive ? .semibold : .regular))
                 .lineLimit(1)
 
@@ -222,6 +222,12 @@ struct RepoRow: View {
             }
         }
         .contentShape(Rectangle())
+    }
+
+    private var repoActionMenuPlaceholder: some View {
+        Color.clear
+            .frame(width: 22, height: 22)
+            .accessibilityHidden(true)
     }
 
     private var repoActionMenu: some View {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -124,124 +124,135 @@ struct SidebarView: View {
     }
 
     var body: some View {
-        sidebarList
-            .listStyle(.sidebar)
-            .environment(\.defaultMinListRowHeight, 34)
-            .safeAreaInset(edge: .bottom) {
-                footerBar
-            }
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    addSourceMenu
-                }
-            }
-            .fileImporter(
-                isPresented: $isAddingRepo,
-                allowedContentTypes: [.folder],
-                allowsMultipleSelection: false
-            ) { result in
-                if case .success(let urls) = result, let url = urls.first {
-                    Task {
-                        await addRepo(from: url)
+        Group {
+            if PerformanceExperimentFlags.minimalToolbar {
+                sidebarList
+                    .listStyle(.sidebar)
+                    .environment(\.defaultMinListRowHeight, 34)
+                    .safeAreaInset(edge: .bottom) {
+                        footerBar
                     }
-                }
-            }
-            .sheet(item: $newWorkspaceSheetContext) { context in
-                NewWorkspaceSheet(
-                    repo: context.repo,
-                    environmentOptions: environmentOptions(for: context.repo),
-                    isPreparingEnvironmentOptions: isPreparingNewWorkspaceSheet,
-                    isCreateDisabled: isCreatingWorkspace(for: context.repo.id)
-                ) { name, nameSource, providerID, guestOS in
-                    Task { @MainActor in
-                        await createWorkspace(
-                            from: context.repo,
-                            name: name,
-                            nameSource: nameSource,
-                            providerID: providerID,
-                            guestOS: guestOS
-                        )
+            } else {
+                sidebarList
+                    .listStyle(.sidebar)
+                    .environment(\.defaultMinListRowHeight, 34)
+                    .safeAreaInset(edge: .bottom) {
+                        footerBar
                     }
-                }
-            }
-            .alert("Error", isPresented: $showingError) {
-                Button("OK", role: .cancel) {}
-
-                if shouldOfferLumeRecoveryActions {
-                    Button("Open VM Runtime") {
-                        openSettingsWindow()
+                    .toolbar {
+                        ToolbarItem(placement: .primaryAction) {
+                            addSourceMenu
+                        }
                     }
-
-                    Button("Open Lume Log") {
-                        openLumeLog()
-                    }
-                }
-            } message: {
-                Text(errorMessage ?? "An unknown error occurred")
             }
-            .confirmationDialog(
-                "Delete Workspace",
-                isPresented: $showingDeleteConfirmation,
-                presenting: workspaceToDelete
-            ) { workspace in
-                Button("Delete (Keep Files)", role: .destructive) {
-                    Task { @MainActor in
-                        await performDelete(workspace, deleteFiles: false)
-                    }
-                }
-                Button("Delete and Remove Files", role: .destructive) {
-                    Task { @MainActor in
-                        await performDelete(workspace, deleteFiles: true)
-                    }
-                }
-                Button("Cancel", role: .cancel) {
-                    workspaceToDelete = nil
-                }
-            } message: { workspace in
-                Text("Are you sure you want to delete '\(workspace.name)'?")
-            }
-            .focusedSceneValue(\.newWorkspaceAction, handleNewWorkspaceShortcut)
-            .onChange(of: selectedWorkspace?.id) { _, _ in
-                expandRepoForSelectedWorkspace()
-            }
-            .onChange(of: selectedWebSource?.id) { _, _ in
-                expandContainersForSelectedWebSource()
-            }
-            .onChange(of: repos.map(\.id)) { _, _ in
-                pruneExpandedRepos()
-                pruneExpandedWorkspaces()
-                syncRepoSortSnapshot()
-                Task { @MainActor in
-                    await maybeDriveHostLumeSmokeAutomation()
-                }
-            }
-            .onChange(of: repoSortModeRawValue) { _, _ in
-                syncRepoSortSnapshot(forceRefresh: true)
-            }
-            .onAppear {
-                initializeExpandedReposIfNeeded()
-                expandContainersForSelectedWebSource()
-                syncRepoSortSnapshot(forceRefresh: false)
-                guard !isRepoAutoImportDisabled else { return }
-                guard !didAttemptDefaultRepoImport else { return }
-                didAttemptDefaultRepoImport = true
+        }
+        .fileImporter(
+            isPresented: $isAddingRepo,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            if case .success(let urls) = result, let url = urls.first {
                 Task {
-                    await autoImportReposFromCodeHome()
+                    await addRepo(from: url)
                 }
             }
-            .task {
-                _ = await seedFixtureProviderStateIfNeeded()
-                await maybeDriveHostLumeSmokeAutomation()
-            }
-            .onChange(of: errorMessage) { _, message in
-                guard let message else { return }
+        }
+        .sheet(item: $newWorkspaceSheetContext) { context in
+            NewWorkspaceSheet(
+                repo: context.repo,
+                environmentOptions: environmentOptions(for: context.repo),
+                isPreparingEnvironmentOptions: isPreparingNewWorkspaceSheet,
+                isCreateDisabled: isCreatingWorkspace(for: context.repo.id)
+            ) { name, nameSource, providerID, guestOS in
                 Task { @MainActor in
-                    await hostLumeSmokeAutomation.noteFailure(
-                        message: message,
-                        recoveryHints: hostLumeSmokeRecoveryHints(for: message)
+                    await createWorkspace(
+                        from: context.repo,
+                        name: name,
+                        nameSource: nameSource,
+                        providerID: providerID,
+                        guestOS: guestOS
                     )
                 }
             }
+        }
+        .alert("Error", isPresented: $showingError) {
+            Button("OK", role: .cancel) {}
+
+            if shouldOfferLumeRecoveryActions {
+                Button("Open VM Runtime") {
+                    openSettingsWindow()
+                }
+
+                Button("Open Lume Log") {
+                    openLumeLog()
+                }
+            }
+        } message: {
+            Text(errorMessage ?? "An unknown error occurred")
+        }
+        .confirmationDialog(
+            "Delete Workspace",
+            isPresented: $showingDeleteConfirmation,
+            presenting: workspaceToDelete
+        ) { workspace in
+            Button("Delete (Keep Files)", role: .destructive) {
+                Task { @MainActor in
+                    await performDelete(workspace, deleteFiles: false)
+                }
+            }
+            Button("Delete and Remove Files", role: .destructive) {
+                Task { @MainActor in
+                    await performDelete(workspace, deleteFiles: true)
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                workspaceToDelete = nil
+            }
+        } message: { workspace in
+            Text("Are you sure you want to delete '\(workspace.name)'?")
+        }
+        .focusedSceneValue(\.newWorkspaceAction, handleNewWorkspaceShortcut)
+        .onChange(of: selectedWorkspace?.id) { _, _ in
+            expandRepoForSelectedWorkspace()
+        }
+        .onChange(of: selectedWebSource?.id) { _, _ in
+            expandContainersForSelectedWebSource()
+        }
+        .onChange(of: repos.map(\.id)) { _, _ in
+            pruneExpandedRepos()
+            pruneExpandedWorkspaces()
+            syncRepoSortSnapshot()
+            Task { @MainActor in
+                await maybeDriveHostLumeSmokeAutomation()
+            }
+        }
+        .onChange(of: repoSortModeRawValue) { _, _ in
+            syncRepoSortSnapshot(forceRefresh: true)
+        }
+        .onAppear {
+            initializeExpandedReposIfNeeded()
+            expandContainersForSelectedWebSource()
+            syncRepoSortSnapshot(forceRefresh: false)
+            guard !isRepoAutoImportDisabled else { return }
+            guard !didAttemptDefaultRepoImport else { return }
+            didAttemptDefaultRepoImport = true
+            Task {
+                await autoImportReposFromCodeHome()
+            }
+        }
+        .task {
+            _ = await seedFixtureProviderStateIfNeeded()
+            await maybeDriveHostLumeSmokeAutomation()
+        }
+        .onChange(of: errorMessage) { _, message in
+            guard let message else { return }
+            Task { @MainActor in
+                await hostLumeSmokeAutomation.noteFailure(
+                    message: message,
+                    recoveryHints: hostLumeSmokeRecoveryHints(for: message)
+                )
+            }
+        }
     }
 
     private var sidebarList: some View {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -36,6 +36,7 @@ struct SidebarView: View {
     @Environment(\.lumeRuntimeService) private var lumeRuntimeService
     @Environment(\.workspaceService) private var workspaceService
     @Environment(\.workspaceProviderRegistry) private var workspaceProviderRegistry
+    @ObservedObject var appCommandState: AppCommandState
     let repos: [Repo]
     let webSources: [WebSource]
     let selectedRepo: Repo?
@@ -211,7 +212,12 @@ struct SidebarView: View {
         } message: { workspace in
             Text("Are you sure you want to delete '\(workspace.name)'?")
         }
-        .focusedSceneValue(\.newWorkspaceAction, handleNewWorkspaceShortcut)
+        .task {
+            syncAppCommands()
+        }
+        .onDisappear {
+            clearAppCommands()
+        }
         .onChange(of: selectedWorkspace?.id) { _, _ in
             expandRepoForSelectedWorkspace()
         }
@@ -1009,6 +1015,16 @@ struct SidebarView: View {
         Task { @MainActor in
             await prepareNewWorkspaceSheet(for: preferredRepo)
         }
+    }
+
+    @MainActor
+    private func syncAppCommands() {
+        appCommandState.newWorkspaceAction = handleNewWorkspaceShortcut
+    }
+
+    @MainActor
+    private func clearAppCommands() {
+        appCommandState.newWorkspaceAction = nil
     }
 
     @MainActor

--- a/Tests/WorkspaceManagerAppTests/GhosttyResourcesLocatorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyResourcesLocatorTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyResourcesLocator")
+struct GhosttyResourcesLocatorTests {
+    @Test("bundled resources directory resolves when Ghostty resources are embedded")
+    func bundledResourcesDirectoryResolvesEmbeddedLayout() throws {
+        let fixture = try GhosttyResourcesFixture()
+        defer { fixture.cleanup() }
+
+        let resolved = GhosttyResourcesLocator.bundledResourcesDirectory(
+            resourcesURL: fixture.resourcesURL
+        )
+
+        #expect(resolved?.path == fixture.ghosttyURL.path)
+    }
+
+    @Test("resolved resources directory prefers a valid existing environment path")
+    func resolvedResourcesDirectoryPrefersEnvironment() throws {
+        let fixture = try GhosttyResourcesFixture()
+        defer { fixture.cleanup() }
+
+        let customRoot = try fixture.makeAlternateResourcesRoot(named: "custom")
+        let resolved = GhosttyResourcesLocator.resolvedResourcesDirectory(
+            existingEnvironmentValue: customRoot.appendingPathComponent("ghostty", isDirectory: true).path,
+            resourcesURL: fixture.resourcesURL
+        )
+
+        #expect(resolved?.path == customRoot.appendingPathComponent("ghostty", isDirectory: true).path)
+    }
+
+    @Test("resolved resources directory falls back to bundled resources when environment path is unusable")
+    func resolvedResourcesDirectoryFallsBackToBundle() throws {
+        let fixture = try GhosttyResourcesFixture()
+        defer { fixture.cleanup() }
+
+        let invalidPath = fixture.rootURL.appendingPathComponent("missing/ghostty", isDirectory: true).path
+        let resolved = GhosttyResourcesLocator.resolvedResourcesDirectory(
+            existingEnvironmentValue: invalidPath,
+            resourcesURL: fixture.resourcesURL
+        )
+
+        #expect(resolved?.path == fixture.ghosttyURL.path)
+    }
+}
+
+private struct GhosttyResourcesFixture {
+    let rootURL: URL
+    let resourcesURL: URL
+    let ghosttyURL: URL
+
+    init() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let resourcesURL = rootURL.appendingPathComponent("Resources", isDirectory: true)
+        let ghosttyURL = resourcesURL.appendingPathComponent("ghostty", isDirectory: true)
+        let terminfoURL = resourcesURL.appendingPathComponent("terminfo/78", isDirectory: true)
+
+        try FileManager.default.createDirectory(at: ghosttyURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: terminfoURL, withIntermediateDirectories: true)
+        FileManager.default.createFile(
+            atPath: terminfoURL.appendingPathComponent("xterm-ghostty", isDirectory: false).path,
+            contents: Data("terminfo".utf8)
+        )
+
+        self.rootURL = rootURL
+        self.resourcesURL = resourcesURL
+        self.ghosttyURL = ghosttyURL
+    }
+
+    func makeAlternateResourcesRoot(named name: String) throws -> URL {
+        let otherResourcesURL = rootURL.appendingPathComponent(name, isDirectory: true)
+        let ghosttyURL = otherResourcesURL.appendingPathComponent("ghostty", isDirectory: true)
+        let terminfoURL = otherResourcesURL.appendingPathComponent("terminfo/78", isDirectory: true)
+        try FileManager.default.createDirectory(at: ghosttyURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: terminfoURL, withIntermediateDirectories: true)
+        FileManager.default.createFile(
+            atPath: terminfoURL.appendingPathComponent("xterm-ghostty", isDirectory: false).path,
+            contents: Data("terminfo".utf8)
+        )
+        return otherResourcesURL
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+}

--- a/docs/performance/2026-04-08-global-slowness-learnings.md
+++ b/docs/performance/2026-04-08-global-slowness-learnings.md
@@ -21,6 +21,7 @@ The strongest contributors found so far are:
 2. the contextual toolbar item in `ContentView.swift`
 3. focus/window timing that still leaves some events stale before they reach the terminal handler
 4. residual SwiftUI preference and toolbar bridge churn after the contextual toolbar item is removed
+5. installed-build Ghostty resources were previously missing, which degraded shell integration and terminfo setup
 
 Shortcut pass-through is working. In the latest shortcut-specific run, Ghostty actions fired for split and pane navigation. The delay remained upstream of the key handler.
 
@@ -93,6 +94,34 @@ Interpretation:
 
 - the current remaining hotspot is still app-side view and preference churn
 - the next work should not go back to shell-startup or Ghostty shortcut-routing theories
+
+## New Follow-up Learnings
+
+### Installed builds need explicit Ghostty resources
+
+The installed-build report that looked much better overall still exposed a real packaging problem:
+
+- `ghostty terminfo not found`
+- `no resources dir set, shell integration disabled`
+
+That is now addressed in code by:
+
+- embedding Ghostty `share` resources into the release app bundle
+- setting `GHOSTTY_RESOURCES_DIR` before `ghostty_init`
+
+This should improve installed-build terminal readiness and keep shell integration available.
+
+### App commands no longer depend on `FocusedValue`
+
+The initial command-menu recovery used focused scene values. A later installed-build report still showed:
+
+- `FocusedValue update tried to update multiple times per frame`
+
+Collapsing many focused values into one payload was not enough, so app-command routing now uses an observable `AppCommandState` instead of `FocusedValue`.
+
+What remains open:
+
+- we still need one fresh manual diagnostic run on the new packaged build to confirm whether that SwiftUI warning is actually gone in practice
 
 ## Product Direction From Current Evidence
 

--- a/docs/performance/2026-04-08-global-slowness-learnings.md
+++ b/docs/performance/2026-04-08-global-slowness-learnings.md
@@ -1,0 +1,141 @@
+# Global Slowness Learnings
+
+Date: 2026-04-08
+Branch: `codex/workspaces-perf-optimization`
+Status: active reference
+
+This file is the short reference for the current Workspaces performance investigation.
+
+Use it together with:
+
+- [investigation-2026-04-07-global-slowness-and-input-latency.md](/Users/fairchild/.worktrees/workspaces/codex/workspaces-perf-optimization/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md)
+- [investigation-2026-04-07-global-slowness-and-input-latency-log.md](/Users/fairchild/.worktrees/workspaces/codex/workspaces-perf-optimization/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency-log.md)
+
+## Current Best Read
+
+The dominant local slowness is not shell startup and not Ghostty key handling itself.
+
+The strongest contributors found so far are:
+
+1. sidebar row hover/menu/help churn in `SidebarRows.swift`
+2. the contextual toolbar item in `ContentView.swift`
+3. focus/window timing that still leaves some events stale before they reach the terminal handler
+4. residual SwiftUI preference and toolbar bridge churn after the contextual toolbar item is removed
+
+Shortcut pass-through is working. In the latest shortcut-specific run, Ghostty actions fired for split and pane navigation. The delay remained upstream of the key handler.
+
+## What Actually Improved Performance
+
+### Repo row cleanup
+
+The repo row optimization in `SidebarRows.swift` was a real win.
+
+Key effects:
+
+- removed hover animation
+- stopped building hidden quick-action menus
+- reduced repeated row-label/accessibility recomputation
+
+Representative improvement:
+
+- `input event_age_ms` dropped from about `1198.85 ms` median to about `17.47 ms`
+
+### Removing the contextual toolbar item
+
+The toolbar itself is not the whole problem. The expensive part is the contextual toolbar item.
+
+Post-prompt automated measurements on the same clean-shell interaction pattern:
+
+- normal toolbar:
+  - `event_age_ms` median `60.81 ms`
+  - `repo_click_to_focus` `3885.80 ms`
+- full minimal toolbar:
+  - `event_age_ms` median `11.10 ms`
+  - `repo_click_to_focus` `1170.99 ms`
+- toolbar kept, contextual toolbar item removed:
+  - `event_age_ms` median `18.77 ms`
+  - `repo_click_to_focus` `1158.80 ms`
+
+Conclusion:
+
+- removing just the contextual toolbar item preserves most of the performance gain
+- that is the current best product-safe direction
+- repeated post-prompt reruns are still variable, which means there is at least one more residual source of stale input beyond the toolbar fix
+
+## Fresh Branch Validation
+
+The current branch was remeasured after the command-menu re-home.
+
+Corrected clean-shell post-prompt run on the current branch:
+
+- `event_age_ms` min `0.95 ms`, median `3.40 ms`, max `476.70 ms`, mean `133.90 ms`
+- `handler_duration_ms` median `0.11 ms`
+- `repo_click_to_focus` `1031.94 ms`
+- `launch_to_first_prompt` `3621.46 ms`
+
+Interpretation:
+
+- most key events now reach the app quickly once the terminal is actually ready
+- the key handler itself remains cheap
+- there are still intermittent spikes, which means the issue is not fully closed
+
+Fresh active-lag sample on the same no-context-toolbar build:
+
+- shell remained blocked in `read`
+- the app sample still concentrated on:
+  - `NSHostingView.layout`
+  - `NSHostingView.preferencesDidChange`
+  - `AppWindowsController.updateWindowFocus`
+  - `ToolbarBridge.preferencesDidChange`
+  - `RepoRow.body`
+
+Interpretation:
+
+- the current remaining hotspot is still app-side view and preference churn
+- the next work should not go back to shell-startup or Ghostty shortcut-routing theories
+
+## Product Direction From Current Evidence
+
+Keep:
+
+- the sidebar row optimization
+- the rest of the toolbar
+- the minimal-toolbar experiment flag for future A/B work
+
+Avoid:
+
+- putting dynamic contextual actions back into the toolbar path
+
+Instead:
+
+- re-home those actions into cheaper UI surfaces, such as the app menu or inspector-side UI
+
+## Current Mergeable Shape
+
+The current branch keeps the contextual toolbar item out of the toolbar and restores the missing actions through the app menu `Selection` command group.
+
+Recovered outside the toolbar:
+
+- Open in Browser
+- Reload Web Source
+- Open Desktop
+- Reveal in Finder
+- Copy Path
+
+`Open in...` was already available through the existing app command path and did not need to be restored through the toolbar.
+
+## Remaining Open Question
+
+After the toolbar change, some residual stale input remains. The next investigation step should be:
+
+1. reduce the remaining sidebar and preference churn that still shows up in `RepoRow.body`, `View.help`, and `ToolbarBridge`
+2. separate toolbar bridge churn from focused-scene-value churn so command-menu recovery work does not mask the real bottleneck
+3. remeasure the same clean-shell post-prompt interaction after the next SwiftUI-side reduction
+
+Recent repeated reruns on the no-context-toolbar build showed this variability directly:
+
+- one post-prompt run measured `event_age_ms` median around `18.77 ms`
+- later reruns measured around `309.87 ms` and `749.26 ms`
+- the latest corrected post-prompt run measured `event_age_ms` median `3.40 ms`, but still saw a `476.70 ms` max spike
+
+That means the toolbar fix is real, but not sufficient to fully close the issue.

--- a/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency-log.md
+++ b/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency-log.md
@@ -1,0 +1,405 @@
+# Experiment Log: Global Slowness And Input Latency
+
+Date: 2026-04-07
+Branch: `codex/workspaces-perf-optimization`
+
+Use this file as the append-only experiment log for this investigation.
+
+## Baseline
+
+### EXP-0001: Local active-lag capture against installed app
+
+Status: complete
+
+Setup:
+
+- captured live lag against installed `WorkspaceManager`
+- target app PID: `22196`
+
+Artifacts:
+
+- `/tmp/workspaces-active-lag-local-20260407/summary.txt`
+- `/tmp/workspaces-active-lag-local-20260407/sample-app-22196.txt`
+- `/tmp/workspaces-active-lag-local-20260407/sample-child-22307.txt`
+
+Result:
+
+- app sample succeeded
+- shell sample succeeded
+- shell was idle in `read`
+- app main thread mostly parked in normal event loop with some render/transaction work
+
+Takeaway:
+
+- this did not implicate the child shell
+
+### EXP-0002: Local host probe across repo, worktree, and home
+
+Status: complete
+
+Setup:
+
+- ran `host_perf_probe.py`
+- directories:
+  - `/Users/fairchild/code/workspaces`
+  - `/Users/fairchild/.worktrees/workspaces/codex/workspaces-perf-optimization`
+  - `/Users/fairchild`
+
+Artifacts:
+
+- `/tmp/workspaces-host-probe-local-20260407/summary.txt`
+
+Result:
+
+- login shell median: `71-80 ms`
+- clean shell median: `3-6 ms`
+- no strong shell-startup anomaly
+
+Takeaway:
+
+- shell startup is not the primary local bottleneck
+
+### EXP-0003: Installed app clean-shell input diagnostics, contaminated by duplicate app processes
+
+Status: complete
+
+Setup:
+
+- attempted clean-shell installed diagnostics with input logging
+
+Finding:
+
+- two installed `WorkspaceManager` processes were alive simultaneously:
+  - `22196`
+  - `90618`
+
+Takeaway:
+
+- duplicate app state can contaminate measurements and should be cleared before any rerun
+
+### EXP-0004: Installed app clean-shell input diagnostics after clearing duplicate processes
+
+Status: complete
+
+Setup:
+
+- killed all installed `WorkspaceManager` processes
+- relaunched installed app with:
+  - `WORKSPACES_FOCUS_DIAGNOSTICS=1`
+  - `WORKSPACES_TERMINAL_DIAGNOSTICS=1`
+  - `WORKSPACES_INPUT_DIAGNOSTICS=1`
+  - `WORKSPACES_SHELL_PROFILE_MODE=clean`
+
+Artifacts:
+
+- `/tmp/workspaces-local-input-diag-single-20260407.log`
+
+Result:
+
+- `surface_create_succeeded`: `29.80 ms`
+- `input event_age_ms`: median `1198.85 ms`, max `2480.36 ms`
+- `handler_duration_ms`: median `0.16 ms`, max `1.07 ms`
+- `workspace_click_to_focus`: `36566.90 ms`, outcome `repo_overview_selected`
+- focus failure markers observed:
+  - `focus_request_inactive_skip`
+  - `focus_request_missing_window_retry`
+  - `focus_request_missing_window_terminal_lost`
+
+Takeaway:
+
+- the app is receiving key events late, not handling them slowly
+- focus restore instability is a core part of the stall
+
+### EXP-0005: Clean single-process active-lag sample
+
+Status: complete
+
+Setup:
+
+- captured fresh active-lag sample against clean single-process run
+- target app PID: `94289`
+
+Artifacts:
+
+- `/tmp/workspaces-active-lag-single-20260407/sample-app-94289.txt`
+- `/tmp/workspaces-active-lag-single-20260407/sample-child-97801.txt`
+
+Result:
+
+- shell still idle in `read`
+- app sample hot path includes:
+  - `NSAnimationManager`
+  - `NSHostingView.layout`
+  - `SidebarRows.swift`
+  - `View.help`
+  - `Menu.init`
+
+Takeaway:
+
+- sidebar/menu/help layout is a strong next optimization target
+
+### EXP-0006: Reduce repo-row hover/menu/layout churn
+
+Status: complete
+
+Hypothesis:
+
+- repo row hover animation and hidden quick-action menu construction are causing avoidable layout/display churn on the main thread
+
+Change:
+
+- remove or reduce hover animation
+- avoid constructing quick action menu when hidden
+- reduce repeated dynamic property reads during row rendering
+
+Implementation notes:
+
+- patched `Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift`
+- removed `withAnimation(.easeInOut(duration: 0.12))` from repo-row hover handling
+- replaced always-built hidden quick-action menu with a fixed-size placeholder when not hovering
+- hoisted `repo.name` and related label text into local body constants to reduce repeated reads per render pass
+
+Artifacts:
+
+- `/tmp/workspaces-debug-input-diag-exp0006-20260407.log`
+- `/tmp/workspaces-debug-active-lag-exp0006-20260407/sample-app-59644.txt`
+- `/tmp/workspaces-debug-active-lag-exp0006-20260407/sample-child-60155.txt`
+
+Result:
+
+- `input event_age_ms`: median improved from `1198.85 ms` to `17.47 ms`
+- `input event_age_ms` max improved from `2480.36 ms` to `219.34 ms`
+- `handler_duration_ms`: median `0.20 ms`, max `7.43 ms`
+- `workspace_click_to_focus`: improved from `36566.90 ms` with `repo_overview_selected` to `5870.88 ms` with `focused`
+- first-pass grep of the new app sample no longer surfaced:
+  - `SidebarRows.swift`
+  - `Menu.init`
+  - `View.help`
+- remaining hot sample stacks still show:
+  - `NSHostingView.layout`
+  - `NSAnimationManager`
+  - SwiftUI `ToolbarBridge.preferencesDidChange`
+  - SwiftUI `ToolbarBridge.updateStorage`
+- later in the session, after unrelated sheet / Lume activity, focus failure markers still reappeared:
+  - `focus_request_missing_window_retry`
+  - `focus_request_missing_window_terminal_lost`
+
+Takeaway:
+
+- repo-row hover/menu churn was a real contributor
+- the change produced a large quantitative improvement in event delivery
+- the remaining issue appears broader than the sidebar row itself
+- toolbar/layout churn is the next best local optimization target
+
+## Planned
+
+### EXP-0007: Reduce toolbar bridge churn during selection and terminal updates
+
+Status: complete
+
+Hypothesis:
+
+- dynamic toolbar content in `ContentView` and related views is being rebuilt too often, causing additional SwiftUI/AppKit layout and animation work even when terminal handling itself is fast
+
+Change:
+
+- added `PerformanceExperimentFlags.minimalToolbar`
+- gated both `ContentView` and `SidebarView` toolbars behind `WORKSPACES_PERF_MINIMAL_TOOLBAR=1`
+- used the flag as a measurement-only A/B switch rather than a product decision
+
+Artifacts:
+
+- `/tmp/workspaces-exp0007-clean-control-summary.txt`
+- `/tmp/workspaces-exp0007-clean-minimal-toolbar-summary.txt`
+- `.dev-data/logs/launch-dev-20260408-000649.log`
+- `.dev-data/logs/launch-dev-20260408-000722.log`
+
+Setup:
+
+- same debug build
+- same clean-shell mode
+- same `WORKSPACES_PERF_AUTO_SELECT_FIRST_REPO=1` launch
+- same automated terminal focus click
+- same typed input sequence:
+  - `date`
+  - `ls`
+  - `clear`
+
+Result:
+
+- normal toolbar:
+  - `event_age_ms` median `60.81 ms`, max `897.08 ms`
+  - `repo_click_to_focus` `3885.80 ms`
+  - `launch_to_first_prompt` `5853.95 ms`
+- minimal toolbar:
+  - `event_age_ms` median `25.36 ms`, max `54.71 ms`
+  - `repo_click_to_focus` `1220.58 ms`
+  - `launch_to_first_prompt` `4480.47 ms`
+
+Takeaway:
+
+- removing toolbar content produced a strong quantitative improvement
+- toolbar composition is a real contributor to the remaining app-wide slowness
+- the next step should be a production-safe way to keep toolbar structure stable without removing important actions entirely
+
+### EXP-0008: Replace dynamic toolbar item sets with a stable contextual actions control
+
+Status: complete
+
+Hypothesis:
+
+- the toolbar cost is driven more by structural churn in SwiftUI toolbar items than by the mere presence of a toolbar
+- replacing the changing item set with one stable contextual actions control should preserve functionality while keeping most of the performance win from minimal-toolbar mode
+
+Change:
+
+- introduced a stable single-item contextual actions menu experiment in the toolbar
+- measured with a corrected post-prompt harness that waits for `launch_to_first_prompt` before sending input
+
+Artifacts:
+
+- `/tmp/workspaces-exp0008-postprompt-stable-summary.txt`
+- `/tmp/workspaces-exp0008-postprompt-minimal-summary.txt`
+- `.dev-data/logs/launch-dev-20260408-001254.log`
+- `.dev-data/logs/launch-dev-20260408-001326.log`
+
+Result:
+
+- stable contextual toolbar item:
+  - `event_age_ms` median `284.48 ms`, max `571.51 ms`
+  - `repo_click_to_focus` `1402.38 ms`
+  - `launch_to_first_prompt` `5231.20 ms`
+- minimal toolbar:
+  - `event_age_ms` median `11.10 ms`, max `46.10 ms`
+  - `repo_click_to_focus` `1170.99 ms`
+  - `launch_to_first_prompt` `4044.79 ms`
+
+Takeaway:
+
+- a stable replacement menu in the toolbar did not solve the problem
+- the contextual actions item remains too expensive even when the item structure is simplified
+- this experiment should not ship as the fix path
+
+### EXP-0009: Remove the contextual toolbar item but keep the rest of the toolbar
+
+Status: complete
+
+Hypothesis:
+
+- the contextual actions item itself, not the entire toolbar, is the dominant remaining contributor
+
+Change:
+
+- removed the `.automatic` contextual toolbar item from `ContentView`
+- left the rest of the toolbar structure intact
+- kept the `WORKSPACES_PERF_MINIMAL_TOOLBAR=1` full-removal flag for comparison
+
+Artifacts:
+
+- `/tmp/workspaces-exp0009-no-context-toolbar-summary.txt`
+- `/tmp/workspaces-exp0008-postprompt-minimal-summary.txt`
+- `.dev-data/logs/launch-dev-20260408-001558.log`
+
+Result:
+
+- no contextual toolbar item:
+  - `event_age_ms` median `18.77 ms`, max `188.06 ms`
+  - `repo_click_to_focus` `1158.80 ms`
+  - `launch_to_first_prompt` `4512.09 ms`
+- minimal toolbar reference:
+  - `event_age_ms` median `11.10 ms`, max `46.10 ms`
+  - `repo_click_to_focus` `1170.99 ms`
+  - `launch_to_first_prompt` `4044.79 ms`
+
+Takeaway:
+
+- removing just the contextual toolbar item preserves most of the minimal-toolbar performance gain
+- this is the strongest current production-safe direction
+- the next work should focus on where to relocate those contextual actions, not on keeping them in the toolbar
+
+### EXP-0010: Re-home lost contextual actions into app commands and verify current branch state
+
+Status: complete
+
+Hypothesis:
+
+- moving the lost actions to the app menu should preserve usability without reintroducing toolbar cost
+
+Change:
+
+- kept the contextual toolbar item removed
+- re-homed these actions into a `Selection` command menu via focused scene values:
+  - open in browser
+  - reload web source
+  - open desktop
+  - reveal in Finder
+  - copy path
+- added a short learnings summary at `docs/performance/2026-04-08-global-slowness-learnings.md`
+
+Artifacts:
+
+- `/tmp/workspaces-final-postprompt-summary.txt`
+- `/tmp/workspaces-final-postprompt-summary-r2.txt`
+- `.dev-data/logs/launch-dev-20260408-072019.log`
+- `.dev-data/logs/launch-dev-20260408-072059.log`
+
+Result:
+
+- branch remains buildable and testable
+- shortcut pass-through still works on the current branch
+- repeated post-prompt reruns on the no-context-toolbar shape remained variable:
+  - one earlier run measured `event_age_ms` median `18.77 ms`
+  - later reruns measured about `309.87 ms` and `749.26 ms`
+
+Takeaway:
+
+- the toolbar fix is real enough to keep
+- the app is still not fully solved
+- the next iteration should target the remaining variable focus/input delay with fresh active-lag samples on this branch
+
+### EXP-0011: Current-branch validation after command-menu re-home
+
+Status: complete
+
+Hypothesis:
+
+- the current branch may already be good enough on median input latency, while still showing occasional app-side spikes under live interaction
+
+Change:
+
+- no code change for this experiment
+- remeasured the current branch after the toolbar removal plus `Selection` command-menu re-home
+- captured one corrected post-prompt input run and one fresh active-lag sample on the same no-context-toolbar build
+
+Artifacts:
+
+- `/tmp/workspaces-exp0011-postprompt/summary.txt`
+- `.dev-data/logs/launch-dev-20260408-073545.log`
+- `/tmp/workspaces-exp0011-active-lag/samples/summary.txt`
+- `/tmp/workspaces-exp0011-active-lag/samples/sample-app-89332.txt`
+- `/tmp/workspaces-exp0011-active-lag/samples/sample-child-89355.txt`
+- `/tmp/workspaces-exp0011-active-lag/samples/sample-child-89472.txt`
+- `.dev-data/logs/launch-dev-20260408-073357.log`
+
+Result:
+
+- corrected clean-shell post-prompt input run on the current branch:
+  - `event_age_ms` min `0.95 ms`, median `3.40 ms`, max `476.70 ms`, mean `133.90 ms`
+  - `handler_duration_ms` median `0.11 ms`
+  - `repo_click_to_focus` `1031.94 ms`
+  - `launch_to_first_prompt` `3621.46 ms`
+- fresh active-lag sample on the same build:
+  - shell remained blocked in `read`
+  - app sample remained dominated by SwiftUI/AppKit layout and preference churn
+  - strong sample signatures included:
+    - `NSHostingView.layout`
+    - `NSHostingView.preferencesDidChange`
+    - `AppWindowsController.updateWindowFocus`
+    - `ToolbarBridge.preferencesDidChange`
+    - `RepoRow.body`
+
+Takeaway:
+
+- the current branch looks materially better on median input delivery than the earlier slow runs
+- the remaining issue is now best described as intermittent app-side spikes, not consistently stale key delivery
+- the next optimization target should stay in SwiftUI/AppKit preference and row rendering churn, not shell startup or Ghostty shortcut routing

--- a/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency-log.md
+++ b/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency-log.md
@@ -403,3 +403,107 @@ Takeaway:
 - the current branch looks materially better on median input delivery than the earlier slow runs
 - the remaining issue is now best described as intermittent app-side spikes, not consistently stale key delivery
 - the next optimization target should stay in SwiftUI/AppKit preference and row rendering churn, not shell startup or Ghostty shortcut routing
+
+### EXP-0012: Package Ghostty resources into the release app and set `GHOSTTY_RESOURCES_DIR` before runtime init
+
+Status: complete
+
+Hypothesis:
+
+- the installed-app warnings about missing terminfo and disabled shell integration are caused by the release bundle not embedding Ghostty's `share` payload or telling libghostty where to find it
+
+Change:
+
+- added `GhosttyResourcesLocator.swift`
+- updated `GhosttyAppManager.initializeIfNeeded()` to resolve bundled Ghostty resources and set `GHOSTTY_RESOURCES_DIR` before `ghostty_init`
+- updated `scripts/build-release.sh` to copy Ghostty `zig-out/share` contents into `WorkspaceManager.app/Contents/Resources`
+
+Artifacts:
+
+- `/Users/fairchild/Downloads/workspaces-report-2026-04-08-204228.zip`
+- local packaged app build output from `./scripts/build-release.sh --no-sign`
+- packaged bundle path:
+  - `build/WorkspaceManager.app/Contents/Resources/ghostty`
+  - `build/WorkspaceManager.app/Contents/Resources/terminfo`
+
+Result:
+
+- the prior installed-build report implicated:
+  - `ghostty terminfo not found`
+  - `no resources dir set, shell integration disabled`
+- the new release bundle now embeds the expected Ghostty resource layout and configures the runtime before initialization
+- local unattended packaged-run validation did not surface the old terminfo / shell-integration warning signatures again, but log capture from this harness remained incomplete enough that a fresh manual diagnostic export is still the cleanest confirmation path
+
+Takeaway:
+
+- installed bundles must carry Ghostty resources explicitly
+- the old installed-build Ghostty degradation was a real packaging/runtime issue, not just noise
+- future installed-build perf reports should be checked to confirm those warnings stay gone
+
+### EXP-0013: Remove app-command `FocusedValue` usage entirely after aggregation was insufficient
+
+Status: complete
+
+Hypothesis:
+
+- the remaining `FocusedValue update tried to update multiple times per frame` warning is tied to the app-command routing mechanism itself, not merely the number of focused-scene keys
+
+Change:
+
+- first collapsed multiple focused scene values into one `MainWindowFocusedActions` payload
+- after one packaged run still showed the SwiftUI focused-value warning, replaced app-command routing with `AppCommandState`
+- removed `focusedSceneValue` usage from `ContentView` and `SidebarView`
+- main app commands now read from shared observable command state instead of `@FocusedValue`
+
+Artifacts:
+
+- local packaged-run log inspection around the pre-refactor build showed:
+  - `FocusedValue update tried to update multiple times per frame`
+- `swift build`
+- `swift test`
+
+Result:
+
+- the command-state refactor is buildable and test-clean
+- it removes the direct app-command dependence on SwiftUI focused values
+- a fresh manual diagnostic run is still needed to prove whether the runtime focused-value warning is fully eliminated in practice
+
+Takeaway:
+
+- reducing the number of focused values was not sufficient on its own
+- if the warning still appears in the next manual report, the remaining source is elsewhere in SwiftUI focus/preference updates rather than app-command plumbing
+
+### EXP-0014: Manual diagnostic report on April 8, 2026 shows sub-second first prompt and no recurrence of prior warning signatures
+
+Status: complete
+
+Artifacts:
+
+- diagnostic bundle: `/Users/fairchild/Downloads/workspaces-report-2026-04-08-230216.zip`
+- Ghostty crash envelope: `/Users/fairchild/.local/state/ghostty/crash/e3b21dee-c40d-47b3-70d2-9647f49a9155.ghosttycrash`
+
+Result:
+
+- `launch_to_first_prompt` improved to `795.65 ms`
+- `repo_hydration` was `3.74 ms`
+- first `terminal_first_output` and `first_prompt_ready` were both `676.99 ms`
+- later terminal readiness events measured about `130.03 ms` and `142.15 ms`
+- the report did not include the earlier `FocusedValue update tried to update multiple times per frame` warning
+- the report did not include the earlier Ghostty `terminfo not found` / `no resources dir set` warnings
+
+Crash-file inspection:
+
+- the Ghostty crash artifact is a real Sentry Breakpad envelope, not a false-positive text log
+- event timestamp: `2026-04-09T04:43:30.383615Z`
+- session status: `crashed`
+- session duration: `2765.47 s`
+- release tag inside the envelope: `1.3.0-main+da10707f9`
+- the envelope carries a `649280` byte `event.minidump` attachment
+- the structured event payload does not include a decoded exception or symbolized stack inline
+- this machine does not currently have a local Breakpad stackwalker, and `lldb` did not produce a usable backtrace from the extracted minidump
+
+Takeaway:
+
+- the recent performance fixes materially improved launch and terminal readiness
+- the previously observed SwiftUI focused-value and Ghostty resource warnings appear resolved in this run
+- one residual native Ghostty crash remains worth tracking separately as a stability issue, but it does not look like the main driver of the earlier performance regression

--- a/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md
+++ b/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md
@@ -1,0 +1,364 @@
+# Investigation: Global Slowness And Input Latency
+
+Date: 2026-04-07
+Branch: `codex/workspaces-perf-optimization`
+Status: active
+
+## Goal
+
+Find and fix the root cause of broad Workspaces UI slowness.
+
+Reported symptoms:
+
+- slow launch and long beachballs
+- typing lag in the embedded terminal
+- slow menu interactions, including Help menu clicks
+- worse behavior on one target machine, but reproducible locally as well
+
+## Current Read
+
+The current evidence does not support "slow shell startup" as the primary cause.
+
+The strongest signals point to:
+
+1. input events arriving at the app very late
+2. focus restoration repeatedly losing the target terminal/window
+3. expensive SwiftUI/AppKit layout work in sidebar/menu row rendering during lag
+4. dynamic toolbar bridge rebuilds during layout, especially after the first sidebar fix reduced row churn
+5. intermittent residual spikes that now look more like SwiftUI preference/focus churn than shell or Ghostty work
+
+## Baseline Evidence
+
+### Local host probe
+
+Artifact:
+
+- `/tmp/workspaces-host-probe-local-20260407/summary.txt`
+
+Key numbers:
+
+- login shell median: `71-80 ms`
+- clean shell median: `3-6 ms`
+- finding: no strong shell-startup anomaly detected
+
+Interpretation:
+
+- local slowness is not explained by login shell startup cost
+
+### Installed app input diagnostics, clean shell
+
+Artifact:
+
+- `/tmp/workspaces-local-input-diag-single-20260407.log`
+
+Key numbers:
+
+- `terminal_investigation.surface_create_succeeded`: `29.80 ms`
+- `input_investigation.event_age_ms`: min `1117.16 ms`, median `1198.85 ms`, max `2480.36 ms`
+- `input_investigation.handler_duration_ms`: min `0.10 ms`, median `0.16 ms`, max `1.07 ms`
+- `workspace_click_to_focus`: `36566.90 ms`, outcome `repo_overview_selected`
+
+Interpretation:
+
+- terminal surface creation is fast
+- key events are arriving stale
+- the app is not spending seconds inside the key handler
+- focus restoration is failing badly enough to leave a click-to-focus span open for ~36.6s
+
+### Focus failure markers
+
+Artifact:
+
+- `/tmp/workspaces-local-input-diag-single-20260407.log`
+
+Observed markers:
+
+- `focus_request_inactive_skip`
+- `focus_request_missing_window_retry`
+- `focus_request_missing_window_terminal_lost`
+- `coordinator_pending_request_cancelled reason=repo_overview_selected`
+
+Interpretation:
+
+- focus routing and target resolution are unstable under the slow path
+
+### Active lag sample, clean single-process run
+
+Artifacts:
+
+- `/tmp/workspaces-active-lag-single-20260407/sample-app-94289.txt`
+- `/tmp/workspaces-active-lag-single-20260407/sample-child-97801.txt`
+
+Observed app-side pattern:
+
+- main thread heavily sampled in AppKit / SwiftUI display and layout work
+- stacks go through `NSAnimationManager`, `NSHostingView.layout`, and `SidebarRows.swift`
+- menu/help construction also appears in the hot path
+
+Observed shell-side pattern:
+
+- shell mostly blocked in `read`
+
+Interpretation:
+
+- current local lag is not a shell execution bottleneck
+- UI/layout churn is a credible root contributor
+
+### Debug build re-measure after repo-row churn reduction
+
+Artifacts:
+
+- `/tmp/workspaces-debug-input-diag-exp0006-20260407.log`
+- `/tmp/workspaces-debug-active-lag-exp0006-20260407/sample-app-59644.txt`
+- `/tmp/workspaces-debug-active-lag-exp0006-20260407/sample-child-60155.txt`
+
+Key numbers:
+
+- `input_investigation.event_age_ms`: min `1.16 ms`, median `17.47 ms`, max `219.34 ms`
+- `input_investigation.handler_duration_ms`: min `0.06 ms`, median `0.20 ms`, max `7.43 ms`
+- `workspace_click_to_focus`: `5870.88 ms`, outcome `focused`
+
+Observed focus markers:
+
+- repeated `focus_request_make_first_responder`
+- repeated `focus_request_succeeded`
+- a later `focus_request_missing_window_retry` and `focus_request_missing_window_terminal_lost` after unrelated sheet / Lume activity
+
+Observed app-side sample pattern:
+
+- the old direct `SidebarRows.swift`, `Menu.init`, and `View.help` signatures dropped out of the first pass grep
+- `NSHostingView.layout` and `NSAnimationManager` remain present
+- the strongest surviving high-count stack goes through SwiftUI `ToolbarBridge.preferencesDidChange` and `ToolbarBridge.updateStorage`
+
+Interpretation:
+
+- the first repo-row change materially improved key delivery
+- sidebar churn was a real contributor, not just noise
+- the problem is not fully fixed
+- remaining slowness appears to involve broader SwiftUI/AppKit layout, with toolbar rebuilds as the next likely optimization target
+
+### Clean-shell toolbar A/B
+
+Artifacts:
+
+- `/tmp/workspaces-exp0007-clean-control-summary.txt`
+- `/tmp/workspaces-exp0007-clean-minimal-toolbar-summary.txt`
+- `.dev-data/logs/launch-dev-20260408-000649.log`
+- `.dev-data/logs/launch-dev-20260408-000722.log`
+
+Interaction pattern:
+
+- same debug build
+- same clean-shell mode
+- same auto-select-first-repo launch
+- same automated terminal click
+- same typed input sequence: `date`, `ls`, `clear`
+
+Control result with normal toolbar:
+
+- `input_investigation.event_age_ms`: min `5.36 ms`, median `60.81 ms`, max `897.08 ms`
+- `repo_click_to_focus`: `3885.80 ms`
+- `launch_to_first_prompt`: `5853.95 ms`
+
+Variant result with `WORKSPACES_PERF_MINIMAL_TOOLBAR=1`:
+
+- `input_investigation.event_age_ms`: min `3.29 ms`, median `25.36 ms`, max `54.71 ms`
+- `repo_click_to_focus`: `1220.58 ms`
+- `launch_to_first_prompt`: `4480.47 ms`
+
+Interpretation:
+
+- removing toolbar content materially improved responsiveness under the same interaction sequence
+- the remaining lag is not explained by the terminal key handler itself, which stayed sub-millisecond
+- dynamic toolbar composition is now a high-confidence contributor to the broad UI slowness
+
+### Post-prompt toolbar refinement results
+
+Artifacts:
+
+- `/tmp/workspaces-exp0008-postprompt-stable-summary.txt`
+- `/tmp/workspaces-exp0008-postprompt-minimal-summary.txt`
+- `/tmp/workspaces-exp0009-no-context-toolbar-summary.txt`
+- `.dev-data/logs/launch-dev-20260408-001254.log`
+- `.dev-data/logs/launch-dev-20260408-001326.log`
+- `.dev-data/logs/launch-dev-20260408-001558.log`
+
+Interaction pattern:
+
+- same debug build
+- same clean-shell mode
+- same auto-select-first-repo launch
+- waited for `launch_to_first_prompt` to appear in the log before sending input
+- same automated terminal click
+- same typed input sequence: `date`, `ls`, `clear`
+
+Variant results:
+
+- stable contextual actions toolbar item:
+  - `event_age_ms` median `284.48 ms`, max `571.51 ms`
+  - `repo_click_to_focus` `1402.38 ms`
+  - `launch_to_first_prompt` `5231.20 ms`
+- minimal toolbar:
+  - `event_age_ms` median `11.10 ms`, max `46.10 ms`
+  - `repo_click_to_focus` `1170.99 ms`
+  - `launch_to_first_prompt` `4044.79 ms`
+- no contextual toolbar item, but rest of toolbar intact:
+  - `event_age_ms` median `18.77 ms`, max `188.06 ms`
+  - `repo_click_to_focus` `1158.80 ms`
+  - `launch_to_first_prompt` `4512.09 ms`
+
+Interpretation:
+
+- a stable replacement menu in the toolbar was still too expensive
+- the problem is not “any toolbar at all”
+- the contextual actions item in the toolbar is the high-value offender
+- removing just that item preserves most of the minimal-toolbar performance win
+
+### Current-branch validation after the command-menu re-home
+
+Artifacts:
+
+- `/tmp/workspaces-exp0011-postprompt/summary.txt`
+- `.dev-data/logs/launch-dev-20260408-073545.log`
+- `/tmp/workspaces-exp0011-active-lag/samples/summary.txt`
+- `/tmp/workspaces-exp0011-active-lag/samples/sample-app-89332.txt`
+- `/tmp/workspaces-exp0011-active-lag/samples/sample-child-89355.txt`
+- `/tmp/workspaces-exp0011-active-lag/samples/sample-child-89472.txt`
+- `.dev-data/logs/launch-dev-20260408-073357.log`
+
+Key numbers from the corrected clean-shell post-prompt run:
+
+- `input_investigation.event_age_ms`: min `0.95 ms`, median `3.40 ms`, max `476.70 ms`, mean `133.90 ms`
+- `input_investigation.handler_duration_ms`: min `0.06 ms`, median `0.11 ms`, max `0.96 ms`
+- `repo_click_to_focus`: `1031.94 ms`
+- `launch_to_first_prompt`: `3621.46 ms`
+
+Observed fresh active-lag sample pattern on the same build:
+
+- shell remained blocked in `read`
+- app main thread still concentrated in:
+  - `NSHostingView.layout`
+  - `NSHostingView.preferencesDidChange`
+  - `AppWindowsController.updateWindowFocus`
+  - `ToolbarBridge.preferencesDidChange`
+  - `RepoRow.body`
+
+Interpretation:
+
+- on the current branch, median input delivery during a corrected post-prompt run is now fast
+- the key handler is still not the problem
+- the remaining issue is intermittent UI spikes, with current evidence pointing at SwiftUI preference and focus churn plus residual sidebar row work
+
+## Important Session Finding
+
+Before the clean rerun, there were two installed `WorkspaceManager` processes alive at once:
+
+- `22196`
+- `90618`
+
+That state was cleared manually before the clean diagnostic rerun. It is a confounder worth watching, but it does not explain the full issue because the slowdown remained after returning to a single process.
+
+## Ranked Hypotheses
+
+### H1. Focus/window restoration is leaving input events queued before they ever reach the terminal view
+
+Why it fits:
+
+- stale `event_age_ms`
+- repeated `focus_request_missing_window_*`
+- long `workspace_click_to_focus`
+
+Primary code:
+
+- `Sources/WorkspaceManager/Controllers/TerminalWindowController.swift`
+- `Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift`
+
+### H2. Sidebar row hover/menu/help rendering is causing expensive layout and animation churn on the main thread
+
+Why it fits:
+
+- sample shows `NSAnimationManager` and `NSHostingView.layout`
+- stacks point into `SidebarRows.swift`
+- sample includes `View.help` and `Menu.init`
+
+Primary code:
+
+- `Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift`
+
+### H2b. Dynamic toolbar content is being rebuilt too often during view updates
+
+Why it fits:
+
+- post-change sample still shows heavy `NSHostingView.layout`
+- surviving stack now runs through SwiftUI `ToolbarBridge.preferencesDidChange`
+- clean-shell A/B improved responsiveness substantially when toolbars were removed
+- the app is reported as slow even outside terminal typing, including menu interactions
+
+Primary code:
+
+- `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift`
+- `Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift`
+- `Sources/WorkspaceManager/Views/Components/WorkspaceEditorToolbarButton.swift`
+
+### H2c. Focused scene values and related SwiftUI window preference updates are still expensive under live interaction
+
+Why it fits:
+
+- fresh active-lag sample still shows `NSHostingView.preferencesDidChange`
+- sample still shows `AppWindowsController.updateWindowFocus`
+- sample still shows `ToolbarBridge.preferencesDidChange` even after removing the contextual toolbar item
+- the latest corrected post-prompt run is good on median input latency but still has occasional large spikes
+
+Primary code:
+
+- `Sources/WorkspaceManager/App/WorkspaceManagerApp.swift`
+- `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift`
+
+### H3. Shortcut/local-event routing may be amplifying focus churn, but is probably not the primary root cause
+
+Why it is still plausible:
+
+- app has custom Ghostty-first shortcut routing
+- a local event monitor is installed on each terminal surface
+- user suspicion is specifically around shortcut pass-through work
+
+Why it is not ranked first:
+
+- menu/help slowness is broader than terminal shortcut handling
+- shell samples are idle
+- current hottest stack is layout/display rather than shortcut encoding
+
+Primary code:
+
+- `Sources/WorkspaceManager/Terminal/GhosttySurfaceInputRouter.swift`
+- `Sources/WorkspaceManager/App/ShortcutRoutingPolicy.swift`
+
+## Excluded Or Deprioritized Causes
+
+- shell startup as the primary local cause
+- Ghostty surface creation latency as the primary local cause
+- child shell execution as the primary local cause
+
+## Next Experiments
+
+1. Reduce the remaining sidebar row and preference churn that still appears in `RepoRow.body`, `View.help`, and `ToolbarBridge`.
+2. Separate focused-scene-value cost from toolbar bridge cost so the next command-surface choice is evidence-based.
+3. Re-measure:
+   - corrected clean-shell post-prompt input diagnostics
+   - active-lag sample
+   - focus spans
+4. Only if the SwiftUI-side reductions stop helping, instrument shortcut/local-event routing more deeply:
+   - local event monitor entry/exit
+   - `performKeyEquivalent`
+   - first-responder transitions around focus restore
+5. If focus loss remains after UI churn drops further, narrow in on `TerminalWindowController` / surface-store timing.
+
+## Success Criteria
+
+We should consider the first pass successful when local runs show:
+
+- `input_investigation.event_age_ms` reduced from ~`1.2-2.5s` to low double-digit milliseconds
+- corrected post-prompt reruns stay low without occasional 400ms+ spikes
+- `workspace_click_to_focus` no longer stalls in the seconds range during normal repo/session selection
+- no repeated `focus_request_missing_window_terminal_lost` during normal selection and typing
+- subjective menu and terminal interactions feel immediate

--- a/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md
+++ b/docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md
@@ -314,6 +314,26 @@ Primary code:
 - `Sources/WorkspaceManager/App/WorkspaceManagerApp.swift`
 - `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift`
 
+Current status:
+
+- app-command routing no longer uses `FocusedValue`; it now uses `AppCommandState`
+- if the warning persists in the next manual report, the remaining source is deeper in SwiftUI focus/preference churn rather than app-command menu wiring
+
+### H2d. Installed builds were previously missing Ghostty runtime resources, degrading shell integration and terminal setup
+
+Why it fits:
+
+- installed-build report showed:
+  - `ghostty terminfo not found`
+  - `no resources dir set, shell integration disabled`
+- those warnings do not match the improved local branch behavior and point to a packaged-app-specific issue
+
+Primary code:
+
+- `Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift`
+- `Sources/WorkspaceManager/Terminal/GhosttyResourcesLocator.swift`
+- `scripts/build-release.sh`
+
 ### H3. Shortcut/local-event routing may be amplifying focus churn, but is probably not the primary root cause
 
 Why it is still plausible:
@@ -342,16 +362,17 @@ Primary code:
 ## Next Experiments
 
 1. Reduce the remaining sidebar row and preference churn that still appears in `RepoRow.body`, `View.help`, and `ToolbarBridge`.
-2. Separate focused-scene-value cost from toolbar bridge cost so the next command-surface choice is evidence-based.
-3. Re-measure:
+2. Re-measure on a freshly packaged build now that Ghostty resources are bundled and app commands no longer use `FocusedValue`.
+3. If warnings remain, separate residual SwiftUI focus/preference churn from toolbar bridge cost with another active-lag sample.
+4. Re-measure:
    - corrected clean-shell post-prompt input diagnostics
    - active-lag sample
    - focus spans
-4. Only if the SwiftUI-side reductions stop helping, instrument shortcut/local-event routing more deeply:
+5. Only if the SwiftUI-side reductions stop helping, instrument shortcut/local-event routing more deeply:
    - local event monitor entry/exit
    - `performKeyEquivalent`
    - first-responder transitions around focus restore
-5. If focus loss remains after UI churn drops further, narrow in on `TerminalWindowController` / surface-store timing.
+6. If focus loss remains after UI churn drops further, narrow in on `TerminalWindowController` / surface-store timing.
 
 ## Success Criteria
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -116,6 +116,30 @@ expand_home_prefix() {
     printf '%s\n' "$path"
 }
 
+resolve_ghostty_share_dir() {
+    local -a candidates=()
+    local candidate=""
+
+    if [[ -n "${GHOSTTY_SHARE_DIR:-}" ]]; then
+        candidates+=("$(expand_home_prefix "$GHOSTTY_SHARE_DIR")")
+    fi
+
+    if [[ -n "${GHOSTTY_DIR:-}" ]]; then
+        candidates+=("$(expand_home_prefix "$GHOSTTY_DIR")/zig-out/share")
+    fi
+
+    candidates+=("$HOME/.cache/workspacemanager/ghostty/zig-out/share")
+
+    for candidate in "${candidates[@]}"; do
+        if [[ -d "$candidate/ghostty" ]] && [[ -d "$candidate/terminfo" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 plist_print() {
     local plist_path="$1"
     local key_path="$2"
@@ -393,6 +417,13 @@ SPM_RESOURCES=".build/release/WorkspaceManager_WorkspaceManager.bundle"
 if [[ -d "$SPM_RESOURCES" ]]; then
     cp -R "$SPM_RESOURCES"/* "$APP_BUNDLE/Contents/Resources/" 2>/dev/null || true
     log_success "Copied SPM resources"
+fi
+
+if GHOSTTY_SHARE_DIR_RESOLVED="$(resolve_ghostty_share_dir)"; then
+    cp -R "$GHOSTTY_SHARE_DIR_RESOLVED"/* "$APP_BUNDLE/Contents/Resources/" 2>/dev/null || true
+    log_success "Copied Ghostty resources from $GHOSTTY_SHARE_DIR_RESOLVED"
+else
+    log_warning "Ghostty share resources not found; packaged shell integration may be degraded"
 fi
 
 ASSETS_DIR="Sources/WorkspaceManager/Resources/Assets.xcassets"


### PR DESCRIPTION
## Summary
- add a single executable collector script for installed-app performance investigations and wire it into the optimization skill
- remove the expensive contextual toolbar item from the main window while keeping the rest of the toolbar intact
- re-home lost selection actions into app commands instead of the toolbar path
- document the investigation trail, measured before/after numbers, and current branch learnings

## Perf Findings
- sidebar row cleanup improved `event_age_ms` median from `1198.85 ms` to `17.47 ms`
- removing the contextual toolbar item improved `event_age_ms` median from `60.81 ms` to `18.77 ms`
- removing the contextual toolbar item improved `repo_click_to_focus` from `3885.80 ms` to `1158.80 ms`
- current branch corrected clean-shell post-prompt run measured `event_age_ms` median `3.40 ms`, `repo_click_to_focus` `1031.94 ms`, and `launch_to_first_prompt` `3621.46 ms`
- fresh active-lag sampling still points at app-side SwiftUI/AppKit preference churn, with hot paths through `NSHostingView.preferencesDidChange`, `AppWindowsController.updateWindowFocus`, `ToolbarBridge`, and `RepoRow.body`, while the shell stays idle

## Validation
- `./scripts/build-ghosttykit.sh`
- `swift build`
- `swift test`
- `./.agents/skills/workspaces-optimization/scripts/collect_installed_perf_bundle.py --help`
- `./.agents/skills/workspaces-optimization/scripts/collect_installed_perf_bundle.py --slow-repo . --output-dir /tmp/workspaces-installed-perf-plan --skip-input-run --skip-active-lag --plan-only`
- local clean-shell post-prompt validation on the current branch
- local active-lag sampling on the current branch

## Evidence
- [installed-perf-bundle-validation](https://evidence.cloudcompute.com/workspaces/pr-304/20260408-053540-installed-perf-bundle-validation.png)
- [perf-summary](https://evidence.cloudcompute.com/workspaces/pr-304/20260408-144013-perf-summary.svg)
