### PR TITLE
[codex] Configure Matt Pocock skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,20 @@ When the user asks to implement a change, default to carrying it through to a PR
 
 Continuous improvement of `AGENTS.md` is important to the health and longevity of the codebase: it is how this repo teaches future agents to meet product, quality, evidence, and operational objectives. Improve it when the guidance becomes clearer, shorter, or more actionable.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues for `fairchild/workspaces`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the repo's agent lifecycle labels, with `agent:ready` for AFK-ready work and `needs-human` for human-owned work. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo; use root docs plus `docs/decisions/` for architectural decisions. See `docs/agents/domain.md`.
+
 ## Dev Verification Practice (required)
 
 When changing terminal/keyboard/sidebar behavior, use this loop so future sessions can self-verify reliably:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,34 @@
+# Domain Docs
+
+This is a single-context repo. The engineering skills should start with the root product and architecture docs, then read narrower docs for the surface being changed.
+
+## Before Exploring, Read These
+
+- `README.md` for product positioning, supported workflows, and user-facing behavior.
+- `ARCHITECTURE.md` for system structure and architectural patterns.
+- `docs/development/mergeability-standard.md` before planning PR-ready implementation work.
+- `docs/decisions/` for architectural decisions. This repo uses `docs/decisions/` rather than `docs/adr/`.
+- Area docs from the `AGENTS.md` Doc Navigation table when working on terminal focus, Lume, notifications, web dashboard, evidence, or runner behavior.
+
+If a listed file does not exist in a future checkout, proceed silently and use the nearest existing repo documentation.
+
+## Layout
+
+```text
+/
+|-- README.md
+|-- ARCHITECTURE.md
+|-- AGENTS.md
+|-- docs/
+|   |-- decisions/
+|   `-- development/
+|-- Sources/
+|-- Tests/
+`-- web/
+```
+
+There is no root `CONTEXT.md` or `CONTEXT-MAP.md` at setup time. If a future skill creates those files, prefer their glossary and domain language for issue titles, refactor proposals, hypotheses, and test names.
+
+## Decision Conflicts
+
+If a recommendation or implementation contradicts an existing decision under `docs/decisions/` or a development runbook, surface that conflict explicitly rather than silently overriding the repo convention.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `fairchild/workspaces`. Use the `gh` CLI for issue operations from inside this clone.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`
+- **Read an issue**: `gh issue view <number> --comments --json number,title,body,state,labels,comments`
+- **List issues**: `gh issue list --state open --json number,title,body,labels,assignees`
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply or remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close an issue**: `gh issue close <number> --comment "..."`
+
+Infer the repository from `git remote -v`; `gh` resolves `fairchild/workspaces` automatically when run inside this clone.
+
+## When a Skill Says "Publish to the Issue Tracker"
+
+Create a GitHub issue. Use the repo's normal issue labels from `docs/agents/triage-labels.md` and the agent-team conventions in `docs/development/agent-team.md` when the work is meant for the autonomous contributor pipeline.
+
+## When a Skill Says "Fetch the Relevant Ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,24 @@
+# Triage Labels
+
+The Matt Pocock skills speak in five canonical triage roles. This repo already has an agent lifecycle vocabulary, so map the canonical roles to the labels below instead of creating near-duplicates.
+
+| Label in mattpocock/skills | Label in this repo | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate the issue. No existing repo label carries this exact meaning. |
+| `needs-info` | `needs-info` | Waiting on the reporter for more information. No existing repo label carries this exact meaning. |
+| `ready-for-agent` | `agent:ready` | Fully specified, approved, unblocked, and available for an AFK agent to claim. |
+| `ready-for-human` | `needs-human` | Requires human implementation, review, or intervention. |
+| `wontfix` | `wontfix` | Will not be actioned. |
+
+When a skill mentions a canonical role, use the corresponding label string from this table.
+
+## Related Agent Lifecycle Labels
+
+These labels are part of this repo's existing agent pipeline but are not direct replacements for the five canonical triage roles:
+
+- `agent:task` marks a planned agent-team issue.
+- `agent:claimed` marks active agent ownership.
+- `agent:review` marks an issue with an open PR awaiting review.
+- `agent:mergeable` marks an agent-reviewed PR that is ready for owner merge.
+
+See `docs/development/agent-team.md` for the full lifecycle.


### PR DESCRIPTION
## Summary

- Adds repo-local configuration for Matt Pocock engineering skills.
- Links a compact `AGENTS.md` routing block to detailed `docs/agents/` setup docs.
- Maps the skills' issue tracker, triage label, and domain-doc expectations to this repo's existing GitHub and agent-team conventions.

## Mergeability

- Surface: docs
- User-facing behavior changed: no
- Non-happy paths considered: docs record missing `CONTEXT.md`/`CONTEXT-MAP.md` as non-blocking and point skills at existing repo docs.
- Release/ops preconditions: none
- Residual risk or follow-up: `needs-triage` and `needs-info` do not exist as current GitHub labels; the mapping documents them as canonical roles without creating labels.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `git diff --check`; `wc -w AGENTS.md docs/agents/issue-tracker.md docs/agents/triage-labels.md docs/agents/domain.md`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: docs-only setup

## Evidence

- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Validation artifact](https://evidence.cloudcompute.com/workspaces/pr-457/20260509-071638-mattpocock-skills-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence

No blockers.
