### PR TITLE
[codex] Document self-hosted runner operating policy

### DIFF
--- a/.agents/skills/self-hosted-runners/SKILL.md
+++ b/.agents/skills/self-hosted-runners/SKILL.md
@@ -18,6 +18,15 @@ This repo has three important self-hosted lanes:
 - `lume-macos` for macOS CI and agent execution
 - `tart-ui` for UI and perf automation
 
+Default policy:
+
+- Keep the Lume guest runner as the normal `lume-macos` path.
+- Keep host-local runners stopped by default on the interactive machine.
+- Start host-local runners only as explicit, temporary capacity for cases like release signing or CI recovery.
+- Stop those host-local runners again as soon as the targeted jobs complete.
+
+Read [docs/development/self-hosted-runner-policy.md](../../docs/development/self-hosted-runner-policy.md) before leaving any host-local runner online.
+
 ## Quick Start
 
 Summarize GitHub runner inventory, queued jobs, and local runner directories:
@@ -64,8 +73,9 @@ For `lume-macos`:
 1. Confirm the VM exists and is running.
 2. Probe the guest over SSH with `probe_lume_runner_guest.py`.
 3. If the guest runner registration is stale, re-register it.
-4. If the guest is missing Xcode or is otherwise not build-ready, stop using it for CI and switch to a host fallback runner.
+4. If the guest is missing Xcode or is otherwise not build-ready, stop using it for CI and switch to a temporary host fallback runner.
 5. If a host fallback runner goes online and then flips offline while the local process is still alive, treat that as a host-side communication problem rather than a repo problem.
+6. Once the blocked jobs finish, stop the temporary host fallback runner so the host returns to the default stopped state.
 
 For `signing-host`:
 
@@ -104,6 +114,7 @@ Important patterns:
 - Prefer direct SSH into the Lume guest once passwordless SSH works.
 - Prefer a fresh host fallback runner name and directory over trying to salvage a strange local runner state.
 - Prefer proving that a runner can stay online and accept one job before relying on it for release work.
+- Prefer leaving host-local runners stopped when they are not actively needed.
 
 ## Standalone Scripts
 
@@ -130,3 +141,4 @@ Use for `lume-macos` guest recovery.
 - Do not keep rerunning jobs on a Lume guest that is missing Xcode.
 - Do not keep reusing a host fallback runner name that has session-conflict behavior. Register a fresh runner name if needed.
 - When a runner process is alive locally but GitHub shows it offline, classify that as a host-side problem first.
+- Do not leave temporary host-local runners running after the immediate CI or release need has been satisfied.

--- a/docs/development/lume-runner-setup.md
+++ b/docs/development/lume-runner-setup.md
@@ -2,6 +2,14 @@
 
 Use this runbook to provision the `[self-hosted, lume-macos]` runner lane inside a Lume macOS VM for agent workflows that need macOS capabilities (swift build/test, screenshots).
 
+## Default operating policy
+
+- The Lume guest runner is the default `lume-macos` lane to leave available.
+- Host-local `lume-macos` fallback runners on the interactive machine should stay stopped by default.
+- Only start a host-local fallback runner when the Lume guest is unavailable or not build-ready, and stop it again after the blocked jobs finish.
+
+See [self-hosted-runner-policy.md](./self-hosted-runner-policy.md) for the repo-wide default.
+
 ## Secret handling
 
 The unattended profiles in this repo are templates, not ready-to-run secrets. Set a per-host guest password locally and render a local config copy before using any profile that needs auto-login or SSH:
@@ -107,6 +115,8 @@ gh api repos/fairchild/workspaces/actions/runners \
 ```
 
 Confirm there is an online runner with `lume-macos` label.
+
+This is the preferred steady-state lane. If you had to use a host-local fallback runner to recover CI, return to this VM-backed lane and stop the host-local service afterward.
 
 ## 5. Harden and install tools
 
@@ -227,6 +237,13 @@ Stop the VM:
 
 ```bash
 lume stop "$LUME_VM" --storage "$LUME_STORAGE/workspace-vms"
+```
+
+If you temporarily started a host-local fallback runner to unblock CI, stop it after the job finishes:
+
+```bash
+RUNNER_DIR="$HOME/.local/share/actions-runner-workspaces-lume-host-5" \
+  ./scripts/runner.sh service-stop
 ```
 
 Re-register after token expiry:

--- a/docs/development/self-hosted-runner-policy.md
+++ b/docs/development/self-hosted-runner-policy.md
@@ -1,0 +1,47 @@
+# Self-Hosted Runner Policy
+
+Use this policy to decide which runners are allowed to stay online by default.
+
+## Default steady state
+
+- The preferred default runner is the `lume-macos` guest runner (`lume-runner`) inside the dedicated Lume VM.
+- Host-local runners on the interactive desktop stay stopped by default.
+- `signing-host` and `tart-ui` on the local host are opt-in lanes, not ambient background services.
+
+## When host-local runners are allowed
+
+Start host-local runners only for short-lived, explicit tasks such as:
+
+- recovering a blocked `lume-macos` CI queue
+- performing release signing or notarization on an approved host
+- running `tart-ui` automation on the current machine by explicit choice
+
+If a host-local runner is started for one of those cases, treat it as temporary capacity.
+
+## Shutdown rule
+
+- Stop host-local runners as soon as the targeted jobs finish.
+- Do not leave fallback host runners running in the background "just in case".
+
+Examples:
+
+```bash
+RUNNER_DIR="$HOME/.local/share/actions-runner-workspaces-lume-host-5" \
+  ./scripts/runner.sh service-stop
+```
+
+```bash
+RUNNER_DIR="$HOME/.local/share/actions-runner-workspaces" \
+  ./scripts/runner.sh service-stop
+```
+
+## Registration hygiene
+
+- Prefer a fresh runner name and directory for temporary host fallback capacity.
+- Do not keep reusing stale local host runner directories that have shown `offline while busy`, session conflicts, or partial self-update behavior.
+- Once the temporary runner is no longer needed, stop it and leave it out of the normal background set.
+
+## Security posture
+
+- A running host-local runner increases local exposure on the interactive machine.
+- The repo default should therefore be "Lume guest by default, host-local by explicit opt-in".

--- a/docs/development/signing-runner-setup.md
+++ b/docs/development/signing-runner-setup.md
@@ -2,6 +2,14 @@
 
 Use this runbook to provision or relabel the dedicated `[self-hosted, signing-host]` lane required by the `Release` workflow.
 
+## Default operating policy
+
+- `signing-host` on the local interactive machine is opt-in only.
+- Do not leave a local signing runner running in the background when no release is in progress.
+- Start the runner for the release window, verify the release job is claimed, and stop it again when the work is finished.
+
+See [self-hosted-runner-policy.md](./self-hosted-runner-policy.md) for the repo-wide default.
+
 ## Why this exists
 
 The release workflow intentionally does not run on a generic self-hosted runner. It targets `[self-hosted, signing-host]` so signing and notarization stay isolated from routine desktop CI and Tart UI automation.
@@ -68,7 +76,16 @@ The job should report labels including `self-hosted` and `signing-host`, and `ru
 
 If repository release credentials are intentionally unavailable in the current environment, stop after the job is claimed by the correct runner.
 
-## 5. Move or remove the label
+## 5. Stop the local signing runner after use
+
+If the local host was only brought up for a release window, stop it when the release completes:
+
+```bash
+RUNNER_DIR="$HOME/.local/share/actions-runner-workspaces" \
+  ./scripts/runner.sh service-stop
+```
+
+## 6. Move or remove the label
 
 If release duties move to a different host:
 


### PR DESCRIPTION
## Summary
- document the default self-hosted runner operating policy
- clarify that the Lume guest runner is the default `lume-macos` lane
- document that host-local runners are explicit temporary opt-in capacity and should be stopped after use

## Validation
- docs-only change
- `git diff --check`
