### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

Prep for the **v0.11.0** release.

- Bumps `CFBundleShortVersionString`: 0.10.0 → 0.11.0
- Bumps `CFBundleVersion`: 11 → 12

## Why now

54 commits since v0.10.0 (2026-04-11) on origin/main, including 9 `feat` commits (Managed Agents provider, automated PR reviews, Vercel CI/CD pipeline, desktop hardening). Per semver this is a minor bump.

## What happens next

Once this lands on main, I'll run the release skill against `origin/main` — it will tag exactly this commit as `v0.11.0`, push the tag, and trigger `.github/workflows/release.yml` on the signing-host runner (preflight → sign → notarize → DMG → publish). The workflow's `assert-tag-match` step is why the plist bump must be on main *before* tagging.

## Test plan

- [x] `./scripts/release-version.sh set v0.11.0 --bump-build` ran cleanly
- [x] Working tree confirmed minimal (only Info.plist touched)
- [ ] CI green on this PR