### PR TITLE
Refactor main window orchestration into focused controllers

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1443,13 +1443,15 @@ struct ContentView: View {
     }
 
     private func handleTerminalProcessExit(sessionID: UUID) {
-        guard let result = terminalSessionController.handleProcessExit(
-            sessionID: sessionID,
-            hostTerminalState: hostTerminalState,
-            defaultHomeDirectory: resolvedDefaultHostDirectory,
-            repos: repos,
-            normalizePath: normalizePath
-        ) else { return }
+        guard
+            let result = terminalSessionController.handleProcessExit(
+                sessionID: sessionID,
+                hostTerminalState: hostTerminalState,
+                defaultHomeDirectory: resolvedDefaultHostDirectory,
+                repos: repos,
+                normalizePath: normalizePath
+            )
+        else { return }
         applyTerminalSessionResult(result)
     }
 
@@ -1473,49 +1475,57 @@ struct ContentView: View {
 
     @MainActor
     private func createTerminalTabFromCurrentContext() {
-        guard let result = terminalSessionController.createTabFromCurrentContext(
-            hostTerminalState: hostTerminalState,
-            defaultHomeDirectory: resolvedDefaultHostDirectory,
-            repos: repos,
-            normalizePath: normalizePath,
-            activateHostSession: { key, directory, customCommand in
-                activateHostSession(key: key, directory: directory, customCommand: customCommand)
-            }
-        ) else { return }
+        guard
+            let result = terminalSessionController.createTabFromCurrentContext(
+                hostTerminalState: hostTerminalState,
+                defaultHomeDirectory: resolvedDefaultHostDirectory,
+                repos: repos,
+                normalizePath: normalizePath,
+                activateHostSession: { key, directory, customCommand in
+                    activateHostSession(key: key, directory: directory, customCommand: customCommand)
+                }
+            )
+        else { return }
         applyTerminalSessionResult(result)
     }
 
     @MainActor
     private func selectTerminalTab(sessionID: UUID) {
-        guard let result = terminalSessionController.selectTab(
-            sessionID: sessionID,
-            hostTerminalState: hostTerminalState,
-            repos: repos,
-            normalizePath: normalizePath
-        ) else { return }
+        guard
+            let result = terminalSessionController.selectTab(
+                sessionID: sessionID,
+                hostTerminalState: hostTerminalState,
+                repos: repos,
+                normalizePath: normalizePath
+            )
+        else { return }
         applyTerminalSessionResult(result)
     }
 
     @MainActor
     private func selectAdjacentTerminalTab(offset: Int) {
-        guard let result = terminalSessionController.selectAdjacentTab(
-            offset: offset,
-            hostTerminalState: hostTerminalState,
-            repos: repos,
-            normalizePath: normalizePath
-        ) else { return }
+        guard
+            let result = terminalSessionController.selectAdjacentTab(
+                offset: offset,
+                hostTerminalState: hostTerminalState,
+                repos: repos,
+                normalizePath: normalizePath
+            )
+        else { return }
         applyTerminalSessionResult(result)
     }
 
     @MainActor
     private func closeActiveTerminalTab() {
-        guard let result = terminalSessionController.closeActiveTab(
-            hostTerminalState: hostTerminalState,
-            defaultHomeDirectory: resolvedDefaultHostDirectory,
-            repos: repos,
-            normalizePath: normalizePath,
-            requestClose: requestTerminalClose(sessionID:)
-        ) else { return }
+        guard
+            let result = terminalSessionController.closeActiveTab(
+                hostTerminalState: hostTerminalState,
+                defaultHomeDirectory: resolvedDefaultHostDirectory,
+                repos: repos,
+                normalizePath: normalizePath,
+                requestClose: requestTerminalClose(sessionID:)
+            )
+        else { return }
         applyTerminalSessionResult(result)
     }
 
@@ -1549,13 +1559,15 @@ struct ContentView: View {
 
     @MainActor
     private func forceCloseTerminalTab(sessionID: UUID) {
-        guard let result = terminalSessionController.forceCloseTab(
-            sessionID: sessionID,
-            hostTerminalState: hostTerminalState,
-            defaultHomeDirectory: resolvedDefaultHostDirectory,
-            repos: repos,
-            normalizePath: normalizePath
-        ) else { return }
+        guard
+            let result = terminalSessionController.forceCloseTab(
+                sessionID: sessionID,
+                hostTerminalState: hostTerminalState,
+                defaultHomeDirectory: resolvedDefaultHostDirectory,
+                repos: repos,
+                normalizePath: normalizePath
+            )
+        else { return }
         applyTerminalSessionResult(result)
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1591,11 +1591,6 @@ struct ContentView: View {
     }
 
     @MainActor
-    private func syncSidebarSelectionToActiveSession() {
-        syncSidebarSelectionToActiveSessionFromActiveHostSession()
-    }
-
-    @MainActor
     private func performDeferredStartupWorkspaceStatusSync() async {
         guard !didScheduleInitialWorkspaceStatusSync else { return }
         didScheduleInitialWorkspaceStatusSync = true

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -714,7 +714,7 @@ struct ContentView: View {
             }
             .onDisappear {
                 clearAppCommands()
-                accessRecorder.cancelPendingSave()
+                accessRecorder.flushPendingSave(modelContext: modelContext)
             }
             .sheet(item: $repoForNewWorkspaceFromLanding) { repo in
                 NewWorkspaceSheet(

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -53,7 +53,7 @@ struct ContentView: View {
     @State private var landingErrorMessage: String?
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
     @State private var didScheduleInitialWorkspaceStatusSync = false
-    @State private var accessTimestampSaveTask: Task<Void, Never>?
+    @State private var accessRecorder = MainWindowAccessRecorder()
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
     @StateObject private var webSurfaceStore = WebSurfaceStore()
     @StateObject private var terminalFocusCoordinator = TerminalFocusCoordinator()
@@ -66,7 +66,9 @@ struct ContentView: View {
     @State private var mainSelectionCoordinator = MainSelectionCoordinator()
     private let navigationStateController = MainWindowNavigationStateController()
     private let surfaceResolutionController = MainWindowSurfaceResolutionController()
+    private let launchActionHandler = MainWindowLaunchActionHandler()
     private let presentationController = MainWindowPresentationController()
+    private let terminalSessionController = MainWindowTerminalSessionController()
     private let splitRoutingController = SplitRoutingController()
     private let tabRoutingController = TabRoutingController()
     private let workspaceEnvironmentOptionsController = WorkspaceEnvironmentOptionsController()
@@ -561,7 +563,7 @@ struct ContentView: View {
                             requestCloseTerminalTabs(sessionIDs)
                         }
                     )
-                    syncSidebarSelectionToActiveSession()
+                    syncSidebarSelectionToActiveSessionFromActiveHostSession()
                 }
             }
     }
@@ -712,6 +714,7 @@ struct ContentView: View {
             }
             .onDisappear {
                 clearAppCommands()
+                accessRecorder.cancelPendingSave()
             }
             .sheet(item: $repoForNewWorkspaceFromLanding) { repo in
                 NewWorkspaceSheet(
@@ -910,155 +913,61 @@ struct ContentView: View {
     @MainActor
     @discardableResult
     private func applySurfaceResolutionAction(_ action: MainWindowSurfaceResolutionAction) -> Bool {
-        switch action {
-        case .none, .waitForRepos:
-            return false
-
-        case .clearDeepLinkNoMatch(let request):
-            NSLog("[DeepLink] No workspace match for cwd: %@", request.cwd)
-            deepLinkState.clearPendingRequest()
-            return true
-
-        case .selectDeepLinkedWorkspace(let request, let workspace):
-            NSLog(
-                "[DeepLink] Matched workspace '%@' for cwd '%@' (session_id=%@ source=%@)",
-                workspace.name,
-                request.cwd,
-                request.sessionID ?? "",
-                request.source ?? ""
+        launchActionHandler.apply(
+            action,
+            state: &viewState,
+            environment: ProcessInfo.processInfo.environment,
+            pendingRequest: deepLinkState.pendingRequest,
+            bootstrapController: bootstrapController,
+            actions: MainWindowLaunchActionHandler.Actions(
+                clearDeepLink: {
+                    deepLinkState.clearPendingRequest()
+                },
+                clearLastSurface: {
+                    lastSurfaceRawValue = ""
+                },
+                discardPendingRemoteConnection: { reason in
+                    abandonPendingRemoteConnection(reason: reason)
+                },
+                importRepo: { repoRoot in
+                    launchRepositoryService.existingOrImportedRepo(at: repoRoot)
+                },
+                selectWorkspace: { workspace, preferredDirectory in
+                    handleWorkspaceSelection(workspace, preferredDirectory: preferredDirectory)
+                },
+                selectRepoTerminal: { repo, preferredDirectory in
+                    handleRepoTerminalSelection(repo, preferredDirectory: preferredDirectory)
+                },
+                selectWebSource: { source in
+                    handleWebSourceSelection(source)
+                },
+                applyLaunchSurface: { surface in
+                    applyLaunchSurface(surface)
+                },
+                schedulePerfAutoSelect: { repo, shouldAutoOpenNewWorkspace in
+                    schedulePerfAutoSelection(repo, shouldAutoOpenNewWorkspace: shouldAutoOpenNewWorkspace)
+                },
+                focusWorkspaceWindow: {
+                    focusWorkspaceWindow()
+                }
             )
+        )
+    }
 
-            abandonPendingRemoteConnection(reason: "deep_link_selected")
-            handleWorkspaceSelection(
-                workspace,
-                preferredDirectory: URL(fileURLWithPath: request.cwd, isDirectory: true)
-            )
-            deepLinkState.clearPendingRequest()
-            viewState.didResolveInitialSurface = true
-            focusWorkspaceWindow()
-            return false
+    @MainActor
+    private func schedulePerfAutoSelection(_ repo: Repo, shouldAutoOpenNewWorkspace: Bool) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            Task { @MainActor in
+                viewState.didResolveInitialSurface = true
+                handleRepoTerminalSelection(repo)
+                guard shouldAutoOpenNewWorkspace else { return }
 
-        case .selectDeepLinkedRepo(let request, let repo):
-            NSLog(
-                "[DeepLink] Matched repo '%@' for cwd '%@' (session_id=%@ source=%@)",
-                repo.name,
-                request.cwd,
-                request.sessionID ?? "",
-                request.source ?? ""
-            )
-
-            abandonPendingRemoteConnection(reason: "deep_link_selected")
-            handleRepoTerminalSelection(
-                repo,
-                preferredDirectory: URL(fileURLWithPath: request.cwd, isDirectory: true)
-            )
-            deepLinkState.clearPendingRequest()
-            viewState.didResolveInitialSurface = true
-            focusWorkspaceWindow()
-            return false
-
-        case .importDeepLinkedRepo(let request, let repoRoot):
-            guard let repo = launchRepositoryService.existingOrImportedRepo(at: repoRoot) else {
-                NSLog("[DeepLink] Failed to import repo for cwd '%@' repo_root='%@'", request.cwd, repoRoot)
-                deepLinkState.clearPendingRequest()
-                return true
-            }
-
-            NSLog(
-                "[DeepLink] Imported repo '%@' for cwd '%@' (repo_root=%@)",
-                repo.name,
-                request.cwd,
-                repoRoot
-            )
-
-            abandonPendingRemoteConnection(reason: "deep_link_repo_imported")
-            handleRepoTerminalSelection(
-                repo,
-                preferredDirectory: URL(fileURLWithPath: request.cwd, isDirectory: true)
-            )
-            deepLinkState.clearPendingRequest()
-            viewState.didResolveInitialSurface = true
-            focusWorkspaceWindow()
-            return false
-
-        case .perfAutoSelect(let repo):
-            let shouldAutoOpenNewWorkspace = bootstrapController.shouldPerfAutoOpenNewWorkspace(
-                environment: ProcessInfo.processInfo.environment,
-                didRun: viewState.didRunPerfAutoOpenNewWorkspace,
-                pendingRequest: deepLinkState.pendingRequest
-            )
-            viewState.didRunPerfAutoSelection = true
-            if shouldAutoOpenNewWorkspace {
-                viewState.didRunPerfAutoOpenNewWorkspace = true
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                Task { @MainActor in
-                    viewState.didResolveInitialSurface = true
-                    handleRepoTerminalSelection(repo)
-                    guard shouldAutoOpenNewWorkspace else { return }
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        Task { @MainActor in
-                            await presentNewWorkspaceFromLanding(repo)
-                        }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    Task { @MainActor in
+                        await presentNewWorkspaceFromLanding(repo)
                     }
                 }
             }
-            return false
-
-        case .recordMissingPreviewBootstrap(let configuration):
-            viewState.didApplyFixturePreviewBootstrap = true
-            NSLog(
-                "[UIFixture] Preview bootstrap skipped (repo=%@ path=%@)",
-                configuration.repoName,
-                configuration.relativePath
-            )
-            return true
-
-        case .applyPreviewBootstrap(_, let repo, let selection):
-            viewState.didApplyFixturePreviewBootstrap = true
-            viewState.didResolveInitialSurface = true
-            handleRepoTerminalSelection(repo)
-            viewState.selectedCodePreview = selection
-            viewState.isTerminalPanelVisible = true
-            viewState.isRightPaneVisible = true
-
-            NSLog(
-                "[UIFixture] Preview bootstrap applied (repo=%@ file=%@)",
-                repo.name,
-                selection.relativePath
-            )
-            return false
-
-        case .recordMissingWebBootstrap(let targetName):
-            viewState.didApplyFixtureWebBootstrap = true
-            NSLog("[UIFixture] Web bootstrap skipped (target=%@)", targetName)
-            return true
-
-        case .applyWebBootstrap(let targetName, let selectedSource):
-            viewState.didApplyFixtureWebBootstrap = true
-            viewState.didResolveInitialSurface = true
-            handleWebSourceSelection(selectedSource)
-            NSLog(
-                "[UIFixture] Web bootstrap applied (target=%@ selected=%@)",
-                targetName,
-                selectedSource.name
-            )
-            return false
-
-        case .clearInvalidLastSurface:
-            lastSurfaceRawValue = ""
-            return true
-
-        case .restore(let surface):
-            viewState.didResolveInitialSurface = true
-            applyLaunchSurface(surface)
-            return false
-
-        case .fallback(let surface):
-            viewState.didResolveInitialSurface = true
-            applyLaunchSurface(surface)
-            return false
         }
     }
 
@@ -1520,99 +1429,94 @@ struct ContentView: View {
 
     @MainActor
     private func markAccessed(repo: Repo) {
-        repo.lastAccessedAt = Date()
-        saveAccessTimestampChanges()
+        accessRecorder.record(repo: repo, modelContext: modelContext)
     }
 
     @MainActor
     private func markAccessed(workspace: Workspace) {
-        let accessDate = Date()
-        workspace.lastAccessedAt = accessDate
-        workspace.sourceRepo?.lastAccessedAt = accessDate
-        saveAccessTimestampChanges()
+        accessRecorder.record(workspace: workspace, modelContext: modelContext)
     }
 
     @MainActor
     private func markAccessed(webSource: WebSource) {
-        let accessDate = Date()
-        webSource.lastAccessedAt = accessDate
-        webSource.ownerRepo?.lastAccessedAt = accessDate
-        saveAccessTimestampChanges()
+        accessRecorder.record(webSource: webSource, modelContext: modelContext)
+    }
+
+    private func handleTerminalProcessExit(sessionID: UUID) {
+        guard let result = terminalSessionController.handleProcessExit(
+            sessionID: sessionID,
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: resolvedDefaultHostDirectory,
+            repos: repos,
+            normalizePath: normalizePath
+        ) else { return }
+        applyTerminalSessionResult(result)
     }
 
     @MainActor
-    private func saveAccessTimestampChanges() {
-        accessTimestampSaveTask?.cancel()
-        accessTimestampSaveTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(500))
-            guard !Task.isCancelled else { return }
-            do {
-                try modelContext.save()
-            } catch {
-                if modelContext.insertedModelsArray.isEmpty {
-                    creationLog.warning(
-                        "saveAccessTimestampChanges: save failed, rolling back (no pending inserts)"
-                    )
-                    modelContext.rollback()
-                } else {
-                    creationLog.error(
-                        "saveAccessTimestampChanges: save failed with \(modelContext.insertedModelsArray.count) pending inserts — skipping rollback to preserve workspace creation"
-                    )
-                }
-            }
-        }
+    private func applyTerminalSessionResult(
+        _ result: MainWindowTerminalSessionController.SessionFocusResult
+    ) {
+        setSelectedWorkspace(result.syncedWorkspace)
+        focusTerminalTab(result.focusSessionID)
     }
-    private func handleTerminalProcessExit(sessionID: UUID) {
-        NSLog("[HostSession] Process exit detected for session %@", sessionID.uuidString)
-        guard
-            let focusSessionID = hostTerminalState.handleProcessExitAndResolveFocusTarget(
-                for: sessionID,
-                defaultHomeDirectory: resolvedDefaultHostDirectory
-            )
-        else {
-            return
-        }
 
-        // Sync sidebar selection to match the new active session.
-        syncSidebarSelectionToActiveSession()
-
-        terminalFocusCoordinator.requestMainTerminalFocus(
-            targetSessionID: focusSessionID,
-            activateApp: false,
-            surfaceStore: hostTerminalState.surfaceStore,
-            activeSessionID: hostTerminalState.activeSessionID
+    @MainActor
+    private func syncSidebarSelectionToActiveSessionFromActiveHostSession() {
+        let syncedWorkspace = terminalSessionController.syncedWorkspaceSelection(
+            activeHostSession: activeHostSession,
+            repos: repos,
+            normalizePath: normalizePath
         )
+        setSelectedWorkspace(syncedWorkspace)
     }
 
     @MainActor
     private func createTerminalTabFromCurrentContext() {
-        if !hostTerminalState.hasSessions {
-            ensureInitialHostSession()
-        }
-
-        guard let session = hostTerminalState.createTab() else { return }
-        syncSidebarSelectionToActiveSession()
-        focusTerminalTab(session.id)
+        guard let result = terminalSessionController.createTabFromCurrentContext(
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: resolvedDefaultHostDirectory,
+            repos: repos,
+            normalizePath: normalizePath,
+            activateHostSession: { key, directory, customCommand in
+                activateHostSession(key: key, directory: directory, customCommand: customCommand)
+            }
+        ) else { return }
+        applyTerminalSessionResult(result)
     }
 
     @MainActor
     private func selectTerminalTab(sessionID: UUID) {
-        guard hostTerminalState.activateExistingSession(sessionID: sessionID) else { return }
-        syncSidebarSelectionToActiveSession()
-        focusTerminalTab(sessionID)
+        guard let result = terminalSessionController.selectTab(
+            sessionID: sessionID,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        ) else { return }
+        applyTerminalSessionResult(result)
     }
 
     @MainActor
     private func selectAdjacentTerminalTab(offset: Int) {
-        guard let session = hostTerminalState.activateAdjacentTab(offset: offset) else { return }
-        syncSidebarSelectionToActiveSession()
-        focusTerminalTab(session.id)
+        guard let result = terminalSessionController.selectAdjacentTab(
+            offset: offset,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        ) else { return }
+        applyTerminalSessionResult(result)
     }
 
     @MainActor
     private func closeActiveTerminalTab() {
-        guard let activeSessionID = hostTerminalState.activeSessionID else { return }
-        closeTerminalTab(sessionID: activeSessionID)
+        guard let result = terminalSessionController.closeActiveTab(
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: resolvedDefaultHostDirectory,
+            repos: repos,
+            normalizePath: normalizePath,
+            requestClose: requestTerminalClose(sessionID:)
+        ) else { return }
+        applyTerminalSessionResult(result)
     }
 
     @MainActor
@@ -1622,43 +1526,46 @@ struct ContentView: View {
 
     @MainActor
     private func requestCloseTerminalTabs(_ sessionIDs: [UUID]) {
-        for sessionID in sessionIDs {
-            if let terminal = hostTerminalState.surfaceStore.terminal(for: sessionID) {
-                terminal.requestClose()
-            } else {
-                forceCloseTerminalTab(sessionID: sessionID)
-            }
+        let results = terminalSessionController.closeTabs(
+            sessionIDs,
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: resolvedDefaultHostDirectory,
+            repos: repos,
+            normalizePath: normalizePath,
+            requestClose: requestTerminalClose(sessionID:)
+        )
+        for result in results {
+            applyTerminalSessionResult(result)
         }
     }
 
     @MainActor
     private func requestCloseConfirmationForTerminalTab(sessionID: UUID) {
-        let title =
-            hostTerminalState.sessions.first(where: { $0.id == sessionID })
-            .map {
-                hostTerminalState.tabTitleOverride(for: $0.id)
-                    ?? hostTerminalState.surfaceStore.displayTitle(for: $0)
-            }
-            ?? "Terminal"
-        viewState.terminalCloseConfirmation = TerminalCloseConfirmation(
+        viewState.terminalCloseConfirmation = terminalSessionController.closeConfirmation(
             sessionID: sessionID,
-            title: title
+            hostTerminalState: hostTerminalState
         )
     }
 
     @MainActor
     private func forceCloseTerminalTab(sessionID: UUID) {
-        guard
-            let focusSessionID = hostTerminalState.handleProcessExitAndResolveFocusTarget(
-                for: sessionID,
-                defaultHomeDirectory: resolvedDefaultHostDirectory
-            )
-        else {
-            return
-        }
+        guard let result = terminalSessionController.forceCloseTab(
+            sessionID: sessionID,
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: resolvedDefaultHostDirectory,
+            repos: repos,
+            normalizePath: normalizePath
+        ) else { return }
+        applyTerminalSessionResult(result)
+    }
 
-        syncSidebarSelectionToActiveSession()
-        focusTerminalTab(focusSessionID)
+    @MainActor
+    private func requestTerminalClose(sessionID: UUID) -> Bool {
+        guard let terminal = hostTerminalState.surfaceStore.terminal(for: sessionID) else {
+            return false
+        }
+        terminal.requestClose()
+        return true
     }
 
     @MainActor
@@ -1673,12 +1580,7 @@ struct ContentView: View {
 
     @MainActor
     private func syncSidebarSelectionToActiveSession() {
-        let syncedWorkspace = mainSelectionCoordinator.syncedWorkspaceSelection(
-            for: activeHostSession,
-            repos: repos,
-            normalizePath: normalizePath
-        )
-        setSelectedWorkspace(syncedWorkspace)
+        syncSidebarSelectionToActiveSessionFromActiveHostSession()
     }
 
     @MainActor
@@ -1831,10 +1733,12 @@ struct ContentView: View {
 
     @MainActor
     private func ensureInitialHostSession() {
-        guard !hostTerminalState.hasSessions else { return }
-        _ = activateHostSession(
-            key: .defaultHome,
-            directory: resolvedDefaultHostDirectory
+        terminalSessionController.ensureInitialHostSession(
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: resolvedDefaultHostDirectory,
+            activateHostSession: { key, directory, customCommand in
+                activateHostSession(key: key, directory: directory, customCommand: customCommand)
+            }
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowAccessRecorder.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowAccessRecorder.swift
@@ -47,6 +47,13 @@ struct MainWindowAccessRecorder {
     }
 
     @discardableResult
+    mutating func flushPendingSave(modelContext: ModelContext) -> SaveFailureResolution? {
+        guard saveTask != nil else { return nil }
+        cancelPendingSave()
+        return Self.savePendingChanges(modelContext: modelContext)
+    }
+
+    @discardableResult
     static func savePendingChanges(modelContext: ModelContext) -> SaveFailureResolution? {
         do {
             try modelContext.save()

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowAccessRecorder.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowAccessRecorder.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftData
+import WorkspaceManagerCore
+import os.log
+
+private let accessRecorderLog = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceCreation"
+)
+
+@MainActor
+struct MainWindowAccessRecorder {
+    enum SaveFailureResolution: Equatable {
+        case rolledBack
+        case preservedPendingInserts(Int)
+    }
+
+    private let saveDelay: Duration
+    private var saveTask: Task<Void, Never>?
+
+    init(saveDelay: Duration = .milliseconds(500)) {
+        self.saveDelay = saveDelay
+    }
+
+    mutating func record(repo: Repo, modelContext: ModelContext) {
+        repo.lastAccessedAt = Date()
+        scheduleSave(modelContext: modelContext)
+    }
+
+    mutating func record(workspace: Workspace, modelContext: ModelContext) {
+        let accessDate = Date()
+        workspace.lastAccessedAt = accessDate
+        workspace.sourceRepo?.lastAccessedAt = accessDate
+        scheduleSave(modelContext: modelContext)
+    }
+
+    mutating func record(webSource: WebSource, modelContext: ModelContext) {
+        let accessDate = Date()
+        webSource.lastAccessedAt = accessDate
+        webSource.ownerRepo?.lastAccessedAt = accessDate
+        scheduleSave(modelContext: modelContext)
+    }
+
+    mutating func cancelPendingSave() {
+        saveTask?.cancel()
+        saveTask = nil
+    }
+
+    @discardableResult
+    static func savePendingChanges(modelContext: ModelContext) -> SaveFailureResolution? {
+        do {
+            try modelContext.save()
+            return nil
+        } catch {
+            return resolveSaveFailure(modelContext: modelContext)
+        }
+    }
+
+    @discardableResult
+    static func resolveSaveFailure(modelContext: ModelContext) -> SaveFailureResolution {
+        let pendingInsertCount = modelContext.insertedModelsArray.count
+        if pendingInsertCount == 0 {
+            accessRecorderLog.warning(
+                "saveAccessTimestampChanges: save failed, rolling back (no pending inserts)"
+            )
+            modelContext.rollback()
+            return .rolledBack
+        }
+
+        accessRecorderLog.error(
+            "saveAccessTimestampChanges: save failed with \(pendingInsertCount) pending inserts - skipping rollback to preserve workspace creation"
+        )
+        return .preservedPendingInserts(pendingInsertCount)
+    }
+
+    private mutating func scheduleSave(modelContext: ModelContext) {
+        saveTask?.cancel()
+        let delay = saveDelay
+        saveTask = Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            Self.savePendingChanges(modelContext: modelContext)
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowLaunchActionHandler.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowLaunchActionHandler.swift
@@ -1,0 +1,163 @@
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+struct MainWindowLaunchActionHandler {
+    struct Actions {
+        let clearDeepLink: () -> Void
+        let clearLastSurface: () -> Void
+        let discardPendingRemoteConnection: (String) -> Void
+        let importRepo: (String) -> Repo?
+        let selectWorkspace: (Workspace, URL?) -> Void
+        let selectRepoTerminal: (Repo, URL?) -> Void
+        let selectWebSource: (WebSource) -> Void
+        let applyLaunchSurface: (MainWindowLaunchSurface) -> Void
+        let schedulePerfAutoSelect: (Repo, Bool) -> Void
+        let focusWorkspaceWindow: () -> Void
+    }
+
+    @discardableResult
+    func apply(
+        _ action: MainWindowSurfaceResolutionAction,
+        state: inout MainWindowViewState,
+        environment: [String: String],
+        pendingRequest: WorkspaceDeepLink?,
+        bootstrapController: MainWindowBootstrapController,
+        actions: Actions
+    ) -> Bool {
+        switch action {
+        case .none, .waitForRepos:
+            return false
+
+        case .clearDeepLinkNoMatch(let request):
+            NSLog("[DeepLink] No workspace match for cwd: %@", request.cwd)
+            actions.clearDeepLink()
+            return true
+
+        case .selectDeepLinkedWorkspace(let request, let workspace):
+            NSLog(
+                "[DeepLink] Matched workspace '%@' for cwd '%@' (session_id=%@ source=%@)",
+                workspace.name,
+                request.cwd,
+                request.sessionID ?? "",
+                request.source ?? ""
+            )
+            actions.discardPendingRemoteConnection("deep_link_selected")
+            actions.selectWorkspace(
+                workspace,
+                URL(fileURLWithPath: request.cwd, isDirectory: true)
+            )
+            actions.clearDeepLink()
+            state.didResolveInitialSurface = true
+            actions.focusWorkspaceWindow()
+            return false
+
+        case .selectDeepLinkedRepo(let request, let repo):
+            NSLog(
+                "[DeepLink] Matched repo '%@' for cwd '%@' (session_id=%@ source=%@)",
+                repo.name,
+                request.cwd,
+                request.sessionID ?? "",
+                request.source ?? ""
+            )
+            actions.discardPendingRemoteConnection("deep_link_selected")
+            actions.selectRepoTerminal(
+                repo,
+                URL(fileURLWithPath: request.cwd, isDirectory: true)
+            )
+            actions.clearDeepLink()
+            state.didResolveInitialSurface = true
+            actions.focusWorkspaceWindow()
+            return false
+
+        case .importDeepLinkedRepo(let request, let repoRoot):
+            guard let repo = actions.importRepo(repoRoot) else {
+                NSLog("[DeepLink] Failed to import repo for cwd '%@' repo_root='%@'", request.cwd, repoRoot)
+                actions.clearDeepLink()
+                return true
+            }
+
+            NSLog(
+                "[DeepLink] Imported repo '%@' for cwd '%@' (repo_root=%@)",
+                repo.name,
+                request.cwd,
+                repoRoot
+            )
+            actions.discardPendingRemoteConnection("deep_link_repo_imported")
+            actions.selectRepoTerminal(
+                repo,
+                URL(fileURLWithPath: request.cwd, isDirectory: true)
+            )
+            actions.clearDeepLink()
+            state.didResolveInitialSurface = true
+            actions.focusWorkspaceWindow()
+            return false
+
+        case .perfAutoSelect(let repo):
+            let shouldAutoOpenNewWorkspace = bootstrapController.shouldPerfAutoOpenNewWorkspace(
+                environment: environment,
+                didRun: state.didRunPerfAutoOpenNewWorkspace,
+                pendingRequest: pendingRequest
+            )
+            state.didRunPerfAutoSelection = true
+            if shouldAutoOpenNewWorkspace {
+                state.didRunPerfAutoOpenNewWorkspace = true
+            }
+            actions.schedulePerfAutoSelect(repo, shouldAutoOpenNewWorkspace)
+            return false
+
+        case .recordMissingPreviewBootstrap(let configuration):
+            state.didApplyFixturePreviewBootstrap = true
+            NSLog(
+                "[UIFixture] Preview bootstrap skipped (repo=%@ path=%@)",
+                configuration.repoName,
+                configuration.relativePath
+            )
+            return true
+
+        case .applyPreviewBootstrap(_, let repo, let selection):
+            state.didApplyFixturePreviewBootstrap = true
+            state.didResolveInitialSurface = true
+            actions.selectRepoTerminal(repo, nil)
+            state.selectedCodePreview = selection
+            state.isTerminalPanelVisible = true
+            state.isRightPaneVisible = true
+            NSLog(
+                "[UIFixture] Preview bootstrap applied (repo=%@ file=%@)",
+                repo.name,
+                selection.relativePath
+            )
+            return false
+
+        case .recordMissingWebBootstrap(let targetName):
+            state.didApplyFixtureWebBootstrap = true
+            NSLog("[UIFixture] Web bootstrap skipped (target=%@)", targetName)
+            return true
+
+        case .applyWebBootstrap(let targetName, let selectedSource):
+            state.didApplyFixtureWebBootstrap = true
+            state.didResolveInitialSurface = true
+            actions.selectWebSource(selectedSource)
+            NSLog(
+                "[UIFixture] Web bootstrap applied (target=%@ selected=%@)",
+                targetName,
+                selectedSource.name
+            )
+            return false
+
+        case .clearInvalidLastSurface:
+            actions.clearLastSurface()
+            return true
+
+        case .restore(let surface):
+            state.didResolveInitialSurface = true
+            actions.applyLaunchSurface(surface)
+            return false
+
+        case .fallback(let surface):
+            state.didResolveInitialSurface = true
+            actions.applyLaunchSurface(surface)
+            return false
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowTerminalSessionController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowTerminalSessionController.swift
@@ -1,0 +1,212 @@
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+struct MainWindowTerminalSessionController {
+    struct SessionFocusResult: Equatable {
+        let focusSessionID: UUID
+        let syncedWorkspace: Workspace?
+    }
+
+    @discardableResult
+    func ensureInitialHostSession(
+        hostTerminalState: HostTerminalStateStore,
+        defaultHomeDirectory: URL,
+        activateHostSession: (HostTerminalSessionKey, URL, String?) -> HostTerminalSession
+    ) -> HostTerminalSession? {
+        guard !hostTerminalState.hasSessions else { return nil }
+        return activateHostSession(.defaultHome, defaultHomeDirectory, nil)
+    }
+
+    func createTabFromCurrentContext(
+        hostTerminalState: HostTerminalStateStore,
+        defaultHomeDirectory: URL,
+        repos: [Repo],
+        normalizePath: (String) -> String,
+        activateHostSession: (HostTerminalSessionKey, URL, String?) -> HostTerminalSession
+    ) -> SessionFocusResult? {
+        ensureInitialHostSession(
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: defaultHomeDirectory,
+            activateHostSession: activateHostSession
+        )
+
+        guard let session = hostTerminalState.createTab() else { return nil }
+        return focusResult(
+            sessionID: session.id,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        )
+    }
+
+    func selectTab(
+        sessionID: UUID,
+        hostTerminalState: HostTerminalStateStore,
+        repos: [Repo],
+        normalizePath: (String) -> String
+    ) -> SessionFocusResult? {
+        guard hostTerminalState.activateExistingSession(sessionID: sessionID) else { return nil }
+        return focusResult(
+            sessionID: sessionID,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        )
+    }
+
+    func selectAdjacentTab(
+        offset: Int,
+        hostTerminalState: HostTerminalStateStore,
+        repos: [Repo],
+        normalizePath: (String) -> String
+    ) -> SessionFocusResult? {
+        guard let session = hostTerminalState.activateAdjacentTab(offset: offset) else { return nil }
+        return focusResult(
+            sessionID: session.id,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        )
+    }
+
+    func closeActiveTab(
+        hostTerminalState: HostTerminalStateStore,
+        defaultHomeDirectory: URL,
+        repos: [Repo],
+        normalizePath: (String) -> String,
+        requestClose: (UUID) -> Bool
+    ) -> SessionFocusResult? {
+        guard let activeSessionID = hostTerminalState.activeSessionID else { return nil }
+        return closeTabs(
+            [activeSessionID],
+            hostTerminalState: hostTerminalState,
+            defaultHomeDirectory: defaultHomeDirectory,
+            repos: repos,
+            normalizePath: normalizePath,
+            requestClose: requestClose
+        ).last
+    }
+
+    func closeTabs(
+        _ sessionIDs: [UUID],
+        hostTerminalState: HostTerminalStateStore,
+        defaultHomeDirectory: URL,
+        repos: [Repo],
+        normalizePath: (String) -> String,
+        requestClose: (UUID) -> Bool
+    ) -> [SessionFocusResult] {
+        sessionIDs.compactMap { sessionID in
+            if requestClose(sessionID) {
+                return nil
+            }
+            return forceCloseTab(
+                sessionID: sessionID,
+                hostTerminalState: hostTerminalState,
+                defaultHomeDirectory: defaultHomeDirectory,
+                repos: repos,
+                normalizePath: normalizePath
+            )
+        }
+    }
+
+    func closeConfirmation(
+        sessionID: UUID,
+        hostTerminalState: HostTerminalStateStore
+    ) -> TerminalCloseConfirmation {
+        let title =
+            hostTerminalState.sessions.first(where: { $0.id == sessionID })
+            .map {
+                hostTerminalState.tabTitleOverride(for: $0.id)
+                    ?? hostTerminalState.surfaceStore.displayTitle(for: $0)
+            }
+            ?? "Terminal"
+
+        return TerminalCloseConfirmation(sessionID: sessionID, title: title)
+    }
+
+    func handleProcessExit(
+        sessionID: UUID,
+        hostTerminalState: HostTerminalStateStore,
+        defaultHomeDirectory: URL,
+        repos: [Repo],
+        normalizePath: (String) -> String
+    ) -> SessionFocusResult? {
+        NSLog("[HostSession] Process exit detected for session %@", sessionID.uuidString)
+        guard
+            let focusSessionID = hostTerminalState.handleProcessExitAndResolveFocusTarget(
+                for: sessionID,
+                defaultHomeDirectory: defaultHomeDirectory
+            )
+        else {
+            return nil
+        }
+
+        return focusResult(
+            sessionID: focusSessionID,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        )
+    }
+
+    func forceCloseTab(
+        sessionID: UUID,
+        hostTerminalState: HostTerminalStateStore,
+        defaultHomeDirectory: URL,
+        repos: [Repo],
+        normalizePath: (String) -> String
+    ) -> SessionFocusResult? {
+        guard
+            let focusSessionID = hostTerminalState.handleProcessExitAndResolveFocusTarget(
+                for: sessionID,
+                defaultHomeDirectory: defaultHomeDirectory
+            )
+        else {
+            return nil
+        }
+
+        return focusResult(
+            sessionID: focusSessionID,
+            hostTerminalState: hostTerminalState,
+            repos: repos,
+            normalizePath: normalizePath
+        )
+    }
+
+    func syncedWorkspaceSelection(
+        activeHostSession: HostTerminalSession?,
+        repos: [Repo],
+        normalizePath: (String) -> String
+    ) -> Workspace? {
+        MainSelectionCoordinator().syncedWorkspaceSelection(
+            for: activeHostSession,
+            repos: repos,
+            normalizePath: normalizePath
+        )
+    }
+
+    private func focusResult(
+        sessionID: UUID,
+        hostTerminalState: HostTerminalStateStore,
+        repos: [Repo],
+        normalizePath: (String) -> String
+    ) -> SessionFocusResult {
+        SessionFocusResult(
+            focusSessionID: sessionID,
+            syncedWorkspace: syncedWorkspaceSelection(
+                activeHostSession: activeHostSession(in: hostTerminalState),
+                repos: repos,
+                normalizePath: normalizePath
+            )
+        )
+    }
+
+    private func activeHostSession(in hostTerminalState: HostTerminalStateStore) -> HostTerminalSession? {
+        guard let activeSessionID = hostTerminalState.activeSessionID else {
+            return hostTerminalState.sessions.last
+        }
+        return hostTerminalState.sessions.first(where: { $0.id == activeSessionID })
+            ?? hostTerminalState.sessions.last
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowAccessRecorderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowAccessRecorderTests.swift
@@ -67,6 +67,28 @@ struct MainWindowAccessRecorderTests {
         #expect(fetchedRepos.first?.lastAccessedAt ?? .distantPast > Date(timeIntervalSince1970: 10))
     }
 
+    @Test("Flushing pending save persists access without waiting for debounce")
+    func flushingPendingSavePersistsRecordedAccess() throws {
+        let fixture = try makeModelContext()
+        let repo = Repo(
+            name: "alpha",
+            localPath: URL(fileURLWithPath: "/tmp/alpha"),
+            lastAccessedAt: Date(timeIntervalSince1970: 10)
+        )
+        fixture.context.insert(repo)
+        try fixture.context.save()
+
+        var recorder = MainWindowAccessRecorder(saveDelay: .seconds(60))
+        recorder.record(repo: repo, modelContext: fixture.context)
+        let result = recorder.flushPendingSave(modelContext: fixture.context)
+
+        let freshContext = ModelContext(fixture.container)
+        let fetchedRepos = try freshContext.fetch(FetchDescriptor<Repo>())
+        #expect(result == nil)
+        #expect(fetchedRepos.count == 1)
+        #expect(fetchedRepos.first?.lastAccessedAt ?? .distantPast > Date(timeIntervalSince1970: 10))
+    }
+
     @Test("Save failure rollback is skipped when inserts are pending")
     func saveFailureRollbackSkipsPendingInserts() throws {
         let fixture = try makeModelContext()

--- a/Tests/WorkspaceManagerAppTests/MainWindowAccessRecorderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowAccessRecorderTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import SwiftData
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowAccessRecorder")
+struct MainWindowAccessRecorderTests {
+    @Test("Recording access updates repo workspace and web source timestamps")
+    func recordingAccessUpdatesTimestamps() throws {
+        let fixture = try makeModelContext()
+        let repo = Repo(
+            name: "alpha",
+            localPath: URL(fileURLWithPath: "/tmp/alpha"),
+            lastAccessedAt: Date(timeIntervalSince1970: 10)
+        )
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo,
+            lastAccessedAt: Date(timeIntervalSince1970: 20)
+        )
+        let webSource = WebSource(
+            name: "Docs",
+            baseURLString: "https://docs.example.com/",
+            allowedHost: "docs.example.com",
+            lastAccessedAt: Date(timeIntervalSince1970: 30),
+            sourceRepo: repo
+        )
+        fixture.context.insert(repo)
+        fixture.context.insert(workspace)
+        fixture.context.insert(webSource)
+        try fixture.context.save()
+
+        var recorder = MainWindowAccessRecorder(saveDelay: .milliseconds(1))
+        recorder.record(repo: repo, modelContext: fixture.context)
+        #expect(repo.lastAccessedAt > Date(timeIntervalSince1970: 10))
+
+        recorder.record(workspace: workspace, modelContext: fixture.context)
+        #expect(workspace.lastAccessedAt > Date(timeIntervalSince1970: 20))
+        #expect(repo.lastAccessedAt == workspace.lastAccessedAt)
+
+        recorder.record(webSource: webSource, modelContext: fixture.context)
+        #expect(webSource.lastAccessedAt > Date(timeIntervalSince1970: 30))
+        #expect(repo.lastAccessedAt == webSource.lastAccessedAt)
+        recorder.cancelPendingSave()
+    }
+
+    @Test("Debounced save persists recorded access")
+    func debouncedSavePersistsRecordedAccess() async throws {
+        let fixture = try makeModelContext()
+        let repo = Repo(
+            name: "alpha",
+            localPath: URL(fileURLWithPath: "/tmp/alpha"),
+            lastAccessedAt: Date(timeIntervalSince1970: 10)
+        )
+        fixture.context.insert(repo)
+        try fixture.context.save()
+
+        var recorder = MainWindowAccessRecorder(saveDelay: .milliseconds(1))
+        recorder.record(repo: repo, modelContext: fixture.context)
+
+        let fetchedRepos = try await fetchReposAfterDebouncedSave(from: fixture.container)
+        #expect(fetchedRepos.count == 1)
+        #expect(fetchedRepos.first?.lastAccessedAt ?? .distantPast > Date(timeIntervalSince1970: 10))
+    }
+
+    @Test("Save failure rollback is skipped when inserts are pending")
+    func saveFailureRollbackSkipsPendingInserts() throws {
+        let fixture = try makeModelContext()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        fixture.context.insert(repo)
+        try fixture.context.save()
+
+        let pendingWorkspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo
+        )
+        fixture.context.insert(pendingWorkspace)
+
+        let result = MainWindowAccessRecorder.resolveSaveFailure(modelContext: fixture.context)
+
+        #expect(result == .preservedPendingInserts(1))
+        #expect(!fixture.context.insertedModelsArray.isEmpty)
+    }
+
+    @Test("Save failure rolls back when no inserts are pending")
+    func saveFailureRollsBackWithoutPendingInserts() throws {
+        let fixture = try makeModelContext()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        fixture.context.insert(repo)
+        try fixture.context.save()
+        repo.name = "changed"
+
+        let result = MainWindowAccessRecorder.resolveSaveFailure(modelContext: fixture.context)
+
+        #expect(result == .rolledBack)
+        #expect(fixture.context.insertedModelsArray.isEmpty)
+    }
+
+    private func makeModelContext() throws -> ModelContextFixture {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return ModelContextFixture(container: container, context: container.mainContext)
+    }
+
+    private func fetchReposAfterDebouncedSave(from container: ModelContainer) async throws -> [Repo] {
+        let baseline = Date(timeIntervalSince1970: 10)
+        for _ in 0..<50 {
+            try? await Task.sleep(for: .milliseconds(20))
+            let freshContext = ModelContext(container)
+            let fetchedRepos = try freshContext.fetch(FetchDescriptor<Repo>())
+            if fetchedRepos.first?.lastAccessedAt ?? .distantPast > baseline {
+                return fetchedRepos
+            }
+        }
+
+        let freshContext = ModelContext(container)
+        return try freshContext.fetch(FetchDescriptor<Repo>())
+    }
+}
+
+private struct ModelContextFixture {
+    let container: ModelContainer
+    let context: ModelContext
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowLaunchActionHandlerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowLaunchActionHandlerTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowLaunchActionHandler")
+struct MainWindowLaunchActionHandlerTests {
+    private let handler = MainWindowLaunchActionHandler()
+
+    @Test("Deep linked workspace action clears request selects workspace and focuses window")
+    func deepLinkedWorkspaceActionAppliesSideEffects() throws {
+        var state = MainWindowViewState()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo
+        )
+        let request = try #require(makeDeepLink(cwd: "/tmp/alpha/workspaces/feature-a"))
+        var clearedDeepLink = false
+        var discardedReason: String?
+        var selectedWorkspaceID: UUID?
+        var preferredDirectory: URL?
+        var didFocusWindow = false
+
+        let shouldContinue = handler.apply(
+            .selectDeepLinkedWorkspace(request, workspace),
+            state: &state,
+            environment: [:],
+            pendingRequest: request,
+            bootstrapController: MainWindowBootstrapController(),
+            actions: makeActions(
+                clearDeepLink: { clearedDeepLink = true },
+                discardPendingRemoteConnection: { discardedReason = $0 },
+                selectWorkspace: { workspace, directory in
+                    selectedWorkspaceID = workspace.id
+                    preferredDirectory = directory
+                },
+                focusWorkspaceWindow: { didFocusWindow = true }
+            )
+        )
+
+        #expect(!shouldContinue)
+        #expect(state.didResolveInitialSurface)
+        #expect(clearedDeepLink)
+        #expect(discardedReason == "deep_link_selected")
+        #expect(selectedWorkspaceID == workspace.id)
+        #expect(preferredDirectory?.path == request.cwd)
+        #expect(didFocusWindow)
+    }
+
+    @Test("Preview bootstrap selects repo terminal and opens preview pane")
+    func previewBootstrapAppliesPreviewState() throws {
+        var state = MainWindowViewState()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let selection = CodePreviewSelection(
+            rootURL: repo.localURL,
+            relativePath: "README.md"
+        )
+        var selectedRepoID: UUID?
+
+        let shouldContinue = handler.apply(
+            .applyPreviewBootstrap(
+                UIFixturePreviewBootstrapConfiguration(repoName: "alpha", relativePath: "README.md"),
+                repo,
+                selection
+            ),
+            state: &state,
+            environment: [:],
+            pendingRequest: nil,
+            bootstrapController: MainWindowBootstrapController(),
+            actions: makeActions(
+                selectRepoTerminal: { repo, preferredDirectory in
+                    selectedRepoID = repo.id
+                    #expect(preferredDirectory == nil)
+                }
+            )
+        )
+
+        #expect(!shouldContinue)
+        #expect(state.didApplyFixturePreviewBootstrap)
+        #expect(state.didResolveInitialSurface)
+        #expect(state.selectedCodePreview == selection)
+        #expect(state.isTerminalPanelVisible)
+        #expect(state.isRightPaneVisible)
+        #expect(selectedRepoID == repo.id)
+    }
+
+    @Test("Invalid last surface clears before continuing")
+    func invalidLastSurfaceClearsAndContinues() {
+        var state = MainWindowViewState()
+        var clearedLastSurface = false
+
+        let shouldContinue = handler.apply(
+            .clearInvalidLastSurface,
+            state: &state,
+            environment: [:],
+            pendingRequest: nil,
+            bootstrapController: MainWindowBootstrapController(),
+            actions: makeActions(clearLastSurface: { clearedLastSurface = true })
+        )
+
+        #expect(shouldContinue)
+        #expect(clearedLastSurface)
+    }
+
+    @Test("Fallback applies launch surface and marks initial resolution")
+    func fallbackAppliesLaunchSurface() {
+        var state = MainWindowViewState()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        var appliedRepoID: UUID?
+
+        let shouldContinue = handler.apply(
+            .fallback(.repoOverview(repo)),
+            state: &state,
+            environment: [:],
+            pendingRequest: nil,
+            bootstrapController: MainWindowBootstrapController(),
+            actions: makeActions(
+                applyLaunchSurface: { surface in
+                    if case .repoOverview(let repo) = surface {
+                        appliedRepoID = repo.id
+                    }
+                }
+            )
+        )
+
+        #expect(!shouldContinue)
+        #expect(state.didResolveInitialSurface)
+        #expect(appliedRepoID == repo.id)
+    }
+
+    @Test("Perf auto-select records run state and schedules workspace sheet when enabled")
+    func perfAutoSelectRecordsRunState() {
+        var state = MainWindowViewState()
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        var scheduledRepoID: UUID?
+        var scheduledOpenNewWorkspace = false
+
+        let shouldContinue = handler.apply(
+            .perfAutoSelect(repo),
+            state: &state,
+            environment: [
+                "WORKSPACES_PERF_AUTO_SELECT_FIRST_REPO": "1",
+                "WORKSPACES_PERF_AUTO_OPEN_NEW_WORKSPACE": "1",
+            ],
+            pendingRequest: nil,
+            bootstrapController: MainWindowBootstrapController(),
+            actions: makeActions(
+                schedulePerfAutoSelect: { repo, shouldOpenNewWorkspace in
+                    scheduledRepoID = repo.id
+                    scheduledOpenNewWorkspace = shouldOpenNewWorkspace
+                }
+            )
+        )
+
+        #expect(!shouldContinue)
+        #expect(state.didRunPerfAutoSelection)
+        #expect(state.didRunPerfAutoOpenNewWorkspace)
+        #expect(scheduledRepoID == repo.id)
+        #expect(scheduledOpenNewWorkspace)
+    }
+
+    private func makeActions(
+        clearDeepLink: @escaping () -> Void = {},
+        clearLastSurface: @escaping () -> Void = {},
+        discardPendingRemoteConnection: @escaping (String) -> Void = { _ in },
+        importRepo: @escaping (String) -> Repo? = { _ in nil },
+        selectWorkspace: @escaping (Workspace, URL?) -> Void = { _, _ in },
+        selectRepoTerminal: @escaping (Repo, URL?) -> Void = { _, _ in },
+        selectWebSource: @escaping (WebSource) -> Void = { _ in },
+        applyLaunchSurface: @escaping (MainWindowLaunchSurface) -> Void = { _ in },
+        schedulePerfAutoSelect: @escaping (Repo, Bool) -> Void = { _, _ in },
+        focusWorkspaceWindow: @escaping () -> Void = {}
+    ) -> MainWindowLaunchActionHandler.Actions {
+        MainWindowLaunchActionHandler.Actions(
+            clearDeepLink: clearDeepLink,
+            clearLastSurface: clearLastSurface,
+            discardPendingRemoteConnection: discardPendingRemoteConnection,
+            importRepo: importRepo,
+            selectWorkspace: selectWorkspace,
+            selectRepoTerminal: selectRepoTerminal,
+            selectWebSource: selectWebSource,
+            applyLaunchSurface: applyLaunchSurface,
+            schedulePerfAutoSelect: schedulePerfAutoSelect,
+            focusWorkspaceWindow: focusWorkspaceWindow
+        )
+    }
+
+    private func makeDeepLink(cwd: String, repoRoot: String? = nil) -> WorkspaceDeepLink? {
+        let encodedCWD = cwd.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+        let encodedRepoRoot = repoRoot?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let repoRootQuery = encodedRepoRoot.map { "&repo_root=\($0)" } ?? ""
+        let url = URL(string: "workspaces://focus?cwd=\(encodedCWD)\(repoRootQuery)")!
+        return WorkspaceDeepLink(url: url)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowTerminalSessionControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowTerminalSessionControllerTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("MainWindowTerminalSessionController")
+struct MainWindowTerminalSessionControllerTests {
+    private let controller = MainWindowTerminalSessionController()
+
+    @Test("Creating a tab first ensures a default session")
+    func creatingTabEnsuresDefaultSession() throws {
+        let store = HostTerminalStateStore()
+        let defaultDirectory = URL(fileURLWithPath: "/Users/test")
+
+        let result = try #require(
+            controller.createTabFromCurrentContext(
+                hostTerminalState: store,
+                defaultHomeDirectory: defaultDirectory,
+                repos: [],
+                normalizePath: normalizePath,
+                activateHostSession: { key, directory, customCommand in
+                    store.activateSession(
+                        key: key,
+                        directory: directory,
+                        customCommand: customCommand
+                    ).session
+                }
+            )
+        )
+
+        #expect(store.sessions.count == 2)
+        #expect(store.sessions.first?.key == .defaultHome)
+        #expect(result.focusSessionID == store.activeSessionID)
+    }
+
+    @Test("Selecting adjacent tab returns focus target and synced workspace")
+    func selectingAdjacentTabReturnsFocusAndWorkspace() throws {
+        let fixture = makeRepoWorkspaceFixture()
+        let store = HostTerminalStateStore()
+        _ = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        )
+        let workspaceSession = store.activateSession(
+            key: .hostPath(fixture.workspace.path),
+            directory: fixture.workspace.workspaceURL
+        ).session
+
+        let result = try #require(
+            controller.selectAdjacentTab(
+                offset: -1,
+                hostTerminalState: store,
+                repos: [fixture.repo],
+                normalizePath: normalizePath
+            )
+        )
+
+        #expect(result.focusSessionID != workspaceSession.id)
+        #expect(result.syncedWorkspace == nil)
+
+        let workspaceResult = try #require(
+            controller.selectTab(
+                sessionID: workspaceSession.id,
+                hostTerminalState: store,
+                repos: [fixture.repo],
+                normalizePath: normalizePath
+            )
+        )
+        #expect(workspaceResult.focusSessionID == workspaceSession.id)
+        #expect(workspaceResult.syncedWorkspace?.id == fixture.workspace.id)
+    }
+
+    @Test("Force close removes session and resolves fallback focus")
+    func forceCloseResolvesFallbackFocus() throws {
+        let store = HostTerminalStateStore()
+        let first = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        let second = try #require(store.createTab())
+
+        let result = try #require(
+            controller.forceCloseTab(
+                sessionID: second.id,
+                hostTerminalState: store,
+                defaultHomeDirectory: URL(fileURLWithPath: "/Users/test"),
+                repos: [],
+                normalizePath: normalizePath
+            )
+        )
+
+        #expect(store.sessions.map(\.id) == [first.id])
+        #expect(result.focusSessionID == first.id)
+    }
+
+    @Test("Close requests defer to terminal surface when available")
+    func closeRequestsDeferToTerminalSurface() {
+        let store = HostTerminalStateStore()
+        let session = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        var requestedCloseIDs: [UUID] = []
+
+        let results = controller.closeTabs(
+            [session.id],
+            hostTerminalState: store,
+            defaultHomeDirectory: URL(fileURLWithPath: "/Users/test"),
+            repos: [],
+            normalizePath: normalizePath,
+            requestClose: { sessionID in
+                requestedCloseIDs.append(sessionID)
+                return true
+            }
+        )
+
+        #expect(requestedCloseIDs == [session.id])
+        #expect(results.isEmpty)
+        #expect(store.sessions.map(\.id) == [session.id])
+    }
+
+    @Test("Synced workspace selection supports backend session keys")
+    func syncedWorkspaceSelectionSupportsBackendSessions() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "cloud-feature",
+            path: URL(fileURLWithPath: Workspace.remotePathSentinel),
+            sourceRepo: repo,
+            backendIdentifier: "daytona",
+            remoteId: "remote-123",
+            sessionRoutingID: "routing-123"
+        )
+        repo.workspaces = [workspace]
+        let session = HostTerminalSession(
+            key: .backendSession(providerID: "daytona", instanceID: "routing-123"),
+            directory: URL(fileURLWithPath: "/tmp")
+        )
+
+        let syncedWorkspace = controller.syncedWorkspaceSelection(
+            activeHostSession: session,
+            repos: [repo],
+            normalizePath: normalizePath
+        )
+
+        #expect(syncedWorkspace?.id == workspace.id)
+    }
+
+    @Test("Close confirmation uses tab title override")
+    func closeConfirmationUsesTabTitleOverride() throws {
+        let store = HostTerminalStateStore()
+        let session = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        #expect(store.setTabTitle("Build", for: session.id))
+
+        let confirmation = controller.closeConfirmation(
+            sessionID: session.id,
+            hostTerminalState: store
+        )
+
+        #expect(confirmation.sessionID == session.id)
+        #expect(confirmation.title == "Build")
+    }
+
+    private func makeRepoWorkspaceFixture() -> (repo: Repo, workspace: Workspace) {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo
+        )
+        repo.workspaces = [workspace]
+        return (repo, workspace)
+    }
+
+    private func normalizePath(_ rawPath: String) -> String {
+        URL(fileURLWithPath: rawPath).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `MainWindowAccessRecorder`, `MainWindowTerminalSessionController`, and `MainWindowLaunchActionHandler` from `ContentView.swift`.
- Keep root main-window selection methods as thin integration wrappers while moving debounced access saves, terminal tab/session orchestration, and launch-surface action side effects into focused controllers.
- Add focused Swift Testing coverage for access timestamps, tab/session fallback behavior, sidebar sync, launch action application, flushing pending access saves on view teardown, and the final stale wrapper cleanup.

## Mergeability

- Surface: desktop
- User-facing behavior changed: no; behavior-preserving refactor only
- Non-happy paths considered: SwiftData save rollback with pending inserts, terminal close fallback when no terminal surface exists, invalid persisted launch surfaces, missing fixture bootstrap targets, pending access timestamp flush on main-window disappearance
- Release/ops preconditions: none
- Residual risk or follow-up: existing concurrency warnings remain in `StatusLinePayload.swift` and `KeychainHelper.swift`; they are unrelated to this diff

## Validation

- [x] `swift build` (`swift build -Xswiftc -warn-concurrency`, exits 0 with existing unrelated warnings)
- [x] `swift test` (658 tests in 114 suites passed after final polish and rebase onto latest `origin/main`)
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/`; focused `swift test --filter MainWindowTerminalSessionController`; earlier focused `swift test --filter MainWindowAccessRecorder`; earlier focused `swift test --filter MainWindowLaunchActionHandler`
- [x] GitHub `build-and-test` passed on current head `a4e79f92`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence for all PRs must include:

- test results: pass/fail summary with command used
- for UI changes: at least one screenshot or recording proving the result
- for API/backend changes: test report screenshot or output
- hosted links (via upload-evidence.py), not local file paths

Evidence links:

- ![main-window-maintainability-test-evidence-v5](https://evidence.cloudcompute.com/workspaces/pr-486/20260518-032041-main-window-maintainability-test-evidence-v5.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
