### PR TITLE
scripts: make setup pnpm install noninteractive

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -35,7 +35,9 @@ install_deps() {
     (cd "$dir" && bun install)
   elif [[ -f "$dir/pnpm-lock.yaml" ]]; then
     echo "=> $dir: pnpm install"
-    (cd "$dir" && pnpm install)
+    # Codex and CI run setup without a TTY; CI=1 prevents pnpm from aborting
+    # when it needs to recreate node_modules.
+    (cd "$dir" && CI=1 pnpm install)
   elif [[ -f "$dir/package-lock.json" ]]; then
     echo "=> $dir: npm install"
     (cd "$dir" && npm install)


### PR DESCRIPTION
## Summary
- run pnpm installs with CI=1 inside scripts/setup so Codex/non-TTY setup does not abort when node_modules must be recreated

## Mergeability
- Surface: scripts / dev setup
- User-facing behavior changed: Fresh Codex worktrees can complete repo setup without pnpm prompting for TTY confirmation.
- Non-happy paths considered: Existing .env symlink behavior remains unchanged; setup still fails normally if dependency installation fails.
- Residual risk or follow-up: Codex itself still needs to invoke ./scripts/setup for automatic setup; manual invocation is confirmed to work in Codex worktrees.

## Validation
- ./scripts/setup passed in /Users/fairchild/.codex/worktrees/a179/workspaces
- bash -n scripts/setup passed
- git diff --check passed
- evidence upload through symlinked .env passed

## Evidence
- ![codex-env-symlink-confirm](https://evidence.cloudcompute.com/workspaces/pr-409/20260503-052412-codex-env-symlink-confirm.png)