### PR TITLE
ci: harden release follow-up checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ on:
       - "scripts/install-local.sh"
       - "scripts/notarize.sh"
       - "scripts/prepare-release.sh"
+      - "scripts/release-preflight.sh"
       - "scripts/release-version.sh"
       - "scripts/setup-release-secrets.sh"
       - "scripts/verify-app-keychain-signing.sh"
+      - "scripts/verify-installed-perf.sh"
       - "scripts/verify-p12.sh"
       - "scripts/verify-release-bundle.sh"
   pull_request:
@@ -43,9 +45,11 @@ on:
       - "scripts/install-local.sh"
       - "scripts/notarize.sh"
       - "scripts/prepare-release.sh"
+      - "scripts/release-preflight.sh"
       - "scripts/release-version.sh"
       - "scripts/setup-release-secrets.sh"
       - "scripts/verify-app-keychain-signing.sh"
+      - "scripts/verify-installed-perf.sh"
       - "scripts/verify-p12.sh"
       - "scripts/verify-release-bundle.sh"
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
         run: ./scripts/build-ghosttykit.sh
 
       - name: Import signing certificate
+        id: signing
         env:
           APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
           APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
@@ -123,6 +124,13 @@ jobs:
             security list-keychains -d user 2>/dev/null \
             | sed -E 's/^[[:space:]]*"//; s/"$//' || true
           )"
+          echo "keychain_path=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"
+          echo "original_default_keychain=$ORIGINAL_DEFAULT_KEYCHAIN" >> "$GITHUB_OUTPUT"
+          {
+            echo "original_keychain_list<<EOF"
+            echo "$ORIGINAL_KEYCHAIN_LIST"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           if ! (echo "$APPLE_DEVELOPER_ID_CERT_BASE64" | base64 --decode > "$CERT_PATH" 2>/dev/null); then
             echo "$APPLE_DEVELOPER_ID_CERT_BASE64" | base64 -D > "$CERT_PATH"
@@ -163,17 +171,10 @@ jobs:
             exit 1
           fi
 
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "SIGNING_IDENTITY=$SIGNING_IDENTITY" >> "$GITHUB_ENV"
-          echo "CODESIGN_KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "ORIGINAL_DEFAULT_KEYCHAIN=$ORIGINAL_DEFAULT_KEYCHAIN" >> "$GITHUB_ENV"
-          {
-            echo "ORIGINAL_KEYCHAIN_LIST<<EOF"
-            echo "$ORIGINAL_KEYCHAIN_LIST"
-            echo "EOF"
-          } >> "$GITHUB_ENV"
+          echo "signing_identity=$SIGNING_IDENTITY" >> "$GITHUB_OUTPUT"
 
       - name: Prepare provisioning profile
+        id: profile
         env:
           APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64 }}
         run: |
@@ -186,7 +187,7 @@ jobs:
           fi
 
           security cms -D -i "$PROFILE_PATH" >/dev/null
-          echo "PROVISIONING_PROFILE_PATH=$PROFILE_PATH" >> "$GITHUB_ENV"
+          echo "profile_path=$PROFILE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Notarization preflight
         env:
@@ -224,6 +225,9 @@ jobs:
       - name: Build signed app
         env:
           BUNDLE_ID: com.cloudcompute.workspaces
+          CODESIGN_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
+          PROVISIONING_PROFILE_PATH: ${{ steps.profile.outputs.profile_path }}
+          SIGNING_IDENTITY: ${{ steps.signing.outputs.signing_identity }}
           TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
         run: ./scripts/build-release.sh
 
@@ -246,6 +250,9 @@ jobs:
           APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
           APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           BUNDLE_ID: com.cloudcompute.workspaces
+          CODESIGN_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
+          PROVISIONING_PROFILE_PATH: ${{ steps.profile.outputs.profile_path }}
+          SIGNING_IDENTITY: ${{ steps.signing.outputs.signing_identity }}
           TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
         run: bash ./scripts/notarize.sh
 
@@ -303,6 +310,10 @@ jobs:
 
       - name: Cleanup keychain
         if: always()
+        env:
+          KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
+          ORIGINAL_DEFAULT_KEYCHAIN: ${{ steps.signing.outputs.original_default_keychain }}
+          ORIGINAL_KEYCHAIN_LIST: ${{ steps.signing.outputs.original_keychain_list }}
         run: |
           set -euo pipefail
           # Restore prior keychain search/default state on shared self-hosted machines.
@@ -407,3 +418,61 @@ jobs:
                 --latest
             fi
           fi
+
+  validate-published-release-assets:
+    needs:
+      - build-sign-notarize-release
+      - publish-github-release
+    runs-on: macos-15
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Download published release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.build-sign-notarize-release.outputs.tag }}
+          VERSION: ${{ needs.build-sign-notarize-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-downloads
+          gh release download "$TAG" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "WorkSpaces-${VERSION}.dmg" \
+            --pattern "WorkSpaces-latest.dmg" \
+            --pattern "appcast.xml" \
+            --dir release-downloads
+
+      - name: Validate published release assets
+        env:
+          BUILD: ${{ needs.build-sign-notarize-release.outputs.build }}
+          TAG: ${{ needs.build-sign-notarize-release.outputs.tag }}
+          VERSION: ${{ needs.build-sign-notarize-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          DMG_PATH="release-downloads/WorkSpaces-${VERSION}.dmg"
+          LATEST_DMG_PATH="release-downloads/WorkSpaces-latest.dmg"
+          APPCAST_PATH="release-downloads/appcast.xml"
+
+          for asset in "$DMG_PATH" "$LATEST_DMG_PATH" "$APPCAST_PATH"; do
+            if [[ ! -f "$asset" ]]; then
+              echo "::error::Published release asset missing: $asset"
+              exit 1
+            fi
+          done
+
+          shasum -a 256 "$DMG_PATH" "$LATEST_DMG_PATH" "$APPCAST_PATH"
+          if ! cmp -s "$DMG_PATH" "$LATEST_DMG_PATH"; then
+            echo "::error::Latest DMG asset does not match versioned DMG asset"
+            exit 1
+          fi
+
+          xmllint --noout "$APPCAST_PATH"
+          grep -Fq "releases/download/${TAG}/WorkSpaces-${VERSION}.dmg" "$APPCAST_PATH"
+          grep -Fq "<sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>" "$APPCAST_PATH"
+          grep -Fq "<sparkle:version>${BUILD}</sparkle:version>" "$APPCAST_PATH"
+
+          hdiutil imageinfo "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+          spctl --assess --type open --context context:primary-signature --verbose "$DMG_PATH"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -152,7 +152,7 @@ to that environment. The release workflow references this environment before it
 imports signing material, so environment protection is the approval gate for
 Developer ID, notarization, and Sparkle release secrets.
 
-The workflow is split into two jobs:
+The workflow is split into three jobs:
 
 - `build-sign-notarize-release` runs on `[self-hosted, signing-host]` with
   read-only repository permissions. It imports the Developer ID certificate into
@@ -161,6 +161,11 @@ The workflow is split into two jobs:
   deletes the temporary keychain.
 - `publish-github-release` runs on `ubuntu-latest` with `contents: write`. It
   downloads the signed artifacts and creates or updates the GitHub Release.
+- `validate-published-release-assets` runs on GitHub-hosted macOS with
+  read-only repository permissions after publication. It downloads the public
+  release assets, validates the Sparkle appcast, confirms the latest DMG
+  matches the versioned DMG, and runs macOS DMG notarization/Gatekeeper checks
+  against the published asset.
 
 Keep signing/notarization credentials scoped to the steps that need them. Do not
 write generated keychain passwords or Apple notarization credentials to
@@ -262,6 +267,9 @@ The recommended method for production releases.
    - Guardrails:
      - Manual releases fail if started from a non-`main` branch.
      - Release commit must be reachable from `origin/main`.
+     - Release preflight waits for in-flight `build-and-test` checks on source
+       changes before signing starts, so tag-triggered releases do not fail
+       only because CI has not finished yet.
      - Tag-driven releases fail fast if app version metadata does not match the requested release tag.
      - Temporary signing keychain is cleaned up and prior keychain defaults are restored on the shared `signing-host` runner.
    - Actions performed:
@@ -272,6 +280,8 @@ The recommended method for production releases.
      - Verify nested bundle signing before notarization
      - Notarize and staple `.dmg`
      - Publish or refresh a GitHub release with artifacts via `gh`
+     - Download the published assets on hosted macOS and re-check appcast XML,
+       DMG identity, stapling, and Gatekeeper assessment
 
 4. **Release Tag and Assets**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,8 @@ This directory contains build/release helpers plus UI test utilities.
 
 ## First-Run Setup
 
-- `./scripts/setup` is the canonical first-run path. It links local env files from the main worktree when needed, trusts checked-in mise configs, installs mise-managed tools and lockfile dependencies, unsets legacy `core.hooksPath`, and runs `prek install`.
+- `./scripts/setup` is the canonical first-run path. It links local env files from a sibling worktree when needed, trusts checked-in mise configs, installs mise-managed tools and lockfile dependencies, unsets legacy `core.hooksPath`, and runs `prek install`.
+- `./scripts/setup --env-only` refreshes local env-file links without running dependency setup.
 - `./scripts/setup --hooks-only` installs or refreshes the prek git hooks without running dependency setup.
 - `./scripts/install-git-hooks.sh` remains only as a compatibility wrapper around `./scripts/setup --hooks-only`; prefer `./scripts/setup` in new docs and task definitions.
 

--- a/scripts/pr-readiness.py
+++ b/scripts/pr-readiness.py
@@ -21,12 +21,15 @@ DEFAULT_SURFACE = "desktop / web / agent-runtime / infra / docs"
 RELEASE_PATHS = {
     ".github/workflows/release.yml",
     "scripts/build-release.sh",
+    "scripts/generate-sparkle-appcast.sh",
+    "scripts/install-local.sh",
     "scripts/notarize.sh",
     "scripts/prepare-release.sh",
     "scripts/release-preflight.sh",
     "scripts/release-version.sh",
     "scripts/setup-release-secrets.sh",
     "scripts/verify-app-keychain-signing.sh",
+    "scripts/verify-installed-perf.sh",
     "scripts/verify-p12.sh",
     "scripts/verify-release-bundle.sh",
 }

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -13,49 +13,91 @@
 # Exit codes:
 #   0  all required checks passed
 #   1  a required check failed or was not found
+#   2  invalid arguments or environment configuration
 
 set -euo pipefail
 
-DRY_RUN=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-    DRY_RUN=true
-    shift
-fi
+REQUIRED_CI_CHECK="build-and-test"
+ADVISORY_PERF_CHECKS=("perf-validation" "capture")
 
-SHA="${1:?Usage: release-preflight.sh [--dry-run] <sha> [repo]}"
-REPO="${2:-${GITHUB_REPOSITORY:-fairchild/workspaces}}"
+DRY_RUN=false
+SHA=""
+REPO="${GITHUB_REPOSITORY:-fairchild/workspaces}"
 POLL_SECONDS="${RELEASE_PREFLIGHT_POLL_SECONDS:-15}"
 TIMEOUT_SECONDS="${RELEASE_PREFLIGHT_TIMEOUT_SECONDS:-900}"
+CI_RESULT="not_found"
+CI_ELAPSED=0
 
-if ! [[ "$POLL_SECONDS" =~ ^[0-9]+$ ]] || (( POLL_SECONDS < 1 )); then
-    echo "RELEASE_PREFLIGHT_POLL_SECONDS must be a positive integer" >&2
-    exit 2
-fi
-if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
-    echo "RELEASE_PREFLIGHT_TIMEOUT_SECONDS must be a non-negative integer" >&2
-    exit 2
-fi
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/release-preflight.sh [--dry-run] <sha> [repo]
 
-echo "=== Release Preflight ==="
-echo "SHA:  $SHA"
-echo "Repo: $REPO"
-echo ""
+Verify release-blocking checks for the exact commit being published.
+USAGE
+}
 
-# Check a check-run's state for a given SHA.
-# Returns a terminal conclusion, "queued", "in_progress", or "not_found".
+parse_args() {
+    if [[ "${1:-}" == "--dry-run" ]]; then
+        DRY_RUN=true
+        shift
+    fi
+
+    if [[ $# -lt 1 || $# -gt 2 ]]; then
+        usage >&2
+        exit 2
+    fi
+
+    SHA="$1"
+    REPO="${2:-$REPO}"
+}
+
+validate_config() {
+    if ! [[ "$POLL_SECONDS" =~ ^[0-9]+$ ]] || (( POLL_SECONDS < 1 )); then
+        echo "RELEASE_PREFLIGHT_POLL_SECONDS must be a positive integer" >&2
+        exit 2
+    fi
+    if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+        echo "RELEASE_PREFLIGHT_TIMEOUT_SECONDS must be a non-negative integer" >&2
+        exit 2
+    fi
+}
+
+print_header() {
+    echo "=== Release Preflight ==="
+    echo "SHA:  $SHA"
+    echo "Repo: $REPO"
+    echo ""
+}
+
+# Return the latest check-run state for this release SHA:
+# - terminal conclusions such as success, failure, cancelled
+# - queued or in_progress while GitHub Actions is still running
+# - not_found when no matching check run exists on the commit
 check_workflow_state() {
     local workflow_name="$1"
+    local jq_filter
     local state
+
+    jq_filter=".check_runs
+        | map(select(.name == \"$workflow_name\"))
+        | sort_by(.started_at // .created_at // \"\")
+        | last
+        | if . == null then empty
+          elif .status == \"completed\" then .conclusion
+          else .status
+          end"
+
     state=$(gh api \
         "repos/$REPO/commits/$SHA/check-runs" \
-        --jq ".check_runs | map(select(.name == \"$workflow_name\")) | sort_by(.started_at // .created_at // \"\") | last | if . == null then empty elif .status == \"completed\" then .conclusion else .status end" \
+        --jq "$jq_filter" \
         2>/dev/null)
     echo "${state:-not_found}"
 }
 
 check_any_workflow() {
-    local workflow_name=""
+    local workflow_name
     local result="not_found"
+
     for workflow_name in "$@"; do
         result=$(check_workflow_state "$workflow_name")
         if [[ "$result" != "not_found" ]]; then
@@ -66,119 +108,199 @@ check_any_workflow() {
     echo "not_found"
 }
 
-source_change_count() {
-    gh api "repos/$REPO/commits/$SHA" \
-        --jq '[.files[].filename | select(
-            . == ".github/workflows/ci.yml" or
-            . == ".github/workflows/ci-fallback.yml" or
-            . == ".github/workflows/release.yml" or
-            . == ".swift-format" or
-            . == "Package.swift" or
-            . == "Package.resolved" or
-            . == "WorkspaceManager.entitlements" or
-            startswith("Sources/") or
-            startswith("Tests/") or
-            . == "scripts/build-ghosttykit.sh" or
-            . == "scripts/build-release.sh" or
-            . == "scripts/generate-sparkle-appcast.sh" or
-            . == "scripts/install-local.sh" or
-            . == "scripts/notarize.sh" or
-            . == "scripts/prepare-release.sh" or
-            . == "scripts/release-preflight.sh" or
-            . == "scripts/release-version.sh" or
-            . == "scripts/setup-release-secrets.sh" or
-            . == "scripts/verify-app-keychain-signing.sh" or
-            . == "scripts/verify-installed-perf.sh" or
-            . == "scripts/verify-p12.sh" or
-            . == "scripts/verify-release-bundle.sh"
-        )] | length' 2>/dev/null || echo "unknown"
-}
+is_ci_relevant_path() {
+    local path="$1"
 
-EXIT_CODE=0
-
-# --- Required: build-and-test (CI) ---
-echo -n "CI (build-and-test): "
-SOURCE_CHANGES="$(source_change_count)"
-CI_RESULT="not_found"
-elapsed=0
-
-while true; do
-    CI_RESULT=$(check_workflow_state "build-and-test")
-    case "$CI_RESULT" in
-        queued|in_progress|not_found)
-            if [[ "$SOURCE_CHANGES" == "0" && "$CI_RESULT" == "not_found" ]]; then
-                break
-            fi
-            if [[ "$DRY_RUN" == true ]]; then
-                break
-            fi
-            if (( elapsed >= TIMEOUT_SECONDS )); then
-                break
-            fi
-            echo "${CI_RESULT}; waiting ${POLL_SECONDS}s"
-            sleep "$POLL_SECONDS"
-            elapsed=$((elapsed + POLL_SECONDS))
-            echo -n "CI (build-and-test): "
+    case "$path" in
+        Sources/* | Tests/*)
+            return 0
+            ;;
+        .github/workflows/ci.yml | \
+            .github/workflows/ci-fallback.yml | \
+            .github/workflows/release.yml | \
+            .swift-format | \
+            Package.swift | \
+            Package.resolved | \
+            WorkspaceManager.entitlements | \
+            scripts/build-ghosttykit.sh | \
+            scripts/build-release.sh | \
+            scripts/generate-sparkle-appcast.sh | \
+            scripts/install-local.sh | \
+            scripts/notarize.sh | \
+            scripts/prepare-release.sh | \
+            scripts/release-preflight.sh | \
+            scripts/release-version.sh | \
+            scripts/setup-release-secrets.sh | \
+            scripts/verify-app-keychain-signing.sh | \
+            scripts/verify-installed-perf.sh | \
+            scripts/verify-p12.sh | \
+            scripts/verify-release-bundle.sh)
+            return 0
             ;;
         *)
-            break
+            return 1
             ;;
     esac
-done
+}
 
-case "$CI_RESULT" in
-    success)
-        echo "PASS"
-        ;;
-    queued|in_progress)
-        if [[ "$DRY_RUN" == true ]]; then
-            echo "${CI_RESULT} (dry-run: continuing)"
-        else
-            echo "TIMEOUT ($CI_RESULT after ${elapsed}s)"
-            EXIT_CODE=1
+source_change_count() {
+    local changed_files
+    local changed_file
+    local count=0
+
+    if ! changed_files=$(gh api \
+        "repos/$REPO/commits/$SHA" \
+        --jq '.files[].filename' \
+        2>/dev/null); then
+        echo "unknown"
+        return
+    fi
+
+    while IFS= read -r changed_file; do
+        [[ -n "$changed_file" ]] || continue
+        if is_ci_relevant_path "$changed_file"; then
+            count=$((count + 1))
         fi
-        ;;
-    not_found)
-        # Release commits typically only touch CHANGELOG.md and don't trigger CI.
-        # Check if the commit contains any source changes that would need CI.
-        if [[ "$SOURCE_CHANGES" == "0" ]]; then
-            echo "SKIPPED (no source changes in commit)"
-        elif [[ "$DRY_RUN" == true ]]; then
-            echo "NOT FOUND (dry-run: continuing)"
-        else
-            echo "NOT FOUND after ${elapsed}s"
+    done <<<"$changed_files"
+
+    echo "$count"
+}
+
+should_stop_waiting_for_ci() {
+    local source_changes="$1"
+
+    if [[ "$source_changes" == "0" && "$CI_RESULT" == "not_found" ]]; then
+        return 0
+    fi
+    if [[ "$DRY_RUN" == true ]]; then
+        return 0
+    fi
+    if (( CI_ELAPSED >= TIMEOUT_SECONDS )); then
+        return 0
+    fi
+    return 1
+}
+
+wait_for_required_ci() {
+    local source_changes="$1"
+
+    CI_RESULT="not_found"
+    CI_ELAPSED=0
+
+    echo -n "CI ($REQUIRED_CI_CHECK): "
+    while true; do
+        CI_RESULT=$(check_workflow_state "$REQUIRED_CI_CHECK")
+        case "$CI_RESULT" in
+            queued | in_progress | not_found)
+                if should_stop_waiting_for_ci "$source_changes"; then
+                    break
+                fi
+                echo "${CI_RESULT}; waiting ${POLL_SECONDS}s"
+                sleep "$POLL_SECONDS"
+                CI_ELAPSED=$((CI_ELAPSED + POLL_SECONDS))
+                echo -n "CI ($REQUIRED_CI_CHECK): "
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+}
+
+report_required_ci() {
+    local source_changes="$1"
+
+    case "$CI_RESULT" in
+        success)
+            echo "PASS"
+            return 0
+            ;;
+        queued | in_progress)
+            if [[ "$DRY_RUN" == true ]]; then
+                echo "${CI_RESULT} (dry-run: continuing)"
+                return 0
+            fi
+            echo "TIMEOUT ($CI_RESULT after ${CI_ELAPSED}s)"
+            return 1
+            ;;
+        not_found)
+            # Release commits typically only touch CHANGELOG.md and do not
+            # trigger CI. For source-affecting commits, absence of CI remains a
+            # hard release blocker.
+            if [[ "$source_changes" == "0" ]]; then
+                echo "SKIPPED (no source changes in commit)"
+                return 0
+            fi
+            if [[ "$DRY_RUN" == true ]]; then
+                echo "NOT FOUND (dry-run: continuing)"
+                return 0
+            fi
+            echo "NOT FOUND after ${CI_ELAPSED}s"
             echo "  Warning: CI may not have run but source files were changed."
             echo "  Verify manually that no regressions were introduced."
-            EXIT_CODE=1
-        fi
-        ;;
-    *)
-        echo "FAIL ($CI_RESULT)"
-        EXIT_CODE=1
-        ;;
-esac
+            return 1
+            ;;
+        *)
+            echo "FAIL ($CI_RESULT)"
+            return 1
+            ;;
+    esac
+}
 
-# --- Advisory: perf-validation ---
-echo -n "Perf validation: "
-PERF_RESULT=$(check_any_workflow "perf-validation" "capture")
-case "$PERF_RESULT" in
-    success)
-        echo "PASS"
-        ;;
-    not_found)
-        echo "NOT FOUND (advisory — perf may not have run on this SHA)"
-        ;;
-    *)
-        echo "WARN ($PERF_RESULT) — perf regression detected but not blocking release"
-        ;;
-esac
+report_perf_validation() {
+    local perf_result
 
-echo ""
-if [[ "$EXIT_CODE" -eq 0 ]]; then
-    echo "Preflight passed."
-else
-    echo "Preflight FAILED — required checks did not pass on $SHA."
-    echo "Do not publish this release until CI is green."
-fi
+    echo -n "Perf validation: "
+    perf_result=$(check_any_workflow "${ADVISORY_PERF_CHECKS[@]}")
+    case "$perf_result" in
+        success)
+            echo "PASS"
+            ;;
+        not_found)
+            echo "NOT FOUND (advisory — perf may not have run on this SHA)"
+            ;;
+        *)
+            echo "WARN ($perf_result) — perf regression detected but not blocking release"
+            ;;
+    esac
+}
 
-exit "$EXIT_CODE"
+finish_preflight() {
+    local exit_code="$1"
+
+    echo ""
+    if [[ "$exit_code" -eq 0 ]]; then
+        echo "Preflight passed."
+    else
+        echo "Preflight FAILED — required checks did not pass on $SHA."
+        echo "Do not publish this release until CI is green."
+    fi
+
+    exit "$exit_code"
+}
+
+main() {
+    local source_changes
+    local exit_code=0
+
+    parse_args "$@"
+    validate_config
+    print_header
+
+    source_changes="$(source_change_count)"
+
+    # Required gate: the release SHA must either have passing CI or contain no
+    # source-affecting changes that would have triggered CI.
+    wait_for_required_ci "$source_changes"
+    if ! report_required_ci "$source_changes"; then
+        exit_code=1
+    fi
+
+    # Advisory gate: performance validation is useful release context, but it
+    # should not block signing/publishing by itself.
+    report_perf_validation
+
+    finish_preflight "$exit_code"
+}
+
+main "$@"

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -24,30 +24,40 @@ fi
 
 SHA="${1:?Usage: release-preflight.sh [--dry-run] <sha> [repo]}"
 REPO="${2:-${GITHUB_REPOSITORY:-fairchild/workspaces}}"
+POLL_SECONDS="${RELEASE_PREFLIGHT_POLL_SECONDS:-15}"
+TIMEOUT_SECONDS="${RELEASE_PREFLIGHT_TIMEOUT_SECONDS:-900}"
+
+if ! [[ "$POLL_SECONDS" =~ ^[0-9]+$ ]] || (( POLL_SECONDS < 1 )); then
+    echo "RELEASE_PREFLIGHT_POLL_SECONDS must be a positive integer" >&2
+    exit 2
+fi
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+    echo "RELEASE_PREFLIGHT_TIMEOUT_SECONDS must be a non-negative integer" >&2
+    exit 2
+fi
 
 echo "=== Release Preflight ==="
 echo "SHA:  $SHA"
 echo "Repo: $REPO"
 echo ""
 
-# Check a check-run's conclusion for a given SHA.
-# Returns: "success", "failure", "neutral", "cancelled", "skipped",
-#          "timed_out", "action_required", or "not_found"
-check_workflow() {
+# Check a check-run's state for a given SHA.
+# Returns a terminal conclusion, "queued", "in_progress", or "not_found".
+check_workflow_state() {
     local workflow_name="$1"
-    local conclusion
-    conclusion=$(gh api \
+    local state
+    state=$(gh api \
         "repos/$REPO/commits/$SHA/check-runs" \
-        --jq ".check_runs[] | select(.name == \"$workflow_name\") | .conclusion" \
-        2>/dev/null | head -1)
-    echo "${conclusion:-not_found}"
+        --jq ".check_runs | map(select(.name == \"$workflow_name\")) | sort_by(.started_at // .created_at // \"\") | last | if . == null then empty elif .status == \"completed\" then .conclusion else .status end" \
+        2>/dev/null)
+    echo "${state:-not_found}"
 }
 
 check_any_workflow() {
     local workflow_name=""
     local result="not_found"
     for workflow_name in "$@"; do
-        result=$(check_workflow "$workflow_name")
+        result=$(check_workflow_state "$workflow_name")
         if [[ "$result" != "not_found" ]]; then
             echo "$result"
             return
@@ -56,33 +66,87 @@ check_any_workflow() {
     echo "not_found"
 }
 
+source_change_count() {
+    gh api "repos/$REPO/commits/$SHA" \
+        --jq '[.files[].filename | select(
+            . == ".github/workflows/ci.yml" or
+            . == ".github/workflows/ci-fallback.yml" or
+            . == ".github/workflows/release.yml" or
+            . == ".swift-format" or
+            . == "Package.swift" or
+            . == "Package.resolved" or
+            . == "WorkspaceManager.entitlements" or
+            startswith("Sources/") or
+            startswith("Tests/") or
+            . == "scripts/build-ghosttykit.sh" or
+            . == "scripts/build-release.sh" or
+            . == "scripts/generate-sparkle-appcast.sh" or
+            . == "scripts/install-local.sh" or
+            . == "scripts/notarize.sh" or
+            . == "scripts/prepare-release.sh" or
+            . == "scripts/release-preflight.sh" or
+            . == "scripts/release-version.sh" or
+            . == "scripts/setup-release-secrets.sh" or
+            . == "scripts/verify-app-keychain-signing.sh" or
+            . == "scripts/verify-installed-perf.sh" or
+            . == "scripts/verify-p12.sh" or
+            . == "scripts/verify-release-bundle.sh"
+        )] | length' 2>/dev/null || echo "unknown"
+}
+
 EXIT_CODE=0
 
 # --- Required: build-and-test (CI) ---
 echo -n "CI (build-and-test): "
-CI_RESULT=$(check_workflow "build-and-test")
+SOURCE_CHANGES="$(source_change_count)"
+CI_RESULT="not_found"
+elapsed=0
+
+while true; do
+    CI_RESULT=$(check_workflow_state "build-and-test")
+    case "$CI_RESULT" in
+        queued|in_progress|not_found)
+            if [[ "$SOURCE_CHANGES" == "0" && "$CI_RESULT" == "not_found" ]]; then
+                break
+            fi
+            if [[ "$DRY_RUN" == true ]]; then
+                break
+            fi
+            if (( elapsed >= TIMEOUT_SECONDS )); then
+                break
+            fi
+            echo "${CI_RESULT}; waiting ${POLL_SECONDS}s"
+            sleep "$POLL_SECONDS"
+            elapsed=$((elapsed + POLL_SECONDS))
+            echo -n "CI (build-and-test): "
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 case "$CI_RESULT" in
     success)
         echo "PASS"
         ;;
+    queued|in_progress)
+        if [[ "$DRY_RUN" == true ]]; then
+            echo "${CI_RESULT} (dry-run: continuing)"
+        else
+            echo "TIMEOUT ($CI_RESULT after ${elapsed}s)"
+            EXIT_CODE=1
+        fi
+        ;;
     not_found)
         # Release commits typically only touch CHANGELOG.md and don't trigger CI.
         # Check if the commit contains any source changes that would need CI.
-        SOURCE_CHANGES=$(gh api "repos/$REPO/commits/$SHA" \
-            --jq '[.files[].filename | select(
-                startswith("Sources/") or
-                startswith("Tests/") or
-                startswith("scripts/build") or
-                startswith("scripts/release") or
-                startswith("scripts/notarize") or
-                . == "Package.swift"
-            )] | length' 2>/dev/null || echo "unknown")
         if [[ "$SOURCE_CHANGES" == "0" ]]; then
             echo "SKIPPED (no source changes in commit)"
         elif [[ "$DRY_RUN" == true ]]; then
             echo "NOT FOUND (dry-run: continuing)"
         else
-            echo "NOT FOUND"
+            echo "NOT FOUND after ${elapsed}s"
             echo "  Warning: CI may not have run but source files were changed."
             echo "  Verify manually that no regressions were introduced."
             EXIT_CODE=1

--- a/scripts/setup
+++ b/scripts/setup
@@ -12,14 +12,19 @@ Usage: ./scripts/setup [--hooks-only]
 Canonical first-run setup for this repository.
 
 Options:
+  --env-only    Link local env files from another worktree, then exit.
   --hooks-only  Install or refresh prek git hooks, then exit.
   -h, --help    Show this help.
 USAGE
 }
 
+ENV_ONLY=0
 HOOKS_ONLY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --env-only)
+      ENV_ONLY=1
+      ;;
     --hooks-only)
       HOOKS_ONLY=1
       ;;
@@ -64,24 +69,55 @@ if [[ "$HOOKS_ONLY" == "1" ]]; then
   exit 0
 fi
 
-# Symlink .env from main worktree if we're in a worktree and missing it
+# Symlink local env files from another worktree if we're in a worktree and
+# missing them. Prefer the conventional ~/code/<repo> checkout, but fall back to
+# any sibling worktree that actually has the env file.
+env_source_for() {
+  local envfile="$1"
+  local preferred_source="$HOME/code/$(basename "$REPO_ROOT")/$envfile"
+  local worktree_path=""
+
+  if [[ "$preferred_source" != "$REPO_ROOT/$envfile" && -f "$preferred_source" ]]; then
+    printf '%s\n' "$preferred_source"
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        worktree_path="${line#worktree }"
+        if [[ "$worktree_path" != "$REPO_ROOT" && -f "$worktree_path/$envfile" ]]; then
+          printf '%s\n' "$worktree_path/$envfile"
+          return 0
+        fi
+        ;;
+    esac
+  done < <(git worktree list --porcelain 2>/dev/null)
+
+  return 1
+}
+
 link_env_from_main() {
-  local git_common git_dir main_wt
+  local env_source envfile git_common git_dir
   git_common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 0
   git_dir="$(git rev-parse --git-dir 2>/dev/null)" || return 0
   [[ "$git_common" != "$git_dir" ]] || return 0  # not a worktree
 
-  main_wt="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
-  [[ -n "$main_wt" ]] || return 0
-
   for envfile in .env .env.local; do
-    if [[ -f "$main_wt/$envfile" && ! -e "$REPO_ROOT/$envfile" ]]; then
-      echo "=> Symlinking $envfile from main worktree"
-      ln -s "$main_wt/$envfile" "$REPO_ROOT/$envfile"
+    if [[ ! -e "$REPO_ROOT/$envfile" && ! -L "$REPO_ROOT/$envfile" ]]; then
+      env_source="$(env_source_for "$envfile" || true)"
+      if [[ -n "$env_source" ]]; then
+        echo "=> Symlinking $envfile from ${env_source%/*}"
+        ln -s "$env_source" "$REPO_ROOT/$envfile"
+      fi
     fi
   done
 }
 link_env_from_main
+
+if [[ "$ENV_ONLY" == "1" ]]; then
+  exit 0
+fi
 
 # Trust and install mise-managed tools. Codex worktrees run setup without an
 # interactive terminal, so trust every checked-in project config up front.

--- a/scripts/test_pr_readiness.py
+++ b/scripts/test_pr_readiness.py
@@ -90,7 +90,7 @@ class PRReadinessTests(unittest.TestCase):
 
     def test_release_pr_requires_preconditions(self) -> None:
         body = GOOD_BODY.replace("- Release/ops preconditions: not applicable", "- Release/ops preconditions:")
-        result = pr_readiness.evaluate(pr(body), [".github/workflows/release.yml"])
+        result = pr_readiness.evaluate(pr(body), ["scripts/verify-installed-perf.sh"])
         self.assertIn(
             "Release-sensitive files changed; fill 'Release/ops preconditions' in the PR body.",
             result.failures,

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -151,10 +151,17 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("environment: release", workflow)
         self.assertIn("persist-credentials: false", workflow)
         self.assertIn("publish-github-release:", workflow)
+        self.assertIn("validate-published-release-assets:", workflow)
+        self.assertIn("gh release download", workflow)
+        self.assertIn("xcrun stapler validate", workflow)
+        self.assertIn("spctl --assess", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("permissions:\n      contents: write", workflow)
         for forbidden in (
             'echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"',
+            'echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"',
+            'echo "CODESIGN_KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"',
+            'echo "PROVISIONING_PROFILE_PATH=$PROFILE_PATH" >> "$GITHUB_ENV"',
             'echo "APP_PASSWORD=$APPLE_APP_PASSWORD" >> "$GITHUB_ENV"',
             'echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"',
             'echo "TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"',

--- a/scripts/test_setup_env_linking.py
+++ b/scripts/test_setup_env_linking.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for scripts/setup env-file linking behavior."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETUP_SCRIPT = REPO_ROOT / "scripts" / "setup"
+
+
+class SetupEnvLinkingTests(unittest.TestCase):
+    def run_command(
+        self,
+        args: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_env_only_links_from_sibling_worktree_with_env_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            main = tmp_path / "repo"
+            source = tmp_path / "source-worktree"
+            target = tmp_path / "target-worktree"
+
+            main.mkdir()
+            self.assertEqual(self.run_command(["git", "init"], cwd=main).returncode, 0)
+            self.assertEqual(
+                self.run_command(["git", "config", "user.email", "test@example.com"], cwd=main).returncode,
+                0,
+            )
+            self.assertEqual(
+                self.run_command(["git", "config", "user.name", "Test User"], cwd=main).returncode,
+                0,
+            )
+
+            (main / "scripts").mkdir()
+            shutil.copy2(SETUP_SCRIPT, main / "scripts" / "setup")
+            (main / "README.md").write_text("test repo\n", encoding="utf-8")
+            self.assertEqual(
+                self.run_command(["git", "add", "README.md", "scripts/setup"], cwd=main).returncode,
+                0,
+            )
+            self.assertEqual(self.run_command(["git", "commit", "-m", "initial"], cwd=main).returncode, 0)
+
+            self.assertEqual(
+                self.run_command(["git", "worktree", "add", "-b", "env-source", str(source)], cwd=main).returncode,
+                0,
+            )
+            (source / ".env").write_text("EVIDENCE_UPLOAD_TOKEN=test-token\n", encoding="utf-8")
+
+            self.assertEqual(
+                self.run_command(["git", "worktree", "add", "-b", "env-target", str(target)], cwd=main).returncode,
+                0,
+            )
+            result = self.run_command(
+                ["./scripts/setup", "--env-only"],
+                cwd=target,
+                env={"HOME": str(tmp_path / "home")},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            linked_env = target / ".env"
+            self.assertTrue(linked_env.is_symlink())
+            self.assertEqual(linked_env.resolve(), (source / ".env").resolve())
+            self.assertIn("Symlinking .env", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_setup_env_linking.py
+++ b/scripts/test_setup_env_linking.py
@@ -20,6 +20,13 @@ SETUP_SCRIPT = REPO_ROOT / "scripts" / "setup"
 
 
 class SetupEnvLinkingTests(unittest.TestCase):
+    def assert_success(self, result: subprocess.CompletedProcess[str]) -> None:
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"command failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
     def run_command(
         self,
         args: list[str],
@@ -36,6 +43,46 @@ class SetupEnvLinkingTests(unittest.TestCase):
             check=False,
         )
 
+    def create_repo_with_setup_script(self, repo_path: Path) -> None:
+        """Create the smallest real git repo that can add sibling worktrees.
+
+        The production setup script decides whether it is in a linked worktree
+        by comparing git metadata paths, so a mocked directory layout would not
+        exercise the branch this test cares about.
+        """
+
+        repo_path.mkdir()
+        self.assert_success(self.run_command(["git", "init"], cwd=repo_path))
+        self.assert_success(
+            self.run_command(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=repo_path,
+            )
+        )
+        self.assert_success(
+            self.run_command(
+                ["git", "config", "user.name", "Test User"],
+                cwd=repo_path,
+            )
+        )
+
+        (repo_path / "scripts").mkdir()
+        shutil.copy2(SETUP_SCRIPT, repo_path / "scripts" / "setup")
+        (repo_path / "README.md").write_text("test repo\n", encoding="utf-8")
+
+        self.assert_success(
+            self.run_command(["git", "add", "README.md", "scripts/setup"], cwd=repo_path)
+        )
+        self.assert_success(self.run_command(["git", "commit", "-m", "initial"], cwd=repo_path))
+
+    def add_worktree(self, repo_path: Path, branch: str, worktree_path: Path) -> None:
+        self.assert_success(
+            self.run_command(
+                ["git", "worktree", "add", "-b", branch, str(worktree_path)],
+                cwd=repo_path,
+            )
+        )
+
     def test_env_only_links_from_sibling_worktree_with_env_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -43,46 +90,32 @@ class SetupEnvLinkingTests(unittest.TestCase):
             source = tmp_path / "source-worktree"
             target = tmp_path / "target-worktree"
 
-            main.mkdir()
-            self.assertEqual(self.run_command(["git", "init"], cwd=main).returncode, 0)
-            self.assertEqual(
-                self.run_command(["git", "config", "user.email", "test@example.com"], cwd=main).returncode,
-                0,
-            )
-            self.assertEqual(
-                self.run_command(["git", "config", "user.name", "Test User"], cwd=main).returncode,
-                0,
-            )
+            self.create_repo_with_setup_script(main)
 
-            (main / "scripts").mkdir()
-            shutil.copy2(SETUP_SCRIPT, main / "scripts" / "setup")
-            (main / "README.md").write_text("test repo\n", encoding="utf-8")
-            self.assertEqual(
-                self.run_command(["git", "add", "README.md", "scripts/setup"], cwd=main).returncode,
-                0,
-            )
-            self.assertEqual(self.run_command(["git", "commit", "-m", "initial"], cwd=main).returncode, 0)
+            # The source worktree stands in for a developer's existing checkout
+            # that already has local, gitignored secrets such as evidence upload
+            # tokens. The target starts clean and should receive only a symlink.
+            self.add_worktree(main, "env-source", source)
+            source_env = source / ".env"
+            source_env.write_text("EVIDENCE_UPLOAD_TOKEN=test-token\n", encoding="utf-8")
 
-            self.assertEqual(
-                self.run_command(["git", "worktree", "add", "-b", "env-source", str(source)], cwd=main).returncode,
-                0,
-            )
-            (source / ".env").write_text("EVIDENCE_UPLOAD_TOKEN=test-token\n", encoding="utf-8")
+            self.add_worktree(main, "env-target", target)
 
-            self.assertEqual(
-                self.run_command(["git", "worktree", "add", "-b", "env-target", str(target)], cwd=main).returncode,
-                0,
-            )
+            # Keep HOME inside the temp directory so the preferred
+            # ~/code/<repo> lookup cannot accidentally find this developer
+            # machine's real checkout. That forces the sibling-worktree fallback
+            # path under test.
+            isolated_home = tmp_path / "home"
             result = self.run_command(
                 ["./scripts/setup", "--env-only"],
                 cwd=target,
-                env={"HOME": str(tmp_path / "home")},
+                env={"HOME": str(isolated_home)},
             )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assert_success(result)
             linked_env = target / ".env"
             self.assertTrue(linked_env.is_symlink())
-            self.assertEqual(linked_env.resolve(), (source / ".env").resolve())
+            self.assertEqual(linked_env.resolve(), source_env.resolve())
             self.assertIn("Symlinking .env", result.stdout)
 
 

--- a/scripts/test_validate_release_changes.py
+++ b/scripts/test_validate_release_changes.py
@@ -30,6 +30,8 @@ class ValidateReleaseChangesTests(unittest.TestCase):
                 "scripts/generate-sparkle-appcast.sh",
                 "scripts/install-local.sh",
                 "scripts/notarize.sh",
+                "scripts/release-preflight.sh",
+                "scripts/verify-installed-perf.sh",
                 "scripts/unrelated.sh",
             ]
         )
@@ -40,6 +42,8 @@ class ValidateReleaseChangesTests(unittest.TestCase):
                 "scripts/generate-sparkle-appcast.sh",
                 "scripts/install-local.sh",
                 "scripts/notarize.sh",
+                "scripts/release-preflight.sh",
+                "scripts/verify-installed-perf.sh",
             ],
         )
 

--- a/scripts/validate-release-changes.py
+++ b/scripts/validate-release-changes.py
@@ -28,6 +28,7 @@ RELEASE_PATHS = {
     "scripts/release-version.sh",
     "scripts/setup-release-secrets.sh",
     "scripts/verify-app-keychain-signing.sh",
+    "scripts/verify-installed-perf.sh",
     "scripts/verify-p12.sh",
     "scripts/verify-release-bundle.sh",
 }


### PR DESCRIPTION
## Summary

- Make release preflight wait for in-flight `build-and-test` checks, select the latest check run, and align its CI-required file detector with the workflow path filters.
- Narrow release workflow keychain/provisioning propagation to step outputs and the steps that actually need those paths, with cleanup outputs written before import work begins.
- Add a hosted macOS post-publication validator that downloads the public release assets and checks the appcast, latest/versioned DMG identity, stapling, and Gatekeeper assessment.
- Update release docs and release-sensitive PR/readiness tests for the new mechanical release flow.
- Harden `./scripts/setup` so fresh Codex worktrees link local `.env` files from `~/code/workspaces` or another sibling worktree that has them, with an `--env-only` test path.

## Mergeability

- Surface: infra / release automation / docs
- User-facing behavior changed: no app UI changes; release runs now wait for required CI instead of failing on in-flight checks, published release assets get a separate hosted macOS validation pass, and new Codex worktrees should pick up local evidence-upload env automatically.
- Non-happy paths considered: queued/in-progress/missing CI checks, failed signing import cleanup, invalid poll settings, missing release assets, mismatched latest DMG, invalid appcast XML, unstapled DMG, Gatekeeper rejection, missing main-worktree env files, and sibling worktree env fallback.
- Release/ops preconditions: no new secrets or repository settings required; the protected `release` environment and `[self-hosted, signing-host]` lane remain required. The new post-publish validator expects GitHub-hosted macOS to provide `gh`, `xmllint`, `hdiutil`, `xcrun stapler`, and `spctl`.
- Residual risk or follow-up: the next actual release will be the end-to-end proof of the new post-publication validator. `actionlint` is not installed locally, so workflow syntax proof used the repo validator's Ruby YAML parse.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `bash -n scripts/setup scripts/release-preflight.sh` passed
  - `uv run --script scripts/test_setup_env_linking.py` passed: 1 test
  - `uv run --script scripts/validate-release-changes.py --changed-files /tmp/workspaces-followup-changed-files.json` passed, including workflow syntax proof via Ruby YAML parse
  - `uv run --script scripts/test_security_hardening.py` passed: 12 tests
  - `uv run --script scripts/test_validate_release_changes.py` passed: 2 tests
  - `uv run --script scripts/test_pr_readiness.py` passed: 9 tests
  - `RELEASE_PREFLIGHT_TIMEOUT_SECONDS=0 RELEASE_PREFLIGHT_POLL_SECONDS=1 ./scripts/release-preflight.sh --dry-run 4634c98 fairchild/workspaces` passed against the prior successful release SHA

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: not applicable
- Before Summary: not applicable
- After Summary: not applicable
- Delta Summary: not applicable

Performance comparison notes:

- Exact commands used: not applicable
- Workload / environment context: not applicable

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![release-followup-validation](https://evidence.cloudcompute.com/workspaces/pr-440/20260504-040604-release-followup-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence

