### PR TITLE
fix(cd): run vercel CLI from repo root

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
-    defaults:
-      run:
-        working-directory: web
+    # Vercel CLI commands run from the repo root so the spaces-web project's
+    # rootDirectory=web setting resolves correctly. Only pnpm needs to cd into
+    # web/ (for package.json resolution).
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -41,7 +41,9 @@ jobs:
           node-version: 24
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
       - name: Pull Vercel prod env + config
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -198,7 +200,6 @@ jobs:
             echo "::endgroup::"
           done
       - name: Promote validated Vercel preview to prod
-        working-directory: web
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary

Run [24622204138](https://github.com/fairchild/workspaces/actions/runs/24622204138) failed at build:

> Error: ENOENT: no such file or directory, open '/home/runner/work/workspaces/workspaces/web/web/package.json'

The `spaces-web` Vercel project has **Root Directory = `web`**. Running `vercel build` from inside `web/` (via `defaults.run.working-directory: web`) makes Vercel concatenate and look for `web/web/`. The old `web` project we'd been accidentally deploying to had Root Directory empty — which is why the pipeline worked until we correctly re-linked to `spaces-web`.

Fix: drop `defaults.run.working-directory: web` from `preview-web`; keep it only on the pnpm install step. Vercel CLI runs from repo root, reads its project config, and handles the `web/` traversal itself. Same fix on `promote`.

## Test plan

- [ ] Merge; dispatch; build succeeds; deploy emits a `spaces-web-*.vercel.app` URL; validators now see the real app (bypass secret wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)