### PR TITLE
test: smoke test for PR reviewer agent

### DIFF
--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -137,3 +137,5 @@ Read the diff against ${payload.baseRef}, explore the surrounding code, run swif
 	);
 	return session.id;
 }
+
+// PR reviewer smoke test — remove after verifying


### PR DESCRIPTION
## Summary

Trivial change to verify the Managed Agents PR reviewer triggers on `pull_request.opened`.

**Expected behavior:** The webhook fires → `triggerPrReview()` creates a session → the agent reads the diff, explores the code, and attempts to post a review via GitHub MCP.

**Note:** The GitHub MCP vault credential is empty, so the agent can read/test but can't post the review comment yet. Check the Anthropic dashboard for session activity.

This PR should be closed (not merged) after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)