### PR TITLE
fix(cd): target Node 24 + Vercel CLI 51

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
           package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -47,18 +47,18 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: npx vercel@37 pull --yes --environment=production --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
+        run: npx vercel@51 pull --yes --environment=production --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
       - name: Build production artifact
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: npx vercel@37 build --prod --token="$VERCEL_TOKEN"
+        run: npx vercel@51 build --prod --token="$VERCEL_TOKEN"
       - name: Deploy prebuilt artifact to preview URL
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         run: |
-          URL=$(npx vercel@37 deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID")
+          URL=$(npx vercel@51 deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID")
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
           echo "::notice::Preview deployed to $URL"
 
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Deploy to preview env
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
           package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -144,7 +144,7 @@ jobs:
           package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Deploy workers to prod
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -190,7 +190,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         run: |
-          npx vercel@37 promote "${{ needs.preview-web.outputs.preview_url }}" \
+          npx vercel@51 promote "${{ needs.preview-web.outputs.preview_url }}" \
             --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
           echo "::notice::Promoted ${{ needs.preview-web.outputs.preview_url }} to production"
 
@@ -246,7 +246,7 @@ jobs:
           package_json_file: web/package.json
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/scripts/cd/bootstrap-preview.py
+++ b/scripts/cd/bootstrap-preview.py
@@ -403,14 +403,14 @@ def step_vercel(
         teach("`vercel link` is interactive. It writes web/.vercel/project.json.")
         if runner.apply:
             runner.run(
-                npx("vercel@37", "link", "--yes", "--token", token),
+                npx("vercel@51", "link", "--yes", "--token", token),
                 cwd=project_dir,
                 capture=False,
                 quiet=True,
             )
             ids = read_vercel_ids(project_dir)
         else:
-            info(dim("(dry-run: would run `npx vercel@37 link --yes`)"))
+            info(dim("(dry-run: would run `npx vercel@51 link --yes`)"))
 
     if ids:
         ok(f"orgId={mask(ids[0])}  projectId={mask(ids[1])}")


### PR DESCRIPTION
## Summary

Fixes the "Found invalid Node.js Version: 24.x" error from Test 3 run [24619800751](https://github.com/fairchild/workspaces/actions/runs/24619800751).

The Vercel project is configured for Node 24.x but `cd.yml` pinned `vercel@37`, which pre-dates Node 24.x support. Rather than downgrade the Vercel project, bump the CLI + CI Node to match.

## Changes

- `.github/workflows/cd.yml`: `vercel@37` → `vercel@51` × 4 (pull, build, deploy, promote)
- `.github/workflows/cd.yml`: `node-version: 20` → `node-version: 24` × 6 (every pnpm-using job)
- `scripts/cd/bootstrap-preview.py`: `vercel@37` → `vercel@51` × 2 (link command + dry-run help text)

## Test plan

- [ ] Merge, dispatch `cd.yml` against main, confirm `preview-web` gets through `Build production artifact` without the 24.x rejection
- [ ] All 9 CD jobs go green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)