### PR TITLE
Update GhosttyKit to latest stable

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttyClipboardBridge.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyClipboardBridge.swift
@@ -39,12 +39,12 @@ enum GhosttyClipboardBridge {
         userdata: UnsafeMutableRawPointer?,
         location: ghostty_clipboard_e,
         state: UnsafeMutableRawPointer?
-    ) {
+    ) -> Bool {
         let surfaceAddress = GhosttyThreadingBridge.runOnMainSync {
             GhosttyCallbackUserdata.surfaceView(from: userdata)?.surface.map { UInt(bitPattern: $0) }
         }
         let surface = surfaceAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
-        guard let surface else { return }
+        guard let surface else { return false }
 
         let value = GhosttyThreadingBridge.runOnMainSync {
             let pasteboard: NSPasteboard =
@@ -60,6 +60,7 @@ enum GhosttyClipboardBridge {
         value.withCString { pointer in
             ghostty_surface_complete_clipboard_request(surface, pointer, state, false)
         }
+        return true
     }
 
     static func confirmRead(

--- a/Tests/WorkspaceManagerAppTests/GhosttyClipboardBridgeTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyClipboardBridgeTests.swift
@@ -75,7 +75,7 @@ private func withContent(
         for pointer in dataBuffers { pointer?.deallocate() }
     }
 
-    var content: [ghostty_clipboard_content_s] = items.map { item in
+    let content: [ghostty_clipboard_content_s] = items.map { item in
         var value = ghostty_clipboard_content_s()
         if let mime = item.mime {
             let buffer = copyCString(mime)

--- a/Tests/WorkspaceManagerAppTests/GhosttyClipboardBridgeTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyClipboardBridgeTests.swift
@@ -22,7 +22,7 @@ struct GhosttyClipboardBridgeSelectWriteTextTests {
     func prefersTextPlainOverOtherMIME() {
         withContent([
             (mime: "text/html", data: "<b>hi</b>"),
-            (mime: "text/plain", data: "plain hi")
+            (mime: "text/plain", data: "plain hi"),
         ]) { buffer, count in
             #expect(GhosttyClipboardBridge.selectWriteText(from: buffer, count: count) == "plain hi")
         }
@@ -32,7 +32,7 @@ struct GhosttyClipboardBridgeSelectWriteTextTests {
     func fallsBackToFirstEntry() {
         withContent([
             (mime: "text/html", data: "<b>first</b>"),
-            (mime: "application/json", data: "{}")
+            (mime: "application/json", data: "{}"),
         ]) { buffer, count in
             #expect(GhosttyClipboardBridge.selectWriteText(from: buffer, count: count) == "<b>first</b>")
         }

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -152,6 +152,23 @@ Link step may warn about missing `_ImFontConfig_ImFontConfig` /
 
 Treat both as watch items for future Ghostty pin updates.
 
+### Zig 0.15.2 with newer macOS SDKs
+
+Ghostty `v1.3.1` requires Zig `0.15.2`. The upstream Zig 0.15.2 binary can fail
+with Xcode 26.4 while linking its build runner with unresolved libSystem symbols.
+Homebrew's `zig@0.15` formula carries the Darwin linker patch needed on Tahoe
+hosts, so `scripts/build-ghosttykit.sh` prefers:
+- `GHOSTTY_ZIG_BIN`, if set
+- `/opt/homebrew/opt/zig@0.15/bin/zig`, if installed
+- `mise exec zig@0.15.2` as a fallback
+
+Do not bump Ghostty to Zig `0.16.0` for this release line: Ghostty `v1.3.1`
+explicitly rejects that compiler and uses Zig APIs removed in `0.16.0`.
+
+The script passes `-Demit-macos-app=false` because Workspaces only needs
+`GhosttyKit.xcframework`; building Ghostty's full app bundle adds an unrelated
+`xcodebuild` step that can fail after the xcframework has already been produced.
+
 ## Upgrade Procedure (when bumping Ghostty)
 
 1. Edit `GHOSTTY_COMMIT` in `scripts/build-ghosttykit.sh`.

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 # Optional environment variables:
 #   GHOSTTY_DIR       Existing Ghostty checkout (must already be at pinned commit).
 #   GHOSTTY_CACHE_DIR Cache root for auto-cloned Ghostty checkout.
+#   GHOSTTY_ZIG_BIN   Zig executable to use for building Ghostty.
+#   GHOSTTY_ZIG_CACHE_DIR Zig cache root for building Ghostty.
 # -----------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -28,14 +30,18 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 OUT_DIR="$PROJECT_DIR/Frameworks"
 
 # Pinned versions for reproducible builds.
-GHOSTTY_COMMIT="da10707f93104c5466cd4e64b80ff48f789238a0"
+GHOSTTY_COMMIT="332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28"
 ZIG_VERSION="0.15.2"
+HOMEBREW_ZIG_BIN="/opt/homebrew/opt/zig@0.15/bin/zig"
 
 GHOSTTY_REPO_URL="https://github.com/ghostty-org/ghostty.git"
 CACHE_DIR="${GHOSTTY_CACHE_DIR:-$HOME/.cache/workspacemanager}"
+ZIG_CACHE_DIR="${GHOSTTY_ZIG_CACHE_DIR:-$CACHE_DIR/zig-cache/$GHOSTTY_COMMIT}"
 AUTO_CLONE_DIR="$CACHE_DIR/ghostty"
 EXPLICIT_GHOSTTY_DIR="${GHOSTTY_DIR:-}"
+EXPLICIT_ZIG_BIN="${GHOSTTY_ZIG_BIN:-}"
 GHOSTTY_DIR=""
+ZIG_RUNNER=()
 
 die() {
   echo "error: $*" >&2
@@ -53,6 +59,25 @@ require_cmd() {
   fi
 }
 
+resolve_zig_runner() {
+  if [[ -n "$EXPLICIT_ZIG_BIN" ]]; then
+    if [[ ! -x "$EXPLICIT_ZIG_BIN" ]]; then
+      die "GHOSTTY_ZIG_BIN is set but is not executable: $EXPLICIT_ZIG_BIN"
+    fi
+
+    ZIG_RUNNER=("$EXPLICIT_ZIG_BIN")
+    return
+  fi
+
+  if [[ -x "$HOMEBREW_ZIG_BIN" ]]; then
+    ZIG_RUNNER=("$HOMEBREW_ZIG_BIN")
+    return
+  fi
+
+  require_cmd mise "https://mise.jdx.dev/"
+  ZIG_RUNNER=(mise exec "zig@$ZIG_VERSION" -- zig)
+}
+
 rewrite_modulemap() {
   local modulemap_path="$1"
 
@@ -67,6 +92,65 @@ rewrite_modulemap() {
   } > "$modulemap_path"
 }
 
+archive_exports_ghostty_api() {
+  local archive="$1"
+  nm -gU "$archive" 2>/dev/null | grep ' _ghostty_init$' >/dev/null
+}
+
+find_ghostty_archives() {
+  local cache_root="$ZIG_CACHE_DIR/local/o"
+  local candidate
+
+  [[ -d "$cache_root" ]] || return 1
+
+  while IFS= read -r candidate; do
+    printf '%s\n' "$candidate"
+  done < <(find "$cache_root" -type f -name "*.a" -exec ls -1t {} + 2>/dev/null)
+}
+
+repair_ghostty_archive_if_needed() {
+  local archive="$1"
+
+  if archive_exports_ghostty_api "$archive"; then
+    return
+  fi
+
+  local archives_file
+  archives_file="$(mktemp "${TMPDIR:-/tmp}/workspaces-ghostty-archives.XXXXXX")"
+  if ! find_ghostty_archives > "$archives_file" || [[ ! -s "$archives_file" ]]; then
+    rm -f "$archives_file"
+    die "GhosttyKit archive does not export ghostty_init and no Zig cache archives were found"
+  fi
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/workspaces-ghostty-archive.XXXXXX")"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  local index=0
+  local source_archive
+  while IFS= read -r source_archive; do
+    local archive_dir="$tmp_dir/objects/$index"
+    mkdir -p "$archive_dir"
+    (
+      cd "$archive_dir"
+      ar -x "$source_archive"
+    )
+    index=$((index + 1))
+  done < "$archives_file"
+  rm -f "$archives_file"
+
+  chmod -R u+rwX "$tmp_dir"
+  find "$tmp_dir/objects" -type f -name "*.o" -print0 \
+    | xargs -0 libtool -static -o "$tmp_dir/libghostty-fat.a"
+  mv "$tmp_dir/libghostty-fat.a" "$archive"
+  rm -rf "$tmp_dir"
+  trap - RETURN
+
+  if ! archive_exports_ghostty_api "$archive"; then
+    die "repaired GhosttyKit archive still does not export ghostty_init"
+  fi
+}
+
 postprocess_xcframework() {
   local framework_dir="$1"
 
@@ -75,6 +159,7 @@ postprocess_xcframework() {
   done < <(find "$framework_dir" -type f -name module.modulemap)
 
   while IFS= read -r archive; do
+    repair_ghostty_archive_if_needed "$archive"
     xcrun strip -S -x "$archive"
   done < <(find "$framework_dir" -type f -name "libghostty-fat.a")
 }
@@ -115,7 +200,8 @@ ensure_pinned_commit() {
   fi
 
   if [[ "$current_commit" != "$GHOSTTY_COMMIT" ]]; then
-    git -C "$GHOSTTY_DIR" fetch --tags origin
+    # Ghostty's `tip` tag moves; force tag updates so it does not block pinned commits.
+    git -C "$GHOSTTY_DIR" fetch --force --tags origin
     git -C "$GHOSTTY_DIR" checkout --detach "$GHOSTTY_COMMIT"
   fi
 }
@@ -123,8 +209,12 @@ ensure_pinned_commit() {
 build_ghostty_xcframework() {
   (
     cd "$GHOSTTY_DIR"
-    mise exec "zig@$ZIG_VERSION" -- zig build \
+    mkdir -p "$ZIG_CACHE_DIR/local" "$ZIG_CACHE_DIR/global"
+    "${ZIG_RUNNER[@]}" build \
+      --cache-dir "$ZIG_CACHE_DIR/local" \
+      --global-cache-dir "$ZIG_CACHE_DIR/global" \
       -Demit-xcframework=true \
+      -Demit-macos-app=false \
       -Dxcframework-target=native \
       -Doptimize=ReleaseFast
   )
@@ -156,9 +246,9 @@ install_xcframework() {
 }
 
 main() {
-  require_cmd mise "https://mise.jdx.dev/"
   require_cmd git
   require_cmd xcrun
+  resolve_zig_runner
 
   resolve_ghostty_dir
   ensure_ghostty_checkout


### PR DESCRIPTION
## Summary

- Update the pinned GhosttyKit dependency to Ghostty v1.3.1.
- Restore GhosttyKit builds on macOS/Xcode 26.4 by preferring Homebrew's patched zig@0.15 and skipping Ghostty's app-bundle build.
- Adapt the clipboard read callback for the new Ghostty API.

## Validation

- [x] `GHOSTTY_ZIG_BIN=/opt/homebrew/opt/zig@0.15/bin/zig ./scripts/build-ghosttykit.sh`
- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: verified rebuilt archive exports `_ghostty_init`, `_ghostty_app_new`, `_ghostty_surface_new`, and `_ghostty_config_new`; launched debug app and reached terminal prompt readiness in logs.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![ghosttykit-validation](https://evidence.cloudcompute.com/workspaces/pr-380/20260427-023314-ghosttykit-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence