### PR TITLE
[codex] Scope agent sessions to users

### DIFF
--- a/web/e2e/seed.ts
+++ b/web/e2e/seed.ts
@@ -141,6 +141,7 @@ export default async function globalSetup() {
 
 	await db.execute(`CREATE TABLE IF NOT EXISTS agent_sessions (
 		id TEXT PRIMARY KEY,
+		user_id TEXT,
 		repo TEXT NOT NULL,
 		agent_name TEXT NOT NULL,
 		compute_backend TEXT NOT NULL,
@@ -223,11 +224,12 @@ export default async function globalSetup() {
 	const now = new Date().toISOString();
 	await db.execute({
 		sql: `INSERT OR REPLACE INTO agent_sessions (
-			id, repo, agent_name, compute_backend, compute_instance_id,
+			id, user_id, repo, agent_name, compute_backend, compute_instance_id,
 			snapshot_id, thread_id, status, created_at, last_activity_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		args: [
 			SESSION_IDS[0],
+			TEST_USER_ID,
 			TEST_REPO,
 			"april-clearwater",
 			"vercel-sandbox",

--- a/web/scripts/test-sandbox-e2e.ts
+++ b/web/scripts/test-sandbox-e2e.ts
@@ -263,6 +263,7 @@ async function testSessionPersistence() {
 	await test("createSession inserts a row", async () => {
 		await agentSessions.createSession({
 			id: sessionId,
+			userId: "test-user",
 			repo: "fairchild/workspaces",
 			agentName: "april-clearwater",
 			computeBackend: "vercel-sandbox",
@@ -302,6 +303,7 @@ async function testSessionPersistence() {
 	await test("getActiveSessionForThread finds active session", async () => {
 		await agentSessions.updateSessionStatus(sessionId, "active");
 		const session = await agentSessions.getActiveSessionForThread(
+			"test-user",
 			"fairchild/workspaces",
 			"april-clearwater",
 			"test-thread-1",
@@ -313,6 +315,7 @@ async function testSessionPersistence() {
 	await test("getActiveSessionForThread ignores completed sessions", async () => {
 		await agentSessions.updateSessionStatus(sessionId, "completed");
 		const session = await agentSessions.getActiveSessionForThread(
+			"test-user",
 			"fairchild/workspaces",
 			"april-clearwater",
 			"test-thread-1",

--- a/web/src/app/api/managed-agents/transcript/route.ts
+++ b/web/src/app/api/managed-agents/transcript/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: Request): Promise<Response> {
 		return new Response("sessionId required", { status: 400 });
 	}
 
-	const agentSession = await getSessionByInstanceId(sessionId);
+	const agentSession = await getSessionByInstanceId(authed.user.id, sessionId);
 	if (!agentSession) {
 		return new Response("session not found", { status: 404 });
 	}

--- a/web/src/app/api/terminal/resume/route.ts
+++ b/web/src/app/api/terminal/resume/route.ts
@@ -36,7 +36,11 @@ export async function POST(request: Request): Promise<Response> {
 	const unauthorized = await authorizeRepoAccess(session.user.id, body.repo);
 	if (unauthorized) return unauthorized;
 
-	const agentSession = await getSessionForAgent(body.repo, body.agentName);
+	const agentSession = await getSessionForAgent(
+		session.user.id,
+		body.repo,
+		body.agentName,
+	);
 	if (!agentSession) {
 		return Response.json(
 			{ error: "no session found for agent" },

--- a/web/src/app/api/terminal/start/route.ts
+++ b/web/src/app/api/terminal/start/route.ts
@@ -48,7 +48,11 @@ export async function POST(request: Request): Promise<Response> {
 	const agentName = body.agentName ?? process.env.DEFAULT_AGENT ?? "shell";
 
 	// If a live session already exists for this (repo, agent), reuse it
-	const existing = await getSessionForAgent(body.repo, agentName);
+	const existing = await getSessionForAgent(
+		session.user.id,
+		body.repo,
+		agentName,
+	);
 	if (existing?.computeInstanceId && existing.status !== "snapshotted") {
 		return Response.json({
 			sessionId: existing.id,
@@ -114,6 +118,7 @@ export async function POST(request: Request): Promise<Response> {
 	const now = new Date().toISOString();
 	await createSession({
 		id: sessionId,
+		userId: session.user.id,
 		repo: body.repo,
 		agentName,
 		computeBackend: provider.descriptor.id,

--- a/web/src/app/api/terminal/status/route.ts
+++ b/web/src/app/api/terminal/status/route.ts
@@ -94,7 +94,7 @@ export async function GET(request: Request): Promise<Response> {
 	const unauthorized = await authorizeRepoAccess(session.user.id, repo);
 	if (unauthorized) return unauthorized;
 
-	const dbSessions = await getSessionsForRepo(repo);
+	const dbSessions = await getSessionsForRepo(session.user.id, repo);
 	const resolved = await Promise.all(dbSessions.map(resolveSession));
 	const sessions = resolved.filter((s): s is TerminalSessionInfo => s !== null);
 

--- a/web/src/app/api/terminal/stop/route.ts
+++ b/web/src/app/api/terminal/stop/route.ts
@@ -30,7 +30,11 @@ export async function POST(request: Request): Promise<Response> {
 
 	const agentName = body.agentName ?? process.env.DEFAULT_AGENT ?? "shell";
 
-	const agentSession = await getSessionForAgent(body.repo, agentName);
+	const agentSession = await getSessionForAgent(
+		session.user.id,
+		body.repo,
+		agentName,
+	);
 	if (!agentSession?.computeInstanceId) {
 		return Response.json({ stopped: false, reason: "no active session" });
 	}

--- a/web/src/lib/__tests__/agent-sessions.test.ts
+++ b/web/src/lib/__tests__/agent-sessions.test.ts
@@ -12,6 +12,7 @@ function uniqueThread(): string {
 function makeSession(overrides: Partial<AgentSession> = {}): AgentSession {
 	return {
 		id: `test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+		userId: "user-1",
 		repo: "owner/repo",
 		agentName: "test-agent",
 		computeBackend: "vercel-sandbox",
@@ -57,6 +58,7 @@ describe("snapshot session lifecycle", () => {
 		await mod.createSession(session);
 
 		const found = await mod.getSnapshotSessionForThread(
+			session.userId,
 			session.repo,
 			session.agentName,
 			session.threadId,
@@ -73,6 +75,7 @@ describe("snapshot session lifecycle", () => {
 		await mod.createSession(session);
 
 		const found = await mod.getSnapshotSessionForThread(
+			session.userId,
 			session.repo,
 			session.agentName,
 			session.threadId,
@@ -98,6 +101,7 @@ describe("snapshot session lifecycle", () => {
 		await mod.createSession(newer);
 
 		const found = await mod.getSnapshotSessionForThread(
+			newer.userId,
 			older.repo,
 			older.agentName,
 			sharedThread,
@@ -156,6 +160,7 @@ describe("getActiveSessionForThread", () => {
 		await mod.createSession(session);
 
 		const found = await mod.getActiveSessionForThread(
+			session.userId,
 			session.repo,
 			session.agentName,
 			session.threadId,
@@ -171,10 +176,110 @@ describe("getActiveSessionForThread", () => {
 		await mod.createSession(session);
 
 		const found = await mod.getActiveSessionForThread(
+			session.userId,
 			session.repo,
 			session.agentName,
 			session.threadId,
 		);
 		expect(found).toBeNull();
+	});
+
+	it("scopes active sessions by user", async () => {
+		const sharedThread = uniqueThread();
+		const userOne = makeSession({
+			userId: "user-1",
+			status: "active",
+			computeInstanceId: "inst-user-1",
+			threadId: sharedThread,
+		});
+		const userTwo = makeSession({
+			userId: "user-2",
+			status: "active",
+			computeInstanceId: "inst-user-2",
+			threadId: sharedThread,
+		});
+		await mod.createSession(userOne);
+		await mod.createSession(userTwo);
+
+		const found = await mod.getActiveSessionForThread(
+			"user-1",
+			userOne.repo,
+			userOne.agentName,
+			sharedThread,
+		);
+
+		expect(found?.id).toBe(userOne.id);
+		expect(found?.computeInstanceId).toBe("inst-user-1");
+	});
+});
+
+describe("repo session lookups", () => {
+	it("lists only the current user's live sessions for a repo", async () => {
+		const repo = `owner/repo-${uniqueThread()}`;
+		const userOne = makeSession({
+			userId: "user-1",
+			repo,
+			agentName: "april",
+			status: "active",
+			computeInstanceId: "inst-user-1",
+		});
+		const userTwo = makeSession({
+			userId: "user-2",
+			repo,
+			agentName: "april",
+			status: "active",
+			computeInstanceId: "inst-user-2",
+		});
+		await mod.createSession(userOne);
+		await mod.createSession(userTwo);
+
+		const sessions = await mod.getSessionsForRepo("user-1", userOne.repo);
+
+		expect(sessions.map((session) => session.id)).toEqual([userOne.id]);
+	});
+
+	it("finds an agent session only for the current user", async () => {
+		const repo = `owner/repo-${uniqueThread()}`;
+		const userOne = makeSession({
+			userId: "user-1",
+			repo,
+			agentName: "april",
+			status: "active",
+			computeInstanceId: "inst-user-1",
+		});
+		const userTwo = makeSession({
+			userId: "user-2",
+			repo,
+			agentName: "april",
+			status: "active",
+			computeInstanceId: "inst-user-2",
+			lastActivityAt: "2030-01-01T00:00:00Z",
+		});
+		await mod.createSession(userOne);
+		await mod.createSession(userTwo);
+
+		const found = await mod.getSessionForAgent(
+			"user-1",
+			userOne.repo,
+			userOne.agentName,
+		);
+
+		expect(found?.id).toBe(userOne.id);
+	});
+
+	it("finds a transcript session by instance id only for the owner", async () => {
+		const session = makeSession({
+			userId: "user-1",
+			status: "active",
+			computeInstanceId: "shared-instance",
+		});
+		await mod.createSession(session);
+
+		await expect(
+			mod.getSessionByInstanceId("user-2", "shared-instance"),
+		).resolves.toBeNull();
+		await expect(
+			mod.getSessionByInstanceId("user-1", "shared-instance"),
+		).resolves.toMatchObject({ id: session.id });
 	});
 });

--- a/web/src/lib/agent-runtime/__tests__/session-manager.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/session-manager.test.ts
@@ -172,6 +172,7 @@ describe("SessionManager", () => {
 		const params = makeParams();
 		vi.mocked(getSnapshotSessionForThread).mockResolvedValue({
 			id: "session-snap",
+			userId: "user-1",
 			repo: "acme/app",
 			agentName: "april-clearwater",
 			computeBackend: "vercel-sandbox",
@@ -204,6 +205,7 @@ describe("SessionManager", () => {
 		const params = makeParams();
 		vi.mocked(getActiveSessionForThread).mockResolvedValue({
 			id: "session-active",
+			userId: "user-1",
 			repo: "acme/app",
 			agentName: "april-clearwater",
 			computeBackend: "vercel-sandbox",
@@ -234,6 +236,7 @@ describe("SessionManager", () => {
 		const params = makeParams();
 		vi.mocked(getActiveSessionForThread).mockResolvedValue({
 			id: "session-stale",
+			userId: "user-1",
 			repo: "acme/app",
 			agentName: "april-clearwater",
 			computeBackend: "vercel-sandbox",
@@ -269,6 +272,7 @@ describe("SessionManager", () => {
 		const params = makeParams();
 		vi.mocked(getSnapshotSessionForThread).mockResolvedValue({
 			id: "session-race",
+			userId: "user-1",
 			repo: "acme/app",
 			agentName: "april-clearwater",
 			computeBackend: "vercel-sandbox",
@@ -297,6 +301,7 @@ describe("SessionManager", () => {
 		const params = makeParams();
 		vi.mocked(getSnapshotSessionForThread).mockResolvedValue({
 			id: "session-restore-fail",
+			userId: "user-1",
 			repo: "acme/app",
 			agentName: "april-clearwater",
 			computeBackend: "vercel-sandbox",

--- a/web/src/lib/agent-runtime/session-manager.ts
+++ b/web/src/lib/agent-runtime/session-manager.ts
@@ -72,6 +72,7 @@ export class SessionManager {
 
 		// 2. Check for existing active session
 		const existing = await getActiveSessionForThread(
+			params.userId,
 			params.repo,
 			params.agentName,
 			threadId,
@@ -125,6 +126,7 @@ export class SessionManager {
 
 		// 2b. Check for snapshotted session to restore
 		const snapshotted = await getSnapshotSessionForThread(
+			params.userId,
 			params.repo,
 			params.agentName,
 			threadId,
@@ -212,6 +214,7 @@ export class SessionManager {
 		const claudeSessionId = crypto.randomUUID();
 		const session: AgentSession = {
 			id: sessionId,
+			userId: params.userId,
 			repo: params.repo,
 			agentName: params.agentName,
 			computeBackend: provider.descriptor.id,

--- a/web/src/lib/agent-sessions.ts
+++ b/web/src/lib/agent-sessions.ts
@@ -14,6 +14,7 @@ async function ensureSessionTable(): Promise<void> {
 		.createTable("agent_sessions")
 		.ifNotExists()
 		.addColumn("id", "text", (c) => c.primaryKey())
+		.addColumn("user_id", "text", (c) => c.notNull())
 		.addColumn("repo", "text", (c) => c.notNull())
 		.addColumn("agent_name", "text", (c) => c.notNull())
 		.addColumn("compute_backend", "text", (c) => c.notNull())
@@ -33,7 +34,7 @@ async function ensureSessionTable(): Promise<void> {
 		.columns(["repo", "agent_name", "thread_id"])
 		.execute();
 	// Migrate: add columns if table already existed without them
-	for (const col of ["snapshot_id", "claude_session_id"] as const) {
+	for (const col of ["snapshot_id", "claude_session_id", "user_id"] as const) {
 		try {
 			await db.schema
 				.alterTable("agent_sessions")
@@ -43,6 +44,12 @@ async function ensureSessionTable(): Promise<void> {
 			// Column already exists
 		}
 	}
+	await db.schema
+		.createIndex("idx_agent_sessions_user_thread")
+		.ifNotExists()
+		.on("agent_sessions")
+		.columns(["user_id", "repo", "agent_name", "thread_id"])
+		.execute();
 	// Migrate: rename the synthetic terminal slot from "terminal" to "shell".
 	// PR #299 changed the default fallback from "terminal" to "shell" but
 	// existing rows weren't updated. Without this, those rows are orphaned —
@@ -64,6 +71,7 @@ async function ensureSessionTable(): Promise<void> {
 
 function rowToSession(r: {
 	id: string;
+	user_id: string | null;
 	repo: string;
 	agent_name: string;
 	compute_backend: string;
@@ -78,6 +86,7 @@ function rowToSession(r: {
 }): AgentSession {
 	return {
 		id: r.id,
+		userId: r.user_id ?? "",
 		repo: r.repo,
 		agentName: r.agent_name,
 		computeBackend: r.compute_backend as ComputeBackendId,
@@ -99,6 +108,7 @@ export async function createSession(session: AgentSession): Promise<void> {
 		.insertInto("agent_sessions")
 		.values({
 			id: session.id,
+			user_id: session.userId,
 			repo: session.repo,
 			agent_name: session.agentName,
 			compute_backend: session.computeBackend,
@@ -127,6 +137,7 @@ export async function getSession(id: string): Promise<AgentSession | null> {
 }
 
 export async function getSessionByInstanceId(
+	userId: string,
 	instanceId: string,
 ): Promise<AgentSession | null> {
 	await ensureSessionTable();
@@ -134,6 +145,7 @@ export async function getSessionByInstanceId(
 	const row = await db
 		.selectFrom("agent_sessions")
 		.selectAll()
+		.where("user_id", "=", userId)
 		.where("compute_instance_id", "=", instanceId)
 		.orderBy("last_activity_at", "desc")
 		.limit(1)
@@ -142,6 +154,7 @@ export async function getSessionByInstanceId(
 }
 
 export async function getActiveSessionForThread(
+	userId: string,
 	repo: string,
 	agentName: string,
 	threadId: string,
@@ -151,6 +164,7 @@ export async function getActiveSessionForThread(
 	const row = await db
 		.selectFrom("agent_sessions")
 		.selectAll()
+		.where("user_id", "=", userId)
 		.where("repo", "=", repo)
 		.where("agent_name", "=", agentName)
 		.where("thread_id", "=", threadId)
@@ -221,6 +235,7 @@ export async function claimSnapshotSession(id: string): Promise<boolean> {
 
 /** Find the most recent active or snapshotted session for a repo (any agent). */
 export async function getActiveSessionForRepo(
+	userId: string,
 	repo: string,
 ): Promise<AgentSession | null> {
 	await ensureSessionTable();
@@ -228,6 +243,7 @@ export async function getActiveSessionForRepo(
 	const row = await db
 		.selectFrom("agent_sessions")
 		.selectAll()
+		.where("user_id", "=", userId)
 		.where("repo", "=", repo)
 		.where("status", "in", ["active", "streaming", "snapshotted"])
 		.where("compute_instance_id", "is not", null)
@@ -243,6 +259,7 @@ export async function getActiveSessionForRepo(
  * Used by the terminal tab to render agent sub-tabs.
  */
 export async function getSessionsForRepo(
+	userId: string,
 	repo: string,
 ): Promise<AgentSession[]> {
 	await ensureSessionTable();
@@ -250,6 +267,7 @@ export async function getSessionsForRepo(
 	const rows = await db
 		.selectFrom("agent_sessions")
 		.selectAll()
+		.where("user_id", "=", userId)
 		.where("repo", "=", repo)
 		.where("status", "in", ["active", "streaming", "snapshotted"])
 		.where("compute_instance_id", "is not", null)
@@ -275,6 +293,7 @@ export async function getSessionsForRepo(
 
 /** Find the most recent live session for a specific (repo, agent). */
 export async function getSessionForAgent(
+	userId: string,
 	repo: string,
 	agentName: string,
 ): Promise<AgentSession | null> {
@@ -283,6 +302,7 @@ export async function getSessionForAgent(
 	const row = await db
 		.selectFrom("agent_sessions")
 		.selectAll()
+		.where("user_id", "=", userId)
 		.where("repo", "=", repo)
 		.where("agent_name", "=", agentName)
 		.where("status", "in", ["active", "streaming", "snapshotted"])
@@ -295,6 +315,7 @@ export async function getSessionForAgent(
 
 /** Find the most recent snapshotted session for a thread (for restore). */
 export async function getSnapshotSessionForThread(
+	userId: string,
 	repo: string,
 	agentName: string,
 	threadId: string,
@@ -304,6 +325,7 @@ export async function getSnapshotSessionForThread(
 	const row = await db
 		.selectFrom("agent_sessions")
 		.selectAll()
+		.where("user_id", "=", userId)
 		.where("repo", "=", repo)
 		.where("agent_name", "=", agentName)
 		.where("thread_id", "=", threadId)

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -42,6 +42,7 @@ export interface WorkspacesTable {
 
 export interface AgentSessionsTable {
 	id: string;
+	user_id: string | null;
 	repo: string;
 	agent_name: string;
 	compute_backend: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -222,6 +222,7 @@ export type ComputeBackendId =
 
 export interface AgentSession {
 	id: string;
+	userId: string;
 	repo: string;
 	agentName: string;
 	computeBackend: ComputeBackendId;


### PR DESCRIPTION
## Summary
- Add user ownership to `agent_sessions` and write it for terminal/chat sessions.
- Require user id on live, snapshotted, and session-by-instance lookups used by terminal status/start/stop/resume, transcript, and agent chat reuse/restore.
- Keep legacy rows without `user_id` out of user-scoped APIs, favoring restart over cross-user exposure.
- Add cross-user isolation tests for thread, repo, agent, and transcript lookups.

## Why
The security review found terminal sessions were keyed only by repo and agent, so another user authorized for the same repo could reuse, stop, resume, or receive the terminal URL for someone else’s session.

## Validation
- `pnpm test -- src/lib/__tests__/agent-sessions.test.ts src/lib/agent-runtime/__tests__/session-manager.test.ts` passed: 18 files, 162 tests.
- `pnpm typecheck` passed.
- `mise -C web run web:check` passed: typecheck, Biome, 18 files / 162 tests.
- `git diff --check` passed.

## Mergeability
- Surface: web / terminal / agent runtime
- User-facing behavior changed: users only see and control their own terminal/agent sessions. Legacy sessions without ownership may disappear from the UI and need restart.
- Non-happy paths considered: existing tables without `user_id` migrate best-effort; legacy rows are not matched by scoped lookups; snapshot restore and transcript lookup are user-scoped.
- Residual risk or follow-up: session id-only internal mutations remain id-based, but public routes now acquire ids through user-scoped lookups. A future cleanup migration can prune old ownerless rows.
- Release/ops preconditions: none.

## Evidence
- API/runtime change; verification is web check output and remote PR checks.