### PR TITLE
[codex] Harden workflow security

### DIFF
--- a/.github/workflows/agent-carl.yml
+++ b/.github/workflows/agent-carl.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 50
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Run Carl Community
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,11 +28,11 @@ jobs:
     # rootDirectory=web setting resolves correctly. Only pnpm needs to cd into
     # web/ (for package.json resolution).
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           package_json_file: web/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -78,8 +78,8 @@ jobs:
       run:
         working-directory: infra/${{ matrix.worker }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
       - name: Deploy to preview env
@@ -106,11 +106,11 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           package_json_file: web/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -141,11 +141,11 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           package_json_file: web/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -181,8 +181,8 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
       - name: Deploy workers to prod
@@ -212,8 +212,8 @@ jobs:
     steps:
       # Checkout is required so the github-script step can import the shared
       # fail-notify logic at .github/workflows/cd-fail-notify.js.
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: playwright-findings
           path: .
@@ -237,8 +237,8 @@ jobs:
     if: failure() && !cancelled() && needs.lighthouse.result == 'failure'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: lighthouse-findings
           path: .
@@ -265,11 +265,11 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           package_json_file: web/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -308,7 +308,7 @@ jobs:
     if: failure() && !cancelled() && needs.validate-prod.result == 'failure'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: prod-validate-findings
           path: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, lume-macos]
+    runs-on: macos-17
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: macos-17
+    runs-on: macos-15
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -114,10 +114,7 @@ class SecurityHardeningTests(unittest.TestCase):
         """Every `uses:` reference to a third-party action must be pinned to a full SHA."""
         workflows_dir = REPO_ROOT / ".github/workflows"
         floating_refs: list[str] = []
-        tag_pattern = re.compile(
-            r"^\s*uses:\s+(?!\./)(\S+)@([a-z0-9]{40})\b",
-        )
-        uses_pattern = re.compile(r"^\s*uses:\s+(?!\./)(\S+)@(\S+)")
+        uses_pattern = re.compile(r"^\s*(?:-\s*)?uses:\s+(?!\./)(\S+)@(\S+)")
         for wf in sorted(workflows_dir.glob("*.yml")):
             for i, line in enumerate(wf.read_text().splitlines(), 1):
                 m = uses_pattern.match(line)
@@ -131,6 +128,13 @@ class SecurityHardeningTests(unittest.TestCase):
             [],
             "Actions with floating (non-SHA) refs found:\n" + "\n".join(floating_refs),
         )
+
+    def test_pull_request_ci_uses_github_hosted_runner(self) -> None:
+        """Untrusted PR code must not run on persistent self-hosted macOS runners."""
+        workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
+        self.assertIn("pull_request:", workflow)
+        self.assertIn("runs-on: macos-17", workflow)
+        self.assertNotIn("runs-on: [self-hosted, lume-macos]", workflow)
 
     def test_ci_workflows_have_explicit_permissions(self) -> None:
         """CI workflows should declare explicit top-level permissions to limit default token scope."""

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -133,7 +133,7 @@ class SecurityHardeningTests(unittest.TestCase):
         """Untrusted PR code must not run on persistent self-hosted macOS runners."""
         workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
         self.assertIn("pull_request:", workflow)
-        self.assertIn("runs-on: macos-17", workflow)
+        self.assertIn("runs-on: macos-15", workflow)
         self.assertNotIn("runs-on: [self-hosted, lume-macos]", workflow)
 
     def test_ci_workflows_have_explicit_permissions(self) -> None:


### PR DESCRIPTION
## Summary

- Move generic PR CI from the persistent self-hosted `lume-macos` runner to GitHub-hosted `macos-15`.
- Pin remaining floating GitHub Actions refs in `cd.yml` and `agent-carl.yml` to full commit SHAs.
- Fix the workflow action-pinning regression test so it catches both `uses:` and `- uses:` syntax, and add a guard that PR CI stays off the self-hosted macOS runner.

## Why

The security review found that open-source pull requests could execute untrusted code on a persistent self-hosted runner, and that the action-pinning test passed while common workflow syntax still allowed floating action tags. This closes the immediate CI supply-chain exposure and preserves it with a regression test.

## Verification

- `uv run --script scripts/test_security_hardening.py` passes: 10 tests.
- `git diff --check` passes.

## Validation

- Workflow syntax remained parseable under the existing GitHub Actions run.
- PR readiness and evidence gates are expected to run remotely after this body update.

## Mergeability

- Surface: infra / CI
- User-facing behavior changed: No product UI behavior changes; PR CI now runs on GitHub-hosted `macos-15` instead of the persistent Lume self-hosted runner.
- Non-happy paths considered: The regression test now catches both bare `uses:` and list-step `- uses:` syntax so future floating action refs fail locally and in CI.
- Residual risk or follow-up: Remaining security review findings are intentionally out of scope for this PR.
- Release/ops preconditions: None. CI runner selection changes take effect when this workflow lands on `main`.

## Evidence

- Blocked on evidence: `./scripts/evidence.sh --pr 412 --name security-workflow-hardening` failed because `EVIDENCE_UPLOAD_TOKEN` is not set in this worktree `.env` or shell.
- Remote checks on this PR are the available uploaded verification surface for this workflow-only change.

## Release/ops preconditions

- None. CI runner selection changes take effect when this workflow lands on `main`.
