### PR TITLE
[codex] Make agent label migration idempotent

### DIFF
--- a/scripts/migrate-agent-labels.py
+++ b/scripts/migrate-agent-labels.py
@@ -95,11 +95,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def ensure_labels(*, apply: bool) -> None:
-    existing = {
+def fetch_labels() -> dict[str, dict[str, object]]:
+    return {
         item["name"]: item
         for item in run_json(["gh", "label", "list", "--limit", "300", "--json", "name,color,description"])
     }
+
+
+def ensure_labels(existing: dict[str, dict[str, object]], *, apply: bool) -> None:
     for spec in LABELS:
         current = existing.get(spec.name)
         if current is None:
@@ -137,9 +140,11 @@ def ensure_labels(*, apply: bool) -> None:
             ])
 
 
-def migrate_issues(*, apply: bool) -> set[str]:
+def migrate_issues(existing_labels: set[str], *, apply: bool) -> set[str]:
     legacy_seen: set[str] = set()
     for old_label, new_labels in LEGACY_LABELS.items():
+        if old_label not in existing_labels:
+            continue
         issues = run_json([
             "gh",
             "issue",
@@ -183,8 +188,9 @@ def main() -> int:
     args = parse_args()
     if not args.apply:
         print("dry run: pass --apply to update GitHub")
-    ensure_labels(apply=args.apply)
-    legacy_seen = migrate_issues(apply=args.apply)
+    existing = fetch_labels()
+    ensure_labels(existing, apply=args.apply)
+    legacy_seen = migrate_issues(set(existing), apply=args.apply)
     if args.delete_legacy:
         delete_legacy_labels(legacy_seen, apply=args.apply)
     elif legacy_seen:

--- a/scripts/test_migrate_agent_labels.py
+++ b/scripts/test_migrate_agent_labels.py
@@ -44,7 +44,10 @@ class MigrateAgentLabelsTests(unittest.TestCase):
         ):
             output = io.StringIO()
             with contextlib.redirect_stdout(output):
-                migrate_agent_labels.ensure_labels(apply=False)
+                migrate_agent_labels.ensure_labels(
+                    {item["name"]: item for item in existing},
+                    apply=False,
+                )
 
         self.assertIn("update label: claimed", output.getvalue())
         run_checked.assert_not_called()
@@ -65,7 +68,10 @@ class MigrateAgentLabelsTests(unittest.TestCase):
             mock.patch.object(migrate_agent_labels, "run_json", return_value=existing),
             mock.patch.object(migrate_agent_labels, "run_checked") as run_checked,
         ):
-            migrate_agent_labels.ensure_labels(apply=True)
+            migrate_agent_labels.ensure_labels(
+                {item["name"]: item for item in existing},
+                apply=True,
+            )
 
         commands = [call.args[0] for call in run_checked.call_args_list]
         self.assertIn(
@@ -103,6 +109,13 @@ class MigrateAgentLabelsTests(unittest.TestCase):
         self.assertNotIn("agent:review", content)
         self.assertIn('"agent"', content)
         self.assertIn('"ready"', content)
+
+    def test_migration_skips_deleted_legacy_labels(self) -> None:
+        with mock.patch.object(migrate_agent_labels, "run_json") as run_json:
+            seen = migrate_agent_labels.migrate_issues(set(), apply=False)
+
+        self.assertEqual(seen, set())
+        run_json.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- skip legacy issue searches once the legacy label has been deleted from the repository
- keep migration dry-runs clean after the completed agent label cleanup
- add a regression test for the deleted-legacy-label path

## Mergeability
- Surface: agent-runtime / repo automation
- User-facing behavior changed: No app UI behavior change. The GitHub label migration script is now idempotent after legacy labels have been deleted.
- Non-happy paths considered: GitHub issue search can return stale matches for deleted labels; the script now gates legacy migration work on the live label inventory first.
- Residual risk or follow-up: None known.

## Evidence
Hosted evidence: [agent-label-audit](https://evidence.cloudcompute.com/workspaces/pr-470/20260510-203001-agent-label-audit.svg)

Validation run:
- `uv run --script scripts/test_migrate_agent_labels.py` — 4 passed
- `uv run .agents/scripts/test_run_planner.py` — 107 passed
- `uv run --script scripts/test_run_contributor.py` — 33 passed
- `uv run --script scripts/test_agent_triage.py` — 6 passed
- `uv run --script scripts/migrate-agent-labels.py` — dry run reports only canonical labels after cleanup
- `GH_TOKEN=$(gh auth token) uv run .agents/skills/cofounder-contributor/scripts/lifecycle-health-check.py` — 6/6 checks passed
- `GH_TOKEN=$(gh auth token) uv run .agents/skills/cofounder-contributor/scripts/sync-execution-state.py --dry-run` — 0 updates

