### PR TITLE
[codex] Harden release and terminal compute security

### DIFF
--- a/.github/workflows/ci-fallback.yml
+++ b/.github/workflows/ci-fallback.yml
@@ -12,7 +12,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'failure' ||
       github.event.workflow_run.conclusion == 'timed_out'
-    runs-on: [self-hosted, lume-macos]
+    # Transitional fallback while we move toward an explicit Xcode build
+    # trigger. Do not run failed PR heads on persistent self-hosted runners.
+    runs-on: macos-15
     timeout-minutes: 90
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,27 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-sign-notarize-release:
     # Release signing/notarization stays on the dedicated signing lane so it
     # never contends with generic CI or Tart UI automation.
     runs-on: [self-hosted, signing-host]
+    environment: release
     timeout-minutes: 120
+    permissions:
+      contents: read
+      checks: read
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      build: ${{ steps.meta.outputs.build }}
+      tag: ${{ steps.meta.outputs.tag }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Enforce release source branch policy
         run: |
@@ -105,8 +114,10 @@ jobs:
           CERT_PATH="$RUNNER_TEMP/developer-id-application.p12"
           KEYCHAIN_PATH="$RUNNER_TEMP/workspaces-release.keychain-db"
           KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
           ORIGINAL_DEFAULT_KEYCHAIN="$(
-            security default-keychain -d user 2>/dev/null | tr -d '"' || true
+            security default-keychain -d user 2>/dev/null \
+            | sed -E 's/^[[:space:]]*"//; s/"$//' || true
           )"
           ORIGINAL_KEYCHAIN_LIST="$(
             security list-keychains -d user 2>/dev/null \
@@ -153,7 +164,6 @@ jobs:
           fi
 
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
           echo "SIGNING_IDENTITY=$SIGNING_IDENTITY" >> "$GITHUB_ENV"
           echo "CODESIGN_KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           echo "ORIGINAL_DEFAULT_KEYCHAIN=$ORIGINAL_DEFAULT_KEYCHAIN" >> "$GITHUB_ENV"
@@ -178,19 +188,11 @@ jobs:
           security cms -D -i "$PROFILE_PATH" >/dev/null
           echo "PROVISIONING_PROFILE_PATH=$PROFILE_PATH" >> "$GITHUB_ENV"
 
-      - name: Export signing environment
+      - name: Notarization preflight
         env:
           APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
-        run: |
-          set -euo pipefail
-          echo "TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
-          echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"
-          echo "APP_PASSWORD=$APPLE_APP_PASSWORD" >> "$GITHUB_ENV"
-          echo "BUNDLE_ID=com.cloudcompute.workspaces" >> "$GITHUB_ENV"
-
-      - name: Notarization preflight
+          APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           if [[ -n "${APPLE_API_KEY_PATH:-}" ]]; then
@@ -220,6 +222,9 @@ jobs:
           ./scripts/release-version.sh assert-tag-match "${GITHUB_REF_NAME}"
 
       - name: Build signed app
+        env:
+          BUNDLE_ID: com.cloudcompute.workspaces
+          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
         run: ./scripts/build-release.sh
 
       - name: Verify signed app bundle
@@ -237,6 +242,11 @@ jobs:
           if-no-files-found: warn
 
       - name: Notarize and package DMG
+        env:
+          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
+          APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          BUNDLE_ID: com.cloudcompute.workspaces
+          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
         run: bash ./scripts/notarize.sh
 
       - name: Read release metadata
@@ -280,6 +290,50 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --output "${{ steps.meta.outputs.appcast_path }}"
 
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: release-assets-${{ github.run_id }}
+          path: |
+            ${{ steps.meta.outputs.dmg_path }}
+            build/WorkspaceManager-latest.dmg
+            ${{ steps.meta.outputs.appcast_path }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          set -euo pipefail
+          # Restore prior keychain search/default state on shared self-hosted machines.
+          if [[ -n "${ORIGINAL_KEYCHAIN_LIST:-}" ]]; then
+            keychains=()
+            while IFS= read -r line; do
+              [[ -n "$line" ]] && keychains+=("$line")
+            done <<< "${ORIGINAL_KEYCHAIN_LIST}"
+            if (( ${#keychains[@]} > 0 )); then
+              security list-keychains -d user -s "${keychains[@]}" || true
+            fi
+          fi
+          if [[ -n "${ORIGINAL_DEFAULT_KEYCHAIN:-}" ]]; then
+            security default-keychain -d user -s "${ORIGINAL_DEFAULT_KEYCHAIN}" || true
+          fi
+          if [[ -n "${KEYCHAIN_PATH:-}" ]] && [[ -f "${KEYCHAIN_PATH}" ]]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+
+  publish-github-release:
+    needs: build-sign-notarize-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-assets-${{ github.run_id }}
+          path: release-assets
+
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -290,13 +344,21 @@ jobs:
             exit 1
           }
 
-          TAG="${{ steps.meta.outputs.tag }}"
+          TAG="${{ needs.build-sign-notarize-release.outputs.tag }}"
+          VERSION="${{ needs.build-sign-notarize-release.outputs.version }}"
           TITLE="Workspaces ${TAG}"
-          DMG_PATH="${{ steps.meta.outputs.dmg_path }}"
-          APPCAST_PATH="${{ steps.meta.outputs.appcast_path }}"
-          LATEST_DMG_PATH="build/WorkspaceManager-latest.dmg"
+          DMG_PATH="$(find release-assets -type f -name "WorkspaceManager-${VERSION}.dmg" -print -quit)"
+          APPCAST_PATH="$(find release-assets -type f -name "appcast.xml" -print -quit)"
+          LATEST_DMG_PATH="$(find release-assets -type f -name "WorkspaceManager-latest.dmg" -print -quit)"
           GENERATED_NOTES_PATH="$RUNNER_TEMP/release-notes.md"
           IS_PRERELEASE=false
+
+          for asset in "$DMG_PATH" "$LATEST_DMG_PATH" "$APPCAST_PATH"; do
+            if [[ ! -f "$asset" ]]; then
+              echo "::error::Release artifact missing: $asset"
+              exit 1
+            fi
+          done
 
           case "$TAG" in
             v[0-9]*.[0-9]*.[0-9]*-[A-Za-z0-9]*|v[0-9]*.[0-9]*.[0-9]*-[A-Za-z0-9]*.*|workspaces-v*)
@@ -344,25 +406,4 @@ jobs:
                 --generate-notes \
                 --latest
             fi
-          fi
-
-      - name: Cleanup keychain
-        if: always()
-        run: |
-          set -euo pipefail
-          # Restore prior keychain search/default state on shared self-hosted machines.
-          if [[ -n "${ORIGINAL_KEYCHAIN_LIST:-}" ]]; then
-            keychains=()
-            while IFS= read -r line; do
-              [[ -n "$line" ]] && keychains+=("$line")
-            done <<< "${ORIGINAL_KEYCHAIN_LIST}"
-            if (( ${#keychains[@]} > 0 )); then
-              security list-keychains -d user -s "${keychains[@]}" || true
-            fi
-          fi
-          if [[ -n "${ORIGINAL_DEFAULT_KEYCHAIN:-}" ]]; then
-            security default-keychain -d user -s "${ORIGINAL_DEFAULT_KEYCHAIN}" || true
-          fi
-          if [[ -n "${KEYCHAIN_PATH:-}" ]] && [[ -f "${KEYCHAIN_PATH}" ]]; then
-            security delete-keychain "$KEYCHAIN_PATH" || true
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -146,6 +146,27 @@ Then test signing:
 
 ### GitHub Actions Setup (for CI/CD)
 
+Before adding release secrets, create a GitHub Actions environment named
+`release` in repository settings and require reviewer approval for deployments
+to that environment. The release workflow references this environment before it
+imports signing material, so environment protection is the approval gate for
+Developer ID, notarization, and Sparkle release secrets.
+
+The workflow is split into two jobs:
+
+- `build-sign-notarize-release` runs on `[self-hosted, signing-host]` with
+  read-only repository permissions. It imports the Developer ID certificate into
+  a temporary keychain, builds and signs the app, notarizes the DMG, generates
+  the Sparkle appcast, uploads release assets as workflow artifacts, then
+  deletes the temporary keychain.
+- `publish-github-release` runs on `ubuntu-latest` with `contents: write`. It
+  downloads the signed artifacts and creates or updates the GitHub Release.
+
+Keep signing/notarization credentials scoped to the steps that need them. Do not
+write generated keychain passwords or Apple notarization credentials to
+`$GITHUB_ENV`; generated keychain passwords should be masked immediately with
+`::add-mask::` before they can appear in logs.
+
 Preferred setup path:
 
 ```bash

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -136,6 +136,31 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("runs-on: macos-15", workflow)
         self.assertNotIn("runs-on: [self-hosted, lume-macos]", workflow)
 
+    def test_ci_fallback_uses_github_hosted_runner(self) -> None:
+        """Failed PR fallback must not execute untrusted commits on self-hosted runners."""
+        workflow = (REPO_ROOT / ".github/workflows/ci-fallback.yml").read_text()
+        self.assertIn("workflow_run:", workflow)
+        self.assertIn("runs-on: macos-15", workflow)
+        self.assertNotIn("runs-on: [self-hosted, lume-macos]", workflow)
+        self.assertNotIn("runs-on: [self-hosted, signing-host]", workflow)
+
+    def test_release_workflow_does_not_export_secrets_job_wide(self) -> None:
+        """Generated and notarization secrets must not be written into GITHUB_ENV."""
+        workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()
+        self.assertIn("::add-mask::$KEYCHAIN_PASSWORD", workflow)
+        self.assertIn("environment: release", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("publish-github-release:", workflow)
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertIn("permissions:\n      contents: write", workflow)
+        for forbidden in (
+            'echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"',
+            'echo "APP_PASSWORD=$APPLE_APP_PASSWORD" >> "$GITHUB_ENV"',
+            'echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"',
+            'echo "TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"',
+        ):
+            self.assertNotIn(forbidden, workflow)
+
     def test_ci_workflows_have_explicit_permissions(self) -> None:
         """CI workflows should declare explicit top-level permissions to limit default token scope."""
         for name in ("ci.yml", "ci-agents.yml", "web-ci.yml"):

--- a/web/docs/architecture.md
+++ b/web/docs/architecture.md
@@ -91,11 +91,14 @@ User sends message
     → Snapshot and release (save state, stop sandbox)
 ```
 
-Sessions persist across messages via snapshot/restore. The `agent_sessions` table tracks `computeBackend`, `computeInstanceId`, `snapshotId`, and `claudeSessionId` per session.
+Sessions persist across messages via snapshot/restore. The `agent_sessions` table tracks `userId`, `computeBackend`, `computeInstanceId`, `snapshotId`, and `claudeSessionId` per session.
 
 ## Terminal Architecture
 
-The Terminal tab provides shell access to active agent sandboxes.
+The Terminal tab provides shell access to active agent sandboxes. Starting a
+hosted terminal follows the same trusted-operator boundary as hosted agent chat:
+the authenticated user's GitHub login must be present in `ALLOWED_AGENT_LOGINS`
+before the API creates or reuses a terminal-capable sandbox.
 
 ### Direct connection
 
@@ -129,7 +132,7 @@ Every API route that reads or mutates repo-scoped data passes through the two he
 
 The ownership check is backed by `isRepoOwnedByUser` in `src/lib/repos.ts`, which does a pinpoint `SELECT 1 FROM user_repos WHERE user_id=? AND owner=? AND repo=? LIMIT 1` — hits the table's primary key index, one row read per request.
 
-Routes that accept a session or sandbox identifier instead of a repo (e.g. `/api/managed-agents/transcript?sessionId=`) resolve the identifier to its repo via `getSessionByInstanceId` in `src/lib/agent-sessions.ts`, then authorize against that repo. `agent_sessions` has no `user_id` column by design — session ownership is derived from the repo so co-owners can see each other's agent activity on the same repo.
+Routes that accept a session or sandbox identifier instead of a repo (e.g. `/api/managed-agents/transcript?sessionId=`) resolve the identifier through `src/lib/agent-sessions.ts` with the authenticated `user_id`, then authorize against the resolved repo. `agent_sessions` stores `user_id`; terminal status, stop, resume, and transcript lookups must include it so one user cannot attach to another user's live sandbox just because both can access the same repo.
 
 Webhook intake routes (`/api/webhooks/*`) are intentionally unauthenticated and verify GitHub's HMAC signature instead. The Better Auth handler at `/api/auth/[...all]` owns its own auth flow.
 

--- a/web/src/app/api/terminal/start/route.test.ts
+++ b/web/src/app/api/terminal/start/route.test.ts
@@ -15,9 +15,11 @@ const mocks = vi.hoisted(() => {
 	};
 
 	return {
+		allowedAgentLogins: new Set(["fairchild"]),
 		authorizeRepoAccess: vi.fn(),
 		bypassToken: null as string | null,
 		createSession: vi.fn(),
+		fetchGitHubLogin: vi.fn(),
 		getGitHubToken: vi.fn(),
 		getSessionForAgent: vi.fn(),
 		provider,
@@ -30,6 +32,10 @@ vi.mock("@/lib/agent-runtime/provider-registry", () => ({
 		getDefault: () => mocks.provider,
 		all: () => [mocks.provider],
 	}),
+}));
+
+vi.mock("@/lib/agent-runtime/config", () => ({
+	ALLOWED_AGENT_LOGINS: mocks.allowedAgentLogins,
 }));
 
 vi.mock("@/lib/agent-sessions", () => ({
@@ -48,6 +54,7 @@ vi.mock("@/lib/auth-server", () => ({
 }));
 
 vi.mock("@/lib/github", () => ({
+	fetchGitHubLogin: mocks.fetchGitHubLogin,
 	getGitHubToken: mocks.getGitHubToken,
 }));
 
@@ -60,10 +67,14 @@ function jsonRequest(body: unknown): Request {
 
 describe("/api/terminal/start POST", () => {
 	beforeEach(() => {
+		mocks.allowedAgentLogins.clear();
+		mocks.allowedAgentLogins.add("fairchild");
 		mocks.authorizeRepoAccess.mockReset();
 		mocks.authorizeRepoAccess.mockResolvedValue(null);
 		mocks.bypassToken = null;
 		mocks.createSession.mockReset();
+		mocks.fetchGitHubLogin.mockReset();
+		mocks.fetchGitHubLogin.mockResolvedValue("fairchild");
 		mocks.getGitHubToken.mockReset();
 		mocks.getGitHubToken.mockResolvedValue("oauth-token");
 		mocks.getSessionForAgent.mockReset();
@@ -85,6 +96,7 @@ describe("/api/terminal/start POST", () => {
 		);
 
 		expect(response.status).toBe(200);
+		expect(mocks.fetchGitHubLogin).toHaveBeenCalledWith("oauth-token");
 		expect(mocks.provider.createTerminalSandbox).toHaveBeenCalledWith({
 			cloneUrl: "https://github.com/fairchild/workspaces.git",
 			authToken: "oauth-token",
@@ -106,10 +118,44 @@ describe("/api/terminal/start POST", () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.getGitHubToken).not.toHaveBeenCalled();
+		expect(mocks.fetchGitHubLogin).not.toHaveBeenCalled();
 		expect(mocks.provider.createTerminalSandbox).toHaveBeenCalledWith({
 			cloneUrl: "https://github.com/fairchild/workspaces.git",
 			authToken: undefined,
 			branch: undefined,
 		});
+	});
+
+	it("rejects non-allowlisted users before provider work", async () => {
+		mocks.fetchGitHubLogin.mockResolvedValue("external-user");
+
+		const { POST } = await import("./route");
+		const response = await POST(jsonRequest({ repo: "fairchild/workspaces" }));
+
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			error: "Terminal sessions are not yet available for your account",
+		});
+		expect(mocks.getSessionForAgent).not.toHaveBeenCalled();
+		expect(mocks.provider.checkAvailability).not.toHaveBeenCalled();
+		expect(mocks.provider.createTerminalSandbox).not.toHaveBeenCalled();
+		expect(mocks.createSession).not.toHaveBeenCalled();
+	});
+
+	it("does not create a sandbox when repo authorization fails", async () => {
+		mocks.authorizeRepoAccess.mockResolvedValue(
+			Response.json({ error: "repo not in your workspace" }, { status: 403 }),
+		);
+
+		const { POST } = await import("./route");
+		const response = await POST(jsonRequest({ repo: "fairchild/workspaces" }));
+
+		expect(response.status).toBe(403);
+		expect(mocks.getGitHubToken).not.toHaveBeenCalled();
+		expect(mocks.fetchGitHubLogin).not.toHaveBeenCalled();
+		expect(mocks.getSessionForAgent).not.toHaveBeenCalled();
+		expect(mocks.provider.checkAvailability).not.toHaveBeenCalled();
+		expect(mocks.provider.createTerminalSandbox).not.toHaveBeenCalled();
+		expect(mocks.createSession).not.toHaveBeenCalled();
 	});
 });

--- a/web/src/app/api/terminal/start/route.ts
+++ b/web/src/app/api/terminal/start/route.ts
@@ -1,10 +1,11 @@
 import crypto from "node:crypto";
+import { ALLOWED_AGENT_LOGINS } from "@/lib/agent-runtime/config";
 import { getRegistry } from "@/lib/agent-runtime/provider-registry";
 import { isTerminalCapable } from "@/lib/agent-runtime/types";
 import { createSession, getSessionForAgent } from "@/lib/agent-sessions";
 import { authorizeRepoAccess, unauthorizedResponse } from "@/lib/api-auth";
 import { getDevBypassToken, getSession } from "@/lib/auth-server";
-import { getGitHubToken } from "@/lib/github";
+import { fetchGitHubLogin, getGitHubToken } from "@/lib/github";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -45,6 +46,30 @@ export async function POST(request: Request): Promise<Response> {
 	const unauthorized = await authorizeRepoAccess(session.user.id, body.repo);
 	if (unauthorized) return unauthorized;
 
+	let authToken: string | undefined;
+	let login: string;
+	const bypass = getDevBypassToken();
+	if (bypass) {
+		login = "fairchild";
+	} else {
+		const token = await getGitHubToken(session.user.id).catch(() => null);
+		if (!token) {
+			return Response.json(
+				{ error: "GitHub token not found" },
+				{ status: 403 },
+			);
+		}
+		authToken = token;
+		login = await fetchGitHubLogin(token);
+	}
+
+	if (!ALLOWED_AGENT_LOGINS.has(login)) {
+		return Response.json(
+			{ error: "Terminal sessions are not yet available for your account" },
+			{ status: 403 },
+		);
+	}
+
 	const agentName = body.agentName ?? process.env.DEFAULT_AGENT ?? "shell";
 
 	// If a live session already exists for this (repo, agent), reuse it
@@ -64,13 +89,6 @@ export async function POST(request: Request): Promise<Response> {
 
 	// Keep the clone URL token-free so it cannot persist in .git/config.
 	const cloneUrl = `https://github.com/${body.repo}.git`;
-	let authToken: string | undefined;
-	if (!getDevBypassToken()) {
-		const token = await getGitHubToken(session.user.id).catch(() => null);
-		if (token) {
-			authToken = token;
-		}
-	}
 
 	const registry = await getRegistry();
 


### PR DESCRIPTION
## Summary

- Gate hosted terminal creation behind the existing allowed-agent GitHub login boundary.
- Move CI fallback from persistent self-hosted Lume runner to GitHub-hosted macOS.
- Harden release signing by masking generated keychain secrets, narrowing env scope, and publishing releases from a separate write-scoped job.
- Document the mechanical release/terminal authorization changes without publishing the broader security stance doc.

## Mergeability

- Surface: web / agent-runtime / infra / docs
- User-facing behavior changed: Non-allowlisted GitHub users now receive 403 when starting hosted terminal sessions; release publishing behavior is split across signing and publish jobs but release artifacts remain the same.
- Non-happy paths considered: Missing GitHub token, non-allowlisted login, failed repo authz before sandbox creation, missing release artifacts in publish job, failed notarization preflight, failed release workflow secret validation.
- Release/ops preconditions: Configure the GitHub Actions `release` environment with reviewer protection before relying on the environment gate; no long-lived secret rotation required from the deleted log alone unless separate evidence shows credential exposure or signing-host compromise.
- Residual risk or follow-up: Signing still runs on a persistent signing host; future work should evaluate ephemeral signing isolation and the eventual explicit Xcode build trigger that replaces the hosted fallback lane.

## Validation

- `uv run --script scripts/test_security_hardening.py` — 12 tests passed.
- `pnpm test -- terminal/start` — 21 files passed, 179 tests passed.
- `pnpm audit --prod` — No known vulnerabilities found.
- `mise -C web run web:check` — typecheck, lint, and 179 Vitest tests passed.
- `git diff --check` — passed.
- Workflow syntax proof: release workflow structure was validated by `uv run --script scripts/test_security_hardening.py`; changed shell snippets were reviewed with `set -euo pipefail` and existing workflow syntax patterns. No `actionlint` binary is available locally.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: not applicable
- Before Summary: not applicable
- After Summary: not applicable
- Delta Summary: not applicable

Performance comparison notes:

- Exact commands used: not applicable
- Workload / environment context: not applicable

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Test output: `uv run --script scripts/test_security_hardening.py` — 12 tests passed.
- Test output: `pnpm test -- terminal/start` — 21 files passed, 179 tests passed.
- Test output: `mise -C web run web:check` — typecheck, lint, and 179 Vitest tests passed.
- Audit output: `pnpm audit --prod` — No known vulnerabilities found.

## Blockers

- [x] None
- [ ] Blocked on evidence

## Notes

- `docs/security.md` remains local and is intentionally not included in this PR.
- Affected release run logs for 25275948535 were deleted after preserving context in the review thread.
