### PR TITLE
fix(cd): resolve fail-notify module via absolute file URL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -215,7 +215,12 @@ jobs:
           REPRO_HINT: cd web && PLAYWRIGHT_BASE_URL=${{ needs.preview-web.outputs.preview_url }} PLAYWRIGHT_SKIP_WEB_SERVER=1 pnpm exec playwright test --project fast
         with:
           script: |
-            const { default: failNotify } = await import('./.github/workflows/cd-fail-notify.js');
+            // github-script runs from its own dist dir; relative imports look
+            // there, not at the workspace. Resolve via GITHUB_WORKSPACE + file URL.
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const abs = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/cd-fail-notify.js');
+            const { default: failNotify } = await import(pathToFileURL(abs).href);
             await failNotify({ github, context, core });
 
   fail-notify-lighthouse:
@@ -234,7 +239,12 @@ jobs:
           REPRO_HINT: cd web && pnpm exec lhci autorun --config=./lighthouserc.json --collect.url=${{ needs.preview-web.outputs.preview_url }}
         with:
           script: |
-            const { default: failNotify } = await import('./.github/workflows/cd-fail-notify.js');
+            // github-script runs from its own dist dir; relative imports look
+            // there, not at the workspace. Resolve via GITHUB_WORKSPACE + file URL.
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const abs = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/cd-fail-notify.js');
+            const { default: failNotify } = await import(pathToFileURL(abs).href);
             await failNotify({ github, context, core });
 
   validate-prod:


### PR DESCRIPTION
## Summary

Run [24620238352](https://github.com/fairchild/workspaces/actions/runs/24620238352) exposed that both `fail-notify-*` jobs fail before running our logic:

> Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/runner/work/_actions/actions/github-script/.../dist/.github/workflows/cd-fail-notify.js' imported from .../dist/index.js

github-script@v7 executes the inline `script:` from its own dist directory, so relative `await import('./.github/workflows/cd-fail-notify.js')` looks for the file under the action's dist, not the workspace.

Fix: resolve an absolute file URL via `process.env.GITHUB_WORKSPACE` + `pathToFileURL`, which ESM dynamic import handles correctly.

## Test plan

- [ ] Merge. Next dispatch should actually enter our fail-notify logic and either (a) create the rolling issue + dispatch April, or (b) post the needs-human escalation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)