### PR TITLE
Broker managed reviewer completions out of band

### DIFF
--- a/docs/development/security-critical-path.md
+++ b/docs/development/security-critical-path.md
@@ -73,8 +73,8 @@ uv run --script scripts/audit-security-posture.py --repo fairchild/workspaces --
 
 ## Explicit Follow-Ups
 
-- Move PR-review broker execution to a durable queue if Vercel post-response
-  execution proves too short for unusually long managed-agent reviews.
+- Keep PR-review broker execution outside the webhook request path; the
+  scheduled/protected broker route should own completed-session posting.
 - Consider a true WebSocket proxy for terminal access so the browser never sees
   the final ttyd URL after ticket redemption.
 - Keep dependency overrides current and remove them when upstream patched

--- a/scripts/managed-reviewer-ingress-canary.py
+++ b/scripts/managed-reviewer-ingress-canary.py
@@ -3,12 +3,13 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Run the production managed-reviewer ingress canary and run-row monitor.
+"""Run the production managed-reviewer ingress canary, broker, and monitor.
 
 The canary proves the deployed Cloudflare relay can forward a signed,
-reviewer-eligible webhook to the Vercel route in dry-run mode. The monitor then
-checks that recent eligible production webhook activity has matching
-managed_pr_review_runs rows.
+reviewer-eligible webhook to the Vercel route in dry-run mode. The broker then
+posts any completed managed-agent review intents, and the monitor checks that
+recent eligible production webhook activity has matching managed_pr_review_runs
+rows.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ from typing import Any
 CANARY_HEADER = "X-Workspace-Webhook-Canary"
 DEFAULT_CANARY_URL = "https://webhooks.cloudcompute.com/canary/pr-review-ingress"
 DEFAULT_MONITOR_URL = "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-monitor"
+DEFAULT_BROKER_URL = "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-broker"
 SAFE_RESPONSE_KEYS = (
     "ok",
     "canary",
@@ -37,6 +39,10 @@ SAFE_RESPONSE_KEYS = (
     "windowMinutes",
     "eligibleEvents",
     "missingRuns",
+    "checked",
+    "completed",
+    "failed",
+    "skippedRunning",
     "error",
 )
 
@@ -49,9 +55,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--canary-url", default=DEFAULT_CANARY_URL)
     parser.add_argument("--monitor-url", default=DEFAULT_MONITOR_URL)
+    parser.add_argument("--broker-url", default=DEFAULT_BROKER_URL)
     parser.add_argument("--window-minutes", type=int, default=90)
     parser.add_argument("--timeout", type=float, default=20)
     parser.add_argument("--skip-canary", action="store_true")
+    parser.add_argument("--skip-broker", action="store_true")
     parser.add_argument("--skip-monitor", action="store_true")
     return parser.parse_args()
 
@@ -133,7 +141,7 @@ def validate_monitor(payload: dict[str, Any]) -> None:
 def main() -> int:
     args = parse_args()
 
-    if args.skip_canary and args.skip_monitor:
+    if args.skip_canary and args.skip_broker and args.skip_monitor:
         print("No managed reviewer ingress checks requested.")
         return 0
 
@@ -144,6 +152,12 @@ def main() -> int:
             payload = request_json("managed reviewer ingress canary", "POST", args.canary_url, secret, args.timeout)
             validate_canary(payload)
             print(f"managed reviewer ingress canary ok: {json.dumps(safe_payload(payload), sort_keys=True)}")
+
+        if not args.skip_broker:
+            payload = request_json("managed reviewer broker", "POST", args.broker_url, secret, args.timeout)
+            if payload.get("ok") is not True:
+                raise CanaryError(f"managed reviewer broker failed: {json.dumps(safe_payload(payload), sort_keys=True)}")
+            print(f"managed reviewer broker ok: {json.dumps(safe_payload(payload), sort_keys=True)}")
 
         if not args.skip_monitor:
             payload = request_json(

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -361,6 +361,9 @@ class SecurityHardeningTests(unittest.TestCase):
         monitor = (
             REPO_ROOT / "web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts"
         ).read_text()
+        broker = (
+            REPO_ROOT / "web/src/app/api/webhooks/github/pr-reviewer-broker/route.ts"
+        ).read_text()
         runs = (REPO_ROOT / "web/src/lib/agent-runtime/pr-review-runs.ts").read_text()
         route_test = (REPO_ROOT / "web/src/app/api/webhooks/github/route.test.ts").read_text()
         worker = (REPO_ROOT / "infra/cloudflare-webhook-relay/src/index.ts").read_text()
@@ -368,7 +371,7 @@ class SecurityHardeningTests(unittest.TestCase):
         cd_workflow = (REPO_ROOT / ".github/workflows/cd.yml").read_text()
         canary_script = (REPO_ROOT / "scripts/managed-reviewer-ingress-canary.py").read_text()
 
-        for source in (route, monitor, worker, workflow, cd_workflow, canary_script):
+        for source in (route, monitor, broker, worker, workflow, cd_workflow, canary_script):
             self.assertIn("WORKSPACES_WEBHOOK_CANARY_SECRET", source)
 
         self.assertIn("validateCanaryRequest", route)
@@ -385,6 +388,8 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("allowedForwardUrl", worker)
         self.assertIn("managed_pr_review_runs", runs)
         self.assertIn("listRecentPrReviewRuns", monitor)
+        self.assertIn("processPendingPrReviewRuns", broker)
+        self.assertIn("pr-reviewer-broker", canary_script)
         self.assertIn("pr-reviewer-monitor", canary_script)
         self.assertIn("scripts/managed-reviewer-ingress-canary.py", workflow)
         self.assertIn("scripts/managed-reviewer-ingress-canary.py", cd_workflow)

--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -16,7 +16,7 @@ GitHub PR opened
 → sessions.create (mounts repo at PR branch)
 → events.send (kickoff message)
 → Agent runs autonomously on Anthropic → returns review-intent JSON
-→ server-side broker validates intent → posts GitHub review
+→ scheduled/protected broker route validates intent → posts GitHub review
 ```
 
 ## Key Files
@@ -25,7 +25,8 @@ GitHub PR opened
 |------|---------|
 | `web/src/lib/agent-runtime/pr-review.ts` | Agent config, session creation, kickoff |
 | `web/src/lib/agent-runtime/managed-agents-cache.ts` | Idempotent agent/environment creation with DB cache |
-| `web/src/app/api/webhooks/github/route.ts` | Webhook handler — triggers on `pull_request.opened` |
+| `web/src/app/api/webhooks/github/route.ts` | Webhook handler — starts reviewer sessions and returns after kickoff |
+| `web/src/app/api/webhooks/github/pr-reviewer-broker/route.ts` | Protected broker route — processes completed sessions from `managed_pr_review_runs` and posts reviews |
 | `web/src/app/api/managed-agents/transcript/route.ts` | SSE endpoint for streaming session events to the UI |
 
 ## Environment Variables
@@ -96,8 +97,8 @@ imported by both the Vercel route tests and the Cloudflare relay e2e harness.
 This is the regression guard for drift between "forward this webhook" and
 "start the reviewer".
 
-The production CD `validate-prod` job runs the same canary and monitor after
-promotion, before the production Playwright smoke.
+The production CD `validate-prod` job runs the same canary, broker, and monitor
+after promotion, before the production Playwright smoke.
 
 Production canary:
 
@@ -118,14 +119,21 @@ managed-agent session or GitHub review is created.
 The same workflow also calls:
 
 ```bash
+curl --fail-with-body -sS -X POST \
+  "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-broker?limit=5" \
+  -H "X-Workspace-Webhook-Canary: $WORKSPACES_WEBHOOK_CANARY_SECRET"
+
 curl --fail-with-body -sS \
   "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-monitor?windowMinutes=90" \
   -H "X-Workspace-Webhook-Canary: $WORKSPACES_WEBHOOK_CANARY_SECRET"
 ```
 
-That monitor compares recent reviewer-eligible rows in `webhook_events` with
-`managed_pr_review_runs` records. It returns only run metadata and missing
-event identifiers, not raw payloads or secrets.
+The broker inspects `started` rows in `managed_pr_review_runs`, skips sessions
+that are still running, validates completed review-intent JSON, and posts the
+review with the GitHub App token. The monitor then compares recent
+reviewer-eligible rows in `webhook_events` with `managed_pr_review_runs`
+records. These routes return only run metadata and missing event identifiers,
+not raw payloads or secrets.
 
 ## Observing Sessions
 
@@ -201,6 +209,7 @@ If using the GitHub App: check that `PR_REVIEWER_APP_ID`, `PR_REVIEWER_PRIVATE_K
 
 Check the session events for the final fenced `json` review intent, then check
 Vercel logs for `[pr-review] broker failed`. Common causes:
+- `WORKSPACES_WEBHOOK_CANARY_SECRET` is missing, so scheduled broker calls are not authenticated
 - GitHub App token exchange failed — check Vercel logs for `[pr-review] GitHub App token failed`
 - `PR_REVIEWER_ENABLED=0` is set
 - the managed agent did not return valid fenced JSON with `event`, `body`, and `labels`

--- a/web/src/app/api/webhooks/github/pr-reviewer-broker/route.test.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-broker/route.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	processPendingPrReviewRuns: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime/pr-review", () => ({
+	processPendingPrReviewRuns: mocks.processPendingPrReviewRuns,
+}));
+
+const BROKER_SECRET = "broker-secret";
+
+function brokerRequest(headers: Record<string, string> = {}): Request {
+	return new Request(
+		"http://localhost/api/webhooks/github/pr-reviewer-broker?limit=3",
+		{ method: "POST", headers },
+	);
+}
+
+describe("/api/webhooks/github/pr-reviewer-broker POST", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.stubEnv("WORKSPACES_WEBHOOK_CANARY_SECRET", BROKER_SECRET);
+		vi.stubEnv("PR_REVIEWER_ENABLED", "");
+		mocks.processPendingPrReviewRuns.mockReset();
+		mocks.processPendingPrReviewRuns.mockResolvedValue({
+			checked: 1,
+			completed: 1,
+			failed: 0,
+			skippedRunning: 0,
+			runs: [
+				{
+					fingerprint: "fp",
+					sessionId: "sesn_123",
+					prNumber: 486,
+					status: "completed",
+				},
+			],
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it("rejects requests without the canary secret", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(brokerRequest());
+
+		expect(response.status).toBe(401);
+		await expect(response.json()).resolves.toMatchObject({
+			ok: false,
+			error: "unauthorized",
+		});
+		expect(mocks.processPendingPrReviewRuns).not.toHaveBeenCalled();
+	});
+
+	it("processes pending runs when authenticated", async () => {
+		const { POST } = await import("./route");
+		const response = await POST(
+			brokerRequest({ "x-workspace-webhook-canary": BROKER_SECRET }),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.processPendingPrReviewRuns).toHaveBeenCalledWith({
+			limit: 3,
+			repoFullName: undefined,
+		});
+		await expect(response.json()).resolves.toMatchObject({
+			ok: true,
+			checked: 1,
+			completed: 1,
+			failed: 0,
+		});
+	});
+
+	it("accepts bearer auth and reports broker failures", async () => {
+		mocks.processPendingPrReviewRuns.mockResolvedValue({
+			checked: 1,
+			completed: 0,
+			failed: 1,
+			skippedRunning: 0,
+			runs: [
+				{
+					fingerprint: "fp",
+					sessionId: "sesn_123",
+					prNumber: 486,
+					status: "failed",
+					error: "No valid PR review intent JSON found",
+				},
+			],
+		});
+
+		const { POST } = await import("./route");
+		const response = await POST(
+			brokerRequest({ authorization: `Bearer ${BROKER_SECRET}` }),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			ok: false,
+			checked: 1,
+			failed: 1,
+		});
+	});
+
+	it("returns not configured when the shared secret is missing", async () => {
+		vi.stubEnv("WORKSPACES_WEBHOOK_CANARY_SECRET", "");
+		const { POST } = await import("./route");
+		const response = await POST(brokerRequest());
+
+		expect(response.status).toBe(404);
+		await expect(response.json()).resolves.toMatchObject({
+			ok: false,
+			error: "broker_not_configured",
+		});
+	});
+});

--- a/web/src/app/api/webhooks/github/pr-reviewer-broker/route.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-broker/route.ts
@@ -1,0 +1,62 @@
+import crypto from "node:crypto";
+import { processPendingPrReviewRuns } from "@/lib/agent-runtime/pr-review";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const SECRET_HEADER = "x-workspace-webhook-canary";
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+function timingSafeStringEqual(actual: string, expected: string): boolean {
+	if (actual.length !== expected.length) return false;
+	return crypto.timingSafeEqual(Buffer.from(actual), Buffer.from(expected));
+}
+
+function secretFromRequest(request: Request): string | null {
+	const bearer = request.headers.get("authorization");
+	if (bearer?.toLowerCase().startsWith("bearer ")) {
+		return bearer.slice("bearer ".length).trim();
+	}
+	return request.headers.get(SECRET_HEADER);
+}
+
+function authenticate(request: Request): Response | null {
+	const expected = process.env.WORKSPACES_WEBHOOK_CANARY_SECRET;
+	if (!expected) {
+		return Response.json(
+			{ ok: false, error: "broker_not_configured" },
+			{ status: 404 },
+		);
+	}
+
+	const provided = secretFromRequest(request);
+	if (!provided || !timingSafeStringEqual(provided, expected)) {
+		return Response.json({ ok: false, error: "unauthorized" }, { status: 401 });
+	}
+
+	return null;
+}
+
+function limitFromUrl(url: URL): number {
+	const raw = Number(url.searchParams.get("limit") ?? "");
+	if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_LIMIT;
+	return Math.min(Math.floor(raw), MAX_LIMIT);
+}
+
+export async function POST(request: Request): Promise<Response> {
+	const authFailure = authenticate(request);
+	if (authFailure) return authFailure;
+
+	if (process.env.PR_REVIEWER_ENABLED === "0") {
+		return Response.json({ ok: true, disabled: true, checked: 0 });
+	}
+
+	const url = new URL(request.url);
+	const result = await processPendingPrReviewRuns({
+		limit: limitFromUrl(url),
+		repoFullName: url.searchParams.get("repo") ?? undefined,
+	});
+
+	return Response.json({ ok: result.failed === 0, ...result });
+}

--- a/web/src/app/api/webhooks/github/route.test.ts
+++ b/web/src/app/api/webhooks/github/route.test.ts
@@ -3,7 +3,6 @@ import { PR_REVIEW_WEBHOOK_CONTRACT_CASES } from "@/lib/agent-runtime/__tests__/
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-	after: vi.fn(),
 	getChatMessageByDiscussionId: vi.fn(),
 	pushChatMessage: vi.fn(),
 	pushEvent: vi.fn(),
@@ -13,10 +12,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/agent-runtime/pr-review", () => ({
 	triggerPrReview: mocks.triggerPrReview,
-}));
-
-vi.mock("next/server", () => ({
-	after: mocks.after,
 }));
 
 vi.mock("@/lib/chat", () => ({
@@ -144,7 +139,6 @@ describe("/api/webhooks/github POST", () => {
 	beforeEach(() => {
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET", "");
 		mocks.getChatMessageByDiscussionId.mockReset();
-		mocks.after.mockReset();
 		mocks.pushChatMessage.mockReset();
 		mocks.pushEvent.mockReset();
 		mocks.pushEvent.mockResolvedValue(undefined);
@@ -189,9 +183,6 @@ describe("/api/webhooks/github POST", () => {
 				repoName: "workspaces",
 			},
 			expect.objectContaining({ kind: "opened" }),
-			expect.objectContaining({
-				onReviewStarted: expect.any(Function),
-			}),
 		);
 		expect(resolved).toBe(false);
 
@@ -216,30 +207,17 @@ describe("/api/webhooks/github POST", () => {
 		expect(consoleError).toHaveBeenCalledWith("[pr-review] failed:", error);
 	});
 
-	it("schedules server-side review publishing after managed-agent kickoff", async () => {
-		const completeReview = vi.fn().mockResolvedValue(undefined);
-		mocks.triggerPrReview.mockImplementation(
-			async (
-				_payload: unknown,
-				_ctx: unknown,
-				options: {
-					onReviewStarted: (completeReview: () => Promise<void>) => void;
-				},
-			) => {
-				options.onReviewStarted(completeReview);
-				return "sesn_123";
-			},
-		);
+	it("leaves review publishing to the broker after kickoff", async () => {
+		mocks.triggerPrReview.mockResolvedValue("sesn_123");
 
 		const { POST } = await import("./route");
 		const response = await POST(pullRequestOpenedRequest());
 
 		expect(response.status).toBe(200);
-		expect(mocks.after).toHaveBeenCalledTimes(1);
-
-		const scheduled = mocks.after.mock.calls[0][0] as () => Promise<void>;
-		await scheduled();
-		expect(completeReview).toHaveBeenCalledTimes(1);
+		expect(mocks.triggerPrReview).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({ kind: "opened" }),
+		);
 	});
 
 	describe("trigger matrix", () => {
@@ -450,7 +428,6 @@ describe("/api/webhooks/github POST", () => {
 			});
 			expect(mocks.pushEvent).not.toHaveBeenCalled();
 			expect(mocks.triggerPrReview).not.toHaveBeenCalled();
-			expect(mocks.after).not.toHaveBeenCalled();
 		});
 
 		it("rejects canary requests with a valid HMAC but the wrong canary secret", async () => {

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -13,7 +13,6 @@ import type {
 	WebhookEvent,
 	WebhookEventType,
 } from "@/lib/types";
-import { after } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -205,17 +204,7 @@ export async function POST(request: Request): Promise<Response> {
 	// serverless teardown cannot drop the session kickoff event.
 	if (trigger) {
 		try {
-			await triggerPrReview(trigger.reviewPayload, trigger.context, {
-				onReviewStarted: (completeReview) => {
-					after(async () => {
-						try {
-							await completeReview();
-						} catch (err) {
-							console.error("[pr-review] broker failed:", err);
-						}
-					});
-				},
-			});
+			await triggerPrReview(trigger.reviewPayload, trigger.context);
 		} catch (err) {
 			console.error("[pr-review] failed:", err);
 		}

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -104,3 +104,46 @@ describe("recordRunStart", () => {
 		expect(retry.priorStatus).toBe("started");
 	});
 });
+
+describe("listStartedPrReviewRuns", () => {
+	it("returns only started rows with a session id in oldest-first order", async () => {
+		const { listStartedPrReviewRuns, recordRunStart, recordRunResult } =
+			await loadModule();
+		const started = makeInput({
+			fingerprint: "fp_started",
+			prNumber: 1,
+			headSha: "started-sha",
+		});
+		const completed = makeInput({
+			fingerprint: "fp_completed",
+			prNumber: 2,
+			headSha: "completed-sha",
+		});
+		const noSession = makeInput({
+			fingerprint: "fp_no_session",
+			prNumber: 3,
+			headSha: "no-session-sha",
+		});
+
+		await recordRunStart(started);
+		await recordRunResult(started.fingerprint, {
+			sessionId: "sesn_started",
+			status: "started",
+		});
+		await recordRunStart(completed);
+		await recordRunResult(completed.fingerprint, {
+			sessionId: "sesn_completed",
+			status: "completed",
+		});
+		await recordRunStart(noSession);
+
+		const rows = await listStartedPrReviewRuns();
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			fingerprint: "fp_started",
+			prNumber: 1,
+			sessionId: "sesn_started",
+		});
+	});
+});

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	createSession: vi.fn(),
+	listEvents: vi.fn(),
 	sendEvent: vi.fn(),
 	uploadFile: vi.fn(),
 	getOrCreateAgent: vi.fn(),
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
 	fetch: vi.fn(),
 	recordRunStart: vi.fn(),
 	recordRunResult: vi.fn(),
+	listStartedPrReviewRuns: vi.fn(),
 	computeRunFingerprint: vi.fn(),
 }));
 
@@ -22,6 +24,7 @@ vi.mock("@anthropic-ai/sdk", () => {
 			sessions: {
 				create: mocks.createSession,
 				events: {
+					list: mocks.listEvents,
 					send: mocks.sendEvent,
 				},
 			},
@@ -41,6 +44,7 @@ vi.mock("../../github-app-auth", () => ({
 
 vi.mock("../pr-review-runs", () => ({
 	computeRunFingerprint: mocks.computeRunFingerprint,
+	listStartedPrReviewRuns: mocks.listStartedPrReviewRuns,
 	recordRunStart: mocks.recordRunStart,
 	recordRunResult: mocks.recordRunResult,
 }));
@@ -54,6 +58,7 @@ import {
 	formatPrEvidenceContext,
 	formatPrNarrativeContext,
 	parseReviewIntentFromText,
+	processPendingPrReviewRuns,
 	triggerPrReview,
 } from "../pr-review";
 
@@ -112,6 +117,12 @@ function githubIssueComment(
 		user: { login: "fairchild" },
 		...overrides,
 	};
+}
+
+async function* asyncEvents(events: unknown[]) {
+	for (const event of events) {
+		yield event;
+	}
 }
 
 function mockPrList(prs: unknown[]) {
@@ -194,6 +205,7 @@ beforeEach(() => {
 	vi.stubEnv("PR_REVIEWER_PRIVATE_KEY", "private-key");
 	vi.stubEnv("PR_REVIEWER_INSTALLATION_ID", "456");
 	mocks.createSession.mockReset();
+	mocks.listEvents.mockReset();
 	mocks.sendEvent.mockReset();
 	mocks.uploadFile.mockReset();
 	mocks.getOrCreateAgent.mockReset();
@@ -202,6 +214,7 @@ beforeEach(() => {
 	mocks.fetch.mockReset();
 	mocks.recordRunStart.mockReset();
 	mocks.recordRunResult.mockReset();
+	mocks.listStartedPrReviewRuns.mockReset();
 	mocks.computeRunFingerprint.mockReset();
 
 	mocks.getOrCreateAgent.mockResolvedValue("agent_01");
@@ -213,6 +226,7 @@ beforeEach(() => {
 	mocks.computeRunFingerprint.mockReturnValue("fp_test");
 	mocks.recordRunStart.mockResolvedValue({ inserted: true });
 	mocks.recordRunResult.mockResolvedValue(undefined);
+	mocks.listStartedPrReviewRuns.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -471,6 +485,138 @@ describe("parseReviewIntentFromText", () => {
 				'```json\n{"event":"MERGE","body":"ship it","labels":[]}\n```',
 			),
 		).toThrow(/unsupported review event/);
+	});
+});
+
+describe("processPendingPrReviewRuns", () => {
+	it("posts completed review intents from started managed-agent sessions", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_486",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 486,
+				headSha: "head-sha",
+				triggerKind: "opened",
+				triggerSourceId: "head-sha",
+				sessionId: "sesn_486",
+				createdAt: "2026-05-17T06:24:27Z",
+				updatedAt: "2026-05-17T06:24:27Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [
+						{
+							type: "text",
+							text: `Review complete.
+
+\`\`\`json
+{
+  "event": "COMMENT",
+  "body": "💬 **Comment** — No blocking issues found.\\n\\n## Evidence\\nSwift unavailable in managed environment.",
+  "labels": ["refactor"]
+}
+\`\`\``,
+						},
+					],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(
+			async (url: string, options?: RequestInit) => {
+				if (url.endsWith("/pulls/486")) {
+					return {
+						ok: true,
+						json: async () =>
+							githubPr(486, {
+								title: "Refactor main window orchestration",
+								html_url: "https://github.com/fairchild/workspaces/pull/486",
+								body: "PR body",
+								head: { ref: "codex/main-window", sha: "head-sha" },
+								base: { ref: "main" },
+							}),
+					};
+				}
+				if (url.includes("/pulls?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/labels?")) {
+					return { ok: true, json: async () => [githubLabel("refactor")] };
+				}
+				if (url.includes("/pulls/") && url.includes("/reviews?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.endsWith("/pulls/486/reviews")) {
+					expect(options?.method).toBe("POST");
+					expect(JSON.parse(String(options?.body))).toMatchObject({
+						event: "COMMENT",
+						body: expect.stringContaining("No blocking issues found"),
+					});
+					return { ok: true, text: async () => "", json: async () => ({}) };
+				}
+				if (url.endsWith("/issues/486/labels")) {
+					expect(options?.method).toBe("POST");
+					expect(JSON.parse(String(options?.body))).toEqual({
+						labels: ["refactor"],
+					});
+					return { ok: true, text: async () => "", json: async () => ({}) };
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			},
+		);
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 1,
+			failed: 0,
+			skippedRunning: 0,
+		});
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_486", {
+			sessionId: "sesn_486",
+			status: "completed",
+		});
+	});
+
+	it("leaves still-running sessions in started state", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_running",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 486,
+				headSha: "head-sha",
+				triggerKind: "opened",
+				triggerSourceId: "head-sha",
+				sessionId: "sesn_running",
+				createdAt: "2026-05-17T06:24:27Z",
+				updatedAt: "2026-05-17T06:24:27Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [{ type: "text", text: "still working" }],
+				},
+			]),
+		);
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			failed: 0,
+			skippedRunning: 1,
+		});
+		expect(mocks.recordRunResult).not.toHaveBeenCalled();
 	});
 });
 

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -190,6 +190,7 @@ export async function recordRunResult(
 }
 
 export interface PrReviewRunSummary {
+	fingerprint: string;
 	repoFullName: string;
 	prNumber: number;
 	headSha: string;
@@ -197,6 +198,18 @@ export interface PrReviewRunSummary {
 	triggerSourceId: string;
 	status: PrReviewRunStatus;
 	sessionId: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface StartedPrReviewRun {
+	fingerprint: string;
+	repoFullName: string;
+	prNumber: number;
+	headSha: string;
+	triggerKind: string;
+	triggerSourceId: string;
+	sessionId: string;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -209,6 +222,7 @@ export async function listRecentPrReviewRuns(input: {
 	const rows = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select([
+			"fingerprint",
 			"repo_full_name",
 			"pr_number",
 			"head_sha",
@@ -224,6 +238,7 @@ export async function listRecentPrReviewRuns(input: {
 		.execute();
 
 	return rows.map((row) => ({
+		fingerprint: row.fingerprint,
 		repoFullName: row.repo_full_name,
 		prNumber: row.pr_number,
 		headSha: row.head_sha,
@@ -234,6 +249,50 @@ export async function listRecentPrReviewRuns(input: {
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	}));
+}
+
+export async function listStartedPrReviewRuns(
+	input: {
+		limit?: number;
+		repoFullName?: string;
+	} = {},
+): Promise<StartedPrReviewRun[]> {
+	await ensureRunsTable();
+	let query = getDb()
+		.selectFrom("managed_pr_review_runs")
+		.select([
+			"fingerprint",
+			"repo_full_name",
+			"pr_number",
+			"head_sha",
+			"trigger_kind",
+			"trigger_source_id",
+			"session_id",
+			"created_at",
+			"updated_at",
+		])
+		.where("status", "=", "started")
+		.where("session_id", "is not", null)
+		.orderBy("updated_at", "asc")
+		.limit(input.limit ?? 10);
+	if (input.repoFullName) {
+		query = query.where("repo_full_name", "=", input.repoFullName);
+	}
+	const rows = await query.execute();
+
+	return rows
+		.filter((row) => row.session_id)
+		.map((row) => ({
+			fingerprint: row.fingerprint,
+			repoFullName: row.repo_full_name,
+			prNumber: row.pr_number,
+			headSha: row.head_sha,
+			triggerKind: row.trigger_kind,
+			triggerSourceId: row.trigger_source_id,
+			sessionId: row.session_id as string,
+			createdAt: row.created_at,
+			updatedAt: row.updated_at,
+		}));
 }
 
 /** Test-only hook so per-test in-memory DBs re-run table creation. */

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -6,9 +6,10 @@ import {
 	getOrCreateAgent,
 	getOrCreateEnvironment,
 } from "./managed-agents-cache";
-import { streamWithReconnect } from "./managed-agents-events";
 import {
+	type StartedPrReviewRun,
 	computeRunFingerprint,
+	listStartedPrReviewRuns,
 	recordRunResult,
 	recordRunStart,
 } from "./pr-review-runs";
@@ -759,26 +760,178 @@ async function postGitHubReviewIntent(
 	}
 }
 
-async function collectReviewIntentText(
+async function collectCompletedReviewIntentText(
 	client: Anthropic,
 	sessionId: string,
-): Promise<string> {
+): Promise<{ done: boolean; output: string; stopReason?: string }> {
 	let output = "";
-	for await (const chunk of streamWithReconnect(client, sessionId, {
-		maxReconnects: 6,
+	let done = false;
+	let stopReason: string | undefined;
+
+	for await (const event of client.beta.sessions.events.list(sessionId, {
+		order: "asc",
 	})) {
-		if (chunk.type === "text") {
-			output += chunk.content;
+		if (event.type === "agent.message") {
+			for (const block of event.content ?? []) {
+				if (block?.type === "text" && typeof block.text === "string") {
+					output += block.text;
+				}
+			}
 		}
-		if (chunk.type === "error") {
-			throw new Error(chunk.content);
+		if (event.type === "session.error") {
+			const err = event.error as
+				| { message?: string; type?: string }
+				| undefined;
+			throw new Error(err?.message ?? err?.type ?? "session.error");
+		}
+		if (event.type === "session.status_idle") {
+			const reason = event.stop_reason?.type;
+			if (reason === "end_turn" || reason === "retries_exhausted") {
+				done = true;
+				stopReason = reason;
+			}
 		}
 	}
-	return output;
+
+	return { done, output, stopReason };
 }
 
-export interface TriggerPrReviewOptions {
-	onReviewStarted?: (completeReview: () => Promise<void>) => void;
+async function payloadFromStartedRun(
+	githubToken: string,
+	run: StartedPrReviewRun,
+): Promise<PrReviewPayload | null> {
+	const [owner, repo] = run.repoFullName.split("/");
+	if (!owner || !repo) return null;
+	const fetched = await fetchPrHeadMetadata(
+		githubToken,
+		run.repoFullName,
+		run.prNumber,
+	);
+	if (!fetched) return null;
+	return {
+		number: run.prNumber,
+		title: fetched.title,
+		htmlUrl: fetched.htmlUrl,
+		body: fetched.body,
+		headRef: fetched.headRef,
+		headSha: run.headSha || fetched.headSha,
+		baseRef: fetched.baseRef,
+		repoUrl: `https://github.com/${run.repoFullName}`,
+		repoFullName: run.repoFullName,
+		repoName: repo,
+	};
+}
+
+export interface PrReviewBrokerRunResult {
+	fingerprint: string;
+	sessionId: string;
+	prNumber: number;
+	status: "completed" | "failed" | "skipped_running";
+	error?: string;
+}
+
+export interface PrReviewBrokerResult {
+	checked: number;
+	completed: number;
+	failed: number;
+	skippedRunning: number;
+	runs: PrReviewBrokerRunResult[];
+}
+
+export async function processPendingPrReviewRuns(
+	input: {
+		limit?: number;
+		repoFullName?: string;
+	} = {},
+): Promise<PrReviewBrokerResult> {
+	const apiKey = process.env.ANTHROPIC_API_KEY;
+	const githubToken = await resolveGitHubToken();
+	if (!apiKey || !githubToken) {
+		throw new Error(
+			"missing ANTHROPIC_API_KEY, GitHub App credentials, or reviewer is disabled",
+		);
+	}
+
+	const client = new Anthropic({ apiKey });
+	const pendingRuns = await listStartedPrReviewRuns({
+		limit: input.limit ?? 5,
+		repoFullName: input.repoFullName,
+	});
+	const result: PrReviewBrokerResult = {
+		checked: pendingRuns.length,
+		completed: 0,
+		failed: 0,
+		skippedRunning: 0,
+		runs: [],
+	};
+
+	for (const run of pendingRuns) {
+		try {
+			const collected = await collectCompletedReviewIntentText(
+				client,
+				run.sessionId,
+			);
+			if (!collected.done) {
+				result.skippedRunning += 1;
+				result.runs.push({
+					fingerprint: run.fingerprint,
+					sessionId: run.sessionId,
+					prNumber: run.prNumber,
+					status: "skipped_running",
+				});
+				continue;
+			}
+
+			const payload = await payloadFromStartedRun(githubToken, run);
+			if (!payload) {
+				throw new Error(
+					`could not resolve PR metadata for ${run.repoFullName}#${run.prNumber}`,
+				);
+			}
+
+			const narrativeContext = await fetchPrNarrativeContext(
+				githubToken,
+				payload,
+			);
+			const intent = parseReviewIntentFromText(
+				collected.output,
+				narrativeContext.availableLabels.map((label) => label.name),
+			);
+			await postGitHubReviewIntent(githubToken, payload, intent);
+			await recordRunResult(run.fingerprint, {
+				sessionId: run.sessionId,
+				status: "completed",
+			});
+			result.completed += 1;
+			result.runs.push({
+				fingerprint: run.fingerprint,
+				sessionId: run.sessionId,
+				prNumber: run.prNumber,
+				status: "completed",
+			});
+			console.log(
+				`[pr-review] Broker posted review for PR #${run.prNumber} (${run.triggerKind}): ${run.sessionId}`,
+			);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			await recordRunResult(run.fingerprint, {
+				sessionId: run.sessionId,
+				status: "failed",
+				error: reason,
+			});
+			result.failed += 1;
+			result.runs.push({
+				fingerprint: run.fingerprint,
+				sessionId: run.sessionId,
+				prNumber: run.prNumber,
+				status: "failed",
+				error: reason,
+			});
+			console.error("[pr-review] broker failed:", err);
+		}
+	}
+
+	return result;
 }
 
 /**
@@ -795,7 +948,6 @@ export async function triggerPrReview(
 		triggerSourceId: payload.headSha || payload.headRef,
 		reason: "PR opened",
 	},
-	options: TriggerPrReviewOptions = {},
 ): Promise<string | null> {
 	const apiKey = process.env.ANTHROPIC_API_KEY;
 	const githubToken = await resolveGitHubToken();
@@ -1026,33 +1178,6 @@ In "## Project Thread", include a short label rationale using the first applicab
 				},
 			],
 		});
-
-		const completeReview = async () => {
-			try {
-				const output = await collectReviewIntentText(client, session.id);
-				const intent = parseReviewIntentFromText(
-					output,
-					narrativeContext.availableLabels.map((label) => label.name),
-				);
-				await postGitHubReviewIntent(githubToken, resolvedPayload, intent);
-				await recordRunResult(fingerprint, {
-					sessionId: session.id,
-					status: "completed",
-				});
-				console.log(
-					`[pr-review] Posted review for PR #${resolvedPayload.number} (${trigger.kind}): ${session.id}`,
-				);
-			} catch (err) {
-				const reason = err instanceof Error ? err.message : String(err);
-				await recordRunResult(fingerprint, {
-					sessionId: session.id,
-					status: "failed",
-					error: reason,
-				});
-				throw err;
-			}
-		};
-		options.onReviewStarted?.(completeReview);
 
 		console.log(
 			`[pr-review] Session created for PR #${resolvedPayload.number} (${trigger.kind}): ${session.id}`,


### PR DESCRIPTION
## Summary

- Move managed-reviewer review publishing out of the GitHub webhook request path.
- Add a protected `pr-reviewer-broker` route that processes completed `managed_pr_review_runs` sessions, validates the review intent, and posts the GitHub review.
- Extend the managed-reviewer canary script and docs so scheduled/CD validation runs canary → broker → monitor.

## Mergeability

- Surface: web managed PR reviewer runtime / webhook route / scheduled canary tooling.
- User-facing behavior changed: reviewer webhook handling no longer times out while waiting for long managed-agent reviews to finish.
- Non-happy paths considered: still-running sessions stay `started`; invalid final intent marks the run failed; broker route is canary-secret gated.
- Release/ops preconditions: `WORKSPACES_WEBHOOK_CANARY_SECRET` still must be configured in Vercel, Cloudflare, and GitHub Actions for scheduled broker/canary runs.
- Residual risk or follow-up: after deploy and secret configuration, run the broker against the existing PR #486 session and confirm the GitHub review posts.

## Validation

- [x] Other checks run:
  - pnpm exec vitest run src/app/api/webhooks/github/route.test.ts src/app/api/webhooks/github/pr-reviewer-broker/route.test.ts src/lib/agent-runtime/__tests__/pr-review.test.ts src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
  - mise -C web run web:check
  - UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/test_security_hardening.py
  - python3 scripts/managed-reviewer-ingress-canary.py --skip-canary --skip-broker --skip-monitor
  - git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check

## Performance

- [x] Not a performance-sensitive change

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![managed-reviewer-broker](https://evidence.cloudcompute.com/workspaces/pr-489/20260517-063855-managed-reviewer-broker.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
