### PR TITLE
[codex] add local SQLite state store foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Single-context repo; use root docs plus `docs/decisions/` for architectural deci
 
 ### Local state schema
 
-The native app's local SQLite sidecar schema lives in `docs/schema.sql`. Use it when working on continuity, diagnostics, exports, or local state history. Keep it manually in sync with `LocalStateStore` migrations whenever tables, indexes, or persisted meanings change.
+The native app's local SQLite sidecar schema lives in `docs/schema.sql`, with the implementation plan in `docs/development/local-state-store-plan.md`. Use them when working on continuity, diagnostics, exports, or local state history. Keep the schema doc manually in sync with `LocalStateStore` migrations whenever tables, indexes, or persisted meanings change.
 
 ## Dev Verification Practice (required)
 
@@ -261,6 +261,7 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | Terminal keyboard focus | docs/development/solution-terminal-keyboard.md | - |
 | Evidence guide | docs/development/evidence.md | - |
 | Local SQLite state schema | docs/schema.sql | - |
+| Local state store plan | docs/development/local-state-store-plan.md | - |
 | Lume runner setup | docs/development/lume-runner-setup.md | - |
 | Lume daemon reliability | docs/development/lume-integration.md § "Daemon Reliability" | - |
 | Web architecture | web/docs/architecture.md | - |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ Use lane + state labels: `agent`/`human` for ownership, `ready`/`claimed`/`revie
 
 Single-context repo; use root docs plus `docs/decisions/` for architectural decisions. See `docs/agents/domain.md`.
 
+### Local state schema
+
+The native app's local SQLite sidecar schema lives in `docs/schema.sql`. Use it when working on continuity, diagnostics, exports, or local state history. Keep it manually in sync with `LocalStateStore` migrations whenever tables, indexes, or persisted meanings change.
+
 ## Dev Verification Practice (required)
 
 When changing terminal/keyboard/sidebar behavior, use this loop so future sessions can self-verify reliably:
@@ -256,6 +260,7 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | Debug an issue | docs/development/troubleshooting.md | - |
 | Terminal keyboard focus | docs/development/solution-terminal-keyboard.md | - |
 | Evidence guide | docs/development/evidence.md | - |
+| Local SQLite state schema | docs/schema.sql | - |
 | Lume runner setup | docs/development/lume-runner-setup.md | - |
 | Lume daemon reliability | docs/development/lume-integration.md § "Daemon Reliability" | - |
 | Web architecture | web/docs/architecture.md | - |
@@ -271,6 +276,7 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | Data models | Sources/WorkspaceManagerCore/Models/Models.swift |
 | Git operations | Sources/WorkspaceManagerCore/Services/GitService.swift |
 | Workspace lifecycle | Sources/WorkspaceManagerCore/Services/WorkspaceService.swift |
+| Local state history | Sources/WorkspaceManagerCore/Services/LocalStateStore.swift |
 | Service protocols | Sources/WorkspaceManagerCore/Services/Protocols.swift |
 | Backend abstraction | Sources/WorkspaceManagerCore/Services/LocalBackend.swift |
 | Lume runtime setup | Sources/WorkspaceManagerCore/Services/LumeRuntimeService.swift |

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "22dd4c721ba9c7d4112b150900f631484b8870f3b0fbfa95df776daf9866d7ad",
+  "originHash" : "0dd64303b8c013b665473e4ffac938bfa28d31719cbae98d4fc58eb1899ee988",
   "pins" : [
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
         .executable(name: "WorkspaceManagerCLI", targets: ["WorkspaceManagerCLI"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.10.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.1")
     ],
     targets: [
@@ -45,6 +46,9 @@ let package = Package(
         // or potentially shared with a CLI tool in the future.
         .target(
             name: "WorkspaceManagerCore",
+            dependencies: [
+                .product(name: "GRDB", package: "GRDB.swift")
+            ],
             swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
         ),
 
@@ -119,7 +123,10 @@ let package = Package(
         // ====================================================================
         .testTarget(
             name: "WorkspaceManagerTests",
-            dependencies: ["WorkspaceManagerCore"]
+            dependencies: [
+                "WorkspaceManagerCore",
+                .product(name: "GRDB", package: "GRDB.swift")
+            ]
         ),
         .testTarget(
             name: "WorkspaceManagerAppTests",

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -37,6 +37,9 @@ struct WorkspaceManagerApp: App {
             launchEnvironment: ProcessInfo.processInfo.environment
         )
         LocalStateStoreController.shared.apply(localStateBootstrap)
+        Task {
+            await StartupDiagnosticsStore.shared.attach(localStateStore: localStateBootstrap.store)
+        }
 
         ModelStoreStatusController.shared.apply(bootstrap)
         _appCommandState = StateObject(wrappedValue: AppCommandState())

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -20,6 +20,7 @@ struct WorkspaceManagerApp: App {
     @StateObject private var agentSessionRegistry: AgentSessionRegistry
     @StateObject private var claudeIntegrationLifecycle: ClaudeIntegrationLifecycle
     private let appRuntimeDependencies = AppRuntimeDependencies.resolved()
+    private let localStateStore: LocalStateStore?
     let sharedModelContainer: ModelContainer
 
     init() {
@@ -32,14 +33,20 @@ struct WorkspaceManagerApp: App {
             seedUIFixtureDataIfNeeded(in: bootstrap.container.mainContext)
         }
 
+        let localStateBootstrap = LocalStateStoreBootstrapper.bootstrap(
+            launchEnvironment: ProcessInfo.processInfo.environment
+        )
+        LocalStateStoreController.shared.apply(localStateBootstrap)
+
         ModelStoreStatusController.shared.apply(bootstrap)
         _appCommandState = StateObject(wrappedValue: AppCommandState())
         _modelStoreStatusController = StateObject(wrappedValue: .shared)
         _softwareUpdateController = StateObject(wrappedValue: SoftwareUpdateController())
         _claudeIntegrationLifecycle = StateObject(wrappedValue: ClaudeIntegrationLifecycle.shared)
-        let registry = AgentSessionRegistry()
+        let registry = AgentSessionRegistry(localStateStore: localStateBootstrap.store)
         _agentSessionRegistry = StateObject(wrappedValue: registry)
         self.sharedModelContainer = bootstrap.container
+        self.localStateStore = localStateBootstrap.store
 
         // Stand up the hook listener and notification poster on the same registry instance.
         // The listener binds to a Unix socket under Application Support keyed by pid.
@@ -63,6 +70,7 @@ struct WorkspaceManagerApp: App {
             .environmentObject(modelStoreStatusController)
             .environmentObject(agentSessionRegistry)
             .environment(\.agentSessionRegistry, agentSessionRegistry)
+            .environment(\.localStateStore, localStateStore)
             .frame(minWidth: 1000, minHeight: 700)
             .onAppear {
                 softwareUpdateController.installCheckForUpdatesMenuItem()
@@ -333,11 +341,16 @@ private struct MainWindowRootView: View {
 /// where production POSTs to `/event` had nowhere to land.
 private struct AgentSessionRegistryAttacher: ViewModifier {
     @EnvironmentObject private var registry: AgentSessionRegistry
+    @Environment(\.localStateStore) private var localStateStore
     let hostTerminalState: HostTerminalStateStore
 
     func body(content: Content) -> some View {
         content.onAppear {
-            hostTerminalState.attach(agentSessionRegistry: registry)
+            hostTerminalState.attach(
+                agentSessionRegistry: registry,
+                localStateStore: localStateStore,
+                hooksSocketPath: ClaudeIntegrationLifecycle.shared.socketPath
+            )
         }
     }
 }
@@ -533,6 +546,10 @@ private struct AgentSessionRegistryKey: EnvironmentKey {
     static let defaultValue: AgentSessionRegistry? = nil
 }
 
+private struct LocalStateStoreKey: EnvironmentKey {
+    static let defaultValue: LocalStateStore? = nil
+}
+
 private struct ClaudeSettingsInstallerKey: EnvironmentKey {
     static let defaultValue: (any ClaudeSettingsInstalling)? = nil
 }
@@ -571,6 +588,11 @@ extension EnvironmentValues {
     var agentSessionRegistry: AgentSessionRegistry? {
         get { self[AgentSessionRegistryKey.self] }
         set { self[AgentSessionRegistryKey.self] = newValue }
+    }
+
+    var localStateStore: LocalStateStore? {
+        get { self[LocalStateStoreKey.self] }
+        set { self[LocalStateStoreKey.self] = newValue }
     }
 
     var claudeSettingsInstaller: (any ClaudeSettingsInstalling)? {

--- a/Sources/WorkspaceManager/Diagnostics/DiagnosticReportExporter.swift
+++ b/Sources/WorkspaceManager/Diagnostics/DiagnosticReportExporter.swift
@@ -11,6 +11,8 @@ enum DiagnosticReportExporter {
         let generatedAt: Date
         let system: SystemInfo
         let modelStore: ModelStoreStatusSnapshot
+        let localStateStore: LocalStateStoreStatusSnapshot
+        let localStateSummary: LocalStateStoreSummary?
         let startupDiagnostics: StartupDiagnosticsStore.DiagnosticsBundle
     }
 
@@ -58,15 +60,35 @@ enum DiagnosticReportExporter {
         let modelStoreSnapshot = await MainActor.run {
             ModelStoreStatusController.shared.snapshot
         }
+        let (localStateSnapshot, localStateStore) = await MainActor.run {
+            (
+                LocalStateStoreController.shared.snapshot,
+                LocalStateStoreController.shared.store
+            )
+        }
+        let localStateSummary = try? await localStateStore?.summary()
         let report = makeReport(
             diagnosticsBundle: diagnosticsBundle,
             systemInfo: systemInfo,
-            modelStoreSnapshot: modelStoreSnapshot
+            modelStoreSnapshot: modelStoreSnapshot,
+            localStateSnapshot: localStateSnapshot,
+            localStateSummary: localStateSummary
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         try encoder.encode(report).write(to: tempDir.appendingPathComponent("report.json"))
+        if let localStateSummary {
+            try encoder.encode(localStateSummary).write(to: tempDir.appendingPathComponent("local-state-summary.json"))
+            try? await localStateStore?.recordDiagnosticExport(
+                appVersion: appVersion,
+                buildNumber: buildNumber,
+                filename: zipURL.lastPathComponent,
+                redactionLevel: "summary",
+                status: "created",
+                rowCounts: localStateSummary.tableCounts
+            )
+        }
 
         // system-profile.txt
         let profile = gatherSystemProfile(systemInfo)
@@ -87,13 +109,17 @@ enum DiagnosticReportExporter {
     static func makeReport(
         diagnosticsBundle: StartupDiagnosticsStore.DiagnosticsBundle,
         systemInfo: SystemInfo,
-        modelStoreSnapshot: ModelStoreStatusSnapshot
+        modelStoreSnapshot: ModelStoreStatusSnapshot,
+        localStateSnapshot: LocalStateStoreStatusSnapshot,
+        localStateSummary: LocalStateStoreSummary?
     ) -> Report {
         Report(
-            schemaVersion: 2,
+            schemaVersion: 3,
             generatedAt: Date(),
             system: systemInfo,
             modelStore: modelStoreSnapshot,
+            localStateStore: localStateSnapshot,
+            localStateSummary: localStateSummary,
             startupDiagnostics: diagnosticsBundle
         )
     }
@@ -148,6 +174,21 @@ enum DiagnosticReportExporter {
         } else {
             lines.append("  Bootstrap Errors:")
             for error in modelStore.bootstrapErrors {
+                lines.append("    - \(error)")
+            }
+        }
+        lines.append("")
+        lines.append("Local State Store:")
+        let localStateStore = MainActor.assumeIsolated {
+            LocalStateStoreController.shared.snapshot
+        }
+        lines.append("  Mode: \(localStateStore.mode.label)")
+        lines.append("  Path: \(localStateStore.mode.path ?? "none")")
+        if localStateStore.bootstrapErrors.isEmpty {
+            lines.append("  Bootstrap Errors: none")
+        } else {
+            lines.append("  Bootstrap Errors:")
+            for error in localStateStore.bootstrapErrors {
                 lines.append("    - \(error)")
             }
         }

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -37,6 +37,7 @@ final class HostTerminalStateStore: ObservableObject {
     /// Agent session registry attached at scene mount. Optional because previews and
     /// fixtures construct stores without an app-scoped registry.
     private weak var agentSessionRegistry: AgentSessionRegistry?
+    private var localStateStore: LocalStateStore?
     /// Stub probe used to seed `kind` on register; PR #1 ships a fail-safe
     /// `.claudeCode` default. Replace with the real probe in a Channel 3 follow-up.
     private let foregroundProbe = PTYForegroundProbe()
@@ -47,14 +48,17 @@ final class HostTerminalStateStore: ObservableObject {
     func attach(agentSessionRegistry: AgentSessionRegistry) {
         attach(
             agentSessionRegistry: agentSessionRegistry,
+            localStateStore: nil,
             hooksSocketPath: ClaudeIntegrationLifecycle.shared.socketPath
         )
     }
 
     func attach(
         agentSessionRegistry: AgentSessionRegistry,
+        localStateStore: LocalStateStore?,
         hooksSocketPath: String?
     ) {
+        self.localStateStore = localStateStore
         self.surfaceStore.hooksSocketPath = hooksSocketPath
         guard self.agentSessionRegistry !== agentSessionRegistry else {
             syncRegistry()
@@ -437,6 +441,13 @@ final class HostTerminalStateStore: ObservableObject {
         }
 
         syncRegistry()
+
+        for session in sessions {
+            recordTerminalSession(session, isActive: session.id == activeSessionID)
+        }
+        for splitSession in splitSessionsByPrimaryID.values {
+            recordTerminalSession(splitSession, isActive: false)
+        }
     }
 
     /// Mirror the coordinator's session list into the agent session registry so the
@@ -458,12 +469,14 @@ final class HostTerminalStateStore: ObservableObject {
                 kind: kind
             )
             registeredAgentSessionIDs.insert(session.id)
+            recordTerminalSession(session, isActive: session.id == activeSessionID)
         }
 
         // Deregister sessions that have left the coordinator.
         let removed = registeredAgentSessionIDs.subtracting(liveIDs)
         for sessionID in removed {
             registry.deregister(hostSessionID: sessionID)
+            recordTerminalSessionEnded(sessionID)
         }
         registeredAgentSessionIDs.subtract(removed)
     }
@@ -473,11 +486,33 @@ final class HostTerminalStateStore: ObservableObject {
             surfaceStore.invalidate(sessionID: splitSession.id)
             if registeredAgentSessionIDs.contains(splitSession.id) {
                 agentSessionRegistry?.deregister(hostSessionID: splitSession.id)
+                recordTerminalSessionEnded(splitSession.id)
                 registeredAgentSessionIDs.remove(splitSession.id)
             }
         }
         splitLayoutsByPrimaryID.removeValue(forKey: primarySessionID)
         splitFractionsByPrimaryID.removeValue(forKey: primarySessionID)
+    }
+
+    private func recordTerminalSession(_ session: HostTerminalSession, isActive: Bool) {
+        guard let localStateStore else { return }
+        let terminalMode = TerminalMultiplexingMode.resolve().rawValue
+        let hooksSocketPath = surfaceStore.hooksSocketPath
+        Task {
+            try? await localStateStore.recordTerminalSession(
+                session,
+                terminalMode: terminalMode,
+                isActive: isActive,
+                hooksSocketPath: hooksSocketPath
+            )
+        }
+    }
+
+    private func recordTerminalSessionEnded(_ sessionID: UUID) {
+        guard let localStateStore else { return }
+        Task {
+            try? await localStateStore.markTerminalSessionEnded(hostSessionID: sessionID)
+        }
     }
 
     private func resolvedPrimarySessionID(_ sourceSessionID: UUID?) -> UUID? {

--- a/Sources/WorkspaceManagerCore/Services/AgentSessionRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentSessionRegistry.swift
@@ -34,9 +34,14 @@ public final class AgentSessionRegistry: ObservableObject, AgentSessionRegistryP
 
     private var bookkeeping: [UUID: Bookkeeping] = [:]
     private let clock: @Sendable () -> Date
+    private let localStateStore: LocalStateStore?
 
-    public init(clock: @escaping @Sendable () -> Date = { Date() }) {
+    public init(
+        clock: @escaping @Sendable () -> Date = { Date() },
+        localStateStore: LocalStateStore? = nil
+    ) {
         self.clock = clock
+        self.localStateStore = localStateStore
     }
 
     // MARK: - Public surface
@@ -144,6 +149,20 @@ public final class AgentSessionRegistry: ObservableObject, AgentSessionRegistryP
         }
         statuses[hostSessionID] = status
         bookkeeping[hostSessionID] = book
+
+        if let localStateStore {
+            let persistedEvents = events
+            let persistedStatus = status
+            Task {
+                try? await localStateStore.recordAgentEvents(
+                    persistedEvents,
+                    hostSessionID: hostSessionID,
+                    origin: origin,
+                    status: persistedStatus,
+                    occurredAt: now
+                )
+            }
+        }
     }
 
     // MARK: - Internal

--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -1,0 +1,790 @@
+//
+//  LocalStateStore.swift
+//  WorkspaceManagerCore
+//
+//  Durable local SQLite sidecar for WorkSpaces state history. SwiftData remains
+//  the canonical owner of Repository, Workspace, and Web Source rows; this store
+//  records queryable state history for continuity, diagnostics, and export.
+//
+
+import Foundation
+@preconcurrency import GRDB
+
+public enum LocalStateStoreMode: Codable, Equatable, Sendable {
+    case persistent(path: String)
+    case disabled(reason: String)
+    case unavailable
+
+    public var path: String? {
+        switch self {
+        case .persistent(let path):
+            return path
+        case .disabled, .unavailable:
+            return nil
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .persistent:
+            return "Persistent"
+        case .disabled:
+            return "Disabled"
+        case .unavailable:
+            return "Unavailable"
+        }
+    }
+}
+
+public struct LocalStateStoreBootstrapResult: Sendable {
+    public let store: LocalStateStore?
+    public let mode: LocalStateStoreMode
+    public let bootstrapErrors: [String]
+}
+
+public struct LocalStateStoreStatusSnapshot: Codable, Equatable, Sendable {
+    public let mode: LocalStateStoreMode
+    public let bootstrapErrors: [String]
+
+    public init(mode: LocalStateStoreMode, bootstrapErrors: [String]) {
+        self.mode = mode
+        self.bootstrapErrors = bootstrapErrors
+    }
+}
+
+@MainActor
+public final class LocalStateStoreController {
+    public static let shared = LocalStateStoreController()
+
+    public private(set) var store: LocalStateStore?
+    public private(set) var mode: LocalStateStoreMode = .unavailable
+    public private(set) var bootstrapErrors: [String] = []
+
+    public var snapshot: LocalStateStoreStatusSnapshot {
+        LocalStateStoreStatusSnapshot(mode: mode, bootstrapErrors: bootstrapErrors)
+    }
+
+    public func apply(_ result: LocalStateStoreBootstrapResult) {
+        store = result.store
+        mode = result.mode
+        bootstrapErrors = result.bootstrapErrors
+    }
+}
+
+public enum LocalStateStoreBootstrapper {
+    public static let databaseFileName = "local-state.sqlite"
+
+    public static func bootstrap(
+        launchEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> LocalStateStoreBootstrapResult {
+        if launchEnvironment["WORKSPACES_UI_FIXTURE"] == "1",
+            explicitStoreDirectory(from: launchEnvironment) == nil
+        {
+            return LocalStateStoreBootstrapResult(
+                store: nil,
+                mode: .disabled(reason: "WORKSPACES_UI_FIXTURE without an explicit state directory"),
+                bootstrapErrors: []
+            )
+        }
+
+        do {
+            let databaseURL = try defaultDatabaseURL(
+                launchEnvironment: launchEnvironment,
+                fileManager: fileManager
+            )
+            let store = try LocalStateStore(databaseURL: databaseURL)
+            return LocalStateStoreBootstrapResult(
+                store: store,
+                mode: .persistent(path: databaseURL.path),
+                bootstrapErrors: []
+            )
+        } catch {
+            let message = "Failed to open local state store: \(String(describing: error))"
+            NSLog("[LocalStateStore] %@", message)
+            return LocalStateStoreBootstrapResult(
+                store: nil,
+                mode: .unavailable,
+                bootstrapErrors: [message]
+            )
+        }
+    }
+
+    public static func defaultDatabaseURL(
+        launchEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let directory: URL
+        if let explicitDirectory = explicitStoreDirectory(from: launchEnvironment) {
+            directory = explicitDirectory
+        } else {
+            let appSupportDirectory = try fileManager.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            directory = appSupportDirectory.appendingPathComponent("WorkspaceManager", isDirectory: true)
+        }
+
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent(databaseFileName, isDirectory: false)
+    }
+
+    private static func explicitStoreDirectory(from environment: [String: String]) -> URL? {
+        let rawValue =
+            environment["WORKSPACES_LOCAL_STATE_DIR"]
+            ?? environment["WORKSPACES_DATA_DIR"]
+        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawValue.isEmpty
+        else {
+            return nil
+        }
+
+        let expandedPath = (rawValue as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expandedPath, isDirectory: true)
+    }
+}
+
+public struct LocalStateStoreSummary: Codable, Equatable, Sendable {
+    public let schemaVersion: Int
+    public let databasePath: String
+    public let generatedAt: Date
+    public let tableCounts: [String: Int]
+
+    public init(
+        schemaVersion: Int,
+        databasePath: String,
+        generatedAt: Date,
+        tableCounts: [String: Int]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.databasePath = databasePath
+        self.generatedAt = generatedAt
+        self.tableCounts = tableCounts
+    }
+}
+
+public actor LocalStateStore {
+    public static let schemaVersion = 1
+    public let databaseURL: URL
+
+    private let dbPool: DatabasePool
+
+    public init(databaseURL: URL) throws {
+        self.databaseURL = databaseURL
+
+        var configuration = Configuration()
+        configuration.label = "WorkSpaces local state"
+        configuration.busyMode = .timeout(5.0)
+        configuration.prepareDatabase { db in
+            try db.execute(sql: "PRAGMA foreign_keys = ON")
+            try db.execute(sql: "PRAGMA journal_mode = WAL")
+            try db.execute(sql: "PRAGMA synchronous = NORMAL")
+        }
+
+        dbPool = try DatabasePool(path: databaseURL.path, configuration: configuration)
+        try Self.migrator.migrate(dbPool)
+        try Self.writeMetadata(in: dbPool)
+    }
+
+    public func recordTerminalSession(
+        _ session: HostTerminalSession,
+        terminalMode: String,
+        isActive: Bool,
+        hooksSocketPath: String?
+    ) async throws {
+        let now = Self.isoString(Date())
+        let target = Self.targetFields(for: session.key)
+        let customCommandPresent = session.customCommand == nil ? 0 : 1
+        let activeValue = isActive ? 1 : 0
+        let tmuxSessionName = Self.tmuxSessionName(for: session.directoryURL, terminalMode: terminalMode)
+
+        try await dbPool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal_sessions (
+                        host_session_id,
+                        session_key,
+                        target_kind,
+                        target_id,
+                        target_path,
+                        backend_identifier,
+                        backend_instance_id,
+                        directory_path,
+                        terminal_mode,
+                        tmux_session_name,
+                        custom_command_present,
+                        hooks_socket_path,
+                        is_active,
+                        created_at,
+                        last_seen_at,
+                        ended_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                    ON CONFLICT(host_session_id) DO UPDATE SET
+                        session_key = excluded.session_key,
+                        target_kind = excluded.target_kind,
+                        target_id = excluded.target_id,
+                        target_path = excluded.target_path,
+                        backend_identifier = excluded.backend_identifier,
+                        backend_instance_id = excluded.backend_instance_id,
+                        directory_path = excluded.directory_path,
+                        terminal_mode = excluded.terminal_mode,
+                        tmux_session_name = excluded.tmux_session_name,
+                        custom_command_present = excluded.custom_command_present,
+                        hooks_socket_path = excluded.hooks_socket_path,
+                        is_active = excluded.is_active,
+                        last_seen_at = excluded.last_seen_at,
+                        ended_at = NULL
+                    """,
+                arguments: [
+                    session.id.uuidString,
+                    session.key.debugDescription,
+                    target.kind,
+                    target.id,
+                    target.path,
+                    target.backendIdentifier,
+                    target.backendInstanceID,
+                    session.directoryPath,
+                    terminalMode,
+                    tmuxSessionName,
+                    customCommandPresent,
+                    hooksSocketPath,
+                    activeValue,
+                    now,
+                    now,
+                ])
+        }
+    }
+
+    public func markTerminalSessionEnded(hostSessionID: UUID) async throws {
+        let now = Self.isoString(Date())
+        try await dbPool.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE terminal_sessions
+                    SET ended_at = ?, is_active = 0, last_seen_at = ?
+                    WHERE host_session_id = ?
+                    """,
+                arguments: [now, now, hostSessionID.uuidString])
+        }
+    }
+
+    public func recordTerminalLayoutSnapshot(
+        activeHostSessionID: UUID?,
+        selectedSurfaceKind: String?,
+        selectedSurfaceID: String?,
+        splitPanes: [TerminalSplitSnapshotInput] = []
+    ) async throws {
+        let snapshotID = UUID().uuidString
+        let now = Self.isoString(Date())
+        try await dbPool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO terminal_layout_snapshots (
+                        id, captured_at, active_host_session_id, selected_surface_kind, selected_surface_id
+                    )
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    snapshotID,
+                    now,
+                    activeHostSessionID?.uuidString,
+                    selectedSurfaceKind,
+                    selectedSurfaceID,
+                ])
+
+            for splitPane in splitPanes {
+                try db.execute(
+                    sql: """
+                        INSERT INTO terminal_split_snapshots (
+                            snapshot_id,
+                            primary_host_session_id,
+                            split_host_session_id,
+                            axis,
+                            split_before_primary,
+                            split_fraction
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                    arguments: [
+                        snapshotID,
+                        splitPane.primaryHostSessionID.uuidString,
+                        splitPane.splitHostSessionID.uuidString,
+                        splitPane.axis,
+                        splitPane.splitBeforePrimary ? 1 : 0,
+                        splitPane.splitFraction,
+                    ])
+            }
+        }
+    }
+
+    public func recordAgentEvents(
+        _ events: [AgentEvent],
+        hostSessionID: UUID,
+        origin: AgentEventOrigin,
+        status: AgentSessionStatus,
+        occurredAt: Date = Date()
+    ) async throws {
+        guard !events.isEmpty else { return }
+        let now = Self.isoString(occurredAt)
+        let originFields = Self.originFields(origin)
+        let runState = Self.runStateName(status.run)
+
+        try await dbPool.write { db in
+            for event in events {
+                let eventFields = Self.eventFields(event)
+                try db.execute(
+                    sql: """
+                        INSERT INTO agent_status_events (
+                            id,
+                            host_session_id,
+                            agent_session_id,
+                            agent_kind,
+                            origin,
+                            origin_detail,
+                            event_name,
+                            run_state,
+                            cwd,
+                            tool_name,
+                            tool_detail,
+                            awaiting_reason,
+                            error_category,
+                            error_message,
+                            prompt_present,
+                            model_display_name,
+                            context_used_percent,
+                            five_hour_limit_used_percent,
+                            five_hour_limit_resets_at,
+                            cost_usd,
+                            event_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                    arguments: [
+                        UUID().uuidString,
+                        hostSessionID.uuidString,
+                        status.agentSessionID,
+                        status.kind.rawValue,
+                        originFields.name,
+                        originFields.detail,
+                        eventFields.name,
+                        runState,
+                        status.cwd,
+                        eventFields.toolName,
+                        eventFields.toolDetail,
+                        eventFields.awaitingReason,
+                        eventFields.errorCategory,
+                        eventFields.errorMessage,
+                        eventFields.promptPresent,
+                        status.modelDisplayName,
+                        status.contextUsedPercent,
+                        status.fiveHourLimitUsedPercent,
+                        status.fiveHourLimitResetsAt.map(Self.isoString),
+                        status.costUSD,
+                        now,
+                    ])
+            }
+        }
+    }
+
+    public func recordDiagnosticEvent(
+        metric: String,
+        durationMs: Double,
+        labels: [String: String] = [:],
+        occurredAt: Date = Date()
+    ) async throws {
+        let labelsJSON = try Self.jsonString(labels)
+        let now = Self.isoString(occurredAt)
+        try await dbPool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO diagnostic_events (id, metric, duration_ms, labels_json, event_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                arguments: [UUID().uuidString, metric, durationMs, labelsJSON, now])
+        }
+    }
+
+    public func recordDiagnosticExport(
+        appVersion: String,
+        buildNumber: String,
+        filename: String,
+        redactionLevel: String,
+        status: String,
+        rowCounts: [String: Int]
+    ) async throws {
+        let rowCountsJSON = try Self.jsonString(rowCounts)
+        let now = Self.isoString(Date())
+        try await dbPool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO diagnostic_exports (
+                        id,
+                        created_at,
+                        app_version,
+                        build_number,
+                        filename,
+                        redaction_level,
+                        status,
+                        row_counts_json
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                arguments: [
+                    UUID().uuidString,
+                    now,
+                    appVersion,
+                    buildNumber,
+                    filename,
+                    redactionLevel,
+                    status,
+                    rowCountsJSON,
+                ])
+        }
+    }
+
+    public func summary() async throws -> LocalStateStoreSummary {
+        let tables = [
+            "terminal_sessions",
+            "terminal_layout_snapshots",
+            "terminal_split_snapshots",
+            "agent_status_events",
+            "diagnostic_events",
+            "diagnostic_exports",
+        ]
+
+        let counts = try await dbPool.read { db -> [String: Int] in
+            var result: [String: Int] = [:]
+            for table in tables {
+                result[table] = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)") ?? 0
+            }
+            return result
+        }
+
+        return LocalStateStoreSummary(
+            schemaVersion: Self.schemaVersion,
+            databasePath: databaseURL.path,
+            generatedAt: Date(),
+            tableCounts: counts
+        )
+    }
+
+    private static func writeMetadata(in dbPool: DatabasePool) throws {
+        let now = Self.isoString(Date())
+        try dbPool.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO local_state_metadata (key, value, updated_at)
+                    VALUES ('schema_version', ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                        value = excluded.value,
+                        updated_at = excluded.updated_at
+                    """,
+                arguments: [String(Self.schemaVersion), now])
+        }
+    }
+
+    private static var migrator: DatabaseMigrator {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("v1") { db in
+            try db.execute(
+                sql: """
+                    CREATE TABLE IF NOT EXISTS local_state_metadata (
+                        key TEXT PRIMARY KEY NOT NULL,
+                        value TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    ) STRICT;
+
+                    CREATE TABLE IF NOT EXISTS terminal_sessions (
+                        host_session_id TEXT PRIMARY KEY NOT NULL,
+                        session_key TEXT NOT NULL,
+                        target_kind TEXT NOT NULL
+                            CHECK (target_kind IN ('default_home', 'repo', 'workspace', 'host_path', 'backend_session')),
+                        target_id TEXT,
+                        target_path TEXT,
+                        backend_identifier TEXT,
+                        backend_instance_id TEXT,
+                        directory_path TEXT NOT NULL,
+                        terminal_mode TEXT NOT NULL,
+                        tmux_session_name TEXT,
+                        custom_command_present INTEGER NOT NULL DEFAULT 0
+                            CHECK (custom_command_present IN (0, 1)),
+                        hooks_socket_path TEXT,
+                        is_active INTEGER NOT NULL DEFAULT 0
+                            CHECK (is_active IN (0, 1)),
+                        created_at TEXT NOT NULL,
+                        last_seen_at TEXT NOT NULL,
+                        ended_at TEXT
+                    ) STRICT;
+
+                    CREATE INDEX IF NOT EXISTS idx_terminal_sessions_target
+                        ON terminal_sessions(target_kind, target_id, target_path);
+                    CREATE INDEX IF NOT EXISTS idx_terminal_sessions_last_seen
+                        ON terminal_sessions(last_seen_at DESC);
+
+                    CREATE TABLE IF NOT EXISTS terminal_layout_snapshots (
+                        id TEXT PRIMARY KEY NOT NULL,
+                        captured_at TEXT NOT NULL,
+                        active_host_session_id TEXT,
+                        selected_surface_kind TEXT,
+                        selected_surface_id TEXT,
+                        FOREIGN KEY (active_host_session_id)
+                            REFERENCES terminal_sessions(host_session_id)
+                            ON DELETE SET NULL
+                    ) STRICT;
+
+                    CREATE INDEX IF NOT EXISTS idx_terminal_layout_snapshots_captured
+                        ON terminal_layout_snapshots(captured_at DESC);
+
+                    CREATE TABLE IF NOT EXISTS terminal_split_snapshots (
+                        snapshot_id TEXT NOT NULL,
+                        primary_host_session_id TEXT NOT NULL,
+                        split_host_session_id TEXT NOT NULL,
+                        axis TEXT NOT NULL CHECK (axis IN ('leading_trailing', 'top_bottom')),
+                        split_before_primary INTEGER NOT NULL CHECK (split_before_primary IN (0, 1)),
+                        split_fraction REAL NOT NULL CHECK (split_fraction >= 0.0 AND split_fraction <= 1.0),
+                        PRIMARY KEY (snapshot_id, primary_host_session_id),
+                        FOREIGN KEY (snapshot_id)
+                            REFERENCES terminal_layout_snapshots(id)
+                            ON DELETE CASCADE,
+                        FOREIGN KEY (primary_host_session_id)
+                            REFERENCES terminal_sessions(host_session_id)
+                            ON DELETE CASCADE,
+                        FOREIGN KEY (split_host_session_id)
+                            REFERENCES terminal_sessions(host_session_id)
+                            ON DELETE CASCADE
+                    ) STRICT;
+
+                    CREATE TABLE IF NOT EXISTS agent_status_events (
+                        id TEXT PRIMARY KEY NOT NULL,
+                        host_session_id TEXT NOT NULL,
+                        agent_session_id TEXT,
+                        agent_kind TEXT NOT NULL,
+                        origin TEXT NOT NULL CHECK (origin IN ('hook', 'osc', 'status_line', 'transcript', 'bell')),
+                        origin_detail TEXT,
+                        event_name TEXT NOT NULL,
+                        run_state TEXT NOT NULL,
+                        cwd TEXT NOT NULL,
+                        tool_name TEXT,
+                        tool_detail TEXT,
+                        awaiting_reason TEXT,
+                        error_category TEXT,
+                        error_message TEXT,
+                        prompt_present INTEGER NOT NULL DEFAULT 0 CHECK (prompt_present IN (0, 1)),
+                        model_display_name TEXT,
+                        context_used_percent REAL,
+                        five_hour_limit_used_percent REAL,
+                        five_hour_limit_resets_at TEXT,
+                        cost_usd REAL,
+                        event_at TEXT NOT NULL,
+                        FOREIGN KEY (host_session_id)
+                            REFERENCES terminal_sessions(host_session_id)
+                            ON DELETE CASCADE
+                    ) STRICT;
+
+                    CREATE INDEX IF NOT EXISTS idx_agent_status_events_host_time
+                        ON agent_status_events(host_session_id, event_at DESC);
+                    CREATE INDEX IF NOT EXISTS idx_agent_status_events_agent_session
+                        ON agent_status_events(agent_session_id, event_at DESC);
+                    CREATE INDEX IF NOT EXISTS idx_agent_status_events_run_state
+                        ON agent_status_events(run_state, event_at DESC);
+
+                    CREATE TABLE IF NOT EXISTS diagnostic_events (
+                        id TEXT PRIMARY KEY NOT NULL,
+                        metric TEXT NOT NULL,
+                        duration_ms REAL NOT NULL,
+                        labels_json TEXT NOT NULL DEFAULT '{}',
+                        event_at TEXT NOT NULL
+                    ) STRICT;
+
+                    CREATE INDEX IF NOT EXISTS idx_diagnostic_events_metric_time
+                        ON diagnostic_events(metric, event_at DESC);
+
+                    CREATE TABLE IF NOT EXISTS diagnostic_exports (
+                        id TEXT PRIMARY KEY NOT NULL,
+                        created_at TEXT NOT NULL,
+                        app_version TEXT NOT NULL,
+                        build_number TEXT NOT NULL,
+                        filename TEXT NOT NULL,
+                        redaction_level TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        row_counts_json TEXT NOT NULL DEFAULT '{}'
+                    ) STRICT;
+
+                    CREATE INDEX IF NOT EXISTS idx_diagnostic_exports_created
+                        ON diagnostic_exports(created_at DESC);
+                    """)
+        }
+        return migrator
+    }
+
+    private static func targetFields(
+        for key: HostTerminalSessionKey
+    ) -> (
+        kind: String,
+        id: String?,
+        path: String?,
+        backendIdentifier: String?,
+        backendInstanceID: String?
+    ) {
+        switch key {
+        case .defaultHome:
+            return ("default_home", nil, nil, nil, nil)
+        case .repoPath(let path):
+            return ("repo", nil, path, nil, nil)
+        case .hostPath(let path):
+            return ("host_path", nil, path, nil, nil)
+        case .backendSession(let providerID, let instanceID):
+            return ("backend_session", nil, nil, providerID, instanceID)
+        }
+    }
+
+    private static func eventFields(
+        _ event: AgentEvent
+    ) -> (
+        name: String,
+        toolName: String?,
+        toolDetail: String?,
+        awaitingReason: String?,
+        errorCategory: String?,
+        errorMessage: String?,
+        promptPresent: Int
+    ) {
+        switch event {
+        case .sessionStart:
+            return ("session_start", nil, nil, nil, nil, nil, 0)
+        case .userPrompt(let prompt):
+            return ("user_prompt", nil, nil, nil, nil, nil, prompt == nil ? 0 : 1)
+        case .toolStart(let name, let detail):
+            return ("tool_start", name, detail, nil, nil, nil, 0)
+        case .toolEnd(let name, _):
+            return ("tool_end", name, nil, nil, nil, nil, 0)
+        case .toolBatchEnd:
+            return ("tool_batch_end", nil, nil, nil, nil, nil, 0)
+        case .toolFailed(let name, let error):
+            return ("tool_failed", name, nil, nil, AgentErrorCategory.toolFailure.rawValue, error, 0)
+        case .awaitingInput(let reason, _, _):
+            return ("awaiting_input", nil, nil, reason.rawValue, nil, nil, 0)
+        case .stopped(let error):
+            return ("stopped", nil, nil, nil, nil, error, 0)
+        case .errored(let category, let message):
+            return ("errored", nil, nil, nil, category.rawValue, message, 0)
+        case .statusFields:
+            return ("status_fields", nil, nil, nil, nil, nil, 0)
+        case .workingDirectory:
+            return ("working_directory", nil, nil, nil, nil, nil, 0)
+        case .bell:
+            return ("bell", nil, nil, nil, nil, nil, 0)
+        }
+    }
+
+    private static func originFields(_ origin: AgentEventOrigin) -> (name: String, detail: String?) {
+        switch origin {
+        case .hook:
+            return ("hook", nil)
+        case .osc(let surfaceID):
+            return ("osc", surfaceID.map(String.init))
+        case .statusLine:
+            return ("status_line", nil)
+        case .transcript:
+            return ("transcript", nil)
+        case .bell:
+            return ("bell", nil)
+        }
+    }
+
+    private static func runStateName(_ runState: AgentRunState) -> String {
+        switch runState {
+        case .idle:
+            return "idle"
+        case .thinking:
+            return "thinking"
+        case .runningTool:
+            return "running_tool"
+        case .awaitingInput:
+            return "awaiting_input"
+        case .complete:
+            return "complete"
+        case .errored:
+            return "errored"
+        }
+    }
+
+    private static func tmuxSessionName(for directory: URL, terminalMode: String) -> String? {
+        guard terminalMode == "tmux_per_session" else { return nil }
+        let normalizedPath = directory
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        let baseComponent = directory.lastPathComponent.isEmpty ? "session" : directory.lastPathComponent
+        let sanitizedBase = sanitizeSessionComponent(baseComponent)
+        let hash = fnv1a64(normalizedPath)
+        let hashPrefix = String(format: "%016llx", hash).prefix(8)
+        return "wm-\(sanitizedBase)-\(hashPrefix)"
+    }
+
+    private static func sanitizeSessionComponent(_ value: String) -> String {
+        let transformed = value.lowercased().map { character -> Character in
+            if character.isASCII, character.isLetter || character.isNumber {
+                return character
+            }
+            return "-"
+        }
+
+        let collapsed = String(transformed)
+            .replacingOccurrences(of: "-+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+
+        if collapsed.isEmpty {
+            return "session"
+        }
+
+        return String(collapsed.prefix(20))
+    }
+
+    private static func fnv1a64(_ value: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x0100_0000_01b3
+        }
+        return hash
+    }
+
+    private static func isoString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    private static func jsonString<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+public struct TerminalSplitSnapshotInput: Sendable, Equatable {
+    public let primaryHostSessionID: UUID
+    public let splitHostSessionID: UUID
+    public let axis: String
+    public let splitBeforePrimary: Bool
+    public let splitFraction: Double
+
+    public init(
+        primaryHostSessionID: UUID,
+        splitHostSessionID: UUID,
+        axis: String,
+        splitBeforePrimary: Bool,
+        splitFraction: Double
+    ) {
+        self.primaryHostSessionID = primaryHostSessionID
+        self.splitHostSessionID = splitHostSessionID
+        self.axis = axis
+        self.splitBeforePrimary = splitBeforePrimary
+        self.splitFraction = splitFraction
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/StartupDiagnosticsStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/StartupDiagnosticsStore.swift
@@ -4,7 +4,8 @@
 //
 //  In-memory accumulator for startup diagnostic events. Events are recorded
 //  during launch and provider-availability checks, then exported on demand
-//  as a self-contained JSON bundle. No disk I/O happens on the hot path.
+//  as a self-contained JSON bundle. Optional local-state persistence is
+//  fire-and-forget so no disk I/O happens on the hot path.
 //
 
 import Foundation
@@ -56,15 +57,37 @@ public actor StartupDiagnosticsStore {
 
     private var events: [DiagnosticEvent] = []
     private let maxEvents: Int
+    private var localStateStore: LocalStateStore?
+    private var persistedEventCount = 0
 
     public init(maxEvents: Int = 200) {
         self.maxEvents = maxEvents
     }
 
+    public func attach(localStateStore: LocalStateStore?) {
+        self.localStateStore = localStateStore
+        guard let localStateStore else {
+            persistedEventCount = 0
+            return
+        }
+
+        let firstUnpersistedIndex = min(persistedEventCount, events.count)
+        let pendingEvents = Array(events.dropFirst(firstUnpersistedIndex))
+        persistedEventCount = events.count
+        Self.enqueuePersistence(of: pendingEvents, to: localStateStore)
+    }
+
     public func record(_ event: DiagnosticEvent) {
         events.append(event)
         if events.count > maxEvents {
-            events.removeFirst()
+            let overflow = events.count - maxEvents
+            events.removeFirst(overflow)
+            persistedEventCount = max(0, persistedEventCount - overflow)
+        }
+
+        if let localStateStore {
+            persistedEventCount = events.count
+            Self.enqueuePersistence(of: [event], to: localStateStore)
         }
     }
 
@@ -116,6 +139,7 @@ public actor StartupDiagnosticsStore {
 
     public func clear() {
         events.removeAll()
+        persistedEventCount = 0
     }
 
     private func currentArchitecture() -> String {
@@ -126,5 +150,22 @@ public actor StartupDiagnosticsStore {
         #else
             return "unknown"
         #endif
+    }
+
+    private static func enqueuePersistence(
+        of events: [DiagnosticEvent],
+        to localStateStore: LocalStateStore
+    ) {
+        guard !events.isEmpty else { return }
+        Task {
+            for event in events {
+                try? await localStateStore.recordDiagnosticEvent(
+                    metric: event.metric,
+                    durationMs: event.durationMs,
+                    labels: event.labels,
+                    occurredAt: event.timestamp
+                )
+            }
+        }
     }
 }

--- a/Tests/WorkspaceManagerAppTests/DiagnosticReportExporterTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DiagnosticReportExporterTests.swift
@@ -36,14 +36,28 @@ struct DiagnosticReportExporterTests {
             mode: .inMemoryDegraded,
             bootstrapErrors: ["primary failed", "fallback failed"]
         )
+        let localStateSnapshot = LocalStateStoreStatusSnapshot(
+            mode: .persistent(path: "/tmp/local-state.sqlite"),
+            bootstrapErrors: []
+        )
+        let localStateSummary = LocalStateStoreSummary(
+            schemaVersion: 1,
+            databasePath: "/tmp/local-state.sqlite",
+            generatedAt: Date(),
+            tableCounts: ["terminal_sessions": 1]
+        )
 
         let report = DiagnosticReportExporter.makeReport(
             diagnosticsBundle: diagnostics,
             systemInfo: systemInfo,
-            modelStoreSnapshot: snapshot
+            modelStoreSnapshot: snapshot,
+            localStateSnapshot: localStateSnapshot,
+            localStateSummary: localStateSummary
         )
 
         #expect(report.modelStore == snapshot)
-        #expect(report.schemaVersion == 2)
+        #expect(report.localStateStore == localStateSnapshot)
+        #expect(report.localStateSummary == localStateSummary)
+        #expect(report.schemaVersion == 3)
     }
 }

--- a/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+@preconcurrency import GRDB
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("LocalStateStore")
+struct LocalStateStoreTests {
+    @Test("Records terminal, agent, and diagnostic state")
+    func recordsStateHistory() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let databaseURL = fixture.url.appendingPathComponent("state.sqlite")
+        let store = try LocalStateStore(databaseURL: databaseURL)
+        let sessionID = UUID(uuidString: "8A0F7340-6896-4CF3-BD94-2E10D02732F1")!
+        let session = HostTerminalSession(
+            id: sessionID,
+            key: .repoPath("/tmp/workspaces/repo"),
+            directory: URL(fileURLWithPath: "/tmp/workspaces/repo")
+        )
+
+        try await store.recordTerminalSession(
+            session,
+            terminalMode: "tmux_per_session",
+            isActive: true,
+            hooksSocketPath: "/tmp/workspaces-hooks.sock"
+        )
+
+        let status = AgentSessionStatus(
+            hostSessionID: sessionID,
+            agentSessionID: "claude-session-1",
+            kind: .claudeCode,
+            cwd: "/tmp/workspaces/repo",
+            run: .runningTool(name: "Read", detail: "README.md"),
+            modelDisplayName: "Claude",
+            lastEventAt: Date(timeIntervalSince1970: 1_700_000_000),
+            hookActive: true,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try await store.recordAgentEvents(
+            [.toolStart(name: "Read", detail: "README.md")],
+            hostSessionID: sessionID,
+            origin: .hook,
+            status: status,
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_001)
+        )
+        try await store.recordDiagnosticEvent(
+            metric: "launch_to_first_prompt",
+            durationMs: 180.5,
+            labels: ["surface": "repo_terminal"],
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_002)
+        )
+
+        let summary = try await store.summary()
+        #expect(summary.schemaVersion == 1)
+        #expect(summary.tableCounts["terminal_sessions"] == 1)
+        #expect(summary.tableCounts["agent_status_events"] == 1)
+        #expect(summary.tableCounts["diagnostic_events"] == 1)
+
+        let dbQueue = try DatabaseQueue(path: databaseURL.path)
+        let targetKind = try await dbQueue.read {
+            try String.fetchOne(
+                $0,
+                sql: "SELECT target_kind FROM terminal_sessions WHERE host_session_id = ?",
+                arguments: [sessionID.uuidString]
+            )
+        }
+        #expect(targetKind == "repo")
+    }
+
+    @Test("docs/schema.sql loads as runnable SQLite")
+    func schemaDocumentLoads() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let databaseURL = fixture.url.appendingPathComponent("schema.sqlite")
+        let schemaURL = repoRoot()
+            .appendingPathComponent("docs", isDirectory: true)
+            .appendingPathComponent("schema.sql", isDirectory: false)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        process.arguments = [
+            databaseURL.path,
+            ".read \(schemaURL.path)",
+        ]
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+
+        let dbQueue = try DatabaseQueue(path: databaseURL.path)
+        let tableCount = try await dbQueue.read {
+            try Int.fetchOne(
+                $0,
+                sql: """
+                    SELECT COUNT(*)
+                    FROM sqlite_master
+                    WHERE type = 'table'
+                      AND name IN (
+                        'local_state_metadata',
+                        'terminal_sessions',
+                        'terminal_layout_snapshots',
+                        'terminal_split_snapshots',
+                        'agent_status_events',
+                        'diagnostic_events',
+                        'diagnostic_exports'
+                      )
+                    """
+            )
+        }
+        #expect(tableCount == 7)
+    }
+
+    private func repoRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}
+
+private struct TemporaryDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalStateStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}

--- a/Tests/WorkspaceManagerTests/StartupDiagnosticsStoreTests.swift
+++ b/Tests/WorkspaceManagerTests/StartupDiagnosticsStoreTests.swift
@@ -75,6 +75,31 @@ struct StartupDiagnosticsStoreTests {
         #expect(await store.allEvents().isEmpty)
     }
 
+    @Test("Attached local state store receives existing and future events")
+    func attachedLocalStateStorePersistsDiagnostics() async throws {
+        let fixture = try StartupDiagnosticsTemporaryDirectory()
+        defer { fixture.cleanup() }
+        let localStateStore = try LocalStateStore(
+            databaseURL: fixture.url.appendingPathComponent("state.sqlite", isDirectory: false)
+        )
+        let store = StartupDiagnosticsStore()
+
+        await store.record(
+            metric: "before_attach",
+            durationMs: 1,
+            labels: ["phase": "bootstrap"]
+        )
+        await store.attach(localStateStore: localStateStore)
+        try await waitForDiagnosticEventCount(1, in: localStateStore)
+
+        await store.record(
+            metric: "after_attach",
+            durationMs: 2,
+            labels: ["phase": "runtime"]
+        )
+        try await waitForDiagnosticEventCount(2, in: localStateStore)
+    }
+
     @Test("Export produces a valid bundle with metadata")
     func exportProducesValidBundle() async {
         let store = StartupDiagnosticsStore()
@@ -171,5 +196,39 @@ struct StartupDiagnosticsStoreTests {
 
         #expect(decoded.events.isEmpty)
         #expect(decoded.appVersion == "1.0.0")
+    }
+
+    private func waitForDiagnosticEventCount(
+        _ expectedCount: Int,
+        in localStateStore: LocalStateStore
+    ) async throws {
+        var latestCount = 0
+        for _ in 0..<20 {
+            let summary = try await localStateStore.summary()
+            latestCount = summary.tableCounts["diagnostic_events"] ?? 0
+            if latestCount == expectedCount {
+                return
+            }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+
+        #expect(latestCount == expectedCount)
+    }
+}
+
+private struct StartupDiagnosticsTemporaryDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "StartupDiagnosticsStoreTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: url)
     }
 }

--- a/docs/development/local-state-store-plan.md
+++ b/docs/development/local-state-store-plan.md
@@ -1,0 +1,76 @@
+# Local State Store Plan
+
+This plan tracks the local SQLite sidecar that records WorkSpaces state history for continuity, diagnostics, and export. SwiftData remains the canonical store for Repository, Workspace, and Web Source rows. The SQLite store records append-friendly, queryable history around Terminal Sessions, Surfaces, agent state, and diagnostic events.
+
+The foundation landed in commit `759ebd3c`:
+
+- GRDB-backed `LocalStateStore` with WAL mode, foreign keys, migrations, and summary reporting.
+- Runtime tables for terminal sessions, terminal layout snapshots, split snapshots, agent status events, diagnostic events, and diagnostic export ledger rows.
+- `docs/schema.sql` as the readable and runnable schema document. Keep it manually in sync with `LocalStateStore` migrations.
+- App bootstrap, agent status event persistence, terminal session persistence, and diagnostic report summary export.
+
+## Goals
+
+- Keep everything local. No cloud persistence, no remote sync, and no raw prompt storage by default.
+- Give a new app process enough recent history to understand the previous Terminal Sessions and agent state.
+- Give diagnostic exports a compact, safe summary of local state, with a path toward optional database snapshots later.
+- Keep the schema understandable to coding agents and humans through `docs/schema.sql`, AGENTS guidance, and focused tests.
+
+## Non-Goals
+
+- Do not replace SwiftData as the owner of Repository, Workspace, or Web Source models.
+- Do not persist raw terminal transcripts, raw prompts, raw tool payloads, secrets, or complete diagnostic logs in SQLite.
+- Do not add cross-device sync or external storage.
+
+## Implementation Slices
+
+1. Persist startup diagnostics into `diagnostic_events`.
+   - Attach `StartupDiagnosticsStore` to `LocalStateStore` during app bootstrap.
+   - Flush existing in-memory events once and persist future events asynchronously.
+   - Preserve the current hot-path behavior: diagnostics recording must not await disk I/O.
+   - Tests: `StartupDiagnosticsStore` records events into a temporary `LocalStateStore`; existing export tests still pass.
+
+2. Record richer Surface and terminal layout snapshots.
+   - Write `terminal_layout_snapshots` when the selected Surface changes and when split state changes.
+   - Include selected Surface kind/id using domain terms: repo overview, repository terminal, workspace terminal, or web source.
+   - Include split pane rows from `HostTerminalStateStore`.
+   - Tests: selecting Surfaces produces expected snapshot rows and split rows without requiring UI automation.
+
+3. Add startup read models for continuity.
+   - Add local-state queries for latest active Terminal Sessions, latest agent status per host session, and latest layout snapshot.
+   - Keep restore conservative: resolve Repository/Workspace IDs through current SwiftData rows and fall back when a row is missing.
+   - Tests: deleted or stale targets do not restore invalid Surfaces.
+
+4. Expose local state in diagnostics.
+   - Add a diagnostics panel or section that shows store mode, database path, schema version, table counts, latest event times, and last write failure if any.
+   - Keep direct database actions explicit and local-only.
+   - Tests: view model renders degraded/unavailable/persistent states.
+
+5. Expand diagnostic exports safely.
+   - Keep `local-state-summary.json` as the default safe export.
+   - Consider an opt-in SQLite snapshot using SQLite backup or `VACUUM INTO` after redaction policy is settled.
+   - Tests: default export never includes raw prompts or terminal transcript payloads.
+
+6. Add retention and health checks.
+   - Define retention for high-volume event tables.
+   - Add a lightweight integrity probe with `PRAGMA quick_check`.
+   - Add cleanup hooks for ended sessions and old diagnostic events.
+   - Tests: retention deletes old rows while preserving recent continuity rows.
+
+## Schema Stewardship
+
+- `LocalStateStore.schemaVersion` and `docs/schema.sql` must change together.
+- Any table/index/meaning change needs a runtime migration plus matching `docs/schema.sql` update.
+- Keep comments in `docs/schema.sql` focused on concepts and relationships, not implementation trivia.
+- Prefer additive migrations until a cleanup release explicitly removes obsolete fields.
+
+## Verification
+
+Every slice should run:
+
+```bash
+swift-format lint --strict --recursive Sources/ Tests/
+swift test --filter 'LocalStateStoreTests|StartupDiagnosticsStoreTests|DiagnosticReportExporterTests'
+```
+
+Before PR creation, run full `swift test` and collect evidence according to `AGENTS.md`.

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,0 +1,205 @@
+-- WorkSpaces local state schema
+-- =============================
+--
+-- This file is both documentation and a runnable SQLite schema for the native
+-- app's local state sidecar database. It mirrors LocalStateStore schema version
+-- 1 in Sources/WorkspaceManagerCore/Services/LocalStateStore.swift.
+--
+-- Keep this file manually in sync whenever LocalStateStore migrations change.
+-- SwiftData remains the canonical store for Repository, Workspace, and Web
+-- Source rows. This SQLite database records local state history for continuity,
+-- diagnostics, and export.
+--
+-- Try it locally:
+--
+--   sqlite3 /tmp/workspaces-local-state.sqlite < docs/schema.sql
+--   sqlite3 /tmp/workspaces-local-state.sqlite '.schema'
+--
+-- Runtime note: GRDB adds its own migration bookkeeping table when the app opens
+-- the database. That internal table is intentionally not documented here.
+
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA user_version = 1;
+
+BEGIN;
+
+-- Application-level key/value metadata for this sidecar store. The runtime
+-- writes schema_version here so diagnostic exports can identify the app schema
+-- without depending on GRDB's internal migration table.
+CREATE TABLE IF NOT EXISTS local_state_metadata (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+) STRICT;
+
+INSERT INTO local_state_metadata (key, value, updated_at)
+VALUES ('schema_version', '1', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+ON CONFLICT(key) DO UPDATE SET
+    value = excluded.value,
+    updated_at = excluded.updated_at;
+
+-- Durable record of host terminal sessions known to the native app.
+--
+-- Domain mapping:
+-- - Repository and Workspace identity is still owned by SwiftData.
+-- - target_kind says how this terminal relates to the WorkSpaces domain.
+-- - target_id is reserved for explicit Repository/Workspace UUIDs when a call
+--   site has that identity.
+-- - target_path captures current path-derived session keys.
+-- - backend_identifier/backend_instance_id identify provider-backed sessions.
+-- - tmux_session_name is nullable because tmux is mode-dependent.
+CREATE TABLE IF NOT EXISTS terminal_sessions (
+    host_session_id TEXT PRIMARY KEY NOT NULL,
+    session_key TEXT NOT NULL,
+    target_kind TEXT NOT NULL
+        CHECK (target_kind IN ('default_home', 'repo', 'workspace', 'host_path', 'backend_session')),
+    target_id TEXT,
+    target_path TEXT,
+    backend_identifier TEXT,
+    backend_instance_id TEXT,
+    directory_path TEXT NOT NULL,
+    terminal_mode TEXT NOT NULL,
+    tmux_session_name TEXT,
+    custom_command_present INTEGER NOT NULL DEFAULT 0
+        CHECK (custom_command_present IN (0, 1)),
+    hooks_socket_path TEXT,
+    is_active INTEGER NOT NULL DEFAULT 0
+        CHECK (is_active IN (0, 1)),
+    created_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    ended_at TEXT
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_terminal_sessions_target
+    ON terminal_sessions(target_kind, target_id, target_path);
+CREATE INDEX IF NOT EXISTS idx_terminal_sessions_last_seen
+    ON terminal_sessions(last_seen_at DESC);
+
+-- Point-in-time layout snapshots for the terminal surface. This table is ready
+-- for UI restore and diagnostics even before every layout-producing call site
+-- writes to it.
+CREATE TABLE IF NOT EXISTS terminal_layout_snapshots (
+    id TEXT PRIMARY KEY NOT NULL,
+    captured_at TEXT NOT NULL,
+    active_host_session_id TEXT,
+    selected_surface_kind TEXT,
+    selected_surface_id TEXT,
+    FOREIGN KEY (active_host_session_id)
+        REFERENCES terminal_sessions(host_session_id)
+        ON DELETE SET NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_terminal_layout_snapshots_captured
+    ON terminal_layout_snapshots(captured_at DESC);
+
+-- Split-pane details for a layout snapshot. The current product model is one
+-- primary terminal plus an optional split for that primary terminal.
+CREATE TABLE IF NOT EXISTS terminal_split_snapshots (
+    snapshot_id TEXT NOT NULL,
+    primary_host_session_id TEXT NOT NULL,
+    split_host_session_id TEXT NOT NULL,
+    axis TEXT NOT NULL CHECK (axis IN ('leading_trailing', 'top_bottom')),
+    split_before_primary INTEGER NOT NULL CHECK (split_before_primary IN (0, 1)),
+    split_fraction REAL NOT NULL CHECK (split_fraction >= 0.0 AND split_fraction <= 1.0),
+    PRIMARY KEY (snapshot_id, primary_host_session_id),
+    FOREIGN KEY (snapshot_id)
+        REFERENCES terminal_layout_snapshots(id)
+        ON DELETE CASCADE,
+    FOREIGN KEY (primary_host_session_id)
+        REFERENCES terminal_sessions(host_session_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY (split_host_session_id)
+        REFERENCES terminal_sessions(host_session_id)
+        ON DELETE CASCADE
+) STRICT;
+
+-- Normalized agent state events from hooks, OSC, status line, transcript, and
+-- bell inputs. Raw prompts and raw tool inputs are not persisted by default.
+-- prompt_present records that a user prompt existed without storing the prompt.
+CREATE TABLE IF NOT EXISTS agent_status_events (
+    id TEXT PRIMARY KEY NOT NULL,
+    host_session_id TEXT NOT NULL,
+    agent_session_id TEXT,
+    agent_kind TEXT NOT NULL,
+    origin TEXT NOT NULL CHECK (origin IN ('hook', 'osc', 'status_line', 'transcript', 'bell')),
+    origin_detail TEXT,
+    event_name TEXT NOT NULL,
+    run_state TEXT NOT NULL,
+    cwd TEXT NOT NULL,
+    tool_name TEXT,
+    tool_detail TEXT,
+    awaiting_reason TEXT,
+    error_category TEXT,
+    error_message TEXT,
+    prompt_present INTEGER NOT NULL DEFAULT 0 CHECK (prompt_present IN (0, 1)),
+    model_display_name TEXT,
+    context_used_percent REAL,
+    five_hour_limit_used_percent REAL,
+    five_hour_limit_resets_at TEXT,
+    cost_usd REAL,
+    event_at TEXT NOT NULL,
+    FOREIGN KEY (host_session_id)
+        REFERENCES terminal_sessions(host_session_id)
+        ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_agent_status_events_host_time
+    ON agent_status_events(host_session_id, event_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_status_events_agent_session
+    ON agent_status_events(agent_session_id, event_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_status_events_run_state
+    ON agent_status_events(run_state, event_at DESC);
+
+-- Local performance and startup diagnostics. labels_json is intentionally a
+-- bounded JSON object of safe diagnostic labels, not arbitrary raw logs.
+CREATE TABLE IF NOT EXISTS diagnostic_events (
+    id TEXT PRIMARY KEY NOT NULL,
+    metric TEXT NOT NULL,
+    duration_ms REAL NOT NULL,
+    labels_json TEXT NOT NULL DEFAULT '{}',
+    event_at TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_events_metric_time
+    ON diagnostic_events(metric, event_at DESC);
+
+-- Diagnostic report export ledger. The export itself is a zip file; this table
+-- keeps local metadata and row counts so support/debug flows can answer what
+-- state existed when the report was produced.
+CREATE TABLE IF NOT EXISTS diagnostic_exports (
+    id TEXT PRIMARY KEY NOT NULL,
+    created_at TEXT NOT NULL,
+    app_version TEXT NOT NULL,
+    build_number TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    redaction_level TEXT NOT NULL,
+    status TEXT NOT NULL,
+    row_counts_json TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_diagnostic_exports_created
+    ON diagnostic_exports(created_at DESC);
+
+COMMIT;
+
+-- Useful exploration queries:
+--
+-- Recent terminal sessions:
+--   SELECT target_kind, target_path, directory_path, terminal_mode, is_active, last_seen_at
+--   FROM terminal_sessions
+--   ORDER BY last_seen_at DESC
+--   LIMIT 20;
+--
+-- Agent state timeline for one host terminal session:
+--   SELECT event_at, origin, event_name, run_state, tool_name, awaiting_reason
+--   FROM agent_status_events
+--   WHERE host_session_id = '<uuid>'
+--   ORDER BY event_at ASC;
+--
+-- Diagnostic event counts:
+--   SELECT metric, count(*) AS events, max(event_at) AS latest
+--   FROM diagnostic_events
+--   GROUP BY metric
+--   ORDER BY latest DESC;


### PR DESCRIPTION
## Summary

- Add a GRDB-backed local SQLite sidecar for WorkSpaces continuity, diagnostics, and export state.
- Add `docs/schema.sql` as the manually maintained runnable schema document and `docs/development/local-state-store-plan.md` as the rollout plan.
- Persist terminal sessions, agent state events, startup diagnostics, and diagnostic export summaries locally without storing raw prompts by default.

## Mergeability

- Surface: desktop / docs
- User-facing behavior changed: The native app now creates a local SQLite sidecar under the WorkSpaces data directory and includes local-state summary metadata in diagnostic exports.
- Non-happy paths considered: UI fixture mode disables persistence unless an explicit data directory is provided; bootstrap failures degrade to an unavailable local state store and are reported in diagnostics.
- Release/ops preconditions: macOS CI must pass before merge. Release follows the existing main-branch release workflow after merge.
- Residual risk or follow-up: This is the foundation plus first diagnostic-persistence slice; UI restore/read-model behavior remains in the checked-in follow-up plan.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/`; `swift test --filter 'LocalStateStoreTests|StartupDiagnosticsStoreTests|DiagnosticReportExporterTests'`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Hosted validation evidence](https://evidence.cloudcompute.com/workspaces/pr-483/20260517-034817-local-state-store-validation.svg)
- UI evidence not applicable: this change adds persistence, diagnostics metadata, docs, and tests without changing visible UI.

## Blockers

- [x] None
- [ ] Blocked on evidence

No known blockers. Waiting on CI and review.