### PR TITLE
[codex] Teach PR reviewer narrative labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Mac-native app for managing AI coding sessions with embedded terminal.
 
 Craft matters. Plan work so it can land mergeably: correct, coherent with the product, reviewable, verified, and leaving the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist.
 
+When the user asks to implement a change, default to carrying it through to a PR: branch if needed, make the edit, verify it, commit, rebase on the latest `origin/main`, push, open the PR, and report its status. Treat this as a strong default, not a mandate; pause short of PR creation when the user asks for exploration only, says not to publish, or evidence/permissions are blocked.
+
 ## Startup Instruction Budget
 
 `AGENTS.md` is startup context for every repo session. Keep it under about **4,500 tokens** (roughly **3,300 words**) unless the added guidance is more important than the recurring context cost. Prefer tightening, deduplicating, or moving detailed policy into linked docs over expanding this file.

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -61,6 +61,7 @@ function githubPr(number: number, overrides: Record<string, unknown> = {}) {
 		state: number % 2 === 0 ? "closed" : "open",
 		updated_at: `2026-05-0${number}T12:00:00Z`,
 		body: `Description for PR ${number}`,
+		labels: [],
 		head: { ref: `branch-${number}` },
 		base: { ref: "main" },
 		...overrides,
@@ -145,6 +146,22 @@ describe("fetchPrNarrativeContext", () => {
 		expect(context.unavailableReason).toBeUndefined();
 	});
 
+	it("includes labels from previous PRs in narrative context", async () => {
+		mockPrList([
+			githubPr(9),
+			githubPr(8, {
+				labels: [{ name: "security" }, { name: "agent-runtime" }],
+			}),
+		]);
+
+		const context = await fetchPrNarrativeContext("ghp_test", payload());
+
+		expect(context.relationshipCandidates[0].labels).toEqual([
+			"security",
+			"agent-runtime",
+		]);
+	});
+
 	it("returns a non-fatal unavailable reason on GitHub API failure", async () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		mocks.fetch.mockResolvedValue({
@@ -198,8 +215,30 @@ describe("triggerPrReview", () => {
 		expect(message).toContain("Previous PR narrative context:");
 		expect(message).toContain("Most recently updated PR descriptions");
 		expect(message).toContain("PR #8: PR 8");
+		expect(message).toContain("Labels: (none)");
 		expect(message).toContain("## Project Thread");
 		expect(message).toContain("Reference at least one previous PR by number");
+	});
+
+	it("instructs the reviewer to apply high-confidence related labels and suggest label opportunities", async () => {
+		mockPrList([githubPr(9), githubPr(8, { labels: [{ name: "security" }] })]);
+
+		await expect(triggerPrReview(payload())).resolves.toBe("sesn_01");
+
+		const [, params] = mocks.sendEvent.mock.calls[0];
+		const message = params.events[0].content[0].text;
+		expect(message).toContain("Labels: security");
+		expect(message).toContain(
+			"POST https://api.github.com/repos/fairchild/workspaces/issues/9/labels",
+		);
+		expect(message).toContain(
+			"apply that label using the labels endpoint before posting the review",
+		);
+		expect(message).toContain(
+			'Mention the applied label in "## Project Thread"',
+		);
+		expect(message).toContain("Label suggestion:");
+		expect(message).toContain("Do not create labels");
 	});
 
 	it("still starts the reviewer when previous PR context is unavailable", async () => {

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -67,6 +67,8 @@ Keep the decision banner to one sentence and no more than 140 characters. It sho
   \`<details><summary>Details</summary> ... </details>\`
 - Do not add the \`open\` attribute to the \`<details>\` tag
 - Include a short \`## Project Thread\` section that references at least one previous PR by number and explains the relationship when previous PR context is available
+- In \`## Project Thread\`, mention any labels you applied because of that relationship
+- If you notice a distinct dimension of work that deserves a repo label, suggest it as a brief \`Label suggestion:\` trailer at the end of \`## Project Thread\`; prefer reusing or consolidating labels over increasing label count
 - Use bullet points and code blocks
 - Cite \`file:line\` for every comment
 - Skip nits unless they materially affect correctness or readability
@@ -108,6 +110,7 @@ export interface PrContextItem {
 	updatedAt: string;
 	headRef: string;
 	baseRef: string;
+	labels: string[];
 	body: string;
 }
 
@@ -124,6 +127,7 @@ interface GitHubPullRequest {
 	state: string | null;
 	updated_at: string | null;
 	body: string | null;
+	labels?: Array<{ name?: string | null }> | null;
 	head?: { ref?: string | null } | null;
 	base?: { ref?: string | null } | null;
 }
@@ -169,6 +173,9 @@ function toPrContextItem(pr: GitHubPullRequest): PrContextItem {
 		updatedAt: pr.updated_at ?? "",
 		headRef: pr.head?.ref ?? "",
 		baseRef: pr.base?.ref ?? "",
+		labels: (pr.labels ?? [])
+			.map((label) => label.name?.trim() ?? "")
+			.filter((name) => name.length > 0),
 		body: truncateBody(pr.body ?? ""),
 	};
 }
@@ -225,6 +232,7 @@ function formatPrContextItem(item: PrContextItem): string {
   State: ${item.state}
   Updated: ${item.updatedAt}
   Branches: ${item.headRef} -> ${item.baseRef}
+  Labels: ${item.labels.length > 0 ? item.labels.join(", ") : "(none)"}
   Description:
 ${description
 	.split("\n")
@@ -346,9 +354,16 @@ ${formatPrNarrativeContext(narrativeContext)}
 GitHub API endpoint for posting the review:
 POST https://api.github.com/repos/${owner}/${repo}/pulls/${payload.number}/reviews
 
+GitHub API endpoint for applying labels when you are highly confident a label from a related PR also applies:
+POST https://api.github.com/repos/${owner}/${repo}/issues/${payload.number}/labels
+
 Read the diff against ${payload.baseRef}, explore the surrounding code, run swift build and swift test if the project supports them, then post the review using the GitHub API with the token at /workspace/.github-token.
 
-Your review must include a short "## Project Thread" section. Reference at least one previous PR by number and explain how this PR relates to it when previous PR context is available. If one of the first 3 relationship candidates is clearly related, use it. If none are clearly related, inspect up to 5 candidates and reference the most clearly related one. If no previous PR exists or the previous PR context is unavailable, say that explicitly instead of inventing a relationship.`,
+Your review must include a short "## Project Thread" section. Reference at least one previous PR by number and explain how this PR relates to it when previous PR context is available. If one of the first 3 relationship candidates is clearly related, use it. If none are clearly related, inspect up to 5 candidates and reference the most clearly related one. If no previous PR exists or the previous PR context is unavailable, say that explicitly instead of inventing a relationship.
+
+Pay attention to labels on related PRs. When you are highly confident an existing label from a related PR should also apply to this PR, apply that label using the labels endpoint before posting the review. Mention the applied label in "## Project Thread". Do not apply labels on weak or speculative matches.
+
+Also consider whether this PR reveals a distinct dimension of work that would be worth tagging with a label. The repo label set is not well managed yet; prefer labels that improve review/routing clarity while staying within the current label count or reducing it through consolidation. Do not create labels. If you see a high-value new-label opportunity, add a brief "Label suggestion:" trailer at the end of "## Project Thread".`,
 					},
 				],
 			},


### PR DESCRIPTION
## Summary
- include related PR labels in the managed PR reviewer narrative context
- instruct the reviewer to apply existing labels only on high-confidence related-PR matches and mention that in Project Thread
- add a Label suggestion trailer path for new label opportunities without creating labels
- update AGENTS.md so implementation requests default toward PR delivery after rebasing on latest origin/main

## Mergeability
- Surface: web / agent-runtime / docs
- User-facing behavior changed: Managed PR reviews may now apply an existing GitHub label when a related PR makes the match high-confidence, and may suggest a new label in the Project Thread narrative.
- Non-happy paths considered: Label application is explicitly gated to high-confidence existing labels; weak matches are instructed not to apply labels; agents are told not to create labels.
- Release/ops preconditions: Deploy the web app so the updated reviewer prompt reaches production.
- Residual risk or follow-up: Label quality still depends on the current unmanaged repository label set; the reviewer can suggest cleanup opportunities but does not manage labels directly.

## Validation
- [ ] swift build
- [ ] swift test
- [x] Other checks run:
  - mise -C web run web:check

## Performance
- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:
- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:
- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence
- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (command output summary)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:
- ![thread-narrative-labels](https://evidence.cloudcompute.com/workspaces/pr-430/20260503-184019-thread-narrative-labels.svg)

## Blockers
- [x] None
- [ ] Blocked on evidence