### PR TITLE
[codex] Add privacy-first Sparkle updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           missing=()
@@ -76,6 +77,7 @@ jobs:
           [[ -n "$APPLE_ID" ]] || missing+=("APPLE_ID")
           [[ -n "$APPLE_APP_PASSWORD" ]] || missing+=("APPLE_APP_PASSWORD")
           [[ -n "$APPLE_TEAM_ID" ]] || missing+=("APPLE_TEAM_ID")
+          [[ -n "$SPARKLE_PRIVATE_KEY" ]] || missing+=("SPARKLE_PRIVATE_KEY")
 
           if (( ${#missing[@]} > 0 )); then
             echo "::error::Missing required repository release config: ${missing[*]}"
@@ -231,6 +233,7 @@ jobs:
             fi
           fi
           DMG_PATH="build/WorkspaceManager-${VERSION}.dmg"
+          APPCAST_PATH="build/appcast.xml"
 
           if [[ ! -f "$DMG_PATH" ]]; then
             echo "::error::Expected DMG not found at $DMG_PATH"
@@ -241,6 +244,18 @@ jobs:
           echo "build=$BUILD" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "dmg_path=$DMG_PATH" >> "$GITHUB_OUTPUT"
+          echo "appcast_path=$APPCAST_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Sparkle appcast
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          ./scripts/generate-sparkle-appcast.sh \
+            --dmg "${{ steps.meta.outputs.dmg_path }}" \
+            --tag "${{ steps.meta.outputs.tag }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --output "${{ steps.meta.outputs.appcast_path }}"
 
       - name: Publish GitHub release
         env:
@@ -255,6 +270,7 @@ jobs:
           TAG="${{ steps.meta.outputs.tag }}"
           TITLE="Workspaces ${TAG}"
           DMG_PATH="${{ steps.meta.outputs.dmg_path }}"
+          APPCAST_PATH="${{ steps.meta.outputs.appcast_path }}"
           LATEST_DMG_PATH="build/WorkspaceManager-latest.dmg"
           GENERATED_NOTES_PATH="$RUNNER_TEMP/release-notes.md"
           IS_PRERELEASE=false
@@ -274,6 +290,7 @@ jobs:
               --jq '.body' >"$GENERATED_NOTES_PATH"
 
             gh release upload "$TAG" "$DMG_PATH" "$LATEST_DMG_PATH" --clobber --repo "${GITHUB_REPOSITORY}"
+            gh release upload "$TAG" "$APPCAST_PATH" --clobber --repo "${GITHUB_REPOSITORY}"
             if [[ "$IS_PRERELEASE" == true ]]; then
               gh release edit "$TAG" \
                 --title "$TITLE" \
@@ -289,7 +306,7 @@ jobs:
             fi
           else
             if [[ "$IS_PRERELEASE" == true ]]; then
-              gh release create "$TAG" "$DMG_PATH" "$LATEST_DMG_PATH" \
+              gh release create "$TAG" "$DMG_PATH" "$LATEST_DMG_PATH" "$APPCAST_PATH" \
                 --repo "${GITHUB_REPOSITORY}" \
                 --title "$TITLE" \
                 --target "${GITHUB_SHA}" \
@@ -297,7 +314,7 @@ jobs:
                 --prerelease \
                 --latest=false
             else
-              gh release create "$TAG" "$DMG_PATH" "$LATEST_DMG_PATH" \
+              gh release create "$TAG" "$DMG_PATH" "$LATEST_DMG_PATH" "$APPCAST_PATH" \
                 --repo "${GITHUB_REPOSITORY}" \
                 --title "$TITLE" \
                 --target "${GITHUB_SHA}" \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "22dd4c721ba9c7d4112b150900f631484b8870f3b0fbfa95df776daf9866d7ad",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,9 @@ let package = Package(
         .executable(name: "workspaces", targets: ["WorkspaceManagerCLI"]),
         .executable(name: "WorkspaceManagerCLI", targets: ["WorkspaceManagerCLI"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.1")
+    ],
     targets: [
         // ====================================================================
         // Core Library
@@ -61,7 +63,11 @@ let package = Package(
         // Resources are bundled for the .app bundle creation.
         .executableTarget(
             name: "WorkspaceManager",
-            dependencies: ["WorkspaceManagerCore", "GhosttyKit"],
+            dependencies: [
+                "WorkspaceManagerCore",
+                "GhosttyKit",
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
             // Exclude Info.plist from automatic resource discovery
             // (SPM forbids Info.plist as a bundled resource; it's copied by build-release.sh)
             exclude: ["Resources/Info.plist"],
@@ -81,7 +87,13 @@ let package = Package(
                 .linkedFramework("QuartzCore"),
                 .linkedFramework("UniformTypeIdentifiers"),
                 .linkedFramework("UserNotifications"),
-                .linkedFramework("WebKit")
+                .linkedFramework("WebKit"),
+                .unsafeFlags([
+                    "-Xlinker",
+                    "-rpath",
+                    "-Xlinker",
+                    "@executable_path/../Frameworks"
+                ])
             ]
         ),
 

--- a/Sources/WorkspaceManager/App/SoftwareUpdateController.swift
+++ b/Sources/WorkspaceManager/App/SoftwareUpdateController.swift
@@ -1,0 +1,162 @@
+//
+//  SoftwareUpdateController.swift
+//  WorkspaceManager
+//
+//  Privacy-first Sparkle update integration.
+//
+
+import AppKit
+import Combine
+import Foundation
+import Sparkle
+
+enum SoftwareUpdateConstants {
+    static let feedURLString = "https://github.com/fairchild/workspaces/releases/latest/download/appcast.xml"
+    static let manualCheckDisclosureAcceptedKey = "softwareUpdateManualCheckDisclosureAccepted"
+    static let automaticCheckDisclosure =
+        "When enabled, WorkSpaces periodically contacts GitHub Releases to check for a signed appcast. WorkSpaces does not send telemetry, system profile information, or custom tracking parameters. GitHub may receive normal HTTP request metadata such as your IP address."
+    static let manualCheckDisclosure =
+        "WorkSpaces will contact GitHub Releases to check for a signed appcast. WorkSpaces does not send telemetry, system profile information, or custom tracking parameters. GitHub may receive normal HTTP request metadata such as your IP address."
+}
+
+enum SoftwareUpdatePrivacyPolicy {
+    static let shouldPromptForAutomaticCheckPermission = false
+    static let feedParameters: [[String: String]] = []
+    static let allowedSystemProfileKeys: [String] = []
+}
+
+@MainActor
+private protocol SoftwareUpdateCheckGate: AnyObject {
+    func shouldAllowSparkleUpdateCheck(_ updateCheck: SPUUpdateCheck) -> Bool
+}
+
+@MainActor
+final class SoftwareUpdateDelegate: NSObject, SPUUpdaterDelegate {
+    fileprivate weak var checkGate: SoftwareUpdateCheckGate?
+
+    func updater(_ updater: SPUUpdater, mayPerform updateCheck: SPUUpdateCheck) throws {
+        guard checkGate?.shouldAllowSparkleUpdateCheck(updateCheck) ?? true else {
+            throw NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
+        }
+    }
+
+    func updaterShouldPromptForPermissionToCheck(forUpdates updater: SPUUpdater) -> Bool {
+        SoftwareUpdatePrivacyPolicy.shouldPromptForAutomaticCheckPermission
+    }
+
+    func feedParameters(
+        for updater: SPUUpdater,
+        sendingSystemProfile sendingProfile: Bool
+    ) -> [[String: String]] {
+        SoftwareUpdatePrivacyPolicy.feedParameters
+    }
+
+    func allowedSystemProfileKeys(for updater: SPUUpdater) -> [String]? {
+        SoftwareUpdatePrivacyPolicy.allowedSystemProfileKeys
+    }
+}
+
+@MainActor
+final class SoftwareUpdateController: NSObject, ObservableObject, NSMenuItemValidation, SoftwareUpdateCheckGate {
+    @Published private(set) var canCheckForUpdates = false
+
+    private static let checkForUpdatesMenuTitle = "Check for Updates..."
+
+    private let updaterController: SPUStandardUpdaterController
+    private let updaterDelegate: SoftwareUpdateDelegate
+    private let userDefaults: UserDefaults
+    private var canCheckForUpdatesCancellable: AnyCancellable?
+
+    var updater: SPUUpdater {
+        updaterController.updater
+    }
+
+    init(
+        startUpdater: Bool = true,
+        userDefaults: UserDefaults = .standard
+    ) {
+        self.updaterDelegate = SoftwareUpdateDelegate()
+        self.userDefaults = userDefaults
+        let shouldStartUpdater = startUpdater && Self.isSparkleConfigured()
+        self.updaterController = SPUStandardUpdaterController(
+            startingUpdater: shouldStartUpdater,
+            updaterDelegate: updaterDelegate,
+            userDriverDelegate: nil
+        )
+        super.init()
+        self.updaterDelegate.checkGate = self
+        self.canCheckForUpdates = updaterController.updater.canCheckForUpdates
+        self.canCheckForUpdatesCancellable = updaterController.updater
+            .publisher(for: \.canCheckForUpdates, options: [.initial, .new])
+            .receive(on: RunLoop.main)
+            .sink { [weak self] canCheck in
+                self?.canCheckForUpdates = canCheck
+                self?.installCheckForUpdatesMenuItem()
+            }
+    }
+
+    static func isSparkleConfigured(bundle: Bundle = .main) -> Bool {
+        guard let feedURL = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String,
+            let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+        else {
+            return false
+        }
+        return !feedURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !publicKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func checkForUpdatesWithDisclosure() {
+        guard confirmManualCheckDisclosureIfNeeded() else { return }
+        updater.checkForUpdates()
+    }
+
+    func installCheckForUpdatesMenuItem() {
+        installCheckForUpdatesMenuItem(in: NSApp.mainMenu)
+    }
+
+    func installCheckForUpdatesMenuItem(in menu: NSMenu?) {
+        guard let appMenu = menu?.items.first?.submenu else { return }
+
+        for item in appMenu.items where item.title == Self.checkForUpdatesMenuTitle {
+            item.target = self
+            item.action = #selector(checkForUpdatesMenuItem(_:))
+            item.isEnabled = canCheckForUpdates
+        }
+    }
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        guard menuItem.action == #selector(checkForUpdatesMenuItem(_:)) else {
+            return true
+        }
+        return canCheckForUpdates
+    }
+
+    @objc private func checkForUpdatesMenuItem(_ sender: Any?) {
+        checkForUpdatesWithDisclosure()
+    }
+
+    fileprivate func shouldAllowSparkleUpdateCheck(_ updateCheck: SPUUpdateCheck) -> Bool {
+        guard updateCheck == .updates else {
+            return true
+        }
+        return confirmManualCheckDisclosureIfNeeded()
+    }
+
+    private func confirmManualCheckDisclosureIfNeeded() -> Bool {
+        if userDefaults.bool(forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey) {
+            return true
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Check for WorkSpaces Updates?"
+        alert.informativeText = SoftwareUpdateConstants.manualCheckDisclosure
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Check for Updates")
+        alert.addButton(withTitle: "Cancel")
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return false }
+        userDefaults.set(true, forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey)
+        return true
+    }
+}

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -16,6 +16,7 @@ struct WorkspaceManagerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var appCommandState: AppCommandState
     @StateObject private var modelStoreStatusController: ModelStoreStatusController
+    @StateObject private var softwareUpdateController: SoftwareUpdateController
     private let appRuntimeDependencies = AppRuntimeDependencies.resolved()
     let sharedModelContainer: ModelContainer
 
@@ -32,6 +33,7 @@ struct WorkspaceManagerApp: App {
         ModelStoreStatusController.shared.apply(bootstrap)
         _appCommandState = StateObject(wrappedValue: AppCommandState())
         _modelStoreStatusController = StateObject(wrappedValue: .shared)
+        _softwareUpdateController = StateObject(wrappedValue: SoftwareUpdateController())
         self.sharedModelContainer = bootstrap.container
     }
 
@@ -48,6 +50,9 @@ struct WorkspaceManagerApp: App {
             )
             .environmentObject(modelStoreStatusController)
             .frame(minWidth: 1000, minHeight: 700)
+            .onAppear {
+                softwareUpdateController.installCheckForUpdatesMenuItem()
+            }
         }
         .modelContainer(sharedModelContainer)
         .defaultSize(width: 1400, height: 900)
@@ -56,6 +61,13 @@ struct WorkspaceManagerApp: App {
         .windowStyle(.automatic)
         .windowToolbarStyle(.unifiedCompact(showsTitle: true))
         .commands {
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates...") {
+                    softwareUpdateController.checkForUpdatesWithDisclosure()
+                }
+                .disabled(!softwareUpdateController.canCheckForUpdates)
+            }
+
             CommandGroup(replacing: .newItem) {
                 Button("New Workspace...") {
                     appCommandState.performNewWorkspace()
@@ -198,7 +210,7 @@ struct WorkspaceManagerApp: App {
         }
 
         Settings {
-            SettingsView()
+            SettingsView(softwareUpdateController: softwareUpdateController)
                 .environment(\.lumeRuntimeService, appRuntimeDependencies.lumeRuntimeService)
                 .environment(\.workspaceProviderRegistry, appRuntimeDependencies.workspaceProviderRegistry)
                 .environmentObject(modelStoreStatusController)

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -54,5 +54,19 @@
 	<string>NSApplication</string>
 	<key>NSSupportsSecureStateCoding</key>
 	<true/>
+	<key>SUAllowsAutomaticUpdates</key>
+	<false/>
+	<key>SUAutomaticallyUpdate</key>
+	<false/>
+	<key>SUEnableAutomaticChecks</key>
+	<false/>
+	<key>SUEnableSystemProfiling</key>
+	<false/>
+	<key>SUFeedURL</key>
+	<string>https://github.com/fairchild/workspaces/releases/latest/download/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>2iJCG30PnNC42c7NxxsMNFup+mnlKOU2/MZMEwm6lg4=</string>
+	<key>SUScheduledCheckInterval</key>
+	<integer>604800</integer>
 </dict>
 </plist>

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -30,9 +30,14 @@ struct SettingsView: View {
     @State private var isRunningRuntimeAction = false
 
     private let commandLineToolService: CommandLineToolService
+    private let softwareUpdateController: SoftwareUpdateController?
 
-    init(commandLineToolService: CommandLineToolService = CommandLineToolService()) {
+    init(
+        commandLineToolService: CommandLineToolService = CommandLineToolService(),
+        softwareUpdateController: SoftwareUpdateController? = nil
+    ) {
         self.commandLineToolService = commandLineToolService
+        self.softwareUpdateController = softwareUpdateController
         _commandLineToolStatus = State(initialValue: nil)
     }
 
@@ -92,6 +97,18 @@ struct SettingsView: View {
                 }
             } header: {
                 Text("General")
+            }
+
+            Section {
+                if let softwareUpdateController {
+                    SoftwareUpdateSettingsView(updater: softwareUpdateController.updater)
+                } else {
+                    Text("Update settings are unavailable in this preview.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("Updates")
             }
 
             Section {

--- a/Sources/WorkspaceManager/Views/SoftwareUpdateSettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SoftwareUpdateSettingsView.swift
@@ -1,0 +1,63 @@
+//
+//  SoftwareUpdateSettingsView.swift
+//  WorkspaceManager
+//
+//  Transparent controls for privacy-preserving update checks.
+//
+
+import Sparkle
+import SwiftUI
+
+struct SoftwareUpdateSettingsView: View {
+    private let updater: SPUUpdater
+    @State private var automaticallyChecksForUpdates: Bool
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        self._automaticallyChecksForUpdates = State(
+            initialValue: updater.automaticallyChecksForUpdates
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Updates")
+                .font(.headline)
+
+            Toggle(
+                "Automatically check for updates",
+                isOn: $automaticallyChecksForUpdates
+            )
+            .onChange(of: automaticallyChecksForUpdates) { _, newValue in
+                updater.automaticallyChecksForUpdates = newValue
+                if !newValue {
+                    updater.automaticallyDownloadsUpdates = false
+                }
+            }
+
+            Text(SoftwareUpdateConstants.automaticCheckDisclosure)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(
+                "Automatic downloads and silent installs are disabled. "
+                    + "Installing an update always requires user confirmation."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Text("Appcast")
+                Spacer()
+                Text(SoftwareUpdateConstants.feedURLString)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .font(.caption)
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SoftwareUpdatePrivacyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SoftwareUpdatePrivacyTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("SoftwareUpdatePrivacy")
+struct SoftwareUpdatePrivacyTests {
+    @Test("Sparkle plist defaults are privacy preserving")
+    func sparklePlistDefaultsArePrivacyPreserving() throws {
+        let plistURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/WorkspaceManager/Resources/Info.plist")
+        let data = try Data(contentsOf: plistURL)
+        let plist = try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        #expect(plist["SUFeedURL"] as? String == SoftwareUpdateConstants.feedURLString)
+        #expect(plist["SUPublicEDKey"] as? String == "2iJCG30PnNC42c7NxxsMNFup+mnlKOU2/MZMEwm6lg4=")
+        #expect(plist["SUScheduledCheckInterval"] as? Int == 604_800)
+        #expect(plist["SUEnableAutomaticChecks"] as? Bool == false)
+        #expect(plist["SUAutomaticallyUpdate"] as? Bool == false)
+        #expect(plist["SUAllowsAutomaticUpdates"] as? Bool == false)
+        #expect(plist["SUEnableSystemProfiling"] as? Bool == false)
+    }
+
+    @Test("Updater delegate policy sends no telemetry")
+    func updaterDelegatePolicySendsNoTelemetry() {
+        #expect(SoftwareUpdatePrivacyPolicy.shouldPromptForAutomaticCheckPermission == false)
+        #expect(SoftwareUpdatePrivacyPolicy.feedParameters.isEmpty)
+        #expect(SoftwareUpdatePrivacyPolicy.allowedSystemProfileKeys.isEmpty)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SparkleAppcastScriptTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SparkleAppcastScriptTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@Suite("SparkleAppcastScript", .serialized)
+struct SparkleAppcastScriptTests {
+    private let testPrivateKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+    @Test("Missing private key fails clearly")
+    func missingPrivateKeyFailsClearly() throws {
+        let fixture = try makeFixture()
+        let result = runAppcastScript(
+            arguments: [
+                "--dmg", fixture.dmg.path,
+                "--app", fixture.app.path,
+                "--tag", "v9.9.9",
+                "--output", fixture.output.path,
+            ],
+            environment: [:]
+        )
+
+        #expect(result.exitCode == 1)
+        #expect(result.stderr.contains("SPARKLE_PRIVATE_KEY is required"))
+    }
+
+    @Test("Generated appcast contains signed release metadata")
+    func generatedAppcastContainsSignedReleaseMetadata() throws {
+        let fixture = try makeFixture()
+        let result = runAppcastScript(
+            arguments: [
+                "--dmg", fixture.dmg.path,
+                "--app", fixture.app.path,
+                "--tag", "v9.9.9",
+                "--repo", "fairchild/workspaces",
+                "--output", fixture.output.path,
+            ],
+            environment: ["SPARKLE_PRIVATE_KEY": testPrivateKey]
+        )
+
+        #expect(result.exitCode == 0)
+        let xml = try String(contentsOf: fixture.output, encoding: .utf8)
+        #expect(xml.contains("<sparkle:version>999</sparkle:version>"))
+        #expect(xml.contains("<sparkle:shortVersionString>9.9.9</sparkle:shortVersionString>"))
+        #expect(xml.contains("<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>"))
+        let dmgURL =
+            "https://github.com/fairchild/workspaces/releases/download/v9.9.9/"
+            + "WorkspaceManager-9.9.9.dmg"
+        #expect(xml.contains(dmgURL))
+        #expect(xml.contains("sparkle:edSignature="))
+        #expect(xml.contains("length=\"4\""))
+    }
+
+    private func makeFixture() throws -> (app: URL, dmg: URL, output: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SparkleAppcastScriptTests-\(UUID().uuidString)", isDirectory: true)
+        let app = root.appendingPathComponent("WorkspaceManager.app", isDirectory: true)
+        let contents = app.appendingPathComponent("Contents", isDirectory: true)
+        let dmg = root.appendingPathComponent("WorkspaceManager-9.9.9.dmg")
+        let output = root.appendingPathComponent("appcast.xml")
+
+        try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+        let plist: [String: Any] = [
+            "CFBundleVersion": "999",
+            "CFBundleShortVersionString": "9.9.9",
+            "LSMinimumSystemVersion": "14.0",
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: contents.appendingPathComponent("Info.plist"))
+        try Data("test".utf8).write(to: dmg)
+
+        return (app, dmg, output)
+    }
+
+    private func runAppcastScript(
+        arguments: [String],
+        environment: [String: String]
+    ) -> (exitCode: Int32, stdout: String, stderr: String) {
+        let repoRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let process = Process()
+        process.currentDirectoryURL = repoRoot
+        process.executableURL = repoRoot.appendingPathComponent("scripts/generate-sparkle-appcast.sh")
+        process.arguments = arguments
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return (127, "", error.localizedDescription)
+        }
+
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, stdoutText, stderrText)
+    }
+}

--- a/backlog/sparkle-autoupdate-plan.md
+++ b/backlog/sparkle-autoupdate-plan.md
@@ -1,8 +1,8 @@
 ---
-status: pending
+status: in_progress
 category: plan
 pr: null
-branch: null
+branch: codex/privacy-first-sparkle-updates
 score: null
 retro_summary: null
 completed: null
@@ -10,306 +10,64 @@ completed: null
 
 > **GitHub Issue**: https://github.com/fairchild/workspaces/issues/2
 
-
-# Sparkle Auto-Update Integration
+# Privacy-First Sparkle Update Integration
 
 ## Problem Statement
 
-WorkspaceManager is distributed directly (notarized DMG) rather than through the Mac App Store. Without built-in auto-update capability, users must manually check for and download new versions, leading to:
-
-- Fragmented user base on different versions
-- Critical bug fixes not reaching users promptly
-- Poor user experience for a developer tool
-
-Sparkle is the de-facto standard for macOS app auto-updates, used by VS Code, Sublime Text, and most non-App Store apps.
+WorkSpaces is distributed directly as a notarized DMG, so users need a safer path than manually polling GitHub Releases. The updater must still fit highly restricted corporate environments: no update checks, telemetry, profiling, background downloads, or silent installs may happen by default.
 
 ## Key Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Framework | Sparkle 2.x | Industry standard, Swift support, SPM compatible |
-| Signing | EdDSA (ed25519) | Sparkle 2.x default, more secure than DSA |
-| Appcast hosting | GitHub Pages | Free, reliable, version-controlled |
-| Update channel | Single (stable) | Start simple, add beta channel later if needed |
-| Check frequency | Weekly + manual | Balance between freshness and annoyance |
+| Framework | Sparkle 2.x | Native macOS updater with EdDSA verification and SwiftPM support |
+| Default network behavior | Off | No update request is made unless the user manually checks or explicitly enables automatic checks |
+| Telemetry/system profiling | Off, with delegate guardrails | Sparkle profiling remains disabled and the delegate returns no profile keys or feed parameters |
+| Automatic downloads/installs | Disabled | Corporate users should always confirm installs visibly |
+| Appcast hosting | GitHub Release asset | `latest/download/appcast.xml` avoids GitHub Pages cache lag |
+| Signing | Sparkle EdDSA | Private key stored outside the repo as `SPARKLE_PRIVATE_KEY`; public key committed in `Info.plist` |
 
-## Architecture
+## Implementation Shape
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    WorkspaceManager.app                     │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │ SPUStandardUpdaterController (Sparkle)               │   │
-│  │ - Automatic check on launch (configurable)           │   │
-│  │ - "Check for Updates" menu item                      │   │
-│  │ - EdDSA signature verification                       │   │
-│  └─────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼ HTTPS fetch
-┌─────────────────────────────────────────────────────────────┐
-│              GitHub Pages (appcast.xml)                     │
-│  - Version info, release notes                              │
-│  - Download URLs (GitHub Releases)                          │
-│  - EdDSA signatures                                         │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼ Download
-┌─────────────────────────────────────────────────────────────┐
-│              GitHub Releases (DMG files)                    │
-│  - WorkspaceManager-1.0.0.dmg                              │
-│  - WorkspaceManager-1.1.0.dmg                              │
-└─────────────────────────────────────────────────────────────┘
-```
+The app owns a single `SoftwareUpdateController` that wraps `SPUStandardUpdaterController`. The controller is shared by:
 
-## Implementation Phases
+- App menu command: `Check for Updates...`
+- Settings > Updates toggle: `Automatically check for updates`
+- A defensive `SoftwareUpdateDelegate`
 
-### Phase 1: Add Sparkle Dependency
+The first manual check shows a disclosure before invoking Sparkle. The disclosure states that WorkSpaces contacts GitHub Releases, sends no telemetry/system profile/custom parameters, and that GitHub may receive normal HTTP request metadata such as IP address.
 
-**Files to modify:**
-- `Package.swift` - Add Sparkle package dependency
+Info.plist defaults:
 
-```swift
-dependencies: [
-    .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
-    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0")
-],
-targets: [
-    .executableTarget(
-        name: "WorkspaceManager",
-        dependencies: [
-            "WorkspaceManagerCore",
-            "SwiftTerm",
-            .product(name: "Sparkle", package: "Sparkle")
-        ],
-        ...
-    )
-]
-```
+- `SUFeedURL = https://github.com/fairchild/workspaces/releases/latest/download/appcast.xml`
+- `SUEnableAutomaticChecks = false`
+- `SUAutomaticallyUpdate = false`
+- `SUAllowsAutomaticUpdates = false`
+- `SUEnableSystemProfiling = false`
+- `SUScheduledCheckInterval = 604800`
+- `SUPublicEDKey = <production public key>`
 
-**Acceptance criteria:**
-- [ ] `swift build` succeeds with Sparkle dependency
-- [ ] Sparkle framework included in app bundle
+## Release Integration
 
-### Phase 2: Generate Signing Keys
+Release builds bundle `Sparkle.framework` into `Contents/Frameworks` and sign it with the rest of the app bundle. The release workflow requires `SPARKLE_PRIVATE_KEY`, generates `build/appcast.xml` after the DMG is created, and uploads the appcast beside the DMG assets.
 
-**Files to create:**
-- `scripts/generate-sparkle-keys.sh` - One-time key generation script
+The generated appcast uses:
 
-```bash
-#!/bin/bash
-# Generate EdDSA key pair for Sparkle updates
-# Run once, store private key securely (never commit!)
+- `CFBundleVersion` for `sparkle:version`
+- `CFBundleShortVersionString` for `sparkle:shortVersionString`
+- `LSMinimumSystemVersion` for `sparkle:minimumSystemVersion`
+- Sparkle `sign_update` output for `sparkle:edSignature` and `length`
+- the tagged GitHub Release DMG URL as the enclosure URL
 
-./Sparkle/bin/generate_keys
+## Verification
 
-# Output:
-# - Private key: Add to CI secrets as SPARKLE_PRIVATE_KEY
-# - Public key: Add to Info.plist as SUPublicEDKey
-```
-
-**Acceptance criteria:**
-- [ ] EdDSA key pair generated
-- [ ] Private key stored in secure location (1Password, GitHub Secrets)
-- [ ] Public key ready for Info.plist
-
-### Phase 3: Configure Info.plist
-
-**Files to modify:**
-- `Sources/WorkspaceManager/Resources/Info.plist` - Add Sparkle configuration
-
-Required keys:
-```xml
-<!-- Sparkle Configuration -->
-<key>SUFeedURL</key>
-<string>https://cloudcompute.github.io/workspaces/appcast.xml</string>
-
-<key>SUPublicEDKey</key>
-<string>{PUBLIC_EDKEY_FROM_GENERATION}</string>
-
-<key>SUEnableAutomaticChecks</key>
-<true/>
-
-<key>SUScheduledCheckInterval</key>
-<integer>604800</integer> <!-- Weekly (7 * 24 * 60 * 60) -->
-
-<key>SUAllowsAutomaticUpdates</key>
-<true/>
-```
-
-**Acceptance criteria:**
-- [ ] SUFeedURL points to valid appcast location
-- [ ] SUPublicEDKey contains generated public key
-
-### Phase 4: Integrate Updater in App
-
-**Files to modify:**
-- `WorkspaceManager/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift` - Add updater controller
-
-```swift
-import Sparkle
-
-@main
-struct WorkspaceManagerApp: App {
-    private let updaterController: SPUStandardUpdaterController
-
-    init() {
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
-    }
-
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-        }
-        .commands {
-            CommandGroup(after: .appInfo) {
-                CheckForUpdatesView(updater: updaterController.updater)
-            }
-        }
-    }
-}
-```
-
-**Files to create:**
-- `WorkspaceManager/Sources/WorkspaceManager/Views/CheckForUpdatesView.swift`
-
-```swift
-import SwiftUI
-import Sparkle
-
-struct CheckForUpdatesView: View {
-    @ObservedObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
-
-    init(updater: SPUUpdater) {
-        self.checkForUpdatesViewModel = CheckForUpdatesViewModel(updater: updater)
-    }
-
-    var body: some View {
-        Button("Check for Updates…", action: checkForUpdatesViewModel.checkForUpdates)
-            .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
-    }
-}
-
-final class CheckForUpdatesViewModel: ObservableObject {
-    @Published var canCheckForUpdates = false
-
-    private let updater: SPUUpdater
-
-    init(updater: SPUUpdater) {
-        self.updater = updater
-        updater.publisher(for: \.canCheckForUpdates)
-            .assign(to: &$canCheckForUpdates)
-    }
-
-    func checkForUpdates() {
-        updater.checkForUpdates()
-    }
-}
-```
-
-**Acceptance criteria:**
-- [ ] "Check for Updates…" appears in app menu
-- [ ] Menu item disabled during check, enabled when idle
-- [ ] Automatic check runs on app launch
-
-### Phase 5: Set Up Appcast Infrastructure
-
-**Files to create:**
-- `docs/appcast.xml` - Initial appcast (empty or with v1.0.0)
-- `.github/workflows/update-appcast.yml` - Automation for appcast updates
-
-Appcast template:
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-  <channel>
-    <title>WorkspaceManager Updates</title>
-    <link>https://cloudcompute.github.io/workspaces/appcast.xml</link>
-    <description>Most recent changes with links to updates.</description>
-    <language>en</language>
-    <item>
-      <title>Version 1.0.0</title>
-      <sparkle:version>1</sparkle:version>
-      <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
-      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-      <pubDate>Mon, 01 Jan 2026 00:00:00 +0000</pubDate>
-      <enclosure
-        url="https://github.com/cloudcompute/workspaces/releases/download/v1.0.0/WorkspaceManager-1.0.0.dmg"
-        sparkle:edSignature="{SIGNATURE}"
-        length="{FILE_SIZE}"
-        type="application/octet-stream" />
-      <description><![CDATA[
-        <h2>Initial Release</h2>
-        <ul>
-          <li>Terminal-based workspace management</li>
-          <li>Git integration</li>
-          <li>SwiftUI interface</li>
-        </ul>
-      ]]></description>
-    </item>
-  </channel>
-</rss>
-```
-
-**Acceptance criteria:**
-- [ ] Appcast accessible at SUFeedURL
-- [ ] GitHub Pages configured for docs/ folder
-- [ ] XML validates against Sparkle schema
-
-### Phase 6: Release Signing Script
-
-**Files to modify:**
-- `scripts/notarize.sh` - Add Sparkle signing step
-
-Add after DMG creation:
-```bash
-# Sign for Sparkle
-SIGNATURE=$(./Sparkle/bin/sign_update "$DMG_PATH" --ed-key-file "$SPARKLE_PRIVATE_KEY_FILE")
-echo "Sparkle signature: $SIGNATURE"
-```
-
-**Files to create:**
-- `scripts/update-appcast.sh` - Script to update appcast with new release
-
-**Acceptance criteria:**
-- [ ] DMG signed with EdDSA key during release
-- [ ] Signature included in appcast entry
-
-## Verification Commands
-
-```bash
-# Build with Sparkle
-swift build -c release
-
-# Verify Sparkle linked
-otool -L .build/release/WorkspaceManager | grep Sparkle
-
-# Test appcast fetch (after deployment)
-curl -s https://cloudcompute.github.io/workspaces/appcast.xml | xmllint --format -
-
-# Verify signature
-./Sparkle/bin/sign_update --verify "$DMG_PATH" --ed-key-file "$PUBLIC_KEY_FILE"
-```
+- `plutil -lint Sources/WorkspaceManager/Resources/Info.plist`
+- `swift build`
+- `swift test`
+- `./scripts/build-release.sh --no-sign`
+- `bash -n scripts/build-release.sh scripts/generate-sparkle-appcast.sh scripts/notarize.sh`
+- Runtime screenshots of Settings > Updates and the first manual-check disclosure uploaded with `./scripts/evidence.sh`
 
 ## Rollback Plan
 
-If Sparkle causes issues:
-1. Remove Sparkle dependency from Package.swift
-2. Remove updater code from WorkspaceManagerApp.swift
-3. Remove CheckForUpdatesView.swift
-4. Remove Sparkle keys from Info.plist
-5. Rebuild and release without auto-update
-
-Users on broken version can manually download from GitHub Releases.
-
-## References
-
-- [Sparkle Documentation](https://sparkle-project.org/documentation/)
-- [Sparkle 2 Migration Guide](https://sparkle-project.org/documentation/upgrading/)
-- [Sparkle SPM Integration](https://github.com/sparkle-project/Sparkle#swift-package-manager)
-- `Package.swift:1-29` - Current package configuration
-- `scripts/notarize.sh` - Current release script
+Remove the Sparkle dependency, updater controller, Settings section, Sparkle Info.plist keys, appcast generation step, and Sparkle framework bundling. Users can continue downloading DMGs manually from GitHub Releases.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -350,6 +350,28 @@ verify_release_bundle_signing() {
     log_success "$output"
 }
 
+verify_sparkle_bundle_linkage() {
+    local executable="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+    local framework_binary="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle"
+
+    log_step "Verifying Sparkle bundle linkage"
+
+    [[ -x "$executable" ]] || fail "Release executable not found: $executable"
+    [[ -f "$framework_binary" ]] || fail "Bundled Sparkle framework binary not found: $framework_binary"
+
+    if otool -L "$executable" | grep -q "@rpath/Sparkle.framework/Versions/B/Sparkle"; then
+        log_success "Verified Sparkle framework load command"
+    else
+        fail "Release executable is not linked against @rpath/Sparkle.framework/Versions/B/Sparkle"
+    fi
+
+    if otool -l "$executable" | grep -q "@executable_path/../Frameworks"; then
+        log_success "Verified executable rpath includes Contents/Frameworks"
+    else
+        fail "Release executable is missing @executable_path/../Frameworks rpath for Sparkle.framework"
+    fi
+}
+
 for arg in "$@"; do
     case "$arg" in
         --no-sign)
@@ -409,6 +431,7 @@ log_success "Build complete"
 log_step "Creating app bundle"
 
 mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Frameworks"
 mkdir -p "$APP_BUNDLE/Contents/Helpers"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 
@@ -435,6 +458,14 @@ SPM_RESOURCES=".build/release/WorkspaceManager_WorkspaceManager.bundle"
 if [[ -d "$SPM_RESOURCES" ]]; then
     cp -R "$SPM_RESOURCES"/* "$APP_BUNDLE/Contents/Resources/" 2>/dev/null || true
     log_success "Copied SPM resources"
+fi
+
+SPARKLE_FRAMEWORK=".build/artifacts/sparkle/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
+if [[ -d "$SPARKLE_FRAMEWORK" ]]; then
+    cp -R "$SPARKLE_FRAMEWORK" "$APP_BUNDLE/Contents/Frameworks/"
+    log_success "Copied Sparkle.framework"
+else
+    fail "Sparkle.framework not found at $SPARKLE_FRAMEWORK; run swift package resolve"
 fi
 
 if GHOSTTY_SHARE_DIR_RESOLVED="$(resolve_ghostty_share_dir)"; then
@@ -505,6 +536,8 @@ if [[ "$SIGN_APP" == true ]] && [[ -n "${SIGNING_IDENTITY:-}" ]]; then
 else
     log_warning "Skipping code signing"
 fi
+
+verify_sparkle_bundle_linkage
 
 echo ""
 echo "============================================================================"

--- a/scripts/generate-sparkle-appcast.sh
+++ b/scripts/generate-sparkle-appcast.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# ============================================================================
+# generate-sparkle-appcast.sh - Generate a signed Sparkle appcast for a DMG
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+PLIST_BUDDY="/usr/libexec/PlistBuddy"
+
+DMG_PATH=""
+APP_BUNDLE="$PROJECT_DIR/build/WorkspaceManager.app"
+OUTPUT_PATH="$PROJECT_DIR/build/appcast.xml"
+REPO="${GITHUB_REPOSITORY:-fairchild/workspaces}"
+TAG=""
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/generate-sparkle-appcast.sh --dmg <path> --tag <tag> [options]
+
+Options:
+  --app <path>       App bundle used for version metadata (default: build/WorkspaceManager.app)
+  --output <path>    Output appcast path (default: build/appcast.xml)
+  --repo <owner/repo> GitHub repository for release asset URLs (default: GITHUB_REPOSITORY or fairchild/workspaces)
+  --help            Show this help
+
+Required environment:
+  SPARKLE_PRIVATE_KEY  Private EdDSA key exported by Sparkle generate_keys -x.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dmg)
+            DMG_PATH="${2:-}"
+            shift 2
+            ;;
+        --app)
+            APP_BUNDLE="${2:-}"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_PATH="${2:-}"
+            shift 2
+            ;;
+        --repo)
+            REPO="${2:-}"
+            shift 2
+            ;;
+        --tag)
+            TAG="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+[[ -n "$DMG_PATH" ]] || { echo "Missing required --dmg path" >&2; exit 2; }
+[[ -n "$TAG" ]] || { echo "Missing required --tag" >&2; exit 2; }
+[[ -f "$DMG_PATH" ]] || { echo "DMG not found: $DMG_PATH" >&2; exit 1; }
+[[ -d "$APP_BUNDLE" ]] || { echo "App bundle not found: $APP_BUNDLE" >&2; exit 1; }
+[[ -n "${SPARKLE_PRIVATE_KEY:-}" ]] || {
+    echo "SPARKLE_PRIVATE_KEY is required to sign Sparkle update archives" >&2
+    exit 1
+}
+
+SIGN_UPDATE="$PROJECT_DIR/.build/artifacts/sparkle/Sparkle/bin/sign_update"
+[[ -x "$SIGN_UPDATE" ]] || {
+    echo "Sparkle sign_update tool not found at $SIGN_UPDATE; run swift package resolve" >&2
+    exit 1
+}
+
+INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
+[[ -f "$INFO_PLIST" ]] || { echo "Info.plist not found in app bundle: $INFO_PLIST" >&2; exit 1; }
+
+VERSION="$("$PLIST_BUDDY" -c "Print :CFBundleVersion" "$INFO_PLIST")"
+SHORT_VERSION="$("$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$INFO_PLIST")"
+MIN_SYSTEM_VERSION="$("$PLIST_BUDDY" -c "Print :LSMinimumSystemVersion" "$INFO_PLIST")"
+DMG_BASENAME="$(basename "$DMG_PATH")"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$DMG_BASENAME"
+RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
+PUB_DATE="$(LC_ALL=C date -u "+%a, %d %b %Y %H:%M:%S +0000")"
+
+SIGNATURE_ATTRIBUTES="$(
+    printf "%s" "$SPARKLE_PRIVATE_KEY" \
+        | "$SIGN_UPDATE" --ed-key-file - "$DMG_PATH"
+)"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+cat >"$OUTPUT_PATH" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>WorkSpaces Updates</title>
+    <link>https://github.com/$REPO/releases/latest</link>
+    <description>Signed WorkSpaces releases.</description>
+    <language>en</language>
+    <item>
+      <title>WorkSpaces $SHORT_VERSION</title>
+      <link>$RELEASE_URL</link>
+      <sparkle:version>$VERSION</sparkle:version>
+      <sparkle:shortVersionString>$SHORT_VERSION</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>$MIN_SYSTEM_VERSION</sparkle:minimumSystemVersion>
+      <pubDate>$PUB_DATE</pubDate>
+      <enclosure url="$DOWNLOAD_URL" $SIGNATURE_ATTRIBUTES type="application/octet-stream" />
+      <description><![CDATA[
+        <p>See the GitHub release notes for WorkSpaces $SHORT_VERSION.</p>
+      ]]></description>
+    </item>
+  </channel>
+</rss>
+XML
+
+echo "Generated Sparkle appcast: $OUTPUT_PATH"


### PR DESCRIPTION
## Summary
- Add Sparkle 2.x update support with privacy-preserving defaults: automatic checks, automatic installs/downloads, system profiling, feed parameters, and telemetry all default off.
- Add Settings > Updates with an explicit opt-in toggle and visible transparency copy for GitHub appcast checks.
- Add a Check for Updates... app command gated by WorkSpaces disclosure, plus a Sparkle delegate gate so direct Sparkle user-initiated checks cannot bypass disclosure.
- Bundle Sparkle.framework in release builds and add LC_RPATH verification for @executable_path/../Frameworks to prevent the boot crash reported from missing @rpath/Sparkle.framework.
- Add appcast generation for GitHub Releases, require SPARKLE_PRIVATE_KEY in release validation, and upload appcast.xml with the DMG.
- Replace the backlog/issue language that previously recommended weekly automatic checks by default.

## Crash Fix
The reported crash was a dyld launch failure for `@rpath/Sparkle.framework/Versions/B/Sparkle`. This PR fixes both sides of the load path: the release bundle copies `Sparkle.framework` into `Contents/Frameworks`, and the app executable now carries `@executable_path/../Frameworks` in LC_RPATH. `./scripts/build-release.sh --no-sign` now fails if either the Sparkle load command or rpath is missing.

## Evidence
- ![privacy-first-updates-settings](https://evidence.cloudcompute.com/workspaces/pr-413/20260503-055753-privacy-first-updates-settings.png)
- ![privacy-first-packaged-launch](https://evidence.cloudcompute.com/workspaces/pr-413/20260503-055810-privacy-first-packaged-launch.png)
- ![privacy-first-validation-summary](https://evidence.cloudcompute.com/workspaces/pr-413/20260503-055928-privacy-first-validation-summary.svg)

## Validation
- `plutil -lint Sources/WorkspaceManager/Resources/Info.plist`
- `bash -n scripts/build-release.sh scripts/generate-sparkle-appcast.sh scripts/notarize.sh`
- `git diff --check HEAD~1..HEAD`
- `swift build`
- `swift test` - 510 tests in 88 suites passed
- `./scripts/build-release.sh --no-sign` - copied Sparkle.framework and verified Sparkle load command plus `@executable_path/../Frameworks` rpath
- Appcast smoke generated XML with bundle version 12, short version 0.11.0, minimum macOS 14.0, GitHub Releases DMG URL, file length, and EdDSA signature
- `otool -L build/WorkspaceManager.app/Contents/MacOS/WorkspaceManager` includes `@rpath/Sparkle.framework/Versions/B/Sparkle`
- `otool -l build/WorkspaceManager.app/Contents/MacOS/WorkspaceManager` includes `LC_RPATH @executable_path/../Frameworks`

## Notes
- Production Sparkle public key is committed in Info.plist. The private key was stored as the GitHub Actions secret `SPARKLE_PRIVATE_KEY` and is not committed.
- Full app bundle codesign verification is intentionally skipped for `--no-sign`; the signed release path still runs the existing codesign and release-bundle verifiers.
- Shared-desktop automation was unstable for capturing the first manual-check disclosure modal. The implementation now enforces the disclosure in both the WorkSpaces menu wrapper and Sparkle `mayPerformUpdateCheck` delegate, so direct Sparkle user-initiated checks cannot bypass it.


## Mergeability
- Surface: desktop, release, docs
- User-facing behavior changed: Adds manual update checking plus an opt-in automatic update check toggle; default behavior remains no network update checks.
- Non-happy paths considered: Missing Sparkle framework/rpath now fails release packaging; missing SPARKLE_PRIVATE_KEY fails release validation; direct Sparkle user-initiated checks are gated by the disclosure delegate.
- Residual risk or follow-up: First manual-check modal screenshot was blocked by shared-desktop focus automation; code and tests cover the privacy defaults and delegate policy, and Settings/runtime launch evidence is uploaded.
- Release/ops preconditions: Production Sparkle public key is committed; private key is stored as GitHub Actions secret SPARKLE_PRIVATE_KEY; release workflow validates the secret before publishing and uploads appcast.xml with the DMG.
