### PR TITLE
refactor: centralize Ghostty callback userdata resolution

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
@@ -120,10 +120,9 @@ final class GhosttyAppManager: NSObject {
     // MARK: Runtime callbacks
 
     nonisolated static func wakeup(_ userdata: UnsafeMutableRawPointer?) {
-        let userdataAddress = userdata.map { UInt(bitPattern: $0) }
+        let userdataAddress = GhosttyCallbackUserdata.address(from: userdata)
         GhosttyThreadingBridge.runOnMainAsync {
-            let userdata = userdataAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
-            guard let manager = GhosttyCallbackUserdata.manager(from: userdata) else { return }
+            guard let manager = GhosttyCallbackUserdata.manager(from: userdataAddress) else { return }
             manager.tick()
         }
     }
@@ -146,10 +145,9 @@ final class GhosttyAppManager: NSObject {
     }
 
     nonisolated static func closeSurface(_ userdata: UnsafeMutableRawPointer?, processAlive: Bool) {
-        let userdataAddress = userdata.map { UInt(bitPattern: $0) }
+        let userdataAddress = GhosttyCallbackUserdata.address(from: userdata)
         GhosttyThreadingBridge.runOnMainAsync {
-            let userdata = userdataAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
-            guard let surfaceView = GhosttyCallbackUserdata.surfaceView(from: userdata) else { return }
+            guard let surfaceView = GhosttyCallbackUserdata.surfaceView(from: userdataAddress) else { return }
             surfaceView.runtimeDidRequestClose(processAlive: processAlive)
         }
     }

--- a/Sources/WorkspaceManager/Terminal/GhosttyCallbackUserdata.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyCallbackUserdata.swift
@@ -7,9 +7,21 @@ import Foundation
 import GhosttyKit
 
 enum GhosttyCallbackUserdata {
+    static func address(from userdata: UnsafeMutableRawPointer?) -> UInt? {
+        userdata.map { UInt(bitPattern: $0) }
+    }
+
+    static func pointer(from address: UInt?) -> UnsafeMutableRawPointer? {
+        address.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
+    }
+
     static func manager(from userdata: UnsafeMutableRawPointer?) -> GhosttyAppManager? {
         guard let userdata else { return nil }
         return Unmanaged<GhosttyAppManager>.fromOpaque(userdata).takeUnretainedValue()
+    }
+
+    static func manager(from address: UInt?) -> GhosttyAppManager? {
+        manager(from: pointer(from: address))
     }
 
     static func surfaceView(from userdata: UnsafeMutableRawPointer?) -> GhosttySurfaceView? {
@@ -31,9 +43,18 @@ enum GhosttyCallbackUserdata {
         surfaceUserdata(from: target).map { UInt(bitPattern: $0) }
     }
 
+    @MainActor
+    static func surfaceAddress(from userdata: UnsafeMutableRawPointer?) -> UInt? {
+        surfaceView(from: userdata)?.surface.map { UInt(bitPattern: $0) }
+    }
+
+    @MainActor
+    static func surfaceAddress(from address: UInt?) -> UInt? {
+        surfaceAddress(from: pointer(from: address))
+    }
+
     static func surfaceView(from address: UInt?) -> GhosttySurfaceView? {
-        guard let address else { return nil }
-        return surfaceView(from: UnsafeMutableRawPointer(bitPattern: address))
+        surfaceView(from: pointer(from: address))
     }
 
     static func surfaceView(from target: ghostty_target_s) -> GhosttySurfaceView? {

--- a/Sources/WorkspaceManager/Terminal/GhosttyClipboardBridge.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyClipboardBridge.swift
@@ -40,12 +40,11 @@ enum GhosttyClipboardBridge {
         location: ghostty_clipboard_e,
         state: UnsafeMutableRawPointer?
     ) -> Bool {
-        let userdataAddress = userdata.map { UInt(bitPattern: $0) }
+        let userdataAddress = GhosttyCallbackUserdata.address(from: userdata)
         let surfaceAddress = GhosttyThreadingBridge.runOnMainSync {
-            let userdata = userdataAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
-            return GhosttyCallbackUserdata.surfaceView(from: userdata)?.surface.map { UInt(bitPattern: $0) }
+            GhosttyCallbackUserdata.surfaceAddress(from: userdataAddress)
         }
-        let surface = surfaceAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
+        let surface = GhosttyCallbackUserdata.pointer(from: surfaceAddress)
         guard let surface else { return false }
 
         let value = GhosttyThreadingBridge.runOnMainSync {
@@ -69,12 +68,11 @@ enum GhosttyClipboardBridge {
         userdata: UnsafeMutableRawPointer?,
         state: UnsafeMutableRawPointer?
     ) {
-        let userdataAddress = userdata.map { UInt(bitPattern: $0) }
+        let userdataAddress = GhosttyCallbackUserdata.address(from: userdata)
         let surfaceAddress = GhosttyThreadingBridge.runOnMainSync {
-            let userdata = userdataAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
-            return GhosttyCallbackUserdata.surfaceView(from: userdata)?.surface.map { UInt(bitPattern: $0) }
+            GhosttyCallbackUserdata.surfaceAddress(from: userdataAddress)
         }
-        let surface = surfaceAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
+        let surface = GhosttyCallbackUserdata.pointer(from: surfaceAddress)
         guard let surface else { return }
 
         "".withCString { pointer in
@@ -88,10 +86,9 @@ enum GhosttyClipboardBridge {
         content: UnsafePointer<ghostty_clipboard_content_s>?,
         len: Int
     ) {
-        let userdataAddress = userdata.map { UInt(bitPattern: $0) }
+        let userdataAddress = GhosttyCallbackUserdata.address(from: userdata)
         let hasSurfaceView = GhosttyThreadingBridge.runOnMainSync {
-            let userdata = userdataAddress.flatMap(UnsafeMutableRawPointer.init(bitPattern:))
-            return GhosttyCallbackUserdata.surfaceView(from: userdata) != nil
+            GhosttyCallbackUserdata.surfaceView(from: userdataAddress) != nil
         }
 
         guard location == GHOSTTY_CLIPBOARD_STANDARD,

--- a/Tests/WorkspaceManagerAppTests/GhosttyCallbackUserdataTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyCallbackUserdataTests.swift
@@ -12,9 +12,36 @@ import Testing
 @Suite("GhosttyCallbackUserdata")
 @MainActor
 struct GhosttyCallbackUserdataTests {
+    @Test("address(from:) returns nil for nil userdata")
+    func addressNilForNilUserdata() {
+        #expect(GhosttyCallbackUserdata.address(from: nil) == nil)
+    }
+
+    @Test("pointer(from:) returns nil for nil address")
+    func pointerNilForNilAddress() {
+        #expect(GhosttyCallbackUserdata.pointer(from: nil) == nil)
+    }
+
+    @Test("address and pointer round-trip an opaque userdata pointer")
+    func userdataAddressRoundTrip() {
+        let view = GhosttySurfaceView(workingDirectory: FileManager.default.temporaryDirectory)
+        let opaque = Unmanaged.passUnretained(view).toOpaque()
+
+        let address = GhosttyCallbackUserdata.address(from: opaque)
+
+        #expect(address == UInt(bitPattern: opaque))
+        #expect(GhosttyCallbackUserdata.pointer(from: address) == opaque)
+    }
+
     @Test("manager(from:) returns nil for a nil userdata pointer")
     func managerNilForNilUserdata() {
-        #expect(GhosttyCallbackUserdata.manager(from: nil) == nil)
+        #expect(GhosttyCallbackUserdata.manager(from: nil as UnsafeMutableRawPointer?) == nil)
+    }
+
+    @Test("manager(from address:) returns nil for a nil address")
+    func managerNilForNilAddress() {
+        let address: UInt? = nil
+        #expect(GhosttyCallbackUserdata.manager(from: address) == nil)
     }
 
     @Test("surfaceView(from:) returns nil for a nil userdata pointer")
@@ -46,6 +73,17 @@ struct GhosttyCallbackUserdataTests {
 
         let resolved = GhosttyCallbackUserdata.surfaceView(from: address)
         #expect(resolved === view)
+    }
+
+    @Test("surfaceAddress(from userdata:) returns nil for nil userdata")
+    func surfaceAddressFromNilUserdata() {
+        #expect(GhosttyCallbackUserdata.surfaceAddress(from: nil as UnsafeMutableRawPointer?) == nil)
+    }
+
+    @Test("surfaceAddress(from address:) returns nil for a nil address")
+    func surfaceAddressFromNilAddress() {
+        let address: UInt? = nil
+        #expect(GhosttyCallbackUserdata.surfaceAddress(from: address) == nil)
     }
 
     @Test("surfaceUserdata(from target:) returns nil when the target is an app target")


### PR DESCRIPTION
## Summary
- centralize Ghostty callback userdata address/pointer conversion in GhosttyCallbackUserdata
- route Ghostty app wakeup/close and clipboard callbacks through the shared helper
- add deterministic tests for nil and address round-trip behavior

## Verification
- swift test --filter GhosttyCallbackUserdata
- swift test --filter Ghostty
- swift test
- git diff --check
- ./scripts/pr-evidence.sh --pr 394 --profile swift-unit --filter GhosttyCallbackUserdata --name ghostty-callback-userdata

## Evidence
- ![ghostty-callback-userdata](https://evidence.cloudcompute.com/workspaces/pr-394/20260502-060449-ghostty-callback-userdata.svg)

## Notes
- User-visible behavior unchanged. This is a narrow callback maintainability cleanup.
