### PR TITLE
Fix main window surface restore after relaunch

### DIFF
--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -275,7 +275,7 @@ private struct MainWindowRootView: View {
     private let appRuntimeDependencies: AppRuntimeDependencies
     @ObservedObject private var appCommandState: AppCommandState
     @State private var deepLinkState = WorkspaceDeepLinkState()
-    @SceneStorage(MainWindowLastSurface.storageKey) private var lastSurfaceRawValue = ""
+    @AppStorage(MainWindowLastSurface.storageKey) private var lastSurfaceRawValue = ""
     @StateObject private var hostTerminalState = HostTerminalStateStore()
     @StateObject private var workspaceProviderSetupCoordinator = WorkspaceProviderSetupCoordinator()
     @StateObject private var hostLumeSmokeAutomation: HostLumeSmokeAutomationController


### PR DESCRIPTION
## Summary

- Persist the main window's last selected surface in app storage instead of scene storage.
- Restore repo terminal selection across app terminate/relaunch so the continuity manifest reopens into the expected terminal surface.

## Mergeability

- Surface: desktop
- User-facing behavior changed: app relaunch now restores the last selected repo terminal surface instead of falling back to repo overview.
- Non-happy paths considered: invalid stored surface cleanup remains unchanged through existing bootstrap sanitization; visual evidence includes full terminate/relaunch with exact PID/window capture.
- Release/ops preconditions: none.
- Residual risk or follow-up: no known follow-up; this does not claim sleep/wake or reboot validation beyond terminate/relaunch.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: `./scripts/build-ghosttykit.sh`; manual debug UI close/reopen evidence captured by exact window id.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Before close screenshot](https://evidence.cloudcompute.com/workspaces/pr-447/20260505-030033-continuity-before-close-after-fix.png)
- [Closed process proof](https://evidence.cloudcompute.com/workspaces/pr-447/20260505-030034-continuity-closed-after-fix.png)
- [After reopen screenshot](https://evidence.cloudcompute.com/workspaces/pr-447/20260505-030035-continuity-after-reopen-after-fix.png)

## Blockers

- [x] None
- [ ] Blocked on evidence