### PR TITLE
Enable Command+, and align shortcut catalog

### DIFF
--- a/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
+++ b/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
@@ -8,6 +8,12 @@
 import AppKit
 import SwiftUI
 
+private struct AppChromeShortcutDefinition {
+    let keyString: String
+    let modifiers: NSEvent.ModifierFlags
+    let defaultRoute: ShortcutRouteTarget
+}
+
 enum AppChromeShortcut: CaseIterable {
     case toggleSidebar
     case toggleInspector
@@ -20,30 +26,38 @@ enum AppChromeShortcut: CaseIterable {
     case alternateNextTerminalTab
     case alternatePreviousTerminalTab
     case openInEditor
+    case settings
 
-    var keyString: String {
+    private var definition: AppChromeShortcutDefinition {
         switch self {
         case .toggleSidebar:
-            return "b"
+            return AppChromeShortcutDefinition(keyString: "b", modifiers: [.command], defaultRoute: .appChrome)
         case .toggleInspector:
-            return "b"
+            return AppChromeShortcutDefinition(keyString: "b", modifiers: [.command, .shift], defaultRoute: .appChrome)
         case .toggleTerminalPanel:
-            return "j"
+            return AppChromeShortcutDefinition(keyString: "j", modifiers: [.command], defaultRoute: .appChrome)
         case .newWorkspace:
-            return "n"
+            return AppChromeShortcutDefinition(keyString: "n", modifiers: [.command], defaultRoute: .appChrome)
         case .newTerminalTab:
-            return "t"
+            return AppChromeShortcutDefinition(keyString: "t", modifiers: [.command], defaultRoute: .appChrome)
         case .closeTerminalTab:
-            return "w"
+            return AppChromeShortcutDefinition(keyString: "w", modifiers: [.command], defaultRoute: .appChrome)
         case .nextTerminalTab, .previousTerminalTab:
-            return "\t"
+            let modifiers: NSEvent.ModifierFlags = self == .nextTerminalTab ? [.control] : [.control, .shift]
+            return AppChromeShortcutDefinition(keyString: "\t", modifiers: modifiers, defaultRoute: .appChrome)
         case .alternateNextTerminalTab:
-            return "]"
+            return AppChromeShortcutDefinition(keyString: "]", modifiers: [.command, .shift], defaultRoute: .appChrome)
         case .alternatePreviousTerminalTab:
-            return "["
+            return AppChromeShortcutDefinition(keyString: "[", modifiers: [.command, .shift], defaultRoute: .appChrome)
         case .openInEditor:
-            return "o"
+            return AppChromeShortcutDefinition(keyString: "o", modifiers: [.command, .shift], defaultRoute: .ghostty)
+        case .settings:
+            return AppChromeShortcutDefinition(keyString: ",", modifiers: [.command], defaultRoute: .appChrome)
         }
+    }
+
+    var keyString: String {
+        definition.keyString
     }
 
     var keyCharacter: Character {
@@ -51,53 +65,15 @@ enum AppChromeShortcut: CaseIterable {
     }
 
     var appKitModifiers: NSEvent.ModifierFlags {
-        switch self {
-        case .toggleSidebar:
-            return [.command]
-        case .toggleInspector:
-            return [.command, .shift]
-        case .toggleTerminalPanel:
-            return [.command]
-        case .newWorkspace:
-            return [.command]
-        case .newTerminalTab:
-            return [.command]
-        case .closeTerminalTab:
-            return [.command]
-        case .nextTerminalTab:
-            return [.control]
-        case .previousTerminalTab:
-            return [.control, .shift]
-        case .alternateNextTerminalTab, .alternatePreviousTerminalTab:
-            return [.command, .shift]
-        case .openInEditor:
-            return [.command, .shift]
-        }
+        definition.modifiers
+    }
+
+    var defaultRoute: ShortcutRouteTarget {
+        definition.defaultRoute
     }
 
     var eventModifiers: EventModifiers {
-        switch self {
-        case .toggleSidebar:
-            return [.command]
-        case .toggleInspector:
-            return [.command, .shift]
-        case .toggleTerminalPanel:
-            return [.command]
-        case .newWorkspace:
-            return [.command]
-        case .newTerminalTab:
-            return [.command]
-        case .closeTerminalTab:
-            return [.command]
-        case .nextTerminalTab:
-            return [.control]
-        case .previousTerminalTab:
-            return [.control, .shift]
-        case .alternateNextTerminalTab, .alternatePreviousTerminalTab:
-            return [.command, .shift]
-        case .openInEditor:
-            return [.command, .shift]
-        }
+        EventModifiers(appKitModifiers: appKitModifiers)
     }
 
     var keyEquivalent: KeyEquivalent {
@@ -113,20 +89,18 @@ enum AppChromeShortcut: CaseIterable {
 }
 
 enum AppChromeShortcutCatalog {
-    // Keep this list intentionally narrow; context-dependent shortcuts can be
-    // routed via ShortcutRoutingPolicy overrides.
-    static let appOwnedDefaults: [AppChromeShortcut] = [
-        .toggleSidebar,
-        .toggleInspector,
-        .toggleTerminalPanel,
-        .newWorkspace,
-        .newTerminalTab,
-        .closeTerminalTab,
-        .nextTerminalTab,
-        .previousTerminalTab,
-        .alternateNextTerminalTab,
-        .alternatePreviousTerminalTab,
-    ]
+    static let appOwnedDefaults: [AppChromeShortcut] =
+        AppChromeShortcut.allCases.filter { $0.defaultRoute == .appChrome }
 
     static let appOwnedDefaultChords: Set<ShortcutChord> = Set(appOwnedDefaults.map(\.chord))
+}
+
+extension EventModifiers {
+    fileprivate init(appKitModifiers: NSEvent.ModifierFlags) {
+        self = []
+        if appKitModifiers.contains(.command) { insert(.command) }
+        if appKitModifiers.contains(.control) { insert(.control) }
+        if appKitModifiers.contains(.option) { insert(.option) }
+        if appKitModifiers.contains(.shift) { insert(.shift) }
+    }
 }

--- a/Sources/WorkspaceManager/App/SettingsWindowPresenter.swift
+++ b/Sources/WorkspaceManager/App/SettingsWindowPresenter.swift
@@ -1,0 +1,20 @@
+//
+//  SettingsWindowPresenter.swift
+//  WorkspaceManager
+//
+//  Shared bridge for opening the SwiftUI Settings scene from AppKit command paths.
+//
+
+import AppKit
+
+@MainActor
+enum SettingsWindowPresenter {
+    @discardableResult
+    static func open() -> Bool {
+        if NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil) {
+            return true
+        }
+
+        return NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+    }
+}

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -80,6 +80,16 @@ struct WorkspaceManagerApp: App {
                 .disabled(!softwareUpdateController.canCheckForUpdates)
             }
 
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings...") {
+                    SettingsWindowPresenter.open()
+                }
+                .keyboardShortcut(
+                    AppChromeShortcut.settings.keyEquivalent,
+                    modifiers: AppChromeShortcut.settings.eventModifiers
+                )
+            }
+
             CommandGroup(replacing: .newItem) {
                 Button("New Workspace...") {
                     appCommandState.performNewWorkspace()

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -643,12 +643,7 @@ struct SidebarView: View {
     }
 
     private func openSettingsWindow() {
-        let selector = Selector(("showSettingsWindow:"))
-        if NSApp.sendAction(selector, to: nil, from: nil) {
-            return
-        }
-
-        _ = NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+        SettingsWindowPresenter.open()
     }
 
     private func openLumeLog() {

--- a/Tests/WorkspaceManagerAppTests/ShortcutRoutingPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ShortcutRoutingPolicyTests.swift
@@ -42,16 +42,10 @@ struct ShortcutRoutingPolicyTests {
     func appOwnedDefaultsRouteToAppChrome() {
         policy.clearOverrides()
 
-        #expect(policy.route(for: AppChromeShortcut.toggleSidebar.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.toggleInspector.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.toggleTerminalPanel.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.newWorkspace.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.newTerminalTab.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.closeTerminalTab.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.nextTerminalTab.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.previousTerminalTab.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.alternateNextTerminalTab.chord) == .appChrome)
-        #expect(policy.route(for: AppChromeShortcut.alternatePreviousTerminalTab.chord) == .appChrome)
+        for shortcut in AppChromeShortcutCatalog.appOwnedDefaults {
+            #expect(policy.route(for: shortcut.chord) == .appChrome)
+        }
+        #expect(AppChromeShortcutCatalog.appOwnedDefaults.contains(.settings))
     }
 
     @Test("Non-reserved shortcuts route to Ghostty by default")
@@ -61,6 +55,15 @@ struct ShortcutRoutingPolicyTests {
         let splitChord = chord("d", modifiers: [.command])
         #expect(policy.route(for: splitChord) == .ghostty)
         #expect(policy.route(for: AppChromeShortcut.openInEditor.chord) == .ghostty)
+    }
+
+    @Test("App-owned default catalog is derived from shortcut route policy")
+    func appOwnedDefaultCatalogMatchesShortcutRoutePolicy() {
+        let expectedDefaults = AppChromeShortcut.allCases.filter { $0.defaultRoute == .appChrome }
+
+        #expect(AppChromeShortcutCatalog.appOwnedDefaults == expectedDefaults)
+        #expect(!AppChromeShortcutCatalog.appOwnedDefaults.contains(.openInEditor))
+        #expect(AppChromeShortcut.openInEditor.defaultRoute == .ghostty)
     }
 
     @Test("Overrides are applied and removable")
@@ -99,6 +102,8 @@ struct ShortcutRoutingPolicyTests {
         let inspectorUp = keyEvent(type: .keyUp, key: "B", modifiers: [.command, .shift])
         let terminalDown = keyEvent(type: .keyDown, key: "j", modifiers: [.command])
         let terminalUp = keyEvent(type: .keyUp, key: "j", modifiers: [.command])
+        let settingsDown = keyEvent(type: .keyDown, key: ",", modifiers: [.command])
+        let settingsUp = keyEvent(type: .keyUp, key: ",", modifiers: [.command])
         let splitUp = keyEvent(type: .keyUp, key: "d", modifiers: [.command])
 
         #expect(policy.route(for: sidebarDown) == .appChrome)
@@ -107,6 +112,8 @@ struct ShortcutRoutingPolicyTests {
         #expect(policy.route(for: inspectorUp) == .appChrome)
         #expect(policy.route(for: terminalDown) == .appChrome)
         #expect(policy.route(for: terminalUp) == .appChrome)
+        #expect(policy.route(for: settingsDown) == .appChrome)
+        #expect(policy.route(for: settingsUp) == .appChrome)
         #expect(policy.route(for: splitUp) == .ghostty)
     }
 }

--- a/backlog/managed-pr-reviewer-continuous-reruns_plan.md
+++ b/backlog/managed-pr-reviewer-continuous-reruns_plan.md
@@ -1,0 +1,232 @@
+---
+topic: pr-reviewer
+priority: 1
+description: Make the managed PR reviewer run again on meaningful PR updates while carrying forward prior review context and avoiding review loops.
+---
+
+# Managed PR Reviewer Continuous Reruns
+
+## Problem Statement
+
+The managed PR reviewer currently behaves like a one-shot opening review. That was enough for initial coverage, but PR #460 exposed a workflow gap: the bot requested changes for missing evidence, the author later added evidence and all checks passed, but the managed reviewer did not run again. The stale request-changes review had to be handled manually even though the new PR body and comments contained the information the reviewer asked for.
+
+We need a continuous review model that reruns on meaningful PR updates and gives the reviewer its own previous output as context. This should let it approve or revise a stale evidence-only request after new commits, PR body edits, or evidence comments, without requiring a human to dismiss the stale review. The production reviewer should still use server-side trusted context assembly and must not load mutable skill instructions from the PR branch.
+
+## Investigation Notes
+
+- `web/src/app/api/webhooks/github/route.ts:149` triggers `triggerPrReview()` only for `pull_request.opened`.
+- `web/docs/pr-reviewer.md:169` documents the same limitation and only sketches adding `reopened` or `synchronize`.
+- `web/src/lib/agent-runtime/pr-review.ts:345` fetches recent issue comments for evidence context, but does not fetch prior managed reviews for the current PR.
+- `web/src/lib/agent-runtime/pr-review.ts:249` only checks whether relationship-candidate PRs have been reviewed by the managed reviewer. It records a boolean, not the previous review body or decision.
+- `web/src/lib/agent-runtime/pr-review.ts:494` injects previous PR narrative context and current PR comments into the kickoff message, but does not include same-PR review history, stale review state, dismissed review state, or commit-to-commit delta context.
+- `web/src/lib/db.ts:75` has `managed_agents_cache` for agent/environment IDs, but no table that tracks reviewer runs, trigger fingerprints, session IDs, or last reviewed head SHA.
+- In PR #460, an `@claude` comment fired `Agent: Mention Triage` but the workflow skipped, and a direct reviewer request to `workspaces-claude-pr-reviewer[bot]` left no pending reviewer. The managed reviewer does not currently expose a reliable manual rerun path.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Trigger scope | Rerun on `pull_request.opened`, `reopened`, `ready_for_review`, `synchronize`, PR body `edited`, and evidence-bearing PR comments | These events cover new code, changed evidence, and revived PRs without waiting for manual dismissal |
+| Same-PR context | Fetch prior managed reviewer reviews for the current PR and include their state, commit SHA, submitted time, dismissal state, and a truncated body | The reviewer needs to know whether it is revisiting its own prior request, especially evidence-only blockers |
+| Idempotency | Add durable reviewer-run fingerprints keyed by repo, PR number, head SHA, trigger kind, trigger source ID, and reviewer config hash | This prevents duplicate sessions from webhook retries and bot self-triggered events while still allowing same-head evidence reruns |
+| Loop guards | Skip events from `workspaces-claude-pr-reviewer[bot]`, skip GitHub Actions bot evidence reminders unless author-supplied evidence changed, and skip PRs with an existing completed managed review for the same fingerprint | Continuous review must not create bot-review loops or cost spikes |
+| Runtime boundary | Keep prompt/context assembly in `web/src/lib/agent-runtime/pr-review.ts`; do not load local skills into the managed-agent session | Prior reviewer work established server-side context as deterministic and safer than branch-local prompt loading |
+| Manual path | Add a trusted operator rerun command or route after automatic reruns work | PR #460 showed we need an explicit fallback when event triggers do not cover a real-world case |
+
+## Proposed Architecture
+
+```text
+GitHub webhook
+  |
+  v
+web/src/app/api/webhooks/github/route.ts
+  |
+  +--> parsePrReviewTrigger(eventType, action, payload)
+  |      - opened/reopened/ready_for_review
+  |      - synchronize
+  |      - edited body/title changes
+  |      - issue_comment.created with evidence-like content
+  |
+  +--> shouldStartPrReview(trigger)
+  |      - skip draft PRs
+  |      - skip reviewer bot events
+  |      - skip duplicate fingerprint
+  |      - optionally debounce same-PR bursts
+  |
+  v
+triggerPrReview(payload, triggerContext)
+  |
+  +--> fetchPrNarrativeContext()
+  +--> fetchPrEvidenceContext()
+  +--> fetchCurrentPrReviewHistory()
+  +--> record reviewer run start
+  |
+  v
+Managed Agent kickoff
+  |
+  +--> current PR body and comments
+  +--> previous PR narrative context
+  +--> same-PR managed review history
+  +--> trigger reason and delta hint
+```
+
+## Implementation Phases
+
+### Phase 1: Extract Trigger Parsing
+
+**Files to modify:**
+- `web/src/app/api/webhooks/github/route.ts` - replace the inline `pull_request.opened` condition with a small trigger parser and dispatcher.
+- `web/src/app/api/webhooks/github/route.test.ts` - add trigger matrix coverage.
+- `web/docs/pr-reviewer.md` - document continuous rerun behavior and loop guards.
+
+**Trigger rules:**
+- `pull_request.opened`: initial review.
+- `pull_request.reopened`: rerun because old review state may be stale.
+- `pull_request.ready_for_review`: run when a draft becomes reviewable.
+- `pull_request.synchronize`: rerun when the head SHA changes.
+- `pull_request.edited`: rerun when the PR body changes and the PR is not a draft.
+- `issue_comment.created`: rerun only on PR comments by non-bot trusted users when the body contains evidence-like signals such as `evidence.cloudcompute.com`, `Evidence:`, `swift test`, `Playwright`, `screenshot`, `recording`, or `validation`.
+
+**Acceptance criteria:**
+- [ ] `triggerPrReview()` still runs for `pull_request.opened`.
+- [ ] `triggerPrReview()` runs for `synchronize` with the new head SHA.
+- [ ] A PR body edit reruns the reviewer when evidence links are added.
+- [ ] A trusted evidence comment reruns the reviewer even when the head SHA is unchanged.
+- [ ] Comments from `workspaces-claude-pr-reviewer[bot]`, `github-actions[bot]`, and other bots do not trigger a rerun.
+- [ ] Draft PRs are skipped unless the action is `ready_for_review`.
+
+### Phase 2: Add Durable Reviewer Run State
+
+**Files to modify:**
+- `web/src/lib/db.ts` - add a `managed_pr_review_runs` table type.
+- `web/src/lib/agent-runtime/pr-review-runs.ts` - create a small helper for table creation, fingerprinting, start records, and completion/error updates.
+- `web/src/lib/agent-runtime/pr-review.ts` - record session IDs and trigger metadata when a session starts.
+- `web/src/lib/agent-runtime/__tests__/pr-review.test.ts` - cover run recording and duplicate handling.
+
+**Table shape:**
+
+```sql
+CREATE TABLE IF NOT EXISTS managed_pr_review_runs (
+  fingerprint TEXT PRIMARY KEY,
+  repo TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  head_sha TEXT NOT NULL,
+  trigger_kind TEXT NOT NULL,
+  trigger_source_id TEXT NOT NULL,
+  reviewer_config_hash TEXT NOT NULL,
+  session_id TEXT,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  error TEXT
+);
+```
+
+**Acceptance criteria:**
+- [ ] Webhook retries do not start duplicate sessions for the same fingerprint.
+- [ ] A same-head evidence comment can start a new review because its `trigger_source_id` differs from the prior run.
+- [ ] A new head SHA starts a new review even when the trigger kind is still `synchronize`.
+- [ ] Failed session creation records a failed run with enough error text for operator debugging.
+
+### Phase 3: Fetch Same-PR Managed Review History
+
+**Files to modify:**
+- `web/src/lib/agent-runtime/pr-review.ts` - add `fetchCurrentPrReviewHistory()` and `formatCurrentPrReviewHistory()`.
+- `web/src/lib/agent-runtime/__tests__/pr-review.test.ts` - cover prior request-changes, prior approval, dismissed review, and no-history cases.
+
+**Context to fetch:**
+- REST `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews`.
+- Filter to `workspaces-claude-pr-reviewer[bot]`.
+- Keep the newest 3 managed reviews.
+- Include:
+  - review state: `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, or `DISMISSED`.
+  - review commit SHA.
+  - submitted timestamp.
+  - body truncated to a safe size.
+  - whether the review is on the current head SHA.
+  - dismissal message when available from the API.
+
+**Kickoff instruction changes:**
+- Tell the reviewer when it is rerunning because evidence or code changed.
+- Tell it to explicitly reconsider any prior `REQUEST_CHANGES` review in light of current PR body, comments, and head SHA.
+- Tell it to approve if the prior blocker is now resolved and no new blockers exist.
+- Tell it not to repeat a stale evidence request if current evidence satisfies the previously requested proof.
+
+**Acceptance criteria:**
+- [ ] Kickoff message contains `Current PR managed review history:` for reruns.
+- [ ] Prior evidence-only request-changes reviews appear as untrusted context.
+- [ ] The reviewer can distinguish stale old-head review state from current-head review state.
+- [ ] Prompt tests assert that prior review content is treated as untrusted data, not instructions.
+
+### Phase 4: Add Manual Rerun Support
+
+**Files to modify:**
+- `web/src/app/api/webhooks/github/route.ts` or a new internal route under `web/src/app/api/managed-agents/` - support a trusted rerun entry point.
+- `web/docs/pr-reviewer.md` - document the operator command.
+- Optional: `scripts/pr-reviewer-status.py` - add a `rerun` subcommand if it can authenticate safely.
+
+**Options to evaluate:**
+- A trusted PR comment command, for example `/pr-reviewer rerun`, accepted only from repository owners/collaborators.
+- A protected internal HTTP route using existing app auth or a shared operator secret.
+- A `workflow_dispatch` wrapper that calls the production route with a signed GitHub event-like payload.
+
+**Acceptance criteria:**
+- [ ] Maintainers can retrigger the managed reviewer for PR #460-style cases without manually dismissing reviews first.
+- [ ] Untrusted PR comments cannot trigger privileged review compute.
+- [ ] Manual reruns still use the same idempotency and loop-guard layer.
+
+### Phase 5: Production Safety And Observability
+
+**Files to modify:**
+- `web/docs/pr-reviewer.md` - add troubleshooting for continuous reruns.
+- `scripts/test_security_hardening.py` - add coverage if trigger expansion affects public-content event handling.
+- `web/src/lib/agent-runtime/config.ts` - add optional `PR_REVIEWER_RERUNS_ENABLED` or similar rollout flag if needed.
+
+**Safety controls:**
+- Keep `PR_REVIEWER_ENABLED=1` as the primary gate.
+- Consider `PR_REVIEWER_RERUNS_ENABLED=1` for staged rollout.
+- Add event logs for skip reasons: draft, bot author, duplicate fingerprint, missing PR payload, unsupported action.
+- Keep GitHub write credentials out of managed-agent resources.
+- Continue to let the server-side broker validate final review intent before posting.
+
+**Acceptance criteria:**
+- [ ] Vercel logs show why a potential rerun was skipped or started.
+- [ ] Duplicate webhook deliveries are visible but harmless.
+- [ ] The reviewer cannot trigger itself through its own review or comment.
+- [ ] Security hardening tests still pass.
+
+## Verification Commands
+
+```bash
+# Web checks for implementation PR
+mise -C web run web:check
+
+# Security workflow checks if triggers or privileged events change
+uv run --script scripts/test_security_hardening.py
+
+# Targeted webhook route tests during development
+cd web
+pnpm vitest run src/app/api/webhooks/github/route.test.ts
+pnpm vitest run src/lib/agent-runtime/__tests__/pr-review.test.ts
+
+# Manual production observation after deploy
+./scripts/pr-reviewer-status.py --errors
+./scripts/pr-reviewer-status.py
+```
+
+## Rollback Plan
+
+1. Disable continuous reruns with `PR_REVIEWER_RERUNS_ENABLED=0` if a rollout flag is added.
+2. Revert the route trigger expansion while keeping same-PR review history formatting if it is useful for opened reviews.
+3. Keep the durable run table in place; unused rows are harmless and can support a later retry.
+4. If prior-review context makes the reviewer echo stale findings, remove only the same-PR review-history block from the kickoff message and keep the trigger/idempotency layer.
+
+## References
+
+- `web/src/app/api/webhooks/github/route.ts:149` - current one-shot `pull_request.opened` trigger.
+- `web/docs/pr-reviewer.md:169` - current docs for manually changing the trigger.
+- `web/src/lib/agent-runtime/pr-review.ts:345` - current evidence comment context.
+- `web/src/lib/agent-runtime/pr-review.ts:494` - kickoff context assembly.
+- `web/src/lib/db.ts:75` - current DB table registry with no reviewer run table.
+- `backlog/pr-reviewer-narration-eval-skill_plan.md` - related eval skill plan; keep this runtime change separate from eval tooling.
+- PR #460 - concrete incident: stale evidence-only request-changes review after evidence was added.


### PR DESCRIPTION
## Summary

- Add Command+, as a first-class app-owned shortcut for opening Settings.
- Route the Settings shortcut away from Ghostty when terminal focus is active.
- Derive the app-owned shortcut routing catalog from each shortcut's declared default route so future standard app shortcuts are defined once and routed consistently.
- Share the AppKit Settings-window presenter between the menu command and existing sidebar recovery action.

## Mergeability

- Surface: desktop
- User-facing behavior changed: Command+, now opens the existing Settings window from the app menu, including when a terminal surface has focus.
- Non-happy paths considered: Settings presenter falls back from showSettingsWindow: to showPreferencesWindow: to preserve the existing sidebar behavior; contextual shortcuts such as Open in Editor remain Ghostty-routed by default until promoted by an explicit override.
- Release/ops preconditions: None.
- Residual risk or follow-up: Live foreground keypress acceptance was not run on the shared desktop; shortcut routing is covered by tests and the debug app launch/window was verified in no-activate mode.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/`; `swift test --filter ShortcutRoutingPolicyTests`; `./scripts/launch-dev.sh --no-build --no-activate --trust-mise --foreground`; `./scripts/capture-window.sh --pid 96201 --output /tmp/workspaces-shortcut-catalog-window-final.png`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Swift test evidence](https://evidence.cloudcompute.com/workspaces/pr-460/20260510-041812-shortcut-catalog-final-swift-test.svg)
- [Debug app window evidence](https://evidence.cloudcompute.com/workspaces/pr-460/20260510-041814-shortcut-catalog-final-debug-window.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
