### PR TITLE
Speed up Conductor workspace setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env 2>/dev/null || true; bash ./scripts/setup",
+    "setup": "ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env 2>/dev/null || true; bash ./scripts/setup --fast",
     "archive": "cd \"$CONDUCTOR_ROOT_PATH\" && git fetch origin"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,11 +4,13 @@ This directory contains build/release helpers plus UI test utilities.
 
 ## First-Run Setup
 
-- `./scripts/setup` is the canonical first-run path. It links local env files from a sibling worktree when needed, validates and trusts only the reviewed root/web mise configs, installs mise-managed tools from `mise.lock`, unsets legacy `core.hooksPath`, and runs `prek install`.
+- `./scripts/setup --fast` is the Conductor workspace-creation path. It links local env files from a sibling worktree when needed, then validates and trusts only the reviewed root/web mise configs.
+- `./scripts/setup` or `./scripts/setup --full` is the full bootstrap path. It runs fast setup, installs mise-managed tools from `mise.lock`, refreshes prek hooks, and installs dependencies when needed.
 - `./scripts/setup --env-only` refreshes local env-file links without running dependency setup.
 - `./scripts/setup --hooks-only` installs or refreshes the prek git hooks without running dependency setup.
 - `./scripts/install-git-hooks.sh` remains only as a compatibility wrapper around `./scripts/setup --hooks-only`; prefer `./scripts/setup` in new docs and task definitions.
 - mise security rules live in [docs/development/mise-security.md](../docs/development/mise-security.md). Keep secrets and global trust bypasses out of mise config.
+- `web/.npmrc` enables pnpm's experimental global virtual store so repeated warm installs across Conductor workspaces reuse a shared virtual store.
 
 ## Root Mise Task Catalog
 
@@ -16,7 +18,7 @@ Use `./scripts/setup` for first-run bootstrap. After that, prefer the root `mise
 
 | Task | Backend | Purpose |
 |------|---------|---------|
-| `mise run setup` | `./scripts/setup` | Re-run bootstrap setup after the checkout is trusted. |
+| `mise run setup` | `./scripts/setup` | Re-run full bootstrap setup after the checkout is trusted. |
 | `mise run hooks-install` | `./scripts/setup --hooks-only` | Refresh prek hooks only. |
 | `mise run build-ghosttykit` | `./scripts/build-ghosttykit.sh` | Build the pinned GhosttyKit framework. |
 | `mise run lint` | `swift-format lint --strict --recursive Sources/ Tests/` | Check Swift formatting. |

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Trust mise config and install project dependencies"
+#MISE description="Trust mise config and optionally install project dependencies"
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -7,11 +7,13 @@ cd "$REPO_ROOT"
 
 usage() {
   cat <<'USAGE'
-Usage: ./scripts/setup [--hooks-only]
+Usage: ./scripts/setup [--fast|--full|--env-only|--hooks-only]
 
 Canonical first-run setup for this repository.
 
 Options:
+  --fast        Link env files and trust reviewed mise configs, then exit.
+  --full        Run the full bootstrap: trust, tools, hooks, and dependencies.
   --env-only    Link local env files from another worktree, then exit.
   --hooks-only  Install or refresh prek git hooks, then exit.
   -h, --help    Show this help.
@@ -19,9 +21,16 @@ USAGE
 }
 
 ENV_ONLY=0
+FAST=0
 HOOKS_ONLY=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --fast)
+      FAST=1
+      ;;
+    --full)
+      FAST=0
+      ;;
     --env-only)
       ENV_ONLY=1
       ;;
@@ -156,6 +165,11 @@ done < <(
     -path "*/node_modules" -prune -o \
     -name ".mise.toml" -print | sort
 )
+
+if [[ "$FAST" == "1" ]]; then
+  exit 0
+fi
+
 if [[ -f .mise.toml ]]; then
   MISE_IGNORED_CONFIG_PATHS="${HOME}/.config/mise${MISE_IGNORED_CONFIG_PATHS:+:$MISE_IGNORED_CONFIG_PATHS}" \
     MISE_PARANOID=1 \
@@ -170,6 +184,13 @@ install_deps() {
     (cd "$dir" && bun install)
   elif [[ -f "$dir/pnpm-lock.yaml" ]]; then
     echo "=> $dir: pnpm install"
+    if [[ -f "$dir/node_modules/.modules.yaml" \
+      && "$dir/node_modules/.modules.yaml" -nt "$dir/pnpm-lock.yaml" \
+      && (! -f "$dir/package.json" || "$dir/node_modules/.modules.yaml" -nt "$dir/package.json") \
+      && (! -f "$dir/.npmrc" || "$dir/node_modules/.modules.yaml" -nt "$dir/.npmrc") ]]; then
+      echo "=> $dir: pnpm dependencies already current"
+      return 0
+    fi
     # Codex and CI run setup without a TTY; CI=1 prevents pnpm from aborting
     # when it needs to recreate node_modules.
     (cd "$dir" && CI=1 pnpm install)

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import plistlib
 import re
@@ -271,9 +272,16 @@ class SecurityHardeningTests(unittest.TestCase):
 
         setup = (REPO_ROOT / "scripts/setup").read_text()
         self.assertIn('"$REPO_ROOT/.mise.toml"|"$REPO_ROOT/web/.mise.toml"', setup)
+        self.assertIn('if [[ "$FAST" == "1" ]]', setup)
         self.assertIn("mise install --locked zig@0.15.2", setup)
         self.assertIn("MISE_IGNORED_CONFIG_PATHS=", setup)
         self.assertNotIn("trust every checked-in project config", setup)
+
+        conductor = json.loads((REPO_ROOT / "conductor.json").read_text())
+        self.assertIn("./scripts/setup --fast", conductor["scripts"]["setup"])
+
+        web_npmrc = (REPO_ROOT / "web/.npmrc").read_text()
+        self.assertIn("enable-global-virtual-store=true", web_npmrc)
 
         sandbox = (REPO_ROOT / "web/src/lib/agent-runtime/vercel-sandbox.ts").read_text()
         self.assertIn("MISE_VERSION='v2026.5.3'", sandbox)

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,3 @@
+# Experimental: share pnpm's virtual store across Conductor workspaces so warm
+# installs do less per-workspace node_modules hydration.
+enable-global-virtual-store=true


### PR DESCRIPTION
## Summary

- Makes Conductor workspace creation use a fast setup path that links env files and trusts reviewed mise configs without running full dependency bootstrap.
- Keeps full bootstrap available through `./scripts/setup --full` / `mise run setup`, with a pnpm freshness guard for repeat runs.
- Enables pnpm's experimental global virtual store for `web/` and adds regression checks for the setup contract.

## Mergeability

- Surface: docs / web / setup scripts
- User-facing behavior changed: new Conductor workspaces should finish setup faster because the default setup script no longer hydrates `web/node_modules`.
- Non-happy paths considered: full setup remains available for dependency installation, and pnpm install still reruns when lockfile, package.json, or `.npmrc` changes.
- Release/ops preconditions: none.
- Residual risk or follow-up: the pre-setup Terminal tab mise warning requires a Conductor startup-order change; this PR only optimizes repo setup after the setup script starts.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `bash -n scripts/setup`; `./scripts/setup --fast`; `./scripts/setup --full` twice; `pnpm config get enable-global-virtual-store`; `uv run --script scripts/test_security_hardening.py`; `uv run --script scripts/test_setup_env_linking.py`; `mise -C web run web:check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: Existing Conductor setup hydrated `web/node_modules` during workspace creation; recent run took about 12s for 569 packages.
- After Summary: `./scripts/setup --fast` only trusts root/web mise configs; repeat `./scripts/setup --full` skips pnpm when dependencies are current.
- Delta Summary: Fast setup avoids the recurring pnpm install on Conductor workspace creation.

Performance comparison notes:

- Exact commands used: `./scripts/setup --fast`; `./scripts/setup --full`; repeat `./scripts/setup --full`
- Workload / environment context: local macOS checkout, warm pnpm store, `web/` dependencies already present after first full setup.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Validation evidence](https://evidence.cloudcompute.com/workspaces/pr-465/20260510-155909-setup-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
