### PR TITLE
[codex] Make PR reviewer kickoff reliable

### DIFF
--- a/web/src/app/api/webhooks/github/route.test.ts
+++ b/web/src/app/api/webhooks/github/route.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getChatMessageByDiscussionId: vi.fn(),
+	pushChatMessage: vi.fn(),
+	pushEvent: vi.fn(),
+	triggerPrReview: vi.fn(),
+	updateChatMessageContent: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime/pr-review", () => ({
+	triggerPrReview: mocks.triggerPrReview,
+}));
+
+vi.mock("@/lib/chat", () => ({
+	getChatMessageByDiscussionId: mocks.getChatMessageByDiscussionId,
+	pushChatMessage: mocks.pushChatMessage,
+	updateChatMessageContent: mocks.updateChatMessageContent,
+}));
+
+vi.mock("@/lib/events", () => ({
+	pushEvent: mocks.pushEvent,
+}));
+
+function pullRequestOpenedRequest(): Request {
+	return new Request("http://localhost/api/webhooks/github", {
+		method: "POST",
+		headers: {
+			"x-github-delivery": "delivery-1",
+			"x-github-event": "pull_request",
+		},
+		body: JSON.stringify({
+			action: "opened",
+			repository: {
+				full_name: "fairchild/workspaces",
+				html_url: "https://github.com/fairchild/workspaces",
+				name: "workspaces",
+			},
+			pull_request: {
+				number: 123,
+				title: "Fix review kickoff",
+				html_url: "https://github.com/fairchild/workspaces/pull/123",
+				head: { ref: "codex-fix-review-kickoff" },
+				base: { ref: "main" },
+			},
+		}),
+	});
+}
+
+describe("/api/webhooks/github POST", () => {
+	beforeEach(() => {
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET", "");
+		mocks.getChatMessageByDiscussionId.mockReset();
+		mocks.pushChatMessage.mockReset();
+		mocks.pushEvent.mockReset();
+		mocks.pushEvent.mockResolvedValue(undefined);
+		mocks.triggerPrReview.mockReset();
+		mocks.updateChatMessageContent.mockReset();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it("awaits PR review session kickoff before returning", async () => {
+		let resolveReview: (sessionId: string) => void = () => {};
+		const reviewStarted = new Promise<string>((resolve) => {
+			resolveReview = resolve;
+		});
+		mocks.triggerPrReview.mockReturnValue(reviewStarted);
+
+		const { POST } = await import("./route");
+		let resolved = false;
+		const responsePromise = POST(pullRequestOpenedRequest()).then(
+			(response) => {
+				resolved = true;
+				return response;
+			},
+		);
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(mocks.triggerPrReview).toHaveBeenCalledWith({
+			number: 123,
+			title: "Fix review kickoff",
+			htmlUrl: "https://github.com/fairchild/workspaces/pull/123",
+			headRef: "codex-fix-review-kickoff",
+			baseRef: "main",
+			repoUrl: "https://github.com/fairchild/workspaces",
+			repoFullName: "fairchild/workspaces",
+			repoName: "workspaces",
+		});
+		expect(resolved).toBe(false);
+
+		resolveReview("sesn_123");
+		const response = await responsePromise;
+
+		expect(response.status).toBe(200);
+		expect(resolved).toBe(true);
+	});
+
+	it("logs PR review kickoff failures without failing the webhook", async () => {
+		const error = new Error("session kickoff failed");
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		mocks.triggerPrReview.mockRejectedValue(error);
+
+		const { POST } = await import("./route");
+		const response = await POST(pullRequestOpenedRequest());
+
+		expect(response.status).toBe(200);
+		expect(consoleError).toHaveBeenCalledWith("[pr-review] failed:", error);
+	});
+});

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -144,7 +144,8 @@ export async function POST(request: Request): Promise<Response> {
 		await updateDispatchFromWebhook(eventType, action, payload);
 	}
 
-	// Trigger automated PR review via Managed Agents (fire-and-forget)
+	// Trigger automated PR review via Managed Agents before returning so
+	// serverless teardown cannot drop the session kickoff event.
 	if (eventType === "pull_request" && action === "opened") {
 		const pr = payload.pull_request as Record<string, unknown> | undefined;
 		const repoObj = payload.repository as Record<string, unknown> | undefined;
@@ -161,9 +162,11 @@ export async function POST(request: Request): Promise<Response> {
 				repoFullName: String(repoObj.full_name ?? ""),
 				repoName: String(repoObj.name ?? ""),
 			};
-			triggerPrReview(reviewPayload).catch((err) => {
+			try {
+				await triggerPrReview(reviewPayload);
+			} catch (err) {
 				console.error("[pr-review] failed:", err);
-			});
+			}
 		}
 	}
 

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -168,6 +168,24 @@ describe("fetchPrNarrativeContext", () => {
 });
 
 describe("triggerPrReview", () => {
+	it("configures the review prompt to render details collapsed by default", async () => {
+		mockPrList([githubPr(9), githubPr(8)]);
+
+		await expect(triggerPrReview(payload())).resolves.toBe("sesn_01");
+
+		expect(mocks.getOrCreateAgent).toHaveBeenCalledTimes(1);
+		const [, config] = mocks.getOrCreateAgent.mock.calls[0];
+		const prompt = config.systemPrompt;
+		expect(prompt).toContain("<details>\n<summary>Details</summary>");
+		expect(prompt).toContain(
+			"<details><summary>Details</summary> ... </details>",
+		);
+		expect(prompt).toContain("Do not add the `open` attribute");
+		expect(prompt).not.toContain(
+			"Use real headings (`## Summary`, `## Details`)",
+		);
+	});
+
 	it("sends previous PR context and narrative instructions in the kickoff message", async () => {
 		mockPrList([githubPr(9), githubPr(8), githubPr(7), githubPr(6)]);
 

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -33,8 +33,12 @@ cat > ./tmp/review.md << 'REVIEW_EOF'
 ## Summary
 Your summary here...
 
-## Details
+<details>
+<summary>Details</summary>
+
 - \`file.swift:42\` — description of issue
+
+</details>
 REVIEW_EOF
 
 # 2. Use jq to build valid JSON from the file, then post
@@ -58,7 +62,10 @@ Your review body MUST begin with a one-line decision banner. The first character
 
 Keep the decision banner to one sentence and no more than 140 characters. It should summarize the outcome, not repeat the PR title.
 
-- Use real headings (\`## Summary\`, \`## Details\`)
+- Use \`## Summary\` as a real heading
+- Put the details section in a GitHub-rendered HTML details block that is collapsed by default:
+  \`<details><summary>Details</summary> ... </details>\`
+- Do not add the \`open\` attribute to the \`<details>\` tag
 - Include a short \`## Project Thread\` section that references at least one previous PR by number and explains the relationship when previous PR context is available
 - Use bullet points and code blocks
 - Cite \`file:line\` for every comment


### PR DESCRIPTION
## Summary

- Await managed PR reviewer session kickoff before returning from the GitHub webhook handler.
- Keep PR reviewer "Details" output in a GitHub `<details>` block so it renders collapsed by default.
- Add regression coverage for both the webhook await behavior and the collapsed-details prompt contract.

## Mergeability

- Surface: web / agent-runtime
- User-facing behavior changed: PR reviewer reviews should no longer be intermittently dropped after webhook responses; review details should render collapsed by default on GitHub.
- Non-happy paths considered: kickoff failures are logged and the webhook still returns 200 so GitHub delivery does not retry unrelated webhook work.
- Release/ops preconditions: deploy the web app so the webhook handler change reaches production.
- Residual risk or follow-up: none known.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `cd web && pnpm typecheck`
  - `cd web && pnpm lint`
  - `cd web && pnpm test`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Web CI passed](https://github.com/fairchild/workspaces/actions/runs/25275648312/job/74105076774)
- [Vercel preview passed](https://vercel.com/cloudcompute/spaces-web/5Wk9KmzrWMNQotv2NDtDPKTCYEpa)
- Local validation from commit `578277df7913db2adf5e7abb070f58aa9ba096d2`:
  - `cd web && pnpm typecheck` passed
  - `cd web && pnpm lint` passed
  - `cd web && pnpm test` passed: 21 files, 177 tests

## Blockers

- [x] None
- [ ] Blocked on evidence
