### PR TITLE
[codex] verify mise security changes

### DIFF
--- a/.github/workflows/mise-security.yml
+++ b/.github/workflows/mise-security.yml
@@ -1,0 +1,57 @@
+name: Mise Security
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/mise-security.yml"
+      - ".mise.toml"
+      - "web/.mise.toml"
+      - "mise.lock"
+      - "scripts/setup"
+      - "scripts/build-ghosttykit.sh"
+      - "scripts/verify-mise-security.sh"
+      - "scripts/test_security_hardening.py"
+      - "docs/development/mise-security.md"
+      - "web/src/lib/agent-runtime/vercel-sandbox.ts"
+  pull_request:
+    paths:
+      - ".github/workflows/mise-security.yml"
+      - ".mise.toml"
+      - "web/.mise.toml"
+      - "mise.lock"
+      - "scripts/setup"
+      - "scripts/build-ghosttykit.sh"
+      - "scripts/verify-mise-security.sh"
+      - "scripts/test_security_hardening.py"
+      - "docs/development/mise-security.md"
+      - "web/src/lib/agent-runtime/vercel-sandbox.ts"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mise-security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install pinned mise binary
+        run: |
+          set -euo pipefail
+          MISE_VERSION="$(awk -F= '/^MISE_EXPECTED_VERSION=/{ gsub(/"/, "", $2); print $2 }' scripts/verify-mise-security.sh)"
+          MISE_SHA256="$(awk -F= '/^MISE_EXPECTED_LINUX_X64_SHA256=/{ gsub(/"/, "", $2); print $2 }' scripts/verify-mise-security.sh)"
+          test -n "$MISE_VERSION"
+          test -n "$MISE_SHA256"
+          curl -fsSL "https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64" -o /tmp/mise
+          echo "${MISE_SHA256}  /tmp/mise" | sha256sum -c -
+          sudo install -m 755 /tmp/mise /usr/local/bin/mise
+          mise --version
+
+      - name: Verify mise security controls
+        run: ./scripts/verify-mise-security.sh

--- a/docs/development/mise-security.md
+++ b/docs/development/mise-security.md
@@ -34,8 +34,9 @@ configs can affect every later command in a checkout.
 ## Verification
 
 ```bash
-uv run --script scripts/test_security_hardening.py
-MISE_TRUSTED_CONFIG_PATHS="$PWD" mise lock --dry-run --platform macos-arm64,linux-x64 zig
-MISE_IGNORED_CONFIG_PATHS="$HOME/.config/mise" MISE_TRUSTED_CONFIG_PATHS="$PWD" mise exec --locked zig@0.15.2 -- zig version
-curl -fsSL https://api.github.com/repos/jdx/mise/releases/latest | jq -r '.tag_name, "draft=\(.draft)", "prerelease=\(.prerelease)"'
+./scripts/verify-mise-security.sh
 ```
+
+The `Mise Security` workflow runs this verifier whenever mise configs,
+`mise.lock`, the setup/build scripts, the sandbox mise installer, or this doc
+change.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ This directory contains build/release helpers plus UI test utilities.
 - `./scripts/setup --env-only` refreshes local env-file links without running dependency setup.
 - `./scripts/setup --hooks-only` installs or refreshes the prek git hooks without running dependency setup.
 - `./scripts/install-git-hooks.sh` remains only as a compatibility wrapper around `./scripts/setup --hooks-only`; prefer `./scripts/setup` in new docs and task definitions.
-- mise security rules live in [docs/development/mise-security.md](../docs/development/mise-security.md). Keep secrets and global trust bypasses out of mise config.
+- mise security rules live in [docs/development/mise-security.md](../docs/development/mise-security.md). Run `./scripts/verify-mise-security.sh` after touching mise config, lockfiles, setup/build scripts, or the sandbox mise installer. Keep secrets and global trust bypasses out of mise config.
 - `web/.npmrc` enables pnpm's experimental global virtual store so repeated warm installs across Conductor workspaces reuse a shared virtual store.
 
 ## Root Mise Task Catalog

--- a/scripts/setup
+++ b/scripts/setup
@@ -163,6 +163,7 @@ done < <(
   find "$REPO_ROOT" \
     -path "*/.git" -prune -o \
     -path "*/node_modules" -prune -o \
+    -path "*/.pnpm-store" -prune -o \
     -name ".mise.toml" -print | sort
 )
 

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -264,6 +264,12 @@ class SecurityHardeningTests(unittest.TestCase):
             self.assertTrue(entry["url"].startswith("https://"))
 
     def test_mise_invocations_are_locked_and_pinned(self) -> None:
+        verify_mise = (REPO_ROOT / "scripts/verify-mise-security.sh").read_text()
+        self.assertIn("MISE_EXPECTED_VERSION=\"v2026.5.5\"", verify_mise)
+        self.assertIn("verify_locked_zig_exec", verify_mise)
+        self.assertIn("github.com/repos/jdx/mise/releases/latest", verify_mise)
+        self.assertIn("SHASUMS256.txt", verify_mise)
+
         build_ghosttykit = (REPO_ROOT / "scripts/build-ghosttykit.sh").read_text()
         self.assertIn('mise exec --locked "zig@$ZIG_VERSION" -- zig', build_ghosttykit)
         self.assertIn("MISE_CONFIG_FILE=$PROJECT_DIR/.mise.toml", build_ghosttykit)
@@ -275,6 +281,7 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn('if [[ "$FAST" == "1" ]]', setup)
         self.assertIn("mise install --locked zig@0.15.2", setup)
         self.assertIn("MISE_IGNORED_CONFIG_PATHS=", setup)
+        self.assertIn('-path "*/.pnpm-store" -prune', setup)
         self.assertNotIn("trust every checked-in project config", setup)
 
         conductor = json.loads((REPO_ROOT / "conductor.json").read_text())
@@ -284,10 +291,25 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("enable-global-virtual-store=true", web_npmrc)
 
         sandbox = (REPO_ROOT / "web/src/lib/agent-runtime/vercel-sandbox.ts").read_text()
-        self.assertIn("MISE_VERSION='v2026.5.3'", sandbox)
-        self.assertIn("MISE_SHA256='9a4f228158a316b236653ff615e9955f50c56c6a3ef719135d327c7fc632b89b'", sandbox)
+        self.assertIn("MISE_VERSION='v2026.5.5'", sandbox)
+        self.assertIn("MISE_SHA256='3aaab5c05a8a94a93b42b4f581779bbd5c44ddb251e7f3639fc671ec5c6aab8a'", sandbox)
         self.assertIn("sha256sum -c -", sandbox)
         self.assertNotIn("mise-latest-linux-x64", sandbox)
+
+    def test_mise_security_workflow_runs_for_mise_changes(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/mise-security.yml").read_text()
+        self.assertIn("name: Mise Security", workflow)
+        self.assertIn("scripts/verify-mise-security.sh", workflow)
+        for expected_path in (
+            ".mise.toml",
+            "web/.mise.toml",
+            "mise.lock",
+            "scripts/setup",
+            "scripts/build-ghosttykit.sh",
+            "scripts/verify-mise-security.sh",
+            "web/src/lib/agent-runtime/vercel-sandbox.ts",
+        ):
+            self.assertIn(expected_path, workflow)
 
     def test_release_workflow_publishes_and_validates_manifest_and_appcast_signature(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()

--- a/scripts/verify-mise-security.sh
+++ b/scripts/verify-mise-security.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+MISE_EXPECTED_VERSION="v2026.5.5"
+MISE_EXPECTED_LINUX_X64_SHA256="3aaab5c05a8a94a93b42b4f581779bbd5c44ddb251e7f3639fc671ec5c6aab8a"
+ZIG_VERSION="0.15.2"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+verify_mise_configs() {
+  local config relative
+  local -a configs=()
+  local -a expected=(".mise.toml" "web/.mise.toml")
+  local forbidden_regex='(^[[:space:]]*\[(env|hooks)\][[:space:]]*$|trusted_config_paths|^[[:space:]]*(yes|ci)[[:space:]]*=[[:space:]]*true([[:space:]]*(#.*)?)?$|_[.](source|file)[[:space:]]*=)'
+
+  while IFS= read -r config; do
+    relative="${config#$REPO_ROOT/}"
+    configs+=("$relative")
+  done < <(
+    find "$REPO_ROOT" \
+      -path "*/.git" -prune -o \
+      -path "*/node_modules" -prune -o \
+      -path "*/.pnpm-store" -prune -o \
+      -name ".mise.toml" -print | sort
+  )
+
+  [[ "${configs[*]}" == "${expected[*]}" ]] \
+    || fail "unexpected mise config set: ${configs[*]:-(none)}"
+
+  for relative in "${configs[@]}"; do
+    if grep -En "$forbidden_regex" "$REPO_ROOT/$relative" >&2; then
+      fail "forbidden trust/env directive in $relative"
+    fi
+  done
+
+  echo "verified mise config allowlist"
+}
+
+verify_mise_lock() {
+  python3 - <<'PY'
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+root = Path.cwd()
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+root_mise = (root / ".mise.toml").read_text()
+settings = re.search(r"(?ms)^\[settings\]\s*(.*?)(?=^\[|\Z)", root_mise)
+tools = re.search(r"(?ms)^\[tools\]\s*(.*?)(?=^\[|\Z)", root_mise)
+require(settings is not None, ".mise.toml missing [settings]")
+require(tools is not None, ".mise.toml missing [tools]")
+require(re.search(r"(?m)^lockfile\s*=\s*true\s*$", settings.group(1)) is not None, ".mise.toml must enable lockfile")
+require(re.search(r'(?m)^zig\s*=\s*"0\.15\.2"\s*$', tools.group(1)) is not None, ".mise.toml must pin zig 0.15.2")
+
+lock = (root / "mise.lock").read_text()
+zig_entries = re.findall(r"(?ms)^\[\[tools\.zig\]\]\s*(.*?)(?=^\[\[|\Z)", lock)
+require(len(zig_entries) == 1, "mise.lock must contain exactly one zig entry")
+zig = zig_entries[0]
+require(re.search(r'(?m)^version\s*=\s*"0\.15\.2"\s*$', zig) is not None, "mise.lock must pin zig 0.15.2")
+require(re.search(r'(?m)^backend\s*=\s*"core:zig"\s*$', zig) is not None, "mise.lock must use core:zig")
+for platform in ("linux-x64", "macos-arm64"):
+    platform_match = re.search(rf'(?m)^"platforms\.{platform}"\s*=\s*\{{(?P<body>[^}}]+)\}}\s*$', zig)
+    require(platform_match is not None, f"mise.lock missing zig {platform} entry")
+    body = platform_match.group("body")
+    require(
+        re.search(r'checksum\s*=\s*"sha256:[a-f0-9]{64}"', body) is not None,
+        f"mise.lock must pin zig {platform} with a sha256 checksum",
+    )
+    require(
+        re.search(r'url\s*=\s*"https://[^"]+"', body) is not None,
+        f"mise.lock must pin zig {platform} with an https URL",
+    )
+PY
+
+  echo "verified mise.lock"
+}
+
+verify_repo_invocations() {
+  grep -Fq 'mise exec --locked "zig@$ZIG_VERSION" -- zig' scripts/build-ghosttykit.sh \
+    || fail "build-ghosttykit must use locked mise exec"
+  grep -Fq 'MISE_CONFIG_FILE=$PROJECT_DIR/.mise.toml' scripts/build-ghosttykit.sh \
+    || fail "build-ghosttykit must pin the repo mise config file"
+  grep -Fq 'MISE_CONFIG_ROOT=$PROJECT_DIR' scripts/build-ghosttykit.sh \
+    || fail "build-ghosttykit must pin the repo mise config root"
+  grep -Fq 'MISE_IGNORED_CONFIG_PATHS=$HOME/.config/mise' scripts/build-ghosttykit.sh \
+    || fail "build-ghosttykit must ignore global mise config"
+  grep -Fq 'mise install --locked zig@0.15.2' scripts/setup \
+    || fail "setup must install Zig through locked mise"
+  grep -Fq 'path "*/.pnpm-store" -prune' scripts/setup \
+    || fail "setup must ignore generated pnpm store directories"
+
+  echo "verified repo mise invocations"
+}
+
+verify_latest_mise_pin() {
+  require_cmd curl
+  require_cmd python3
+
+  local latest_json latest_tag prerelease draft shasum_line
+  latest_json="$(curl -fsSL https://api.github.com/repos/jdx/mise/releases/latest)"
+  latest_tag="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])' <<<"$latest_json")"
+  prerelease="$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["prerelease"]).lower())' <<<"$latest_json")"
+  draft="$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["draft"]).lower())' <<<"$latest_json")"
+
+  [[ "$draft" == "false" ]] || fail "latest mise release is a draft: $latest_tag"
+  [[ "$prerelease" == "false" ]] || fail "latest mise release is a prerelease: $latest_tag"
+  [[ "$latest_tag" == "$MISE_EXPECTED_VERSION" ]] \
+    || fail "sandbox mise pin $MISE_EXPECTED_VERSION is not latest stable $latest_tag"
+
+  grep -Fq "MISE_VERSION='$MISE_EXPECTED_VERSION'" web/src/lib/agent-runtime/vercel-sandbox.ts \
+    || fail "sandbox mise version is not pinned to $MISE_EXPECTED_VERSION"
+  grep -Fq "MISE_SHA256='$MISE_EXPECTED_LINUX_X64_SHA256'" web/src/lib/agent-runtime/vercel-sandbox.ts \
+    || fail "sandbox mise sha256 does not match verifier"
+  grep -Fq "sha256sum -c -" web/src/lib/agent-runtime/vercel-sandbox.ts \
+    || fail "sandbox must verify mise checksum"
+  grep -Fq "mise-latest-linux-x64" web/src/lib/agent-runtime/vercel-sandbox.ts \
+    && fail "sandbox must not use moving mise latest URL"
+
+  shasum_line="$(curl -fsSL "https://github.com/jdx/mise/releases/download/${MISE_EXPECTED_VERSION}/SHASUMS256.txt" \
+    | awk -v asset="./mise-${MISE_EXPECTED_VERSION}-linux-x64" '$2 == asset { print }')"
+  [[ "$shasum_line" == "$MISE_EXPECTED_LINUX_X64_SHA256  ./mise-${MISE_EXPECTED_VERSION}-linux-x64" ]] \
+    || fail "sandbox mise sha256 does not match upstream SHASUMS256.txt"
+
+  if command -v mise >/dev/null 2>&1; then
+    local installed_version
+    installed_version="$(mise --version | awk '{print $1}')"
+    [[ "$installed_version" == "${MISE_EXPECTED_VERSION#v}" ]] \
+      || fail "installed mise $installed_version does not match $MISE_EXPECTED_VERSION"
+  fi
+
+  echo "verified latest stable mise pin"
+}
+
+verify_locked_zig_exec() {
+  if ! command -v mise >/dev/null 2>&1; then
+    echo "skipping locked Zig execution: mise not installed"
+    return
+  fi
+
+  local zig_output
+  local cache_dir="${TMPDIR:-/tmp}/workspaces-mise-security-cache"
+  mkdir -p "$cache_dir"
+
+  zig_output="$(
+    MISE_CONFIG_FILE="$REPO_ROOT/.mise.toml" \
+      MISE_CONFIG_ROOT="$REPO_ROOT" \
+      MISE_CACHE_DIR="$cache_dir" \
+      MISE_IGNORED_CONFIG_PATHS="$HOME/.config/mise${MISE_IGNORED_CONFIG_PATHS:+:$MISE_IGNORED_CONFIG_PATHS}" \
+      MISE_TRUSTED_CONFIG_PATHS="$REPO_ROOT${MISE_TRUSTED_CONFIG_PATHS:+:$MISE_TRUSTED_CONFIG_PATHS}" \
+      MISE_PARANOID=1 \
+      mise exec --locked "zig@$ZIG_VERSION" -- zig version
+  )"
+  [[ "$zig_output" == "$ZIG_VERSION" ]] \
+    || fail "locked Zig exec returned '$zig_output', expected '$ZIG_VERSION'"
+
+  echo "verified locked Zig execution"
+}
+
+main() {
+  verify_mise_configs
+  verify_mise_lock
+  verify_repo_invocations
+  verify_latest_mise_pin
+  verify_locked_zig_exec
+}
+
+main "$@"

--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -348,8 +348,8 @@ async function resolveBaseSnapshot(): Promise<string> {
 			"-c",
 			[
 				"set -euo pipefail",
-				"MISE_VERSION='v2026.5.3'",
-				"MISE_SHA256='9a4f228158a316b236653ff615e9955f50c56c6a3ef719135d327c7fc632b89b'",
+				"MISE_VERSION='v2026.5.5'",
+				"MISE_SHA256='3aaab5c05a8a94a93b42b4f581779bbd5c44ddb251e7f3639fc671ec5c6aab8a'",
 				'MISE_URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64"',
 				"echo '--- downloading mise ---'",
 				'curl -fsSL "$MISE_URL" -o /tmp/mise',


### PR DESCRIPTION
## Summary

- Add scripts/verify-mise-security.sh to verify mise config allowlists, locked Zig resolution, latest stable mise pinning, and upstream checksum matching.
- Add a Mise Security workflow that runs whenever mise-related config, setup, build, sandbox installer, verifier, or docs change.
- Update the sandbox mise pin to latest stable v2026.5.5 and install the same pinned/checksummed binary in CI.
- Update setup/docs/tests so generated pnpm stores are ignored and the verifier is the documented mise security gate.

## Mergeability

- Surface: agent-runtime / infra / docs
- User-facing behavior changed: No end-user UI behavior change; sandbox bootstrap now installs the current pinned mise release.
- Non-happy paths considered: Verifier fails closed on unreviewed mise configs, trust/env bypasses, stale mise pins, checksum drift, missing lockfile coverage, and unlocked Zig execution.
- Release/ops preconditions: None.
- Residual risk or follow-up: Branch protection should require the Mise Security check after this lands; a scheduled drift monitor would catch new mise releases even when no mise files change.

## Validation

- [ ] swift build
- [ ] swift test
- [x] Other checks run:
  - ./scripts/verify-mise-security.sh
  - uv run --script scripts/test_security_hardening.py
  - MISE_TRUSTED_CONFIG_PATHS=/Users/fairchild/.codex/worktrees/647a/workspaces:/Users/fairchild/.codex/worktrees/647a/workspaces/web mise -C web run web:check
  - direct download + sha256 verification for mise v2026.5.5 linux-x64
  - git diff --check

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![mise-security-verifier-v2026-5-5](https://evidence.cloudcompute.com/workspaces/pr-458/20260510-212301-mise-security-verifier-v2026-5-5.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence