### PR TITLE
fix(desktop): gate runtime NSApp.activate via AppActivationPolicy (shared-desktop Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,7 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 
 5. **Keyboard Focus**: Ghostty-style retry-based focus restoration. See `docs/development/solution-terminal-keyboard.md`.
 
-6. **App Activation Policy**: All `NSApp.activate(ignoringOtherApps:)` calls — launch and runtime — route through `AppActivationPolicy` (`Sources/WorkspaceManager/App/AppActivationPolicy.swift`). Two env vars suppress activation:
+6. **App Activation Policy**: All `NSApp.activate(ignoringOtherApps:)` calls — launch and runtime — route through `AppActivationPolicy` (`Sources/WorkspaceManager/App/AppActivationPolicy.swift`). Three modes:
    - Normal launch: `.regular` + `activate()` — full foreground
    - `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1`: `.regular`, no `activate()` on launch *or* during runtime focus restoration — dock visible, no focus steal ever
    - `CI=true`: `.accessory` — fully invisible (no dock, no Cmd+Tab); the policy also blocks runtime activate calls for clarity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,12 +287,12 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 
 5. **Keyboard Focus**: Ghostty-style retry-based focus restoration. See `docs/development/solution-terminal-keyboard.md`.
 
-6. **CI Activation Policy**: The app auto-detects CI via the `CI` env var and uses `.accessory` activation policy (no dock, no Cmd+Tab, no focus steal). Three modes:
+6. **App Activation Policy**: All `NSApp.activate(ignoringOtherApps:)` calls — launch and runtime — route through `AppActivationPolicy` (`Sources/WorkspaceManager/App/AppActivationPolicy.swift`). Two env vars suppress activation:
    - Normal launch: `.regular` + `activate()` — full foreground
-   - `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1`: `.regular`, no `activate()` — dock visible, no focus steal
-   - `CI=true`: `.accessory` — fully invisible
+   - `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1`: `.regular`, no `activate()` on launch *or* during runtime focus restoration — dock visible, no focus steal ever
+   - `CI=true`: `.accessory` — fully invisible (no dock, no Cmd+Tab); the policy also blocks runtime activate calls for clarity
 
-   This prevents the app from stealing focus on self-hosted runners. Any script that launches the app headlessly should set `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1`. See `WorkspaceManagerApp.swift` `AppDelegate`.
+   This prevents the app from stealing focus on self-hosted runners *and* on a shared desktop during normal use (e.g., when a teammate's automation triggers a workspace selection). Any script that launches the app headlessly should set `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1`. The env var name is historical — it now governs runtime activation too. See `AppActivationPolicy.swift` and `WorkspaceManagerApp.swift` `AppDelegate`.
 
 ## Testing
 

--- a/Sources/WorkspaceManager/App/AppActivationPolicy.swift
+++ b/Sources/WorkspaceManager/App/AppActivationPolicy.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Foundation
+
+/// Process-wide gate for `NSApp.activate(ignoringOtherApps:)` calls.
+///
+/// Two environment signals suppress activation:
+/// - `CI=*` — running under continuous integration. The AppDelegate also flips the
+///   activation policy to `.accessory`, but this policy still blocks runtime
+///   activate calls for clarity and testability.
+/// - `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1` (or `true`/`yes`/`on`) — shared-desktop
+///   mode. The app keeps its `.regular` policy and dock presence but never steals
+///   foreground focus, on launch *or* during runtime.
+///
+/// All call sites that would otherwise call `NSApp.activate` route through this
+/// policy. See `docs/development/shortcut-routing.md` and the `--no-activate`
+/// option in `scripts/launch-dev.sh`.
+@MainActor
+public struct AppActivationPolicy {
+    public let allowsActivation: Bool
+
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        let isCI = environment["CI"] != nil
+        let noActivate = Self.parseBool(environment["WORKSPACES_NO_ACTIVATE_ON_LAUNCH"])
+        self.allowsActivation = !isCI && !noActivate
+    }
+
+    /// Activate the app, but only if the policy allows. Use at launch.
+    public func activateIfAllowed() {
+        guard allowsActivation else { return }
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// Activate the app and bring the front-most window to key, but only if
+    /// the policy allows. Use for runtime focus restoration paths.
+    public func activateAndFocusFrontWindowIfAllowed() {
+        guard allowsActivation else { return }
+        NSApp.activate(ignoringOtherApps: true)
+        let window = NSApp.windows.first(where: \.isVisible) ?? NSApp.windows.first
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    private static func parseBool(_ value: String?) -> Bool {
+        guard let raw = value else { return false }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on": return true
+        default: return false
+        }
+    }
+
+    public static let shared = AppActivationPolicy()
+}

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -249,7 +249,6 @@ private struct MainWindowRootView: View {
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var windowObserver: Any?
-    private static let noActivateOnLaunchEnvKey = "WORKSPACES_NO_ACTIVATE_ON_LAUNCH"
     private static let appVariantEnvKey = "WORKSPACES_APP_VARIANT"
 
     private enum AppVariant {
@@ -289,14 +288,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // CI: fully invisible — no dock icon, no app-switcher, no focus steal.
             NSApp.setActivationPolicy(.accessory)
             NSLog("[AppDelegate] CI detected: .accessory policy (background)")
-        } else if !shouldActivateOnLaunch() {
-            // Shared-desktop: stay in dock/Cmd+Tab but don't steal focus.
-            NSApp.setActivationPolicy(.regular)
-            NSLog("[AppDelegate] No-activate mode: .regular policy, skipping activation")
         } else {
+            // Shared-desktop mode keeps .regular policy + dock presence but
+            // suppresses every NSApp.activate call (launch and runtime), via
+            // AppActivationPolicy. See WORKSPACES_NO_ACTIVATE_ON_LAUNCH.
             NSApp.setActivationPolicy(.regular)
-            NSApp.activate(ignoringOtherApps: true)
-            NSLog("[AppDelegate] Set activation policy to .regular and activated")
+            AppActivationPolicy.shared.activateIfAllowed()
+            NSLog(
+                "[AppDelegate] activation policy=.regular allowsActivation=\(AppActivationPolicy.shared.allowsActivation)"
+            )
         }
         // Applying after activation-policy setup avoids Dock showing the generic executable icon.
         applyApplicationIconIfAvailable()
@@ -321,19 +321,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     self.applyVariantPresentation(to: window)
                 }
             }
-        }
-    }
-
-    private func shouldActivateOnLaunch() -> Bool {
-        guard let rawValue = ProcessInfo.processInfo.environment[Self.noActivateOnLaunchEnvKey] else {
-            return true
-        }
-
-        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "1", "true", "yes", "on":
-            return false
-        default:
-            return true
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1896,9 +1896,8 @@ struct ContentView: View {
     private func focusWorkspaceWindow() {
         // Window activation only — the coordinator drives terminal focus
         // via requestMainTerminalFocus called from the selection handlers.
-        NSApp.activate(ignoringOtherApps: true)
-        let window = NSApp.windows.first(where: \.isVisible) ?? NSApp.windows.first
-        window?.makeKeyAndOrderFront(nil)
+        // Gated by AppActivationPolicy so shared-desktop mode never steals focus.
+        AppActivationPolicy.shared.activateAndFocusFrontWindowIfAllowed()
     }
 
     private func preferredSessionDirectory(_ preferredDirectory: URL?, inside root: URL) -> URL {

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
@@ -95,9 +95,8 @@ final class TerminalFocusCoordinator: ObservableObject, TerminalFocusWindowDeleg
                 phase: "coordinator_activate_requested",
                 fields: focusFields
             )
-            NSApp.activate(ignoringOtherApps: true)
-            let window = NSApp.windows.first(where: \.isVisible) ?? NSApp.windows.first
-            window?.makeKeyAndOrderFront(nil)
+            // Gated by AppActivationPolicy so shared-desktop mode never steals focus.
+            AppActivationPolicy.shared.activateAndFocusFrontWindowIfAllowed()
         }
 
         guard let targetSessionID else {

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalFocusCoordinator.swift
@@ -91,11 +91,15 @@ final class TerminalFocusCoordinator: ObservableObject, TerminalFocusWindowDeleg
         )
 
         if activateApp {
+            // Truthful diagnostic: the activation may be gated by AppActivationPolicy
+            // (shared-desktop mode), so the log says "attempted" and includes the
+            // policy outcome rather than implying activation always happened.
+            var activateFields = focusFields
+            activateFields["policy_allows"] = AppActivationPolicy.shared.allowsActivation ? "true" : "false"
             InvestigationDiagnostics.emitFocus(
-                phase: "coordinator_activate_requested",
-                fields: focusFields
+                phase: "coordinator_activate_attempted",
+                fields: activateFields
             )
-            // Gated by AppActivationPolicy so shared-desktop mode never steals focus.
             AppActivationPolicy.shared.activateAndFocusFrontWindowIfAllowed()
         }
 

--- a/Tests/WorkspaceManagerAppTests/AppActivationPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppActivationPolicyTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("AppActivationPolicy")
+struct AppActivationPolicyTests {
+    @Test("Empty environment allows activation")
+    @MainActor
+    func emptyEnvironmentAllowsActivation() {
+        let policy = AppActivationPolicy(environment: [:])
+        #expect(policy.allowsActivation)
+    }
+
+    @Test("WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1 suppresses activation")
+    @MainActor
+    func noActivateEnvVarSuppressesActivation() {
+        let policy = AppActivationPolicy(environment: ["WORKSPACES_NO_ACTIVATE_ON_LAUNCH": "1"])
+        #expect(!policy.allowsActivation)
+    }
+
+    @Test("Truthy strings suppress activation")
+    @MainActor
+    func truthyStringsSuppressActivation() {
+        for raw in ["1", "true", "TRUE", "yes", "Yes", "on", " on "] {
+            let policy = AppActivationPolicy(environment: ["WORKSPACES_NO_ACTIVATE_ON_LAUNCH": raw])
+            #expect(!policy.allowsActivation, "\(raw) should suppress activation")
+        }
+    }
+
+    @Test("Falsy strings allow activation")
+    @MainActor
+    func falsyStringsAllowActivation() {
+        for raw in ["0", "false", "no", "off", "", "definitely-not"] {
+            let policy = AppActivationPolicy(environment: ["WORKSPACES_NO_ACTIVATE_ON_LAUNCH": raw])
+            #expect(policy.allowsActivation, "\(raw) should allow activation")
+        }
+    }
+
+    @Test("CI presence suppresses activation regardless of value")
+    @MainActor
+    func ciSuppressesActivation() {
+        for raw in ["1", "true", "github-actions", ""] {
+            let policy = AppActivationPolicy(environment: ["CI": raw])
+            #expect(!policy.allowsActivation, "CI=\(raw) should suppress activation")
+        }
+    }
+
+    @Test("CI plus shared-desktop both suppress activation")
+    @MainActor
+    func ciAndSharedDesktopBothSuppress() {
+        let policy = AppActivationPolicy(environment: [
+            "CI": "1",
+            "WORKSPACES_NO_ACTIVATE_ON_LAUNCH": "1",
+        ])
+        #expect(!policy.allowsActivation)
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Phase 1 gap in `backlog/shared-desktop-focus-contention-followup.md`. Two runtime sites still called `NSApp.activate(ignoringOtherApps:)` regardless of the launch-time gate, so workspace selection and focus restoration stole foreground focus on a shared desktop even when the app was launched with `--no-activate`.

- New `Sources/WorkspaceManager/App/AppActivationPolicy.swift` — single MainActor helper. Reads `CI` and `WORKSPACES_NO_ACTIVATE_ON_LAUNCH` once at init; exposes `activateIfAllowed()` and `activateAndFocusFrontWindowIfAllowed()`. Process-wide `shared` instance reads `ProcessInfo` once.
- Routed 3 `NSApp.activate` sites through the helper: `WorkspaceManagerApp` (launch), `ContentView.focusWorkspaceWindow`, `TerminalFocusCoordinator` (coordinator_activate_requested branch).
- Removed redundant `shouldActivateOnLaunch()` + `noActivateOnLaunchEnvKey` from `AppDelegate`; the policy is now the single source of truth.
- Updated `CLAUDE.md`'s activation-policy section. Env var name kept — it's historical; the *scope* is now broader (launch + runtime).
- 6 tests in `Tests/WorkspaceManagerAppTests/AppActivationPolicyTests.swift` covering empty env, truthy/falsy parsing, `CI` presence, and combined cases.

## Validation

- [x] `swift build` — passes (18.9s)
- [x] `swift test` — 452 tests, 77 suites, all green (1.5s); new `AppActivationPolicy` suite is 6 tests in 0.001s
- [x] prek pre-commit ran: large-files passed, swift-format passed, biome-web skipped
- [ ] Manual verification (Michael, at the keyboard): `./scripts/launch-dev.sh --no-activate`, click around the sidebar to trigger workspace selection, confirm the app does not come to front. Can't run from this session because shared-desktop `screencapture` is exactly what this PR is designed to make safe — that's the dependency loop the backlog item names.

```
◇ Suite "AppActivationPolicy" started.
✔ Test "Empty environment allows activation" passed after 0.001 seconds.
✔ Test "WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1 suppresses activation" passed after 0.001 seconds.
✔ Test "Truthy strings suppress activation" passed after 0.001 seconds.
✔ Test "Falsy strings allow activation" passed after 0.001 seconds.
✔ Test "CI presence suppresses activation regardless of value" passed after 0.001 seconds.
✔ Test "CI plus shared-desktop both suppress activation" passed after 0.001 seconds.
✔ Suite "AppActivationPolicy" passed after 0.001 seconds.
✔ Test run with 6 tests in 1 suite passed after 0.001 seconds.
```

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached — focused-suite output inlined above; full-suite count (452) noted

This PR adds one helper + tests + 3 small call-site edits + a docs paragraph. Diff is the artifact; no R2 upload performed.

## Blockers

- [x] None

---

Session notes:

- Run via `/improve-codebase desktop`. Continuation of the session that produced #369 + #372.
- Phase 1 of `backlog/shared-desktop-focus-contention-followup.md` was previously gated only at launch; this PR extends the gate to runtime focus restoration paths.
- Item #2 in the same backlog (window-target capture flow) is already shipped (`scripts/capture-window.sh`). Items #3–#5 (handshake protocol, separate user account, VM-backed CI lane) are out of scope for this PR.
- Once you've manually verified, the backlog item is ready to move to `backlog/done/` in a follow-up — happy to do that in a small docs PR.