### PR TITLE
[codex] Refresh improve-codebase QA flow

### DIFF
--- a/.claude/commands/improve-codebase.md
+++ b/.claude/commands/improve-codebase.md
@@ -30,7 +30,7 @@ Read live state and write yourself a short inventory. Batch these where possible
 
 1. **Repo state** — `git status`, current branch, open PRs (`gh pr list --state open`), recent activity (`git log --oneline -20`). If the current branch is not `main` or a working branch you intentionally chose, treat the worktree as untrusted and resolve before proposing.
 2. **Roadmap** — `backlog/ROADMAP.md`. Identify active P0 theme and active milestone. **If any open PR touches `backlog/ROADMAP.md` or files in your focus area's planning surface, also read the PR-branch version (`git show origin/<branch>:<path>`) before forming hypotheses** — working-tree state is stale relative to in-flight planning changes.
-3. **TODO** — `TODO.md`. These are ideas to challenge, not a worklist. Convert at most one to a backlog item per session, and only if it clearly belongs.
+3. **TODO (optional)** — If `TODO.md` exists, read it. These are ideas to challenge, not a worklist. Convert at most one to a backlog item per session, and only if it clearly belongs. Do not block if the file is absent.
 4. **Drift** — skim `backlog/*.md` and `docs/` for items stale relative to what the code and ROADMAP now say.
 5. **Focus-area inputs**:
    - `desktop` → `config/performance/contract.json`, latest `docs/performance/*`, current baselines, known symptoms. Load the `workspaces-performance-system` skill if perf is in scope.
@@ -56,7 +56,7 @@ While waiting, you may do the following without further approval (Michael said "
 
 - Fix obvious stale pointers in `backlog/` and `docs/`.
 - Normalize whitespace, broken links, or outdated file references in docs you already read.
-- Convert a single uncontroversial `TODO.md` line into a `backlog/*.md` stub (do not delete the TODO entry; link it).
+- If `TODO.md` exists, convert a single uncontroversial line into a `backlog/*.md` stub (do not delete the TODO entry; link it).
 
 Do not touch source, tests, scripts, CI, or perf baselines before approval.
 

--- a/web/e2e/explore/README.md
+++ b/web/e2e/explore/README.md
@@ -20,7 +20,7 @@ Video and trace are always on for this project. Artifacts land under `web/playwr
 When an exploratory spec finds a behavior worth locking in, `qa-web-agent` promotes it via its Author phase:
 1. Write a spec under `web/specs/<slug>.md`.
 2. Human approves.
-3. `mise run web:qa:generate` emits a durable test under `web/e2e/full/<slug>.spec.ts`.
+3. `mise run web:qa:codegen [url]` launches interactive Playwright codegen so the author can record the durable test under `web/e2e/full/<slug>.spec.ts`.
 4. `web/tests/LEDGER.md` gets a row.
 
 The exploratory spec can then be deleted — the durable test is the new source of truth.

--- a/web/specs/README.md
+++ b/web/specs/README.md
@@ -34,7 +34,7 @@ A test written from the implementation tends to mirror the implementation — an
 
 1. `qa-web-agent` writes a spec here from an exploratory finding or an uncovered behavior in `web/tests/LEDGER.md`.
 2. A human reviews the spec. Common feedback: wrong oracle, missing negative case, wrong layer.
-3. On approval, `mise run web:qa:generate` invokes Playwright's Generator (Test Agents 1.56+), which writes `web/e2e/<layer>/<slug>.spec.ts` with live-verified selectors.
+3. On approval, `mise run web:qa:codegen [url]` launches Playwright codegen against the dev server so the author can record live-verified selectors into `web/e2e/<layer>/<slug>.spec.ts`.
 4. `web/tests/LEDGER.md` gets a new row.
 5. The spec stays in this directory as the durable source of intent — do not delete specs after generation.
 


### PR DESCRIPTION
## Summary
- Treat `TODO.md` as optional during `/improve-codebase` orientation and safe waiting cleanup.
- Replace stale `web:qa:generate` guidance with the current `mise run web:qa:codegen [url]` flow across the scoped command/spec/exploration docs.
- Preserve the command's hypothesis-before-work policy.

## Mergeability
- Surface: docs
- User-facing behavior changed: No runtime behavior changed; developer command guidance now reflects the current repo flow.
- Non-happy paths considered: Missing `TODO.md` is explicitly non-blocking, and stale QA command references were checked in the scoped docs.
- Release/ops preconditions: None.
- Residual risk or follow-up: None known.

## Validation
- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `rg "TODO.md|web:qa:generate" .claude/commands/improve-codebase.md web/specs/README.md web/e2e/explore/README.md`; `rg "web:qa:generate" .claude/commands/improve-codebase.md web/specs/README.md web/e2e/explore/README.md`; `git diff --check HEAD~1..HEAD`

Tests passed: docs-only verification checks passed; `web:qa:generate` has no remaining matches in the scoped files.

## Performance
- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:
- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:
- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence
- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:
- Docs-only PR; validation commands and passed results are listed above.

## Parent review
- Reviewed worker changes against the item 4 scope, `code-review` skill checklist, and `docs/development/mergeability-standard.md`.
- Addressed the reviewer-noted same-scope stale QA reference in `web/e2e/explore/README.md`.

## Blockers
- [x] None
- [ ] Blocked on evidence