### PR TITLE
Fix release workflow asset validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
       build: ${{ steps.meta.outputs.build }}
       tag: ${{ steps.meta.outputs.tag }}
       bundle_id: ${{ steps.meta.outputs.bundle_id }}
-      team_id: ${{ steps.meta.outputs.team_id }}
       sparkle_public_key: ${{ steps.meta.outputs.sparkle_public_key }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -78,7 +77,7 @@ jobs:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           set -euo pipefail
@@ -235,7 +234,7 @@ jobs:
           CODESIGN_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
           PROVISIONING_PROFILE_PATH: ${{ steps.profile.outputs.profile_path }}
           SIGNING_IDENTITY: ${{ steps.signing.outputs.signing_identity }}
-          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
+          TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: ./scripts/build-release.sh
 
       - name: Verify signed app bundle
@@ -261,13 +260,13 @@ jobs:
           CODESIGN_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
           PROVISIONING_PROFILE_PATH: ${{ steps.profile.outputs.profile_path }}
           SIGNING_IDENTITY: ${{ steps.signing.outputs.signing_identity }}
-          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
+          TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: bash ./scripts/notarize.sh
 
       - name: Read release metadata
         id: meta
         env:
-          TEAM_ID: ${{ vars.APPLE_TEAM_ID != '' && vars.APPLE_TEAM_ID || secrets.APPLE_TEAM_ID }}
+          TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
 
@@ -309,6 +308,8 @@ jobs:
           echo "appcast_path=$APPCAST_PATH" >> "$GITHUB_OUTPUT"
           echo "manifest_path=$MANIFEST_PATH" >> "$GITHUB_OUTPUT"
           echo "bundle_id=$BUNDLE_ID" >> "$GITHUB_OUTPUT"
+          # Keep team_id step-local. GitHub may redact it if exposed as a job
+          # output, which breaks downstream validation.
           echo "team_id=$TEAM_ID" >> "$GITHUB_OUTPUT"
           echo "sparkle_public_key=$SPARKLE_PUBLIC_KEY" >> "$GITHUB_OUTPUT"
 
@@ -543,9 +544,9 @@ jobs:
         env:
           BUILD: ${{ needs.build-sign-notarize-release.outputs.build }}
           BUNDLE_ID: ${{ needs.build-sign-notarize-release.outputs.bundle_id }}
+          EXPECTED_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
           EXPECTED_SPARKLE_PUBLIC_KEY: ${{ needs.build-sign-notarize-release.outputs.sparkle_public_key }}
           TAG: ${{ needs.build-sign-notarize-release.outputs.tag }}
-          TEAM_ID: ${{ needs.build-sign-notarize-release.outputs.team_id }}
           VERSION: ${{ needs.build-sign-notarize-release.outputs.version }}
         run: |
           set -euo pipefail
@@ -556,6 +557,10 @@ jobs:
           MANIFEST_PATH="release-downloads/release-manifest.json"
           COMMITTED_SPARKLE_PUBLIC_KEY="$(/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" Sources/WorkspaceManager/Resources/Info.plist)"
 
+          if [[ -z "$EXPECTED_TEAM_ID" ]]; then
+            echo "::error::APPLE_TEAM_ID repository variable is required for post-publish release validation"
+            exit 1
+          fi
           for asset in "$DMG_PATH" "$LATEST_DMG_PATH" "$APPCAST_PATH" "$MANIFEST_PATH"; do
             if [[ ! -f "$asset" ]]; then
               echo "::error::Published release asset missing: $asset"
@@ -594,7 +599,7 @@ jobs:
             --latest-dmg "$LATEST_DMG_PATH" \
             --appcast "$APPCAST_PATH" \
             --bundle-id "$BUNDLE_ID" \
-            --team-id "$TEAM_ID" \
+            --team-id "$EXPECTED_TEAM_ID" \
             --sparkle-public-key "$COMMITTED_SPARKLE_PUBLIC_KEY"
 
           hdiutil imageinfo "$DMG_PATH"


### PR DESCRIPTION
## Summary

- Make APPLE_TEAM_ID a required non-secret repository variable throughout the release workflow.
- Stop exposing team_id as a cross-job output so GitHub secret redaction cannot blank post-publish validation.
- Keep team_id as a step-local signing job output for manifest generation.

## Mergeability

- Surface: infra
- User-facing behavior changed: no
- Non-happy paths considered: missing APPLE_TEAM_ID repo variable now fails during release secret validation before signing/publishing; post-publish validation also fails explicitly if the variable is absent.
- Release/ops preconditions: APPLE_TEAM_ID must remain configured as a repository variable; verified it is currently present.
- Residual risk or follow-up: none known.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parses"'
  - `git diff --check`
  - `./scripts/release-manifest.sh validate --manifest /tmp/workspaces-v0.12.0-assets/release-manifest.json --commit b2b39b9facbc0d48476d8ab1d0fe9ecf28bd92c3 --tag v0.12.0 --version 0.12.0 --build 15 --dmg /tmp/workspaces-v0.12.0-assets/WorkSpaces-0.12.0.dmg --latest-dmg /tmp/workspaces-v0.12.0-assets/WorkSpaces-latest.dmg --appcast /tmp/workspaces-v0.12.0-assets/appcast.xml --bundle-id com.cloudcompute.workspaces --team-id $(gh variable get APPLE_TEAM_ID --repo fairchild/workspaces) --sparkle-public-key <committed SUPublicEDKey>`
  - `./scripts/validate-release-changes.py --changed-files /tmp/workspaces-release-changed-files.json`
  - `uv run --script scripts/test_validate_release_changes.py`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [release workflow validation](https://evidence.cloudcompute.com/workspaces/pr-450/20260507-005350-release-workflow-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
