### PR TITLE
fix(cd): pair VERCEL_PROJECT_ID with VERCEL_ORG_ID on deploy+promote

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           URL=$(npx vercel@51 deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID")
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
@@ -189,6 +190,7 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
           npx vercel@51 promote "${{ needs.preview-web.outputs.preview_url }}" \
             --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"


### PR DESCRIPTION
## Summary

Test 3 run [24620083728](https://github.com/fairchild/workspaces/actions/runs/24620083728) got past build but failed at `Deploy prebuilt artifact to preview URL`:

> Error: You specified \`VERCEL_ORG_ID\` but you forgot to specify \`VERCEL_PROJECT_ID\`. You need to specify both to deploy to a custom project.

Vercel CLI v51 enforces that these two env vars travel together. The `pull` step already sets both; `deploy` and `promote` were only setting `VERCEL_ORG_ID`. Added `VERCEL_PROJECT_ID` to both env blocks.

## Test plan

- [ ] Merge; dispatch cd.yml; confirm `preview-web` → deploy emits `*.vercel.app` URL
- [ ] Downstream validators + promote chain goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)