### PR TITLE
web: add PR review narrative context

### DIFF
--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	createSession: vi.fn(),
+	sendEvent: vi.fn(),
+	uploadFile: vi.fn(),
+	getOrCreateAgent: vi.fn(),
+	getOrCreateEnvironment: vi.fn(),
+	fetch: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	class FakeAnthropic {
+		beta = {
+			files: {
+				upload: mocks.uploadFile,
+			},
+			sessions: {
+				create: mocks.createSession,
+				events: {
+					send: mocks.sendEvent,
+				},
+			},
+		};
+	}
+	return { default: FakeAnthropic };
+});
+
+vi.mock("../managed-agents-cache", () => ({
+	getOrCreateAgent: mocks.getOrCreateAgent,
+	getOrCreateEnvironment: mocks.getOrCreateEnvironment,
+}));
+
+vi.stubGlobal("fetch", mocks.fetch);
+
+import {
+	type PrReviewPayload,
+	fetchPrNarrativeContext,
+	triggerPrReview,
+} from "../pr-review";
+
+function payload(overrides: Partial<PrReviewPayload> = {}): PrReviewPayload {
+	return {
+		number: 9,
+		title: "Add narrative review context",
+		htmlUrl: "https://github.com/fairchild/workspaces/pull/9",
+		headRef: "feature/pr-narrative",
+		baseRef: "main",
+		repoUrl: "https://github.com/fairchild/workspaces",
+		repoFullName: "fairchild/workspaces",
+		repoName: "workspaces",
+		...overrides,
+	};
+}
+
+function githubPr(number: number, overrides: Record<string, unknown> = {}) {
+	return {
+		number,
+		title: `PR ${number}`,
+		html_url: `https://github.com/fairchild/workspaces/pull/${number}`,
+		state: number % 2 === 0 ? "closed" : "open",
+		updated_at: `2026-05-0${number}T12:00:00Z`,
+		body: `Description for PR ${number}`,
+		head: { ref: `branch-${number}` },
+		base: { ref: "main" },
+		...overrides,
+	};
+}
+
+function mockPrList(prs: unknown[]) {
+	mocks.fetch.mockResolvedValue({
+		ok: true,
+		json: async () => prs,
+	});
+}
+
+beforeEach(() => {
+	vi.stubEnv("ANTHROPIC_API_KEY", "sk-test");
+	vi.stubEnv("GITHUB_TOKEN", "ghp_test");
+	vi.stubEnv("PR_REVIEWER_MODEL", "claude-test");
+	vi.stubEnv("PR_REVIEWER_APP_ID", "");
+	vi.stubEnv("PR_REVIEWER_PRIVATE_KEY", "");
+	vi.stubEnv("PR_REVIEWER_INSTALLATION_ID", "");
+	mocks.createSession.mockReset();
+	mocks.sendEvent.mockReset();
+	mocks.uploadFile.mockReset();
+	mocks.getOrCreateAgent.mockReset();
+	mocks.getOrCreateEnvironment.mockReset();
+	mocks.fetch.mockReset();
+
+	mocks.getOrCreateAgent.mockResolvedValue("agent_01");
+	mocks.getOrCreateEnvironment.mockResolvedValue("env_01");
+	mocks.uploadFile.mockResolvedValue({ id: "file_01" });
+	mocks.createSession.mockResolvedValue({ id: "sesn_01" });
+	mocks.sendEvent.mockResolvedValue({});
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+});
+
+describe("fetchPrNarrativeContext", () => {
+	it("excludes the current PR and caps recent descriptions and relationship candidates", async () => {
+		mockPrList([
+			githubPr(9),
+			githubPr(8),
+			githubPr(7),
+			githubPr(6),
+			githubPr(5),
+			githubPr(4),
+			githubPr(3),
+		]);
+
+		const context = await fetchPrNarrativeContext("ghp_test", payload());
+
+		expect(context.recentDescriptions.map((pr) => pr.number)).toEqual([
+			8, 7, 6,
+		]);
+		expect(context.relationshipCandidates.map((pr) => pr.number)).toEqual([
+			8, 7, 6, 5, 4,
+		]);
+		expect(context.relationshipCandidates.some((pr) => pr.number === 9)).toBe(
+			false,
+		);
+		expect(mocks.fetch).toHaveBeenCalledWith(
+			"https://api.github.com/repos/fairchild/workspaces/pulls?state=all&sort=updated&direction=desc&per_page=10",
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer ghp_test",
+				}),
+			}),
+		);
+	});
+
+	it("handles fewer than three previous PRs", async () => {
+		mockPrList([githubPr(9), githubPr(8), githubPr(7)]);
+
+		const context = await fetchPrNarrativeContext("ghp_test", payload());
+
+		expect(context.recentDescriptions.map((pr) => pr.number)).toEqual([8, 7]);
+		expect(context.relationshipCandidates.map((pr) => pr.number)).toEqual([
+			8, 7,
+		]);
+		expect(context.unavailableReason).toBeUndefined();
+	});
+
+	it("returns a non-fatal unavailable reason on GitHub API failure", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		mocks.fetch.mockResolvedValue({
+			ok: false,
+			status: 500,
+			text: async () => "server error",
+		});
+
+		const context = await fetchPrNarrativeContext("ghp_test", payload());
+
+		expect(context).toEqual({
+			recentDescriptions: [],
+			relationshipCandidates: [],
+			unavailableReason: "GitHub API 500",
+		});
+		expect(warn).toHaveBeenCalledWith(
+			"[pr-review] previous PR context unavailable:",
+			"GitHub API 500",
+		);
+	});
+});
+
+describe("triggerPrReview", () => {
+	it("sends previous PR context and narrative instructions in the kickoff message", async () => {
+		mockPrList([githubPr(9), githubPr(8), githubPr(7), githubPr(6)]);
+
+		await expect(triggerPrReview(payload())).resolves.toBe("sesn_01");
+
+		expect(mocks.createSession).toHaveBeenCalledTimes(1);
+		expect(mocks.sendEvent).toHaveBeenCalledTimes(1);
+		const [, params] = mocks.sendEvent.mock.calls[0];
+		const message = params.events[0].content[0].text;
+		expect(message).toContain("Previous PR narrative context:");
+		expect(message).toContain("Most recently updated PR descriptions");
+		expect(message).toContain("PR #8: PR 8");
+		expect(message).toContain("## Project Thread");
+		expect(message).toContain("Reference at least one previous PR by number");
+	});
+
+	it("still starts the reviewer when previous PR context is unavailable", async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		mocks.fetch.mockResolvedValue({
+			ok: false,
+			status: 403,
+			text: async () => "forbidden",
+		});
+
+		await expect(triggerPrReview(payload())).resolves.toBe("sesn_01");
+
+		expect(mocks.createSession).toHaveBeenCalledTimes(1);
+		expect(mocks.sendEvent).toHaveBeenCalledTimes(1);
+		const [, params] = mocks.sendEvent.mock.calls[0];
+		const message = params.events[0].content[0].text;
+		expect(message).toContain(
+			"Previous PR context unavailable: GitHub API 403",
+		);
+		expect(message).toContain(
+			"If no previous PR exists or the previous PR context is unavailable",
+		);
+	});
+});

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -59,6 +59,7 @@ Your review body MUST begin with a one-line decision banner. The first character
 Keep the decision banner to one sentence and no more than 140 characters. It should summarize the outcome, not repeat the PR title.
 
 - Use real headings (\`## Summary\`, \`## Details\`)
+- Include a short \`## Project Thread\` section that references at least one previous PR by number and explains the relationship when previous PR context is available
 - Use bullet points and code blocks
 - Cite \`file:line\` for every comment
 - Skip nits unless they materially affect correctness or readability
@@ -76,6 +77,11 @@ const TOOLS = [
 	},
 ];
 
+const GITHUB_API = "https://api.github.com";
+const RECENT_DESCRIPTION_COUNT = 3;
+const RELATIONSHIP_CANDIDATE_COUNT = 5;
+const BODY_TRUNCATE_LENGTH = 1200;
+
 export interface PrReviewPayload {
 	number: number;
 	title: string;
@@ -85,6 +91,34 @@ export interface PrReviewPayload {
 	repoUrl: string;
 	repoFullName: string;
 	repoName: string;
+}
+
+export interface PrContextItem {
+	number: number;
+	title: string;
+	url: string;
+	state: string;
+	updatedAt: string;
+	headRef: string;
+	baseRef: string;
+	body: string;
+}
+
+export interface PrNarrativeContext {
+	recentDescriptions: PrContextItem[];
+	relationshipCandidates: PrContextItem[];
+	unavailableReason?: string;
+}
+
+interface GitHubPullRequest {
+	number: number;
+	title: string | null;
+	html_url: string | null;
+	state: string | null;
+	updated_at: string | null;
+	body: string | null;
+	head?: { ref?: string | null } | null;
+	base?: { ref?: string | null } | null;
 }
 
 async function resolveGitHubToken(): Promise<string | null> {
@@ -114,6 +148,102 @@ async function resolveGitHubToken(): Promise<string | null> {
 	return process.env.GITHUB_TOKEN ?? null;
 }
 
+function truncateBody(body: string): string {
+	if (body.length <= BODY_TRUNCATE_LENGTH) return body;
+	return `${body.slice(0, BODY_TRUNCATE_LENGTH).trimEnd()}\n...[truncated]`;
+}
+
+function toPrContextItem(pr: GitHubPullRequest): PrContextItem {
+	return {
+		number: Number(pr.number),
+		title: pr.title ?? "",
+		url: pr.html_url ?? "",
+		state: pr.state ?? "",
+		updatedAt: pr.updated_at ?? "",
+		headRef: pr.head?.ref ?? "",
+		baseRef: pr.base?.ref ?? "",
+		body: truncateBody(pr.body ?? ""),
+	};
+}
+
+export async function fetchPrNarrativeContext(
+	githubToken: string,
+	payload: PrReviewPayload,
+): Promise<PrNarrativeContext> {
+	const [owner, repo] = payload.repoFullName.split("/");
+	if (!owner || !repo) {
+		return {
+			recentDescriptions: [],
+			relationshipCandidates: [],
+			unavailableReason: "Repository owner/name was unavailable.",
+		};
+	}
+
+	const url = `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls?state=all&sort=updated&direction=desc&per_page=10`;
+
+	try {
+		const res = await fetch(url, {
+			headers: {
+				Authorization: `Bearer ${githubToken}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		});
+		if (!res.ok) {
+			throw new Error(`GitHub API ${res.status}`);
+		}
+		const prs = ((await res.json()) as GitHubPullRequest[])
+			.filter((pr) => Number(pr.number) !== payload.number)
+			.map(toPrContextItem);
+
+		return {
+			recentDescriptions: prs.slice(0, RECENT_DESCRIPTION_COUNT),
+			relationshipCandidates: prs.slice(0, RELATIONSHIP_CANDIDATE_COUNT),
+		};
+	} catch (err) {
+		const reason = err instanceof Error ? err.message : String(err);
+		console.warn("[pr-review] previous PR context unavailable:", reason);
+		return {
+			recentDescriptions: [],
+			relationshipCandidates: [],
+			unavailableReason: reason,
+		};
+	}
+}
+
+function formatPrContextItem(item: PrContextItem): string {
+	const description = item.body.trim() || "(no description)";
+	return `- PR #${item.number}: ${item.title}
+  URL: ${item.url}
+  State: ${item.state}
+  Updated: ${item.updatedAt}
+  Branches: ${item.headRef} -> ${item.baseRef}
+  Description:
+${description
+	.split("\n")
+	.map((line) => `    ${line}`)
+	.join("\n")}`;
+}
+
+export function formatPrNarrativeContext(context: PrNarrativeContext): string {
+	if (context.unavailableReason) {
+		return `Previous PR context unavailable: ${context.unavailableReason}`;
+	}
+
+	if (
+		context.recentDescriptions.length === 0 &&
+		context.relationshipCandidates.length === 0
+	) {
+		return "No previous PRs were found for this repository.";
+	}
+
+	return `Most recently updated PR descriptions (always scan these 3 if present):
+${context.recentDescriptions.map(formatPrContextItem).join("\n\n")}
+
+Relationship candidates (scan the first 3; if none are clearly related, scan up to 5 and use the most clearly related):
+${context.relationshipCandidates.map(formatPrContextItem).join("\n\n")}`;
+}
+
 /**
  * Fire-and-forget: creates a Managed Agents session that reviews the PR
  * and posts a review via the GitHub API. Returns the session ID,
@@ -133,6 +263,7 @@ export async function triggerPrReview(
 		return null;
 	}
 
+	const narrativeContext = await fetchPrNarrativeContext(githubToken, payload);
 	const client = new Anthropic({ apiKey });
 	const model = process.env.PR_REVIEWER_MODEL ?? "claude-opus-4-6";
 
@@ -202,10 +333,15 @@ Head branch: ${payload.headRef}
 Base branch: ${payload.baseRef}
 Repo mounted at: ${mountPath}
 
+Previous PR narrative context:
+${formatPrNarrativeContext(narrativeContext)}
+
 GitHub API endpoint for posting the review:
 POST https://api.github.com/repos/${owner}/${repo}/pulls/${payload.number}/reviews
 
-Read the diff against ${payload.baseRef}, explore the surrounding code, run swift build and swift test if the project supports them, then post the review using the GitHub API with the token at /workspace/.github-token.`,
+Read the diff against ${payload.baseRef}, explore the surrounding code, run swift build and swift test if the project supports them, then post the review using the GitHub API with the token at /workspace/.github-token.
+
+Your review must include a short "## Project Thread" section. Reference at least one previous PR by number and explain how this PR relates to it when previous PR context is available. If one of the first 3 relationship candidates is clearly related, use it. If none are clearly related, inspect up to 5 candidates and reference the most clearly related one. If no previous PR exists or the previous PR context is unavailable, say that explicitly instead of inventing a relationship.`,
 					},
 				],
 			},


### PR DESCRIPTION
## Summary
- fetch recent previous PR context server-side before managed review sessions start
- require managed reviewer output to include a Project Thread relationship to a prior PR when context exists
- add Vitest coverage for candidate selection, fallback, failure handling, and kickoff prompt content

## Mergeability
- Surface: web / agent-runtime
- User-facing behavior changed: Managed PR reviewer comments now include a Project Thread narrative reference to related previous PRs when context exists.
- Non-happy paths considered: GitHub previous-PR context fetch failures are non-fatal and produce an explicit unavailable-context instruction instead of blocking review startup.
- Residual risk or follow-up: The relationship choice is still made by the managed agent from server-provided candidates; production validation should confirm the next opened PR includes the narrative section.

## Validation
- pnpm typecheck passed
- pnpm lint passed
- pnpm test passed: 153 passed
- git diff --check passed

## Evidence
- Evidence upload unavailable locally: ./scripts/evidence.sh could not upload because EVIDENCE_UPLOAD_TOKEN is not set in this worktree environment.
- Local verification output files were generated under /tmp/pr409-*.txt.