### PR TITLE
Codex local environment setup

### DIFF
--- a/.codex/environments/workspaces.toml
+++ b/.codex/environments/workspaces.toml
@@ -1,0 +1,4 @@
+name = "WorkSpaces"
+
+[setup]
+script = "./scripts/setup"

--- a/scripts/setup
+++ b/scripts/setup
@@ -24,8 +24,18 @@ link_env_from_main() {
 }
 link_env_from_main
 
-# Trust and install mise-managed tools
-[[ -f .mise.toml ]] && mise trust && mise install
+# Trust and install mise-managed tools. Codex worktrees run setup without an
+# interactive terminal, so trust every checked-in project config up front.
+while IFS= read -r mise_config; do
+  echo "=> Trusting mise config ${mise_config#$REPO_ROOT/}"
+  mise trust "$mise_config"
+done < <(
+  find "$REPO_ROOT" \
+    -path "*/.git" -prune -o \
+    -path "*/node_modules" -prune -o \
+    -name ".mise.toml" -print | sort
+)
+[[ -f .mise.toml ]] && mise install
 
 # Install dependencies per lockfile
 install_deps() {


### PR DESCRIPTION
## Summary
- add a repo-owned Codex local environment that runs ./scripts/setup for new worktrees
- trust all checked-in .mise.toml files during setup so root and web mise tasks work non-interactively
- keep the existing dependency install and .env symlink flow intact

## Mergeability
- Surface: agent-runtime / infra
- User-facing behavior changed: New Codex worktree sessions can run the repo setup script automatically, including env symlinks and dependency install.
- Non-happy paths considered: Fresh Codex worktrees without .env still use scripts/setup to symlink from the main worktree when available; missing main-worktree env files remain non-fatal.
- Evidence: https://evidence.cloudcompute.com/workspaces/pr-411/20260503-053326-codex-local-environment-setup.svg
- Residual risk or follow-up: Codex local environment schema is based on the installed Codex app parser and was kept minimal to name/setup.script only.

## Verification
- passed: bash -n scripts/setup
- passed: uv run python TOML parse check for .codex/environments/workspaces.toml
- passed: ./scripts/setup
- passed: mise -C web run web:check (typecheck, lint, 153 Vitest tests)
- passed: .env symlink points to /Users/fairchild/code/workspaces/.env and EVIDENCE_UPLOAD_TOKEN is present

## Evidence
![codex-local-environment-setup](https://evidence.cloudcompute.com/workspaces/pr-411/20260503-053326-codex-local-environment-setup.svg)