### PR TITLE
docs: define agent startup instruction budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,13 @@ Mac-native app for managing AI coding sessions with embedded terminal.
 
 ## Quality and Mergeability
 
-Craft matters. Work is mergeable when it is correct, coherent with the product, reviewable, verified, and leaves the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist.
+Craft matters. Plan work so it can land mergeably: correct, coherent with the product, reviewable, verified, and leaving the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist.
+
+## Startup Instruction Budget
+
+`AGENTS.md` is startup context for every repo session. Keep it under about **4,500 tokens** (roughly **3,300 words**) unless the added guidance is more important than the recurring context cost. Prefer tightening, deduplicating, or moving detailed policy into linked docs over expanding this file.
+
+Continuous improvement of `AGENTS.md` is important to the health and longevity of the codebase: it is how this repo teaches future agents to meet product, quality, evidence, and operational objectives. Improve it when the guidance becomes clearer, shorter, or more actionable.
 
 ## Dev Verification Practice (required)
 


### PR DESCRIPTION
## Summary
- Keep mergeability expectations visible in startup guidance as a planning constraint
- Define the AGENTS.md startup budget at about 4,500 tokens / 3,300 words
- State that continuous improvement of AGENTS.md matters, while favoring clearer and shorter guidance over expansion

## Mergeability
- Surface: docs
- User-facing behavior changed: future agent sessions get compact guidance to plan toward mergeable outcomes while preserving the startup-token budget
- Non-happy paths considered: detailed policy remains linked instead of copied into startup context; AGENTS.md remains under the stated word proxy budget
- Release/ops preconditions: not applicable
- Residual risk or follow-up: none

## Validation
- [x] Other checks run: git diff --check
- [x] Other checks run: wc -w AGENTS.md

AGENTS.md word count: 3,075, under the stated 3,300-word proxy budget.

## Performance
- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:
- Scenario ID: not applicable
- Before Summary: not applicable
- After Summary: not applicable
- Delta Summary: not applicable

Performance comparison notes:
- Exact commands used: not applicable
- Workload / environment context: not applicable

## Evidence
- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:
- Not applicable; docs-only startup guidance change

## Blockers
- [x] None
- [ ] Blocked on evidence