### PR TITLE
[codex] Remove PR reviewer attribution line

### DIFF
--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -30,8 +30,6 @@ mkdir -p ./tmp
 cat > ./tmp/review.md << 'REVIEW_EOF'
 ✅ **Approve** — Clean, behavior-preserving change with no blocking issues.
 
-> 🤖 **Automated review by Claude** (Managed Agent)
-
 ## Summary
 Your summary here...
 


### PR DESCRIPTION
## Summary

Remove the remaining automated-review attribution line from the Managed Agents PR reviewer example body.

## Changes

- Deletes `> 🤖 **Automated review by Claude** (Managed Agent)` from the review body template.
- Leaves the decision emoji + one-line summary as the first line, followed directly by `## Summary`.

## Validation

- Local: `pnpm typecheck` passed
- Local: `pnpm lint` passed
- Local: `pnpm test` passed: 15 files, 146 tests
- CI: Web CI passed on the PR branch

## Evidence

- Web CI: [Lint, Typecheck & Build passed](https://github.com/fairchild/workspaces/actions/runs/25245598112/job/74029226776)
- Vercel preview: [deployment passed](https://vercel.com/cloudcompute/spaces-web/ERGzupWnjtazH4W3MCQJCKYTaFG3)
- PR perf evidence gate: [enforce-perf-evidence passed](https://github.com/fairchild/workspaces/actions/runs/25245598122/job/74029226721)