### PR TITLE
[codex] Rename displayed app brand to WorkSpaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Workspaces
+# WorkSpaces
 
 **Terminal-first workspace manager for AI coding sessions on macOS.**
 
- Workspaces gives you a native app that wraps a terminal with some niceties for spinning up isolated workspaces. Designed to optimize terminal-based coding agent workflows.
+WorkSpaces gives you a native app that wraps a terminal with some niceties for spinning up isolated workspaces. Designed to optimize terminal-based coding agent workflows.
 
-![Workspaces main window][screenshot-main]
+![WorkSpaces main window][screenshot-main]
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
@@ -28,7 +28,7 @@
 ### From DMG (Recommended)
 
 1. Download the latest `.dmg` from [Releases](https://github.com/fairchild/workspaces/releases)
-2. Open the DMG and drag **Workspaces** to Applications
+2. Open the DMG and drag **WorkSpaces** to Applications
 3. Launch from Applications (first time: right-click > Open)
 
 ## Features
@@ -71,7 +71,7 @@ Open Settings (`Cmd+,`) to configure workspace root location.
 
 ## Fork & Customize
 
-Workspaces is designed to be forked. There's no plugin system or extension API — instead, the codebase itself is the API. Common customizations:
+WorkSpaces is designed to be forked. There's no plugin system or extension API — instead, the codebase itself is the API. Common customizations:
 
 - **Change the layout**: Edit `ContentView.swift` to rearrange panes
 - **Add lifecycle hooks**: Drop scripts into workspace directories (`setup.sh`, `archive.sh`)
@@ -109,7 +109,7 @@ For VM and provider-backed workspace architecture, see:
 - [docs/development/codespaces-claude-worker.md](./docs/development/codespaces-claude-worker.md)
 - [docs/development/evidence.md](./docs/development/evidence.md)
 
-The Lume validation flow uses isolated Workspaces-managed VM storage and a standalone validated-base manifest before the app will reuse a macOS base VM.
+The Lume validation flow uses isolated WorkSpaces-managed VM storage and a standalone validated-base manifest before the app will reuse a macOS base VM.
 
 For UI smoke/capture script entry points, see:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -318,7 +318,7 @@ For testing or when CI isn't available.
    ```bash
    # Create release with GitHub CLI
    gh release create v0.3.1 \
-       --title "Workspaces v0.3.1" \
+       --title "WorkSpaces v0.3.1" \
        --notes "Release notes here" \
        build/WorkspaceManager-0.3.1.dmg
    ```
@@ -435,7 +435,7 @@ security find-identity -v -p codesigning
 When announcing a release:
 
 ```markdown
-## Workspaces v0.3.1
+## WorkSpaces v0.3.1
 
 ### What's New
 - Feature 1
@@ -451,6 +451,6 @@ When announcing a release:
 
 ### Installation
 1. Download the DMG
-2. Drag Workspaces to Applications
+2. Drag WorkSpaces to Applications
 3. Launch from Applications folder
 ```

--- a/Sources/WorkspaceManager/App/UIFixtureLumeEnvironment.swift
+++ b/Sources/WorkspaceManager/App/UIFixtureLumeEnvironment.swift
@@ -566,13 +566,13 @@ extension UIFixtureLumeWorkspaceProvider: WorkspaceProviderSetupCapable {
                     primaryButtonTitle: primaryButtonTitle,
                     introductoryText: [
                         "Lume is an MIT open-source VM runtime that uses Apple's native Virtualization Framework to run macOS and Linux VMs at near-native speed on Apple Silicon.",
-                        "Workspaces needs it so it can create VM-backed workspaces, open an in-app terminal with `lume ssh`, and launch full desktop access via VNC.",
+                        "WorkSpaces needs it so it can create VM-backed workspaces, open an in-app terminal with `lume ssh`, and launch full desktop access via VNC.",
                     ],
                     learnMoreLabel: "Learn more about Lume",
                     learnMoreURL: URL(
                         string: "https://cua.ai/docs/lume/guide/getting-started/introduction"
                     ),
-                    explanatoryStepsTitle: "What Workspaces will do",
+                    explanatoryStepsTitle: "What WorkSpaces will do",
                     explanatorySteps: [
                         "Install the official Lume CLI in ~/.local/bin",
                         "Install and load the user LaunchAgent on localhost:7777",
@@ -586,10 +586,10 @@ extension UIFixtureLumeWorkspaceProvider: WorkspaceProviderSetupCapable {
                             "Default macOS VM: \($0.displayName)"
                         },
                     footerText:
-                        "This is a one-time setup on this Mac. No admin access is required. After setup finishes, Workspaces will continue automatically.",
+                        "This is a one-time setup on this Mac. No admin access is required. After setup finishes, WorkSpaces will continue automatically.",
                     progressTitle: "Preparing macOS VM Support",
                     progressBody:
-                        "Workspaces is setting up the local Lume runtime and will continue automatically when it is ready.",
+                        "WorkSpaces is setting up the local Lume runtime and will continue automatically when it is ready.",
                     initialProgress: WorkspaceProviderSetupProgress(
                         id: LumeRuntimeSetupStep.checkingHost.rawValue,
                         label: LumeRuntimeSetupStep.checkingHost.label

--- a/Sources/WorkspaceManager/Diagnostics/DiagnosticReportExporter.swift
+++ b/Sources/WorkspaceManager/Diagnostics/DiagnosticReportExporter.swift
@@ -119,7 +119,7 @@ enum DiagnosticReportExporter {
 
     private static func gatherSystemProfile(_ info: SystemInfo) -> String {
         var lines: [String] = []
-        lines.append("WorkspaceManager Diagnostic Report")
+        lines.append("WorkSpaces Diagnostic Report")
         lines.append("Generated: \(ISO8601DateFormatter().string(from: Date()))")
         lines.append("")
         lines.append("System:")

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>Workspaces</string>
+	<string>WorkSpaces</string>
 	<key>CFBundleExecutable</key>
 	<string>WorkspaceManager</string>
 	<key>CFBundleIconFile</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Workspaces</string>
+	<string>WorkSpaces</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -43,7 +43,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>Workspaces uses automation to integrate with other development tools.</string>
+	<string>WorkSpaces uses automation to integrate with other development tools.</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/Sources/WorkspaceManager/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/WorkspaceManager/Resources/PrivacyInfo.xcprivacy
@@ -40,7 +40,7 @@
          Required API declarations for APIs that Apple considers
          privacy-sensitive and requires justification for use.
 
-         Workspaces accesses:
+         WorkSpaces accesses:
          - File system (for workspace management)
          - Process APIs (for terminal/shell execution)
          - System boot time (for session management)

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2113,11 +2113,11 @@ struct MainTerminalDetailView: View {
             return selectedRepo.name
         }
 
-        guard let activeHostSession else { return "WorkspaceManager" }
+        guard let activeHostSession else { return "WorkSpaces" }
 
         switch activeHostSession.key {
         case .defaultHome:
-            return "WorkspaceManager"
+            return "WorkSpaces"
         case .repoPath, .hostPath:
             return activeHostSession.directoryURL.lastPathComponent
         case .backendSession(_, let instanceID):

--- a/Sources/WorkspaceManager/Views/MainWindow/WebSourceCreationSupport.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WebSourceCreationSupport.swift
@@ -29,7 +29,7 @@ enum WebSourceCreationTarget: Identifiable {
     var subtitle: String {
         switch self {
         case .global:
-            return "Browse a domain inside Workspaces"
+            return "Browse a domain inside WorkSpaces"
         case .repo(let repo):
             return "Attach a web view to \(repo.name)"
         case .workspace(let workspace):

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
@@ -739,9 +739,9 @@ struct WorkspaceEnvironmentOptionsController {
 
         switch snapshot.state {
         case .setupRequired:
-            return "\(base) Workspaces will install and verify Lume automatically the first time you use this."
+            return "\(base) WorkSpaces will install and verify Lume automatically the first time you use this."
         case .repairRequired:
-            return "\(base) Workspaces will repair the local VM runtime automatically before continuing."
+            return "\(base) WorkSpaces will repair the local VM runtime automatically before continuing."
         case .ready, .installing, .verifying, .unsupportedHost:
             break
         }
@@ -749,26 +749,26 @@ struct WorkspaceEnvironmentOptionsController {
         if let baseSnapshot = snapshot.baseVM {
             switch baseSnapshot.status {
             case .ready:
-                return "\(base) Workspaces will clone the prepared base VM for a faster macOS workspace start."
+                return "\(base) WorkSpaces will clone the prepared base VM for a faster macOS workspace start."
             case .preparing:
-                return "\(base) A prepared base VM is already being created. Workspaces will clone it once it is ready."
+                return "\(base) A prepared base VM is already being created. WorkSpaces will clone it once it is ready."
             case .missing:
                 if baseSnapshot.profile.imageReference != nil {
                     return """
-                        \(base) Workspaces will download the matching base VM once, then clone it for faster future macOS workspaces.
+                        \(base) WorkSpaces will download the matching base VM once, then clone it for faster future macOS workspaces.
                         """
                 }
                 return """
-                    \(base) No host-matched golden image is available yet, so Workspaces will prepare a stock macOS base VM once and clone it for faster future workspaces.
+                    \(base) No host-matched golden image is available yet, so WorkSpaces will prepare a stock macOS base VM once and clone it for faster future workspaces.
                     """
             case .repairRequired:
-                return "\(base) Workspaces will repair or recreate the prepared base VM before continuing."
+                return "\(base) WorkSpaces will repair or recreate the prepared base VM before continuing."
             }
         }
 
         if snapshot.defaultMacOSImage == nil, snapshot.defaultMacOSImageError != nil {
             return """
-                \(base) No host-matched golden image is available yet, so Workspaces will fall back to stock macOS setup automatically.
+                \(base) No host-matched golden image is available yet, so WorkSpaces will fall back to stock macOS setup automatically.
                 """
         }
 
@@ -785,9 +785,9 @@ struct WorkspaceEnvironmentOptionsController {
 
         switch snapshot.state {
         case .setupRequired:
-            return "\(base) Workspaces will install and verify Lume automatically the first time you use this."
+            return "\(base) WorkSpaces will install and verify Lume automatically the first time you use this."
         case .repairRequired:
-            return "\(base) Workspaces will repair the local VM runtime automatically before continuing."
+            return "\(base) WorkSpaces will repair the local VM runtime automatically before continuing."
         case .ready, .installing, .verifying, .unsupportedHost:
             return base
         }
@@ -801,7 +801,7 @@ struct WorkspaceEnvironmentOptionsController {
         }
 
         if snapshot.defaultMacOSImage == nil, snapshot.defaultMacOSImageError != nil {
-            return "Workspaces will use stock macOS because no host-matched golden image is available yet."
+            return "WorkSpaces will use stock macOS because no host-matched golden image is available yet."
         }
 
         return nil

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingsView: View {
         Form {
             Section {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Workspaces Location")
+                    Text("WorkSpaces Location")
                         .font(.headline)
 
                     HStack {
@@ -96,7 +96,7 @@ struct SettingsView: View {
 
             Section {
                 VStack(alignment: .leading, spacing: 10) {
-                    Text("Use Workspaces from Terminal")
+                    Text("Use WorkSpaces from Terminal")
                         .font(.headline)
 
                     if let commandLineToolStatus {
@@ -629,7 +629,7 @@ struct SettingsView: View {
 
         switch status.reason {
         case .active:
-            return "The `workspaces` command is ready to open Workspaces from Terminal."
+            return "The `workspaces` command is ready to open WorkSpaces from Terminal."
         case .missing:
             return "Install the `workspaces` command at \(commandPath) so `workspaces .` opens the current folder."
         case .missingFromPath:

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -118,14 +118,14 @@ private final class CLIApp {
         guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: Self.appBundleIdentifier)
         else {
             throw CLIError(
-                "Could not find the Workspaces app. Install it first so the 'workspaces' launcher can hand off to the GUI."
+                "Could not find the WorkSpaces app. Install it first so the 'workspaces' launcher can hand off to the GUI."
             )
         }
 
         if let request {
             let deepLinkURL = request.deepLinkURL
             guard NSWorkspace.shared.open(deepLinkURL) else {
-                throw CLIError("Failed to open Workspaces for path: \(request.launchDirectory.path)")
+                throw CLIError("Failed to open WorkSpaces for path: \(request.launchDirectory.path)")
             }
             return 0
         }
@@ -825,7 +825,7 @@ private func openApplication(at appURL: URL, configuration: NSWorkspace.OpenConf
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
         NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, error in
             if let error {
-                continuation.resume(throwing: CLIError("Failed to launch Workspaces: \(error.localizedDescription)"))
+                continuation.resume(throwing: CLIError("Failed to launch WorkSpaces: \(error.localizedDescription)"))
                 return
             }
 
@@ -920,7 +920,7 @@ private func writeStderr(_ message: String) {
 private func printHelp() {
     print(
         """
-        WorkspaceManager CLI
+        WorkSpaces CLI
 
         Usage:
           workspaces
@@ -941,7 +941,7 @@ private func printHelp() {
           workspaces help
 
         Launch behavior:
-          - no args: open the Workspaces app
+          - no args: open the WorkSpaces app
           - path arg: open the app and focus the matching workspace or repo
 
         Workspace selectors:

--- a/Sources/WorkspaceManagerCore/Services/LumeRuntimeService.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeRuntimeService.swift
@@ -757,7 +757,7 @@ public actor LumeRuntimeService: LumeRuntimeServiceProtocol {
                     sourceKind: sourceKind,
                     vmStatus: details.status,
                     reason: validationReason
-                        ?? "The validated base macOS VM is running. Workspaces will stop it before cloning."
+                        ?? "The validated base macOS VM is running. WorkSpaces will stop it before cloning."
                 )
             case .stopped:
                 snapshot = LumeBaseVMSnapshot(

--- a/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
@@ -1321,13 +1321,13 @@ extension LumeWorkspaceProvider: WorkspaceProviderSetupCapable {
                     primaryButtonTitle: primaryButtonTitle,
                     introductoryText: [
                         "Lume is an MIT open-source VM runtime that uses Apple's native Virtualization Framework to run macOS and Linux VMs at near-native speed on Apple Silicon.",
-                        "Workspaces needs it so it can create VM-backed workspaces, open an in-app terminal with `lume ssh`, and launch full desktop access via VNC.",
+                        "WorkSpaces needs it so it can create VM-backed workspaces, open an in-app terminal with `lume ssh`, and launch full desktop access via VNC.",
                     ],
                     learnMoreLabel: "Learn more about Lume",
                     learnMoreURL: URL(
                         string: "https://cua.ai/docs/lume/guide/getting-started/introduction"
                     ),
-                    explanatoryStepsTitle: "What Workspaces will do",
+                    explanatoryStepsTitle: "What WorkSpaces will do",
                     explanatorySteps: [
                         "Install the official Lume CLI in ~/.local/bin",
                         "Install and load the user LaunchAgent on localhost:7777",
@@ -1341,10 +1341,10 @@ extension LumeWorkspaceProvider: WorkspaceProviderSetupCapable {
                             "Default macOS VM: \($0.displayName)"
                         },
                     footerText:
-                        "This is a one-time setup on this Mac. No admin access is required. After setup finishes, Workspaces will continue automatically.",
+                        "This is a one-time setup on this Mac. No admin access is required. After setup finishes, WorkSpaces will continue automatically.",
                     progressTitle: "Preparing macOS VM Support",
                     progressBody:
-                        "Workspaces is setting up the local Lume runtime and will continue automatically when it is ready.",
+                        "WorkSpaces is setting up the local Lume runtime and will continue automatically when it is ready.",
                     initialProgress: WorkspaceProviderSetupProgress(
                         id: LumeRuntimeSetupStep.checkingHost.rawValue,
                         label: LumeRuntimeSetupStep.checkingHost.label

--- a/Tests/WorkspaceManagerAppTests/WorkspaceEnvironmentOptionsControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceEnvironmentOptionsControllerTests.swift
@@ -224,7 +224,7 @@ struct WorkspaceEnvironmentOptionsControllerTests {
         #if arch(arm64)
             #expect(
                 option.availabilityReason
-                    == "Workspaces will use stock macOS because no host-matched golden image is available yet."
+                    == "WorkSpaces will use stock macOS because no host-matched golden image is available yet."
             )
         #endif
     }

--- a/Tests/WorkspaceManagerAppTests/WorkspaceProviderSetupActionRunnerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceProviderSetupActionRunnerTests.swift
@@ -145,7 +145,7 @@ struct WorkspaceProviderSetupActionRunnerTests {
             introductoryText: ["Intro"],
             learnMoreLabel: "Learn more",
             learnMoreURL: URL(string: "https://example.com/setup"),
-            explanatoryStepsTitle: "What Workspaces will do",
+            explanatoryStepsTitle: "What WorkSpaces will do",
             explanatorySteps: ["Step 1", "Step 2"],
             supplementaryText: "Default macOS VM: Tahoe",
             footerText: "Footer",

--- a/Tests/WorkspaceManagerAppTests/WorkspaceProviderSetupCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceProviderSetupCoordinatorTests.swift
@@ -99,7 +99,7 @@ struct WorkspaceProviderSetupCoordinatorTests {
             introductoryText: ["Intro"],
             learnMoreLabel: "Learn more",
             learnMoreURL: URL(string: "https://example.com/setup"),
-            explanatoryStepsTitle: "What Workspaces will do",
+            explanatoryStepsTitle: "What WorkSpaces will do",
             explanatorySteps: ["Step 1", "Step 2"],
             supplementaryText: "Default macOS VM: Tahoe",
             footerText: "Footer",

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,4 +1,4 @@
-# Workspaces Branding
+# WorkSpaces Branding
 
 ## App Icon
 

--- a/docs/design/brainstorm/index.html
+++ b/docs/design/brainstorm/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Workspaces Design Brainstorm</title>
+  <title>WorkSpaces Design Brainstorm</title>
   <style>
     :root {
       --bg-primary: #f5f5f5;
@@ -333,7 +333,7 @@
   <header>
     <div class="header-top">
       <div class="header-left">
-        <h1>Workspaces Design Brainstorm</h1>
+        <h1>WorkSpaces Design Brainstorm</h1>
         <p class="subtitle">AI-generated mockups for Mac workspace manager</p>
       </div>
       <nav class="nav-links">
@@ -348,7 +348,7 @@
     <summary>Context for Reviewers</summary>
     <div class="context-content">
       <p>
-        <strong>What is Workspaces?</strong> A Mac app for managing isolated AI coding sessions.
+        <strong>What is WorkSpaces?</strong> A Mac app for managing isolated AI coding sessions.
         Users add git repos, fork them into independent workspaces, and run Claude Code in an embedded terminal.
       </p>
       <p><strong>Key Design Constraints:</strong></p>
@@ -573,7 +573,7 @@
             <span>Show prompt</span>
           </button>
           <div class="prompt-content">
-            <pre>Mac desktop application screenshot mockup: Settings window for workspace manager. Clean form layout with sections: 'Workspaces Location' showing a path input field '/Users/dev/workspaces' with a 'Choose...' button, 'Terminal' section with font size slider. Reset to Default button at bottom. Native macOS settings window style.</pre>
+            <pre>Mac desktop application screenshot mockup: Settings window for workspace manager. Clean form layout with sections: 'WorkSpaces Location' showing a path input field '/Users/dev/workspaces' with a 'Choose...' button, 'Terminal' section with font size slider. Reset to Default button at bottom. Native macOS settings window style.</pre>
           </div>
         </div>
         <div class="feedback-section">
@@ -658,7 +658,7 @@
       'terminal-focus': { number: 6, title: 'Terminal Focus Mode', file: 'terminal-focus-01.jpg' },
     };
 
-    const projectName = 'Workspaces';
+    const projectName = 'WorkSpaces';
     const storageKey = `${projectName.toLowerCase().replace(/\s+/g, '-')}-feedback`;
     const ratingEmoji = { 'love': '++', 'like': '+', 'meh': '~', 'dislike': '-' };
 

--- a/docs/design/design-brief.html
+++ b/docs/design/design-brief.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Workspaces Design Brief</title>
+  <title>WorkSpaces Design Brief</title>
   <style>
     :root {
       --bg-primary: #ffffff;
@@ -454,9 +454,9 @@
   <div class="container">
     <!-- Hero -->
     <div class="hero">
-      <img src="brief/hero.jpg" alt="Workspaces - Isolated AI coding sessions for Mac" style="width: 100%; display: block;">
+      <img src="brief/hero.jpg" alt="WorkSpaces - Isolated AI coding sessions for Mac" style="width: 100%; display: block;">
       <div class="hero-overlay" style="position: absolute; bottom: 0; left: 0; right: 0; padding: 2rem; background: linear-gradient(transparent, rgba(0,0,0,0.8)); color: white;">
-        <h1 style="font-size: 2.5rem; font-weight: 700; margin-bottom: 0.5rem;">Workspaces</h1>
+        <h1 style="font-size: 2.5rem; font-weight: 700; margin-bottom: 0.5rem;">WorkSpaces</h1>
         <p class="tagline" style="font-size: 1.25rem; opacity: 0.9;">Isolated AI coding sessions for Mac</p>
       </div>
     </div>
@@ -473,9 +473,9 @@
     <section>
       <h2>Executive Summary</h2>
       <div class="summary-grid">
-        <img src="brief/app-icon.png" alt="Workspaces App Icon" class="app-icon">
+        <img src="brief/app-icon.png" alt="WorkSpaces App Icon" class="app-icon">
         <div class="summary-content">
-          <h3>What is Workspaces?</h3>
+          <h3>What is WorkSpaces?</h3>
           <p>A Mac-native app for managing isolated AI coding sessions. Users add git repositories, fork them into independent workspaces, and run Claude Code or similar AI tools in an embedded terminal.</p>
           <p><strong>The key differentiator:</strong> Terminal-first design with automatic lifecycle hooks (setup.sh/archive.sh) that eliminate repetitive project setup.</p>
         </div>
@@ -511,7 +511,7 @@
         </div>
         <div class="solution">
           <h4>Our Solution</h4>
-          <p>Workspaces creates <strong>isolated copies of repos with embedded terminal support</strong>. Each workspace runs setup.sh automatically, giving you a clean slate for every AI coding session. Think of it as <strong>git worktrees with a terminal-first UI</strong>.</p>
+          <p>WorkSpaces creates <strong>isolated copies of repos with embedded terminal support</strong>. Each workspace runs setup.sh automatically, giving you a clean slate for every AI coding session. Think of it as <strong>git worktrees with a terminal-first UI</strong>.</p>
         </div>
       </div>
     </section>
@@ -617,7 +617,7 @@
     <!-- Visual Direction -->
     <section>
       <h2>Visual Direction</h2>
-      <p>Workspaces follows macOS design language: clean lines, subtle shadows, native controls. The terminal uses a dark theme by default (matching developer preferences) while the chrome can follow system appearance.</p>
+      <p>WorkSpaces follows macOS design language: clean lines, subtle shadows, native controls. The terminal uses a dark theme by default (matching developer preferences) while the chrome can follow system appearance.</p>
 
       <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem;">
         <img src="brainstorm/main-window-02.jpg" alt="Main Window with Nested Sidebar" style="width: 100%; border-radius: 8px; box-shadow: 0 2px 8px var(--shadow); cursor: pointer;" onclick="openLightbox(this.src)">
@@ -690,7 +690,7 @@
     </section>
 
     <footer>
-      <p>Workspaces Design Brief v1 &bull; Generated with Claude Code &bull; January 2026</p>
+      <p>WorkSpaces Design Brief v1 &bull; Generated with Claude Code &bull; January 2026</p>
     </footer>
   </div>
 </body>

--- a/docs/design/stories/index.html
+++ b/docs/design/stories/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Workspaces Story Flows</title>
+  <title>WorkSpaces Story Flows</title>
   <style>
     :root {
       --bg-primary: #f5f5f5;
@@ -231,7 +231,7 @@
 </head>
 <body>
   <header>
-    <h1>Workspaces Story Flows</h1>
+    <h1>WorkSpaces Story Flows</h1>
     <p class="subtitle">Visual walkthrough of key user journeys</p>
     <nav class="nav-links">
       <a href="../design-brief.html">Design Brief</a>
@@ -243,7 +243,7 @@
   <details class="product-context" open>
     <summary>Product Context</summary>
     <div class="context-content">
-      <p>Workspaces is a Mac app for managing isolated AI coding sessions. Users add git repos from their Mac, fork them into independent workspaces, and run Claude Code or similar tools in an embedded terminal. Each workspace is a clean copy with automatic setup via lifecycle hooks.</p>
+      <p>WorkSpaces is a Mac app for managing isolated AI coding sessions. Users add git repos from their Mac, fork them into independent workspaces, and run Claude Code or similar tools in an embedded terminal. Each workspace is a clean copy with automatic setup via lifecycle hooks.</p>
     </div>
   </details>
 
@@ -258,7 +258,7 @@
   <section id="story-1" class="story-section active">
     <div class="story-header">
       <h2><span class="story-badge">STORY 1</span> First-Time Setup</h2>
-      <p class="actor">As a developer new to Workspaces</p>
+      <p class="actor">As a developer new to WorkSpaces</p>
       <p class="goal">I want to add my first repository and create a workspace so that I can start an isolated AI coding session</p>
       <p class="context">User has just installed the app and wants to set up their first workspace for a project.</p>
     </div>

--- a/docs/development/notifications.md
+++ b/docs/development/notifications.md
@@ -291,7 +291,7 @@ WORKSPACES_NOTIFICATION_URL=http://localhost:8787 ./scripts/launch-dev.sh --no-b
 
 ## GitHub App
 
-- **App name**: Workspaces Notify
+- **App name**: WorkSpaces Notify
 - **Client ID**: `Iv23liJBRgQoWIWjtRoO` (in `NotificationConstants.gitHubAppClientID`)
 - **Subscribed events**: pull_request, discussion, discussion_comment, check_run, check_suite
 - **Webhook URL**: `https://webhooks.cloudcompute.com/webhook`

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workspaces - AI Coding Session Manager for macOS</title>
+    <title>WorkSpaces - AI Coding Session Manager for macOS</title>
     <meta name="description" content="A native macOS app for managing AI coding session workspaces with integrated terminal.">
 
     <style>
@@ -294,7 +294,7 @@
     <div class="container">
         <header>
             <span class="badge badge--beta">Beta</span>
-            <h1>Workspaces</h1>
+            <h1>WorkSpaces</h1>
             <p class="tagline">AI Coding Session Manager for macOS</p>
 
             <a href="https://github.com/fairchild/workspaces/releases/latest/download/WorkspaceManager-latest.dmg"
@@ -351,7 +351,7 @@
             <h2>Installation</h2>
             <ol class="steps">
                 <li>Download the DMG file using the button above</li>
-                <li>Open the DMG and drag <strong>Workspaces</strong> to your Applications folder</li>
+                <li>Open the DMG and drag <strong>WorkSpaces</strong> to your Applications folder</li>
                 <li>On first launch, right-click the app and select <strong>Open</strong> to bypass Gatekeeper</li>
                 <li>Configure your workspace root directory in Settings</li>
             </ol>

--- a/docs/original_spec.md
+++ b/docs/original_spec.md
@@ -333,7 +333,7 @@ App settings (Cmd+,).
 │  General                                                │
 ├─────────────────────────────────────────────────────────┤
 │                                                         │
-│  Workspaces Location                                    │
+│  WorkSpaces Location                                    │
 │  ┌─────────────────────────────────────────┐            │
 │  │ ~/workspaces                        [📁]│            │
 │  └─────────────────────────────────────────┘            │
@@ -364,7 +364,7 @@ struct SettingsView: View {
         Form {
             Section("General") {
                 HStack {
-                    TextField("Workspaces Location", text: $workspacesRootPath)
+                    TextField("WorkSpaces Location", text: $workspacesRootPath)
                     Button("Choose...") {
                         // Open folder picker
                     }

--- a/docs/product_overview.md
+++ b/docs/product_overview.md
@@ -1,4 +1,4 @@
-# Workspaces — Product Overview
+# WorkSpaces — Product Overview
 
 ## Problem Statement
 
@@ -11,7 +11,7 @@ Developers using terminal-based coding agents (Claude Code, Aider, Codex CLI, Co
 
 ## Solution Summary
 
-**Workspaces** is a Mac-native app for terminal-first AI coding with fast context switching. It discovers local repositories in `~/code`, restores the last surface you were using, opens repo overviews for navigation and launch actions, and lets you spin up isolated workspace copies when needed.
+**WorkSpaces** is a Mac-native app for terminal-first AI coding with fast context switching. It discovers local repositories in `~/code`, restores the last surface you were using, opens repo overviews for navigation and launch actions, and lets you spin up isolated workspace copies when needed.
 
 Think of it as **a terminal session manager for your code portfolio, with workspace isolation when you need it**.
 
@@ -73,7 +73,7 @@ Developers who regularly use terminal-based coding agents (Claude Code, Aider, C
 
 1. **Terminal-First**: The embedded terminal IS the experience. This is not a code editor — use your preferred external editor alongside.
 
-2. **Ghostty-First Input Model**: Workspaces wraps a fully functional embedded Ghostty experience. Shortcut handling defaults to Ghostty unless a shortcut is explicitly reserved for app chrome.
+2. **Ghostty-First Input Model**: WorkSpaces wraps a fully functional embedded Ghostty experience. Shortcut handling defaults to Ghostty unless a shortcut is explicitly reserved for app chrome.
 
 3. **Native Mac Feel**: SwiftUI + AppKit patterns. Three-column layout like Finder/Mail. Keyboard shortcuts that feel familiar.
 

--- a/docs/user-guide/index.html
+++ b/docs/user-guide/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Workspaces User Guide</title>
+    <title>WorkSpaces User Guide</title>
     <style>
         :root {
             --color-bg: #0d1117;
@@ -288,7 +288,7 @@
 <div class="container">
 
     <header>
-        <h1>Workspaces User Guide</h1>
+        <h1>WorkSpaces User Guide</h1>
         <p>Cloud workspaces with Daytona</p>
     </header>
 
@@ -328,7 +328,7 @@
 
         <div class="callout">
             <strong>Note</strong>
-            When Workspaces launches, it checks for <code>uv</code> on your system. If found, the "Remote VM" option appears when creating new workspaces. No additional configuration needed.
+            When WorkSpaces launches, it checks for <code>uv</code> on your system. If found, the "Remote VM" option appears when creating new workspaces. No additional configuration needed.
         </div>
     </section>
 
@@ -437,7 +437,7 @@
 
         <div class="callout">
             <strong>Status sync</strong>
-            On launch, Workspaces checks the actual state of all cloud sandboxes via the Daytona API and updates the sidebar to match. If a sandbox was auto-stopped or archived externally, you'll see the correct state.
+            On launch, WorkSpaces checks the actual state of all cloud sandboxes via the Daytona API and updates the sidebar to match. If a sandbox was auto-stopped or archived externally, you'll see the correct state.
         </div>
     </section>
 
@@ -501,7 +501,7 @@
         <h2>Troubleshooting</h2>
 
         <h3>"Remote VM" option doesn't appear</h3>
-        <p>Workspaces checks for <code>uv</code> on launch. Make sure it's installed (<code>brew install uv</code>) and on your PATH. Relaunch the app after installing.</p>
+        <p>WorkSpaces checks for <code>uv</code> on launch. Make sure it's installed (<code>brew install uv</code>) and on your PATH. Relaunch the app after installing.</p>
 
         <h3>Connection fails or times out</h3>
         <p>Check your API key in <code>~/.env</code>. The key should be on its own line: <code>DAYTONA_API_KEY=dyt_...</code>. Also verify your internet connection &mdash; the sandbox runs in Daytona's cloud.</p>
@@ -510,14 +510,14 @@
         <p>Stop operations have a 180-second timeout. If the sandbox is under heavy load, the stop may take longer. Try again, or archive instead (archive stops the sandbox first, then moves to cold storage).</p>
 
         <h3>Status shows wrong state after restart</h3>
-        <p>Workspaces syncs cloud workspace statuses on every launch. If it looks wrong, relaunch the app. You can also right-click and use the lifecycle actions to force a state change.</p>
+        <p>WorkSpaces syncs cloud workspace statuses on every launch. If it looks wrong, relaunch the app. You can also right-click and use the lifecycle actions to force a state change.</p>
 
         <h3>SSH session dies immediately</h3>
         <p>The SSH access token expires after 8 hours. If your session drops, click the workspace again to get a fresh token and reconnect.</p>
     </section>
 
     <footer>
-        Workspaces &mdash; Terminal-first workspace manager for macOS
+        WorkSpaces &mdash; Terminal-first workspace manager for macOS
     </footer>
 
 </div>

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,8 +1,8 @@
-# Workspaces User Stories
+# WorkSpaces User Stories
 
 ## Product Context
 
-Workspaces is a Mac app for managing isolated AI coding sessions. Users add git repos, fork them into workspaces, and run terminal-based coding agents (Claude Code, Aider, Codex CLI, or any shell command) in an embedded terminal. Each workspace is a clean copy with automatic setup.
+WorkSpaces is a Mac app for managing isolated AI coding sessions. Users add git repos, fork them into workspaces, and run terminal-based coding agents (Claude Code, Aider, Codex CLI, or any shell command) in an embedded terminal. Each workspace is a clean copy with automatic setup.
 
 ### Current Behavior Snapshot (2026-03-10)
 
@@ -20,7 +20,7 @@ Workspaces is a Mac app for managing isolated AI coding sessions. Users add git 
 
 ## Story 1: First-Time Setup (Repo-First)
 
-**As a** developer new to Workspaces
+**As a** developer new to WorkSpaces
 **I want to** add my first repository and create a workspace
 **So that** I can start an isolated AI coding session
 
@@ -29,7 +29,7 @@ Workspaces is a Mac app for managing isolated AI coding sessions. Users add git 
 ```mermaid
 sequenceDiagram
     actor User
-    participant App as Workspaces
+    participant App as WorkSpaces
     participant Finder
     participant Terminal
 
@@ -53,7 +53,7 @@ sequenceDiagram
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│  Workspaces                                              [−] [□] [×]     │
+│  WorkSpaces                                              [−] [□] [×]     │
 ├────────────────┬─────────────────────────────────────────┬───────────────┤
 │                │                                         │ [Files][∆ 3]  │
 │ M my-api    ⋯ +│  $ claude                               │───────────────│
@@ -288,7 +288,7 @@ sequenceDiagram
 │  Settings                                    [×]    │
 ├─────────────────────────────────────────────────────┤
 │                                                     │
-│  Workspaces Location                                │
+│  WorkSpaces Location                                │
 │  ┌───────────────────────────────────────┐          │
 │  │ /Volumes/Code/workspaces          [📁]│          │
 │  └───────────────────────────────────────┘          │
@@ -353,7 +353,7 @@ sequenceDiagram
 │ frontend                                │
 │ ~/code/frontend                         │
 │                                         │
-│  Workspaces                             │
+│  WorkSpaces                             │
 │   • sidebar-cleanup                     │
 │   • release-prep                        │
 │                                         │
@@ -375,7 +375,7 @@ sequenceDiagram
 
 **As a** terminal-first developer already fluent in Ghostty
 **I want to** keep expected Ghostty keybindings inside embedded terminals
-**So that** Workspaces feels like Ghostty with management chrome, not a different terminal
+**So that** WorkSpaces feels like Ghostty with management chrome, not a different terminal
 
 ### Flow Diagram
 
@@ -384,7 +384,7 @@ sequenceDiagram
     actor User
     participant Keyboard
     participant Router as Shortcut Router
-    participant AppChrome as Workspaces Chrome
+    participant AppChrome as WorkSpaces Chrome
     participant Ghostty as Embedded Ghostty
 
     User->>Keyboard: Presses shortcut
@@ -422,7 +422,7 @@ sequenceDiagram
 
 ### Acceptance Criteria
 
-1. Workspaces defines and documents a default-first routing policy: Ghostty gets terminal shortcuts by default.
+1. WorkSpaces defines and documents a default-first routing policy: Ghostty gets terminal shortcuts by default.
 2. App-level shortcuts are explicitly scoped to wrapper chrome behaviors only.
 3. Shortcut collisions are treated as policy decisions, not hardcoded one-off exceptions.
 4. Product backlog includes user-configurable routing overrides (`App` vs `Ghostty`) for conflicting shortcuts.

--- a/scripts/capture-window.sh
+++ b/scripts/capture-window.sh
@@ -120,7 +120,7 @@ read_window_id() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -288,6 +288,7 @@ fi
 log_step "Stopping running app (if open)"
 osascript -e 'tell application id "com.cloudcompute.workspaces" to quit' >/dev/null 2>&1 || true
 osascript -e 'tell application "WorkspaceManager" to quit' >/dev/null 2>&1 || true
+osascript -e 'tell application "WorkSpaces" to quit' >/dev/null 2>&1 || true
 osascript -e 'tell application "Workspaces" to quit' >/dev/null 2>&1 || true
 pkill -x WorkspaceManager >/dev/null 2>&1 || true
 sleep 1

--- a/scripts/launch-dev.sh
+++ b/scripts/launch-dev.sh
@@ -432,7 +432,7 @@ read_window_id() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/lib/ui-test-common.sh
+++ b/scripts/lib/ui-test-common.sh
@@ -126,7 +126,7 @@ ws_get_window_geometry() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 
@@ -240,7 +240,7 @@ ws_get_window_id() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -289,7 +289,7 @@ window_click_coordinates() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/shortcut-pass-through-smoke.sh
+++ b/scripts/shortcut-pass-through-smoke.sh
@@ -107,7 +107,7 @@ window_click_coordinates() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/tart-webview-demo.py
+++ b/scripts/tart-webview-demo.py
@@ -32,7 +32,7 @@ WINDOW_PROBE_SWIFT = r"""swift - <<'SWIFT'
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 
@@ -597,7 +597,8 @@ def main() -> int:
 
         def activate_workspace_manager() -> None:
             activate_cmd = (
-                "osascript -e 'tell application \"Workspaces\" to activate' "
+                "osascript -e 'tell application \"WorkSpaces\" to activate' "
+                "|| osascript -e 'tell application \"Workspaces\" to activate' "
                 "|| osascript -e 'tell application \"WorkspaceManager\" to activate'"
             )
             ssh_exec(ssh_client, f"{activate_cmd} >/dev/null 2>&1 || true", timeout=20)


### PR DESCRIPTION
## Summary
- Rename app-facing bundle metadata and default window/title copy to `WorkSpaces`.
- Align CLI/help text, setup copy, privacy/docs, and public docs with the new brand casing.
- Keep `WorkspaceManager` for executable, module, process, app-support, and compatibility paths.
- Add `WorkSpaces` to UI capture/evidence script owner fallbacks while preserving legacy `Workspaces` and `WorkspaceManager` matches.

## Validation
- [GitHub CI build-and-test passed](https://github.com/fairchild/workspaces/actions/runs/25245641800/job/74029338089)
- [Vercel preview passed](https://vercel.com/cloudcompute/spaces-web/5FCPTqD9fdRgza3o9mskPadudXJ8)
- `plutil -lint Sources/WorkspaceManager/Resources/Info.plist Sources/WorkspaceManager/Resources/PrivacyInfo.xcprivacy`
- `git diff --check`
- `./scripts/build-release.sh --no-sign`
- Built bundle metadata: `CFBundleDisplayName=WorkSpaces`, `CFBundleName=WorkSpaces`, `CFBundleExecutable=WorkspaceManager`
- `swift test` (487 tests passed)

## Evidence
- [Validation summary](https://evidence.cloudcompute.com/workspaces/pr-396/20260503-020616-workspaces-brand-validation.svg)
- [Running debug app screenshot](https://evidence.cloudcompute.com/workspaces/pr-396/20260503-020617-workspaces-running-app.png)
