### PR TITLE
fix(release): skip perf parity in non-foreground runner sessions

### DIFF
--- a/scripts/verify-installed-perf.sh
+++ b/scripts/verify-installed-perf.sh
@@ -120,6 +120,15 @@ if rg -n "CVDisplayLinkCreateWithCGDisplays error -6661|embedded_window: error i
     fail "Installed-build perf verification requires an interactive display-capable macOS session; Ghostty surface initialization failed in the current environment"
 fi
 
+# Apps launched in CI go into .accessory policy (no foreground activation),
+# so the terminal never becomes key and first_prompt_ready never fires. The
+# terminal surface itself is healthy — this is a foreground-session
+# limitation of the runner, not a perf regression.
+if rg -n "CI detected: \.accessory policy" "$LOG_FILE" >/dev/null \
+   && [[ "$ALLOW_SKIP_NONINTERACTIVE" -eq 1 ]]; then
+    skip_noninteractive "Installed-build perf verification requires a foreground GUI session; runner launched the app under .accessory policy"
+fi
+
 python3 - "$SUMMARY_JSON" <<'PY'
 import json
 import sys


### PR DESCRIPTION
## Summary

Second blocker for v0.11.0 release. Codesign now passes (#388) but the next step — `Verify installed-build perf parity` — fails on the signing-host runner because the app detects CI=true and goes \`.accessory\` (background, no dock), so the terminal never becomes key and \`first_prompt_ready\` / \`terminal_first_output\` never emit.

Run that hit it: https://github.com/fairchild/workspaces/actions/runs/25243075606

\`\`\`
[AppDelegate] CI detected: .accessory policy (background)
[Perf] metric=focus_investigation phase=focus_request_inactive_skip app_active=false ...
##[error] missing installed perf metrics: terminal_first_output, first_prompt_ready
\`\`\`

The terminal surface itself is healthy (\`surface_create_succeeded duration_ms=91.34\` fires). It's the foreground-focus path that's gated on a real Aqua session.

## Change

Extend the skip heuristic in \`scripts/verify-installed-perf.sh\` (the existing one only catches display-init crashes). New matcher:

\`\`\`bash
if rg -n "CI detected: \.accessory policy" "\$LOG_FILE" >/dev/null \\
   && [[ "\$ALLOW_SKIP_NONINTERACTIVE" -eq 1 ]]; then
    skip_noninteractive "...runner launched the app under .accessory policy"
fi
\`\`\`

The release workflow already passes \`--allow-skip-noninteractive\`, so this lights up automatically for release runs without changing behavior in interactive contexts.

## Why this is a real skip, not a regression masker

The metric is genuinely unmeasurable without a foreground GUI session. We're not hiding a perf regression — we're declining to measure under conditions where measurement is impossible. The terminal surface created successfully; that's already verified before this skip path.

## Future-proofing

Longer-term we should run installed-perf parity on a \`tart-ui\` runner that has a foreground session, separate from the signing-host. Out of scope for this PR.

## Test plan

- [ ] Merge after #388
- [ ] \`gh workflow run release.yml --ref main\`
- [ ] \`gh release view v0.11.0\` shows \`WorkspaceManager-0.11.0.dmg\` attached