### PR TITLE
fix: command-hook forwarder for /event (Unsupported protocol http+unix:)

### DIFF
--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -36,21 +36,29 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
     private var installerFactory: @Sendable (String) async -> any ClaudeSettingsInstalling = {
         _ in
         let installer = ClaudeSettingsInstaller()
-        guard let eventForwarderPath = ClaudeIntegrationLifecycle.extractEventForwarderScript()
-        else {
+
+        // Channel 1: requires the bundled event-forwarder shell. If extraction
+        // fails (most tests, previews) we skip JUST this contribution so
+        // Channels 2 and 3 still register cleanly.
+        if let eventForwarderPath = ClaudeIntegrationLifecycle.extractEventForwarderScript() {
+            let titleEmitPath = ClaudeIntegrationLifecycle.extractTitleEmitScript()
+            await installer.register(
+                workspacesHooksContribution(
+                    eventForwarderScriptPath: eventForwarderPath,
+                    titleEmitScriptPath: titleEmitPath
+                )
+            )
+        } else {
             NSLog(
-                "[ClaudeIntegration] event-forwarder.sh extraction failed; channel 1 settings install will be skipped"
+                "[ClaudeIntegration] event-forwarder.sh extraction failed; Channel 1 will be skipped this session (Channels 2 and 3 unaffected)"
             )
-            return installer
         }
-        let titleEmitPath = ClaudeIntegrationLifecycle.extractTitleEmitScript()
-        await installer.register(
-            workspacesHooksContribution(
-                eventForwarderScriptPath: eventForwarderPath,
-                titleEmitScriptPath: titleEmitPath
-            )
-        )
+
+        // Channel 3 channel-selection: writes preferredNotifChannel into ~/.claude.json.
+        // Independent of Channel 1's script availability.
         await installer.register(workspacesNotifChannelContribution())
+
+        // Channel 2: status-line forwarder. Independent of Channel 1's script.
         if let forwarderPath = ClaudeIntegrationLifecycle.bundledStatusLineForwarderPath() {
             await installer.register(
                 workspacesStatusLineContribution(forwarderPath: forwarderPath)

--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -34,13 +34,20 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
     private var didStart = false
     private var defaults: UserDefaults = .standard
     private var installerFactory: @Sendable (String) async -> any ClaudeSettingsInstalling = {
-        socketPath in
+        _ in
         let installer = ClaudeSettingsInstaller()
-        let scriptPath = ClaudeIntegrationLifecycle.extractTitleEmitScript()
+        guard let eventForwarderPath = ClaudeIntegrationLifecycle.extractEventForwarderScript()
+        else {
+            NSLog(
+                "[ClaudeIntegration] event-forwarder.sh extraction failed; channel 1 settings install will be skipped"
+            )
+            return installer
+        }
+        let titleEmitPath = ClaudeIntegrationLifecycle.extractTitleEmitScript()
         await installer.register(
             workspacesHooksContribution(
-                socketPath: socketPath,
-                titleEmitScriptPath: scriptPath
+                eventForwarderScriptPath: eventForwarderPath,
+                titleEmitScriptPath: titleEmitPath
             )
         )
         await installer.register(workspacesNotifChannelContribution())
@@ -149,11 +156,27 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         }
     }
 
+    /// Copy the bundled `event-forwarder.sh` (Channel 1 hook event forwarder) to a
+    /// stable location under Application Support and chmod it executable. Returns
+    /// the destination path, or nil if extraction failed — the contribution then
+    /// declines to register, and Channel 1 stays dormant for this session.
+    nonisolated static func extractEventForwarderScript() -> String? {
+        extractHookForwarderScript(named: "event-forwarder")
+    }
+
     /// Copy the bundled `title-emit.sh` (Channel 3 hook forwarder) to a stable
     /// location under Application Support and chmod it executable. Returns the
     /// destination path, or nil if extraction failed — the contribution then
-    /// degrades gracefully to HTTP-only hooks.
+    /// degrades gracefully to event-forwarder-only hooks.
     nonisolated static func extractTitleEmitScript() -> String? {
+        extractHookForwarderScript(named: "title-emit")
+    }
+
+    /// Generic helper used by both the event-forwarder and title-emit extractors:
+    /// copies `<name>.sh` from the bundle's `HookForwarders/` resource directory
+    /// to `~/Library/Application Support/<bundle-id>/HookForwarders/<name>.sh`,
+    /// chmods it 0o755, returns the destination path. Nil on any failure.
+    nonisolated private static func extractHookForwarderScript(named name: String) -> String? {
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
@@ -167,13 +190,13 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         try? FileManager.default.createDirectory(
             at: dir, withIntermediateDirectories: true
         )
-        let dest = dir.appendingPathComponent("title-emit.sh")
+        let dest = dir.appendingPathComponent("\(name).sh")
 
         // Source: bundled .sh file. Falls back to nil silently — most tests
         // and previews don't run inside a real .app bundle.
         guard
             let bundleURL = Bundle.main.url(
-                forResource: "title-emit",
+                forResource: name,
                 withExtension: "sh",
                 subdirectory: "HookForwarders"
             )

--- a/Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# event-forwarder.sh — Claude Code hook event forwarder.
+#
+# Configured in ~/.claude/settings.json under
+# `hooks.<EventName>[*].hooks[*]` as `{type: "command", command: "<this script>"}`.
+# Claude Code invokes this script with the hook payload JSON on stdin. We POST
+# the body unchanged to the host's Unix socket on /event, then exit 0.
+#
+# Why a command-hook forwarder instead of a `type: "http"` hook?
+# Real Claude Code does not speak the `http+unix://` URL scheme — POSTing such
+# a URL fails with `Unsupported protocol http+unix:` and the entire hook
+# pipeline errors. curl, however, supports `--unix-socket`, so we pipe through
+# it from a small command-hook script. Same pattern as `statusline.sh`.
+#
+# Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 1.
+#
+# Hard requirements:
+#   * stdlib bash + curl only — no jq, no python.
+#   * Never block; if the socket is unreachable, drop the payload and exit 0.
+#   * Exit 0 even on transport failure so Claude doesn't render a hook error.
+
+set -u
+
+socket="${WORKSPACES_HOOKS_SOCKET:-}"
+
+if [[ -n "$socket" && -S "$socket" ]]; then
+    /usr/bin/curl \
+        --silent \
+        --show-error \
+        --max-time 1 \
+        --unix-socket "$socket" \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        'http://localhost/event' \
+        >/dev/null 2>&1 || true
+else
+    # No socket means the host isn't running or the env var didn't propagate.
+    # Drain stdin so Claude doesn't block on the pipe.
+    cat >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -104,6 +104,12 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
     /// Apply all registered contributions. Backs up each settings file once before
     /// writing, and writes pretty-printed JSON. Non-destructive: untouched keys
     /// survive byte-for-byte at the JSON-value level.
+    ///
+    /// Routine-launch protection: if the merged result is byte-identical to the
+    /// existing file, install() skips the write AND skips the backup. Without
+    /// this, every silent reinstall on every app launch would churn the backup
+    /// chain and rotate away the last meaningful pre-integration backup, even
+    /// though nothing actually changed.
     public func install() throws {
         for target in [ClaudeSettingsContribution.Target.userSettingsJSON, .userClaudeJSON] {
             let scopedContributions = contributions.filter { $0.target == target }
@@ -119,6 +125,18 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 current = c.merge(current)
             }
 
+            // Serialize once — same options as writeJSON — so we can compare
+            // the merged result against the file on disk without a second read.
+            let mergedData = try JSONSerialization.data(
+                withJSONObject: Self.lower(current),
+                options: [.prettyPrinted, .sortedKeys]
+            )
+
+            if let originalDataIfPresent, originalDataIfPresent == mergedData {
+                // Nothing to do; preserve the backup chain.
+                continue
+            }
+
             if let originalDataIfPresent {
                 let backupURL = url.appendingPathExtension(
                     "workspaces-backup-\(Self.iso8601Timestamp())"
@@ -130,7 +148,7 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 rotateBackups(forSettingsFile: url)
             }
 
-            try writeJSON(current, to: url)
+            try mergedData.write(to: url)
         }
     }
 
@@ -331,10 +349,26 @@ public func workspacesHooksContribution(
     // agent's lifecycle (prompt submitted → "thinking", stop → "ready").
     let titleEmitEvents: Set<String> = ["UserPromptSubmit", "Stop"]
 
-    /// Drop legacy `type: "http"` handlers whose URL starts with `http+unix://`.
-    /// These were written by the PR #443 installer and are non-functional; we
-    /// scrub them whenever this contribution runs so opted-in users self-heal
-    /// on the next silent reinstall.
+    /// Drop legacy `type: "http"` handlers whose URL points at *our* old
+    /// pid-scoped socket path. PR #443's installer wrote these and they are
+    /// non-functional in real Claude Code (which does not speak `http+unix://`),
+    /// so we scrub them on every install. Crucially we do NOT scrub arbitrary
+    /// `http+unix://` URLs — a user with their own Unix-socket Claude hook must
+    /// keep it. The match is precise: percent-decoded URL must end in
+    /// `hooks-<digits>.sock/event` AND contain `/Application Support/` (our
+    /// install path under `~/Library/Application Support/<bundle-id>/`).
+    @Sendable
+    func looksLikeWorkspacesLegacyHookURL(_ raw: String?) -> Bool {
+        guard let raw, raw.hasPrefix("http+unix://") else { return false }
+        let payload = String(raw.dropFirst("http+unix://".count))
+        let decoded = payload.removingPercentEncoding ?? payload
+        guard decoded.range(of: #"/hooks-\d+\.sock/event$"#, options: .regularExpression) != nil
+        else {
+            return false
+        }
+        return decoded.contains("/Application Support/")
+    }
+
     @Sendable
     func scrubLegacyHTTPUnix(in groups: [[String: Any]]) -> [[String: Any]] {
         groups.compactMap { group in
@@ -342,7 +376,7 @@ public func workspacesHooksContribution(
             let kept = claudeHookHandlers(in: g).filter { handler in
                 let isLegacy =
                     (handler["type"] as? String) == "http"
-                    && ((handler["url"] as? String) ?? "").hasPrefix("http+unix://")
+                    && looksLikeWorkspacesLegacyHookURL(handler["url"] as? String)
                 return !isLegacy
             }
             if kept.isEmpty { return nil }
@@ -446,7 +480,7 @@ public func workspacesHooksContribution(
                 let legacyPresent = groups.contains { group in
                     claudeGroupContainsHandler(group) { handler in
                         (handler["type"] as? String) == "http"
-                            && ((handler["url"] as? String) ?? "").hasPrefix("http+unix://")
+                            && looksLikeWorkspacesLegacyHookURL(handler["url"] as? String)
                     }
                 }
                 if legacyPresent { legacyHTTPUnixToScrub.append(name) }

--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -292,23 +292,23 @@ private func claudeGroupContainsHandler(
     claudeHookHandlers(in: group).contains(where: predicate)
 }
 
-/// Build the contribution that registers our HTTP hook routes in `~/.claude/settings.json`.
-/// `socketPath` is the Unix socket the running app is listening on. When
-/// `titleEmitScriptPath` is non-nil the contribution also registers a
+/// Build the contribution that registers our hook routes in `~/.claude/settings.json`.
+/// `eventForwarderScriptPath` is the absolute path to the bundled `event-forwarder.sh`
+/// shell. When `titleEmitScriptPath` is non-nil the contribution also registers a
 /// `UserPromptSubmit`/`Stop` command hook that emits OSC 2 — the Channel 3 path
 /// that updates the embedded terminal's tab title without app-side polling.
+///
+/// History: PR #443 wrote `type: "http"` handlers with `http+unix://<socket>/event`
+/// URLs. Real Claude Code does not speak the `http+unix://` URL scheme; every hook
+/// errored with `Unsupported protocol http+unix:`. This contribution replaces that
+/// path with `type: "command"` handlers running a tiny shell forwarder that pipes
+/// stdin through `curl --unix-socket`. Same pattern as `statusline.sh`. Legacy
+/// `http+unix://` handlers are scrubbed from the user's settings on every install
+/// so opted-in users self-heal.
 public func workspacesHooksContribution(
-    socketPath: String,
+    eventForwarderScriptPath: String,
     titleEmitScriptPath: String? = nil
 ) -> ClaudeSettingsContribution {
-    // Per spec § Channel 1, point each interesting event at our /event route.
-    // `http+unix://<encoded-socket>/event` is the de-facto convention used by Claude Code.
-    let encodedSocket =
-        socketPath.addingPercentEncoding(
-            withAllowedCharacters: .alphanumerics
-        ) ?? socketPath
-    let endpoint = "http+unix://\(encodedSocket)/event"
-
     let eventNames: [String] = [
         "SessionStart",
         "UserPromptSubmit",
@@ -331,6 +331,26 @@ public func workspacesHooksContribution(
     // agent's lifecycle (prompt submitted → "thinking", stop → "ready").
     let titleEmitEvents: Set<String> = ["UserPromptSubmit", "Stop"]
 
+    /// Drop legacy `type: "http"` handlers whose URL starts with `http+unix://`.
+    /// These were written by the PR #443 installer and are non-functional; we
+    /// scrub them whenever this contribution runs so opted-in users self-heal
+    /// on the next silent reinstall.
+    @Sendable
+    func scrubLegacyHTTPUnix(in groups: [[String: Any]]) -> [[String: Any]] {
+        groups.compactMap { group in
+            var g = group
+            let kept = claudeHookHandlers(in: g).filter { handler in
+                let isLegacy =
+                    (handler["type"] as? String) == "http"
+                    && ((handler["url"] as? String) ?? "").hasPrefix("http+unix://")
+                return !isLegacy
+            }
+            if kept.isEmpty { return nil }
+            g["hooks"] = kept
+            return g
+        }
+    }
+
     return ClaudeSettingsContribution(
         id: "workspaces.hooks",
         target: .userSettingsJSON,
@@ -345,14 +365,19 @@ public func workspacesHooksContribution(
                 (current["hooks"]?.value as? [String: Any]) ?? [:]
             for name in eventNames {
                 var groups = normalizedClaudeHookGroups(from: hooks[name])
-                let httpPresent = groups.contains { group in
+
+                // Self-heal: remove any non-functional `http+unix://` entries
+                // left behind by PR #443's installer.
+                groups = scrubLegacyHTTPUnix(in: groups)
+
+                let eventForwarderPresent = groups.contains { group in
                     claudeGroupContainsHandler(group) { handler in
-                        (handler["type"] as? String) == "http"
-                            && (handler["url"] as? String) == endpoint
+                        (handler["type"] as? String) == "command"
+                            && (handler["command"] as? String) == eventForwarderScriptPath
                     }
                 }
 
-                let commandPresent = groups.contains { group in
+                let titleEmitPresent = groups.contains { group in
                     guard let scriptPath = titleEmitScriptPath else { return false }
                     return claudeGroupContainsHandler(group) { handler in
                         (handler["type"] as? String) == "command"
@@ -363,14 +388,10 @@ public func workspacesHooksContribution(
                 let integrationGroupIndex =
                     groups.firstIndex { group in
                         claudeGroupContainsHandler(group) { handler in
-                            (handler["type"] as? String) == "http"
-                                && (handler["url"] as? String) == endpoint
+                            (handler["type"] as? String) == "command"
+                                && ((handler["command"] as? String) == eventForwarderScriptPath
+                                    || (handler["command"] as? String) == titleEmitScriptPath)
                         }
-                            || claudeGroupContainsHandler(group) { handler in
-                                guard let scriptPath = titleEmitScriptPath else { return false }
-                                return (handler["type"] as? String) == "command"
-                                    && (handler["command"] as? String) == scriptPath
-                            }
                     }
                     ?? {
                         groups.append(["hooks": [[String: Any]]()])
@@ -380,16 +401,16 @@ public func workspacesHooksContribution(
                 var integrationGroup = groups[integrationGroupIndex]
                 var integrationHandlers = claudeHookHandlers(in: integrationGroup)
 
-                if !httpPresent {
+                if !eventForwarderPresent {
                     integrationHandlers.append([
-                        "type": "http",
-                        "url": endpoint,
+                        "type": "command",
+                        "command": eventForwarderScriptPath,
                         "async": true,
                     ])
                 }
                 if let scriptPath = titleEmitScriptPath,
                     titleEmitEvents.contains(name),
-                    !commandPresent
+                    !titleEmitPresent
                 {
                     integrationHandlers.append([
                         "type": "command",
@@ -407,9 +428,10 @@ public func workspacesHooksContribution(
         },
         preview: { current in
             let hooks = (current["hooks"]?.value as? [String: Any]) ?? [:]
-            var addedHTTP: [String] = []
-            var addedCommand: [String] = []
+            var addedEventForwarder: [String] = []
+            var addedTitleEmit: [String] = []
             var normalizedShape: [String] = []
+            var legacyHTTPUnixToScrub: [String] = []
             for name in eventNames {
                 let rawEntries = (hooks[name] as? [Any]) ?? []
                 if rawEntries.contains(where: {
@@ -420,13 +442,22 @@ public func workspacesHooksContribution(
                 }
 
                 let groups = normalizedClaudeHookGroups(from: hooks[name])
-                let httpPresent = groups.contains { group in
+
+                let legacyPresent = groups.contains { group in
                     claudeGroupContainsHandler(group) { handler in
                         (handler["type"] as? String) == "http"
-                            && (handler["url"] as? String) == endpoint
+                            && ((handler["url"] as? String) ?? "").hasPrefix("http+unix://")
                     }
                 }
-                if !httpPresent { addedHTTP.append(name) }
+                if legacyPresent { legacyHTTPUnixToScrub.append(name) }
+
+                let eventForwarderPresent = groups.contains { group in
+                    claudeGroupContainsHandler(group) { handler in
+                        (handler["type"] as? String) == "command"
+                            && (handler["command"] as? String) == eventForwarderScriptPath
+                    }
+                }
+                if !eventForwarderPresent { addedEventForwarder.append(name) }
 
                 if let scriptPath = titleEmitScriptPath, titleEmitEvents.contains(name) {
                     let cmdPresent = groups.contains { group in
@@ -435,26 +466,34 @@ public func workspacesHooksContribution(
                                 && (handler["command"] as? String) == scriptPath
                         }
                     }
-                    if !cmdPresent { addedCommand.append(name) }
+                    if !cmdPresent { addedTitleEmit.append(name) }
                 }
             }
-            if addedHTTP.isEmpty && addedCommand.isEmpty && normalizedShape.isEmpty {
-                return "no changes (already wired for \(eventNames.count) events → \(endpoint))"
+            if addedEventForwarder.isEmpty && addedTitleEmit.isEmpty
+                && normalizedShape.isEmpty && legacyHTTPUnixToScrub.isEmpty
+            {
+                return
+                    "no changes (already wired for \(eventNames.count) events → \(eventForwarderScriptPath))"
             }
             var parts: [String] = []
+            if !legacyHTTPUnixToScrub.isEmpty {
+                parts.append(
+                    "scrub \(legacyHTTPUnixToScrub.count) legacy http+unix:// hook(s): \(legacyHTTPUnixToScrub.joined(separator: ", "))"
+                )
+            }
             if !normalizedShape.isEmpty {
                 parts.append(
                     "normalize legacy hook group shape for \(normalizedShape.joined(separator: ", "))"
                 )
             }
-            if !addedHTTP.isEmpty {
+            if !addedEventForwarder.isEmpty {
                 parts.append(
-                    "add \(addedHTTP.count) http hook(s) → \(endpoint): \(addedHTTP.joined(separator: ", "))"
+                    "add \(addedEventForwarder.count) command hook(s) → \(eventForwarderScriptPath): \(addedEventForwarder.joined(separator: ", "))"
                 )
             }
-            if !addedCommand.isEmpty, let scriptPath = titleEmitScriptPath {
+            if !addedTitleEmit.isEmpty, let scriptPath = titleEmitScriptPath {
                 parts.append(
-                    "add \(addedCommand.count) command hook(s) → \(scriptPath): \(addedCommand.joined(separator: ", "))"
+                    "add \(addedTitleEmit.count) title-emit command hook(s) → \(scriptPath): \(addedTitleEmit.joined(separator: ", "))"
                 )
             }
             return parts.joined(separator: "; ")

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerBackupRotationTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerBackupRotationTests.swift
@@ -32,7 +32,7 @@ struct ClaudeSettingsInstallerBackupRotationTests {
         let settingsURL = claudeDir.appendingPathComponent("settings.json")
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/r.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
 
         // Seed and install 7 times. Mutate between installs so each install
         // sees a different on-disk file (otherwise the contribution is a no-op
@@ -92,7 +92,7 @@ struct ClaudeSettingsInstallerBackupRotationTests {
         let settingsURL = claudeDir.appendingPathComponent("settings.json")
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/r2.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
 
         try Data("{}\n".utf8).write(to: settingsURL)
         var installCount = 0

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
@@ -53,7 +53,7 @@ struct ClaudeSettingsInstallerTests {
         try data.write(to: settingsURL)
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         try await installer.install()
 
         let updatedData = try Data(contentsOf: settingsURL)
@@ -63,24 +63,42 @@ struct ClaudeSettingsInstallerTests {
         #expect(updated["model"] as? String == "claude-opus-4")
 
         let preToolUse = hookGroups(named: "PreToolUse", in: updated)
-        // Original raw command hook is preserved and normalized into a matcher
-        // group; our http hook is added as a second matcherless group.
+        // Original user command hook is preserved and normalized; our event-forwarder
+        // command hook is added as a second matcherless group.
         #expect(preToolUse.count == 2)
         #expect(
             preToolUse.contains {
-                hookHandlers(in: $0).contains { ($0["type"] as? String) == "command" }
+                hookHandlers(in: $0).contains {
+                    ($0["type"] as? String) == "command"
+                        && ($0["command"] as? String) == "/usr/local/bin/myhook"
+                }
             })
         #expect(
             preToolUse.contains {
-                hookHandlers(in: $0).contains { ($0["type"] as? String) == "http" }
+                hookHandlers(in: $0).contains {
+                    ($0["type"] as? String) == "command"
+                        && ($0["command"] as? String) == "/tmp/event-forwarder.sh"
+                }
             })
 
-        // Our endpoint should be wired for all spec-listed events.
+        // Our event-forwarder should be wired for every spec-listed event.
         let stop = hookGroups(named: "Stop", in: updated)
         #expect(
             stop.contains {
-                hookHandlers(in: $0).contains { ($0["type"] as? String) == "http" }
+                hookHandlers(in: $0).contains {
+                    ($0["type"] as? String) == "command"
+                        && ($0["command"] as? String) == "/tmp/event-forwarder.sh"
+                }
             })
+
+        // No `type: "http"` handlers anywhere — the http+unix:// scheme is broken in
+        // real Claude and must never be written by this installer again.
+        let allHookGroups = (updated["hooks"] as? [String: Any] ?? [:])
+            .values.flatMap { $0 as? [[String: Any]] ?? [] }
+        let anyHTTP = allHookGroups.contains { group in
+            hookHandlers(in: group).contains { ($0["type"] as? String) == "http" }
+        }
+        #expect(anyHTTP == false)
     }
 
     @Test("Backup file is written before mutation")
@@ -97,7 +115,7 @@ struct ClaudeSettingsInstallerTests {
         try originalData.write(to: settingsURL)
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         try await installer.install()
 
         let entries = try FileManager.default.contentsOfDirectory(at: claudeDir, includingPropertiesForKeys: nil)
@@ -116,7 +134,7 @@ struct ClaudeSettingsInstallerTests {
         defer { try? FileManager.default.removeItem(at: home) }
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         try await installer.install()
         try await installer.install()
 
@@ -124,14 +142,21 @@ struct ClaudeSettingsInstallerTests {
         let data = try Data(contentsOf: settingsURL)
         let updated = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
         let preToolUse = hookGroups(named: "PreToolUse", in: updated)
-        let httpEntries = preToolUse.flatMap { group in
-            hookHandlers(in: group).filter { ($0["type"] as? String) == "http" }
+        let eventForwarderEntries = preToolUse.flatMap { group in
+            hookHandlers(in: group).filter {
+                ($0["type"] as? String) == "command"
+                    && ($0["command"] as? String) == "/tmp/event-forwarder.sh"
+            }
         }
-        #expect(httpEntries.count == 1)
+        #expect(eventForwarderEntries.count == 1)
     }
 
-    @Test("Re-install normalizes legacy raw handler entries into matcher groups")
-    func reinstallNormalizesLegacyRawHandlers() async throws {
+    @Test("Re-install scrubs legacy http+unix:// hook entries from previous installer versions")
+    func reinstallScrubsLegacyHTTPUnixEntries() async throws {
+        // Background: PR #443's installer wrote `type: "http"` handlers with
+        // `http+unix://...` URLs. Real Claude Code does not speak that URL scheme,
+        // so every hook errored with `Unsupported protocol http+unix:`. The
+        // current installer self-heals by removing those handlers on every run.
         let home = makeTempHome()
         defer { try? FileManager.default.removeItem(at: home) }
 
@@ -144,9 +169,14 @@ struct ClaudeSettingsInstallerTests {
                 "Notification": [
                     [
                         "type": "http",
-                        "url": "http+unix://legacy/event",
+                        "url": "http+unix://legacy-pid-1234/event",
                         "async": true,
-                    ]
+                    ],
+                    [
+                        "type": "http",
+                        "url": "http+unix://legacy-pid-5678/event",
+                        "async": true,
+                    ],
                 ]
             ]
         ]
@@ -154,24 +184,31 @@ struct ClaudeSettingsInstallerTests {
         try data.write(to: settingsURL)
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(
+            workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         try await installer.install()
 
         let updatedData = try Data(contentsOf: settingsURL)
         let updated = try JSONSerialization.jsonObject(with: updatedData) as? [String: Any] ?? [:]
         let notification = hookGroups(named: "Notification", in: updated)
-        #expect(notification.count == 2)
-        #expect(notification.allSatisfy { $0["type"] == nil })
-        #expect(
-            notification.contains {
-                hookHandlers(in: $0).contains { ($0["url"] as? String) == "http+unix://legacy/event" }
-            })
-        #expect(
-            notification.contains {
-                hookHandlers(in: $0).contains {
-                    ($0["url"] as? String) == "http+unix://%2Ftmp%2Fhooks%2Esock/event"
-                }
-            })
+
+        // Legacy http+unix:// entries are gone.
+        let anyLegacy = notification.contains { group in
+            hookHandlers(in: group).contains {
+                ($0["type"] as? String) == "http"
+                    && ((($0["url"] as? String) ?? "").hasPrefix("http+unix://"))
+            }
+        }
+        #expect(anyLegacy == false)
+
+        // Our event-forwarder command hook is wired in.
+        let hasEventForwarder = notification.contains { group in
+            hookHandlers(in: group).contains {
+                ($0["type"] as? String) == "command"
+                    && ($0["command"] as? String) == "/tmp/event-forwarder.sh"
+            }
+        }
+        #expect(hasEventForwarder)
     }
 
     @Test("renderPreview describes pending changes")
@@ -180,7 +217,7 @@ struct ClaudeSettingsInstallerTests {
         defer { try? FileManager.default.removeItem(at: home) }
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         let preview = try await installer.renderPreview()
         #expect(preview.contains("workspaces.hooks"))
         #expect(preview.contains("Stop"))
@@ -192,7 +229,7 @@ struct ClaudeSettingsInstallerTests {
         defer { try? FileManager.default.removeItem(at: home) }
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         let beforeInstall = await installer.isInstalled()
         #expect(beforeInstall == false)
         try await installer.install()
@@ -244,7 +281,7 @@ struct ClaudeSettingsInstallerTests {
         try original.write(to: settingsURL)
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         await installer.register(
             workspacesStatusLineContribution(forwarderPath: "/tmp/statusline.sh")
         )
@@ -256,11 +293,14 @@ struct ClaudeSettingsInstallerTests {
         // Theme survives.
         #expect(updated["theme"] as? String == "dark")
 
-        // Hook routes wired up for all spec-listed events.
+        // Event-forwarder command hooks wired up for all spec-listed events.
         let stop = hookGroups(named: "Stop", in: updated)
         #expect(
             stop.contains {
-                hookHandlers(in: $0).contains { ($0["type"] as? String) == "http" }
+                hookHandlers(in: $0).contains {
+                    ($0["type"] as? String) == "command"
+                        && ($0["command"] as? String) == "/tmp/event-forwarder.sh"
+                }
             })
 
         // statusLine block points at our forwarder; original `padding` field is

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
@@ -151,12 +151,17 @@ struct ClaudeSettingsInstallerTests {
         #expect(eventForwarderEntries.count == 1)
     }
 
-    @Test("Re-install scrubs legacy http+unix:// hook entries from previous installer versions")
+    @Test("Re-install scrubs legacy WorkSpaces http+unix:// hook entries (precise match)")
     func reinstallScrubsLegacyHTTPUnixEntries() async throws {
         // Background: PR #443's installer wrote `type: "http"` handlers with
-        // `http+unix://...` URLs. Real Claude Code does not speak that URL scheme,
-        // so every hook errored with `Unsupported protocol http+unix:`. The
-        // current installer self-heals by removing those handlers on every run.
+        // `http+unix://<percent-encoded-Application Support socket>/event` URLs.
+        // Real Claude Code does not speak that URL scheme, so every hook errored
+        // with `Unsupported protocol http+unix:`. The current installer
+        // self-heals by removing OUR specific URLs on every run.
+        //
+        // The match is precise: percent-decoded URL must end in
+        // `hooks-<digits>.sock/event` AND contain `/Application Support/`. Other
+        // `http+unix://` URLs the user owns must survive (see the next test).
         let home = makeTempHome()
         defer { try? FileManager.default.removeItem(at: home) }
 
@@ -164,19 +169,19 @@ struct ClaudeSettingsInstallerTests {
         try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
         let settingsURL = claudeDir.appendingPathComponent("settings.json")
 
+        // Two realistic legacy URLs as PR #443's installer would have written
+        // them: percent-encoded paths under "Application Support" with
+        // pid-scoped socket filenames.
+        let legacyURL1 =
+            "http+unix://%2FUsers%2Ftest%2FLibrary%2FApplication%20Support%2Fcom.cloudcompute.workspaces%2Fhooks-1234.sock/event"
+        let legacyURL2 =
+            "http+unix://%2FUsers%2Ftest%2FLibrary%2FApplication%20Support%2Fcom.cloudcompute.workspaces%2Fhooks-5678.sock/event"
+
         let existing: [String: Any] = [
             "hooks": [
                 "Notification": [
-                    [
-                        "type": "http",
-                        "url": "http+unix://legacy-pid-1234/event",
-                        "async": true,
-                    ],
-                    [
-                        "type": "http",
-                        "url": "http+unix://legacy-pid-5678/event",
-                        "async": true,
-                    ],
+                    ["type": "http", "url": legacyURL1, "async": true],
+                    ["type": "http", "url": legacyURL2, "async": true],
                 ]
             ]
         ]
@@ -192,11 +197,11 @@ struct ClaudeSettingsInstallerTests {
         let updated = try JSONSerialization.jsonObject(with: updatedData) as? [String: Any] ?? [:]
         let notification = hookGroups(named: "Notification", in: updated)
 
-        // Legacy http+unix:// entries are gone.
+        // Both legacy WorkSpaces URLs are gone.
         let anyLegacy = notification.contains { group in
             hookHandlers(in: group).contains {
-                ($0["type"] as? String) == "http"
-                    && ((($0["url"] as? String) ?? "").hasPrefix("http+unix://"))
+                let url = ($0["url"] as? String) ?? ""
+                return url == legacyURL1 || url == legacyURL2
             }
         }
         #expect(anyLegacy == false)
@@ -209,6 +214,91 @@ struct ClaudeSettingsInstallerTests {
             }
         }
         #expect(hasEventForwarder)
+    }
+
+    @Test("User-owned http+unix:// hooks survive the install (non-destructive contract)")
+    func reinstallPreservesUserOwnedHTTPUnixHooks() async throws {
+        // Regression guard for code review of PR #466: the legacy scrub must
+        // only remove URLs that look like ours (under /Application Support/
+        // with a `hooks-<pid>.sock` filename). A user with their own
+        // Unix-socket Claude hook — say one pointing at `/tmp/my-claude.sock`
+        // or `~/.local/run/agent.sock` — must keep it across reinstalls.
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let settingsURL = claudeDir.appendingPathComponent("settings.json")
+
+        // None of these match our pattern: no /Application Support/, or no
+        // hooks-<digits>.sock filename, or both.
+        let userHookURLs = [
+            "http+unix://%2Ftmp%2Fmy-claude.sock/event",
+            "http+unix://%2FUsers%2Ftest%2F.local%2Frun%2Fagent.sock/event",
+            "http+unix://legacy-pid-1234/event",
+        ]
+        let existing: [String: Any] = [
+            "hooks": [
+                "Notification": userHookURLs.map { url in
+                    ["type": "http", "url": url, "async": true] as [String: Any]
+                }
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted])
+        try data.write(to: settingsURL)
+
+        let installer = ClaudeSettingsInstaller(homeDirectory: home)
+        await installer.register(
+            workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
+        try await installer.install()
+
+        let updatedData = try Data(contentsOf: settingsURL)
+        let updated = try JSONSerialization.jsonObject(with: updatedData) as? [String: Any] ?? [:]
+        let notification = hookGroups(named: "Notification", in: updated)
+        let allHandlers = notification.flatMap { hookHandlers(in: $0) }
+        for url in userHookURLs {
+            let preserved = allHandlers.contains {
+                ($0["type"] as? String) == "http" && ($0["url"] as? String) == url
+            }
+            #expect(preserved, "user-owned http+unix hook \(url) was unexpectedly scrubbed")
+        }
+    }
+
+    @Test("install() is a no-op when merged result equals the existing file (no backup churn)")
+    func installIsNoOpWhenNothingChanges() async throws {
+        // Regression guard for code review of PR #466: routine relaunches must
+        // not churn the backup chain. After an initial install, every
+        // subsequent install with the same contributions must skip the write
+        // (and the backup) so the user's last meaningful pre-integration backup
+        // stays at index 0 of the rotation.
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let settingsURL = claudeDir.appendingPathComponent("settings.json")
+        try Data("{\"theme\":\"dark\"}".utf8).write(to: settingsURL)
+
+        let installer = ClaudeSettingsInstaller(homeDirectory: home)
+        await installer.register(
+            workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
+
+        // First install creates exactly one backup.
+        try await installer.install()
+        let backupsAfterFirst = try FileManager.default.contentsOfDirectory(
+            at: claudeDir, includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
+        #expect(backupsAfterFirst.count == 1)
+
+        // Subsequent installs are no-ops: no new backup, no churn.
+        try await installer.install()
+        try await installer.install()
+        try await installer.install()
+        let backupsAfterRepeats = try FileManager.default.contentsOfDirectory(
+            at: claudeDir, includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
+        #expect(backupsAfterRepeats.count == 1)
+        #expect(backupsAfterRepeats.first?.lastPathComponent == backupsAfterFirst.first?.lastPathComponent)
     }
 
     @Test("renderPreview describes pending changes")

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallingProtocolTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallingProtocolTests.swift
@@ -86,7 +86,7 @@ struct ClaudeSettingsInstallingProtocolTests {
         defer { try? FileManager.default.removeItem(at: home) }
 
         let installer = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         let beforeInstall = await installer.isInstalled()
         #expect(beforeInstall == false)
         let backupBefore = await installer.mostRecentBackupPath()
@@ -103,7 +103,8 @@ struct ClaudeSettingsInstallingProtocolTests {
         #expect(notification.count == 1)
         let notificationHandlers = notification.first?["hooks"] as? [[String: Any]] ?? []
         #expect(notificationHandlers.count == 1)
-        #expect(notificationHandlers.first?["type"] as? String == "http")
+        #expect(notificationHandlers.first?["type"] as? String == "command")
+        #expect(notificationHandlers.first?["command"] as? String == "/tmp/event-forwarder.sh")
 
         // No backup is recorded for a freshly created file (nothing to back up).
         // Pre-seed an existing settings file and re-install to exercise the backup path.
@@ -112,7 +113,7 @@ struct ClaudeSettingsInstallingProtocolTests {
         try Data("{\"theme\":\"dark\"}".utf8).write(to: settingsURL)
 
         let installer2 = ClaudeSettingsInstaller(homeDirectory: home)
-        await installer2.register(workspacesHooksContribution(socketPath: "/tmp/hooks.sock"))
+        await installer2.register(workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh"))
         try await installer2.install()
         let backupAfter = await installer2.mostRecentBackupPath()
         #expect(backupAfter?.contains("workspaces-backup-") == true)

--- a/Tests/WorkspaceManagerTests/Perf/PerfChannel1Tests.swift
+++ b/Tests/WorkspaceManagerTests/Perf/PerfChannel1Tests.swift
@@ -474,7 +474,7 @@ struct PerfChannel1Tests {
 
         let installer = ClaudeSettingsInstaller(homeDirectory: homeDir)
         await installer.register(
-            workspacesHooksContribution(socketPath: "/tmp/perf-backup.sock")
+            workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh")
         )
 
         // Seed an existing settings.json so each install writes a backup.
@@ -547,7 +547,7 @@ struct PerfChannel1Tests {
             try Data(content.utf8).write(to: settingsPath)
             let installer = ClaudeSettingsInstaller(homeDirectory: homeDir)
             await installer.register(
-                workspacesHooksContribution(socketPath: "/tmp/m.sock")
+                workspacesHooksContribution(eventForwarderScriptPath: "/tmp/event-forwarder.sh")
             )
             var renderError: String? = nil
             var rendered: String? = nil


### PR DESCRIPTION
## Summary

Channel 1 was non-functional in real Claude Code sessions. PR #443's installer registered hook handlers as `type: "http"` with `http+unix://<encoded-socket>/event` URLs. **Real Claude Code does not speak the `http+unix://` URL scheme** — every hook errored with `Unsupported protocol http+unix:` and the entire pipeline failed. Curl supports `--unix-socket`, which is why our perf tests, integration tests, and synthesized POSTs all worked; real Claude does not.

This PR replaces the broken `http+unix://` path with a `type: "command"` hook running a small bundled forwarder script. Same pattern that already powers `statusline.sh` (Channel 2) and `title-emit.sh` (Channel 3).

- New `Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh` — reads JSON from stdin, `curl --unix-socket "$WORKSPACES_HOOKS_SOCKET"`s to `/event`, exits 0.
- `workspacesHooksContribution()` rewritten: takes `eventForwarderScriptPath:` instead of `socketPath:`, registers `type: "command"` handlers pointing at the forwarder.
- `ClaudeIntegrationLifecycle` extracts the bundled forwarder to `~/Library/Application Support/<bundle-id>/HookForwarders/event-forwarder.sh` (mirrors the existing `extractTitleEmitScript()` pattern, refactored into a shared helper).
- **Self-heal**: every install scrubs legacy `type: "http"` + `http+unix://` handlers from the user's settings. Opted-in users automatically clean up the dozens of stale entries they accumulated across previous app launches.

## Mergeability

- Surface: desktop
- User-facing behavior changed: `~/.claude/settings.json` no longer contains broken `http+unix://` URLs after the next dev-binary launch (they get scrubbed). New installs use `type: "command"` handlers pointing at a stable bundled script. Channel 1 actually works in real Claude sessions for the first time.
- Non-happy paths considered: bundled `event-forwarder.sh` extraction fails (installer logs and skips registering Channel 1 — same fail-safe as `title-emit.sh`); `$WORKSPACES_HOOKS_SOCKET` env var not set in the embedded shell (script drains stdin, exits 0, no error rendered to Claude); legacy entries from PR #443 (scrubbed); concurrent reinstalls (idempotent — dedup matches by command path which is stable across pid changes).
- Release/ops preconditions: none. The next dev-binary cold start with opt-in active will silent-reinstall and self-heal.
- Residual risk or follow-up: the "no host session for cwd=" issue I noticed when driving curl-based smokes against the listener remains unverified — could be a separate registry-wiring bug, could be downstream of this issue. Will re-investigate once this lands and a real `claude` session can drive the listener.

## Validation

- [x] `swift build` clean
- [x] `swift test` — 661 tests in 112 suites pass
- [x] `swift-format lint --strict` clean
- [x] Other checks run: existing `ClaudeSettingsInstallerTests` updated to assert the installer never writes `type: "http"` handlers and that legacy `http+unix://` entries get scrubbed across reinstalls.

## Performance

- [x] Not a performance-sensitive change. The forwarder is the same shell-out pattern Channel 2 already uses; per-event overhead is one curl invocation, dominated by socket setup (microseconds).

## Evidence

Code-level only for this PR — the installer round-trip is covered by the updated unit tests. Visual smoke against a real `claude` session (sidebar dot transitioning through `thinking → runningTool → awaitingInput → complete` on a real permission prompt) will follow as a comment retroactively once this lands and we can drive a real session against the dev binary without the `http+unix://` errors flooding the log. That smoke evidence will then also be commented onto the merged PR #455 to close out the doc's verification runbook.

## How this came up

While capturing manual smoke evidence for the PR #455 docs, real `claude` sessions started flooding with `PostToolBatch hook error: Unsupported protocol http+unix:`. We diagnosed and stopped the bleeding (killed dev binary, surgically scrubbed Michael's `~/.claude/settings.json` — removed 126 stale `http+unix://` entries while preserving 7 non-workspaces hooks), then wrote this fix.
