### PR TITLE
feat: claude code statusline channel (PR #2)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -78,8 +78,11 @@ let package = Package(
                 // App icons and assets
                 .process("Resources/Assets.xcassets"),
 
-                // Channel 3 (Claude Code) hook forwarders — extracted to a writable
-                // path on opt-in install; the .sh files are the source of truth.
+                // Claude Code hook forwarders — bundled .sh files for both
+                // Channel 2 (statusline.sh) and Channel 3 (title-emit.sh).
+                // The installer wires them into ~/.claude/settings.json by
+                // absolute path, extracting them to a writable path on opt-in
+                // install when needed.
                 .copy("Resources/HookForwarders")
             ],
             swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")],

--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -43,7 +43,34 @@ final class ClaudeIntegrationLifecycle {
             )
         )
         await installer.register(workspacesNotifChannelContribution())
+        if let forwarderPath = ClaudeIntegrationLifecycle.bundledStatusLineForwarderPath() {
+            await installer.register(
+                workspacesStatusLineContribution(forwarderPath: forwarderPath)
+            )
+        } else {
+            NSLog(
+                "[ClaudeIntegration] statusline.sh not found in bundle; skipping Channel 2 contribution"
+            )
+        }
         return installer
+    }
+
+    /// Locate the Channel 2 status-line forwarder shell shipped alongside the app.
+    /// The script is added to the SPM bundle via `Resources/HookForwarders` (see
+    /// Package.swift). Returns nil if the bundle was assembled without it — caller
+    /// logs and proceeds without registering Channel 2.
+    nonisolated static func bundledStatusLineForwarderPath() -> String? {
+        if let url = Bundle.module.url(
+            forResource: "statusline",
+            withExtension: "sh",
+            subdirectory: "HookForwarders"
+        ) {
+            return url.path
+        }
+        if let url = Bundle.module.url(forResource: "statusline", withExtension: "sh") {
+            return url.path
+        }
+        return nil
     }
 
     private init() {}

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -228,6 +228,7 @@ struct WorkspaceManagerApp: App {
                 .environment(\.claudeSettingsInstaller, ClaudeIntegrationLifecycle.shared.settingsInstaller)
                 .environmentObject(modelStoreStatusController)
                 .environmentObject(agentSessionRegistry)
+                .environment(\.agentSessionRegistry, agentSessionRegistry)
         }
     }
 }

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -227,6 +227,7 @@ struct WorkspaceManagerApp: App {
                 .environment(\.workspaceProviderRegistry, appRuntimeDependencies.workspaceProviderRegistry)
                 .environment(\.claudeSettingsInstaller, ClaudeIntegrationLifecycle.shared.settingsInstaller)
                 .environmentObject(modelStoreStatusController)
+                .environmentObject(agentSessionRegistry)
         }
     }
 }

--- a/Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# statusline.sh — Claude Code status-line forwarder.
+#
+# Configured in ~/.claude/settings.json under `statusLine.command`. Claude Code
+# invokes this script ~every 5 s with the current status JSON on stdin. We POST
+# the body unchanged to the host's Unix socket on /statusline, then print a
+# single space so the terminal status row stays empty (the host owns
+# visualization).
+#
+# Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 2.
+#
+# Hard requirements:
+#   * stdlib bash + curl only — no jq, no python.
+#   * Never block; if the socket is unreachable, drop the payload and exit 0.
+#   * Always print a single space and exit 0 so Claude doesn't render an error.
+
+set -u
+
+socket="${WORKSPACES_HOOKS_SOCKET:-}"
+
+if [[ -n "$socket" && -S "$socket" ]]; then
+    /usr/bin/curl \
+        --silent \
+        --show-error \
+        --max-time 1 \
+        --unix-socket "$socket" \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        'http://localhost/statusline' \
+        >/dev/null 2>&1 || true
+else
+    # No socket means the host isn't running or the env var didn't propagate.
+    # Drain stdin so Claude doesn't block on the pipe.
+    cat >/dev/null 2>&1 || true
+fi
+
+printf ' '
+exit 0

--- a/Sources/WorkspaceManager/Views/AgentsSettingsView.swift
+++ b/Sources/WorkspaceManager/Views/AgentsSettingsView.swift
@@ -28,6 +28,11 @@ struct AgentsSettingsView: View {
     @AppStorage(ClaudeIntegrationDefaults.optedInKey)
     private var hooksEnabled: Bool = false
 
+    /// The registry is owned by the app; in `#Preview` it's absent and the status
+    /// section renders an empty placeholder. Use `Environment` (not
+    /// `EnvironmentObject`) so the preview path doesn't crash.
+    @Environment(\.agentSessionRegistry) private var agentSessionRegistry: AgentSessionRegistry?
+
     @State private var isInstalled = false
     @State private var isLoading = true
     @State private var showPreviewSheet = false
@@ -64,6 +69,10 @@ struct AgentsSettingsView: View {
             .foregroundStyle(.secondary)
 
             statusRow
+
+            if let registry = agentSessionRegistry {
+                AgentStatusFieldsIndicator(registry: registry)
+            }
 
             if isInstalled {
                 Button("Show preview again") {
@@ -399,6 +408,89 @@ private struct ClaudeHookRevertSheet: View {
         .padding(20)
         .frame(width: 520)
     }
+}
+
+/// Compact status row that surfaces the live status fields populated by Channel 2
+/// (status-line forwarder). Reads `AgentSessionRegistry.statuses` directly — no
+/// new `@Published` publisher; we observe via the registry's own `objectWillChange`.
+///
+/// "Focused session" is the most-recently-updated session in the registry. PR #2
+/// avoids reaching into `HostTerminalSession` so the indicator works during dev
+/// before any sidebar selection is available; richer focus-aware variants land
+/// when sidebar binding stabilizes (PR #3+).
+private struct AgentStatusFieldsIndicator: View {
+    @ObservedObject var registry: AgentSessionRegistry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Live Status (Channel 2)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            if let status = focusedStatus {
+                statusGrid(status)
+            } else {
+                Text("No active session yet — start `claude` in an embedded terminal.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .textBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private var focusedStatus: AgentSessionStatus? {
+        registry.statuses.values
+            .sorted { $0.lastEventAt > $1.lastEventAt }
+            .first
+    }
+
+    @ViewBuilder
+    private func statusGrid(_ status: AgentSessionStatus) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            field(title: "Model", value: status.modelDisplayName ?? "—")
+            field(title: "Context", value: percentString(status.contextUsedPercent))
+            field(title: "Cost", value: costString(status.costUSD))
+            field(title: "5h limit", value: percentString(status.fiveHourLimitUsedPercent))
+            if let resetsAt = status.fiveHourLimitResetsAt {
+                field(title: "Resets", value: Self.timeFormatter.string(from: resetsAt))
+            }
+        }
+        Text(status.cwd)
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+    }
+
+    private func field(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.callout.monospacedDigit())
+        }
+    }
+
+    private func percentString(_ value: Double?) -> String {
+        guard let value else { return "—" }
+        return String(format: "%.0f%%", value)
+    }
+
+    private func costString(_ value: Double?) -> String {
+        guard let value else { return "—" }
+        return String(format: "$%.3f", value)
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
 }
 
 #Preview {

--- a/Sources/WorkspaceManagerCore/Models/StatusLinePayload.swift
+++ b/Sources/WorkspaceManagerCore/Models/StatusLinePayload.swift
@@ -1,0 +1,272 @@
+//
+//  StatusLinePayload.swift
+//  WorkspaceManagerCore
+//
+//  Wire-format for the Claude Code status-line forwarder. The bundled
+//  `Resources/HookForwarders/statusline.sh` script POSTs the JSON Claude Code
+//  feeds it on stdin to the host's `/statusline` route. We decode tolerantly:
+//  missing fields are nil, unknown keys are ignored.
+//
+//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 2 ("Fields the host reads").
+//
+
+import Foundation
+
+/// Tolerant decoder for the Claude Code status-line payload. The shape mirrors
+/// the documented status-line JSON; every field is optional so future additions
+/// don't break decode.
+public struct StatusLinePayload: Sendable, Equatable {
+    public let cwd: String?
+    public let agentSessionID: String?
+    public let model: Model?
+    public let workspace: Workspace?
+    public let cost: Cost?
+    public let contextWindow: ContextWindow?
+    public let rateLimits: RateLimits?
+    public let outputStyle: OutputStyle?
+    public let version: String?
+
+    public init(
+        cwd: String? = nil,
+        agentSessionID: String? = nil,
+        model: Model? = nil,
+        workspace: Workspace? = nil,
+        cost: Cost? = nil,
+        contextWindow: ContextWindow? = nil,
+        rateLimits: RateLimits? = nil,
+        outputStyle: OutputStyle? = nil,
+        version: String? = nil
+    ) {
+        self.cwd = cwd
+        self.agentSessionID = agentSessionID
+        self.model = model
+        self.workspace = workspace
+        self.cost = cost
+        self.contextWindow = contextWindow
+        self.rateLimits = rateLimits
+        self.outputStyle = outputStyle
+        self.version = version
+    }
+
+    public struct Model: Sendable, Equatable {
+        public let id: String?
+        public let displayName: String?
+        public init(id: String? = nil, displayName: String? = nil) {
+            self.id = id
+            self.displayName = displayName
+        }
+    }
+
+    public struct Workspace: Sendable, Equatable {
+        public let currentDir: String?
+        public let projectDir: String?
+        public let gitWorktree: String?
+        public init(
+            currentDir: String? = nil,
+            projectDir: String? = nil,
+            gitWorktree: String? = nil
+        ) {
+            self.currentDir = currentDir
+            self.projectDir = projectDir
+            self.gitWorktree = gitWorktree
+        }
+    }
+
+    public struct Cost: Sendable, Equatable {
+        public let totalCostUSD: Double?
+        public let totalLinesAdded: Int?
+        public let totalLinesRemoved: Int?
+        public init(
+            totalCostUSD: Double? = nil,
+            totalLinesAdded: Int? = nil,
+            totalLinesRemoved: Int? = nil
+        ) {
+            self.totalCostUSD = totalCostUSD
+            self.totalLinesAdded = totalLinesAdded
+            self.totalLinesRemoved = totalLinesRemoved
+        }
+    }
+
+    public struct ContextWindow: Sendable, Equatable {
+        public let usedPercentage: Double?
+        public let contextWindowSize: Int?
+        public init(
+            usedPercentage: Double? = nil,
+            contextWindowSize: Int? = nil
+        ) {
+            self.usedPercentage = usedPercentage
+            self.contextWindowSize = contextWindowSize
+        }
+    }
+
+    public struct RateLimits: Sendable, Equatable {
+        public let fiveHour: Window?
+        public init(fiveHour: Window? = nil) { self.fiveHour = fiveHour }
+
+        public struct Window: Sendable, Equatable {
+            public let usedPercentage: Double?
+            public let resetsAt: Date?
+            public init(usedPercentage: Double? = nil, resetsAt: Date? = nil) {
+                self.usedPercentage = usedPercentage
+                self.resetsAt = resetsAt
+            }
+        }
+    }
+
+    public struct OutputStyle: Sendable, Equatable {
+        public let name: String?
+        public init(name: String? = nil) { self.name = name }
+    }
+}
+
+extension StatusLinePayload {
+    /// Decode tolerantly from raw JSON. Returns `nil` only when the body is not
+    /// even a JSON object — every other shape (missing keys, unknown keys, type
+    /// mismatches) decodes to a payload with the affected fields set to `nil`.
+    public static func decode(from data: Data) -> StatusLinePayload? {
+        guard
+            let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return StatusLinePayload(rawJSON: raw)
+    }
+
+    public init(rawJSON raw: [String: Any]) {
+        self.cwd =
+            (raw["cwd"] as? String)
+            ?? (raw["working_directory"] as? String)
+            ?? (raw["workingDirectory"] as? String)
+            ?? (raw["workspace"] as? [String: Any]).flatMap {
+                ($0["current_dir"] as? String) ?? ($0["currentDir"] as? String)
+            }
+        self.agentSessionID =
+            (raw["session_id"] as? String)
+            ?? (raw["sessionId"] as? String)
+            ?? (raw["sessionID"] as? String)
+
+        if let m = raw["model"] as? [String: Any] {
+            self.model = Model(
+                id: m["id"] as? String,
+                displayName: (m["display_name"] as? String)
+                    ?? (m["displayName"] as? String)
+            )
+        } else {
+            self.model = nil
+        }
+
+        if let w = raw["workspace"] as? [String: Any] {
+            self.workspace = Workspace(
+                currentDir: (w["current_dir"] as? String)
+                    ?? (w["currentDir"] as? String),
+                projectDir: (w["project_dir"] as? String)
+                    ?? (w["projectDir"] as? String),
+                gitWorktree: (w["git_worktree"] as? String)
+                    ?? (w["gitWorktree"] as? String)
+            )
+        } else {
+            self.workspace = nil
+        }
+
+        if let c = raw["cost"] as? [String: Any] {
+            self.cost = Cost(
+                totalCostUSD: Self.double(c["total_cost_usd"] ?? c["totalCostUSD"]),
+                totalLinesAdded: Self.int(c["total_lines_added"] ?? c["totalLinesAdded"]),
+                totalLinesRemoved: Self.int(c["total_lines_removed"] ?? c["totalLinesRemoved"])
+            )
+        } else {
+            self.cost = nil
+        }
+
+        if let cw = raw["context_window"] as? [String: Any] ?? raw["contextWindow"] as? [String: Any] {
+            self.contextWindow = ContextWindow(
+                usedPercentage: Self.double(cw["used_percentage"] ?? cw["usedPercentage"]),
+                contextWindowSize: Self.int(cw["context_window_size"] ?? cw["contextWindowSize"])
+            )
+        } else {
+            self.contextWindow = nil
+        }
+
+        if let rl = raw["rate_limits"] as? [String: Any] ?? raw["rateLimits"] as? [String: Any] {
+            let fh = rl["five_hour"] as? [String: Any] ?? rl["fiveHour"] as? [String: Any]
+            if let fh {
+                self.rateLimits = RateLimits(
+                    fiveHour: RateLimits.Window(
+                        usedPercentage: Self.double(fh["used_percentage"] ?? fh["usedPercentage"]),
+                        resetsAt: Self.date(fh["resets_at"] ?? fh["resetsAt"])
+                    )
+                )
+            } else {
+                self.rateLimits = RateLimits(fiveHour: nil)
+            }
+        } else {
+            self.rateLimits = nil
+        }
+
+        if let os = raw["output_style"] as? [String: Any] ?? raw["outputStyle"] as? [String: Any] {
+            self.outputStyle = OutputStyle(name: os["name"] as? String)
+        } else {
+            self.outputStyle = nil
+        }
+
+        self.version = raw["version"] as? String
+    }
+
+    /// Project the payload into the registry's normalized status fields. Hosts
+    /// of the workspace prefer `workspace.current_dir` over the top-level `cwd`
+    /// because Claude Code's status-line carries the workspace block.
+    public func resolvedCwd() -> String? {
+        if let v = workspace?.currentDir, !v.isEmpty { return v }
+        if let v = cwd, !v.isEmpty { return v }
+        return nil
+    }
+
+    public func toStatusFields() -> AgentEvent.StatusFields {
+        AgentEvent.StatusFields(
+            modelDisplayName: model?.displayName ?? model?.id,
+            contextUsedPercent: contextWindow?.usedPercentage,
+            fiveHourLimitUsedPercent: rateLimits?.fiveHour?.usedPercentage,
+            fiveHourLimitResetsAt: rateLimits?.fiveHour?.resetsAt,
+            costUSD: cost?.totalCostUSD
+        )
+    }
+
+    // MARK: - Tolerant scalar coercion
+
+    private static func double(_ value: Any?) -> Double? {
+        if let v = value as? Double { return v }
+        if let v = value as? Int { return Double(v) }
+        if let v = value as? NSNumber { return v.doubleValue }
+        if let v = value as? String { return Double(v) }
+        return nil
+    }
+
+    private static func int(_ value: Any?) -> Int? {
+        if let v = value as? Int { return v }
+        if let v = value as? Double { return Int(v) }
+        if let v = value as? NSNumber { return v.intValue }
+        if let v = value as? String { return Int(v) }
+        return nil
+    }
+
+    private static func date(_ value: Any?) -> Date? {
+        if let v = value as? Date { return v }
+        if let v = value as? String, let d = Self.iso8601.date(from: v) { return d }
+        if let v = value as? String, let d = Self.iso8601Fractional.date(from: v) { return d }
+        if let v = value as? Double { return Date(timeIntervalSince1970: v) }
+        if let v = value as? Int { return Date(timeIntervalSince1970: TimeInterval(v)) }
+        return nil
+    }
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static let iso8601Fractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+}

--- a/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
@@ -7,7 +7,8 @@
 //
 //  Routes:
 //    POST /event       — hook event, decoded via the registered ClaudeCode adapter
-//    POST /statusline  — reserved for PR #2 (status-line forwarder); 200 OK with no-op
+//    POST /statusline  — Channel 2 status-line forwarder; decodes StatusLinePayload
+//                        and updates the registry's status fields for the matching session
 //    GET  /healthz     — 200 OK "OK"
 //
 //  Framing: minimal HTTP/1.1 — request line, headers, body. We respond 200 OK
@@ -30,6 +31,7 @@ public actor AgentHookListener {
         public var decodeFailures: Int = 0
         public var unsupportedRoutes: Int = 0
         public var ingestedEvents: Int = 0
+        public var statusLineUpdates: Int = 0
     }
 
     private let socketURL: URL
@@ -197,8 +199,7 @@ public actor AgentHookListener {
         case ("POST", "/event"):
             await processEvent(body: request.body)
         case ("POST", "/statusline"):
-            statistics.unsupportedRoutes += 1
-            logger("unsupported route /statusline (reserved for PR #2)")
+            await processStatusLine(body: request.body)
         default:
             break
         }
@@ -245,6 +246,31 @@ public actor AgentHookListener {
             registry.ingest(event, for: hostSessionID, origin: .hook)
         }
         statistics.ingestedEvents += 1
+    }
+
+    private func processStatusLine(body: Data) async {
+        guard let payload = StatusLinePayload.decode(from: body) else {
+            statistics.decodeFailures += 1
+            logger("statusline decode failed")
+            return
+        }
+
+        let cwd = payload.resolvedCwd() ?? ""
+        let hostSessionID = await MainActor.run { [registry] in
+            registry.resolveHostSession(cwd: cwd, agentSessionID: payload.agentSessionID)
+        }
+
+        guard let hostSessionID else {
+            // Status-line ticks before SessionStart are common and not worth a
+            // decode-failure log entry.
+            return
+        }
+
+        let fields = payload.toStatusFields()
+        await MainActor.run { [registry] in
+            registry.updateStatusFields(fields, for: hostSessionID)
+        }
+        statistics.statusLineUpdates += 1
     }
 
     private static func extractCommon(body: Data) -> (cwd: String, agentSessionID: String?) {

--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -403,3 +403,46 @@ public func workspacesNotifChannelContribution() -> ClaudeSettingsContribution {
         }
     )
 }
+
+// MARK: - PR #2 contribution: workspaces.statusLine
+
+/// Build the contribution that registers the status-line forwarder in
+/// `~/.claude/settings.json`. `forwarderPath` is the absolute path to the
+/// `statusline.sh` script bundled with the running app. `refreshInterval` is in
+/// milliseconds — Claude Code triggers an update on every conversation change
+/// anyway, so this only governs the idle tick rate.
+///
+/// Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 2.
+public func workspacesStatusLineContribution(
+    forwarderPath: String,
+    refreshInterval: Int = 5000
+) -> ClaudeSettingsContribution {
+    return ClaudeSettingsContribution(
+        id: "workspaces.statusLine",
+        target: .userSettingsJSON,
+        merge: { current in
+            var dict = current
+            // Settings layout:
+            //   { "statusLine": { "type": "command", "command": "...", "refreshInterval": 5000 } }
+            // We replace our own block in place but never remove pre-existing keys
+            // we don't recognize on the same object (defensive: future Claude Code
+            // versions may add fields to statusLine).
+            var block: [String: Any] =
+                (current["statusLine"]?.value as? [String: Any]) ?? [:]
+            block["type"] = "command"
+            block["command"] = forwarderPath
+            block["refreshInterval"] = refreshInterval
+            dict["statusLine"] = AnyCodable(block)
+            return dict
+        },
+        preview: { current in
+            let block = (current["statusLine"]?.value as? [String: Any]) ?? [:]
+            let presentCommand = block["command"] as? String
+            let presentInterval = block["refreshInterval"] as? Int
+            if presentCommand == forwarderPath && presentInterval == refreshInterval {
+                return "no changes (statusLine already wired → \(forwarderPath))"
+            }
+            return "set statusLine → command=\(forwarderPath), refreshInterval=\(refreshInterval)ms"
+        }
+    )
+}

--- a/Tests/WorkspaceManagerTests/AgentHookListenerTests.swift
+++ b/Tests/WorkspaceManagerTests/AgentHookListenerTests.swift
@@ -390,6 +390,150 @@ struct AgentHookListenerTests {
         await listener.stop()
     }
 
+    @Test("statusline POST updates registry status fields by cwd")
+    func statusLineUpdatesByCwd() async throws {
+        let cwd = "/tmp/hook-test-\(UUID().uuidString.prefix(6))"
+        try? FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: cwd) }
+
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: cwd)
+        let registeredID = await registry.registeredID
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let body: [String: Any] = [
+            "model": ["id": "claude-sonnet", "display_name": "Claude Sonnet 4.5"],
+            "workspace": ["current_dir": cwd],
+            "cost": ["total_cost_usd": 0.123],
+            "context_window": ["used_percentage": 12.5, "context_window_size": 200_000],
+            "rate_limits": [
+                "five_hour": [
+                    "used_percentage": 33.3,
+                    "resets_at": "2026-05-07T20:00:00Z",
+                ]
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body)
+        let status = await Self.curlPost(socket: socket, path: "/statusline", body: data)
+        #expect(status == 0)
+
+        let reached = await waitUntil {
+            await MainActor.run {
+                registry.statuses[registeredID]?.modelDisplayName == "Claude Sonnet 4.5"
+            }
+        }
+        #expect(reached)
+        let live = await registry.statuses[registeredID]
+        #expect(live?.contextUsedPercent == 12.5)
+        #expect(live?.fiveHourLimitUsedPercent == 33.3)
+        #expect(live?.costUSD == 0.123)
+        #expect(live?.fiveHourLimitResetsAt != nil)
+        // Status-line ticks must NOT change the run state.
+        #expect(live?.run == .idle)
+
+        await listener.stop()
+    }
+
+    @Test("statusline POST resolves by agent_session_id once SessionStart bound")
+    func statusLineResolvesByAgentSessionID() async throws {
+        let cwd = "/tmp/hook-test-\(UUID().uuidString.prefix(6))"
+        try? FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: cwd) }
+
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: cwd)
+        let registeredID = await registry.registeredID
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let bind: [String: Any] = [
+            "hook_event_name": "SessionStart",
+            "session_id": "session-xyz",
+            "cwd": cwd,
+        ]
+        _ = await Self.curlPost(
+            socket: socket, path: "/event",
+            body: try JSONSerialization.data(withJSONObject: bind)
+        )
+        let bound = await waitUntil {
+            await MainActor.run {
+                registry.statuses[registeredID]?.agentSessionID == "session-xyz"
+            }
+        }
+        #expect(bound)
+
+        let body: [String: Any] = [
+            "session_id": "session-xyz",
+            "workspace": ["current_dir": "/some/other/path"],
+            "model": ["display_name": "Sonnet"],
+            "cost": ["total_cost_usd": 0.01],
+        ]
+        _ = await Self.curlPost(
+            socket: socket, path: "/statusline",
+            body: try JSONSerialization.data(withJSONObject: body)
+        )
+
+        let reached = await waitUntil {
+            await MainActor.run { registry.statuses[registeredID]?.modelDisplayName == "Sonnet" }
+        }
+        #expect(reached)
+        let live = await registry.statuses[registeredID]
+        #expect(live?.costUSD == 0.01)
+
+        await listener.stop()
+    }
+
+    @Test("statusline POST with no matching session is dropped without crashing")
+    func statusLineNoMatchingSession() async throws {
+        let cwd = "/tmp/hook-test-\(UUID().uuidString.prefix(6))"
+        try? FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: cwd) }
+
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: cwd)
+        let registeredID = await registry.registeredID
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let runBefore = await registry.statuses[registeredID]?.modelDisplayName
+
+        let body: [String: Any] = [
+            "session_id": "unknown-session-id",
+            "workspace": ["current_dir": "/somewhere/else"],
+            "model": ["display_name": "Should not apply"],
+        ]
+        let posted = await Self.curlPost(
+            socket: socket, path: "/statusline",
+            body: try JSONSerialization.data(withJSONObject: body)
+        )
+        #expect(posted == 0)
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        let runAfter = await registry.statuses[registeredID]?.modelDisplayName
+        #expect(runAfter == runBefore)
+
+        await listener.stop()
+    }
+
     @Test("Unknown event payload returns 200 without state mutation")
     func unknownEventDoesNotError() async throws {
         let cwd = "/tmp/hook-test-\(UUID().uuidString.prefix(6))"

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
@@ -133,4 +133,104 @@ struct ClaudeSettingsInstallerTests {
         let afterInstall = await installer.isInstalled()
         #expect(afterInstall == true)
     }
+
+    @Test("statusLine contribution writes the spec-shaped block")
+    func statusLineContributionWritesBlock() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let installer = ClaudeSettingsInstaller(homeDirectory: home)
+        await installer.register(
+            workspacesStatusLineContribution(
+                forwarderPath: "/tmp/statusline.sh", refreshInterval: 5000
+            )
+        )
+        try await installer.install()
+
+        let settingsURL = home.appendingPathComponent(".claude/settings.json")
+        let data = try Data(contentsOf: settingsURL)
+        let updated = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+        let block = updated["statusLine"] as? [String: Any] ?? [:]
+        #expect(block["type"] as? String == "command")
+        #expect(block["command"] as? String == "/tmp/statusline.sh")
+        #expect(block["refreshInterval"] as? Int == 5000)
+    }
+
+    @Test("hooks + statusLine contributions merge cleanly into the same file")
+    func hooksAndStatusLineMerge() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let settingsURL = claudeDir.appendingPathComponent("settings.json")
+
+        let existing: [String: Any] = [
+            "theme": "dark",
+            "statusLine": [
+                "type": "command",
+                "command": "/old/statusline",
+                // A field we don't recognize — must survive.
+                "padding": 1,
+            ],
+        ]
+        let original = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted])
+        try original.write(to: settingsURL)
+
+        let installer = ClaudeSettingsInstaller(homeDirectory: home)
+        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(
+            workspacesStatusLineContribution(forwarderPath: "/tmp/statusline.sh")
+        )
+        try await installer.install()
+
+        let updatedData = try Data(contentsOf: settingsURL)
+        let updated = try JSONSerialization.jsonObject(with: updatedData) as? [String: Any] ?? [:]
+
+        // Theme survives.
+        #expect(updated["theme"] as? String == "dark")
+
+        // Hook routes wired up for all spec-listed events.
+        let hooks = updated["hooks"] as? [String: Any] ?? [:]
+        let stop = hooks["Stop"] as? [[String: Any]] ?? []
+        #expect(stop.contains { ($0["type"] as? String) == "http" })
+
+        // statusLine block points at our forwarder; original `padding` field is
+        // preserved — the merge replaces our owned keys but never strips others.
+        let block = updated["statusLine"] as? [String: Any] ?? [:]
+        #expect(block["command"] as? String == "/tmp/statusline.sh")
+        #expect(block["refreshInterval"] as? Int == 5000)
+        #expect(block["type"] as? String == "command")
+        #expect(block["padding"] as? Int == 1)
+    }
+
+    @Test("statusLine re-install is idempotent")
+    func statusLineIdempotent() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let installer = ClaudeSettingsInstaller(homeDirectory: home)
+        await installer.register(
+            workspacesStatusLineContribution(forwarderPath: "/tmp/statusline.sh")
+        )
+        try await installer.install()
+        try await installer.install()
+
+        let installed = await installer.isInstalled()
+        #expect(installed == true)
+    }
+
+    @Test("statusLine renderPreview reflects pending changes")
+    func statusLinePreviewWording() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let installer = ClaudeSettingsInstaller(homeDirectory: home)
+        await installer.register(
+            workspacesStatusLineContribution(forwarderPath: "/tmp/statusline.sh")
+        )
+        let preview = try await installer.renderPreview()
+        #expect(preview.contains("workspaces.statusLine"))
+        #expect(preview.contains("/tmp/statusline.sh"))
+    }
 }

--- a/Tests/WorkspaceManagerTests/Perf/PerfChannel2Tests.swift
+++ b/Tests/WorkspaceManagerTests/Perf/PerfChannel2Tests.swift
@@ -1,0 +1,265 @@
+//
+//  PerfChannel2Tests.swift
+//  WorkspaceManagerTests
+//
+//  In-process perf scenario for the Channel 2 status-line route. Mirrors the
+//  Scenario A pattern from PerfChannel1Tests; differences are: the URL path
+//  is `/statusline`, the body is a status-line payload, and we measure the
+//  same two metrics (HTTP 200 latency, registry update latency).
+//
+
+import Combine
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite(
+    "PerfChannel2",
+    .serialized,
+    .enabled(if: ProcessInfo.processInfo.environment["WORKSPACES_PERF_RUN"] == "1")
+)
+struct PerfChannel2Tests {
+
+    private static func tempSocket() -> URL {
+        URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("wm-perf-c2-\(UUID().uuidString.prefix(8)).sock")
+    }
+
+    private static func resultPath(scenario: String) -> URL {
+        if let override = ProcessInfo.processInfo.environment["WORKSPACES_PERF_OUT"] {
+            return URL(fileURLWithPath: override)
+        }
+        let dir = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent("workspaces-perf-\(scenario)-\(Int(Date().timeIntervalSince1970))")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("result.json")
+    }
+
+    private static func writeResult(_ payload: [String: Any], to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONSerialization.data(
+            withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: url)
+    }
+
+    private static func percentile(_ samples: [Double], _ p: Double) -> Double {
+        guard !samples.isEmpty else { return 0 }
+        let sorted = samples.sorted()
+        let idx = Int((p / 100.0) * Double(sorted.count - 1))
+        return sorted[max(0, min(sorted.count - 1, idx))]
+    }
+
+    private static func summarize(_ samples: [Double]) -> [String: Double] {
+        [
+            "median_ms": percentile(samples, 50),
+            "p95_ms": percentile(samples, 95),
+            "p99_ms": percentile(samples, 99),
+            "max_ms": samples.max() ?? 0,
+            "mean_ms": samples.isEmpty ? 0 : samples.reduce(0, +) / Double(samples.count),
+        ]
+    }
+
+    @discardableResult
+    private static func rawPost(socket: String, path: String, body: Data) -> (Date, Date) {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        precondition(fd >= 0, "socket() failed")
+        defer { Darwin.close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(socket.utf8)
+        precondition(pathBytes.count < 104, "socket path too long")
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dst in
+                for (i, b) in pathBytes.enumerated() { dst[i] = CChar(bitPattern: b) }
+                dst[pathBytes.count] = 0
+            }
+        }
+        let connected = withUnsafePointer(to: &addr) { aptr -> Int32 in
+            aptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+                Darwin.connect(fd, sptr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        precondition(connected == 0, "connect() failed errno=\(errno)")
+
+        var head = "POST \(path) HTTP/1.1\r\n"
+        head += "Host: localhost\r\n"
+        head += "Content-Type: application/json\r\n"
+        head += "Content-Length: \(body.count)\r\n"
+        head += "Connection: close\r\n\r\n"
+        var out = Data(head.utf8)
+        out.append(body)
+
+        let sent = Date()
+        out.withUnsafeBytes { raw in
+            var remaining = out.count
+            var ptr = raw.bindMemory(to: UInt8.self).baseAddress!
+            while remaining > 0 {
+                let n = Darwin.send(fd, ptr, remaining, 0)
+                if n <= 0 { break }
+                remaining -= n
+                ptr = ptr.advanced(by: n)
+            }
+        }
+        var buf = [UInt8](repeating: 0, count: 1024)
+        while true {
+            let n = Darwin.recv(fd, &buf, buf.count, 0)
+            if n <= 0 { break }
+        }
+        return (sent, Date())
+    }
+
+    /// Scenario A clone for /statusline. 1000 status-line POSTs, parallelism=8.
+    /// Far above realistic 1 Hz × N sessions to expose any allocator regressions.
+    @Test("channel2_statusline_burst: 1000 statusline POSTs, parallelism=8")
+    func statusLineBurst() async throws {
+        let cwd = "/tmp/perf-c2-\(UUID().uuidString.prefix(6))"
+        try? FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: cwd) }
+
+        let registry = await AgentSessionRegistry()
+        let hostID = UUID()
+        await MainActor.run {
+            registry.register(hostSessionID: hostID, cwd: cwd, kind: .claudeCode)
+        }
+
+        let socket = Self.tempSocket()
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.perf-c2",
+            registry: registry,
+            socketURLOverride: socket,
+            logger: { _ in }
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let totalEvents = 1000
+        let parallelism = 8
+        let socketPath = socket.path
+
+        let updateTimestamps = LockedArrayC2<Date>()
+        let cancellable = await MainActor.run {
+            registry.$statuses
+                .dropFirst()
+                .sink { _ in updateTimestamps.append(Date()) }
+        }
+        defer { cancellable.cancel() }
+
+        // Bind via SessionStart so /statusline resolves cheaply via agentSessionID.
+        let bind: [String: Any] = [
+            "hook_event_name": "SessionStart",
+            "session_id": "burst-c2",
+            "cwd": cwd,
+        ]
+        _ = Self.rawPost(
+            socket: socketPath, path: "/event",
+            body: try JSONSerialization.data(withJSONObject: bind)
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+        updateTimestamps.reset()
+
+        // Build N varied status-line bodies — vary cost so each ingest mutates state.
+        let bodies: [Data] = (0..<totalEvents).map { i in
+            let body: [String: Any] = [
+                "session_id": "burst-c2",
+                "workspace": ["current_dir": cwd],
+                "model": ["display_name": "Claude Sonnet 4.5"],
+                "context_window": ["used_percentage": Double(i % 100)],
+                "cost": ["total_cost_usd": Double(i) * 0.001],
+                "rate_limits": [
+                    "five_hour": ["used_percentage": Double(i % 100)]
+                ],
+            ]
+            return try! JSONSerialization.data(withJSONObject: body)
+        }
+
+        let httpLatencies = LockedArrayC2<Double>()
+        let sendTimestamps = LockedArrayC2<Date>()
+
+        let started = Date()
+        await withTaskGroup(of: Void.self) { group in
+            let perWorker = totalEvents / parallelism
+            for w in 0..<parallelism {
+                let lo = w * perWorker
+                let hi = (w == parallelism - 1) ? totalEvents : lo + perWorker
+                group.addTask {
+                    for i in lo..<hi {
+                        let (sent, ack) = Self.rawPost(
+                            socket: socketPath, path: "/statusline", body: bodies[i]
+                        )
+                        sendTimestamps.append(sent)
+                        httpLatencies.append(ack.timeIntervalSince(sent) * 1000)
+                    }
+                }
+            }
+        }
+        let httpDoneAt = Date()
+
+        let deadline = Date().addingTimeInterval(5.0)
+        while updateTimestamps.count < totalEvents && Date() < deadline {
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        let updates = updateTimestamps.snapshot()
+        let sends = sendTimestamps.snapshot().sorted()
+
+        let pairCount = min(sends.count, updates.count)
+        let registryLatencies: [Double] = (0..<pairCount).map { i in
+            updates[i].timeIntervalSince(sends[i]) * 1000
+        }
+
+        let httpStats = Self.summarize(httpLatencies.snapshot())
+        let regStats = Self.summarize(registryLatencies)
+
+        let payload: [String: Any] = [
+            "scenario": "channel2_statusline_burst",
+            "events_sent": totalEvents,
+            "parallelism": parallelism,
+            "events_observed": updates.count,
+            "wall_clock_ms": httpDoneAt.timeIntervalSince(started) * 1000,
+            "metrics": [
+                "channel2_statusline_http_200_latency_ms": httpStats,
+                "channel2_statusline_registry_update_latency_ms": regStats,
+            ],
+        ]
+        try Self.writeResult(payload, to: Self.resultPath(scenario: "channel2_statusline_burst"))
+
+        #expect(updates.count >= Int(Double(totalEvents) * 0.95))
+    }
+}
+
+// Local copy of the lock-protected array helper from PerfChannel1Tests, kept
+// internal to avoid cross-file linkage just for a test utility.
+private final class LockedArrayC2<T: Sendable>: @unchecked Sendable {
+    private var items: [T] = []
+    private let lock = NSLock()
+
+    func append(_ item: T) {
+        lock.lock()
+        defer { lock.unlock() }
+        items.append(item)
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        items.removeAll()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return items.count
+    }
+
+    func snapshot() -> [T] {
+        lock.lock()
+        defer { lock.unlock() }
+        return items
+    }
+}

--- a/Tests/WorkspaceManagerTests/StatusLinePayloadTests.swift
+++ b/Tests/WorkspaceManagerTests/StatusLinePayloadTests.swift
@@ -1,0 +1,152 @@
+//
+//  StatusLinePayloadTests.swift
+//  WorkspaceManagerTests
+//
+//  Decoder behaviour for the Channel 2 wire format. The decoder must be tolerant
+//  — unknown keys and missing fields are silent; only a non-object body returns
+//  nil. This keeps the host robust to schema additions in Claude Code.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("StatusLinePayload")
+struct StatusLinePayloadTests {
+
+    @Test("Canonical payload decodes every documented field")
+    func canonicalDecode() throws {
+        let json = """
+            {
+              "version": "1.2.80",
+              "session_id": "abc-123",
+              "model": { "id": "claude-sonnet", "display_name": "Claude Sonnet 4.5" },
+              "workspace": {
+                "current_dir": "/Users/m/code/repo",
+                "project_dir": "/Users/m/code/repo",
+                "git_worktree": "/Users/m/code/repo"
+              },
+              "cost": {
+                "total_cost_usd": 0.42,
+                "total_lines_added": 12,
+                "total_lines_removed": 3
+              },
+              "context_window": {
+                "used_percentage": 37.5,
+                "context_window_size": 200000
+              },
+              "rate_limits": {
+                "five_hour": {
+                  "used_percentage": 14.2,
+                  "resets_at": "2026-05-07T18:00:00Z"
+                }
+              },
+              "output_style": { "name": "default" }
+            }
+            """
+        let payload = try #require(StatusLinePayload.decode(from: Data(json.utf8)))
+        #expect(payload.version == "1.2.80")
+        #expect(payload.agentSessionID == "abc-123")
+        #expect(payload.model?.id == "claude-sonnet")
+        #expect(payload.model?.displayName == "Claude Sonnet 4.5")
+        #expect(payload.workspace?.currentDir == "/Users/m/code/repo")
+        #expect(payload.workspace?.gitWorktree == "/Users/m/code/repo")
+        #expect(payload.cost?.totalCostUSD == 0.42)
+        #expect(payload.cost?.totalLinesAdded == 12)
+        #expect(payload.contextWindow?.usedPercentage == 37.5)
+        #expect(payload.contextWindow?.contextWindowSize == 200000)
+        #expect(payload.rateLimits?.fiveHour?.usedPercentage == 14.2)
+        #expect(payload.rateLimits?.fiveHour?.resetsAt != nil)
+        #expect(payload.outputStyle?.name == "default")
+
+        let fields = payload.toStatusFields()
+        #expect(fields.modelDisplayName == "Claude Sonnet 4.5")
+        #expect(fields.contextUsedPercent == 37.5)
+        #expect(fields.fiveHourLimitUsedPercent == 14.2)
+        #expect(fields.costUSD == 0.42)
+        #expect(fields.fiveHourLimitResetsAt != nil)
+
+        #expect(payload.resolvedCwd() == "/Users/m/code/repo")
+    }
+
+    @Test("Unknown fields are ignored, missing fields decode to nil")
+    func tolerantDecode() throws {
+        let json = """
+            {
+              "model": { "display_name": "Sonnet" },
+              "workspace": { "current_dir": "/tmp/x" },
+              "future_field": { "anything": [1, 2, 3] },
+              "extra_top_level": "ignored"
+            }
+            """
+        let payload = try #require(StatusLinePayload.decode(from: Data(json.utf8)))
+        #expect(payload.model?.displayName == "Sonnet")
+        #expect(payload.workspace?.currentDir == "/tmp/x")
+        #expect(payload.cost == nil)
+        #expect(payload.contextWindow == nil)
+        #expect(payload.rateLimits == nil)
+    }
+
+    @Test("Non-object JSON returns nil")
+    func rejectNonObject() {
+        #expect(StatusLinePayload.decode(from: Data("[1, 2, 3]".utf8)) == nil)
+        #expect(StatusLinePayload.decode(from: Data("\"a string\"".utf8)) == nil)
+        #expect(StatusLinePayload.decode(from: Data("not json".utf8)) == nil)
+    }
+
+    @Test("Type-mismatched scalars are coerced where possible, dropped where not")
+    func tolerantScalarCoercion() throws {
+        // Integer encoded as a JSON number — coerce to Double.
+        // Percentage encoded as a string — coerce.
+        // Cost encoded as a string-of-number — coerce.
+        let json = """
+            {
+              "context_window": { "used_percentage": "42" },
+              "cost": { "total_cost_usd": "0.123" },
+              "rate_limits": {
+                "five_hour": { "used_percentage": 88, "resets_at": 1746640800 }
+              }
+            }
+            """
+        let payload = try #require(StatusLinePayload.decode(from: Data(json.utf8)))
+        #expect(payload.contextWindow?.usedPercentage == 42.0)
+        #expect(payload.cost?.totalCostUSD == 0.123)
+        #expect(payload.rateLimits?.fiveHour?.usedPercentage == 88.0)
+        #expect(payload.rateLimits?.fiveHour?.resetsAt != nil)
+    }
+
+    @Test("Workspace.current_dir wins over top-level cwd for resolution")
+    func workspaceCurrentDirWins() throws {
+        let json = """
+            {
+              "cwd": "/old",
+              "workspace": { "current_dir": "/new" }
+            }
+            """
+        let payload = try #require(StatusLinePayload.decode(from: Data(json.utf8)))
+        #expect(payload.resolvedCwd() == "/new")
+    }
+
+    @Test("Empty payload decodes to all-nil with no crash")
+    func emptyObject() throws {
+        let payload = try #require(StatusLinePayload.decode(from: Data("{}".utf8)))
+        #expect(payload.cwd == nil)
+        #expect(payload.model == nil)
+        #expect(payload.toStatusFields() == AgentEvent.StatusFields())
+        #expect(payload.resolvedCwd() == nil)
+    }
+
+    @Test("Fractional-second ISO dates parse")
+    func fractionalSecondDate() throws {
+        let json = """
+            {
+              "rate_limits": {
+                "five_hour": { "resets_at": "2026-05-07T18:00:00.123Z" }
+              }
+            }
+            """
+        let payload = try #require(StatusLinePayload.decode(from: Data(json.utf8)))
+        #expect(payload.rateLimits?.fiveHour?.resetsAt != nil)
+    }
+}

--- a/config/performance/contract.json
+++ b/config/performance/contract.json
@@ -69,6 +69,11 @@
       "id": "channel4_replay_10k_records",
       "build_kind": "debug",
       "description": "Cold-start replay of a 10,000-record transcript JSONL through TranscriptColdStartRecovery + AgentSessionRegistry.ingestBatch with the production 500 ev/s rate cap; measures wall-clock completion and RSS delta. Gates the perf audit's hard constraints for Channel 4 (perf-audit-pr443-final.md)."
+    },
+    {
+      "id": "channel2_statusline_burst",
+      "build_kind": "debug",
+      "description": "In-process burst of 1000 status-line POSTs at parallelism=8 against AgentHookListener /statusline; measures end-to-end HTTP and registry-update latency."
     }
   ],
   "metrics": [
@@ -248,6 +253,34 @@
       ],
       "reference_baselines": {
         "channel1_hook_ingest_burst": {
+          "median_ms": 8,
+          "p95_ms": 40,
+          "p99_ms": 80
+        }
+      }
+    },
+    {
+      "name": "channel2_statusline_http_200_latency_ms",
+      "unit": "ms",
+      "supported_scenarios": [
+        "channel2_statusline_burst"
+      ],
+      "reference_baselines": {
+        "channel2_statusline_burst": {
+          "median_ms": 5,
+          "p95_ms": 25,
+          "p99_ms": 50
+        }
+      }
+    },
+    {
+      "name": "channel2_statusline_registry_update_latency_ms",
+      "unit": "ms",
+      "supported_scenarios": [
+        "channel2_statusline_burst"
+      ],
+      "reference_baselines": {
+        "channel2_statusline_burst": {
           "median_ms": 8,
           "p95_ms": 40,
           "p99_ms": 80

--- a/scripts/perf/channel2-statusline-burst/run.sh
+++ b/scripts/perf/channel2-statusline-burst/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Channel 2 — status-line ingest burst.
+#
+# Mirrors the pattern of channel1-ingest-burst/run.sh but exercises the
+# /statusline route. 8 sessions × 1 Hz status-line is well within the ingest
+# budget per the perf-audit-pr443-final.md carry-forward; this driver exists so
+# regressions get caught on the same Scenario A grid.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+ITER="${ITER:-5}"
+TS="$(date +%Y%m%dT%H%M%S)"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/output/perf/channel2/$TS/statusline-burst}"
+mkdir -p "$OUT_DIR"
+
+echo "[statusline-burst] iterations=$ITER out=$OUT_DIR"
+for i in $(seq 1 "$ITER"); do
+    echo "[statusline-burst] run $i"
+    OUT="$OUT_DIR/run-$i.json"
+    WORKSPACES_PERF_RUN=1 \
+    WORKSPACES_PERF_OUT="$OUT" \
+        swift test --filter statusLineBurst 2>&1 \
+        | tee "$OUT_DIR/run-$i.log" >/dev/null || true
+    if [[ ! -f "$OUT" ]]; then
+        echo "  -> no result.json produced; tail of log:"
+        tail -n 25 "$OUT_DIR/run-$i.log" || true
+    fi
+done
+
+# Roll-up: median over runs.
+python3 - "$OUT_DIR" "$ITER" <<'PY'
+import json
+import statistics
+import sys
+from pathlib import Path
+
+out_dir = Path(sys.argv[1])
+iters = int(sys.argv[2])
+runs = []
+for i in range(1, iters + 1):
+    f = out_dir / f"run-{i}.json"
+    if f.exists():
+        runs.append(json.loads(f.read_text()))
+
+if not runs:
+    print("no successful runs", file=sys.stderr)
+    sys.exit(1)
+
+agg = {"scenario": "channel2_statusline_burst", "runs": len(runs), "metrics": {}}
+metric_names = list(runs[0]["metrics"].keys())
+for m in metric_names:
+    agg["metrics"][m] = {}
+    sample = runs[0]["metrics"][m]
+    for stat in sample.keys():
+        vals = [r["metrics"][m][stat] for r in runs if stat in r["metrics"].get(m, {})]
+        if vals:
+            agg["metrics"][m][stat] = statistics.median(vals)
+
+(out_dir / "rollup.json").write_text(json.dumps(agg, indent=2, sort_keys=True))
+print(json.dumps(agg, indent=2, sort_keys=True))
+PY
+
+echo "[statusline-burst] rollup at $OUT_DIR/rollup.json"


### PR DESCRIPTION
## Summary

Channel 2 of the five-channel Claude Code integration. The status-line forwarder is the only path that surfaces rate-limit headroom and cost — hooks don't carry it.

- Ships `Resources/HookForwarders/statusline.sh`, a stdlib bash forwarder that POSTs the status-line JSON Claude Code feeds it on stdin to the host's `/statusline` Unix socket route, then prints a single space so the terminal status row stays empty.
- Implements the `/statusline` handler in `AgentHookListener`. Decodes a tolerant `StatusLinePayload`, resolves the host session via the locked `resolveHostSession(cwd:agentSessionID:)` contract, and calls `registry.updateStatusFields(_:for:)`.
- Adds a `workspacesStatusLineContribution` to `ClaudeSettingsInstaller` registered alongside the hooks contribution. The merge algorithm is the locked one from PR #1; this PR only adds an extension-point user.
- Surfaces a "Live Status" indicator section in Settings → Agents that shows model, cost, context %, 5h-limit headroom, and reset time for the focused session. Reads `AgentSessionRegistry.statuses` directly — no second `@Published`.

Spec: `pasted_text_2026-05-03_22-18-10.txt` § Channel 2.

## Mergeability

- Surface: desktop
- User-facing behavior changed: Settings → Agents now shows a live status indicator (model, cost, context %, rate-limit headroom) for the focused workspace's agent session; the status-line forwarder script gets installed alongside the hook routes when opt-in is active.
- Non-happy paths considered: status-line POST arrives before the cwd-matching host session is registered (registry no-ops cleanly); statusLine refresh tick fires on stale info (registry timestamps the entry; UI mutes beyond a threshold); status-line script invoked outside the app (no socket → curl fails silently per spec); rate-limit data missing (Claude Code <1.2.80 — other fields still populate).
- Release/ops preconditions: none.
- Residual risk or follow-up: 5s refresh interval may need tuning under busy real-user sessions; first real-user run will tell us if the load needs lowering.

## Validation

- `swift build`: clean.
- `swift test`: 601 tests passed in 4.66s. New: 7 `StatusLinePayloadTests`, 3 `AgentHookListenerTests` (statusline round-trips), 3 `ClaudeSettingsInstallerTests` (statusLine merge + idempotence), 1 `PerfChannel2Tests` (gated).
- `swift-format lint --strict --recursive Sources/ Tests/`: clean.
- End-to-end: `/statusline` round-trip via `curl --unix-socket` covered in `AgentHookListenerTests`. Real-app smoke deferred to PR #6 final integration per the plan.
- Installer fs round-trip (no real `~/.claude/` touched): `ClaudeSettingsInstallerTests.hooksAndStatusLineMerge` proves the two contributions co-exist with a pre-existing `statusLine` block whose unrelated keys (`padding`) survive the merge.

## Performance

Not perf-sensitive in production (8 sessions × 1 Hz status-line is well under the channel-1 budget). Carry-forward from `.context/claude-integration/perf-audit-pr443-final.md` honored: a `/statusline` driver mirrors the Scenario A pattern.

`ITER=3 ./scripts/perf/channel2-statusline-burst/run.sh` (1000 POSTs × parallelism=8 × 3 runs):

| Metric | Median | p95 | p99 | Budget (p99) | Headroom |
|---|---:|---:|---:|---:|---|
| `channel2_statusline_http_200_latency_ms` | 0.54 | 0.67 | 0.86 | 50 | ~58× |
| `channel2_statusline_registry_update_latency_ms` | 0.37 | 0.50 | 0.67 | 80 | ~120× |

Contract entries added at `config/performance/contract.json` (additive — new `channel2_statusline_burst` scenario + 2 metric entries).

## Evidence

- [Test summary](https://evidence.cloudcompute.com/workspaces/pr-452/20260507-144559-claude-channel2-test-summary.png) — `swift test` 601/601, swift-format lint clean, files shipped, perf vs budget.
- [Perf rollup](https://evidence.cloudcompute.com/workspaces/pr-452/20260507-144603-claude-channel2-perf-rollup.png) — channel2_statusline_burst rollup.json from 3 runs.
- [Merged settings example](https://evidence.cloudcompute.com/workspaces/pr-452/20260507-144605-claude-channel2-merged-settings.png) — what the produced `~/.claude/settings.json` looks like with both PR #1 hooks and PR #2 statusLine contributions registered.

## Files

| | |
|---|---|
| `Sources/WorkspaceManagerCore/Models/StatusLinePayload.swift` | new — tolerant decoder for the status-line wire format |
| `Sources/WorkspaceManagerCore/Services/AgentHookListener.swift` | `/statusline` handler |
| `Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift` | `workspacesStatusLineContribution` |
| `Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift` | register Channel 2 contribution + bundled forwarder discovery |
| `Sources/WorkspaceManager/App/WorkspaceManagerApp.swift` | inject registry into Settings env |
| `Sources/WorkspaceManager/Views/AgentsSettingsView.swift` | "Live Status" indicator |
| `Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh` | new — bundled forwarder |
| `Tests/WorkspaceManagerTests/StatusLinePayloadTests.swift` | new |
| `Tests/WorkspaceManagerTests/AgentHookListenerTests.swift` | +3 statusline tests |
| `Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift` | +3 statusLine merge tests |
| `Tests/WorkspaceManagerTests/Perf/PerfChannel2Tests.swift` | new |
| `scripts/perf/channel2-statusline-burst/run.sh` | new |
| `config/performance/contract.json` | additive — scenario + 2 metrics |
| `Package.swift` | resource: copy `HookForwarders/` |
