### PR TITLE
Fix Ghostty terminal zoom scale

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -6,6 +6,7 @@
 import AppKit
 import Foundation
 import GhosttyKit
+import QuartzCore
 
 @MainActor
 final class GhosttySurfaceView: NSView {
@@ -94,6 +95,7 @@ final class GhosttySurfaceView: NSView {
         if let window {
             TerminalFocusManager.shared.registerWindow(window)
             setupEventMonitor()
+            syncLayerContentsScale()
             updateScaleAndSize()
             applySystemColorSchemeIfNeeded(force: true)
             let shouldSkipRestore =
@@ -142,6 +144,7 @@ final class GhosttySurfaceView: NSView {
 
     override func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
+        syncLayerContentsScale()
         updateScaleAndSize()
     }
 
@@ -261,6 +264,15 @@ final class GhosttySurfaceView: NSView {
         lastScaleAndSize = next
         ghostty_surface_set_content_scale(surface, next.xScale, next.yScale)
         ghostty_surface_set_size(surface, next.width, next.height)
+    }
+
+    private func syncLayerContentsScale() {
+        guard let backingScaleFactor = window?.backingScaleFactor else { return }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.contentsScale = backingScaleFactor
+        CATransaction.commit()
     }
 
     // MARK: - Mouse input


### PR DESCRIPTION
## Summary

- Sync the Ghostty terminal view layer `contentsScale` to the window backing scale when the surface attaches to a window or the backing properties change.
- Keeps Core Animation layer scaling aligned with Ghostty's framebuffer/content-scale updates, which prevents Retina scale mismatches after terminal zoom reset paths such as `Cmd+0`.

## Mergeability

- Surface: desktop
- User-facing behavior changed: Ghostty terminal zoom reset should remain visually contained in the terminal area instead of rendering at the wrong compositor scale.
- Non-happy paths considered: no window attached; backing scale changes after moving between displays.
- Release/ops preconditions: none.
- Residual risk or follow-up: I attempted to recreate the original visible clipping on this host using an unfixed baseline worktree, but the baseline did not reliably reproduce the off-screen rendering. The PR evidence therefore shows the fixed `Cmd+0` state plus scale/build tests, not a conclusive visual before/after failure.

## Validation

- [x] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `./scripts/build-ghosttykit.sh`
  - `swift test --filter GhosttySurfaceScaleCalculator`
  - `swift test --filter Ghostty`
  - `swift build --product WorkspaceManager`
  - `./scripts/dev-smoke.sh --no-build --clean-data --trust-mise --window-timeout 15`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: none; partial ad hoc debug-launch evidence only.
- Before Summary: unfixed baseline worktree launch-to-first-prompt samples from paired capture runs:
  - 2026-05-05 22:47: `436.07 ms`
  - 2026-05-05 22:53: `459.19 ms`
  - 2026-05-06 06:55: `499.16 ms` baseline-only follow-up, not paired with a fixed run.
- After Summary: fixed branch launch-to-first-prompt samples from the same capture harness:
  - 2026-05-05 22:47: `454.42 ms`
  - 2026-05-05 22:53: `409.05 ms`
  - 2026-05-05 22:54: `417.14 ms` fixed-only follow-up.
- Delta Summary:
  - 22:47 paired run: `+18.35 ms` fixed versus baseline.
  - 22:53 paired run: `-50.14 ms` fixed versus baseline.
  - The two paired samples are noisy and non-canonical; they do not indicate an obvious launch/prompt regression from syncing `contentsScale`, but they are incomplete performance evidence.

Performance comparison notes:

- Exact commands used:
  - `/private/tmp/workspaces-ghostty-cmd0-capture.sh /private/tmp/workspaces-ghostty-baseline broken-terminal ...`
  - `/private/tmp/workspaces-ghostty-cmd0-capture.sh /Users/fairchild/.codex/worktrees/e6ff/workspaces fixed-terminal ...`
  - `/private/tmp/workspaces-ghostty-cmd0-capture.sh /private/tmp/workspaces-ghostty-baseline broken-active ...`
  - `/private/tmp/workspaces-ghostty-cmd0-capture.sh /Users/fairchild/.codex/worktrees/e6ff/workspaces fixed-active ...`
  - `/private/tmp/workspaces-ghostty-cmd0-capture.sh /Users/fairchild/.codex/worktrees/e6ff/workspaces fixed-active2 ...`
- Workload / environment context:
  - Debug builds launched with `./scripts/launch-dev.sh --no-build --clean-data --trust-mise --window-timeout 15`.
  - Harness used `WORKSPACES_PERF_AUTO_SELECT_FIRST_REPO=1` and `WORKSPACES_PERF_AUTO_SELECT_REPO_PATH=<repo>`.
  - Metrics came from `[Perf]` log lines: `launch_to_first_prompt`, `terminal_first_output`, `first_prompt_ready`, and `repo_hydration`.
  - This was not a canonical `prepare-perf-evidence.sh` run, not a controlled before/after benchmark, and the original visible clipping did not reproduce reliably on this host.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Validation summary](https://evidence.cloudcompute.com/workspaces/pr-449/20260506-140150-validation-summary.png)
- [Fixed foreground `Cmd+0` screenshot](https://evidence.cloudcompute.com/workspaces/pr-449/20260506-140109-fixed-cmd0-foreground.png)
- [Partial performance summary](https://evidence.cloudcompute.com/workspaces/pr-449/20260506-142014-partial-performance-summary.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
