### PR TITLE
fix: prevent setup prerender auth secret failure

### DIFF
--- a/web/src/app/setup/layout.tsx
+++ b/web/src/app/setup/layout.tsx
@@ -1,6 +1,8 @@
 import { getSession } from "@/lib/auth-server";
 import { PostHogUserIdentify } from "../dashboard/components/posthog-user-identify";
 
+export const dynamic = "force-dynamic";
+
 export default async function SetupLayout({
 	children,
 }: {


### PR DESCRIPTION
## Summary

- Mark the setup layout as dynamic so Next does not prerender /setup during production builds.
- Preserves the runtime-only BETTER_AUTH_SECRET guard instead of injecting a build-time placeholder into the production artifact.

## Mergeability

- Surface: web
- User-facing behavior changed: no intended UI behavior change; /setup remains server-rendered on demand.
- Non-happy paths considered: production build without BETTER_AUTH_SECRET now succeeds, while runtime auth paths still validate production secret presence.
- Release/ops preconditions: production runtime must still define BETTER_AUTH_SECRET in Vercel.
- Residual risk or follow-up: none known.

## Validation

- [ ] swift build
- [ ] swift test
- [x] Other checks run: env -u NODE_ENV pnpm build; pnpm run typecheck; pnpm run lint; pnpm test

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Build/check evidence](https://evidence.cloudcompute.com/workspaces/pr-462/20260510-044418-cd-auth-build-fix.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence