### PR TITLE
[codex] Fail closed without ttyd token secret

### DIFF
--- a/web/src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildGitCloneArgs, ttydPathToken } from "../vercel-sandbox";
+import {
+	VercelSandboxProvider,
+	buildGitCloneArgs,
+	ttydPathToken,
+} from "../vercel-sandbox";
 
 // process.env.X = undefined sets the env var to the literal string "undefined".
 // Reflect.deleteProperty actually removes the key, which is what we want when
@@ -9,20 +13,26 @@ function unset(name: string): void {
 	Reflect.deleteProperty(process.env, name);
 }
 
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) unset(name);
+	else Reflect.set(process.env, name, value);
+}
+
 describe("ttydPathToken", () => {
 	const originalSecret = process.env.TTYD_TOKEN_SECRET;
 	const originalAuth = process.env.BETTER_AUTH_SECRET;
+	const originalNodeEnv = process.env.NODE_ENV;
 
 	beforeEach(() => {
+		Reflect.set(process.env, "NODE_ENV", "test");
 		process.env.TTYD_TOKEN_SECRET = "test-secret-fixed";
 		unset("BETTER_AUTH_SECRET");
 	});
 
 	afterEach(() => {
-		if (originalSecret === undefined) unset("TTYD_TOKEN_SECRET");
-		else process.env.TTYD_TOKEN_SECRET = originalSecret;
-		if (originalAuth === undefined) unset("BETTER_AUTH_SECRET");
-		else process.env.BETTER_AUTH_SECRET = originalAuth;
+		restoreEnv("TTYD_TOKEN_SECRET", originalSecret);
+		restoreEnv("BETTER_AUTH_SECRET", originalAuth);
+		restoreEnv("NODE_ENV", originalNodeEnv);
 	});
 
 	it("returns a deterministic 24-char hex string for the same sandbox id", () => {
@@ -67,6 +77,53 @@ describe("ttydPathToken", () => {
 		const b = ttydPathToken("sbx_y");
 		expect(a).toBe(b);
 		expect(a).toMatch(/^[0-9a-f]{24}$/);
+	});
+
+	it("throws in production when neither secret is set", () => {
+		Reflect.set(process.env, "NODE_ENV", "production");
+		unset("TTYD_TOKEN_SECRET");
+		unset("BETTER_AUTH_SECRET");
+
+		expect(() => ttydPathToken("sbx_y")).toThrow(/TTYD_TOKEN_SECRET/);
+	});
+});
+
+describe("VercelSandboxProvider.checkAvailability", () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	const originalOidc = process.env.VERCEL_OIDC_TOKEN;
+	const originalSecret = process.env.TTYD_TOKEN_SECRET;
+	const originalAuth = process.env.BETTER_AUTH_SECRET;
+
+	beforeEach(() => {
+		Reflect.set(process.env, "NODE_ENV", "production");
+		process.env.VERCEL_OIDC_TOKEN = "oidc-token";
+		unset("TTYD_TOKEN_SECRET");
+		unset("BETTER_AUTH_SECRET");
+	});
+
+	afterEach(() => {
+		restoreEnv("NODE_ENV", originalNodeEnv);
+		restoreEnv("VERCEL_OIDC_TOKEN", originalOidc);
+		restoreEnv("TTYD_TOKEN_SECRET", originalSecret);
+		restoreEnv("BETTER_AUTH_SECRET", originalAuth);
+	});
+
+	it("fails closed in production without a terminal token secret", async () => {
+		const provider = new VercelSandboxProvider();
+
+		await expect(provider.checkAvailability()).resolves.toMatchObject({
+			available: false,
+			reason: expect.stringContaining("TTYD_TOKEN_SECRET"),
+		});
+	});
+
+	it("is available in production when BETTER_AUTH_SECRET can gate terminal URLs", async () => {
+		process.env.BETTER_AUTH_SECRET = "auth-secret";
+		const provider = new VercelSandboxProvider();
+
+		await expect(provider.checkAvailability()).resolves.toEqual({
+			available: true,
+		});
 	});
 });
 

--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -78,6 +78,7 @@ const SANDBOX_REPO_DIR = "/vercel/sandbox/repo";
 const GIT_CREDENTIAL_TOKEN_PATH = "/vercel/sandbox/github-clone-token";
 const GIT_CREDENTIAL_HELPER_PATH =
 	"/vercel/sandbox/github-credential-helper.sh";
+const DEV_TTYD_TOKEN_SECRET = "dev-only-fallback-do-not-use-in-prod";
 
 /**
  * Run a command in a sandbox and throw if it exits non-zero. The
@@ -194,6 +195,21 @@ async function scrubGitOrigin(
 
 function stripQuotes(s: string): string {
 	return s.replace(/^["']|["']$/g, "");
+}
+
+function configuredTtydTokenSecret(): string | null {
+	return (
+		process.env.TTYD_TOKEN_SECRET ?? process.env.BETTER_AUTH_SECRET ?? null
+	);
+}
+
+function resolveTtydTokenSecret(): string {
+	const secret = configuredTtydTokenSecret();
+	if (secret) return secret;
+	if (process.env.NODE_ENV !== "production") return DEV_TTYD_TOKEN_SECRET;
+	throw new Error(
+		"TTYD_TOKEN_SECRET or BETTER_AUTH_SECRET is required for terminal access in production",
+	);
 }
 
 /**
@@ -480,14 +496,23 @@ export class VercelSandboxProvider
 			!!process.env.VERCEL_TEAM_ID &&
 			!!process.env.VERCEL_PROJECT_ID;
 
-		if (hasOidc || hasToken) {
-			return { available: true };
+		if (!hasOidc && !hasToken) {
+			return {
+				available: false,
+				reason:
+					"Missing Vercel credentials (VERCEL_OIDC_TOKEN or VERCEL_TOKEN + VERCEL_TEAM_ID + VERCEL_PROJECT_ID)",
+			};
 		}
-		return {
-			available: false,
-			reason:
-				"Missing Vercel credentials (VERCEL_OIDC_TOKEN or VERCEL_TOKEN + VERCEL_TEAM_ID + VERCEL_PROJECT_ID)",
-		};
+
+		if (!configuredTtydTokenSecret() && process.env.NODE_ENV === "production") {
+			return {
+				available: false,
+				reason:
+					"Missing TTYD_TOKEN_SECRET or BETTER_AUTH_SECRET (required for terminal URL authentication)",
+			};
+		}
+
+		return { available: true };
 	}
 
 	async createSandbox(request: SandboxRequest): Promise<SandboxResult> {
@@ -849,10 +874,7 @@ const ALIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
  * Exported for testing.
  */
 export function ttydPathToken(sandboxId: string): string {
-	const secret =
-		process.env.TTYD_TOKEN_SECRET ??
-		process.env.BETTER_AUTH_SECRET ??
-		"dev-only-fallback-do-not-use-in-prod";
+	const secret = resolveTtydTokenSecret();
 	return crypto
 		.createHmac("sha256", secret)
 		.update(sandboxId)
@@ -867,6 +889,24 @@ export function ttydPathToken(sandboxId: string): string {
 function ttydUrl(domain: string, sandboxId: string): string {
 	const token = ttydPathToken(sandboxId);
 	return `${domain.replace(/\/$/, "")}/${token}/ws`;
+}
+
+function sandboxTerminalState(
+	sandbox: Sandbox,
+	instanceId: string,
+): SandboxState {
+	let domain: string;
+	try {
+		domain = sandbox.domain(7681);
+	} catch {
+		// Pre-v2 sandbox without port 7681 published. We have no way to
+		// connect a terminal to it, so treat it as dead for our purposes.
+		return { alive: false };
+	}
+	return {
+		alive: true,
+		terminalUrl: ttydUrl(domain, instanceId),
+	};
 }
 
 /**
@@ -1031,39 +1071,22 @@ export async function resolveSandboxState(
 	// Fast path: in-memory map (same serverless instance)
 	const cached = activeSandboxes.get(instanceId);
 	if (cached && ALIVE_STATUSES.has(cached.status)) {
-		try {
-			return {
-				alive: true,
-				terminalUrl: ttydUrl(cached.domain(7681), instanceId),
-			};
-		} catch {
-			// Pre-v2 sandbox without port 7681 published. We have no way to
-			// connect a terminal to it, so treat it as dead for our purposes —
-			// reconciliation will mark the session completed and the user can
-			// start a fresh sandbox that has ttyd.
-			return { alive: false };
-		}
+		return sandboxTerminalState(cached, instanceId);
 	}
 
 	// Cross-instance path: single HTTP call to Vercel API
+	let sandbox: Sandbox;
 	try {
-		const sandbox = await Sandbox.get({
+		sandbox = await Sandbox.get({
 			sandboxId: instanceId,
 			...getCredentials(),
 		});
-		if (!ALIVE_STATUSES.has(sandbox.status)) {
-			return { alive: false };
-		}
-		try {
-			return {
-				alive: true,
-				terminalUrl: ttydUrl(sandbox.domain(7681), instanceId),
-			};
-		} catch {
-			return { alive: false };
-		}
 	} catch {
 		// Sandbox record doesn't exist at all (never created, or purged)
 		return { alive: false };
 	}
+	if (!ALIVE_STATUSES.has(sandbox.status)) {
+		return { alive: false };
+	}
+	return sandboxTerminalState(sandbox, instanceId);
 }


### PR DESCRIPTION
## Summary
- Resolve ttyd path-token secrets through a fail-closed production helper instead of the hard-coded fallback.
- Mark the Vercel terminal provider unavailable in production when both `TTYD_TOKEN_SECRET` and `BETTER_AUTH_SECRET` are missing.
- Keep the dev/test fallback for local workflows, and add tests for production throw/unavailable behavior.
- Avoid swallowing missing-secret terminal URL errors as generic dead-sandbox reconciliation.

## Why
The security review found ttyd terminal URLs used a static public fallback secret if `TTYD_TOKEN_SECRET` and `BETTER_AUTH_SECRET` were both missing. That path token gates shell access, so production must fail closed instead of minting predictable terminal URLs.

## Validation
- `pnpm test -- src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts` passed: 19 files, 169 tests.
- `mise -C web run web:check` passed: typecheck, Biome check over 153 files, 19 files / 169 tests.
- `git diff --check` passed.

## Mergeability
- Surface: web / agent runtime / terminal auth.
- User-facing behavior changed: production terminal creation now returns provider-unavailable if no ttyd token secret is configured, instead of issuing predictable terminal URLs.
- Non-happy paths considered: Vercel credential failures keep their existing reason; local dev/test fallback still works; missing production token secret remains an explicit config failure instead of being hidden as a dead sandbox.
- Residual risk or follow-up: production must have `TTYD_TOKEN_SECRET` or `BETTER_AUTH_SECRET` set. If `BETTER_AUTH_SECRET` is already present, no additional secret is required.
- Release/ops preconditions: confirm production has one of `TTYD_TOKEN_SECRET` or `BETTER_AUTH_SECRET` before relying on terminal access.

## Evidence
- API/runtime configuration change; verification is web check output and remote PR checks.