### PR TITLE
fix(cd): bypass Vercel Deployment Protection for preview validators

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,6 +123,7 @@ jobs:
         env:
           PLAYWRIGHT_BASE_URL: ${{ needs.preview-web.outputs.preview_url }}
           PLAYWRIGHT_SKIP_WEB_SERVER: "1"
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set +e
           pnpm exec playwright test --project fast --reporter=json > playwright-report.json
@@ -155,11 +156,19 @@ jobs:
       - name: Warmup preview + run LHCI
         env:
           LHCI_COLLECT_URL: ${{ needs.preview-web.outputs.preview_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
-          curl -sSf "$LHCI_COLLECT_URL/" >/dev/null || true
-          curl -sSf "$LHCI_COLLECT_URL/" >/dev/null || true
+          BYPASS_CURL=()
+          BYPASS_LHCI=()
+          if [ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
+            BYPASS_CURL=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
+            HEADERS_JSON=$(printf '{"x-vercel-protection-bypass":"%s","x-vercel-set-bypass-cookie":"true"}' "$VERCEL_AUTOMATION_BYPASS_SECRET")
+            BYPASS_LHCI=(--collect.settings.extraHeaders="$HEADERS_JSON")
+          fi
+          curl -sSf "${BYPASS_CURL[@]}" "$LHCI_COLLECT_URL/" >/dev/null || true
+          curl -sSf "${BYPASS_CURL[@]}" "$LHCI_COLLECT_URL/" >/dev/null || true
           set +e
-          pnpm exec lhci autorun --config=./lighthouserc.json --collect.url="$LHCI_COLLECT_URL"
+          pnpm exec lhci autorun --config=./lighthouserc.json --collect.url="$LHCI_COLLECT_URL" "${BYPASS_LHCI[@]}"
           LHCI_EXIT=$?
           node scripts/lhci-findings.js .lighthouseci/assertion-results.json > findings.md || echo "_findings script failed_" > findings.md
           exit $LHCI_EXIT

--- a/scripts/cd/bootstrap-preview.py
+++ b/scripts/cd/bootstrap-preview.py
@@ -655,6 +655,10 @@ def step_github(
             "https://dash.cloudflare.com/",
             "sidebar on any account page, or `wrangler whoami`",
         ),
+        "VERCEL_AUTOMATION_BYPASS_SECRET": (
+            "https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation",
+            "Vercel dashboard → Project → Settings → Deployment Protection → Protection Bypass for Automation → Add Secret. Lets Playwright/Lighthouse reach preview URLs that are otherwise gated behind the Vercel login wall.",
+        ),
     }
 
     for name in gh_cfg.get("from_env", []):

--- a/scripts/cd/config.toml
+++ b/scripts/cd/config.toml
@@ -35,6 +35,7 @@ from_env = [
   "VERCEL_TOKEN",
   "CLOUDFLARE_API_TOKEN",
   "CLOUDFLARE_ACCOUNT_ID",
+  "VERCEL_AUTOMATION_BYPASS_SECRET",
 ]
 # Secrets derived from web/.vercel/project.json after `vercel link`.
 from_vercel_link = ["VERCEL_ORG_ID", "VERCEL_PROJECT_ID"]

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -3,6 +3,17 @@ import { defineConfig, devices } from "@playwright/test";
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 const SKIP_WEB_SERVER = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1";
 
+// Vercel Deployment Protection: preview URLs redirect to vercel.com/login
+// unless callers supply the Protection Bypass for Automation secret. When
+// present, send it on every request so validators see the real app.
+const BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+const extraHTTPHeaders = BYPASS_SECRET
+	? {
+			"x-vercel-protection-bypass": BYPASS_SECRET,
+			"x-vercel-set-bypass-cookie": "true",
+		}
+	: undefined;
+
 export default defineConfig({
 	testDir: "./e2e",
 	fullyParallel: true,
@@ -13,6 +24,7 @@ export default defineConfig({
 	use: {
 		baseURL: BASE_URL,
 		trace: "on-first-retry",
+		extraHTTPHeaders,
 	},
 	projects: [
 		{


### PR DESCRIPTION
## Summary

Test 3 run [24620238352](https://github.com/fairchild/workspaces/actions/runs/24620238352) proved the pipeline deploys correctly, but validators fail because Vercel **Deployment Protection** is enabled on the project. Preview URLs redirect unauthenticated callers to `vercel.com/login`, so Playwright sees the Vercel SSO page instead of our app.

Findings downloaded from that run:
- `landing.spec.ts` — expects Spaces branding, sees Vercel login
- `unauth-api.spec.ts` — expects JSON, gets HTML (`\"<!doctype ...\"`)
- `unauth-redirect.spec.ts` — expects `/sign-in`, gets `vercel.com/login?next=...`
- Lighthouse scored the Vercel login page at 0.88 perf

## Fix

Wire `VERCEL_AUTOMATION_BYPASS_SECRET` through every validator surface so CI presents `x-vercel-protection-bypass` on every request:

- `.github/workflows/cd.yml`: secret passed as env to `playwright-validate` and `lighthouse`. Lighthouse warmup curls + `lhci autorun` both send the header (shell-expanded; `lighthouserc.json` stays env-var-free).
- `web/playwright.config.ts`: top-level `use.extraHTTPHeaders` injects the bypass + `x-vercel-set-bypass-cookie` when the env var is present. No-op locally.
- `scripts/cd/config.toml`: `VERCEL_AUTOMATION_BYPASS_SECRET` added to `github_secrets.from_env`.
- `scripts/cd/bootstrap-preview.py`: prompt hint points at the Vercel dashboard location to create the secret.

`validate-prod` runs against the public prod domain (`spaces.cloudcompute.com`), which isn't protection-gated, so it's unchanged.

## 🚨 Operator step required before this helps

Generate the bypass secret in Vercel before (or during) this PR's merge:

1. https://vercel.com/cloudcompute/web/settings/deployment-protection
2. **Protection Bypass for Automation** → **Add Secret** → copy the generated value
3. Either paste into `scripts/cd/.env.bootstrap` as `VERCEL_AUTOMATION_BYPASS_SECRET=...` and re-run `uv run scripts/cd/bootstrap-preview.py --apply`, OR push it manually: `gh secret set VERCEL_AUTOMATION_BYPASS_SECRET --repo fairchild/workspaces`

## Test plan

- [ ] Generate bypass secret + push to GitHub Actions
- [ ] Merge this PR
- [ ] Dispatch cd.yml; validators should run against the real app (not Vercel SSO) and pass
- [ ] promote → validate-prod chain goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)