### PR TITLE
[codex] Keep terminal clone tokens out of URLs

### DIFF
--- a/web/src/app/api/terminal/start/route.test.ts
+++ b/web/src/app/api/terminal/start/route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const provider = {
+		descriptor: {
+			id: "vercel-sandbox",
+			displayName: "Vercel Sandbox",
+			maxSessionDuration: 1800,
+			supportsSnapshot: true,
+			supportsStreaming: true,
+			terminalMode: "pty",
+		},
+		checkAvailability: vi.fn(),
+		createTerminalSandbox: vi.fn(),
+	};
+
+	return {
+		authorizeRepoAccess: vi.fn(),
+		bypassToken: null as string | null,
+		createSession: vi.fn(),
+		getGitHubToken: vi.fn(),
+		getSessionForAgent: vi.fn(),
+		provider,
+		session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+	};
+});
+
+vi.mock("@/lib/agent-runtime/provider-registry", () => ({
+	getRegistry: async () => ({
+		getDefault: () => mocks.provider,
+		all: () => [mocks.provider],
+	}),
+}));
+
+vi.mock("@/lib/agent-sessions", () => ({
+	createSession: mocks.createSession,
+	getSessionForAgent: mocks.getSessionForAgent,
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+	authorizeRepoAccess: mocks.authorizeRepoAccess,
+	unauthorizedResponse: () => new Response("unauthorized", { status: 401 }),
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+	getDevBypassToken: () => mocks.bypassToken,
+	getSession: async () => mocks.session,
+}));
+
+vi.mock("@/lib/github", () => ({
+	getGitHubToken: mocks.getGitHubToken,
+}));
+
+function jsonRequest(body: unknown): Request {
+	return new Request("http://localhost/api/terminal/start", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+describe("/api/terminal/start POST", () => {
+	beforeEach(() => {
+		mocks.authorizeRepoAccess.mockReset();
+		mocks.authorizeRepoAccess.mockResolvedValue(null);
+		mocks.bypassToken = null;
+		mocks.createSession.mockReset();
+		mocks.getGitHubToken.mockReset();
+		mocks.getGitHubToken.mockResolvedValue("oauth-token");
+		mocks.getSessionForAgent.mockReset();
+		mocks.getSessionForAgent.mockResolvedValue(null);
+		mocks.provider.checkAvailability.mockReset();
+		mocks.provider.checkAvailability.mockResolvedValue({ available: true });
+		mocks.provider.createTerminalSandbox.mockReset();
+		mocks.provider.createTerminalSandbox.mockResolvedValue({
+			instanceId: "sb-1",
+			status: "ready",
+		});
+		mocks.session = { user: { id: "user-1" } };
+	});
+
+	it("passes OAuth auth separately from a token-free clone URL", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(
+			jsonRequest({ repo: "fairchild/workspaces", branch: "main" }),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.provider.createTerminalSandbox).toHaveBeenCalledWith({
+			cloneUrl: "https://github.com/fairchild/workspaces.git",
+			authToken: "oauth-token",
+			branch: "main",
+		});
+		const params = mocks.provider.createTerminalSandbox.mock.calls[0][0];
+		expect(params.cloneUrl).not.toContain("oauth-token");
+		expect(params.cloneUrl).not.toContain("x-access-token");
+		expect(mocks.createSession).toHaveBeenCalledWith(
+			expect.objectContaining({ userId: "user-1" }),
+		);
+	});
+
+	it("does not attach the dev bypass placeholder as clone auth", async () => {
+		mocks.bypassToken = "dev-bypass-token";
+
+		const { POST } = await import("./route");
+		const response = await POST(jsonRequest({ repo: "fairchild/workspaces" }));
+
+		expect(response.status).toBe(200);
+		expect(mocks.getGitHubToken).not.toHaveBeenCalled();
+		expect(mocks.provider.createTerminalSandbox).toHaveBeenCalledWith({
+			cloneUrl: "https://github.com/fairchild/workspaces.git",
+			authToken: undefined,
+			branch: undefined,
+		});
+	});
+});

--- a/web/src/app/api/terminal/start/route.ts
+++ b/web/src/app/api/terminal/start/route.ts
@@ -62,12 +62,13 @@ export async function POST(request: Request): Promise<Response> {
 		});
 	}
 
-	// Build clone URL — use token for private repos, fall back to public HTTPS
-	let cloneUrl = `https://github.com/${body.repo}.git`;
+	// Keep the clone URL token-free so it cannot persist in .git/config.
+	const cloneUrl = `https://github.com/${body.repo}.git`;
+	let authToken: string | undefined;
 	if (!getDevBypassToken()) {
 		const token = await getGitHubToken(session.user.id).catch(() => null);
 		if (token) {
-			cloneUrl = `https://x-access-token:${token}@github.com/${body.repo}.git`;
+			authToken = token;
 		}
 	}
 
@@ -101,6 +102,7 @@ export async function POST(request: Request): Promise<Response> {
 	try {
 		result = await provider.createTerminalSandbox({
 			cloneUrl,
+			authToken,
 			branch: body.branch,
 		});
 	} catch (err) {

--- a/web/src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ttydPathToken } from "../vercel-sandbox";
+import { buildGitCloneArgs, ttydPathToken } from "../vercel-sandbox";
 
 // process.env.X = undefined sets the env var to the literal string "undefined".
 // Reflect.deleteProperty actually removes the key, which is what we want when
@@ -67,5 +67,42 @@ describe("ttydPathToken", () => {
 		const b = ttydPathToken("sbx_y");
 		expect(a).toBe(b);
 		expect(a).toMatch(/^[0-9a-f]{24}$/);
+	});
+});
+
+describe("buildGitCloneArgs", () => {
+	it("uses a temporary credential helper without placing the token in argv", () => {
+		const args = buildGitCloneArgs({
+			cloneUrl: "https://github.com/fairchild/workspaces.git",
+			authToken: "gho_secret_token",
+			branch: "main",
+		});
+
+		expect(args).toEqual([
+			"-c",
+			expect.stringContaining("credential.helper="),
+			"clone",
+			"--depth",
+			"1",
+			"--branch",
+			"main",
+			"https://github.com/fairchild/workspaces.git",
+			"/vercel/sandbox/repo",
+		]);
+		expect(args.join(" ")).not.toContain("gho_secret_token");
+	});
+
+	it("clones public URLs directly when no auth token is provided", () => {
+		const args = buildGitCloneArgs({
+			cloneUrl: "https://github.com/fairchild/workspaces.git",
+		});
+
+		expect(args).toEqual([
+			"clone",
+			"--depth",
+			"1",
+			"https://github.com/fairchild/workspaces.git",
+			"/vercel/sandbox/repo",
+		]);
 	});
 });

--- a/web/src/lib/agent-runtime/mock-provider.ts
+++ b/web/src/lib/agent-runtime/mock-provider.ts
@@ -84,6 +84,7 @@ export class MockComputeProvider
 
 	async createTerminalSandbox(params: {
 		cloneUrl: string;
+		authToken?: string;
 		branch?: string;
 	}): Promise<SandboxResult> {
 		const instanceId = `mock-terminal-${counter++}`;

--- a/web/src/lib/agent-runtime/types.ts
+++ b/web/src/lib/agent-runtime/types.ts
@@ -122,6 +122,8 @@ export type SandboxState =
 export interface TerminalCapable {
 	createTerminalSandbox(params: {
 		cloneUrl: string;
+		/** Optional HTTPS clone token. Do not embed this in cloneUrl. */
+		authToken?: string;
 		branch?: string;
 	}): Promise<SandboxResult>;
 	resolveSandboxState(instanceId: string): Promise<SandboxState>;

--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -74,6 +74,10 @@ const BASE_SNAPSHOT_VERSION = "v5-pi-skills";
 const TMUX_STATIC_URL =
 	"https://github.com/mjakob-gh/build-static-tmux/releases/latest/download/tmux.linux-amd64.stripped.gz";
 const PROVIDER_ID = "vercel-sandbox";
+const SANDBOX_REPO_DIR = "/vercel/sandbox/repo";
+const GIT_CREDENTIAL_TOKEN_PATH = "/vercel/sandbox/github-clone-token";
+const GIT_CREDENTIAL_HELPER_PATH =
+	"/vercel/sandbox/github-credential-helper.sh";
 
 /**
  * Run a command in a sandbox and throw if it exits non-zero. The
@@ -107,6 +111,85 @@ async function assertRunCommand(
 			`[vercel-sandbox] ${label} exited ${cmd.exitCode}\n${stderr.slice(0, 2000)}`,
 		);
 	}
+}
+
+function buildGitCredentialHelperFiles(
+	authToken: string,
+): Array<{ path: string; content: Buffer }> {
+	return [
+		{
+			path: GIT_CREDENTIAL_TOKEN_PATH,
+			content: Buffer.from(stripQuotes(authToken)),
+		},
+		{
+			path: GIT_CREDENTIAL_HELPER_PATH,
+			content: Buffer.from(`#!/bin/sh
+case "$1" in
+  get)
+    echo username=x-access-token
+    printf 'password='
+    cat ${GIT_CREDENTIAL_TOKEN_PATH}
+    printf '\\n'
+    ;;
+esac
+`),
+		},
+	];
+}
+
+export function buildGitCloneArgs(params: {
+	cloneUrl: string;
+	authToken?: string;
+	branch?: string;
+}): string[] {
+	const cloneArgs: string[] = [];
+	if (params.authToken) {
+		cloneArgs.push("-c", `credential.helper=${GIT_CREDENTIAL_HELPER_PATH}`);
+	}
+	cloneArgs.push("clone", "--depth", "1");
+	if (params.branch) {
+		cloneArgs.push("--branch", params.branch);
+	}
+	cloneArgs.push(params.cloneUrl, SANDBOX_REPO_DIR);
+	return cloneArgs;
+}
+
+async function prepareGitCloneAuth(
+	sandbox: Sandbox,
+	authToken: string | undefined,
+	label: string,
+): Promise<void> {
+	if (!authToken) return;
+	await sandbox.writeFiles(buildGitCredentialHelperFiles(authToken));
+	await assertRunCommand(sandbox, `chmod git token (${label})`, {
+		cmd: "chmod",
+		args: ["600", GIT_CREDENTIAL_TOKEN_PATH],
+	});
+	await assertRunCommand(sandbox, `chmod git credential helper (${label})`, {
+		cmd: "chmod",
+		args: ["700", GIT_CREDENTIAL_HELPER_PATH],
+	});
+}
+
+async function cleanupGitCloneAuth(
+	sandbox: Sandbox,
+	label: string,
+): Promise<void> {
+	await assertRunCommand(sandbox, `remove git clone credentials (${label})`, {
+		cmd: "rm",
+		args: ["-f", GIT_CREDENTIAL_TOKEN_PATH, GIT_CREDENTIAL_HELPER_PATH],
+	});
+}
+
+async function scrubGitOrigin(
+	sandbox: Sandbox,
+	cloneUrl: string,
+	label: string,
+): Promise<void> {
+	await assertRunCommand(sandbox, `scrub git origin (${label})`, {
+		cmd: "git",
+		args: ["-C", SANDBOX_REPO_DIR, "remote", "set-url", "origin", cloneUrl],
+	});
 }
 
 function stripQuotes(s: string): string {
@@ -659,6 +742,7 @@ export class VercelSandboxProvider
 	 */
 	async createTerminalSandbox(params: {
 		cloneUrl: string;
+		authToken?: string;
 		branch?: string;
 	}): Promise<SandboxResult> {
 		const baseSnapshotId = await getOrCreateBaseSnapshot();
@@ -684,16 +768,17 @@ export class VercelSandboxProvider
 		});
 
 		try {
-			// Clone the target repo
-			const cloneArgs = ["clone", "--depth", "1"];
-			if (params.branch) {
-				cloneArgs.push("--branch", params.branch);
-			}
-			cloneArgs.push(params.cloneUrl, "/vercel/sandbox/repo");
+			await prepareGitCloneAuth(sandbox, params.authToken, "terminal sandbox");
+
+			// Clone the target repo with a token-free URL. If auth is needed,
+			// Git uses a temporary credential helper that is removed below.
+			const cloneArgs = buildGitCloneArgs(params);
 			await assertRunCommand(sandbox, "git clone (terminal sandbox)", {
 				cmd: "git",
 				args: cloneArgs,
 			});
+			await scrubGitOrigin(sandbox, params.cloneUrl, "terminal sandbox");
+			await cleanupGitCloneAuth(sandbox, "terminal sandbox");
 
 			// Same claude auth setup as the agent path so `claude` works
 			// out of the box from the shell.
@@ -715,6 +800,7 @@ export class VercelSandboxProvider
 			activeSandboxes.set(instanceId, sandbox);
 			return { instanceId, status: "ready" };
 		} catch (err) {
+			await cleanupGitCloneAuth(sandbox, "terminal sandbox").catch(() => {});
 			await sandbox.stop().catch(() => {});
 			throw err;
 		}


### PR DESCRIPTION
## Summary
- Keep `/api/terminal/start` clone URLs token-free and pass OAuth clone auth separately to terminal providers.
- Teach the Vercel terminal sandbox to clone with a temporary Git credential helper, scrub `origin` back to the public GitHub URL, and remove the helper/token before starting ttyd.
- Add route coverage proving the OAuth token is not embedded in the clone URL and sandbox coverage proving the token is not placed in Git argv.

## Why
The security review found the terminal start path embedded the user OAuth token directly in `https://x-access-token:...@github.com/owner/repo.git`. That can persist in `.git/config`, appear in process metadata or provider logs, and be read later by code running inside the sandbox.

## Validation
- `pnpm test -- src/app/api/terminal/start/route.test.ts src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts` passed: 19 files, 166 tests.
- `pnpm typecheck` passed.
- `mise -C web run web:check` passed: typecheck, Biome check over 153 files, 19 files / 166 tests.
- `git diff --check` passed.

## Mergeability
- Surface: web / terminal / agent runtime.
- User-facing behavior changed: terminal private-repo clone still authenticates, but the resulting repo `origin` no longer carries reusable OAuth credentials.
- Non-happy paths considered: clone failures still stop the sandbox; cleanup runs on both success and failure; cleanup/scrub failure prevents exposing a terminal with clone credentials left behind.
- Residual risk or follow-up: this still uses the user OAuth token as the clone credential because terminal sandboxes do not yet have per-repo GitHub App installation-token plumbing. The token is no longer in the URL or Git argv and is removed before the shell starts.
- Release/ops preconditions: none.

## Evidence
- API/runtime change; verification is web check output and remote PR checks.