### PR TITLE
test(desktop): harden Ghostty appearance sync coverage

### DIFF
--- a/Tests/WorkspaceManagerAppTests/GhosttyAppearanceSyncTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyAppearanceSyncTests.swift
@@ -50,6 +50,39 @@ struct GhosttyAppearanceSyncTests {
         )
     }
 
+    @Test("Next color scheme returns resolved scheme for first application")
+    func nextColorSchemeReturnsResolvedSchemeForFirstApplication() throws {
+        let appearance = try #require(NSAppearance(named: .darkAqua))
+        let darkScheme = GhosttyAppearanceSync.colorScheme(for: appearance)
+
+        let nextScheme = GhosttyAppearanceSync.nextColorScheme(
+            for: appearance,
+            currentColorScheme: nil
+        )
+
+        #expect(nextScheme?.rawValue == darkScheme.rawValue)
+    }
+
+    @Test("Resolved next color scheme skips duplicates unless forced")
+    func resolvedNextColorSchemeSkipsDuplicatesUnlessForced() throws {
+        let appearance = try #require(NSAppearance(named: .aqua))
+        let lightScheme = GhosttyAppearanceSync.colorScheme(for: appearance)
+
+        #expect(
+            GhosttyAppearanceSync.nextColorScheme(
+                resolvedColorScheme: lightScheme,
+                currentColorScheme: lightScheme
+            ) == nil
+        )
+        #expect(
+            GhosttyAppearanceSync.nextColorScheme(
+                resolvedColorScheme: lightScheme,
+                currentColorScheme: lightScheme,
+                force: true
+            )?.rawValue == lightScheme.rawValue
+        )
+    }
+
     @Test("Resolved next color scheme returns new values when the scheme changes")
     func resolvedNextColorSchemeReturnsChangedValues() throws {
         let darkAppearance = try #require(NSAppearance(named: .darkAqua))

--- a/backlog/ghostty-appearance-hardening_followup.md
+++ b/backlog/ghostty-appearance-hardening_followup.md
@@ -80,12 +80,14 @@ Recent hardening overlays:
 - `Tests/WorkspaceManagerAppTests/GhosttyAppearanceIntegrationTests.swift` - Integration-focused test coverage for surface/app scheme application decisions (dedupe semantics).
 
 Status:
-- Split-routing controller coverage shipped in PR #379. Remaining test work should stay focused on appearance-specific dedupe/application behavior and shortcut override interplay.
+- Split-routing controller coverage shipped in PR #379.
+- Appearance mapper and dedupe coverage now protects first-application, duplicate-skip, forced-refresh, and scheme-change decisions without UI automation.
+- Remaining test work should stay focused on shortcut override interplay if new behavior is added.
 
 **Acceptance criteria:**
-- [ ] New tests fail when scheme application or route interactions regress.
-- [ ] Existing shortcut and terminal-state suites remain green.
-- [ ] No brittle test dependence on interactive UI automation.
+- [x] New tests fail when scheme application or route interactions regress.
+- [x] Existing shortcut and terminal-state suites remain green.
+- [x] No brittle test dependence on interactive UI automation.
 
 ### Phase 3: Smoke + Verification Hardening
 

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -136,6 +136,7 @@ Reason: keep integration on stable C fields and avoid config file management in 
 
 - Surface-level updates call `ghostty_surface_set_color_scheme(...)` only when the resolved scheme actually changes, unless the caller explicitly forces a refresh.
 - App-level updates call `ghostty_app_set_color_scheme(...)` through the same dedupe helper so the global Ghostty app and the active surface stay in sync without duplicate writes.
+- `GhosttyAppearanceSync.nextColorScheme(...)` is the pure test seam for first application, duplicate skipping, forced refresh, and scheme-change decisions.
 - Current mapping stays intentionally small: Aqua -> light, Dark Aqua -> dark.
 
 ## Known Warnings / Quirks


### PR DESCRIPTION
## Summary
- cover first-application and resolved duplicate/forced-refresh Ghostty appearance decisions
- document `GhosttyAppearanceSync.nextColorScheme(...)` as the pure appearance-sync test seam
- update the Ghostty appearance follow-up to reflect shipped split-routing and appearance dedupe coverage

## Tests
- `swift test --filter GhosttyAppearanceSync`
- `swift test --filter ShortcutRoutingPolicy`
- `swift test`

## Evidence
![ghostty-appearance-hardening-test-output](https://evidence.cloudcompute.com/workspaces/pr-383/20260427-041450-ghostty-appearance-hardening-test-output.svg)

## Notes
- The focused suites and full Swift suite were rerun locally for this PR; the evidence image includes the actual pass lines.
- The first sandboxed capture attempt hit SwiftPM's manifest sandbox restriction, so the same `swift test` commands were rerun outside the tool sandbox.
- No script, GhosttyKit pinning, or PR #335-overlap files changed.
