### PR TITLE
[codex] Verify repo selections server-side

### DIFF
--- a/web/src/app/api/repos/route.test.ts
+++ b/web/src/app/api/repos/route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	bypassToken: null as string | null,
+	fetchUserRepos: vi.fn(),
+	getGitHubToken: vi.fn(),
+	session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+	setUserRepos: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+	getDevBypassToken: () => mocks.bypassToken,
+	getSession: async () => mocks.session,
+}));
+
+vi.mock("@/lib/github", () => {
+	class GitHubApiError extends Error {
+		constructor(
+			public status: number,
+			public body: string,
+		) {
+			super(`GitHub API ${status}`);
+		}
+	}
+
+	return {
+		GitHubApiError,
+		fetchUserRepos: mocks.fetchUserRepos,
+		getGitHubToken: mocks.getGitHubToken,
+	};
+});
+
+vi.mock("@/lib/repos", () => ({
+	getUserRepos: vi.fn(async () => []),
+	setUserRepos: mocks.setUserRepos,
+}));
+
+function jsonRequest(body: unknown): Request {
+	return new Request("http://localhost/api/repos", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+describe("/api/repos POST", () => {
+	beforeEach(() => {
+		mocks.bypassToken = null;
+		mocks.fetchUserRepos.mockReset();
+		mocks.fetchUserRepos.mockResolvedValue([
+			{
+				full_name: "fairchild/workspaces",
+				owner: "fairchild",
+				name: "workspaces",
+				pushed_at: "2026-01-01T00:00:00Z",
+				description: null,
+			},
+			{
+				full_name: "Acme/Private-Repo",
+				owner: "Acme",
+				name: "Private-Repo",
+				pushed_at: "2026-01-01T00:00:00Z",
+				description: null,
+			},
+		]);
+		mocks.getGitHubToken.mockReset();
+		mocks.getGitHubToken.mockResolvedValue("oauth-token");
+		mocks.session = { user: { id: "user-1" } };
+		mocks.setUserRepos.mockReset();
+	});
+
+	it("rejects unauthenticated requests", async () => {
+		mocks.session = null;
+
+		const { POST } = await import("./route");
+		const response = await POST(jsonRequest({ repos: [] }));
+
+		expect(response.status).toBe(401);
+		expect(mocks.setUserRepos).not.toHaveBeenCalled();
+	});
+
+	it("rejects repos the authenticated user's GitHub token cannot list", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(
+			jsonRequest({
+				repos: [
+					{ owner: "fairchild", repo: "workspaces" },
+					{ owner: "other", repo: "secret" },
+				],
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			error: "repo_not_accessible",
+			repos: ["other/secret"],
+			needsReauth: true,
+		});
+		expect(mocks.setUserRepos).not.toHaveBeenCalled();
+	});
+
+	it("canonicalizes and dedupes the server-verified GitHub repo list", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(
+			jsonRequest({
+				repos: [
+					{ owner: "FAIRCHILD", repo: "WORKSPACES" },
+					{ owner: "fairchild", repo: "workspaces" },
+					{ owner: "acme", repo: "private-repo" },
+				],
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.setUserRepos).toHaveBeenCalledWith("user-1", [
+			{ owner: "fairchild", repo: "workspaces" },
+			{ owner: "Acme", repo: "Private-Repo" },
+		]);
+	});
+
+	it("uses the dev bypass token when present", async () => {
+		mocks.bypassToken = "dev-token";
+
+		const { POST } = await import("./route");
+		const response = await POST(
+			jsonRequest({ repos: [{ owner: "fairchild", repo: "workspaces" }] }),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.getGitHubToken).not.toHaveBeenCalled();
+		expect(mocks.fetchUserRepos).toHaveBeenCalledWith("dev-token");
+	});
+
+	it("requires GitHub reauth when no OAuth token is available", async () => {
+		mocks.getGitHubToken.mockResolvedValue(null);
+
+		const { POST } = await import("./route");
+		const response = await POST(
+			jsonRequest({ repos: [{ owner: "fairchild", repo: "workspaces" }] }),
+		);
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toMatchObject({
+			error: "no_github_token",
+			needsReauth: true,
+		});
+		expect(mocks.setUserRepos).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/app/api/repos/route.ts
+++ b/web/src/app/api/repos/route.ts
@@ -1,6 +1,135 @@
 import { unauthorizedResponse } from "@/lib/api-auth";
-import { getSession } from "@/lib/auth-server";
+import { getDevBypassToken, getSession } from "@/lib/auth-server";
+import { GitHubApiError, fetchUserRepos, getGitHubToken } from "@/lib/github";
 import { getUserRepos, setUserRepos } from "@/lib/repos";
+
+const MAX_REPOS_PER_SELECTION = 100;
+const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
+
+function parseRequestedRepos(body: unknown):
+	| {
+			ok: true;
+			repos: Array<{ owner: string; repo: string }>;
+	  }
+	| { ok: false; response: Response } {
+	if (!body || typeof body !== "object" || !("repos" in body)) {
+		return {
+			ok: false,
+			response: Response.json(
+				{ error: "repos must be an array" },
+				{ status: 400 },
+			),
+		};
+	}
+
+	const repos = (body as { repos: unknown }).repos;
+	if (!Array.isArray(repos)) {
+		return {
+			ok: false,
+			response: Response.json(
+				{ error: "repos must be an array" },
+				{ status: 400 },
+			),
+		};
+	}
+	if (repos.length > MAX_REPOS_PER_SELECTION) {
+		return {
+			ok: false,
+			response: Response.json(
+				{
+					error: `repos cannot include more than ${MAX_REPOS_PER_SELECTION} entries`,
+				},
+				{ status: 400 },
+			),
+		};
+	}
+
+	const normalized = new Map<string, { owner: string; repo: string }>();
+	for (const item of repos) {
+		if (!item || typeof item !== "object") {
+			return {
+				ok: false,
+				response: Response.json(
+					{ error: "each repo must include owner and repo" },
+					{ status: 400 },
+				),
+			};
+		}
+		const { owner, repo } = item as { owner?: unknown; repo?: unknown };
+		if (
+			typeof owner !== "string" ||
+			typeof repo !== "string" ||
+			!OWNER_PATTERN.test(owner) ||
+			!REPO_PATTERN.test(repo)
+		) {
+			return {
+				ok: false,
+				response: Response.json(
+					{ error: "each repo must include a valid owner and repo" },
+					{ status: 400 },
+				),
+			};
+		}
+		normalized.set(`${owner.toLowerCase()}/${repo.toLowerCase()}`, {
+			owner,
+			repo,
+		});
+	}
+
+	return { ok: true, repos: [...normalized.values()] };
+}
+
+async function getRequestGitHubToken(
+	userId: string,
+): Promise<string | Response> {
+	const bypassToken = getDevBypassToken();
+	if (bypassToken) return bypassToken;
+
+	const ghToken = await getGitHubToken(userId);
+	if (!ghToken) {
+		return Response.json(
+			{ error: "no_github_token", needsReauth: true },
+			{ status: 403 },
+		);
+	}
+	return ghToken;
+}
+
+async function verifyReposForToken(
+	token: string,
+	repos: Array<{ owner: string; repo: string }>,
+): Promise<Array<{ owner: string; repo: string }> | Response> {
+	const availableRepos = await fetchUserRepos(token);
+	const byFullName = new Map(
+		availableRepos.map((repo) => [repo.full_name.toLowerCase(), repo]),
+	);
+
+	const verified: Array<{ owner: string; repo: string }> = [];
+	const inaccessible: string[] = [];
+	for (const requested of repos) {
+		const fullName = `${requested.owner}/${requested.repo}`;
+		const available = byFullName.get(fullName.toLowerCase());
+		if (!available) {
+			inaccessible.push(fullName);
+			continue;
+		}
+		verified.push({ owner: available.owner, repo: available.name });
+	}
+
+	if (inaccessible.length > 0) {
+		return Response.json(
+			{
+				error: "repo_not_accessible",
+				repos: inaccessible,
+				needsReauth: true,
+			},
+			{ status: 403 },
+		);
+	}
+
+	return verified;
+}
 
 export async function GET(): Promise<Response> {
 	const session = await getSession();
@@ -14,14 +143,45 @@ export async function POST(request: Request): Promise<Response> {
 	const session = await getSession();
 	if (!session) return unauthorizedResponse();
 
-	const body = (await request.json()) as {
-		repos: Array<{ owner: string; repo: string }>;
-	};
-
-	if (!Array.isArray(body.repos)) {
-		return Response.json({ error: "repos must be an array" }, { status: 400 });
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return Response.json({ error: "invalid_json" }, { status: 400 });
 	}
 
-	await setUserRepos(session.user.id, body.repos);
-	return Response.json({ ok: true });
+	const parsed = parseRequestedRepos(body);
+	if (!parsed.ok) return parsed.response;
+
+	try {
+		const token = await getRequestGitHubToken(session.user.id);
+		if (token instanceof Response) return token;
+
+		const verifiedRepos = await verifyReposForToken(token, parsed.repos);
+		if (verifiedRepos instanceof Response) return verifiedRepos;
+
+		await setUserRepos(session.user.id, verifiedRepos);
+		return Response.json({ ok: true });
+	} catch (err) {
+		if (err instanceof GitHubApiError) {
+			if (err.status === 401)
+				return Response.json(
+					{ error: "token_expired", needsReauth: true },
+					{ status: 401 },
+				);
+			if (err.status === 403)
+				return Response.json(
+					{ error: "insufficient_scope", needsReauth: true },
+					{ status: 403 },
+				);
+		}
+		const message =
+			err instanceof GitHubApiError
+				? `GitHub API ${err.status}`
+				: err instanceof Error
+					? err.message
+					: "unknown error";
+		console.error("[/api/repos]", message, err);
+		return Response.json({ error: message }, { status: 500 });
+	}
 }

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -139,10 +139,15 @@ interface GHRepo {
 export function fetchUserRepos(token: string): Promise<GitHubRepo[]> {
 	const keyHash = token.slice(-8);
 	return cached(`repos:${keyHash}`, FIVE_MIN, async () => {
-		const repos = await ghFetch<GHRepo[]>(
-			"/user/repos?sort=pushed&direction=desc&per_page=100",
-			token,
-		);
+		const repos: GHRepo[] = [];
+		for (let page = 1; page <= 10; page++) {
+			const batch = await ghFetch<GHRepo[]>(
+				`/user/repos?sort=pushed&direction=desc&per_page=100&page=${page}`,
+				token,
+			);
+			repos.push(...batch);
+			if (batch.length < 100) break;
+		}
 		return repos.map((r) => ({
 			full_name: r.full_name,
 			owner: r.owner.login,


### PR DESCRIPTION
## Summary

- Validate `/api/repos` POST selections server-side against the authenticated user's GitHub repo list before writing `user_repos`.
- Canonicalize and dedupe saved repos from GitHub's response so client-provided casing and duplicates do not control stored authz rows.
- Page `/user/repos` up to 1,000 repos so validation is not limited to the first 100 results.
- Add route tests covering self-grant rejection, canonicalization, dev bypass, unauthenticated requests, and missing OAuth tokens.

## Why

The security review found that a logged-in user could POST arbitrary repo rows and then pass `authorizeRepoAccess()` for repo-scoped web APIs backed by local data. This changes the saved repo list from client-trusted preferences into a server-verified selection.

## Validation

- `pnpm test -- src/app/api/repos/route.test.ts src/lib/__tests__/repos.test.ts src/lib/__tests__/github-token.test.ts` passed: 18 files, 158 tests.
- `mise -C web run web:check` passed: typecheck, Biome, and 18 files / 158 tests.
- `git diff --check` passed.

## Mergeability

- Surface: web / authz
- User-facing behavior changed: Repo saving now rejects repos the authenticated GitHub token cannot list and may ask the user to reauthenticate when token access is missing or insufficient.
- Non-happy paths considered: Invalid JSON, malformed repo payloads, missing OAuth token, GitHub 401/403, duplicate submitted repos, and case-mismatched repo names are handled.
- Residual risk or follow-up: Existing saved rows remain trusted until the user next saves their repo list; a future migration could re-verify or prune historical rows.
- Release/ops preconditions: None.

## Evidence

- API-only change; verification is the web check output above and the remote PR checks.
