### PR TITLE
refactor(sidebar): extract expansion state controller

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarExpansionStateController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarExpansionStateController.swift
@@ -1,0 +1,88 @@
+//
+//  SidebarExpansionStateController.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+struct SidebarExpansionStateController {
+    private(set) var expandedRepoIDs: Set<UUID> = []
+    private(set) var expandedWorkspaceIDs: Set<UUID> = []
+    private(set) var didInitializeRepoExpansion = false
+
+    func isRepoExpanded(_ repoID: UUID) -> Bool {
+        expandedRepoIDs.contains(repoID)
+    }
+
+    mutating func toggleRepoExpansion(_ repoID: UUID) {
+        if expandedRepoIDs.contains(repoID) {
+            expandedRepoIDs.remove(repoID)
+        } else {
+            expandedRepoIDs.insert(repoID)
+        }
+    }
+
+    mutating func expandRepo(_ repoID: UUID) {
+        expandedRepoIDs.insert(repoID)
+    }
+
+    func isWorkspaceExpanded(_ workspaceID: UUID) -> Bool {
+        expandedWorkspaceIDs.contains(workspaceID)
+    }
+
+    mutating func toggleWorkspaceExpansion(_ workspaceID: UUID, hasWebSources: Bool) {
+        guard hasWebSources else { return }
+
+        if expandedWorkspaceIDs.contains(workspaceID) {
+            expandedWorkspaceIDs.remove(workspaceID)
+        } else {
+            expandedWorkspaceIDs.insert(workspaceID)
+        }
+    }
+
+    mutating func initializeRepoExpansionIfNeeded(
+        repoIDs: [UUID],
+        selectedWorkspaceRepoID: UUID?,
+        isUIFixtureMode: Bool
+    ) {
+        guard !didInitializeRepoExpansion else { return }
+        didInitializeRepoExpansion = true
+
+        if isUIFixtureMode {
+            expandedRepoIDs = Set(repoIDs)
+            return
+        }
+
+        if let selectedWorkspaceRepoID {
+            expandedRepoIDs.insert(selectedWorkspaceRepoID)
+        }
+    }
+
+    mutating func expandSelectedWorkspace(
+        workspaceID: UUID?,
+        repoID: UUID?,
+        hasWebSources: Bool
+    ) {
+        guard let workspaceID, let repoID else { return }
+        expandedRepoIDs.insert(repoID)
+
+        if hasWebSources {
+            expandedWorkspaceIDs.insert(workspaceID)
+        }
+    }
+
+    mutating func expandSelectedWebSource(repoID: UUID?, workspaceID: UUID?) {
+        if let repoID {
+            expandedRepoIDs.insert(repoID)
+        }
+
+        if let workspaceID {
+            expandedWorkspaceIDs.insert(workspaceID)
+        }
+    }
+
+    mutating func prune(validRepoIDs: Set<UUID>, validWorkspaceIDs: Set<UUID>) {
+        expandedRepoIDs.formIntersection(validRepoIDs)
+        expandedWorkspaceIDs.formIntersection(validWorkspaceIDs)
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -69,9 +69,7 @@ struct SidebarView: View {
     @State private var showingDeleteConfirmation = false
 
     @State private var didAttemptDefaultRepoImport = false
-    @State private var expandedRepoIDs: Set<UUID> = []
-    @State private var expandedWorkspaceIDs: Set<UUID> = []
-    @State private var didInitializeRepoExpansion = false
+    @State private var expansionController = SidebarExpansionStateController()
     @State private var workspaceAction: WorkspaceActionState?
     @State private var workspaceCreationStatusByRepoID: [UUID: WorkspaceCreationStatus] = [:]
     @State private var repoLastAccessedSnapshotByID: [UUID: Date] = [:]
@@ -225,8 +223,7 @@ struct SidebarView: View {
             expandContainersForSelectedWebSource()
         }
         .onChange(of: repos.map(\.id)) { _, _ in
-            pruneExpandedRepos()
-            pruneExpandedWorkspaces()
+            pruneExpandedContainers()
             syncRepoSortSnapshot()
             Task { @MainActor in
                 await maybeDriveHostLumeSmokeAutomation()
@@ -394,7 +391,7 @@ struct SidebarView: View {
             },
             onSelectRepo: {
                 if !isRepoExpanded(repo) {
-                    expandedRepoIDs.insert(repo.id)
+                    expansionController.expandRepo(repo.id)
                 }
                 onRepoSelected(repo)
             },
@@ -736,7 +733,7 @@ struct SidebarView: View {
     ) async {
         let repoID = repo.id
         guard !isCreatingWorkspace(for: repoID) else { return }
-        expandedRepoIDs.insert(repoID)
+        expansionController.expandRepo(repoID)
         workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
             message: initialCreationMessage(for: providerID)
         )
@@ -1311,73 +1308,52 @@ struct SidebarView: View {
     }
 
     private func isRepoExpanded(_ repo: Repo) -> Bool {
-        expandedRepoIDs.contains(repo.id)
+        expansionController.isRepoExpanded(repo.id)
     }
 
     private func toggleRepoExpansion(_ repo: Repo) {
-        if expandedRepoIDs.contains(repo.id) {
-            expandedRepoIDs.remove(repo.id)
-        } else {
-            expandedRepoIDs.insert(repo.id)
-        }
+        expansionController.toggleRepoExpansion(repo.id)
     }
 
     private func isWorkspaceExpanded(_ workspace: Workspace) -> Bool {
-        expandedWorkspaceIDs.contains(workspace.id)
+        expansionController.isWorkspaceExpanded(workspace.id)
     }
 
     private func toggleWorkspaceExpansion(_ workspace: Workspace) {
-        guard !workspace.webSources.isEmpty else { return }
-
-        if expandedWorkspaceIDs.contains(workspace.id) {
-            expandedWorkspaceIDs.remove(workspace.id)
-        } else {
-            expandedWorkspaceIDs.insert(workspace.id)
-        }
+        expansionController.toggleWorkspaceExpansion(
+            workspace.id,
+            hasWebSources: !workspace.webSources.isEmpty
+        )
     }
 
     private func initializeExpandedReposIfNeeded() {
-        guard !didInitializeRepoExpansion else { return }
-        didInitializeRepoExpansion = true
-
-        if isUIFixtureMode {
-            expandedRepoIDs = Set(repos.map(\.id))
-            return
-        }
-
-        guard let selectedRepoID = selectedWorkspace?.sourceRepo?.id else { return }
-        expandedRepoIDs.insert(selectedRepoID)
+        expansionController.initializeRepoExpansionIfNeeded(
+            repoIDs: repos.map(\.id),
+            selectedWorkspaceRepoID: selectedWorkspace?.sourceRepo?.id,
+            isUIFixtureMode: isUIFixtureMode
+        )
     }
 
     private func expandRepoForSelectedWorkspace() {
-        guard let selectedWorkspace else { return }
-        guard let selectedRepoID = selectedWorkspace.sourceRepo?.id else { return }
-        expandedRepoIDs.insert(selectedRepoID)
-        if !selectedWorkspace.webSources.isEmpty {
-            expandedWorkspaceIDs.insert(selectedWorkspace.id)
-        }
+        expansionController.expandSelectedWorkspace(
+            workspaceID: selectedWorkspace?.id,
+            repoID: selectedWorkspace?.sourceRepo?.id,
+            hasWebSources: selectedWorkspace?.webSources.isEmpty == false
+        )
     }
 
     private func expandContainersForSelectedWebSource() {
-        guard let selectedWebSource else { return }
-
-        if let repoID = selectedWebSource.ownerRepo?.id {
-            expandedRepoIDs.insert(repoID)
-        }
-
-        if let workspaceID = selectedWebSource.sourceWorkspace?.id {
-            expandedWorkspaceIDs.insert(workspaceID)
-        }
+        expansionController.expandSelectedWebSource(
+            repoID: selectedWebSource?.ownerRepo?.id,
+            workspaceID: selectedWebSource?.sourceWorkspace?.id
+        )
     }
 
-    private func pruneExpandedRepos() {
-        let currentRepoIDs = Set(repos.map(\.id))
-        expandedRepoIDs.formIntersection(currentRepoIDs)
-    }
-
-    private func pruneExpandedWorkspaces() {
-        let currentWorkspaceIDs = Set(repos.flatMap(\.workspaces).map(\.id))
-        expandedWorkspaceIDs.formIntersection(currentWorkspaceIDs)
+    private func pruneExpandedContainers() {
+        expansionController.prune(
+            validRepoIDs: Set(repos.map(\.id)),
+            validWorkspaceIDs: Set(repos.flatMap(\.workspaces).map(\.id))
+        )
     }
 
     private func updateRepoSortMode(_ mode: SidebarRepoSortMode) {

--- a/Tests/WorkspaceManagerAppTests/SidebarExpansionStateControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarExpansionStateControllerTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("SidebarExpansionStateController")
+struct SidebarExpansionStateControllerTests {
+    @Test("Repo expansion toggles and explicit expansion is idempotent")
+    func repoExpansionTogglesAndExpands() {
+        let repoID = UUID()
+        var controller = SidebarExpansionStateController()
+
+        #expect(!controller.isRepoExpanded(repoID))
+
+        controller.toggleRepoExpansion(repoID)
+        #expect(controller.isRepoExpanded(repoID))
+
+        controller.expandRepo(repoID)
+        #expect(controller.isRepoExpanded(repoID))
+
+        controller.toggleRepoExpansion(repoID)
+        #expect(!controller.isRepoExpanded(repoID))
+    }
+
+    @Test("Workspace expansion is ignored when there are no web sources")
+    func workspaceExpansionRequiresWebSources() {
+        let workspaceID = UUID()
+        var controller = SidebarExpansionStateController()
+
+        controller.toggleWorkspaceExpansion(workspaceID, hasWebSources: false)
+        #expect(!controller.isWorkspaceExpanded(workspaceID))
+
+        controller.toggleWorkspaceExpansion(workspaceID, hasWebSources: true)
+        #expect(controller.isWorkspaceExpanded(workspaceID))
+
+        controller.toggleWorkspaceExpansion(workspaceID, hasWebSources: true)
+        #expect(!controller.isWorkspaceExpanded(workspaceID))
+    }
+
+    @Test("Fixture initialization expands all repos only once")
+    func fixtureInitializationExpandsAllReposOnce() {
+        let repoA = UUID()
+        let repoB = UUID()
+        let repoC = UUID()
+        var controller = SidebarExpansionStateController()
+
+        controller.initializeRepoExpansionIfNeeded(
+            repoIDs: [repoA, repoB],
+            selectedWorkspaceRepoID: nil,
+            isUIFixtureMode: true
+        )
+
+        #expect(controller.didInitializeRepoExpansion)
+        #expect(controller.isRepoExpanded(repoA))
+        #expect(controller.isRepoExpanded(repoB))
+        #expect(!controller.isRepoExpanded(repoC))
+
+        controller.initializeRepoExpansionIfNeeded(
+            repoIDs: [repoC],
+            selectedWorkspaceRepoID: nil,
+            isUIFixtureMode: true
+        )
+
+        #expect(controller.isRepoExpanded(repoA))
+        #expect(controller.isRepoExpanded(repoB))
+        #expect(!controller.isRepoExpanded(repoC))
+    }
+
+    @Test("Normal initialization expands the selected workspace repo")
+    func normalInitializationExpandsSelectedWorkspaceRepo() {
+        let selectedRepoID = UUID()
+        let otherRepoID = UUID()
+        var controller = SidebarExpansionStateController()
+
+        controller.initializeRepoExpansionIfNeeded(
+            repoIDs: [selectedRepoID, otherRepoID],
+            selectedWorkspaceRepoID: selectedRepoID,
+            isUIFixtureMode: false
+        )
+
+        #expect(controller.isRepoExpanded(selectedRepoID))
+        #expect(!controller.isRepoExpanded(otherRepoID))
+    }
+
+    @Test("Selected workspace expands its repo and only expands workspace when web sources exist")
+    func selectedWorkspaceExpansionRespectsWebSourcePresence() {
+        let repoID = UUID()
+        let workspaceWithoutSourcesID = UUID()
+        let workspaceWithSourcesID = UUID()
+        var controller = SidebarExpansionStateController()
+
+        controller.expandSelectedWorkspace(
+            workspaceID: workspaceWithoutSourcesID,
+            repoID: repoID,
+            hasWebSources: false
+        )
+
+        #expect(controller.isRepoExpanded(repoID))
+        #expect(!controller.isWorkspaceExpanded(workspaceWithoutSourcesID))
+
+        controller.expandSelectedWorkspace(
+            workspaceID: workspaceWithSourcesID,
+            repoID: repoID,
+            hasWebSources: true
+        )
+
+        #expect(controller.isWorkspaceExpanded(workspaceWithSourcesID))
+    }
+
+    @Test("Selected web source expands both owner containers when present")
+    func selectedWebSourceExpandsOwnerContainers() {
+        let repoID = UUID()
+        let workspaceID = UUID()
+        var controller = SidebarExpansionStateController()
+
+        controller.expandSelectedWebSource(repoID: repoID, workspaceID: workspaceID)
+
+        #expect(controller.isRepoExpanded(repoID))
+        #expect(controller.isWorkspaceExpanded(workspaceID))
+    }
+
+    @Test("Pruning removes stale repo and workspace expansion IDs")
+    func pruningRemovesStaleExpansionIDs() {
+        let currentRepoID = UUID()
+        let staleRepoID = UUID()
+        let currentWorkspaceID = UUID()
+        let staleWorkspaceID = UUID()
+        var controller = SidebarExpansionStateController()
+
+        controller.expandRepo(currentRepoID)
+        controller.expandRepo(staleRepoID)
+        controller.expandSelectedWebSource(repoID: nil, workspaceID: currentWorkspaceID)
+        controller.expandSelectedWebSource(repoID: nil, workspaceID: staleWorkspaceID)
+
+        controller.prune(
+            validRepoIDs: [currentRepoID],
+            validWorkspaceIDs: [currentWorkspaceID]
+        )
+
+        #expect(controller.isRepoExpanded(currentRepoID))
+        #expect(!controller.isRepoExpanded(staleRepoID))
+        #expect(controller.isWorkspaceExpanded(currentWorkspaceID))
+        #expect(!controller.isWorkspaceExpanded(staleWorkspaceID))
+    }
+}

--- a/backlog/main-window-sidebar-maintainability_followup.md
+++ b/backlog/main-window-sidebar-maintainability_followup.md
@@ -54,6 +54,7 @@ Status:
 - `MainWindowNavigationStateController`, `MainWindowSurfaceResolutionController`, and `MainWindowRemoteWorkspaceStateController` now centralize previously ad hoc selection and lifecycle behavior.
 - Selection state now stores stable IDs/lightweight structs instead of live SwiftData objects to avoid stale-object hazards after deletion or async completion.
 - `SidebarRepoSortController` now holds stable repository sorting rules instead of burying sort policy in `SidebarView`.
+- `SidebarExpansionStateController` now holds repo/workspace expansion state, selected-container expansion, and stale-ID pruning rules instead of keeping those transitions inline in `SidebarView`.
 
 ### Phase 3: Ghostty boundary cleanup
 


### PR DESCRIPTION
## Summary

- Extract sidebar repo/workspace expansion transitions into `SidebarExpansionStateController`.
- Replace raw expansion sets in `SidebarView` with controller calls while preserving current UI behavior.
- Add deterministic Swift Testing coverage for toggles, fixture initialization, selected workspace/web-source expansion, and stale-ID pruning.
- Update the maintainability follow-up backlog note for the completed extraction.

## Mergeability

- Surface: desktop
- User-facing behavior changed: No; this is a behavior-preserving sidebar maintainability refactor.
- Non-happy paths considered: Workspace expansion still ignores workspaces without web sources; stale repo/workspace expansion IDs are pruned together when repo data changes; fixture-mode initialization remains one-shot.
- Release/ops preconditions: None.
- Residual risk or follow-up: The remaining P0 #2 work is still incremental `ContentView` / `SidebarView` / `GhosttySurfaceView` shrinkage.

## Validation

- [ ] `swift build`
- [x] `swift test`
- [x] Other checks run: `swift test --filter SidebarExpansionStateController`; `swift test --filter Sidebar`; `swift build -Xswiftc -warn-concurrency`; `git diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: pure state-controller extraction; no runtime performance path changed

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Swift unit evidence](https://evidence.cloudcompute.com/workspaces/pr-426/20260503-175312-swift-unit.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
