### PR TITLE
[codex] Simplify agent lifecycle labels

### DIFF
--- a/.agents/config/peter-planner.toml
+++ b/.agents/config/peter-planner.toml
@@ -1,12 +1,16 @@
-default_labels = ["enhancement", "agent:task"]
+default_labels = ["enhancement", "agent", "task"]
 
 [labels.enhancement]
 color = "a2eeef"
 description = "New feature or request"
 
-[labels."agent:task"]
+[labels.agent]
+color = "5319e7"
+description = "Work owned by the agent execution lane"
+
+[labels.task]
 color = "0E8A16"
-description = "Planned by the agent team"
+description = "Planned work item"
 
 [labels."area: ui"]
 color = "c5def5"

--- a/.agents/scripts/fixtures/contributor-prompt-injection.json
+++ b/.agents/scripts/fixtures/contributor-prompt-injection.json
@@ -39,10 +39,13 @@
         "labels": {
           "nodes": [
             {
-              "name": "agent:task"
+              "name": "agent"
             },
             {
-              "name": "agent:ready"
+              "name": "task"
+            },
+            {
+              "name": "ready"
             }
           ]
         },
@@ -141,10 +144,13 @@
     "labels": {
       "nodes": [
         {
-          "name": "agent:task"
+          "name": "agent"
         },
         {
-          "name": "agent:ready"
+          "name": "task"
+        },
+        {
+          "name": "ready"
         }
       ]
     },

--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -252,7 +252,7 @@ class RunPlannerTests(unittest.TestCase):
         labels = run_planner.normalize_labels(["ci", "ui"], CATALOG)
         self.assertEqual(
             labels,
-            ["enhancement", "agent:task", "area: platform", "area: ui"],
+            ["enhancement", "agent", "task", "area: platform", "area: ui"],
         )
 
     def test_normalize_plan_derives_milestone_from_discussion_title(self) -> None:
@@ -1401,7 +1401,7 @@ class RunContributorTests(unittest.TestCase):
                 "title": "Fix environment status color semantics in NewWorkspaceSheet",
                 "url": "https://github.com/fairchild/workspaces/issues/116",
                 "body": issue_body,
-                "labels": {"nodes": [{"name": "agent:task"}, {"name": "agent:ready"}]},
+                "labels": {"nodes": [{"name": "agent"}, {"name": "task"}, {"name": "ready"}]},
                 "comments": {"nodes": []},
             }
         ]
@@ -1418,7 +1418,7 @@ class RunContributorTests(unittest.TestCase):
         )
         self.assertEqual(len(classified["ready_issues"]), 1)
         self.assertEqual(classified["ready_issues"][0]["issue_number"], 116)
-        self.assertEqual(classified["ready_issues"][0]["approval_reason"], "agent:ready label present")
+        self.assertEqual(classified["ready_issues"][0]["approval_reason"], "ready label present")
 
     def test_claim_is_stale_after_24_hours_without_pr(self) -> None:
         claim = {
@@ -2412,7 +2412,7 @@ class RunContributorTests(unittest.TestCase):
                 "title": "Fix status color",
                 "url": "https://github.com/fairchild/workspaces/issues/116",
                 "body": issue_body,
-                "labels": {"nodes": [{"name": "agent:task"}, {"name": "agent:ready"}]},
+                "labels": {"nodes": [{"name": "agent"}, {"name": "task"}, {"name": "ready"}]},
                 "comments": {"nodes": []},
             }
         ]
@@ -2463,7 +2463,7 @@ class RunContributorTests(unittest.TestCase):
                 "title": "Fix status color",
                 "url": "https://github.com/fairchild/workspaces/issues/116",
                 "body": issue_body,
-                "labels": {"nodes": [{"name": "agent:task"}, {"name": "agent:ready"}]},
+                "labels": {"nodes": [{"name": "agent"}, {"name": "task"}, {"name": "ready"}]},
                 "comments": {"nodes": []},
             }
         ]
@@ -2514,7 +2514,7 @@ class RunContributorTests(unittest.TestCase):
                 "title": "Fix status color",
                 "url": "https://github.com/fairchild/workspaces/issues/116",
                 "body": issue_body,
-                "labels": {"nodes": [{"name": "agent:task"}, {"name": "agent:ready"}]},
+                "labels": {"nodes": [{"name": "agent"}, {"name": "task"}, {"name": "ready"}]},
                 "comments": {"nodes": []},
             }
         ]
@@ -2566,7 +2566,7 @@ class RunContributorTests(unittest.TestCase):
                 "title": "Fix status color",
                 "url": "https://github.com/fairchild/workspaces/issues/116",
                 "body": issue_body,
-                "labels": {"nodes": [{"name": "agent:task"}, {"name": "agent:ready"}, {"name": "agent:claimed"}]},
+                "labels": {"nodes": [{"name": "agent"}, {"name": "task"}, {"name": "ready"}, {"name": "claimed"}]},
                 "comments": {
                     "nodes": [
                         {

--- a/.agents/skills/cofounder-contributor/SKILL.md
+++ b/.agents/skills/cofounder-contributor/SKILL.md
@@ -28,7 +28,7 @@ Use this skill to run the shared contributor runtime with one of the repo's cofo
 
 1. Load the selected persona prompt.
 2. Gather current repo and GitHub context.
-3. Sync execution-state labels (`agent:ready`, `agent:claimed`) from discussion approval, blockers, open PRs, and stale claims.
+3. Sync execution-state labels (`ready`, `claimed`) on `agent` + `task` issues from discussion approval, blockers, open PRs, and stale claims.
 4. Run a read-only selection phase over normalized workflow state, then run the action phase with GitHub-authored text labeled as untrusted data.
 5. For execution actions, export `HEAD` into an isolated scratch workspace with no `.git`, apply the model-authored patch back into the real checkout only after validation, and keep GitHub mutations in trusted runtime code.
 6. Validate the YAML frontmatter output.
@@ -73,7 +73,7 @@ See `docs/development/lume-runner-setup.md` for full details on the R2 evidence 
 The runtime enforces work-in-progress limits to keep the backlog focused:
 
 - **Discussion cap**: 12 open discussions. When reached, agents cannot propose new ideas — they must close stale discussions or comment on existing ones first.
-- **Issue cap**: 30 open `agent:task` issues. Peter Planner refuses to create issues that would exceed this cap.
+- **Issue cap**: 30 open issues labeled with both `agent` and `task`. Peter Planner refuses to create issues that would exceed this cap.
 - **Stale threshold**: Discussions idle for 14+ days are flagged as stale and prioritized for closure.
 - **Auto-close**: `sync-execution-state.py` automatically closes discussions whose Peter-planned child issues are all resolved.
 

--- a/.agents/skills/cofounder-contributor/scripts/_helpers.py
+++ b/.agents/skills/cofounder-contributor/scripts/_helpers.py
@@ -19,13 +19,19 @@ GITHUB_API_TIMEOUT = 30
 CLAUDE_TIMEOUT = 300
 VALIDATION_TIMEOUT = 30
 
-AGENT_READY_LABEL = "agent:ready"
+AGENT_LANE_LABEL = "agent"
+AGENT_LANE_LABEL_COLOR = "5319e7"
+AGENT_LANE_LABEL_DESCRIPTION = "Work owned by the agent execution lane"
+AGENT_TASK_LABEL = "task"
+AGENT_TASK_LABEL_COLOR = "0E8A16"
+AGENT_TASK_LABEL_DESCRIPTION = "Planned work item"
+AGENT_READY_LABEL = "ready"
 AGENT_READY_LABEL_COLOR = "5319e7"
 AGENT_READY_LABEL_DESCRIPTION = "Execution-approved and ready for an automated contributor to claim"
-AGENT_CLAIM_LABEL = "agent:claimed"
+AGENT_CLAIM_LABEL = "claimed"
 AGENT_CLAIM_LABEL_COLOR = "1d76db"
 AGENT_CLAIM_LABEL_DESCRIPTION = "Currently being executed by an automated contributor"
-AGENT_MERGEABLE_LABEL = "agent:mergeable"
+AGENT_MERGEABLE_LABEL = "mergeable"
 AGENT_MERGEABLE_LABEL_COLOR = "0e8a16"
 AGENT_MERGEABLE_LABEL_DESCRIPTION = "Agent-approved, ready for owner merge"
 

--- a/.agents/skills/cofounder-contributor/scripts/execution.py
+++ b/.agents/skills/cofounder-contributor/scripts/execution.py
@@ -12,6 +12,9 @@ from _helpers import (
     AGENT_CLAIM_LABEL,
     AGENT_CLAIM_LABEL_COLOR,
     AGENT_CLAIM_LABEL_DESCRIPTION,
+    AGENT_LANE_LABEL,
+    AGENT_LANE_LABEL_COLOR,
+    AGENT_LANE_LABEL_DESCRIPTION,
     AGENT_MERGEABLE_LABEL,
     AGENT_MERGEABLE_LABEL_COLOR,
     AGENT_MERGEABLE_LABEL_DESCRIPTION,
@@ -124,6 +127,7 @@ def ensure_label_exists(env: dict[str, str], name: str, color: str, description:
 
 
 def ensure_claim_label(env: dict[str, str]) -> None:
+    ensure_label_exists(env, AGENT_LANE_LABEL, AGENT_LANE_LABEL_COLOR, AGENT_LANE_LABEL_DESCRIPTION)
     ensure_label_exists(env, AGENT_CLAIM_LABEL, AGENT_CLAIM_LABEL_COLOR, AGENT_CLAIM_LABEL_DESCRIPTION)
 
 
@@ -221,7 +225,16 @@ def ensure_issue_claimed(
     )
     if not already_claimed:
         ensure_claim_label(env)
-        cmd = ["gh", "issue", "edit", str(issue_number), "--add-label", AGENT_CLAIM_LABEL]
+        cmd = [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--add-label",
+            AGENT_LANE_LABEL,
+            "--add-label",
+            AGENT_CLAIM_LABEL,
+        ]
         if AGENT_READY_LABEL in current_labels:
             cmd.extend(["--remove-label", AGENT_READY_LABEL])
         run_checked(cmd, timeout=GITHUB_API_TIMEOUT, cwd=REPO_ROOT, env=env)

--- a/.agents/skills/cofounder-contributor/scripts/lifecycle-health-check.py
+++ b/.agents/skills/cofounder-contributor/scripts/lifecycle-health-check.py
@@ -5,7 +5,7 @@
 # ///
 """Check agent lifecycle invariants against live GitHub state.
 
-Queries open agent:task issues and open PRs, then verifies label exclusivity,
+Queries open agent task issues and open PRs, then verifies label exclusivity,
 PR↔label consistency, assignment tracking, and stale-claim expiry.
 
 JSON report to stdout, human summary to stderr. Exit 0 if all pass, 1 otherwise.
@@ -26,7 +26,10 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 GITHUB_API_TIMEOUT = 30
 STALE_CLAIM_HOURS = 24
 
-PHASE_LABELS = {"agent:ready", "agent:claimed", "agent:review"}
+LANE_LABEL = "agent"
+TASK_LABEL = "task"
+PHASE_LABELS = {"ready", "claimed", "review"}
+MERGEABLE_LABEL = "mergeable"
 CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
@@ -149,13 +152,13 @@ def check_review_pr_consistency(issues: list[dict[str, Any]], prs_by_issue: dict
     for issue in issues:
         n = issue["number"]
         labels = label_names(issue)
-        has_review = "agent:review" in labels
+        has_review = "review" in labels
         has_pr = n in prs_by_issue
 
         if has_review and not has_pr:
-            problems.append({"number": n, "problem": "agent:review but no open PR references this issue"})
+            problems.append({"number": n, "problem": "review but no open PR references this issue"})
         if has_pr and not has_review:
-            problems.append({"number": n, "problem": f"open PR exists but agent:review missing (sync may not have run yet)", "severity": "warn"})
+            problems.append({"number": n, "problem": f"open PR exists but review missing (sync may not have run yet)", "severity": "warn"})
     return {"name": "review_pr_consistency", "pass": all(p.get("severity") == "warn" for p in problems) if problems else True, "issues": problems}
 
 
@@ -166,8 +169,8 @@ def check_claim_assignment_consistency(issues: list[dict[str, Any]]) -> dict[str
         labels = label_names(issue)
         bots = bot_assignees(issue)
 
-        if "agent:claimed" in labels and not bots:
-            problems.append({"number": n, "problem": "agent:claimed but no bot assignee"})
+        if "claimed" in labels and not bots:
+            problems.append({"number": n, "problem": "claimed but no bot assignee"})
     return {"name": "claim_assignment_consistency", "pass": len(problems) == 0, "issues": problems}
 
 
@@ -176,14 +179,14 @@ def check_mergeable_coherence(issues: list[dict[str, Any]], prs_by_issue: dict[i
     for issue in issues:
         n = issue["number"]
         labels = label_names(issue)
-        if "agent:mergeable" not in labels:
+        if MERGEABLE_LABEL not in labels:
             continue
-        if "agent:review" not in labels:
-            problems.append({"number": n, "problem": "agent:mergeable without agent:review"})
+        if "review" not in labels:
+            problems.append({"number": n, "problem": "mergeable without review"})
             continue
         prs = prs_by_issue.get(n, [])
         if prs and all(pr.get("reviews", {}).get("totalCount", 0) == 0 for pr in prs):
-            problems.append({"number": n, "problem": "agent:mergeable but linked PR has no approved reviews"})
+            problems.append({"number": n, "problem": "mergeable but linked PR has no approved reviews"})
     return {"name": "mergeable_coherence", "pass": len(problems) == 0, "issues": problems}
 
 
@@ -192,7 +195,7 @@ def check_stale_claims(issues: list[dict[str, Any]], prs_by_issue: dict[int, lis
     for issue in issues:
         n = issue["number"]
         labels = label_names(issue)
-        if "agent:claimed" not in labels:
+        if "claimed" not in labels:
             continue
         if n in prs_by_issue:
             continue
@@ -203,7 +206,7 @@ def check_stale_claims(issues: list[dict[str, Any]], prs_by_issue: dict[int, lis
         created = parse_dt(claim["createdAt"])
         if created and now - created >= timedelta(hours=STALE_CLAIM_HOURS):
             age_h = (now - created).total_seconds() / 3600
-            problems.append({"number": n, "problem": f"agent:claimed for {age_h:.0f}h with no PR (stale)"})
+            problems.append({"number": n, "problem": f"claimed for {age_h:.0f}h with no PR (stale)"})
     return {"name": "stale_claims", "pass": len(problems) == 0, "issues": problems}
 
 
@@ -213,7 +216,7 @@ def check_orphaned_assignments(issues: list[dict[str, Any]]) -> dict[str, Any]:
         n = issue["number"]
         labels = label_names(issue)
         bots = bot_assignees(issue)
-        if bots and "agent:claimed" not in labels and "agent:review" not in labels:
+        if bots and "claimed" not in labels and "review" not in labels:
             problems.append({"number": n, "problem": f"bot {bots[0]} assigned but no claimed/review label"})
     return {"name": "orphaned_assignments", "pass": len(problems) == 0, "issues": problems}
 
@@ -227,7 +230,10 @@ def main() -> int:
     data = run_query(env)
     now = datetime.now(timezone.utc)
 
-    task_issues = [i for i in data["issues"] if "agent:task" in label_names(i)]
+    task_issues = [
+        i for i in data["issues"]
+        if {LANE_LABEL, TASK_LABEL}.issubset(label_names(i))
+    ]
     prs_by_issue = pr_issue_map(data["pull_requests"])
 
     checks = [
@@ -252,7 +258,7 @@ def main() -> int:
 
     print(json.dumps(report, indent=2))
 
-    log(f"Checked {len(task_issues)} agent:task issue(s)")
+    log(f"Checked {len(task_issues)} agent task issue(s)")
     for check in checks:
         status = "PASS" if check["pass"] else "FAIL"
         log(f"  {status}  {check['name']}")

--- a/.agents/skills/cofounder-contributor/scripts/sync-execution-state.py
+++ b/.agents/skills/cofounder-contributor/scripts/sync-execution-state.py
@@ -91,13 +91,19 @@ CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
 
-AGENT_READY_LABEL = "agent:ready"
+AGENT_LANE_LABEL = "agent"
+AGENT_LANE_LABEL_COLOR = "5319e7"
+AGENT_LANE_LABEL_DESCRIPTION = "Work owned by the agent execution lane"
+AGENT_TASK_LABEL = "task"
+AGENT_TASK_LABEL_COLOR = "0E8A16"
+AGENT_TASK_LABEL_DESCRIPTION = "Planned work item"
+AGENT_READY_LABEL = "ready"
 AGENT_READY_LABEL_COLOR = "5319e7"
 AGENT_READY_LABEL_DESCRIPTION = "Execution-approved and ready for an automated contributor to claim"
-AGENT_CLAIM_LABEL = "agent:claimed"
+AGENT_CLAIM_LABEL = "claimed"
 AGENT_CLAIM_LABEL_COLOR = "1d76db"
 AGENT_CLAIM_LABEL_DESCRIPTION = "Currently being executed by an automated contributor"
-AGENT_REVIEW_LABEL = "agent:review"
+AGENT_REVIEW_LABEL = "review"
 AGENT_REVIEW_LABEL_COLOR = "fbca04"
 AGENT_REVIEW_LABEL_DESCRIPTION = "PR opened, awaiting review"
 TRUSTED_AUTHOR_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
@@ -536,12 +542,13 @@ def unassign_issue(
 
 
 def fetch_agent_task_issues(env: dict[str, str]) -> list[dict[str, Any]]:
-    """Fetch all agent:task issues (open and closed) with their bodies."""
+    """Fetch all agent task issues (open and closed) with their bodies."""
     result = run_checked(
         [
             "gh", "issue", "list",
             "--state", "all",
-            "--label", "agent:task",
+            "--label", AGENT_LANE_LABEL,
+            "--label", AGENT_TASK_LABEL,
             "--limit", "200",
             "--json", "number,body,state",
         ],
@@ -562,6 +569,8 @@ def main() -> int:
     now = datetime.now(timezone.utc)
 
     existing_labels = fetch_existing_labels(env)
+    ensure_label(existing_labels, env, AGENT_LANE_LABEL, AGENT_LANE_LABEL_COLOR, AGENT_LANE_LABEL_DESCRIPTION)
+    ensure_label(existing_labels, env, AGENT_TASK_LABEL, AGENT_TASK_LABEL_COLOR, AGENT_TASK_LABEL_DESCRIPTION)
     ensure_label(existing_labels, env, AGENT_READY_LABEL, AGENT_READY_LABEL_COLOR, AGENT_READY_LABEL_DESCRIPTION)
     ensure_label(existing_labels, env, AGENT_CLAIM_LABEL, AGENT_CLAIM_LABEL_COLOR, AGENT_CLAIM_LABEL_DESCRIPTION)
     ensure_label(existing_labels, env, AGENT_REVIEW_LABEL, AGENT_REVIEW_LABEL_COLOR, AGENT_REVIEW_LABEL_DESCRIPTION)
@@ -581,7 +590,7 @@ def main() -> int:
     updated = 0
     for issue in work_state["issues"]:
         current_labels = issue_label_names(issue)
-        if "agent:task" not in current_labels:
+        if AGENT_LANE_LABEL not in current_labels or AGENT_TASK_LABEL not in current_labels:
             continue
         desired_labels, reason = desired_execution_labels(
             issue,
@@ -610,7 +619,7 @@ def main() -> int:
 
     # Auto-close discussions whose Peter-planned issues are all closed.
     # work_state["issues"] only contains OPEN issues, so we fetch all
-    # agent:task issues (open + closed) to build the complete child map.
+    # agent task issues (open + closed) to build the complete child map.
     all_agent_task_issues = fetch_agent_task_issues(env)
     discussion_child_issues: dict[int, list[int]] = {}
     for issue in all_agent_task_issues:

--- a/.agents/skills/cofounder-contributor/scripts/triage.py
+++ b/.agents/skills/cofounder-contributor/scripts/triage.py
@@ -9,7 +9,9 @@ from datetime import datetime, timedelta, timezone
 
 from _helpers import (
     AGENT_CLAIM_LABEL,
+    AGENT_LANE_LABEL,
     AGENT_READY_LABEL,
+    AGENT_TASK_LABEL,
     GITHUB_API_TIMEOUT,
     REPO_ROOT,
     _normalize_login,
@@ -336,7 +338,7 @@ def compute_wip_state(
     open_discussions = len(discussions)
     open_agent_issues = sum(
         1 for issue in issues
-        if "agent:task" in issue_label_names(issue)
+        if {AGENT_LANE_LABEL, AGENT_TASK_LABEL}.issubset(issue_label_names(issue))
     )
 
     stale: list[dict[str, object]] = []
@@ -376,7 +378,7 @@ def compute_wip_state(
 def format_wip_state(wip: dict[str, object]) -> str:
     lines = [
         f"WIP state: {wip['open_discussions']}/{wip['discussion_cap']} open discussions, "
-        f"{wip['open_agent_issues']}/{wip['issue_cap']} open agent:task issues"
+        f"{wip['open_agent_issues']}/{wip['issue_cap']} open agent task issues"
     ]
     if wip["discussions_at_cap"]:
         lines.append(
@@ -777,9 +779,13 @@ def classify_execution_work(
 
     for issue in issues:
         labels = issue_label_names(issue)
-        if AGENT_CLAIM_LABEL not in labels and AGENT_READY_LABEL not in labels and "agent:task" not in labels:
+        if (
+            AGENT_CLAIM_LABEL not in labels
+            and AGENT_READY_LABEL not in labels
+            and not {AGENT_LANE_LABEL, AGENT_TASK_LABEL}.issubset(labels)
+        ):
             continue
-        if "agent:task" not in labels:
+        if not {AGENT_LANE_LABEL, AGENT_TASK_LABEL}.issubset(labels):
             continue
 
         issue_number = int(issue["number"])

--- a/.agents/skills/peter-planner/config/peter-planner.toml
+++ b/.agents/skills/peter-planner/config/peter-planner.toml
@@ -1,12 +1,16 @@
-default_labels = ["enhancement", "agent:task"]
+default_labels = ["enhancement", "agent", "task"]
 
 [labels.enhancement]
 color = "a2eeef"
 description = "New feature or request"
 
-[labels."agent:task"]
+[labels.agent]
+color = "5319e7"
+description = "Work owned by the agent execution lane"
+
+[labels.task]
 color = "0E8A16"
-description = "Planned by the agent team"
+description = "Planned work item"
 
 [labels."area: ui"]
 color = "c5def5"

--- a/.agents/skills/peter-planner/references/peter-planner.md
+++ b/.agents/skills/peter-planner/references/peter-planner.md
@@ -24,7 +24,8 @@ You receive a trusted planning envelope plus an untrusted GitHub discussion payl
 Use only these labels:
 
 - `enhancement`
-- `agent:task`
+- `agent`
+- `task`
 - `area: ui`
 - `area: isolation`
 - `area: distribution`
@@ -66,7 +67,7 @@ Always respect scope guidance from the original proposal and any human modificat
 Prefer fewer, higher-signal issues when substeps are tightly coupled enough to ship together in one PR.
 When 3+ issues are needed, derive `milestone_name` directly from the discussion title without inventing a synonym.
 
-**WIP cap**: The runtime enforces a cap of 30 open `agent:task` issues. If the plan would exceed this cap, the workflow fails. Scope plans tightly — prefer fewer issues that can be combined rather than many granular ones.
+**WIP cap**: The runtime enforces a cap of 30 open issues labeled with both `agent` and `task`. If the plan would exceed this cap, the workflow fails. Scope plans tightly — prefer fewer issues that can be combined rather than many granular ones.
 
 ## Output Format
 

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -61,6 +61,8 @@ ISSUE_MARKER_RE = re.compile(
 )
 MILESTONE_MARKER_RE = re.compile(r"<!-- peter-planner:discussion=(?P<number>\d+);milestone -->")
 AGENT_ISSUE_WIP_CAP = 30
+AGENT_LANE_LABEL = "agent"
+AGENT_TASK_LABEL = "task"
 LEGACY_ACK_SNIPPET = "*Peter Planner*\n\nWorking on it"
 LEGACY_RECONCILIATION_MILESTONES = {43: {2, 3}}
 ISSUE_TITLE_STOPWORDS = {
@@ -1327,15 +1329,15 @@ def main() -> int:
     open_agent_task_count = sum(
         1 for issue in existing_issues
         if issue.get("state", "").upper() == "OPEN"
-        and any(
-            (label.get("name") if isinstance(label, dict) else label) == "agent:task"
+        and {AGENT_LANE_LABEL, AGENT_TASK_LABEL}.issubset({
+            label.get("name") if isinstance(label, dict) else label
             for label in (issue.get("labels") or [])
-        )
+        })
     )
     new_issue_count = sum(1 for item in execution.issues if item.existing_issue is None)
     if open_agent_task_count + new_issue_count > AGENT_ISSUE_WIP_CAP:
         raise PlannerError(
-            f"WIP cap exceeded: {open_agent_task_count} open agent:task issues + "
+            f"WIP cap exceeded: {open_agent_task_count} open agent task issues + "
             f"{new_issue_count} new planned issues = {open_agent_task_count + new_issue_count}, "
             f"cap is {AGENT_ISSUE_WIP_CAP}. Close existing issues before planning new ones."
         )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Issues and PRDs live in GitHub Issues for `fairchild/workspaces`. See `docs/agen
 
 ### Triage labels
 
-Use the repo's agent lifecycle labels, with `agent:ready` for AFK-ready work and `needs-human` for human-owned work. See `docs/agents/triage-labels.md`.
+Use lane + state labels: `agent`/`human` for ownership, `ready`/`claimed`/`review`/`mergeable` for lifecycle, and `needs-human` only for human intervention blockers. See `docs/agents/triage-labels.md`.
 
 ### Domain docs
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,24 +1,99 @@
 # Triage Labels
 
-The Matt Pocock skills speak in five canonical triage roles. This repo already has an agent lifecycle vocabulary, so map the canonical roles to the labels below instead of creating near-duplicates.
+This repo uses composable labels instead of namespaced lifecycle labels. Labels answer one of four questions:
+
+- **Lane**: who owns the work?
+- **State**: what should happen next?
+- **Dimension**: what topic or surface is this about?
+- **Gate**: what special approval or intervention is required?
+
+Do not create duplicate labels that combine these meanings. Prefer adding the right lane plus the right state.
+
+## Lane Labels
+
+| Label | Meaning |
+| --- | --- |
+| `agent` | Work is meant for the agent execution lane. April, Plat, Peter, and the dashboard treat this as agent-owned work. |
+| `human` | Work is explicitly owned by a human. Use this for work that should not be picked up by the scheduled agent pipeline. |
+
+The default for planned work is agent-driven. Peter-created execution issues should carry both `agent` and `task`.
+
+## State Labels
+
+| Label | Meaning |
+| --- | --- |
+| `needs-triage` | Maintainer needs to evaluate the issue. |
+| `needs-info` | Waiting on the reporter for specific missing information. Prefer this over the generic GitHub `question` label. |
+| `task` | Planned work item. Combine with `agent` for agent pipeline work. |
+| `ready` | Ready for the owning lane to act. `agent` + `ready` means an agent may claim it. `human` + `ready` means a human may pick it up. |
+| `claimed` | Actively owned and in progress. For agent work, claim comments and assignees identify which agent owns it. |
+| `review` | A PR exists and is awaiting review. |
+| `mergeable` | Additive review signal: an agent reviewed and approved the linked PR; owner merge is now appropriate. |
+| `blocked` | Progress is blocked by a dependency that should be resolved before work continues. |
+| `wontfix` | Closed or closing as not planned. |
+
+Exactly one of `ready`, `claimed`, and `review` should be present on an active `agent` + `task` issue. `mergeable` may stack with `review`.
+
+## Human Intervention
+
+`human` and `needs-human` are intentionally different:
+
+- `human` is a lane label. It means a human owns the work.
+- `needs-human` is a gate label. It means the current lane needs human intervention before continuing.
+
+Use `agent` + `needs-human` when the work remains agent-owned but needs a decision, credential, manual approval, or merge call. Remove `needs-human` once the intervention is resolved.
+
+Use `human` when the work itself should be done by a person.
+
+## Gate Labels
+
+Gate labels are not ownership or topic labels. They authorize or block a specific automation path.
+
+| Label | Meaning |
+| --- | --- |
+| `needs-human` | The current lane needs human intervention before continuing. May be used with either `agent` or `human`. |
+| `safe-to-run-agent` | Maintainer approval for the GitHub Actions mention executor to run against a public issue or PR request. The executor consumes and clears this gate through its own workflow. |
+| `privileged-agent-patch` | Break-glass approval for an agent patch to touch privileged repo-control, auth/token/sandbox, release/signing, or infra-secret paths. |
+
+Do not use gate labels as backlog categories. Remove them when the gate has been consumed or the intervention is no longer needed.
+
+## Matt Pocock Triage Mapping
 
 | Label in mattpocock/skills | Label in this repo | Meaning |
 | --- | --- | --- |
-| `needs-triage` | `needs-triage` | Maintainer needs to evaluate the issue. No existing repo label carries this exact meaning. |
-| `needs-info` | `needs-info` | Waiting on the reporter for more information. No existing repo label carries this exact meaning. |
-| `ready-for-agent` | `agent:ready` | Fully specified, approved, unblocked, and available for an AFK agent to claim. |
-| `ready-for-human` | `needs-human` | Requires human implementation, review, or intervention. |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate the issue. |
+| `needs-info` | `needs-info` | Waiting on the reporter for more information. |
+| `ready-for-agent` | `agent` + `ready` | Fully specified, approved, unblocked, and available for an AFK agent to claim. |
+| `ready-for-human` | `human` + `ready` | Ready for a human to implement, review, or operate. |
 | `wontfix` | `wontfix` | Will not be actioned. |
 
-When a skill mentions a canonical role, use the corresponding label string from this table.
+## Dimension Labels
 
-## Related Agent Lifecycle Labels
+Dimension labels are topical and should stay separate from triage state. The managed PR reviewer uses repository label history to apply these labels so PR history can be browsed by topic.
 
-These labels are part of this repo's existing agent pipeline but are not direct replacements for the five canonical triage roles:
+Examples: `security`, `quality`, `devEx`, `documentation`, `enhancement`, `bug`, `area: ui`, `area: isolation`, `area: distribution`, `area: platform`, `web`.
 
-- `agent:task` marks a planned agent-team issue.
-- `agent:claimed` marks active agent ownership.
-- `agent:review` marks an issue with an open PR awaiting review.
-- `agent:mergeable` marks an agent-reviewed PR that is ready for owner merge.
+Do not replace dimension labels with lifecycle labels. A PR or issue can be `agent` + `ready` + `security`, where `agent` and `ready` drive execution and `security` preserves topical history.
 
-See `docs/development/agent-team.md` for the full lifecycle.
+## GitHub Actions Agents
+
+April, Plat, and Peter are label-driven:
+
+- Peter creates planned issues with `agent` + `task`.
+- The execution-state sync promotes approved, unblocked `agent` + `task` issues to `ready`, `claimed`, or `review`.
+- The lifecycle health check enforces one active phase among `ready`, `claimed`, and `review` for open `agent` + `task` issues.
+- The web dashboard fetches pipeline columns by `agent` plus the state label.
+
+See `docs/development/agent-team.md` for the full agent lifecycle.
+
+## Live Label Migration
+
+The repository no longer uses `agent:*` labels as the canonical model. After this code is on the default branch, migrate GitHub issue labels with:
+
+```bash
+uv run --script scripts/migrate-agent-labels.py
+uv run --script scripts/migrate-agent-labels.py --apply
+uv run --script scripts/migrate-agent-labels.py --apply --delete-legacy
+```
+
+The script is dry-run by default. Do not delete legacy labels until the dry run shows the expected issue updates.

--- a/docs/development/agent-owner-protocol.md
+++ b/docs/development/agent-owner-protocol.md
@@ -30,12 +30,12 @@ The current control points are:
 |------|-------------|--------------|
 | Let agents ideate | Do nothing | April and Plat review PRs, deepen discussions, or propose a new `[idea]` discussion on schedule |
 | Turn an idea into a plan | Reply on the discussion with `plan it` | Peter creates issue(s) and, if needed, a milestone |
-| Start coding | React with 👍 on Peter's summary comment | The next contributor wake-up syncs the mission into `agent:ready` issue state, then April and Plat may claim ready issues and open PRs |
+| Start coding | React with 👍 on Peter's summary comment | The next contributor wake-up syncs the mission into `agent` + `ready` issue state, then April and Plat may claim ready issues and open PRs |
 | Keep agents focused on PRs | Leave approved work in place | Contributors prioritize re-reviews, open PRs, then ready issues before new ideation |
 | Stop new execution from starting | Remove the 👍 from Peter's summary comment | Unclaimed issues in that discussion stop being execution-approved |
 | Redirect work | Comment on the discussion, issue, or PR with explicit instructions | Peter uses discussion guidance for planning; April and Plat use PR review and issue/PR context during execution |
 | Stop a bad PR from landing | Request changes or leave review comments | Agents should work the PR to closure, but they do not merge |
-| See what's ready to merge | Filter issues by `agent:mergeable` | An agent approved the PR; review and merge at your discretion |
+| See what's ready to merge | Filter issues by `agent` + `mergeable` | An agent approved the PR; review and merge at your discretion |
 | Ship the change | Merge the PR yourself | `main` only moves when you do it |
 
 ## Exact Signals
@@ -66,10 +66,10 @@ Why: that reaction is the execution gate April and Plat check before claiming wo
 
 Internally, the next contributor wake-up converts that discussion approval into explicit issue state:
 
-- `agent:ready` means the issue is execution-approved, unblocked, and available to claim
-- `agent:claimed` means an agent claimed it and is assigned to work it toward a PR
-- `agent:review` means the issue has an open PR awaiting review
-- `agent:mergeable` means an agent reviewed and approved the PR — ready for your merge
+- `agent` + `ready` means the issue is execution-approved, unblocked, and available to claim
+- `agent` + `claimed` means an agent claimed it and is assigned to work it toward a PR
+- `agent` + `review` means the issue has an open PR awaiting review
+- `agent` + `mergeable` means an agent reviewed and approved the PR — ready for your merge
 
 ### 3. Merge Signal
 

--- a/docs/development/agent-team.md
+++ b/docs/development/agent-team.md
@@ -50,9 +50,9 @@ Daily (weekdays, alternating who goes first, 30 min offset):
   Owner reacts 👍 on Peter's summary comment
     │
   Execution-state sync (next contributor wake-up)
-    1. Applies `agent:ready` to approved, unblocked issues with no active PR/claim
-    2. Applies `agent:claimed` to actively claimed issues
-    3. Applies `agent:review` to issues with an open PR
+    1. Applies `ready` to approved, unblocked `agent` + `task` issues with no active PR/claim
+    2. Applies `claimed` to actively claimed `agent` + `task` issues
+    3. Applies `review` to `agent` + `task` issues with an open PR
     4. Expires claim-only issues after 24h if no PR was opened, including unassigning the agent
     │
   Next April / Plat wake-up
@@ -128,10 +128,10 @@ The reply can include modifications — Peter reads the full thread and incorpor
 [idea] New proposal          → open, awaiting review
 [idea][endorsed] Approved    → planned into issues
 [idea][endorsed] + 👍 on Peter summary → execution-approved
-`agent:ready` issue          → ready for a contributor to claim
-`agent:claimed` issue        → claimed, agent assigned, working toward PR
-`agent:review` issue         → PR opened, awaiting review
-`agent:review` + `agent:mergeable` → agent approved, ready for owner merge
+`agent` + `ready` issue      → ready for a contributor to claim
+`agent` + `claimed` issue    → claimed, agent assigned, working toward PR
+`agent` + `review` issue     → PR opened, awaiting review
+`agent` + `review` + `mergeable` → agent approved, ready for owner merge
 [shipped] Completed          → closed after delivery (PR merge auto-closes issue)
 ```
 
@@ -147,7 +147,7 @@ Prompt, runtime, and compatibility responsibilities now split cleanly:
 | `.agents/skills/cofounder-contributor/SKILL.md` | Shared contributor skill for April and Plat |
 | `.agents/skills/cofounder-contributor/references/` | Persona prompt resources for April and Plat |
 | `.agents/skills/cofounder-contributor/scripts/run-contributor.py` | Contributor runtime source of truth |
-| `.agents/skills/cofounder-contributor/scripts/sync-execution-state.py` | Syncs discussion approval into `agent:ready` / `agent:claimed` / `agent:review` issue state |
+| `.agents/skills/cofounder-contributor/scripts/sync-execution-state.py` | Syncs discussion approval into `ready` / `claimed` / `review` state on `agent` + `task` issues |
 | `.agents/skills/peter-planner/SKILL.md` | Planner skill for endorsed discussion → issues/milestone |
 | `.agents/skills/peter-planner/references/peter-planner.md` | Planner prompt resource |
 | `.agents/skills/peter-planner/config/peter-planner.toml` | Allowed planner labels + alias mapping |
@@ -180,14 +180,14 @@ April, Plat, and Peter now use thin workflow wrappers. Their workflow YAML keeps
 
 The shared contributor behavior now lives in `.agents/skills/cofounder-contributor/scripts/run-contributor.py` plus the execution-state sync script:
 
-1. sync `agent:ready` / `agent:claimed` / `agent:review` from discussion approval, blockers, open PRs, and stale claims
+1. sync `ready` / `claimed` / `review` on `agent` + `task` issues from discussion approval, blockers, open PRs, and stale claims
 2. build a normalized read-only selection index from repo/GitHub state without exposing raw GitHub text to the privileged selector prompt
 3. run a selector phase to choose the next task from that normalized index
 4. fetch only the chosen target's GitHub payload and pass it to Claude as explicit untrusted data alongside the selected persona prompt
 5. validate YAML frontmatter output through the shared validator
 6. either pretty-print validated JSON for dry runs or route the action back into GitHub
 
-When Peter has already planned a discussion, execution approval lives on Peter's summary comment. A 👍 reaction from the repo owner is the mission-level signal. The sync step turns that into explicit per-issue `agent:ready` state, transitions to `agent:review` when a PR opens, and expires `agent:claimed` issues after 24 hours when no PR exists (including unassigning the agent).
+When Peter has already planned a discussion, execution approval lives on Peter's summary comment. A 👍 reaction from the repo owner is the mission-level signal. The sync step turns that into explicit per-issue `agent` + `ready` state, transitions to `review` when a PR opens, and expires `claimed` issues after 24 hours when no PR exists (including unassigning the agent).
 
 April and Plat workflows now invoke the skill runtime directly. The old `.agents/scripts/run-contributor.py` path remains only as a compatibility shim for any external callers that still depend on it.
 
@@ -217,7 +217,7 @@ The agent team enforces work-in-progress limits to prevent unbounded growth of d
 | Metric | Cap | Enforcement |
 |--------|-----|-------------|
 | Open discussions | 12 | Proposals blocked when cap reached; agents redirected to close stale discussions |
-| Open `agent:task` issues | 30 | Peter Planner refuses plans that would exceed cap |
+| Open `agent` + `task` issues | 30 | Peter Planner refuses plans that would exceed cap |
 | Stale discussion threshold | 14 days idle | Flagged in agent context; prioritized for closure |
 
 When caps are reached:
@@ -237,10 +237,10 @@ The `recommend_close` action lets contributors close stale discussions with a su
 - **Shell safety** — event context passed via env vars, body content via temp files
 - **Catalog-backed labels** — Peter can only use repo-managed labels from `.agents/skills/peter-planner/config/peter-planner.toml`, with alias normalization for common CI/platform terms
 - **Idempotent planning markers** — planner comments, milestone descriptions, and issue bodies carry machine markers so retries reuse existing artifacts instead of leaking duplicates
-- **Explicit execution-state labels** — contributor workflows translate mission approval into `agent:ready`, `agent:claimed`, and `agent:review`, so execution no longer depends on contributors reparsing discussion reactions on every decision
+- **Explicit execution-state labels** — contributor workflows translate mission approval into `ready`, `claimed`, and `review` on `agent` + `task` issues, so execution no longer depends on contributors reparsing discussion reactions on every decision
 - **GitHub-native assignment tracking** — agents assign themselves to issues on claim, providing native GitHub filtering via `--assignee`; sync unassigns on stale-claim expiry
-- **Additive mergeable signal** — `agent:mergeable` stacks on `agent:review` when an agent approves a PR, and is removed when changes are requested; it is not managed by sync
-- **Stale-claim recovery** — claims without a PR automatically expire after 24 hours, return to `agent:ready`, and unassign the agent on the next sync pass
+- **Additive mergeable signal** — `mergeable` stacks on `review` when an agent approves a PR, and is removed when changes are requested; it is not managed by sync
+- **Stale-claim recovery** — claims without a PR automatically expire after 24 hours, return to `ready`, and unassign the agent on the next sync pass
 - **Discussion token override** — `permissions.discussions: write` is enough for comments, issues, and milestones, but GitHub's built-in Actions token still cannot retitle discussions via `updateDiscussion` in this repo. `agent-peter.yml` therefore prefers the repo secret `PETER_DISCUSSION_TOKEN` when present, and the repo's default Actions workflow permission should stay at `write`
 - **OpenAI env compatibility** — agent runtimes treat `OPENAI_API_KEY` as the canonical provider variable and fall back to `GITHUB_CODESPACES_OPENAI_API_KEY` when present so local Codespaces-oriented `.env` files can still work without changing the runtime contract
 - **Simple operational memory** — GitHub stays the raw event source; `docs/ops/` stores small checked-in snapshots and dashboards instead of introducing a separate analytics service or database in v1

--- a/docs/superpowers/specs/2026-03-24-agent-discovery-dashboard-design.md
+++ b/docs/superpowers/specs/2026-03-24-agent-discovery-dashboard-design.md
@@ -16,7 +16,7 @@ Phase 1 delivers: repo selection, agent discovery via GitHub Contents API, and i
 | Data sources | Repos + .agents/ scan + Issues API | Pipeline kanban is the signature feature; Discussions deferred |
 | Repo population | User-selected from sorted list | `GET /user/repos?sort=pushed` — user picks which to monitor |
 | Onboarding | Full-screen repo selector | First visit shows selector; sidebar "+" button for later additions |
-| Pipeline columns | ready → claimed → review → mergeable | `agent:task` and `agent:decision` shown as badges on cards |
+| Pipeline columns | ready → claimed → review → mergeable | `task` and `decision` shown as badges on cards |
 | Design system | Existing tokens | Instrument Serif, JetBrains Mono, mint `#a6ffdf`, dark surfaces |
 | Caching | 5min repos, 15min agent scans, 5min issues | Avoids GitHub rate limits while keeping data fresh |
 
@@ -64,15 +64,15 @@ When a repo is selected in the sidebar, the center panel shows:
 
 **Stats row**: 4 cards — agent count, skill count, open PRs, ready issues. Open PRs fetched via `GET /repos/{owner}/{repo}/pulls?state=open` (cached 5min alongside issues).
 
-**Agent team grid**: Cards for each discovered agent. Phase 1 treats every `.agents/skills/*/` directory entry as an agent — the directory name is the agent name, role is parsed from SKILL.md frontmatter `description` field (or null), skills listed from subdirectory names. Status derived from `agent:*` labeled issues (active if any issue has `agent:claimed` or `agent:review` with matching assignee, idle otherwise).
+**Agent team grid**: Cards for each discovered agent. Phase 1 treats every `.agents/skills/*/` directory entry as an agent — the directory name is the agent name, role is parsed from SKILL.md frontmatter `description` field (or null), skills listed from subdirectory names. Status is derived from issues labeled `agent` plus `claimed` or `review` with matching assignee.
 
 **Issue pipeline kanban**: 4 columns matching these exact labels:
-- `agent:ready` → Ready
-- `agent:claimed` → Claimed
-- `agent:review` → Review
-- `agent:mergeable` → Mergeable
+- `agent` + `ready` → Ready
+- `agent` + `claimed` → Claimed
+- `agent` + `review` → Review
+- `agent` + `mergeable` → Mergeable
 
-Issues fetched via `GET /repos/{owner}/{repo}/issues?labels=agent:ready` (one call per column). Issues that also carry `agent:task` or `agent:decision` labels show those as colored secondary badges on the card.
+Issues are fetched with the `agent` lane label plus the column state label. Issues that also carry `task` or `decision` labels show those as colored secondary badges on the card.
 
 ### Activity Feed
 
@@ -199,7 +199,7 @@ CREATE TABLE IF NOT EXISTS user_repos (
 - [ ] Selecting a repo shows stats row (agents, skills, open PRs, ready issues)
 - [ ] Agent team grid shows discovered agents with status and skills
 - [ ] Pipeline kanban shows `agent:*` labeled issues in correct columns
-- [ ] `agent:task` and `agent:decision` appear as badges on pipeline cards
+- [ ] `task` and `decision` appear as badges on pipeline cards
 - [ ] Activity feed filters to selected repo
 - [ ] Repos without `.agents/` show "no agent setup" state
 - [ ] GitHub API responses cached (5min repos, 15min agent scans, 5min issues)

--- a/fixtures/carl-community/active-day/issues.json
+++ b/fixtures/carl-community/active-day/issues.json
@@ -6,7 +6,7 @@
     "createdAt": "2026-03-19T10:00:00Z",
     "updatedAt": "2026-03-21T07:00:00Z",
     "closedAt": "2026-03-21T07:00:00Z",
-    "labels": [{"name": "agent:ready"}],
+    "labels": [{"name": "agent"}, {"name": "ready"}],
     "milestone": {"title": "M5: Agent Coordination"},
     "assignees": [{"login": "plat-ironwood[bot]"}]
   },

--- a/fixtures/carl-community/first-run/issues.json
+++ b/fixtures/carl-community/first-run/issues.json
@@ -6,7 +6,7 @@
     "createdAt": "2026-03-21T08:00:00Z",
     "updatedAt": "2026-03-21T08:00:00Z",
     "closedAt": null,
-    "labels": [{"name": "agent:ready"}],
+    "labels": [{"name": "agent"}, {"name": "ready"}],
     "milestone": {"title": "M5: Agent Coordination"},
     "assignees": []
   }

--- a/fixtures/ops-report/throughput-breach/issues.json
+++ b/fixtures/ops-report/throughput-breach/issues.json
@@ -14,7 +14,10 @@
     },
     "labels": [
       {
-        "name": "agent:task"
+        "name": "agent"
+      },
+      {
+        "name": "task"
       }
     ],
     "closedByPullRequestsReferences": []
@@ -34,7 +37,10 @@
     },
     "labels": [
       {
-        "name": "agent:task"
+        "name": "agent"
+      },
+      {
+        "name": "task"
       }
     ],
     "closedByPullRequestsReferences": []
@@ -54,7 +60,10 @@
     },
     "labels": [
       {
-        "name": "agent:task"
+        "name": "agent"
+      },
+      {
+        "name": "task"
       }
     ],
     "closedByPullRequestsReferences": []
@@ -74,7 +83,10 @@
     },
     "labels": [
       {
-        "name": "agent:task"
+        "name": "agent"
+      },
+      {
+        "name": "task"
       }
     ],
     "closedByPullRequestsReferences": []

--- a/scripts/migrate-agent-labels.py
+++ b/scripts/migrate-agent-labels.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Migrate agent lifecycle labels to lane + state labels.
+
+Dry-run by default. Use --apply after the code that understands the new labels
+has landed on the default branch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GITHUB_TIMEOUT = 30
+
+
+@dataclass(frozen=True)
+class LabelSpec:
+    name: str
+    color: str
+    description: str
+
+
+LABELS = [
+    LabelSpec("agent", "5319e7", "Work owned by the agent execution lane"),
+    LabelSpec("human", "ededed", "Work explicitly owned by a human"),
+    LabelSpec("task", "0E8A16", "Planned work item"),
+    LabelSpec("ready", "5319e7", "Ready for the owning lane to act"),
+    LabelSpec("claimed", "1d76db", "Actively owned and in progress"),
+    LabelSpec("review", "fbca04", "PR opened and awaiting review"),
+    LabelSpec("mergeable", "0e8a16", "Agent-approved, ready for owner merge"),
+    LabelSpec("decision", "D93F0B", "Needs a scoped decision before continuing"),
+    LabelSpec("blocked", "d93f0b", "Blocked by a dependency or unresolved condition"),
+    LabelSpec("needs-human", "ededed", "Needs human intervention before continuing"),
+    LabelSpec("needs-info", "D876E3", "Waiting on the reporter for more information"),
+    LabelSpec("needs-triage", "FFD33D", "Maintainer needs to evaluate the issue"),
+    LabelSpec("safe-to-run-agent", "0e8a16", "Maintainer approval for mention-triggered agent execution"),
+    LabelSpec("privileged-agent-patch", "b60205", "Break-glass approval for privileged agent patch scope"),
+]
+
+LEGACY_LABELS: dict[str, tuple[str, ...]] = {
+    "agent:task": ("agent", "task"),
+    "agent:ready": ("agent", "ready"),
+    "agent:claimed": ("agent", "claimed"),
+    "agent:review": ("agent", "review"),
+    "agent:mergeable": ("agent", "mergeable"),
+    "agent:decision": ("agent", "decision"),
+}
+
+
+def run_json(cmd: list[str]) -> object:
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=GITHUB_TIMEOUT,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip() or result.stdout.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode or 1)
+    return json.loads(result.stdout or "null")
+
+
+def run_checked(cmd: list[str]) -> None:
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=GITHUB_TIMEOUT,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip() or result.stdout.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode or 1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="perform GitHub label and issue updates")
+    parser.add_argument(
+        "--delete-legacy",
+        action="store_true",
+        help="delete old agent:* labels after issues have been migrated",
+    )
+    return parser.parse_args()
+
+
+def ensure_labels(*, apply: bool) -> None:
+    existing = {
+        item["name"]: item
+        for item in run_json(["gh", "label", "list", "--limit", "300", "--json", "name,color,description"])
+    }
+    for spec in LABELS:
+        if spec.name in existing:
+            print(f"label exists: {spec.name}")
+            continue
+        print(f"create label: {spec.name}")
+        if apply:
+            run_checked([
+                "gh",
+                "label",
+                "create",
+                spec.name,
+                "--color",
+                spec.color,
+                "--description",
+                spec.description,
+            ])
+
+
+def migrate_issues(*, apply: bool) -> set[str]:
+    legacy_seen: set[str] = set()
+    for old_label, new_labels in LEGACY_LABELS.items():
+        issues = run_json([
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--label",
+            old_label,
+            "--limit",
+            "1000",
+            "--json",
+            "number,title,labels",
+        ])
+        if not issues:
+            continue
+        legacy_seen.add(old_label)
+        for issue in issues:
+            current = {
+                label["name"]
+                for label in issue.get("labels", [])
+                if isinstance(label, dict) and label.get("name")
+            }
+            missing = [label for label in new_labels if label not in current]
+            print(f"issue #{issue['number']}: {old_label} -> {', '.join(new_labels)}")
+            if apply and missing:
+                cmd = ["gh", "issue", "edit", str(issue["number"])]
+                for label in missing:
+                    cmd.extend(["--add-label", label])
+                run_checked(cmd)
+    return legacy_seen
+
+
+def delete_legacy_labels(labels: set[str], *, apply: bool) -> None:
+    for label in sorted(labels):
+        print(f"delete legacy label: {label}")
+        if apply:
+            run_checked(["gh", "label", "delete", label, "--yes"])
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.apply:
+        print("dry run: pass --apply to update GitHub")
+    ensure_labels(apply=args.apply)
+    legacy_seen = migrate_issues(apply=args.apply)
+    if args.delete_legacy:
+        delete_legacy_labels(legacy_seen, apply=args.apply)
+    elif legacy_seen:
+        print("legacy labels still present; rerun with --apply --delete-legacy after reviewing the dry run")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_run_contributor.py
+++ b/scripts/test_run_contributor.py
@@ -84,7 +84,7 @@ class RunContributorEvidenceTests(unittest.TestCase):
                     run_contributor.enforce_agent_patch_policy(
                         artifact,
                         {},
-                        selection_item={"labels": ["agent:task"]},
+                        selection_item={"labels": ["agent", "task"]},
                         cli_override=False,
                     )
 

--- a/web/src/app/api/repos/[owner]/[repo]/agents/route.ts
+++ b/web/src/app/api/repos/[owner]/[repo]/agents/route.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/github";
 import { isRepoOwnedByUser } from "@/lib/repos";
 import type { AgentDiscoveryResponse } from "@/lib/types";
-import { PIPELINE_GITHUB_LABELS } from "@/lib/types";
+import { AGENT_PIPELINE_LABEL, PIPELINE_GITHUB_LABELS } from "@/lib/types";
 
 export async function GET(
 	_request: Request,
@@ -68,16 +68,27 @@ export async function GET(
 		);
 
 		const [ready, claimed, review, mergeable, openPRs] = await Promise.all([
-			fetchIssuesByLabel(token, owner, repo, PIPELINE_GITHUB_LABELS.ready),
-			fetchIssuesByLabel(token, owner, repo, PIPELINE_GITHUB_LABELS.claimed),
-			fetchIssuesByLabel(token, owner, repo, PIPELINE_GITHUB_LABELS.review),
-			fetchIssuesByLabel(token, owner, repo, PIPELINE_GITHUB_LABELS.mergeable),
+			fetchIssuesByLabel(token, owner, repo, [
+				AGENT_PIPELINE_LABEL,
+				PIPELINE_GITHUB_LABELS.ready,
+			]),
+			fetchIssuesByLabel(token, owner, repo, [
+				AGENT_PIPELINE_LABEL,
+				PIPELINE_GITHUB_LABELS.claimed,
+			]),
+			fetchIssuesByLabel(token, owner, repo, [
+				AGENT_PIPELINE_LABEL,
+				PIPELINE_GITHUB_LABELS.review,
+			]),
+			fetchIssuesByLabel(token, owner, repo, [
+				AGENT_PIPELINE_LABEL,
+				PIPELINE_GITHUB_LABELS.mergeable,
+			]),
 			fetchOpenPRCount(token, owner, repo),
 		]);
 
-		// Any claimed/review issue with an agent-named label counts as that
-		// agent being active — the label is the only cross-reference from an
-		// issue back to the agent persona that claimed it.
+		// Any claimed/review issue with an agent-specific label counts as that
+		// agent being active — assignees are not reliable for all bot accounts.
 		if (claimed.length > 0 || review.length > 0) {
 			for (const agent of agents) {
 				const hasActivity = [...claimed, ...review].some((issue) =>

--- a/web/src/app/dashboard/components/pipeline.tsx
+++ b/web/src/app/dashboard/components/pipeline.tsx
@@ -3,7 +3,7 @@ import type {
 	PipelineIssue,
 	Pipeline as PipelineType,
 } from "@/lib/types";
-import { PIPELINE_LABELS } from "@/lib/types";
+import { AGENT_TASK_LABEL, PIPELINE_LABELS } from "@/lib/types";
 import styles from "./pipeline.module.css";
 
 interface PipelineProps {
@@ -25,8 +25,8 @@ const COLUMN_STYLE: Record<PipelineColumn, string> = {
 };
 
 function IssueCard({ issue }: { issue: PipelineIssue }) {
-	const hasTask = issue.labels.some((l) => l === "agent:task");
-	const hasDecision = issue.labels.some((l) => l === "agent:decision");
+	const hasTask = issue.labels.some((l) => l === AGENT_TASK_LABEL);
+	const hasDecision = issue.labels.some((l) => l === "decision");
 
 	return (
 		<a

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -236,11 +236,13 @@ export function fetchIssuesByLabel(
 	token: string,
 	owner: string,
 	repo: string,
-	label: string,
+	label: string | string[],
 ): Promise<PipelineIssue[]> {
-	return cached(`issues:${owner}/${repo}:${label}`, FIVE_MIN, async () => {
+	const labels = Array.isArray(label) ? label : [label];
+	const labelKey = labels.join(",");
+	return cached(`issues:${owner}/${repo}:${labelKey}`, FIVE_MIN, async () => {
 		const issues = await ghFetch<GHIssue[]>(
-			`/repos/${owner}/${repo}/issues?labels=${encodeURIComponent(label)}&state=open&per_page=100`,
+			`/repos/${owner}/${repo}/issues?labels=${encodeURIComponent(labelKey)}&state=open&per_page=100`,
 			token,
 		);
 		return issues.map((i) => ({

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -186,11 +186,14 @@ export type TimelineEntry =
 	| (ChatMessage & { kind: "chat" });
 
 export const PIPELINE_GITHUB_LABELS: Record<PipelineColumn, string> = {
-	ready: "agent:ready",
-	claimed: "agent:claimed",
-	review: "agent:review",
-	mergeable: "agent:mergeable",
+	ready: "ready",
+	claimed: "claimed",
+	review: "review",
+	mergeable: "mergeable",
 };
+
+export const AGENT_PIPELINE_LABEL = "agent";
+export const AGENT_TASK_LABEL = "task";
 
 export interface GitHubRepo {
 	full_name: string;


### PR DESCRIPTION
## Summary

- Replace namespaced agent lifecycle labels with composable lane + state labels: `agent`/`human` plus `task`, `ready`, `claimed`, `review`, and `mergeable`.
- Update Peter, April/Plat contributor sync, lifecycle health checks, and dashboard pipeline queries to use the new model.
- Expand `docs/agents/triage-labels.md` with lane/state/dimension/gate guidance and add a dry-run migration script for live GitHub labels.

## Mergeability

- Surface: web / agent-runtime / docs
- User-facing behavior changed: agent pipeline labels become composable instead of `agent:*` namespaced labels once the migration script is applied after merge.
- Non-happy paths considered: migration script is dry-run by default and should be reviewed before applying/deleting legacy labels.
- Release/ops preconditions: after merge, run `scripts/migrate-agent-labels.py` dry-run, then apply, then delete legacy labels if output is expected.
- Residual risk or follow-up: live GitHub labels are not mutated by this PR branch to avoid breaking `main` before the code lands.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `uv run .agents/scripts/test_run_planner.py`; `uv run --script scripts/test_run_contributor.py`; `uv run --script scripts/test_agent_triage.py`; `uv run --script scripts/migrate-agent-labels.py`; `env PYTHONPYCACHEPREFIX=/tmp/workspaces-pycache python3 -m py_compile scripts/migrate-agent-labels.py`; `mise -C web run web:check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![agent-label-verification-rebased](https://evidence.cloudcompute.com/workspaces/pr-467/20260510-191517-agent-label-verification-rebased.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
