### PR TITLE
Fix privacy disclosure gate for update checks

### DIFF
--- a/Sources/WorkspaceManager/App/SoftwareUpdateController.swift
+++ b/Sources/WorkspaceManager/App/SoftwareUpdateController.swift
@@ -34,6 +34,7 @@ private protocol SoftwareUpdateCheckGate: AnyObject {
 final class SoftwareUpdateDelegate: NSObject, SPUUpdaterDelegate {
     fileprivate weak var checkGate: SoftwareUpdateCheckGate?
 
+    @objc(updater:mayPerformUpdateCheck:error:)
     func updater(_ updater: SPUUpdater, mayPerform updateCheck: SPUUpdateCheck) throws {
         guard checkGate?.shouldAllowSparkleUpdateCheck(updateCheck) ?? true else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
@@ -65,6 +66,7 @@ final class SoftwareUpdateController: NSObject, ObservableObject, NSMenuItemVali
     private let updaterController: SPUStandardUpdaterController
     private let updaterDelegate: SoftwareUpdateDelegate
     private let userDefaults: UserDefaults
+    private let manualCheckDisclosurePresenter: @MainActor () -> Bool
     private var canCheckForUpdatesCancellable: AnyCancellable?
 
     var updater: SPUUpdater {
@@ -73,10 +75,13 @@ final class SoftwareUpdateController: NSObject, ObservableObject, NSMenuItemVali
 
     init(
         startUpdater: Bool = true,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        manualCheckDisclosurePresenter: @escaping @MainActor () -> Bool = SoftwareUpdateController
+            .presentManualCheckDisclosure
     ) {
         self.updaterDelegate = SoftwareUpdateDelegate()
         self.userDefaults = userDefaults
+        self.manualCheckDisclosurePresenter = manualCheckDisclosurePresenter
         let shouldStartUpdater = startUpdater && Self.isSparkleConfigured()
         self.updaterController = SPUStandardUpdaterController(
             startingUpdater: shouldStartUpdater,
@@ -135,18 +140,24 @@ final class SoftwareUpdateController: NSObject, ObservableObject, NSMenuItemVali
         checkForUpdatesWithDisclosure()
     }
 
-    fileprivate func shouldAllowSparkleUpdateCheck(_ updateCheck: SPUUpdateCheck) -> Bool {
+    func shouldAllowSparkleUpdateCheck(_ updateCheck: SPUUpdateCheck) -> Bool {
         guard updateCheck == .updates else {
             return true
         }
         return confirmManualCheckDisclosureIfNeeded()
     }
 
-    private func confirmManualCheckDisclosureIfNeeded() -> Bool {
+    func confirmManualCheckDisclosureIfNeeded() -> Bool {
         if userDefaults.bool(forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey) {
             return true
         }
 
+        guard manualCheckDisclosurePresenter() else { return false }
+        userDefaults.set(true, forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey)
+        return true
+    }
+
+    private static func presentManualCheckDisclosure() -> Bool {
         let alert = NSAlert()
         alert.messageText = "Check for WorkSpaces Updates?"
         alert.informativeText = SoftwareUpdateConstants.manualCheckDisclosure
@@ -155,8 +166,6 @@ final class SoftwareUpdateController: NSObject, ObservableObject, NSMenuItemVali
         alert.addButton(withTitle: "Cancel")
 
         let response = alert.runModal()
-        guard response == .alertFirstButtonReturn else { return false }
-        userDefaults.set(true, forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey)
-        return true
+        return response == .alertFirstButtonReturn
     }
 }

--- a/Tests/WorkspaceManagerAppTests/SoftwareUpdatePrivacyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SoftwareUpdatePrivacyTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import Foundation
+import Sparkle
 import Testing
 
 @testable import WorkspaceManager
@@ -28,5 +30,104 @@ struct SoftwareUpdatePrivacyTests {
         #expect(SoftwareUpdatePrivacyPolicy.shouldPromptForAutomaticCheckPermission == false)
         #expect(SoftwareUpdatePrivacyPolicy.feedParameters.isEmpty)
         #expect(SoftwareUpdatePrivacyPolicy.allowedSystemProfileKeys.isEmpty)
+    }
+
+    @Test("Updater delegate exposes Sparkle update-check gate selector")
+    @MainActor
+    func updaterDelegateExposesSparkleUpdateCheckGateSelector() {
+        let delegate = SoftwareUpdateDelegate()
+
+        #expect(delegate.responds(to: NSSelectorFromString("updater:mayPerformUpdateCheck:error:")))
+    }
+
+    @Test("Manual update check asks for disclosure before Sparkle may check")
+    @MainActor
+    func manualUpdateCheckAsksForDisclosureBeforeSparkleMayCheck() {
+        let suiteName = "SoftwareUpdatePrivacyTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        var promptCount = 0
+        let controller = SoftwareUpdateController(
+            startUpdater: false,
+            userDefaults: defaults,
+            manualCheckDisclosurePresenter: {
+                promptCount += 1
+                return false
+            }
+        )
+
+        #expect(controller.shouldAllowSparkleUpdateCheck(.updates) == false)
+        #expect(promptCount == 1)
+        #expect(defaults.bool(forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey) == false)
+    }
+
+    @Test("Check for Updates menu item is routed through disclosure gate")
+    @MainActor
+    func checkForUpdatesMenuItemIsRoutedThroughDisclosureGate() {
+        let suiteName = "SoftwareUpdatePrivacyTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        var promptCount = 0
+        let controller = SoftwareUpdateController(
+            startUpdater: false,
+            userDefaults: defaults,
+            manualCheckDisclosurePresenter: {
+                promptCount += 1
+                return false
+            }
+        )
+
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: "WorkSpaces")
+        let checkForUpdatesItem = NSMenuItem(
+            title: "Check for Updates...",
+            action: NSSelectorFromString("checkForUpdates:"),
+            keyEquivalent: ""
+        )
+        appMenu.addItem(checkForUpdatesItem)
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        controller.installCheckForUpdatesMenuItem(in: mainMenu)
+
+        #expect(checkForUpdatesItem.target === controller)
+        #expect(checkForUpdatesItem.action == NSSelectorFromString("checkForUpdatesMenuItem:"))
+
+        _ = controller.perform(NSSelectorFromString("checkForUpdatesMenuItem:"), with: checkForUpdatesItem)
+
+        #expect(promptCount == 1)
+        #expect(defaults.bool(forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey) == false)
+    }
+
+    @Test("Manual disclosure confirmation is remembered")
+    @MainActor
+    func manualDisclosureConfirmationIsRemembered() {
+        let suiteName = "SoftwareUpdatePrivacyTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        var promptCount = 0
+        let controller = SoftwareUpdateController(
+            startUpdater: false,
+            userDefaults: defaults,
+            manualCheckDisclosurePresenter: {
+                promptCount += 1
+                return true
+            }
+        )
+
+        #expect(controller.shouldAllowSparkleUpdateCheck(.updates) == true)
+        #expect(controller.shouldAllowSparkleUpdateCheck(.updates) == true)
+        #expect(promptCount == 1)
+        #expect(defaults.bool(forKey: SoftwareUpdateConstants.manualCheckDisclosureAcceptedKey) == true)
     }
 }


### PR DESCRIPTION
## Summary

- Fix the Sparkle manual update path so direct `checkForUpdates:` menu/action routing still hits the WorkSpaces privacy disclosure gate before any network update check.
- Make the manual disclosure presenter injectable for deterministic tests while preserving the same AppKit alert in production.
- Add regression coverage for the Sparkle delegate selector, disclosure persistence, and app-menu retargeting to `checkForUpdatesMenuItem:`.

## Mergeability

- Surface: desktop
- User-facing behavior changed: first manual update checks now reliably show the WorkSpaces privacy disclosure before Sparkle can contact GitHub Releases.
- Non-happy paths considered: canceling the disclosure leaves the accepted default unset and blocks the update check; previously accepted disclosure is remembered; non-manual Sparkle probes are not blocked.
- Release/ops preconditions: none beyond normal release signing/notarization.
- Residual risk or follow-up: none known.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `plutil -lint Sources/WorkspaceManager/Resources/Info.plist`
  - `swift-format lint --strict --recursive Sources/ Tests/`
  - `git diff --check HEAD~1..HEAD`
  - `swift test --filter SoftwareUpdatePrivacy`
  - `./scripts/build-release.sh --no-sign`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Swift privacy tests and full suite](https://evidence.cloudcompute.com/workspaces/pr-441/20260504-042823-privacy-disclosure-tests.svg)
- [First manual-check privacy disclosure](https://evidence.cloudcompute.com/workspaces/pr-441/20260504-042654-privacy-disclosure-dialog.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
