### PR TITLE
Release: allow notarization credential fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
@@ -84,14 +86,27 @@ jobs:
           [[ -n "$APPLE_DEVELOPER_ID_CERT_BASE64" ]] || missing+=("APPLE_DEVELOPER_ID_CERT_BASE64")
           [[ -n "$APPLE_DEVELOPER_ID_CERT_PASSWORD" ]] || missing+=("APPLE_DEVELOPER_ID_CERT_PASSWORD")
           [[ -n "$APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64" ]] || missing+=("APPLE_DEVELOPER_ID_PROVISIONING_PROFILE_BASE64")
-          [[ -n "$APPLE_API_KEY_BASE64" ]] || missing+=("APPLE_API_KEY_BASE64")
-          [[ -n "$APPLE_API_KEY_ID" ]] || missing+=("APPLE_API_KEY_ID")
-          [[ -n "$APPLE_API_ISSUER_ID" ]] || missing+=("APPLE_API_ISSUER_ID")
           [[ -n "$APPLE_TEAM_ID" ]] || missing+=("APPLE_TEAM_ID")
           [[ -n "$SPARKLE_PRIVATE_KEY" ]] || missing+=("SPARKLE_PRIVATE_KEY")
 
           if (( ${#missing[@]} > 0 )); then
             echo "::error::Missing required repository release config: ${missing[*]}"
+            exit 1
+          fi
+
+          api_missing=()
+          [[ -n "$APPLE_API_KEY_BASE64" ]] || api_missing+=("APPLE_API_KEY_BASE64")
+          [[ -n "$APPLE_API_KEY_ID" ]] || api_missing+=("APPLE_API_KEY_ID")
+          [[ -n "$APPLE_API_ISSUER_ID" ]] || api_missing+=("APPLE_API_ISSUER_ID")
+
+          legacy_missing=()
+          [[ -n "$APPLE_ID" ]] || legacy_missing+=("APPLE_ID")
+          [[ -n "$APPLE_APP_PASSWORD" ]] || legacy_missing+=("APPLE_APP_PASSWORD")
+
+          if (( ${#api_missing[@]} > 0 && ${#legacy_missing[@]} > 0 )); then
+            echo "::error::Missing notarization config. Configure either APPLE_API_KEY_BASE64 APPLE_API_KEY_ID APPLE_API_ISSUER_ID, or APPLE_ID APPLE_APP_PASSWORD."
+            echo "::error::Missing API-key config: ${api_missing[*]}"
+            echo "::error::Missing Apple ID config: ${legacy_missing[*]}"
             exit 1
           fi
 
@@ -197,25 +212,33 @@ jobs:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           API_KEY_PATH="$RUNNER_TEMP/notary-api-key.p8"
           echo "api_key_path=$API_KEY_PATH" >> "$GITHUB_OUTPUT"
 
-          if ! (echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$API_KEY_PATH" 2>/dev/null); then
-            echo "$APPLE_API_KEY_BASE64" | base64 -D > "$API_KEY_PATH"
+          notary_args=()
+          if [[ -n "${APPLE_API_KEY_BASE64:-}" && -n "${APPLE_API_KEY_ID:-}" && -n "${APPLE_API_ISSUER_ID:-}" ]]; then
+            if ! (echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$API_KEY_PATH" 2>/dev/null); then
+              echo "$APPLE_API_KEY_BASE64" | base64 -D > "$API_KEY_PATH"
+            fi
+            chmod 600 "$API_KEY_PATH"
+            notary_args=(--key "$API_KEY_PATH" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
+            echo "auth_mode=api-key" >> "$GITHUB_OUTPUT"
+          else
+            notary_args=(--apple-id "$APPLE_ID" --password "$APPLE_APP_PASSWORD" --team-id "$APPLE_TEAM_ID")
+            echo "auth_mode=apple-id" >> "$GITHUB_OUTPUT"
           fi
-          chmod 600 "$API_KEY_PATH"
 
-          if ! out=$(xcrun notarytool history \
-            --key "$API_KEY_PATH" \
-            --key-id "$APPLE_API_KEY_ID" \
-            --issuer "$APPLE_API_ISSUER_ID" 2>&1); then
-            echo "::error::Apple notarization API-key preflight failed:"
+          if ! out=$(xcrun notarytool history "${notary_args[@]}" 2>&1); then
+            echo "::error::Apple notarization preflight failed:"
             echo "$out"
             exit 1
           fi
-          echo "Notarization API-key credentials OK"
+          echo "Notarization credentials OK"
 
       - name: Validate app version metadata
         if: startsWith(github.ref, 'refs/tags/')
@@ -251,6 +274,8 @@ jobs:
           APPLE_API_KEY_PATH: ${{ steps.notarization.outputs.api_key_path }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_ID: ${{ vars.APPLE_ID != '' && vars.APPLE_ID || secrets.APPLE_ID }}
+          APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
           BUNDLE_ID: com.cloudcompute.workspaces
           CODESIGN_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
           PROVISIONING_PROFILE_PATH: ${{ steps.profile.outputs.profile_path }}

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -143,23 +143,36 @@ if [[ -z "$TEAM_ID" ]] || [[ "$TEAM_ID" == "XXXXXXXXXX" ]]; then
     exit 1
 fi
 
-if [[ -z "$APPLE_API_KEY_PATH" ]]; then
-    log_error "APPLE_API_KEY_PATH not configured (path to .p8 private key; set in scripts/signing-config.sh or environment; see RELEASING.md)"
-    exit 1
-fi
-
-if [[ -z "$APPLE_API_KEY_ID" ]]; then
-    log_error "APPLE_API_KEY_ID not configured (10-character key ID from App Store Connect; see RELEASING.md)"
-    exit 1
-fi
-
-if [[ -z "$APPLE_API_ISSUER_ID" ]]; then
-    log_error "APPLE_API_ISSUER_ID not configured (Issuer UUID from App Store Connect; see RELEASING.md)"
-    exit 1
-fi
-
 if [[ -z "$SIGNING_IDENTITY" ]] || [[ "$SIGNING_IDENTITY" == *"Your Name"* ]]; then
     log_error "SIGNING_IDENTITY not configured (set in scripts/signing-config.sh or environment; see RELEASING.md)"
+    exit 1
+fi
+
+APPLE_API_KEY_PATH="${APPLE_API_KEY_PATH:-}"
+APPLE_API_KEY_ID="${APPLE_API_KEY_ID:-}"
+APPLE_API_ISSUER_ID="${APPLE_API_ISSUER_ID:-}"
+APPLE_ID="${APPLE_ID:-}"
+APP_PASSWORD="${APP_PASSWORD:-${APPLE_APP_PASSWORD:-}}"
+NOTARY_AUTH_ARGS=()
+
+if [[ -n "$APPLE_API_KEY_ID" || -n "$APPLE_API_ISSUER_ID" ]]; then
+    if [[ -z "$APPLE_API_KEY_PATH" || ! -f "$APPLE_API_KEY_PATH" ]]; then
+        log_error "APPLE_API_KEY_PATH not configured or not readable (path to .p8 private key; see RELEASING.md)"
+        exit 1
+    fi
+    if [[ -z "$APPLE_API_KEY_ID" ]]; then
+        log_error "APPLE_API_KEY_ID not configured (10-character key ID from App Store Connect; see RELEASING.md)"
+        exit 1
+    fi
+    if [[ -z "$APPLE_API_ISSUER_ID" ]]; then
+        log_error "APPLE_API_ISSUER_ID not configured (Issuer UUID from App Store Connect; see RELEASING.md)"
+        exit 1
+    fi
+    NOTARY_AUTH_ARGS=(--key "$APPLE_API_KEY_PATH" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER_ID")
+elif [[ -n "$APPLE_ID" && -n "$APP_PASSWORD" ]]; then
+    NOTARY_AUTH_ARGS=(--apple-id "$APPLE_ID" --password "$APP_PASSWORD" --team-id "$TEAM_ID")
+else
+    log_error "Notarization credentials not configured. Set either APPLE_API_KEY_PATH/APPLE_API_KEY_ID/APPLE_API_ISSUER_ID or APPLE_ID/APP_PASSWORD."
     exit 1
 fi
 
@@ -259,9 +272,7 @@ else
 
     # Submit and wait for result
     xcrun notarytool submit "$DMG_PATH" \
-        --key "$APPLE_API_KEY_PATH" \
-        --key-id "$APPLE_API_KEY_ID" \
-        --issuer "$APPLE_API_ISSUER_ID" \
+        "${NOTARY_AUTH_ARGS[@]}" \
         --wait \
         --output-format plist >"$NOTARY_RESULT_PLIST"
 
@@ -270,7 +281,7 @@ else
         log_error "Notarization failed"
         echo ""
         echo "To see detailed logs, run:"
-        echo "  xcrun notarytool log <submission-id> --key <path-to.p8> --key-id $APPLE_API_KEY_ID --issuer $APPLE_API_ISSUER_ID"
+        echo "  xcrun notarytool log <submission-id> <notarization-auth-args>"
         exit 1
     fi
 
@@ -283,9 +294,7 @@ else
         if [[ -n "$NOTARY_SUBMISSION_ID" ]]; then
             echo "Submission ID: $NOTARY_SUBMISSION_ID"
             xcrun notarytool log "$NOTARY_SUBMISSION_ID" \
-                --key "$APPLE_API_KEY_PATH" \
-                --key-id "$APPLE_API_KEY_ID" \
-                --issuer "$APPLE_API_ISSUER_ID" \
+                "${NOTARY_AUTH_ARGS[@]}" \
                 --output-format json >"$NOTARY_LOG_PATH" || true
             if [[ -f "$NOTARY_LOG_PATH" ]]; then
                 echo "Saved notarization log to $NOTARY_LOG_PATH"


### PR DESCRIPTION
## Summary
- Keep App Store Connect API-key notarization as the preferred release path.
- Allow the currently configured Apple ID/app-password repository secrets as a compatibility fallback.
- Preserve scoped credential handling: notarization credentials stay on the protected release job and are not exported through GITHUB_ENV.

## Mergeability
- Surface: release workflow and notarization script.
- User-facing behavior changed: no app behavior changes; release operators can publish from the currently configured repository secrets while API-key secrets are being provisioned.
- Non-happy paths considered: release validation fails if neither API-key nor Apple ID notarization credentials are complete; partial API-key config still fails clearly.
- Residual risk or follow-up: configure APPLE_API_KEY_BASE64, APPLE_API_KEY_ID, and APPLE_API_ISSUER_ID, then remove the fallback once an API-key release succeeds.
- Release/ops preconditions: current repository secrets include APPLE_ID and APPLE_APP_PASSWORD, but not APPLE_API_KEY_BASE64 / APPLE_API_KEY_ID / APPLE_API_ISSUER_ID.

## Validation
- bash -n scripts/notarize.sh scripts/build-release.sh scripts/setup-release-secrets.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- uv run --script scripts/test_security_hardening.py
- uv run --script scripts/validate-release-changes.py --changed-files /private/tmp/release-hotfix-files.json
- git diff --check

## Evidence
- Tests passed: `uv run --script scripts/test_security_hardening.py` ran 13 tests successfully.
