### PR TITLE
Add runtime diagnostics inspector

### DIFF
--- a/Sources/WorkspaceManager/Diagnostics/RuntimeDiagnosticsViewModel.swift
+++ b/Sources/WorkspaceManager/Diagnostics/RuntimeDiagnosticsViewModel.swift
@@ -1,0 +1,115 @@
+//
+//  RuntimeDiagnosticsViewModel.swift
+//  WorkspaceManager
+//
+//  Main-actor bridge between the inspector UI and core runtime diagnostics sampler.
+//
+
+import Foundation
+import SwiftUI
+import WorkspaceManagerCore
+
+enum RuntimeDiagnosticsRange: String, CaseIterable, Identifiable {
+    case fiveMinutes = "5m"
+    case fifteenMinutes = "15m"
+    case thirtyMinutes = "30m"
+    case oneHour = "1h"
+
+    var id: String { rawValue }
+
+    var duration: TimeInterval {
+        switch self {
+        case .fiveMinutes: return 300
+        case .fifteenMinutes: return 900
+        case .thirtyMinutes: return 1_800
+        case .oneHour: return 3_600
+        }
+    }
+}
+
+@MainActor
+final class RuntimeDiagnosticsViewModel: ObservableObject {
+    @Published private(set) var snapshot: RuntimeDiagnosticsSnapshot?
+    @Published private(set) var history = RuntimeProcessHistory(snapshots: [])
+    @Published private(set) var summary = RuntimeDiagnosticsSummary.make(events: [], agentStatuses: [])
+    @Published private(set) var isRefreshing = false
+    @Published private(set) var lastCheckedAt: Date?
+
+    private let sampler: RuntimeDiagnosticsSampler
+    private var pollingTask: Task<Void, Never>?
+    private var workspaceDirectories: [URL] = []
+    private var agentStatuses: [AgentSessionStatus] = []
+    private var selectedRange: RuntimeDiagnosticsRange = .fifteenMinutes
+
+    init(sampler: RuntimeDiagnosticsSampler = .shared) {
+        self.sampler = sampler
+    }
+
+    func start(
+        workspaceDirectories: [URL],
+        agentStatuses: [AgentSessionStatus],
+        selectedRange: RuntimeDiagnosticsRange
+    ) {
+        updateContext(
+            workspaceDirectories: workspaceDirectories,
+            agentStatuses: agentStatuses,
+            selectedRange: selectedRange
+        )
+
+        guard pollingTask == nil else { return }
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refresh(forceSample: false)
+                try? await Task.sleep(for: .seconds(5))
+            }
+        }
+    }
+
+    func stop() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    func updateContext(
+        workspaceDirectories: [URL],
+        agentStatuses: [AgentSessionStatus],
+        selectedRange: RuntimeDiagnosticsRange
+    ) {
+        self.workspaceDirectories = workspaceDirectories
+        self.agentStatuses = agentStatuses
+        self.selectedRange = selectedRange
+        Task { await refreshSummaryAndHistory() }
+    }
+
+    func refreshNow() {
+        Task { await refresh(forceSample: true) }
+    }
+
+    private func refresh(forceSample: Bool) async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        let nextSnapshot: RuntimeDiagnosticsSnapshot?
+        if forceSample {
+            nextSnapshot = await sampler.sample(workspaceDirectories: workspaceDirectories)
+        } else {
+            nextSnapshot = await sampler.sampleIfNeeded(workspaceDirectories: workspaceDirectories)
+        }
+
+        if let nextSnapshot {
+            snapshot = nextSnapshot
+        }
+        lastCheckedAt = Date()
+        await refreshSummaryAndHistory()
+    }
+
+    private func refreshSummaryAndHistory() async {
+        history = await sampler.history(duration: selectedRange.duration)
+        if snapshot == nil {
+            snapshot = await sampler.latestSnapshot()
+        }
+
+        let events = await StartupDiagnosticsStore.shared.allEvents()
+        summary = RuntimeDiagnosticsSummary.make(events: events, agentStatuses: agentStatuses)
+    }
+}

--- a/Sources/WorkspaceManager/Diagnostics/RuntimeDiagnosticsViewModel.swift
+++ b/Sources/WorkspaceManager/Diagnostics/RuntimeDiagnosticsViewModel.swift
@@ -97,7 +97,10 @@ final class RuntimeDiagnosticsViewModel: ObservableObject {
         }
 
         if let nextSnapshot {
-            snapshot = nextSnapshot
+            snapshot = RuntimeDiagnosticsSampler.rescopeWorkspaceProcesses(
+                in: nextSnapshot,
+                workspaceDirectories: workspaceDirectories
+            )
         }
         lastCheckedAt = Date()
         await refreshSummaryAndHistory()
@@ -105,8 +108,11 @@ final class RuntimeDiagnosticsViewModel: ObservableObject {
 
     private func refreshSummaryAndHistory() async {
         history = await sampler.history(duration: selectedRange.duration)
-        if snapshot == nil {
-            snapshot = await sampler.latestSnapshot()
+        if let latestSnapshot = await sampler.latestSnapshot() {
+            snapshot = RuntimeDiagnosticsSampler.rescopeWorkspaceProcesses(
+                in: latestSnapshot,
+                workspaceDirectories: workspaceDirectories
+            )
         }
 
         let events = await StartupDiagnosticsStore.shared.allEvents()

--- a/Sources/WorkspaceManager/Diagnostics/RuntimeDiagnosticsViewModel.swift
+++ b/Sources/WorkspaceManager/Diagnostics/RuntimeDiagnosticsViewModel.swift
@@ -2,7 +2,7 @@
 //  RuntimeDiagnosticsViewModel.swift
 //  WorkspaceManager
 //
-//  Main-actor bridge between the inspector UI and core runtime diagnostics sampler.
+//  Main-actor bridge between the Detail Pane UI and core runtime diagnostics sampler.
 //
 
 import Foundation

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -211,6 +211,10 @@ struct ContentView: View {
         UIFixtureWebBootstrapConfiguration.from(environment: ProcessInfo.processInfo.environment)
     }
 
+    private var fixtureDiagnosticsBootstrapConfiguration: UIFixtureDiagnosticsBootstrapConfiguration? {
+        UIFixtureDiagnosticsBootstrapConfiguration.from(environment: ProcessInfo.processInfo.environment)
+    }
+
     private var openInEditorTarget: OpenInEditorTarget? {
         presentationController.openInEditorTarget(
             selectedCodePreview: viewState.selectedCodePreview,
@@ -333,6 +337,7 @@ struct ContentView: View {
             activeSplitFraction: hostTerminalState.splitFraction(for: hostTerminalState.activeSessionID),
             hostSurfaceStore: hostTerminalState.surfaceStore,
             tabTitleOverrides: hostTerminalState.tabTitleOverridesBySessionID,
+            agentStatuses: Array(agentSessionRegistry.statuses.values),
             terminalContextMenuProvider: terminalContextMenu(for:),
             onSplitFractionChanged: { nextFraction in
                 guard let activeSessionID = hostTerminalState.activeSessionID else { return }
@@ -479,6 +484,7 @@ struct ContentView: View {
                 )
                 ensureInitialHostSession()
                 resolveSurfaceLifecycle()
+                applyDiagnosticsFixtureIfNeeded()
                 pruneRightPaneState()
                 syncOpenInEditorShortcutRouting()
                 Task { @MainActor in
@@ -505,6 +511,7 @@ struct ContentView: View {
                 )
                 reconcileSelectionAfterModelChange()
                 resolveSurfaceLifecycle()
+                applyDiagnosticsFixtureIfNeeded()
                 hostTerminalState.pruneRepoSessions(validRepoPaths: normalizedRepoPathSnapshot)
             }
             .onChange(of: inspectorTargetIDSet) { _, _ in
@@ -868,6 +875,35 @@ struct ContentView: View {
             )
 
             guard applySurfaceResolutionAction(action) else { break }
+        }
+    }
+
+    @MainActor
+    private func applyDiagnosticsFixtureIfNeeded() {
+        guard fixtureDiagnosticsBootstrapConfiguration != nil else { return }
+        guard !viewState.didApplyFixtureDiagnosticsBootstrap else { return }
+        guard deepLinkState.pendingRequest == nil else { return }
+
+        if let workspace =
+            repos
+            .flatMap(\.workspaces)
+            .sorted(by: { $0.lastAccessedAt > $1.lastAccessedAt })
+            .first
+        {
+            handleWorkspaceSelection(workspace)
+            rightPaneStateStore.state(for: workspace).selectedTab = .diagnostics
+            viewState.isRightPaneVisible = true
+            viewState.didApplyFixtureDiagnosticsBootstrap = true
+            NSLog("[UIFixture] Diagnostics bootstrap applied (workspace=%@)", workspace.name)
+            return
+        }
+
+        if let repo = repos.first {
+            handleRepoTerminalSelection(repo)
+            rightPaneStateStore.state(for: repo).selectedTab = .diagnostics
+            viewState.isRightPaneVisible = true
+            viewState.didApplyFixtureDiagnosticsBootstrap = true
+            NSLog("[UIFixture] Diagnostics bootstrap applied (repo=%@)", repo.name)
         }
     }
 
@@ -2225,6 +2261,7 @@ struct MainTerminalDetailView: View {
     let activeSplitFraction: CGFloat?
     let hostSurfaceStore: HostTerminalSurfaceStore
     let tabTitleOverrides: [UUID: String]
+    let agentStatuses: [AgentSessionStatus]
     let terminalContextMenuProvider: (HostTerminalSession) -> NSMenu?
     let onSplitFractionChanged: (CGFloat) -> Void
     var onSelectTerminalTab: ((UUID) -> Void)?
@@ -2249,23 +2286,54 @@ struct MainTerminalDetailView: View {
             // Collapsible right pane
             if isRightPaneVisible {
                 if let selectedWorkspace {
+                    let state = rightPaneStateStore.state(for: selectedWorkspace)
                     RightPaneView(
                         workspace: selectedWorkspace,
-                        state: rightPaneStateStore.state(for: selectedWorkspace),
+                        state: state,
+                        diagnosticWorkspaceDirectories: diagnosticWorkspaceDirectories,
+                        agentStatuses: agentStatuses,
                         onFileSelected: onFileSelected
                     )
-                    .frame(minWidth: 220, idealWidth: 280, maxWidth: 400)
+                    .rightPaneWidth(for: state)
                 } else if let selectedRepo {
+                    let state = rightPaneStateStore.state(for: selectedRepo)
                     RightPaneView(
                         repo: selectedRepo,
-                        state: rightPaneStateStore.state(for: selectedRepo),
+                        state: state,
+                        diagnosticWorkspaceDirectories: diagnosticWorkspaceDirectories,
+                        agentStatuses: agentStatuses,
                         onFileSelected: onFileSelected
                     )
-                    .frame(minWidth: 220, idealWidth: 280, maxWidth: 400)
+                    .rightPaneWidth(for: state)
                 }
             }
         }
         .navigationTitle(navigationTitle)
+    }
+
+    private var diagnosticWorkspaceDirectories: [URL] {
+        var seen = Set<String>()
+        var directories: [URL] = []
+
+        var candidateDirectories = hostTerminalSessions.map(\.directoryURL)
+        if let activeSplitHostSession {
+            candidateDirectories.append(activeSplitHostSession.directoryURL)
+        }
+        if let selectedWorkspaceDirectory = selectedWorkspace?.localDirectoryURL {
+            candidateDirectories.append(selectedWorkspaceDirectory)
+        }
+        if let selectedRepo {
+            candidateDirectories.append(selectedRepo.localURL)
+        }
+
+        for directory in candidateDirectories {
+            let path = directory.standardizedFileURL.resolvingSymlinksInPath().path
+            if seen.insert(path).inserted {
+                directories.append(URL(fileURLWithPath: path, isDirectory: true))
+            }
+        }
+
+        return directories
     }
 
     @ViewBuilder

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -313,25 +313,58 @@ private struct DiagnosticsAboutDisclosure: View {
     @Binding var isExpanded: Bool
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(
-                    "Sampling starts when this tab appears, runs every five seconds, and keeps a one-hour in-memory history."
-                )
-                Text("Process samples are not persisted; export uses the existing diagnostic report bundle.")
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(.snappy(duration: 0.16)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 10)
+
+                    Image(systemName: "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Text("About Diagnostics")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    Text("Samples local process and trace telemetry while this tab is open.")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+                }
+                .contentShape(.rect)
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .padding(.top, 4)
-        } label: {
-            Label("Samples local process and trace telemetry while this tab is open.", systemImage: "info.circle")
-                .font(.callout.weight(.medium))
-        }
-        .padding(10)
-        .background(Color(nsColor: .controlBackgroundColor).opacity(0.55), in: .rect(cornerRadius: 8))
-        .overlay {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.secondary.opacity(0.14), lineWidth: 1)
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(
+                        "Diagnostics shows the running WorkSpaces app process tree alongside workspace and agent processes for the selected item."
+                    )
+                    Text(
+                        "Sampling starts when this tab appears, runs every five seconds, and keeps a one-hour in-memory history."
+                    )
+                    Text("Process samples are not persisted; export uses the existing diagnostic report bundle.")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(Color(nsColor: .controlBackgroundColor).opacity(0.48), in: .rect(cornerRadius: 8))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.secondary.opacity(0.12), lineWidth: 1)
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
         .help("Open for details about what Diagnostics samples and whether the tab adds runtime overhead.")
         .accessibilityIdentifier("inspector.diagnostics.about")

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -15,11 +15,13 @@ struct DiagnosticsTabView: View {
 
     @StateObject private var viewModel = RuntimeDiagnosticsViewModel()
     @State private var selectedRange: RuntimeDiagnosticsRange = .fifteenMinutes
+    @State private var isAboutExpanded = false
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 18) {
                 diagnosticsHeader
+                DiagnosticsAboutDisclosure(isExpanded: $isAboutExpanded)
 
                 if let errorMessage = viewModel.snapshot?.errorMessage {
                     DiagnosticsInlineError(message: errorMessage)
@@ -85,10 +87,13 @@ struct DiagnosticsTabView: View {
                     await DiagnosticReportExporter.exportWithSavePanel()
                 }
             } label: {
-                Image(systemName: "folder")
+                Image(systemName: "square.and.arrow.up")
             }
             .buttonStyle(.borderless)
-            .help("Export Diagnostic Report")
+            .help(
+                "Export Diagnostic Report: save a zip with app diagnostics, system profile, recent logs, and startup telemetry."
+            )
+            .accessibilityLabel("Export Diagnostic Report")
             .accessibilityIdentifier("inspector.diagnostics.export")
 
             Button {
@@ -104,22 +109,31 @@ struct DiagnosticsTabView: View {
     }
 
     private var liveProcessesSection: some View {
-        DiagnosticsPanel(title: "Live Processes", accessibilityID: "inspector.diagnostics.app-processes") {
+        DiagnosticsPanel(title: "WorkSpaces App Tree", accessibilityID: "inspector.diagnostics.app-processes") {
+            DiagnosticsConceptNote(
+                icon: "scope",
+                tint: .orange,
+                title: "Headline process",
+                text: "The root is this running WorkSpaces app; child rows are processes it launched.",
+                helpText:
+                    "This separates WorkSpaces runtime overhead from commands that happen inside workspace directories."
+            )
+
             MetricsGrid {
                 DiagnosticsMetricCard(
-                    label: "Child Processes",
+                    label: "Descendants",
                     value: "\(max((viewModel.snapshot?.appTreeTotals.processCount ?? 0) - 1, 0))"
                 )
                 DiagnosticsMetricCard(
-                    label: "CPU",
+                    label: "App Tree CPU",
                     value: percentString(viewModel.snapshot?.appTreeTotals.cpuPercent ?? 0)
                 )
                 DiagnosticsMetricCard(
-                    label: "Memory",
+                    label: "App Tree Memory",
                     value: byteString(viewModel.snapshot?.appTreeTotals.residentMemoryBytes ?? 0)
                 )
                 DiagnosticsMetricCard(
-                    label: "App PID",
+                    label: "WorkSpaces PID",
                     value: "\(viewModel.snapshot?.appPID ?? 0)"
                 )
             }
@@ -135,6 +149,12 @@ struct DiagnosticsTabView: View {
     private var resourceHistorySection: some View {
         DiagnosticsPanel(title: "Resource History", accessibilityID: "inspector.diagnostics.resource-history") {
             HStack(alignment: .firstTextBaseline) {
+                Text("App tree CPU over time")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
                 Picker("History Range", selection: $selectedRange) {
                     ForEach(RuntimeDiagnosticsRange.allCases) { range in
                         Text(range.rawValue)
@@ -144,8 +164,6 @@ struct DiagnosticsTabView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()
                 .frame(width: 250)
-
-                Spacer()
 
                 Text(sampleText)
                     .font(.caption)
@@ -159,28 +177,40 @@ struct DiagnosticsTabView: View {
                     value: "\(viewModel.history.sampleCount)"
                 )
                 DiagnosticsMetricCard(
-                    label: "Avg CPU",
+                    label: "App Avg CPU",
                     value: percentString(viewModel.history.appCPUAverage)
                 )
                 DiagnosticsMetricCard(
-                    label: "Peak CPU",
+                    label: "App Peak CPU",
                     value: percentString(viewModel.history.appCPUPeak)
                 )
                 DiagnosticsMetricCard(
-                    label: "Max Memory",
+                    label: "App Max Memory",
                     value: byteString(viewModel.history.appMemoryPeakBytes)
                 )
             }
 
             RuntimeResourceChart(history: viewModel.history)
-                .frame(height: 130)
+                .frame(height: 170)
+                .help(
+                    "Charts WorkSpaces app tree CPU percentage over the selected range. Hover for sample time, CPU, memory, and process count."
+                )
                 .accessibilityIdentifier("inspector.diagnostics.resource-chart")
         }
     }
 
     private var agentProcessesSection: some View {
-        DiagnosticsPanel(title: "Agent / Workspace Processes", accessibilityID: "inspector.diagnostics.agent-processes")
+        DiagnosticsPanel(title: "Workspace / Agent Processes", accessibilityID: "inspector.diagnostics.agent-processes")
         {
+            DiagnosticsConceptNote(
+                icon: "terminal",
+                tint: .mint,
+                title: "Workspace scope",
+                text: "Rows here are host processes whose current directory is inside the selected workspace or repo.",
+                helpText:
+                    "This is intentionally different from the app tree: it finds commands by workspace directory, including agent tools and terminals that WorkSpaces did not directly launch."
+            )
+
             MetricsGrid {
                 DiagnosticsMetricCard(
                     label: "Workspace Processes",
@@ -279,6 +309,35 @@ struct DiagnosticsTabView: View {
     }
 }
 
+private struct DiagnosticsAboutDisclosure: View {
+    @Binding var isExpanded: Bool
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(
+                    "Sampling starts when this tab appears, runs every five seconds, and keeps a one-hour in-memory history."
+                )
+                Text("Process samples are not persisted; export uses the existing diagnostic report bundle.")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.top, 4)
+        } label: {
+            Label("Samples local process and trace telemetry while this tab is open.", systemImage: "info.circle")
+                .font(.callout.weight(.medium))
+        }
+        .padding(10)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.55), in: .rect(cornerRadius: 8))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.secondary.opacity(0.14), lineWidth: 1)
+        }
+        .help("Open for details about what Diagnostics samples and whether the tab adds runtime overhead.")
+        .accessibilityIdentifier("inspector.diagnostics.about")
+    }
+}
+
 private struct DiagnosticsPanel<Content: View>: View {
     let title: String
     let accessibilityID: String
@@ -307,6 +366,36 @@ private struct DiagnosticsPanel<Content: View>: View {
             .clipShape(.rect(cornerRadius: 8))
         }
         .accessibilityIdentifier(accessibilityID)
+    }
+}
+
+private struct DiagnosticsConceptNote: View {
+    let icon: String
+    let tint: Color
+    let title: String
+    let text: String
+    let helpText: String
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(text)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } icon: {
+            Image(systemName: icon)
+                .font(.callout)
+                .foregroundStyle(tint)
+        }
+        .padding(9)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tint.opacity(0.08), in: .rect(cornerRadius: 7))
+        .help(helpText)
     }
 }
 
@@ -375,10 +464,106 @@ private struct DiagnosticsMetricCard: View {
     }
 }
 
+enum RuntimeProcessTableColumn: CaseIterable {
+    case name
+    case cpu
+    case memory
+    case pid
+    case command
+
+    var title: String {
+        switch self {
+        case .name: return "Name"
+        case .cpu: return "CPU"
+        case .memory: return "Memory"
+        case .pid: return "PID"
+        case .command: return "Command"
+        }
+    }
+}
+
+enum RuntimeProcessSortDirection {
+    case ascending
+    case descending
+}
+
+struct RuntimeProcessTableSortState: Equatable {
+    var column: RuntimeProcessTableColumn?
+    var direction: RuntimeProcessSortDirection?
+
+    mutating func cycle(column nextColumn: RuntimeProcessTableColumn) {
+        if column != nextColumn {
+            column = nextColumn
+            direction = .ascending
+            return
+        }
+
+        switch direction {
+        case .ascending:
+            direction = .descending
+        case .descending:
+            column = nil
+            direction = nil
+        case nil:
+            direction = .ascending
+        }
+    }
+
+    func sorted(_ rows: [RuntimeProcessSample]) -> [RuntimeProcessSample] {
+        guard let column, let direction else { return rows }
+
+        return rows.enumerated().sorted { lhs, rhs in
+            let comparison = compare(lhs.element, rhs.element, by: column)
+            guard comparison != .orderedSame else {
+                return lhs.offset < rhs.offset
+            }
+
+            switch direction {
+            case .ascending:
+                return comparison == .orderedAscending
+            case .descending:
+                return comparison == .orderedDescending
+            }
+        }
+        .map(\.element)
+    }
+
+    private func compare(
+        _ lhs: RuntimeProcessSample,
+        _ rhs: RuntimeProcessSample,
+        by column: RuntimeProcessTableColumn
+    ) -> ComparisonResult {
+        switch column {
+        case .name:
+            return lhs.name.localizedStandardCompare(rhs.name)
+        case .cpu:
+            return compare(lhs.cpuPercent, rhs.cpuPercent)
+        case .memory:
+            return compare(lhs.residentMemoryBytes, rhs.residentMemoryBytes)
+        case .pid:
+            return compare(lhs.pid, rhs.pid)
+        case .command:
+            return lhs.command.localizedStandardCompare(rhs.command)
+        }
+    }
+
+    private func compare<T: Comparable>(_ lhs: T, _ rhs: T) -> ComparisonResult {
+        if lhs < rhs { return .orderedAscending }
+        if lhs > rhs { return .orderedDescending }
+        return .orderedSame
+    }
+}
+
 private struct RuntimeProcessTable: View {
     let rows: [RuntimeProcessSample]
     let emptyText: String
     let accessibilityID: String
+
+    @State private var sortState = RuntimeProcessTableSortState()
+
+    private var displayedRows: [RuntimeProcessSample] {
+        sortState.sorted(rows)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -391,9 +576,9 @@ private struct RuntimeProcessTable: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 14)
             } else {
-                ForEach(rows.prefix(10)) { row in
+                ForEach(displayedRows.prefix(10)) { row in
                     processRow(row)
-                    if row.pid != rows.prefix(10).last?.pid {
+                    if row.pid != displayedRows.prefix(10).last?.pid {
                         Divider()
                     }
                 }
@@ -404,20 +589,54 @@ private struct RuntimeProcessTable: View {
 
     private var tableHeader: some View {
         HStack(spacing: 12) {
-            Text("Name")
-                .frame(minWidth: 110, alignment: .leading)
-            Text("CPU")
-                .frame(width: 58, alignment: .trailing)
-            Text("Memory")
-                .frame(width: 82, alignment: .trailing)
-            Text("PID")
-                .frame(width: 54, alignment: .trailing)
-            Text("Command")
-                .frame(minWidth: 160, alignment: .leading)
+            sortableHeader(.name, minWidth: 110, alignment: .leading)
+            sortableHeader(.cpu, width: 58, alignment: .trailing)
+            sortableHeader(.memory, width: 82, alignment: .trailing)
+            sortableHeader(.pid, width: 54, alignment: .trailing)
+            sortableHeader(.command, minWidth: 160, alignment: .leading)
         }
         .font(.caption.weight(.semibold))
         .foregroundStyle(.secondary)
         .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private func sortableHeader(
+        _ column: RuntimeProcessTableColumn,
+        minWidth: CGFloat? = nil,
+        width: CGFloat? = nil,
+        alignment: Alignment
+    ) -> some View {
+        let header = Button {
+            sortState.cycle(column: column)
+        } label: {
+            HStack(spacing: 3) {
+                Text(column.title)
+                    .lineLimit(1)
+                sortIndicator(for: column)
+            }
+            .frame(maxWidth: .infinity, alignment: alignment)
+        }
+        .buttonStyle(.plain)
+        .help("Sort by \(column.title). Click again to reverse; click a third time to restore the default order.")
+
+        if let width {
+            header.frame(width: width, alignment: alignment)
+        } else {
+            header.frame(minWidth: minWidth ?? 0, alignment: alignment)
+        }
+    }
+
+    @ViewBuilder
+    private func sortIndicator(for column: RuntimeProcessTableColumn) -> some View {
+        if sortState.column == column {
+            Image(systemName: sortState.direction == .ascending ? "chevron.up" : "chevron.down")
+                .font(.caption2.weight(.bold))
+        } else {
+            Image(systemName: "arrow.up.arrow.down")
+                .font(.caption2)
+                .opacity(0.22)
+        }
     }
 
     private func processRow(_ row: RuntimeProcessSample) -> some View {
@@ -471,33 +690,96 @@ private struct RuntimeProcessTable: View {
 private struct RuntimeResourceChart: View {
     let history: RuntimeProcessHistory
 
+    @State private var hoveredIndex: Int?
+
+    private var hoveredSnapshot: RuntimeDiagnosticsSnapshot? {
+        guard let hoveredIndex, history.snapshots.indices.contains(hoveredIndex) else {
+            return nil
+        }
+        return history.snapshots[hoveredIndex]
+    }
+
     var body: some View {
-        GeometryReader { proxy in
-            let snapshots = history.snapshots
-            let maxCPU = max(history.appCPUPeak, 1)
-            HStack(alignment: .bottom, spacing: 3) {
-                if snapshots.isEmpty {
-                    Rectangle()
-                        .fill(Color.secondary.opacity(0.15))
-                        .frame(height: 2)
-                } else {
-                    ForEach(Array(snapshots.enumerated()), id: \.element.sampledAt) { _, snapshot in
-                        let heightRatio = min(max(snapshot.appTreeTotals.cpuPercent / maxCPU, 0), 1)
-                        RoundedRectangle(cornerRadius: 3, style: .continuous)
-                            .fill(chartColor(for: snapshot.appTreeTotals.cpuPercent))
-                            .frame(
-                                width: barWidth(totalWidth: proxy.size.width, count: snapshots.count),
-                                height: max(2, proxy.size.height * heightRatio)
-                            )
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                Label("WorkSpaces app tree CPU", systemImage: "waveform.path.ecg")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text(hoveredSnapshot.map(sampleDescription) ?? "Hover for sample details")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            GeometryReader { proxy in
+                let snapshots = history.snapshots
+                let maxCPU = max(history.appCPUPeak, 1)
+                ZStack(alignment: .topTrailing) {
+                    HStack(alignment: .bottom, spacing: 3) {
+                        if snapshots.isEmpty {
+                            Rectangle()
+                                .fill(Color.secondary.opacity(0.15))
+                                .frame(height: 2)
+                        } else {
+                            ForEach(Array(snapshots.enumerated()), id: \.element.sampledAt) { index, snapshot in
+                                let heightRatio = min(max(snapshot.appTreeTotals.cpuPercent / maxCPU, 0), 1)
+                                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                    .fill(
+                                        chartColor(
+                                            for: snapshot.appTreeTotals.cpuPercent, isHovered: index == hoveredIndex)
+                                    )
+                                    .frame(
+                                        width: barWidth(totalWidth: proxy.size.width, count: snapshots.count),
+                                        height: max(2, proxy.size.height * heightRatio)
+                                    )
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .fill(Color.secondary.opacity(0.30))
+                            .frame(height: 1)
+                    }
+
+                    if let hoveredSnapshot {
+                        chartCallout(hoveredSnapshot)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onContinuousHover(coordinateSpace: .local) { phase in
+                    switch phase {
+                    case .active(let location):
+                        hoveredIndex = hoveredIndex(
+                            for: location.x,
+                            width: proxy.size.width,
+                            count: snapshots.count
+                        )
+                    case .ended:
+                        hoveredIndex = nil
                     }
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .fill(Color.secondary.opacity(0.30))
-                    .frame(height: 1)
-            }
+        }
+    }
+
+    private func chartCallout(_ snapshot: RuntimeDiagnosticsSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(snapshot.sampledAt.formatted(date: .omitted, time: .standard))
+                .font(.caption.weight(.semibold))
+            Text("CPU \(percentString(snapshot.appTreeTotals.cpuPercent))")
+            Text("Memory \(byteString(snapshot.appTreeTotals.residentMemoryBytes))")
+            Text("\(snapshot.appTreeTotals.processCount) processes")
+        }
+        .font(.caption2.monospacedDigit())
+        .padding(8)
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.92), in: .rect(cornerRadius: 7))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(Color.secondary.opacity(0.22), lineWidth: 1)
         }
     }
 
@@ -506,10 +788,22 @@ private struct RuntimeResourceChart: View {
         return max(3, min(18, (totalWidth / CGFloat(count)) - 3))
     }
 
-    private func chartColor(for cpu: Double) -> Color {
-        if cpu >= 80 { return .red.opacity(0.85) }
-        if cpu >= 40 { return .yellow.opacity(0.85) }
-        return .secondary.opacity(0.75)
+    private func chartColor(for cpu: Double, isHovered: Bool) -> Color {
+        let opacity = isHovered ? 1.0 : 0.78
+        if cpu >= 80 { return .red.opacity(opacity) }
+        if cpu >= 40 { return .yellow.opacity(opacity) }
+        return .secondary.opacity(opacity)
+    }
+
+    private func hoveredIndex(for x: CGFloat, width: CGFloat, count: Int) -> Int? {
+        guard count > 0, width > 0 else { return nil }
+        let clampedX = min(max(x, 0), width)
+        let rawIndex = Int((clampedX / width) * CGFloat(count))
+        return min(max(rawIndex, 0), count - 1)
+    }
+
+    private func sampleDescription(_ snapshot: RuntimeDiagnosticsSnapshot) -> String {
+        "\(snapshot.sampledAt.formatted(date: .omitted, time: .shortened))  CPU \(percentString(snapshot.appTreeTotals.cpuPercent))  Mem \(byteString(snapshot.appTreeTotals.residentMemoryBytes))"
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -1,0 +1,617 @@
+//
+//  DiagnosticsTabView.swift
+//  WorkspaceManager
+//
+//  Live runtime diagnostics for the right inspector.
+//
+
+import Foundation
+import SwiftUI
+import WorkspaceManagerCore
+
+struct DiagnosticsTabView: View {
+    let workspaceDirectories: [URL]
+    let agentStatuses: [AgentSessionStatus]
+
+    @StateObject private var viewModel = RuntimeDiagnosticsViewModel()
+    @State private var selectedRange: RuntimeDiagnosticsRange = .fifteenMinutes
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 18) {
+                diagnosticsHeader
+
+                if let errorMessage = viewModel.snapshot?.errorMessage {
+                    DiagnosticsInlineError(message: errorMessage)
+                }
+
+                liveProcessesSection
+                resourceHistorySection
+                agentProcessesSection
+                traceDiagnosticsSection
+                latestFailuresSection
+            }
+            .padding(16)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .accessibilityIdentifier("inspector.diagnostics.root")
+        .onAppear {
+            viewModel.start(
+                workspaceDirectories: workspaceDirectories,
+                agentStatuses: agentStatuses,
+                selectedRange: selectedRange
+            )
+        }
+        .onDisappear {
+            viewModel.stop()
+        }
+        .onChange(of: selectedRange) { _, range in
+            viewModel.updateContext(
+                workspaceDirectories: workspaceDirectories,
+                agentStatuses: agentStatuses,
+                selectedRange: range
+            )
+        }
+        .onChange(of: workspaceDirectories) { _, directories in
+            viewModel.updateContext(
+                workspaceDirectories: directories,
+                agentStatuses: agentStatuses,
+                selectedRange: selectedRange
+            )
+        }
+        .onChange(of: agentStatuses) { _, statuses in
+            viewModel.updateContext(
+                workspaceDirectories: workspaceDirectories,
+                agentStatuses: statuses,
+                selectedRange: selectedRange
+            )
+        }
+    }
+
+    private var diagnosticsHeader: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Diagnostics")
+                    .font(.headline)
+                Text(checkedText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                Task {
+                    await DiagnosticReportExporter.exportWithSavePanel()
+                }
+            } label: {
+                Image(systemName: "folder")
+            }
+            .buttonStyle(.borderless)
+            .help("Export Diagnostic Report")
+            .accessibilityIdentifier("inspector.diagnostics.export")
+
+            Button {
+                viewModel.refreshNow()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.borderless)
+            .disabled(viewModel.isRefreshing)
+            .help("Refresh Diagnostics")
+            .accessibilityIdentifier("inspector.diagnostics.refresh")
+        }
+    }
+
+    private var liveProcessesSection: some View {
+        DiagnosticsPanel(title: "Live Processes", accessibilityID: "inspector.diagnostics.app-processes") {
+            MetricsGrid {
+                DiagnosticsMetricCard(
+                    label: "Child Processes",
+                    value: "\(max((viewModel.snapshot?.appTreeTotals.processCount ?? 0) - 1, 0))"
+                )
+                DiagnosticsMetricCard(
+                    label: "CPU",
+                    value: percentString(viewModel.snapshot?.appTreeTotals.cpuPercent ?? 0)
+                )
+                DiagnosticsMetricCard(
+                    label: "Memory",
+                    value: byteString(viewModel.snapshot?.appTreeTotals.residentMemoryBytes ?? 0)
+                )
+                DiagnosticsMetricCard(
+                    label: "App PID",
+                    value: "\(viewModel.snapshot?.appPID ?? 0)"
+                )
+            }
+
+            RuntimeProcessTable(
+                rows: viewModel.snapshot?.appTreeProcesses ?? [],
+                emptyText: "No live descendant processes found.",
+                accessibilityID: "inspector.diagnostics.app-process-table"
+            )
+        }
+    }
+
+    private var resourceHistorySection: some View {
+        DiagnosticsPanel(title: "Resource History", accessibilityID: "inspector.diagnostics.resource-history") {
+            HStack(alignment: .firstTextBaseline) {
+                Picker("History Range", selection: $selectedRange) {
+                    ForEach(RuntimeDiagnosticsRange.allCases) { range in
+                        Text(range.rawValue)
+                            .tag(range)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 250)
+
+                Spacer()
+
+                Text(sampleText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityIdentifier("inspector.diagnostics.range")
+
+            MetricsGrid {
+                DiagnosticsMetricCard(
+                    label: "Samples",
+                    value: "\(viewModel.history.sampleCount)"
+                )
+                DiagnosticsMetricCard(
+                    label: "Avg CPU",
+                    value: percentString(viewModel.history.appCPUAverage)
+                )
+                DiagnosticsMetricCard(
+                    label: "Peak CPU",
+                    value: percentString(viewModel.history.appCPUPeak)
+                )
+                DiagnosticsMetricCard(
+                    label: "Max Memory",
+                    value: byteString(viewModel.history.appMemoryPeakBytes)
+                )
+            }
+
+            RuntimeResourceChart(history: viewModel.history)
+                .frame(height: 130)
+                .accessibilityIdentifier("inspector.diagnostics.resource-chart")
+        }
+    }
+
+    private var agentProcessesSection: some View {
+        DiagnosticsPanel(title: "Agent / Workspace Processes", accessibilityID: "inspector.diagnostics.agent-processes")
+        {
+            MetricsGrid {
+                DiagnosticsMetricCard(
+                    label: "Workspace Processes",
+                    value: "\(viewModel.snapshot?.workspaceTotals.processCount ?? 0)"
+                )
+                DiagnosticsMetricCard(
+                    label: "Workspace CPU",
+                    value: percentString(viewModel.snapshot?.workspaceTotals.cpuPercent ?? 0)
+                )
+                DiagnosticsMetricCard(
+                    label: "Workspace Memory",
+                    value: byteString(viewModel.snapshot?.workspaceTotals.residentMemoryBytes ?? 0)
+                )
+                DiagnosticsMetricCard(
+                    label: "Agent Sessions",
+                    value: "\(viewModel.summary.activeAgentSessionCount)"
+                )
+            }
+
+            RuntimeProcessTable(
+                rows: viewModel.snapshot?.workspaceProcesses ?? [],
+                emptyText: "No active workspace processes found.",
+                accessibilityID: "inspector.diagnostics.agent-process-table"
+            )
+
+            AgentSessionStatusList(statuses: agentStatuses)
+                .accessibilityIdentifier("inspector.diagnostics.agent-sessions")
+        }
+    }
+
+    private var traceDiagnosticsSection: some View {
+        DiagnosticsPanel(title: "Trace Diagnostics", accessibilityID: "inspector.diagnostics.trace-summary") {
+            MetricsGrid {
+                DiagnosticsMetricCard(label: "Spans", value: "\(viewModel.summary.spanCount)")
+                DiagnosticsMetricCard(
+                    label: "Failures",
+                    value: "\(viewModel.summary.failureCount)",
+                    prominence: viewModel.summary.failureCount > 0 ? .critical : .normal
+                )
+                DiagnosticsMetricCard(
+                    label: "Slow Spans",
+                    value: "\(viewModel.summary.slowSpanCount)",
+                    prominence: viewModel.summary.slowSpanCount > 0 ? .warning : .normal
+                )
+                DiagnosticsMetricCard(label: "Parse Errors", value: "\(viewModel.summary.parseErrorCount)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var latestFailuresSection: some View {
+        DiagnosticsPanel(title: "Latest Failures", accessibilityID: "inspector.diagnostics.latest-failures") {
+            if viewModel.summary.latestFailures.isEmpty {
+                Text("No recent diagnostic failures.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(viewModel.summary.latestFailures) { failure in
+                        VStack(alignment: .leading, spacing: 3) {
+                            HStack {
+                                Text(failure.title)
+                                    .font(.callout.weight(.semibold))
+                                    .lineLimit(1)
+                                Spacer()
+                                Text(failure.timestamp.formatted(.relative(presentation: .named)))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Text(failure.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                        .padding(.vertical, 8)
+
+                        if failure.id != viewModel.summary.latestFailures.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var checkedText: String {
+        guard let lastCheckedAt = viewModel.lastCheckedAt else { return "Waiting for first sample" }
+        return "Checked \(lastCheckedAt.formatted(.relative(presentation: .named)))"
+    }
+
+    private var sampleText: String {
+        let count = viewModel.history.sampleCount
+        return count == 1 ? "1 sample" : "\(count) samples"
+    }
+}
+
+private struct DiagnosticsPanel<Content: View>: View {
+    let title: String
+    let accessibilityID: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.35))
+                    .frame(width: 14, height: 1)
+                Text(title.uppercased())
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                content
+            }
+            .padding(12)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.78))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+            }
+            .clipShape(.rect(cornerRadius: 8))
+        }
+        .accessibilityIdentifier(accessibilityID)
+    }
+}
+
+private struct MetricsGrid<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    private let columns = [
+        GridItem(.adaptive(minimum: 120, maximum: 180), spacing: 0)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 0) {
+            content
+        }
+    }
+}
+
+private enum DiagnosticsMetricProminence {
+    case normal
+    case warning
+    case critical
+}
+
+private struct DiagnosticsMetricCard: View {
+    let label: String
+    let value: String
+    var prominence: DiagnosticsMetricProminence = .normal
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label.uppercased())
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            Text(value)
+                .font(.system(.title3, design: .monospaced, weight: .semibold))
+                .foregroundStyle(valueStyle)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .overlay(alignment: .trailing) {
+            Rectangle()
+                .fill(Color.secondary.opacity(0.10))
+                .frame(width: 1)
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.secondary.opacity(0.10))
+                .frame(height: 1)
+        }
+    }
+
+    private var valueStyle: Color {
+        switch prominence {
+        case .normal:
+            return .primary
+        case .warning:
+            return .yellow
+        case .critical:
+            return .red
+        }
+    }
+}
+
+private struct RuntimeProcessTable: View {
+    let rows: [RuntimeProcessSample]
+    let emptyText: String
+    let accessibilityID: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            tableHeader
+
+            if rows.isEmpty {
+                Text(emptyText)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 14)
+            } else {
+                ForEach(rows.prefix(10)) { row in
+                    processRow(row)
+                    if row.pid != rows.prefix(10).last?.pid {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(accessibilityID)
+    }
+
+    private var tableHeader: some View {
+        HStack(spacing: 12) {
+            Text("Name")
+                .frame(minWidth: 110, alignment: .leading)
+            Text("CPU")
+                .frame(width: 58, alignment: .trailing)
+            Text("Memory")
+                .frame(width: 82, alignment: .trailing)
+            Text("PID")
+                .frame(width: 54, alignment: .trailing)
+            Text("Command")
+                .frame(minWidth: 160, alignment: .leading)
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .padding(.bottom, 8)
+    }
+
+    private func processRow(_ row: RuntimeProcessSample) -> some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(processColor(row))
+                    .frame(width: 7, height: 7)
+                Text(row.name)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+            }
+            .frame(minWidth: 110, alignment: .leading)
+
+            Text(percentString(row.cpuPercent))
+                .font(.system(.callout, design: .monospaced))
+                .frame(width: 58, alignment: .trailing)
+
+            Text(byteString(row.residentMemoryBytes))
+                .font(.system(.callout, design: .monospaced))
+                .frame(width: 82, alignment: .trailing)
+
+            Text("\(row.pid)")
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 54, alignment: .trailing)
+
+            Text(row.command)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+                .frame(minWidth: 160, alignment: .leading)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func processColor(_ row: RuntimeProcessSample) -> Color {
+        if isKnownAgent(row) { return .mint }
+        if row.parentPID == 1 { return .secondary }
+        return .orange
+    }
+
+    private func isKnownAgent(_ row: RuntimeProcessSample) -> Bool {
+        let haystack = "\(row.name) \(row.command)".lowercased()
+        return ["claude", "codex", "aider", "cursor", "opencode", "pi"].contains { haystack.contains($0) }
+    }
+}
+
+private struct RuntimeResourceChart: View {
+    let history: RuntimeProcessHistory
+
+    var body: some View {
+        GeometryReader { proxy in
+            let snapshots = history.snapshots
+            let maxCPU = max(history.appCPUPeak, 1)
+            HStack(alignment: .bottom, spacing: 3) {
+                if snapshots.isEmpty {
+                    Rectangle()
+                        .fill(Color.secondary.opacity(0.15))
+                        .frame(height: 2)
+                } else {
+                    ForEach(Array(snapshots.enumerated()), id: \.element.sampledAt) { _, snapshot in
+                        let heightRatio = min(max(snapshot.appTreeTotals.cpuPercent / maxCPU, 0), 1)
+                        RoundedRectangle(cornerRadius: 3, style: .continuous)
+                            .fill(chartColor(for: snapshot.appTreeTotals.cpuPercent))
+                            .frame(
+                                width: barWidth(totalWidth: proxy.size.width, count: snapshots.count),
+                                height: max(2, proxy.size.height * heightRatio)
+                            )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.30))
+                    .frame(height: 1)
+            }
+        }
+    }
+
+    private func barWidth(totalWidth: CGFloat, count: Int) -> CGFloat {
+        guard count > 0 else { return totalWidth }
+        return max(3, min(18, (totalWidth / CGFloat(count)) - 3))
+    }
+
+    private func chartColor(for cpu: Double) -> Color {
+        if cpu >= 80 { return .red.opacity(0.85) }
+        if cpu >= 40 { return .yellow.opacity(0.85) }
+        return .secondary.opacity(0.75)
+    }
+}
+
+private struct AgentSessionStatusList: View {
+    let statuses: [AgentSessionStatus]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("ACTIVE AGENT SESSIONS")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 6)
+
+            if sortedStatuses.isEmpty {
+                Text("No active agent sessions registered.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+            } else {
+                ForEach(sortedStatuses, id: \.hostSessionID) { status in
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Circle()
+                            .fill(color(for: status.run))
+                            .frame(width: 7, height: 7)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(sessionTitle(status))
+                                .font(.callout.weight(.medium))
+                            Text(status.cwd)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        Spacer()
+                        Text(status.lastEventAt.formatted(.relative(presentation: .named)))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 7)
+                }
+            }
+        }
+    }
+
+    private var sortedStatuses: [AgentSessionStatus] {
+        statuses.sorted { $0.lastEventAt > $1.lastEventAt }
+    }
+
+    private func sessionTitle(_ status: AgentSessionStatus) -> String {
+        let model = status.modelDisplayName ?? status.kind.rawValue
+        return "\(model) - \(runStateLabel(status.run))"
+    }
+
+    private func runStateLabel(_ state: AgentRunState) -> String {
+        switch state {
+        case .idle: return "Idle"
+        case .thinking: return "Thinking"
+        case .runningTool(let name, _): return "Running \(name)"
+        case .awaitingInput(let reason): return "Awaiting \(reason.rawValue)"
+        case .complete: return "Complete"
+        case .errored(let category, _): return "Errored: \(category.rawValue)"
+        }
+    }
+
+    private func color(for state: AgentRunState) -> Color {
+        switch state {
+        case .idle, .complete:
+            return .secondary
+        case .thinking, .runningTool:
+            return .blue
+        case .awaitingInput:
+            return .yellow
+        case .errored:
+            return .red
+        }
+    }
+}
+
+private struct DiagnosticsInlineError: View {
+    let message: String
+
+    var body: some View {
+        Label {
+            Text(message)
+                .font(.caption)
+                .lineLimit(2)
+        } icon: {
+            Image(systemName: "exclamationmark.triangle")
+        }
+        .foregroundStyle(.orange)
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier("inspector.diagnostics.error")
+    }
+}
+
+private func percentString(_ value: Double) -> String {
+    String(format: "%.1f%%", value)
+}
+
+private func byteString(_ bytes: Int64) -> String {
+    ByteCountFormatter.string(fromByteCount: bytes, countStyle: .memory)
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -2,7 +2,7 @@
 //  DiagnosticsTabView.swift
 //  WorkspaceManager
 //
-//  Live runtime diagnostics for the right inspector.
+//  Live runtime diagnostics for the Detail Pane.
 //
 
 import Foundation
@@ -126,11 +126,11 @@ struct DiagnosticsTabView: View {
                 )
                 DiagnosticsMetricCard(
                     label: "App Tree CPU",
-                    value: percentString(viewModel.snapshot?.appTreeTotals.cpuPercent ?? 0)
+                    value: DiagnosticsValueFormatting.percent(viewModel.snapshot?.appTreeTotals.cpuPercent ?? 0)
                 )
                 DiagnosticsMetricCard(
                     label: "App Tree Memory",
-                    value: byteString(viewModel.snapshot?.appTreeTotals.residentMemoryBytes ?? 0)
+                    value: DiagnosticsValueFormatting.bytes(viewModel.snapshot?.appTreeTotals.residentMemoryBytes ?? 0)
                 )
                 DiagnosticsMetricCard(
                     label: "WorkSpaces PID",
@@ -178,15 +178,15 @@ struct DiagnosticsTabView: View {
                 )
                 DiagnosticsMetricCard(
                     label: "App Avg CPU",
-                    value: percentString(viewModel.history.appCPUAverage)
+                    value: DiagnosticsValueFormatting.percent(viewModel.history.appCPUAverage)
                 )
                 DiagnosticsMetricCard(
                     label: "App Peak CPU",
-                    value: percentString(viewModel.history.appCPUPeak)
+                    value: DiagnosticsValueFormatting.percent(viewModel.history.appCPUPeak)
                 )
                 DiagnosticsMetricCard(
                     label: "App Max Memory",
-                    value: byteString(viewModel.history.appMemoryPeakBytes)
+                    value: DiagnosticsValueFormatting.bytes(viewModel.history.appMemoryPeakBytes)
                 )
             }
 
@@ -200,39 +200,41 @@ struct DiagnosticsTabView: View {
     }
 
     private var agentProcessesSection: some View {
-        DiagnosticsPanel(title: "Workspace / Agent Processes", accessibilityID: "inspector.diagnostics.agent-processes")
+        DiagnosticsPanel(title: "Workspace & Agent Processes", accessibilityID: "inspector.diagnostics.agent-processes")
         {
             DiagnosticsConceptNote(
                 icon: "terminal",
                 tint: .mint,
                 title: "Workspace scope",
-                text: "Rows here are host processes whose current directory is inside the selected workspace or repo.",
+                text:
+                    "Rows here are host processes whose current directory is inside the selected Workspace or Repository.",
                 helpText:
-                    "This is intentionally different from the app tree: it finds commands by workspace directory, including agent tools and terminals that WorkSpaces did not directly launch."
+                    "This is intentionally different from the app tree: it finds commands by Repository or Workspace directory, including agent tools and Terminal Sessions that WorkSpaces did not directly launch."
             )
 
             MetricsGrid {
                 DiagnosticsMetricCard(
-                    label: "Workspace Processes",
+                    label: "Scoped Processes",
                     value: "\(viewModel.snapshot?.workspaceTotals.processCount ?? 0)"
                 )
                 DiagnosticsMetricCard(
-                    label: "Workspace CPU",
-                    value: percentString(viewModel.snapshot?.workspaceTotals.cpuPercent ?? 0)
+                    label: "Scoped CPU",
+                    value: DiagnosticsValueFormatting.percent(viewModel.snapshot?.workspaceTotals.cpuPercent ?? 0)
                 )
                 DiagnosticsMetricCard(
-                    label: "Workspace Memory",
-                    value: byteString(viewModel.snapshot?.workspaceTotals.residentMemoryBytes ?? 0)
+                    label: "Scoped Memory",
+                    value: DiagnosticsValueFormatting.bytes(
+                        viewModel.snapshot?.workspaceTotals.residentMemoryBytes ?? 0)
                 )
                 DiagnosticsMetricCard(
-                    label: "Agent Sessions",
+                    label: "Agent Runs",
                     value: "\(viewModel.summary.activeAgentSessionCount)"
                 )
             }
 
             RuntimeProcessTable(
                 rows: viewModel.snapshot?.workspaceProcesses ?? [],
-                emptyText: "No active workspace processes found.",
+                emptyText: "No active Repository or Workspace processes found.",
                 accessibilityID: "inspector.diagnostics.agent-process-table"
             )
 
@@ -333,7 +335,7 @@ private struct DiagnosticsAboutDisclosure: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
 
-                    Text("Samples local process and trace telemetry while this tab is open.")
+                    Text("Samples local processes while open; trace counts use existing telemetry.")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
@@ -347,7 +349,7 @@ private struct DiagnosticsAboutDisclosure: View {
             if isExpanded {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(
-                        "Diagnostics shows the running WorkSpaces app process tree alongside workspace and agent processes for the selected item."
+                        "Diagnostics samples the local process list while this tab is open and shows it beside existing trace telemetry for the selected Repository or Workspace."
                     )
                     Text(
                         "Sampling starts when this tab appears, runs every five seconds, and keeps a one-hour in-memory history."
@@ -366,7 +368,7 @@ private struct DiagnosticsAboutDisclosure: View {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
-        .help("Open for details about what Diagnostics samples and whether the tab adds runtime overhead.")
+        .help("Open for details about process sampling, existing trace telemetry, and runtime overhead.")
         .accessibilityIdentifier("inspector.diagnostics.about")
     }
 }
@@ -497,539 +499,18 @@ private struct DiagnosticsMetricCard: View {
     }
 }
 
-enum RuntimeProcessTableColumn: CaseIterable {
-    case name
-    case cpu
-    case memory
-    case pid
-    case command
-
-    var title: String {
-        switch self {
-        case .name: return "Name"
-        case .cpu: return "CPU"
-        case .memory: return "Memory"
-        case .pid: return "PID"
-        case .command: return "Command"
-        }
-    }
-}
-
-enum RuntimeProcessSortDirection {
-    case ascending
-    case descending
-}
-
-struct RuntimeProcessTableSortState: Equatable {
-    var column: RuntimeProcessTableColumn?
-    var direction: RuntimeProcessSortDirection?
-
-    mutating func cycle(column nextColumn: RuntimeProcessTableColumn) {
-        if column != nextColumn {
-            column = nextColumn
-            direction = .ascending
-            return
-        }
-
-        switch direction {
-        case .ascending:
-            direction = .descending
-        case .descending:
-            column = nil
-            direction = nil
-        case nil:
-            direction = .ascending
-        }
-    }
-
-    func sorted(_ rows: [RuntimeProcessSample]) -> [RuntimeProcessSample] {
-        guard let column, let direction else { return rows }
-
-        return rows.enumerated().sorted { lhs, rhs in
-            let comparison = compare(lhs.element, rhs.element, by: column)
-            guard comparison != .orderedSame else {
-                return lhs.offset < rhs.offset
-            }
-
-            switch direction {
-            case .ascending:
-                return comparison == .orderedAscending
-            case .descending:
-                return comparison == .orderedDescending
-            }
-        }
-        .map(\.element)
-    }
-
-    private func compare(
-        _ lhs: RuntimeProcessSample,
-        _ rhs: RuntimeProcessSample,
-        by column: RuntimeProcessTableColumn
-    ) -> ComparisonResult {
-        switch column {
-        case .name:
-            return lhs.name.localizedStandardCompare(rhs.name)
-        case .cpu:
-            return compare(lhs.cpuPercent, rhs.cpuPercent)
-        case .memory:
-            return compare(lhs.residentMemoryBytes, rhs.residentMemoryBytes)
-        case .pid:
-            return compare(lhs.pid, rhs.pid)
-        case .command:
-            return lhs.command.localizedStandardCompare(rhs.command)
-        }
-    }
-
-    private func compare<T: Comparable>(_ lhs: T, _ rhs: T) -> ComparisonResult {
-        if lhs < rhs { return .orderedAscending }
-        if lhs > rhs { return .orderedDescending }
-        return .orderedSame
-    }
-}
-
-private struct RuntimeProcessTable: View {
-    let rows: [RuntimeProcessSample]
-    let emptyText: String
-    let accessibilityID: String
-
-    @State private var sortState = RuntimeProcessTableSortState()
-
-    private var displayedRows: [RuntimeProcessSample] {
-        sortState.sorted(rows)
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            tableHeader
-
-            if rows.isEmpty {
-                Text(emptyText)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 14)
-            } else {
-                ForEach(displayedRows.prefix(10)) { row in
-                    processRow(row)
-                    if row.pid != displayedRows.prefix(10).last?.pid {
-                        Divider()
-                    }
-                }
-            }
-        }
-        .accessibilityIdentifier(accessibilityID)
-    }
-
-    private var tableHeader: some View {
-        HStack(spacing: 12) {
-            sortableHeader(.name, minWidth: 110, alignment: .leading)
-            sortableHeader(.cpu, width: 58, alignment: .trailing)
-            sortableHeader(.memory, width: 82, alignment: .trailing)
-            sortableHeader(.pid, width: 54, alignment: .trailing)
-            sortableHeader(.command, minWidth: 160, alignment: .leading)
-        }
-        .font(.caption.weight(.semibold))
-        .foregroundStyle(.secondary)
-        .padding(.bottom, 8)
-    }
-
-    @ViewBuilder
-    private func sortableHeader(
-        _ column: RuntimeProcessTableColumn,
-        minWidth: CGFloat? = nil,
-        width: CGFloat? = nil,
-        alignment: Alignment
-    ) -> some View {
-        let header = Button {
-            sortState.cycle(column: column)
-        } label: {
-            HStack(spacing: 3) {
-                Text(column.title)
-                    .lineLimit(1)
-                sortIndicator(for: column)
-            }
-            .frame(maxWidth: .infinity, alignment: alignment)
-        }
-        .buttonStyle(.plain)
-        .help("Sort by \(column.title). Click again to reverse; click a third time to restore the default order.")
-
-        if let width {
-            header.frame(width: width, alignment: alignment)
-        } else {
-            header.frame(minWidth: minWidth ?? 0, alignment: alignment)
-        }
-    }
-
-    @ViewBuilder
-    private func sortIndicator(for column: RuntimeProcessTableColumn) -> some View {
-        if sortState.column == column {
-            Image(systemName: sortState.direction == .ascending ? "chevron.up" : "chevron.down")
-                .font(.caption2.weight(.bold))
-        } else {
-            Image(systemName: "arrow.up.arrow.down")
-                .font(.caption2)
-                .opacity(0.22)
-        }
-    }
-
-    private func processRow(_ row: RuntimeProcessSample) -> some View {
-        HStack(spacing: 12) {
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(processColor(row))
-                    .frame(width: 7, height: 7)
-                Text(row.name)
-                    .font(.callout.weight(.medium))
-                    .lineLimit(1)
-            }
-            .frame(minWidth: 110, alignment: .leading)
-
-            Text(percentString(row.cpuPercent))
-                .font(.system(.callout, design: .monospaced))
-                .frame(width: 58, alignment: .trailing)
-
-            Text(byteString(row.residentMemoryBytes))
-                .font(.system(.callout, design: .monospaced))
-                .frame(width: 82, alignment: .trailing)
-
-            Text("\(row.pid)")
-                .font(.system(.callout, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .frame(width: 54, alignment: .trailing)
-
-            Text(row.command)
-                .font(.system(.caption, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .textSelection(.enabled)
-                .frame(minWidth: 160, alignment: .leading)
-        }
-        .padding(.vertical, 8)
-    }
-
-    private func processColor(_ row: RuntimeProcessSample) -> Color {
-        if isKnownAgent(row) { return .mint }
-        if row.parentPID == 1 { return .secondary }
-        return .orange
-    }
-
-    private func isKnownAgent(_ row: RuntimeProcessSample) -> Bool {
-        let haystack = "\(row.name) \(row.command)".lowercased()
-        return ["claude", "codex", "aider", "cursor", "opencode", "pi"].contains { haystack.contains($0) }
-    }
-}
-
-private enum RuntimeResourceChartMetric: String, CaseIterable, Identifiable {
-    case cpu
-    case memory
-
-    var id: Self { self }
-
-    var title: String {
-        switch self {
-        case .cpu: "WorkSpaces app tree CPU"
-        case .memory: "WorkSpaces app tree Memory"
-        }
-    }
-
-    var optionTitle: String {
-        switch self {
-        case .cpu: "CPU"
-        case .memory: "Memory"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .cpu: "waveform.path.ecg"
-        case .memory: "memorychip"
-        }
-    }
-
-    var next: RuntimeResourceChartMetric {
-        switch self {
-        case .cpu: .memory
-        case .memory: .cpu
-        }
-    }
-
-    func value(in snapshot: RuntimeDiagnosticsSnapshot) -> Double {
-        switch self {
-        case .cpu:
-            snapshot.appTreeTotals.cpuPercent
-        case .memory:
-            Double(snapshot.appTreeTotals.residentMemoryBytes)
-        }
-    }
-
-    func peak(in history: RuntimeProcessHistory) -> Double {
-        switch self {
-        case .cpu:
-            max(history.appCPUPeak, 1)
-        case .memory:
-            max(Double(history.appMemoryPeakBytes), 1)
-        }
-    }
-
-    func formattedValue(in snapshot: RuntimeDiagnosticsSnapshot) -> String {
-        switch self {
-        case .cpu:
-            percentString(snapshot.appTreeTotals.cpuPercent)
-        case .memory:
-            byteString(snapshot.appTreeTotals.residentMemoryBytes)
-        }
-    }
-
-    func chartColor(for value: Double, isHovered: Bool) -> Color {
-        let opacity = isHovered ? 1.0 : 0.78
-        switch self {
-        case .cpu:
-            if value >= 80 { return .red.opacity(opacity) }
-            if value >= 40 { return .yellow.opacity(opacity) }
-            return .secondary.opacity(opacity)
-        case .memory:
-            return .teal.opacity(opacity)
-        }
-    }
-}
-
-private struct RuntimeResourceChart: View {
-    let history: RuntimeProcessHistory
-
-    @State private var hoveredIndex: Int?
-    @State private var selectedMetric: RuntimeResourceChartMetric = .cpu
-    @State private var isMetricSelectorHovered = false
-    @State private var isMetricDropdownVisible = false
-    @State private var metricHoverGeneration = 0
-
-    private var hoveredSnapshot: RuntimeDiagnosticsSnapshot? {
-        guard let hoveredIndex, history.snapshots.indices.contains(hoveredIndex) else {
-            return nil
-        }
-        return history.snapshots[hoveredIndex]
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .firstTextBaseline) {
-                chartMetricSelector
-
-                Spacer()
-
-                Text(hoveredSnapshot.map(sampleDescription) ?? "Hover for sample details")
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-
-            GeometryReader { proxy in
-                let snapshots = history.snapshots
-                let peakValue = selectedMetric.peak(in: history)
-                ZStack(alignment: .topTrailing) {
-                    HStack(alignment: .bottom, spacing: 3) {
-                        if snapshots.isEmpty {
-                            Rectangle()
-                                .fill(Color.secondary.opacity(0.15))
-                                .frame(height: 2)
-                        } else {
-                            ForEach(Array(snapshots.enumerated()), id: \.element.sampledAt) { index, snapshot in
-                                let value = selectedMetric.value(in: snapshot)
-                                let heightRatio = min(max(value / peakValue, 0), 1)
-                                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                                    .fill(
-                                        selectedMetric.chartColor(
-                                            for: value,
-                                            isHovered: index == hoveredIndex
-                                        )
-                                    )
-                                    .frame(
-                                        width: barWidth(totalWidth: proxy.size.width, count: snapshots.count),
-                                        height: max(2, proxy.size.height * heightRatio)
-                                    )
-                            }
-                        }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-                    .overlay(alignment: .bottom) {
-                        Rectangle()
-                            .fill(Color.secondary.opacity(0.30))
-                            .frame(height: 1)
-                    }
-
-                    if let hoveredSnapshot {
-                        chartCallout(hoveredSnapshot)
-                    }
-                }
-                .contentShape(Rectangle())
-                .onContinuousHover(coordinateSpace: .local) { phase in
-                    switch phase {
-                    case .active(let location):
-                        hoveredIndex = hoveredIndex(
-                            for: location.x,
-                            width: proxy.size.width,
-                            count: snapshots.count
-                        )
-                    case .ended:
-                        hoveredIndex = nil
-                    }
-                }
-            }
-        }
-    }
-
-    private var chartMetricSelector: some View {
-        Button {
-            selectedMetric = selectedMetric.next
-            showMetricDropdown()
-        } label: {
-            Label(selectedMetric.title, systemImage: selectedMetric.systemImage)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-        .onContinuousHover { phase in
-            switch phase {
-            case .active:
-                updateMetricSelectorHover(true)
-            case .ended:
-                updateMetricSelectorHover(false)
-            }
-        }
-        .help("Click to switch between CPU and memory. Hover to choose a metric.")
-        .accessibilityIdentifier("inspector.diagnostics.resource-chart.metric-selector")
-        .overlay(alignment: .topLeading) {
-            if isMetricDropdownVisible {
-                metricDropdown
-                    .offset(y: 20)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-                    .zIndex(1)
-            }
-        }
-        .animation(.snappy(duration: 0.14), value: isMetricDropdownVisible)
-        .animation(.snappy(duration: 0.14), value: selectedMetric)
-    }
-
-    private var metricDropdown: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            ForEach(RuntimeResourceChartMetric.allCases) { metric in
-                Button {
-                    selectedMetric = metric
-                    showMetricDropdown()
-                } label: {
-                    HStack(spacing: 7) {
-                        Image(systemName: metric.systemImage)
-                            .font(.caption2)
-                            .frame(width: 12)
-                        Text(metric.optionTitle)
-                            .font(.caption.weight(.medium))
-                        if metric == selectedMetric {
-                            Image(systemName: "checkmark")
-                                .font(.caption2.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .foregroundStyle(metric == selectedMetric ? .primary : .secondary)
-                    .frame(minWidth: 92, alignment: .leading)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .contentShape(.rect)
-                }
-                .buttonStyle(.plain)
-            }
-        }
-        .padding(4)
-        .background(Color(nsColor: .windowBackgroundColor).opacity(0.97), in: .rect(cornerRadius: 7))
-        .overlay {
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
-        }
-        .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 4)
-        .onContinuousHover { phase in
-            switch phase {
-            case .active:
-                updateMetricSelectorHover(true)
-            case .ended:
-                updateMetricSelectorHover(false)
-            }
-        }
-        .accessibilityIdentifier("inspector.diagnostics.resource-chart.metric-menu")
-    }
-
-    private func chartCallout(_ snapshot: RuntimeDiagnosticsSnapshot) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(snapshot.sampledAt.formatted(date: .omitted, time: .standard))
-                .font(.caption.weight(.semibold))
-            Text("\(selectedMetric.optionTitle) \(selectedMetric.formattedValue(in: snapshot))")
-                .font(.caption2.weight(.semibold).monospacedDigit())
-            if selectedMetric != .cpu {
-                Text("CPU \(percentString(snapshot.appTreeTotals.cpuPercent))")
-            }
-            if selectedMetric != .memory {
-                Text("Memory \(byteString(snapshot.appTreeTotals.residentMemoryBytes))")
-            }
-            Text("\(snapshot.appTreeTotals.processCount) processes")
-        }
-        .font(.caption2.monospacedDigit())
-        .padding(8)
-        .background(Color(nsColor: .windowBackgroundColor).opacity(0.92), in: .rect(cornerRadius: 7))
-        .overlay {
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .stroke(Color.secondary.opacity(0.22), lineWidth: 1)
-        }
-    }
-
-    private func barWidth(totalWidth: CGFloat, count: Int) -> CGFloat {
-        guard count > 0 else { return totalWidth }
-        return max(3, min(18, (totalWidth / CGFloat(count)) - 3))
-    }
-
-    private func hoveredIndex(for x: CGFloat, width: CGFloat, count: Int) -> Int? {
-        guard count > 0, width > 0 else { return nil }
-        let clampedX = min(max(x, 0), width)
-        let rawIndex = Int((clampedX / width) * CGFloat(count))
-        return min(max(rawIndex, 0), count - 1)
-    }
-
-    private func sampleDescription(_ snapshot: RuntimeDiagnosticsSnapshot) -> String {
-        "\(snapshot.sampledAt.formatted(date: .omitted, time: .shortened))  \(selectedMetric.optionTitle) \(selectedMetric.formattedValue(in: snapshot))"
-    }
-
-    private func showMetricDropdown() {
-        metricHoverGeneration += 1
-        isMetricDropdownVisible = true
-    }
-
-    private func updateMetricSelectorHover(_ isHovered: Bool) {
-        metricHoverGeneration += 1
-        let generation = metricHoverGeneration
-        isMetricSelectorHovered = isHovered
-
-        if isHovered {
-            isMetricDropdownVisible = true
-        } else {
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(240))
-                guard generation == metricHoverGeneration, !isMetricSelectorHovered else { return }
-                isMetricDropdownVisible = false
-            }
-        }
-    }
-}
-
 private struct AgentSessionStatusList: View {
     let statuses: [AgentSessionStatus]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("ACTIVE AGENT SESSIONS")
+            Text("ACTIVE AGENT RUNS")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
                 .padding(.bottom, 6)
 
             if sortedStatuses.isEmpty {
-                Text("No active agent sessions registered.")
+                Text("No active agent runs registered.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1111,12 +592,4 @@ private struct DiagnosticsInlineError: View {
         .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
         .accessibilityIdentifier("inspector.diagnostics.error")
     }
-}
-
-private func percentString(_ value: Double) -> String {
-    String(format: "%.1f%%", value)
-}
-
-private func byteString(_ bytes: Int64) -> String {
-    ByteCountFormatter.string(fromByteCount: bytes, countStyle: .memory)
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -149,7 +149,7 @@ struct DiagnosticsTabView: View {
     private var resourceHistorySection: some View {
         DiagnosticsPanel(title: "Resource History", accessibilityID: "inspector.diagnostics.resource-history") {
             HStack(alignment: .firstTextBaseline) {
-                Text("App tree CPU over time")
+                Text("App tree resources over time")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
 
@@ -193,7 +193,7 @@ struct DiagnosticsTabView: View {
             RuntimeResourceChart(history: viewModel.history)
                 .frame(height: 170)
                 .help(
-                    "Charts WorkSpaces app tree CPU percentage over the selected range. Hover for sample time, CPU, memory, and process count."
+                    "Charts WorkSpaces app tree CPU or memory over the selected range. Hover for sample time, CPU, memory, and process count."
                 )
                 .accessibilityIdentifier("inspector.diagnostics.resource-chart")
         }
@@ -720,10 +720,88 @@ private struct RuntimeProcessTable: View {
     }
 }
 
+private enum RuntimeResourceChartMetric: String, CaseIterable, Identifiable {
+    case cpu
+    case memory
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .cpu: "WorkSpaces app tree CPU"
+        case .memory: "WorkSpaces app tree Memory"
+        }
+    }
+
+    var optionTitle: String {
+        switch self {
+        case .cpu: "CPU"
+        case .memory: "Memory"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .cpu: "waveform.path.ecg"
+        case .memory: "memorychip"
+        }
+    }
+
+    var next: RuntimeResourceChartMetric {
+        switch self {
+        case .cpu: .memory
+        case .memory: .cpu
+        }
+    }
+
+    func value(in snapshot: RuntimeDiagnosticsSnapshot) -> Double {
+        switch self {
+        case .cpu:
+            snapshot.appTreeTotals.cpuPercent
+        case .memory:
+            Double(snapshot.appTreeTotals.residentMemoryBytes)
+        }
+    }
+
+    func peak(in history: RuntimeProcessHistory) -> Double {
+        switch self {
+        case .cpu:
+            max(history.appCPUPeak, 1)
+        case .memory:
+            max(Double(history.appMemoryPeakBytes), 1)
+        }
+    }
+
+    func formattedValue(in snapshot: RuntimeDiagnosticsSnapshot) -> String {
+        switch self {
+        case .cpu:
+            percentString(snapshot.appTreeTotals.cpuPercent)
+        case .memory:
+            byteString(snapshot.appTreeTotals.residentMemoryBytes)
+        }
+    }
+
+    func chartColor(for value: Double, isHovered: Bool) -> Color {
+        let opacity = isHovered ? 1.0 : 0.78
+        switch self {
+        case .cpu:
+            if value >= 80 { return .red.opacity(opacity) }
+            if value >= 40 { return .yellow.opacity(opacity) }
+            return .secondary.opacity(opacity)
+        case .memory:
+            return .teal.opacity(opacity)
+        }
+    }
+}
+
 private struct RuntimeResourceChart: View {
     let history: RuntimeProcessHistory
 
     @State private var hoveredIndex: Int?
+    @State private var selectedMetric: RuntimeResourceChartMetric = .cpu
+    @State private var isMetricSelectorHovered = false
+    @State private var isMetricDropdownVisible = false
+    @State private var metricHoverGeneration = 0
 
     private var hoveredSnapshot: RuntimeDiagnosticsSnapshot? {
         guard let hoveredIndex, history.snapshots.indices.contains(hoveredIndex) else {
@@ -735,9 +813,7 @@ private struct RuntimeResourceChart: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline) {
-                Label("WorkSpaces app tree CPU", systemImage: "waveform.path.ecg")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                chartMetricSelector
 
                 Spacer()
 
@@ -749,7 +825,7 @@ private struct RuntimeResourceChart: View {
 
             GeometryReader { proxy in
                 let snapshots = history.snapshots
-                let maxCPU = max(history.appCPUPeak, 1)
+                let peakValue = selectedMetric.peak(in: history)
                 ZStack(alignment: .topTrailing) {
                     HStack(alignment: .bottom, spacing: 3) {
                         if snapshots.isEmpty {
@@ -758,11 +834,14 @@ private struct RuntimeResourceChart: View {
                                 .frame(height: 2)
                         } else {
                             ForEach(Array(snapshots.enumerated()), id: \.element.sampledAt) { index, snapshot in
-                                let heightRatio = min(max(snapshot.appTreeTotals.cpuPercent / maxCPU, 0), 1)
+                                let value = selectedMetric.value(in: snapshot)
+                                let heightRatio = min(max(value / peakValue, 0), 1)
                                 RoundedRectangle(cornerRadius: 3, style: .continuous)
                                     .fill(
-                                        chartColor(
-                                            for: snapshot.appTreeTotals.cpuPercent, isHovered: index == hoveredIndex)
+                                        selectedMetric.chartColor(
+                                            for: value,
+                                            isHovered: index == hoveredIndex
+                                        )
                                     )
                                     .frame(
                                         width: barWidth(totalWidth: proxy.size.width, count: snapshots.count),
@@ -799,12 +878,97 @@ private struct RuntimeResourceChart: View {
         }
     }
 
+    private var chartMetricSelector: some View {
+        Button {
+            selectedMetric = selectedMetric.next
+            showMetricDropdown()
+        } label: {
+            Label(selectedMetric.title, systemImage: selectedMetric.systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                updateMetricSelectorHover(true)
+            case .ended:
+                updateMetricSelectorHover(false)
+            }
+        }
+        .help("Click to switch between CPU and memory. Hover to choose a metric.")
+        .accessibilityIdentifier("inspector.diagnostics.resource-chart.metric-selector")
+        .overlay(alignment: .topLeading) {
+            if isMetricDropdownVisible {
+                metricDropdown
+                    .offset(y: 20)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .zIndex(1)
+            }
+        }
+        .animation(.snappy(duration: 0.14), value: isMetricDropdownVisible)
+        .animation(.snappy(duration: 0.14), value: selectedMetric)
+    }
+
+    private var metricDropdown: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(RuntimeResourceChartMetric.allCases) { metric in
+                Button {
+                    selectedMetric = metric
+                    showMetricDropdown()
+                } label: {
+                    HStack(spacing: 7) {
+                        Image(systemName: metric.systemImage)
+                            .font(.caption2)
+                            .frame(width: 12)
+                        Text(metric.optionTitle)
+                            .font(.caption.weight(.medium))
+                        if metric == selectedMetric {
+                            Image(systemName: "checkmark")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .foregroundStyle(metric == selectedMetric ? .primary : .secondary)
+                    .frame(minWidth: 92, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.97), in: .rect(cornerRadius: 7))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 4)
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                updateMetricSelectorHover(true)
+            case .ended:
+                updateMetricSelectorHover(false)
+            }
+        }
+        .accessibilityIdentifier("inspector.diagnostics.resource-chart.metric-menu")
+    }
+
     private func chartCallout(_ snapshot: RuntimeDiagnosticsSnapshot) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(snapshot.sampledAt.formatted(date: .omitted, time: .standard))
                 .font(.caption.weight(.semibold))
-            Text("CPU \(percentString(snapshot.appTreeTotals.cpuPercent))")
-            Text("Memory \(byteString(snapshot.appTreeTotals.residentMemoryBytes))")
+            Text("\(selectedMetric.optionTitle) \(selectedMetric.formattedValue(in: snapshot))")
+                .font(.caption2.weight(.semibold).monospacedDigit())
+            if selectedMetric != .cpu {
+                Text("CPU \(percentString(snapshot.appTreeTotals.cpuPercent))")
+            }
+            if selectedMetric != .memory {
+                Text("Memory \(byteString(snapshot.appTreeTotals.residentMemoryBytes))")
+            }
             Text("\(snapshot.appTreeTotals.processCount) processes")
         }
         .font(.caption2.monospacedDigit())
@@ -821,13 +985,6 @@ private struct RuntimeResourceChart: View {
         return max(3, min(18, (totalWidth / CGFloat(count)) - 3))
     }
 
-    private func chartColor(for cpu: Double, isHovered: Bool) -> Color {
-        let opacity = isHovered ? 1.0 : 0.78
-        if cpu >= 80 { return .red.opacity(opacity) }
-        if cpu >= 40 { return .yellow.opacity(opacity) }
-        return .secondary.opacity(opacity)
-    }
-
     private func hoveredIndex(for x: CGFloat, width: CGFloat, count: Int) -> Int? {
         guard count > 0, width > 0 else { return nil }
         let clampedX = min(max(x, 0), width)
@@ -836,7 +993,28 @@ private struct RuntimeResourceChart: View {
     }
 
     private func sampleDescription(_ snapshot: RuntimeDiagnosticsSnapshot) -> String {
-        "\(snapshot.sampledAt.formatted(date: .omitted, time: .shortened))  CPU \(percentString(snapshot.appTreeTotals.cpuPercent))  Mem \(byteString(snapshot.appTreeTotals.residentMemoryBytes))"
+        "\(snapshot.sampledAt.formatted(date: .omitted, time: .shortened))  \(selectedMetric.optionTitle) \(selectedMetric.formattedValue(in: snapshot))"
+    }
+
+    private func showMetricDropdown() {
+        metricHoverGeneration += 1
+        isMetricDropdownVisible = true
+    }
+
+    private func updateMetricSelectorHover(_ isHovered: Bool) {
+        metricHoverGeneration += 1
+        let generation = metricHoverGeneration
+        isMetricSelectorHovered = isHovered
+
+        if isHovered {
+            isMetricDropdownVisible = true
+        } else {
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(240))
+                guard generation == metricHoverGeneration, !isMetricSelectorHovered else { return }
+                isMetricDropdownVisible = false
+            }
+        }
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsValueFormatting.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsValueFormatting.swift
@@ -1,0 +1,18 @@
+//
+//  DiagnosticsValueFormatting.swift
+//  WorkspaceManager
+//
+//  Shared display formatting for runtime diagnostics values.
+//
+
+import Foundation
+
+enum DiagnosticsValueFormatting {
+    static func percent(_ value: Double) -> String {
+        String(format: "%.1f%%", value)
+    }
+
+    static func bytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .memory)
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
@@ -55,6 +55,7 @@ struct MainWindowViewState {
     var didRunPerfAutoOpenNewWorkspace = false
     var didApplyFixturePreviewBootstrap = false
     var didApplyFixtureWebBootstrap = false
+    var didApplyFixtureDiagnosticsBootstrap = false
     var didResolveInitialSurface = false
     var openInEditorErrorMessage: String?
     var workspaceOperationErrorMessage: String?

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -15,13 +15,18 @@ struct RightPaneTabPolicy {
     let notificationsEnabled: Bool
 
     var visibleTabs: [RightPaneView.Tab] {
-        let canShowActivity = showActivity && notificationsEnabled
+        var tabs: [RightPaneView.Tab] = [.files]
         if supportsFilesystemInspection {
-            return canShowActivity
-                ? RightPaneView.Tab.allCases
-                : RightPaneView.Tab.allCases.filter { $0 != .activity }
+            tabs.append(.changes)
         }
-        return canShowActivity ? [.activity] : [.files]
+
+        let canShowActivity = showActivity && notificationsEnabled
+        if canShowActivity {
+            tabs.append(.activity)
+        }
+
+        tabs.append(.diagnostics)
+        return tabs
     }
 
     func normalizedSelection(for selectedTab: RightPaneView.Tab) -> RightPaneView.Tab {
@@ -29,6 +34,40 @@ struct RightPaneTabPolicy {
             return selectedTab
         }
         return visibleTabs[0]
+    }
+}
+
+struct RightPaneWidth: Equatable {
+    let minimum: CGFloat
+    let ideal: CGFloat
+    let maximum: CGFloat
+}
+
+struct RightPaneWidthPolicy {
+    func width(for selectedTab: RightPaneView.Tab) -> RightPaneWidth {
+        selectedTab == .diagnostics
+            ? RightPaneWidth(minimum: 360, ideal: 640, maximum: 760)
+            : RightPaneWidth(minimum: 220, ideal: 280, maximum: 400)
+    }
+}
+
+private struct RightPaneWidthModifier: ViewModifier {
+    @ObservedObject var state: RightPaneSessionState
+    private let policy = RightPaneWidthPolicy()
+
+    func body(content: Content) -> some View {
+        let width = policy.width(for: state.selectedTab)
+        content.frame(
+            minWidth: width.minimum,
+            idealWidth: width.ideal,
+            maxWidth: width.maximum
+        )
+    }
+}
+
+extension View {
+    func rightPaneWidth(for state: RightPaneSessionState) -> some View {
+        modifier(RightPaneWidthModifier(state: state))
     }
 }
 
@@ -74,6 +113,8 @@ struct RightPaneView: View {
     let targetID: String
     let directoryURL: URL?
     let onFileSelected: (CodePreviewSelection) -> Void
+    let diagnosticWorkspaceDirectories: [URL]
+    let agentStatuses: [AgentSessionStatus]
     private let showActivity: Bool
     private let supportsFilesystemInspection: Bool
 
@@ -87,12 +128,14 @@ struct RightPaneView: View {
         case files = "Files"
         case changes = "Changes"
         case activity = "Activity"
+        case diagnostics = "Diagnostics"
 
         var icon: String {
             switch self {
             case .files: return "folder"
             case .changes: return "arrow.triangle.2.circlepath"
             case .activity: return "bell"
+            case .diagnostics: return "waveform.path.ecg"
             }
         }
     }
@@ -100,12 +143,16 @@ struct RightPaneView: View {
     init(
         workspace: Workspace,
         state: RightPaneSessionState,
+        diagnosticWorkspaceDirectories: [URL] = [],
+        agentStatuses: [AgentSessionStatus] = [],
         onFileSelected: @escaping (CodePreviewSelection) -> Void = { _ in }
     ) {
         self.targetID = "workspace-\(workspace.id.uuidString)"
         self.directoryURL = workspace.localDirectoryURL
         self.state = state
         self.onFileSelected = onFileSelected
+        self.diagnosticWorkspaceDirectories = diagnosticWorkspaceDirectories
+        self.agentStatuses = agentStatuses
         self.showActivity = true
         self.supportsFilesystemInspection = workspace.localDirectoryURL != nil
     }
@@ -113,12 +160,16 @@ struct RightPaneView: View {
     init(
         repo: Repo,
         state: RightPaneSessionState,
+        diagnosticWorkspaceDirectories: [URL] = [],
+        agentStatuses: [AgentSessionStatus] = [],
         onFileSelected: @escaping (CodePreviewSelection) -> Void = { _ in }
     ) {
         self.targetID = "repo-\(repo.id.uuidString)"
         self.directoryURL = repo.localURL
         self.state = state
         self.onFileSelected = onFileSelected
+        self.diagnosticWorkspaceDirectories = diagnosticWorkspaceDirectories
+        self.agentStatuses = agentStatuses
         self.showActivity = false
         self.supportsFilesystemInspection = true
     }
@@ -183,6 +234,11 @@ struct RightPaneView: View {
                         isConnected: notificationCoordinator.isStreamConnected,
                         authState: notificationCoordinator.authState
                     )
+                case .diagnostics:
+                    DiagnosticsTabView(
+                        workspaceDirectories: diagnosticWorkspaceDirectories,
+                        agentStatuses: agentStatuses
+                    )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -195,6 +251,13 @@ struct RightPaneView: View {
                         .fill(notificationCoordinator.isStreamConnected ? Color.mint : Color.secondary)
                         .frame(width: 6, height: 6)
                     Text(notificationCoordinator.isStreamConnected ? "Connected" : "Disconnected")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if displayedTab == .diagnostics {
+                    Circle()
+                        .fill(Color.mint)
+                        .frame(width: 6, height: 6)
+                    Text("Live runtime diagnostics")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else if state.isLoading {
@@ -211,7 +274,7 @@ struct RightPaneView: View {
 
                 Spacer()
 
-                if supportsFilesystemInspection, displayedTab != .activity {
+                if supportsFilesystemInspection, displayedTab == .files || displayedTab == .changes {
                     Button {
                         Task { await refresh() }
                     } label: {
@@ -273,6 +336,8 @@ struct RightPaneView: View {
         case .activity:
             let count = notificationCoordinator.unseenEventCount
             return count > 0 ? count : nil
+        case .diagnostics:
+            return nil
         }
     }
 
@@ -373,6 +438,8 @@ struct RightPaneView: View {
             return notificationCoordinator.isStreamConnected
                 ? "Live workspace activity"
                 : "Activity stream disconnected"
+        case .diagnostics:
+            return "Runtime health and process history"
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -2,7 +2,7 @@
 //  RightPaneView.swift
 //  WorkspaceManager
 //
-//  Collapsible right pane with Files and Changes tabs
+//  Collapsible Detail Pane with Files, Changes, Activity, and Diagnostics tabs.
 //
 
 import AppKit
@@ -179,7 +179,7 @@ struct RightPaneView: View {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Inspector")
+                        Text("Detail Pane")
                             .font(.headline)
 
                         Text(summaryText)
@@ -198,7 +198,7 @@ struct RightPaneView: View {
                     }
                 }
 
-                Picker("Inspector Tab", selection: selectedTabBinding) {
+                Picker("Detail Pane Tab", selection: selectedTabBinding) {
                     ForEach(visibleTabs, id: \.self) { tab in
                         Text(tab.rawValue)
                             .tag(tab)
@@ -264,7 +264,7 @@ struct RightPaneView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .help(
-                            "Diagnostics starts a 5-second in-memory process sampler only while this tab is visible. Samples are not persisted."
+                            "Diagnostics starts a 5-second in-memory process sampler only while this tab is visible. Trace counts come from existing telemetry; process samples are not persisted."
                         )
                 } else if state.isLoading {
                     ProgressView()

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -257,9 +257,15 @@ struct RightPaneView: View {
                     Circle()
                         .fill(Color.mint)
                         .frame(width: 6, height: 6)
-                    Text("Live runtime diagnostics")
+                    Text("Sampling while open")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    Image(systemName: "info.circle")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .help(
+                            "Diagnostics starts a 5-second in-memory process sampler only while this tab is visible. Samples are not persisted."
+                        )
                 } else if state.isLoading {
                     ProgressView()
                         .controlSize(.small)

--- a/Sources/WorkspaceManager/Views/MainWindow/RuntimeProcessTable.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RuntimeProcessTable.swift
@@ -1,0 +1,236 @@
+//
+//  RuntimeProcessTable.swift
+//  WorkspaceManager
+//
+//  Sortable process table used by the Diagnostics Detail Pane tab.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+enum RuntimeProcessTableColumn: CaseIterable {
+    case name
+    case cpu
+    case memory
+    case pid
+    case command
+
+    var title: String {
+        switch self {
+        case .name: return "Name"
+        case .cpu: return "CPU"
+        case .memory: return "Memory"
+        case .pid: return "PID"
+        case .command: return "Command"
+        }
+    }
+}
+
+enum RuntimeProcessSortDirection {
+    case ascending
+    case descending
+}
+
+struct RuntimeProcessTableSortState: Equatable {
+    var column: RuntimeProcessTableColumn?
+    var direction: RuntimeProcessSortDirection?
+
+    mutating func cycle(column nextColumn: RuntimeProcessTableColumn) {
+        if column != nextColumn {
+            column = nextColumn
+            direction = .ascending
+            return
+        }
+
+        switch direction {
+        case .ascending:
+            direction = .descending
+        case .descending:
+            column = nil
+            direction = nil
+        case nil:
+            direction = .ascending
+        }
+    }
+
+    func sorted(_ rows: [RuntimeProcessSample]) -> [RuntimeProcessSample] {
+        guard let column, let direction else { return rows }
+
+        return rows.enumerated().sorted { lhs, rhs in
+            let comparison = compare(lhs.element, rhs.element, by: column)
+            guard comparison != .orderedSame else {
+                return lhs.offset < rhs.offset
+            }
+
+            switch direction {
+            case .ascending:
+                return comparison == .orderedAscending
+            case .descending:
+                return comparison == .orderedDescending
+            }
+        }
+        .map(\.element)
+    }
+
+    private func compare(
+        _ lhs: RuntimeProcessSample,
+        _ rhs: RuntimeProcessSample,
+        by column: RuntimeProcessTableColumn
+    ) -> ComparisonResult {
+        switch column {
+        case .name:
+            return lhs.name.localizedStandardCompare(rhs.name)
+        case .cpu:
+            return compare(lhs.cpuPercent, rhs.cpuPercent)
+        case .memory:
+            return compare(lhs.residentMemoryBytes, rhs.residentMemoryBytes)
+        case .pid:
+            return compare(lhs.pid, rhs.pid)
+        case .command:
+            return lhs.command.localizedStandardCompare(rhs.command)
+        }
+    }
+
+    private func compare<T: Comparable>(_ lhs: T, _ rhs: T) -> ComparisonResult {
+        if lhs < rhs { return .orderedAscending }
+        if lhs > rhs { return .orderedDescending }
+        return .orderedSame
+    }
+}
+
+struct RuntimeProcessTable: View {
+    let rows: [RuntimeProcessSample]
+    let emptyText: String
+    let accessibilityID: String
+
+    @State private var sortState = RuntimeProcessTableSortState()
+
+    private var displayedRows: [RuntimeProcessSample] {
+        sortState.sorted(rows)
+    }
+
+    private var visibleRows: [RuntimeProcessSample] {
+        Array(displayedRows.prefix(10))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            tableHeader
+
+            if rows.isEmpty {
+                Text(emptyText)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 14)
+            } else {
+                ForEach(Array(visibleRows.enumerated()), id: \.offset) { index, row in
+                    processRow(row)
+                    if index < visibleRows.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(accessibilityID)
+    }
+
+    private var tableHeader: some View {
+        HStack(spacing: 12) {
+            sortableHeader(.name, minWidth: 110, alignment: .leading)
+            sortableHeader(.cpu, width: 58, alignment: .trailing)
+            sortableHeader(.memory, width: 82, alignment: .trailing)
+            sortableHeader(.pid, width: 54, alignment: .trailing)
+            sortableHeader(.command, minWidth: 160, alignment: .leading)
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private func sortableHeader(
+        _ column: RuntimeProcessTableColumn,
+        minWidth: CGFloat? = nil,
+        width: CGFloat? = nil,
+        alignment: Alignment
+    ) -> some View {
+        let header = Button {
+            sortState.cycle(column: column)
+        } label: {
+            HStack(spacing: 3) {
+                Text(column.title)
+                    .lineLimit(1)
+                sortIndicator(for: column)
+            }
+            .frame(maxWidth: .infinity, alignment: alignment)
+        }
+        .buttonStyle(.plain)
+        .help("Sort by \(column.title). Click again to reverse; click a third time to restore the default order.")
+
+        if let width {
+            header.frame(width: width, alignment: alignment)
+        } else {
+            header.frame(minWidth: minWidth ?? 0, alignment: alignment)
+        }
+    }
+
+    @ViewBuilder
+    private func sortIndicator(for column: RuntimeProcessTableColumn) -> some View {
+        if sortState.column == column {
+            Image(systemName: sortState.direction == .ascending ? "chevron.up" : "chevron.down")
+                .font(.caption2.weight(.bold))
+        } else {
+            Image(systemName: "arrow.up.arrow.down")
+                .font(.caption2)
+                .opacity(0.22)
+        }
+    }
+
+    private func processRow(_ row: RuntimeProcessSample) -> some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(processColor(row))
+                    .frame(width: 7, height: 7)
+                Text(row.name)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+            }
+            .frame(minWidth: 110, alignment: .leading)
+
+            Text(DiagnosticsValueFormatting.percent(row.cpuPercent))
+                .font(.system(.callout, design: .monospaced))
+                .frame(width: 58, alignment: .trailing)
+
+            Text(DiagnosticsValueFormatting.bytes(row.residentMemoryBytes))
+                .font(.system(.callout, design: .monospaced))
+                .frame(width: 82, alignment: .trailing)
+
+            Text("\(row.pid)")
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 54, alignment: .trailing)
+
+            Text(row.command)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+                .frame(minWidth: 160, alignment: .leading)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func processColor(_ row: RuntimeProcessSample) -> Color {
+        if isKnownAgent(row) { return .mint }
+        if row.parentPID == 1 { return .secondary }
+        return .orange
+    }
+
+    private func isKnownAgent(_ row: RuntimeProcessSample) -> Bool {
+        let haystack = "\(row.name) \(row.command)".lowercased()
+        return ["claude", "codex", "aider", "cursor", "opencode", "pi"].contains { haystack.contains($0) }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/RuntimeResourceChart.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RuntimeResourceChart.swift
@@ -1,0 +1,307 @@
+//
+//  RuntimeResourceChart.swift
+//  WorkspaceManager
+//
+//  CPU and memory history chart for the Diagnostics Detail Pane tab.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+private enum RuntimeResourceChartMetric: String, CaseIterable, Identifiable {
+    case cpu
+    case memory
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .cpu: "WorkSpaces app tree CPU"
+        case .memory: "WorkSpaces app tree Memory"
+        }
+    }
+
+    var optionTitle: String {
+        switch self {
+        case .cpu: "CPU"
+        case .memory: "Memory"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .cpu: "waveform.path.ecg"
+        case .memory: "memorychip"
+        }
+    }
+
+    var next: RuntimeResourceChartMetric {
+        switch self {
+        case .cpu: .memory
+        case .memory: .cpu
+        }
+    }
+
+    func value(in snapshot: RuntimeDiagnosticsSnapshot) -> Double {
+        switch self {
+        case .cpu:
+            snapshot.appTreeTotals.cpuPercent
+        case .memory:
+            Double(snapshot.appTreeTotals.residentMemoryBytes)
+        }
+    }
+
+    func peak(in history: RuntimeProcessHistory) -> Double {
+        switch self {
+        case .cpu:
+            max(history.appCPUPeak, 1)
+        case .memory:
+            max(Double(history.appMemoryPeakBytes), 1)
+        }
+    }
+
+    func formattedValue(in snapshot: RuntimeDiagnosticsSnapshot) -> String {
+        switch self {
+        case .cpu:
+            DiagnosticsValueFormatting.percent(snapshot.appTreeTotals.cpuPercent)
+        case .memory:
+            DiagnosticsValueFormatting.bytes(snapshot.appTreeTotals.residentMemoryBytes)
+        }
+    }
+
+    func chartColor(for value: Double, isHovered: Bool) -> Color {
+        let opacity = isHovered ? 1.0 : 0.78
+        switch self {
+        case .cpu:
+            if value >= 80 { return .red.opacity(opacity) }
+            if value >= 40 { return .yellow.opacity(opacity) }
+            return .secondary.opacity(opacity)
+        case .memory:
+            return .teal.opacity(opacity)
+        }
+    }
+}
+
+struct RuntimeResourceChart: View {
+    let history: RuntimeProcessHistory
+
+    @State private var hoveredIndex: Int?
+    @State private var selectedMetric: RuntimeResourceChartMetric = .cpu
+    @State private var isMetricSelectorHovered = false
+    @State private var isMetricDropdownVisible = false
+    @State private var metricHoverGeneration = 0
+
+    private var hoveredSnapshot: RuntimeDiagnosticsSnapshot? {
+        guard let hoveredIndex, history.snapshots.indices.contains(hoveredIndex) else {
+            return nil
+        }
+        return history.snapshots[hoveredIndex]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                chartMetricSelector
+
+                Spacer()
+
+                Text(hoveredSnapshot.map(sampleDescription) ?? "Hover for sample details")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            GeometryReader { proxy in
+                let snapshots = history.snapshots
+                let peakValue = selectedMetric.peak(in: history)
+                ZStack(alignment: .topTrailing) {
+                    HStack(alignment: .bottom, spacing: 3) {
+                        if snapshots.isEmpty {
+                            Rectangle()
+                                .fill(Color.secondary.opacity(0.15))
+                                .frame(height: 2)
+                        } else {
+                            ForEach(Array(snapshots.enumerated()), id: \.element.sampledAt) { index, snapshot in
+                                let value = selectedMetric.value(in: snapshot)
+                                let heightRatio = min(max(value / peakValue, 0), 1)
+                                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                    .fill(
+                                        selectedMetric.chartColor(
+                                            for: value,
+                                            isHovered: index == hoveredIndex
+                                        )
+                                    )
+                                    .frame(
+                                        width: barWidth(totalWidth: proxy.size.width, count: snapshots.count),
+                                        height: max(2, proxy.size.height * heightRatio)
+                                    )
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .fill(Color.secondary.opacity(0.30))
+                            .frame(height: 1)
+                    }
+
+                    if let hoveredSnapshot {
+                        chartCallout(hoveredSnapshot)
+                    }
+                }
+                .contentShape(Rectangle())
+                .onContinuousHover(coordinateSpace: .local) { phase in
+                    switch phase {
+                    case .active(let location):
+                        hoveredIndex = hoveredIndex(
+                            for: location.x,
+                            width: proxy.size.width,
+                            count: snapshots.count
+                        )
+                    case .ended:
+                        hoveredIndex = nil
+                    }
+                }
+            }
+        }
+    }
+
+    private var chartMetricSelector: some View {
+        Button {
+            selectedMetric = selectedMetric.next
+            showMetricDropdown()
+        } label: {
+            Label(selectedMetric.title, systemImage: selectedMetric.systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                updateMetricSelectorHover(true)
+            case .ended:
+                updateMetricSelectorHover(false)
+            }
+        }
+        .help("Click to switch between CPU and memory. Hover to choose a metric.")
+        .accessibilityIdentifier("inspector.diagnostics.resource-chart.metric-selector")
+        .overlay(alignment: .topLeading) {
+            if isMetricDropdownVisible {
+                metricDropdown
+                    .offset(y: 20)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .zIndex(1)
+            }
+        }
+        .animation(.snappy(duration: 0.14), value: isMetricDropdownVisible)
+        .animation(.snappy(duration: 0.14), value: selectedMetric)
+    }
+
+    private var metricDropdown: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(RuntimeResourceChartMetric.allCases) { metric in
+                Button {
+                    selectedMetric = metric
+                    showMetricDropdown()
+                } label: {
+                    HStack(spacing: 7) {
+                        Image(systemName: metric.systemImage)
+                            .font(.caption2)
+                            .frame(width: 12)
+                        Text(metric.optionTitle)
+                            .font(.caption.weight(.medium))
+                        if metric == selectedMetric {
+                            Image(systemName: "checkmark")
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .foregroundStyle(metric == selectedMetric ? .primary : .secondary)
+                    .frame(minWidth: 92, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .contentShape(.rect)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.97), in: .rect(cornerRadius: 7))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 1)
+        }
+        .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 4)
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                updateMetricSelectorHover(true)
+            case .ended:
+                updateMetricSelectorHover(false)
+            }
+        }
+        .accessibilityIdentifier("inspector.diagnostics.resource-chart.metric-menu")
+    }
+
+    private func chartCallout(_ snapshot: RuntimeDiagnosticsSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(snapshot.sampledAt.formatted(date: .omitted, time: .standard))
+                .font(.caption.weight(.semibold))
+            Text("\(selectedMetric.optionTitle) \(selectedMetric.formattedValue(in: snapshot))")
+                .font(.caption2.weight(.semibold).monospacedDigit())
+            if selectedMetric != .cpu {
+                Text("CPU \(DiagnosticsValueFormatting.percent(snapshot.appTreeTotals.cpuPercent))")
+            }
+            if selectedMetric != .memory {
+                Text("Memory \(DiagnosticsValueFormatting.bytes(snapshot.appTreeTotals.residentMemoryBytes))")
+            }
+            Text("\(snapshot.appTreeTotals.processCount) processes")
+        }
+        .font(.caption2.monospacedDigit())
+        .padding(8)
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.92), in: .rect(cornerRadius: 7))
+        .overlay {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .stroke(Color.secondary.opacity(0.22), lineWidth: 1)
+        }
+    }
+
+    private func barWidth(totalWidth: CGFloat, count: Int) -> CGFloat {
+        guard count > 0 else { return totalWidth }
+        return max(3, min(18, (totalWidth / CGFloat(count)) - 3))
+    }
+
+    private func hoveredIndex(for x: CGFloat, width: CGFloat, count: Int) -> Int? {
+        guard count > 0, width > 0 else { return nil }
+        let clampedX = min(max(x, 0), width)
+        let rawIndex = Int((clampedX / width) * CGFloat(count))
+        return min(max(rawIndex, 0), count - 1)
+    }
+
+    private func sampleDescription(_ snapshot: RuntimeDiagnosticsSnapshot) -> String {
+        "\(snapshot.sampledAt.formatted(date: .omitted, time: .shortened))  \(selectedMetric.optionTitle) \(selectedMetric.formattedValue(in: snapshot))"
+    }
+
+    private func showMetricDropdown() {
+        metricHoverGeneration += 1
+        isMetricDropdownVisible = true
+    }
+
+    private func updateMetricSelectorHover(_ isHovered: Bool) {
+        metricHoverGeneration += 1
+        let generation = metricHoverGeneration
+        isMetricSelectorHovered = isHovered
+
+        if isHovered {
+            isMetricDropdownVisible = true
+        } else {
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(240))
+                guard generation == metricHoverGeneration, !isMetricSelectorHovered else { return }
+                isMetricDropdownVisible = false
+            }
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/UIFixtureDiagnosticsBootstrap.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/UIFixtureDiagnosticsBootstrap.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct UIFixtureDiagnosticsBootstrapConfiguration: Equatable, Sendable {
+    static let flagKey = "WORKSPACES_UI_FIXTURE_OPEN_DIAGNOSTICS"
+
+    static func from(environment: [String: String]) -> Self? {
+        guard environment["WORKSPACES_UI_FIXTURE"] == "1" else { return nil }
+        guard enabled(environment[flagKey]) else { return nil }
+        return Self()
+    }
+
+    private static func enabled(_ rawValue: String?) -> Bool {
+        guard let rawValue else { return false }
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["1", "true", "yes", "on"].contains(value)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
+++ b/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
@@ -2,7 +2,7 @@
 //  RuntimeDiagnostics.swift
 //  WorkspaceManagerCore
 //
-//  Lightweight process and trace diagnostics for the WorkSpaces inspector.
+//  Lightweight process and trace diagnostics for the WorkSpaces Detail Pane.
 //
 
 import Foundation

--- a/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
+++ b/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
@@ -1,0 +1,573 @@
+//
+//  RuntimeDiagnostics.swift
+//  WorkspaceManagerCore
+//
+//  Lightweight process and trace diagnostics for the WorkSpaces inspector.
+//
+
+import Foundation
+
+public struct RuntimeProcessSample: Codable, Equatable, Identifiable, Sendable {
+    public var id: Int32 { pid }
+
+    public let pid: Int32
+    public let parentPID: Int32
+    public let name: String
+    public let command: String
+    public let cpuPercent: Double
+    public let residentMemoryBytes: Int64
+    public let cpuTimeSeconds: TimeInterval
+    public let currentDirectory: String?
+
+    public init(
+        pid: Int32,
+        parentPID: Int32,
+        name: String,
+        command: String,
+        cpuPercent: Double,
+        residentMemoryBytes: Int64,
+        cpuTimeSeconds: TimeInterval = 0,
+        currentDirectory: String? = nil
+    ) {
+        self.pid = pid
+        self.parentPID = parentPID
+        self.name = name
+        self.command = command
+        self.cpuPercent = cpuPercent
+        self.residentMemoryBytes = residentMemoryBytes
+        self.cpuTimeSeconds = cpuTimeSeconds
+        self.currentDirectory = currentDirectory
+    }
+}
+
+public struct RuntimeResourceTotals: Codable, Equatable, Sendable {
+    public let processCount: Int
+    public let cpuPercent: Double
+    public let residentMemoryBytes: Int64
+    public let cpuTimeSeconds: TimeInterval
+
+    public init(
+        processCount: Int,
+        cpuPercent: Double,
+        residentMemoryBytes: Int64,
+        cpuTimeSeconds: TimeInterval
+    ) {
+        self.processCount = processCount
+        self.cpuPercent = cpuPercent
+        self.residentMemoryBytes = residentMemoryBytes
+        self.cpuTimeSeconds = cpuTimeSeconds
+    }
+
+    public static let empty = RuntimeResourceTotals(
+        processCount: 0,
+        cpuPercent: 0,
+        residentMemoryBytes: 0,
+        cpuTimeSeconds: 0
+    )
+}
+
+public struct RuntimeDiagnosticsSnapshot: Codable, Equatable, Sendable {
+    public let sampledAt: Date
+    public let appPID: Int32
+    public let allProcesses: [RuntimeProcessSample]
+    public let appTreeProcesses: [RuntimeProcessSample]
+    public let appTreeTotals: RuntimeResourceTotals
+    public let workspaceProcesses: [RuntimeProcessSample]
+    public let workspaceTotals: RuntimeResourceTotals
+    public let errorMessage: String?
+
+    public init(
+        sampledAt: Date,
+        appPID: Int32,
+        allProcesses: [RuntimeProcessSample],
+        appTreeProcesses: [RuntimeProcessSample],
+        appTreeTotals: RuntimeResourceTotals,
+        workspaceProcesses: [RuntimeProcessSample],
+        workspaceTotals: RuntimeResourceTotals,
+        errorMessage: String? = nil
+    ) {
+        self.sampledAt = sampledAt
+        self.appPID = appPID
+        self.allProcesses = allProcesses
+        self.appTreeProcesses = appTreeProcesses
+        self.appTreeTotals = appTreeTotals
+        self.workspaceProcesses = workspaceProcesses
+        self.workspaceTotals = workspaceTotals
+        self.errorMessage = errorMessage
+    }
+}
+
+public struct RuntimeProcessHistory: Equatable, Sendable {
+    public let snapshots: [RuntimeDiagnosticsSnapshot]
+
+    public init(snapshots: [RuntimeDiagnosticsSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    public var sampleCount: Int { snapshots.count }
+
+    public var latest: RuntimeDiagnosticsSnapshot? { snapshots.last }
+
+    public var appCPUAverage: Double {
+        average { $0.appTreeTotals.cpuPercent }
+    }
+
+    public var appCPUPeak: Double {
+        snapshots.map(\.appTreeTotals.cpuPercent).max() ?? 0
+    }
+
+    public var appMemoryPeakBytes: Int64 {
+        snapshots.map(\.appTreeTotals.residentMemoryBytes).max() ?? 0
+    }
+
+    public var workspaceCPUAverage: Double {
+        average { $0.workspaceTotals.cpuPercent }
+    }
+
+    public var workspaceCPUPeak: Double {
+        snapshots.map(\.workspaceTotals.cpuPercent).max() ?? 0
+    }
+
+    public var workspaceMemoryPeakBytes: Int64 {
+        snapshots.map(\.workspaceTotals.residentMemoryBytes).max() ?? 0
+    }
+
+    private func average(_ value: (RuntimeDiagnosticsSnapshot) -> Double) -> Double {
+        guard !snapshots.isEmpty else { return 0 }
+        return snapshots.map(value).reduce(0, +) / Double(snapshots.count)
+    }
+}
+
+public struct RuntimeDiagnosticFailure: Equatable, Identifiable, Sendable {
+    public let id: String
+    public let timestamp: Date
+    public let title: String
+    public let detail: String
+
+    public init(id: String, timestamp: Date, title: String, detail: String) {
+        self.id = id
+        self.timestamp = timestamp
+        self.title = title
+        self.detail = detail
+    }
+}
+
+public struct RuntimeDiagnosticsSummary: Equatable, Sendable {
+    public let spanCount: Int
+    public let failureCount: Int
+    public let slowSpanCount: Int
+    public let parseErrorCount: Int
+    public let activeAgentSessionCount: Int
+    public let latestFailures: [RuntimeDiagnosticFailure]
+
+    public init(
+        spanCount: Int,
+        failureCount: Int,
+        slowSpanCount: Int,
+        parseErrorCount: Int,
+        activeAgentSessionCount: Int,
+        latestFailures: [RuntimeDiagnosticFailure]
+    ) {
+        self.spanCount = spanCount
+        self.failureCount = failureCount
+        self.slowSpanCount = slowSpanCount
+        self.parseErrorCount = parseErrorCount
+        self.activeAgentSessionCount = activeAgentSessionCount
+        self.latestFailures = latestFailures
+    }
+
+    public static func make(
+        events: [StartupDiagnosticsStore.DiagnosticEvent],
+        agentStatuses: [AgentSessionStatus],
+        slowSpanThresholdMs: Double = 1_000,
+        maxFailures: Int = 5
+    ) -> RuntimeDiagnosticsSummary {
+        let eventFailures = events.enumerated().compactMap { index, event -> RuntimeDiagnosticFailure? in
+            guard isFailure(event) else { return nil }
+            let reason =
+                event.labels["failure_reason"]
+                ?? event.labels["outcome"]
+                ?? event.labels["error"]
+                ?? "failed"
+            return RuntimeDiagnosticFailure(
+                id: "event-\(index)-\(event.timestamp.timeIntervalSinceReferenceDate)",
+                timestamp: event.timestamp,
+                title: event.metric,
+                detail: reason
+            )
+        }
+
+        let agentFailures = agentStatuses.compactMap { status -> RuntimeDiagnosticFailure? in
+            guard case .errored(let category, let message) = status.run else { return nil }
+            return RuntimeDiagnosticFailure(
+                id: "agent-\(status.hostSessionID.uuidString)",
+                timestamp: status.lastEventAt,
+                title: "\(status.kind.rawValue) \(category.rawValue)",
+                detail: message ?? status.cwd
+            )
+        }
+
+        let latestFailures = (eventFailures + agentFailures)
+            .sorted { $0.timestamp > $1.timestamp }
+            .prefix(maxFailures)
+
+        return RuntimeDiagnosticsSummary(
+            spanCount: events.count,
+            failureCount: eventFailures.count + agentFailures.count,
+            slowSpanCount: events.filter { $0.durationMs >= slowSpanThresholdMs }.count,
+            parseErrorCount: events.filter(Self.isParseError).count,
+            activeAgentSessionCount: agentStatuses.filter { status in
+                if case .complete = status.run { return false }
+                return true
+            }.count,
+            latestFailures: Array(latestFailures)
+        )
+    }
+
+    private static func isFailure(_ event: StartupDiagnosticsStore.DiagnosticEvent) -> Bool {
+        if event.labels["failure_reason"] != nil || event.labels["error"] != nil {
+            return true
+        }
+        if let outcome = event.labels["outcome"]?.lowercased() {
+            return outcome.contains("failure") || outcome == "failed"
+        }
+        return event.metric.lowercased().contains("failure")
+    }
+
+    private static func isParseError(_ event: StartupDiagnosticsStore.DiagnosticEvent) -> Bool {
+        let metric = event.metric.lowercased()
+        guard metric.contains("parse") else { return false }
+        return isFailure(event) || metric.contains("error")
+    }
+}
+
+public protocol RuntimeProcessSnapshotProviding: Sendable {
+    func processes() async throws -> [RuntimeProcessSample]
+}
+
+public struct LiveRuntimeProcessSnapshotProvider: RuntimeProcessSnapshotProviding {
+    public init() {}
+
+    public func processes() async throws -> [RuntimeProcessSample] {
+        async let processOutput = ProcessRunner.run(
+            executable: "/bin/ps",
+            arguments: ["-axo", "pid=,ppid=,pcpu=,rss=,time=,comm=,args="]
+        )
+        async let cwdOutput = ProcessRunner.run(
+            executable: "/usr/sbin/lsof",
+            arguments: ["-d", "cwd", "-F", "pcn"]
+        )
+
+        let processResult = try await processOutput
+        guard processResult.exitCode == 0 else {
+            throw RuntimeDiagnosticsError.commandFailed(
+                command: "ps",
+                stderr: processResult.stderr
+            )
+        }
+
+        let cwdByPID: [Int32: String]
+        do {
+            let cwdResult = try await cwdOutput
+            cwdByPID =
+                cwdResult.exitCode == 0
+                ? RuntimeDiagnosticsParser.parseLsofCWDs(cwdResult.stdout)
+                : [:]
+        } catch {
+            cwdByPID = [:]
+        }
+
+        return RuntimeDiagnosticsParser.parsePS(processResult.stdout, cwdByPID: cwdByPID)
+    }
+}
+
+public enum RuntimeDiagnosticsError: Error, CustomStringConvertible, Equatable, Sendable {
+    case commandFailed(command: String, stderr: String)
+
+    public var description: String {
+        switch self {
+        case .commandFailed(let command, let stderr):
+            let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty
+                ? "\(command) failed while collecting diagnostics."
+                : "\(command) failed while collecting diagnostics: \(trimmed)"
+        }
+    }
+}
+
+public enum RuntimeDiagnosticsParser {
+    public static func parsePS(
+        _ output: String,
+        cwdByPID: [Int32: String] = [:]
+    ) -> [RuntimeProcessSample] {
+        output.split(separator: "\n").compactMap { line in
+            parsePSLine(String(line), cwdByPID: cwdByPID)
+        }
+    }
+
+    static func parsePSLine(
+        _ line: String,
+        cwdByPID: [Int32: String]
+    ) -> RuntimeProcessSample? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let parts = trimmed.split(separator: " ", maxSplits: 6, omittingEmptySubsequences: true)
+        guard
+            parts.count >= 6,
+            let pid = Int32(parts[0]),
+            let parentPID = Int32(parts[1]),
+            let cpuPercent = Double(parts[2]),
+            let residentMemoryKB = Int64(parts[3])
+        else {
+            return nil
+        }
+
+        let cpuTimeSeconds = parseCPUTime(String(parts[4]))
+        let name = String(parts[5])
+        let command = parts.count >= 7 ? String(parts[6]) : name
+
+        return RuntimeProcessSample(
+            pid: pid,
+            parentPID: parentPID,
+            name: name,
+            command: command,
+            cpuPercent: cpuPercent,
+            residentMemoryBytes: residentMemoryKB * 1_024,
+            cpuTimeSeconds: cpuTimeSeconds,
+            currentDirectory: cwdByPID[pid]
+        )
+    }
+
+    public static func parseLsofCWDs(_ output: String) -> [Int32: String] {
+        var result: [Int32: String] = [:]
+        var currentPID: Int32?
+
+        for rawLine in output.split(separator: "\n") {
+            let line = String(rawLine)
+            guard let prefix = line.first else { continue }
+            let value = String(line.dropFirst())
+
+            switch prefix {
+            case "p":
+                currentPID = Int32(value)
+            case "n":
+                if let currentPID {
+                    result[currentPID] = value
+                }
+            default:
+                break
+            }
+        }
+
+        return result
+    }
+
+    public static func parseCPUTime(_ value: String) -> TimeInterval {
+        let daySplit = value.split(separator: "-", maxSplits: 1)
+        let dayCount: Int
+        let timePart: Substring
+        if daySplit.count == 2 {
+            dayCount = Int(daySplit[0]) ?? 0
+            timePart = daySplit[1]
+        } else {
+            dayCount = 0
+            timePart = Substring(value)
+        }
+
+        let parts = timePart.split(separator: ":").compactMap { Double($0) }
+        let seconds: Double
+        switch parts.count {
+        case 3:
+            seconds = (parts[0] * 3_600) + (parts[1] * 60) + parts[2]
+        case 2:
+            seconds = (parts[0] * 60) + parts[1]
+        case 1:
+            seconds = parts[0]
+        default:
+            seconds = 0
+        }
+
+        return Double(dayCount * 86_400) + seconds
+    }
+}
+
+public actor RuntimeDiagnosticsSampler {
+    public static let shared = RuntimeDiagnosticsSampler()
+
+    private let provider: any RuntimeProcessSnapshotProviding
+    private let processIdentifier: @Sendable () -> Int32
+    private let clock: @Sendable () -> Date
+    private let minimumSampleInterval: TimeInterval
+    private let maxHistoryDuration: TimeInterval
+
+    private var snapshots: [RuntimeDiagnosticsSnapshot] = []
+    private var lastErrorMessage: String?
+
+    public init(
+        provider: any RuntimeProcessSnapshotProviding = LiveRuntimeProcessSnapshotProvider(),
+        processIdentifier: @escaping @Sendable () -> Int32 = { ProcessInfo.processInfo.processIdentifier },
+        clock: @escaping @Sendable () -> Date = { Date() },
+        minimumSampleInterval: TimeInterval = 5,
+        maxHistoryDuration: TimeInterval = 3_600
+    ) {
+        self.provider = provider
+        self.processIdentifier = processIdentifier
+        self.clock = clock
+        self.minimumSampleInterval = minimumSampleInterval
+        self.maxHistoryDuration = maxHistoryDuration
+    }
+
+    public func sampleIfNeeded(workspaceDirectories: [URL]) async -> RuntimeDiagnosticsSnapshot? {
+        let now = clock()
+        if let latest = snapshots.last,
+            now.timeIntervalSince(latest.sampledAt) < minimumSampleInterval
+        {
+            return latest
+        }
+        return await sample(workspaceDirectories: workspaceDirectories)
+    }
+
+    @discardableResult
+    public func sample(workspaceDirectories: [URL]) async -> RuntimeDiagnosticsSnapshot? {
+        let now = clock()
+        let appPID = processIdentifier()
+
+        do {
+            let allProcesses = try await provider.processes()
+            let appTreeProcesses = Self.appTreeProcesses(from: allProcesses, rootPID: appPID)
+            let workspaceProcesses = Self.workspaceProcesses(
+                from: allProcesses,
+                workspaceDirectories: workspaceDirectories
+            )
+            let snapshot = RuntimeDiagnosticsSnapshot(
+                sampledAt: now,
+                appPID: appPID,
+                allProcesses: allProcesses,
+                appTreeProcesses: appTreeProcesses,
+                appTreeTotals: Self.totals(for: appTreeProcesses),
+                workspaceProcesses: workspaceProcesses,
+                workspaceTotals: Self.totals(for: workspaceProcesses),
+                errorMessage: nil
+            )
+            snapshots.append(snapshot)
+            lastErrorMessage = nil
+            trimHistory(relativeTo: now)
+            return snapshot
+        } catch {
+            lastErrorMessage = String(describing: error)
+            if let latest = snapshots.last {
+                let failedSnapshot = RuntimeDiagnosticsSnapshot(
+                    sampledAt: latest.sampledAt,
+                    appPID: latest.appPID,
+                    allProcesses: latest.allProcesses,
+                    appTreeProcesses: latest.appTreeProcesses,
+                    appTreeTotals: latest.appTreeTotals,
+                    workspaceProcesses: latest.workspaceProcesses,
+                    workspaceTotals: latest.workspaceTotals,
+                    errorMessage: lastErrorMessage
+                )
+                snapshots[snapshots.count - 1] = failedSnapshot
+                return failedSnapshot
+            }
+            return RuntimeDiagnosticsSnapshot(
+                sampledAt: now,
+                appPID: appPID,
+                allProcesses: [],
+                appTreeProcesses: [],
+                appTreeTotals: .empty,
+                workspaceProcesses: [],
+                workspaceTotals: .empty,
+                errorMessage: lastErrorMessage
+            )
+        }
+    }
+
+    public func history(duration: TimeInterval) -> RuntimeProcessHistory {
+        let cutoff = clock().addingTimeInterval(-duration)
+        return RuntimeProcessHistory(
+            snapshots: snapshots.filter { $0.sampledAt >= cutoff }
+        )
+    }
+
+    public func latestSnapshot() -> RuntimeDiagnosticsSnapshot? {
+        snapshots.last
+    }
+
+    public func reset() {
+        snapshots = []
+        lastErrorMessage = nil
+    }
+
+    public static func totals(for processes: [RuntimeProcessSample]) -> RuntimeResourceTotals {
+        RuntimeResourceTotals(
+            processCount: processes.count,
+            cpuPercent: processes.map(\.cpuPercent).reduce(0, +),
+            residentMemoryBytes: processes.map(\.residentMemoryBytes).reduce(0, +),
+            cpuTimeSeconds: processes.map(\.cpuTimeSeconds).reduce(0, +)
+        )
+    }
+
+    public static func appTreeProcesses(
+        from processes: [RuntimeProcessSample],
+        rootPID: Int32
+    ) -> [RuntimeProcessSample] {
+        let childrenByParent = Dictionary(grouping: processes, by: \.parentPID)
+        var includedPIDs: Set<Int32> = []
+        var stack = [rootPID]
+
+        while let pid = stack.popLast() {
+            guard includedPIDs.insert(pid).inserted else { continue }
+            for child in childrenByParent[pid] ?? [] {
+                stack.append(child.pid)
+            }
+        }
+
+        return
+            processes
+            .filter { includedPIDs.contains($0.pid) }
+            .sorted { lhs, rhs in
+                if lhs.pid == rootPID { return true }
+                if rhs.pid == rootPID { return false }
+                return lhs.pid < rhs.pid
+            }
+    }
+
+    public static func workspaceProcesses(
+        from processes: [RuntimeProcessSample],
+        workspaceDirectories: [URL]
+    ) -> [RuntimeProcessSample] {
+        let prefixes =
+            workspaceDirectories
+            .map { normalizedPath($0.path) }
+            .filter { !$0.isEmpty }
+
+        guard !prefixes.isEmpty else { return [] }
+
+        return processes.filter { process in
+            guard let currentDirectory = process.currentDirectory else { return false }
+            let normalizedDirectory = normalizedPath(currentDirectory)
+            return prefixes.contains { prefix in
+                normalizedDirectory == prefix || normalizedDirectory.hasPrefix(prefix + "/")
+            }
+        }
+        .sorted { lhs, rhs in
+            if lhs.cpuPercent != rhs.cpuPercent {
+                return lhs.cpuPercent > rhs.cpuPercent
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    private func trimHistory(relativeTo now: Date) {
+        let cutoff = now.addingTimeInterval(-maxHistoryDuration)
+        snapshots.removeAll { $0.sampledAt < cutoff }
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
+++ b/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
@@ -499,6 +499,27 @@ public actor RuntimeDiagnosticsSampler {
         lastErrorMessage = nil
     }
 
+    public static func rescopeWorkspaceProcesses(
+        in snapshot: RuntimeDiagnosticsSnapshot,
+        workspaceDirectories: [URL]
+    ) -> RuntimeDiagnosticsSnapshot {
+        let workspaceProcesses = workspaceProcesses(
+            from: snapshot.allProcesses,
+            workspaceDirectories: workspaceDirectories
+        )
+
+        return RuntimeDiagnosticsSnapshot(
+            sampledAt: snapshot.sampledAt,
+            appPID: snapshot.appPID,
+            allProcesses: snapshot.allProcesses,
+            appTreeProcesses: snapshot.appTreeProcesses,
+            appTreeTotals: snapshot.appTreeTotals,
+            workspaceProcesses: workspaceProcesses,
+            workspaceTotals: totals(for: workspaceProcesses),
+            errorMessage: snapshot.errorMessage
+        )
+    }
+
     public static func totals(for processes: [RuntimeProcessSample]) -> RuntimeResourceTotals {
         RuntimeResourceTotals(
             processCount: processes.count,

--- a/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
@@ -97,8 +97,8 @@ struct RightPaneTabPolicyTests {
         #expect(policy.normalizedSelection(for: .diagnostics) == .diagnostics)
     }
 
-    @Test("Diagnostics tab uses widened inspector dimensions")
-    func diagnosticsTabUsesWidenedInspectorDimensions() {
+    @Test("Diagnostics tab uses widened Detail Pane dimensions")
+    func diagnosticsTabUsesWidenedDetailPaneDimensions() {
         let policy = RightPaneWidthPolicy()
 
         #expect(policy.width(for: .files) == RightPaneWidth(minimum: 220, ideal: 280, maximum: 400))

--- a/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
@@ -12,7 +12,7 @@ struct RightPaneTabPolicyTests {
             notificationsEnabled: true
         )
 
-        #expect(policy.visibleTabs == [.files, .changes, .activity])
+        #expect(policy.visibleTabs == [.files, .changes, .activity, .diagnostics])
     }
 
     @Test("Workspace tabs exclude activity when notifications are disabled")
@@ -23,7 +23,7 @@ struct RightPaneTabPolicyTests {
             notificationsEnabled: false
         )
 
-        #expect(policy.visibleTabs == [.files, .changes])
+        #expect(policy.visibleTabs == [.files, .changes, .diagnostics])
     }
 
     @Test("Disabling notifications normalizes activity selection to files")
@@ -50,8 +50,8 @@ struct RightPaneTabPolicyTests {
             notificationsEnabled: true
         )
 
-        #expect(disabledPolicy.visibleTabs == [.files, .changes])
-        #expect(enabledPolicy.visibleTabs == [.files, .changes])
+        #expect(disabledPolicy.visibleTabs == [.files, .changes, .diagnostics])
+        #expect(enabledPolicy.visibleTabs == [.files, .changes, .diagnostics])
     }
 
     @Test("Disabled notifications preserve non-activity tab selections")
@@ -64,6 +64,7 @@ struct RightPaneTabPolicyTests {
 
         #expect(disabledPolicy.normalizedSelection(for: .files) == .files)
         #expect(disabledPolicy.normalizedSelection(for: .changes) == .changes)
+        #expect(disabledPolicy.normalizedSelection(for: .diagnostics) == .diagnostics)
     }
 
     @Test("Re-enabling notifications keeps a previously normalized files selection")
@@ -82,5 +83,25 @@ struct RightPaneTabPolicyTests {
 
         #expect(normalizedSelection == .files)
         #expect(reenabledPolicy.normalizedSelection(for: normalizedSelection) == .files)
+    }
+
+    @Test("Diagnostics stays visible without filesystem inspection")
+    func diagnosticsStaysVisibleWithoutFilesystemInspection() {
+        let policy = RightPaneTabPolicy(
+            supportsFilesystemInspection: false,
+            showActivity: true,
+            notificationsEnabled: false
+        )
+
+        #expect(policy.visibleTabs == [.files, .diagnostics])
+        #expect(policy.normalizedSelection(for: .diagnostics) == .diagnostics)
+    }
+
+    @Test("Diagnostics tab uses widened inspector dimensions")
+    func diagnosticsTabUsesWidenedInspectorDimensions() {
+        let policy = RightPaneWidthPolicy()
+
+        #expect(policy.width(for: .files) == RightPaneWidth(minimum: 220, ideal: 280, maximum: 400))
+        #expect(policy.width(for: .diagnostics) == RightPaneWidth(minimum: 360, ideal: 640, maximum: 760))
     }
 }

--- a/Tests/WorkspaceManagerAppTests/RuntimeProcessTableSortTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RuntimeProcessTableSortTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@Suite("RuntimeProcessTableSort")
+struct RuntimeProcessTableSortTests {
+    @Test("Cycles ascending descending and default order")
+    func cyclesAscendingDescendingAndDefaultOrder() {
+        var sortState = RuntimeProcessTableSortState()
+        let rows = [
+            sample(pid: 30, name: "zsh", cpu: 2),
+            sample(pid: 10, name: "claude", cpu: 50),
+            sample(pid: 20, name: "node", cpu: 20),
+        ]
+
+        sortState.cycle(column: .cpu)
+        #expect(sortState.sorted(rows).map(\.pid) == [30, 20, 10])
+
+        sortState.cycle(column: .cpu)
+        #expect(sortState.sorted(rows).map(\.pid) == [10, 20, 30])
+
+        sortState.cycle(column: .cpu)
+        #expect(sortState.sorted(rows).map(\.pid) == [30, 10, 20])
+    }
+
+    @Test("Switching columns starts ascending")
+    func switchingColumnsStartsAscending() {
+        var sortState = RuntimeProcessTableSortState(column: .cpu, direction: .descending)
+        let rows = [
+            sample(pid: 30, name: "zsh", cpu: 2),
+            sample(pid: 10, name: "claude", cpu: 50),
+            sample(pid: 20, name: "node", cpu: 20),
+        ]
+
+        sortState.cycle(column: .name)
+
+        #expect(sortState.column == .name)
+        #expect(sortState.direction == .ascending)
+        #expect(sortState.sorted(rows).map(\.name) == ["claude", "node", "zsh"])
+    }
+
+    private func sample(
+        pid: Int32,
+        name: String,
+        cpu: Double,
+        memory: Int64 = 0
+    ) -> RuntimeProcessSample {
+        RuntimeProcessSample(
+            pid: pid,
+            parentPID: 1,
+            name: name,
+            command: name,
+            cpuPercent: cpu,
+            residentMemoryBytes: memory
+        )
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/UIFixtureDiagnosticsBootstrapTests.swift
+++ b/Tests/WorkspaceManagerAppTests/UIFixtureDiagnosticsBootstrapTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("UIFixtureDiagnosticsBootstrap")
+struct UIFixtureDiagnosticsBootstrapTests {
+    @Test("Requires fixture mode and diagnostics flag")
+    func requiresFixtureModeAndDiagnosticsFlag() {
+        #expect(UIFixtureDiagnosticsBootstrapConfiguration.from(environment: [:]) == nil)
+        #expect(
+            UIFixtureDiagnosticsBootstrapConfiguration.from(
+                environment: ["WORKSPACES_UI_FIXTURE_OPEN_DIAGNOSTICS": "1"]
+            ) == nil
+        )
+        #expect(
+            UIFixtureDiagnosticsBootstrapConfiguration.from(
+                environment: ["WORKSPACES_UI_FIXTURE": "1"]
+            ) == nil
+        )
+    }
+
+    @Test("Accepts common truthy values")
+    func acceptsCommonTruthyValues() {
+        for value in ["1", "true", "yes", "on"] {
+            #expect(
+                UIFixtureDiagnosticsBootstrapConfiguration.from(
+                    environment: [
+                        "WORKSPACES_UI_FIXTURE": "1",
+                        "WORKSPACES_UI_FIXTURE_OPEN_DIAGNOSTICS": value,
+                    ]
+                ) != nil
+            )
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/RuntimeDiagnosticsTests.swift
+++ b/Tests/WorkspaceManagerTests/RuntimeDiagnosticsTests.swift
@@ -77,6 +77,42 @@ struct RuntimeDiagnosticsTests {
         #expect(workspaceProcesses.map(\.pid) == [12, 11])
     }
 
+    @Test("snapshot workspace scope can update without a new process sample")
+    func snapshotWorkspaceScopeCanUpdateWithoutNewProcessSample() {
+        let firstWorkspace = URL(fileURLWithPath: "/Users/fairchild/code/project")
+        let secondWorkspace = URL(fileURLWithPath: "/Users/fairchild/code/other")
+        let snapshot = RuntimeDiagnosticsSnapshot(
+            sampledAt: Date(timeIntervalSinceReferenceDate: 10),
+            appPID: 10,
+            allProcesses: [
+                sample(pid: 10, parentPID: 1, name: "WorkspaceManager", cwd: "/Applications"),
+                sample(pid: 11, parentPID: 10, name: "claude", cpu: 25, cwd: "/Users/fairchild/code/project"),
+                sample(pid: 12, parentPID: 10, name: "node", cpu: 50, cwd: "/Users/fairchild/code/other"),
+            ],
+            appTreeProcesses: [],
+            appTreeTotals: .empty,
+            workspaceProcesses: [
+                sample(pid: 11, parentPID: 10, name: "claude", cpu: 25, cwd: "/Users/fairchild/code/project")
+            ],
+            workspaceTotals: RuntimeDiagnosticsSampler.totals(for: [
+                sample(pid: 11, parentPID: 10, name: "claude", cpu: 25, cwd: "/Users/fairchild/code/project")
+            ])
+        )
+
+        let rescoped = RuntimeDiagnosticsSampler.rescopeWorkspaceProcesses(
+            in: snapshot,
+            workspaceDirectories: [secondWorkspace]
+        )
+
+        #expect(
+            RuntimeDiagnosticsSampler.rescopeWorkspaceProcesses(
+                in: snapshot,
+                workspaceDirectories: [firstWorkspace]
+            ).workspaceProcesses.map(\.pid) == [11])
+        #expect(rescoped.workspaceProcesses.map(\.pid) == [12])
+        #expect(rescoped.workspaceTotals.cpuPercent == 50)
+    }
+
     @Test("sampler trims history to configured duration")
     func samplerTrimsHistoryToConfiguredDuration() async {
         let clock = MutableClock(Date(timeIntervalSinceReferenceDate: 0))

--- a/Tests/WorkspaceManagerTests/RuntimeDiagnosticsTests.swift
+++ b/Tests/WorkspaceManagerTests/RuntimeDiagnosticsTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("RuntimeDiagnostics")
+struct RuntimeDiagnosticsTests {
+    @Test("ps parser preserves process metrics and command")
+    func psParserPreservesProcessMetricsAndCommand() {
+        let output = """
+              100     1   1.5  2048 00:01:02 WorkSpaces /Applications/WorkSpaces.app/Contents/MacOS/WorkSpaces
+              101   100  81.8 65536 01:02:03 claude claude --continue
+            """
+
+        let processes = RuntimeDiagnosticsParser.parsePS(
+            output,
+            cwdByPID: [101: "/Users/fairchild/code/project"]
+        )
+
+        #expect(processes.count == 2)
+        #expect(processes[0].pid == 100)
+        #expect(processes[0].parentPID == 1)
+        #expect(processes[0].cpuPercent == 1.5)
+        #expect(processes[0].residentMemoryBytes == 2_097_152)
+        #expect(processes[0].cpuTimeSeconds == 62)
+        #expect(processes[1].name == "claude")
+        #expect(processes[1].command == "claude --continue")
+        #expect(processes[1].currentDirectory == "/Users/fairchild/code/project")
+    }
+
+    @Test("lsof parser maps cwd by pid")
+    func lsofParserMapsCWDByPID() {
+        let output = """
+            p100
+            cWorkSpaces
+            n/Applications/WorkSpaces.app
+            p101
+            cclaude
+            n/Users/fairchild/code/project
+            """
+
+        let cwdByPID = RuntimeDiagnosticsParser.parseLsofCWDs(output)
+
+        #expect(cwdByPID[100] == "/Applications/WorkSpaces.app")
+        #expect(cwdByPID[101] == "/Users/fairchild/code/project")
+    }
+
+    @Test("descendant tree includes root and nested children only")
+    func descendantTreeIncludesRootAndNestedChildrenOnly() {
+        let processes = [
+            sample(pid: 10, parentPID: 1, name: "WorkspaceManager"),
+            sample(pid: 11, parentPID: 10, name: "zsh"),
+            sample(pid: 12, parentPID: 11, name: "claude"),
+            sample(pid: 20, parentPID: 1, name: "Other"),
+        ]
+
+        let tree = RuntimeDiagnosticsSampler.appTreeProcesses(from: processes, rootPID: 10)
+
+        #expect(tree.map(\.pid) == [10, 11, 12])
+    }
+
+    @Test("workspace processes match cwd prefixes")
+    func workspaceProcessesMatchCWDPrefixes() {
+        let workspace = URL(fileURLWithPath: "/Users/fairchild/code/project")
+        let processes = [
+            sample(pid: 10, parentPID: 1, name: "WorkspaceManager", cwd: "/Applications"),
+            sample(pid: 11, parentPID: 10, name: "claude", cpu: 25, cwd: "/Users/fairchild/code/project"),
+            sample(pid: 12, parentPID: 10, name: "node", cpu: 50, cwd: "/Users/fairchild/code/project/web"),
+            sample(pid: 20, parentPID: 1, name: "Other", cwd: "/Users/fairchild/code/other"),
+        ]
+
+        let workspaceProcesses = RuntimeDiagnosticsSampler.workspaceProcesses(
+            from: processes,
+            workspaceDirectories: [workspace]
+        )
+
+        #expect(workspaceProcesses.map(\.pid) == [12, 11])
+    }
+
+    @Test("sampler trims history to configured duration")
+    func samplerTrimsHistoryToConfiguredDuration() async {
+        let clock = MutableClock(Date(timeIntervalSinceReferenceDate: 0))
+        let provider = StubRuntimeProcessProvider(processes: [
+            sample(pid: 100, parentPID: 1, name: "WorkspaceManager")
+        ])
+        let sampler = RuntimeDiagnosticsSampler(
+            provider: provider,
+            processIdentifier: { 100 },
+            clock: { clock.now },
+            minimumSampleInterval: 0,
+            maxHistoryDuration: 10
+        )
+
+        _ = await sampler.sample(workspaceDirectories: [])
+        clock.advance(by: 5)
+        _ = await sampler.sample(workspaceDirectories: [])
+        clock.advance(by: 20)
+        _ = await sampler.sample(workspaceDirectories: [])
+
+        let history = await sampler.history(duration: 60)
+
+        #expect(history.sampleCount == 1)
+        #expect(history.latest?.sampledAt == clock.now)
+    }
+
+    @Test("summary counts event and agent failures")
+    func summaryCountsEventAndAgentFailures() {
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+        let events = [
+            StartupDiagnosticsStore.DiagnosticEvent(
+                timestamp: now,
+                metric: "workspace_status_sync",
+                durationMs: 250,
+                labels: ["outcome": "success"]
+            ),
+            StartupDiagnosticsStore.DiagnosticEvent(
+                timestamp: now.addingTimeInterval(1),
+                metric: "open_in_editor_launch",
+                durationMs: 1_500,
+                labels: ["outcome": "failure", "failure_reason": "editor_not_installed"]
+            ),
+            StartupDiagnosticsStore.DiagnosticEvent(
+                timestamp: now.addingTimeInterval(2),
+                metric: "trace_parse_error",
+                durationMs: 10,
+                labels: ["error": "bad_payload"]
+            ),
+        ]
+        let statuses = [
+            AgentSessionStatus(
+                hostSessionID: UUID(),
+                kind: .claudeCode,
+                cwd: "/repo",
+                run: .errored(category: .toolFailure, message: "tool failed"),
+                lastEventAt: now.addingTimeInterval(3)
+            )
+        ]
+
+        let summary = RuntimeDiagnosticsSummary.make(events: events, agentStatuses: statuses)
+
+        #expect(summary.spanCount == 3)
+        #expect(summary.failureCount == 3)
+        #expect(summary.slowSpanCount == 1)
+        #expect(summary.parseErrorCount == 1)
+        #expect(summary.activeAgentSessionCount == 1)
+        #expect(summary.latestFailures.count == 3)
+    }
+
+    private func sample(
+        pid: Int32,
+        parentPID: Int32,
+        name: String,
+        cpu: Double = 0,
+        memory: Int64 = 0,
+        cwd: String? = nil
+    ) -> RuntimeProcessSample {
+        RuntimeProcessSample(
+            pid: pid,
+            parentPID: parentPID,
+            name: name,
+            command: name,
+            cpuPercent: cpu,
+            residentMemoryBytes: memory,
+            currentDirectory: cwd
+        )
+    }
+}
+
+private struct StubRuntimeProcessProvider: RuntimeProcessSnapshotProviding {
+    let processes: [RuntimeProcessSample]
+
+    func processes() async throws -> [RuntimeProcessSample] {
+        processes
+    }
+}
+
+private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    init(_ value: Date) {
+        self.value = value
+    }
+
+    var now: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.lock()
+        value = value.addingTimeInterval(seconds)
+        lock.unlock()
+    }
+}

--- a/backlog/detail-pane-sticky-width-followup.md
+++ b/backlog/detail-pane-sticky-width-followup.md
@@ -1,22 +1,22 @@
 ---
 topic: runtime-diagnostics
 priority: 2
-description: Preserve the user's preferred inspector width across tab changes, including the wider Diagnostics tab.
+description: Preserve the user's preferred Detail Pane width across tab changes, including the wider Diagnostics tab.
 ---
 
-# Sticky Inspector Width Across Tabs
+# Sticky Detail Pane Width Across Tabs
 
 ## Problem Statement
 
-The Diagnostics inspector currently widens when selected and returns to the older narrow maximum on other tabs. User review found the default Diagnostics width good, but the max-width transition feels awkward when moving between tabs.
+The Diagnostics Detail Pane currently widens when selected and returns to the older narrow maximum on other tabs. User review found the default Diagnostics width good, but the max-width transition feels awkward when moving between tabs.
 
-The follow-up should make the inspector remember the last width the user actually used and preserve that width across Files, Changes, Activity, and Diagnostics. Tab changes should not create a visible snap unless the current width is outside a hard safety bound for the selected surface.
+The follow-up should make the Detail Pane remember the last width the user actually used and preserve that width across Files, Changes, Activity, and Diagnostics. Tab changes should not create a visible snap unless the current width is outside a hard safety bound for the selected Surface.
 
 ## Key Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Width ownership | Store per-target inspector width in right-pane state | Width is part of the inspector session, like selected tab and expansion state. |
+| Width ownership | Store per-target Detail Pane width in right-pane state | Width is part of the Detail Pane session, like selected tab and expansion state. |
 | Default width | Keep the current Diagnostics default | User feedback says the default width is good. |
 | Cross-tab behavior | Prefer sticky width over per-tab max-width snapping | The awkwardness comes from changing constraints as tabs switch. |
 | Persistence | Start with in-memory state; consider durable persistence only after interaction review | Avoid adding storage/migration work before the behavior feels right. |
@@ -52,7 +52,7 @@ The view should still provide sensible defaults when no measured/user width exis
 **Acceptance criteria:**
 
 - [ ] Selecting Diagnostics uses the current wider default when no prior width exists.
-- [ ] Manually resizing the inspector and switching tabs preserves the selected width.
+- [ ] Manually resizing the Detail Pane and switching tabs preserves the selected width.
 - [ ] Switching away from Diagnostics does not snap back to a 400 px max width.
 - [ ] Width remains bounded enough that compact file/change tabs do not break layout.
 
@@ -65,7 +65,7 @@ The view should still provide sensible defaults when no measured/user width exis
 **Acceptance criteria:**
 
 - [ ] Width transitions do not animate awkwardly during tab changes.
-- [ ] The pane remains usable after changing selection between workspace and repo inspector targets.
+- [ ] The pane remains usable after changing selection between Workspace and Repository Detail Pane targets.
 - [ ] If durable persistence is added, it is keyed by stable target identity and does not require SwiftData migration.
 
 ## Verification Commands
@@ -80,10 +80,10 @@ swift build
 
 ## Rollback Plan
 
-Restore the current `RightPaneWidthPolicy` behavior and fixed tab-derived constraints. This is isolated to the right inspector view layer.
+Restore the current `RightPaneWidthPolicy` behavior and fixed tab-derived constraints. This is isolated to the Detail Pane view layer.
 
 ## References
 
-- PR #482: Runtime Diagnostics Inspector
+- PR #482: Runtime Diagnostics Detail Pane
 - `Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift`
 - `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift`

--- a/backlog/inspector-sticky-width_followup.md
+++ b/backlog/inspector-sticky-width_followup.md
@@ -1,0 +1,89 @@
+---
+topic: runtime-diagnostics
+priority: 2
+description: Preserve the user's preferred inspector width across tab changes, including the wider Diagnostics tab.
+---
+
+# Sticky Inspector Width Across Tabs
+
+## Problem Statement
+
+The Diagnostics inspector currently widens when selected and returns to the older narrow maximum on other tabs. User review found the default Diagnostics width good, but the max-width transition feels awkward when moving between tabs.
+
+The follow-up should make the inspector remember the last width the user actually used and preserve that width across Files, Changes, Activity, and Diagnostics. Tab changes should not create a visible snap unless the current width is outside a hard safety bound for the selected surface.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Width ownership | Store per-target inspector width in right-pane state | Width is part of the inspector session, like selected tab and expansion state. |
+| Default width | Keep the current Diagnostics default | User feedback says the default width is good. |
+| Cross-tab behavior | Prefer sticky width over per-tab max-width snapping | The awkwardness comes from changing constraints as tabs switch. |
+| Persistence | Start with in-memory state; consider durable persistence only after interaction review | Avoid adding storage/migration work before the behavior feels right. |
+
+## Architecture
+
+Current width selection lives in:
+
+- `Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift` - `RightPaneWidthPolicy` and `rightPaneWidth(for:)`
+- `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift` - applies the width modifier around `RightPaneView`
+
+The follow-up should replace the tab-only width policy with state that can represent:
+
+```text
+RightPaneSessionState
+  selectedTab
+  preferredWidth
+  lastUserAdjustedWidth
+```
+
+The view should still provide sensible defaults when no measured/user width exists.
+
+## Implementation Phases
+
+### Phase 1: Capture And Preserve Width
+
+**Files to modify:**
+
+- `Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift` - add width state and a policy that clamps only to broad safety bounds.
+- `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift` - replace fixed tab-derived frame constraints with sticky width handling.
+- `Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift` - update or split width policy tests for sticky behavior.
+
+**Acceptance criteria:**
+
+- [ ] Selecting Diagnostics uses the current wider default when no prior width exists.
+- [ ] Manually resizing the inspector and switching tabs preserves the selected width.
+- [ ] Switching away from Diagnostics does not snap back to a 400 px max width.
+- [ ] Width remains bounded enough that compact file/change tabs do not break layout.
+
+### Phase 2: Interaction Polish
+
+**Files to modify:**
+
+- `Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift`
+
+**Acceptance criteria:**
+
+- [ ] Width transitions do not animate awkwardly during tab changes.
+- [ ] The pane remains usable after changing selection between workspace and repo inspector targets.
+- [ ] If durable persistence is added, it is keyed by stable target identity and does not require SwiftData migration.
+
+## Verification Commands
+
+```bash
+swift-format lint --strict --recursive Sources/ Tests/
+swift test --filter RightPaneTabPolicy
+swift test
+swift build
+./scripts/launch-dev.sh --no-build --fixture --clean-data --trust-mise --env WORKSPACES_UI_FIXTURE_OPEN_DIAGNOSTICS=1 --window-timeout 15
+```
+
+## Rollback Plan
+
+Restore the current `RightPaneWidthPolicy` behavior and fixed tab-derived constraints. This is isolated to the right inspector view layer.
+
+## References
+
+- PR #482: Runtime Diagnostics Inspector
+- `Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift`
+- `Sources/WorkspaceManager/Views/MainWindow/ContentView.swift`


### PR DESCRIPTION
## Summary
- add a live Diagnostics Detail Pane tab with runtime process metrics, resource history, trace summaries, latest failures, refresh, and export
- add a core runtime diagnostics sampler with injectable process provider, ps/lsof parsing, descendant-tree aggregation, scoped process matching, and 1-hour in-memory history
- widen the Detail Pane when Diagnostics is selected and keep Diagnostics visible independent of notification settings
- refine the live review surface with compact About disclosure, clearer app-tree/scoped-process explanations, distinct export affordance, chart hover details, sortable process tables, and a quiet CPU/Memory metric selector
- keep scoped process rows aligned to the current selected Repository or Workspace when reusing the latest in-memory process sample
- polish the final architecture by extracting process table, resource chart, and value formatting into focused SwiftUI modules
- align visible Detail Pane copy with `CONTEXT.md` vocabulary and rename the sticky-width backlog follow-up to `backlog/detail-pane-sticky-width-followup.md`

## Tests
- swift-format lint --strict --recursive Sources/ Tests/
- swift test --filter RuntimeDiagnostics
- swift test --filter RuntimeProcessTableSort
- swift test --filter RightPaneTabPolicy
- swift test
- swift build -c release
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --cached --check

## Evidence
- ![diagnostics-verification-summary](https://evidence.cloudcompute.com/workspaces/pr-482/20260516-163211-diagnostics-verification-summary.png)

## Evidence Status
- Final commit: `74a732b5`.
- Debug app launched from `.build/arm64-apple-macosx/debug/WorkspaceManager` with `WORKSPACES_UI_FIXTURE_OPEN_DIAGNOSTICS=1`.
- Latest local validation instance is running in tmux session `wm-diagnostics-review`; the launch log recorded `[UIFixture] Diagnostics bootstrap applied (workspace=skills-v13)`.
- Window screenshot capture remains blocked in this environment: `capture-window` found the WorkspaceManager window id, but `screencapture` returned `could not create image from window` in earlier attempts. I did not use a full-screen fallback because it could capture unrelated desktop contents.

## Mergeability
- Surface: desktop Detail Pane UI, WorkspaceManagerCore runtime diagnostics sampling, right-pane tab policy, and a backlog follow-up.
- User-facing behavior changed: yes, Repository and Workspace Detail Panes now expose Diagnostics with live process tables, resource history, trace summary, latest failures, refresh, export, progressive disclosure, sortable tables, CPU/Memory chart switching from the resource chart title, and current scope matching for reused samples.
- Non-happy paths considered: sampler failures keep the last successful sample with an inline error, no-descendant/no-agent states render empty tables, disabled notifications only hide Activity, table sorting can be cleared back to the default order, resource chart defaults to CPU when no selection has been made, and scoped process rows are re-scoped without extra sampling when the selected target changes.
- Residual risk or follow-up: window-level app screenshot evidence needs capture on a GUI-capable runner; current evidence covers launch/log selection, tests, and build. Sticky Detail Pane width is tracked in `backlog/detail-pane-sticky-width-followup.md`.