### PR TITLE
[codex] Harden Workspaces performance system

### DIFF
--- a/.agents/skills/workspaces-optimization/SKILL.md
+++ b/.agents/skills/workspaces-optimization/SKILL.md
@@ -57,11 +57,23 @@ Launch an installed build with focused diagnostics enabled:
 ./scripts/launch-installed-diagnostics.sh --clean-shell
 ```
 
+Run one canonical perf scenario through the shared wrapper:
+
+```bash
+./scripts/perf-runner.sh --scenario debug_no_activate --assert-budget
+```
+
 Summarize the resulting `[Perf]` log:
 
 ```bash
 ./.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py \
   /tmp/workspaces-installed-diagnostics-YYYYMMDD-HHMMSS.log
+```
+
+Compare two canonical summaries:
+
+```bash
+./scripts/perf-compare.py before-summary.json after-summary.json
 ```
 
 Run the repo's repeated launch baseline when you have a checkout and can use the debug app:
@@ -79,6 +91,7 @@ Run the repo's repeated launch baseline when you have a checkout and can use the
 - If the machine has both the installed app and a repo checkout, prefer `collect_installed_perf_bundle.py` so the operator can run one command and return one zip bundle.
 - If the machine only has the installed app, run `host_perf_probe.py` in the slow repo and use the installed app for manual repro.
 - If you have a repo checkout and want an instrumented installed build run, use `./scripts/launch-installed-diagnostics.sh` with either `--clean-shell` or `--login-shell`.
+- If you need deterministic scenario output across debug and installed runs, prefer `./scripts/perf-runner.sh --scenario <id>`.
 - If you have the repo checkout and can build locally, use the repo perf scripts after the host probe so you have both target-machine and debug-build evidence.
 
 ### 2. Collect the smallest useful baseline

--- a/.agents/skills/workspaces-optimization/scripts/summarize_diagnostic_report.py
+++ b/.agents/skills/workspaces-optimization/scripts/summarize_diagnostic_report.py
@@ -20,6 +20,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from perf_schema import canonical_summary, load_contract, numeric_stats
+
 
 @dataclass
 class MetricEvent:
@@ -44,6 +49,11 @@ def parse_args() -> argparse.Namespace:
         "--json",
         action="store_true",
         help="Emit the summary as JSON instead of human-readable text.",
+    )
+    parser.add_argument(
+        "--scenario",
+        default="installed_login_shell",
+        help="Canonical scenario id for the report. Default: installed_login_shell.",
     )
     return parser.parse_args()
 
@@ -114,7 +124,13 @@ def recent_logs_empty(recent_logs: str | None) -> bool:
     return False
 
 
-def build_summary(report: dict[str, Any], system_profile: str | None, recent_logs: str | None) -> dict[str, Any]:
+def build_summary(
+    report: dict[str, Any],
+    system_profile: str | None,
+    recent_logs: str | None,
+    *,
+    scenario: str,
+) -> dict[str, Any]:
     events = parse_events(report)
     launch = find_event(events, "launch_to_first_prompt")
     hydration = find_event(events, "repo_hydration")
@@ -168,44 +184,76 @@ def build_summary(report: dict[str, Any], system_profile: str | None, recent_log
                 app_path = stripped.removeprefix("Path: ")
                 break
 
-    return {
-        "report_path": str(report.get("_report_path", "")),
-        "generated_at": report.get("generatedAt"),
-        "system": {
-            "model": system.get("hardwareModel"),
-            "architecture": system.get("architecture"),
-            "memory_gb": system.get("physicalMemoryGB"),
-            "processors": system.get("processorCount"),
-            "os_version": system.get("osVersion"),
-            "os_build": system.get("osBuild"),
+    canonical_metrics: dict[str, dict[str, Any]] = {}
+    by_metric: dict[str, list[float]] = {}
+    for event in events:
+        by_metric.setdefault(event.metric, []).append(event.duration_ms)
+    for metric_name, values in sorted(by_metric.items()):
+        stats = numeric_stats(values)
+        if stats is not None:
+            canonical_metrics[metric_name] = stats
+
+    summary = canonical_summary(
+        scenario=scenario,
+        build_kind="installed",
+        metrics=canonical_metrics,
+        diagnostic_findings=findings,
+        artifacts={
+            "report_path": str(report.get("_report_path", "")),
+            "generated_at": report.get("generatedAt"),
+            "recent_logs_empty": recent_logs_empty(recent_logs),
         },
-        "app": {
-            "version": diagnostics.get("appVersion"),
-            "build_number": diagnostics.get("buildNumber"),
-            "app_path": app_path,
+        app_version=(
+            f"{diagnostics.get('appVersion')} ({diagnostics.get('buildNumber')})"
+            if diagnostics.get("appVersion") and diagnostics.get("buildNumber")
+            else diagnostics.get("appVersion")
+        ),
+        os_version=system.get("osVersion"),
+        os_build=system.get("osBuild"),
+        machine_model=system.get("hardwareModel"),
+        arch=system.get("architecture"),
+        contract=load_contract(),
+        extra={
+            "report_path": str(report.get("_report_path", "")),
+            "generated_at": report.get("generatedAt"),
+            "system": {
+                "model": system.get("hardwareModel"),
+                "architecture": system.get("architecture"),
+                "memory_gb": system.get("physicalMemoryGB"),
+                "processors": system.get("processorCount"),
+                "os_version": system.get("osVersion"),
+                "os_build": system.get("osBuild"),
+            },
+            "app": {
+                "version": diagnostics.get("appVersion"),
+                "build_number": diagnostics.get("buildNumber"),
+                "app_path": app_path,
+            },
+            "event_metrics": {
+                "launch_to_first_prompt_ms": launch.duration_ms if launch else None,
+                "launch_started_at": launch.started_at.isoformat() if launch and launch.started_at else None,
+                "launch_recorded_at": launch.timestamp.isoformat() if launch and launch.timestamp else None,
+                "repo_hydration_ms": hydration.duration_ms if hydration else None,
+                "repo_hydration_recorded_at": hydration.timestamp.isoformat() if hydration and hydration.timestamp else None,
+                "repo_hydration_labels": hydration.labels if hydration else None,
+                "terminal_first_output_ms": first_output.duration_ms if first_output else None,
+                "terminal_first_output_labels": first_output.labels if first_output else None,
+                "first_prompt_ready_ms": prompt_ready.duration_ms if prompt_ready else None,
+                "first_prompt_ready_labels": prompt_ready.labels if prompt_ready else None,
+            },
+            "recent_logs_empty": recent_logs_empty(recent_logs),
+            "findings": findings,
+            "next_steps": next_steps,
         },
-        "metrics": {
-            "launch_to_first_prompt_ms": launch.duration_ms if launch else None,
-            "launch_started_at": launch.started_at.isoformat() if launch and launch.started_at else None,
-            "launch_recorded_at": launch.timestamp.isoformat() if launch and launch.timestamp else None,
-            "repo_hydration_ms": hydration.duration_ms if hydration else None,
-            "repo_hydration_recorded_at": hydration.timestamp.isoformat() if hydration and hydration.timestamp else None,
-            "repo_hydration_labels": hydration.labels if hydration else None,
-            "terminal_first_output_ms": first_output.duration_ms if first_output else None,
-            "terminal_first_output_labels": first_output.labels if first_output else None,
-            "first_prompt_ready_ms": prompt_ready.duration_ms if prompt_ready else None,
-            "first_prompt_ready_labels": prompt_ready.labels if prompt_ready else None,
-        },
-        "recent_logs_empty": recent_logs_empty(recent_logs),
-        "findings": findings,
-        "next_steps": next_steps,
-    }
+    )
+    summary["metrics_legacy"] = summary["event_metrics"]
+    return summary
 
 
 def print_text(summary: dict[str, Any]) -> None:
     system = summary["system"]
     app = summary["app"]
-    metrics = summary["metrics"]
+    metrics = summary["event_metrics"]
 
     print("Workspaces diagnostic summary")
     print(f"  model: {system['model']} ({system['architecture']})")
@@ -246,7 +294,7 @@ def main() -> int:
     args = parse_args()
     report, system_profile, recent_logs = load_report(args.report_zip)
     report["_report_path"] = str(args.report_zip)
-    summary = build_summary(report, system_profile, recent_logs)
+    summary = build_summary(report, system_profile, recent_logs, scenario=args.scenario)
 
     if args.json:
         json.dump(summary, sys.stdout, indent=2, sort_keys=True)

--- a/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py
+++ b/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py
@@ -20,6 +20,11 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from perf_schema import app_version_from_binary, canonical_summary, load_contract, numeric_stats
+
 
 PERF_PATTERN = re.compile(r"\[Perf\]\s+(?P<body>.*)")
 FIELD_PATTERN = re.compile(r"(?P<key>[A-Za-z0-9_]+)=(?P<value>\S+)")
@@ -40,6 +45,20 @@ def parse_args() -> argparse.Namespace:
         action="append",
         default=[],
         help="Only include selected metric names. Can be passed more than once.",
+    )
+    parser.add_argument(
+        "--scenario",
+        help="Canonical scenario id. If omitted, infer from the parsed metrics when possible.",
+    )
+    parser.add_argument(
+        "--build-kind",
+        choices=["debug", "installed"],
+        help="Build kind for the canonical summary. Defaults to an inference based on the log path.",
+    )
+    parser.add_argument(
+        "--app-path",
+        type=Path,
+        help="Optional app bundle or binary path used to resolve the app version.",
     )
     return parser.parse_args()
 
@@ -72,7 +91,118 @@ def summarize_numeric(values: list[float]) -> dict[str, float]:
     }
 
 
-def build_summary(log_file: Path, metrics_filter: set[str]) -> dict[str, Any]:
+def infer_scenario(
+    requested: str | None,
+    phase_summaries: dict[str, Any],
+    phase_keys: set[str],
+) -> str:
+    if requested:
+        return requested
+    if "input_investigation:key_down_handled" in phase_keys:
+        return "installed_input_short_capture"
+
+    terminal_summary = phase_summaries.get("terminal_investigation:surface_create_succeeded")
+    shell_modes = (
+        terminal_summary.get("categorical_fields", {}).get("shell_profile_mode", {})
+        if terminal_summary else {}
+    )
+    if "clean" in shell_modes:
+        return "installed_clean_shell"
+    if "login" in shell_modes:
+        return "installed_login_shell"
+    return "unknown"
+
+
+def infer_build_kind(requested: str | None, log_file: Path, scenario: str) -> str:
+    if requested:
+        return requested
+    if scenario.startswith("debug_"):
+        return "debug"
+    if "installed" in log_file.name:
+        return "installed"
+    return "debug"
+
+
+def build_canonical_metrics(
+    all_metrics: dict[str, list[dict[str, str]]],
+    phase_summaries: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    metrics: dict[str, dict[str, Any]] = {}
+
+    for metric_name, events in sorted(all_metrics.items()):
+        durations = [
+            float(duration)
+            for duration in (
+                event.get("duration_ms")
+                for event in events
+            )
+            if duration is not None and maybe_number(duration) is not None
+        ]
+        stats = numeric_stats(durations)
+        if stats is not None:
+            metrics[metric_name] = stats
+
+    input_summary = phase_summaries.get("input_investigation:key_down_handled")
+    if input_summary:
+        event_age_stats = input_summary["numeric_fields"].get("event_age_ms")
+        handler_stats = input_summary["numeric_fields"].get("handler_duration_ms")
+        if event_age_stats:
+            metrics["input_event_age_ms_median"] = {
+                "count": event_age_stats["count"],
+                "min": event_age_stats["min"],
+                "median": event_age_stats["median"],
+                "mean": event_age_stats["mean"],
+                "max": event_age_stats["max"],
+                "p95": event_age_stats["max"],
+                "unit": "ms",
+            }
+        if handler_stats:
+            metrics["input_handler_duration_ms_median"] = {
+                "count": handler_stats["count"],
+                "min": handler_stats["min"],
+                "median": handler_stats["median"],
+                "mean": handler_stats["mean"],
+                "max": handler_stats["max"],
+                "p95": handler_stats["max"],
+                "unit": "ms",
+            }
+    else:
+        aggregate_summary = phase_summaries.get("input_investigation:key_down_summary")
+        if aggregate_summary:
+            age_stats = aggregate_summary["numeric_fields"].get("event_age_median_ms")
+            handler_stats = aggregate_summary["numeric_fields"].get("handler_duration_median_ms")
+            if age_stats:
+                metrics["input_event_age_ms_median"] = {
+                    "count": age_stats["count"],
+                    "min": age_stats["min"],
+                    "median": age_stats["median"],
+                    "mean": age_stats["mean"],
+                    "max": age_stats["max"],
+                    "p95": age_stats["max"],
+                    "unit": "ms",
+                }
+            if handler_stats:
+                metrics["input_handler_duration_ms_median"] = {
+                    "count": handler_stats["count"],
+                    "min": handler_stats["min"],
+                    "median": handler_stats["median"],
+                    "mean": handler_stats["mean"],
+                    "max": handler_stats["max"],
+                    "p95": handler_stats["max"],
+                    "unit": "ms",
+                }
+
+    return metrics
+
+
+def build_summary(
+    log_file: Path,
+    metrics_filter: set[str],
+    *,
+    requested_scenario: str | None,
+    requested_build_kind: str | None,
+    app_path: Path | None,
+) -> dict[str, Any]:
     lines = log_file.read_text(encoding="utf-8", errors="replace").splitlines()
 
     parsed_events: list[dict[str, Any]] = []
@@ -138,15 +268,36 @@ def build_summary(log_file: Path, metrics_filter: set[str]) -> dict[str, Any]:
         }
 
     findings = derive_findings(phase_summaries)
-
-    return {
-        "log_file": str(log_file),
-        "line_count": len(lines),
-        "perf_event_count": len(parsed_events),
-        "metrics": metric_summaries,
-        "phases": phase_summaries,
-        "findings": findings,
-    }
+    scenario = infer_scenario(requested_scenario, phase_summaries, set(phase_summaries))
+    build_kind = infer_build_kind(requested_build_kind, log_file, scenario)
+    app_version = app_version_from_binary(app_path)
+    canonical_metrics = build_canonical_metrics(all_metrics, phase_summaries)
+    contract = load_contract()
+    summary = canonical_summary(
+        scenario=scenario,
+        build_kind=build_kind,
+        metrics=canonical_metrics,
+        diagnostic_findings=findings,
+        artifacts={
+            "log_file": str(log_file),
+            "line_count": len(lines),
+            "perf_event_count": len(parsed_events),
+        },
+        app_version=app_version,
+        contract=contract,
+        extra={
+            "log_file": str(log_file),
+            "line_count": len(lines),
+            "perf_event_count": len(parsed_events),
+            "phases": phase_summaries,
+            "findings": findings,
+            "legacy_metric_summaries": metric_summaries,
+        },
+    )
+    summary["metrics_by_phase"] = phase_summaries
+    summary["metrics_detected"] = metric_summaries
+    summary["findings"] = findings
+    return summary
 
 
 def derive_findings(phase_summaries: dict[str, Any]) -> list[str]:
@@ -253,21 +404,33 @@ def derive_findings(phase_summaries: dict[str, Any]) -> list[str]:
 def print_text(summary: dict[str, Any]) -> None:
     print("WorkspaceManager perf log summary")
     print(f"  log_file: {summary['log_file']}")
+    print(f"  scenario: {summary['scenario']}")
+    print(f"  build_kind: {summary['environment']['build_kind']}")
     print(f"  total_lines: {summary['line_count']}")
     print(f"  perf_events: {summary['perf_event_count']}")
     print()
 
     print("Metrics:")
-    if not summary["metrics"]:
+    if not summary["metrics_detected"]:
         print("- no [Perf] metrics found")
     else:
         for metric, details in sorted(summary["metrics"].items()):
-            phases = ", ".join(details["phases"])
-            print(f"- {metric}: count={details['count']} phases={phases}")
+            budget = summary["budget_results"].get(metric, {})
+            budget_suffix = ""
+            if budget.get("gate_budget_ms") is not None:
+                budget_suffix = (
+                    f" gate<={budget['gate_budget_ms']}ms"
+                    f" status={budget['status']}"
+                )
+            print(
+                f"- {metric}: count={details['count']} min={details['min']:.2f} "
+                f"median={details['median']:.2f} p95={details['p95']:.2f} "
+                f"max={details['max']:.2f}{budget_suffix}"
+            )
 
     print()
     print("Phase summaries:")
-    for key, details in sorted(summary["phases"].items()):
+    for key, details in sorted(summary["metrics_by_phase"].items()):
         print(f"- {key}: count={details['count']}")
         for field, stats in sorted(details["numeric_fields"].items()):
             print(
@@ -287,7 +450,13 @@ def print_text(summary: dict[str, Any]) -> None:
 
 def main() -> int:
     args = parse_args()
-    summary = build_summary(args.log_file, set(args.metric))
+    summary = build_summary(
+        args.log_file,
+        set(args.metric),
+        requested_scenario=args.scenario,
+        requested_build_kind=args.build_kind,
+        app_path=args.app_path,
+    )
     if args.json:
         json.dump(summary, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")

--- a/.agents/skills/workspaces-performance-system/SKILL.md
+++ b/.agents/skills/workspaces-performance-system/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: workspaces-performance-system
+description: >
+  Run and maintain the canonical Workspaces performance contract across debug,
+  installed, release, and CI environments. Use when collecting comparable
+  before/after metrics, asserting scenario budgets, verifying installed-build
+  parity, refreshing baselines, or classifying self-hosted perf lane failures
+  as infrastructure versus product regressions. Prefer this skill over
+  workspaces-optimization when the task is to operate the standardized
+  performance system rather than investigate an unknown slowdown.
+---
+
+# Workspaces Performance System
+
+Use this skill when the task is to run the performance system correctly and produce comparable evidence.
+
+Use `workspaces-optimization` instead when the task is root-cause investigation on a slow machine or an unknown latency path.
+
+## Quick Start
+
+Run one canonical scenario and assert budgets:
+
+```bash
+./scripts/perf-runner.sh --scenario debug_no_activate --assert-budget
+```
+
+Compare before and after summaries:
+
+```bash
+./scripts/perf-compare.py before-summary.json after-summary.json
+```
+
+Verify release-bundle installed-build parity:
+
+```bash
+./scripts/verify-installed-perf.sh build/WorkspaceManager.app
+```
+
+## Core Workflow
+
+### 1. Start from the contract
+
+Read these first:
+
+- `config/performance/contract.json`
+- `docs/performance/metrics-reference.md`
+- `docs/performance-testing.md`
+
+The contract is the source of truth for:
+
+- scenario ids
+- metric coverage
+- budget formulas
+- PR versus scheduled-main gate policy
+
+Do not invent new scenario names or hand-tuned thresholds in ad hoc scripts.
+
+### 2. Pick the smallest canonical scenario
+
+Use these scenario ids exactly:
+
+- `debug_no_activate`
+- `debug_activate`
+- `installed_clean_shell`
+- `installed_login_shell`
+- `installed_input_short_capture`
+
+Guidance:
+
+- Use `debug_no_activate` for low-variance local branch comparisons.
+- Use `debug_activate` for interactive local validation.
+- Use `installed_clean_shell` to isolate app and terminal surface cost.
+- Use `installed_login_shell` to include shell-init overhead.
+- Use `installed_input_short_capture` only for short focused typing captures.
+
+### 3. Run through the wrapper first
+
+Prefer the shared wrapper over calling collectors manually:
+
+```bash
+./scripts/perf-runner.sh --scenario installed_clean_shell --assert-budget
+```
+
+The wrapper exists to keep artifact shape consistent across debug and installed runs.
+
+Use the older standalone scripts only when you need a narrower benchmark:
+
+- `./scripts/perf-baseline.sh`
+- `./scripts/new-workspace-perf.sh`
+- `./scripts/launch-installed-diagnostics.sh`
+- `./.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py`
+- `./.agents/skills/workspaces-optimization/scripts/summarize_diagnostic_report.py`
+
+### 4. Compare canonical summaries, not raw impressions
+
+For every optimization or regression check:
+
+1. capture `before`
+2. capture `after`
+3. compare with `./scripts/perf-compare.py`
+4. report metric deltas and budget status
+
+Prefer median as the gate signal. Treat max and p95 as diagnostic signals.
+
+### 5. Treat installed-build parity as mandatory
+
+Before release or packaged-app signoff:
+
+1. build the packaged app
+2. run `./scripts/verify-release-bundle.sh`
+3. run `./scripts/verify-installed-perf.sh`
+
+Installed validation must confirm:
+
+- bundled `ghostty` resources exist
+- bundled `terminfo` exists
+- installed clean-shell capture emits `terminal_first_output`
+- installed clean-shell capture emits `first_prompt_ready`
+- logs do not contain missing-resource warnings
+
+If the verifier fails because the machine is headless or lacks a real display session, classify that as an environment limitation, not a product perf result.
+
+### 6. Separate infra failures from perf regressions
+
+For CI and scheduled runs, read:
+
+- `.github/workflows/perf-validation.yml`
+- `docs/development/self-hosted-runner-incidents.md`
+
+Rules:
+
+- `runner-lane-health` answers whether the lane is available.
+- `perf-validation` answers whether the product met the scenario.
+- Do not report `tart-ui` offline or runner disconnects as app regressions.
+- On PRs, local evidence plus build/test is merge-critical; self-hosted perf stays advisory until lane stability is proven.
+
+## Outputs To Produce
+
+When this skill is used successfully, produce:
+
+- canonical `summary.json`
+- short human-readable summary
+- before/after delta report when comparing changes
+- explicit classification of any infra-only failure
+
+## Guardrails
+
+- Do not bypass `contract.json` with custom thresholds.
+- Do not compare different scenarios as if they were equivalent.
+- Do not claim a regression from one noisy run when a lower-variance scenario is available.
+- Do not treat missing installed-build metrics as product failure before checking Ghostty resources and display/session constraints.
+- Do not mix root-cause debugging with contract validation unless the standardized run has already classified the regression.
+
+## Canonical Files
+
+- `config/performance/contract.json`
+- `scripts/perf-runner.sh`
+- `scripts/perf-compare.py`
+- `scripts/verify-installed-perf.sh`
+- `scripts/perf-baseline.sh`
+- `scripts/new-workspace-perf.sh`
+- `.github/workflows/perf-validation.yml`
+- `.github/workflows/release.yml`
+- `docs/performance-testing.md`
+- `docs/performance/metrics-reference.md`
+- `docs/development/self-hosted-runner-incidents.md`

--- a/.agents/skills/workspaces-performance-system/SKILL.md
+++ b/.agents/skills/workspaces-performance-system/SKILL.md
@@ -71,7 +71,7 @@ Guidance:
 - Use `debug_activate` for interactive local validation.
 - Use `installed_clean_shell` to isolate app and terminal surface cost.
 - Use `installed_login_shell` to include shell-init overhead.
-- Use `installed_input_short_capture` only for short focused typing captures.
+- Use `installed_input_short_capture` only for short interactive focused typing captures.
 
 ### 3. Run through the wrapper first
 
@@ -118,7 +118,7 @@ Installed validation must confirm:
 - installed clean-shell capture emits `first_prompt_ready`
 - logs do not contain missing-resource warnings
 
-If the verifier fails because the machine is headless or lacks a real display session, classify that as an environment limitation, not a product perf result.
+If the verifier fails because the machine is headless or lacks a real display session, classify that as an environment limitation, not a product perf result. Release automation may use `./scripts/verify-installed-perf.sh --allow-skip-noninteractive` for that one case only.
 
 ### 6. Separate infra failures from perf regressions
 

--- a/.agents/skills/workspaces-performance-system/agents/openai.yaml
+++ b/.agents/skills/workspaces-performance-system/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Workspaces Performance System"
+  short_description: "Run the canonical Workspaces perf contract and classify results."
+  default_prompt: "Use $workspaces-performance-system to run the smallest canonical performance scenario, produce comparable summary artifacts, and classify any failures as product regressions or infrastructure issues."

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       lane_available: ${{ steps.inspect.outputs.lane_available }}
+      lane_status: ${{ steps.inspect.outputs.lane_status }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
@@ -48,6 +49,7 @@ jobs:
           python3 - <<'PY'
           import json
           import os
+          import urllib.error
           import urllib.request
           from pathlib import Path
 
@@ -61,40 +63,79 @@ jobs:
                   "X-GitHub-Api-Version": "2022-11-28",
               },
           )
-          with urllib.request.urlopen(req) as response:
-              payload = json.loads(response.read().decode("utf-8"))
+          try:
+              with urllib.request.urlopen(req) as response:
+                  payload = json.loads(response.read().decode("utf-8"))
+          except urllib.error.HTTPError as error:
+              state = {
+                  "lane": "tart-ui",
+                  "available": None,
+                  "status": "inspection_blocked",
+                  "summary": (
+                      "Runner inventory could not be queried with the workflow token. "
+                      "Treat this as infrastructure visibility state, not a product regression."
+                  ),
+                  "error": {
+                      "type": "HTTPError",
+                      "code": error.code,
+                      "reason": str(error.reason),
+                  },
+              }
+              lane_available = "unknown"
+              lane_status = "inspection_blocked"
+          except Exception as error:  # pragma: no cover - defensive workflow guard
+              state = {
+                  "lane": "tart-ui",
+                  "available": None,
+                  "status": "inspection_error",
+                  "summary": (
+                      "Runner inventory inspection failed unexpectedly. "
+                      "Treat this as infrastructure state, not a product regression."
+                  ),
+                  "error": {
+                      "type": type(error).__name__,
+                      "message": str(error),
+                  },
+              }
+              lane_available = "unknown"
+              lane_status = "inspection_error"
+          else:
+              lane_runners = []
+              for runner in payload.get("runners", []):
+                  labels = {label.get("name") for label in runner.get("labels", [])}
+                  if "tart-ui" not in labels:
+                      continue
+                  lane_runners.append(
+                      {
+                          "name": runner.get("name"),
+                          "status": runner.get("status"),
+                          "busy": runner.get("busy"),
+                          "labels": sorted(labels),
+                      }
+                  )
 
-          lane_runners = []
-          for runner in payload.get("runners", []):
-              labels = {label.get("name") for label in runner.get("labels", [])}
-              if "tart-ui" not in labels:
-                  continue
-              lane_runners.append(
-                  {
-                      "name": runner.get("name"),
-                      "status": runner.get("status"),
-                      "busy": runner.get("busy"),
-                      "labels": sorted(labels),
-                  }
+              available = any(
+                  runner["status"] == "online" and runner["busy"] is False
+                  for runner in lane_runners
               )
+              state = {
+                  "lane": "tart-ui",
+                  "available": available,
+                  "status": "available" if available else "unavailable",
+                  "runners": lane_runners,
+                  "summary": (
+                      "At least one tart-ui runner is online and idle."
+                      if available
+                      else "No tart-ui runner is currently online and idle."
+                  ),
+              }
+              lane_available = "true" if available else "false"
+              lane_status = state["status"]
 
-          available = any(
-              runner["status"] == "online" and runner["busy"] is False
-              for runner in lane_runners
-          )
-          state = {
-              "lane": "tart-ui",
-              "available": available,
-              "runners": lane_runners,
-              "summary": (
-                  "At least one tart-ui runner is online and idle."
-                  if available
-                  else "No tart-ui runner is currently online and idle."
-              ),
-          }
           Path("runner-lane-health.json").write_text(json.dumps(state, indent=2) + "\n")
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
-              handle.write(f"lane_available={'true' if available else 'false'}\n")
+              handle.write(f"lane_available={lane_available}\n")
+              handle.write(f"lane_status={lane_status}\n")
           PY
 
       - name: Upload runner lane health artifact
@@ -160,10 +201,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write skip reason
+        env:
+          LANE_AVAILABLE: ${{ needs.runner-lane-health.outputs.lane_available }}
+          LANE_STATUS: ${{ needs.runner-lane-health.outputs.lane_status }}
         run: |
-          cat <<'EOF' > perf-validation-skipped.md
-          Perf validation did not run because the dedicated tart-ui lane was not available.
-          Treat this as infrastructure state, not a product regression.
+          cat <<EOF > perf-validation-skipped.md
+          Perf validation did not run because the dedicated tart-ui lane was not available or could not be inspected.
+          lane_available: ${LANE_AVAILABLE}
+          lane_status: ${LANE_STATUS}
+          If lane_status is inspection_blocked, the workflow token could not query the runner inventory.
+          Treat this as infrastructure visibility state, not a product regression.
           See the runner-lane-health artifact for the runner inventory snapshot.
           EOF
 

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -9,8 +9,13 @@ on:
       - codex/**
     paths:
       - .github/workflows/perf-validation.yml
+      - config/performance/**
+      - .agents/skills/workspaces-optimization/scripts/**
       - scripts/build-ghosttykit.sh
       - scripts/perf-baseline.sh
+      - scripts/perf-runner.sh
+      - scripts/launch-installed-diagnostics.sh
+      - scripts/verify-installed-perf.sh
       - Sources/**
       - Tests/**
 
@@ -20,9 +25,84 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
+  runner-lane-health:
+    runs-on: ubuntu-latest
+    outputs:
+      lane_available: ${{ steps.inspect.outputs.lane_available }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Inspect tart-ui runner lane
+        id: inspect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          req = urllib.request.Request(
+              f"https://api.github.com/repos/{repo}/actions/runners?per_page=100",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {token}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(req) as response:
+              payload = json.loads(response.read().decode("utf-8"))
+
+          lane_runners = []
+          for runner in payload.get("runners", []):
+              labels = {label.get("name") for label in runner.get("labels", [])}
+              if "tart-ui" not in labels:
+                  continue
+              lane_runners.append(
+                  {
+                      "name": runner.get("name"),
+                      "status": runner.get("status"),
+                      "busy": runner.get("busy"),
+                      "labels": sorted(labels),
+                  }
+              )
+
+          available = any(
+              runner["status"] == "online" and runner["busy"] is False
+              for runner in lane_runners
+          )
+          state = {
+              "lane": "tart-ui",
+              "available": available,
+              "runners": lane_runners,
+              "summary": (
+                  "At least one tart-ui runner is online and idle."
+                  if available
+                  else "No tart-ui runner is currently online and idle."
+              ),
+          }
+          Path("runner-lane-health.json").write_text(json.dumps(state, indent=2) + "\n")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"lane_available={'true' if available else 'false'}\n")
+          PY
+
+      - name: Upload runner lane health artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: runner-lane-health-${{ github.run_id }}
+          path: runner-lane-health.json
+          if-no-files-found: error
+
   perf-validation:
+    needs: runner-lane-health
+    if: needs.runner-lane-health.outputs.lane_available == 'true'
     # Run perf validation on the dedicated Tart UI lane so app-launching checks
     # never contend with generic CI or the interactive desktop runner.
     runs-on: [self-hosted, tart-ui]
@@ -69,3 +149,23 @@ jobs:
           name: performance-dashboard-${{ github.run_id }}
           path: perf-artifacts
           if-no-files-found: warn
+
+  perf-validation-skipped:
+    needs: runner-lane-health
+    if: needs.runner-lane-health.outputs.lane_available != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write skip reason
+        run: |
+          cat <<'EOF' > perf-validation-skipped.md
+          Perf validation did not run because the dedicated tart-ui lane was not available.
+          Treat this as infrastructure state, not a product regression.
+          See the runner-lane-health artifact for the runner inventory snapshot.
+          EOF
+
+      - name: Upload skip artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: perf-validation-skipped-${{ github.run_id }}
+          path: perf-validation-skipped.md
+          if-no-files-found: error

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -14,6 +14,10 @@ on:
       - scripts/build-ghosttykit.sh
       - scripts/perf-baseline.sh
       - scripts/perf-runner.sh
+      - scripts/perf_schema.py
+      - scripts/perf-compare.py
+      - scripts/new-workspace-perf.sh
+      - scripts/test_perf_tools.py
       - scripts/launch-installed-diagnostics.sh
       - scripts/verify-installed-perf.sh
       - Sources/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,9 @@ jobs:
       - name: Verify signed app bundle
         run: ./scripts/verify-release-bundle.sh build/WorkspaceManager.app
 
+      - name: Verify installed-build perf parity
+        run: ./scripts/verify-installed-perf.sh build/WorkspaceManager.app build/release-installed-perf
+
       - name: Notarize and package DMG
         run: bash ./scripts/notarize.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,15 @@ jobs:
         run: ./scripts/verify-release-bundle.sh build/WorkspaceManager.app
 
       - name: Verify installed-build perf parity
-        run: ./scripts/verify-installed-perf.sh build/WorkspaceManager.app build/release-installed-perf
+        run: ./scripts/verify-installed-perf.sh --allow-skip-noninteractive build/WorkspaceManager.app build/release-installed-perf
+
+      - name: Upload installed-build perf verification artifact
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: release-installed-perf-${{ github.run_id }}
+          path: build/release-installed-perf
+          if-no-files-found: warn
 
       - name: Notarize and package DMG
         run: bash ./scripts/notarize.sh

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -60,80 +60,80 @@ struct WorkspaceManagerApp: App {
         .commands {
             CommandGroup(after: .newItem) {
                 Button("New Workspace...") {
-                    appCommandState.newWorkspaceAction?()
+                    appCommandState.performNewWorkspace()
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.newWorkspace.keyEquivalent,
                     modifiers: AppChromeShortcut.newWorkspace.eventModifiers
                 )
-                .disabled(appCommandState.newWorkspaceAction == nil)
+                .disabled(!appCommandState.canCreateWorkspace)
 
                 Button("Open in...") {
-                    appCommandState.mainWindowActions.openInEditor?()
+                    appCommandState.perform(.openInEditor)
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.openInEditor.keyEquivalent,
                     modifiers: AppChromeShortcut.openInEditor.eventModifiers
                 )
-                .disabled(appCommandState.mainWindowActions.openInEditor == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canOpenInEditor)
 
                 Button("Toggle Sidebar") {
-                    appCommandState.mainWindowActions.toggleSidebar?()
+                    appCommandState.perform(.toggleSidebar)
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.toggleSidebar.keyEquivalent,
                     modifiers: AppChromeShortcut.toggleSidebar.eventModifiers
                 )
-                .disabled(appCommandState.mainWindowActions.toggleSidebar == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canToggleSidebar)
 
                 Button("Toggle Inspector") {
-                    appCommandState.mainWindowActions.toggleInspector?()
+                    appCommandState.perform(.toggleInspector)
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.toggleInspector.keyEquivalent,
                     modifiers: AppChromeShortcut.toggleInspector.eventModifiers
                 )
-                .disabled(appCommandState.mainWindowActions.toggleInspector == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canToggleInspector)
 
                 Button("Toggle Terminal Panel") {
-                    appCommandState.mainWindowActions.toggleTerminalPanel?()
+                    appCommandState.perform(.toggleTerminalPanel)
                 }
                 .keyboardShortcut(
                     AppChromeShortcut.toggleTerminalPanel.keyEquivalent,
                     modifiers: AppChromeShortcut.toggleTerminalPanel.eventModifiers
                 )
-                .disabled(appCommandState.mainWindowActions.toggleTerminalPanel == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canToggleTerminalPanel)
             }
 
             SidebarCommands()
 
             CommandMenu("Selection") {
                 Button("Open in Browser") {
-                    appCommandState.mainWindowActions.openInBrowser?()
+                    appCommandState.perform(.openInBrowser)
                 }
-                .disabled(appCommandState.mainWindowActions.openInBrowser == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canOpenInBrowser)
 
                 Button("Reload Web Source") {
-                    appCommandState.mainWindowActions.reloadWebSource?()
+                    appCommandState.perform(.reloadWebSource)
                 }
-                .disabled(appCommandState.mainWindowActions.reloadWebSource == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canReloadWebSource)
 
                 Divider()
 
                 Button("Open Desktop") {
-                    appCommandState.mainWindowActions.openDesktop?()
+                    appCommandState.perform(.openDesktop)
                 }
-                .disabled(appCommandState.mainWindowActions.openDesktop == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canOpenDesktop)
 
                 Button("Reveal in Finder") {
-                    appCommandState.mainWindowActions.revealInFinder?()
+                    appCommandState.perform(.revealInFinder)
                 }
-                .disabled(appCommandState.mainWindowActions.revealInFinder == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canRevealInFinder)
 
                 Button("Copy Path") {
-                    appCommandState.mainWindowActions.copyPath?()
+                    appCommandState.perform(.copyPath)
                 }
-                .disabled(appCommandState.mainWindowActions.copyPath == nil)
+                .disabled(!appCommandState.mainWindowAvailability.canCopyPath)
             }
 
             CommandGroup(after: .help) {
@@ -591,8 +591,94 @@ struct MainWindowFocusedActions {
     static let empty = MainWindowFocusedActions()
 }
 
+struct MainWindowCommandAvailability: Equatable {
+    let canToggleSidebar: Bool
+    let canToggleInspector: Bool
+    let canToggleTerminalPanel: Bool
+    let canOpenInEditor: Bool
+    let canOpenInBrowser: Bool
+    let canReloadWebSource: Bool
+    let canOpenDesktop: Bool
+    let canRevealInFinder: Bool
+    let canCopyPath: Bool
+
+    static let empty = MainWindowCommandAvailability(
+        canToggleSidebar: false,
+        canToggleInspector: false,
+        canToggleTerminalPanel: false,
+        canOpenInEditor: false,
+        canOpenInBrowser: false,
+        canReloadWebSource: false,
+        canOpenDesktop: false,
+        canRevealInFinder: false,
+        canCopyPath: false
+    )
+}
+
+enum MainWindowCommand {
+    case toggleSidebar
+    case toggleInspector
+    case toggleTerminalPanel
+    case openInEditor
+    case openInBrowser
+    case reloadWebSource
+    case openDesktop
+    case revealInFinder
+    case copyPath
+}
+
 @MainActor
 final class AppCommandState: ObservableObject {
-    @Published var newWorkspaceAction: (@MainActor () -> Void)?
-    @Published var mainWindowActions = MainWindowFocusedActions.empty
+    @Published private(set) var canCreateWorkspace = false
+    @Published private(set) var mainWindowAvailability = MainWindowCommandAvailability.empty
+
+    private var newWorkspaceAction: (@MainActor () -> Void)?
+    private var mainWindowActions = MainWindowFocusedActions.empty
+
+    func setNewWorkspaceAction(_ action: (@MainActor () -> Void)?) {
+        newWorkspaceAction = action
+        let nextAvailability = action != nil
+        guard canCreateWorkspace != nextAvailability else { return }
+        canCreateWorkspace = nextAvailability
+    }
+
+    func setMainWindowActions(
+        _ actions: MainWindowFocusedActions,
+        availability: MainWindowCommandAvailability
+    ) {
+        mainWindowActions = actions
+        guard mainWindowAvailability != availability else { return }
+        mainWindowAvailability = availability
+    }
+
+    func clearMainWindowActions() {
+        setMainWindowActions(.empty, availability: .empty)
+    }
+
+    func performNewWorkspace() {
+        newWorkspaceAction?()
+    }
+
+    func perform(_ command: MainWindowCommand) {
+        switch command {
+        case .toggleSidebar:
+            mainWindowActions.toggleSidebar?()
+        case .toggleInspector:
+            mainWindowActions.toggleInspector?()
+        case .toggleTerminalPanel:
+            mainWindowActions.toggleTerminalPanel?()
+        case .openInEditor:
+            mainWindowActions.openInEditor?()
+        case .openInBrowser:
+            mainWindowActions.openInBrowser?()
+        case .reloadWebSource:
+            mainWindowActions.reloadWebSource?()
+        case .openDesktop:
+            mainWindowActions.openDesktop?()
+        case .revealInFinder:
+            mainWindowActions.revealInFinder?()
+        case .copyPath:
+            mainWindowActions.copyPath?()
+        }
+    }
 }

--- a/Sources/WorkspaceManager/Diagnostics/InvestigationDiagnostics.swift
+++ b/Sources/WorkspaceManager/Diagnostics/InvestigationDiagnostics.swift
@@ -1,14 +1,67 @@
 import Foundation
 
 enum InvestigationDiagnostics {
+    private enum InputMode: String {
+        case disabled
+        case summary
+        case detailed
+    }
+
+    private struct InputAggregate {
+        var eventAgeValues: [Double] = []
+        var handlerDurationValues: [Double] = []
+        var surfaceMissingCount = 0
+        var windowNotKeyCount = 0
+
+        var count: Int {
+            eventAgeValues.count
+        }
+
+        mutating func record(
+            eventAgeMs: Double,
+            handlerDurationMs: Double,
+            surfaceMissing: Bool,
+            windowKey: Bool
+        ) {
+            eventAgeValues.append(eventAgeMs)
+            handlerDurationValues.append(handlerDurationMs)
+            if surfaceMissing {
+                surfaceMissingCount += 1
+            }
+            if !windowKey {
+                windowNotKeyCount += 1
+            }
+        }
+
+        mutating func takeIfReady(batchSize: Int) -> InputAggregate? {
+            guard count >= batchSize else { return nil }
+            let snapshot = self
+            self = InputAggregate()
+            return snapshot
+        }
+    }
+
     private static let focusEnabled =
         ProcessInfo.processInfo.environment["WORKSPACES_FOCUS_DIAGNOSTICS"] == "1"
     private static let sheetEnabled =
         ProcessInfo.processInfo.environment["WORKSPACES_SHEET_DIAGNOSTICS"] == "1"
     private static let terminalEnabled =
         ProcessInfo.processInfo.environment["WORKSPACES_TERMINAL_DIAGNOSTICS"] == "1"
-    private static let inputEnabled =
-        ProcessInfo.processInfo.environment["WORKSPACES_INPUT_DIAGNOSTICS"] == "1"
+    private static let inputMode: InputMode = {
+        let rawValue = ProcessInfo.processInfo.environment["WORKSPACES_INPUT_DIAGNOSTICS"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        switch rawValue {
+        case "1", "detailed":
+            return .detailed
+        case "summary":
+            return .summary
+        default:
+            return .disabled
+        }
+    }()
+    nonisolated(unsafe) private static var inputAggregate = InputAggregate()
+    private static let inputSummaryBatchSize = 12
 
     static func emitFocus(phase: String, fields: [String: String] = [:]) {
         guard focusEnabled else { return }
@@ -26,8 +79,48 @@ enum InvestigationDiagnostics {
     }
 
     static func emitInput(phase: String, fields: [String: String] = [:]) {
-        guard inputEnabled else { return }
+        guard inputMode == .detailed else { return }
         emit(metric: "input_investigation", phase: phase, fields: fields)
+    }
+
+    static func recordInputHandled(
+        eventAgeMs: Double,
+        handlerDurationMs: Double,
+        surfaceMissing: Bool,
+        windowKey: Bool,
+        detailedFields: [String: String]
+    ) {
+        switch inputMode {
+        case .disabled:
+            return
+        case .detailed:
+            emit(metric: "input_investigation", phase: "key_down_handled", fields: detailedFields)
+        case .summary:
+            inputAggregate.record(
+                eventAgeMs: eventAgeMs,
+                handlerDurationMs: handlerDurationMs,
+                surfaceMissing: surfaceMissing,
+                windowKey: windowKey
+            )
+            guard let snapshot = inputAggregate.takeIfReady(batchSize: inputSummaryBatchSize) else {
+                return
+            }
+            emit(
+                metric: "input_investigation",
+                phase: "key_down_summary",
+                fields: [
+                    "count": "\(snapshot.count)",
+                    "event_age_max_ms": format(snapshot.eventAgeValues.max() ?? 0),
+                    "event_age_mean_ms": format(mean(snapshot.eventAgeValues)),
+                    "event_age_median_ms": format(median(snapshot.eventAgeValues)),
+                    "handler_duration_max_ms": format(snapshot.handlerDurationValues.max() ?? 0),
+                    "handler_duration_mean_ms": format(mean(snapshot.handlerDurationValues)),
+                    "handler_duration_median_ms": format(median(snapshot.handlerDurationValues)),
+                    "surface_missing_count": "\(snapshot.surfaceMissingCount)",
+                    "window_not_key_count": "\(snapshot.windowNotKeyCount)",
+                ]
+            )
+        }
     }
 
     private static func emit(metric: String, phase: String, fields: [String: String]) {
@@ -50,5 +143,24 @@ enum InvestigationDiagnostics {
             .replacingOccurrences(of: " ", with: "_")
             .replacingOccurrences(of: "\n", with: "_")
             .replacingOccurrences(of: "\t", with: "_")
+    }
+
+    private static func mean(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.2f", value)
     }
 }

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceInputRouter.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceInputRouter.swift
@@ -204,9 +204,13 @@ enum GhosttySurfaceInputRouter {
 
         defer {
             let handlerDurationMs = max(0, (ProcessInfo.processInfo.systemUptime - handlerStartedAt) * 1000)
-            InvestigationDiagnostics.emitInput(
-                phase: "key_down_handled",
-                fields: [
+            let isWindowKey = view.window?.isKeyWindow == true
+            InvestigationDiagnostics.recordInputHandled(
+                eventAgeMs: eventAgeMs,
+                handlerDurationMs: handlerDurationMs,
+                surfaceMissing: surfaceMissing,
+                windowKey: isWindowKey,
+                detailedFields: [
                     "chars": event.charactersIgnoringModifiers ?? "",
                     "event_age_ms": String(format: "%.2f", eventAgeMs),
                     "focused": view.focused ? "true" : "false",
@@ -217,7 +221,7 @@ enum GhosttySurfaceInputRouter {
                     "repeat": event.isARepeat ? "true" : "false",
                     "surface_missing": surfaceMissing ? "true" : "false",
                     "text_mode": textMode,
-                    "window_key": view.window?.isKeyWindow == true ? "true" : "false",
+                    "window_key": isWindowKey ? "true" : "false",
                 ]
             )
         }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -16,18 +16,6 @@ private let creationLog = Logger(
     category: "WorkspaceCreation"
 )
 
-private struct MainWindowCommandAvailabilitySnapshot: Equatable {
-    let canToggleSidebar: Bool
-    let canToggleInspector: Bool
-    let canToggleTerminalPanel: Bool
-    let canOpenInEditor: Bool
-    let canOpenInBrowser: Bool
-    let canReloadWebSource: Bool
-    let canOpenDesktop: Bool
-    let canRevealInFinder: Bool
-    let canCopyPath: Bool
-}
-
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Binding var deepLinkState: WorkspaceDeepLinkState
@@ -279,8 +267,8 @@ struct ContentView: View {
         )
     }
 
-    private var mainWindowCommandAvailabilitySnapshot: MainWindowCommandAvailabilitySnapshot {
-        MainWindowCommandAvailabilitySnapshot(
+    private var mainWindowCommandAvailabilitySnapshot: MainWindowCommandAvailability {
+        MainWindowCommandAvailability(
             canToggleSidebar: true,
             canToggleInspector: true,
             canToggleTerminalPanel: true,
@@ -1778,12 +1766,15 @@ struct ContentView: View {
 
     @MainActor
     private func syncAppCommands() {
-        appCommandState.mainWindowActions = mainWindowFocusedActions
+        appCommandState.setMainWindowActions(
+            mainWindowFocusedActions,
+            availability: mainWindowCommandAvailabilitySnapshot
+        )
     }
 
     @MainActor
     private func clearAppCommands() {
-        appCommandState.mainWindowActions = .empty
+        appCommandState.clearMainWindowActions()
     }
 
     private func persistLastSurface(_ surface: MainWindowLastSurface) {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -1019,12 +1019,12 @@ struct SidebarView: View {
 
     @MainActor
     private func syncAppCommands() {
-        appCommandState.newWorkspaceAction = handleNewWorkspaceShortcut
+        appCommandState.setNewWorkspaceAction(handleNewWorkspaceShortcut)
     }
 
     @MainActor
     private func clearAppCommands() {
-        appCommandState.newWorkspaceAction = nil
+        appCommandState.setNewWorkspaceAction(nil)
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
@@ -15,6 +15,8 @@ final class TerminalFocusCoordinator: ObservableObject {
         let activateApp: Bool
         let activeSessionID: UUID?
         let onTargetFocused: (() -> Void)?
+        let requestedAtUptime: TimeInterval
+        var surfaceResolvedAtUptime: TimeInterval?
     }
 
     private weak var attachedSurfaceStore: HostTerminalSurfaceStore?
@@ -99,7 +101,9 @@ final class TerminalFocusCoordinator: ObservableObject {
             sessionID: targetSessionID,
             activateApp: activateApp,
             activeSessionID: activeSessionID,
-            onTargetFocused: onTargetFocused
+            onTargetFocused: onTargetFocused,
+            requestedAtUptime: ProcessInfo.processInfo.systemUptime,
+            surfaceResolvedAtUptime: nil
         )
         attemptPendingFocus(using: surfaceStore, reason: "request_started")
     }
@@ -205,7 +209,7 @@ final class TerminalFocusCoordinator: ObservableObject {
     }
 
     private func attemptPendingFocus(using surfaceStore: HostTerminalSurfaceStore, reason: String) {
-        guard let pendingFocusRequest else { return }
+        guard var pendingFocusRequest else { return }
 
         let focusFields = [
             "activate_app": pendingFocusRequest.activateApp ? "true" : "false",
@@ -222,9 +226,21 @@ final class TerminalFocusCoordinator: ObservableObject {
             return
         }
 
+        let surfaceResolvedAtUptime = ProcessInfo.processInfo.systemUptime
+        let resolutionDurationMs = max(
+            0,
+            (surfaceResolvedAtUptime - pendingFocusRequest.requestedAtUptime) * 1000
+        )
+        pendingFocusRequest.surfaceResolvedAtUptime = surfaceResolvedAtUptime
+        self.pendingFocusRequest = pendingFocusRequest
+
         InvestigationDiagnostics.emitFocus(
             phase: "focus_surface_resolution",
-            fields: focusFields.merging(["sub_span": "focus_surface_resolution"]) { _, new in new }
+            fields: focusFields.merging([
+                "duration_ms": String(format: "%.2f", resolutionDurationMs),
+                "status": "completed",
+                "sub_span": "focus_surface_resolution",
+            ]) { _, new in new }
         )
         InvestigationDiagnostics.emitFocus(
             phase: "coordinator_target_terminal_resolved",
@@ -241,18 +257,34 @@ final class TerminalFocusCoordinator: ObservableObject {
             for: terminal,
             onFocused: { [weak self] in
                 guard let self else { return }
-                guard self.pendingFocusRequest?.sessionID == pendingFocusRequest.sessionID else { return }
+                guard let pendingRequest = self.pendingFocusRequest,
+                    pendingRequest.sessionID == pendingFocusRequest.sessionID
+                else { return }
                 self.pendingFocusRequest = nil
+                let focusCompletedAtUptime = ProcessInfo.processInfo.systemUptime
+                let firstResponderDurationMs = max(
+                    0,
+                    (focusCompletedAtUptime
+                        - (pendingRequest.surfaceResolvedAtUptime ?? pendingRequest.requestedAtUptime))
+                        * 1000
+                )
+                let totalFocusDurationMs = max(
+                    0,
+                    (focusCompletedAtUptime - pendingRequest.requestedAtUptime) * 1000
+                )
                 InvestigationDiagnostics.emitFocus(
                     phase: "focus_request_to_first_responder",
                     fields: focusFields.merging([
+                        "duration_ms": String(format: "%.2f", firstResponderDurationMs),
                         "sub_span": "focus_request_to_first_responder",
                         "status": "completed",
                     ]) { _, new in new }
                 )
                 InvestigationDiagnostics.emitFocus(
                     phase: "coordinator_target_focused",
-                    fields: focusFields
+                    fields: focusFields.merging([
+                        "duration_ms": String(format: "%.2f", totalFocusDurationMs)
+                    ]) { _, new in new }
                 )
                 pendingFocusRequest.onTargetFocused?()
             }

--- a/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
@@ -1,0 +1,90 @@
+import Combine
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("AppCommandState")
+struct AppCommandStateTests {
+    @Test("new workspace availability only publishes when availability changes")
+    func newWorkspaceAvailabilityOnlyPublishesWhenAvailabilityChanges() {
+        let state = AppCommandState()
+        var emissions = 0
+        let cancellable = state.objectWillChange.sink { _ in
+            emissions += 1
+        }
+        defer { cancellable.cancel() }
+
+        state.setNewWorkspaceAction({})
+        #expect(state.canCreateWorkspace)
+        #expect(emissions == 1)
+
+        state.setNewWorkspaceAction({})
+        #expect(state.canCreateWorkspace)
+        #expect(emissions == 1)
+
+        state.setNewWorkspaceAction(nil)
+        #expect(!state.canCreateWorkspace)
+        #expect(emissions == 2)
+    }
+
+    @Test("main window actions only publish when availability changes")
+    func mainWindowActionsOnlyPublishWhenAvailabilityChanges() {
+        let state = AppCommandState()
+        var emissions = 0
+        let cancellable = state.objectWillChange.sink { _ in
+            emissions += 1
+        }
+        defer { cancellable.cancel() }
+
+        let availability = MainWindowCommandAvailability(
+            canToggleSidebar: true,
+            canToggleInspector: false,
+            canToggleTerminalPanel: false,
+            canOpenInEditor: true,
+            canOpenInBrowser: false,
+            canReloadWebSource: false,
+            canOpenDesktop: false,
+            canRevealInFinder: false,
+            canCopyPath: false
+        )
+
+        state.setMainWindowActions(
+            MainWindowFocusedActions(
+                toggleSidebar: {},
+                toggleInspector: nil,
+                toggleTerminalPanel: nil,
+                openInEditor: {},
+                openInBrowser: nil,
+                reloadWebSource: nil,
+                openDesktop: nil,
+                revealInFinder: nil,
+                copyPath: nil
+            ),
+            availability: availability
+        )
+        #expect(state.mainWindowAvailability == availability)
+        #expect(emissions == 1)
+
+        state.setMainWindowActions(
+            MainWindowFocusedActions(
+                toggleSidebar: {},
+                toggleInspector: nil,
+                toggleTerminalPanel: nil,
+                openInEditor: {},
+                openInBrowser: nil,
+                reloadWebSource: nil,
+                openDesktop: nil,
+                revealInFinder: nil,
+                copyPath: nil
+            ),
+            availability: availability
+        )
+        #expect(state.mainWindowAvailability == availability)
+        #expect(emissions == 1)
+
+        state.clearMainWindowActions()
+        #expect(state.mainWindowAvailability == .empty)
+        #expect(emissions == 2)
+    }
+}

--- a/config/performance/contract.json
+++ b/config/performance/contract.json
@@ -1,0 +1,210 @@
+{
+  "version": 1,
+  "reference_baseline_note": "Seed baseline derived from validated local runs and historical debug gates. Refresh with a 10-run reference capture before tightening budgets.",
+  "budget_formula": {
+    "gate": {
+      "stat": "median",
+      "multiplier": 1.25,
+      "rounding": "ceil"
+    },
+    "diagnostic": {
+      "stat": "p95",
+      "multiplier": 1.5,
+      "rounding": "ceil"
+    }
+  },
+  "gate_policy": {
+    "pr": {
+      "local_evidence_required": true,
+      "self_hosted_perf_required": false,
+      "self_hosted_perf_mode": "advisory"
+    },
+    "main_scheduled": {
+      "self_hosted_perf_required": true,
+      "self_hosted_perf_condition": "after_7_day_lane_stability"
+    }
+  },
+  "scenarios": [
+    {
+      "id": "debug_no_activate",
+      "build_kind": "debug",
+      "description": "Debug binary launched without activation for reproducible local startup and switch timing."
+    },
+    {
+      "id": "debug_activate",
+      "build_kind": "debug",
+      "description": "Debug binary launched with normal activation for interactive startup timing."
+    },
+    {
+      "id": "installed_clean_shell",
+      "build_kind": "installed",
+      "description": "Installed app launched with clean shell profiles to isolate app and terminal surface cost."
+    },
+    {
+      "id": "installed_login_shell",
+      "build_kind": "installed",
+      "description": "Installed app launched with normal login shell profiles to include shell-init overhead."
+    },
+    {
+      "id": "installed_input_short_capture",
+      "build_kind": "installed",
+      "description": "Short focused typing capture on the installed app for event-age and handler timing."
+    }
+  ],
+  "metrics": [
+    {
+      "name": "launch_to_first_prompt",
+      "unit": "ms",
+      "supported_scenarios": [
+        "debug_no_activate",
+        "debug_activate",
+        "installed_clean_shell",
+        "installed_login_shell"
+      ],
+      "reference_baselines": {
+        "debug_no_activate": {
+          "median_ms": 200,
+          "p95_ms": 260
+        },
+        "debug_activate": {
+          "median_ms": 220,
+          "p95_ms": 300
+        },
+        "installed_clean_shell": {
+          "median_ms": 640,
+          "p95_ms": 760
+        },
+        "installed_login_shell": {
+          "median_ms": 900,
+          "p95_ms": 1100
+        }
+      }
+    },
+    {
+      "name": "terminal_first_output",
+      "unit": "ms",
+      "supported_scenarios": [
+        "installed_clean_shell",
+        "installed_login_shell"
+      ],
+      "reference_baselines": {
+        "installed_clean_shell": {
+          "median_ms": 540,
+          "p95_ms": 650
+        },
+        "installed_login_shell": {
+          "median_ms": 700,
+          "p95_ms": 900
+        }
+      }
+    },
+    {
+      "name": "first_prompt_ready",
+      "unit": "ms",
+      "supported_scenarios": [
+        "installed_clean_shell",
+        "installed_login_shell"
+      ],
+      "reference_baselines": {
+        "installed_clean_shell": {
+          "median_ms": 540,
+          "p95_ms": 650
+        },
+        "installed_login_shell": {
+          "median_ms": 700,
+          "p95_ms": 900
+        }
+      }
+    },
+    {
+      "name": "repo_hydration",
+      "unit": "ms",
+      "supported_scenarios": [
+        "debug_no_activate",
+        "debug_activate",
+        "installed_clean_shell",
+        "installed_login_shell"
+      ],
+      "reference_baselines": {
+        "debug_no_activate": {
+          "median_ms": 20,
+          "p95_ms": 30
+        },
+        "debug_activate": {
+          "median_ms": 20,
+          "p95_ms": 30
+        },
+        "installed_clean_shell": {
+          "median_ms": 20,
+          "p95_ms": 30
+        },
+        "installed_login_shell": {
+          "median_ms": 20,
+          "p95_ms": 30
+        }
+      }
+    },
+    {
+      "name": "repo_click_to_focus",
+      "unit": "ms",
+      "supported_scenarios": [
+        "debug_no_activate",
+        "debug_activate"
+      ],
+      "reference_baselines": {
+        "debug_no_activate": {
+          "median_ms": 200,
+          "p95_ms": 260
+        },
+        "debug_activate": {
+          "median_ms": 220,
+          "p95_ms": 300
+        }
+      }
+    },
+    {
+      "name": "workspace_click_to_focus",
+      "unit": "ms",
+      "supported_scenarios": [
+        "debug_no_activate",
+        "debug_activate"
+      ],
+      "reference_baselines": {
+        "debug_no_activate": {
+          "median_ms": 220,
+          "p95_ms": 300
+        },
+        "debug_activate": {
+          "median_ms": 240,
+          "p95_ms": 320
+        }
+      }
+    },
+    {
+      "name": "input_event_age_ms_median",
+      "unit": "ms",
+      "supported_scenarios": [
+        "installed_input_short_capture"
+      ],
+      "reference_baselines": {
+        "installed_input_short_capture": {
+          "median_ms": 12,
+          "p95_ms": 25
+        }
+      }
+    },
+    {
+      "name": "input_handler_duration_ms_median",
+      "unit": "ms",
+      "supported_scenarios": [
+        "installed_input_short_capture"
+      ],
+      "reference_baselines": {
+        "installed_input_short_capture": {
+          "median_ms": 1,
+          "p95_ms": 4
+        }
+      }
+    }
+  ]
+}

--- a/config/performance/contract.json
+++ b/config/performance/contract.json
@@ -48,7 +48,7 @@
     {
       "id": "installed_input_short_capture",
       "build_kind": "installed",
-      "description": "Short focused typing capture on the installed app for event-age and handler timing."
+      "description": "Short interactive focused typing capture on the installed app for event-age and handler timing."
     }
   ],
   "metrics": [

--- a/docs/development/self-hosted-runner-incidents.md
+++ b/docs/development/self-hosted-runner-incidents.md
@@ -1,0 +1,39 @@
+# Self-Hosted Runner Incidents
+
+This document records infrastructure failure modes for the repo's self-hosted lanes.
+
+## Classification Rule
+
+When a runner shows `online`, accepts work, then flips `offline` or stops reporting while the job is still queued or running, classify that as an infrastructure incident first, not a product regression.
+
+Reason:
+
+- the app perf signal is invalid if the execution lane cannot stay connected
+- a flaky lane can create false negatives that look like code regressions
+- product performance and runner health must be reviewed independently
+
+## Current Incident Signature
+
+Signature:
+
+- runner becomes eligible for a job
+- GitHub shows the lane as `offline`, `lost communication`, or leaves the job queued
+- the local runner process may still be alive
+
+Interpretation:
+
+- lane-health failure
+- not evidence that the checked code regressed
+
+## Required Response
+
+1. Capture runner state with the self-hosted-runner tooling.
+2. Attach the lane-health artifact or local runner evidence.
+3. Mark the perf result as skipped or infra-blocked.
+4. Do not treat the skipped perf lane as proof of a product regression.
+
+## Related Files
+
+- `.github/workflows/perf-validation.yml`
+- `.agents/skills/self-hosted-runners/SKILL.md`
+- `scripts/runner.sh`

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -32,6 +32,7 @@ Use the scripted baseline runner:
 ```bash
 ./scripts/perf-baseline.sh 5 8
 ./scripts/perf-baseline.sh 5 8 --launch-mode activate
+./scripts/perf-runner.sh --scenario debug_no_activate --assert-budget
 ```
 
 To persist results and generate a visual trend dashboard:
@@ -51,7 +52,7 @@ What it does:
 1. Kills existing `WorkspaceManager` process.
 2. Launches app with `WORKSPACES_PERF_AUTO_SELECT_FIRST_REPO=1`.
 3. Collects `[Perf]` metric log lines from each run.
-4. Produces `summary.txt` with min/median/mean/max.
+4. Produces canonical `summary.json` plus `summary.txt`.
 
 Output location:
 
@@ -78,6 +79,19 @@ The dedicated GitHub Actions workflow is `.github/workflows/perf-validation.yml`
 - It runs on `[self-hosted, tart-ui]`, not in the main `CI` workflow, so app-launching perf checks stay off the interactive desktop.
 - It rebuilds the app before capture, but leaves the full Swift test suite to the main `CI` workflow on GitHub-hosted macOS; this avoids headless keychain-specific failures on the Tart lane from blocking perf artifact generation.
 - On `codex/**` branches, pushes that change the perf workflow, perf script, or app/test sources also trigger it so branch-local validation is possible before merge.
+- A separate ubuntu-hosted runner-lane-health job classifies tart-ui availability so offline runners are treated as infra state, not product regressions.
+
+## Installed-build parity workflow
+
+Use the canonical installed-build wrapper when validating packaged or installed apps:
+
+```bash
+./scripts/perf-runner.sh --scenario installed_clean_shell --app /Applications/WorkspaceManager.app/Contents/MacOS/WorkspaceManager
+./scripts/perf-runner.sh --scenario installed_login_shell --app /Applications/WorkspaceManager.app/Contents/MacOS/WorkspaceManager
+./scripts/verify-installed-perf.sh build/WorkspaceManager.app
+```
+
+These runs use the same summary schema as the debug baseline, so before/after comparisons can flow through `./scripts/perf-compare.py`.
 
 ## Why `WORKSPACES_PERF_AUTO_SELECT_FIRST_REPO=1` is used
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -88,10 +88,16 @@ Use the canonical installed-build wrapper when validating packaged or installed 
 ```bash
 ./scripts/perf-runner.sh --scenario installed_clean_shell --app /Applications/WorkspaceManager.app/Contents/MacOS/WorkspaceManager
 ./scripts/perf-runner.sh --scenario installed_login_shell --app /Applications/WorkspaceManager.app/Contents/MacOS/WorkspaceManager
+./scripts/perf-runner.sh --scenario installed_input_short_capture --capture-seconds 15
 ./scripts/verify-installed-perf.sh build/WorkspaceManager.app
 ```
 
 These runs use the same summary schema as the debug baseline, so before/after comparisons can flow through `./scripts/perf-compare.py`.
+
+Notes:
+
+- `installed_input_short_capture` is intentionally interactive. The app activates and you must type in the focused terminal during the capture window.
+- `verify-installed-perf.sh --allow-skip-noninteractive` is reserved for release automation on runners that may lack an interactive Aqua session.
 
 ## Why `WORKSPACES_PERF_AUTO_SELECT_FIRST_REPO=1` is used
 

--- a/docs/performance/metrics-reference.md
+++ b/docs/performance/metrics-reference.md
@@ -2,6 +2,20 @@
 
 This page explains what each dashboard metric means, where timing starts/ends, and the runtime flow being measured.
 
+The machine-readable source of truth for scenarios, metric coverage, and budget formulas is:
+
+- `config/performance/contract.json`
+
+Canonical scenarios:
+
+| Scenario | Build Kind | Purpose |
+|---|---|---|
+| `debug_no_activate` | `debug` | Low-variance local startup and switch timing without app activation |
+| `debug_activate` | `debug` | Interactive debug startup timing with normal activation |
+| `installed_clean_shell` | `installed` | Installed-app startup with shell init bypassed |
+| `installed_login_shell` | `installed` | Installed-app startup with normal login shell cost included |
+| `installed_input_short_capture` | `installed` | Short focused typing capture for input event age and handler timing |
+
 ## Metric Definitions
 
 ### `launch_to_first_prompt`
@@ -236,17 +250,29 @@ sequenceDiagram
     end
 ```
 
-## Enforced Budget Targets
+## Budget Contract
 
-The three core startup metrics have enforced performance budgets. When `perf-baseline.sh` is invoked with `--assert-budget`, it exits nonzero if any metric's median exceeds its target.
+Budgets are derived from the reference baselines in `config/performance/contract.json` using one formula everywhere:
 
-| Metric | Budget |
-|---|---:|
-| `launch_to_first_prompt` | <= 250 ms |
-| `repo_hydration` | <= 25 ms |
-| `repo_click_to_focus` | <= 250 ms |
+- gate budget: `ceil(reference median * 1.25)`
+- diagnostic threshold: `ceil(reference p95 * 1.5)`
 
-These are enforced in the `perf-validation.yml` workflow. A budget breach fails the workflow run. Release blocking via required check status is tracked in #98.
+Rules:
+
+- median is the gating statistic
+- p95 is diagnostic and should trigger investigation even when median still passes
+- existing `[Perf]` metric names remain the raw telemetry source; contract logic sits above them
+
+Enforcement points:
+
+- `./scripts/perf-baseline.sh --assert-budget`
+- `./scripts/perf-runner.sh --scenario <id> --assert-budget`
+- `.github/workflows/perf-validation.yml`
+
+Installed-build parity is verified separately in the release path:
+
+- `./scripts/verify-release-bundle.sh`
+- `./scripts/verify-installed-perf.sh`
 
 ## Interpreting Dashboard Changes
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,19 @@ This directory contains build/release helpers plus UI test utilities.
 - `./scripts/release-version.sh`
   - Reads, sets, and validates app release version metadata from `Sources/WorkspaceManager/Resources/Info.plist`.
   - Use this instead of editing `Info.plist` by hand before tagging or notarizing a release.
+- `./scripts/verify-installed-perf.sh`
+  - Verifies packaged-app Ghostty resource presence plus a clean-shell installed-build perf capture.
+  - Fails if `terminal_first_output` / `first_prompt_ready` are missing or if known Ghostty resource warnings appear.
+  - Requires an interactive display-capable macOS session; it is not valid in headless AppKit environments.
+
+## Performance Contract
+
+- `./scripts/perf-runner.sh --scenario <id>`
+  - Runs one canonical scenario and writes a canonical summary artifact.
+- `./scripts/perf-compare.py before.json after.json`
+  - Compares two canonical summaries and prints metric deltas plus gate status.
+- Contract source of truth:
+  - `./config/performance/contract.json`
 
 ## Installed Diagnostics
 
@@ -43,6 +56,7 @@ This directory contains build/release helpers plus UI test utilities.
     - `--clean-shell` to bypass shell profile loading in embedded terminals
     - `--with-input-diagnostics` for short active-typing captures
     - `--no-activate` to avoid app activation on launch
+    - `--capture-seconds <n>` for unattended installed-build captures
     - `--log-file <path>` to choose the capture log path
 
 ## Primary UI Test Entry Points

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,7 @@ This directory contains build/release helpers plus UI test utilities.
   - Verifies packaged-app Ghostty resource presence plus a clean-shell installed-build perf capture.
   - Fails if `terminal_first_output` / `first_prompt_ready` are missing or if known Ghostty resource warnings appear.
   - Requires an interactive display-capable macOS session; it is not valid in headless AppKit environments.
+  - `--allow-skip-noninteractive` converts only the known display-session limitation into a recorded skip for release automation.
 
 ## Performance Contract
 

--- a/scripts/launch-installed-diagnostics.sh
+++ b/scripts/launch-installed-diagnostics.sh
@@ -13,6 +13,7 @@ Options:
   --log-file <path>      Path to write combined stdout/stderr.
   --clean-shell          Launch embedded terminals with clean shell profiles.
   --login-shell          Launch embedded terminals with normal login profiles.
+  --capture-seconds <n>  Auto-terminate the app after n seconds and keep the log.
   --with-input-diagnostics
                          Enable per-key input diagnostics. Use only for short captures.
   --no-activate          Do not activate the app on launch.
@@ -34,6 +35,7 @@ SHELL_MODE=""
 NO_ACTIVATE=0
 DISABLE_AUTO_IMPORT=1
 WITH_INPUT_DIAGNOSTICS=0
+CAPTURE_SECONDS=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -56,6 +58,10 @@ while [[ $# -gt 0 ]]; do
         --with-input-diagnostics)
             WITH_INPUT_DIAGNOSTICS=1
             shift
+            ;;
+        --capture-seconds)
+            CAPTURE_SECONDS="$2"
+            shift 2
             ;;
         --no-activate)
             NO_ACTIVATE=1
@@ -88,7 +94,7 @@ ENV_VARS=(
 )
 
 if [[ "$WITH_INPUT_DIAGNOSTICS" -eq 1 ]]; then
-    ENV_VARS+=("WORKSPACES_INPUT_DIAGNOSTICS=1")
+    ENV_VARS+=("WORKSPACES_INPUT_DIAGNOSTICS=detailed")
 fi
 
 if [[ -n "$SHELL_MODE" ]]; then
@@ -111,6 +117,14 @@ for entry in "${ENV_VARS[@]}"; do
     echo "    $entry"
 done
 echo "  summarize:"
-echo "    uv run --script .agents/skills/workspaces-optimization/scripts/summarize_perf_log.py $LOG_FILE"
-
-env "${ENV_VARS[@]}" "$APP_PATH" 2>&1 | tee "$LOG_FILE"
+echo "    ./.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py $LOG_FILE"
+if [[ "$CAPTURE_SECONDS" -gt 0 ]]; then
+    echo "  capture_seconds: $CAPTURE_SECONDS"
+    env "${ENV_VARS[@]}" "$APP_PATH" > >(tee "$LOG_FILE") 2>&1 &
+    APP_PID=$!
+    sleep "$CAPTURE_SECONDS"
+    kill "$APP_PID" 2>/dev/null || true
+    wait "$APP_PID" 2>/dev/null || true
+else
+    env "${ENV_VARS[@]}" "$APP_PATH" 2>&1 | tee "$LOG_FILE"
+fi

--- a/scripts/new-workspace-perf.sh
+++ b/scripts/new-workspace-perf.sh
@@ -123,12 +123,14 @@ ARCH="$(uname -m)"
 MODEL="$(sysctl -n hw.model 2>/dev/null || echo unknown)"
 TIMESTAMP="$(date '+%Y-%m-%dT%H:%M:%S%z')"
 
-python3 - "$OUTPUT_DIR" "$RUNS" "$SLEEP_SECONDS" "$TIMESTAMP" "$OS_VERSION" "$OS_BUILD" "$ARCH" "$MODEL" "$LAUNCH_MODE" <<'PY'
+PERF_SUMMARY_TIMESTAMP="$TIMESTAMP" PYTHONPATH="$ROOT_DIR/scripts${PYTHONPATH:+:$PYTHONPATH}" python3 - "$OUTPUT_DIR" "$RUNS" "$SLEEP_SECONDS" "$TIMESTAMP" "$OS_VERSION" "$OS_BUILD" "$ARCH" "$MODEL" "$LAUNCH_MODE" <<'PY'
 import json
 import pathlib
 import re
 import statistics
 import sys
+
+from perf_schema import canonical_summary, load_contract
 
 out_dir = pathlib.Path(sys.argv[1])
 runs = int(sys.argv[2])
@@ -199,31 +201,61 @@ def summarize(values: list[float]):
     if not values:
         return None
     return {
-        "n": len(values),
+        "count": len(values),
         "min": min(values),
         "max": max(values),
         "median": statistics.median(values),
         "mean": statistics.mean(values),
+        "p95": max(values),
+        "unit": "ms",
     }
 
 
-summary = {
-    "metadata": {
-        "timestamp": timestamp,
+scenario = "debug_no_activate" if launch_mode == "no-activate" else "debug_activate"
+canonical_metrics = {
+    metric: stats
+    for metric, values in metric_values.items()
+    if (stats := summarize(values)) is not None
+}
+findings = []
+sheet_stats = canonical_metrics.get("new_workspace_sheet_ready")
+if sheet_stats and sheet_stats["median"] > 500:
+    findings.append(
+        f"new_workspace_sheet_ready median is {sheet_stats['median']:.2f} ms. Opening the sheet still carries noticeable deferred work."
+    )
+if not findings:
+    findings.append("No automated new-workspace perf findings were derived from the captured [Perf] lines.")
+
+summary = canonical_summary(
+    scenario=scenario,
+    build_kind="debug",
+    metrics=canonical_metrics,
+    diagnostic_findings=findings,
+    artifacts={
+        "output_dir": str(out_dir),
         "runs_requested": runs,
         "sleep_seconds": sleep_seconds,
-        "launch_mode": launch_mode,
-        "os_version": os_version,
-        "os_build": os_build,
-        "arch": arch,
-        "model": model,
-        "new_workspace_sheet_triggers": sorted(set(new_workspace_triggers)),
+        "log_files": [str(path) for path in sorted(out_dir.glob("run-*.log"))],
     },
-    "metrics": {
-        metric: summarize(values)
-        for metric, values in metric_values.items()
+    os_version=os_version,
+    os_build=os_build,
+    machine_model=model,
+    arch=arch,
+    contract=load_contract(),
+    extra={
+        "metadata": {
+            "timestamp": timestamp,
+            "runs_requested": runs,
+            "sleep_seconds": sleep_seconds,
+            "launch_mode": launch_mode,
+            "os_version": os_version,
+            "os_build": os_build,
+            "arch": arch,
+            "model": model,
+            "new_workspace_sheet_triggers": sorted(set(new_workspace_triggers)),
+        }
     },
-}
+)
 
 summary_lines = []
 for metric in [
@@ -243,8 +275,8 @@ for metric in [
         summary_lines.append(f"{metric}: missing")
         continue
     summary_lines.append(
-        f"{metric}: n={stats['n']} min={stats['min']:.2f} max={stats['max']:.2f} "
-        f"median={stats['median']:.2f} mean={stats['mean']:.2f}"
+        f"{metric}: count={stats['count']} min={stats['min']:.2f} max={stats['max']:.2f} "
+        f"median={stats['median']:.2f} mean={stats['mean']:.2f} p95={stats['p95']:.2f}"
     )
 
 summary_lines.append(

--- a/scripts/ops-report.py
+++ b/scripts/ops-report.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import math
 import os
 import re
 import shutil
@@ -22,6 +23,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+from perf_schema import load_contract
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -51,11 +54,19 @@ ISSUE_MARKER_RE = re.compile(
 )
 IDEA_PATTERN = re.compile(r"\[idea\](?:\[endorsed\])?", re.IGNORECASE)
 
-PERF_TARGETS_MS = {
-    "launch_to_first_prompt": 250.0,
-    "repo_hydration": 25.0,
-    "repo_click_to_focus": 250.0,
-}
+def load_perf_targets_ms() -> dict[str, float]:
+    contract = load_contract()
+    scenario = "debug_no_activate"
+    targets: dict[str, float] = {}
+    for metric in contract.get("metrics", []):
+        reference = metric.get("reference_baselines", {}).get(scenario)
+        if reference is None:
+            continue
+        targets[metric["name"]] = math.ceil(float(reference["median_ms"]) * 1.25)
+    return targets
+
+
+PERF_TARGETS_MS = load_perf_targets_ms()
 FAILURE_CONCLUSIONS = {"failure", "timed_out", "startup_failure", "action_required"}
 AGENT_WORKFLOW_PREFIX = "Agent: "
 OPS_IDEA_TITLES = {

--- a/scripts/perf-baseline.sh
+++ b/scripts/perf-baseline.sh
@@ -142,7 +142,7 @@ ARCH="$(uname -m)"
 MODEL="$(sysctl -n hw.model 2>/dev/null || echo unknown)"
 TIMESTAMP="$(date '+%Y-%m-%dT%H:%M:%S%z')"
 
-python3 - "$OUTPUT_DIR" "$ROOT_DIR" "$RUNS" "$SLEEP_SECONDS" "$RECORD" "$TIMESTAMP" "$OS_VERSION" "$OS_BUILD" "$ARCH" "$MODEL" "$LAUNCH_MODE" "$ASSERT_BUDGET" <<'PY'
+PERF_SUMMARY_TIMESTAMP="$TIMESTAMP" PYTHONPATH="$ROOT_DIR/scripts${PYTHONPATH:+:$PYTHONPATH}" python3 - "$OUTPUT_DIR" "$ROOT_DIR" "$RUNS" "$SLEEP_SECONDS" "$RECORD" "$TIMESTAMP" "$OS_VERSION" "$OS_BUILD" "$ARCH" "$MODEL" "$LAUNCH_MODE" "$ASSERT_BUDGET" <<'PY'
 import csv
 from datetime import datetime
 import json
@@ -150,6 +150,8 @@ import pathlib
 import re
 import statistics
 import sys
+
+from perf_schema import canonical_summary, load_contract
 
 out_dir = pathlib.Path(sys.argv[1])
 root_dir = pathlib.Path(sys.argv[2])
@@ -224,41 +226,82 @@ def summarize(values):
     if not values:
         return None
     return {
-        "n": len(values),
+        "count": len(values),
         "min": min(values),
         "max": max(values),
         "median": statistics.median(values),
         "mean": statistics.mean(values),
+        "p95": max(values),
+        "unit": "ms",
     }
 
 
-summary = {metric: summarize(values) for metric, values in metrics.items()}
-summary["metadata"] = {
-    "timestamp": timestamp,
-    "runs_requested": runs,
-    "sleep_seconds": sleep_seconds,
-    "launch_mode": launch_mode,
-    "os_version": os_version,
-    "os_build": os_build,
-    "arch": arch,
-    "model": model,
-    "discovered_repos_median": int(statistics.median(discovered_values)) if discovered_values else None,
-    "imported_repos_median": int(statistics.median(imported_values)) if imported_values else None,
-    "activation_to_first_prompt_median_ms": (
-        statistics.median(activation_to_first_prompt_values)
-        if activation_to_first_prompt_values else None
-    ),
-}
+scenario = "debug_no_activate" if launch_mode == "no-activate" else "debug_activate"
+metrics_summary = {}
+for metric, values in metrics.items():
+    stats = summarize(values)
+    if stats is not None:
+        metrics_summary[metric] = stats
+
+findings = []
+launch_stats = metrics_summary.get("launch_to_first_prompt")
+if launch_stats and launch_stats["median"] > 500:
+    findings.append(
+        f"launch_to_first_prompt median is {launch_stats['median']:.2f} ms in {scenario}. Startup remains visibly slower than the debug gate."
+    )
+repo_focus_stats = metrics_summary.get("repo_click_to_focus")
+if repo_focus_stats and repo_focus_stats["median"] > 300:
+    findings.append(
+        f"repo_click_to_focus median is {repo_focus_stats['median']:.2f} ms. Repo switching still has measurable post-prompt lag."
+    )
+if not findings:
+    findings.append("No automated debug perf findings were derived from the captured [Perf] lines.")
+
+summary = canonical_summary(
+    scenario=scenario,
+    build_kind="debug",
+    metrics=metrics_summary,
+    diagnostic_findings=findings,
+    artifacts={
+        "output_dir": str(out_dir),
+        "runs_requested": runs,
+        "sleep_seconds": sleep_seconds,
+        "log_files": [str(path) for path in sorted(out_dir.glob("run-*.log"))],
+    },
+    os_version=os_version,
+    os_build=os_build,
+    machine_model=model,
+    arch=arch,
+    contract=load_contract(),
+    extra={
+        "metadata": {
+            "timestamp": timestamp,
+            "runs_requested": runs,
+            "sleep_seconds": sleep_seconds,
+            "launch_mode": launch_mode,
+            "os_version": os_version,
+            "os_build": os_build,
+            "arch": arch,
+            "model": model,
+            "discovered_repos_median": int(statistics.median(discovered_values)) if discovered_values else None,
+            "imported_repos_median": int(statistics.median(imported_values)) if imported_values else None,
+            "activation_to_first_prompt_median_ms": (
+                statistics.median(activation_to_first_prompt_values)
+                if activation_to_first_prompt_values else None
+            ),
+        }
+    },
+)
 
 summary_lines = []
 for metric in metric_order:
-    stats = summary[metric]
+    stats = summary["metrics"].get(metric)
     if stats is None:
         summary_lines.append(f"{metric}: missing")
         continue
     summary_lines.append(
-        f"{metric}: n={stats['n']} min={stats['min']:.2f} max={stats['max']:.2f} "
-        f"median={stats['median']:.2f} mean={stats['mean']:.2f}"
+        f"{metric}: count={stats['count']} min={stats['min']:.2f} max={stats['max']:.2f} "
+        f"median={stats['median']:.2f} mean={stats['mean']:.2f} p95={stats['p95']:.2f}"
     )
 
 summary_path = out_dir / "summary.txt"
@@ -267,31 +310,28 @@ summary_path.write_text("\n".join(summary_lines) + "\n")
 summary_json_path.write_text(json.dumps(summary, indent=2) + "\n")
 
 print(summary_path)
+print(f"scenario: {scenario}")
 print(f"launch_mode: {launch_mode}")
 print("\n".join(summary_lines))
 print(f"summary_json={summary_json_path}")
 
-# Budget targets for the three core metrics (used by both --record dashboard
-# and --assert-budget enforcement).
-budget_specs = [
-    ("launch_to_first_prompt", 250.0),
-    ("repo_hydration", 25.0),
-    ("repo_click_to_focus", 250.0),
-]
-
 budget_exit_code = 0
 if assert_budget:
     violations = []
-    for metric_name, target in budget_specs:
-        stats = summary.get(metric_name)
+    for metric_name in ["launch_to_first_prompt", "repo_hydration", "repo_click_to_focus"]:
+        stats = summary["metrics"].get(metric_name)
+        budget = summary["budget_results"].get(metric_name, {})
+        target = budget.get("gate_budget_ms")
         if stats is None:
             violations.append(f"  {metric_name}: MISSING (no data collected)")
             continue
-        median = stats["median"]
-        if median > target:
-            overshoot = median - target
+        if target is None:
+            continue
+        median = float(stats["median"])
+        if median > float(target):
+            overshoot = median - float(target)
             violations.append(
-                f"  {metric_name}: {median:.2f} ms (budget {target:.0f} ms, over by {overshoot:.2f} ms)"
+                f"  {metric_name}: {median:.2f} ms (budget {float(target):.0f} ms, over by {overshoot:.2f} ms)"
             )
     if violations:
         budget_exit_code = 1
@@ -314,6 +354,8 @@ latest_json_path = perf_dir / "latest-summary.json"
 latest_json_path.write_text(json.dumps(summary, indent=2) + "\n")
 
 fieldnames = [
+    "scenario",
+    "build_kind",
     "timestamp",
     "runs_requested",
     "sleep_seconds",
@@ -335,6 +377,8 @@ fieldnames = [
 ]
 
 record_row = {
+    "scenario": scenario,
+    "build_kind": "debug",
     "timestamp": timestamp,
     "runs_requested": runs,
     "sleep_seconds": sleep_seconds,
@@ -344,14 +388,14 @@ record_row = {
     "model": model,
     "discovered_repos_median": summary["metadata"]["discovered_repos_median"],
     "imported_repos_median": summary["metadata"]["imported_repos_median"],
-    "launch_to_first_prompt_median_ms": summary["launch_to_first_prompt"]["median"] if summary["launch_to_first_prompt"] else "",
-    "repo_hydration_median_ms": summary["repo_hydration"]["median"] if summary["repo_hydration"] else "",
-    "repo_click_to_focus_median_ms": summary["repo_click_to_focus"]["median"] if summary["repo_click_to_focus"] else "",
-    "workspace_click_to_focus_median_ms": summary["workspace_click_to_focus"]["median"] if summary["workspace_click_to_focus"] else "",
-    "launch_to_first_prompt_mean_ms": summary["launch_to_first_prompt"]["mean"] if summary["launch_to_first_prompt"] else "",
-    "repo_hydration_mean_ms": summary["repo_hydration"]["mean"] if summary["repo_hydration"] else "",
-    "repo_click_to_focus_mean_ms": summary["repo_click_to_focus"]["mean"] if summary["repo_click_to_focus"] else "",
-    "workspace_click_to_focus_mean_ms": summary["workspace_click_to_focus"]["mean"] if summary["workspace_click_to_focus"] else "",
+    "launch_to_first_prompt_median_ms": summary["metrics"]["launch_to_first_prompt"]["median"] if summary["metrics"].get("launch_to_first_prompt") else "",
+    "repo_hydration_median_ms": summary["metrics"]["repo_hydration"]["median"] if summary["metrics"].get("repo_hydration") else "",
+    "repo_click_to_focus_median_ms": summary["metrics"]["repo_click_to_focus"]["median"] if summary["metrics"].get("repo_click_to_focus") else "",
+    "workspace_click_to_focus_median_ms": summary["metrics"]["workspace_click_to_focus"]["median"] if summary["metrics"].get("workspace_click_to_focus") else "",
+    "launch_to_first_prompt_mean_ms": summary["metrics"]["launch_to_first_prompt"]["mean"] if summary["metrics"].get("launch_to_first_prompt") else "",
+    "repo_hydration_mean_ms": summary["metrics"]["repo_hydration"]["mean"] if summary["metrics"].get("repo_hydration") else "",
+    "repo_click_to_focus_mean_ms": summary["metrics"]["repo_click_to_focus"]["mean"] if summary["metrics"].get("repo_click_to_focus") else "",
+    "workspace_click_to_focus_mean_ms": summary["metrics"]["workspace_click_to_focus"]["mean"] if summary["metrics"].get("workspace_click_to_focus") else "",
     "activation_to_first_prompt_median_ms": summary["metadata"]["activation_to_first_prompt_median_ms"] or "",
 }
 
@@ -375,7 +419,9 @@ with history_csv_path.open(newline="") as f:
     rows = list(reader)
 
 metric_specs = [
-    (f"{name}_median_ms", name, target) for name, target in budget_specs
+    ("launch_to_first_prompt_median_ms", "launch_to_first_prompt"),
+    ("repo_hydration_median_ms", "repo_hydration"),
+    ("repo_click_to_focus_median_ms", "repo_click_to_focus"),
 ]
 
 def parse_float(value):
@@ -416,14 +462,19 @@ dashboard_lines.append("")
 dashboard_lines.append("| Metric | Median (ms) | Mean (ms) | Target (ms) | Status | Delta vs Previous |")
 dashboard_lines.append("|---|---:|---:|---:|---|---|")
 
-for median_key, metric_name, target in metric_specs:
+for median_key, metric_name in metric_specs:
     median_value = parse_float(latest.get(median_key) if latest else None)
     mean_value = parse_float(latest.get(f"{metric_name}_mean_ms") if latest else None)
     prev_value = parse_float(previous.get(median_key) if previous else None)
-    status = "pass" if median_value is not None and median_value <= target else "fail"
+    budget = summary["budget_results"].get(metric_name, {})
+    target = budget.get("gate_budget_ms")
+    if target is None:
+        status = "ungated"
+    else:
+        status = "pass" if median_value is not None and median_value <= target else "fail"
     dashboard_lines.append(
         f"| `{metric_name}` | {fmt_ms(median_value)} | "
-        f"{fmt_ms(mean_value)} | <= {target:.0f} | {status} | "
+        f"{fmt_ms(mean_value)} | <= {target if target is not None else 'n/a'} | {status} | "
         f"{delta_text(median_value, prev_value)} |"
     )
 
@@ -448,7 +499,8 @@ else:
     dashboard_lines.append(
         f"- Portfolio size changed from discovered={previous_discovered} to discovered={latest_discovered}, "
         f"but `repo_hydration` only moved {delta_text(latest_hydration, previous_hydration)} and remains "
-        f"{'within' if latest_hydration is not None and latest_hydration <= 25.0 else 'outside'} the `<= 25 ms` gate."
+        f"{'within' if latest_hydration is not None and latest_hydration <= (summary['budget_results'].get('repo_hydration', {}).get('gate_budget_ms') or 0) else 'outside'} "
+        f"the configured gate."
     )
 
     dashboard_lines.append(
@@ -498,14 +550,16 @@ dashboard_lines.append("")
 dashboard_lines.append("## Visual Bars (Last 10 Run Window)")
 dashboard_lines.append("")
 
-for median_key, metric_name, target in metric_specs:
+for median_key, metric_name in metric_specs:
     current = parse_float(latest.get(median_key) if latest else None)
-    target_pct = (current / target * 100.0) if current is not None and target > 0 else None
+    target = summary["budget_results"].get(metric_name, {}).get("gate_budget_ms")
+    target_pct = (current / target * 100.0) if current is not None and target is not None and target > 0 else None
     target_pct_text = f"{target_pct:.1f}%" if target_pct is not None else "n/a"
-    dashboard_lines.append(f"`{metric_name}` target <= {target:.0f} ms")
+    target_text = f"{target:.0f}" if target is not None else "n/a"
+    dashboard_lines.append(f"`{metric_name}` target <= {target_text} ms")
     dashboard_lines.append("")
     dashboard_lines.append(f"current {fmt_ms(current)} ms ({target_pct_text} of target)")
-    dashboard_lines.append(f"[{bar(current, target)}]")
+    dashboard_lines.append(f"[{bar(current, target or 0)}]")
     dashboard_lines.append("")
 
 dashboard_lines.append("## Run Context")

--- a/scripts/perf-compare.py
+++ b/scripts/perf-compare.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Compare two canonical Workspaces performance summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from perf_schema import load_contract
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("before", type=Path, help="Path to the baseline summary JSON.")
+    parser.add_argument("after", type=Path, help="Path to the candidate summary JSON.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+    return parser.parse_args()
+
+
+def load_summary(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def compare(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    metric_names = sorted(set(before.get("metrics", {})) | set(after.get("metrics", {})))
+    comparisons: dict[str, Any] = {}
+
+    for metric_name in metric_names:
+        before_metric = before.get("metrics", {}).get(metric_name) or {}
+        after_metric = after.get("metrics", {}).get(metric_name) or {}
+        before_median = before_metric.get("median")
+        after_median = after_metric.get("median")
+        delta_ms = None
+        delta_percent = None
+        if before_median is not None and after_median is not None:
+            delta_ms = float(after_median) - float(before_median)
+            if float(before_median) != 0:
+                delta_percent = (delta_ms / float(before_median)) * 100.0
+
+        comparisons[metric_name] = {
+            "before": before_metric,
+            "after": after_metric,
+            "delta_ms": delta_ms,
+            "delta_percent": delta_percent,
+            "after_budget": after.get("budget_results", {}).get(metric_name),
+        }
+
+    return {
+        "scenario_before": before.get("scenario"),
+        "scenario_after": after.get("scenario"),
+        "comparisons": comparisons,
+        "contract_version": load_contract().get("version"),
+    }
+
+
+def print_text(payload: dict[str, Any]) -> None:
+    print("Workspaces perf comparison")
+    print(f"  before: {payload['scenario_before']}")
+    print(f"  after:  {payload['scenario_after']}")
+    print()
+
+    for metric_name, metric_payload in payload["comparisons"].items():
+        before_median = metric_payload["before"].get("median")
+        after_median = metric_payload["after"].get("median")
+        delta_ms = metric_payload["delta_ms"]
+        delta_percent = metric_payload["delta_percent"]
+        budget = metric_payload["after_budget"] or {}
+
+        before_text = f"{before_median:.2f}" if before_median is not None else "n/a"
+        after_text = f"{after_median:.2f}" if after_median is not None else "n/a"
+        if delta_ms is None:
+            delta_text = "n/a"
+        else:
+            delta_text = f"{delta_ms:+.2f} ms"
+            if delta_percent is not None:
+                delta_text += f" ({delta_percent:+.1f}%)"
+
+        status = budget.get("status", "ungated")
+        budget_text = budget.get("gate_budget_ms")
+        if budget_text is None:
+            budget_suffix = "ungated"
+        else:
+            budget_suffix = f"gate <= {budget_text} ms [{status}]"
+        print(f"- {metric_name}: {before_text} -> {after_text}; {delta_text}; {budget_suffix}")
+
+
+def main() -> int:
+    args = parse_args()
+    payload = compare(load_summary(args.before), load_summary(args.after))
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_text(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/perf-runner.sh
+++ b/scripts/perf-runner.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Run a canonical Workspaces performance scenario and emit summary artifacts.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/perf-runner.sh --scenario <id> [options]
+
+Scenarios:
+  debug_no_activate
+  debug_activate
+  installed_clean_shell
+  installed_login_shell
+  installed_input_short_capture
+
+Options:
+  --scenario <id>         Canonical scenario id.
+  --app <path>            App bundle or binary to use for installed scenarios.
+  --output-dir <path>     Output directory. Default: /tmp/workspaces-perf-runner-<timestamp>/<scenario>
+  --runs <n>              Debug scenario run count. Default: 5.
+  --sleep-seconds <n>     Debug scenario sleep per run. Default: 8.
+  --capture-seconds <n>   Installed scenario capture length. Default: 12.
+  --record                Pass through to perf-baseline.sh for debug scenarios.
+  --assert-budget         Enforce the configured budget for the scenario.
+  -h, --help              Show this help text.
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCENARIO=""
+APP_PATH="/Applications/WorkspaceManager.app/Contents/MacOS/WorkspaceManager"
+RUNS=5
+SLEEP_SECONDS=8
+CAPTURE_SECONDS=12
+RECORD=0
+ASSERT_BUDGET=0
+OUTPUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenario)
+            SCENARIO="$2"
+            shift 2
+            ;;
+        --app)
+            APP_PATH="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --runs)
+            RUNS="$2"
+            shift 2
+            ;;
+        --sleep-seconds)
+            SLEEP_SECONDS="$2"
+            shift 2
+            ;;
+        --capture-seconds)
+            CAPTURE_SECONDS="$2"
+            shift 2
+            ;;
+        --record)
+            RECORD=1
+            shift
+            ;;
+        --assert-budget)
+            ASSERT_BUDGET=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unexpected argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$SCENARIO" ]]; then
+    echo "--scenario is required" >&2
+    usage
+    exit 1
+fi
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    OUTPUT_DIR="/tmp/workspaces-perf-runner-$(date +%Y%m%d-%H%M%S)/$SCENARIO"
+fi
+mkdir -p "$OUTPUT_DIR"
+
+run_debug() {
+    local launch_mode="$1"
+    local latest_before=""
+    latest_before="$(ls -td /tmp/workspaces-perf-baseline-* 2>/dev/null | head -n 1 || true)"
+    local cmd=("$ROOT_DIR/scripts/perf-baseline.sh" "$RUNS" "$SLEEP_SECONDS" "--launch-mode" "$launch_mode")
+    if [[ "$RECORD" -eq 1 ]]; then
+        cmd+=("--record")
+    fi
+    if [[ "$ASSERT_BUDGET" -eq 1 ]]; then
+        cmd+=("--assert-budget")
+    fi
+    "${cmd[@]}"
+
+    local latest_after=""
+    latest_after="$(ls -td /tmp/workspaces-perf-baseline-* 2>/dev/null | head -n 1 || true)"
+    if [[ -n "$latest_after" && "$latest_after" != "$latest_before" ]]; then
+        rm -rf "$OUTPUT_DIR"
+        mkdir -p "$OUTPUT_DIR"
+        cp -R "$latest_after"/. "$OUTPUT_DIR"/
+        echo "copied_artifacts=$OUTPUT_DIR"
+    fi
+}
+
+run_installed() {
+    local shell_mode_flag="$1"
+    shift
+    local log_file="$OUTPUT_DIR/$SCENARIO.log"
+    local summary_json="$OUTPUT_DIR/summary.json"
+    local summary_txt="$OUTPUT_DIR/summary.txt"
+    mkdir -p "$OUTPUT_DIR/app-data"
+
+    WORKSPACES_DATA_DIR="$OUTPUT_DIR/app-data" "$ROOT_DIR/scripts/launch-installed-diagnostics.sh" \
+        --app "$APP_PATH" \
+        "$shell_mode_flag" \
+        --no-activate \
+        --capture-seconds "$CAPTURE_SECONDS" \
+        "$@" \
+        --log-file "$log_file"
+
+    "$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
+        --json \
+        --scenario "$SCENARIO" \
+        --build-kind installed \
+        --app-path "$APP_PATH" \
+        "$log_file" >"$summary_json"
+
+    "$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
+        --scenario "$SCENARIO" \
+        --build-kind installed \
+        --app-path "$APP_PATH" \
+        "$log_file" >"$summary_txt"
+
+    echo "summary_json=$summary_json"
+    echo "summary_txt=$summary_txt"
+    echo "log_file=$log_file"
+}
+
+case "$SCENARIO" in
+    debug_no_activate)
+        run_debug "no-activate"
+        ;;
+    debug_activate)
+        run_debug "activate"
+        ;;
+    installed_clean_shell)
+        run_installed "--clean-shell"
+        ;;
+    installed_login_shell)
+        run_installed "--login-shell"
+        ;;
+    installed_input_short_capture)
+        run_installed "--login-shell" "--with-input-diagnostics"
+        ;;
+    *)
+        echo "Unsupported scenario: $SCENARIO" >&2
+        usage
+        exit 1
+        ;;
+esac

--- a/scripts/perf-runner.sh
+++ b/scripts/perf-runner.sh
@@ -120,19 +120,34 @@ run_debug() {
 
 run_installed() {
     local shell_mode_flag="$1"
-    shift
+    local activate_mode="${2:-no-activate}"
+    shift 2
     local log_file="$OUTPUT_DIR/$SCENARIO.log"
     local summary_json="$OUTPUT_DIR/summary.json"
     local summary_txt="$OUTPUT_DIR/summary.txt"
     mkdir -p "$OUTPUT_DIR/app-data"
 
-    WORKSPACES_DATA_DIR="$OUTPUT_DIR/app-data" "$ROOT_DIR/scripts/launch-installed-diagnostics.sh" \
-        --app "$APP_PATH" \
-        "$shell_mode_flag" \
-        --no-activate \
-        --capture-seconds "$CAPTURE_SECONDS" \
-        "$@" \
+    local launch_args=(
+        --app "$APP_PATH"
+        "$shell_mode_flag"
+        --capture-seconds "$CAPTURE_SECONDS"
         --log-file "$log_file"
+    )
+    if [[ "$activate_mode" == "no-activate" ]]; then
+        launch_args+=(--no-activate)
+    fi
+
+    WORKSPACES_DATA_DIR="$OUTPUT_DIR/app-data" "$ROOT_DIR/scripts/launch-installed-diagnostics.sh" \
+        "${launch_args[@]}" \
+        "$@"
+
+    summarize_installed_log "$log_file" "$summary_json" "$summary_txt"
+}
+
+summarize_installed_log() {
+    local log_file="$1"
+    local summary_json="$2"
+    local summary_txt="$3"
 
     "$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
         --json \
@@ -152,6 +167,50 @@ run_installed() {
     echo "log_file=$log_file"
 }
 
+run_installed_input_short_capture() {
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        echo "installed_input_short_capture requires an interactive terminal and focused manual typing." >&2
+        echo "Run this scenario from a local terminal session so Workspaces can activate and receive input." >&2
+        exit 1
+    fi
+
+    local log_file="$OUTPUT_DIR/$SCENARIO.log"
+    local summary_json="$OUTPUT_DIR/summary.json"
+    local summary_txt="$OUTPUT_DIR/summary.txt"
+    mkdir -p "$OUTPUT_DIR/app-data"
+
+    echo "Interactive capture: Workspaces will activate and run for $CAPTURE_SECONDS seconds."
+    echo "Type in the focused terminal during that window to produce input metrics."
+
+    WORKSPACES_DATA_DIR="$OUTPUT_DIR/app-data" "$ROOT_DIR/scripts/launch-installed-diagnostics.sh" \
+        --app "$APP_PATH" \
+        --login-shell \
+        --with-input-diagnostics \
+        --capture-seconds "$CAPTURE_SECONDS" \
+        --log-file "$log_file"
+
+    summarize_installed_log "$log_file" "$summary_json" "$summary_txt"
+
+    python3 - "$summary_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text())
+metrics = summary.get("metrics", {})
+missing = [
+    metric
+    for metric in ("input_event_age_ms_median", "input_handler_duration_ms_median")
+    if metric not in metrics
+]
+if missing:
+    raise SystemExit(
+        "interactive input capture did not produce canonical input metrics: "
+        + ", ".join(missing)
+    )
+PY
+}
+
 case "$SCENARIO" in
     debug_no_activate)
         run_debug "no-activate"
@@ -160,13 +219,13 @@ case "$SCENARIO" in
         run_debug "activate"
         ;;
     installed_clean_shell)
-        run_installed "--clean-shell"
+        run_installed "--clean-shell" "no-activate"
         ;;
     installed_login_shell)
-        run_installed "--login-shell"
+        run_installed "--login-shell" "no-activate"
         ;;
     installed_input_short_capture)
-        run_installed "--login-shell" "--with-input-diagnostics"
+        run_installed_input_short_capture
         ;;
     *)
         echo "Unsupported scenario: $SCENARIO" >&2

--- a/scripts/perf_schema.py
+++ b/scripts/perf_schema.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import plistlib
+import statistics
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT_PATH = REPO_ROOT / "config" / "performance" / "contract.json"
+
+
+def load_contract(path: Path | None = None) -> dict[str, Any]:
+    contract_path = path or DEFAULT_CONTRACT_PATH
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
+def percentile(values: list[float], percentile_value: float) -> float:
+    if not values:
+        raise ValueError("percentile() requires at least one value")
+    if len(values) == 1:
+        return values[0]
+
+    sorted_values = sorted(values)
+    rank = (len(sorted_values) - 1) * (percentile_value / 100.0)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return sorted_values[lower]
+    lower_weight = upper - rank
+    upper_weight = rank - lower
+    return (sorted_values[lower] * lower_weight) + (sorted_values[upper] * upper_weight)
+
+
+def numeric_stats(values: list[float], unit: str = "ms") -> dict[str, Any] | None:
+    if not values:
+        return None
+    return {
+        "count": len(values),
+        "min": min(values),
+        "median": statistics.median(values),
+        "mean": statistics.mean(values),
+        "max": max(values),
+        "p95": percentile(values, 95),
+        "unit": unit,
+    }
+
+
+def metric_aliases(summary: dict[str, Any]) -> dict[str, Any]:
+    return {
+        metric_name: metric_stats
+        for metric_name, metric_stats in summary.get("metrics", {}).items()
+    }
+
+
+def _round_budget(value: float, mode: str) -> int:
+    if mode == "ceil":
+        return math.ceil(value)
+    if mode == "floor":
+        return math.floor(value)
+    if mode == "round":
+        return round(value)
+    raise ValueError(f"Unsupported rounding mode: {mode}")
+
+
+def _metric_reference(contract: dict[str, Any], scenario: str, metric_name: str) -> dict[str, Any] | None:
+    for metric in contract.get("metrics", []):
+        if metric.get("name") != metric_name:
+            continue
+        return metric.get("reference_baselines", {}).get(scenario)
+    return None
+
+
+def evaluate_budgets(
+    contract: dict[str, Any],
+    scenario: str,
+    metrics: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    formula = contract.get("budget_formula", {})
+    gate_formula = formula.get("gate", {})
+    diagnostic_formula = formula.get("diagnostic", {})
+
+    gate_stat = gate_formula.get("stat", "median")
+    gate_multiplier = float(gate_formula.get("multiplier", 1.25))
+    gate_rounding = gate_formula.get("rounding", "ceil")
+
+    diagnostic_stat = diagnostic_formula.get("stat", "p95")
+    diagnostic_multiplier = float(diagnostic_formula.get("multiplier", 1.5))
+    diagnostic_rounding = diagnostic_formula.get("rounding", "ceil")
+
+    results: dict[str, dict[str, Any]] = {}
+    for metric_name, metric_stats in metrics.items():
+        reference = _metric_reference(contract, scenario, metric_name)
+        if reference is None:
+            results[metric_name] = {
+                "status": "ungated",
+                "reason": "no_reference_baseline",
+            }
+            continue
+
+        gate_reference = float(reference[f"{gate_stat}_ms"])
+        diagnostic_reference = float(reference[f"{diagnostic_stat}_ms"])
+        gate_budget_ms = _round_budget(gate_reference * gate_multiplier, gate_rounding)
+        diagnostic_threshold_ms = _round_budget(
+            diagnostic_reference * diagnostic_multiplier,
+            diagnostic_rounding,
+        )
+        observed_median_ms = metric_stats.get("median")
+        observed_p95_ms = metric_stats.get("p95")
+
+        status = "pass"
+        if observed_median_ms is None:
+            status = "missing"
+        elif float(observed_median_ms) > gate_budget_ms:
+            status = "fail"
+        elif observed_p95_ms is not None and float(observed_p95_ms) > diagnostic_threshold_ms:
+            status = "warn"
+
+        results[metric_name] = {
+            "status": status,
+            "gate_budget_ms": gate_budget_ms,
+            "diagnostic_threshold_ms": diagnostic_threshold_ms,
+            "observed_median_ms": observed_median_ms,
+            "observed_p95_ms": observed_p95_ms,
+            "reference_baseline": reference,
+        }
+
+    return results
+
+
+def detect_environment(
+    *,
+    build_kind: str,
+    app_version: str | None = None,
+    os_version: str | None = None,
+    os_build: str | None = None,
+    machine_model: str | None = None,
+    arch: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "build_kind": build_kind,
+        "app_version": app_version,
+        "os_version": os_version or read_command_text(["sw_vers", "-productVersion"]),
+        "os_build": os_build or read_command_text(["sw_vers", "-buildVersion"]),
+        "machine_model": machine_model or read_command_text(["sysctl", "-n", "hw.model"]),
+        "arch": arch or read_command_text(["uname", "-m"]),
+    }
+
+
+def read_command_text(command: list[str]) -> str | None:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def app_version_from_binary(binary_path: Path | None) -> str | None:
+    if binary_path is None:
+        return None
+
+    resolved = binary_path.expanduser().resolve()
+    if resolved.name == "WorkspaceManager" and resolved.parent.name == "MacOS":
+        info_plist = resolved.parents[2] / "Info.plist"
+    elif resolved.name == "Info.plist":
+        info_plist = resolved
+    else:
+        info_plist = resolved / "Contents" / "Info.plist"
+
+    if not info_plist.is_file():
+        return None
+
+    with info_plist.open("rb") as handle:
+        info = plistlib.load(handle)
+    short_version = info.get("CFBundleShortVersionString")
+    build_version = info.get("CFBundleVersion")
+    if short_version and build_version:
+        return f"{short_version} ({build_version})"
+    if short_version:
+        return str(short_version)
+    if build_version:
+        return str(build_version)
+    return None
+
+
+def canonical_summary(
+    *,
+    scenario: str,
+    build_kind: str,
+    metrics: dict[str, dict[str, Any]],
+    diagnostic_findings: list[str],
+    artifacts: dict[str, Any],
+    app_version: str | None = None,
+    os_version: str | None = None,
+    os_build: str | None = None,
+    machine_model: str | None = None,
+    arch: str | None = None,
+    contract: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    loaded_contract = contract or load_contract()
+    summary = {
+        "schema_version": 1,
+        "scenario": scenario,
+        "environment": detect_environment(
+            build_kind=build_kind,
+            app_version=app_version,
+            os_version=os_version,
+            os_build=os_build,
+            machine_model=machine_model,
+            arch=arch,
+        ),
+        "metrics": metrics,
+        "diagnostic_findings": diagnostic_findings,
+        "budget_results": evaluate_budgets(loaded_contract, scenario, metrics),
+        "artifacts": artifacts,
+    }
+    if extra:
+        summary.update(extra)
+    summary.update(metric_aliases(summary))
+    metadata = dict(summary.get("metadata", {}))
+    metadata.update({
+        "schema_version": summary["schema_version"],
+        "scenario": scenario,
+        "build_kind": build_kind,
+        "timestamp": os.environ.get("PERF_SUMMARY_TIMESTAMP"),
+    })
+    summary["metadata"] = metadata
+    return summary

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -30,7 +30,7 @@ echo "SHA:  $SHA"
 echo "Repo: $REPO"
 echo ""
 
-# Check a workflow's conclusion for a given SHA.
+# Check a check-run's conclusion for a given SHA.
 # Returns: "success", "failure", "neutral", "cancelled", "skipped",
 #          "timed_out", "action_required", or "not_found"
 check_workflow() {
@@ -41,6 +41,19 @@ check_workflow() {
         --jq ".check_runs[] | select(.name == \"$workflow_name\") | .conclusion" \
         2>/dev/null | head -1)
     echo "${conclusion:-not_found}"
+}
+
+check_any_workflow() {
+    local workflow_name=""
+    local result="not_found"
+    for workflow_name in "$@"; do
+        result=$(check_workflow "$workflow_name")
+        if [[ "$result" != "not_found" ]]; then
+            echo "$result"
+            return
+        fi
+    done
+    echo "not_found"
 }
 
 EXIT_CODE=0
@@ -83,7 +96,7 @@ esac
 
 # --- Advisory: perf-validation ---
 echo -n "Perf validation: "
-PERF_RESULT=$(check_workflow "capture")
+PERF_RESULT=$(check_any_workflow "perf-validation" "capture")
 case "$PERF_RESULT" in
     success)
         echo "PASS"

--- a/scripts/test_perf_tools.py
+++ b/scripts/test_perf_tools.py
@@ -154,6 +154,31 @@ class PerfSummarizerTests(unittest.TestCase):
             self.assertEqual(payload["environment"]["build_kind"], "installed")
             self.assertIn("terminal_first_output", payload["metrics"])
 
+    def test_installed_input_log_summary_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "installed-input.log"
+            log_path.write_text(
+                "\n".join(
+                    [
+                        "2026-04-11 10:00:00.000 [Perf] metric=input_investigation phase=key_down_handled event_age_ms=14.00 handler_duration_ms=0.80 window_key=true surface_missing=false",
+                        "2026-04-11 10:00:00.100 [Perf] metric=input_investigation phase=key_down_handled event_age_ms=11.00 handler_duration_ms=0.60 window_key=true surface_missing=false",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            payload = self.run_json(
+                [
+                    str(SUMMARIZE_PERF_LOG),
+                    "--json",
+                    str(log_path),
+                ]
+            )
+            self.assertEqual(payload["scenario"], "installed_input_short_capture")
+            self.assertEqual(payload["environment"]["build_kind"], "installed")
+            self.assertIn("input_event_age_ms_median", payload["metrics"])
+            self.assertIn("input_handler_duration_ms_median", payload["metrics"])
+
     def test_diagnostic_report_summary_is_canonical(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             zip_path = Path(tmpdir) / "workspaces-report.zip"

--- a/scripts/test_perf_tools.py
+++ b/scripts/test_perf_tools.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Fixture tests for the Workspaces performance contract and summary tooling."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from perf_schema import evaluate_budgets, load_contract
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUMMARIZE_PERF_LOG = (
+    REPO_ROOT
+    / ".agents"
+    / "skills"
+    / "workspaces-optimization"
+    / "scripts"
+    / "summarize_perf_log.py"
+)
+SUMMARIZE_DIAGNOSTIC_REPORT = (
+    REPO_ROOT
+    / ".agents"
+    / "skills"
+    / "workspaces-optimization"
+    / "scripts"
+    / "summarize_diagnostic_report.py"
+)
+
+
+class PerfContractTests(unittest.TestCase):
+    def test_budget_evaluator_uses_contract_formula(self) -> None:
+        contract = load_contract()
+        result = evaluate_budgets(
+            contract,
+            "debug_no_activate",
+            {
+                "launch_to_first_prompt": {
+                    "count": 10,
+                    "min": 180.0,
+                    "median": 210.0,
+                    "mean": 205.0,
+                    "max": 230.0,
+                    "p95": 225.0,
+                    "unit": "ms",
+                }
+            },
+        )
+        self.assertEqual(result["launch_to_first_prompt"]["gate_budget_ms"], 250)
+        self.assertEqual(result["launch_to_first_prompt"]["diagnostic_threshold_ms"], 390)
+        self.assertEqual(result["launch_to_first_prompt"]["status"], "pass")
+
+
+class PerfSummarizerTests(unittest.TestCase):
+    def run_json(self, command: list[str]) -> dict:
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            self.fail(f"command failed: {' '.join(command)}\n{result.stderr}\n{result.stdout}")
+        return json.loads(result.stdout)
+
+    def test_debug_perf_log_summary_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "debug.log"
+            log_path.write_text(
+                "\n".join(
+                    [
+                        "2026-04-11 10:00:00.000 [Perf] metric=launch_to_first_prompt duration_ms=240.00 trigger=terminal_focus",
+                        "2026-04-11 10:00:00.100 [Perf] metric=repo_hydration duration_ms=12.00 discovered=18 imported=0",
+                        "2026-04-11 10:00:00.200 [Perf] metric=repo_click_to_focus duration_ms=180.00 session=abc outcome=focused",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            payload = self.run_json(
+                [
+                    str(SUMMARIZE_PERF_LOG),
+                    "--json",
+                    "--scenario",
+                    "debug_no_activate",
+                    "--build-kind",
+                    "debug",
+                    str(log_path),
+                ]
+            )
+            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["scenario"], "debug_no_activate")
+            self.assertEqual(payload["environment"]["build_kind"], "debug")
+            self.assertIn("launch_to_first_prompt", payload["metrics"])
+            self.assertEqual(payload["budget_results"]["launch_to_first_prompt"]["gate_budget_ms"], 250)
+
+    def test_installed_clean_log_summary_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "installed-clean.log"
+            log_path.write_text(
+                "\n".join(
+                    [
+                        "2026-04-11 10:00:00.000 [Perf] metric=terminal_investigation phase=surface_create_succeeded duration_ms=120.00 shell_profile_mode=clean",
+                        "2026-04-11 10:00:00.100 [Perf] metric=terminal_first_output duration_ms=500.00 signal=pwd shell_profile_mode=clean",
+                        "2026-04-11 10:00:00.200 [Perf] metric=first_prompt_ready duration_ms=520.00 signal=pwd shell_profile_mode=clean",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            payload = self.run_json(
+                [
+                    str(SUMMARIZE_PERF_LOG),
+                    "--json",
+                    str(log_path),
+                ]
+            )
+            self.assertEqual(payload["scenario"], "installed_clean_shell")
+            self.assertEqual(payload["environment"]["build_kind"], "installed")
+            self.assertIn("terminal_first_output", payload["metrics"])
+            self.assertIn("first_prompt_ready", payload["metrics"])
+
+    def test_installed_login_log_summary_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "installed-login.log"
+            log_path.write_text(
+                "\n".join(
+                    [
+                        "2026-04-11 10:00:00.000 [Perf] metric=terminal_investigation phase=surface_create_succeeded duration_ms=180.00 shell_profile_mode=login",
+                        "2026-04-11 10:00:00.100 [Perf] metric=terminal_first_output duration_ms=700.00 signal=set_title shell_profile_mode=login",
+                        "2026-04-11 10:00:00.200 [Perf] metric=first_prompt_ready duration_ms=730.00 signal=set_title shell_profile_mode=login",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            payload = self.run_json(
+                [
+                    str(SUMMARIZE_PERF_LOG),
+                    "--json",
+                    str(log_path),
+                ]
+            )
+            self.assertEqual(payload["scenario"], "installed_login_shell")
+            self.assertEqual(payload["environment"]["build_kind"], "installed")
+            self.assertIn("terminal_first_output", payload["metrics"])
+
+    def test_diagnostic_report_summary_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            zip_path = Path(tmpdir) / "workspaces-report.zip"
+            report = {
+                "generatedAt": "2026-04-11T10:00:00Z",
+                "system": {
+                    "hardwareModel": "Mac16,13",
+                    "architecture": "arm64",
+                    "physicalMemoryGB": 32,
+                    "processorCount": 10,
+                    "osVersion": "26.3.1",
+                    "osBuild": "25D2128",
+                },
+                "startupDiagnostics": {
+                    "appVersion": "0.10.0",
+                    "buildNumber": "11",
+                    "events": [
+                        {
+                            "metric": "launch_to_first_prompt",
+                            "durationMs": 780.0,
+                            "timestamp": "2026-04-11T10:00:01Z",
+                            "labels": {"trigger": "terminal_focus"},
+                        },
+                        {
+                            "metric": "terminal_first_output",
+                            "durationMs": 600.0,
+                            "timestamp": "2026-04-11T10:00:01Z",
+                            "labels": {"signal": "pwd"},
+                        },
+                        {
+                            "metric": "first_prompt_ready",
+                            "durationMs": 620.0,
+                            "timestamp": "2026-04-11T10:00:01Z",
+                            "labels": {"signal": "pwd"},
+                        },
+                    ],
+                },
+            }
+            with zipfile.ZipFile(zip_path, "w") as archive:
+                archive.writestr("report.json", json.dumps(report))
+                archive.writestr("system-profile.txt", "Path: /Applications/WorkspaceManager.app\n")
+                archive.writestr("recent-logs.txt", "Timestamp Message\n")
+
+            payload = self.run_json(
+                [
+                    str(SUMMARIZE_DIAGNOSTIC_REPORT),
+                    "--json",
+                    str(zip_path),
+                ]
+            )
+            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["scenario"], "installed_login_shell")
+            self.assertIn("launch_to_first_prompt", payload["metrics"])
+            self.assertIn("terminal_first_output", payload["metrics"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-installed-perf.sh
+++ b/scripts/verify-installed-perf.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 usage() {
     cat <<'EOF'
 Usage:
-  ./scripts/verify-installed-perf.sh <WorkspaceManager.app|binary> [output_dir]
+  ./scripts/verify-installed-perf.sh [--allow-skip-noninteractive] <WorkspaceManager.app|binary> [output_dir]
 
 Checks:
   - bundled Ghostty resources exist
@@ -21,9 +21,42 @@ fail() {
     exit 1
 }
 
+write_status() {
+    local status="$1"
+    local reason="$2"
+    local status_file="${OUTPUT_DIR:-}/verification-status.json"
+    [[ -n "${OUTPUT_DIR:-}" ]] || return 0
+    cat >"$status_file" <<EOF
+{
+  "status": "$status",
+  "reason": "$reason",
+  "app_bundle": "${APP_BUNDLE:-}",
+  "app_binary": "${APP_BINARY:-}",
+  "log_file": "${LOG_FILE:-}",
+  "summary_json": "${SUMMARY_JSON:-}",
+  "summary_txt": "${SUMMARY_TXT:-}"
+}
+EOF
+}
+
+skip_noninteractive() {
+    local reason="$1"
+    write_status "skipped_noninteractive_display" "$reason"
+    echo "[verify-installed-perf] WARNING: $reason" >&2
+    echo "[verify-installed-perf] status: skipped_noninteractive_display" >&2
+    exit 0
+}
+
+ALLOW_SKIP_NONINTERACTIVE=0
+
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     usage
     exit 0
+fi
+
+if [[ "${1:-}" == "--allow-skip-noninteractive" ]]; then
+    ALLOW_SKIP_NONINTERACTIVE=1
+    shift
 fi
 
 [[ $# -ge 1 ]] || {
@@ -81,6 +114,9 @@ if rg -n "ghostty terminfo not found|no resources dir set, shell integration dis
 fi
 
 if rg -n "CVDisplayLinkCreateWithCGDisplays error -6661|embedded_window: error initializing surface err=error.OutOfMemory" "$LOG_FILE" >/dev/null; then
+    if [[ "$ALLOW_SKIP_NONINTERACTIVE" -eq 1 ]]; then
+        skip_noninteractive "Installed-build perf verification requires an interactive display-capable macOS session; Ghostty surface initialization failed in the current environment"
+    fi
     fail "Installed-build perf verification requires an interactive display-capable macOS session; Ghostty surface initialization failed in the current environment"
 fi
 
@@ -100,6 +136,7 @@ if missing:
     raise SystemExit(f"missing installed perf metrics: {', '.join(missing)}")
 PY
 
+write_status "verified" "installed clean-shell metrics present"
 echo "Verified installed perf parity for $APP_BUNDLE"
 echo "  log: $LOG_FILE"
 echo "  summary_json: $SUMMARY_JSON"

--- a/scripts/verify-installed-perf.sh
+++ b/scripts/verify-installed-perf.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Verify installed-build performance parity and resource packaging for a packaged app.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/verify-installed-perf.sh <WorkspaceManager.app|binary> [output_dir]
+
+Checks:
+  - bundled Ghostty resources exist
+  - bundled terminfo exists
+  - installed clean-shell capture emits terminal_first_output and first_prompt_ready
+  - log does not contain known Ghostty resource packaging warnings
+EOF
+}
+
+fail() {
+    echo "[verify-installed-perf] ERROR: $*" >&2
+    exit 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+[[ $# -ge 1 ]] || {
+    usage
+    exit 1
+}
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$1"
+OUTPUT_DIR="${2:-/tmp/workspaces-installed-perf-verify-$(date +%Y%m%d-%H%M%S)}"
+
+if [[ -d "$TARGET" ]]; then
+    APP_BUNDLE="$TARGET"
+    APP_BINARY="$APP_BUNDLE/Contents/MacOS/WorkspaceManager"
+else
+    APP_BINARY="$TARGET"
+    APP_BUNDLE="$(cd "$(dirname "$APP_BINARY")/../.." && pwd)"
+fi
+
+[[ -x "$APP_BINARY" ]] || fail "App binary not found: $APP_BINARY"
+[[ -d "$APP_BUNDLE" ]] || fail "App bundle not found: $APP_BUNDLE"
+
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/app-data"
+
+[[ -d "$APP_BUNDLE/Contents/Resources/ghostty" ]] || fail "Missing Ghostty resources directory"
+[[ -d "$APP_BUNDLE/Contents/Resources/terminfo" ]] || fail "Missing bundled terminfo directory"
+
+LOG_FILE="$OUTPUT_DIR/installed-clean.log"
+SUMMARY_JSON="$OUTPUT_DIR/installed-clean-summary.json"
+SUMMARY_TXT="$OUTPUT_DIR/installed-clean-summary.txt"
+
+WORKSPACES_DATA_DIR="$OUTPUT_DIR/app-data" "$ROOT_DIR/scripts/launch-installed-diagnostics.sh" \
+    --app "$APP_BINARY" \
+    --clean-shell \
+    --no-activate \
+    --capture-seconds 12 \
+    --log-file "$LOG_FILE"
+
+"$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
+    --json \
+    --scenario installed_clean_shell \
+    --build-kind installed \
+    --app-path "$APP_BINARY" \
+    "$LOG_FILE" >"$SUMMARY_JSON"
+
+"$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
+    --scenario installed_clean_shell \
+    --build-kind installed \
+    --app-path "$APP_BINARY" \
+    "$LOG_FILE" >"$SUMMARY_TXT"
+
+if rg -n "ghostty terminfo not found|no resources dir set, shell integration disabled" "$LOG_FILE" >/dev/null; then
+    fail "Detected Ghostty resource packaging warnings in $LOG_FILE"
+fi
+
+if rg -n "CVDisplayLinkCreateWithCGDisplays error -6661|embedded_window: error initializing surface err=error.OutOfMemory" "$LOG_FILE" >/dev/null; then
+    fail "Installed-build perf verification requires an interactive display-capable macOS session; Ghostty surface initialization failed in the current environment"
+fi
+
+python3 - "$SUMMARY_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text())
+metrics = summary.get("metrics", {})
+missing = [
+    metric
+    for metric in ("terminal_first_output", "first_prompt_ready")
+    if metric not in metrics
+]
+if missing:
+    raise SystemExit(f"missing installed perf metrics: {', '.join(missing)}")
+PY
+
+echo "Verified installed perf parity for $APP_BUNDLE"
+echo "  log: $LOG_FILE"
+echo "  summary_json: $SUMMARY_JSON"
+echo "  summary_txt: $SUMMARY_TXT"

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -26,7 +26,8 @@ usage() {
 Usage: ./scripts/verify-release-bundle.sh <WorkspaceManager.app>
 
 Verifies that the packaged app bundle and nested Mach-O code objects are signed
-with a non-ad-hoc Developer ID signature and a real team identifier.
+with a non-ad-hoc Developer ID signature and a real team identifier. Also
+verifies that the bundled Ghostty resources required at runtime are present.
 EOF
 }
 
@@ -101,6 +102,8 @@ require_cmd find
 
 APP_BUNDLE="${APP_BUNDLE/#\~/$HOME}"
 [[ -d "$APP_BUNDLE" ]] || fail "App bundle not found: $APP_BUNDLE"
+[[ -d "$APP_BUNDLE/Contents/Resources/ghostty" ]] || fail "Missing Ghostty resources directory"
+[[ -d "$APP_BUNDLE/Contents/Resources/terminfo" ]] || fail "Missing bundled terminfo directory"
 
 CODE_OBJECTS_FILE="$TMP_DIR/code-objects.txt"
 : >"$CODE_OBJECTS_FILE"


### PR DESCRIPTION
## Summary

- add a machine-readable performance contract at `config/performance/contract.json` and shared schema/budget evaluation in `scripts/perf_schema.py`
- add canonical perf tooling: `scripts/perf-runner.sh`, `scripts/perf-compare.py`, `scripts/verify-installed-perf.sh`, and canonical JSON output from the existing summarizers and baseline scripts
- simplify the app hot path by keeping `AppCommandState` as the stable command-routing surface, aggregating input diagnostics, and adding narrower focus timing instrumentation
- split runner lane health from perf validation in CI/release flows and add a dedicated `workspaces-performance-system` skill for operating the standardized perf system

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `./scripts/test_perf_tools.py`
  - `./scripts/perf-runner.sh --scenario debug_no_activate --runs 3 --sleep-seconds 6 --output-dir /tmp/workspaces-pr-perf-current`
  - `./scripts/dev-smoke.sh --no-build --no-activate`

## Performance

- [ ] Not a performance-sensitive change
- [x] Baseline metrics were provided with the task
- [x] Baseline metrics were gathered before changes
- [x] Post-change metrics were gathered at the end of the work
- [x] Before/after/delta is included below
- [x] Any meaningful change, missing metric, target crossing, or non-comparable context is called out below

Performance evidence for this PR comes from two sources:

1. Checked-in investigation notes that captured the original slow-path regressions and the follow-up fixes that are part of this branch:
   - `docs/performance/investigation-2026-04-07-global-slowness-and-input-latency.md`
   - `docs/performance/2026-04-08-global-slowness-learnings.md`
2. A fresh canonical contract run on this branch:
   - `./scripts/perf-runner.sh --scenario debug_no_activate --runs 3 --sleep-seconds 6 --output-dir /tmp/workspaces-pr-perf-current`

Performance evidence:

- historical `input_investigation.event_age_ms` median: `1198.85 ms` -> `3.40 ms`
- historical `repo_click_to_focus`: `3885.80 ms` -> `1031.94 ms`
- historical installed `launch_to_first_prompt`: `2852.72 ms` -> `795.65 ms`
- current canonical `debug_no_activate` run on this branch:
  - `launch_to_first_prompt` median: `785.16 ms`
  - `repo_click_to_focus` median: `211.00 ms`
  - `repo_hydration` median: `1.37 ms`

Performance comparison notes:

- The historical values above are the user-facing before/after measurements from the checked-in investigation work that this PR publishes.
- The fresh canonical `debug_no_activate` run is the standardized contract proof from the exact branch under review.
- `repo_click_to_focus` is now back inside the `<= 250 ms` debug gate on the canonical run.
- `launch_to_first_prompt` is still above the debug gate on the canonical run, so this PR improves reliability and comparability of the performance system while still leaving startup latency as an active optimization target.
- Installed-build runtime verification requires an interactive display-capable macOS session; the verifier now classifies display/session limitations explicitly instead of misreporting them as product perf failures.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Validation + perf summary: [perf-system-summary](https://evidence.cloudcompute.com/workspaces/pr-338/20260413-053611-perf-system-summary.svg)
- Debug app window capture: [dev-smoke-window](https://evidence.cloudcompute.com/workspaces/pr-338/20260413-053614-dev-smoke-window.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
