### PR TITLE
[codex] Add root mise task catalog

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,21 @@
 [tools]
 zig = "0.15.2"
 
+[tasks.setup]
+description = "Bootstrap this checkout with tools, dependencies, env links, and prek hooks."
+run = "./scripts/setup"
+
+[tasks."hooks-install"]
+description = "Install or refresh prek git hooks without running dependency setup."
+run = "./scripts/setup --hooks-only"
+
 [tasks.build-ghosttykit]
 description = "Build GhosttyKit.xcframework (required once or after pin changes)."
 run = "./scripts/build-ghosttykit.sh"
+
+[tasks.lint]
+description = "Lint Swift formatting without modifying files."
+run = "swift-format lint --strict --recursive Sources/ Tests/"
 
 [tasks.build]
 description = "Build the WorkspaceManager app."
@@ -12,6 +24,15 @@ run = "swift build"
 [tasks.test]
 description = "Run the test suite."
 run = "swift test"
+
+[tasks.check]
+description = "Run the local Swift validation gate: lint, build, and tests."
+run = """
+set -e
+swift-format lint --strict --recursive Sources/ Tests/
+swift build
+swift test
+"""
 
 [tasks."dev-launch"]
 description = "Launch the debug app and require a visible window."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,42 +7,42 @@ Thanks for contributing to Workspaces.
 - macOS 14.0+ (Sonoma or newer)
 - Xcode 15.0+ or Swift 5.10+
 - [mise](https://mise.jdx.dev/) (toolchain management)
-- Optional: [mask](https://github.com/jacobdeichert/mask) (`brew install mask`) — a markdown-based task runner. If installed, you can use `mask <task>` as a shorthand for the commands below. See [maskfile.md](./maskfile.md) for all available tasks.
 
 ## Local Setup
 
 From repo root:
 
 ```bash
-./scripts/setup               # first-run: tools, dependencies, and prek hooks
-./scripts/build-ghosttykit.sh  # one-time: build terminal framework
-swift build
-swift test
+./scripts/setup  # first-run: tools, dependencies, env links, and prek hooks
 ```
 
-Or with mask: `mask setup && mask build && mask test`
+After the first-run bootstrap, use the root `mise` tasks for normal development:
+
+```bash
+mise run build-ghosttykit  # one-time or after Ghostty pin changes
+mise run build
+mise run test
+```
 
 To refresh git hooks without running full setup:
 
 ```bash
-./scripts/setup --hooks-only
+mise run hooks-install
 ```
 
-Or with mask: `mask hooks-install`
+The underlying script path remains `./scripts/setup --hooks-only`.
 
 To run the app in dev mode (isolated data directory):
 
 ```bash
-./scripts/launch-dev.sh
+mise run dev-launch
 ```
-
-Or with mask: `mask dev`
 
 `launch-dev.sh` runs the debug binary from `.build/` with an isolated local data root. Useful options:
 
 ```bash
-./scripts/launch-dev.sh --no-build      # skip rebuild, launch existing binary
-./scripts/launch-dev.sh --no-activate    # don't steal foreground focus
+mise run dev-launch -- --no-build       # skip rebuild, launch existing binary
+mise run dev-launch -- --no-activate    # don't steal foreground focus
 ```
 
 If your shell restricts writes to `~/Library/Application Support`, set a custom data dir:
@@ -56,12 +56,10 @@ WORKSPACES_DATA_DIR="$PWD/.workspacemanager-data" swift run WorkspaceManager
 Run before and after non-trivial changes:
 
 ```bash
-swift-format lint --strict --recursive Sources/ Tests/
-swift build
-swift test
+mise run check
 ```
 
-Or with mask: `mask ci`
+`mise run check` runs Swift format lint, `swift build`, and `swift test`.
 
 ## Local Install Workflow
 
@@ -105,7 +103,7 @@ workspaces/
 
 1. Keep scope focused and prefer incremental, testable changes.
 2. Add or update tests when behavior changes.
-3. Run local checks (`swift test`, `swift build`, lint when relevant).
+3. Run local checks (`mise run check`, or focused build/test commands when appropriate).
 4. Include a concise summary of behavior changes and verification results in the PR.
 
 ## CI Runner Lanes

--- a/README.md
+++ b/README.md
@@ -87,7 +87,36 @@ If you build something interesting on top of this, open an issue.
 
 ## Developer Setup and Contributing
 
-For all development setup, local build/test workflows, contribution guidelines, and project structure, see:
+Bootstrap a fresh checkout with:
+
+```bash
+./scripts/setup
+```
+
+After bootstrap, use the root `mise` catalog for day-to-day work:
+
+```bash
+mise run build-ghosttykit
+mise run build
+mise run test
+mise run check
+mise run dev-launch
+mise run dev-smoke
+mise run evidence -- --pr <number> --name <slug>
+```
+
+Lume validation entry points are also available from the root catalog:
+
+```bash
+mise run dev-lume-ensure
+mise run dev-lume-preflight
+mise run dev-lume-standalone-validate
+mise run dev-lume-macos-smoke
+```
+
+Run `mise tasks` for the full top-level catalog. Web dashboard tasks stay in `web/.mise.toml`; run them with `mise -C web run <task>`.
+
+For contribution guidelines and project structure, see:
 
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 
@@ -114,15 +143,6 @@ The Lume validation flow uses isolated WorkSpaces-managed VM storage and a stand
 For UI smoke/capture script entry points, see:
 
 - [scripts/README.md](./scripts/README.md)
-
-If you use `mise`, developer convenience tasks include:
-
-- `mise run dev-launch`
-- `mise run dev-watch`
-- `mise run dev-smoke`
-- `mise run dev-lume-preflight`
-- `mise run dev-lume-standalone-validate`
-- `mise run dev-lume-macos-smoke`
 
 ## License
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,40 @@ This directory contains build/release helpers plus UI test utilities.
 - `./scripts/setup --hooks-only` installs or refreshes the prek git hooks without running dependency setup.
 - `./scripts/install-git-hooks.sh` remains only as a compatibility wrapper around `./scripts/setup --hooks-only`; prefer `./scripts/setup` in new docs and task definitions.
 
+## Root Mise Task Catalog
+
+Use `./scripts/setup` for first-run bootstrap. After that, prefer the root `mise` tasks for common flows; they wrap the scripts and stable commands listed in this guide.
+
+| Task | Backend | Purpose |
+|------|---------|---------|
+| `mise run setup` | `./scripts/setup` | Re-run bootstrap setup after the checkout is trusted. |
+| `mise run hooks-install` | `./scripts/setup --hooks-only` | Refresh prek hooks only. |
+| `mise run build-ghosttykit` | `./scripts/build-ghosttykit.sh` | Build the pinned GhosttyKit framework. |
+| `mise run lint` | `swift-format lint --strict --recursive Sources/ Tests/` | Check Swift formatting. |
+| `mise run build` | `swift build` | Build the app and CLI targets. |
+| `mise run test` | `swift test` | Run the Swift test suite. |
+| `mise run check` | Swift format lint, build, and test | Run the local Swift validation gate. |
+| `mise run dev-launch` | `./scripts/launch-dev.sh` | Launch the debug app with isolated data. |
+| `mise run dev-watch` | `./scripts/launch-dev.sh --watch` | Launch and keep logs attached. |
+| `mise run dev-smoke` | `./scripts/dev-smoke.sh` | Run the fast debug startup smoke. |
+| `mise run evidence -- --pr <N> --name <slug>` | `./scripts/evidence.sh` | Capture and upload PR evidence. |
+
+Lume entry points:
+
+| Task | Backend |
+|------|---------|
+| `mise run lume-status` | `uv run --script ./scripts/lume-status.py` |
+| `mise run dev-lume-ensure` | `./scripts/lume-ensure-daemon.sh` |
+| `mise run dev-lume-preflight` | `./scripts/lume-host-preflight.sh` |
+| `mise run dev-lume-standalone-preflight` | `./scripts/lume-standalone-preflight.sh` |
+| `mise run dev-lume-standalone-prepare-base` | `./scripts/lume-standalone-prepare-base.sh` |
+| `mise run dev-lume-standalone-verify-base` | `./scripts/lume-standalone-verify-base.sh` |
+| `mise run dev-lume-standalone-clone-smoke` | `./scripts/lume-standalone-clone-smoke.sh` |
+| `mise run dev-lume-standalone-validate` | `./scripts/lume-standalone-validate.sh` |
+| `mise run dev-lume-macos-smoke` | `./scripts/lume-host-macos-smoke.sh` |
+
+Run `mise tasks` from the repo root for the current catalog. Web dashboard tasks live in `web/.mise.toml`; use `mise -C web run <task>` for those.
+
 ## Ops Reporting
 
 - `uv run --script ./scripts/ops-report.py`
@@ -252,10 +286,11 @@ Activation-driving shortcut smoke:
 - Requires `Terminal Multiplexing Mode = Ghostty Splits`; the script exits early in `tmux` mode.
 - Intentionally not shared-desktop-safe. Use it only when foreground input is acceptable, or move to Tart/Lume / a separate user session.
 
-If you use `mise`, equivalent convenience tasks are:
+Root `mise` equivalents for this loop:
 - `mise run build-ghosttykit`
 - `mise run build`
 - `mise run test`
+- `mise run check`
 - `mise run dev-launch`
 - `mise run dev-watch`
 - `mise run dev-smoke`


### PR DESCRIPTION
## Summary

- Add root `mise` tasks for setup, hook refresh, Swift lint, and a local `check` gate.
- Keep existing build/test/dev/Lume/evidence task names intact.
- Update README, contributing docs, and scripts guide to make `./scripts/setup` the bootstrap path and root `mise` tasks the day-to-day command surface.

## Mergeability

- Surface: docs / config
- User-facing behavior changed: contributors now see `mise run ...` as the primary local task interface after bootstrap.
- Non-happy paths considered: hook refresh remains available through `mise run hooks-install` and the underlying `./scripts/setup --hooks-only`.
- Release/ops preconditions: none.
- Residual risk or follow-up: full `mise run check` was not run because this PR changes task catalog/docs; the lint task and task arg-forwarding paths were verified directly.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `mise trust .mise.toml`
  - `mise tasks`
  - `mise run setup -- --help`
  - `mise run build -- --help`
  - `mise run dev-launch -- --help`
  - `mise run hooks-install`
  - `mise run lint`
  - `git diff --check HEAD~1..HEAD`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (command output summary)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![dx-mise-task-catalog-verification](https://evidence.cloudcompute.com/workspaces/pr-427/20260503-175349-dx-mise-task-catalog-verification.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
