### PR TITLE
fix(cd): checkout repo in fail-notify jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -204,6 +204,9 @@ jobs:
     if: failure() && !cancelled() && needs.playwright-validate.result == 'failure'
     runs-on: ubuntu-latest
     steps:
+      # Checkout is required so the github-script step can import the shared
+      # fail-notify logic at .github/workflows/cd-fail-notify.js.
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: playwright-findings
@@ -228,6 +231,7 @@ jobs:
     if: failure() && !cancelled() && needs.lighthouse.result == 'failure'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: lighthouse-findings


### PR DESCRIPTION
## Summary

PR #353 made the absolute-path dynamic import resolve correctly, but run [24620749168](https://github.com/fairchild/workspaces/actions/runs/24620749168) still 404'd on the module:

> Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/runner/work/workspaces/workspaces/.github/workflows/cd-fail-notify.js'

The path is right — but the file isn't there because `fail-notify-playwright` / `fail-notify-lighthouse` never `actions/checkout@v4`. They only download the findings artifact. Adding checkout brings the `.github/` tree onto disk so the shared module can be imported.

## Test plan

- [ ] Merge. Force a validator fail. `fail-notify-*` should now enter `cd-fail-notify.js`, create the rolling issue, and dispatch April.

🤖 Generated with [Claude Code](https://claude.com/claude-code)