### PR TITLE
[codex] Align roadmap web runtime facts

### DIFF
--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -24,11 +24,11 @@ Workspaces now spans three surfaces — a Mac-native app, a web dashboard, and a
 
 **Desktop app.** Terminal-first main window with repo overview and persistent repo/workspace terminals. Calmer repo-first sidebar with explicit sorting and per-window last-surface restoration. Ghostty-backed terminal with split/focus/resize/equalize and working shortcut routing. Local workspaces plus Lume and Daytona provider tracks, including host-side validation and setup flows for Lume. Notification/auth/activity infrastructure, workspace process monitoring, and agent-awareness in repo overview cards. A canonical performance system (`workspaces-performance-system` skill + `config/performance/contract.json`) enforces scenario budgets across debug, installed, release, and CI environments.
 
-**Web dashboard** (`web/`). Next.js 15 on Vercel with GitHub OAuth (Better Auth) and LibSQL+Kysely persistence. A ghostty-web terminal tab and a TerminalShare Cloudflare Worker proxy. A multi-provider agent runtime now covering Vercel Sandbox, Cloudflare Sandbox, Daytona, GitHub Actions, and Anthropic Managed Agents (#332). Persistent-sandbox snapshot/restore for conversation continuity (#277); tmux inside the sandbox for real resume continuity (#311/#312/#315, clarified in #324). Automated PR review posted by Managed Agents (#345). Preview → validate → promote CD pipeline with a bootstrap orchestrator (#344). PostHog telemetry (#336). A `qa-web` skill + subagent (#343) covers black-box exploratory testing, author-mode spec generation, and heal-mode regression-vs-selector-drift triage.
+**Web dashboard** (`web/`). Next.js 15 on Vercel with GitHub OAuth (Better Auth) and LibSQL+Kysely persistence. A ghostty-web terminal tab and a TerminalShare Cloudflare Worker proxy. A multi-provider agent runtime now covering Vercel Sandbox and Anthropic Managed Agents, with Daytona/GitHub Actions registered as unavailable stubs and `mock` available for tests (#332). Persistent-sandbox snapshot/restore for conversation continuity (#277); tmux inside the sandbox for real resume continuity (#311/#312/#315, clarified in #324). Automated PR review posted by Managed Agents (#345). Preview → validate → promote CD pipeline with a bootstrap orchestrator (#344). PostHog telemetry (#336). A `qa-web` skill + subagent (#343) covers black-box exploratory testing, author-mode spec generation, and heal-mode regression-vs-selector-drift triage.
 
 **Agent automation.** The `.agents/skills/` library (`workspaces-performance-system`, `workspaces-optimization`, `drive`, `peter-planner`, `gh-discuss`, and others). April agent workflow runs on a Lume self-hosted runner. Most autonomous automations are currently gated off behind `AGENT_AUTOMATIONS_ENABLED`, pending runner policy and prompt-injection defense hardening.
 
-**Shipping cadence.** Weekly-ish releases. Latest release `v0.10.0`.
+**Shipping cadence.** Weekly-ish releases. Latest release `v0.11.1`.
 
 What this means for planning.
 
@@ -57,7 +57,7 @@ Web:
 
 - dashboard with repo browsing, workspace/agent activity feeds, and terminal attachment
 - ghostty-web terminal tab; TerminalShare Cloudflare Worker proxy
-- multi-provider agent runtime (Vercel Sandbox, Cloudflare Sandbox, Daytona, GitHub Actions, Anthropic Managed Agents)
+- multi-provider agent runtime (Vercel Sandbox and Anthropic Managed Agents; Daytona/GitHub Actions unavailable stubs; mock test provider)
 - persistent sandbox snapshot/restore; tmux-in-sandbox for resume continuity
 - automated PR review via Managed Agents
 - preview → validate → promote CD pipeline with bootstrap orchestrator
@@ -259,7 +259,7 @@ Archived (in `backlog/done/`):
 - Pane-tree terminal tiling model — not chosen; see `docs/decisions/terminal-multiplexing.md` (2026-04-23)
 - Terminal multiplexing decision session — resolved by `docs/decisions/terminal-multiplexing.md` (2026-04-23)
 - Isolation strategies (research) — superseded by Tahoe VZ execution brief
-- Cloudflare Sandbox live plan — scaffold deleted in PR #321
+- `cloudflare-sandbox` live plan — scaffold deleted in PR #321
 - Landing page plan — shipped in PR #188
 - Persistent sandbox conversation continuity — shipped in PR #277
 - Main window composition and inspector tests — shipped

--- a/web/README.md
+++ b/web/README.md
@@ -8,7 +8,7 @@ Next.js dashboard for the Workspaces app — chat with AI agents, manage sandbox
 - **Better Auth** for GitHub OAuth
 - **LibSQL / Kysely** for persistence
 - **ghostty-web** (WASM-compiled Ghostty) for browser terminal
-- **Vercel Sandbox SDK** for agent compute (multi-provider: Vercel, Cloudflare, Daytona)
+- **Compute provider registry** for agent compute (Vercel Sandbox and Anthropic Managed Agents; Daytona/GitHub Actions stubs; mock for tests)
 - **Biome** for linting
 - **Vitest** for unit tests, **Playwright** for E2E
 - **pnpm** package manager

--- a/web/docs/architecture.md
+++ b/web/docs/architecture.md
@@ -39,12 +39,12 @@
 │  - user_repos    │ │  - Discussions│ │  │ (Firecracker microVM)│   │
 │  - webhook_events│ │  - Webhooks   │ │  └─────────────────────┘   │
 │                  │ │               │ │  ┌─────────────────────┐   │
-│                  │ │               │ │  │ Cloudflare Sandbox  │   │
-│                  │ │               │ │  │ (Container)         │   │
+│                  │ │               │ │  │ Anthropic Managed   │   │
+│                  │ │               │ │  │ Agents              │   │
 │                  │ │               │ │  └─────────────────────┘   │
 │                  │ │               │ │  ┌─────────────────────┐   │
 │                  │ │               │ │  │ Daytona / GitHub    │   │
-│                  │ │               │ │  │ Actions / Mock      │   │
+│                  │ │               │ │  │ Actions stubs / Mock│   │
 │                  │ │               │ │  └─────────────────────┘   │
 └──────────────────┘ └───────────────┘ └─────────────────────────────┘
 ```
@@ -58,7 +58,7 @@
 | Database | LibSQL + Kysely | Chat messages, sessions, repos, events |
 | Styling | CSS Modules + CSS custom properties | Dark theme, no Tailwind |
 | Terminal | ghostty-web (WASM) | Browser terminal emulator |
-| Agent runtime | Vercel Sandbox SDK | Sandboxed Claude Code sessions |
+| Agent runtime | Compute provider registry | Vercel Sandbox and Anthropic Managed Agents sessions |
 | Linting | Biome | Format + lint |
 | Unit tests | Vitest | Fast unit/integration tests |
 | E2E tests | Playwright | Browser tests with video capture |
@@ -67,14 +67,15 @@
 
 ## Agent Runtime
 
-The agent runtime executes Claude Code inside sandboxed environments. The `ComputeProviderRegistry` at `src/lib/agent-runtime/provider-registry.ts` supports multiple backends:
+The agent runtime executes Claude Code through the `ComputeProviderRegistry` at `src/lib/agent-runtime/provider-registry.ts`. The registry loads Vercel Sandbox, Daytona, GitHub Actions, and Anthropic Managed Agents providers by default; Daytona and GitHub Actions are registered stubs that currently report unavailable. `MOCK_AGENT=1` adds the test-only mock provider and makes it the default.
 
 | Provider | Backend | Snapshot | Terminal |
 |----------|---------|----------|----------|
 | `vercel-sandbox` | Firecracker microVM | Yes (ephemeral) | Via ttyd + tmux |
-| `daytona` | VM | No | — |
-| `github-actions` | Runner | No | — |
-| `mock` | In-process | Yes | — |
+| `managed-agents` | Anthropic Managed Agents | No | Transcript |
+| `daytona` | VM stub | No | Transcript stub |
+| `github-actions` | Runner stub | No | Transcript stub |
+| `mock` | In-process test provider | Yes | PTY stub |
 
 > Historical note: `cloudflare-sandbox` was scaffolded alongside the Vercel provider as a multi-provider proof-of-concept. The Worker and provider class were deleted in PR #321 because the scaffold had never been wired to a real Cloudflare account and was sitting in the runtime as ~500 lines of dead code. Design notes preserved in `backlog/cloudflare-sandbox-live-plan.md`.
 


### PR DESCRIPTION
## Summary

- Update the roadmap latest-release reference to `v0.11.1`.
- Remove Cloudflare Sandbox from active web agent runtime/provider descriptions.
- Align web architecture docs with the current compute provider registry: Vercel Sandbox and Managed Agents are active; Daytona/GitHub Actions are unavailable stubs; mock is test-only.

## Mergeability

- Surface: docs
- User-facing behavior changed: none.
- Non-happy paths considered: historical `cloudflare-sandbox` references remain where they explicitly describe the deleted scaffold.
- Release/ops preconditions: none.
- Residual risk or follow-up: none.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `git tag --list 'v*' --sort=-version:refname | sed -n '1,5p'`
  - `rg --files web/src/lib/agent-runtime | sort`
  - `rg "v0\.10\.0|Cloudflare Sandbox" backlog/ROADMAP.md web/README.md web/docs/architecture.md` (no matches)
  - `git diff --check HEAD~1..HEAD`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [x] Not a testable change (docs-only, config)
- [x] Test evidence attached (command output summary)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![dx-docs-drift-verification](https://evidence.cloudcompute.com/workspaces/pr-428/20260503-180716-dx-docs-drift-verification.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
