### PR TITLE
release: migrate notarize to App Store Connect API-key auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,9 @@ jobs:
           APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
           APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
           APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64 }}
-          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
@@ -83,8 +84,9 @@ jobs:
           [[ -n "$APPLE_DEVELOPER_ID_CERT_BASE64" ]] || missing+=("APPLE_DEVELOPER_ID_CERT_BASE64")
           [[ -n "$APPLE_DEVELOPER_ID_CERT_PASSWORD" ]] || missing+=("APPLE_DEVELOPER_ID_CERT_PASSWORD")
           [[ -n "$APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64" ]] || missing+=("APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64")
-          [[ -n "$APPLE_ID" ]] || missing+=("APPLE_ID")
-          [[ -n "$APPLE_APP_PASSWORD" ]] || missing+=("APPLE_APP_PASSWORD")
+          [[ -n "$APPLE_API_KEY_BASE64" ]] || missing+=("APPLE_API_KEY_BASE64")
+          [[ -n "$APPLE_API_KEY_ID" ]] || missing+=("APPLE_API_KEY_ID")
+          [[ -n "$APPLE_API_ISSUER_ID" ]] || missing+=("APPLE_API_ISSUER_ID")
           [[ -n "$APPLE_TEAM_ID" ]] || missing+=("APPLE_TEAM_ID")
           [[ -n "$SPARKLE_PRIVATE_KEY" ]] || missing+=("SPARKLE_PRIVATE_KEY")
 
@@ -190,31 +192,30 @@ jobs:
           echo "profile_path=$PROFILE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Notarization preflight
+        id: notarization
         env:
-          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
-          APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: |
           set -euo pipefail
-          if [[ -n "${APPLE_API_KEY_PATH:-}" ]]; then
-            args=(--key "$APPLE_API_KEY_PATH" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
-          elif [[ -n "${APPLE_ID:-}" ]]; then
-            args=(--apple-id "$APPLE_ID" --password "$APP_PASSWORD" --team-id "$TEAM_ID")
-          else
-            echo "::error::No Apple notarization credentials present in env"
+          API_KEY_PATH="$RUNNER_TEMP/notary-api-key.p8"
+          echo "api_key_path=$API_KEY_PATH" >> "$GITHUB_OUTPUT"
+
+          if ! (echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$API_KEY_PATH" 2>/dev/null); then
+            echo "$APPLE_API_KEY_BASE64" | base64 -D > "$API_KEY_PATH"
+          fi
+          chmod 600 "$API_KEY_PATH"
+
+          if ! out=$(xcrun notarytool history \
+            --key "$API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" 2>&1); then
+            echo "::error::Apple notarization API-key preflight failed:"
+            echo "$out"
             exit 1
           fi
-          if ! out=$(xcrun notarytool history "${args[@]}" 2>&1); then
-            if grep -qi "agreement" <<<"$out"; then
-              echo "::error::Apple notarization rejected: required agreement is missing or expired."
-              echo "::error::Account Holder for team $TEAM_ID must accept the pending Developer Program License Agreement at https://developer.apple.com/account/"
-            else
-              echo "::error::Apple notarization preflight failed:"
-              echo "$out"
-            fi
-            exit 1
-          fi
-          echo "Notarization credentials OK"
+          echo "Notarization API-key credentials OK"
 
       - name: Validate app version metadata
         if: startsWith(github.ref, 'refs/tags/')
@@ -247,8 +248,9 @@ jobs:
 
       - name: Notarize and package DMG
         env:
-          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
-          APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_API_KEY_PATH: ${{ steps.notarization.outputs.api_key_path }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           BUNDLE_ID: com.cloudcompute.workspaces
           CODESIGN_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
           PROVISIONING_PROFILE_PATH: ${{ steps.profile.outputs.profile_path }}
@@ -311,6 +313,7 @@ jobs:
       - name: Cleanup keychain
         if: always()
         env:
+          APPLE_API_KEY_PATH: ${{ steps.notarization.outputs.api_key_path }}
           KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
           ORIGINAL_DEFAULT_KEYCHAIN: ${{ steps.signing.outputs.original_default_keychain }}
           ORIGINAL_KEYCHAIN_LIST: ${{ steps.signing.outputs.original_keychain_list }}
@@ -331,6 +334,9 @@ jobs:
           fi
           if [[ -n "${KEYCHAIN_PATH:-}" ]] && [[ -f "${KEYCHAIN_PATH}" ]]; then
             security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          if [[ -n "${APPLE_API_KEY_PATH:-}" ]] && [[ -f "${APPLE_API_KEY_PATH}" ]]; then
+            rm -f "$APPLE_API_KEY_PATH" || true
           fi
 
   publish-github-release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,23 +78,23 @@ mkdir -p ~/.config/apple
 mv ~/Downloads/WorkspaceManager.provisionprofile ~/.config/apple/workspaces.provisionprofile
 ```
 
-#### Step 4: Create an App-Specific Password
+#### Step 4: Create an App Store Connect API Key
 
-Notarization requires an app-specific password (your regular Apple ID password won't work).
+Notarization uses App Store Connect API-key authentication rather than an
+Apple ID app-specific password.
 
-1. Go to [account.apple.com](https://account.apple.com) > Sign-In and Security > App-Specific Passwords
-2. Click "Generate an app-specific password"
-3. Name it something like "workspaces-notarytool"
-4. Copy the generated `xxxx-xxxx-xxxx-xxxx` password
-
-You can optionally store this in Keychain instead of a file:
+1. Go to App Store Connect > Users and Access > Integrations > App Store Connect API
+2. Create an API key with notarization access
+3. Download the `.p8` private key once and store it outside the repository, for example:
 
 ```bash
-xcrun notarytool store-credentials "workspaces-notarize" \
-    --apple-id your@email.com \
-    --team-id XXXXXXXXXX \
-    --password xxxx-xxxx-xxxx-xxxx
+mkdir -p ~/.config/apple
+mv ~/Downloads/AuthKey_XXXXXXXXXX.p8 ~/.config/apple/
+chmod 600 ~/.config/apple/AuthKey_XXXXXXXXXX.p8
 ```
+
+Record the key ID and issuer ID shown in App Store Connect. The key ID is also
+embedded in the downloaded filename.
 
 #### Step 5: Configure Local Signing
 
@@ -108,6 +108,7 @@ Set both:
 
 - `SIGNING_IDENTITY` to your Developer ID Application certificate
 - `PROVISIONING_PROFILE_PATH` to the downloaded `.provisionprofile`
+- `APPLE_API_KEY_PATH`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID` for notarization
 
 Use `scripts/signing-config.sh` for local signing/notarization only. For GitHub Actions release setup, use `./scripts/setup-release-secrets.sh`.
 
@@ -177,7 +178,10 @@ Preferred setup path:
 ```bash
 ./scripts/setup-release-secrets.sh \
     --p12-path ~/.config/apple/Developer_ID_Application_<TEAM_ID>.p12 \
-    --profile-path ~/.config/apple/workspaces.provisionprofile
+    --profile-path ~/.config/apple/workspaces.provisionprofile \
+    --api-key-path ~/.config/apple/AuthKey_<KEY_ID>.p8 \
+    --api-key-id <KEY_ID> \
+    --api-issuer-id <ISSUER_ID>
 ```
 
 Notes:
@@ -193,13 +197,14 @@ If you prefer to configure GitHub manually, add these **secrets** to your GitHub
 | `APPLE_DEVELOPER_ID_CERT_BASE64` | Base64-encoded .p12 certificate |
 | `APPLE_DEVELOPER_ID_CERT_PASSWORD` | Password for the .p12 file |
 | `APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64` | Base64-encoded Developer ID provisioning profile with keychain sharing |
-| `APPLE_APP_PASSWORD` | App-specific password |
+| `APPLE_API_KEY_BASE64` | Base64-encoded App Store Connect API `.p8` key |
+| `APPLE_API_KEY_ID` | App Store Connect API key ID |
+| `APPLE_API_ISSUER_ID` | App Store Connect issuer ID |
 
 Add these **variables** to your GitHub repository (Settings > Secrets and variables > Actions > Variables):
 
 | Variable | Description |
 |--------|-------------|
-| `APPLE_ID` | Your Apple ID email |
 | `APPLE_TEAM_ID` | 10-character Team ID |
 
 To export your certificate for CI or for `setup-release-secrets.sh`:
@@ -219,6 +224,13 @@ To export the provisioning profile for CI:
 ```bash
 base64 -i ~/.config/apple/workspaces.provisionprofile | pbcopy
 # Paste as APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64 secret
+```
+
+To export the App Store Connect API key for CI:
+
+```bash
+base64 -i ~/.config/apple/AuthKey_<KEY_ID>.p8 | pbcopy
+# Paste as APPLE_API_KEY_BASE64 secret
 ```
 
 ---
@@ -417,9 +429,9 @@ Download the DMG from GitHub Releases onto a Mac that has never seen the app:
 View the notarization log:
 ```bash
 xcrun notarytool log <submission-id> \
-    --apple-id your@email.com \
-    --password xxxx-xxxx-xxxx-xxxx \
-    --team-id XXXXXXXXXX
+    --key "$APPLE_API_KEY_PATH" \
+    --key-id "$APPLE_API_KEY_ID" \
+    --issuer "$APPLE_API_ISSUER_ID"
 ```
 
 When `scripts/notarize.sh` fails, it also saves Apple's JSON response to:

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -67,7 +67,16 @@ for arg in "$@"; do
             shift
             ;;
         --help|-h)
-            head -n 25 "$0" | tail -n +2 | sed 's/^# //' | sed 's/^#//'
+            awk '
+                NR == 1 { next }
+                /^set -e/ { exit }
+                /^#/ {
+                    sub(/^# ?/, "")
+                    print
+                    next
+                }
+                { exit }
+            ' "$0"
             exit 0
             ;;
         *)
@@ -134,13 +143,18 @@ if [[ -z "$TEAM_ID" ]] || [[ "$TEAM_ID" == "XXXXXXXXXX" ]]; then
     exit 1
 fi
 
-if [[ -z "$APPLE_ID" ]] || [[ "$APPLE_ID" == *"example.com" ]]; then
-    log_error "APPLE_ID not configured (set in scripts/signing-config.sh or environment; see RELEASING.md)"
+if [[ -z "$APPLE_API_KEY_PATH" ]]; then
+    log_error "APPLE_API_KEY_PATH not configured (path to .p8 private key; set in scripts/signing-config.sh or environment; see RELEASING.md)"
     exit 1
 fi
 
-if [[ -z "$APP_PASSWORD" ]] || [[ "$APP_PASSWORD" == "xxxx-xxxx-xxxx-xxxx" ]]; then
-    log_error "APP_PASSWORD not configured (set in scripts/signing-config.sh or environment; see RELEASING.md)"
+if [[ -z "$APPLE_API_KEY_ID" ]]; then
+    log_error "APPLE_API_KEY_ID not configured (10-character key ID from App Store Connect; see RELEASING.md)"
+    exit 1
+fi
+
+if [[ -z "$APPLE_API_ISSUER_ID" ]]; then
+    log_error "APPLE_API_ISSUER_ID not configured (Issuer UUID from App Store Connect; see RELEASING.md)"
     exit 1
 fi
 
@@ -245,9 +259,9 @@ else
 
     # Submit and wait for result
     xcrun notarytool submit "$DMG_PATH" \
-        --apple-id "$APPLE_ID" \
-        --password "$APP_PASSWORD" \
-        --team-id "$TEAM_ID" \
+        --key "$APPLE_API_KEY_PATH" \
+        --key-id "$APPLE_API_KEY_ID" \
+        --issuer "$APPLE_API_ISSUER_ID" \
         --wait \
         --output-format plist >"$NOTARY_RESULT_PLIST"
 
@@ -256,7 +270,7 @@ else
         log_error "Notarization failed"
         echo ""
         echo "To see detailed logs, run:"
-        echo "  xcrun notarytool log <submission-id> --apple-id $APPLE_ID --password <password> --team-id $TEAM_ID"
+        echo "  xcrun notarytool log <submission-id> --key <path-to.p8> --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER_ID"
         exit 1
     fi
 
@@ -269,9 +283,9 @@ else
         if [[ -n "$NOTARY_SUBMISSION_ID" ]]; then
             echo "Submission ID: $NOTARY_SUBMISSION_ID"
             xcrun notarytool log "$NOTARY_SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" \
-                --password "$APP_PASSWORD" \
-                --team-id "$TEAM_ID" \
+                --key "$APPLE_API_KEY_PATH" \
+                --key-id "$APPLE_API_KEY_ID" \
+                --issuer "$APPLE_API_ISSUER_ID" \
                 --output-format json >"$NOTARY_LOG_PATH" || true
             if [[ -f "$NOTARY_LOG_PATH" ]]; then
                 echo "Saved notarization log to $NOTARY_LOG_PATH"

--- a/scripts/setup-release-secrets.sh
+++ b/scripts/setup-release-secrets.sh
@@ -9,10 +9,11 @@
 #   - APPLE_DEVELOPER_ID_CERT_BASE64
 #   - APPLE_DEVELOPER_ID_CERT_PASSWORD
 #   - APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64
-#   - APPLE_APP_PASSWORD
+#   - APPLE_API_KEY_BASE64
+#   - APPLE_API_KEY_ID
+#   - APPLE_API_ISSUER_ID
 #
 # Variables (non-sensitive):
-#   - APPLE_ID
 #   - APPLE_TEAM_ID
 #
 # Behavior:
@@ -25,10 +26,11 @@
 # Usage (interactive):
 #   ./scripts/setup-release-secrets.sh \
 #     --p12-path ~/.config/apple/Developer_ID_Application_LKVN4J3C6C.p12 \
-#     --profile-path ~/.config/apple/workspaces.provisionprofile
+#     --profile-path ~/.config/apple/workspaces.provisionprofile \
+#     --api-key-path ~/.config/apple/AuthKey_XXXXXXXXXX.p8
 #
 # Usage (non-interactive):
-#   P12_PASSWORD='...' APPLE_ID='...' APPLE_APP_PASSWORD='...' \
+#   P12_PASSWORD='...' APPLE_API_KEY_PATH='...' APPLE_API_KEY_ID='...' APPLE_API_ISSUER_ID='...' \
 #   ./scripts/setup-release-secrets.sh \
 #     --p12-path ~/.config/apple/Developer_ID_Application_LKVN4J3C6C.p12 \
 #     --profile-path ~/.config/apple/workspaces.provisionprofile \
@@ -53,8 +55,10 @@ EXPECTED_BUNDLE_ID="com.cloudcompute.workspaces"
 P12_PATH="${P12:-$DEFAULT_P12_PATH}"
 PROFILE_PATH="${PROVISIONING_PROFILE_PATH:-$DEFAULT_PROFILE_PATH}"
 TEAM_ID="${APPLE_TEAM_ID:-$DEFAULT_TEAM_ID}"
-APPLE_ID_VALUE="${APPLE_ID:-}"
-APPLE_APP_PASSWORD_VALUE="${APPLE_APP_PASSWORD:-}"
+APPLE_API_KEY_PATH_VALUE="${APPLE_API_KEY_PATH:-}"
+APPLE_API_KEY_BASE64_VALUE="${APPLE_API_KEY_BASE64:-}"
+APPLE_API_KEY_ID_VALUE="${APPLE_API_KEY_ID:-}"
+APPLE_API_ISSUER_ID_VALUE="${APPLE_API_ISSUER_ID:-}"
 P12_PASSWORD_VALUE="${P12_PASSWORD:-}"
 
 NON_INTERACTIVE=false
@@ -71,8 +75,10 @@ Options:
   --p12-path PATH         Path to Developer ID Application .p12
   --profile-path PATH     Path to Developer ID provisioning profile
   --team-id TEAM          Apple Team ID (default: LKVN4J3C6C)
-  --apple-id EMAIL        Apple ID for notarization
-  --app-password PASS     App-specific password for notarization
+  --api-key-path PATH     Path to App Store Connect notarization .p8 key
+  --api-key-base64 VALUE  Base64-encoded App Store Connect notarization .p8 key
+  --api-key-id ID         App Store Connect API key ID
+  --api-issuer-id UUID    App Store Connect issuer ID
   --p12-password PASS     Export password used to protect the .p12
   --non-interactive       Do not prompt; fail if required values are missing
   --force                 Overwrite existing secrets/variables
@@ -82,7 +88,8 @@ Options:
   --help                  Show this help
 
 Env alternatives:
-  P12, P12_PASSWORD, PROVISIONING_PROFILE_PATH, APPLE_ID, APPLE_APP_PASSWORD, APPLE_TEAM_ID
+  P12, P12_PASSWORD, PROVISIONING_PROFILE_PATH, APPLE_API_KEY_PATH,
+  APPLE_API_KEY_BASE64, APPLE_API_KEY_ID, APPLE_API_ISSUER_ID, APPLE_TEAM_ID
 
 Defaults:
   p12 path: ~/.config/apple/Developer_ID_Application_LKVN4J3C6C.p12
@@ -193,14 +200,24 @@ while [[ $# -gt 0 ]]; do
             PROFILE_PATH="$2"
             shift 2
             ;;
-        --apple-id)
-            [[ $# -ge 2 ]] || fail "--apple-id requires a value"
-            APPLE_ID_VALUE="$2"
+        --api-key-path)
+            [[ $# -ge 2 ]] || fail "--api-key-path requires a value"
+            APPLE_API_KEY_PATH_VALUE="$2"
             shift 2
             ;;
-        --app-password)
-            [[ $# -ge 2 ]] || fail "--app-password requires a value"
-            APPLE_APP_PASSWORD_VALUE="$2"
+        --api-key-base64)
+            [[ $# -ge 2 ]] || fail "--api-key-base64 requires a value"
+            APPLE_API_KEY_BASE64_VALUE="$2"
+            shift 2
+            ;;
+        --api-key-id)
+            [[ $# -ge 2 ]] || fail "--api-key-id requires a value"
+            APPLE_API_KEY_ID_VALUE="$2"
+            shift 2
+            ;;
+        --api-issuer-id)
+            [[ $# -ge 2 ]] || fail "--api-issuer-id requires a value"
+            APPLE_API_ISSUER_ID_VALUE="$2"
             shift 2
             ;;
         --p12-password)
@@ -251,8 +268,9 @@ gh auth status >/dev/null
 NEED_CERT_B64=false
 NEED_CERT_PASSWORD=false
 NEED_PROFILE_B64=false
-NEED_APP_PASSWORD=false
-NEED_APPLE_ID_VAR=false
+NEED_API_KEY_B64=false
+NEED_API_KEY_ID=false
+NEED_API_ISSUER_ID=false
 NEED_TEAM_ID_VAR=false
 
 if [[ "$FORCE" == true ]] || ! have_secret "APPLE_DEVELOPER_ID_CERT_BASE64"; then
@@ -264,11 +282,14 @@ fi
 if [[ "$FORCE" == true ]] || ! have_secret "APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64"; then
     NEED_PROFILE_B64=true
 fi
-if [[ "$FORCE" == true ]] || ! have_secret "APPLE_APP_PASSWORD"; then
-    NEED_APP_PASSWORD=true
+if [[ "$FORCE" == true ]] || ! have_secret "APPLE_API_KEY_BASE64"; then
+    NEED_API_KEY_B64=true
 fi
-if [[ "$FORCE" == true ]] || ! have_variable "APPLE_ID"; then
-    NEED_APPLE_ID_VAR=true
+if [[ "$FORCE" == true ]] || ! have_secret "APPLE_API_KEY_ID"; then
+    NEED_API_KEY_ID=true
+fi
+if [[ "$FORCE" == true ]] || ! have_secret "APPLE_API_ISSUER_ID"; then
+    NEED_API_ISSUER_ID=true
 fi
 if [[ "$FORCE" == true ]] || ! have_variable "APPLE_TEAM_ID"; then
     NEED_TEAM_ID_VAR=true
@@ -345,23 +366,37 @@ if [[ "$NEED_PROFILE_B64" == true ]]; then
     rm -f "$PROFILE_PLIST"
 fi
 
-if [[ "$NEED_APPLE_ID_VAR" == true ]]; then
-    if [[ "$NON_INTERACTIVE" == true ]]; then
-        [[ -n "$APPLE_ID_VALUE" ]] || fail "APPLE_ID/--apple-id is required in non-interactive mode."
-    elif [[ -z "$APPLE_ID_VALUE" ]]; then
-        read -r -p "Enter Apple ID for notarization: " APPLE_ID_VALUE
+if [[ "$NEED_API_KEY_B64" == true ]]; then
+    if [[ -z "$APPLE_API_KEY_BASE64_VALUE" ]]; then
+        if [[ "$NON_INTERACTIVE" == true ]]; then
+            [[ -n "$APPLE_API_KEY_PATH_VALUE" ]] || fail "APPLE_API_KEY_PATH/--api-key-path or APPLE_API_KEY_BASE64/--api-key-base64 is required in non-interactive mode."
+        elif [[ -z "$APPLE_API_KEY_PATH_VALUE" ]]; then
+            read -r -p "Enter path to App Store Connect API .p8 key: " APPLE_API_KEY_PATH_VALUE
+        fi
+        [[ -n "$APPLE_API_KEY_PATH_VALUE" ]] || fail "App Store Connect API key path cannot be empty."
+        APPLE_API_KEY_PATH_VALUE="${APPLE_API_KEY_PATH_VALUE/#\~/$HOME}"
+        APPLE_API_KEY_PATH_VALUE="$(cd "$(dirname "$APPLE_API_KEY_PATH_VALUE")" && pwd)/$(basename "$APPLE_API_KEY_PATH_VALUE")"
+        [[ -f "$APPLE_API_KEY_PATH_VALUE" ]] || fail "App Store Connect API key file not found: $APPLE_API_KEY_PATH_VALUE"
+        grep -Eq "BEGIN .*PRIVATE KEY" "$APPLE_API_KEY_PATH_VALUE" || fail "App Store Connect API key does not look like a .p8 private key: $APPLE_API_KEY_PATH_VALUE"
     fi
-    [[ -n "$APPLE_ID_VALUE" ]] || fail "Apple ID cannot be empty."
 fi
 
-if [[ "$NEED_APP_PASSWORD" == true ]]; then
+if [[ "$NEED_API_KEY_ID" == true ]]; then
     if [[ "$NON_INTERACTIVE" == true ]]; then
-        [[ -n "$APPLE_APP_PASSWORD_VALUE" ]] || fail "APPLE_APP_PASSWORD/--app-password is required in non-interactive mode."
-    elif [[ -z "$APPLE_APP_PASSWORD_VALUE" ]]; then
-        read -r -s -p "Enter Apple app-specific password: " APPLE_APP_PASSWORD_VALUE
-        echo ""
+        [[ -n "$APPLE_API_KEY_ID_VALUE" ]] || fail "APPLE_API_KEY_ID/--api-key-id is required in non-interactive mode."
+    elif [[ -z "$APPLE_API_KEY_ID_VALUE" ]]; then
+        read -r -p "Enter App Store Connect API key ID: " APPLE_API_KEY_ID_VALUE
     fi
-    [[ -n "$APPLE_APP_PASSWORD_VALUE" ]] || fail "Apple app-specific password cannot be empty."
+    [[ -n "$APPLE_API_KEY_ID_VALUE" ]] || fail "App Store Connect API key ID cannot be empty."
+fi
+
+if [[ "$NEED_API_ISSUER_ID" == true ]]; then
+    if [[ "$NON_INTERACTIVE" == true ]]; then
+        [[ -n "$APPLE_API_ISSUER_ID_VALUE" ]] || fail "APPLE_API_ISSUER_ID/--api-issuer-id is required in non-interactive mode."
+    elif [[ -z "$APPLE_API_ISSUER_ID_VALUE" ]]; then
+        read -r -p "Enter App Store Connect issuer ID: " APPLE_API_ISSUER_ID_VALUE
+    fi
+    [[ -n "$APPLE_API_ISSUER_ID_VALUE" ]] || fail "App Store Connect issuer ID cannot be empty."
 fi
 
 if [[ "$NEED_TEAM_ID_VAR" == true ]]; then
@@ -370,12 +405,16 @@ fi
 
 TMP_B64=""
 TMP_PROFILE_B64=""
+TMP_API_KEY_B64=""
 cleanup() {
     if [[ -n "$TMP_B64" ]]; then
         rm -f "$TMP_B64"
     fi
     if [[ -n "$TMP_PROFILE_B64" ]]; then
         rm -f "$TMP_PROFILE_B64"
+    fi
+    if [[ -n "$TMP_API_KEY_B64" ]]; then
+        rm -f "$TMP_API_KEY_B64"
     fi
 }
 trap cleanup EXIT
@@ -395,6 +434,15 @@ if [[ "$NEED_PROFILE_B64" == true ]]; then
         base64 -i "$PROFILE_PATH" > "$TMP_PROFILE_B64"
     else
         base64 "$PROFILE_PATH" > "$TMP_PROFILE_B64"
+    fi
+fi
+
+if [[ "$NEED_API_KEY_B64" == true && -z "$APPLE_API_KEY_BASE64_VALUE" ]]; then
+    TMP_API_KEY_B64="$(mktemp)"
+    if base64 -i "$APPLE_API_KEY_PATH_VALUE" >/dev/null 2>&1; then
+        base64 -i "$APPLE_API_KEY_PATH_VALUE" > "$TMP_API_KEY_B64"
+    else
+        base64 "$APPLE_API_KEY_PATH_VALUE" > "$TMP_API_KEY_B64"
     fi
 fi
 
@@ -421,18 +469,29 @@ else
     log "Skip secret APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64 (already set)"
 fi
 
-if [[ "$NEED_APP_PASSWORD" == true ]]; then
-    gh secret set APPLE_APP_PASSWORD -b "$APPLE_APP_PASSWORD_VALUE"
-    log "Set secret APPLE_APP_PASSWORD"
+if [[ "$NEED_API_KEY_B64" == true ]]; then
+    if [[ -n "$APPLE_API_KEY_BASE64_VALUE" ]]; then
+        gh secret set APPLE_API_KEY_BASE64 -b "$APPLE_API_KEY_BASE64_VALUE"
+    else
+        gh secret set APPLE_API_KEY_BASE64 < "$TMP_API_KEY_B64"
+    fi
+    log "Set secret APPLE_API_KEY_BASE64"
 else
-    log "Skip secret APPLE_APP_PASSWORD (already set)"
+    log "Skip secret APPLE_API_KEY_BASE64 (already set)"
 fi
 
-if [[ "$NEED_APPLE_ID_VAR" == true ]]; then
-    gh variable set APPLE_ID -b "$APPLE_ID_VALUE"
-    log "Set variable APPLE_ID"
+if [[ "$NEED_API_KEY_ID" == true ]]; then
+    gh secret set APPLE_API_KEY_ID -b "$APPLE_API_KEY_ID_VALUE"
+    log "Set secret APPLE_API_KEY_ID"
 else
-    log "Skip variable APPLE_ID (already set)"
+    log "Skip secret APPLE_API_KEY_ID (already set)"
+fi
+
+if [[ "$NEED_API_ISSUER_ID" == true ]]; then
+    gh secret set APPLE_API_ISSUER_ID -b "$APPLE_API_ISSUER_ID_VALUE"
+    log "Set secret APPLE_API_ISSUER_ID"
+else
+    log "Skip secret APPLE_API_ISSUER_ID (already set)"
 fi
 
 if [[ "$NEED_TEAM_ID_VAR" == true ]]; then

--- a/scripts/signing-config.sh.template
+++ b/scripts/signing-config.sh.template
@@ -15,7 +15,7 @@
 # Prerequisites:
 # - Apple Developer Program membership ($99/year)
 # - Developer ID Application certificate installed in Keychain
-# - App-specific password created at appleid.apple.com
+# - App Store Connect API key with notarization access
 #
 # ============================================================================
 
@@ -36,26 +36,12 @@ export SIGNING_IDENTITY="Developer ID Application: Your Name ($TEAM_ID)"
 # certificate so they can claim the data protection keychain access group.
 export PROVISIONING_PROFILE_PATH="$HOME/.config/apple/workspaces.provisionprofile"
 
-# Your Apple ID email (used for notarization)
-export APPLE_ID="your.email@example.com"
-
-# App-specific password for notarization
-# Create one at: https://appleid.apple.com -> App-Specific Passwords
-# Store securely - never share or commit this!
-export APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
-
-# ============================================================================
-# Alternative: Keychain Storage (More Secure)
-# ============================================================================
-# Instead of storing APP_PASSWORD in this file, you can store it in Keychain:
-#
-# 1. Store the password:
-#    security add-generic-password -a "$APPLE_ID" -s "notarytool" -w "your-app-password"
-#
-# 2. Comment out APP_PASSWORD above and uncomment this:
-# export APP_PASSWORD=$(security find-generic-password -a "$APPLE_ID" -s "notarytool" -w 2>/dev/null)
-#
-# ============================================================================
+# App Store Connect API key for notarization.
+# Create this in App Store Connect > Users and Access > Integrations > App Store Connect API.
+# Store the downloaded .p8 file outside the repository.
+export APPLE_API_KEY_PATH="$HOME/.config/apple/AuthKey_XXXXXXXXXX.p8"
+export APPLE_API_KEY_ID="XXXXXXXXXX"
+export APPLE_API_ISSUER_ID="00000000-0000-0000-0000-000000000000"
 
 # ============================================================================
 # Verification Commands

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -155,6 +155,9 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("gh release download", workflow)
         self.assertIn("xcrun stapler validate", workflow)
         self.assertIn("spctl --assess", workflow)
+        self.assertIn("APPLE_API_KEY_BASE64", workflow)
+        self.assertIn("APPLE_API_KEY_ID", workflow)
+        self.assertIn("APPLE_API_ISSUER_ID", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("permissions:\n      contents: write", workflow)
         for forbidden in (
@@ -165,8 +168,23 @@ class SecurityHardeningTests(unittest.TestCase):
             'echo "APP_PASSWORD=$APPLE_APP_PASSWORD" >> "$GITHUB_ENV"',
             'echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"',
             'echo "TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"',
+            'echo "APPLE_API_KEY_PATH=$API_KEY_PATH" >> "$GITHUB_ENV"',
+            'echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"',
+            'echo "APPLE_API_ISSUER_ID=$APPLE_API_ISSUER_ID" >> "$GITHUB_ENV"',
         ):
             self.assertNotIn(forbidden, workflow)
+
+    def test_release_setup_uses_app_store_connect_api_key_notarization(self) -> None:
+        """Release setup should configure App Store Connect API-key notarization."""
+        setup_script = (REPO_ROOT / "scripts/setup-release-secrets.sh").read_text()
+        signing_template = (REPO_ROOT / "scripts/signing-config.sh.template").read_text()
+        releasing_doc = (REPO_ROOT / "RELEASING.md").read_text()
+
+        for content in (setup_script, signing_template, releasing_doc):
+            self.assertIn("APPLE_API_KEY_ID", content)
+            self.assertIn("APPLE_API_ISSUER_ID", content)
+            self.assertNotIn("APPLE_APP_PASSWORD", content)
+            self.assertNotIn("--app-password", content)
 
     def test_ci_workflows_have_explicit_permissions(self) -> None:
         """CI workflows should declare explicit top-level permissions to limit default token scope."""


### PR DESCRIPTION
## Summary

Migrates release notarization from Apple ID/app-specific password auth to App Store Connect API-key auth while preserving the hardened release workflow shape now on `main`.

Changes include:
- `release.yml` now validates `APPLE_API_KEY_BASE64`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID` instead of `APPLE_ID` / `APPLE_APP_PASSWORD`.
- The API private key is decoded to `$RUNNER_TEMP/notary-api-key.p8`, passed only to notarization steps, and deleted in the `always()` cleanup step.
- Notarization credentials are no longer exported through job-wide `$GITHUB_ENV`; they stay scoped to the preflight and packaging steps.
- `scripts/notarize.sh`, `scripts/setup-release-secrets.sh`, `scripts/signing-config.sh.template`, and `RELEASING.md` now document/use App Store Connect API-key notarization.
- Regression tests cover the release workflow secret-scoping rules and setup-script cutover.

## Security Review

The main credential threat surface is the App Store Connect `.p8` private key. This PR mitigates that by storing it only as a GitHub secret, decoding it only inside the protected release environment, using `chmod 600`, avoiding job-wide environment export, and deleting the temporary key file during cleanup. The signing job remains read-only for repository contents; GitHub Release publishing stays split into a separate `contents: write` job that does not receive signing or notarization secrets.

The old `APPLE_ID` and `APPLE_APP_PASSWORD` values are no longer used by the workflow after this cutover. Keep them until the first API-key release succeeds if you want rollback evidence; then remove them from repository secrets.

## Mergeability

- Surface: release automation / release scripts / release docs
- User-facing behavior changed: No app behavior changes; release operators now configure App Store Connect API-key notarization instead of Apple ID app-password notarization.
- Non-happy paths considered: missing API-key config fails in `Validate release secrets`; invalid API-key config fails during `notarytool history` preflight before packaging; temporary `.p8` cleanup runs on success or failure.
- Residual risk or follow-up: GitHub currently has the legacy `APPLE_ID` / `APPLE_APP_PASSWORD` secret names, but not the new `APPLE_API_*` secret names. Configure the API-key secrets before the next release dispatch, then run one release to verify notarization logs and published assets.
- Release/ops preconditions: Configure `APPLE_API_KEY_BASE64`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER_ID` repository secrets before dispatching the next release workflow. Confirmed on 2026-05-04 via `gh secret list`: the legacy Apple ID/app-password names exist and the new `APPLE_API_*` names are not present yet.

## Validation

- `uv run --script scripts/test_security_hardening.py` passed: 13 tests.
- `uv run --script scripts/validate-release-changes.py --changed-files /tmp/pr398-changed-files.json` passed, including `bash -n` for `scripts/notarize.sh` and `scripts/setup-release-secrets.sh`, plus Ruby YAML parsing for `.github/workflows/release.yml`.
- `git diff --check origin/main...HEAD` passed.
- `./scripts/notarize.sh --help` passed and no longer emits executable code in help output.
- Evidence: https://evidence.cloudcompute.com/workspaces/pr-398/20260504-144130-pr398-release-api-key-validation.svg
