### PR TITLE
ci: add pull request readiness gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - Surface: desktop / web / agent-runtime / infra / docs
 - User-facing behavior changed:
 - Non-happy paths considered:
+- Release/ops preconditions:
 - Residual risk or follow-up:
 
 ## Validation
@@ -68,4 +69,4 @@ Evidence links:
 - [ ] None
 - [ ] Blocked on evidence
 
-If blocked on evidence, explain why here. Do not merge UI-affecting work without explicit approval to ship without visual proof.
+If blocked on evidence, explain why here. UI-affecting work needs explicit approval before shipping without visual proof.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,7 +129,7 @@ jobs:
           node scripts/playwright-findings.js playwright-report.json > findings.md || echo "_findings script failed_" > findings.md
           exit $PW_EXIT
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-findings
           path: web/findings.md
@@ -171,7 +171,7 @@ jobs:
           node scripts/lhci-findings.js .lighthouseci/assertion-results.json > findings.md || echo "_findings script failed_" > findings.md
           exit $LHCI_EXIT
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: lighthouse-findings
           path: web/findings.md
@@ -298,7 +298,7 @@ jobs:
           node scripts/playwright-findings.js prod-report.json > findings.md || echo "_findings script failed_" > findings.md
           exit $PW_EXIT
       - if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: prod-validate-findings
           path: web/findings.md

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -1,0 +1,69 @@
+name: PR Readiness
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-readiness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  readiness:
+    if: "!github.event.pull_request.draft"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          CHANGED_FILES_PATH: ${{ runner.temp }}/changed-files.json
+        with:
+          script: |
+            const fs = require('fs');
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            fs.writeFileSync(process.env.CHANGED_FILES_PATH, JSON.stringify(files.map((file) => file.filename)));
+
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
+      - name: Validate PR readiness
+        run: uv run --script scripts/pr-readiness.py --event "$GITHUB_EVENT_PATH" --changed-files "$RUNNER_TEMP/changed-files.json"
+
+  release-change-validation:
+    if: "!github.event.pull_request.draft"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          CHANGED_FILES_PATH: ${{ runner.temp }}/changed-files.json
+        with:
+          script: |
+            const fs = require('fs');
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            fs.writeFileSync(process.env.CHANGED_FILES_PATH, JSON.stringify(files.map((file) => file.filename)));
+
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
+      - name: Validate release-sensitive changes
+        run: uv run --script scripts/validate-release-changes.py --changed-files "$RUNNER_TEMP/changed-files.json"

--- a/docs/development/mergeability-standard.md
+++ b/docs/development/mergeability-standard.md
@@ -15,6 +15,7 @@ Work is mergeable when it is correct, coherent with the product, reviewable, ver
 - Match tests and evidence to the risk and blast radius. For docs-only changes, `git diff --check` plus a clear note is usually enough.
 - State what changed, how it was verified, and what residual risk or follow-up remains.
 - If evidence is blocked, say so explicitly before merge and explain what approval or environment is needed.
+- Use machine-readable blocker labels when a PR is not merge-ready: `blocked:ci`, `blocked:secrets`, `blocked:evidence`, or `blocked:review`.
 
 ## Surface Checklists
 
@@ -42,6 +43,7 @@ Work is mergeable when it is correct, coherent with the product, reviewable, ver
 ### Infrastructure, CI, and Release
 
 - Runner choice, secrets, permissions, rollback, and failure notifications are explicit.
+- Release-sensitive PRs fill `Release/ops preconditions` in the PR template and should not merge while required secrets, credentials, or operator steps remain incomplete.
 - Performance-sensitive changes include canonical before/after/delta evidence from the configured scenario contract.
 - CI changes avoid bare `self-hosted` labels and preserve the repo's runner policy.
 - Release/signing/notarization changes keep version metadata and artifact provenance aligned.

--- a/scripts/pr-readiness.py
+++ b/scripts/pr-readiness.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Validate PR readiness signals from the GitHub pull_request event."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SURFACE = "desktop / web / agent-runtime / infra / docs"
+RELEASE_PATHS = {
+    ".github/workflows/release.yml",
+    "scripts/build-release.sh",
+    "scripts/notarize.sh",
+    "scripts/prepare-release.sh",
+    "scripts/release-preflight.sh",
+    "scripts/release-version.sh",
+    "scripts/setup-release-secrets.sh",
+    "scripts/verify-app-keychain-signing.sh",
+    "scripts/verify-p12.sh",
+    "scripts/verify-release-bundle.sh",
+}
+
+
+@dataclass(frozen=True)
+class Result:
+    failures: list[str]
+    notices: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+def load_json(path: str | None, default: Any) -> Any:
+    if not path:
+        return default
+    with Path(path).open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def extract_section(body: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"(?ims)^##+\s+{re.escape(heading)}\s*$\n(?P<section>.*?)(?=^##+\s+\S|\Z)"
+    )
+    match = pattern.search(body)
+    return match.group("section").strip() if match else ""
+
+
+def field_value(section: str, label: str) -> str | None:
+    pattern = re.compile(rf"(?im)^[ \t]*[-*][ \t]*{re.escape(label)}[ \t]*:[ \t]*(?P<value>.*)$")
+    match = pattern.search(section)
+    if not match:
+        return None
+    return match.group("value").strip()
+
+
+def is_blank_value(value: str | None, *, default: str | None = None) -> bool:
+    if value is None:
+        return True
+    normalized = normalize(value)
+    if not normalized or normalized in {"-", "n/a", "tbd", "todo", "pending"}:
+        return True
+    return default is not None and normalized == normalize(default)
+
+
+def label_names(pr: dict[str, Any]) -> list[str]:
+    return [item.get("name", "") for item in pr.get("labels", []) if isinstance(item, dict)]
+
+
+def has_checked_box(body: str, label: str) -> bool:
+    return bool(re.search(rf"(?im)^\s*[-*]\s*\[x\]\s*{re.escape(label)}\b", body))
+
+
+def has_any_evidence(body: str) -> bool:
+    lowered = body.lower()
+    return any(
+        (
+            "evidence.cloudcompute.com" in lowered,
+            bool(re.search(r"!\[.*\]\(https?://", body)),
+            bool(re.search(r"(?i)(test|tests).*(pass|passed)|\d+\s+passed", body)),
+            has_checked_box(body, "Not a testable change"),
+        )
+    )
+
+
+def changed_release_files(files: list[str]) -> list[str]:
+    return [path for path in files if path in RELEASE_PATHS]
+
+
+def evaluate(pr: dict[str, Any], files: list[str]) -> Result:
+    body = pr.get("body") or ""
+    title = pr.get("title") or ""
+    labels = label_names(pr)
+    failures: list[str] = []
+    notices: list[str] = []
+
+    if pr.get("draft"):
+        notices.append("Draft PR: readiness gate is advisory until the PR is ready for review.")
+        return Result(failures, notices)
+
+    mergeability = extract_section(body, "Mergeability")
+    if not mergeability:
+        failures.append("Missing ## Mergeability section from the PR body.")
+    else:
+        required = {
+            "Surface": DEFAULT_SURFACE,
+            "User-facing behavior changed": None,
+            "Non-happy paths considered": None,
+            "Residual risk or follow-up": None,
+        }
+        for field, default in required.items():
+            value = field_value(mergeability, field)
+            if is_blank_value(value, default=default):
+                failures.append(f"Mergeability field is empty or still default: {field}.")
+
+    blocking_labels = sorted(label for label in labels if label.startswith("blocked:"))
+    if blocking_labels:
+        failures.append(f"Blocking label present: {', '.join(blocking_labels)}.")
+
+    if has_checked_box(body, "Blocked on evidence"):
+        failures.append("PR is checked as blocked on evidence.")
+
+    if re.search(r"(?i)\bdo not merge(?:\s+this\s+pr|\s+until|\b)", f"{title}\n{body}"):
+        failures.append("PR text contains a merge-stop instruction.")
+
+    if not has_any_evidence(body):
+        failures.append("No test/evidence signal found in PR body.")
+
+    release_files = changed_release_files(files)
+    if release_files:
+        release_preconditions = field_value(mergeability, "Release/ops preconditions")
+        if is_blank_value(release_preconditions):
+            failures.append(
+                "Release-sensitive files changed; fill 'Release/ops preconditions' in the PR body."
+            )
+
+        if re.search(r"(?i)(secret|credential).{0,80}(must|need|required).{0,80}before merging", body):
+            failures.append(
+                "Release PR says secrets/credentials must be added before merging; use blocked:secrets until complete."
+            )
+
+        validation = extract_section(body, "Validation")
+        if not re.search(r"(?i)(validate-release-changes|bash -n|actionlint|workflow syntax)", validation):
+            failures.append(
+                "Release-sensitive files changed; validation should include validate-release-changes, bash -n, actionlint, or workflow syntax proof."
+            )
+
+    return Result(failures, notices)
+
+
+def emit(result: Result) -> None:
+    for notice in result.notices:
+        print(f"::notice::{notice}" if os.environ.get("GITHUB_ACTIONS") else f"NOTICE: {notice}")
+
+    if result.failures:
+        print("PR readiness failed:")
+        for failure in result.failures:
+            prefix = "::error::" if os.environ.get("GITHUB_ACTIONS") else "ERROR:"
+            print(f"{prefix}{failure}")
+    else:
+        print("PR readiness passed.")
+
+    if summary_path := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary_path).open("a", encoding="utf-8") as summary:
+            summary.write("## PR Readiness\n\n")
+            if result.ok:
+                summary.write("- Status: pass\n")
+            else:
+                summary.write("- Status: fail\n")
+                for failure in result.failures:
+                    summary.write(f"- {failure}\n")
+            for notice in result.notices:
+                summary.write(f"- Notice: {notice}\n")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", default=os.environ.get("GITHUB_EVENT_PATH"))
+    parser.add_argument("--changed-files", help="JSON file containing a list of changed file paths.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    event = load_json(args.event, {})
+    pr = event.get("pull_request") or event
+    files = load_json(args.changed_files, [])
+    result = evaluate(pr, files)
+    emit(result)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test_pr_readiness.py
+++ b/scripts/test_pr_readiness.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for scripts/pr-readiness.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pr-readiness.py"
+
+spec = importlib.util.spec_from_file_location("pr_readiness", SCRIPT_PATH)
+assert spec and spec.loader
+pr_readiness = importlib.util.module_from_spec(spec)
+sys.modules["pr_readiness"] = pr_readiness
+spec.loader.exec_module(pr_readiness)
+
+
+def pr(body: str, *, labels: list[str] | None = None, draft: bool = False) -> dict:
+    return {
+        "title": "Example PR",
+        "body": body,
+        "draft": draft,
+        "labels": [{"name": name} for name in labels or []],
+    }
+
+
+GOOD_BODY = """## Summary
+
+- Improve callback helper maintainability
+
+## Mergeability
+
+- Surface: desktop
+- User-facing behavior changed: none; refactor only
+- Non-happy paths considered: nil userdata and zero address behavior covered
+- Release/ops preconditions: not applicable
+- Residual risk or follow-up: none
+
+## Validation
+
+- [x] Other checks run: swift test --filter GhosttyCallbackUserdata
+
+## Evidence
+
+- ![tests](https://evidence.cloudcompute.com/workspaces/pr-1/tests.svg)
+
+## Blockers
+
+- [x] None
+- [ ] Blocked on evidence
+"""
+
+
+class PRReadinessTests(unittest.TestCase):
+    def test_clean_pr_passes(self) -> None:
+        result = pr_readiness.evaluate(pr(GOOD_BODY), ["Sources/WorkspaceManager/Foo.swift"])
+        self.assertEqual(result.failures, [])
+
+    def test_default_mergeability_surface_fails(self) -> None:
+        body = GOOD_BODY.replace("- Surface: desktop", "- Surface: desktop / web / agent-runtime / infra / docs")
+        result = pr_readiness.evaluate(pr(body), ["Sources/WorkspaceManager/Foo.swift"])
+        self.assertIn("Mergeability field is empty or still default: Surface.", result.failures)
+
+    def test_blocked_label_fails(self) -> None:
+        result = pr_readiness.evaluate(pr(GOOD_BODY, labels=["blocked:ci"]), [])
+        self.assertIn("Blocking label present: blocked:ci.", result.failures)
+
+    def test_checked_blocked_evidence_fails(self) -> None:
+        body = GOOD_BODY.replace("- [ ] Blocked on evidence", "- [x] Blocked on evidence")
+        result = pr_readiness.evaluate(pr(body), [])
+        self.assertIn("PR is checked as blocked on evidence.", result.failures)
+
+    def test_template_guidance_does_not_trigger_merge_stop(self) -> None:
+        body = GOOD_BODY + "\nUI-affecting work needs explicit approval before shipping without visual proof.\n"
+        result = pr_readiness.evaluate(pr(body), [])
+        self.assertEqual(result.failures, [])
+
+    def test_explicit_do_not_merge_fails(self) -> None:
+        body = GOOD_BODY + "\nDo not merge this PR until the secret is present.\n"
+        result = pr_readiness.evaluate(pr(body), [])
+        self.assertIn("PR text contains a merge-stop instruction.", result.failures)
+
+    def test_release_pr_requires_preconditions(self) -> None:
+        body = GOOD_BODY.replace("- Release/ops preconditions: not applicable", "- Release/ops preconditions:")
+        result = pr_readiness.evaluate(pr(body), [".github/workflows/release.yml"])
+        self.assertIn(
+            "Release-sensitive files changed; fill 'Release/ops preconditions' in the PR body.",
+            result.failures,
+        )
+
+    def test_release_pr_with_unresolved_secret_precondition_fails(self) -> None:
+        body = GOOD_BODY + "\nThree new GitHub secrets must be added BEFORE merging.\n"
+        result = pr_readiness.evaluate(pr(body), ["scripts/notarize.sh"])
+        self.assertIn(
+            "Release PR says secrets/credentials must be added before merging; use blocked:secrets until complete.",
+            result.failures,
+        )
+
+    def test_draft_pr_is_advisory(self) -> None:
+        result = pr_readiness.evaluate(pr("", draft=True), [".github/workflows/release.yml"])
+        self.assertEqual(result.failures, [])
+        self.assertTrue(result.notices)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_release_changes.py
+++ b/scripts/test_validate_release_changes.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for scripts/validate-release-changes.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate-release-changes.py"
+
+spec = importlib.util.spec_from_file_location("validate_release_changes", SCRIPT_PATH)
+assert spec and spec.loader
+validate_release_changes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validate_release_changes)
+
+
+class ValidateReleaseChangesTests(unittest.TestCase):
+    def test_filters_to_release_sensitive_files(self) -> None:
+        files = validate_release_changes.release_files(
+            [
+                "README.md",
+                ".github/workflows/release.yml",
+                "scripts/notarize.sh",
+                "scripts/unrelated.sh",
+            ]
+        )
+        self.assertEqual(files, [".github/workflows/release.yml", "scripts/notarize.sh"])
+
+    def test_no_release_files_returns_empty(self) -> None:
+        self.assertEqual(validate_release_changes.release_files(["README.md"]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-release-changes.py
+++ b/scripts/validate-release-changes.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Run focused syntax checks for release-sensitive PR changes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_PATHS = {
+    ".github/workflows/release.yml",
+    "scripts/build-release.sh",
+    "scripts/notarize.sh",
+    "scripts/prepare-release.sh",
+    "scripts/release-preflight.sh",
+    "scripts/release-version.sh",
+    "scripts/setup-release-secrets.sh",
+    "scripts/verify-app-keychain-signing.sh",
+    "scripts/verify-p12.sh",
+    "scripts/verify-release-bundle.sh",
+}
+
+
+def load_files(path: str | None) -> list[str]:
+    if not path:
+        return []
+    with Path(path).open(encoding="utf-8") as file:
+        data = json.load(file)
+    return [str(item) for item in data]
+
+
+def run(command: list[str]) -> int:
+    print("$", shlex.join(command), flush=True)
+    result = subprocess.run(command, cwd=REPO_ROOT, text=True, check=False)
+    return result.returncode
+
+
+def validate_shell(path: str) -> int:
+    return run(["bash", "-n", path])
+
+
+def validate_workflow_yaml(path: str) -> int:
+    if not shutil.which("ruby"):
+        print("notice: ruby unavailable; skipping YAML parser check")
+        return 0
+    script = "require 'yaml'; YAML.load_file(ARGV.fetch(0)); puts 'YAML parse OK'"
+    return run(["ruby", "-e", script, path])
+
+
+def release_files(files: list[str]) -> list[str]:
+    return [path for path in files if path in RELEASE_PATHS]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changed-files", required=True, help="JSON file containing changed file paths.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    files = release_files(load_files(args.changed_files))
+    if not files:
+        print("No release-sensitive files changed.")
+        return 0
+
+    print("Release-sensitive files changed:", flush=True)
+    for path in files:
+        print(f"- {path}")
+
+    status = 0
+    for path in files:
+        if path.endswith(".sh") and (REPO_ROOT / path).exists():
+            status |= validate_shell(path)
+
+    if ".github/workflows/release.yml" in files:
+        status |= validate_workflow_yaml(".github/workflows/release.yml")
+
+    if status == 0:
+        print("Release change validation passed.")
+    else:
+        print("Release change validation failed.", file=sys.stderr)
+    return 1 if status else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Add a PR Readiness workflow that validates mergeability fields, blocker labels/text, evidence signals, and release-sensitive preconditions
- Add a focused release-change validator for shell syntax and release workflow YAML parsing
- Add tests for the new validators and pin existing upload-artifact refs in cd.yml so workflow hardening stays green

## Mergeability
- Surface: infra / docs
- User-facing behavior changed: PRs now get an explicit readiness check that surfaces missing mergeability fields, blockers, evidence gaps, and release preconditions before review
- Non-happy paths considered: draft PRs are advisory, blocker labels fail readiness, checked evidence blockers fail readiness, template guidance does not trigger false merge-stop failures, and release PRs with unresolved secrets are blocked
- Release/ops preconditions: no new secrets or operator setup required; workflow uses read-only PR permissions and pinned third-party actions
- Residual risk or follow-up: existing open PRs only pick this up on edit/synchronize/label events; old PR bodies may need template fields filled when touched

## Validation
- [x] Other checks run: uv run --script scripts/test_pr_readiness.py
- [x] Other checks run: uv run --script scripts/test_validate_release_changes.py
- [x] Other checks run: uv run --script scripts/test_security_hardening.py
- [x] Other checks run: ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-readiness.yml'); YAML.load_file('.github/workflows/cd.yml'); puts 'YAML parse OK'"
- [x] Other checks run: uv run --script scripts/validate-release-changes.py --changed-files /tmp/release-files.json
- [x] Other checks run: git diff --cached --check

Tests passed locally: readiness tests, release validator tests, workflow hardening tests, YAML parse checks, and synthetic release-change validation all passed.

## Performance
- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:
- Scenario ID: not applicable
- Before Summary: not applicable
- After Summary: not applicable
- Delta Summary: not applicable

Performance comparison notes:
- Exact commands used: not applicable
- Workload / environment context: not applicable

## Evidence
- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:
- Local command output summarized above; no UI evidence applicable for workflow/script validation

## Blockers
- [x] None
- [ ] Blocked on evidence