### PR TITLE
[codex] Remove legacy Workspaces display fallbacks

### DIFF
--- a/scripts/capture-window.sh
+++ b/scripts/capture-window.sh
@@ -120,7 +120,7 @@ read_window_id() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -289,7 +289,6 @@ log_step "Stopping running app (if open)"
 osascript -e 'tell application id "com.cloudcompute.workspaces" to quit' >/dev/null 2>&1 || true
 osascript -e 'tell application "WorkspaceManager" to quit' >/dev/null 2>&1 || true
 osascript -e 'tell application "WorkSpaces" to quit' >/dev/null 2>&1 || true
-osascript -e 'tell application "Workspaces" to quit' >/dev/null 2>&1 || true
 pkill -x WorkspaceManager >/dev/null 2>&1 || true
 sleep 1
 

--- a/scripts/launch-dev.sh
+++ b/scripts/launch-dev.sh
@@ -432,7 +432,7 @@ read_window_id() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/lib/ui-test-common.sh
+++ b/scripts/lib/ui-test-common.sh
@@ -126,7 +126,7 @@ ws_get_window_geometry() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 
@@ -240,7 +240,7 @@ ws_get_window_id() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/pr-evidence.sh
+++ b/scripts/pr-evidence.sh
@@ -289,7 +289,7 @@ window_click_coordinates() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/shortcut-pass-through-smoke.sh
+++ b/scripts/shortcut-pass-through-smoke.sh
@@ -107,7 +107,7 @@ window_click_coordinates() {
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/scripts/tart-webview-demo.py
+++ b/scripts/tart-webview-demo.py
@@ -32,7 +32,7 @@ WINDOW_PROBE_SWIFT = r"""swift - <<'SWIFT'
 import CoreGraphics
 import Foundation
 
-let ownerCandidates: Set<String> = ["WorkSpaces", "Workspaces", "WorkspaceManager"]
+let ownerCandidates: Set<String> = ["WorkSpaces", "WorkspaceManager"]
 let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
 let windows = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
 
@@ -598,7 +598,6 @@ def main() -> int:
         def activate_workspace_manager() -> None:
             activate_cmd = (
                 "osascript -e 'tell application \"WorkSpaces\" to activate' "
-                "|| osascript -e 'tell application \"Workspaces\" to activate' "
                 "|| osascript -e 'tell application \"WorkspaceManager\" to activate'"
             )
             ssh_exec(ssh_client, f"{activate_cmd} >/dev/null 2>&1 || true", timeout=20)


### PR DESCRIPTION
## Summary
- remove obsolete `Workspaces` display-name fallback from window-owner probes
- remove obsolete `Workspaces` AppleScript activation and quit fallback paths
- keep `WorkSpaces` for the current display name and `WorkspaceManager` for the executable/process compatibility path

## Evidence
- ![remove-legacy-fallbacks-capture](https://evidence.cloudcompute.com/workspaces/pr-402/20260503-040126-remove-legacy-fallbacks-capture.png)

## Validation
- `swift test` passed: 487 tests
- `git diff --check` passed
- obsolete fallback scan returned no matches: `rg -n "ownerCandidates: Set<String> = \[\"WorkSpaces\", \"Workspaces\"|tell application \"Workspaces\"|\"WorkSpaces\", \"Workspaces\"" scripts Sources Tests`
- shell syntax passed: `bash -n scripts/capture-window.sh scripts/install-local.sh scripts/launch-dev.sh scripts/lib/ui-test-common.sh scripts/pr-evidence.sh scripts/shortcut-pass-through-smoke.sh`
- Python no-bytecode compile passed for `scripts/tart-webview-demo.py`
- runtime smoke passed: `./scripts/launch-dev.sh --no-build --no-activate --watch` found visible debug window id 4533, then `./scripts/capture-window.sh --output /tmp/remove-fallbacks-window.png` captured it successfully