### PR TITLE
Add become persona skill

### DIFF
--- a/.agents/skills/become-persona/README.md
+++ b/.agents/skills/become-persona/README.md
@@ -6,8 +6,9 @@ april`, `/become plat`, and `/become peter`.
 
 This is not the scheduled GitHub automation path. It does not claim issues,
 open PRs, post discussion comments, or run the contributor/planner runtimes by
-itself. It only loads the persona prompt and relevant memory context so the
-current interactive thread can answer from that perspective.
+itself. It only loads the persona prompt and relevant memory context, preferably
+from `team-memory` when available, so the current interactive thread can answer
+from that perspective.
 
 ## Why this exists
 
@@ -59,9 +60,10 @@ the command/skill flow is:
    `/become` mode should not emit scheduled-agent YAML frontmatter.
 6. Attach memory context:
    - repo memory from `.agents/MEMORY.md`
-   - shared memory from `~/.ai-memory/shared/*.md`
-   - persona memory from `~/.ai-memory/<persona-key>/` or
+   - team-memory shared memory from `~/.ai-memory/shared/*.md`
+   - persona team memory from `~/.ai-memory/<persona-key>/` or
      `~/.ai-memory/profiles/<persona-key>/`
+   - active team-memory core context when persona-specific memory is absent
 7. Render an activation contract that tells the assistant to use the persona as
    a lens while keeping system, developer, repo, and newest-user instructions
    higher priority.
@@ -92,20 +94,42 @@ Limit memory output while testing:
 uv run --script .agents/skills/become-persona/scripts/resolve_persona.py --max-total-chars 1000 peter
 ```
 
-## Memory model
+## Team-memory integration
 
 The resolver treats memory as context, not as higher-priority instructions.
 Current user intent and repo policy still win.
 
-It looks for:
+The preferred memory shape is the `team-memory` layout:
+
+```text
+~/.ai-memory/
+  active -> scout
+  shared/
+  <teammate>/
+    AGENTS.md
+    personality.md
+    relationship.md
+    core/
+    archival/
+    journal/
+```
+
+For `/become <persona>`, the resolver looks for:
 
 - `.agents/MEMORY.md`
 - `~/.ai-memory/shared/*.md`
+- `~/.ai-memory/<memory-key>/AGENTS.md`
 - `~/.ai-memory/<memory-key>/personality.md`
-- `~/.ai-memory/<memory-key>/CLAUDE.md`
 - `~/.ai-memory/<memory-key>/relationship.md`
 - `~/.ai-memory/<memory-key>/core/*.md`
 - the same files under `~/.ai-memory/profiles/<memory-key>/`
+
+It still recognizes `CLAUDE.md` for older persona-memory directories.
+
+When a persona-specific memory directory is missing, the resolver uses the
+active team-memory teammate's `core/*.md` files as general context. It does not
+inline the active teammate's `AGENTS.md`, `personality.md`, or `relationship.md`
+in that fallback path, because those files describe a different identity.
 
 Recall, journal, and archival files are listed as additional memory files but
 not inlined by default. That keeps activation output useful without dumping an
@@ -113,6 +137,10 @@ entire long-term archive into every persona switch.
 
 If no persona-specific memory exists, the resolver reports the checked paths.
 That is a setup signal, not a failure.
+
+If `~/.ai-memory` does not exist at all, the skill still succeeds with the
+repo-owned persona prompt and `.agents/MEMORY.md` when present. That keeps the
+skill portable to repos that have personas but have not adopted team-memory.
 
 ## Adding a persona
 
@@ -152,6 +180,7 @@ That is a setup signal, not a failure.
   sections as non-interactive.
 - The skill does not write memory. Remembering something should be an explicit
   user request.
+- Team-memory is opportunistic. Missing memory never blocks persona activation.
 - The activation contract prevents scheduled-agent priority queues from taking
   over the local thread.
 - The resolver is a single-file UV script with no dependencies, matching this

--- a/.agents/skills/become-persona/README.md
+++ b/.agents/skills/become-persona/README.md
@@ -7,8 +7,7 @@ april`, `/become plat`, and `/become peter`.
 This is not the scheduled GitHub automation path. It does not claim issues,
 open PRs, post discussion comments, or run the contributor/planner runtimes by
 itself. It only loads the persona prompt and relevant memory context, preferably
-from `team-memory` when available, so the current interactive thread can answer
-from that perspective.
+from `team-memory` when available, for the current interactive thread.
 
 ## Why this exists
 
@@ -64,9 +63,9 @@ the command/skill flow is:
    - persona team memory from `~/.ai-memory/<persona-key>/` or
      `~/.ai-memory/profiles/<persona-key>/`
    - active team-memory core context when persona-specific memory is absent
-7. Render an activation contract that tells the assistant to use the persona as
-   a lens while keeping system, developer, repo, and newest-user instructions
-   higher priority.
+7. Render an activation contract that tells the assistant to use the persona
+   prompt and memory as context while keeping system, developer, repo, and
+   newest-user instructions higher priority.
 
 ## Resolver usage
 

--- a/.agents/skills/become-persona/README.md
+++ b/.agents/skills/become-persona/README.md
@@ -1,0 +1,189 @@
+# `become-persona`
+
+`become-persona` lets a local assistant thread temporarily operate through one
+of the repo's standing agent personas. It is the machinery behind `/become
+april`, `/become plat`, and `/become peter`.
+
+This is not the scheduled GitHub automation path. It does not claim issues,
+open PRs, post discussion comments, or run the contributor/planner runtimes by
+itself. It only loads the persona prompt and relevant memory context so the
+current interactive thread can answer from that perspective.
+
+## Why this exists
+
+Workspaces has several named agents with stable areas of concern:
+
+- April Clearwater: application, UI, UX, terminal behavior, native app feel
+- Plat Ironwood: platform, CI, infrastructure, release, runner reliability
+- Peter Planner: approved discussion to issue/milestone planning
+
+Those personas already exist as workflow prompts. `/become` reuses those prompts
+for local collaboration instead of duplicating them in a separate command. The
+resolver also adds memory context so the persona can use durable project and
+human preferences when available.
+
+## File map
+
+- `SKILL.md` - agent-facing instructions for invoking the skill correctly.
+- `README.md` - human-facing explanation of the system.
+- `references/personas.toml` - persona catalog, aliases, prompt paths, memory
+  keys, and runtime-only sections to strip.
+- `scripts/resolve_persona.py` - deterministic resolver used by the skill and
+  command fallback.
+- `scripts/test_resolve_persona.py` - stdlib tests for alias resolution,
+  prompt stripping, memory discovery, and error handling.
+- `.claude/commands/become.md` - slash command wrapper that delegates here.
+
+## Flow
+
+When a user types:
+
+```text
+/become april review this layout
+```
+
+the command/skill flow is:
+
+1. Parse `april` as the requested persona and keep `review this layout` as the
+   first task after switching.
+2. Run:
+
+   ```bash
+   uv run --script .agents/skills/become-persona/scripts/resolve_persona.py april review this layout
+   ```
+
+3. Resolve `april` through `references/personas.toml`.
+4. Load the prompt file, for example
+   `.agents/skills/cofounder-contributor/references/april-clearwater.md`.
+5. Strip runtime-only sections such as `## Output Format`, because interactive
+   `/become` mode should not emit scheduled-agent YAML frontmatter.
+6. Attach memory context:
+   - repo memory from `.agents/MEMORY.md`
+   - shared memory from `~/.ai-memory/shared/*.md`
+   - persona memory from `~/.ai-memory/<persona-key>/` or
+     `~/.ai-memory/profiles/<persona-key>/`
+7. Render an activation contract that tells the assistant to use the persona as
+   a lens while keeping system, developer, repo, and newest-user instructions
+   higher priority.
+
+## Resolver usage
+
+List supported personas:
+
+```bash
+uv run --script .agents/skills/become-persona/scripts/resolve_persona.py --list
+```
+
+Render the human-readable activation context:
+
+```bash
+uv run --script .agents/skills/become-persona/scripts/resolve_persona.py april
+```
+
+Render JSON for debugging or future tooling:
+
+```bash
+uv run --script .agents/skills/become-persona/scripts/resolve_persona.py --json plat
+```
+
+Limit memory output while testing:
+
+```bash
+uv run --script .agents/skills/become-persona/scripts/resolve_persona.py --max-total-chars 1000 peter
+```
+
+## Memory model
+
+The resolver treats memory as context, not as higher-priority instructions.
+Current user intent and repo policy still win.
+
+It looks for:
+
+- `.agents/MEMORY.md`
+- `~/.ai-memory/shared/*.md`
+- `~/.ai-memory/<memory-key>/personality.md`
+- `~/.ai-memory/<memory-key>/CLAUDE.md`
+- `~/.ai-memory/<memory-key>/relationship.md`
+- `~/.ai-memory/<memory-key>/core/*.md`
+- the same files under `~/.ai-memory/profiles/<memory-key>/`
+
+Recall, journal, and archival files are listed as additional memory files but
+not inlined by default. That keeps activation output useful without dumping an
+entire long-term archive into every persona switch.
+
+If no persona-specific memory exists, the resolver reports the checked paths.
+That is a setup signal, not a failure.
+
+## Adding a persona
+
+1. Add or choose a persona prompt file. The first heading should identify the
+   display name and role, for example:
+
+   ```markdown
+   # Alex Example - Systems Lead
+   ```
+
+2. Add an entry to `references/personas.toml`:
+
+   ```toml
+   [personas.alex]
+   display_name = "Alex Example"
+   role = "Systems Lead"
+   persona_path = ".agents/skills/example/references/alex-example.md"
+   aliases = ["alex", "alex-example"]
+   memory_keys = ["alex-example", "alex"]
+   strip_sections_from = ["## Output Format"]
+   ```
+
+3. Add or update tests in `scripts/test_resolve_persona.py` if the new persona
+   changes lookup behavior.
+4. Run:
+
+   ```bash
+   uv run --script .agents/skills/become-persona/scripts/test_resolve_persona.py
+   uv run --script .agents/skills/become-persona/scripts/resolve_persona.py --list
+   ```
+
+## Design constraints
+
+- The catalog is explicit. The resolver does not scan every prompt file because
+  `/become april` should be stable and predictable.
+- Prompt stripping is per persona. Different runtimes can mark different
+  sections as non-interactive.
+- The skill does not write memory. Remembering something should be an explicit
+  user request.
+- The activation contract prevents scheduled-agent priority queues from taking
+  over the local thread.
+- The resolver is a single-file UV script with no dependencies, matching this
+  repo's standalone Python preference.
+
+## Troubleshooting
+
+Unknown persona:
+
+```text
+error: unknown persona 'alex'. Available personas: april, peter, plat
+```
+
+Add the persona to `references/personas.toml` or use one of the listed aliases.
+
+Prompt not found:
+
+```text
+error: persona prompt not found: ...
+```
+
+Check that `persona_path` is relative to the repository root and that the file
+exists on the current branch.
+
+Memory looks missing:
+
+The resolver reports missing persona memory directories when none of the
+configured `memory_keys` exist. Create a matching directory under
+`~/.ai-memory/` or `~/.ai-memory/profiles/` only if that persona needs durable
+local memory.
+
+Runtime YAML appears in interactive answers:
+
+Confirm the persona catalog includes the relevant heading under
+`strip_sections_from`. April, Plat, and Peter all strip `## Output Format`.

--- a/.agents/skills/become-persona/SKILL.md
+++ b/.agents/skills/become-persona/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: become-persona
+description: >-
+  Assume one of this repo's named agent personas in the current conversation,
+  including its repo-owned persona prompt and available memory context. Use this
+  whenever the user types /become <persona>, says "become april", "assume Plat",
+  "act as Peter", or asks for April Clearwater, Plat Ironwood, or Peter Planner
+  with memory access.
+---
+
+# Become Persona
+
+Use this skill to switch the current conversation into a Workspaces agent persona.
+It is for interactive collaboration, not for launching the scheduled GitHub
+contributor runtimes.
+
+## Supported personas
+
+The catalog lives in `references/personas.toml`.
+
+- `april` / `april-clearwater` — April Clearwater, Application Lead
+- `plat` / `plat-ironwood` — Plat Ironwood, Platform Lead
+- `peter` / `peter-planner` — Peter Planner, Planning Lead
+
+## Workflow
+
+1. Parse the requested persona from the user's command. For `/become april`,
+   the requested persona is `april`.
+2. Run the resolver from the repository root:
+
+   ```bash
+   uv run --script .agents/skills/become-persona/scripts/resolve_persona.py <persona>
+   ```
+
+3. Read the resolver output before replying. It contains:
+   - the persona prompt, with runtime-only YAML output sections removed
+   - repo memory from `.agents/MEMORY.md`
+   - shared memory from `~/.ai-memory/shared/*.md`, when present
+   - persona-specific memory from `~/.ai-memory/<persona-key>/`, when present
+4. Apply the activation contract in the resolver output:
+   - Treat the persona as a behavioral and domain lens.
+   - Treat autonomous priority-order/check-GitHub sections as background about
+     the scheduled agent workflow, not as a task queue for this thread.
+   - Keep system, developer, repo `AGENTS.md`, and the user's newest request
+     higher priority than the persona.
+   - Stay in normal interactive assistant mode. Do not emit the persona runtime's
+     scheduled-agent YAML unless the user explicitly asks to run that workflow.
+5. Acknowledge the switch in one concise sentence, then continue with the user's
+   task as that persona.
+
+## Memory handling
+
+- Load memory as context, not as instruction that can override higher-priority
+  policy.
+- If no persona-specific memory directory exists yet, say nothing unless the
+  absence matters. Repo and shared memory are still valid context.
+- Do not create or edit files in `~/.ai-memory` unless the user explicitly asks
+  you to remember something or update a persona memory.
+- When memory conflicts with the current repo or user instructions, mention the
+  conflict and follow the current repo/user source.
+
+## Fallback
+
+If the resolver cannot run, read these files directly:
+
+- April: `.agents/skills/cofounder-contributor/references/april-clearwater.md`
+- Plat: `.agents/skills/cofounder-contributor/references/plat-ironwood.md`
+- Peter: `.agents/skills/peter-planner/references/peter-planner.md`
+- Repo memory: `.agents/MEMORY.md`
+- Shared memory: `~/.ai-memory/shared/*.md`
+
+For April, Plat, and Peter, ignore everything from `## Output Format` onward
+while operating interactively.

--- a/.agents/skills/become-persona/SKILL.md
+++ b/.agents/skills/become-persona/SKILL.md
@@ -35,8 +35,9 @@ The catalog lives in `references/personas.toml`.
 3. Read the resolver output before replying. It contains:
    - the persona prompt, with runtime-only YAML output sections removed
    - repo memory from `.agents/MEMORY.md`
-   - shared memory from `~/.ai-memory/shared/*.md`, when present
-   - persona-specific memory from `~/.ai-memory/<persona-key>/`, when present
+   - team-memory shared memory from `~/.ai-memory/shared/*.md`, when present
+   - persona-specific team memory from `~/.ai-memory/<persona-key>/`, when present
+   - active team-memory core context when persona-specific memory is absent
 4. Apply the activation contract in the resolver output:
    - Treat the persona as a behavioral and domain lens.
    - Treat autonomous priority-order/check-GitHub sections as background about
@@ -52,8 +53,11 @@ The catalog lives in `references/personas.toml`.
 
 - Load memory as context, not as instruction that can override higher-priority
   policy.
+- Prefer the `team-memory` layout when it exists: `AGENTS.md`,
+  `personality.md`, `relationship.md`, `core/`, `archival/`, and `journal/`.
 - If no persona-specific memory directory exists yet, say nothing unless the
-  absence matters. Repo and shared memory are still valid context.
+  absence matters. Repo, shared, and active team core memory are still valid
+  context.
 - Do not create or edit files in `~/.ai-memory` unless the user explicitly asks
   you to remember something or update a persona memory.
 - When memory conflicts with the current repo or user instructions, mention the

--- a/.agents/skills/become-persona/SKILL.md
+++ b/.agents/skills/become-persona/SKILL.md
@@ -39,7 +39,7 @@ The catalog lives in `references/personas.toml`.
    - persona-specific team memory from `~/.ai-memory/<persona-key>/`, when present
    - active team-memory core context when persona-specific memory is absent
 4. Apply the activation contract in the resolver output:
-   - Treat the persona as a behavioral and domain lens.
+   - Use the persona prompt and loaded memory as context for the response.
    - Treat autonomous priority-order/check-GitHub sections as background about
      the scheduled agent workflow, not as a task queue for this thread.
    - Keep system, developer, repo `AGENTS.md`, and the user's newest request

--- a/.agents/skills/become-persona/references/personas.toml
+++ b/.agents/skills/become-persona/references/personas.toml
@@ -1,0 +1,23 @@
+[personas.april]
+display_name = "April Clearwater"
+role = "Application Lead"
+persona_path = ".agents/skills/cofounder-contributor/references/april-clearwater.md"
+aliases = ["april", "april-clearwater", "application-lead"]
+memory_keys = ["april-clearwater", "april"]
+strip_sections_from = ["## Output Format"]
+
+[personas.plat]
+display_name = "Plat Ironwood"
+role = "Platform Lead"
+persona_path = ".agents/skills/cofounder-contributor/references/plat-ironwood.md"
+aliases = ["plat", "plat-ironwood", "platform-lead"]
+memory_keys = ["plat-ironwood", "plat"]
+strip_sections_from = ["## Output Format"]
+
+[personas.peter]
+display_name = "Peter Planner"
+role = "Planning Lead"
+persona_path = ".agents/skills/peter-planner/references/peter-planner.md"
+aliases = ["peter", "peter-planner", "planner"]
+memory_keys = ["peter-planner", "peter"]
+strip_sections_from = ["## Output Format"]

--- a/.agents/skills/become-persona/scripts/resolve_persona.py
+++ b/.agents/skills/become-persona/scripts/resolve_persona.py
@@ -297,7 +297,7 @@ def render_markdown(
             "## Activation Contract",
             "",
             f"You are now operating as {persona.display_name} for this conversation.",
-            "Use the persona as a behavioral, domain, and prioritization lens.",
+            "Use the persona prompt and loaded memory as context for the response.",
             "Higher-priority system, developer, repo, and newest-user instructions still win.",
             "This is interactive session mode, not a scheduled GitHub workflow run.",
             "Autonomous priority-order/check-GitHub sections are background, not a task queue.",

--- a/.agents/skills/become-persona/scripts/resolve_persona.py
+++ b/.agents/skills/become-persona/scripts/resolve_persona.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Resolve a Workspaces agent persona and render its interactive context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+SKILL_ROOT = SCRIPT_PATH.parents[1]
+REPO_ROOT = SCRIPT_PATH.parents[4]
+CATALOG_PATH = SKILL_ROOT / "references" / "personas.toml"
+DEFAULT_MEMORY_ROOT = Path.home() / ".ai-memory"
+DEFAULT_MAX_FILE_CHARS = 8000
+DEFAULT_MAX_TOTAL_CHARS = 32000
+
+
+@dataclass(frozen=True)
+class Persona:
+    key: str
+    display_name: str
+    role: str
+    persona_path: Path
+    aliases: tuple[str, ...]
+    memory_keys: tuple[str, ...]
+    strip_sections_from: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MemoryFile:
+    label: str
+    path: Path
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class ResolvedPersona:
+    persona: Persona
+    prompt: str
+    requested_alias: str
+    remaining_request: str
+    memory_files: tuple[MemoryFile, ...]
+    optional_memory_files: tuple[Path, ...]
+    missing_memory_dirs: tuple[Path, ...]
+
+
+class PersonaResolutionError(ValueError):
+    """Raised when the requested persona cannot be resolved."""
+
+
+def normalize_alias(value: str) -> str:
+    return value.strip().lower().removeprefix("@").replace("_", "-")
+
+
+def parse_requested_text(parts: list[str]) -> tuple[str, str]:
+    raw = " ".join(part for part in parts if part).strip()
+    if raw.startswith("/become "):
+        raw = raw.removeprefix("/become ").strip()
+    elif raw == "/become":
+        raw = ""
+
+    if not raw:
+        raise PersonaResolutionError("missing persona name")
+
+    try:
+        tokens = shlex.split(raw)
+    except ValueError:
+        tokens = raw.split()
+
+    if tokens and normalize_alias(tokens[0]) == "become":
+        tokens = tokens[1:]
+    if not tokens:
+        raise PersonaResolutionError("missing persona name")
+
+    alias = normalize_alias(tokens[0])
+    remaining = raw
+    first_index = raw.lower().find(tokens[0].lower())
+    if first_index >= 0:
+        remaining = raw[first_index + len(tokens[0]) :].strip()
+    return alias, remaining
+
+
+def load_catalog(catalog_path: Path = CATALOG_PATH, repo_root: Path = REPO_ROOT) -> dict[str, Persona]:
+    data = tomllib.loads(catalog_path.read_text(encoding="utf-8"))
+    personas: dict[str, Persona] = {}
+    alias_to_key: dict[str, str] = {}
+
+    for key, value in data.get("personas", {}).items():
+        persona_path = repo_root / value["persona_path"]
+        persona = Persona(
+            key=key,
+            display_name=value["display_name"],
+            role=value["role"],
+            persona_path=persona_path,
+            aliases=tuple(value.get("aliases", [])),
+            memory_keys=tuple(value.get("memory_keys", [])),
+            strip_sections_from=tuple(value.get("strip_sections_from", [])),
+        )
+        personas[key] = persona
+        for alias in (key, *persona.aliases):
+            normalized = normalize_alias(alias)
+            if normalized in alias_to_key and alias_to_key[normalized] != key:
+                raise PersonaResolutionError(
+                    f"alias '{normalized}' is used by both {alias_to_key[normalized]} and {key}"
+                )
+            alias_to_key[normalized] = key
+
+    return personas
+
+
+def resolve_alias(alias: str, personas: dict[str, Persona]) -> Persona:
+    normalized = normalize_alias(alias)
+    for persona in personas.values():
+        if normalized == persona.key or normalized in {normalize_alias(a) for a in persona.aliases}:
+            return persona
+    available = ", ".join(sorted(personas))
+    raise PersonaResolutionError(f"unknown persona '{alias}'. Available personas: {available}")
+
+
+def strip_runtime_sections(text: str, headings: tuple[str, ...]) -> str:
+    end = len(text)
+    for heading in headings:
+        index = text.find(heading)
+        if index >= 0:
+            end = min(end, index)
+    return text[:end].rstrip()
+
+
+def discover_memory_files(
+    persona: Persona,
+    repo_root: Path = REPO_ROOT,
+    memory_root: Path = DEFAULT_MEMORY_ROOT,
+) -> tuple[tuple[MemoryFile, ...], tuple[Path, ...], tuple[Path, ...]]:
+    required: list[MemoryFile] = []
+    optional: list[Path] = []
+    missing_dirs: list[Path] = []
+
+    repo_memory = repo_root / ".agents" / "MEMORY.md"
+    if repo_memory.exists():
+        required.append(MemoryFile("Repo Memory", repo_memory))
+
+    shared_dir = memory_root / "shared"
+    if shared_dir.is_dir():
+        for path in sorted(shared_dir.glob("*.md")):
+            required.append(MemoryFile("Shared Memory", path))
+
+    found_persona_dir = False
+    for key in persona.memory_keys:
+        for directory in (memory_root / key, memory_root / "profiles" / key):
+            if not directory.is_dir():
+                missing_dirs.append(directory)
+                continue
+
+            found_persona_dir = True
+            for name in ("personality.md", "CLAUDE.md", "relationship.md"):
+                path = directory / name
+                if path.exists():
+                    required.append(MemoryFile("Persona Memory", path))
+
+            core_dir = directory / "core"
+            if core_dir.is_dir():
+                for path in sorted(core_dir.glob("*.md")):
+                    required.append(MemoryFile("Persona Core Memory", path))
+
+            for optional_dir_name in ("recall", "journal", "archival"):
+                optional_dir = directory / optional_dir_name
+                if optional_dir.is_dir():
+                    optional.extend(sorted(optional_dir.glob("*.md")))
+
+    if not found_persona_dir:
+        # Keep the checked list in the output so setup problems are visible
+        # without making the normal no-memory case fail.
+        missing_dirs = sorted(set(missing_dirs))
+
+    return tuple(required), tuple(optional), tuple(missing_dirs)
+
+
+def resolve_persona_context(
+    requested_parts: list[str],
+    *,
+    repo_root: Path = REPO_ROOT,
+    memory_root: Path = DEFAULT_MEMORY_ROOT,
+    catalog_path: Path = CATALOG_PATH,
+) -> ResolvedPersona:
+    requested_alias, remaining_request = parse_requested_text(requested_parts)
+    personas = load_catalog(catalog_path, repo_root)
+    persona = resolve_alias(requested_alias, personas)
+
+    if not persona.persona_path.exists():
+        raise PersonaResolutionError(f"persona prompt not found: {persona.persona_path}")
+
+    prompt = strip_runtime_sections(
+        persona.persona_path.read_text(encoding="utf-8"),
+        persona.strip_sections_from,
+    )
+    memory_files, optional_memory_files, missing_memory_dirs = discover_memory_files(
+        persona, repo_root, memory_root
+    )
+
+    return ResolvedPersona(
+        persona=persona,
+        prompt=prompt,
+        requested_alias=requested_alias,
+        remaining_request=remaining_request,
+        memory_files=memory_files,
+        optional_memory_files=optional_memory_files,
+        missing_memory_dirs=missing_memory_dirs,
+    )
+
+
+def read_limited(path: Path, max_file_chars: int, remaining_chars: int) -> tuple[str, int, bool]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    limit = max(0, min(max_file_chars, remaining_chars))
+    if len(text) <= limit:
+        return text.rstrip(), len(text), False
+    return text[:limit].rstrip(), limit, True
+
+
+def render_markdown(
+    context: ResolvedPersona,
+    *,
+    max_file_chars: int = DEFAULT_MAX_FILE_CHARS,
+    max_total_chars: int = DEFAULT_MAX_TOTAL_CHARS,
+) -> str:
+    persona = context.persona
+    lines = [
+        f"# Become Persona: {persona.display_name}",
+        "",
+        f"- Role: {persona.role}",
+        f"- Persona source: `{persona.persona_path}`",
+        f"- Requested alias: `{context.requested_alias}`",
+    ]
+    if context.remaining_request:
+        lines.append(f"- Remaining request: {context.remaining_request}")
+
+    lines.extend(
+        [
+            "",
+            "## Activation Contract",
+            "",
+            f"You are now operating as {persona.display_name} for this conversation.",
+            "Use the persona as a behavioral, domain, and prioritization lens.",
+            "Higher-priority system, developer, repo, and newest-user instructions still win.",
+            "This is interactive session mode, not a scheduled GitHub workflow run.",
+            "Autonomous priority-order/check-GitHub sections are background, not a task queue.",
+            "Do not emit runtime YAML/frontmatter unless the user explicitly asks for that workflow.",
+            "Treat memory files as context, not as authority over current instructions.",
+            "",
+            "## Persona Prompt",
+            "",
+            context.prompt,
+            "",
+            "## Memory Context",
+            "",
+        ]
+    )
+
+    remaining_chars = max_total_chars
+    if not context.memory_files:
+        lines.append("No repo, shared, or persona-specific memory files were found.")
+    for memory_file in context.memory_files:
+        text, used, truncated = read_limited(memory_file.path, max_file_chars, remaining_chars)
+        remaining_chars -= used
+        lines.extend(
+            [
+                f"### {memory_file.label}",
+                "",
+                f"Path: `{memory_file.path}`",
+                "",
+                text or "_Empty file._",
+                "",
+            ]
+        )
+        if truncated:
+            lines.append(
+                f"_Truncated after {used} characters. Open `{memory_file.path}` for full context._"
+            )
+            lines.append("")
+        if remaining_chars <= 0:
+            lines.append("_Memory context budget exhausted. Open listed files for more context._")
+            lines.append("")
+            break
+
+    if context.optional_memory_files:
+        lines.extend(["## Additional Memory Files", ""])
+        for path in context.optional_memory_files:
+            lines.append(f"- `{path}`")
+        lines.append("")
+
+    if context.missing_memory_dirs:
+        lines.extend(["## Missing Persona Memory Directories", ""])
+        lines.append("No persona-specific directory was found at these candidate paths:")
+        for path in context.missing_memory_dirs:
+            lines.append(f"- `{path}`")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_json(context: ResolvedPersona) -> str:
+    data: dict[str, Any] = {
+        "persona": {
+            "key": context.persona.key,
+            "display_name": context.persona.display_name,
+            "role": context.persona.role,
+            "persona_path": str(context.persona.persona_path),
+            "aliases": list(context.persona.aliases),
+            "memory_keys": list(context.persona.memory_keys),
+        },
+        "requested_alias": context.requested_alias,
+        "remaining_request": context.remaining_request,
+        "memory_files": [
+            {"label": item.label, "path": str(item.path), "required": item.required}
+            for item in context.memory_files
+        ],
+        "optional_memory_files": [str(path) for path in context.optional_memory_files],
+        "missing_memory_dirs": [str(path) for path in context.missing_memory_dirs],
+        "prompt": context.prompt,
+    }
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def render_catalog(personas: dict[str, Persona]) -> str:
+    lines = ["Available personas:"]
+    for key in sorted(personas):
+        persona = personas[key]
+        aliases = ", ".join(persona.aliases)
+        lines.append(f"- {key}: {persona.display_name} ({persona.role}); aliases: {aliases}")
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("persona", nargs="*", help="Persona name, e.g. april, plat, peter")
+    parser.add_argument("--list", action="store_true", help="List available personas")
+    parser.add_argument("--json", action="store_true", help="Render machine-readable context")
+    parser.add_argument(
+        "--memory-root",
+        type=Path,
+        default=DEFAULT_MEMORY_ROOT,
+        help="Memory root to read (default: ~/.ai-memory)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root (default: inferred from this script)",
+    )
+    parser.add_argument(
+        "--max-file-chars",
+        type=int,
+        default=DEFAULT_MAX_FILE_CHARS,
+        help="Maximum characters to include from one memory file",
+    )
+    parser.add_argument(
+        "--max-total-chars",
+        type=int,
+        default=DEFAULT_MAX_TOTAL_CHARS,
+        help="Maximum total characters to include from memory files",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        personas = load_catalog(repo_root=args.repo_root)
+        if args.list:
+            print(render_catalog(personas), end="")
+            return 0
+
+        context = resolve_persona_context(
+            args.persona,
+            repo_root=args.repo_root,
+            memory_root=args.memory_root,
+        )
+        if args.json:
+            print(render_json(context), end="")
+        else:
+            print(
+                render_markdown(
+                    context,
+                    max_file_chars=args.max_file_chars,
+                    max_total_chars=args.max_total_chars,
+                ),
+                end="",
+            )
+        return 0
+    except PersonaResolutionError as error:
+        print(f"error: {error}", file=sys.stderr)
+        try:
+            print(render_catalog(load_catalog(repo_root=args.repo_root)), file=sys.stderr)
+        except Exception:
+            pass
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/become-persona/scripts/resolve_persona.py
+++ b/.agents/skills/become-persona/scripts/resolve_persona.py
@@ -24,6 +24,8 @@ CATALOG_PATH = SKILL_ROOT / "references" / "personas.toml"
 DEFAULT_MEMORY_ROOT = Path.home() / ".ai-memory"
 DEFAULT_MAX_FILE_CHARS = 8000
 DEFAULT_MAX_TOTAL_CHARS = 32000
+PERSONA_INLINE_FILES = ("AGENTS.md", "CLAUDE.md", "personality.md", "relationship.md")
+OPTIONAL_MEMORY_DIRS = ("recall", "journal", "archival")
 
 
 @dataclass(frozen=True)
@@ -150,11 +152,6 @@ def discover_memory_files(
     if repo_memory.exists():
         required.append(MemoryFile("Repo Memory", repo_memory))
 
-    shared_dir = memory_root / "shared"
-    if shared_dir.is_dir():
-        for path in sorted(shared_dir.glob("*.md")):
-            required.append(MemoryFile("Shared Memory", path))
-
     found_persona_dir = False
     for key in persona.memory_keys:
         for directory in (memory_root / key, memory_root / "profiles" / key):
@@ -163,27 +160,77 @@ def discover_memory_files(
                 continue
 
             found_persona_dir = True
-            for name in ("personality.md", "CLAUDE.md", "relationship.md"):
-                path = directory / name
-                if path.exists():
-                    required.append(MemoryFile("Persona Memory", path))
-
-            core_dir = directory / "core"
-            if core_dir.is_dir():
-                for path in sorted(core_dir.glob("*.md")):
-                    required.append(MemoryFile("Persona Core Memory", path))
-
-            for optional_dir_name in ("recall", "journal", "archival"):
-                optional_dir = directory / optional_dir_name
-                if optional_dir.is_dir():
-                    optional.extend(sorted(optional_dir.glob("*.md")))
+            append_teammate_memory(required, optional, directory, "Persona Team Memory")
 
     if not found_persona_dir:
         # Keep the checked list in the output so setup problems are visible
         # without making the normal no-memory case fail.
         missing_dirs = sorted(set(missing_dirs))
+        active_dir = active_team_memory_dir(memory_root)
+        if active_dir is not None:
+            append_active_team_context(required, optional, active_dir)
+
+    shared_dir = memory_root / "shared"
+    if shared_dir.is_dir():
+        for path in sorted(shared_dir.glob("*.md")):
+            required.append(MemoryFile("Shared Memory", path))
 
     return tuple(required), tuple(optional), tuple(missing_dirs)
+
+
+def append_teammate_memory(
+    required: list[MemoryFile],
+    optional: list[Path],
+    directory: Path,
+    label_prefix: str,
+) -> None:
+    """Append a team-memory/persona-memory directory without assuming it exists."""
+    for name in PERSONA_INLINE_FILES:
+        path = directory / name
+        if path.exists():
+            required.append(MemoryFile(label_prefix, path))
+
+    core_dir = directory / "core"
+    if core_dir.is_dir():
+        for path in sorted(core_dir.glob("*.md")):
+            required.append(MemoryFile(f"{label_prefix} Core", path))
+
+    for optional_dir_name in OPTIONAL_MEMORY_DIRS:
+        optional_dir = directory / optional_dir_name
+        if optional_dir.is_dir():
+            optional.extend(sorted(optional_dir.glob("*.md")))
+
+
+def active_team_memory_dir(memory_root: Path) -> Path | None:
+    """Return the active team-memory teammate directory when one is configured."""
+    active = memory_root / "active"
+    try:
+        if not active.exists():
+            return None
+        resolved = active.resolve()
+    except OSError:
+        return None
+
+    if resolved.is_dir() and resolved != memory_root:
+        return resolved
+    return None
+
+
+def append_active_team_context(
+    required: list[MemoryFile],
+    optional: list[Path],
+    active_dir: Path,
+) -> None:
+    """Use active team memory as context without importing another teammate identity."""
+    core_dir = active_dir / "core"
+    if core_dir.is_dir():
+        for path in sorted(core_dir.glob("*.md")):
+            required.append(MemoryFile("Active Team Memory Core", path))
+
+    for optional_dir_name in OPTIONAL_MEMORY_DIRS:
+        optional_dir = active_dir / optional_dir_name
+        if optional_dir.is_dir():
+            optional.extend(sorted(optional_dir.glob("*.md")))
 
 
 def resolve_persona_context(

--- a/.agents/skills/become-persona/scripts/test_resolve_persona.py
+++ b/.agents/skills/become-persona/scripts/test_resolve_persona.py
@@ -65,8 +65,13 @@ class ResolvePersonaTests(unittest.TestCase):
             (memory_root / "shared").mkdir()
             (memory_root / "shared" / "human.md").write_text("Shared note", encoding="utf-8")
             (memory_root / "april").mkdir()
+            (memory_root / "april" / "AGENTS.md").write_text("Team bootstrap", encoding="utf-8")
             (memory_root / "april" / "personality.md").write_text(
                 "April memory", encoding="utf-8"
+            )
+            (memory_root / "april" / "core").mkdir()
+            (memory_root / "april" / "core" / "pattern.md").write_text(
+                "Team core", encoding="utf-8"
             )
 
             context = resolver.resolve_persona_context(
@@ -77,8 +82,31 @@ class ResolvePersonaTests(unittest.TestCase):
             paths = {item.path.name for item in context.memory_files}
 
         self.assertIn("MEMORY.md", paths)
+        self.assertIn("AGENTS.md", paths)
         self.assertIn("human.md", paths)
         self.assertIn("personality.md", paths)
+        self.assertIn("pattern.md", paths)
+
+    def test_uses_active_team_core_when_persona_memory_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            memory_root = Path(tmp)
+            (memory_root / "shared").mkdir()
+            (memory_root / "shared" / "human.md").write_text("Shared note", encoding="utf-8")
+            scout = memory_root / "scout"
+            (scout / "core").mkdir(parents=True)
+            (scout / "core" / "workflow.md").write_text("Active core", encoding="utf-8")
+            (memory_root / "active").symlink_to(scout, target_is_directory=True)
+
+            context = resolver.resolve_persona_context(
+                ["april"],
+                repo_root=REPO_ROOT,
+                memory_root=memory_root,
+            )
+            memory_by_name = {item.path.name: item.label for item in context.memory_files}
+            names = [item.path.name for item in context.memory_files]
+
+        self.assertEqual(memory_by_name["workflow.md"], "Active Team Memory Core")
+        self.assertLess(names.index("workflow.md"), names.index("human.md"))
 
     def test_unknown_persona_lists_available_personas(self) -> None:
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):

--- a/.agents/skills/become-persona/scripts/test_resolve_persona.py
+++ b/.agents/skills/become-persona/scripts/test_resolve_persona.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for the become-persona resolver."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+
+
+def load_resolver():
+    path = SCRIPT_PATH.parent / "resolve_persona.py"
+    spec = importlib.util.spec_from_file_location("resolve_persona", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["resolve_persona"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+resolver = load_resolver()
+
+
+class ResolvePersonaTests(unittest.TestCase):
+    def test_resolves_short_aliases(self) -> None:
+        personas = resolver.load_catalog(repo_root=REPO_ROOT)
+
+        self.assertEqual(resolver.resolve_alias("april", personas).display_name, "April Clearwater")
+        self.assertEqual(resolver.resolve_alias("plat", personas).display_name, "Plat Ironwood")
+        self.assertEqual(resolver.resolve_alias("peter", personas).display_name, "Peter Planner")
+
+    def test_parse_requested_text_accepts_command_form(self) -> None:
+        alias, remaining = resolver.parse_requested_text(["/become april review this layout"])
+
+        self.assertEqual(alias, "april")
+        self.assertEqual(remaining, "review this layout")
+
+    def test_interactive_prompt_strips_runtime_output_format(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            context = resolver.resolve_persona_context(
+                ["april"],
+                repo_root=REPO_ROOT,
+                memory_root=Path(tmp),
+            )
+
+        self.assertIn("You are April Clearwater", context.prompt)
+        self.assertNotIn("## Output Format", context.prompt)
+        self.assertNotIn("Your entire output must be valid YAML frontmatter", context.prompt)
+
+    def test_discovers_shared_and_persona_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            memory_root = Path(tmp)
+            (memory_root / "shared").mkdir()
+            (memory_root / "shared" / "human.md").write_text("Shared note", encoding="utf-8")
+            (memory_root / "april").mkdir()
+            (memory_root / "april" / "personality.md").write_text(
+                "April memory", encoding="utf-8"
+            )
+
+            context = resolver.resolve_persona_context(
+                ["april"],
+                repo_root=REPO_ROOT,
+                memory_root=memory_root,
+            )
+            paths = {item.path.name for item in context.memory_files}
+
+        self.assertIn("MEMORY.md", paths)
+        self.assertIn("human.md", paths)
+        self.assertIn("personality.md", paths)
+
+    def test_unknown_persona_lists_available_personas(self) -> None:
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            result = resolver.main(["unknown"])
+
+        self.assertEqual(result, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/commands/become.md
+++ b/.claude/commands/become.md
@@ -1,0 +1,39 @@
+Assume one of this repo's named agent personas in the current thread.
+
+## Usage
+
+```
+/become april
+/become plat
+/become peter
+```
+
+The text after `/become` is the requested persona. If the user includes more
+text after the persona, treat it as the first task to handle after the switch.
+
+## Flow
+
+Invoke the repo-local `become-persona` skill with the exact arguments:
+
+```
+$ARGUMENTS
+```
+
+If the Skill tool is unavailable, follow the skill manually:
+
+1. Run:
+
+   ```bash
+   uv run --script .agents/skills/become-persona/scripts/resolve_persona.py -- "$ARGUMENTS"
+   ```
+
+2. Read the resolver output fully enough to apply:
+   - the persona prompt
+   - the activation contract
+   - repo/shared/persona memory context
+3. Acknowledge the switch in one concise sentence.
+4. Continue as that persona for the rest of the current thread, until the user
+   asks to become someone else or stop using the persona.
+
+Do not run the scheduled GitHub contributor or planner workflow just because the
+persona prompt mentions one. This command is for interactive session identity.

--- a/docs/development/agent-team.md
+++ b/docs/development/agent-team.md
@@ -102,8 +102,8 @@ Directed contributor runs still use the same contributor runtime with a directed
 
 ### Local Persona Mode
 
-Use `/become <persona>` in a local assistant thread to adopt a standing agent's
-interactive perspective without launching the GitHub automation:
+Use `/become <persona>` in a local assistant thread to load a standing agent's
+persona context without launching the GitHub automation:
 
 - `/become april` — load April Clearwater's Application Lead prompt
 - `/become plat` — load Plat Ironwood's Platform Lead prompt

--- a/docs/development/agent-team.md
+++ b/docs/development/agent-team.md
@@ -100,6 +100,20 @@ Public requests must mention exactly one agent. If multiple agents are mentioned
 
 Directed contributor runs still use the same contributor runtime with a directed message (`--message`), which overrides the normal priority order. Mention-triggered executor runs use separate concurrency groups (`agent-approved-april-*`, etc.) so they do not interfere with scheduled cron runs.
 
+### Local Persona Mode
+
+Use `/become <persona>` in a local assistant thread to adopt a standing agent's
+interactive perspective without launching the GitHub automation:
+
+- `/become april` — load April Clearwater's Application Lead prompt
+- `/become plat` — load Plat Ironwood's Platform Lead prompt
+- `/become peter` — load Peter Planner's planning prompt
+
+The command is backed by `.agents/skills/become-persona/SKILL.md`. It resolves
+aliases through `.agents/skills/become-persona/references/personas.toml`, strips
+runtime-only YAML output sections from the persona prompts, and loads repo,
+shared, and persona-specific memory context when available.
+
 ### Approval Keywords
 
 Reply to any `[idea]` discussion with one of these to trigger Peter Planner:


### PR DESCRIPTION
## Summary
- Add a repo-local become-persona skill with an explicit April/Plat/Peter catalog.
- Add a /become command that delegates to the skill and keeps persona prompts in interactive mode.
- Add a UV resolver script that loads persona prompts, strips runtime-only output sections, and includes repo/shared/persona memory context.
- Add a human-facing README explaining the system architecture, flow, memory model, extension points, and troubleshooting.
- Prefer team-memory when available: persona-specific team memory is loaded when present, active teammate core memory is used as neutral fallback, and missing memory never blocks persona activation.
- Keep local persona activation generic: /become loads persona prompt and memory context without prescribing a specific kind of lens or granting automation authority.

## Mergeability
- Surface: agent-runtime / docs
- User-facing behavior changed: Yes — adds the local /become assistant command; no app UI/runtime behavior changes.
- Non-happy paths considered: Unknown persona names, missing persona prompt files, missing persona-specific memory directories, absent ~/.ai-memory/team-memory setup, active-team fallback, and memory output truncation.
- Residual risk or follow-up: No persona-specific memory directories exist yet for April, Plat, or Peter on this host; the resolver falls back to active team-memory core context and reports the missing persona directories without failing.

## Evidence
- [CI — Agent Scripts / test passed](https://github.com/fairchild/workspaces/actions/runs/25298278734/job/74160630096)
- [PR Readiness passed](https://github.com/fairchild/workspaces/actions/runs/25298282480/job/74160643122)
- [Evidence Reminder passed](https://github.com/fairchild/workspaces/actions/runs/25298282470/job/74160640272)
- Uploaded visual evidence is not applicable for this docs/skill/script change; local R2 upload was unavailable because EVIDENCE_UPLOAD_TOKEN is not set in this worktree.

## Validation
- env PYTHONDONTWRITEBYTECODE=1 uv run --script .agents/skills/become-persona/scripts/test_resolve_persona.py — passed, 6 tests.
- env PYTHONDONTWRITEBYTECODE=1 uv run --script .agents/skills/become-persona/scripts/resolve_persona.py --max-total-chars 1200 april — passed, activation contract now uses generic persona-context wording.
- git diff --check — passed.