### PR TITLE
[codex] Harden agent label migration

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -1601,6 +1601,28 @@ class RunContributorTests(unittest.TestCase):
         self.assertEqual(labels, {sync_execution_state.AGENT_READY_LABEL})
         self.assertEqual(reason, "execution-approved and ready")
 
+    def test_sync_dry_run_does_not_create_missing_labels(self) -> None:
+        args = type("Args", (), {"dry_run": True})()
+        env = {"GH_TOKEN": "token", "GITHUB_REPOSITORY": "fairchild/workspaces"}
+
+        with (
+            mock.patch.dict(os.environ, env, clear=True),
+            mock.patch.object(sync_execution_state, "parse_args", return_value=args),
+            mock.patch.object(sync_execution_state, "repo_owner_name", return_value=("fairchild", "workspaces")),
+            mock.patch.object(
+                sync_execution_state,
+                "fetch_work_state",
+                return_value={"discussions": [], "issues": [], "pull_requests": []},
+            ),
+            mock.patch.object(sync_execution_state, "fetch_issue_state_map", return_value={}),
+            mock.patch.object(sync_execution_state, "fetch_existing_labels", return_value=set()),
+            mock.patch.object(sync_execution_state, "fetch_agent_task_issues", return_value=[]),
+            mock.patch.object(sync_execution_state, "ensure_label") as ensure_label,
+        ):
+            self.assertEqual(sync_execution_state.main(), 0)
+
+        ensure_label.assert_not_called()
+
     def test_extract_pr_issue_reference_reads_pr_marker(self) -> None:
         issue_number, agent = run_contributor.extract_pr_issue_reference(
             "Closes #116\n\n<!-- contributor:issue=116;agent=april-clearwater -->"

--- a/.agents/skills/cofounder-contributor/scripts/sync-execution-state.py
+++ b/.agents/skills/cofounder-contributor/scripts/sync-execution-state.py
@@ -569,11 +569,42 @@ def main() -> int:
     now = datetime.now(timezone.utc)
 
     existing_labels = fetch_existing_labels(env)
-    ensure_label(existing_labels, env, AGENT_LANE_LABEL, AGENT_LANE_LABEL_COLOR, AGENT_LANE_LABEL_DESCRIPTION)
-    ensure_label(existing_labels, env, AGENT_TASK_LABEL, AGENT_TASK_LABEL_COLOR, AGENT_TASK_LABEL_DESCRIPTION)
-    ensure_label(existing_labels, env, AGENT_READY_LABEL, AGENT_READY_LABEL_COLOR, AGENT_READY_LABEL_DESCRIPTION)
-    ensure_label(existing_labels, env, AGENT_CLAIM_LABEL, AGENT_CLAIM_LABEL_COLOR, AGENT_CLAIM_LABEL_DESCRIPTION)
-    ensure_label(existing_labels, env, AGENT_REVIEW_LABEL, AGENT_REVIEW_LABEL_COLOR, AGENT_REVIEW_LABEL_DESCRIPTION)
+    if not args.dry_run:
+        ensure_label(
+            existing_labels,
+            env,
+            AGENT_LANE_LABEL,
+            AGENT_LANE_LABEL_COLOR,
+            AGENT_LANE_LABEL_DESCRIPTION,
+        )
+        ensure_label(
+            existing_labels,
+            env,
+            AGENT_TASK_LABEL,
+            AGENT_TASK_LABEL_COLOR,
+            AGENT_TASK_LABEL_DESCRIPTION,
+        )
+        ensure_label(
+            existing_labels,
+            env,
+            AGENT_READY_LABEL,
+            AGENT_READY_LABEL_COLOR,
+            AGENT_READY_LABEL_DESCRIPTION,
+        )
+        ensure_label(
+            existing_labels,
+            env,
+            AGENT_CLAIM_LABEL,
+            AGENT_CLAIM_LABEL_COLOR,
+            AGENT_CLAIM_LABEL_DESCRIPTION,
+        )
+        ensure_label(
+            existing_labels,
+            env,
+            AGENT_REVIEW_LABEL,
+            AGENT_REVIEW_LABEL_COLOR,
+            AGENT_REVIEW_LABEL_DESCRIPTION,
+        )
 
     discussions = {
         int(discussion["number"]): discussion

--- a/scripts/migrate-agent-labels.py
+++ b/scripts/migrate-agent-labels.py
@@ -101,15 +101,34 @@ def ensure_labels(*, apply: bool) -> None:
         for item in run_json(["gh", "label", "list", "--limit", "300", "--json", "name,color,description"])
     }
     for spec in LABELS:
-        if spec.name in existing:
+        current = existing.get(spec.name)
+        if current is None:
+            print(f"create label: {spec.name}")
+            if apply:
+                run_checked([
+                    "gh",
+                    "label",
+                    "create",
+                    spec.name,
+                    "--color",
+                    spec.color,
+                    "--description",
+                    spec.description,
+                ])
+            continue
+
+        current_color = str(current.get("color", ""))
+        current_description = str(current.get("description", ""))
+        if current_color.lower() == spec.color.lower() and current_description == spec.description:
             print(f"label exists: {spec.name}")
             continue
-        print(f"create label: {spec.name}")
+
+        print(f"update label: {spec.name}")
         if apply:
             run_checked([
                 "gh",
                 "label",
-                "create",
+                "edit",
                 spec.name,
                 "--color",
                 spec.color,

--- a/scripts/test_migrate_agent_labels.py
+++ b/scripts/test_migrate_agent_labels.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Stdlib tests for agent label migration helpers."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+migrate_agent_labels = load_module(
+    "migrate_agent_labels",
+    REPO_ROOT / "scripts" / "migrate-agent-labels.py",
+)
+
+
+class MigrateAgentLabelsTests(unittest.TestCase):
+    def test_dry_run_reports_metadata_drift_without_editing(self) -> None:
+        existing = [{"name": "claimed", "color": "fbca04", "description": "Old description"}]
+
+        with (
+            mock.patch.object(migrate_agent_labels, "run_json", return_value=existing),
+            mock.patch.object(migrate_agent_labels, "run_checked") as run_checked,
+        ):
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                migrate_agent_labels.ensure_labels(apply=False)
+
+        self.assertIn("update label: claimed", output.getvalue())
+        run_checked.assert_not_called()
+
+    def test_apply_reconciles_existing_label_metadata(self) -> None:
+        existing = [
+            {"name": spec.name, "color": spec.color, "description": spec.description}
+            for spec in migrate_agent_labels.LABELS
+        ]
+        for item in existing:
+            if item["name"] == "claimed":
+                item["color"] = "fbca04"
+                item["description"] = "Old description"
+            if item["name"] == "needs-human":
+                item["description"] = ""
+
+        with (
+            mock.patch.object(migrate_agent_labels, "run_json", return_value=existing),
+            mock.patch.object(migrate_agent_labels, "run_checked") as run_checked,
+        ):
+            migrate_agent_labels.ensure_labels(apply=True)
+
+        commands = [call.args[0] for call in run_checked.call_args_list]
+        self.assertIn(
+            [
+                "gh",
+                "label",
+                "edit",
+                "claimed",
+                "--color",
+                "1d76db",
+                "--description",
+                "Actively owned and in progress",
+            ],
+            commands,
+        )
+        self.assertIn(
+            [
+                "gh",
+                "label",
+                "edit",
+                "needs-human",
+                "--color",
+                "ededed",
+                "--description",
+                "Needs human intervention before continuing",
+            ],
+            commands,
+        )
+
+    def test_webhook_simulation_uses_composable_agent_labels(self) -> None:
+        content = (REPO_ROOT / "web" / "scripts" / "simulate-webhooks.ts").read_text(encoding="utf-8")
+
+        self.assertNotIn("agent:ready", content)
+        self.assertNotIn("agent:claimed", content)
+        self.assertNotIn("agent:review", content)
+        self.assertIn('"agent"', content)
+        self.assertIn('"ready"', content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/scripts/simulate-webhooks.ts
+++ b/web/scripts/simulate-webhooks.ts
@@ -96,9 +96,10 @@ const templates: EventTemplate[] = [
 				labels: [
 					{
 						name: pick([
-							"agent:ready",
-							"agent:claimed",
-							"agent:review",
+							"agent",
+							"ready",
+							"claimed",
+							"review",
 							"enhancement",
 							"bug",
 						]),


### PR DESCRIPTION
## Summary
- make the execution-state sync dry-run path non-mutating
- reconcile canonical GitHub label metadata in the migration script
- update stale webhook simulation labels to the lane/state model
- add focused tests for migration metadata, sync dry-run behavior, and sample label drift

## Mergeability
- Surface: agent-runtime / web / docs
- User-facing behavior changed: No direct app UI behavior change. GitHub label migration tooling now updates canonical label metadata before the live migration.
- Non-happy paths considered: Dry-run paths are covered so verification cannot create labels accidentally; stale sample data is covered by a text assertion.
- Residual risk or follow-up: Live GitHub label mutation remains the follow-up operation after this code lands on main.

## Evidence
Hosted evidence: [agent-label-followup](https://evidence.cloudcompute.com/workspaces/pr-469/20260510-201943-agent-label-followup.svg)

Validation run:
- `uv run --script scripts/test_migrate_agent_labels.py` — 3 passed
- `uv run .agents/scripts/test_run_planner.py` — 107 passed
- `uv run --script scripts/test_run_contributor.py` — 33 passed
- `uv run --script scripts/test_agent_triage.py` — 6 passed
- `uv run --script scripts/migrate-agent-labels.py` — dry run completed with expected creates/updates/backfills
- `GH_TOKEN=$(gh auth token) uv run .agents/skills/cofounder-contributor/scripts/sync-execution-state.py --dry-run` — completed with 0 updates
- `GH_TOKEN=$(gh auth token) uv run .agents/skills/cofounder-contributor/scripts/lifecycle-health-check.py` — 6/6 checks passed
- `mise -C web run web:check` — typecheck, lint, and 232 web tests passed

## Live Migration
Apply the live label migration only after this code is on `main`:

```bash
uv run --script scripts/migrate-agent-labels.py
uv run --script scripts/migrate-agent-labels.py --apply
uv run --script scripts/migrate-agent-labels.py --apply --delete-legacy
gh label delete question --yes
gh label delete "help wanted" --yes
```
