### PR TITLE
test(desktop): regression surface for workspace creation hang race + PR #190 guard

### DIFF
--- a/Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import SwiftData
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+/// Regression surface for the workspace-creation-hang follow-up
+/// (`backlog/workspace-creation-hang-root-cause_followup.md`).
+///
+/// These tests exercise the two concrete hypotheses PR #190 addressed:
+/// 1. A debounced `ContentView.saveAccessTimestampChanges`-style `modelContext.save()`
+///    Task firing concurrently with `SidebarWorkspaceController.createWorkspace`'s
+///    upsert path on the same `ModelContext`.
+/// 2. The rollback-on-save-failure path losing pending workspace inserts, which is
+///    the bug PR #190's `insertedModelsArray.isEmpty` guard prevents.
+///
+/// A clean pass does not prove the production hang is fixed — these tests only
+/// exercise unit-test conditions (in-memory `ModelContainer`, synthesized MainActor
+/// scheduling). A live repro after shared-desktop isolation (P0 #3) is still the
+/// ultimate confirmation. A failure here, however, is high-signal.
+@Suite("WorkspaceCreationRace")
+struct WorkspaceCreationRaceTests {
+    @Test(
+        "Debounced save Task racing with workspace creation preserves both writes without deadlock"
+    )
+    @MainActor
+    func debouncedSaveDuringCreationPreservesBothWrites() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        context.insert(repo)
+        try context.save()
+        let initialTimestamp = repo.lastAccessedAt
+
+        let workspaceService = MockWorkspaceService()
+        workspaceService.createWorkspaceDelay = {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()]
+        )
+
+        async let createdWorkspace = controller.createWorkspace(
+            from: repo,
+            name: "feature-a",
+            providerID: LocalWorkspaceProvider.identifier
+        )
+
+        let debouncedSave = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(5))
+            repo.lastAccessedAt = Date()
+            try? await Task.sleep(for: .milliseconds(5))
+            do {
+                try context.save()
+            } catch {
+                if context.insertedModelsArray.isEmpty {
+                    context.rollback()
+                }
+            }
+        }
+
+        let workspace = try await createdWorkspace
+        await debouncedSave.value
+
+        let workspaces = try context.fetch(FetchDescriptor<Workspace>())
+        #expect(workspaces.count == 1)
+        #expect(workspaces.first?.name == "feature-a")
+        #expect(workspace.name == "feature-a")
+        #expect(repo.lastAccessedAt != initialTimestamp)
+    }
+
+    @Test(
+        "Unguarded rollback discards pending workspace insert — the bug PR #190 prevents"
+    )
+    @MainActor
+    func unguardedRollbackDiscardsPendingInsert() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        context.insert(repo)
+        try context.save()
+
+        let partial = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/api/workspaces/feature-a"),
+            sourceRepo: repo,
+            status: .active
+        )
+        context.insert(partial)
+
+        #expect(!context.insertedModelsArray.isEmpty)
+        #expect(context.insertedModelsArray.count == 1)
+
+        context.rollback()
+
+        let workspaces = try context.fetch(FetchDescriptor<Workspace>())
+        #expect(workspaces.isEmpty)
+        #expect(context.insertedModelsArray.isEmpty)
+    }
+
+    @Test(
+        "Skipping rollback when inserts pend lets the next save commit the partial workspace"
+    )
+    @MainActor
+    func skippedRollbackPreservesPendingInsertAcrossSave() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        context.insert(repo)
+        try context.save()
+
+        let partial = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/api/workspaces/feature-a"),
+            sourceRepo: repo,
+            status: .active
+        )
+        context.insert(partial)
+
+        #expect(!context.insertedModelsArray.isEmpty)
+
+        try context.save()
+
+        let workspaces = try context.fetch(FetchDescriptor<Workspace>())
+        #expect(workspaces.count == 1)
+        #expect(workspaces.first?.name == "feature-a")
+        #expect(context.insertedModelsArray.isEmpty)
+    }
+
+    @MainActor
+    private func makeModelContext() throws -> ModelContextFixture {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return ModelContextFixture(container: container, context: container.mainContext)
+    }
+
+    @MainActor
+    private func makeController(
+        context: ModelContext,
+        workspaceService: MockWorkspaceService,
+        providers: [any WorkspaceProviderProtocol]
+    ) -> SidebarWorkspaceController {
+        SidebarWorkspaceController(
+            modelContext: context,
+            workspaceService: workspaceService,
+            workspaceProviderRegistry: WorkspaceProviderRegistry(providers: providers)
+        )
+    }
+}
+
+private struct ModelContextFixture {
+    let container: ModelContainer
+    let context: ModelContext
+}
+
+private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked Sendable {
+    var workspacesRootValue = URL(fileURLWithPath: "/tmp/workspaces")
+    var workspacesRoot: URL {
+        get async { workspacesRootValue }
+    }
+
+    var createWorkspaceDelay: @Sendable () async -> Void = {}
+
+    func createWorkspace(
+        repoName: String,
+        repoLocalURL: URL,
+        name: String,
+        progress: WorkspaceCreationProgressHandler?
+    ) async throws -> NewWorkspaceInfo {
+        await createWorkspaceDelay()
+        let sanitizedName = WorkspaceService.sanitizeWorkspaceNameComponent(name)
+        return NewWorkspaceInfo(
+            name: name,
+            path:
+                workspacesRootValue
+                .appendingPathComponent(repoName, isDirectory: true)
+                .appendingPathComponent(sanitizedName, isDirectory: true),
+            gitBranch: "workspace/\(sanitizedName)"
+        )
+    }
+
+    func archiveWorkspace(at workspaceURL: URL) async throws {}
+
+    func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws {}
+
+    func runLifecycleScript(
+        _ scriptName: String,
+        in directory: URL
+    ) async throws -> WorkspaceService.ScriptResult {
+        WorkspaceService.ScriptResult(exitCode: 0, stdout: "", stderr: "")
+    }
+
+    func getWorkspaceSize(at workspaceURL: URL) async throws -> Int64 { 0 }
+
+    func sanitizeFilename(_ name: String) async -> String { name }
+}


### PR DESCRIPTION
## Summary

Three Swift Testing tests in a new `Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift`, exercising the two hypotheses called out in `backlog/workspace-creation-hang-root-cause_followup.md`:

1. **Debounced save Task racing with workspace creation preserves both writes without deadlock** — simulates `ContentView.saveAccessTimestampChanges`'s 500ms debounced save Task running on `@MainActor` while `SidebarWorkspaceController.createWorkspace` is mid-flight on the same `ModelContext`. Asserts the workspace persists, the repo's access timestamp persists, and the test does not hang.
2. **Unguarded rollback discards pending workspace insert** — locks down the exact bug PR #190 prevents: `modelContext.rollback()` while a partial workspace is in `insertedModelsArray` discards it, leaving the user's "Finishing workspace…" indefinitely.
3. **Skipping rollback when inserts pend lets the next save commit the partial workspace** — the positive case of the #190 guard: when rollback is skipped due to pending inserts, a subsequent successful `save()` commits the workspace.

## What this rules in / out

- **Rules out:** a basic deadlock between debounced save and upsert under unit-test conditions (in-memory `ModelContainer`, synthesized MainActor scheduling). The race test passes cleanly in 39ms.
- **Does NOT rule out** the production hang. Real-hardware factors — slow disk I/O, vanished store path (`/private/tmp/` perf-baseline-dir cleanup), SwiftData internal locks under WAL pressure — are not modeled by an in-memory test. The follow-up's step 1 ("reproduce the hang with the new diagnostics") still depends on shared-desktop isolation landing (P0 #3) for low-friction live repro.
- **Locks down** the behavioral premise PR #190's guard relies on (`insertedModelsArray` reflects pending inserts; `rollback()` discards them) as a regression net.

## Validation

- [x] `swift build` — passes (19.8s)
- [x] `swift test` — 449 tests, 77 suites, all green (1.9s); the new `WorkspaceCreationRace` suite is 3 tests in 39ms
- [x] prek pre-commit ran: large-files passed; swift-format passed; biome-web skipped (no relevant files)

```
◇ Suite "WorkspaceCreationRace" started.
◇ Test "Debounced save Task racing with workspace creation preserves both writes without deadlock" started.
◇ Test "Skipping rollback when inserts pend lets the next save commit the partial workspace" started.
◇ Test "Unguarded rollback discards pending workspace insert — the bug PR #190 prevents" started.
✔ Test "Skipping rollback when inserts pend lets the next save commit the partial workspace" passed after 0.012 seconds.
✔ Test "Unguarded rollback discards pending workspace insert — the bug PR #190 prevents" passed after 0.014 seconds.
✔ Test "Debounced save Task racing with workspace creation preserves both writes without deadlock" passed after 0.039 seconds.
✔ Suite "WorkspaceCreationRace" passed after 0.039 seconds.
✔ Test run with 3 tests in 1 suite passed after 0.039 seconds.
```

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached — full focused-suite output inlined above; the diff is the artifact

This PR adds tests, no production code. The test output above IS the evidence. Per the project's "trivial PR may ship without uploaded evidence" exception, no R2 upload is performed; if you'd prefer a hosted artifact I can capture and add one.

## Blockers

- [x] None

---

Session notes:

- Run via `/improve-codebase desktop` (continuation of the session that produced PR #369). Approved by Michael as P0 #1 unit; tests-only path chosen explicitly to keep production code untouched while turning a "hard to reproduce" investigation into a "deterministic test" surface.
- Tests live in `Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift`. Helpers are intentionally duplicated from `SidebarWorkspaceControllerBehaviorTests.swift` (private scope) — a factor-out is a candidate for a separate "test infrastructure" PR if it's worth doing.
- Follow-up: the backlog item stays pending. The next move on this thread is a live reproduction once shared-desktop isolation (P0 #3) lands, OR an exploratory probe targeting the `/private/tmp/` store-path-cleanup angle if you want to push further without waiting.