### PR TITLE
docs: move mergeability detail out of agent startup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,13 @@
 
 -
 
+## Mergeability
+
+- Surface: desktop / web / agent-runtime / infra / docs
+- User-facing behavior changed:
+- Non-happy paths considered:
+- Residual risk or follow-up:
+
 ## Validation
 
 - [ ] `swift build`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,29 +2,9 @@
 
 Mac-native app for managing AI coding sessions with embedded terminal.
 
-## Craft and Quality Bar
+## Quality and Mergeability
 
-Craft matters in this codebase. Treat quality as part of the requested work, not as optional polish after functionality lands.
-
-- Prefer solutions that feel native, coherent, and durable over quick patches that only satisfy the narrow repro.
-- Match the existing architecture, naming, interaction patterns, and visual language before introducing new conventions.
-- Keep user-facing flows quiet, focused, and reliable; avoid adding persistent chrome, noisy affordances, or explanatory UI unless the workflow truly needs it.
-- For UI work, verify fit, spacing, focus behavior, keyboard behavior, and empty/error/loading states. A feature is not done just because the happy path compiles.
-- For service and infrastructure work, preserve clear contracts, observable error handling, and diagnostics that make production failures easier to understand.
-- Prefer small, well-finished changes with evidence over broad changes with unclear blast radius.
-
-## Definition of Mergeable
-
-Work is mergeable when it is correct, coherent with the product, reviewable, verified, and leaves the system easier to operate.
-
-- The change solves the real user or maintainer problem, not only the narrow symptom in the first repro.
-- The implementation matches existing architecture, naming, data flow, UI language, and operational conventions.
-- The scope is tight: no unrelated refactors, formatting churn, dependency changes, generated artifacts, or opportunistic rewrites.
-- User-facing work covers the non-happy paths a reviewer would expect: empty, loading, error, permissions, timing, focus, and recovery states.
-- Service and infrastructure work has clear contracts, observable failure modes, useful logs or diagnostics, and no hidden production assumptions.
-- Tests or verification evidence match the risk and blast radius. For docs-only changes, `git diff --check` plus a clear note is usually enough.
-- The PR tells a reviewer what changed, how it was verified, and what residual risk or follow-up remains.
-- If evidence is blocked, say so explicitly before merge and explain what approval or environment is needed.
+Craft matters. Work is mergeable when it is correct, coherent with the product, reviewable, verified, and leaves the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist.
 
 ## Dev Verification Practice (required)
 

--- a/docs/development/mergeability-standard.md
+++ b/docs/development/mergeability-standard.md
@@ -1,0 +1,53 @@
+# Mergeability Standard
+
+This is the full review standard behind the compact rule in `AGENTS.md`. Use it when opening, reviewing, or deciding whether to merge a PR.
+
+## Core Bar
+
+Work is mergeable when it is correct, coherent with the product, reviewable, verified, and leaves the system easier to operate.
+
+- Solve the real user or maintainer problem, not only the narrow symptom in the first repro.
+- Match existing architecture, naming, data flow, UI language, and operational conventions.
+- Keep scope tight: no unrelated refactors, formatting churn, dependency changes, generated artifacts, or opportunistic rewrites.
+- Prefer native-feeling, durable solutions over quick patches.
+- Cover the non-happy paths a reviewer would expect: empty, loading, error, permissions, timing, focus, and recovery states.
+- Preserve clear service contracts, observable failure modes, useful logs or diagnostics, and explicit production assumptions.
+- Match tests and evidence to the risk and blast radius. For docs-only changes, `git diff --check` plus a clear note is usually enough.
+- State what changed, how it was verified, and what residual risk or follow-up remains.
+- If evidence is blocked, say so explicitly before merge and explain what approval or environment is needed.
+
+## Surface Checklists
+
+### Desktop App
+
+- The terminal-first loop remains calm: select context, get a ready terminal, inspect files or changes, keep working.
+- Terminal focus, shortcut routing, restore behavior, split behavior, and no-activation behavior are considered when touched.
+- UI states fit the native Mac surface: spacing, keyboard behavior, empty/error/loading states, and visible feedback are verified.
+- Shared-desktop validation uses the documented no-activation and capture flow when relevant.
+
+### Web Dashboard
+
+- Repo scoping, auth state, loading/error/empty states, keyboard behavior, and constrained layouts are considered.
+- Agent, chat, terminal, and activity surfaces stay coordinated rather than becoming parallel sources of truth.
+- Accessibility and behavior coverage are reflected in `web/tests/LEDGER.md` when the behavior is user-visible and worth preserving.
+- Evidence uses the web mise tasks and Playwright artifacts when runtime UI behavior changes.
+
+### Agent Runtime
+
+- Sandbox creation, auth/token plumbing, streaming, snapshot/restore, and terminal attach behavior are proven when touched.
+- Production-like agent paths are validated when unit tests cannot cover the real failure mode.
+- Logs and diagnostics make failed sandbox, stream, or provider interactions understandable without guessing.
+- Public or GitHub-sourced text remains untrusted input across privileged execution boundaries.
+
+### Infrastructure, CI, and Release
+
+- Runner choice, secrets, permissions, rollback, and failure notifications are explicit.
+- Performance-sensitive changes include canonical before/after/delta evidence from the configured scenario contract.
+- CI changes avoid bare `self-hosted` labels and preserve the repo's runner policy.
+- Release/signing/notarization changes keep version metadata and artifact provenance aligned.
+
+### Docs and Config
+
+- Normative docs stay aligned with `AGENTS.md`, the PR template, and `docs/development/evidence.md`.
+- Configuration changes explain the operational effect and any environment-specific assumptions.
+- Docs-only changes should still pass `git diff --check` and mark evidence as not applicable in the PR.


### PR DESCRIPTION
## Summary
- Compress AGENTS.md quality guidance into a compact startup rule and pointer
- Move the full mergeability checklist into docs/development/mergeability-standard.md
- Add concise mergeability prompts to the PR template where they are used

## Mergeability
- Surface: docs / repo process
- User-facing behavior changed: new agent sessions carry less startup guidance while preserving the full quality standard in a referenced doc
- Non-happy paths considered: docs-only changes still point reviewers to evidence and blocked-evidence handling
- Residual risk or follow-up: none

## Validation
- [x] Other checks run: git diff --cached --check

## Performance
- [x] Not a performance-sensitive change

## Evidence
- [x] Not a testable change (docs-only, config)

Evidence links:
- Not applicable; docs-only process change

## Blockers
- [x] None