### PR TITLE
[codex] add sandboxed mise wrapper

### DIFF
--- a/docs/development/mise-security.md
+++ b/docs/development/mise-security.md
@@ -40,3 +40,18 @@ configs can affect every later command in a checkout.
 The `Mise Security` workflow runs this verifier whenever mise configs,
 `mise.lock`, the setup/build scripts, the sandbox mise installer, or this doc
 change.
+
+## Sandboxed Agent Runs
+
+When Codex or another sandbox blocks writes to user-level mise state or cache
+directories, run mise through:
+
+```bash
+./scripts/mise-sandbox -C web run web:check
+```
+
+The wrapper redirects only `XDG_STATE_HOME` and `MISE_CACHE_DIR` to temp
+directories, ignores user-level mise config, preserves explicit trust for the
+reviewed root and web mise configs, enables paranoid mode, and then execs `mise`
+normally. It does not redirect `MISE_DATA_DIR`, suppress stderr, or weaken task
+failure behavior.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ This directory contains build/release helpers plus UI test utilities.
 - `./scripts/setup --hooks-only` installs or refreshes the prek git hooks without running dependency setup.
 - `./scripts/install-git-hooks.sh` remains only as a compatibility wrapper around `./scripts/setup --hooks-only`; prefer `./scripts/setup` in new docs and task definitions.
 - mise security rules live in [docs/development/mise-security.md](../docs/development/mise-security.md). Run `./scripts/verify-mise-security.sh` after touching mise config, lockfiles, setup/build scripts, or the sandbox mise installer. Keep secrets and global trust bypasses out of mise config.
+- In sandboxed agent sessions where mise cannot write user state/cache metadata, use `./scripts/mise-sandbox <mise args>` instead of suppressing warnings.
 - `web/.npmrc` enables pnpm's experimental global virtual store so repeated warm installs across Conductor workspaces reuse a shared virtual store.
 
 ## Root Mise Task Catalog

--- a/scripts/mise-sandbox
+++ b/scripts/mise-sandbox
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+STATE_HOME="${WORKSPACES_MISE_STATE_HOME:-${TMPDIR:-/tmp}/workspaces-mise-state}"
+CACHE_DIR="${WORKSPACES_MISE_CACHE_DIR:-${TMPDIR:-/tmp}/workspaces-mise-cache}"
+TRUSTED_PATHS="$REPO_ROOT:$REPO_ROOT/web"
+IGNORED_CONFIG_PATHS="$HOME/.config/mise"
+
+mkdir -p "$STATE_HOME" "$CACHE_DIR"
+
+if [[ -n "${MISE_TRUSTED_CONFIG_PATHS:-}" ]]; then
+  TRUSTED_PATHS="$TRUSTED_PATHS:$MISE_TRUSTED_CONFIG_PATHS"
+fi
+
+if [[ -n "${MISE_IGNORED_CONFIG_PATHS:-}" ]]; then
+  IGNORED_CONFIG_PATHS="$IGNORED_CONFIG_PATHS:$MISE_IGNORED_CONFIG_PATHS"
+fi
+
+export XDG_STATE_HOME="$STATE_HOME"
+export MISE_CACHE_DIR="$CACHE_DIR"
+export MISE_TRUSTED_CONFIG_PATHS="$TRUSTED_PATHS"
+export MISE_IGNORED_CONFIG_PATHS="$IGNORED_CONFIG_PATHS"
+export MISE_PARANOID="${MISE_PARANOID:-1}"
+
+exec mise "$@"

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -265,7 +265,7 @@ class SecurityHardeningTests(unittest.TestCase):
 
     def test_mise_invocations_are_locked_and_pinned(self) -> None:
         verify_mise = (REPO_ROOT / "scripts/verify-mise-security.sh").read_text()
-        self.assertIn("MISE_EXPECTED_VERSION=\"v2026.5.5\"", verify_mise)
+        self.assertIn("MISE_EXPECTED_VERSION=\"v2026.5.7\"", verify_mise)
         self.assertIn("verify_locked_zig_exec", verify_mise)
         self.assertIn("github.com/repos/jdx/mise/releases/latest", verify_mise)
         self.assertIn("SHASUMS256.txt", verify_mise)
@@ -291,10 +291,19 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("enable-global-virtual-store=true", web_npmrc)
 
         sandbox = (REPO_ROOT / "web/src/lib/agent-runtime/vercel-sandbox.ts").read_text()
-        self.assertIn("MISE_VERSION='v2026.5.5'", sandbox)
-        self.assertIn("MISE_SHA256='3aaab5c05a8a94a93b42b4f581779bbd5c44ddb251e7f3639fc671ec5c6aab8a'", sandbox)
+        self.assertIn("MISE_VERSION='v2026.5.7'", sandbox)
+        self.assertIn("MISE_SHA256='f70272c144e6a3da52cea68d544bb43ef5410905efe6f3bfc2c9d448949e1ce5'", sandbox)
         self.assertIn("sha256sum -c -", sandbox)
         self.assertNotIn("mise-latest-linux-x64", sandbox)
+
+        mise_sandbox = (REPO_ROOT / "scripts/mise-sandbox").read_text()
+        self.assertIn('export XDG_STATE_HOME="$STATE_HOME"', mise_sandbox)
+        self.assertIn('export MISE_CACHE_DIR="$CACHE_DIR"', mise_sandbox)
+        self.assertIn('TRUSTED_PATHS="$REPO_ROOT:$REPO_ROOT/web"', mise_sandbox)
+        self.assertIn('IGNORED_CONFIG_PATHS="$HOME/.config/mise"', mise_sandbox)
+        self.assertIn('export MISE_PARANOID="${MISE_PARANOID:-1}"', mise_sandbox)
+        self.assertIn('exec mise "$@"', mise_sandbox)
+        self.assertNotIn("MISE_DATA_DIR", mise_sandbox)
 
     def test_mise_security_workflow_runs_for_mise_changes(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/mise-security.yml").read_text()

--- a/scripts/verify-mise-security.sh
+++ b/scripts/verify-mise-security.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
-MISE_EXPECTED_VERSION="v2026.5.5"
-MISE_EXPECTED_LINUX_X64_SHA256="3aaab5c05a8a94a93b42b4f581779bbd5c44ddb251e7f3639fc671ec5c6aab8a"
+MISE_EXPECTED_VERSION="v2026.5.7"
+MISE_EXPECTED_LINUX_X64_SHA256="f70272c144e6a3da52cea68d544bb43ef5410905efe6f3bfc2c9d448949e1ce5"
 ZIG_VERSION="0.15.2"
 
 fail() {
@@ -139,7 +139,7 @@ verify_latest_mise_pin() {
 
   if command -v mise >/dev/null 2>&1; then
     local installed_version
-    installed_version="$(mise --version | awk '{print $1}')"
+    installed_version="$(mise -q version | awk '{print $1}')"
     [[ "$installed_version" == "${MISE_EXPECTED_VERSION#v}" ]] \
       || fail "installed mise $installed_version does not match $MISE_EXPECTED_VERSION"
   fi

--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -348,8 +348,8 @@ async function resolveBaseSnapshot(): Promise<string> {
 			"-c",
 			[
 				"set -euo pipefail",
-				"MISE_VERSION='v2026.5.5'",
-				"MISE_SHA256='3aaab5c05a8a94a93b42b4f581779bbd5c44ddb251e7f3639fc671ec5c6aab8a'",
+				"MISE_VERSION='v2026.5.7'",
+				"MISE_SHA256='f70272c144e6a3da52cea68d544bb43ef5410905efe6f3bfc2c9d448949e1ce5'",
 				'MISE_URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64"',
 				"echo '--- downloading mise ---'",
 				'curl -fsSL "$MISE_URL" -o /tmp/mise',


### PR DESCRIPTION
## Summary

- Add scripts/mise-sandbox for sandboxed agent runs that need mise without user state/cache write noise.
- Keep the wrapper security-oriented: temp state/cache only, reviewed root/web config trust, ignored user-level mise config, paranoid mode, normal stderr and task failures.
- Update mise docs/tests and refresh the sandbox mise pin to latest stable v2026.5.7.

## Mergeability

- Surface: agent-runtime / infra / docs
- User-facing behavior changed: No app UI behavior change; sandboxed agent command docs gain a quiet mise invocation path.
- Non-happy paths considered: The wrapper does not redirect MISE_DATA_DIR, does not suppress stderr, preserves task failures, ignores user-level mise config, and still requires reviewed config trust paths.
- Release/ops preconditions: None.
- Residual risk or follow-up: Branch protection should continue requiring the Mise Security check; a scheduled mise release drift monitor remains a separate nice-to-have.

## Validation

- [ ] swift build
- [ ] swift test
- [x] Other checks run:
  - ./scripts/mise-sandbox -C web run web:check
  - ./scripts/verify-mise-security.sh
  - uv run --script scripts/test_security_hardening.py
  - direct download + sha256 verification for mise v2026.5.7 linux-x64
  - git -c core.whitespace=trailing-space,space-before-tab diff --check

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![mise-sandbox-wrapper](https://evidence.cloudcompute.com/workspaces/pr-479/20260514-042616-mise-sandbox-wrapper.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence