### PR TITLE
[codex] Fix Xcode Cloud Ghostty gettext setup

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -27,4 +27,20 @@ if ! command -v swift-format >/dev/null 2>&1; then
   brew install swift-format
 fi
 
+if ! command -v msgfmt >/dev/null 2>&1; then
+  brew install gettext
+fi
+
+gettext_prefix="$(brew --prefix gettext 2>/dev/null || true)"
+if [ -n "$gettext_prefix" ] && [ -x "$gettext_prefix/bin/msgfmt" ]; then
+  export PATH="$gettext_prefix/bin:$PATH"
+fi
+
+if ! command -v msgfmt >/dev/null 2>&1; then
+  echo "error: msgfmt is required to build Ghostty translations; install Homebrew gettext" >&2
+  exit 1
+fi
+
+msgfmt --version | head -n 1
+
 ./scripts/build-ghosttykit.sh

--- a/docs/development/xcode-cloud.md
+++ b/docs/development/xcode-cloud.md
@@ -24,6 +24,17 @@ Do not rename the SwiftPM targets as part of Xcode Cloud setup. Do not use the r
   - `swift build -c release`
   - `swift test`
 
+## Tooling Dependencies
+
+`ci_post_clone.sh` installs the host tools that are not guaranteed by the Xcode
+Cloud image:
+- `mise` for the pinned Zig toolchain
+- `swift-format` for the SwiftPM validation gate
+- `gettext` for Ghostty's `msgfmt` translation compilation step
+
+Homebrew's `gettext` may be keg-only, so the script prepends
+`$(brew --prefix gettext)/bin` before building GhosttyKit.
+
 ## Manual Xcode Cloud Setup
 
 1. Open `WorkSpacesCloudCI.xcodeproj` in Xcode.

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -78,6 +78,23 @@ resolve_zig_runner() {
   ZIG_RUNNER=(mise exec "zig@$ZIG_VERSION" -- zig)
 }
 
+require_msgfmt() {
+  if command -v msgfmt >/dev/null 2>&1; then
+    return
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    local gettext_prefix
+    gettext_prefix="$(brew --prefix gettext 2>/dev/null || true)"
+    if [[ -x "$gettext_prefix/bin/msgfmt" ]]; then
+      export PATH="$gettext_prefix/bin:$PATH"
+      return
+    fi
+  fi
+
+  die "msgfmt is required to build Ghostty translations (install Homebrew gettext; if it is keg-only, add \$(brew --prefix gettext)/bin to PATH)"
+}
+
 rewrite_modulemap() {
   local modulemap_path="$1"
 
@@ -248,6 +265,7 @@ install_xcframework() {
 main() {
   require_cmd git
   require_cmd xcrun
+  require_msgfmt
   resolve_zig_runner
 
   resolve_ghostty_dir


### PR DESCRIPTION
## Summary

- Fix Xcode Cloud GhosttyKit setup by installing Homebrew gettext before the pinned Ghostty build runs.
- Add a fail-fast msgfmt check to scripts/build-ghosttykit.sh so missing gettext fails with a clear WorkSpaces-owned error instead of Zig FileNotFound noise.
- Document the Xcode Cloud host tooling dependencies.

## Mergeability

- Surface: infra / docs
- User-facing behavior changed: No app runtime behavior changes; Xcode Cloud macOS builds can now compile Ghostty translations.
- Non-happy paths considered: gettext may be keg-only, so both the Xcode Cloud hook and GhosttyKit build script prepend $(brew --prefix gettext)/bin when available and fail clearly if msgfmt remains missing.
- Release/ops preconditions: Xcode Cloud image must have Homebrew available, which the existing hook already requires for mise and swift-format.
- Residual risk or follow-up: CI must confirm the App Store Connect/Xcode Cloud environment exposes Homebrew gettext as expected after install.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: `sh -n ci_scripts/ci_post_clone.sh`; `sh -n ci_scripts/ci_pre_xcodebuild.sh`; `bash -n scripts/build-ghosttykit.sh`; `./scripts/build-ghosttykit.sh`; `CI_XCODEBUILD_ACTION=build ./ci_scripts/ci_pre_xcodebuild.sh`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Xcode Cloud gettext validation](https://evidence.cloudcompute.com/workspaces/pr-459/20260509-072639-xcode-cloud-gettext-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
