### PR TITLE
chore(backlog): tighten ROADMAP for fresh-session fitness

### DIFF
--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -136,13 +136,18 @@ Priority is driven by three filters, in this order:
 
 `backlog/workspace-creation-hang-root-cause_followup.md`
 
-Diagnostics shipped in PR #190 (`os.Logger` signposts + a 30-second watchdog). Root cause still uncertain. Reliability blocker — hangs in the creation path erode core-loop trust the fastest.
+Diagnostics shipped in PR #190 (`os.Logger` signposts + a 30-second watchdog). Regression net for the PR #190 guard added in PR #372. Root cause still uncertain. Reliability blocker — hangs in the creation path erode core-loop trust the fastest.
+
+**Gate: live repro.** The hang has not been reproduced with the current diagnostics. In-vitro investigation has gone as far as it can — `WorkspaceCreationRaceTests` rules out a basic deadlock under in-memory SwiftData, and code reading shows the MainActor-serialized save path can't deadlock without an external factor (slow disk, vanished store path, SwiftData internal locks under WAL pressure). Tackle this after a deliberate interactive session at the keyboard, not as the first reach for an autonomous session.
 
 #### 2. Main-window + Ghostty boundaries maintainability
 
-`backlog/main-window-sidebar-maintainability_followup.md`, `backlog/ghostty-appearance-hardening_followup.md`
+Two parallel sub-tracks under one P0 theme. Either can move independently; pick by time/risk appetite.
 
-Sidebar Phase 1 landed (PR #36). Remaining sidebar scope plus Ghostty appearance hardening stays P0 because the AppKit bridge is still the riskiest surface to change.
+- **2a. Main-window + sidebar maintainability** (structural). `backlog/main-window-sidebar-maintainability_followup.md`. Sidebar Phase 1 landed (PR #36). Remaining sidebar scope + Ghostty boundary cleanup is the deeper structural work; high-leverage but high-blast-radius. Start here when you have a focused session and accept the surface area.
+- **2b. Ghostty appearance hardening** (narrow). `backlog/ghostty-appearance-hardening_followup.md`. Doc parity, test coverage, smoke verification. Smaller scope, lower risk, can ship in a single session. Start here when 2a is too large for the session shape.
+
+P0 because the AppKit bridge is still the riskiest surface to change as remote/activity work continues to land.
 
 #### 3. Shared-desktop + evidence-loop reliability — Phase 1 done; Phase 2 deferred to P2
 

--- a/backlog/ghostty-appearance-hardening_followup.md
+++ b/backlog/ghostty-appearance-hardening_followup.md
@@ -115,8 +115,8 @@ ps aux | rg '.build/arm64-apple-macosx/debug/WorkspaceManager'
 
 ## Roadmap Position
 
-- Place this follow-up in the same daily-driver hardening band as PR #18/#19 outcomes.
-- Sequence after the current maintainability pass, because both rely on stable routing semantics and benefit from cleaner seams.
+- Sits in P0 #2 as sub-track **2b** (narrow), alongside the structural main-window/sidebar maintainability work in 2a. See `backlog/ROADMAP.md` Priority Bands for the current pairing.
+- Either sub-track can move independently. This one is the smaller, lower-risk option — pick it when 2a is too large for the session shape.
 - Treat as a risk-reduction task, not a feature track.
 
 ## References


### PR DESCRIPTION
## Summary

Three small clarifications surfaced by a fresh-session readiness audit (the goal: a `/improve-codebase` invocation with no conversation history should be able to pick a productive next unit without falling into known dead-ends).

- **P0 #1 (workspace creation hang) — add explicit live-repro gate.** In-vitro investigation has gone as far as it can: PR #372's `WorkspaceCreationRaceTests` rules out a basic deadlock under in-memory SwiftData, and code reading shows the MainActor-serialized save path can't deadlock without an external factor (slow disk, vanished store path, SwiftData internal locks under WAL pressure). A fresh autonomous session shouldn't pick this as a first reach; it needs a deliberate interactive repro at the keyboard. Note added.
- **P0 #2 (main-window + Ghostty maintainability) — split the band entry into two parallel sub-tracks.** Was previously listing two backlog files under one entry without ranking. Now: 2a structural (`main-window-sidebar-maintainability_followup.md`) and 2b narrow (`ghostty-appearance-hardening_followup.md`). A fresh session picks by time/risk appetite rather than guessing.
- **`ghostty-appearance-hardening_followup.md` — refresh stale "Roadmap Position".** Old text referenced "the same daily-driver hardening band as PR #18/#19 outcomes" — a framing the ROADMAP no longer uses. New text matches its current placement as P0 #2 sub-track 2b.

## Validation

- [x] Not a code change — `swift build` / `swift test` not required
- prek pre-commit ran: large-files passed; swift-format and biome-web skipped (no relevant files)
- All references in the diff resolve to existing files

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only). The diff is the artifact.

## Blockers

- [x] None