### PR TITLE
web: add landing login link

### DIFF
--- a/web/e2e/fast/landing.spec.ts
+++ b/web/e2e/fast/landing.spec.ts
@@ -5,4 +5,12 @@ test.describe("Landing page", () => {
 		await page.goto("/");
 		await expect(page.getByText("Spaces", { exact: true }).first()).toBeVisible();
 	});
+
+	test("links to login", async ({ page }) => {
+		await page.goto("/");
+		const loginLink = page.getByRole("link", { name: /> login/i });
+
+		await expect(loginLink).toBeVisible();
+		await expect(loginLink).toHaveAttribute("href", "/sign-in");
+	});
 });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -38,6 +38,9 @@ export default function Home() {
 
 				{/* Footer links */}
 				<nav className={styles.nav}>
+					<a href="/sign-in" className={styles.navLink}>
+						<span className={styles.navChevron}>&gt;</span> login
+					</a>
 					<a
 						href="https://github.com/fairchild/workspaces"
 						className={styles.navLink}


### PR DESCRIPTION
## Summary

- Add a login link to the Spaces landing page that routes to `/sign-in`
- Cover the landing login link in the fast Playwright smoke spec

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `cd web && pnpm lint`
  - `cd web && pnpm typecheck`
  - `cd web && pnpm test`
  - `cd web && pnpm exec playwright test e2e/fast/landing.spec.ts --project=fast`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Test results: https://evidence.cloudcompute.com/workspaces/pr-384/20260427-040619-landing-login-tests.svg
- UI screenshot: https://evidence.cloudcompute.com/workspaces/pr-384/20260427-040617-landing-login-ui.png

## Blockers

- [x] None
- [ ] Blocked on evidence
