### PR TITLE
chore(backlog): close Ghostty appearance hardening follow-up

### DIFF
--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -142,10 +142,10 @@ Diagnostics shipped in PR #190 (`os.Logger` signposts + a 30-second watchdog). R
 
 #### 2. Main-window + Ghostty boundaries maintainability
 
-Two parallel sub-tracks under one P0 theme. Either can move independently; pick by time/risk appetite.
+The remaining active P0 work is the structural maintainability lane. The narrow Ghostty appearance hardening lane has shipped.
 
 - **2a. Main-window + sidebar maintainability** (structural). `backlog/main-window-sidebar-maintainability_followup.md`. Sidebar Phase 1 landed (PR #36). Remaining sidebar scope + Ghostty boundary cleanup is the deeper structural work; high-leverage but high-blast-radius. Start here when you have a focused session and accept the surface area.
-- **2b. Ghostty appearance hardening** (narrow). `backlog/ghostty-appearance-hardening_followup.md`. Doc parity and smoke verification remain; split-routing controller coverage shipped in PR #379. Smaller scope, lower risk, can ship in a single session. Start here when 2a is too large for the session shape.
+- **2b. Ghostty appearance hardening** (completed). `backlog/ghostty-appearance-hardening_followup.md`. Split-routing controller coverage shipped in PR #379. Appearance dedupe coverage and docs parity shipped in PR #383, and current smoke docs/scripts already state the Ghostty-splits/tmux preconditions.
 
 P0 because the AppKit bridge is still the riskiest surface to change as remote/activity work continues to land.
 
@@ -219,7 +219,7 @@ Theme-to-milestone map:
 
 ## Backlog Index
 
-**Index policy** — one comprehensive index, tagged by Scope. Priority Bands above stay strategic-product-only. Quality, ops, and tooling items live in this index so nothing becomes an orphan, but they do not clutter the bands. Priority values match the bands; items not yet promoted show `—` (awaiting promotion or awaiting a dependent decision).
+**Index policy** — one comprehensive index, tagged by Scope. Priority Bands above stay strategic-product-only. Quality, ops, and tooling items live in this index so nothing becomes an orphan, but they do not clutter the bands. Priority values match the bands; completed items show `Done`, and items not yet promoted show `—` (awaiting promotion or awaiting a dependent decision).
 
 Scope tags:
 
@@ -232,7 +232,7 @@ Scope tags:
 |------|-------|----------|---------|
 | Workspace creation hang root cause | product | P0 | `backlog/workspace-creation-hang-root-cause_followup.md` |
 | Main-window + sidebar maintainability | product | P0 | `backlog/main-window-sidebar-maintainability_followup.md` |
-| Ghostty appearance hardening | product | P0 | `backlog/ghostty-appearance-hardening_followup.md` |
+| Ghostty appearance hardening | product | Done | `backlog/ghostty-appearance-hardening_followup.md` |
 | Tmux per-worktree implementation | product | P1 | `backlog/tmux-support_plan.md` (chosen 2026-04-23 — `docs/decisions/terminal-multiplexing.md`) |
 | Desktop continuity (across-session restore) | product | P1 | `backlog/desktop-continuity_plan.md` (paired with tmux implementation) |
 | Lume runtime architecture follow-ups | product | P1 | `backlog/lume-runtime-architecture-followups_followup.md` |

--- a/backlog/ghostty-appearance-hardening_followup.md
+++ b/backlog/ghostty-appearance-hardening_followup.md
@@ -1,8 +1,9 @@
 ---
-status: pending
+status: completed
 category: followup
 issue: 84
 milestone: 1
+completed_prs: [379, 383]
 ---
 
 # Ghostty Appearance Sync Hardening
@@ -11,7 +12,7 @@ milestone: 1
 
 Ghostty system appearance sync shipped in PR #14 and is now in mainline. Since then, PR #18 and PR #19 introduced additional hardening around open-in-editor shortcut flow, metrics, and broader terminal-mode behavior. The appearance sync remains relevant and active, but we now need a focused hardening pass to ensure it remains deterministic when combined with new routing and mode semantics.
 
-This work is deferred because the merged behavior is functionally correct today and current active priority is the maintainability-first quality pass in the main window/sidebar/Ghostty surfaces. The risk is not immediate feature breakage; it is regression risk as terminal routing continues to evolve.
+This focused hardening slice is complete for the currently shipped behavior. The remaining P0 #2 work now lives in the broader main-window/sidebar/Ghostty boundary maintainability track, not in this appearance-specific follow-up.
 
 ## Key Decisions
 
@@ -19,7 +20,7 @@ This work is deferred because the merged behavior is functionally correct today 
 |----------|--------|-----------|
 | Backlog category | `followup` | This is post-merge quality hardening, not new product surface area. |
 | Scope | Validate + harden interactions, not redesign appearance sync | The implementation in `/Sources/WorkspaceManager/Terminal` is already small and correct. |
-| Roadmap placement | Sequence as a small Ghostty-quality follow-up within or just after the current maintainability milestone | It directly depends on recent routing/mode changes and should ride the same quality-first execution wave. |
+| Roadmap placement | Completed P0 #2 sub-track | PR #379 covered split-routing mode behavior, and PR #383 covered appearance dedupe behavior plus docs parity. |
 | Risk control | Add explicit tests/smoke coverage for mode + shortcut interactions | Existing tests cover mapping, but not enough integration interaction points. |
 
 ## Architecture
@@ -54,6 +55,12 @@ Recent hardening overlays:
 - PR #379 added direct split-routing coverage for the terminal-mode overlay:
   - `Tests/WorkspaceManagerAppTests/SplitRoutingControllerTests.swift`
   - covered `new_split`, `goto_split`, `resize_split`, `equalize_splits`, tmux-mode rejection, and invalid payload rejection
+- PR #383 added deterministic appearance coverage for first application, duplicate skipping, forced refresh, and scheme-change decisions.
+- Current smoke docs and scripts already state the required `Terminal Multiplexing Mode = Ghostty Splits` precondition and the tmux-mode early-exit behavior:
+  - `scripts/shortcut-pass-through-smoke.sh`
+  - `scripts/README.md`
+  - `docs/development/libghostty-integration.md`
+  - `docs/development/shortcut-routing.md`
 
 ## Implementation Phases
 
@@ -65,9 +72,9 @@ Recent hardening overlays:
 - `docs/development/shortcut-routing.md` - Clarify open-in-editor override interplay and multiplexing-mode implications for terminal verification.
 
 **Acceptance criteria:**
-- [ ] Roadmap explicitly positions this follow-up among recent hardening items.
-- [ ] Terminal docs reflect current behavior and verification commands.
-- [ ] Shortcut docs match current app-owned and dynamic override behavior.
+- [x] Roadmap explicitly positions this follow-up among recent hardening items.
+- [x] Terminal docs reflect current behavior and verification commands.
+- [x] Shortcut docs match current app-owned and dynamic override behavior.
 
 ### Phase 2: Interaction Test Coverage
 
@@ -96,9 +103,12 @@ Status:
 - `scripts/README.md` - Document smoke semantics and expected logs when mode is tmux vs ghostty-managed.
 
 **Acceptance criteria:**
-- [ ] Smoke script outputs actionable failure reason if mode preconditions are not met.
-- [ ] Verification guidance includes appearance-related checks in the standard loop.
-- [ ] Shared-desktop runbook remains usable without forcing app activation.
+- [x] Smoke script outputs actionable failure reason if mode preconditions are not met.
+- [x] Verification guidance includes appearance-related checks in the standard loop.
+- [x] Shared-desktop runbook remains usable without forcing app activation.
+
+Status:
+- Satisfied by the current script/docs state on `main`. No new activation-driving smoke run was required for this docs reconciliation; running `shortcut-pass-through-smoke.sh` remains an explicit foreground-input action.
 
 ## Verification Commands
 
@@ -123,9 +133,8 @@ ps aux | rg '.build/arm64-apple-macosx/debug/WorkspaceManager'
 
 ## Roadmap Position
 
-- Sits in P0 #2 as sub-track **2b** (narrow), alongside the structural main-window/sidebar maintainability work in 2a. See `backlog/ROADMAP.md` Priority Bands for the current pairing.
-- Either sub-track can move independently. This one is the smaller, lower-risk option — pick it when 2a is too large for the session shape.
-- Treat as a risk-reduction task, not a feature track.
+- Completed former P0 #2 sub-track **2b**. See `backlog/ROADMAP.md` Priority Bands for the remaining active 2a work.
+- Treat future appearance-specific work as a new regression follow-up only when new shortcut, mode, or Ghostty lifecycle behavior creates a fresh gap.
 
 ## References
 


### PR DESCRIPTION
## Summary
- mark the Ghostty appearance hardening follow-up as completed after PR #379 and PR #383
- update the roadmap so P0 #2 only treats the structural main-window/sidebar/Ghostty boundary lane as active
- define `Done` in the backlog index and move Ghostty appearance hardening out of active P0

## Verification
- `git diff --check`
- `rg` check confirmed stale Ghostty appearance P0/pending checklist patterns no longer match

## Evidence
![ghostty-appearance-followup-close](https://evidence.cloudcompute.com/workspaces/pr-385/20260427-042240-ghostty-appearance-followup-close.svg)

## Notes
- Docs-only reconciliation.
- No source, test, script, or GhosttyKit pinning files changed.
- Did not run `scripts/shortcut-pass-through-smoke.sh` because it is activation-driving foreground input automation.
