### PR TITLE
chore(backlog): refresh after PRs #372 and #374

### DIFF
--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -144,11 +144,11 @@ Diagnostics shipped in PR #190 (`os.Logger` signposts + a 30-second watchdog). R
 
 Sidebar Phase 1 landed (PR #36). Remaining sidebar scope plus Ghostty appearance hardening stays P0 because the AppKit bridge is still the riskiest surface to change.
 
-#### 3. Shared-desktop + evidence-loop reliability
+#### 3. Shared-desktop + evidence-loop reliability — Phase 1 done; Phase 2 deferred to P2
 
 `backlog/shared-desktop-focus-contention-followup.md`
 
-`--no-activate` exists in `launch-dev.sh`, but Phase 1 (execution mode that never steals focus) is not complete. This slows every UI/terminal refactor's confidence gate.
+Phase 1 complete: `AppActivationPolicy` (PR #374) gates all `NSApp.activate` calls — launch *and* runtime — behind `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1` / `CI`. `scripts/capture-window.sh` provides window-id capture without activation. Remaining items (capture handshake, separate-user execution lane, VM-backed CI lane) drop to P2 — promote back when a concrete daily-driver scenario forces the issue.
 
 #### 4. Remote workspace identity + sendability cleanup
 
@@ -275,6 +275,13 @@ Archived (in `backlog/done/`):
 ---
 
 ## Learnings
+
+### 2026-04-25 — Workspace-creation regression net + shared-desktop Phase 1 (PRs #372, #374)
+
+- **Tests as a probe, even when they pass.** PR #372 added a deterministic regression surface for the workspace-creation hang. The tests passed cleanly under in-memory SwiftData, which doesn't prove the production hang is fixed, but the artifact is still load-bearing: it locks down PR #190's `insertedModelsArray` premise so a future refactor can't silently regress the guard. "Did the tests reproduce the bug?" is the wrong question — "do the tests prevent the regression we already fixed?" is the right one.
+- **Helper-based gates pay for themselves at three call sites.** `AppActivationPolicy` (PR #374) replaced three direct `NSApp.activate(ignoringOtherApps:)` sites with one-line calls into a tested helper. The dedup ratio was modest, but the *contract* is now centralized: when a fourth activation site shows up, the next person doesn't have to remember the env var. Helpers earn their keep when behavior must be uniform across many sites, not just when there's syntactic duplication.
+- **Truthful diagnostics survive review better than aspirational ones.** The first version of the policy-gated `TerminalFocusCoordinator` log said `coordinator_activate_requested` and fired before the gate. Code review caught it. The fix renamed to `_attempted` and added a `policy_allows` field so traces show whether the call actually happened. Diagnostic phase names are part of the contract — wrong names are quietly worse than missing logs.
+- **Shared-desktop is its own dependency loop for verification.** Verifying PR #374 needs interactive `launch-dev.sh --no-activate` + clicking around — exactly the workflow the PR is making safer. The PR body called this out explicitly rather than claiming verified behavior; the manual step belongs to Michael at the keyboard. Be honest about which loops your session can close and which it can't.
 
 ### 2026-04-23 — Terminal multiplexing decision session (PR #369)
 

--- a/backlog/shared-desktop-focus-contention-followup.md
+++ b/backlog/shared-desktop-focus-contention-followup.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: phase-1-complete
 category: followup
 issue: 82
 milestone: 1
@@ -23,15 +23,19 @@ Reduce focus and input contention for local automation while keeping day-to-day 
 
 ## Proposed Follow-up Work
 
-1. Add a dedicated execution mode for automation that never activates app windows by default.
-2. Move screenshot verification to window-target capture flow that does not require app-front activation.
-3. Add a simple capture handshake protocol for shared sessions (explicit "capture now" gate).
-4. Evaluate running automation under a separate macOS user account with isolated login session.
-5. Evaluate VM-backed CI/execution lane for UI verification to remove local desktop coupling.
+1. ~~Add a dedicated execution mode for automation that never activates app windows by default.~~ **Done** — `AppActivationPolicy` (PR #374) gates all `NSApp.activate(ignoringOtherApps:)` calls — launch *and* runtime — behind `WORKSPACES_NO_ACTIVATE_ON_LAUNCH=1` and `CI`.
+2. ~~Move screenshot verification to window-target capture flow that does not require app-front activation.~~ **Done** — `scripts/capture-window.sh` shipped earlier; uses `screencapture -l <window-id>` with `CGWindowListCopyWindowInfo` lookup, no activation required.
+3. Add a simple capture handshake protocol for shared sessions (explicit "capture now" gate). *Phase 2.*
+4. Evaluate running automation under a separate macOS user account with isolated login session. *Phase 2.*
+5. Evaluate VM-backed CI/execution lane for UI verification to remove local desktop coupling. *Phase 2 — partially overlapping with the Lume runner work tracked separately in `backlog/lume-runtime-architecture-followups_followup.md`.*
 
 ## Acceptance Criteria
 
-- [ ] Agent-driven launch/capture loop can run without bringing WorkspaceManager to foreground.
-- [ ] Visual verification scripts produce stable artifacts without interrupting active typing in other apps.
-- [ ] Shared-session protocol is documented in agent/dev docs.
-- [ ] Follow-on plan exists for separate-user or VM execution path.
+- [x] Agent-driven launch/capture loop can run without bringing WorkspaceManager to foreground. (PR #374 + `capture-window.sh`)
+- [x] Visual verification scripts produce stable artifacts without interrupting active typing in other apps. (Same.)
+- [ ] Shared-session protocol is documented in agent/dev docs. *Partially — `CLAUDE.md` "App Activation Policy" section covers the activation gate; explicit handshake protocol still pending.*
+- [ ] Follow-on plan exists for separate-user or VM execution path. *Phase 2.*
+
+## Phase 2 — remaining work
+
+The remaining items (capture handshake, separate user account, VM-backed CI lane) are quality-of-life improvements rather than P0 blockers. They drop to P2 in the priority bands now that the core "agent-driven loop never steals focus" property holds. Promote back to P1+ when a concrete daily-driver scenario forces the issue.

--- a/backlog/workspace-creation-hang-root-cause_followup.md
+++ b/backlog/workspace-creation-hang-root-cause_followup.md
@@ -13,9 +13,10 @@ PR #190 added diagnostics (os.Logger, 30s watchdog) and a debounced save rollbac
 
 ## What was done
 
-- Added `os.Logger` tracing to `SidebarWorkspaceController`, `SidebarView`, and `ContentView` workspace creation paths
-- Guarded `modelContext.rollback()` in the debounced `saveAccessTimestampChanges` to skip rollback when pending inserts exist
-- Added 30-second watchdog that surfaces stalled creation in the UI and logs
+- Added `os.Logger` tracing to `SidebarWorkspaceController`, `SidebarView`, and `ContentView` workspace creation paths (PR #190)
+- Guarded `modelContext.rollback()` in the debounced `saveAccessTimestampChanges` to skip rollback when pending inserts exist (PR #190)
+- Added 30-second watchdog that surfaces stalled creation in the UI and logs (PR #190)
+- Added regression surface in `Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift` (PR #372): three Swift Testing tests exercise the debounced-save vs upsert race and lock down the PR #190 guard's behavioral premise (`insertedModelsArray` reflects pending inserts; `rollback()` discards them). Tests pass under in-memory SwiftData, which rules OUT a basic deadlock under unit-test conditions but does not prove the production hang is fixed.
 
 ## What remains
 


### PR DESCRIPTION
## Summary

- **`backlog/workspace-creation-hang-root-cause_followup.md`** — add a "What was done" bullet for PR #372's regression suite. The "What remains" section is unchanged: the production hang is still unrepro'd, and the test artifact rules out a basic in-memory deadlock without proving the production case is fixed.
- **`backlog/shared-desktop-focus-contention-followup.md`** — mark Phase 1 complete. Items #1 (dedicated execution mode that never activates) and #2 (window-target capture flow) are done via PR #374 + `scripts/capture-window.sh`. First two acceptance criteria ticked. Remaining items (#3 capture handshake, #4 separate user account, #5 VM-backed CI lane) drop to P2 hardening. Status: `pending` → `phase-1-complete`.
- **`backlog/ROADMAP.md`** — P0 band #3 description rewritten to reflect Phase 1 done + Phase 2 deferred to P2. New `2026-04-25` Learnings entry covering both PRs (tests-as-probe, helper-based gates, truthful diagnostics, the shared-desktop verification dependency loop).

## Validation

- [x] Not a code change — `swift build` / `swift test` not required
- prek pre-commit ran: large-files passed; swift-format and biome-web skipped (no relevant files)
- Every backlog/* and PR-number reference in the diff resolves

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config). The diff is the artifact.

## Blockers

- [x] None

---

Session notes:

- Run via `/improve-codebase desktop`. Closes the bookkeeping after PRs #372 and #374 merged.
- P0 #3's slot in the priority bands now describes Phase-1 completion rather than the old "Phase 1 incomplete" framing. The next ROADMAP refresh can decide whether to retire the slot entirely or rename it for whatever Phase-2 thread, if any, gets promoted next.