### PR TITLE
fix(cd): point pnpm/action-setup at web/package.json

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -104,6 +106,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -136,6 +140,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -236,6 +242,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary

First workflow_dispatch of `cd.yml` after #344 merged failed immediately at `preview-web`'s pnpm setup step with:

> No pnpm version is specified.
> Please specify it by one of the following ways:
> - in the GitHub Action config with the key "version"
> - in the package.json with the key "packageManager"

Root cause: `pnpm/action-setup@v4` reads `packageManager` from `./package.json` by default, but this repo has no root `package.json` — only `web/package.json` (where `packageManager: pnpm@10.18.3` is pinned). All four invocations in `cd.yml` now pass `package_json_file: web/package.json` explicitly.

## Evidence

- Failed run: https://github.com/fairchild/workspaces/actions/runs/24619686877 (preview-web, job 71987967833)
- After fix: YAML parses, 9 jobs present, all four setup sites patched.

## Test plan

- [ ] `gh workflow run cd.yml --ref main` after merge; confirm `preview-web` gets past setup and produces a preview URL
- [ ] Remainder of the pipeline (`preview-workers`, `playwright-validate`, `lighthouse`, `promote`) goes green as designed

🤖 Generated with [Claude Code](https://claude.com/claude-code)