### PR TITLE
[codex] Repair first-run hook setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ Thanks for contributing to Workspaces.
 From repo root:
 
 ```bash
+./scripts/setup               # first-run: tools, dependencies, and prek hooks
 ./scripts/build-ghosttykit.sh  # one-time: build terminal framework
 swift build
 swift test
@@ -21,13 +22,13 @@ swift test
 
 Or with mask: `mask setup && mask build && mask test`
 
-Install git hooks so commits run lint automatically:
+To refresh git hooks without running full setup:
 
 ```bash
-mask hooks-install
+./scripts/setup --hooks-only
 ```
 
-`mask setup` now installs hooks for you as part of first-time setup.
+Or with mask: `mask hooks-install`
 
 To run the app in dev mode (isolated data directory):
 

--- a/maskfile.md
+++ b/maskfile.md
@@ -5,19 +5,19 @@ that uses markdown. Install with `brew install mask`, then run `mask <task>`.
 
 ## setup
 
-> One-time setup: install repo hooks + build GhosttyKit (required before build/test)
+> One-time setup: install tools, dependencies, prek hooks, and GhosttyKit
 
 ```bash
-./scripts/install-git-hooks.sh
+./scripts/setup
 ./scripts/build-ghosttykit.sh
 ```
 
 ## hooks-install
 
-> Install repo-managed git hooks (enables pre-commit lint check)
+> Install or refresh prek git hooks
 
 ```bash
-./scripts/install-git-hooks.sh
+./scripts/setup --hooks-only
 ```
 
 ## build

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,12 @@
 
 This directory contains build/release helpers plus UI test utilities.
 
+## First-Run Setup
+
+- `./scripts/setup` is the canonical first-run path. It links local env files from the main worktree when needed, trusts checked-in mise configs, installs mise-managed tools and lockfile dependencies, unsets legacy `core.hooksPath`, and runs `prek install`.
+- `./scripts/setup --hooks-only` installs or refreshes the prek git hooks without running dependency setup.
+- `./scripts/install-git-hooks.sh` remains only as a compatibility wrapper around `./scripts/setup --hooks-only`; prefer `./scripts/setup` in new docs and task definitions.
+
 ## Ops Reporting
 
 - `uv run --script ./scripts/ops-report.py`

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,33 +1,11 @@
 #!/usr/bin/env bash
 # ==========================================================================
-# install-git-hooks.sh - Install repository-managed Git hooks
+# install-git-hooks.sh - Compatibility wrapper for prek hook installation
 # ==========================================================================
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-HOOKS_DIR="$REPO_ROOT/.githooks"
 
-if [[ ! -d "$HOOKS_DIR" ]]; then
-    echo "ERROR: hooks directory not found: $HOOKS_DIR" >&2
-    exit 1
-fi
-
-chmod +x "$HOOKS_DIR"/pre-commit
-
-if git -C "$REPO_ROOT" config --worktree core.hooksPath "$HOOKS_DIR" 2>/dev/null; then
-    # Avoid leaking a worktree-specific absolute path into shared repo config.
-    current_local_hooks_path="$(git -C "$REPO_ROOT" config --local --get core.hooksPath || true)"
-    if [[ "$current_local_hooks_path" == "$HOOKS_DIR" ]]; then
-        git -C "$REPO_ROOT" config --local --unset core.hooksPath || true
-    fi
-    config_scope="worktree"
-else
-    git -C "$REPO_ROOT" config --local core.hooksPath "$HOOKS_DIR"
-    config_scope="local"
-fi
-
-echo "Installed Git hooks:"
-echo "  scope=$config_scope"
-echo "  core.hooksPath=$HOOKS_DIR"
+echo "=> scripts/install-git-hooks.sh is a compatibility wrapper; use ./scripts/setup for first-run setup."
+exec "$SCRIPT_DIR/setup" --hooks-only

--- a/scripts/setup
+++ b/scripts/setup
@@ -5,6 +5,65 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/setup [--hooks-only]
+
+Canonical first-run setup for this repository.
+
+Options:
+  --hooks-only  Install or refresh prek git hooks, then exit.
+  -h, --help    Show this help.
+USAGE
+}
+
+HOOKS_ONLY=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hooks-only)
+      HOOKS_ONLY=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown setup option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+print_prek_install_instructions() {
+  echo "error: prek not found in PATH but prek.toml is present." >&2
+  echo "Install it with one of:" >&2
+  echo "  brew install prek           # macOS" >&2
+  echo "  cargo install --locked prek # cargo" >&2
+  echo "  curl -LsSf https://prek.j178.dev/install.sh | sh" >&2
+}
+
+install_prek_hooks() {
+  [[ -f "$REPO_ROOT/prek.toml" ]] || return 0
+
+  if ! command -v prek >/dev/null 2>&1; then
+    print_prek_install_instructions
+    exit 1
+  fi
+
+  # Remove any legacy core.hooksPath so prek can install into the per-worktree hooks dir.
+  git config --unset-all --worktree core.hooksPath 2>/dev/null || true
+  git config --unset-all --local core.hooksPath 2>/dev/null || true
+  echo "=> Installing prek hooks"
+  prek install
+}
+
+if [[ "$HOOKS_ONLY" == "1" ]]; then
+  install_prek_hooks
+  exit 0
+fi
+
 # Symlink .env from main worktree if we're in a worktree and missing it
 link_env_from_main() {
   local git_common git_dir main_wt
@@ -58,21 +117,7 @@ install_deps() {
 }
 
 # Install prek pre-commit hooks (idempotent, required)
-if [[ -f "$REPO_ROOT/prek.toml" ]]; then
-  if ! command -v prek >/dev/null 2>&1; then
-    echo "error: prek not found in PATH but prek.toml is present." >&2
-    echo "Install it with one of:" >&2
-    echo "  brew install prek           # macOS" >&2
-    echo "  cargo install --locked prek # cargo" >&2
-    echo "  curl -LsSf https://prek.j178.dev/install.sh | sh" >&2
-    exit 1
-  fi
-  # Remove any legacy core.hooksPath so prek can install into the per-worktree hooks dir.
-  git config --unset-all --worktree core.hooksPath 2>/dev/null || true
-  git config --unset-all --local core.hooksPath 2>/dev/null || true
-  echo "=> Installing prek hooks"
-  prek install
-fi
+install_prek_hooks
 
 # Root dependencies
 install_deps "$REPO_ROOT"


### PR DESCRIPTION
## Summary

- Make `scripts/setup` the canonical first-run setup path in contributor docs and mask tasks.
- Add `./scripts/setup --hooks-only` for the narrow hook refresh path.
- Convert `scripts/install-git-hooks.sh` into a compatibility wrapper around the prek hook installer.

## Mergeability

- Surface: docs / scripts
- User-facing behavior changed: first-run contributors are directed through `scripts/setup`; legacy hook installer now works instead of failing on missing `.githooks`.
- Non-happy paths considered: missing `prek` reports install instructions.
- Release/ops preconditions: none.
- Residual risk or follow-up: full `./scripts/setup` was not run because it installs dependencies and tools; the new hook-only path was verified directly.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `bash -n scripts/setup scripts/install-git-hooks.sh`
  - `./scripts/install-git-hooks.sh`
  - `./scripts/setup --hooks-only`
  - `env PATH=/usr/bin:/bin ./scripts/setup --hooks-only`
  - `git diff --check`
  - `rg -n "\.githooks" scripts/README.md CONTRIBUTING.md maskfile.md scripts/setup scripts/install-git-hooks.sh`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (command output summary)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![dx-bootstrap-hooks-verification](https://evidence.cloudcompute.com/workspaces/pr-422/20260503-160223-dx-bootstrap-hooks-verification.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
