### PR TITLE
Fix PR reviewer webhook relay

### DIFF
--- a/docs/development/notifications.md
+++ b/docs/development/notifications.md
@@ -126,8 +126,14 @@ bun run --bun wrangler deploy --env preview # preview
 - `GITHUB_WEBHOOK_SECRET` — shared secret for GitHub webhook signature verification
 - `JWT_SIGNING_SECRET` — HMAC-SHA256 key for JWT signing/verification
 
+**Vars** (set in `wrangler.toml` or via Cloudflare):
+- `WEBHOOK_FORWARD_URL` — optional web app webhook endpoint. Production uses
+  `https://spaces.cloudcompute.com/api/webhooks/github` so managed PR review
+  triggers reach the Next.js route after the relay verifies GitHub's signature.
+  The relay accepts HTTPS URLs in production and local HTTP URLs only for tests.
+
 **Routes:**
-- `POST /webhook` — receives GitHub webhooks, verifies signature, forwards to org DO
+- `POST /webhook` — receives GitHub webhooks, verifies signature, forwards to org DO, and forwards managed-review trigger candidates to the web app
 - `POST /auth/session` — exchanges GitHub token for JWT
 - `GET /ws/{owner}` — WebSocket upgrade with per-client repo filtering (requires JWT + GitHub token)
 - `GET /health` — health check
@@ -140,7 +146,7 @@ bun run --bun wrangler deploy --env preview # preview
 | `src/webhook-relay.ts` | `WebhookRelay` Durable Object — SQLite event storage, WebSocket lifecycle, broadcast |
 | `src/github-verify.ts` | Crypto — HMAC-SHA256 signature verification, JWT sign/verify, timing-safe compare |
 | `src/log.ts` | Structured JSON logging helper (`{ level, msg, ts, ...context }`) |
-| `test/e2e.ts` | E2E test harness — orchestrates mock + wrangler dev + 11 behavior-level scenarios |
+| `test/e2e.ts` | E2E test harness — orchestrates mock + wrangler dev + behavior-level scenarios |
 | `test/mock-github.ts` | Mock GitHub API server with token-dependent behavior |
 
 ### Durable Object Lifecycle

--- a/infra/cloudflare-webhook-relay/src/index.ts
+++ b/infra/cloudflare-webhook-relay/src/index.ts
@@ -14,7 +14,11 @@ function githubAPI(env: Env, path: string): string {
 }
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname;
 
@@ -27,7 +31,7 @@ export default {
     }
 
     if (path === "/webhook" && request.method === "POST") {
-      return handleWebhook(request, env);
+      return handleWebhook(request, env, ctx);
     }
 
     const wsMatch = path.match(/^\/ws\/([^/]+)$/);
@@ -118,7 +122,145 @@ async function handleAuthSession(request: Request, env: Env): Promise<Response> 
 // Webhook ingress — forward to org-level DO
 // ---------------------------------------------------------------------------
 
-async function handleWebhook(request: Request, env: Env): Promise<Response> {
+const EVIDENCE_SIGNAL =
+  /(evidence\.cloudcompute\.com|^Evidence:|swift test|playwright|screenshot|recording|validation)/im;
+
+function isBotSender(payload: Record<string, unknown>): boolean {
+  const sender = payload.sender as Record<string, unknown> | undefined;
+  const login = String(sender?.login ?? "");
+  if (login.endsWith("[bot]")) return true;
+  return String(sender?.type ?? "").toLowerCase() === "bot";
+}
+
+function shouldForwardToWebApp(
+  eventType: string,
+  payload: Record<string, unknown>
+): boolean {
+  if (isBotSender(payload)) return false;
+
+  const action = String(payload.action ?? "");
+  if (eventType === "pull_request") {
+    const pr = payload.pull_request as Record<string, unknown> | undefined;
+    if (!pr) return false;
+    const isDraft = Boolean(pr.draft);
+
+    if (["opened", "reopened", "synchronize", "edited"].includes(action)) {
+      if (isDraft) return false;
+      if (action !== "edited") return true;
+      const changes = payload.changes as Record<string, unknown> | undefined;
+      return Boolean(changes?.body !== undefined || changes?.base !== undefined);
+    }
+
+    return action === "ready_for_review";
+  }
+
+  if (eventType === "issue_comment" && action === "created") {
+    const issue = payload.issue as Record<string, unknown> | undefined;
+    const comment = payload.comment as Record<string, unknown> | undefined;
+    if (!issue?.pull_request) return false;
+    const body = String(comment?.body ?? "");
+    return EVIDENCE_SIGNAL.test(body);
+  }
+
+  return false;
+}
+
+async function forwardWebhookToWebApp(
+  env: Env,
+  body: string,
+  headers: Headers,
+  eventType: string,
+  deliveryId: string | undefined,
+  repo: string
+): Promise<void> {
+  const forwardUrl = env.WEBHOOK_FORWARD_URL?.trim();
+  if (!forwardUrl) {
+    log.warn("webhook_forward_not_configured", {
+      delivery_id: deliveryId,
+      event_type: eventType,
+      repo,
+    });
+    return;
+  }
+
+  let parsedForwardUrl: URL;
+  try {
+    parsedForwardUrl = new URL(forwardUrl);
+  } catch {
+    log.error("webhook_forward_invalid_url", {
+      delivery_id: deliveryId,
+      event_type: eventType,
+      repo,
+    });
+    return;
+  }
+  const localDevForward =
+    parsedForwardUrl.protocol === "http:" &&
+    ["127.0.0.1", "localhost"].includes(parsedForwardUrl.hostname);
+  if (parsedForwardUrl.protocol !== "https:" && !localDevForward) {
+    log.error("webhook_forward_insecure_url", {
+      delivery_id: deliveryId,
+      event_type: eventType,
+      repo,
+      protocol: parsedForwardUrl.protocol,
+    });
+    return;
+  }
+
+  const signature = headers.get("X-Hub-Signature-256");
+  if (!signature) {
+    log.warn("webhook_forward_missing_signature", {
+      delivery_id: deliveryId,
+      event_type: eventType,
+      repo,
+    });
+    return;
+  }
+
+  try {
+    const forwardHeaders = new Headers({
+      "Content-Type": headers.get("Content-Type") ?? "application/json",
+      "X-GitHub-Event": eventType,
+      "X-Hub-Signature-256": signature,
+      "User-Agent": "WorkspaceManager-WebhookRelay",
+      "X-Workspace-Webhook-Relay": "cloudflare",
+    });
+    if (deliveryId) {
+      forwardHeaders.set("X-GitHub-Delivery", deliveryId);
+    }
+
+    const response = await fetch(forwardUrl, {
+      method: "POST",
+      headers: forwardHeaders,
+      body,
+    });
+
+    if (!response.ok) {
+      log.error("webhook_forward_failed", { delivery_id: deliveryId, event_type: eventType, repo, status: response.status });
+      return;
+    }
+
+    log.info("webhook_forwarded", {
+      delivery_id: deliveryId,
+      event_type: eventType,
+      repo,
+      status: response.status,
+    });
+  } catch (err) {
+    log.error("webhook_forward_error", {
+      delivery_id: deliveryId,
+      event_type: eventType,
+      repo,
+      detail: String(err),
+    });
+  }
+}
+
+async function handleWebhook(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<Response> {
   const signature = request.headers.get("X-Hub-Signature-256");
   if (!signature) {
     log.warn("webhook_missing_signature");
@@ -148,6 +290,10 @@ async function handleWebhook(request: Request, env: Env): Promise<Response> {
 
   const doId = env.WEBHOOK_RELAY.idFromName(owner);
   const stub = env.WEBHOOK_RELAY.get(doId);
+
+  if (shouldForwardToWebApp(eventType, payload)) {
+    ctx.waitUntil(forwardWebhookToWebApp(env, body, request.headers, eventType, deliveryId, fullName));
+  }
 
   return stub.fetch(
     new Request(request.url, { method: "POST", headers: request.headers, body })

--- a/infra/cloudflare-webhook-relay/src/webhook-relay.ts
+++ b/infra/cloudflare-webhook-relay/src/webhook-relay.ts
@@ -6,6 +6,7 @@ export interface Env {
   GITHUB_WEBHOOK_SECRET: string;
   JWT_SIGNING_SECRET: string;
   GITHUB_API_BASE?: string;
+  WEBHOOK_FORWARD_URL?: string;
 }
 
 interface StoredEvent {

--- a/infra/cloudflare-webhook-relay/test/e2e.ts
+++ b/infra/cloudflare-webhook-relay/test/e2e.ts
@@ -6,17 +6,25 @@
  */
 
 import { signJWT } from "../src/github-verify";
-import { writeFileSync, existsSync, rmSync } from "fs";
+import { writeFileSync, readFileSync, existsSync, rmSync } from "fs";
 import { resolve } from "path";
 
 const WORKER_PORT = 8787;
 const MOCK_PORT = 8788;
+const FORWARD_PORT = 8789;
 const WORKER_URL = `http://localhost:${WORKER_PORT}`;
+const FORWARD_URL = `http://127.0.0.1:${FORWARD_PORT}/api/webhooks/github`;
 const WEBHOOK_SECRET = "test-webhook-secret-e2e";
 const JWT_SECRET = "test-jwt-secret-e2e";
 
 const projectDir = resolve(import.meta.dir, "..");
 const stateDir = resolve(projectDir, ".wrangler/state");
+const devVarsPath = resolve(projectDir, ".dev.vars");
+const originalDevVars = existsSync(devVarsPath) ? readFileSync(devVarsPath, "utf-8") : null;
+const forwardedRequests: Array<{
+  body: string;
+  headers: Record<string, string>;
+}> = [];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -161,6 +169,20 @@ async function expectNoExtraWebSocketMessage(
   }
 }
 
+async function waitForForwardedRequestCount(
+  expected: number,
+  timeoutMs = 3000
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (forwardedRequests.length >= expected) {
+      return;
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error(`Expected ${expected} forwarded request(s), got ${forwardedRequests.length}`);
+}
+
 async function readCatchupEvents(
   owner: string,
   jwt: string,
@@ -210,17 +232,20 @@ async function runSQLite(sqlitePath: string, sql: string): Promise<string> {
 // Lifecycle
 // ---------------------------------------------------------------------------
 
-// Ensure .dev.vars exists
-const devVarsPath = resolve(projectDir, ".dev.vars");
-if (!existsSync(devVarsPath)) {
-  writeFileSync(
-    devVarsPath,
-    `GITHUB_WEBHOOK_SECRET=${WEBHOOK_SECRET}\nJWT_SIGNING_SECRET=${JWT_SECRET}\nGITHUB_API_BASE=http://127.0.0.1:${MOCK_PORT}\n`
-  );
-}
+writeFileSync(
+  devVarsPath,
+  [
+    `GITHUB_WEBHOOK_SECRET=${WEBHOOK_SECRET}`,
+    `JWT_SIGNING_SECRET=${JWT_SECRET}`,
+    `GITHUB_API_BASE=http://127.0.0.1:${MOCK_PORT}`,
+    `WEBHOOK_FORWARD_URL=${FORWARD_URL}`,
+    "",
+  ].join("\n")
+);
 
 let mockProc: ReturnType<typeof Bun.spawn> | null = null;
 let wranglerProc: ReturnType<typeof Bun.spawn> | null = null;
+let forwardServer: ReturnType<typeof Bun.serve> | null = null;
 
 async function killProcessesOnPort(port: number): Promise<void> {
   try {
@@ -270,6 +295,30 @@ async function stopMock(): Promise<void> {
   await waitForPortToClear(MOCK_PORT);
 }
 
+async function startForwardMock(): Promise<void> {
+  if (forwardServer) return;
+  forwardedRequests.length = 0;
+  if (await portHasListener(FORWARD_PORT)) {
+    throw new Error(`Forward mock port ${FORWARD_PORT} is already in use`);
+  }
+  forwardServer = Bun.serve({
+    port: FORWARD_PORT,
+    async fetch(request) {
+      const headers = Object.fromEntries(request.headers.entries()) as Record<string, string>;
+      forwardedRequests.push({ body: await request.text(), headers });
+      return new Response("OK", { status: 200 });
+    },
+  });
+}
+
+async function stopForwardMock(): Promise<void> {
+  if (forwardServer) {
+    forwardServer.stop(true);
+    forwardServer = null;
+  }
+  await waitForPortToClear(FORWARD_PORT);
+}
+
 async function startMock(): Promise<void> {
   if (mockProc) return;
   console.log("Starting mock GitHub API...");
@@ -310,6 +359,12 @@ async function restartWorker(): Promise<void> {
 async function cleanup() {
   await stopWorker();
   await stopMock();
+  await stopForwardMock();
+  if (originalDevVars === null) {
+    rmSync(devVarsPath, { force: true });
+  } else {
+    writeFileSync(devVarsPath, originalDevVars);
+  }
 }
 
 async function waitForWorker(maxWaitMs = 30000) {
@@ -331,8 +386,10 @@ async function waitForWorker(maxWaitMs = 30000) {
 try {
   await stopWorker();
   await stopMock();
+  await stopForwardMock();
   rmSync(stateDir, { recursive: true, force: true });
 
+  await startForwardMock();
   await startMock();
   await startWorker();
   console.log("\nRunning e2e tests...\n");
@@ -398,7 +455,45 @@ try {
     }
   });
 
-  // Test 6: Duplicate webhook delivery is ignored
+  // Test 6: PR-review trigger events are forwarded to the web app route
+  await test("PR-review trigger webhooks are forwarded with the original signature", async () => {
+    forwardedRequests.length = 0;
+    const payload = payloadForPR(9090, "Forwarded Review PR", "opened");
+    const expectedSignature = await hmacSign(WEBHOOK_SECRET, payload);
+
+    const resp = await postWebhook(payload, "forward-review-delivery-1");
+    assert(resp.status === 200, `Webhook POST returned ${resp.status}`);
+
+    await waitForForwardedRequestCount(1);
+    const forwarded = forwardedRequests[0];
+    assert(forwarded.body === payload, "Expected forwarded body to preserve the raw GitHub payload");
+    assert(
+      forwarded.headers["x-hub-signature-256"] === expectedSignature,
+      "Expected forwarded signature to match the original GitHub HMAC"
+    );
+    assert(
+      forwarded.headers["x-github-event"] === "pull_request",
+      `Expected pull_request event header, got ${forwarded.headers["x-github-event"]}`
+    );
+    assert(
+      forwarded.headers["x-github-delivery"] === "forward-review-delivery-1",
+      `Expected delivery header, got ${forwarded.headers["x-github-delivery"]}`
+    );
+  });
+
+  // Test 7: Non-review lifecycle events stay relay-local
+  await test("Non-review PR lifecycle events are not forwarded", async () => {
+    forwardedRequests.length = 0;
+    const payload = payloadForPR(9091, "Closed PR", "closed");
+
+    const resp = await postWebhook(payload, "forward-review-delivery-2");
+    assert(resp.status === 200, `Webhook POST returned ${resp.status}`);
+
+    await Bun.sleep(500);
+    assert(forwardedRequests.length === 0, `Expected no forwarded requests, got ${forwardedRequests.length}`);
+  });
+
+  // Test 8: Duplicate webhook delivery is ignored
   await test("Duplicate webhook payload only appears once", async () => {
     const jwt = await makeJWT();
     const payload = payloadForPR(4242, "Duplicate PR", "opened");
@@ -425,7 +520,7 @@ try {
     assert(duplicateEntries.length === 1, `Expected 1 duplicate-test event in catchup, got ${duplicateEntries.length}`);
   });
 
-  // Test 7: Equivalent payloads with different key order are deduped
+  // Test 9: Equivalent payloads with different key order are deduped
   await test("Semantically equivalent payloads only appear once", async () => {
     const jwt = await makeJWT();
     const payloadA = payloadForPR(4343, "Key Order PR", "opened");
@@ -458,7 +553,7 @@ try {
     assert(matching.length === 1, `Expected 1 key-order event in catchup, got ${matching.length}`);
   });
 
-  // Test 8: Distinct lifecycle events for the same PR are preserved
+  // Test 10: Distinct lifecycle events for the same PR are preserved
   await test("Distinct events for the same PR are not over-deduped", async () => {
     const jwt = await makeJWT();
     const openedPayload = payloadForPR(5151, "Lifecycle PR", "opened");
@@ -489,7 +584,7 @@ try {
     assert(matching.length === 2, `Expected 2 lifecycle events in catchup, got ${matching.length}`);
   });
 
-  // Test 9: Duplicate suppression survives worker restart
+  // Test 11: Duplicate suppression survives worker restart
   await test("Duplicate suppression survives worker restart", async () => {
     const jwt = await makeJWT();
     const payload = payloadForPR(6262, "Restart Stable PR", "opened");
@@ -519,7 +614,7 @@ try {
     assert(finalMatches.length === 1, `Expected 1 restarted event after duplicate resend, got ${finalMatches.length}`);
   });
 
-  // Test 10: Startup cleanup prunes legacy duplicate rows
+  // Test 12: Startup cleanup prunes legacy duplicate rows
   await test("Startup cleanup collapses legacy duplicate rows before catchup", async () => {
     const jwt = await makeJWT();
     const payload = payloadForPR(7373, "Legacy Cleanup PR", "opened");
@@ -564,7 +659,7 @@ try {
     assert(matching.length === 1, `Expected 1 legacy-cleanup event in catchup, got ${matching.length}`);
   });
 
-  // Test 11: Per-client repo filtering
+  // Test 13: Per-client repo filtering
   await test("Repo filtering: ghp_repo_b_only only receives repo-b events", async () => {
     const jwt = await makeJWT();
     const bws = await connectWebSocket("test-org", jwt, "ghp_repo_b_only");

--- a/infra/cloudflare-webhook-relay/wrangler.toml
+++ b/infra/cloudflare-webhook-relay/wrangler.toml
@@ -14,6 +14,9 @@ new_sqlite_classes = ["WebhookRelay"]
 pattern = "webhooks.cloudcompute.com"
 custom_domain = true
 
+[vars]
+WEBHOOK_FORWARD_URL = "https://spaces.cloudcompute.com/api/webhooks/github"
+
 # --- Preview environment ---
 [env.preview]
 name = "webhook-relay-preview"

--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -10,7 +10,7 @@ intent and posts the GitHub review with the PR reviewer GitHub App token.
 ```
 GitHub PR opened
 → Cloudflare webhook relay
-→ web/api/webhooks/github (webhook route)
+→ signed forward to web/api/webhooks/github (webhook route)
 → triggerPrReview() (fire-and-forget)
 → getOrCreateAgent/Environment (idempotent, DB-cached)
 → sessions.create (mounts repo at PR branch)
@@ -39,6 +39,8 @@ GitHub PR opened
 | `PR_REVIEWER_ENABLED` | Vercel (optional) | `0` disables the reviewer; `1` enables it explicitly. If omitted, complete App credentials enable it. |
 | `PR_REVIEWER_VAULT_ID` | Vercel (optional) | Vault for MCP credentials (not currently used) |
 | `PR_REVIEWER_MODEL` | Vercel (optional) | Override model (default: `claude-opus-4-6`) |
+| `GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET` | Vercel | Same GitHub webhook secret used by the Cloudflare relay; verifies the forwarded raw payload |
+| `WEBHOOK_FORWARD_URL` | Cloudflare Worker | HTTPS web app webhook endpoint, currently `https://spaces.cloudcompute.com/api/webhooks/github` |
 
 ### GitHub App setup
 
@@ -49,6 +51,9 @@ Reviews are posted by the `workspaces-pr-reviewer` GitHub App, which gives them 
    broker to apply validated label suggestions
 2. Install the app on `fairchild/workspaces` and note the installation ID
 3. Set `PR_REVIEWER_APP_ID`, `PR_REVIEWER_PRIVATE_KEY`, and `PR_REVIEWER_INSTALLATION_ID` in Vercel
+4. Confirm the Cloudflare relay has `WEBHOOK_FORWARD_URL` configured and that
+   `GITHUB_WEBHOOK_SECRET` in Cloudflare matches
+   `GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET` in Vercel
 
 The app generates short-lived installation tokens (1-hour TTL) on demand. If
 the App credentials are missing or token exchange fails, `triggerPrReview()`
@@ -62,6 +67,12 @@ agent workspace and does not appear in the prompt or message stream.
 **Security:** Never print App private keys or installation tokens to logs. Use
 files or secret-manager flows, never standalone `echo`/`print` of credential
 values.
+
+The Cloudflare relay forwards only managed-review trigger candidates:
+`pull_request.opened`, `reopened`, `ready_for_review`, `synchronize`, eligible
+`edited` events, and evidence-bearing PR comments. It preserves the original
+GitHub HMAC signature and raw body; the Vercel route independently verifies the
+signature before creating any managed-agent session.
 
 ## Observing Sessions
 


### PR DESCRIPTION
## Summary
- Forward managed-review trigger candidates from the Cloudflare webhook relay to the Next.js GitHub webhook route.
- Preserve the raw GitHub payload and HMAC signature so the web app independently verifies the event before starting a managed-agent review.
- Configure the production relay forward URL and document the shared-secret contract.
- Add relay e2e coverage for signed forwarding and non-review event filtering.

## Why
PR #477 should have triggered the managed reviewer: #476 was promoted to production at 2026-05-12 08:08:49 UTC and prod validation finished at 08:09:43 UTC; #477 opened at 08:59:53 UTC as a non-draft PR. GitHub shows no reviews on #477. The remaining gap was that production webhooks enter the Cloudflare relay, which was only storing/broadcasting events and never reaching `/api/webhooks/github`.

## Security
- The relay still verifies GitHub HMAC before any forwarding.
- The web app re-verifies the original GitHub HMAC over the original raw body.
- Forwarding is limited to managed-review trigger candidates and evidence-bearing PR comments.
- Forward destinations must be HTTPS, except localhost HTTP in the test harness.
- GitHub App review credentials remain server-side in Vercel and are not added to the Worker.

## Mergeability
- Surface: infra webhook relay, managed PR reviewer ingress, docs
- User-facing behavior changed: managed PR reviews can start for new eligible PRs because relay webhook intake now reaches the web app review route.
- Non-happy paths considered: missing forward URL logs a warning; insecure or invalid forward URLs are rejected; forwarding failures are logged without breaking GitHub webhook intake; duplicate deliveries still rely on web-side run dedupe.
- Residual risk or follow-up: confirm Cloudflare `GITHUB_WEBHOOK_SECRET` and Vercel `GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET` remain the same secret in production.

## Evidence
- `bun run --bun wrangler deploy --dry-run` — Worker bundle succeeded; Wrangler emitted only a local log-file EPERM warning in the sandbox.
- `bun run test:e2e` — 13 passed, 0 failed. [Uploaded evidence](https://evidence.cloudcompute.com/workspaces/pr-478/20260512-145301-pr-review-relay-e2e.png).
