### PR TITLE
Fix deployment-safe web smoke validation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,14 +117,14 @@ jobs:
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install chromium --with-deps
-      - name: Run Playwright fast against preview
+      - name: Run Playwright deployment smoke against preview
         env:
           PLAYWRIGHT_BASE_URL: ${{ needs.preview-web.outputs.preview_url }}
           PLAYWRIGHT_SKIP_WEB_SERVER: "1"
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set +e
-          pnpm exec playwright test --project fast --reporter=json > playwright-report.json
+          pnpm exec playwright test --project deployment-smoke --reporter=json > playwright-report.json
           PW_EXIT=$?
           node scripts/playwright-findings.js playwright-report.json > findings.md || echo "_findings script failed_" > findings.md
           exit $PW_EXIT
@@ -132,7 +132,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-findings
-          path: web/findings.md
+          path: |
+            web/findings.md
+            web/playwright-report.json
 
   lighthouse:
     needs: preview-web
@@ -221,7 +223,7 @@ jobs:
         env:
           VALIDATOR: playwright
           PREVIEW_URL: ${{ needs.preview-web.outputs.preview_url }}
-          REPRO_HINT: cd web && PLAYWRIGHT_BASE_URL=${{ needs.preview-web.outputs.preview_url }} PLAYWRIGHT_SKIP_WEB_SERVER=1 pnpm exec playwright test --project fast
+          REPRO_HINT: cd web && PLAYWRIGHT_BASE_URL=${{ needs.preview-web.outputs.preview_url }} PLAYWRIGHT_SKIP_WEB_SERVER=1 pnpm exec playwright test --project deployment-smoke
         with:
           script: |
             // github-script runs from its own dist dir; relative imports look
@@ -287,13 +289,13 @@ jobs:
           done
           echo "::error::Prod unreachable after 5 attempts"
           exit 1
-      - name: Playwright fast against prod
+      - name: Playwright deployment smoke against prod
         env:
           PLAYWRIGHT_BASE_URL: https://spaces.cloudcompute.com
           PLAYWRIGHT_SKIP_WEB_SERVER: "1"
         run: |
           set +e
-          pnpm exec playwright test --project fast --reporter=json > prod-report.json
+          pnpm exec playwright test --project deployment-smoke --reporter=json > prod-report.json
           PW_EXIT=$?
           node scripts/playwright-findings.js prod-report.json > findings.md || echo "_findings script failed_" > findings.md
           exit $PW_EXIT
@@ -301,7 +303,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: prod-validate-findings
-          path: web/findings.md
+          path: |
+            web/findings.md
+            web/prod-report.json
 
   post-prod-alert:
     needs: [promote, validate-prod]

--- a/backlog/done/pre-release-deployment-smoke_plan.md
+++ b/backlog/done/pre-release-deployment-smoke_plan.md
@@ -1,7 +1,14 @@
 ---
+status: done
+category: plan
 topic: web-cd
 priority: 2
 description: Add a remote-safe, skippable Playwright smoke lane for CD preview and prod validation.
+pr: 442
+branch: codex-deployment-smoke-auth-env
+score: null
+retro_summary: CD now runs a remote-safe deployment-smoke Playwright lane and validates required Vercel auth runtime env by name.
+completed: 2026-05-04
 ---
 
 # Pre-Release Deployment Smoke
@@ -69,10 +76,10 @@ Main CD
   behavior without depending on runner-local seeded data.
 
 **Acceptance criteria:**
-- [ ] CD preview validation runs only deployment-safe tests against the preview URL.
-- [ ] CD prod validation runs the same deployment-safe tests against the prod URL.
-- [ ] Local seeded-DB tests still run under Web CI's `fast` project.
-- [ ] A new local-only Playwright spec cannot accidentally run in CD unless it is
+- [x] CD preview validation runs only deployment-safe tests against the preview URL.
+- [x] CD prod validation runs the same deployment-safe tests against the prod URL.
+- [x] Local seeded-DB tests still run under Web CI's `fast` project.
+- [x] A new local-only Playwright spec cannot accidentally run in CD unless it is
   placed in the deployment-smoke project or tagged for it.
 
 ### Phase 2: Improve validator diagnostics
@@ -85,9 +92,9 @@ Main CD
   deployment-smoke failures, not only `findings.md`.
 
 **Acceptance criteria:**
-- [ ] A deployment-smoke failure artifact identifies the failing URL, project,
+- [x] A deployment-smoke failure artifact identifies the failing URL, project,
   spec, assertion, and any redirect target.
-- [ ] Skipped tests are visible in the report but do not cause CD failure.
+- [x] Skipped tests are visible in the report but do not cause CD failure.
 
 ## Verification Commands
 

--- a/scripts/cd/.env.bootstrap.example
+++ b/scripts/cd/.env.bootstrap.example
@@ -22,3 +22,10 @@ PW_JWT_SIGNING_SECRET=
 
 # evidence-store preview
 PW_EVIDENCE_UPLOAD_TOKEN=
+
+# --- Vercel runtime env checked by `--only validate` ---
+# Set these in Vercel Project Settings for Preview and Production. They are
+# intentionally not pushed through this bootstrap file.
+# BETTER_AUTH_SECRET
+# GITHUB_WEB_WORKSPACES_CLIENT_ID
+# GITHUB_WEB_WORKSPACES_CLIENT_SECRET

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -46,7 +46,8 @@ After: every push to `main` produces a preview deployment, gets validated agains
              ▼         ▼                    │
       ┌──────────┐ ┌──────────┐             │
       │playwright│ │lighthouse│             │
-      │  fast    │ │ 3 runs   │             │
+      │deployment│ │ 3 runs   │             │
+      │  smoke   │ │ desktop  │             │
       │  project │ │ desktop  │             │
       └────┬─────┘ └────┬─────┘             │
            │            │                   │
@@ -72,15 +73,15 @@ After: every push to `main` produces a preview deployment, gets validated agains
 
 | File | What it does |
 |---|---|
-| `.github/workflows/cd.yml` | The 7-job CD pipeline: preview-web, preview-workers, playwright-validate, lighthouse, promote, fail-notify-{playwright,lighthouse}. |
+| `.github/workflows/cd.yml` | The CD pipeline: preview-web, preview-workers, deployment-smoke Playwright validation, lighthouse, promote, and failure notification. |
 | `.github/workflows/web-preview.yml` | Path-filtered PR preview deployment for `web/**`, with a single updated PR comment. |
 | `scripts/cd/bootstrap-preview.py` | Interactive setup wizard for first-time configuration. Prompts for tokens, writes secrets to GitHub + Cloudflare, generates `web/vercel.json`. |
 | `scripts/cd/config.toml` | Declarative manifest. Workers, preview health URLs, secret names, GitHub Actions secrets. **Add a worker = one TOML block.** |
 | `scripts/cd/.env.bootstrap.example` | Template for the gitignored `.env.bootstrap` where the operator's tokens live locally. |
 | `web/vercel.json` | Generated. Contains `git.deploymentEnabled = false` — disables Vercel's automatic Git deployments so Actions owns PR previews and production promotion. |
-| `web/playwright.config.ts` | Honors `PLAYWRIGHT_BASE_URL` to target the preview URL; skips the local `webServer` block when set. |
+| `web/playwright.config.ts` | Honors `PLAYWRIGHT_BASE_URL` to target the preview URL; skips the local `webServer` and seed/teardown blocks when `PLAYWRIGHT_SKIP_WEB_SERVER=1`. |
 | `web/lighthouserc.json` | Perf budgets: LCP ≤2500ms, CLS ≤0.1, TBT ≤200ms, perf score ≥0.9. Desktop preset, 3 runs, median assertions. URL passed at invocation via `--collect.url`. |
-| `web/scripts/{playwright,lhci}-findings.mjs` | Render validator JSON output into markdown tables for the failure-issue body. |
+| `web/scripts/{playwright,lhci}-findings.*` | Render validator JSON output into markdown tables for the failure-issue body. |
 | `infra/<worker>/wrangler.toml` | Each in-tree worker has an `[env.preview]` block with separate routes/bindings (e.g. `evidence-screenshots-preview` R2 bucket). |
 
 ## Bootstrap (first-time setup)
@@ -99,12 +100,14 @@ What gets set up automatically:
 - `web/vercel.json` — Git auto-deploy guard (offered-to-commit interactively)
 - Cloudflare Worker preview secrets — per worker, per `wrangler secret put`
 - GitHub Actions repo secrets — `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` — verified via `gh secret list` after push
+- Vercel runtime env presence — `BETTER_AUTH_SECRET`, `GITHUB_WEB_WORKSPACES_CLIENT_ID`, and `GITHUB_WEB_WORKSPACES_CLIENT_SECRET` are checked in Preview and Production during validation
 - Vercel project link — runs `vercel link` if `web/.vercel/project.json` doesn't exist
 - Preview worker custom-domain DNS — when a health URL is unreachable but dry-run passes, the script offers to run a real `wrangler deploy --env preview`. Wrangler provisions DNS for any `custom_domain = true` route automatically.
 
 What still requires you (no API exists for these):
 - Creating the Vercel token (dashboard)
 - Creating the Cloudflare API token (dashboard)
+- Setting Vercel runtime auth values in Project Settings; the bootstrap validates names only and never stores these secrets in repo files
 
 ## Adding a new worker to CD
 
@@ -140,7 +143,7 @@ What still requires you (no API exists for these):
 ## Design decisions worth understanding
 
 - **Why monolithic `cd.yml` not split workflows.** Promote needs `needs:` semantics across web + workers. Splitting loses the "all validators must pass before any promote" atomicity.
-- **Why `fast` Playwright project only.** `full` needs a seeded DB; preview targets Vercel's serverless DB which we can't seed from CI. Future: staging env with seeded Turso.
+- **Why `deployment-smoke` Playwright project only.** CD runs deployed-app-safe tests that prove the preview/prod artifact serves, redirects, and rejects unauthenticated API calls correctly without relying on runner-local seeded data. Local integration and cross-tenant authorization coverage stay in the `fast` project under Web CI.
 - **Why separate R2 bucket for evidence-store preview.** Preview test writes would otherwise pollute the prod keyspace and share the prod auth token's blast radius. 7-day lifecycle on `evidence-screenshots-preview` keeps storage cost ~$0.
 - **Why `vercel.json` over dashboard branch flip.** Code-controlled, survives project recreation, visible in diffs. Vercel's deprecated `github.enabled` is the legacy form; `git.deploymentEnabled` is current.
 - **Why Actions-owned PR previews.** Vercel's ignored-build path still creates canceled deployments; the path-filtered workflow avoids deployments entirely for non-web PRs.

--- a/scripts/cd/bootstrap-preview.py
+++ b/scripts/cd/bootstrap-preview.py
@@ -32,6 +32,9 @@ import sys
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 CD_DIR = Path(__file__).resolve().parent
@@ -741,10 +744,106 @@ def deploy_preview_real(runner: Runner, worker_dir: Path) -> bool:
         return False
 
 
-def step_validate(runner: Runner, prompt: Prompt, cfg: dict) -> bool:
+def vercel_env_keys_from_payload(payload: object) -> set[str] | None:
+    if isinstance(payload, dict):
+        envs = payload.get("envs", [])
+    elif isinstance(payload, list):
+        envs = payload
+    else:
+        return None
+
+    return {
+        item["key"]
+        for item in envs
+        if isinstance(item, dict) and isinstance(item.get("key"), str)
+    }
+
+
+def parse_vercel_env_keys(raw: str) -> set[str] | None:
+    text = raw.strip()
+    starts = [idx for idx in (text.find("{"), text.find("[")) if idx >= 0]
+    if not starts:
+        return None
+
+    try:
+        payload = json.loads(text[min(starts) :])
+    except json.JSONDecodeError:
+        return None
+    return vercel_env_keys_from_payload(payload)
+
+
+def list_vercel_env_keys_via_api(env: dict[str, str], target: str) -> set[str] | None:
+    token = env.get("VERCEL_TOKEN")
+    project_id = env.get("VERCEL_PROJECT_ID")
+    org_id = env.get("VERCEL_ORG_ID")
+    if not token or not project_id:
+        return None
+
+    query = urlencode({"target": target, **({"teamId": org_id} if org_id else {})})
+    url = f"https://api.vercel.com/v10/projects/{project_id}/env?{query}"
+    request = Request(url)
+    request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urlopen(request, timeout=15) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError):
+        return None
+
+    return vercel_env_keys_from_payload(payload)
+
+
+def list_vercel_env_keys(
+    project_dir: Path,
+    target: str,
+    env: dict[str, str],
+) -> set[str] | None:
+    try:
+        result = subprocess.run(
+            npx("vercel@51", "env", "ls", target, "--format", "json"),
+            cwd=project_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        keys = parse_vercel_env_keys(result.stdout)
+        if keys is not None:
+            return keys
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return list_vercel_env_keys_via_api(env, target)
+    return list_vercel_env_keys_via_api(env, target)
+
+
+def step_validate(
+    runner: Runner,
+    prompt: Prompt,
+    cfg: dict,
+    env: dict[str, str],
+) -> bool:
     step(5, "Validate wiring")
-    teach("Dry-runs `wrangler deploy --env preview` and hits each preview /health URL.")
+    teach(
+        "Checks Vercel runtime env, dry-runs `wrangler deploy --env preview`, "
+        "and hits each preview /health URL."
+    )
     all_ok = True
+
+    vercel_cfg = cfg.get("vercel", {})
+    project_dir = ROOT / vercel_cfg.get("project_dir", "web")
+    required_env = vercel_cfg.get("runtime_env", [])
+    if required_env:
+        info(bold("Vercel runtime env"))
+        for target in ("preview", "production"):
+            existing = list_vercel_env_keys(project_dir, target, env)
+            if existing is None:
+                warn(f"could not list Vercel {target} env vars")
+                all_ok = False
+                continue
+            missing = [name for name in required_env if name not in existing]
+            if missing:
+                warn(f"{target}: missing {', '.join(missing)}")
+                all_ok = False
+            else:
+                ok(f"{target}: required auth env present")
+
     for w in cfg.get("workers", []):
         worker_dir = ROOT / w["dir"]
         if not validate_worker_wiring(runner, worker_dir):
@@ -932,7 +1031,7 @@ def main() -> int:
 
     validate_ok = True
     if only in (None, "validate"):
-        validate_ok = step_validate(runner, prompt, cfg)
+        validate_ok = step_validate(runner, prompt, cfg, env)
 
     if only is None:
         gh_cfg = cfg.get("github_secrets", {})

--- a/scripts/cd/config.toml
+++ b/scripts/cd/config.toml
@@ -15,6 +15,11 @@ slug = "fairchild/workspaces"
 # <project_dir>/vercel.json so Vercel's git integration stops auto-deploying
 # branches and PRs. No dashboard step required.
 project_dir = "web"
+runtime_env = [
+  "BETTER_AUTH_SECRET",
+  "GITHUB_WEB_WORKSPACES_CLIENT_ID",
+  "GITHUB_WEB_WORKSPACES_CLIENT_SECRET",
+]
 
 [[workers]]
 dir = "infra/cloudflare-webhook-relay"

--- a/web/e2e/deployment-smoke/api.spec.ts
+++ b/web/e2e/deployment-smoke/api.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Deployment smoke API", () => {
+	test("rejects unauthenticated workspace sync requests", async ({ request }) => {
+		const response = await request.post("/api/workspaces/sync", {
+			data: { workspaces: [] },
+		});
+
+		expect(response.status()).toBe(401);
+		expect(await response.json()).toEqual({ error: "unauthorized" });
+	});
+
+	test("starts GitHub social sign-in from the served origin", async ({
+		baseURL,
+		request,
+	}) => {
+		test.skip(
+			process.env.PLAYWRIGHT_SKIP_WEB_SERVER !== "1" &&
+				!process.env.GITHUB_WEB_WORKSPACES_CLIENT_ID,
+			"local smoke needs OAuth env to exercise social sign-in",
+		);
+
+		const origin = baseURL ? new URL(baseURL).origin : "http://localhost:3000";
+		const response = await request.post("/api/auth/sign-in/social", {
+			data: { provider: "github", callbackURL: "/dashboard" },
+			headers: { Origin: origin },
+		});
+
+		expect(response.status()).toBeLessThan(500);
+
+		const location = response.headers().location ?? "";
+		const body = await response.text();
+		const redirectSurface = `${location}\n${body}`;
+
+		expect(redirectSurface).toContain("github.com/login/oauth/authorize");
+		expect(redirectSurface).not.toContain("localhost:3000");
+		expect(redirectSurface).not.toContain("http://localhost");
+	});
+});

--- a/web/e2e/deployment-smoke/landing.spec.ts
+++ b/web/e2e/deployment-smoke/landing.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Deployment smoke landing", () => {
+	test("serves the Spaces landing page with a sign-in path", async ({ page }) => {
+		await page.goto("/");
+
+		await expect(page.getByText("Spaces", { exact: true }).first()).toBeVisible();
+		await expect(page.getByRole("link", { name: /> login/i })).toHaveAttribute(
+			"href",
+			"/sign-in",
+		);
+	});
+
+	test("redirects dashboard visitors without a session to sign-in", async ({
+		page,
+	}) => {
+		await page.goto("/dashboard");
+
+		await expect(page).toHaveURL(/\/sign-in/);
+	});
+});

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
 		"test:unit": "vitest run",
 		"test:e2e": "playwright test",
 		"test:e2e:fast": "playwright test --project fast",
+		"test:e2e:deployment-smoke": "playwright test --project deployment-smoke",
 		"test:e2e:full": "playwright test --project full",
 		"lhci": "lhci autorun --config=./lighthouserc.json --collect.url=$LHCI_COLLECT_URL"
 	},

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -36,6 +36,11 @@ export default defineConfig({
 			use: { ...devices["Desktop Chrome"] },
 		},
 		{
+			name: "deployment-smoke",
+			testMatch: "deployment-smoke/**",
+			use: { ...devices["Desktop Chrome"] },
+		},
+		{
 			name: "full",
 			testMatch: "full/**",
 			use: { ...devices["Desktop Chrome"] },
@@ -60,8 +65,8 @@ export default defineConfig({
 			},
 		},
 	],
-	globalSetup: "./e2e/seed.ts",
-	globalTeardown: "./e2e/teardown.ts",
+	globalSetup: SKIP_WEB_SERVER ? undefined : "./e2e/seed.ts",
+	globalTeardown: SKIP_WEB_SERVER ? undefined : "./e2e/teardown.ts",
 	webServer: SKIP_WEB_SERVER
 		? undefined
 		: {

--- a/web/scripts/playwright-findings.js
+++ b/web/scripts/playwright-findings.js
@@ -20,10 +20,12 @@ const ansiRegex = new RegExp(
 const stripAnsi = (s) => s.replace(ansiRegex, "");
 
 const failures = [];
+const projects = new Set();
 function walk(suite, trail) {
 	const here = trail.concat(suite.title ? [suite.title] : []);
 	for (const spec of suite.specs ?? []) {
 		for (const test of spec.tests ?? []) {
+			if (test.projectName) projects.add(test.projectName);
 			for (const result of test.results ?? []) {
 				if (result.status === "failed" || result.status === "timedOut") {
 					const rawErr =
@@ -45,9 +47,19 @@ function walk(suite, trail) {
 for (const suite of report.suites ?? []) walk(suite, []);
 
 const stats = report.stats ?? {};
+const skipped = stats.skipped ?? 0;
+const failed = stats.unexpected ?? failures.length;
+const passed = stats.expected ?? "?";
+const projectNames = [
+	...new Set([...projects, ...failures.map((f) => f.project).filter(Boolean)]),
+].sort();
 const lines = [];
 lines.push(
-	`**Summary:** ${stats.unexpected ?? failures.length} failed / ${stats.expected ?? "?"} passed / ${stats.flaky ?? 0} flaky`,
+	`**Summary:** ${failed} failed / ${passed} passed / ${skipped} skipped / ${stats.flaky ?? 0} flaky`,
+);
+lines.push(`**Base URL:** ${process.env.PLAYWRIGHT_BASE_URL ?? "not set"}`);
+lines.push(
+	`**Project(s):** ${projectNames.length ? projectNames.join(", ") : "unknown"}`,
 );
 lines.push("");
 if (failures.length === 0) {

--- a/web/src/app/api/auth/[...all]/route.ts
+++ b/web/src/app/api/auth/[...all]/route.ts
@@ -3,6 +3,9 @@ import type { NextRequest } from "next/server";
 export const dynamic = "force-dynamic";
 
 async function handler(request: NextRequest) {
+	const { ensureAuthTables } = await import("@/lib/db");
+	await ensureAuthTables();
+
 	const { auth } = await import("@/lib/auth");
 	const { toNextJsHandler } = await import("better-auth/next-js");
 	const { GET: get, POST: post } = toNextJsHandler(auth);

--- a/web/src/lib/__tests__/db.test.ts
+++ b/web/src/lib/__tests__/db.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getDatabaseURL } from "../db";
+
+describe("getDatabaseURL", () => {
+	it("uses TURSO_DATABASE_URL when configured", () => {
+		expect(
+			getDatabaseURL({
+				TURSO_DATABASE_URL: "libsql://example.turso.io",
+				VERCEL_ENV: "preview",
+			}),
+		).toBe("libsql://example.turso.io");
+	});
+
+	it("uses an ephemeral sqlite file on Vercel preview without Turso env", () => {
+		expect(
+			getDatabaseURL({
+				VERCEL: "1",
+				VERCEL_ENV: "preview",
+				VERCEL_URL: "spaces-preview.vercel.app",
+			}),
+		).toBe("file:/tmp/workspaces-auth.db");
+	});
+
+	it("fails closed on production Vercel without Turso env", () => {
+		expect(() =>
+			getDatabaseURL({
+				VERCEL: "1",
+				VERCEL_ENV: "production",
+				VERCEL_URL: "spaces.cloudcompute.com",
+			}),
+		).toThrow(/TURSO_DATABASE_URL/);
+	});
+
+	it("keeps the local file fallback outside Vercel", () => {
+		expect(getDatabaseURL({ NODE_ENV: "development" })).toBe(
+			"file:data/auth.db",
+		);
+	});
+});

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -84,10 +84,27 @@ interface Database {
 let _turso: Client | undefined;
 let _dialect: LibsqlDialect | undefined;
 let _db: Kysely<Database> | undefined;
+let _authSchema: Promise<void> | undefined;
+
+export function getDatabaseURL(
+	env: Record<string, string | undefined> = process.env,
+): string {
+	if (env.TURSO_DATABASE_URL) return env.TURSO_DATABASE_URL;
+
+	if (env.VERCEL_ENV === "production") {
+		throw new Error("TURSO_DATABASE_URL is required in production");
+	}
+
+	if (env.VERCEL === "1" || env.VERCEL_ENV || env.VERCEL_URL) {
+		return "file:/tmp/workspaces-auth.db";
+	}
+
+	return "file:data/auth.db";
+}
 
 export function getTurso(): Client {
 	if (!_turso) {
-		const url = process.env.TURSO_DATABASE_URL ?? "file:data/auth.db";
+		const url = getDatabaseURL();
 		if (url.startsWith("file:")) {
 			mkdirSync(dirname(url.slice(5)), { recursive: true });
 		}
@@ -108,4 +125,72 @@ export function getDb(): Kysely<Database> {
 		_db = new Kysely<Database>({ dialect: getDialect() });
 	}
 	return _db;
+}
+
+async function createAuthTables(): Promise<void> {
+	const db = getTurso();
+	await db.execute(`CREATE TABLE IF NOT EXISTS "user" (
+		id TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		email TEXT NOT NULL UNIQUE,
+		emailVerified INTEGER NOT NULL DEFAULT 0,
+		image TEXT,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS session (
+		id TEXT PRIMARY KEY,
+		expiresAt TEXT NOT NULL,
+		token TEXT NOT NULL UNIQUE,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+		ipAddress TEXT,
+		userAgent TEXT,
+		userId TEXT NOT NULL,
+		FOREIGN KEY (userId) REFERENCES "user"(id) ON DELETE CASCADE
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_session_userId ON session(userId)",
+	);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS account (
+		id TEXT PRIMARY KEY,
+		accountId TEXT NOT NULL,
+		providerId TEXT NOT NULL,
+		userId TEXT NOT NULL,
+		accessToken TEXT,
+		refreshToken TEXT,
+		idToken TEXT,
+		accessTokenExpiresAt TEXT,
+		refreshTokenExpiresAt TEXT,
+		scope TEXT,
+		password TEXT,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now')),
+		FOREIGN KEY (userId) REFERENCES "user"(id) ON DELETE CASCADE
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_account_userId ON account(userId)",
+	);
+
+	await db.execute(`CREATE TABLE IF NOT EXISTS verification (
+		id TEXT PRIMARY KEY,
+		identifier TEXT NOT NULL,
+		value TEXT NOT NULL,
+		expiresAt TEXT NOT NULL,
+		createdAt TEXT NOT NULL DEFAULT (datetime('now')),
+		updatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+	)`);
+	await db.execute(
+		"CREATE INDEX IF NOT EXISTS idx_verification_identifier ON verification(identifier)",
+	);
+}
+
+export function ensureAuthTables(): Promise<void> {
+	_authSchema ??= createAuthTables().catch((error) => {
+		_authSchema = undefined;
+		throw error;
+	});
+	return _authSchema;
 }

--- a/web/tests/LEDGER.md
+++ b/web/tests/LEDGER.md
@@ -25,6 +25,10 @@ Add a `[gap]` row for behaviors you know matter but aren't yet tested. `qa-web-a
 | Landing page loads with Spaces branding | e2e-fast | `fast/landing.spec.ts :: loads with Spaces branding` | 2026-04-17 | qa-web-agent |
 | `POST /api/workspaces/sync` rejects unauthenticated requests | e2e-fast | `fast/unauth-api.spec.ts :: POST /api/workspaces/sync without auth returns unauthorized` | 2026-04-17 | qa-web-agent |
 | `GET /dashboard` redirects unauthenticated users to sign-in | e2e-fast | `fast/unauth-redirect.spec.ts :: GET /dashboard without auth redirects to sign-in` | 2026-04-17 | qa-web-agent |
+| Deployed app serves landing page and sign-in path | e2e-deployment-smoke | `deployment-smoke/landing.spec.ts :: serves the Spaces landing page with a sign-in path` | 2026-05-04 | qa-web-agent |
+| Deployed app redirects unauthenticated dashboard visits to sign-in | e2e-deployment-smoke | `deployment-smoke/landing.spec.ts :: redirects dashboard visitors without a session to sign-in` | 2026-05-04 | qa-web-agent |
+| Deployed app rejects unauthenticated workspace sync requests | e2e-deployment-smoke | `deployment-smoke/api.spec.ts :: rejects unauthenticated workspace sync requests` | 2026-05-04 | qa-web-agent |
+| Deployed app starts GitHub social sign-in without localhost callback origin | e2e-deployment-smoke | `deployment-smoke/api.spec.ts :: starts GitHub social sign-in from the served origin` | 2026-05-04 | qa-web-agent |
 
 ### API authorization
 


### PR DESCRIPTION
## Summary

- Add a dedicated Playwright deployment-smoke project for preview/prod validation.
- Switch CD preview and prod validators from local seeded fast specs to deployment-safe smoke specs.
- Fix preview auth startup fallback so Vercel preview sign-in does not 500 when Turso env is absent.
- Verify required Vercel auth runtime env names during CD bootstrap validation.
- Move the pre-release deployment smoke backlog plan to done.

## Mergeability

- Surface: web / infra / docs
- User-facing behavior changed: No direct product UI change; deployment validation now covers served landing, auth redirect, unauth API rejection, and GitHub social sign-in startup on real deployments. Preview auth startup no longer falls back to a repo-local data path that cannot exist in Vercel serverless.
- Non-happy paths considered: Missing production Turso env now fails closed; Vercel preview without Turso env uses an ephemeral /tmp sqlite file and idempotently creates Better Auth tables; missing Vercel auth env fails bootstrap validation by name; Playwright findings include base URL, project, skipped count, and JSON report artifacts.
- Release/ops preconditions: Vercel Preview and Production have BETTER_AUTH_SECRET, GITHUB_WEB_WORKSPACES_CLIENT_ID, and GITHUB_WEB_WORKSPACES_CLIENT_SECRET set; protected preview validation still uses the existing VERCEL_AUTOMATION_BYPASS_SECRET in CD.
- Residual risk or follow-up: Low; smoke coverage is intentionally shallow and deployment-safe, while seeded authorization depth remains in the fast project. Full browser Playwright against the PR preview requires the CD-only Vercel protection bypass secret, so final PR preview probing used authenticated Vercel CLI access.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `pnpm lint`
  - `pnpm typecheck`
  - `pnpm test` (198 tests)
  - `pnpm run build`
  - `uv run python -m py_compile scripts/cd/bootstrap-preview.py`
  - `node --check web/scripts/playwright-findings.js`
  - local deployment-smoke after auth schema bootstrap: 4 passed
  - production deployment-smoke against https://spaces.cloudcompute.com: 4 passed
  - targeted fast authz regression: 8 passed
  - Vercel env names verified for preview and production: BETTER_AUTH_SECRET, GITHUB_WEB_WORKSPACES_CLIENT_ID, GITHUB_WEB_WORKSPACES_CLIENT_SECRET
  - final PR preview probe via `vercel curl`: GET / returned 200; POST /api/auth/sign-in/social returned 200 with github.com/login/oauth/authorize and preview-origin redirect_uri

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![deployment-smoke-validation-v3](https://evidence.cloudcompute.com/workspaces/pr-442/20260504-054919-deployment-smoke-validation-v3.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
