### PR TITLE
Fix CD authz Playwright validation

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -60,12 +60,8 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
-      - name: Pull Vercel prod env + config
-        # The generated PR URL is still a protected preview deployment, but
-        # auth-backed routes need the same runtime secrets as production. The
-        # Vercel preview env is intentionally sparse today and produces a
-        # Better Auth default-secret 500 on /api/auth/sign-in/social.
-        run: npx vercel@51 pull --yes --environment=production --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
+      - name: Pull Vercel preview env + config
+        run: npx vercel@51 pull --yes --environment=preview --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
 
       - name: Build preview artifact
         run: npx vercel@51 build --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -60,8 +60,12 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
-      - name: Pull Vercel preview env + config
-        run: npx vercel@51 pull --yes --environment=preview --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
+      - name: Pull Vercel prod env + config
+        # The generated PR URL is still a protected preview deployment, but
+        # auth-backed routes need the same runtime secrets as production. The
+        # Vercel preview env is intentionally sparse today and produces a
+        # Better Auth default-secret 500 on /api/auth/sign-in/social.
+        run: npx vercel@51 pull --yes --environment=production --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
 
       - name: Build preview artifact
         run: npx vercel@51 build --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"

--- a/backlog/pre-release-deployment-smoke_plan.md
+++ b/backlog/pre-release-deployment-smoke_plan.md
@@ -1,0 +1,119 @@
+---
+topic: web-cd
+priority: 2
+description: Add a remote-safe, skippable Playwright smoke lane for CD preview and prod validation.
+---
+
+# Pre-Release Deployment Smoke
+
+## Problem Statement
+
+The CD pipeline currently runs the whole Playwright `fast` project against the
+fresh Vercel preview before promotion. That caught real deployment-protection
+issues, but it also couples deployed-app smoke validation to local integration
+tests that seed runner-local databases and create synthetic Better Auth
+sessions.
+
+PR #433 added cross-tenant API authorization coverage in
+`web/e2e/fast/api-authorization.spec.ts`. That suite is valuable in local CI,
+but it cannot run against a deployed preview because the preview app cannot see
+the runner-local `file:data/e2e-auth.db`, and the tests use synthetic cookies
+signed with a local placeholder secret. The result was repeated CD failures on
+main starting with run `25288822616`: `apiRequestContext.get: Max redirect count
+exceeded` in the first authz test.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Deployment validation lane | Add a dedicated Playwright project such as `deployment-smoke` | CD should run only tests that are meaningful against a deployed preview/prod app |
+| Local integration lane | Keep seeded DB/authz tests in `fast` | They protect route wiring and cross-tenant authorization, but require local test data control |
+| Skippability | Make smoke specs explicitly remote-safe and tag or isolate them by directory | Future local-only specs should not accidentally block deployment |
+| CD command | Run `pnpm exec playwright test --project deployment-smoke` in preview and prod validators | The command communicates the validator's purpose better than running all `fast/**` specs |
+
+## Architecture
+
+```text
+Pull Request / Web CI
+  pnpm run test:e2e:fast
+    ├── landing/auth redirect checks
+    ├── local seeded-DB API authz checks
+    └── other fast integration checks
+
+Main CD
+  preview-web deploys Vercel preview
+  playwright-validate runs deployment-smoke against preview URL
+  promote aliases validated artifact to prod
+  validate-prod runs deployment-smoke against prod URL
+```
+
+## Implementation Phases
+
+### Phase 1: Add the deployment-smoke project
+
+**Files to modify:**
+- `web/playwright.config.ts` - add a `deployment-smoke` project that matches a
+  remote-safe test directory or tag, and keeps the existing Vercel deployment
+  protection bypass headers.
+- `.github/workflows/cd.yml` - change `playwright-validate` and `validate-prod`
+  from `--project fast` to `--project deployment-smoke`.
+- `web/package.json` - add `test:e2e:deployment-smoke` if useful for local
+  reproduction.
+- `web/tests/LEDGER.md` - add rows for the smoke behaviors that CD is expected
+  to prove.
+
+**Files to create:**
+- `web/e2e/deployment-smoke/landing.spec.ts` - prove the deployed app serves the
+  Spaces landing page and login link.
+- `web/e2e/deployment-smoke/api.spec.ts` - prove representative public/unauth API
+  behavior without depending on runner-local seeded data.
+
+**Acceptance criteria:**
+- [ ] CD preview validation runs only deployment-safe tests against the preview URL.
+- [ ] CD prod validation runs the same deployment-safe tests against the prod URL.
+- [ ] Local seeded-DB tests still run under Web CI's `fast` project.
+- [ ] A new local-only Playwright spec cannot accidentally run in CD unless it is
+  placed in the deployment-smoke project or tagged for it.
+
+### Phase 2: Improve validator diagnostics
+
+**Files to modify:**
+- `web/scripts/playwright-findings.js` - include skipped counts and the project
+  name in the summary so skipped local-only suites are visible without being
+  noisy.
+- `.github/workflows/cd.yml` - upload the JSON report or trace artifact for
+  deployment-smoke failures, not only `findings.md`.
+
+**Acceptance criteria:**
+- [ ] A deployment-smoke failure artifact identifies the failing URL, project,
+  spec, assertion, and any redirect target.
+- [ ] Skipped tests are visible in the report but do not cause CD failure.
+
+## Verification Commands
+
+```bash
+cd web
+pnpm run test:e2e:fast
+PLAYWRIGHT_BASE_URL=https://<preview-url> \
+  PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+  VERCEL_AUTOMATION_BYPASS_SECRET=<secret> \
+  pnpm exec playwright test --project deployment-smoke
+```
+
+## Rollback Plan
+
+Revert the `deployment-smoke` project and CD workflow command changes, then run
+CD with the previous `--project fast` command. Keep any local-only suite skips
+that are already justified by runner-local fixture requirements.
+
+## References
+
+- `.github/workflows/cd.yml` - current preview, Playwright, promote, and prod
+  validation pipeline.
+- `web/playwright.config.ts` - current `fast`, `full`, `demo`, and `qa-explore`
+  Playwright projects plus Vercel protection bypass headers.
+- `web/e2e/fast/api-authorization.spec.ts` - local-only cross-tenant authz
+  coverage that exposed the need for a separate deployment-smoke lane.
+- GitHub issue #356 - rolling CD Playwright failure issue.
+- GitHub Actions runs `25288822616`, `25289164169`, `25289267410`, and
+  `25296406474` - repeated failures after PR #433 merged.

--- a/scripts/cd/config.toml
+++ b/scripts/cd/config.toml
@@ -11,9 +11,9 @@ slug = "fairchild/workspaces"
 
 [vercel]
 # Directory containing the Next.js app and the Vercel project link.
-# The bootstrap also writes/merges `git.deploymentEnabled.main = false` into
-# <project_dir>/vercel.json so Vercel's git integration stops auto-promoting
-# main. No dashboard step required.
+# The bootstrap also writes/merges `git.deploymentEnabled = false` into
+# <project_dir>/vercel.json so Vercel's git integration stops auto-deploying
+# branches and PRs. No dashboard step required.
 project_dir = "web"
 
 [[workers]]

--- a/web/e2e/fast/api-authorization.spec.ts
+++ b/web/e2e/fast/api-authorization.spec.ts
@@ -7,6 +7,8 @@ const DB_URL =
 	(process.env.CI ? "file:data/e2e-auth.db" : process.env.TURSO_DATABASE_URL) ??
 	"file:data/auth.db";
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+const RUNNING_AGAINST_DEPLOYED_APP =
+	process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1";
 
 const USER_A = {
 	id: "e2e-authz-user-a",
@@ -150,6 +152,10 @@ function expectForbidden(response: { status(): number }) {
 
 test.describe("API authorization", () => {
 	test.describe.configure({ mode: "serial" });
+	test.skip(
+		RUNNING_AGAINST_DEPLOYED_APP,
+		"local seeded-DB authorization coverage cannot run against deployed apps",
+	);
 
 	let db: Client | undefined;
 

--- a/web/src/lib/__tests__/auth-base-url.test.ts
+++ b/web/src/lib/__tests__/auth-base-url.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getAuthBaseURL } from "../auth-base-url";
+
+describe("getAuthBaseURL", () => {
+	it("uses an explicit non-Vercel BETTER_AUTH_URL unchanged", () => {
+		expect(
+			getAuthBaseURL({
+				BETTER_AUTH_URL: "https://spaces.cloudcompute.com",
+				NODE_ENV: "production",
+			}),
+		).toBe("https://spaces.cloudcompute.com");
+	});
+
+	it("derives Vercel auth origins from the request host with a deployment fallback", () => {
+		expect(
+			getAuthBaseURL({
+				VERCEL: "1",
+				VERCEL_ENV: "preview",
+				VERCEL_URL: "spaces-gw9l63dw8-cloudcompute.vercel.app",
+				NODE_ENV: "production",
+			}),
+		).toEqual({
+			allowedHosts: [
+				"spaces.cloudcompute.com",
+				"*.cloudcompute.vercel.app",
+				"*.vercel.app",
+				"localhost:*",
+				"127.0.0.1:*",
+			],
+			protocol: "https",
+			fallback: "https://spaces-gw9l63dw8-cloudcompute.vercel.app",
+		});
+	});
+
+	it("keeps Vercel dynamic even when BETTER_AUTH_URL is configured", () => {
+		expect(
+			getAuthBaseURL({
+				BETTER_AUTH_URL: "https://spaces.cloudcompute.com",
+				VERCEL: "1",
+				VERCEL_ENV: "production",
+				VERCEL_URL: "spaces.cloudcompute.com",
+				NODE_ENV: "production",
+			}),
+		).toMatchObject({
+			protocol: "https",
+			fallback: "https://spaces.cloudcompute.com",
+		});
+	});
+
+	it("allows localhost origins in development", () => {
+		expect(getAuthBaseURL({ NODE_ENV: "development" })).toEqual({
+			allowedHosts: ["localhost:*", "127.0.0.1:*"],
+			protocol: "http",
+			fallback: "http://localhost:3000",
+		});
+	});
+});

--- a/web/src/lib/auth-base-url.ts
+++ b/web/src/lib/auth-base-url.ts
@@ -1,0 +1,49 @@
+type DynamicAuthBaseURL = {
+	allowedHosts: string[];
+	protocol: "http" | "https" | "auto";
+	fallback?: string;
+};
+
+export type AuthBaseURL = string | DynamicAuthBaseURL;
+
+const LOCAL_ALLOWED_HOSTS = ["localhost:*", "127.0.0.1:*"];
+const VERCEL_ALLOWED_HOSTS = [
+	"spaces.cloudcompute.com",
+	"*.cloudcompute.vercel.app",
+	"*.vercel.app",
+];
+
+function withHttps(hostOrUrl: string): string {
+	if (hostOrUrl.startsWith("http://") || hostOrUrl.startsWith("https://")) {
+		return hostOrUrl;
+	}
+	return `https://${hostOrUrl}`;
+}
+
+function vercelFallback(env: NodeJS.ProcessEnv): string | undefined {
+	if (env.BETTER_AUTH_URL) return env.BETTER_AUTH_URL;
+	if (env.VERCEL_URL) return withHttps(env.VERCEL_URL);
+	return undefined;
+}
+
+export function getAuthBaseURL(env = process.env): AuthBaseURL {
+	if (env.VERCEL === "1" || env.VERCEL_ENV || env.VERCEL_URL) {
+		return {
+			allowedHosts: [...VERCEL_ALLOWED_HOSTS, ...LOCAL_ALLOWED_HOSTS],
+			protocol: "https",
+			...(vercelFallback(env) ? { fallback: vercelFallback(env) } : {}),
+		};
+	}
+
+	if (env.BETTER_AUTH_URL) return env.BETTER_AUTH_URL;
+
+	if (env.NODE_ENV === "development") {
+		return {
+			allowedHosts: LOCAL_ALLOWED_HOSTS,
+			protocol: "http",
+			fallback: "http://localhost:3000",
+		};
+	}
+
+	return "http://localhost:3000";
+}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,17 +1,6 @@
 import { betterAuth } from "better-auth";
+import { getAuthBaseURL } from "./auth-base-url";
 import { getDialect } from "./db";
-
-function getAuthBaseURL() {
-	if (process.env.BETTER_AUTH_URL) return process.env.BETTER_AUTH_URL;
-	if (process.env.NODE_ENV === "development") {
-		return {
-			allowedHosts: ["localhost:*", "127.0.0.1:*"],
-			protocol: "http" as const,
-			fallback: "http://localhost:3000",
-		};
-	}
-	return "http://localhost:3000";
-}
 
 export const auth = betterAuth({
 	secret: process.env.BETTER_AUTH_SECRET,


### PR DESCRIPTION
## Summary

- Skip the local seeded-DB API authorization Playwright suite when the runner is validating an already-deployed app with `PLAYWRIGHT_SKIP_WEB_SERVER=1`.
- Keep that authorization suite active for local/Web CI coverage, where it can seed the test DB and sign synthetic Better Auth cookies.
- Derive Better Auth callback origin from Vercel request host/config so preview/prod OAuth redirects do not fall back to `http://localhost:3000`.
- Add a backlog plan for a dedicated `deployment-smoke` Playwright lane so CD no longer depends on every `fast/**` spec being remote-safe.

## Mergeability

- Surface: web / docs / CI test selection.
- User-facing behavior changed: no product UI behavior changed; deployed preview/prod auth routes now have a Vercel-aware Better Auth base URL when the required runtime secrets exist.
- Non-happy paths considered: deployed-app Playwright mode explicitly skips the local seeded-DB authz fixture; local production-mode Playwright still exercises all eight authorization assertions.
- Release/ops preconditions: Vercel preview/production must define `BETTER_AUTH_SECRET`; GitHub OAuth client env should also be present for social sign-in. Current preview `/api/auth/sign-in/social` 500 logs show Better Auth rejecting the default secret, which is an environment blocker outside this repo diff.
- Residual risk or follow-up: backlog item tracks replacing broad CD `fast` validation with a dedicated remote-safe deployment smoke project.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `git diff --check`
  - `cd web && pnpm typecheck`
  - `cd web && pnpm lint`
  - `cd web && pnpm test`
  - `cd web && pnpm exec vitest run src/lib/__tests__/auth-base-url.test.ts`
  - `cd web && PLAYWRIGHT_SKIP_WEB_SERVER=1 PLAYWRIGHT_BASE_URL=https://spaces-j0vpwnb7t-cloudcompute.vercel.app pnpm exec playwright test --project=fast e2e/fast/api-authorization.spec.ts --reporter=list`
  - `cd web && NODE_ENV=production CI=true PORT=3109 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3109 BETTER_AUTH_SECRET=ci-placeholder-secret-for-build-only pnpm exec playwright test --project=fast e2e/fast/api-authorization.spec.ts --reporter=list`
  - `cd web && NODE_ENV=production BETTER_AUTH_SECRET=ci-placeholder-secret-for-build-only TURSO_DATABASE_URL=file:data/e2e-auth.db pnpm run build`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Playwright deployed-app skip evidence](https://evidence.cloudcompute.com/workspaces/pr-439/20260504-021933-playwright-cd-skip.svg)
- [Playwright local authz coverage evidence](https://evidence.cloudcompute.com/workspaces/pr-439/20260504-021942-playwright-local-authz.svg)
- [Web typecheck, lint, and unit evidence](https://evidence.cloudcompute.com/workspaces/pr-439/20260504-021957-web-checks.svg)
- [Vercel auth-origin unit evidence](https://evidence.cloudcompute.com/workspaces/pr-439/20260504-024327-auth-origin-unit.svg)

## Blockers

- Preview social sign-in remains blocked until the Vercel project has `BETTER_AUTH_SECRET` configured for preview/production. This PR fixes the code-side callback origin and the CD Playwright false failure, but it cannot supply the missing deployment secret from source control.
