### PR TITLE
Add desktop terminal continuity manifest

### DIFF
--- a/Sources/WorkspaceManager/App/TerminalMultiplexingMode.swift
+++ b/Sources/WorkspaceManager/App/TerminalMultiplexingMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum TerminalMultiplexingMode: String, CaseIterable, Identifiable {
+enum TerminalMultiplexingMode: String, CaseIterable, Identifiable, Codable {
     case ghosttyManagedSplits = "ghostty_managed_splits"
     case tmuxPerSession = "tmux_per_session"
 

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -136,7 +136,7 @@ struct GhosttyTerminalConfig {
         return false
     }
 
-    private static func tmuxSessionName(for directory: URL) -> String {
+    static func tmuxSessionName(for directory: URL) -> String {
         let normalizedPath = directory
             .standardizedFileURL
             .resolvingSymlinksInPath()

--- a/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
@@ -1,0 +1,106 @@
+//
+//  TerminalContinuityManifest.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+struct TerminalContinuityManifest: Codable, Equatable {
+    enum TargetKind: String, Codable {
+        case repo
+        case workspace
+    }
+
+    static let storageKey = "terminalContinuity.manifest.v1"
+
+    let version: Int
+    let targetKind: TargetKind
+    let targetID: UUID
+    let rootPath: String
+    let launchPath: String
+    let terminalMode: TerminalMultiplexingMode
+    let tmuxSessionName: String
+    let updatedAt: Date
+
+    init(
+        targetKind: TargetKind,
+        targetID: UUID,
+        rootURL: URL,
+        launchURL: URL,
+        terminalMode: TerminalMultiplexingMode,
+        updatedAt: Date = Date()
+    ) {
+        let normalizedRoot = Self.normalizedPath(for: rootURL)
+        let normalizedLaunch = Self.normalizedPath(for: launchURL)
+
+        self.version = 1
+        self.targetKind = targetKind
+        self.targetID = targetID
+        self.rootPath = normalizedRoot
+        self.launchPath = normalizedLaunch
+        self.terminalMode = terminalMode
+        self.tmuxSessionName = GhosttyTerminalConfig.tmuxSessionName(
+            for: URL(fileURLWithPath: normalizedLaunch, isDirectory: true)
+        )
+        self.updatedAt = updatedAt
+    }
+
+    var rawValue: String {
+        guard let data = try? JSONEncoder().encode(self) else { return "" }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    static func decode(from rawValue: String) -> TerminalContinuityManifest? {
+        guard !rawValue.isEmpty else { return nil }
+        guard let data = rawValue.data(using: .utf8) else { return nil }
+        guard let manifest = try? JSONDecoder().decode(TerminalContinuityManifest.self, from: data) else {
+            return nil
+        }
+        guard manifest.version == 1 else { return nil }
+        return manifest
+    }
+
+    func launchDirectory(
+        for targetKind: TargetKind,
+        targetID: UUID,
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let normalizedRoot = Self.normalizedPath(for: rootURL)
+        guard self.targetKind == targetKind,
+            self.targetID == targetID,
+            rootPath == normalizedRoot
+        else {
+            return nil
+        }
+
+        if Self.isExistingDirectory(launchPath, fileManager: fileManager),
+            Self.path(launchPath, isInside: normalizedRoot)
+        {
+            return URL(fileURLWithPath: launchPath, isDirectory: true)
+        }
+
+        guard Self.isExistingDirectory(normalizedRoot, fileManager: fileManager) else {
+            return nil
+        }
+        return URL(fileURLWithPath: normalizedRoot, isDirectory: true)
+    }
+
+    private static func normalizedPath(for url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private static func isExistingDirectory(_ path: String, fileManager: FileManager) -> Bool {
+        var isDirectory = ObjCBool(false)
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory) else {
+            return false
+        }
+        return isDirectory.boolValue
+    }
+
+    private static func path(_ path: String, isInside root: String) -> Bool {
+        if path == root { return true }
+        guard root != "/" else { return true }
+        return path.hasPrefix(root + "/")
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -34,6 +34,8 @@ struct ContentView: View {
     @Query(sort: \WebSource.addedAt, order: .reverse) private var webSources: [WebSource]
     @AppStorage(TerminalMultiplexingMode.storageKey)
     private var terminalMultiplexingModeRawValue: String = TerminalMultiplexingMode.defaultValue.rawValue
+    @AppStorage(TerminalContinuityManifest.storageKey)
+    private var terminalContinuityManifestRawValue = ""
     @AppStorage(NotificationConstants.enabledKey)
     private var notificationsEnabled = NotificationConstants.defaultEnabled
     @Environment(\.externalEditorService) private var externalEditorService
@@ -1098,9 +1100,15 @@ struct ContentView: View {
         case .repoOverview(let repo):
             handleRepoSelection(repo)
         case .repoTerminal(let repo):
-            handleRepoTerminalSelection(repo)
+            handleRepoTerminalSelection(
+                repo,
+                preferredDirectory: restoredLaunchDirectory(for: repo)
+            )
         case .workspace(let workspace):
-            handleWorkspaceSelection(workspace)
+            handleWorkspaceSelection(
+                workspace,
+                preferredDirectory: restoredLaunchDirectory(for: workspace)
+            )
         case .webView(let source):
             handleWebSourceSelection(source)
         }
@@ -1134,6 +1142,12 @@ struct ContentView: View {
         let session = activateHostSession(
             key: .repoPath(repoDirectory.path),
             directory: launchDirectory
+        )
+        persistTerminalContinuity(
+            targetKind: .repo,
+            targetID: repo.id,
+            rootURL: repoDirectory,
+            launchURL: launchDirectory
         )
         terminalFocusCoordinator.beginRepoClickMeasurement(
             sessionID: session.id,
@@ -1176,6 +1190,12 @@ struct ContentView: View {
             let session = activateHostSession(
                 key: .hostPath(workspaceDirectory.path),
                 directory: launchDirectory
+            )
+            persistTerminalContinuity(
+                targetKind: .workspace,
+                targetID: workspace.id,
+                rootURL: workspaceDirectory,
+                launchURL: launchDirectory
             )
             terminalFocusCoordinator.beginWorkspaceClickMeasurement(
                 sessionID: session.id,
@@ -1931,6 +1951,53 @@ struct ContentView: View {
 
     private func persistLastSurface(_ surface: MainWindowLastSurface) {
         lastSurfaceRawValue = surface.rawValue
+    }
+
+    private func persistTerminalContinuity(
+        targetKind: TerminalContinuityManifest.TargetKind,
+        targetID: UUID,
+        rootURL: URL,
+        launchURL: URL
+    ) {
+        let manifest = TerminalContinuityManifest(
+            targetKind: targetKind,
+            targetID: targetID,
+            rootURL: rootURL,
+            launchURL: launchURL,
+            terminalMode: TerminalMultiplexingMode(rawValue: terminalMultiplexingModeRawValue)
+                ?? TerminalMultiplexingMode.defaultValue
+        )
+        terminalContinuityManifestRawValue = manifest.rawValue
+        NSLog(
+            "[TerminalContinuity] persisted kind=%@ id=%@ root=%@ launch=%@ tmux_session=%@ mode=%@",
+            targetKind.rawValue,
+            targetID.uuidString,
+            manifest.rootPath,
+            manifest.launchPath,
+            manifest.tmuxSessionName,
+            manifest.terminalMode.rawValue
+        )
+    }
+
+    private func restoredLaunchDirectory(for repo: Repo) -> URL? {
+        let repoDirectory = repo.localURL.standardizedFileURL.resolvingSymlinksInPath()
+        return TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue)?
+            .launchDirectory(
+                for: .repo,
+                targetID: repo.id,
+                rootURL: repoDirectory
+            )
+    }
+
+    private func restoredLaunchDirectory(for workspace: Workspace) -> URL? {
+        guard workspace.backend == .local else { return nil }
+        let workspaceDirectory = workspace.workspaceURL.standardizedFileURL.resolvingSymlinksInPath()
+        return TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue)?
+            .launchDirectory(
+                for: .workspace,
+                targetID: workspace.id,
+                rootURL: workspaceDirectory
+            )
     }
 
     private func terminalContextMenu(for session: HostTerminalSession) -> NSMenu? {

--- a/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
@@ -1,0 +1,126 @@
+//
+//  TerminalContinuityManifestTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("TerminalContinuityManifest")
+struct TerminalContinuityManifestTests {
+    @Test("Manifest round trips terminal continuity fields")
+    func manifestRoundTrips() throws {
+        let targetID = UUID()
+        let manifest = TerminalContinuityManifest(
+            targetKind: .workspace,
+            targetID: targetID,
+            rootURL: URL(fileURLWithPath: "/tmp/repo/workspace", isDirectory: true),
+            launchURL: URL(fileURLWithPath: "/tmp/repo/workspace/subdir", isDirectory: true),
+            terminalMode: .tmuxPerSession,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let decoded = try #require(TerminalContinuityManifest.decode(from: manifest.rawValue))
+
+        #expect(decoded == manifest)
+        #expect(decoded.targetKind == .workspace)
+        #expect(decoded.targetID == targetID)
+        #expect(decoded.terminalMode == .tmuxPerSession)
+        #expect(decoded.tmuxSessionName.hasPrefix("wm-subdir-"))
+    }
+
+    @Test("Launch directory restores only for matching target")
+    func launchDirectoryRequiresMatchingTarget() throws {
+        let root = try temporaryDirectory()
+        let child = root.appendingPathComponent("child", isDirectory: true)
+        try FileManager.default.createDirectory(at: child, withIntermediateDirectories: true)
+
+        let targetID = UUID()
+        let manifest = TerminalContinuityManifest(
+            targetKind: .repo,
+            targetID: targetID,
+            rootURL: root,
+            launchURL: child,
+            terminalMode: .tmuxPerSession
+        )
+
+        #expect(
+            manifest.launchDirectory(
+                for: .repo,
+                targetID: targetID,
+                rootURL: root
+            )?.path == child.path
+        )
+        #expect(
+            manifest.launchDirectory(
+                for: .workspace,
+                targetID: targetID,
+                rootURL: root
+            ) == nil
+        )
+        #expect(
+            manifest.launchDirectory(
+                for: .repo,
+                targetID: UUID(),
+                rootURL: root
+            ) == nil
+        )
+    }
+
+    @Test("Missing launch directory falls back to root")
+    func missingLaunchDirectoryFallsBackToRoot() throws {
+        let root = try temporaryDirectory()
+        let missingChild = root.appendingPathComponent("missing", isDirectory: true)
+        let targetID = UUID()
+        let manifest = TerminalContinuityManifest(
+            targetKind: .workspace,
+            targetID: targetID,
+            rootURL: root,
+            launchURL: missingChild,
+            terminalMode: .ghosttyManagedSplits
+        )
+
+        let restored = try #require(
+            manifest.launchDirectory(
+                for: .workspace,
+                targetID: targetID,
+                rootURL: root
+            )
+        )
+
+        #expect(restored.path == root.path)
+    }
+
+    @Test("Launch directory outside root is rejected")
+    func launchDirectoryOutsideRootIsRejected() throws {
+        let root = try temporaryDirectory()
+        let outside = try temporaryDirectory()
+        let targetID = UUID()
+        let manifest = TerminalContinuityManifest(
+            targetKind: .repo,
+            targetID: targetID,
+            rootURL: root,
+            launchURL: outside,
+            terminalMode: .tmuxPerSession
+        )
+
+        let restored = try #require(
+            manifest.launchDirectory(
+                for: .repo,
+                targetID: targetID,
+                rootURL: root
+            )
+        )
+
+        #expect(restored.path == root.path)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalContinuityManifestTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+}

--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -162,7 +162,7 @@ Phase 1 complete: `AppActivationPolicy` (PR #374) gates all `NSApp.activate` cal
 
 `backlog/tmux-support_plan.md` (multiplexing implementation), `backlog/desktop-continuity_plan.md` (across-session restore)
 
-Decided 2026-04-23 (`docs/decisions/terminal-multiplexing.md`): tmux primary; pane-tree deferred indefinitely. Two paired plans now sit under one theme. Tmux delivers reattach within a session. The continuity plan addresses the gap tmux does not close (close laptop, reopen, pick up where you left off). Implement tmux first; promote continuity to active when the gap is reproducible against the new model.
+Decided 2026-04-23 (`docs/decisions/terminal-multiplexing.md`): tmux primary; pane-tree deferred indefinitely. Two paired plans now sit under one theme. Tmux delivers reattach within a session. The continuity plan addresses the gap tmux does not close (close laptop, reopen, pick up where you left off). First continuity slice is active on `codex-continuity-dimension`: tmux preserves live process state when the server survives, and a terminal continuity manifest records the target plus launch directory for the honest fallback when it does not.
 
 #### 5. Lume runtime architecture cleanup
 

--- a/backlog/desktop-continuity_plan.md
+++ b/backlog/desktop-continuity_plan.md
@@ -1,9 +1,10 @@
 ---
-status: pending
+status: active
 category: plan
 priority: P1
 created: 2026-04-23
 related_decision: docs/decisions/terminal-multiplexing.md
+branch: codex-continuity-dimension
 ---
 
 # Desktop Continuity — Pick Up Where You Left Off
@@ -22,6 +23,12 @@ Web has solved an analogous problem via persistent-sandbox snapshot/restore (#27
 
 Make "close the laptop, reopen tomorrow, pick up where you left off" a working desktop default for at least one well-defined daily-driver scenario.
 
+## First-phase continuity contract
+
+Scenario: a user opens a local repo or local workspace terminal, works inside a deterministic Workspaces tmux session for that terminal's launch directory, quits and reopens the app, and lands back on the same terminal target. If the OS tmux server survived, Workspaces reattaches to the same tmux session with its live cwd, panes, scrollback, and running process. If the tmux server did not survive, Workspaces falls back to the persisted terminal continuity manifest and relaunches the same terminal target from the last known launch directory, or from the target root if that directory disappeared.
+
+This is intentionally narrower than full shell resurrection. It makes the same-OS-session case genuinely continuous and makes cross-reboot recovery explicit instead of pretending in-flight processes can be recreated.
+
 ## Possible approaches (do not pre-decide)
 
 1. **Tmux as continuity.** Once tmux primary ships, every workspace terminal lives inside a tmux session whose state survives Ghostty surface restarts. Restoring on app reopen reattaches via `tmux attach`. Limitation: only survives if the tmux server itself survives, which depends on user-shell daemonization and OS reboot policy.
@@ -29,9 +36,18 @@ Make "close the laptop, reopen tomorrow, pick up where you left off" a working d
 3. **Per-workspace launchd daemon.** Run a background tmux server per workspace under launchd so the server survives logouts. Higher infra cost; clearest semantics.
 4. **Hybrid.** Tmux for survival of in-flight processes within the same OS session; restore manifest for cross-reboot recovery.
 
+First phase chooses the hybrid path because it has the clearest semantics: tmux preserves real process state when the server exists, and the manifest defines the honest fallback when it does not.
+
+## Implementation notes
+
+- `TerminalContinuityManifest` persists the last local repo/workspace terminal target, normalized root path, launch path, selected terminal multiplexing mode, deterministic Workspaces tmux session name for the launch path, and timestamp in app storage.
+- Restored repo/workspace terminal launches consult that manifest before falling back to the target root directory.
+- Remote/provider-backed workspaces are out of this first slice because their lifecycle continuity belongs to the provider-specific terminal launch contract.
+- `scripts/tmux-continuity-probe.sh` provides a manual start/check/cleanup loop for recording tmux survival across app restart, sleep/wake, logout, and reboot boundaries.
+
 ## Inputs to gather before promotion
 
-- Confirm what tmux state actually survives Ghostty surface restart vs full app restart vs full OS reboot, on real hardware.
+- Confirm what tmux state actually survives Ghostty surface restart vs full app restart vs full OS reboot, on real hardware. Use `scripts/tmux-continuity-probe.sh start <path> <label>` before the boundary and `scripts/tmux-continuity-probe.sh check <path> <label>` after it.
 - Re-read `Sources/WorkspaceManagerCore/Services/WorkspaceService.swift` for current per-workspace lifecycle hooks.
 - Re-read `backlog/done/persistent-sandbox-conversation-continuity_plan.md` for design lessons that transfer from web's snapshot/restore work.
 - Define one concrete daily-driver scenario the first phase must pass (e.g., "agent chat in workspace A is mid-stream when I sleep my laptop; tomorrow morning I open the app and the agent stream resumes within 3 seconds").

--- a/docs/development/desktop-continuity.md
+++ b/docs/development/desktop-continuity.md
@@ -1,0 +1,47 @@
+# Desktop Terminal Continuity
+
+Desktop continuity means reopening Workspaces and landing back in the same local repo or local workspace terminal with the strongest state the host can honestly preserve.
+
+## First-phase contract
+
+For local repo/workspace terminals:
+
+1. Workspaces launches tmux mode into a deterministic tmux session for the terminal launch directory on the `workspaces` socket.
+2. Workspaces persists a terminal continuity manifest for the last opened local terminal target.
+3. On app restore, the last terminal surface is selected and the manifest's launch directory is preferred if it still exists under the same target root.
+4. If the tmux server survived, tmux reattach preserves live process state, panes, cwd, and scrollback.
+5. If the tmux server did not survive, Workspaces relaunches from the manifest launch directory or target root. In-flight processes are not recreated.
+
+Remote/provider-backed workspaces are not covered by this first phase.
+
+## Manual probe
+
+Use this loop to record survival across lifecycle boundaries:
+
+```bash
+scripts/tmux-continuity-probe.sh start /path/to/workspace app-restart
+# Quit/reopen Workspaces, sleep/wake, logout, or reboot.
+scripts/tmux-continuity-probe.sh check /path/to/workspace app-restart
+scripts/tmux-continuity-probe.sh cleanup /path/to/workspace app-restart
+```
+
+Expected result for an app quit/reopen inside the same login session: `check` reports `survived`.
+
+Expected result after reboot may be `missing`; in that case the manifest fallback is the intended recovery behavior.
+
+## Verification
+
+For code changes touching this area:
+
+```bash
+./scripts/build-ghosttykit.sh
+swift build
+swift test
+./scripts/launch-dev.sh --no-build --no-activate
+ps aux | rg '.build/arm64-apple-macosx/debug/WorkspaceManager'
+scripts/tmux-continuity-probe.sh start "$PWD" app-restart
+scripts/tmux-continuity-probe.sh check "$PWD" app-restart
+scripts/tmux-continuity-probe.sh cleanup "$PWD" app-restart
+```
+
+Capture evidence with `./scripts/evidence.sh --pr <number> --name <slug>` before creating or marking a PR ready.

--- a/scripts/tmux-continuity-probe.sh
+++ b/scripts/tmux-continuity-probe.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/tmux-continuity-probe.sh start <path> [label]
+  scripts/tmux-continuity-probe.sh check <path> [label]
+  scripts/tmux-continuity-probe.sh cleanup <path> [label]
+
+Starts or checks a deterministic Workspaces tmux session on the dedicated
+"workspaces" socket. Use start before an app restart, sleep/wake, logout, or
+reboot boundary; use check after the boundary to record whether the session,
+cwd, and marker state survived.
+EOF
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 64
+fi
+
+action="$1"
+target_path="$2"
+label="${3:-manual}"
+socket_name="workspaces"
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is not available on PATH" >&2
+  exit 69
+fi
+
+if [[ ! -d "$target_path" ]]; then
+  echo "target path is not a directory: $target_path" >&2
+  exit 66
+fi
+
+real_path="$(cd "$target_path" && pwd -P)"
+base="$(basename "$real_path" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/^$/session/')"
+base="${base:0:20}"
+hash_prefix="$(printf '%s' "$real_path" | shasum -a 256 | awk '{print substr($1, 1, 8)}')"
+session_name="probe-${base}-${hash_prefix}"
+marker="/tmp/workspaces-continuity-${session_name}.txt"
+
+case "$action" in
+  start)
+    tmux -L "$socket_name" new-session -A -d -s "$session_name" -c "$real_path" \
+      "printf 'started %s\npath %s\nlabel %s\n' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"$real_path\" \"$label\" > '$marker'; while true; do sleep 60; done"
+    echo "started session=$session_name socket=$socket_name path=$real_path marker=$marker"
+    ;;
+  check)
+    if ! tmux -L "$socket_name" has-session -t "$session_name" 2>/dev/null; then
+      echo "missing session=$session_name socket=$socket_name"
+      exit 1
+    fi
+
+    pane_cwd="$(tmux -L "$socket_name" display-message -p -t "$session_name" '#{pane_current_path}')"
+    if [[ ! -f "$marker" ]]; then
+      echo "session=$session_name survived but marker missing marker=$marker"
+      exit 1
+    fi
+
+    echo "survived session=$session_name socket=$socket_name cwd=$pane_cwd marker=$marker"
+    cat "$marker"
+    ;;
+  cleanup)
+    tmux -L "$socket_name" kill-session -t "$session_name" 2>/dev/null || true
+    rm -f "$marker"
+    echo "cleaned session=$session_name marker=$marker"
+    ;;
+  *)
+    usage
+    exit 64
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a terminal continuity manifest for the last local repo/workspace terminal target and launch directory
- restore local terminal launches through that manifest while tmux preserves live state when its server survives
- document the first-phase continuity contract and add a tmux continuity probe script

## Verification
- swift test
- ./scripts/dev-smoke.sh --no-build
- scripts/tmux-continuity-probe.sh start/check/cleanup /Users/fairchild/.codex/worktrees/364f/workspaces final

## Evidence
- ![continuity-dev-smoke](https://evidence.cloudcompute.com/workspaces/pr-408/20260504-033106-continuity-dev-smoke.png)

## Mergeability
- Surface: desktop terminal continuity
- User-facing behavior changed: local repo/workspace terminal restore now prefers the persisted terminal continuity manifest launch directory, while tmux mode can reattach to the deterministic launch-directory session when the tmux server survives.
- Non-happy paths considered: stale target ids, missing launch directories, launch directories outside the target root, missing tmux server after reboot, and remote/provider-backed workspaces being out of scope for this slice.
- Residual risk or follow-up: full sleep/wake, logout, and reboot survival still need real-host probe evidence beyond the same-session smoke; provider-backed terminal continuity remains a separate provider contract.
