### PR TITLE
[codex] Add PostHog telemetry to desktop

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "03ea9ce3d029c0217e3878f7e55ea886e615d3bd9c308ee82268c536726e6123",
+  "pins" : [
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
+        "version" : "1.12.2"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "19d0df316c68ff2e806eaa73563e7fb79788f978",
+        "version" : "3.50.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,9 @@ let package = Package(
         .executable(name: "workspaces", targets: ["WorkspaceManagerCLI"]),
         .executable(name: "WorkspaceManagerCLI", targets: ["WorkspaceManagerCLI"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
+    ],
     targets: [
         // ====================================================================
         // Core Library
@@ -61,7 +63,11 @@ let package = Package(
         // Resources are bundled for the .app bundle creation.
         .executableTarget(
             name: "WorkspaceManager",
-            dependencies: ["WorkspaceManagerCore", "GhosttyKit"],
+            dependencies: [
+                "WorkspaceManagerCore",
+                "GhosttyKit",
+                .product(name: "PostHog", package: "posthog-ios"),
+            ],
             // Exclude Info.plist from automatic resource discovery
             // (SPM forbids Info.plist as a bundled resource; it's copied by build-release.sh)
             exclude: ["Resources/Info.plist"],

--- a/Sources/WorkspaceManager/App/AppRuntimeDependencies.swift
+++ b/Sources/WorkspaceManager/App/AppRuntimeDependencies.swift
@@ -11,6 +11,7 @@ import WorkspaceManagerCore
 struct AppRuntimeDependencies {
     let lumeRuntimeService: any LumeRuntimeServiceProtocol
     let workspaceProviderRegistry: WorkspaceProviderRegistry
+    let telemetryService: DesktopTelemetryService
 
     static func resolved(
         environment: [String: String] = ProcessInfo.processInfo.environment
@@ -25,7 +26,8 @@ struct AppRuntimeDependencies {
                         UIFixtureDaytonaWorkspaceProvider(),
                         UIFixtureLumeWorkspaceProvider(runtimeService: runtimeService),
                     ]
-                )
+                ),
+                telemetryService: .disabled
             )
         }
 
@@ -60,7 +62,8 @@ struct AppRuntimeDependencies {
                         LumeWorkspaceProvider(runtimeService: runtimeService)
                     },
                 ]
-            )
+            ),
+            telemetryService: DesktopTelemetryService.live(environment: environment)
         )
     }
 }

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -46,6 +46,7 @@ struct WorkspaceManagerApp: App {
                 appCommandState: appCommandState
             )
             .environment(\.lumeRuntimeService, appRuntimeDependencies.lumeRuntimeService)
+            .environment(\.telemetryService, appRuntimeDependencies.telemetryService)
             .environment(
                 \.workspaceProviderRegistry,
                 appRuntimeDependencies.workspaceProviderRegistry
@@ -148,6 +149,7 @@ struct WorkspaceManagerApp: App {
         Settings {
             SettingsView()
                 .environment(\.lumeRuntimeService, appRuntimeDependencies.lumeRuntimeService)
+                .environment(\.telemetryService, appRuntimeDependencies.telemetryService)
                 .environment(\.workspaceProviderRegistry, appRuntimeDependencies.workspaceProviderRegistry)
         }
     }
@@ -543,6 +545,10 @@ private struct WorkspaceProviderRegistryKey: EnvironmentKey {
     static let defaultValue = WorkspaceProviderRegistry.live
 }
 
+private struct TelemetryServiceKey: EnvironmentKey {
+    static let defaultValue = DesktopTelemetryService.disabled
+}
+
 extension EnvironmentValues {
     var gitService: any GitServiceProtocol {
         get { self[GitServiceKey.self] }
@@ -572,6 +578,11 @@ extension EnvironmentValues {
     var workspaceProviderRegistry: WorkspaceProviderRegistry {
         get { self[WorkspaceProviderRegistryKey.self] }
         set { self[WorkspaceProviderRegistryKey.self] = newValue }
+    }
+
+    var telemetryService: DesktopTelemetryService {
+        get { self[TelemetryServiceKey.self] }
+        set { self[TelemetryServiceKey.self] = newValue }
     }
 }
 

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -33,6 +33,10 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>11</string>
+	<key>PostHogAPIKey</key>
+	<string></string>
+	<key>PostHogHost</key>
+	<string>https://us.i.posthog.com</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>

--- a/Sources/WorkspaceManager/Services/DesktopTelemetryService.swift
+++ b/Sources/WorkspaceManager/Services/DesktopTelemetryService.swift
@@ -1,0 +1,181 @@
+import Foundation
+import PostHog
+
+enum DesktopTelemetryEvent: String {
+    case appLaunched = "desktop_app_launched"
+    case repoAdded = "desktop_repo_added"
+    case workspaceCreated = "desktop_workspace_created"
+    case workspaceOpened = "desktop_workspace_opened"
+    case webSourceCreated = "desktop_web_source_created"
+    case editorOpened = "desktop_editor_opened"
+}
+
+struct DesktopTelemetryConfiguration: Equatable {
+    let apiKey: String
+    let host: String
+    let debug: Bool
+}
+
+enum DesktopTelemetryConfigurationResolver {
+    private static let doNotTrackEnvironmentKey = "DO_NOT_TRACK"
+    private static let apiKeyEnvironmentKey = "WORKSPACES_POSTHOG_API_KEY"
+    private static let hostEnvironmentKey = "WORKSPACES_POSTHOG_HOST"
+    private static let debugEnvironmentKey = "WORKSPACES_POSTHOG_DEBUG"
+    private static let apiKeyInfoKey = "PostHogAPIKey"
+    private static let hostInfoKey = "PostHogHost"
+    private static let defaultHost = "https://us.i.posthog.com"
+
+    static func resolve(
+        environment: [String: String],
+        infoDictionary: [String: Any]
+    ) -> DesktopTelemetryConfiguration? {
+        guard !isEnabledValue(environment[doNotTrackEnvironmentKey]) else {
+            return nil
+        }
+
+        guard
+            let apiKey = normalizedValue(environment[apiKeyEnvironmentKey])
+                ?? normalizedValue(infoDictionary[apiKeyInfoKey] as? String)
+        else {
+            return nil
+        }
+
+        let host =
+            normalizedValue(environment[hostEnvironmentKey])
+            ?? normalizedValue(infoDictionary[hostInfoKey] as? String)
+            ?? defaultHost
+        let debug = isEnabledValue(environment[debugEnvironmentKey])
+
+        return DesktopTelemetryConfiguration(apiKey: apiKey, host: host, debug: debug)
+    }
+
+    private static func normalizedValue(_ rawValue: String?) -> String? {
+        guard let rawValue else {
+            return nil
+        }
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            return nil
+        }
+        return normalized
+    }
+
+    private static func isEnabledValue(_ rawValue: String?) -> Bool {
+        guard let normalized = normalizedValue(rawValue)?.lowercased() else {
+            return false
+        }
+
+        switch normalized {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+final class DesktopTelemetryService {
+    static let disabled = DesktopTelemetryService()
+
+    let isEnabled: Bool
+
+    private let defaultProperties: [String: Any]
+
+    static func live(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        userDefaults: UserDefaults = .standard,
+        buildIdentity: AppBuildIdentity = .current
+    ) -> DesktopTelemetryService {
+        guard
+            let configuration = DesktopTelemetryConfigurationResolver.resolve(
+                environment: environment,
+                infoDictionary: infoDictionary
+            )
+        else {
+            return .disabled
+        }
+
+        return DesktopTelemetryService(
+            configuration: configuration,
+            userDefaults: userDefaults,
+            buildIdentity: buildIdentity,
+            infoDictionary: infoDictionary
+        )
+    }
+
+    private init() {
+        self.isEnabled = false
+        self.defaultProperties = [:]
+    }
+
+    private init(
+        configuration: DesktopTelemetryConfiguration,
+        userDefaults: UserDefaults,
+        buildIdentity: AppBuildIdentity,
+        infoDictionary: [String: Any]
+    ) {
+        self.isEnabled = true
+        self.defaultProperties = Self.defaultProperties(
+            buildIdentity: buildIdentity,
+            infoDictionary: infoDictionary
+        )
+
+        let config = PostHogConfig(apiKey: configuration.apiKey, host: configuration.host)
+        config.debug = configuration.debug
+        config.captureApplicationLifecycleEvents = true
+        config.captureScreenViews = false
+        PostHogSDK.shared.setup(config)
+
+        let distinctID = Self.resolveDistinctID(userDefaults: userDefaults)
+        PostHogSDK.shared.identify(distinctID, userProperties: defaultProperties)
+        PostHogSDK.shared.capture(DesktopTelemetryEvent.appLaunched.rawValue, properties: defaultProperties)
+    }
+
+    func capture(
+        _ event: DesktopTelemetryEvent,
+        properties: [String: Any] = [:]
+    ) {
+        guard isEnabled else { return }
+        PostHogSDK.shared.capture(
+            event.rawValue,
+            properties: defaultProperties.merging(properties) { _, newValue in newValue }
+        )
+    }
+
+    private static func resolveDistinctID(userDefaults: UserDefaults) -> String {
+        let key = "posthogDistinctID"
+        if let existing = userDefaults.string(forKey: key), !existing.isEmpty {
+            return existing
+        }
+
+        let distinctID = "macos-\(UUID().uuidString.lowercased())"
+        userDefaults.set(distinctID, forKey: key)
+        return distinctID
+    }
+
+    private static func defaultProperties(
+        buildIdentity: AppBuildIdentity,
+        infoDictionary: [String: Any]
+    ) -> [String: Any] {
+        var properties: [String: Any] = [
+            "app_platform": "macos",
+            "build_channel": buildIdentity.channel.rawValue,
+            "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
+        ]
+
+        if let version = infoDictionary["CFBundleShortVersionString"] as? String,
+            !version.isEmpty
+        {
+            properties["app_version"] = version
+        }
+
+        if let buildNumber = infoDictionary["CFBundleVersion"] as? String,
+            !buildNumber.isEmpty
+        {
+            properties["app_build"] = buildNumber
+        }
+
+        return properties
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -46,6 +46,7 @@ struct ContentView: View {
     @Environment(\.lumeRuntimeService) private var lumeRuntimeService
     @Environment(\.workspaceService) private var workspaceService
     @Environment(\.workspaceProviderRegistry) private var workspaceProviderRegistry
+    @Environment(\.telemetryService) private var telemetryService
     @ObservedObject private var notificationCoordinator = NotificationCoordinator.shared
 
     @State private var viewState = MainWindowViewState()
@@ -1112,6 +1113,14 @@ struct ContentView: View {
         if workspace.backendIdentifier != LocalWorkspaceProvider.identifier {
             handleProviderBackedWorkspaceSelection(workspace)
         } else {
+            telemetryService.capture(
+                .workspaceOpened,
+                properties: [
+                    "provider_id": workspace.backendIdentifier,
+                    "is_remote": false,
+                    "workspace_status": workspace.status.rawValue,
+                ]
+            )
             abandonPendingRemoteConnection(reason: "local_workspace_selected")
             markAccessed(workspace: workspace)
             applyNavigationDestination(.workspaceTerminal(workspace))
@@ -1140,7 +1149,6 @@ struct ContentView: View {
                 }
             )
         }
-
     }
 
     @MainActor
@@ -1160,6 +1168,14 @@ struct ContentView: View {
             markAccessed(workspace: workspace)
             applyNavigationDestination(.workspaceTerminal(workspace))
             hostTerminalState.activateExistingSession(sessionID: existing.id)
+            telemetryService.capture(
+                .workspaceOpened,
+                properties: [
+                    "provider_id": workspace.backendIdentifier,
+                    "is_remote": true,
+                    "workspace_status": workspace.status.rawValue,
+                ]
+            )
             terminalFocusCoordinator.requestMainTerminalFocus(
                 targetSessionID: existing.id,
                 surfaceStore: hostTerminalState.surfaceStore,
@@ -1202,6 +1218,14 @@ struct ContentView: View {
                 customCommand: launchSpec.customCommand
             )
             viewState.columnVisibility = .all
+            telemetryService.capture(
+                .workspaceOpened,
+                properties: [
+                    "provider_id": workspace.backendIdentifier,
+                    "is_remote": true,
+                    "workspace_status": workspace.status.rawValue,
+                ]
+            )
             terminalFocusCoordinator.requestMainTerminalFocus(
                 targetSessionID: session.id,
                 surfaceStore: hostTerminalState.surfaceStore,
@@ -1306,7 +1330,8 @@ struct ContentView: View {
         let controller = SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: workspaceProviderRegistry
+            workspaceProviderRegistry: workspaceProviderRegistry,
+            telemetryService: telemetryService
         )
         let workspace = try await controller.createWorkspace(
             from: repo,
@@ -1331,7 +1356,8 @@ struct ContentView: View {
             let controller = SidebarWorkspaceController(
                 modelContext: modelContext,
                 workspaceService: workspaceService,
-                workspaceProviderRegistry: workspaceProviderRegistry
+                workspaceProviderRegistry: workspaceProviderRegistry,
+                telemetryService: telemetryService
             )
             do {
                 try await controller.archive(workspace)
@@ -1351,6 +1377,14 @@ struct ContentView: View {
                 editorID: nil,
                 externalEditorService: externalEditorService,
                 trigger: .uiPrimaryAction
+            )
+            telemetryService.capture(
+                .editorOpened,
+                properties: [
+                    "editor_id": externalEditorService.defaultEditor.rawValue,
+                    "target_kind": "project",
+                    "trigger": OpenInEditorLaunchTrigger.uiPrimaryAction.rawValue,
+                ]
             )
         } catch {
             presentOpenInEditorError(error)
@@ -1375,6 +1409,10 @@ struct ContentView: View {
 
             modelContext.insert(source)
             try modelContext.save()
+            telemetryService.capture(
+                .webSourceCreated,
+                properties: ["scope": telemetryScope(for: target)]
+            )
             handleWebSourceSelection(source)
         } catch {
             if let validationError = error as? WebSourceValidationError {
@@ -1699,6 +1737,14 @@ struct ContentView: View {
                 externalEditorService: externalEditorService,
                 trigger: trigger
             )
+            telemetryService.capture(
+                .editorOpened,
+                properties: [
+                    "editor_id": (editorID ?? externalEditorService.defaultEditor).rawValue,
+                    "target_kind": telemetryTargetKind(for: openInEditorTarget),
+                    "trigger": trigger.rawValue,
+                ]
+            )
         } catch {
             presentOpenInEditorError(error)
         }
@@ -1742,6 +1788,28 @@ struct ContentView: View {
         }
 
         return .uiPrimaryAction
+    }
+
+    private func telemetryScope(for target: WebSourceCreationTarget) -> String {
+        switch target {
+        case .global:
+            return "global"
+        case .repo:
+            return "repo"
+        case .workspace:
+            return "workspace"
+        }
+    }
+
+    private func telemetryTargetKind(for target: OpenInEditorTarget?) -> String {
+        switch target {
+        case .project:
+            return "project"
+        case .projectAndFile:
+            return "project_and_file"
+        case nil:
+            return "unknown"
+        }
     }
 
     private func handleCodePreviewSelection(_ selection: CodePreviewSelection) {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -37,6 +37,7 @@ struct SidebarView: View {
     @Environment(\.workspaceService) private var workspaceService
     @Environment(\.workspaceProviderRegistry) private var workspaceProviderRegistry
     @ObservedObject var appCommandState: AppCommandState
+    @Environment(\.telemetryService) private var telemetryService
     let repos: [Repo]
     let webSources: [WebSource]
     let selectedRepo: Repo?
@@ -90,7 +91,8 @@ struct SidebarView: View {
         SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: workspaceProviderRegistry
+            workspaceProviderRegistry: workspaceProviderRegistry,
+            telemetryService: telemetryService
         )
     }
 
@@ -613,7 +615,16 @@ struct SidebarView: View {
             modelContext.insert(repo)
             if !saveModelContext(action: "save repository") {
                 modelContext.rollback()
+                return
             }
+
+            telemetryService.capture(
+                .repoAdded,
+                properties: [
+                    "source": "file_importer",
+                    "has_remote": repo.remoteURL != nil,
+                ]
+            )
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -31,6 +31,7 @@ struct SidebarWorkspaceController {
     let modelContext: ModelContext
     let workspaceService: any WorkspaceServiceProtocol
     let workspaceProviderRegistry: WorkspaceProviderRegistry
+    let telemetryService: DesktopTelemetryService
 
     nonisolated static func preferredRepoForNewWorkspace(
         selectedWorkspace: Workspace?,
@@ -135,6 +136,15 @@ struct SidebarWorkspaceController {
                 throw ControllerError.message("Failed to create workspace record.")
             }
 
+            telemetryService.capture(
+                .workspaceCreated,
+                properties: [
+                    "provider_id": providerID,
+                    "guest_os": guestOS?.rawValue ?? "host",
+                    "is_remote": provider.descriptor.usesHostWorkspaceFiles == false,
+                    "name_source": nameSource.rawValue,
+                ]
+            )
             await Self.nameReservationStore.release(reservation)
             log.info("createWorkspace: success, returning workspace")
             return persistedWorkspace

--- a/Tests/WorkspaceManagerAppTests/DesktopTelemetryConfigurationResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DesktopTelemetryConfigurationResolverTests.swift
@@ -1,0 +1,71 @@
+import Testing
+@testable import WorkspaceManager
+
+struct DesktopTelemetryConfigurationResolverTests {
+    @Test
+    func prefersEnvironmentOverrides() {
+        let configuration = DesktopTelemetryConfigurationResolver.resolve(
+            environment: [
+                "WORKSPACES_POSTHOG_API_KEY": "phc_env",
+                "WORKSPACES_POSTHOG_HOST": "https://eu.i.posthog.com",
+                "WORKSPACES_POSTHOG_DEBUG": "1",
+            ],
+            infoDictionary: [
+                "PostHogAPIKey": "phc_info",
+                "PostHogHost": "https://us.i.posthog.com",
+            ]
+        )
+
+        #expect(
+            configuration
+                == DesktopTelemetryConfiguration(
+                    apiKey: "phc_env",
+                    host: "https://eu.i.posthog.com",
+                    debug: true
+                )
+        )
+    }
+
+    @Test
+    func fallsBackToInfoDictionaryValues() {
+        let configuration = DesktopTelemetryConfigurationResolver.resolve(
+            environment: [:],
+            infoDictionary: [
+                "PostHogAPIKey": "  phc_info  ",
+                "PostHogHost": "  https://us.i.posthog.com  ",
+            ]
+        )
+
+        #expect(
+            configuration
+                == DesktopTelemetryConfiguration(
+                    apiKey: "phc_info",
+                    host: "https://us.i.posthog.com",
+                    debug: false
+                )
+        )
+    }
+
+    @Test
+    func disablesTelemetryWithoutAPIKey() {
+        let configuration = DesktopTelemetryConfigurationResolver.resolve(
+            environment: [:],
+            infoDictionary: [:]
+        )
+
+        #expect(configuration == nil)
+    }
+
+    @Test
+    func respectsDoNotTrackEnvironmentVariable() {
+        let configuration = DesktopTelemetryConfigurationResolver.resolve(
+            environment: [
+                "DO_NOT_TRACK": "1",
+                "WORKSPACES_POSTHOG_API_KEY": "phc_env",
+            ],
+            infoDictionary: [:]
+        )
+
+        #expect(configuration == nil)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -549,7 +549,8 @@ struct SidebarWorkspaceControllerBehaviorTests {
         SidebarWorkspaceController(
             modelContext: context,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: WorkspaceProviderRegistry(providers: providers)
+            workspaceProviderRegistry: WorkspaceProviderRegistry(providers: providers),
+            telemetryService: .disabled
         )
     }
 


### PR DESCRIPTION
## Summary

- stacked follow-up to #336 with the macOS/Desktop PostHog telemetry work
- add the desktop telemetry service, wire it through app dependencies, and capture app launch, repo add, workspace create/open, web source create, and editor-open events
- honor `DO_NOT_TRACK` on desktop and pin the `posthog-ios` dependency in `Package.resolved`

## Validation

- [ ] `swift build`
- [x] `swift test`
- [ ] Other checks run:

## Performance

- [x] Not a performance-sensitive change
- [ ] Baseline metrics were provided with the task
- [ ] Baseline metrics were gathered before changes
- [ ] Post-change metrics were gathered at the end of the work
- [ ] Before/after/delta is included below
- [ ] Any meaningful change, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Not applicable.

Performance comparison notes:

- Not applicable.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-335/20260412-022432-desktop-posthog-telemetry-validation.png

## Blockers

- [x] None
- [ ] Blocked on evidence
