### PR TITLE
fix(cd): deploy prebuilt with --prod --skip-domain

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,8 +58,11 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        # --prod: deploy target must match `vercel build --prod` (CLI v51 enforces this).
+        # --skip-domain: don't auto-alias the prod domain; let the `promote` job do that
+        # after validators pass — preserves the "validated artifact ships" invariant.
         run: |
-          URL=$(npx vercel@51 deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID")
+          URL=$(npx vercel@51 deploy --prebuilt --prod --skip-domain --archive=tgz --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID")
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
           echo "::notice::Preview deployed to $URL"
 


### PR DESCRIPTION
## Summary

Test 3 run [24620150033](https://github.com/fairchild/workspaces/actions/runs/24620150033) got past all prior bugs but failed the deploy step:

> Error: The \`--prebuilt\` option was used with the target environment \"preview\", but the prebuilt output found in \`.vercel/output\` was built with target environment \"production\". Please run \`vercel --prebuilt --prod\`.

Vercel CLI v51 hard-errors on build/deploy target mismatch. Our build uses `--prod` to preserve the \"validated artifact ships\" invariant (same bytes we test are the bytes we promote), so the deploy must also target prod.

## Change

- `vercel@51 deploy --prebuilt --archive=tgz` → `vercel@51 deploy --prebuilt --prod --skip-domain --archive=tgz`
- Inline comment explains why both flags are load-bearing.

`--skip-domain` is critical: it deploys *as prod* (so the target matches the build), but doesn't auto-alias the prod domain. The later `promote` step does the alias swap once validators have signed off on the specific unique deployment URL.

## Test plan

- [ ] Merge; dispatch cd.yml; deploy emits `*.vercel.app` URL; validators run against it; promote aliases prod on pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)