### PR TITLE
fix(web): ensure tmux socket dir exists before starting ttyd

### DIFF
--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -721,6 +721,23 @@ function ttydUrl(domain: string, sandboxId: string): string {
  */
 async function startTtyd(sandbox: Sandbox): Promise<void> {
 	const token = ttydPathToken(sandbox.sandboxId);
+
+	// Ensure the tmux socket directory exists before ttyd launches tmux.
+	// After snapshot restore `/tmp` may be empty, and the static tmux
+	// binary sometimes fails to create `/tmp/tmux-<uid>/` on its own
+	// (produces: "tmux socket dir: `/tmp/tmux-0` does not exist"). We
+	// also remove any stale socket files left over from a previous tmux
+	// server that was running when the snapshot was taken — a dead socket
+	// prevents `new-session -A` from starting a fresh server.
+	await sandbox.runCommand({
+		cmd: "bash",
+		args: [
+			"-c",
+			"rm -rf /tmp/tmux-* && mkdir -p /tmp/tmux-0 && chmod 700 /tmp/tmux-0",
+		],
+		sudo: true,
+	});
+
 	// tmux is a static binary in /usr/local/bin/tmux — no library
 	// path setup needed. ttyd execs tmux directly.
 	await sandbox.runCommand({


### PR DESCRIPTION
## Summary

- Pre-create `/tmp/tmux-0` (mode 700) and clean stale sockets before launching ttyd+tmux in `startTtyd()`
- Fixes "tmux socket dir: `/tmp/tmux-0` does not exist — no tmux sockets found" error that appears when connecting to Vercel sandbox terminals

## Root cause

The `startTtyd` function launches ttyd which wraps `tmux new-session -A -s shell`. Two failure modes caused the error:

1. **Empty `/tmp` after snapshot restore**: Vercel sandbox snapshots may not preserve `/tmp` contents, leaving no socket directory for tmux
2. **Stale socket files**: When restoring a snapshot taken while tmux was running, the socket file exists but points to a dead server, blocking `new-session -A` from starting fresh

The fix adds a pre-flight step that removes stale tmux socket dirs and creates a fresh `/tmp/tmux-0` with correct permissions before every ttyd launch.

## Evidence

blocked on evidence — requires a live Vercel sandbox to verify the terminal connects without the socket error

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes  
- [x] `pnpm test` — 103 tests pass (9 suites)
- [ ] Manual: start a terminal sandbox, verify no tmux socket error
- [ ] Manual: pause + resume a sandbox, verify tmux reattaches cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)