### PR TITLE
fix(release): harden codesign against errSecInternalComponent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,17 @@ jobs:
 
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
+          # Add the release keychain to the user search list so codesign's
+          # securityd lookups succeed even when --keychain isn't passed.
+          # The Cleanup keychain step at the end restores the original list.
+          search_list_args=("$KEYCHAIN_PATH")
+          if [[ -n "$ORIGINAL_KEYCHAIN_LIST" ]]; then
+            while IFS= read -r kc; do
+              [[ -n "$kc" ]] && search_list_args+=("$kc")
+            done <<< "$ORIGINAL_KEYCHAIN_LIST"
+          fi
+          security list-keychains -d user -s "${search_list_args[@]}"
+
           SIGNING_IDENTITY="$(
             security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
             | sed -n 's/.*"\(Developer ID Application:.*\)".*/\1/p' \

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -234,6 +234,12 @@ codesign_with_identity() {
     local target="$1"
     shift
 
+    # SwiftPM ad-hoc signs binaries at build time. Replacing that signature
+    # has surfaced errSecInternalComponent on self-hosted runners where
+    # securityd's access path is fragile; stripping first avoids the replace
+    # codepath entirely.
+    codesign --remove-signature "$target" 2>/dev/null || true
+
     local -a cmd=(
         codesign
         --sign "$SIGNING_IDENTITY"
@@ -251,7 +257,19 @@ codesign_with_identity() {
     fi
 
     cmd+=("$target")
-    "${cmd[@]}"
+
+    local attempt rc=0
+    for attempt in 1 2 3; do
+        if "${cmd[@]}"; then
+            return 0
+        fi
+        rc=$?
+        if (( attempt < 3 )); then
+            log_warning "codesign failed for $target (attempt $attempt/3), retrying in 2s..."
+            sleep 2
+        fi
+    done
+    return "$rc"
 }
 
 prepare_signing_assets() {


### PR DESCRIPTION
## Summary

The v0.11.0 release attempt failed twice on the same step — `Build signed app` exited 1 with:

\`\`\`
.../Helpers/workspaces: replacing existing signature
.../Helpers/workspaces: errSecInternalComponent
\`\`\`

Run: https://github.com/fairchild/workspaces/actions/runs/25242684833

The signing logic was unchanged from v0.10.0 (which succeeded on the same runner), so the failure points at runner / securityd state drift over the past three weeks. Rather than chase the runner, this hardens the workflow to be robust against the failure mode that's already biting us.

## Changes

**\`scripts/build-release.sh#codesign_with_identity\`**
- Strip the SwiftPM ad-hoc signature before re-signing. \`errSecInternalComponent\` consistently fires on the "replacing existing signature" codepath; removing the signature first sidesteps it.
- Wrap \`codesign\` in a 3-attempt retry with 2s backoff. Even when the underlying issue is fixed at the runner level, \`errSecInternalComponent\` is famously transient on macOS — cheap insurance.

**\`.github/workflows/release.yml\` (Import signing certificate step)**
- Add the ephemeral release keychain to the user search list. Defends against \`securityd\` falling back to the user list when codesign's \`--keychain\` arg isn't honored. The existing \`Cleanup keychain\` step already restores the original list, so this is symmetric.

## Recovery for v0.11.0

After this merges, re-trigger the release workflow against main:

\`\`\`bash
gh workflow run release.yml --ref main
\`\`\`

The workflow's "Read release metadata" step locates the existing \`v0.11.0\` tag from the plist version, so the DMG attaches to the existing release with \`--clobber\`. No retag, no new release.

## Test plan

- [ ] PR CI green
- [ ] Merge
- [ ] \`gh workflow run release.yml --ref main\`
- [ ] \`gh release view v0.11.0\` shows \`WorkspaceManager-0.11.0.dmg\` attached