### PR TITLE
tooling: add performance PR evidence profile

### DIFF
--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -30,10 +30,24 @@ This ensures perf changes are not hiding functional regressions.
 Performance-sensitive PRs must carry canonical before/after evidence in the PR body. The expected workflow is:
 
 ```bash
+./scripts/pr-evidence.sh --pr <N> --profile performance --scenario debug_no_activate
+```
+
+When the before/after summaries were captured on separate commits, reuse them through the same PR evidence wrapper:
+
+```bash
+./scripts/pr-evidence.sh --pr <N> --profile performance --scenario debug_no_activate \
+  --before-summary /tmp/before/summary.json --after-summary /tmp/after/summary.json \
+  --skip-before --skip-after
+```
+
+The lower-level helper remains available when you only need local Markdown fields without uploading an evidence artifact:
+
+```bash
 ./scripts/prepare-perf-evidence.sh --scenario debug_no_activate
 ```
 
-That script runs the canonical scenario, captures `before` and `after` summaries, compares them with `./scripts/perf-compare.py`, and prints PR-ready fields that match `.github/pull_request_template.md`.
+The PR evidence wrapper runs the canonical scenario, captures `before` and `after` summaries, compares them with `./scripts/perf-compare.py`, writes local PR-ready Markdown, and uploads an SVG delta summary through `./scripts/evidence.sh`.
 
 Required PR fields for `performance-sensitive` work:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,6 +41,11 @@ This directory contains build/release helpers plus UI test utilities.
   - Runs one canonical scenario and writes a canonical summary artifact.
 - `./scripts/perf-compare.py before.json after.json`
   - Compares two canonical summaries and prints metric deltas plus gate status.
+- `./scripts/pr-evidence.sh --pr <N> --profile performance`
+  - Runs the PR evidence wrapper around canonical performance comparison.
+  - Writes before/after artifacts under `./output/evidence/pr-<number>/.../performance/`.
+  - Uploads an SVG delta summary through `./scripts/evidence.sh`.
+  - Use `--before-summary`, `--after-summary`, `--skip-before`, and `--skip-after` when comparing summaries captured on separate commits.
 - Contract source of truth:
   - `./config/performance/contract.json`
 
@@ -71,9 +76,12 @@ Use these scripts for day-to-day UI verification:
 - Initial profiles:
   - `swift-unit`: focused Swift tests, full Swift tests, and `git diff --check`.
   - `ghostty-shortcuts`: GhosttyKit build, app build, watched debug launch, foreground `Cmd+D` / `Cmd+[` / `Cmd+]` shortcut smoke, runtime log summary, and window capture.
+  - `performance`: canonical before/after performance comparison rendered as uploadable PR evidence.
 - Examples:
   - `./scripts/pr-evidence.sh --pr 387 --profile swift-unit --filter GhosttyRuntimeConfigFactory`
   - `./scripts/pr-evidence.sh --pr 387 --profile ghostty-shortcuts`
+  - `./scripts/pr-evidence.sh --pr 387 --profile performance --scenario debug_no_activate`
+  - `./scripts/pr-evidence.sh --pr 387 --profile performance --scenario debug_no_activate --before-summary /tmp/before/summary.json --after-summary /tmp/after/summary.json --skip-before --skip-after`
 
 1. `./scripts/launch-dev.sh`
 - Canonical local launch for active development.

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -6,10 +6,13 @@
 # Usage:
 #   ./scripts/pr-evidence.sh --pr 387 --profile swift-unit --filter Ghostty
 #   ./scripts/pr-evidence.sh --pr 387 --profile ghostty-shortcuts
+#   ./scripts/pr-evidence.sh --pr 387 --profile performance --scenario debug_no_activate \
+#     --before-summary /tmp/before-summary.json --after-summary /tmp/after-summary.json
 #
 # Profiles:
 #   swift-unit        Run focused Swift tests, full Swift tests, diff check, upload summary.
 #   ghostty-shortcuts Build, launch debug app, drive Ghostty split shortcuts, upload log + window evidence.
+#   performance       Compare canonical before/after perf summaries and upload a delta summary.
 #
 # ==========================================================================
 
@@ -22,6 +25,12 @@ PR=""
 PROFILE=""
 NAME=""
 FILTER="Ghostty"
+SCENARIO="debug_no_activate"
+PERF_OUTPUT_DIR=""
+SKIP_BEFORE=0
+SKIP_AFTER=0
+BEFORE_SUMMARY=""
+AFTER_SUMMARY=""
 UPLOAD=true
 RUN_DIR=""
 LAUNCH_WATCH_PID=""
@@ -32,8 +41,14 @@ Usage: ./scripts/pr-evidence.sh --pr <number> --profile <profile> [options]
 
 Options:
   --pr <number>         PR number for evidence upload.
-  --profile <profile>   Evidence profile: swift-unit, ghostty-shortcuts.
+  --profile <profile>   Evidence profile: swift-unit, ghostty-shortcuts, performance.
   --filter <pattern>    Focused Swift test filter for swift-unit (default: Ghostty).
+  --scenario <id>       Canonical performance scenario (default: debug_no_activate).
+  --perf-output-dir <p> Performance evidence output directory (default: run dir/performance).
+  --skip-before         Performance profile: use --before-summary instead of capturing before.
+  --skip-after          Performance profile: use --after-summary instead of capturing after.
+  --before-summary <p>  Performance profile: existing before summary.json.
+  --after-summary <p>   Performance profile: existing after summary.json.
   --name <slug>         Evidence slug prefix (default: profile name).
   --no-upload           Generate local artifacts without uploading.
   --help, -h            Show this help.
@@ -41,6 +56,9 @@ Options:
 Examples:
   ./scripts/pr-evidence.sh --pr 387 --profile swift-unit --filter GhosttyRuntimeConfigFactory
   ./scripts/pr-evidence.sh --pr 387 --profile ghostty-shortcuts
+  ./scripts/pr-evidence.sh --pr 387 --profile performance --scenario debug_no_activate \
+    --before-summary /tmp/before/summary.json --after-summary /tmp/after/summary.json \
+    --skip-before --skip-after
 USAGE
 }
 
@@ -73,6 +91,34 @@ parse_args() {
             --filter)
                 [[ $# -ge 2 ]] || fail "--filter requires a value"
                 FILTER="$2"
+                shift 2
+                ;;
+            --scenario)
+                [[ $# -ge 2 ]] || fail "--scenario requires a value"
+                SCENARIO="$2"
+                shift 2
+                ;;
+            --perf-output-dir)
+                [[ $# -ge 2 ]] || fail "--perf-output-dir requires a value"
+                PERF_OUTPUT_DIR="$2"
+                shift 2
+                ;;
+            --skip-before)
+                SKIP_BEFORE=1
+                shift
+                ;;
+            --skip-after)
+                SKIP_AFTER=1
+                shift
+                ;;
+            --before-summary)
+                [[ $# -ge 2 ]] || fail "--before-summary requires a value"
+                BEFORE_SUMMARY="$2"
+                shift 2
+                ;;
+            --after-summary)
+                [[ $# -ge 2 ]] || fail "--after-summary requires a value"
+                AFTER_SUMMARY="$2"
                 shift 2
                 ;;
             --name)
@@ -353,6 +399,80 @@ profile_ghostty_shortcuts() {
     upload_artifact "$NAME-window" "$screenshot"
 }
 
+profile_performance() {
+    local perf_dir="$PERF_OUTPUT_DIR"
+    if [[ -z "$perf_dir" ]]; then
+        perf_dir="$RUN_DIR/performance"
+    fi
+    mkdir -p "$perf_dir"
+
+    local args=(--scenario "$SCENARIO" --output-dir "$perf_dir")
+    if [[ "$SKIP_BEFORE" -eq 1 ]]; then
+        args+=(--skip-before)
+    fi
+    if [[ "$SKIP_AFTER" -eq 1 ]]; then
+        args+=(--skip-after)
+    fi
+    if [[ -n "$BEFORE_SUMMARY" ]]; then
+        args+=(--before-summary "$BEFORE_SUMMARY")
+    fi
+    if [[ -n "$AFTER_SUMMARY" ]]; then
+        args+=(--after-summary "$AFTER_SUMMARY")
+    fi
+
+    run_logged "performance-evidence" "$REPO_ROOT/scripts/prepare-perf-evidence.sh" "${args[@]}"
+
+    local compare_output="$perf_dir/compare.txt"
+    [[ -f "$compare_output" ]] || fail "missing performance comparison output: $compare_output"
+
+    local before_path="$BEFORE_SUMMARY"
+    local after_path="$AFTER_SUMMARY"
+    if [[ -z "$before_path" ]]; then
+        before_path="$perf_dir/before/summary.json"
+    fi
+    if [[ -z "$after_path" ]]; then
+        after_path="$perf_dir/after/summary.json"
+    fi
+
+    local before_label="${before_path/#$REPO_ROOT\//}"
+    local after_label="${after_path/#$REPO_ROOT\//}"
+    local markdown_path="$RUN_DIR/$NAME.md"
+    {
+        echo "Performance evidence for PR #$PR"
+        echo ""
+        echo "- Scenario ID: \`$SCENARIO\`"
+        echo "- Before Summary: \`$before_path\`"
+        echo "- After Summary: \`$after_path\`"
+        echo "- Delta Summary:"
+        echo ""
+        echo '```'
+        cat "$compare_output"
+        echo '```'
+        echo ""
+        echo "Local artifacts: \`$perf_dir\`"
+    } >"$markdown_path"
+
+    local svg_lines=(
+        "Scenario: $SCENARIO"
+        "Before: $before_label"
+        "After: $after_label"
+        "Delta summary:"
+    )
+    local line
+    local count=0
+    while IFS= read -r line && [[ "$count" -lt 8 ]]; do
+        svg_lines+=("$line")
+        count=$((count + 1))
+    done <"$compare_output"
+
+    local svg_path="$RUN_DIR/$NAME.svg"
+    render_summary_svg "$svg_path" "PR #$PR Performance Evidence" "${svg_lines[@]}" \
+        "NOTE: PR markdown stored in $markdown_path"
+
+    upload_artifact "$NAME" "$svg_path"
+    log "Performance PR markdown: $markdown_path"
+}
+
 main() {
     parse_args "$@"
     init_run_dir
@@ -363,6 +483,9 @@ main() {
             ;;
         ghostty-shortcuts)
             profile_ghostty_shortcuts
+            ;;
+        performance)
+            profile_performance
             ;;
         *)
             fail "unknown profile: $PROFILE"

--- a/scripts/prepare-perf-evidence.sh
+++ b/scripts/prepare-perf-evidence.sh
@@ -91,8 +91,12 @@ mkdir -p "$OUTPUT_DIR"
 run_capture() {
     local phase="$1"
     local phase_dir="$OUTPUT_DIR/$phase"
+    local runner_log="$phase_dir/perf-runner.log"
     mkdir -p "$phase_dir"
-    "$ROOT_DIR/scripts/perf-runner.sh" --scenario "$SCENARIO" --output-dir "$phase_dir"
+    if ! "$ROOT_DIR/scripts/perf-runner.sh" --scenario "$SCENARIO" --output-dir "$phase_dir" >"$runner_log" 2>&1; then
+        tail -n 120 "$runner_log" >&2 || true
+        exit 1
+    fi
     echo "$phase_dir/summary.json"
 }
 


### PR DESCRIPTION
## Summary
- add a performance profile to scripts/pr-evidence.sh for canonical before/after perf comparison evidence
- render perf deltas into an uploadable SVG and local PR-ready Markdown
- make prepare-perf-evidence.sh capture perf-runner output cleanly while preserving failure tails
- document the wrapper in scripts and performance testing docs

## Verification
- bash -n scripts/pr-evidence.sh
- bash -n scripts/prepare-perf-evidence.sh
- git diff --check
- ./scripts/pr-evidence.sh --pr 0 --profile performance --scenario debug_no_activate --before-summary /tmp/workspaces-perf-fixtures/before.json --after-summary /tmp/workspaces-perf-fixtures/after.json --skip-before --skip-after --name performance-fixture --no-upload
- ./scripts/pr-evidence.sh --pr 391 --profile performance --scenario debug_no_activate --before-summary /tmp/workspaces-perf-fixtures/before.json --after-summary /tmp/workspaces-perf-fixtures/after.json --skip-before --skip-after --name performance-profile-fixture

## Evidence
- ![performance-profile-fixture](https://evidence.cloudcompute.com/workspaces/pr-391/20260502-055140-performance-profile-fixture.svg)

## Notes
- Tooling/docs only. No Swift runtime behavior changed, so no Swift test run was required.
- The uploaded evidence uses canonical synthetic before/after summaries to verify the new profile renders and uploads comparison deltas without launching the app.
