### PR TITLE
refactor(sidebar): extract workspace presentation controller

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -103,6 +103,7 @@ struct SidebarView: View {
     }
 
     private let workspaceEnvironmentOptionsController = WorkspaceEnvironmentOptionsController()
+    private let workspacePresentationController = SidebarWorkspacePresentationController()
 
     private var repoSortMode: SidebarRepoSortMode {
         SidebarRepoSortMode(rawValue: repoSortModeRawValue) ?? .alphabetical
@@ -1198,40 +1199,55 @@ struct SidebarView: View {
     }
 
     private func paneCount(for key: HostTerminalSessionKey) -> Int {
-        paneCountBySessionKey[key] ?? 0
+        workspacePresentationController.paneCount(
+            for: key,
+            paneCountBySessionKey: paneCountBySessionKey
+        )
     }
 
     private func sessionKey(for workspace: Workspace) -> HostTerminalSessionKey {
-        if let provider = workspaceProviderRegistry.provider(for: workspace) {
-            return provider.sessionKey(for: WorkspaceProviderTarget(workspace))
-        }
-
-        return .hostPath(normalizePath(workspace.workspaceURL))
+        workspacePresentationController.sessionKey(
+            for: workspace,
+            registry: workspaceProviderRegistry,
+            normalizePath: normalizePath(_:)
+        )
     }
 
     private func sessionActivity(for key: HostTerminalSessionKey) -> SidebarSessionActivity {
-        SidebarSessionActivity(
-            hasLiveSession: paneCount(for: key) > 0,
-            isActiveSession: activeSessionKey == key
+        workspacePresentationController.sessionActivity(
+            for: key,
+            paneCountBySessionKey: paneCountBySessionKey,
+            activeSessionKey: activeSessionKey
         )
     }
 
     private func workspaceStatusMessage(_ workspace: Workspace) -> String? {
-        if connectingWorkspaceID == workspace.id { return "Connecting..." }
-        if let action = workspaceAction, action.workspaceID == workspace.id { return action.message }
-        return nil
+        workspacePresentationController.workspaceStatusMessage(
+            workspaceID: workspace.id,
+            connectingWorkspaceID: connectingWorkspaceID,
+            workspaceAction: workspaceAction
+        )
     }
 
     private func usesHostWorkspaceFiles(for workspace: Workspace) -> Bool {
-        providerDescriptor(for: workspace)?.usesHostWorkspaceFiles ?? !workspace.isRemote
+        workspacePresentationController.usesHostWorkspaceFiles(
+            for: workspace,
+            registry: workspaceProviderRegistry
+        )
     }
 
     private func providerDescriptor(for workspace: Workspace) -> WorkspaceProviderDescriptor? {
-        workspaceProviderRegistry.provider(for: workspace)?.descriptor
+        workspacePresentationController.providerDescriptor(
+            for: workspace,
+            registry: workspaceProviderRegistry
+        )
     }
 
     private func providerDisplayName(for providerID: String) -> String {
-        workspaceProviderRegistry.provider(for: providerID)?.descriptor.displayName ?? providerID
+        workspacePresentationController.providerDisplayName(
+            for: providerID,
+            registry: workspaceProviderRegistry
+        )
     }
 
     private func environmentOptions(for repo: Repo) -> [WorkspaceEnvironmentSheetOption] {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspacePresentationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspacePresentationController.swift
@@ -1,0 +1,72 @@
+//
+//  SidebarWorkspacePresentationController.swift
+//  WorkspaceManager
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+struct SidebarWorkspacePresentationController {
+    func paneCount(
+        for key: HostTerminalSessionKey,
+        paneCountBySessionKey: [HostTerminalSessionKey: Int]
+    ) -> Int {
+        paneCountBySessionKey[key] ?? 0
+    }
+
+    func sessionKey(
+        for workspace: Workspace,
+        registry: WorkspaceProviderRegistry,
+        normalizePath: (URL) -> String
+    ) -> HostTerminalSessionKey {
+        if let provider = registry.provider(for: workspace) {
+            return provider.sessionKey(for: WorkspaceProviderTarget(workspace))
+        }
+
+        return .hostPath(normalizePath(workspace.workspaceURL))
+    }
+
+    func sessionActivity(
+        for key: HostTerminalSessionKey,
+        paneCountBySessionKey: [HostTerminalSessionKey: Int],
+        activeSessionKey: HostTerminalSessionKey?
+    ) -> SidebarSessionActivity {
+        SidebarSessionActivity(
+            hasLiveSession: paneCount(for: key, paneCountBySessionKey: paneCountBySessionKey) > 0,
+            isActiveSession: activeSessionKey == key
+        )
+    }
+
+    func workspaceStatusMessage(
+        workspaceID: UUID,
+        connectingWorkspaceID: UUID?,
+        workspaceAction: WorkspaceActionState?
+    ) -> String? {
+        if connectingWorkspaceID == workspaceID { return "Connecting..." }
+        if let workspaceAction, workspaceAction.workspaceID == workspaceID {
+            return workspaceAction.message
+        }
+        return nil
+    }
+
+    func providerDescriptor(
+        for workspace: Workspace,
+        registry: WorkspaceProviderRegistry
+    ) -> WorkspaceProviderDescriptor? {
+        registry.provider(for: workspace)?.descriptor
+    }
+
+    func providerDisplayName(
+        for providerID: String,
+        registry: WorkspaceProviderRegistry
+    ) -> String {
+        registry.provider(for: providerID)?.descriptor.displayName ?? providerID
+    }
+
+    func usesHostWorkspaceFiles(
+        for workspace: Workspace,
+        registry: WorkspaceProviderRegistry
+    ) -> Bool {
+        providerDescriptor(for: workspace, registry: registry)?.usesHostWorkspaceFiles ?? !workspace.isRemote
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspacePresentationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspacePresentationControllerTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@Suite("SidebarWorkspacePresentationController")
+struct SidebarWorkspacePresentationControllerTests {
+    private let controller = SidebarWorkspacePresentationController()
+
+    @Test("Pane count defaults to zero for missing sessions")
+    func paneCountDefaultsToZero() {
+        let key = HostTerminalSessionKey.repoPath("/repo")
+
+        #expect(controller.paneCount(for: key, paneCountBySessionKey: [:]) == 0)
+        #expect(controller.paneCount(for: key, paneCountBySessionKey: [key: 3]) == 3)
+    }
+
+    @Test("Session activity derives live and active state from pane counts and active key")
+    func sessionActivityDerivesState() {
+        let key = HostTerminalSessionKey.repoPath("/repo")
+        let otherKey = HostTerminalSessionKey.repoPath("/other")
+
+        #expect(
+            controller.sessionActivity(
+                for: key,
+                paneCountBySessionKey: [:],
+                activeSessionKey: nil
+            ) == .inactive
+        )
+        #expect(
+            controller.sessionActivity(
+                for: key,
+                paneCountBySessionKey: [key: 1],
+                activeSessionKey: otherKey
+            ) == .live
+        )
+        #expect(
+            controller.sessionActivity(
+                for: key,
+                paneCountBySessionKey: [:],
+                activeSessionKey: key
+            ) == .active
+        )
+    }
+
+    @Test("Local workspace session key falls back to normalized host path")
+    func localWorkspaceSessionKeyUsesNormalizedHostPath() {
+        let repo = Repo(name: "repo", localPath: URL(fileURLWithPath: "/tmp/repo"))
+        let workspace = Workspace(
+            name: "feature",
+            path: URL(fileURLWithPath: "/tmp/repo/../repo/workspaces/feature"),
+            sourceRepo: repo
+        )
+
+        let key = controller.sessionKey(
+            for: workspace,
+            registry: WorkspaceProviderRegistry(providers: []),
+            normalizePath: { $0.standardizedFileURL.path }
+        )
+
+        #expect(key == .hostPath("/tmp/repo/workspaces/feature"))
+    }
+
+    @Test("Provider workspace session key delegates to provider")
+    func providerWorkspaceSessionKeyDelegatesToProvider() {
+        let provider = MockPresentationProvider(
+            descriptor: descriptor(id: "test-provider", displayName: "Test Provider")
+        )
+        let repo = Repo(name: "repo", localPath: URL(fileURLWithPath: "/tmp/repo"))
+        let workspace = Workspace(
+            name: "remote",
+            path: URL(fileURLWithPath: Workspace.remotePathSentinel),
+            sourceRepo: repo,
+            backendIdentifier: "test-provider",
+            remoteId: "remote-123"
+        )
+
+        let key = controller.sessionKey(
+            for: workspace,
+            registry: WorkspaceProviderRegistry(providers: [provider]),
+            normalizePath: { $0.path }
+        )
+
+        #expect(key == .backendSession(providerID: "test-provider", instanceID: "remote-123"))
+    }
+
+    @Test("Workspace status message prioritizes connecting over action message")
+    func workspaceStatusMessagePriority() {
+        let workspaceID = UUID()
+
+        let message = controller.workspaceStatusMessage(
+            workspaceID: workspaceID,
+            connectingWorkspaceID: workspaceID,
+            workspaceAction: WorkspaceActionState(workspaceID: workspaceID, message: "Starting...")
+        )
+
+        #expect(message == "Connecting...")
+        #expect(
+            controller.workspaceStatusMessage(
+                workspaceID: workspaceID,
+                connectingWorkspaceID: nil,
+                workspaceAction: WorkspaceActionState(workspaceID: workspaceID, message: "Starting...")
+            ) == "Starting..."
+        )
+        #expect(
+            controller.workspaceStatusMessage(
+                workspaceID: workspaceID,
+                connectingWorkspaceID: nil,
+                workspaceAction: WorkspaceActionState(workspaceID: UUID(), message: "Starting...")
+            ) == nil
+        )
+    }
+
+    @Test("Provider display name falls back to provider identifier")
+    func providerDisplayNameFallback() {
+        let provider = MockPresentationProvider(
+            descriptor: descriptor(id: "lume", displayName: "Lume")
+        )
+        let registry = WorkspaceProviderRegistry(providers: [provider])
+
+        #expect(controller.providerDisplayName(for: "lume", registry: registry) == "Lume")
+        #expect(controller.providerDisplayName(for: "missing", registry: registry) == "missing")
+    }
+
+    @Test("Host workspace file policy uses provider descriptor before workspace fallback")
+    func hostWorkspaceFilePolicyUsesProviderDescriptorBeforeFallback() {
+        let hostFileProvider = MockPresentationProvider(
+            descriptor: descriptor(
+                id: "remote-host-files",
+                displayName: "Remote Host Files",
+                usesHostWorkspaceFiles: true
+            )
+        )
+        let registry = WorkspaceProviderRegistry(providers: [hostFileProvider])
+        let repo = Repo(name: "repo", localPath: URL(fileURLWithPath: "/tmp/repo"))
+        let providerWorkspace = Workspace(
+            name: "provider",
+            path: URL(fileURLWithPath: Workspace.remotePathSentinel),
+            sourceRepo: repo,
+            backendIdentifier: "remote-host-files"
+        )
+        let remoteWithoutProvider = Workspace(
+            name: "remote",
+            path: URL(fileURLWithPath: Workspace.remotePathSentinel),
+            sourceRepo: repo,
+            backendIdentifier: "unknown-remote"
+        )
+        let localWorkspace = Workspace(
+            name: "local",
+            path: URL(fileURLWithPath: "/tmp/repo/local"),
+            sourceRepo: repo
+        )
+
+        #expect(controller.usesHostWorkspaceFiles(for: providerWorkspace, registry: registry))
+        #expect(!controller.usesHostWorkspaceFiles(for: remoteWithoutProvider, registry: registry))
+        #expect(controller.usesHostWorkspaceFiles(for: localWorkspace, registry: registry))
+    }
+
+    private func descriptor(
+        id: String,
+        displayName: String,
+        usesHostWorkspaceFiles: Bool = false
+    ) -> WorkspaceProviderDescriptor {
+        WorkspaceProviderDescriptor(
+            id: id,
+            displayName: displayName,
+            description: "\(displayName) provider",
+            usesHostWorkspaceFiles: usesHostWorkspaceFiles
+        )
+    }
+}
+
+private actor MockPresentationProvider: WorkspaceProviderProtocol {
+    nonisolated let descriptor: WorkspaceProviderDescriptor
+
+    init(descriptor: WorkspaceProviderDescriptor) {
+        self.descriptor = descriptor
+    }
+
+    func availability() async -> WorkspaceProviderAvailability {
+        .available
+    }
+
+    nonisolated func sessionKey(for workspace: WorkspaceProviderTarget) -> HostTerminalSessionKey {
+        .backendSession(providerID: descriptor.id, instanceID: workspace.terminalSessionIdentifier)
+    }
+
+    func createWorkspace(
+        request: WorkspaceProviderCreationRequest,
+        workspaceService: any WorkspaceServiceProtocol,
+        progress: WorkspaceProviderProgressHandler?,
+        persist: WorkspaceProviderPersistenceHandler?
+    ) async throws -> WorkspaceProviderCreationResult {
+        throw WorkspaceProviderError.unavailable("Not used in this test.")
+    }
+
+    func terminalLaunchSpec(for workspace: WorkspaceProviderTarget) async throws -> TerminalLaunchSpec {
+        throw WorkspaceProviderError.unavailable("Not used in this test.")
+    }
+}

--- a/backlog/main-window-sidebar-maintainability_followup.md
+++ b/backlog/main-window-sidebar-maintainability_followup.md
@@ -55,6 +55,7 @@ Status:
 - Selection state now stores stable IDs/lightweight structs instead of live SwiftData objects to avoid stale-object hazards after deletion or async completion.
 - `SidebarRepoSortController` now holds stable repository sorting rules instead of burying sort policy in `SidebarView`.
 - `SidebarExpansionStateController` now holds repo/workspace expansion state, selected-container expansion, and stale-ID pruning rules instead of keeping those transitions inline in `SidebarView`.
+- `SidebarWorkspacePresentationController` now holds workspace row presentation rules for session activity, pane counts, provider display names, host-file availability, and transient status messages.
 
 ### Phase 3: Ghostty boundary cleanup
 


### PR DESCRIPTION
## Summary
- Extract sidebar workspace row presentation rules into `SidebarWorkspacePresentationController`.
- Keep `SidebarView` behavior unchanged while moving pane counts, session activity, provider labels, host-file policy, and transient status message logic behind deterministic tests.
- Update the main-window/sidebar maintainability follow-up with the completed extraction slice.

## Validation
- `swift test --filter SidebarWorkspacePresentationController` passed: 7 tests.
- `swift test --filter Sidebar` passed: 39 tests in 6 suites.
- `swift test` passed: 524 tests in 90 suites.
- `swift build -Xswiftc -warn-concurrency` passed; only existing `KeychainHelper` mutable-static warnings appeared.
- `git diff --check` passed.

## Evidence
- ![sidebar-presentation-controller](https://evidence.cloudcompute.com/workspaces/pr-431/20260503-184615-sidebar-presentation-controller.svg)

## Performance
- No runtime behavior change intended; pure presentation-rule extraction.
- No performance-sensitive path changed, so no before/after performance profile was captured.

## Mergeability
- Surface: desktop sidebar maintainability and backlog docs.
- User-facing behavior changed: No; this extracts existing workspace-row presentation logic behind tests.
- Non-happy paths considered: Missing providers, remote workspaces without provider descriptors, unrelated action messages, and missing pane-count entries are covered by the new tests.
- Residual risk or follow-up: Low; remaining P0 #2 work is later extraction around sidebar commands/menus, tracked in the backlog follow-up.
- Rebase state: Rebased on `origin/main` at `6f65399` before opening.
- Overlap: Scope avoids GhosttyKit, scripts, web, and PR #335 overlap.