### PR TITLE
Supersede stale managed reviewer sessions

### DIFF
--- a/docs/development/security-critical-path.md
+++ b/docs/development/security-critical-path.md
@@ -33,7 +33,9 @@ not a broad public security stance.
   repository cloning. It does not write a token into the prompt or filesystem
   for the agent to discover. The agent produces a structured review intent, and
   the server-side broker validates and posts the GitHub review with the App
-  token.
+  token. The broker re-checks current managed reviews before posting and
+  supersedes stale session output that did not account for a review posted while
+  the session was running.
 - Managed reviewer ingress canaries are HMAC verified and gated by
   `WORKSPACES_WEBHOOK_CANARY_SECRET`; the dry-run response returns before DB
   writes or managed-agent session creation.

--- a/scripts/managed-reviewer-ingress-canary.py
+++ b/scripts/managed-reviewer-ingress-canary.py
@@ -43,6 +43,8 @@ SAFE_RESPONSE_KEYS = (
     "completed",
     "failed",
     "skippedRunning",
+    "superseded",
+    "requeued",
     "error",
 )
 

--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -130,7 +130,11 @@ curl --fail-with-body -sS \
 
 The broker inspects `started` rows in `managed_pr_review_runs`, skips sessions
 that are still running, validates completed review-intent JSON, and posts the
-review with the GitHub App token. The monitor then compares recent
+review with the GitHub App token. Before posting, it re-checks current managed
+reviews on the PR; if another managed review was submitted after the session
+started, the stale session is marked `superseded`. If the superseding review is
+for an older head, the broker starts a fresh follow-up session so the newer-head
+review includes the prior review context. The monitor then compares recent
 reviewer-eligible rows in `webhook_events` with `managed_pr_review_runs`
 records. These routes return only run metadata and missing event identifiers,
 not raw payloads or secrets.

--- a/web/src/app/api/webhooks/github/pr-reviewer-broker/route.test.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-broker/route.test.ts
@@ -28,6 +28,8 @@ describe("/api/webhooks/github/pr-reviewer-broker POST", () => {
 			completed: 1,
 			failed: 0,
 			skippedRunning: 0,
+			superseded: 0,
+			requeued: 0,
 			runs: [
 				{
 					fingerprint: "fp",
@@ -81,6 +83,8 @@ describe("/api/webhooks/github/pr-reviewer-broker POST", () => {
 			completed: 0,
 			failed: 1,
 			skippedRunning: 0,
+			superseded: 0,
+			requeued: 0,
 			runs: [
 				{
 					fingerprint: "fp",

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -68,6 +68,22 @@ describe("recordRunStart", () => {
 		expect(retry.priorStatus).toBe("completed");
 	});
 
+	it("treats a superseded prior run as a permanent skip", async () => {
+		const { recordRunStart, recordRunResult } = await loadModule();
+		const input = makeInput();
+
+		await recordRunStart(input);
+		await recordRunResult(input.fingerprint, {
+			sessionId: "sesn_old",
+			status: "superseded",
+			error: "newer review already posted",
+		});
+
+		const retry = await recordRunStart(input);
+		expect(retry.inserted).toBe(false);
+		expect(retry.priorStatus).toBe("superseded");
+	});
+
 	it("retries when the prior run failed", async () => {
 		const { recordRunStart, recordRunResult } = await loadModule();
 		const input = makeInput();

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -618,6 +618,197 @@ describe("processPendingPrReviewRuns", () => {
 		});
 		expect(mocks.recordRunResult).not.toHaveBeenCalled();
 	});
+
+	it("supersedes a completed session when a newer managed review already covers the same head", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_stale",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 489,
+				headSha: "same-head",
+				triggerKind: "edited",
+				triggerSourceId: "body-123",
+				sessionId: "sesn_stale",
+				createdAt: "2026-05-17T06:39:00Z",
+				updatedAt: "2026-05-17T06:39:10Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [{ type: "text", text: "stale review intent" }],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(async (url: string) => {
+			if (url.endsWith("/pulls/489")) {
+				return {
+					ok: true,
+					json: async () =>
+						githubPr(489, {
+							title: "Broker managed reviewer completions",
+							html_url: "https://github.com/fairchild/workspaces/pull/489",
+							body: "PR body",
+							head: { ref: "codex/reviewer", sha: "same-head" },
+							base: { ref: "main" },
+						}),
+				};
+			}
+			if (url.includes("/pulls/489/reviews?")) {
+				return {
+					ok: true,
+					json: async () => [
+						{
+							id: 4304929065,
+							state: "APPROVED",
+							body: "First managed review.",
+							submitted_at: "2026-05-17T06:42:30Z",
+							commit_id: "same-head",
+							user: { login: "workspaces-claude-pr-reviewer[bot]" },
+						},
+					],
+				};
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			failed: 0,
+			skippedRunning: 0,
+			superseded: 1,
+			requeued: 0,
+			runs: [
+				{
+					fingerprint: "fp_stale",
+					status: "superseded",
+					supersededByReviewId: 4304929065,
+					retrySessionId: null,
+				},
+			],
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_stale", {
+			sessionId: "sesn_stale",
+			status: "superseded",
+			error: expect.stringContaining("same head"),
+		});
+	});
+
+	it("requeues a stale completed session when the newer managed review is for an older head", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_new_head_stale",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 489,
+				headSha: "new-head",
+				triggerKind: "synchronize",
+				triggerSourceId: "new-head",
+				sessionId: "sesn_new_head_stale",
+				createdAt: "2026-05-17T06:39:00Z",
+				updatedAt: "2026-05-17T06:39:10Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [{ type: "text", text: "stale review intent" }],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(async (url: string) => {
+			if (url.endsWith("/pulls/489")) {
+				return {
+					ok: true,
+					json: async () =>
+						githubPr(489, {
+							title: "Broker managed reviewer completions",
+							html_url: "https://github.com/fairchild/workspaces/pull/489",
+							body: "PR body",
+							head: { ref: "codex/reviewer", sha: "new-head" },
+							base: { ref: "main" },
+						}),
+				};
+			}
+			if (url.includes("/pulls/489/reviews?")) {
+				return {
+					ok: true,
+					json: async () => [
+						{
+							id: 4304929065,
+							state: "APPROVED",
+							body: "First managed review on old head.",
+							submitted_at: "2026-05-17T06:42:30Z",
+							commit_id: "old-head",
+							user: { login: "workspaces-claude-pr-reviewer[bot]" },
+						},
+					],
+				};
+			}
+			if (url.includes("/pulls?")) {
+				return { ok: true, json: async () => [] };
+			}
+			if (url.includes("/labels?")) {
+				return { ok: true, json: async () => [] };
+			}
+			if (url.includes("/issues/489/comments?")) {
+				return { ok: true, json: async () => [] };
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			failed: 0,
+			superseded: 1,
+			requeued: 1,
+			runs: [
+				{
+					fingerprint: "fp_new_head_stale",
+					status: "superseded",
+					supersededByReviewId: 4304929065,
+					retrySessionId: "sesn_01",
+				},
+			],
+		});
+		expect(mocks.recordRunStart).toHaveBeenCalledWith(
+			expect.objectContaining({
+				prNumber: 489,
+				headSha: "new-head",
+				triggerKind: "superseded_retry",
+				triggerSourceId: "review-4304929065-head-new-head",
+			}),
+		);
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_test", {
+			sessionId: "sesn_01",
+			status: "started",
+		});
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_new_head_stale", {
+			sessionId: "sesn_new_head_stale",
+			status: "superseded",
+			error: expect.stringContaining("retry session sesn_01 started"),
+		});
+		const [, params] = mocks.sendEvent.mock.calls[0];
+		const message = params.events[0].content[0].text;
+		expect(message).toContain("You reviewed this PR before");
+		expect(message).toContain("First managed review on old head.");
+	});
 });
 
 describe("triggerPrReview", () => {

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import { getDb } from "../db";
 
-export type PrReviewRunStatus = "started" | "completed" | "failed";
+export type PrReviewRunStatus =
+	| "started"
+	| "completed"
+	| "failed"
+	| "superseded";
 
 export interface PrReviewRunFingerprintInput {
 	repoFullName: string;
@@ -76,6 +80,8 @@ const STALE_STARTED_MS = 15 * 60 * 1000;
  * The semantics are:
  * - no row → insert and proceed.
  * - row with `completed` → skip; the previous run already produced a review.
+ * - row with `superseded` → skip; a later broker pass intentionally retired
+ *   that run because a newer managed review was already visible.
  * - row with `failed` → reset to `started` and proceed; lets a later
  *   redelivery (or a follow-on event with the same fingerprint) recover from
  *   a transient session-create or events.send failure.
@@ -141,7 +147,7 @@ export async function recordRunStart(
 	}
 
 	const priorStatus = existing.status as PrReviewRunStatus;
-	if (priorStatus === "completed") {
+	if (priorStatus === "completed" || priorStatus === "superseded") {
 		return { inserted: false, priorStatus };
 	}
 	if (priorStatus === "started") {

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -107,7 +107,8 @@ export type PrReviewTriggerKind =
 	| "ready_for_review"
 	| "synchronize"
 	| "edited"
-	| "evidence_comment";
+	| "evidence_comment"
+	| "superseded_retry";
 
 export interface PrReviewTrigger {
 	kind: PrReviewTriggerKind;
@@ -822,12 +823,46 @@ async function payloadFromStartedRun(
 	};
 }
 
+function reviewSubmittedAfter(
+	review: PrPriorReviewItem,
+	thresholdIso: string,
+): boolean {
+	const submittedMs = Date.parse(review.submittedAt);
+	const thresholdMs = Date.parse(thresholdIso);
+	if (!Number.isFinite(submittedMs) || !Number.isFinite(thresholdMs)) {
+		return false;
+	}
+	return submittedMs > thresholdMs;
+}
+
+function reviewsAfterRunStarted(
+	history: PrPriorReviewContext,
+	run: StartedPrReviewRun,
+): PrPriorReviewItem[] {
+	if (history.unavailableReason) return [];
+	return history.reviews.filter((review) =>
+		reviewSubmittedAfter(review, run.createdAt),
+	);
+}
+
+function currentHeadAlreadyReviewed(
+	review: PrPriorReviewItem,
+	run: StartedPrReviewRun,
+	payload: PrReviewPayload,
+): boolean {
+	const reviewedSha = review.commitSha.trim();
+	const runSha = (run.headSha || payload.headSha).trim();
+	return Boolean(reviewedSha && runSha && reviewedSha === runSha);
+}
+
 export interface PrReviewBrokerRunResult {
 	fingerprint: string;
 	sessionId: string;
 	prNumber: number;
-	status: "completed" | "failed" | "skipped_running";
+	status: "completed" | "failed" | "skipped_running" | "superseded";
 	error?: string;
+	supersededByReviewId?: number;
+	retrySessionId?: string | null;
 }
 
 export interface PrReviewBrokerResult {
@@ -835,6 +870,8 @@ export interface PrReviewBrokerResult {
 	completed: number;
 	failed: number;
 	skippedRunning: number;
+	superseded: number;
+	requeued: number;
 	runs: PrReviewBrokerRunResult[];
 }
 
@@ -862,6 +899,8 @@ export async function processPendingPrReviewRuns(
 		completed: 0,
 		failed: 0,
 		skippedRunning: 0,
+		superseded: 0,
+		requeued: 0,
 		runs: [],
 	};
 
@@ -887,6 +926,59 @@ export async function processPendingPrReviewRuns(
 				throw new Error(
 					`could not resolve PR metadata for ${run.repoFullName}#${run.prNumber}`,
 				);
+			}
+
+			const currentReviewHistory = await fetchCurrentPrReviewHistory(
+				githubToken,
+				payload,
+			);
+			const supersedingReviews = reviewsAfterRunStarted(
+				currentReviewHistory,
+				run,
+			);
+			const supersedingReview = supersedingReviews[0] ?? null;
+			if (supersedingReview) {
+				let retrySessionId: string | null = null;
+				const reviewedCurrentHead = supersedingReviews.some((review) =>
+					currentHeadAlreadyReviewed(review, run, payload),
+				);
+				if (!reviewedCurrentHead) {
+					try {
+						retrySessionId = await triggerPrReview(payload, {
+							kind: "superseded_retry",
+							triggerSourceId: `review-${supersedingReview.id}-head-${run.headSha || payload.headSha}`,
+							reason: `Managed review ${supersedingReview.id} posted after session ${run.sessionId} started; re-running with prior review context.`,
+						});
+					} catch (err) {
+						console.error("[pr-review] superseded retry failed:", err);
+					}
+				}
+
+				const error = reviewedCurrentHead
+					? `Superseded by managed review ${supersedingReview.id} on the same head.`
+					: retrySessionId
+						? `Superseded by managed review ${supersedingReview.id}; retry session ${retrySessionId} started.`
+						: `Superseded by managed review ${supersedingReview.id}; retry session was not started.`;
+				await recordRunResult(run.fingerprint, {
+					sessionId: run.sessionId,
+					status: "superseded",
+					error,
+				});
+				result.superseded += 1;
+				if (retrySessionId) result.requeued += 1;
+				result.runs.push({
+					fingerprint: run.fingerprint,
+					sessionId: run.sessionId,
+					prNumber: run.prNumber,
+					status: "superseded",
+					error,
+					supersededByReviewId: supersedingReview.id,
+					retrySessionId,
+				});
+				console.log(
+					`[pr-review] Broker superseded stale review for PR #${run.prNumber}: ${run.sessionId}`,
+				);
+				continue;
 			}
 
 			const narrativeContext = await fetchPrNarrativeContext(


### PR DESCRIPTION
## Summary

- Add a broker-time stale-session guard before posting managed-reviewer output.
- Mark sessions as `superseded` when another managed review landed after that session started, avoiding stale duplicate reviews.
- Requeue a fresh `superseded_retry` session when the stale output was for a newer head that still needs a review including the late prior-review context.

## Mergeability

- Surface: web managed PR reviewer broker / run state tracking / canary docs.
- User-facing behavior changed: stale managed-agent review output is no longer posted after a newer managed review exists.
- Non-happy paths considered: same-head stale sessions are retired without retry; newer-head stale sessions start a follow-up retry; retry failures leave the stale session explicitly superseded with diagnostic text.
- Release/ops preconditions: `WORKSPACES_WEBHOOK_CANARY_SECRET` is still required in Vercel, GitHub Actions, and Cloudflare for scheduled broker/canary execution.
- Residual risk or follow-up: after deploy, run the broker against any outstanding `started` sessions and confirm no duplicate stale reviews post.

## Validation

- [x] Other checks run:
  - pnpm exec vitest run src/lib/agent-runtime/__tests__/pr-review.test.ts src/lib/agent-runtime/__tests__/pr-review-runs.test.ts src/app/api/webhooks/github/pr-reviewer-broker/route.test.ts
  - mise -C web run web:check
  - UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/test_security_hardening.py
  - python3 scripts/managed-reviewer-ingress-canary.py --skip-canary --skip-broker --skip-monitor
  - git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check

## Performance

- [x] Not a performance-sensitive change

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![managed-reviewer-stale-guard](https://evidence.cloudcompute.com/workspaces/pr-490/20260517-102905-managed-reviewer-stale-guard.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
