### PR TITLE
chore(cd): enable push trigger for main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,17 +1,13 @@
 name: CD
 
-# Activation: this workflow ships with the push trigger DISABLED so the merge
-# commit doesn't kick off a failing run before bootstrap is complete. After:
-#   1. `uv run scripts/cd/bootstrap-preview.py --apply` (sets all secrets,
-#      generates web/vercel.json, links Vercel project)
-#   2. Cloudflare DNS for evidence-preview.cloudcompute.com added
-#   3. Verify a manual workflow_dispatch run goes green end-to-end
-# … then uncomment the `push: branches: [main]` block in a follow-up PR.
-# See scripts/cd/README.md for the full bootstrap walkthrough.
+# Every push to main goes through preview → validate → promote. Manual
+# dispatches (Actions tab / `gh workflow run cd.yml --ref main`) run the same
+# pipeline on demand. See scripts/cd/README.md for the mental model and
+# bootstrap walkthrough.
 
 on:
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Enables `on: push: branches: [main]` now that Test 3 has fully validated the pipeline.

Final Test 3 run: [24622467336](https://github.com/fairchild/workspaces/actions/runs/24622467336) — all 9 jobs green, including `promote` aliasing `spaces.cloudcompute.com` to the validated deployment and `validate-prod` smoke-testing prod post-flip.

After this merges, every merge to main will:
1. Deploy preview (web + workers)
2. Run Playwright fast + Lighthouse against the preview
3. On pass: alias-swap Vercel prod + `wrangler deploy` workers to prod
4. Post-prod smoke test; alert issue on regression

`workflow_dispatch` stays for on-demand runs.

⚠ **Heads-up**: when this PR itself merges, the merge commit will trigger the first automated push-triggered CD run. The diff from the current main to this PR is a one-line workflow change + comment rewrite — no web or worker code change — so the preview build should be byte-stable with prod.

## Test plan

- [ ] Merge. Confirm the merge commit triggers a CD run that goes green.
- [ ] Next unrelated merge to main also triggers CD automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)