### PR TITLE
[codex] Scope workspace sync by owner

### DIFF
--- a/web/src/app/api/workspaces/sync/route.test.ts
+++ b/web/src/app/api/workspaces/sync/route.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getSession: vi.fn(),
+	getWorkspaces: vi.fn(),
+	syncWorkspaces: vi.fn(),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+	unauthorizedResponse: () =>
+		Response.json({ error: "unauthorized" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+	getSession: mocks.getSession,
+}));
+
+vi.mock("@/lib/workspaces", () => ({
+	DEFAULT_WORKSPACE_OWNER_ID: "default",
+	getWorkspaces: mocks.getWorkspaces,
+	syncWorkspaces: mocks.syncWorkspaces,
+}));
+
+const originalSyncKey = process.env.WORKSPACE_SYNC_API_KEY;
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) Reflect.deleteProperty(process.env, name);
+	else Reflect.set(process.env, name, value);
+}
+
+function jsonRequest(body: unknown, token?: string): Request {
+	const headers = new Headers({ "content-type": "application/json" });
+	if (token) headers.set("authorization", `Bearer ${token}`);
+	return new Request("http://localhost/api/workspaces/sync", {
+		method: "POST",
+		headers,
+		body: JSON.stringify(body),
+	});
+}
+
+function getRequest(token?: string): Request {
+	const headers = new Headers();
+	if (token) headers.set("authorization", `Bearer ${token}`);
+	return new Request("http://localhost/api/workspaces/sync", { headers });
+}
+
+function workspace() {
+	return {
+		id: "ws-1",
+		name: "Workspaces",
+		path: "/Users/dev/workspaces",
+		repoId: null,
+		repoName: "fairchild/workspaces",
+		createdAt: "2026-01-01T00:00:00Z",
+		lastAccessedAt: "2026-01-02T00:00:00Z",
+		status: "active",
+		gitBranch: "main",
+		backendIdentifier: "local",
+	};
+}
+
+describe("/api/workspaces/sync", () => {
+	beforeEach(() => {
+		Reflect.set(process.env, "WORKSPACE_SYNC_API_KEY", "sync-secret");
+		mocks.getSession.mockReset();
+		mocks.getSession.mockResolvedValue({ user: { id: "user-1" } });
+		mocks.getWorkspaces.mockReset();
+		mocks.getWorkspaces.mockResolvedValue([]);
+		mocks.syncWorkspaces.mockReset();
+		mocks.syncWorkspaces.mockResolvedValue(1);
+	});
+
+	afterEach(() => {
+		restoreEnv("WORKSPACE_SYNC_API_KEY", originalSyncKey);
+	});
+
+	it("rejects session-authenticated writes without the sync API key", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(jsonRequest({ workspaces: [workspace()] }));
+
+		expect(response.status).toBe(401);
+		expect(mocks.syncWorkspaces).not.toHaveBeenCalled();
+	});
+
+	it("accepts writes only with the sync API key and default owner", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(
+			jsonRequest({ workspaces: [workspace()] }, "sync-secret"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ ok: true, count: 1 });
+		expect(mocks.syncWorkspaces).toHaveBeenCalledWith("default", [workspace()]);
+	});
+
+	it("scopes session reads to the authenticated user id", async () => {
+		const { GET } = await import("./route");
+		const response = await GET(getRequest());
+
+		expect(response.status).toBe(200);
+		expect(mocks.getWorkspaces).toHaveBeenCalledWith("user-1");
+	});
+
+	it("scopes sync API key reads to the default sync owner", async () => {
+		const { GET } = await import("./route");
+		const response = await GET(getRequest("sync-secret"));
+
+		expect(response.status).toBe(200);
+		expect(mocks.getSession).not.toHaveBeenCalled();
+		expect(mocks.getWorkspaces).toHaveBeenCalledWith("default");
+	});
+});

--- a/web/src/app/api/workspaces/sync/route.ts
+++ b/web/src/app/api/workspaces/sync/route.ts
@@ -3,33 +3,39 @@ import { unauthorizedResponse } from "@/lib/api-auth";
 import { getSession } from "@/lib/auth-server";
 import { isWorkspace } from "@/lib/workspace-utils";
 import {
+	DEFAULT_WORKSPACE_OWNER_ID,
 	type SyncWorkspaceInput,
 	getWorkspaces,
 	syncWorkspaces,
 } from "@/lib/workspaces";
-
-const SYNC_API_KEY = process.env.WORKSPACE_SYNC_API_KEY;
 
 function safeEqual(a: string, b: string): boolean {
 	if (a.length !== b.length) return false;
 	return timingSafeEqual(Buffer.from(a), Buffer.from(b));
 }
 
-/** Resolve user ID from API key header or session cookie. */
-async function authenticateRequest(request: Request): Promise<string | null> {
-	const authHeader = request.headers.get("authorization");
-	if (authHeader?.startsWith("Bearer ") && SYNC_API_KEY) {
-		const token = authHeader.slice(7);
-		if (safeEqual(token, SYNC_API_KEY)) return "default";
-	}
+function syncApiKey(): string | undefined {
+	return process.env.WORKSPACE_SYNC_API_KEY;
+}
 
+function hasSyncApiKey(request: Request): boolean {
+	const authHeader = request.headers.get("authorization");
+	const key = syncApiKey();
+	if (authHeader?.startsWith("Bearer ") && key) {
+		const token = authHeader.slice(7);
+		return safeEqual(token, key);
+	}
+	return false;
+}
+
+async function readOwnerId(request: Request): Promise<string | null> {
+	if (hasSyncApiKey(request)) return DEFAULT_WORKSPACE_OWNER_ID;
 	const session = await getSession();
 	return session?.user.id ?? null;
 }
 
 export async function POST(request: Request): Promise<Response> {
-	const userId = await authenticateRequest(request);
-	if (!userId) return unauthorizedResponse();
+	if (!hasSyncApiKey(request)) return unauthorizedResponse();
 
 	let body: unknown;
 	try {
@@ -55,15 +61,18 @@ export async function POST(request: Request): Promise<Response> {
 		}
 	}
 
-	const count = await syncWorkspaces(workspaces as SyncWorkspaceInput[]);
+	const count = await syncWorkspaces(
+		DEFAULT_WORKSPACE_OWNER_ID,
+		workspaces as SyncWorkspaceInput[],
+	);
 	return Response.json({ ok: true, count });
 }
 
-export async function GET(): Promise<Response> {
-	const session = await getSession();
-	if (!session) return unauthorizedResponse();
+export async function GET(request: Request): Promise<Response> {
+	const ownerId = await readOwnerId(request);
+	if (!ownerId) return unauthorizedResponse();
 
-	const workspaces = await getWorkspaces();
+	const workspaces = await getWorkspaces(ownerId);
 
 	return Response.json({ workspaces });
 }

--- a/web/src/lib/__tests__/workspaces.test.ts
+++ b/web/src/lib/__tests__/workspaces.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatRelativeTime } from "../timeline-utils";
 import type { Workspace } from "../types";
 import {
+	DEFAULT_WORKSPACE_OWNER_ID,
 	type SyncWorkspaceInput,
 	formatWorkspaceStatusCard,
 	getWorkspaces,
@@ -126,24 +127,45 @@ describe("syncWorkspaces (parallel upserts)", () => {
 			makeInput(`${prefix}-${i}`, { repoName: `acme/repo-${i}` }),
 		);
 
-		const count = await syncWorkspaces(inputs);
+		const count = await syncWorkspaces(DEFAULT_WORKSPACE_OWNER_ID, inputs);
 		expect(count).toBe(20);
 
 		// Pull each back individually to avoid accidentally matching rows from
 		// other tests in the shared DB.
-		const all = await getWorkspaces();
+		const all = await getWorkspaces(DEFAULT_WORKSPACE_OWNER_ID);
 		const ours = all.filter((w) => w.id.startsWith(prefix));
 		expect(ours).toHaveLength(20);
 	});
 
 	it("upserts existing rows with new field values", async () => {
 		const id = `upsert-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-		await syncWorkspaces([makeInput(id, { status: "active" })]);
-		await syncWorkspaces([makeInput(id, { status: "stopped" })]);
+		await syncWorkspaces(DEFAULT_WORKSPACE_OWNER_ID, [
+			makeInput(id, { status: "active" }),
+		]);
+		await syncWorkspaces(DEFAULT_WORKSPACE_OWNER_ID, [
+			makeInput(id, { status: "stopped" }),
+		]);
 
-		const all = await getWorkspaces();
+		const all = await getWorkspaces(DEFAULT_WORKSPACE_OWNER_ID);
 		const ours = all.filter((w) => w.id === id);
 		expect(ours).toHaveLength(1);
 		expect(ours[0].status).toBe("stopped");
+	});
+
+	it("lists only workspaces for the requested owner", async () => {
+		const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+		const ownerOne = `owner-1-${suffix}`;
+		const ownerTwo = `owner-2-${suffix}`;
+		await syncWorkspaces(ownerOne, [
+			makeInput(`scoped-a-${suffix}`, { name: "owner-one" }),
+		]);
+		await syncWorkspaces(ownerTwo, [
+			makeInput(`scoped-b-${suffix}`, { name: "owner-two" }),
+		]);
+
+		const workspaces = await getWorkspaces(ownerOne);
+
+		expect(workspaces.map((w) => w.name)).toContain("owner-one");
+		expect(workspaces.map((w) => w.name)).not.toContain("owner-two");
 	});
 });

--- a/web/src/lib/bot.ts
+++ b/web/src/lib/bot.ts
@@ -5,7 +5,11 @@ import { Chat, toAiMessages } from "chat";
 import type { Message, Thread } from "chat";
 import { isAiConfigured, streamResponse } from "./ai";
 import { getEventStats } from "./events";
-import { formatWorkspaceStatusCard, getWorkspaces } from "./workspaces";
+import {
+	DEFAULT_WORKSPACE_OWNER_ID,
+	formatWorkspaceStatusCard,
+	getWorkspaces,
+} from "./workspaces";
 
 let _bot: Chat | undefined;
 
@@ -52,7 +56,7 @@ export function getBot(): Chat {
 		_bot.onNewMessage(/status/i, async (thread) => {
 			const [stats, workspaces] = await Promise.all([
 				getEventStats(),
-				getWorkspaces("default"),
+				getWorkspaces(DEFAULT_WORKSPACE_OWNER_ID),
 			]);
 			const repoList =
 				stats.repos.length > 0
@@ -83,7 +87,7 @@ async function handleAiResponse(
 	if (!isAiConfigured()) {
 		const [stats, workspaces] = await Promise.all([
 			getEventStats(),
-			getWorkspaces("default"),
+			getWorkspaces(DEFAULT_WORKSPACE_OWNER_ID),
 		]);
 		const card = formatWorkspaceStatusCard(workspaces);
 		await thread.post(

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -27,6 +27,7 @@ export interface ChatMessagesTable {
 }
 
 export interface WorkspacesTable {
+	owner_id: string | null;
 	id: string;
 	name: string;
 	path: string;

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -2,6 +2,8 @@ import { getDb } from "./db";
 import { formatRelativeTime } from "./timeline-utils";
 import type { Workspace, WorkspaceStatus } from "./types";
 
+export const DEFAULT_WORKSPACE_OWNER_ID = "default";
+
 let migrated = false;
 
 async function ensureWorkspacesTable(): Promise<void> {
@@ -10,6 +12,9 @@ async function ensureWorkspacesTable(): Promise<void> {
 	await db.schema
 		.createTable("workspaces")
 		.ifNotExists()
+		.addColumn("owner_id", "text", (c) =>
+			c.notNull().defaultTo(DEFAULT_WORKSPACE_OWNER_ID),
+		)
 		.addColumn("id", "text", (c) => c.primaryKey())
 		.addColumn("name", "text", (c) => c.notNull())
 		.addColumn("path", "text", (c) => c.notNull())
@@ -23,6 +28,25 @@ async function ensureWorkspacesTable(): Promise<void> {
 			c.notNull().defaultTo("local"),
 		)
 		.addColumn("synced_at", "text", (c) => c.notNull())
+		.execute();
+	try {
+		await db.schema
+			.alterTable("workspaces")
+			.addColumn("owner_id", "text")
+			.execute();
+	} catch {
+		// Column already exists.
+	}
+	await db
+		.updateTable("workspaces")
+		.set({ owner_id: DEFAULT_WORKSPACE_OWNER_ID })
+		.where("owner_id", "is", null)
+		.execute();
+	await db.schema
+		.createIndex("idx_workspaces_owner")
+		.ifNotExists()
+		.on("workspaces")
+		.column("owner_id")
 		.execute();
 	migrated = true;
 }
@@ -41,6 +65,7 @@ export interface SyncWorkspaceInput {
 }
 
 export async function syncWorkspaces(
+	ownerId: string,
 	workspaces: SyncWorkspaceInput[],
 ): Promise<number> {
 	await ensureWorkspacesTable();
@@ -52,6 +77,7 @@ export async function syncWorkspaces(
 			db
 				.insertInto("workspaces")
 				.values({
+					owner_id: ownerId,
 					id: ws.id,
 					name: ws.name,
 					path: ws.path,
@@ -66,6 +92,7 @@ export async function syncWorkspaces(
 				})
 				.onConflict((oc) =>
 					oc.column("id").doUpdateSet({
+						owner_id: ownerId,
 						name: ws.name,
 						path: ws.path,
 						repo_id: ws.repoId ?? null,
@@ -85,6 +112,7 @@ export async function syncWorkspaces(
 }
 
 export async function getWorkspaces(
+	ownerId: string,
 	repo?: string | null,
 ): Promise<Workspace[]> {
 	await ensureWorkspacesTable();
@@ -92,6 +120,7 @@ export async function getWorkspaces(
 	let query = db
 		.selectFrom("workspaces")
 		.selectAll()
+		.where("owner_id", "=", ownerId)
 		.orderBy("last_accessed_at", "desc");
 	if (repo) {
 		query = query.where("repo_name", "=", repo);


### PR DESCRIPTION
## Summary
- Require `WORKSPACE_SYNC_API_KEY` for `POST /api/workspaces/sync`; web sessions can no longer mutate synced workspace inventory.
- Add `owner_id` to workspace rows, backfill existing rows to the legacy `default` sync owner, and scope workspace reads by owner.
- Keep API-key reads on the `default` sync owner while normal session reads use the authenticated user id.
- Add route and DB tests covering rejected session writes, API-key writes, API-key reads, and owner-scoped reads.

## Why
The security review found any signed-in web session could overwrite the global workspace inventory and read all synced workspace paths because the table had no owner or installation scope.

## Validation
- `pnpm test -- src/app/api/workspaces/sync/route.test.ts src/lib/__tests__/workspaces.test.ts` passed: 20 files / 174 tests.
- `mise -C web run web:check` passed: typecheck, Biome check over 154 files.
- Tests passed: 20 files / 174 tests.
- `git diff --check` passed.

## Mergeability
- Surface: web API / workspace DB access / bot workspace status.
- User-facing behavior changed: session-authenticated workspace sync writes now return 401; session reads return only rows owned by that user id. API-key sync keeps the legacy `default` owner used by the native sync and bot status card.
- Non-happy paths considered: invalid JSON/object validation is unchanged; missing or wrong sync API key returns unauthorized; existing rows are backfilled to `default` during migration.
- Residual risk or follow-up: this preserves the current single API-key sync owner. A future multi-installation model should add explicit installation ownership and a composite key instead of relying on globally unique workspace ids.
- Release/ops preconditions: native sync writers must send `Authorization: Bearer $WORKSPACE_SYNC_API_KEY` for POST writes.

## Evidence
- API/runtime security change; verification is web check output and remote PR checks.