### PR TITLE
[codex] clarify release workflow publication docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -334,10 +334,15 @@ For testing or when CI isn't available.
    mask release near-prod
    ```
 
-4. **Upload to GitHub**
+4. **Exceptional Manual Upload**
+
+   The normal publication path is still the protected GitHub Actions release
+   workflow. Use direct `gh release create` only when intentionally bypassing
+   automation, such as an incident recovery where signed/notarized artifacts
+   already exist and the workflow cannot publish them.
 
    ```bash
-   # Create release with GitHub CLI
+   # Exceptional recovery only: publish already-built release assets directly.
    gh release create v0.3.1 \
        --title "WorkSpaces v0.3.1" \
        --notes "Release notes here" \

--- a/docs/development/signing-runner-setup.md
+++ b/docs/development/signing-runner-setup.md
@@ -8,6 +8,11 @@ The release workflow intentionally does not run on a generic self-hosted runner.
 
 `signing-host` is a mutable GitHub runner label, not repo state. If no online runner advertises it, `Release` jobs will remain queued even when self-hosted runners are otherwise healthy.
 
+Runner readiness is separate from protected environment approval. The release
+workflow may wait on the GitHub `release` environment before checkout, signing
+material import, or notarization begins. Approve that environment only after the
+release tag, version metadata, and changelog are ready to publish.
+
 ## Prerequisites
 
 - GitHub CLI authenticated with permission to inspect and update Actions runners for `fairchild/workspaces`
@@ -65,6 +70,9 @@ gh api repos/fairchild/workspaces/actions/runs/<run-id>/jobs \
 ```
 
 The job should report labels including `self-hosted` and `signing-host`, and `runner_name` should resolve to the designated signing runner instead of remaining empty while queued.
+
+If the run is waiting on the protected `release` environment, approve or reject
+that gate in GitHub Actions before expecting the runner assignment to proceed.
 
 If repository release credentials are intentionally unavailable in the current environment, stop after the job is claimed by the correct runner.
 


### PR DESCRIPTION
## Summary

- Clarify that direct `gh release create` is exceptional recovery, not the normal release publication path.
- Document that `signing-host` runner readiness is separate from protected `release` environment approval.

## Mergeability

- Surface: docs
- User-facing behavior changed: No product behavior change; operator-facing release documentation only.
- Non-happy paths considered: Manual publication is retained for exceptional recovery when signed/notarized artifacts already exist and workflow publication is unavailable.
- Release/ops preconditions: Release workflow remains the normal publication path; protected `release` environment approval must happen before signing/notarization secrets are exposed, and a `signing-host` runner must be online when the workflow proceeds.
- Residual risk or follow-up: The broader `docs/security.md` stance draft remains unpublished and intentionally excluded from this PR.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `uv run --script scripts/validate-release-changes.py --changed-files /tmp/release-docs-changed-files.json` passed
  - `git diff --check` passed

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: Docs-only release process clarification.

## Evidence

- [x] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Validation evidence](https://github.com/fairchild/workspaces/pull/432#issuecomment-4366905369)

Note: `./scripts/evidence.sh --pr 432 --name release-docs-validation --file /tmp/release-docs-validation.md` was attempted, but this worktree does not have `EVIDENCE_UPLOAD_TOKEN` configured. The same validation artifact is posted in the hosted PR comment above.

## Blockers

- [x] None
- [ ] Blocked on evidence
