### PR TITLE
Fix packaged Claude hook resource crash

### DIFF
--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -55,21 +55,10 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
     }
 
     /// Locate the Channel 2 status-line forwarder shell shipped alongside the app.
-    /// The script is added to the SPM bundle via `Resources/HookForwarders` (see
-    /// Package.swift). Returns nil if the bundle was assembled without it — caller
-    /// logs and proceeds without registering Channel 2.
+    /// Returns nil if the bundle was assembled without it — caller logs and
+    /// proceeds without registering Channel 2.
     nonisolated static func bundledStatusLineForwarderPath() -> String? {
-        if let url = Bundle.module.url(
-            forResource: "statusline",
-            withExtension: "sh",
-            subdirectory: "HookForwarders"
-        ) {
-            return url.path
-        }
-        if let url = Bundle.module.url(forResource: "statusline", withExtension: "sh") {
-            return url.path
-        }
-        return nil
+        bundledHookForwarderURL(named: "statusline")?.path
     }
 
     private init() {}
@@ -174,9 +163,9 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         )
         let dest = dir.appendingPathComponent("\(name).sh")
 
-        // Source: bundled .sh file. SwiftPM debug builds expose copied
-        // resources through Bundle.module; packaged app launches may expose
-        // them through Bundle.main.
+        // Source: bundled .sh file. Packaged apps expose flattened resources
+        // through Bundle.main; SwiftPM builds expose them through a sibling
+        // WorkspaceManager_WorkspaceManager.bundle.
         let bundleURL = bundledHookForwarderURL(named: name)
         guard let bundleURL else {
             return nil
@@ -195,17 +184,87 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
     }
 
     nonisolated static func bundledHookForwarderURL(named name: String) -> URL? {
-        Bundle.module.url(
-            forResource: name,
-            withExtension: "sh",
-            subdirectory: "HookForwarders"
+        bundledHookForwarderURL(
+            named: name,
+            mainBundle: .main,
+            swiftPMResourceBundle: { Bundle.module }
         )
-            ?? Bundle.module.url(forResource: name, withExtension: "sh")
-            ?? Bundle.main.url(
+    }
+
+    nonisolated static func bundledHookForwarderURL(
+        named name: String,
+        mainBundle: Bundle,
+        swiftPMResourceBundle: () -> Bundle?
+    ) -> URL? {
+        let appResourceBundles = hookForwarderResourceBundles(mainBundle: mainBundle)
+        if let url = hookForwarderURL(named: name, resourceBundles: appResourceBundles) {
+            return url
+        }
+
+        guard !isApplicationBundle(mainBundle), let swiftPMBundle = swiftPMResourceBundle() else {
+            return nil
+        }
+
+        return hookForwarderURL(
+            named: name,
+            resourceBundles: [swiftPMBundle]
+        )
+    }
+
+    nonisolated static func hookForwarderURL(named name: String, resourceBundles: [Bundle]) -> URL? {
+        for bundle in resourceBundles {
+            if let url = bundle.url(
                 forResource: name,
                 withExtension: "sh",
                 subdirectory: "HookForwarders"
-            )
+            ) {
+                return url
+            }
+            if let url = bundle.url(forResource: name, withExtension: "sh") {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private nonisolated static func hookForwarderResourceBundles(mainBundle: Bundle) -> [Bundle] {
+        let swiftPMResourceBundleName = "WorkspaceManager_WorkspaceManager.bundle"
+        let fileManager = FileManager.default
+        var bundles: [Bundle] = []
+        var seenPaths = Set<String>()
+
+        func appendBundle(_ bundle: Bundle) {
+            let path = bundle.bundleURL.standardizedFileURL.path
+            guard seenPaths.insert(path).inserted else { return }
+            bundles.append(bundle)
+        }
+
+        func appendBundle(at url: URL) {
+            let path = url.standardizedFileURL.path
+            guard seenPaths.insert(path).inserted else { return }
+            guard fileManager.fileExists(atPath: path), let bundle = Bundle(url: url) else { return }
+            bundles.append(bundle)
+        }
+
+        appendBundle(mainBundle)
+
+        let nestedResourceBundleURLs = [
+            mainBundle.resourceURL?
+                .appendingPathComponent(swiftPMResourceBundleName, isDirectory: true),
+            mainBundle.bundleURL
+                .appendingPathComponent(swiftPMResourceBundleName, isDirectory: true),
+        ]
+
+        for url in nestedResourceBundleURLs {
+            guard let url else { continue }
+            appendBundle(at: url)
+        }
+
+        return bundles
+    }
+
+    private nonisolated static func isApplicationBundle(_ bundle: Bundle) -> Bool {
+        bundle.bundleURL.standardizedFileURL.pathExtension == "app"
     }
 
     func stop() async {

--- a/Tests/WorkspaceManagerAppTests/ClaudeIntegrationLifecycleTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ClaudeIntegrationLifecycleTests.swift
@@ -130,4 +130,81 @@ struct ClaudeIntegrationLifecycleTests {
         #expect(FileManager.default.fileExists(atPath: eventForwarder.path))
         #expect(FileManager.default.fileExists(atPath: statusLine.path))
     }
+
+    @Test("packaged app hook forwarder resources resolve from flattened app resources")
+    func packagedAppHookForwarderResourcesResolveFromMainBundle() throws {
+        let fixture = try makePackagedAppFixture(includeEventForwarder: true)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        var didAskForSwiftPMBundle = false
+        let resolvedURL = try #require(
+            ClaudeIntegrationLifecycle.bundledHookForwarderURL(
+                named: "event-forwarder",
+                mainBundle: fixture.appBundle,
+                swiftPMResourceBundle: {
+                    didAskForSwiftPMBundle = true
+                    return nil
+                }
+            ))
+
+        #expect(resolvedURL.standardizedFileURL == fixture.eventForwarderURL?.standardizedFileURL)
+        #expect(!didAskForSwiftPMBundle)
+    }
+
+    @Test("packaged app missing hook forwarder resources does not touch SwiftPM bundle")
+    func packagedAppMissingHookForwarderResourcesDoNotTouchSwiftPMBundle() throws {
+        let fixture = try makePackagedAppFixture(includeEventForwarder: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        var didAskForSwiftPMBundle = false
+        let resolvedURL = ClaudeIntegrationLifecycle.bundledHookForwarderURL(
+            named: "event-forwarder",
+            mainBundle: fixture.appBundle,
+            swiftPMResourceBundle: {
+                didAskForSwiftPMBundle = true
+                return nil
+            }
+        )
+
+        #expect(resolvedURL == nil)
+        #expect(!didAskForSwiftPMBundle)
+    }
+
+    private func makePackagedAppFixture(includeEventForwarder: Bool) throws -> PackagedAppFixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeIntegrationLifecycleTests-\(UUID().uuidString)", isDirectory: true)
+        let appBundleURL = root.appendingPathComponent("WorkSpaces.app", isDirectory: true)
+        let contentsURL = appBundleURL.appendingPathComponent("Contents", isDirectory: true)
+        let hookForwardersURL =
+            contentsURL
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("HookForwarders", isDirectory: true)
+        try FileManager.default.createDirectory(at: hookForwardersURL, withIntermediateDirectories: true)
+
+        let plist: [String: Any] = [
+            "CFBundleExecutable": "WorkspaceManager",
+            "CFBundleIdentifier": "com.cloudcompute.workspaces",
+            "CFBundleName": "WorkSpaces",
+        ]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try plistData.write(to: contentsURL.appendingPathComponent("Info.plist"))
+
+        let eventForwarderURL = hookForwardersURL.appendingPathComponent("event-forwarder.sh")
+        if includeEventForwarder {
+            try "#!/bin/sh\n".write(to: eventForwarderURL, atomically: true, encoding: .utf8)
+        }
+
+        let appBundle = try #require(Bundle(url: appBundleURL))
+        return PackagedAppFixture(
+            root: root,
+            appBundle: appBundle,
+            eventForwarderURL: includeEventForwarder ? eventForwarderURL : nil
+        )
+    }
+
+    private struct PackagedAppFixture {
+        let root: URL
+        let appBundle: Bundle
+        let eventForwarderURL: URL?
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/ReleaseBundleVerificationScriptTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ReleaseBundleVerificationScriptTests.swift
@@ -56,16 +56,29 @@ struct ReleaseBundleVerificationScriptTests {
         #expect(result.stderr.contains("CFBundleExecutable must be WorkspaceManager"))
     }
 
+    @Test("Missing hook forwarder resources fail release verification")
+    func missingHookForwarderResourcesFailReleaseVerification() throws {
+        let fixture = try makeFixture(bundleName: "WorkSpaces.app", includeRuntimeResources: true)
+        defer { fixture.cleanup() }
+
+        let result = runVerifier(appBundle: fixture.appBundle)
+
+        #expect(result.exitCode == 1)
+        #expect(result.stderr.contains("Missing Claude hook event forwarder"))
+    }
+
     private func makeFixture(
         bundleName: String,
         displayName: String = "WorkSpaces",
         bundleDisplayName: String = "WorkSpaces",
-        executableName: String = "WorkspaceManager"
+        executableName: String = "WorkspaceManager",
+        includeRuntimeResources: Bool = false
     ) throws -> Fixture {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("ReleaseBundleVerificationScriptTests-\(UUID().uuidString)", isDirectory: true)
         let appBundle = root.appendingPathComponent(bundleName, isDirectory: true)
         let contents = appBundle.appendingPathComponent("Contents", isDirectory: true)
+        let resources = contents.appendingPathComponent("Resources", isDirectory: true)
 
         try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
 
@@ -76,6 +89,23 @@ struct ReleaseBundleVerificationScriptTests {
         ]
         let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
         try data.write(to: contents.appendingPathComponent("Info.plist"))
+
+        if includeRuntimeResources {
+            let macOS = contents.appendingPathComponent("MacOS", isDirectory: true)
+            try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+            let executable = macOS.appendingPathComponent("WorkspaceManager")
+            try Data().write(to: executable)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+            try FileManager.default.createDirectory(
+                at: resources.appendingPathComponent("ghostty", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: resources.appendingPathComponent("terminfo", isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
 
         return Fixture(root: root, appBundle: appBundle)
     }

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -147,6 +147,8 @@ APP_BUNDLE="${APP_BUNDLE/#\~/$HOME}"
 verify_bundle_identity "$APP_BUNDLE"
 [[ -d "$APP_BUNDLE/Contents/Resources/ghostty" ]] || fail "Missing Ghostty resources directory"
 [[ -d "$APP_BUNDLE/Contents/Resources/terminfo" ]] || fail "Missing bundled terminfo directory"
+[[ -f "$APP_BUNDLE/Contents/Resources/HookForwarders/event-forwarder.sh" ]] || fail "Missing Claude hook event forwarder"
+[[ -f "$APP_BUNDLE/Contents/Resources/HookForwarders/statusline.sh" ]] || fail "Missing Claude status-line forwarder"
 
 CODE_OBJECTS_FILE="$TMP_DIR/code-objects.txt"
 : >"$CODE_OBJECTS_FILE"


### PR DESCRIPTION
## Summary
- Resolve Claude hook forwarder scripts from app-bundle resources before touching SwiftPM Bundle.module.
- Return nil instead of trapping when packaged app hook assets are missing.
- Add packaged-app regression coverage and release-bundle checks for hook forwarders.

## Root Cause
The 0.13.0 packaged app flattens SwiftPM resources into Contents/Resources, but ClaudeIntegrationLifecycle accessed the generated Bundle.module resource bundle first. In the installed .app that generated accessor could not find WorkspaceManager_WorkspaceManager.bundle and asserted before the Bundle.main fallback ran.

## Verification
- swift-format lint --strict --recursive Sources Tests
- swift test
- ./scripts/build-release.sh --no-sign
- build/WorkSpaces.app/Contents/Resources/HookForwarders contains event-forwarder.sh and statusline.sh

## Evidence
- ![verification-summary](https://evidence.cloudcompute.com/workspaces/pr-477/20260512-090426-verification-summary.png)