### PR TITLE
fix(cd): strip ANSI escapes from playwright findings

### DIFF
--- a/web/scripts/playwright-findings.js
+++ b/web/scripts/playwright-findings.js
@@ -9,6 +9,16 @@ if (!reportPath) {
 
 const report = JSON.parse(readFileSync(reportPath, "utf8"));
 
+// Playwright's JSON reporter keeps terminal-formatted ANSI escapes in error
+// messages (e.g. "^[[31mred^[[39m"). Strip CSI-style color/style sequences so
+// markdown issue bodies render cleanly in GitHub. Built at runtime so the
+// source file doesn't embed control chars (biome rejects those literals).
+const ansiRegex = new RegExp(
+	`${String.fromCharCode(0x1b)}\\[[0-9;]*[A-Za-z]`,
+	"g",
+);
+const stripAnsi = (s) => s.replace(ansiRegex, "");
+
 const failures = [];
 function walk(suite, trail) {
 	const here = trail.concat(suite.title ? [suite.title] : []);
@@ -16,13 +26,9 @@ function walk(suite, trail) {
 		for (const test of spec.tests ?? []) {
 			for (const result of test.results ?? []) {
 				if (result.status === "failed" || result.status === "timedOut") {
-					const firstErr = (
-						result.errors?.[0]?.message ??
-						result.error?.message ??
-						""
-					)
-						.split("\n")[0]
-						.slice(0, 300);
+					const rawErr =
+						result.errors?.[0]?.message ?? result.error?.message ?? "";
+					const firstErr = stripAnsi(rawErr).split("\n")[0].slice(0, 300);
 					failures.push({
 						file: spec.file,
 						title: here.concat(spec.title).join(" › "),


### PR DESCRIPTION
## Summary

Playwright's JSON reporter keeps terminal color/style codes in `errors[].message`, so the markdown issue bodies from `fail-notify-playwright` surfaced literal fragments like `^[[2mexpect(^[[22m^[[31mlocator^[[39m^[[2m)...` (see [#356](https://github.com/fairchild/workspaces/issues/356)).

Strip CSI sequences before rendering. Regex is built at runtime via `String.fromCharCode(0x1b)` so the source file doesn't embed control-char literals (biome rejects those).

Smoke test:
```
Input:  "Error: \u001b[31mexpect\u001b[39m failed"
Output: "Error: expect failed"
```

## Test plan

- [ ] Merge; next failing CD run's rolling-issue body shows clean error strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)