### PR TITLE
feat(web): post PR reviews via GitHub API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,7 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | Lume runner setup | docs/development/lume-runner-setup.md | - |
 | Lume daemon reliability | docs/development/lume-integration.md § "Daemon Reliability" | - |
 | Web architecture | web/docs/architecture.md | - |
+| PR reviewer agent | web/docs/pr-reviewer.md | - |
 | Roadmap/planning | backlog/ROADMAP.md | - |
 | Deferred work items | backlog/*.md | - |
 | Prototypes | prototypes/README.md | - |
@@ -266,6 +267,8 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | Web terminal panel | web/src/app/dashboard/components/terminal-panel.tsx |
 | Web terminal API | web/src/app/api/terminal/ |
 | Web API auth helpers | web/src/lib/api-auth.ts |
+| Web PR reviewer agent | web/src/lib/agent-runtime/pr-review.ts |
+| PR reviewer status script | scripts/pr-reviewer-status.py |
 | Web architecture doc | web/docs/architecture.md |
 
 ## Key Patterns

--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -1,6 +1,6 @@
 # PR Reviewer — Managed Agent
 
-Automated code review triggered by GitHub `pull_request.opened` webhooks. The agent runs on Anthropic's infrastructure, reads the diff, explores surrounding code, runs tests, and posts a review via GitHub MCP.
+Automated code review triggered by GitHub `pull_request.opened` webhooks. The agent runs on Anthropic's infrastructure, reads the diff, explores surrounding code, runs tests, and posts a review via the GitHub API.
 
 ## Architecture
 
@@ -12,7 +12,8 @@ GitHub PR opened
         → getOrCreateAgent/Environment (idempotent, DB-cached)
         → sessions.create (mounts repo at PR branch)
         → events.send (kickoff message)
-        → Agent runs autonomously on Anthropic → posts review via GitHub MCP
+        → Files API uploads GitHub token as mounted file
+        → Agent runs autonomously on Anthropic → posts review via GitHub API (curl)
 ```
 
 ## Key Files
@@ -29,9 +30,11 @@ GitHub PR opened
 | Var | Where | Purpose |
 |-----|-------|---------|
 | `ANTHROPIC_API_KEY` | Vercel | Anthropic API authentication |
-| `GITHUB_TOKEN` | Vercel | PAT for cloning repos into the sandbox (needs `repo` scope) |
-| `PR_REVIEWER_VAULT_ID` | Vercel | Vault containing GitHub MCP OAuth credentials |
+| `GITHUB_TOKEN` | Vercel | PAT for cloning repos and posting reviews (needs `repo` scope) |
+| `PR_REVIEWER_VAULT_ID` | Vercel (optional) | Vault for MCP credentials (not currently used) |
 | `PR_REVIEWER_MODEL` | Vercel (optional) | Override model (default: `claude-opus-4-6`) |
+
+**How the token reaches the agent:** `triggerPrReview()` uploads `GITHUB_TOKEN` as a file via the Files API and mounts it at `/workspace/.github-token`. The agent reads it with `cat` and uses `curl` to post the review via the GitHub API. The token never appears in the prompt or message stream.
 
 **Security:** Never print tokens to logs. Use pipes (`gh auth token | vercel env add ...`) or files, never standalone `echo`/`print` of credential values.
 
@@ -115,20 +118,19 @@ vercel deploy --prod
 
 For durable auth, create a GitHub App via the `/gh-apps` skill.
 
-### MCP server auth failed
+### Review not posted to GitHub
 
-The vault credential is empty or expired. Error looks like:
-```
-MCP server 'github' initialize failed: authorization token is invalid or expired
-```
-
-Add a credential to the vault — see `shared/managed-agents-tools.md` §Vaults for the OAuth shape.
+Check the session events for the `curl` call. Common causes:
+- `GITHUB_TOKEN` expired — rotate with `gh auth refresh` then update Vercel (see above)
+- Token file not mounted — check session resources for `/workspace/.github-token`
+- API response `401` — token lacks `repo` scope
+- API response `422` — review body has unescaped JSON characters
 
 ### Webhook fires but no session created
 
 Check Vercel error logs. Common causes:
 - `ANTHROPIC_API_KEY` not set (only in production, not preview)
-- `PR_REVIEWER_VAULT_ID` has a trailing newline (use `printf` not `echo` when setting)
+- Env var has a trailing newline (use `printf` not `echo` when setting)
 - Webhook secret mismatch between GitHub and `GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET`
 
 ### Agent can't find the diff

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -7,16 +7,37 @@ import {
 const SYSTEM_PROMPT = `You are a code reviewer for a Swift project (SwiftUI / Swift Package Manager).
 
 For each PR you receive:
-1. Read the diff. Use \`git diff main...HEAD\` (or the base ref mentioned) to see what changed.
+1. Read the diff. Use \`git diff origin/main...HEAD\` to see what changed. If \`main\` is not available locally, run \`git fetch origin main\` first.
 2. Explore the surrounding code — don't review in isolation. Use grep/glob to find callers, related types, and tests.
-3. If the project builds with SwiftPM, run \`swift build\` and \`swift test\`. Report failures explicitly.
+3. If the project builds with SwiftPM, run \`swift build\` and \`swift test\`. Report failures explicitly. If swift is unavailable, note this and continue.
 4. If a \`.swiftlint.yml\` exists, run \`swiftlint\` if available.
-5. Post a single PR review via the GitHub MCP server with:
-   - A high-level summary of the change
-   - Specific comments for issues (bugs, race conditions, force-unwraps, missing tests, security, performance)
-   - An overall recommendation: approve, request changes, or comment
+5. Post a single PR review using the GitHub API.
 
-Cite file:line for every comment. Skip nits unless they materially affect correctness or readability. Prefer fewer, higher-signal comments.`;
+## Posting the review
+
+A GitHub token is mounted at \`/workspace/.github-token\`. Use it to post the review via curl:
+
+\`\`\`bash
+TOKEN=$(cat /workspace/.github-token)
+curl -s -X POST "https://api.github.com/repos/{owner}/{repo}/pulls/{number}/reviews" \\
+  -H "Authorization: Bearer $TOKEN" \\
+  -H "Accept: application/vnd.github+json" \\
+  -d '{
+    "body": "your review text here (escape JSON properly)",
+    "event": "COMMENT"
+  }'
+\`\`\`
+
+Use \`"event": "APPROVE"\` for clean PRs, \`"event": "REQUEST_CHANGES"\` for issues, \`"event": "COMMENT"\` for informational reviews. Replace {owner}, {repo}, {number} with values from the kickoff message.
+
+## Review style
+
+Cite file:line for every comment. Skip nits unless they materially affect correctness or readability. Prefer fewer, higher-signal comments.
+
+Your review body should include:
+- A high-level summary of the change
+- Specific comments for issues (bugs, race conditions, force-unwraps, missing tests, security, performance)
+- An overall recommendation`;
 
 const TOOLS = [
 	{
@@ -27,15 +48,6 @@ const TOOLS = [
 			{ name: "edit", enabled: false },
 			{ name: "web_search", enabled: false },
 		],
-	},
-	{ type: "mcp_toolset" as const, mcp_server_name: "github" },
-];
-
-const MCP_SERVERS = [
-	{
-		type: "url" as const,
-		name: "github",
-		url: "https://api.githubcopilot.com/mcp/",
 	},
 ];
 
@@ -52,7 +64,7 @@ export interface PrReviewPayload {
 
 /**
  * Fire-and-forget: creates a Managed Agents session that reviews the PR
- * and posts a review via the GitHub MCP server. Returns the session ID,
+ * and posts a review via the GitHub API. Returns the session ID,
  * or null if required env vars are missing.
  */
 export async function triggerPrReview(
@@ -62,9 +74,9 @@ export async function triggerPrReview(
 	const githubToken = process.env.GITHUB_TOKEN;
 	const vaultId = process.env.PR_REVIEWER_VAULT_ID;
 
-	if (!apiKey || !githubToken || !vaultId) {
+	if (!apiKey || !githubToken) {
 		console.log(
-			"[pr-review] skipping — missing ANTHROPIC_API_KEY, GITHUB_TOKEN, or PR_REVIEWER_VAULT_ID",
+			"[pr-review] skipping — missing ANTHROPIC_API_KEY or GITHUB_TOKEN",
 		);
 		return null;
 	}
@@ -77,7 +89,6 @@ export async function triggerPrReview(
 		model,
 		systemPrompt: SYSTEM_PROMPT,
 		tools: TOOLS,
-		mcpServers: MCP_SERVERS,
 	});
 
 	const environmentId = await getOrCreateEnvironment(client, {
@@ -88,13 +99,22 @@ export async function triggerPrReview(
 		},
 	});
 
+	// Upload the GitHub token as a file so the agent can post reviews.
+	// This keeps the token out of the prompt/message stream.
+	const tokenFile = await client.beta.files.upload({
+		file: new File([githubToken], ".github-token", {
+			type: "text/plain",
+		}),
+	});
+
 	const mountPath = `/workspace/${payload.repoName}`;
+	const [owner, repo] = payload.repoFullName.split("/");
 
 	const session = await client.beta.sessions.create({
 		agent: agentId,
 		environment_id: environmentId,
 		title: `Review PR #${payload.number}: ${payload.title}`.slice(0, 256),
-		vault_ids: [vaultId],
+		...(vaultId ? { vault_ids: [vaultId] } : {}),
 		resources: [
 			{
 				type: "github_repository",
@@ -102,6 +122,11 @@ export async function triggerPrReview(
 				authorization_token: githubToken,
 				mount_path: mountPath,
 				checkout: { type: "branch", name: payload.headRef },
+			},
+			{
+				type: "file",
+				file_id: tokenFile.id,
+				mount_path: "/workspace/.github-token",
 			},
 		],
 		metadata: {
@@ -125,7 +150,10 @@ Head branch: ${payload.headRef}
 Base branch: ${payload.baseRef}
 Repo mounted at: ${mountPath}
 
-Read the diff against ${payload.baseRef}, explore the surrounding code, run swift build and swift test if the project supports them, then post a single PR review via the GitHub MCP server.`,
+GitHub API endpoint for posting the review:
+POST https://api.github.com/repos/${owner}/${repo}/pulls/${payload.number}/reviews
+
+Read the diff against ${payload.baseRef}, explore the surrounding code, run swift build and swift test if the project supports them, then post the review using the GitHub API with the token at /workspace/.github-token.`,
 					},
 				],
 			},


### PR DESCRIPTION
## Summary

- Replaces GitHub MCP approach with direct GitHub API calls via `curl`
- `GITHUB_TOKEN` uploaded as a file via Files API, mounted at `/workspace/.github-token`
- Agent reads the token and posts reviews with `curl` — no MCP/vault/OAuth setup needed
- Removes MCP server config and `mcp_toolset` from agent definition
- Updates docs to reflect the new approach

## Why

The MCP approach required a complex OAuth credential flow via vaults. Every session was failing with `MCP server 'github' initialize failed: authorization token is invalid or expired`. The agent was writing thorough reviews but couldn't post them.

The file-mount approach is simpler, uses tools the agent already has (`bash` + `read`), and keeps the token out of the prompt/message stream.

## Test plan

- [x] TypeScript typecheck passes
- [x] 141 unit tests pass
- [ ] Deploy and verify the agent posts a review on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)