### PR TITLE
Add experimental features settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | libghostty internals | docs/development/libghostty-integration.md | - |
 | Notifications / webhooks | docs/development/notifications.md | - |
 | Debug an issue | docs/development/troubleshooting.md | - |
+| Add Settings-gated experimental UI | docs/development/experimental-features.md | - |
 | Terminal keyboard focus | docs/development/solution-terminal-keyboard.md | - |
 | Evidence guide | docs/development/evidence.md | - |
 | UI fixture mode + release screenshots | docs/development/ui-fixture-mode.md | - |

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ For performance testing and benchmarking workflows, see:
 - [docs/performance-testing.md](./docs/performance-testing.md)
 - [docs/performance/dashboard.md](./docs/performance/dashboard.md)
 
+For introducing Settings-gated UI experiments, see:
+
+- [docs/development/experimental-features.md](./docs/development/experimental-features.md)
+
 For VM and provider-backed workspace architecture, see:
 
 - [docs/vm-provider-architecture.md](./docs/vm-provider-architecture.md)

--- a/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
+++ b/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
@@ -1,0 +1,146 @@
+//
+//  ExperimentalFeatures.swift
+//  WorkspaceManager
+//
+
+import Foundation
+import SwiftUI
+
+enum ExperimentalFeature: String, CaseIterable, Identifiable {
+    case minimalToolbar = "minimalToolbar"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .minimalToolbar:
+            return "Minimal Toolbar"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .minimalToolbar:
+            return "Hide secondary toolbar controls so terminal surfaces stay closer to the canvas."
+        }
+    }
+
+    var storageKey: String {
+        "experimentalFeatures.\(rawValue).enabled"
+    }
+
+    var defaultEnabled: Bool {
+        false
+    }
+
+    var forceOnEnvironmentKey: String? {
+        switch self {
+        case .minimalToolbar:
+            return "WORKSPACES_PERF_MINIMAL_TOOLBAR"
+        }
+    }
+}
+
+enum ExperimentalFeatures {
+    static let masterEnabledKey = "experimentalFeatures.enabled"
+    static let defaultMasterEnabled = false
+
+    static func isEnabled(
+        _ feature: ExperimentalFeature,
+        userDefaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        isEnabled(
+            feature,
+            masterEnabled: bool(
+                forKey: masterEnabledKey,
+                defaultValue: defaultMasterEnabled,
+                userDefaults: userDefaults
+            ),
+            featureEnabled: bool(
+                forKey: feature.storageKey,
+                defaultValue: feature.defaultEnabled,
+                userDefaults: userDefaults
+            ),
+            environment: environment
+        )
+    }
+
+    static func isEnabled(
+        _ feature: ExperimentalFeature,
+        masterEnabled: Bool,
+        featureEnabled: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if isForcedOn(feature, environment: environment) {
+            return true
+        }
+
+        return masterEnabled && featureEnabled
+    }
+
+    static func isForcedOn(
+        _ feature: ExperimentalFeature,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard
+            let key = feature.forceOnEnvironmentKey,
+            let rawValue = environment[key]
+        else {
+            return false
+        }
+
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func forcedOnFeatures(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [ExperimentalFeature] {
+        ExperimentalFeature.allCases.filter { isForcedOn($0, environment: environment) }
+    }
+
+    private static func bool(
+        forKey key: String,
+        defaultValue: Bool,
+        userDefaults: UserDefaults
+    ) -> Bool {
+        guard let storedValue = userDefaults.object(forKey: key) as? Bool else {
+            return defaultValue
+        }
+        return storedValue
+    }
+}
+
+@propertyWrapper
+struct ExperimentalFeatureFlag: DynamicProperty {
+    private let feature: ExperimentalFeature
+    private let environment: [String: String]
+
+    @AppStorage(ExperimentalFeatures.masterEnabledKey)
+    private var masterEnabled: Bool = ExperimentalFeatures.defaultMasterEnabled
+
+    @AppStorage private var featureEnabled: Bool
+
+    init(
+        _ feature: ExperimentalFeature,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.feature = feature
+        self.environment = environment
+        _featureEnabled = AppStorage(wrappedValue: feature.defaultEnabled, feature.storageKey)
+    }
+
+    var wrappedValue: Bool {
+        ExperimentalFeatures.isEnabled(
+            feature,
+            masterEnabled: masterEnabled,
+            featureEnabled: featureEnabled,
+            environment: environment
+        )
+    }
+}

--- a/Sources/WorkspaceManager/Diagnostics/PerformanceExperimentFlags.swift
+++ b/Sources/WorkspaceManager/Diagnostics/PerformanceExperimentFlags.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-enum PerformanceExperimentFlags {
-    static let minimalToolbar =
-        ProcessInfo.processInfo.environment["WORKSPACES_PERF_MINIMAL_TOOLBAR"] == "1"
-}

--- a/Sources/WorkspaceManager/Views/ExperimentalFeaturesSettingsView.swift
+++ b/Sources/WorkspaceManager/Views/ExperimentalFeaturesSettingsView.swift
@@ -1,0 +1,103 @@
+//
+//  ExperimentalFeaturesSettingsView.swift
+//  WorkspaceManager
+//
+
+import SwiftUI
+
+struct ExperimentalFeaturesSettingsView: View {
+    @AppStorage(ExperimentalFeatures.masterEnabledKey)
+    private var experimentalFeaturesEnabled: Bool = ExperimentalFeatures.defaultMasterEnabled
+
+    private var forcedOnFeatures: [ExperimentalFeature] {
+        ExperimentalFeatures.forcedOnFeatures()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle("Experimental Features", isOn: $experimentalFeaturesEnabled)
+                .accessibilityIdentifier("settings.experimental.master-toggle")
+
+            Text(
+                "Try work-in-progress UI. Turning this off hides Settings-controlled experiments "
+                    + "without clearing individual choices."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if !forcedOnFeatures.isEmpty {
+                forcedOnNotice
+            }
+
+            if experimentalFeaturesEnabled {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(ExperimentalFeature.allCases) { feature in
+                        ExperimentalFeatureToggleRow(feature: feature)
+                    }
+                }
+                .padding(.top, 2)
+                .accessibilityIdentifier("settings.experimental.list")
+            }
+        }
+        .accessibilityIdentifier("settings.experimental.section")
+    }
+
+    private var forcedOnNotice: some View {
+        Label {
+            Text(
+                "Forced on for this launch: "
+                    + forcedOnFeatures.map(\.title).joined(separator: ", ")
+            )
+        } icon: {
+            Image(systemName: "exclamationmark.triangle.fill")
+        }
+        .font(.caption)
+        .foregroundStyle(.orange)
+        .accessibilityIdentifier("settings.experimental.force-on-note")
+    }
+}
+
+private struct ExperimentalFeatureToggleRow: View {
+    let feature: ExperimentalFeature
+
+    @AppStorage private var isEnabled: Bool
+
+    init(feature: ExperimentalFeature) {
+        self.feature = feature
+        _isEnabled = AppStorage(wrappedValue: feature.defaultEnabled, feature.storageKey)
+    }
+
+    var body: some View {
+        Toggle(isOn: $isEnabled) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(feature.title)
+                    .font(.callout)
+
+                Text(feature.description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if ExperimentalFeatures.isForcedOn(feature),
+                    let key = feature.forceOnEnvironmentKey
+                {
+                    Text("Forced on by \(key) for this launch.")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            }
+        }
+        .accessibilityIdentifier("settings.experimental.feature.\(feature.rawValue)")
+    }
+}
+
+#Preview {
+    Form {
+        Section {
+            ExperimentalFeaturesSettingsView()
+        } header: {
+            Text("Experimental Features")
+        }
+    }
+    .formStyle(.grouped)
+    .frame(width: 560)
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -38,6 +38,8 @@ struct ContentView: View {
     private var terminalContinuityManifestRawValue = ""
     @AppStorage(NotificationConstants.enabledKey)
     private var notificationsEnabled = NotificationConstants.defaultEnabled
+    @ExperimentalFeatureFlag(.minimalToolbar)
+    private var minimalToolbarEnabled: Bool
     @Environment(\.externalEditorService) private var externalEditorService
     @Environment(\.lumeRuntimeService) private var lumeRuntimeService
     @EnvironmentObject private var modelStoreStatusController: ModelStoreStatusController
@@ -483,7 +485,7 @@ struct ContentView: View {
 
     private var splitViewWithToolbar: some View {
         Group {
-            if PerformanceExperimentFlags.minimalToolbar {
+            if minimalToolbarEnabled {
                 splitViewBody
             } else {
                 splitViewBody

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -59,6 +59,8 @@ struct SidebarView: View {
 
     @AppStorage(SidebarRepoSortMode.storageKey)
     private var repoSortModeRawValue: String = SidebarRepoSortMode.alphabetical.rawValue
+    @ExperimentalFeatureFlag(.minimalToolbar)
+    private var minimalToolbarEnabled: Bool
 
     @State private var isAddingRepo = false
     @State private var newWorkspaceSheetContext: NewWorkspaceSheetContext?
@@ -130,7 +132,7 @@ struct SidebarView: View {
 
     var body: some View {
         Group {
-            if PerformanceExperimentFlags.minimalToolbar {
+            if minimalToolbarEnabled {
                 sidebarList
                     .listStyle(.sidebar)
                     .environment(\.defaultMinListRowHeight, 34)

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -456,6 +456,12 @@ struct SettingsView: View {
             }
 
             Section {
+                ExperimentalFeaturesSettingsView()
+            } header: {
+                Text("Experimental Features")
+            }
+
+            Section {
                 HStack {
                     Text("Version")
                     Spacer()

--- a/Tests/WorkspaceManagerAppTests/ExperimentalFeaturesTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ExperimentalFeaturesTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("ExperimentalFeatures")
+struct ExperimentalFeaturesTests {
+    @Test("Features default off when no settings or environment override exist")
+    func featuresDefaultOff() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(!ExperimentalFeatures.isEnabled(.minimalToolbar, userDefaults: defaults, environment: [:]))
+    }
+
+    @Test("Master toggle suppresses enabled per-feature setting")
+    func masterToggleSuppressesFeatureSetting() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: ExperimentalFeatures.masterEnabledKey)
+        defaults.set(true, forKey: ExperimentalFeature.minimalToolbar.storageKey)
+
+        #expect(!ExperimentalFeatures.isEnabled(.minimalToolbar, userDefaults: defaults, environment: [:]))
+    }
+
+    @Test("Feature is enabled when master and per-feature setting are enabled")
+    func masterAndFeatureEnabledResolveOn() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: ExperimentalFeatures.masterEnabledKey)
+        defaults.set(true, forKey: ExperimentalFeature.minimalToolbar.storageKey)
+
+        #expect(ExperimentalFeatures.isEnabled(.minimalToolbar, userDefaults: defaults, environment: [:]))
+    }
+
+    @Test("Environment force-on wins over stored settings")
+    func environmentForceOnWins() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: ExperimentalFeatures.masterEnabledKey)
+        defaults.set(false, forKey: ExperimentalFeature.minimalToolbar.storageKey)
+
+        #expect(
+            ExperimentalFeatures.isEnabled(
+                .minimalToolbar,
+                userDefaults: defaults,
+                environment: ["WORKSPACES_PERF_MINIMAL_TOOLBAR": "1"]
+            )
+        )
+    }
+
+    @Test("Invalid environment force-on values do not override settings")
+    func invalidEnvironmentValuesDoNotOverrideSettings() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: ExperimentalFeatures.masterEnabledKey)
+        defaults.set(true, forKey: ExperimentalFeature.minimalToolbar.storageKey)
+
+        #expect(
+            !ExperimentalFeatures.isEnabled(
+                .minimalToolbar,
+                userDefaults: defaults,
+                environment: ["WORKSPACES_PERF_MINIMAL_TOOLBAR": "0"]
+            )
+        )
+        #expect(
+            !ExperimentalFeatures.isEnabled(
+                .minimalToolbar,
+                userDefaults: defaults,
+                environment: ["WORKSPACES_PERF_MINIMAL_TOOLBAR": "maybe"]
+            )
+        )
+    }
+
+    @Test("Forced-on feature list reflects active environment overrides")
+    func forcedOnFeatureListReflectsEnvironment() {
+        #expect(ExperimentalFeatures.forcedOnFeatures(environment: [:]).isEmpty)
+        #expect(
+            ExperimentalFeatures.forcedOnFeatures(
+                environment: ["WORKSPACES_PERF_MINIMAL_TOOLBAR": "true"]
+            ) == [.minimalToolbar]
+        )
+    }
+
+    @Test("Feature metadata has stable unique non-empty values")
+    func featureMetadataIsUniqueAndNonEmpty() {
+        let features = ExperimentalFeature.allCases
+
+        #expect(Set(features.map(\.id)).count == features.count)
+        #expect(Set(features.map(\.storageKey)).count == features.count)
+
+        for feature in features {
+            #expect(!feature.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            #expect(!feature.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            #expect(!feature.description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            #expect(feature.storageKey.hasPrefix("experimentalFeatures."))
+        }
+    }
+
+    private func makeDefaults() -> (UserDefaults, String) {
+        let suiteName = "ExperimentalFeaturesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -1,0 +1,164 @@
+# Experimental Features
+
+Experimental Features is the app-level path for introducing incomplete or
+high-risk UI behind an explicit Settings gate. Use it when a feature should be
+available for local dogfooding, screenshots, or targeted reviewer testing, but
+should not render for users unless they opt in.
+
+This is not a remote rollout system. Registered experiments are compiled into
+the app and persisted as app preferences in `UserDefaults`.
+
+## Runtime Model
+
+Experimental feature state has three layers:
+
+1. Environment force-on override
+2. Master Settings toggle
+3. Per-feature Settings toggle
+
+The environment force-on override wins for the current launch. Otherwise, a
+feature resolves on only when the master toggle and that feature's toggle are
+both on.
+
+When the master toggle is off, Settings hides the per-feature list but preserves
+the stored choices. Turning the master toggle back on restores the previous
+per-feature selections.
+
+## When To Use It
+
+Use an experimental feature when:
+
+- the UI is useful for dogfooding before it is ready to ship broadly
+- reviewers need a stable switch for side-by-side behavior checks
+- the feature changes a shared surface such as toolbar, sidebar, terminal
+  chrome, Settings, or navigation
+- a developer launch needs an environment flag to force the feature on for
+  evidence capture or performance investigation
+
+Do not use it for:
+
+- security controls or safety gates
+- data migrations
+- server-driven authorization
+- permanent product configuration
+- code paths that must remain invisible even to local users
+
+## Adding A Feature
+
+1. Add a case to `ExperimentalFeature` in
+   `Sources/WorkspaceManager/App/ExperimentalFeatures.swift`.
+2. Add metadata:
+   - stable `rawValue`
+   - user-facing `title`
+   - short `description`
+   - `defaultEnabled`, usually `false`
+   - optional `forceOnEnvironmentKey`
+3. Gate SwiftUI rendering with:
+
+   ```swift
+   @ExperimentalFeatureFlag(.minimalToolbar)
+   private var minimalToolbarEnabled: Bool
+   ```
+
+   Then omit the experimental UI path when the flag is false:
+
+   ```swift
+   if minimalToolbarEnabled {
+       MinimalToolbarView()
+   } else {
+       StandardToolbarView()
+   }
+   ```
+
+4. For non-SwiftUI resolver checks, use:
+
+   ```swift
+   ExperimentalFeatures.isEnabled(.minimalToolbar)
+   ```
+
+5. Add or update tests in `ExperimentalFeaturesTests` for the new metadata and
+   resolver behavior.
+
+The Settings UI enumerates `ExperimentalFeature.allCases`, so a registered
+feature appears automatically under Settings -> Experimental Features when the
+master toggle is on.
+
+## Environment Overrides
+
+Use a force-on environment key only for developer-launch and evidence workflows.
+The current convention is a descriptive `WORKSPACES_*` key, for example:
+
+```bash
+WORKSPACES_PERF_MINIMAL_TOOLBAR=1 ./scripts/launch-dev.sh --no-build
+```
+
+Truthy values are `1`, `true`, `yes`, and `on`, case-insensitive. Any other
+value is ignored and the resolver falls back to Settings state.
+
+When any registered feature is forced on by the environment, Settings shows a
+read-only note for the current launch. The note is not persisted.
+
+## UI Rules
+
+Experimental UI should be absent when disabled, not merely disabled or grayed
+out. This keeps screenshots, accessibility trees, and automation behavior
+honest for the default product state.
+
+For SwiftUI call sites, prefer `@ExperimentalFeatureFlag` over static process
+environment checks. The property wrapper is backed by `@AppStorage`, so views
+re-render immediately when Settings changes.
+
+Keep feature metadata user-facing and specific:
+
+- title: short noun phrase, for example `Minimal Toolbar`
+- description: one sentence explaining what changes on screen
+- raw value: stable identifier; do not rename after release without migrating
+  the stored `UserDefaults` key
+
+## Accessibility
+
+Settings exposes stable identifiers for automation:
+
+- `settings.experimental.section`
+- `settings.experimental.master-toggle`
+- `settings.experimental.force-on-note`
+- `settings.experimental.list`
+- `settings.experimental.feature.<rawValue>`
+
+When adding feature-specific UI outside Settings, add identifiers to the new
+interactive controls when they are important for smoke tests or screenshots.
+
+## Verification
+
+For every new experimental feature:
+
+```bash
+swift test --filter ExperimentalFeaturesTests
+swift test
+```
+
+If the feature affects visible app chrome, also run the local dev loop:
+
+```bash
+./scripts/build-ghosttykit.sh
+swift build
+./scripts/dev-smoke.sh --no-build --trust-mise
+```
+
+Capture Settings evidence showing the master toggle and feature row. For PRs,
+upload screenshots or test evidence with `./scripts/evidence.sh` and include the
+links in the PR body.
+
+## Promotion Or Removal
+
+Before making an experiment the default product behavior:
+
+- remove the Settings gate from the shipping UI path
+- remove the feature case if no other call sites need it
+- delete obsolete force-on environment handling
+- update tests that asserted experimental resolver behavior
+- keep or migrate any persisted preference only if users still need it
+
+Before deleting an experiment, search for the raw value, storage key, and
+environment key. A removed feature should leave no visible Settings row and no
+dead environment flag in production code.


### PR DESCRIPTION
## Summary

- Add a UserDefaults-backed experimental feature registry with a master Settings toggle.
- Move the minimal toolbar experiment from a static env-only flag to a reactive Settings-controlled gate.
- Add focused resolver tests for master/per-feature/env override behavior.

## Mergeability

- Surface: desktop
- User-facing behavior changed: yes, Settings now has an Experimental Features section and Minimal Toolbar can be toggled there.
- Non-happy paths considered: invalid environment override values fall back to stored settings; env force-on still wins for developer launches.
- Release/ops preconditions: none.
- Residual risk or follow-up: low; currently one registered experiment.

## Validation

- [x] `swift-format lint --strict --recursive Sources/ Tests/`
- [x] `./scripts/build-ghosttykit.sh`
- [x] `swift build`
- [x] `swift test --filter ExperimentalFeaturesTests`
- [x] `swift test`
- [x] `./scripts/dev-smoke.sh --no-build --trust-mise`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Experimental feature tests](https://evidence.cloudcompute.com/workspaces/pr-475/20260511-054502-experimental-feature-tests.svg)
- [Settings Experimental Features expanded](https://evidence.cloudcompute.com/workspaces/pr-475/20260511-054518-experimental-settings-expanded.png)
- [Main window dev smoke](https://evidence.cloudcompute.com/workspaces/pr-475/20260511-054747-experimental-main-window-smoke.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
