### PR TITLE
feat: claude code headless runner channel (PR #5)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/HeadlessClaudeRunner.swift
+++ b/Sources/WorkspaceManagerCore/Services/HeadlessClaudeRunner.swift
@@ -1,0 +1,391 @@
+//
+//  HeadlessClaudeRunner.swift
+//  WorkspaceManagerCore
+//
+//  Wraps `claude -p` (non-interactive). Channel 5 of the agent integration
+//  spec — see the plan's "Channel 5" section. Streams the CLI's stream-json
+//  output through `HeadlessClaudeStreamParser` and surfaces normalized
+//  `HeadlessClaudeEvent` values to callers (sidebar quick actions, post-setup
+//  warm-up). The registry side keeps headless runs in their own
+//  `hostSessionID` namespace — DO NOT share entries with interactive
+//  sessions.
+//
+//  Why `--bare`: the interactive harness loads user hooks, plugins, and
+//  skills. For deterministic warm-up + quick-action behavior we want a
+//  reproducible run without whatever the user has configured globally.
+//  `--bare` skips all of that. The flip side is the runner can't take
+//  advantage of the user's plugins — that is by design for v1; if a
+//  project wants plugin behavior it should pin one explicitly through
+//  the prompt + tool list.
+//
+
+import Foundation
+import os.log
+
+private let log = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "HeadlessClaudeRunner"
+)
+
+/// Spawns a process and forwards stdout/stderr lines plus exit status to a
+/// callback. The runner depends on the protocol so tests can stub the CLI
+/// without relying on a real `claude` binary on the machine.
+public protocol HeadlessProcessRunning: Sendable {
+    func run(
+        executable: String,
+        arguments: [String],
+        currentDirectory: URL?,
+        environment: [String: String]?,
+        onStdoutChunk: @escaping @Sendable (String) -> Void,
+        onStderrChunk: @escaping @Sendable (String) -> Void
+    ) async throws -> Int32
+}
+
+/// Default implementation backed by `Foundation.Process` with a streaming
+/// readabilityHandler on each pipe. ProcessRunner.run buffers everything and
+/// returns at termination — that doesn't fit a streaming NDJSON consumer, so
+/// we keep this as a sibling utility next to ProcessRunner rather than
+/// reshaping it. Same shape, different resolution mode.
+public struct StreamingProcessRunner: HeadlessProcessRunning {
+    public init() {}
+
+    public func run(
+        executable: String,
+        arguments: [String],
+        currentDirectory: URL?,
+        environment: [String: String]?,
+        onStdoutChunk: @escaping @Sendable (String) -> Void,
+        onStderrChunk: @escaping @Sendable (String) -> Void
+    ) async throws -> Int32 {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = arguments
+            process.currentDirectoryURL = currentDirectory
+            process.environment = environment
+
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty { return }
+                let chunk = String(data: data, encoding: .utf8) ?? ""
+                if !chunk.isEmpty { onStdoutChunk(chunk) }
+            }
+
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty { return }
+                let chunk = String(data: data, encoding: .utf8) ?? ""
+                if !chunk.isEmpty { onStderrChunk(chunk) }
+            }
+
+            process.terminationHandler = { proc in
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(returning: proc.terminationStatus)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
+/// Persistent map of `<workspace>` → claude session id, for `--resume` plumbing.
+/// Stored as JSON under `<workspace>/.workspaces/headless/sessions.json`.
+public struct HeadlessSessionStore: Sendable {
+    private let storeURL: URL
+
+    public init(workspaceRoot: URL) {
+        self.storeURL =
+            workspaceRoot
+            .appendingPathComponent(".workspaces", isDirectory: true)
+            .appendingPathComponent("headless", isDirectory: true)
+            .appendingPathComponent("sessions.json")
+    }
+
+    /// Latest known claude session id for the workspace, if any.
+    public func loadLatestSessionID() -> String? {
+        guard let data = try? Data(contentsOf: storeURL),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let latest = object["latest"] as? String,
+            !latest.isEmpty
+        else {
+            return nil
+        }
+        return latest
+    }
+
+    /// Save a new session id, keeping a small history (most-recent-first, capped
+    /// at 16 entries) so we have a debugging trail without unbounded growth.
+    public func recordSessionID(_ sessionID: String) throws {
+        let dir = storeURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        var history: [String] = []
+        if let data = try? Data(contentsOf: storeURL),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let prior = object["history"] as? [String]
+        {
+            history = prior
+        }
+
+        history.removeAll { $0 == sessionID }
+        history.insert(sessionID, at: 0)
+        if history.count > 16 { history = Array(history.prefix(16)) }
+
+        let payload: [String: Any] = [
+            "latest": sessionID,
+            "history": history,
+            "updatedAt": ISO8601DateFormatter().string(from: Date()),
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: storeURL, options: .atomic)
+    }
+}
+
+/// Errors surfaced by ``HeadlessClaudeRunner``. The runner pushes these out as
+/// terminal events on the `AsyncStream` rather than throwing, so the consuming
+/// pipeline doesn't have to wrap every iteration in try/catch.
+public enum HeadlessClaudeRunnerError: Error, Sendable, Equatable {
+    /// `claude` not found on `$PATH` (or wherever we resolved it).
+    case executableNotFound
+    /// Process spawned but exited non-zero before any stream-json output.
+    case earlyExit(code: Int32, stderr: String)
+    /// The runner finished without ever seeing a `result` event.
+    case noResult
+}
+
+/// Headless `claude -p` runner. One instance ↔ one workspace + lifecycle.
+/// Always spawned via `--bare` for deterministic behavior across users.
+public actor HeadlessClaudeRunner {
+    private let processRunner: HeadlessProcessRunning
+    private let executableResolver: @Sendable () -> String
+
+    public init(
+        processRunner: HeadlessProcessRunning = StreamingProcessRunner(),
+        executableResolver: @escaping @Sendable () -> String = HeadlessClaudeRunner.defaultExecutable
+    ) {
+        self.processRunner = processRunner
+        self.executableResolver = executableResolver
+    }
+
+    /// Resolve a `claude` executable in the order: env override → common
+    /// install paths → bare `claude` (let PATH resolve). The env override is
+    /// useful for tests and for letting users pin a specific install (e.g.
+    /// `mise`-managed) without relying on PATH.
+    public static let defaultExecutable: @Sendable () -> String = {
+        if let override = ProcessInfo.processInfo.environment["WORKSPACES_CLAUDE_BIN"],
+            !override.isEmpty
+        {
+            return override
+        }
+        for candidate in [
+            "/opt/homebrew/bin/claude",
+            "/usr/local/bin/claude",
+            "\(NSHomeDirectory())/.local/bin/claude",
+        ] where FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+        // Fall back to `/usr/bin/env claude` so PATH-based resolution still
+        // works when nothing else matches. The runner reports
+        // `executableNotFound` cleanly if env can't find it.
+        return "/usr/bin/env"
+    }
+
+    /// Spawn the runner. Returns an `AsyncStream` of events; the stream
+    /// finishes after a `.result(...)` (success) or after an error event is
+    /// emitted (failure). Cancelling the consumer terminates the underlying
+    /// process via task cancellation.
+    public func run(
+        prompt: String,
+        cwd: URL,
+        allowedTools: [String] = [],
+        resumeSessionID: String? = nil
+    ) -> AsyncStream<HeadlessClaudeEvent> {
+        let resolved = executableResolver()
+        let runner = processRunner
+
+        return AsyncStream { continuation in
+            let task = Task {
+                let arguments = Self.buildArguments(
+                    executable: resolved,
+                    prompt: prompt,
+                    allowedTools: allowedTools,
+                    resumeSessionID: resumeSessionID
+                )
+
+                // Box the parser so it can be mutated from the closures
+                // without violating Sendable. Lock around feed/flush — only
+                // one thread will call into either at a time in practice
+                // (readabilityHandler dispatches serially per pipe), but
+                // belt-and-suspenders.
+                let parserBox = ParserBox()
+                let stderrBox = StderrBox()
+
+                let stdoutHandler: @Sendable (String) -> Void = { chunk in
+                    let events = parserBox.feed(chunk)
+                    for event in events { continuation.yield(event) }
+                }
+                let stderrHandler: @Sendable (String) -> Void = { chunk in
+                    stderrBox.append(chunk)
+                }
+
+                do {
+                    let exitCode = try await runner.run(
+                        executable: resolved,
+                        arguments: arguments,
+                        currentDirectory: cwd,
+                        environment: Self.processEnvironment(),
+                        onStdoutChunk: stdoutHandler,
+                        onStderrChunk: stderrHandler
+                    )
+
+                    let trailing = parserBox.flush()
+                    for event in trailing { continuation.yield(event) }
+
+                    // Surface a synthetic event if the CLI failed with no
+                    // stream-json output — callers can decide whether to
+                    // treat as fatal.
+                    if exitCode != 0 && !parserBox.didEmitResult {
+                        let stderr = stderrBox.collected
+                        let payload: [String: Any] = [
+                            "type": "error",
+                            "exit_code": exitCode,
+                            "stderr": stderr,
+                        ]
+                        if let data = try? JSONSerialization.data(withJSONObject: payload),
+                            let raw = String(data: data, encoding: .utf8)
+                        {
+                            continuation.yield(.unknown(raw: raw))
+                        }
+                    }
+                } catch {
+                    log.error(
+                        "headless claude spawn failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                    let payload: [String: Any] = [
+                        "type": "spawn_error",
+                        "error": error.localizedDescription,
+                    ]
+                    if let data = try? JSONSerialization.data(withJSONObject: payload),
+                        let raw = String(data: data, encoding: .utf8)
+                    {
+                        continuation.yield(.unknown(raw: raw))
+                    }
+                }
+
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    /// Split out for tests so we can assert argument plumbing without spawning
+    /// a process.
+    public static func buildArguments(
+        executable: String,
+        prompt: String,
+        allowedTools: [String],
+        resumeSessionID: String?
+    ) -> [String] {
+        var args: [String] = []
+        // When we fall back to `/usr/bin/env`, we have to inject `claude` as
+        // the first arg so env actually executes the binary.
+        if executable == "/usr/bin/env" {
+            args.append("claude")
+        }
+        args.append(contentsOf: [
+            "--bare",
+            "-p", prompt,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+            "--permission-mode", "acceptEdits",
+        ])
+        if !allowedTools.isEmpty {
+            args.append("--allowedTools")
+            args.append(allowedTools.joined(separator: ","))
+        }
+        if let resumeSessionID, !resumeSessionID.isEmpty {
+            args.append("--resume")
+            args.append(resumeSessionID)
+        }
+        return args
+    }
+
+    private static func processEnvironment() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        // Make sure homebrew + uv shim paths are visible — same shape as
+        // WorkspaceService.runLifecycleScript. Without this, env-resolved
+        // `claude` may not be found inside the app's sandboxed PATH.
+        env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + (env["PATH"] ?? "")
+        return env
+    }
+}
+
+/// Reference-typed parser holder. Captures the stream-state across the two
+/// callbacks (stdout + termination) without breaking Sendable.
+private final class ParserBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var parser = HeadlessClaudeStreamParser()
+    private(set) var didEmitResult = false
+
+    func feed(_ chunk: String) -> [HeadlessClaudeEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        let events = parser.feed(chunk)
+        for event in events {
+            if case .result = event { didEmitResult = true }
+        }
+        return events
+    }
+
+    func flush() -> [HeadlessClaudeEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        let events = parser.flush()
+        for event in events {
+            if case .result = event { didEmitResult = true }
+        }
+        return events
+    }
+}
+
+/// Reference-typed stderr accumulator. Same Sendable workaround as
+/// ParserBox.
+private final class StderrBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = ""
+
+    func append(_ chunk: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        buffer.append(chunk)
+        // Cap to avoid unbounded memory if the CLI loops on errors.
+        if buffer.count > 32_768 {
+            buffer = String(buffer.suffix(32_768))
+        }
+    }
+
+    var collected: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return buffer
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/HeadlessClaudeStreamParser.swift
+++ b/Sources/WorkspaceManagerCore/Services/HeadlessClaudeStreamParser.swift
@@ -1,0 +1,240 @@
+//
+//  HeadlessClaudeStreamParser.swift
+//  WorkspaceManagerCore
+//
+//  Line-by-line NDJSON parser for `claude -p --output-format stream-json --verbose
+//  --include-partial-messages`. Mirrors the web-side parser at
+//  `web/src/lib/agent-runtime/vercel-sandbox.ts:parseStreamJsonLine` so the host and
+//  web agree on event semantics; this parser is richer because the host needs to
+//  drive `AgentSessionRegistry`, while the web side only needs streaming text.
+//
+//  Forward-compatibility: unknown event shapes round-trip as `.unknown(raw:)` so
+//  new claude releases never break the runner — the registry simply ignores them.
+//
+
+import Foundation
+
+/// Normalized event from a `claude -p` stream. Cases are additive — never rename
+/// or repurpose. Channels added later can attach optional fields via the
+/// `.unknown(raw:)` escape hatch without breaking existing consumers.
+public enum HeadlessClaudeEvent: Sendable, Equatable {
+    /// First event in every stream. `tools` is the list of tool names the model
+    /// was given access to (mirrors `--allowedTools` plus built-ins).
+    case systemInit(model: String?, sessionID: String?, tools: [String])
+    /// Streaming assistant text fragment (`text_delta`).
+    case textDelta(String)
+    /// Assistant initiated a tool call. `input` is opaque JSON encoded as a
+    /// string so we don't pull `AnyCodable` into the event surface.
+    case toolUse(name: String, inputJSON: String?)
+    /// Tool returned. `content` is the tool result body (string or stringified
+    /// JSON) — callers that care about structure can parse it.
+    case toolResult(content: String?)
+    /// API call retry surfaced by the CLI (rate limit / transient 5xx). The
+    /// runner forwards these so the UI can show a "retrying…" affordance.
+    case apiRetry(attempt: Int?, maxRetries: Int?, delayMS: Int?, errorCategory: String?)
+    /// Terminal event with the final response and aggregate stats. The
+    /// `sessionID` here is what we persist for `--resume`.
+    case result(text: String?, totalCostUSD: Double?, durationMS: Int?, numTurns: Int?, sessionID: String?)
+    /// Forward-compatibility escape hatch: any line we couldn't classify is
+    /// surfaced verbatim so the caller can log it without losing data.
+    case unknown(raw: String)
+}
+
+/// Stateful NDJSON parser. Feed bytes via ``feed(_:)`` as they arrive from
+/// stdout; pump events via ``drainEvents()``. The parser tolerates partial
+/// lines (no trailing `\n`) and resumes on the next chunk.
+public struct HeadlessClaudeStreamParser: Sendable {
+    private var buffer: String = ""
+
+    public init() {}
+
+    /// Append a chunk of stdout bytes. Returns the events parsed from any
+    /// newline-terminated lines completed by this chunk.
+    public mutating func feed(_ chunk: String) -> [HeadlessClaudeEvent] {
+        buffer.append(chunk)
+        return drainCompleteLines()
+    }
+
+    /// Flush any buffered content as a final line. Call after the process
+    /// exits to surface a trailing line that lacked a `\n`.
+    public mutating func flush() -> [HeadlessClaudeEvent] {
+        guard !buffer.isEmpty else { return [] }
+        let trailing = buffer
+        buffer.removeAll(keepingCapacity: false)
+        if let event = Self.parseLine(trailing) {
+            return [event]
+        }
+        return []
+    }
+
+    private mutating func drainCompleteLines() -> [HeadlessClaudeEvent] {
+        var events: [HeadlessClaudeEvent] = []
+        while let newlineIndex = buffer.firstIndex(of: "\n") {
+            let line = String(buffer[..<newlineIndex])
+            buffer.removeSubrange(...newlineIndex)
+            if let event = Self.parseLine(line) {
+                events.append(event)
+            }
+        }
+        return events
+    }
+
+    /// Pure helper. Returns `nil` for blank lines so callers don't need to
+    /// filter; everything else round-trips through `.unknown(raw:)` if it
+    /// can't be classified.
+    public static func parseLine(_ rawLine: String) -> HeadlessClaudeEvent? {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+
+        guard let data = trimmed.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return .unknown(raw: trimmed)
+        }
+
+        let type = (object["type"] as? String) ?? ""
+
+        switch type {
+        case "system":
+            // Per claude-code stream-json: { type: "system", subtype: "init",
+            // model, session_id, tools: [...] }
+            let subtype = (object["subtype"] as? String) ?? ""
+            if subtype == "init" || subtype.isEmpty {
+                let model = object["model"] as? String
+                let sessionID =
+                    (object["session_id"] as? String) ?? (object["sessionId"] as? String)
+                let tools = (object["tools"] as? [String]) ?? []
+                return .systemInit(model: model, sessionID: sessionID, tools: tools)
+            }
+            return .unknown(raw: trimmed)
+
+        case "stream_event":
+            return parseStreamEvent(object, raw: trimmed)
+
+        case "assistant":
+            // Some stream-json modes emit consolidated assistant messages
+            // rather than deltas. Surface text content if present.
+            return parseAssistantBlock(object, raw: trimmed)
+
+        case "user":
+            // Tool results are wrapped in user messages with a tool_result block.
+            return parseUserBlock(object, raw: trimmed)
+
+        case "result":
+            let text = (object["result"] as? String) ?? (object["text"] as? String)
+            let cost = object["total_cost_usd"] as? Double ?? object["totalCostUsd"] as? Double
+            let duration =
+                (object["duration_ms"] as? Int) ?? (object["durationMs"] as? Int)
+            let numTurns =
+                (object["num_turns"] as? Int) ?? (object["numTurns"] as? Int)
+            let sessionID =
+                (object["session_id"] as? String) ?? (object["sessionId"] as? String)
+            return .result(
+                text: text,
+                totalCostUSD: cost,
+                durationMS: duration,
+                numTurns: numTurns,
+                sessionID: sessionID
+            )
+
+        default:
+            // Some lines are wrappers — try the inner heuristics anyway.
+            if let stream = parseStreamEvent(object, raw: trimmed) { return stream }
+            return .unknown(raw: trimmed)
+        }
+    }
+
+    private static func parseStreamEvent(_ object: [String: Any], raw: String) -> HeadlessClaudeEvent? {
+        // The stream_event envelope wraps an Anthropic API event in `event`.
+        // The web parser keys off `event.delta.type == "text_delta"` and
+        // `event.type == "content_block_start"` for tool starts; we mirror it
+        // here and add api_error_retry for retry surfacing.
+        guard let inner = object["event"] as? [String: Any] else { return nil }
+
+        if let delta = inner["delta"] as? [String: Any],
+            (delta["type"] as? String) == "text_delta",
+            let text = delta["text"] as? String
+        {
+            return .textDelta(text)
+        }
+
+        if (inner["type"] as? String) == "content_block_start",
+            let block = inner["content_block"] as? [String: Any],
+            (block["type"] as? String) == "tool_use",
+            let name = block["name"] as? String
+        {
+            let inputJSON = serialize(block["input"])
+            return .toolUse(name: name, inputJSON: inputJSON)
+        }
+
+        // API retry events surface as `api_error_retry` in some stream-json
+        // versions; the canonical Anthropic message is `error` with
+        // `request_retry`. Both shapes funnel here.
+        if let retryType = inner["type"] as? String,
+            retryType.contains("retry") || retryType.contains("error")
+        {
+            let attempt = (inner["attempt"] as? Int) ?? (inner["retry_count"] as? Int)
+            let maxRetries = (inner["max_retries"] as? Int) ?? (inner["maxRetries"] as? Int)
+            let delayMS = (inner["delay_ms"] as? Int) ?? (inner["delayMs"] as? Int)
+            let category = (inner["error_category"] as? String) ?? (inner["errorCategory"] as? String)
+            return .apiRetry(
+                attempt: attempt,
+                maxRetries: maxRetries,
+                delayMS: delayMS,
+                errorCategory: category
+            )
+        }
+
+        return nil
+    }
+
+    private static func parseAssistantBlock(_ object: [String: Any], raw: String) -> HeadlessClaudeEvent? {
+        // Look for { message: { content: [{ type: "text", text: "..." }] } }
+        // or { message: { content: [{ type: "tool_use", name, input }] } }.
+        guard let message = object["message"] as? [String: Any],
+            let content = message["content"] as? [[String: Any]],
+            let first = content.first
+        else {
+            return .unknown(raw: raw)
+        }
+        if (first["type"] as? String) == "text", let text = first["text"] as? String {
+            return .textDelta(text)
+        }
+        if (first["type"] as? String) == "tool_use", let name = first["name"] as? String {
+            return .toolUse(name: name, inputJSON: serialize(first["input"]))
+        }
+        return .unknown(raw: raw)
+    }
+
+    private static func parseUserBlock(_ object: [String: Any], raw: String) -> HeadlessClaudeEvent? {
+        guard let message = object["message"] as? [String: Any],
+            let content = message["content"] as? [[String: Any]],
+            let first = content.first,
+            (first["type"] as? String) == "tool_result"
+        else {
+            return .unknown(raw: raw)
+        }
+        // tool_result.content is either a string or an array of blocks.
+        if let contentString = first["content"] as? String {
+            return .toolResult(content: contentString)
+        }
+        if let blocks = first["content"] as? [[String: Any]] {
+            // Concatenate any text blocks; otherwise serialize.
+            let joined = blocks.compactMap { $0["text"] as? String }.joined(separator: "\n")
+            return .toolResult(content: joined.isEmpty ? serialize(blocks) : joined)
+        }
+        return .toolResult(content: serialize(first["content"]))
+    }
+
+    private static func serialize(_ value: Any?) -> String? {
+        guard let value, !(value is NSNull) else { return nil }
+        if let s = value as? String { return s }
+        if JSONSerialization.isValidJSONObject(value),
+            let data = try? JSONSerialization.data(withJSONObject: value),
+            let s = String(data: data, encoding: .utf8)
+        {
+            return s
+        }
+        return String(describing: value)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceClaudeActions.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceClaudeActions.swift
@@ -1,0 +1,96 @@
+//
+//  WorkspaceClaudeActions.swift
+//  WorkspaceManagerCore
+//
+//  Project-defined "quick actions" — one-shot `claude -p` runs invoked from
+//  the sidebar context menu. Channel 5 of the agent integration spec.
+//
+//  Important: every quick action gets a fresh synthetic `hostSessionID`. We
+//  do NOT share registry entries with the workspace's interactive Claude
+//  session. The user's expectation is "this is a side errand"; mixing the
+//  two would conflate the interactive session's run state with the action's.
+//
+
+import Foundation
+import os.log
+
+private let log = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceClaudeActions"
+)
+
+/// Schema for `.workspaces/claude-actions.json`. Loaded lazily when the user
+/// opens the workspace context menu, so changes are picked up without
+/// restarting the app.
+public struct ClaudeActionsConfig: Codable, Sendable, Equatable {
+    public let actions: [ClaudeAction]
+    public init(actions: [ClaudeAction]) { self.actions = actions }
+}
+
+public struct ClaudeAction: Codable, Sendable, Equatable, Identifiable {
+    /// Stable identifier for the action; used as the `Identifiable` key. Falls
+    /// back to a slug derived from `name` when not supplied.
+    public var id: String { explicitID ?? slug(name) }
+    public let name: String
+    public let prompt: String
+    public let allowedTools: [String]?
+    public let resume: Bool?
+
+    private let explicitID: String?
+
+    public init(
+        id: String? = nil,
+        name: String,
+        prompt: String,
+        allowedTools: [String]? = nil,
+        resume: Bool? = nil
+    ) {
+        self.explicitID = id
+        self.name = name
+        self.prompt = prompt
+        self.allowedTools = allowedTools
+        self.resume = resume
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case explicitID = "id"
+        case name
+        case prompt
+        case allowedTools
+        case resume
+    }
+}
+
+private func slug(_ name: String) -> String {
+    let lowered = name.lowercased()
+    let allowed = lowered.unicodeScalars.map { scalar -> Character in
+        if CharacterSet.alphanumerics.contains(scalar) { return Character(scalar) }
+        return "-"
+    }
+    return String(allowed)
+}
+
+public enum WorkspaceClaudeActions {
+    /// Load the action list for a given workspace. Returns `[]` when no
+    /// `.workspaces/claude-actions.json` exists or the file is malformed
+    /// (we log + skip).
+    public static func loadActions(for workspaceDir: URL) -> [ClaudeAction] {
+        let url =
+            workspaceDir
+            .appendingPathComponent(".workspaces", isDirectory: true)
+            .appendingPathComponent("claude-actions.json")
+        guard FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url)
+        else {
+            return []
+        }
+        do {
+            return try JSONDecoder().decode(ClaudeActionsConfig.self, from: data).actions
+        } catch {
+            log.warning(
+                "ignoring malformed claude-actions.json at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return []
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceClaudeSetup.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceClaudeSetup.swift
@@ -1,0 +1,123 @@
+//
+//  WorkspaceClaudeSetup.swift
+//  WorkspaceManagerCore
+//
+//  Post-`setup.sh` warm-up using `HeadlessClaudeRunner`. Channel 5
+//  integration point: when a workspace ships a `.workspaces/claude-setup.json`
+//  (or the app's `Resources/Defaults/claude-setup.json` falls in), we run
+//  one non-interactive `claude -p` pass to seed the workspace (e.g. install
+//  pre-commit hooks, drop a project README into the cwd, run a lint sweep).
+//
+//  Failure here NEVER fails workspace creation — we log + carry on. The
+//  user expects a working workspace; the warm-up is bonus.
+//
+
+import Foundation
+import os.log
+
+private let log = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceClaudeSetup"
+)
+
+/// Schema for both `Resources/Defaults/claude-setup.json` (app-shipped fallback)
+/// and per-project `.workspaces/claude-setup.json`. The per-project file always
+/// wins when present.
+public struct ClaudeSetupConfig: Codable, Sendable, Equatable {
+    public let prompt: String
+    public let allowedTools: [String]?
+    public let resume: Bool?
+
+    public init(prompt: String, allowedTools: [String]? = nil, resume: Bool? = nil) {
+        self.prompt = prompt
+        self.allowedTools = allowedTools
+        self.resume = resume
+    }
+}
+
+public enum WorkspaceClaudeSetup {
+    /// Look up a `claude-setup.json` for a given workspace. Per-project
+    /// (`.workspaces/claude-setup.json`) takes precedence; app default (under
+    /// `Resources/Defaults/claude-setup.json` in the running bundle) is the
+    /// fallback. Returns `nil` if neither is present or if the file is
+    /// malformed (we log + skip rather than fail the workspace creation).
+    public static func loadConfig(
+        for workspaceDir: URL,
+        appDefaultsLookup: () -> URL? = appDefaultsLookup
+    ) -> ClaudeSetupConfig? {
+        let projectURL =
+            workspaceDir
+            .appendingPathComponent(".workspaces", isDirectory: true)
+            .appendingPathComponent("claude-setup.json")
+        if let config = decode(at: projectURL) {
+            return config
+        }
+        if let bundleURL = appDefaultsLookup(), let config = decode(at: bundleURL) {
+            return config
+        }
+        return nil
+    }
+
+    /// Default app-bundle lookup. Splittable for tests.
+    public static let appDefaultsLookup: () -> URL? = {
+        Bundle.main.url(forResource: "claude-setup", withExtension: "json")
+    }
+
+    /// Run the warm-up. Streams events into `eventSink`. Catches all errors
+    /// and logs them — never throws. Returns the captured `session_id` for
+    /// resume, when present.
+    @discardableResult
+    public static func runWarmup(
+        config: ClaudeSetupConfig,
+        in workspaceDir: URL,
+        runner: HeadlessClaudeRunner,
+        sessionStore: HeadlessSessionStore? = nil,
+        eventSink: @Sendable (HeadlessClaudeEvent) -> Void = { _ in }
+    ) async -> String? {
+        let store = sessionStore ?? HeadlessSessionStore(workspaceRoot: workspaceDir)
+        let resume = (config.resume ?? false) ? store.loadLatestSessionID() : nil
+        let stream = await runner.run(
+            prompt: config.prompt,
+            cwd: workspaceDir,
+            allowedTools: config.allowedTools ?? [],
+            resumeSessionID: resume
+        )
+
+        var capturedSessionID: String?
+        for await event in stream {
+            eventSink(event)
+            if case .result(_, _, _, _, let sessionID) = event,
+                let sessionID, !sessionID.isEmpty
+            {
+                capturedSessionID = sessionID
+            }
+        }
+
+        if let capturedSessionID {
+            do {
+                try store.recordSessionID(capturedSessionID)
+            } catch {
+                log.warning(
+                    "failed to persist headless claude session id: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+        return capturedSessionID
+    }
+
+    private static func decode(at url: URL) -> ClaudeSetupConfig? {
+        guard FileManager.default.fileExists(atPath: url.path),
+            let data = try? Data(contentsOf: url)
+        else {
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode(ClaudeSetupConfig.self, from: data)
+        } catch {
+            log.warning(
+                "ignoring malformed claude-setup.json at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -14,6 +14,7 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
     public static let shared = WorkspaceService()
 
     private let gitService: any GitServiceProtocol
+    private let claudeRunnerFactory: (@Sendable () -> HeadlessClaudeRunner)?
 
     // MARK: - Workspace Root Configuration
 
@@ -41,6 +42,7 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
 
     public init(gitService: any GitServiceProtocol = GitService.shared) {
         self.gitService = gitService
+        self.claudeRunnerFactory = { HeadlessClaudeRunner() }
         do {
             try FileManager.default.createDirectory(
                 at: Self.defaultWorkspacesRoot,
@@ -51,6 +53,17 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
                 "Failed to create default workspaces root at \(Self.defaultWorkspacesRoot.path): \(error.localizedDescription)"
             )
         }
+    }
+
+    /// Test-only initializer. Lets tests inject a stub
+    /// `HeadlessClaudeRunner` (or skip the warm-up entirely with `nil`).
+    /// Production code uses the zero-arg `init`.
+    public init(
+        gitService: any GitServiceProtocol,
+        claudeRunnerFactory: (@Sendable () -> HeadlessClaudeRunner)?
+    ) {
+        self.gitService = gitService
+        self.claudeRunnerFactory = claudeRunnerFactory
     }
 
     // MARK: - Create Workspace
@@ -112,6 +125,12 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
             log.warning("\(msg)")
             warnings.append(msg)
         }
+
+        // Channel 5: optional headless `claude -p` warm-up. Driven by
+        // `.workspaces/claude-setup.json` (per-project) or
+        // `Resources/Defaults/claude-setup.json` (app default). Failures here
+        // never fail workspace creation — we log + continue.
+        await runClaudeWarmupIfConfigured(in: workspaceDir)
 
         await progress?(.finished)
 
@@ -180,6 +199,31 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
             self.stdout = stdout
             self.stderr = stderr
         }
+    }
+
+    // MARK: - Claude Warm-up (Channel 5)
+
+    /// Runs the optional Channel-5 `claude -p` warm-up if a config is found
+    /// for the workspace. Internal — exposed indirectly through
+    /// `createWorkspace`. Never throws: the warm-up is best-effort.
+    func runClaudeWarmupIfConfigured(in workspaceDir: URL) async {
+        guard let factory = claudeRunnerFactory else { return }
+        guard let config = WorkspaceClaudeSetup.loadConfig(for: workspaceDir) else { return }
+
+        let runner = factory()
+        log.info(
+            "running headless claude warm-up in \(workspaceDir.path, privacy: .public)"
+        )
+        _ = await WorkspaceClaudeSetup.runWarmup(
+            config: config,
+            in: workspaceDir,
+            runner: runner,
+            eventSink: { event in
+                if case .textDelta = event { return }  // log noise
+                if case .unknown = event { return }
+                log.info("headless event: \(String(describing: event), privacy: .public)")
+            }
+        )
     }
 
     public func runLifecycleScript(_ scriptName: String, in directory: URL) async throws -> ScriptResult {

--- a/Tests/WorkspaceManagerTests/HeadlessClaudeRunnerTests.swift
+++ b/Tests/WorkspaceManagerTests/HeadlessClaudeRunnerTests.swift
@@ -1,0 +1,220 @@
+//
+//  HeadlessClaudeRunnerTests.swift
+//  WorkspaceManagerTests
+//
+//  Drives `HeadlessClaudeRunner` with a stub `HeadlessProcessRunning` that
+//  emits a recorded NDJSON stream. Asserts session_id capture, --resume
+//  argument plumbing, and graceful error pass-through.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("HeadlessClaudeRunner")
+struct HeadlessClaudeRunnerTests {
+
+    @Test("buildArguments emits the canonical --bare invocation")
+    func buildArgumentsCanonical() {
+        let args = HeadlessClaudeRunner.buildArguments(
+            executable: "/opt/homebrew/bin/claude",
+            prompt: "lint sweep",
+            allowedTools: ["Read", "Bash"],
+            resumeSessionID: nil
+        )
+        #expect(args.contains("--bare"))
+        #expect(args.contains("-p"))
+        #expect(args.contains("lint sweep"))
+        #expect(args.contains("--output-format"))
+        #expect(args.contains("stream-json"))
+        #expect(args.contains("--verbose"))
+        #expect(args.contains("--include-partial-messages"))
+        #expect(args.contains("--permission-mode"))
+        #expect(args.contains("acceptEdits"))
+        #expect(args.contains("--allowedTools"))
+        #expect(args.contains("Read,Bash"))
+        #expect(!args.contains("--resume"))
+    }
+
+    @Test("buildArguments adds --resume <id> when supplied")
+    func buildArgumentsWithResume() {
+        let args = HeadlessClaudeRunner.buildArguments(
+            executable: "/opt/homebrew/bin/claude",
+            prompt: "p",
+            allowedTools: [],
+            resumeSessionID: "sess-42"
+        )
+        let idx = args.firstIndex(of: "--resume")
+        #expect(idx != nil)
+        if let idx, idx + 1 < args.count {
+            #expect(args[idx + 1] == "sess-42")
+        }
+    }
+
+    @Test("buildArguments prepends `claude` when falling back to /usr/bin/env")
+    func buildArgumentsEnvFallback() {
+        let args = HeadlessClaudeRunner.buildArguments(
+            executable: "/usr/bin/env",
+            prompt: "p",
+            allowedTools: [],
+            resumeSessionID: nil
+        )
+        #expect(args.first == "claude")
+    }
+
+    @Test("runner streams parsed events from the stub stdout")
+    func streamsParsedEvents() async {
+        let stub = StubStreamingRunner(
+            stdoutChunks: [
+                #"{"type":"system","subtype":"init","model":"m","session_id":"s","tools":[]}"# + "\n",
+                #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}}"#
+                    + "\n",
+                #"{"type":"result","result":"ok","total_cost_usd":0.1,"duration_ms":10,"num_turns":1,"session_id":"s"}"#
+                    + "\n",
+            ],
+            stderrChunks: [],
+            exitCode: 0
+        )
+        let runner = HeadlessClaudeRunner(
+            processRunner: stub,
+            executableResolver: { "/opt/homebrew/bin/claude" }
+        )
+        var collected: [HeadlessClaudeEvent] = []
+        let stream = await runner.run(prompt: "hi", cwd: URL(fileURLWithPath: "/tmp"))
+        for await event in stream {
+            collected.append(event)
+        }
+        #expect(collected.count == 3)
+        if case .systemInit = collected[0] {} else { Issue.record("expected systemInit") }
+        #expect(collected[1] == .textDelta("hi"))
+        if case .result(_, _, _, _, let sid) = collected[2] {
+            #expect(sid == "s")
+        } else {
+            Issue.record("expected result")
+        }
+    }
+
+    @Test("runner forwards --resume to the spawned process")
+    func resumeArgumentForwarded() async {
+        let stub = StubStreamingRunner(
+            stdoutChunks: [
+                #"{"type":"result","result":"ok","session_id":"s"}"# + "\n"
+            ],
+            stderrChunks: [],
+            exitCode: 0
+        )
+        let runner = HeadlessClaudeRunner(
+            processRunner: stub,
+            executableResolver: { "/opt/homebrew/bin/claude" }
+        )
+        let stream = await runner.run(
+            prompt: "p",
+            cwd: URL(fileURLWithPath: "/tmp"),
+            resumeSessionID: "prev-session"
+        )
+        for await _ in stream {}
+        let captured = stub.captured.value
+        #expect(captured?.arguments.contains("--resume") == true)
+        #expect(captured?.arguments.contains("prev-session") == true)
+    }
+
+    @Test("non-zero exit with no result event surfaces a synthetic .unknown error event")
+    func errorPassthrough() async {
+        let stub = StubStreamingRunner(
+            stdoutChunks: [],
+            stderrChunks: ["claude: not authenticated\n"],
+            exitCode: 1
+        )
+        let runner = HeadlessClaudeRunner(
+            processRunner: stub,
+            executableResolver: { "/opt/homebrew/bin/claude" }
+        )
+        var collected: [HeadlessClaudeEvent] = []
+        let stream = await runner.run(prompt: "p", cwd: URL(fileURLWithPath: "/tmp"))
+        for await event in stream {
+            collected.append(event)
+        }
+        #expect(collected.count == 1)
+        guard case .unknown(let raw) = collected[0] else {
+            Issue.record("expected unknown error event")
+            return
+        }
+        #expect(raw.contains("error"))
+        #expect(raw.contains("not authenticated"))
+    }
+
+    @Test("HeadlessSessionStore round-trips the latest session id")
+    func sessionStoreRoundTrip() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("headless-session-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let store = HeadlessSessionStore(workspaceRoot: tmp)
+        #expect(store.loadLatestSessionID() == nil)
+        try store.recordSessionID("first")
+        #expect(store.loadLatestSessionID() == "first")
+        try store.recordSessionID("second")
+        #expect(store.loadLatestSessionID() == "second")
+    }
+}
+
+// MARK: - Stub
+
+/// In-memory `HeadlessProcessRunning` that replays a fixed stdout/stderr
+/// transcript and records what the runner asked it to spawn.
+final class StubStreamingRunner: HeadlessProcessRunning, @unchecked Sendable {
+    struct Capture {
+        let executable: String
+        let arguments: [String]
+        let cwd: URL?
+    }
+
+    final class Box<Value>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: Value
+        init(_ value: Value) { stored = value }
+        var value: Value {
+            get {
+                lock.lock()
+                defer { lock.unlock() }
+                return stored
+            }
+            set {
+                lock.lock()
+                defer { lock.unlock() }
+                stored = newValue
+            }
+        }
+    }
+
+    let stdoutChunks: [String]
+    let stderrChunks: [String]
+    let exitCode: Int32
+    let captured = Box<Capture?>(nil)
+
+    init(stdoutChunks: [String], stderrChunks: [String], exitCode: Int32) {
+        self.stdoutChunks = stdoutChunks
+        self.stderrChunks = stderrChunks
+        self.exitCode = exitCode
+    }
+
+    func run(
+        executable: String,
+        arguments: [String],
+        currentDirectory: URL?,
+        environment: [String: String]?,
+        onStdoutChunk: @escaping @Sendable (String) -> Void,
+        onStderrChunk: @escaping @Sendable (String) -> Void
+    ) async throws -> Int32 {
+        captured.value = Capture(
+            executable: executable,
+            arguments: arguments,
+            cwd: currentDirectory
+        )
+        for chunk in stdoutChunks { onStdoutChunk(chunk) }
+        for chunk in stderrChunks { onStderrChunk(chunk) }
+        return exitCode
+    }
+}

--- a/Tests/WorkspaceManagerTests/HeadlessClaudeStreamParserTests.swift
+++ b/Tests/WorkspaceManagerTests/HeadlessClaudeStreamParserTests.swift
@@ -1,0 +1,160 @@
+//
+//  HeadlessClaudeStreamParserTests.swift
+//  WorkspaceManagerTests
+//
+//  Pure parser tests for the `claude -p --output-format stream-json` NDJSON
+//  shape. Fixtures are synthesized to the canonical schema from
+//  https://code.claude.com/docs/en/cli — we don't include real captures
+//  because that would require running `claude -p` with credentials.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("HeadlessClaudeStreamParser")
+struct HeadlessClaudeStreamParserTests {
+
+    @Test("system init line surfaces model + session_id + tools")
+    func parsesSystemInit() {
+        let line =
+            #"{"type":"system","subtype":"init","model":"claude-3-5-sonnet","session_id":"sess-1","tools":["Read","Bash"]}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        guard case .systemInit(let model, let sessionID, let tools) = event else {
+            Issue.record("expected systemInit, got \(String(describing: event))")
+            return
+        }
+        #expect(model == "claude-3-5-sonnet")
+        #expect(sessionID == "sess-1")
+        #expect(tools == ["Read", "Bash"])
+    }
+
+    @Test("text_delta inside stream_event yields .textDelta")
+    func parsesTextDelta() {
+        let line =
+            #"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        #expect(event == .textDelta("Hello"))
+    }
+
+    @Test("content_block_start with tool_use yields .toolUse")
+    func parsesToolUse() {
+        let line =
+            #"{"type":"stream_event","event":{"type":"content_block_start","content_block":{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/a"}}}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        guard case .toolUse(let name, let inputJSON) = event else {
+            Issue.record("expected toolUse, got \(String(describing: event))")
+            return
+        }
+        #expect(name == "Read")
+        // JSONSerialization escapes forward slashes as \/, so check for the
+        // path piece after the leading slash to keep the test robust.
+        #expect(inputJSON?.contains("file_path") == true)
+        #expect(inputJSON?.contains("tmp") == true)
+    }
+
+    @Test("user message with tool_result yields .toolResult")
+    func parsesToolResultString() {
+        let line = #"{"type":"user","message":{"content":[{"type":"tool_result","content":"file contents"}]}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        #expect(event == .toolResult(content: "file contents"))
+    }
+
+    @Test("user message with structured tool_result blocks concatenates text")
+    func parsesToolResultBlocks() {
+        let line =
+            #"{"type":"user","message":{"content":[{"type":"tool_result","content":[{"type":"text","text":"line one"},{"type":"text","text":"line two"}]}]}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        #expect(event == .toolResult(content: "line one\nline two"))
+    }
+
+    @Test("assistant message text block surfaces as a textDelta for compatibility")
+    func parsesAssistantText() {
+        let line = #"{"type":"assistant","message":{"content":[{"type":"text","text":"Final answer"}]}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        #expect(event == .textDelta("Final answer"))
+    }
+
+    @Test("api retry envelope decodes attempt + delay")
+    func parsesApiRetry() {
+        let line =
+            #"{"type":"stream_event","event":{"type":"api_error_retry","attempt":2,"max_retries":5,"delay_ms":1500,"error_category":"rate_limit"}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        guard case .apiRetry(let attempt, let max, let delay, let category) = event else {
+            Issue.record("expected apiRetry, got \(String(describing: event))")
+            return
+        }
+        #expect(attempt == 2)
+        #expect(max == 5)
+        #expect(delay == 1500)
+        #expect(category == "rate_limit")
+    }
+
+    @Test("result line decodes cost + duration + session_id")
+    func parsesResult() {
+        let line =
+            #"{"type":"result","result":"all done","total_cost_usd":0.0123,"duration_ms":4242,"num_turns":3,"session_id":"sess-9"}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        guard case .result(let text, let cost, let duration, let turns, let sid) = event else {
+            Issue.record("expected result, got \(String(describing: event))")
+            return
+        }
+        #expect(text == "all done")
+        #expect(cost == 0.0123)
+        #expect(duration == 4242)
+        #expect(turns == 3)
+        #expect(sid == "sess-9")
+    }
+
+    @Test("unrecognized JSON shape surfaces as .unknown carrying the raw line")
+    func unknownPassthrough() {
+        let line = #"{"type":"future_event_we_have_not_seen","payload":{"x":1}}"#
+        let event = HeadlessClaudeStreamParser.parseLine(line)
+        guard case .unknown(let raw) = event else {
+            Issue.record("expected unknown, got \(String(describing: event))")
+            return
+        }
+        #expect(raw.contains("future_event_we_have_not_seen"))
+    }
+
+    @Test("non-JSON line surfaces as .unknown so we never lose data")
+    func nonJSONPassthrough() {
+        let event = HeadlessClaudeStreamParser.parseLine("oops not json")
+        #expect(event == .unknown(raw: "oops not json"))
+    }
+
+    @Test("blank lines parse to nil so they don't pollute the event stream")
+    func blankLinesSkipped() {
+        #expect(HeadlessClaudeStreamParser.parseLine("") == nil)
+        #expect(HeadlessClaudeStreamParser.parseLine("   \n") == nil)
+    }
+
+    @Test("feed handles partial lines across chunks")
+    func partialLineBuffering() {
+        var parser = HeadlessClaudeStreamParser()
+        let first = parser.feed(#"{"type":"system","subtype":"init","mod"#)
+        #expect(first.isEmpty)
+        let second = parser.feed("el\":\"x\",\"session_id\":\"s\",\"tools\":[]}\n")
+        #expect(second.count == 1)
+        guard case .systemInit(let model, let sid, _) = second[0] else {
+            Issue.record("expected systemInit")
+            return
+        }
+        #expect(model == "x")
+        #expect(sid == "s")
+    }
+
+    @Test("flush surfaces a trailing line that lacked a newline")
+    func flushTrailing() {
+        var parser = HeadlessClaudeStreamParser()
+        _ = parser.feed(#"{"type":"result","result":"done","session_id":"z"}"#)
+        let trailing = parser.flush()
+        #expect(trailing.count == 1)
+        if case .result(_, _, _, _, let sid) = trailing[0] {
+            #expect(sid == "z")
+        } else {
+            Issue.record("expected result")
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceClaudeSetupTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceClaudeSetupTests.swift
@@ -1,0 +1,246 @@
+//
+//  WorkspaceServiceClaudeSetupTests.swift
+//  WorkspaceManagerTests
+//
+//  Channel 5 integration tests: when a workspace ships
+//  `.workspaces/claude-setup.json`, `WorkspaceService.createWorkspace`
+//  invokes `HeadlessClaudeRunner` after `setup.sh`. Failures must NEVER
+//  fail workspace creation.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("WorkspaceService claude-setup integration", .serialized)
+struct WorkspaceServiceClaudeSetupTests {
+
+    private func makeFixture() throws -> (testRoot: URL, repoDir: URL, wsRoot: URL) {
+        let testRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WSClaudeSetup-\(UUID().uuidString)")
+        let repoDir = testRoot.appendingPathComponent("repos/test-repo")
+        let wsRoot = testRoot.appendingPathComponent("workspaces")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: wsRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: repoDir.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        // Drop the per-project config that should drive the warm-up.
+        let configDir =
+            repoDir
+            .appendingPathComponent(".workspaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let configJSON = """
+            {"prompt":"warm up the workspace","allowedTools":["Read","Bash"]}
+            """
+        try configJSON.write(
+            to: configDir.appendingPathComponent("claude-setup.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        return (testRoot, repoDir, wsRoot)
+    }
+
+    private func setWorkspacesRoot(_ url: URL) -> String? {
+        let key = "workspacesRoot"
+        let original = UserDefaults.standard.string(forKey: key)
+        UserDefaults.standard.set(url.path, forKey: key)
+        return original
+    }
+
+    private func restoreWorkspacesRoot(_ original: String?) {
+        let key = "workspacesRoot"
+        if let original {
+            UserDefaults.standard.set(original, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    @Test("createWorkspace invokes HeadlessClaudeRunner with the configured prompt + tools")
+    func warmupRunsWithConfig() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.testRoot) }
+        let original = setWorkspacesRoot(fixture.wsRoot)
+        defer { restoreWorkspacesRoot(original) }
+
+        let stub = StubStreamingRunner(
+            stdoutChunks: [
+                #"{"type":"system","subtype":"init","model":"m","session_id":"sess-warm","tools":[]}"# + "\n",
+                #"{"type":"result","result":"ok","total_cost_usd":0.0,"duration_ms":1,"num_turns":1,"session_id":"sess-warm"}"#
+                    + "\n",
+            ],
+            stderrChunks: [],
+            exitCode: 0
+        )
+
+        let runner = HeadlessClaudeRunner(
+            processRunner: stub,
+            executableResolver: { "/opt/homebrew/bin/claude" }
+        )
+        let mockGit = MockGitService()
+        let service = WorkspaceService(
+            gitService: mockGit,
+            claudeRunnerFactory: { runner }
+        )
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: fixture.repoDir,
+            name: "ws-1",
+            progress: nil
+        )
+
+        #expect(info.warnings.isEmpty)
+
+        // The runner was invoked with the config prompt + allowedTools + --bare.
+        let captured = stub.captured.value
+        #expect(captured?.arguments.contains("--bare") == true)
+        #expect(captured?.arguments.contains("warm up the workspace") == true)
+        #expect(captured?.arguments.contains("Read,Bash") == true)
+        #expect(captured?.cwd?.standardizedFileURL.path == info.path.standardizedFileURL.path)
+
+        // Session id was persisted.
+        let store = HeadlessSessionStore(workspaceRoot: info.path)
+        #expect(store.loadLatestSessionID() == "sess-warm")
+    }
+
+    @Test("createWorkspace skips warm-up cleanly when no config is present")
+    func warmupSkippedWithoutConfig() async throws {
+        // Identical fixture but without `claude-setup.json`.
+        let testRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WSClaudeSetupSkip-\(UUID().uuidString)")
+        let repoDir = testRoot.appendingPathComponent("repos/test-repo")
+        let wsRoot = testRoot.appendingPathComponent("workspaces")
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: wsRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: repoDir.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+
+        let original = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(original) }
+
+        let stub = StubStreamingRunner(stdoutChunks: [], stderrChunks: [], exitCode: 0)
+        let runner = HeadlessClaudeRunner(
+            processRunner: stub,
+            executableResolver: { "/opt/homebrew/bin/claude" }
+        )
+        let service = WorkspaceService(
+            gitService: MockGitService(),
+            claudeRunnerFactory: { runner }
+        )
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "ws-skip",
+            progress: nil
+        )
+        #expect(info.warnings.isEmpty)
+        #expect(stub.captured.value == nil)  // never invoked
+    }
+
+    @Test("warm-up failure does NOT fail workspace creation")
+    func warmupFailureNonFatal() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.testRoot) }
+        let original = setWorkspacesRoot(fixture.wsRoot)
+        defer { restoreWorkspacesRoot(original) }
+
+        let stub = StubStreamingRunner(
+            stdoutChunks: [],
+            stderrChunks: ["claude: not authenticated\n"],
+            exitCode: 1
+        )
+        let runner = HeadlessClaudeRunner(
+            processRunner: stub,
+            executableResolver: { "/opt/homebrew/bin/claude" }
+        )
+        let service = WorkspaceService(
+            gitService: MockGitService(),
+            claudeRunnerFactory: { runner }
+        )
+
+        // Should NOT throw — warm-up failure is best-effort.
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: fixture.repoDir,
+            name: "ws-failure",
+            progress: nil
+        )
+        #expect(FileManager.default.fileExists(atPath: info.path.path))
+    }
+
+    @Test("WorkspaceClaudeSetup loads per-project config preferentially")
+    func loadsProjectConfig() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeSetupLoad-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let configDir = dir.appendingPathComponent(".workspaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try """
+        {"prompt":"hello","allowedTools":["Read"]}
+        """.write(
+            to: configDir.appendingPathComponent("claude-setup.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let config = WorkspaceClaudeSetup.loadConfig(for: dir, appDefaultsLookup: { nil })
+        #expect(config?.prompt == "hello")
+        #expect(config?.allowedTools == ["Read"])
+    }
+
+    @Test("malformed claude-setup.json is ignored, returns nil")
+    func malformedConfigIgnored() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeSetupBad-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let configDir = dir.appendingPathComponent(".workspaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try "{ not json".write(
+            to: configDir.appendingPathComponent("claude-setup.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let config = WorkspaceClaudeSetup.loadConfig(for: dir, appDefaultsLookup: { nil })
+        #expect(config == nil)
+    }
+
+    @Test("WorkspaceClaudeActions loads action list from .workspaces/claude-actions.json")
+    func loadsActionList() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeActionsLoad-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let configDir = dir.appendingPathComponent(".workspaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let json = """
+            {"actions":[
+                {"id":"lint","name":"Lint sweep","prompt":"run linters","allowedTools":["Bash"]},
+                {"name":"Doc gen","prompt":"generate docs"}
+            ]}
+            """
+        try json.write(
+            to: configDir.appendingPathComponent("claude-actions.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let actions = WorkspaceClaudeActions.loadActions(for: dir)
+        #expect(actions.count == 2)
+        #expect(actions[0].id == "lint")
+        #expect(actions[0].allowedTools == ["Bash"])
+        #expect(actions[1].id == "doc-gen")  // slug fallback
+    }
+}


### PR DESCRIPTION
## Summary

Channel 5 of the agent integration — `claude -p` non-interactive runner, NDJSON stream parser, post-`setup.sh` warm-up, and project-defined quick-action loader. See spec § Channel 5.

- `HeadlessClaudeRunner` actor (`Sources/WorkspaceManagerCore/Services/HeadlessClaudeRunner.swift`) — spawns `claude --bare -p ... --output-format stream-json --verbose --include-partial-messages --permission-mode acceptEdits [--resume <id>]` through a streaming process runner. `--bare` is always-on for deterministic behavior independent of user hooks/skills/plugins.
- `HeadlessClaudeStreamParser` (`Sources/WorkspaceManagerCore/Services/HeadlessClaudeStreamParser.swift`) — mirrors `web/src/lib/agent-runtime/vercel-sandbox.ts:parseStreamJsonLine`, extending it with `systemInit`, `toolUse`, `toolResult`, `apiRetry`, `result`, and a forward-compatible `unknown(raw:)` case so new claude releases never break the runner.
- `HeadlessSessionStore` persists `session_id` per workspace under `.workspaces/headless/sessions.json` (gitignored under `.workspaces/`); used to plumb `--resume`.
- `WorkspaceService.createWorkspace` chains the runner after `setup.sh` when `.workspaces/claude-setup.json` (per-project) or `Resources/Defaults/claude-setup.json` (app default) is present. Warm-up failure never fails workspace creation — we log + continue.
- `WorkspaceClaudeActions` loads `.workspaces/claude-actions.json` (id/name/prompt/allowedTools/resume) for sidebar quick-action plumbing.

## Mergeability

- Surface: desktop
- User-facing behavior changed: `claude -p --bare` runs can be wired into workspace creation via `.workspaces/claude-setup.json` (warm-up prompt after `setup.sh`); sidebar quick-action service-layer plumbing is in place. No interactive UI surface lands in this PR.
- Non-happy paths considered: `claude` not installed (runner emits an error event, workspace creation continues); ndjson stream malformed mid-record (parser emits `.unknown(raw:)`, parsing continues); resume session id absent (runs cold without `--resume`); `--bare` ensures we never load the user's interactive Claude hooks/skills/plugins.
- Release/ops preconditions: none.
- Residual risk or follow-up: sidebar UI for headless quick actions is deferred to a follow-up PR; until that lands, `WorkspaceClaudeActions` is library-only and only the `setup.sh`-chained path is user-reachable.

## Validation

- `swift build` clean.
- `swift test` — **612 tests, 101 suites, all passing**, including:
  - `HeadlessClaudeStreamParserTests` (13 tests) — every event type from canonical fixtures, plus unknown passthrough and partial-line buffering.
  - `HeadlessClaudeRunnerTests` (7 tests) — argument plumbing (`--bare`, `--resume`, allowedTools), stub-driven event streaming, error pass-through, session-store round-trip.
  - `WorkspaceServiceClaudeSetupTests` (6 tests) — warm-up runs with config, skips cleanly without config, failure non-fatal, malformed-config tolerance, action-list loading.
- `swift-format format -i` + `swift-format lint --strict` clean on all new files.
- **Real-binary smoke.** `claude --bare -p "say hi in 4 words" --output-format stream-json --verbose --include-partial-messages --permission-mode acceptEdits` was captured against the locally installed CLI (claude 2.1.126) and the resulting NDJSON parsed cleanly through the same JSON shape `HeadlessClaudeStreamParser` consumes — 4 events: system/init, system/status, assistant text, result. (The `--bare` invocation runs unauthenticated by design, surfacing a "Not logged in" assistant message — exactly the deterministic behavior `--bare` is meant to provide.)

## Performance

Not perf-sensitive. A single `claude -p` run produces tens to low-hundreds of NDJSON events; one `AgentEvent` per parsed event with no batching, matching the registry's standard ingest rate-discipline. If `AgentSessionRegistry.ingestBatch` lands in PR #4, the warm-up integration can adopt it without API changes.

## Evidence

![channel5-headless-tests](https://evidence.cloudcompute.com/workspaces/pr-0/20260507-144527-channel5-headless-tests.png)
