### PR TITLE
web: fix local login setup flow

### DIFF
--- a/web/e2e/fast/landing.spec.ts
+++ b/web/e2e/fast/landing.spec.ts
@@ -13,4 +13,18 @@ test.describe("Landing page", () => {
 		await expect(loginLink).toBeVisible();
 		await expect(loginLink).toHaveAttribute("href", "/sign-in");
 	});
+
+	test("starts social login from the served origin", async ({ page }) => {
+		await page.goto("/sign-in");
+
+		const response = await page.request.post("/api/auth/sign-in/social", {
+			data: { provider: "github", callbackURL: "/dashboard" },
+			headers: {
+				Origin: new URL(page.url()).origin,
+			},
+		});
+
+		expect(response.status()).not.toBe(403);
+		expect(response.status()).toBeLessThan(500);
+	});
 });

--- a/web/e2e/fast/landing.spec.ts
+++ b/web/e2e/fast/landing.spec.ts
@@ -15,6 +15,11 @@ test.describe("Landing page", () => {
 	});
 
 	test("starts social login from the served origin", async ({ page }) => {
+		test.skip(
+			process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1",
+			"local server origin regression only",
+		);
+
 		await page.goto("/sign-in");
 
 		const response = await page.request.post("/api/auth/sign-in/social", {

--- a/web/e2e/seed.ts
+++ b/web/e2e/seed.ts
@@ -51,6 +51,63 @@ export default async function globalSetup() {
 	mkdirSync("data", { recursive: true });
 	const db = createClient({ url: `file:${DB_PATH}` });
 
+	await db.execute(`CREATE TABLE IF NOT EXISTS "user" (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		email TEXT NOT NULL UNIQUE,
+		emailVerified INTEGER NOT NULL DEFAULT 0,
+		image TEXT,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS session (
+		id TEXT PRIMARY KEY,
+		expiresAt TEXT NOT NULL,
+		token TEXT NOT NULL UNIQUE,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+		ipAddress TEXT,
+		userAgent TEXT,
+		userId TEXT NOT NULL,
+		FOREIGN KEY (userId) REFERENCES "user"(id) ON DELETE CASCADE
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_session_userId ON session(userId)",
+	);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS account (
+		id TEXT PRIMARY KEY,
+		accountId TEXT NOT NULL,
+		providerId TEXT NOT NULL,
+		userId TEXT NOT NULL,
+		accessToken TEXT,
+		refreshToken TEXT,
+		idToken TEXT,
+		accessTokenExpiresAt TEXT,
+		refreshTokenExpiresAt TEXT,
+		scope TEXT,
+		password TEXT,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+		FOREIGN KEY (userId) REFERENCES "user"(id) ON DELETE CASCADE
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_account_userId ON account(userId)",
+	);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS verification (
+		id TEXT PRIMARY KEY,
+		identifier TEXT NOT NULL,
+		value TEXT NOT NULL,
+		expiresAt TEXT NOT NULL,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_verification_identifier ON verification(identifier)",
+	);
+
 	await db.execute(`CREATE TABLE IF NOT EXISTS user_repos (
 		user_id TEXT NOT NULL,
 		owner TEXT NOT NULL,

--- a/web/e2e/seed.ts
+++ b/web/e2e/seed.ts
@@ -3,7 +3,10 @@ import { createClient } from "@libsql/client";
 
 const TEST_USER_ID = "dev-user";
 const TEST_REPO = "fairchild/workspaces";
-const DB_PATH = "data/auth.db";
+const DB_URL =
+	process.env.PLAYWRIGHT_DATABASE_URL ??
+	(process.env.CI ? "file:data/e2e-auth.db" : process.env.TURSO_DATABASE_URL) ??
+	"file:data/auth.db";
 
 // Deterministic IDs for cleanup
 const EVENT_IDS = [
@@ -46,10 +49,8 @@ function minutesAgo(day: number, minutes: number): string {
 }
 
 export default async function globalSetup() {
-	if (process.env.CI) return;
-
 	mkdirSync("data", { recursive: true });
-	const db = createClient({ url: `file:${DB_PATH}` });
+	const db = createClient({ url: DB_URL });
 
 	await db.execute(`CREATE TABLE IF NOT EXISTS "user" (
 		id TEXT PRIMARY KEY,

--- a/web/e2e/teardown.ts
+++ b/web/e2e/teardown.ts
@@ -1,5 +1,10 @@
 import { createClient } from "@libsql/client";
 
+const DB_URL =
+	process.env.PLAYWRIGHT_DATABASE_URL ??
+	(process.env.CI ? "file:data/e2e-auth.db" : process.env.TURSO_DATABASE_URL) ??
+	"file:data/auth.db";
+
 const EVENT_IDS = [
 	"e2e-event-ci-1",
 	"e2e-event-ci-2",
@@ -13,12 +18,17 @@ const EVENT_IDS = [
 	"e2e-event-ci-7",
 	"e2e-event-push-2",
 ];
-const CHAT_IDS = ["e2e-chat-1", "e2e-chat-2", "e2e-chat-3", "e2e-chat-4"];
+const CHAT_IDS = [
+	"e2e-chat-1",
+	"e2e-chat-2",
+	"e2e-chat-3",
+	"e2e-chat-4",
+	"e2e-chat-5",
+	"e2e-chat-6",
+];
 
 export default async function globalTeardown() {
-	if (process.env.CI) return;
-
-	const db = createClient({ url: "file:data/auth.db" });
+	const db = createClient({ url: DB_URL });
 
 	await db.execute({
 		sql: "DELETE FROM user_repos WHERE user_id = ?",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 const SKIP_WEB_SERVER = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1";
+const E2E_DATABASE_URL =
+	process.env.PLAYWRIGHT_DATABASE_URL ??
+	(process.env.CI ? "file:data/e2e-auth.db" : process.env.TURSO_DATABASE_URL);
 
 // Vercel Deployment Protection: preview URLs redirect to vercel.com/login
 // unless callers supply the Protection Bypass for Automation secret. When
@@ -69,6 +72,7 @@ export default defineConfig({
 				env: {
 					DEV_BYPASS_AUTH: "1",
 					MOCK_AGENT: "1",
+					...(E2E_DATABASE_URL ? { TURSO_DATABASE_URL: E2E_DATABASE_URL } : {}),
 				},
 			},
 });

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0e1117"/>
+  <rect x="12" y="12" width="18" height="18" rx="4" fill="#242a3a"/>
+  <rect x="34" y="12" width="18" height="18" rx="4" fill="#242a3a"/>
+  <rect x="12" y="34" width="18" height="18" rx="4" fill="#242a3a"/>
+  <rect x="34" y="34" width="18" height="18" rx="4" fill="#1a1f2e" stroke="#4a6f65" stroke-width="2"/>
+  <path d="M40 42h8l-5 5 5 5h-8l-5-5 5-5Z" fill="#a6ffdf"/>
+</svg>

--- a/web/scripts/dev-seed.js
+++ b/web/scripts/dev-seed.js
@@ -10,6 +10,63 @@ mkdirSync("data", { recursive: true });
 const db = createClient({ url: "file:data/auth.db" });
 
 (async () => {
+	await db.execute(`CREATE TABLE IF NOT EXISTS "user" (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		email TEXT NOT NULL UNIQUE,
+		emailVerified INTEGER NOT NULL DEFAULT 0,
+		image TEXT,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS session (
+		id TEXT PRIMARY KEY,
+		expiresAt TEXT NOT NULL,
+		token TEXT NOT NULL UNIQUE,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+		ipAddress TEXT,
+		userAgent TEXT,
+		userId TEXT NOT NULL,
+		FOREIGN KEY (userId) REFERENCES "user"(id) ON DELETE CASCADE
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_session_userId ON session(userId)",
+	);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS account (
+		id TEXT PRIMARY KEY,
+		accountId TEXT NOT NULL,
+		providerId TEXT NOT NULL,
+		userId TEXT NOT NULL,
+		accessToken TEXT,
+		refreshToken TEXT,
+		idToken TEXT,
+		accessTokenExpiresAt TEXT,
+		refreshTokenExpiresAt TEXT,
+		scope TEXT,
+		password TEXT,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+		FOREIGN KEY (userId) REFERENCES "user"(id) ON DELETE CASCADE
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_account_userId ON account(userId)",
+	);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS verification (
+		id TEXT PRIMARY KEY,
+		identifier TEXT NOT NULL,
+		value TEXT NOT NULL,
+		expiresAt TEXT NOT NULL,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_verification_identifier ON verification(identifier)",
+	);
+
 	await db.execute(`CREATE TABLE IF NOT EXISTS user_repos (
 		user_id TEXT NOT NULL,
 		owner TEXT NOT NULL,

--- a/web/src/app/api/repos/[owner]/[repo]/agents/route.test.ts
+++ b/web/src/app/api/repos/[owner]/[repo]/agents/route.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	bypassToken: null as string | null,
+	isRepoSaved: false,
+}));
+
+vi.mock("@/lib/agent-discovery", () => ({
+	parseAgentTree: () => ({ agents: [], skills: [], configFiles: [] }),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+	authorizeRepoAccess: vi.fn(async () =>
+		Response.json({ error: "repo not in your workspace" }, { status: 403 }),
+	),
+	unauthorizedResponse: () =>
+		Response.json({ error: "unauthorized" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+	getDevBypassToken: () => mocks.bypassToken,
+	getSession: async () => ({
+		user: { id: "user-1" },
+		session: { id: "session-1" },
+	}),
+}));
+
+vi.mock("@/lib/github", () => {
+	class GitHubApiError extends Error {
+		constructor(
+			public status: number,
+			public body: string,
+		) {
+			super(`GitHub API ${status}`);
+		}
+	}
+
+	return {
+		GitHubApiError,
+		fetchFileContent: vi.fn(),
+		fetchIssuesByLabel: vi.fn(async () => []),
+		fetchOpenPRCount: vi.fn(async () => 0),
+		fetchRepoTree: vi.fn(async () => []),
+		getGitHubToken: vi.fn(async () => "oauth-token"),
+	};
+});
+
+vi.mock("@/lib/repos", () => ({
+	isRepoOwnedByUser: vi.fn(async () => mocks.isRepoSaved),
+}));
+
+describe("repo agents route", () => {
+	beforeEach(() => {
+		mocks.bypassToken = null;
+		mocks.isRepoSaved = false;
+	});
+
+	it("allows OAuth users to scan repos that are not saved yet", async () => {
+		const { GET } = await import("./route");
+		const response = await GET(new Request("http://localhost"), {
+			params: Promise.resolve({ owner: "fairchild", repo: "workspaces" }),
+		});
+
+		expect(response.status).toBe(200);
+	});
+
+	it("keeps dev bypass scoped to saved repos", async () => {
+		mocks.bypassToken = "dev-bypass-token";
+
+		const { GET } = await import("./route");
+		const response = await GET(new Request("http://localhost"), {
+			params: Promise.resolve({ owner: "fairchild", repo: "workspaces" }),
+		});
+
+		expect(response.status).toBe(403);
+	});
+});

--- a/web/src/app/api/repos/[owner]/[repo]/agents/route.ts
+++ b/web/src/app/api/repos/[owner]/[repo]/agents/route.ts
@@ -9,6 +9,7 @@ import {
 	fetchRepoTree,
 	getGitHubToken,
 } from "@/lib/github";
+import { isRepoOwnedByUser } from "@/lib/repos";
 import type { AgentDiscoveryResponse } from "@/lib/types";
 import { PIPELINE_GITHUB_LABELS } from "@/lib/types";
 
@@ -20,15 +21,19 @@ export async function GET(
 	if (!session) return unauthorizedResponse();
 
 	const { owner, repo } = await params;
-	const unauthorized = await authorizeRepoAccess(
-		session.user.id,
-		`${owner}/${repo}`,
-	);
-	if (unauthorized) return unauthorized;
+	const repoFullName = `${owner}/${repo}`;
+	const repoIsSaved = await isRepoOwnedByUser(session.user.id, repoFullName);
 
 	let token: string;
 	const bypassToken = getDevBypassToken();
 	if (bypassToken) {
+		if (!repoIsSaved) {
+			const unauthorized = await authorizeRepoAccess(
+				session.user.id,
+				repoFullName,
+			);
+			if (unauthorized) return unauthorized;
+		}
 		token = bypassToken;
 	} else {
 		const ghToken = await getGitHubToken(session.user.id);

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -20,6 +20,9 @@ export const metadata: Metadata = {
 	title: "Spaces",
 	description: "Workspace management for AI coding sessions",
 	metadataBase: new URL("https://spaces.cloudcompute.com"),
+	icons: {
+		icon: "/favicon.svg",
+	},
 	openGraph: {
 		title: "Spaces",
 		description: "Workspace management for AI coding sessions",
@@ -36,6 +39,7 @@ export default function RootLayout({
 		<html
 			lang="en"
 			className={`${instrumentSerif.variable} ${jetbrainsMono.variable}`}
+			suppressHydrationWarning
 		>
 			<body>
 				{children}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,9 +1,21 @@
 import { betterAuth } from "better-auth";
 import { getDialect } from "./db";
 
+function getAuthBaseURL() {
+	if (process.env.BETTER_AUTH_URL) return process.env.BETTER_AUTH_URL;
+	if (process.env.NODE_ENV === "development") {
+		return {
+			allowedHosts: ["localhost:*", "127.0.0.1:*"],
+			protocol: "http" as const,
+			fallback: "http://localhost:3000",
+		};
+	}
+	return "http://localhost:3000";
+}
+
 export const auth = betterAuth({
 	secret: process.env.BETTER_AUTH_SECRET,
-	baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:3000",
+	baseURL: getAuthBaseURL(),
 	database: { dialect: getDialect(), type: "sqlite" },
 	socialProviders: {
 		github: {


### PR DESCRIPTION
## Summary

- Allow local Better Auth social sign-in to use the served localhost or 127.0.0.1 origin in development
- Seed Better Auth core tables for local dev and Playwright setup, including CI production-mode E2E runs
- Fix setup repo agent probing so OAuth users can scan candidate repos before saving them
- Suppress extension-caused root hydration warnings and add a favicon
- Add regression coverage for social login origin handling and setup agent access

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `cd web && pnpm lint`
  - `cd web && pnpm typecheck`
  - `cd web && pnpm test`
  - `cd web && env -u NODE_ENV BETTER_AUTH_SECRET=ci-placeholder-secret-for-build-only TURSO_DATABASE_URL=file::memory: pnpm build`
  - `cd web && env -u NODE_ENV CI=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3102 PORT=3102 BETTER_AUTH_SECRET=ci-placeholder-secret-for-build-only TURSO_DATABASE_URL=file::memory: pnpm exec playwright test e2e/fast/landing.spec.ts --project=fast`
  - `cd web && env -u NODE_ENV CI=1 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3102 PORT=3102 BETTER_AUTH_SECRET=ci-placeholder-secret-for-build-only TURSO_DATABASE_URL=file::memory: pnpm run test:e2e:fast`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Test results: https://evidence.cloudcompute.com/workspaces/pr-400/20260502-235107-login-setup-tests.svg
- UI screenshot: https://evidence.cloudcompute.com/workspaces/pr-400/20260502-235109-login-setup-ui.png

## Blockers

- [x] None
- [ ] Blocked on evidence
