### PR TITLE
Cover stale reviewer current-head reviews

### DIFF
--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -731,6 +731,97 @@ describe("processPendingPrReviewRuns", () => {
 		});
 	});
 
+	it("does not requeue when any newer managed review covers the current head", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_mixed_reviews",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 489,
+				headSha: "current-head",
+				triggerKind: "synchronize",
+				triggerSourceId: "current-head",
+				sessionId: "sesn_mixed_reviews",
+				createdAt: "2026-05-17T06:39:00Z",
+				updatedAt: "2026-05-17T06:39:10Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [{ type: "text", text: "stale review intent" }],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(async (url: string) => {
+			if (url.endsWith("/pulls/489")) {
+				return {
+					ok: true,
+					json: async () =>
+						githubPr(489, {
+							title: "Broker managed reviewer completions",
+							html_url: "https://github.com/fairchild/workspaces/pull/489",
+							body: "PR body",
+							head: { ref: "codex/reviewer", sha: "current-head" },
+							base: { ref: "main" },
+						}),
+				};
+			}
+			if (url.includes("/pulls/489/reviews?")) {
+				return {
+					ok: true,
+					json: async () => [
+						{
+							id: 4304929509,
+							state: "APPROVED",
+							body: "Later review on an older head.",
+							submitted_at: "2026-05-17T06:43:04Z",
+							commit_id: "old-head",
+							user: { login: "workspaces-claude-pr-reviewer[bot]" },
+						},
+						{
+							id: 4304929065,
+							state: "APPROVED",
+							body: "Earlier review on the current head.",
+							submitted_at: "2026-05-17T06:42:30Z",
+							commit_id: "current-head",
+							user: { login: "workspaces-claude-pr-reviewer[bot]" },
+						},
+					],
+				};
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			failed: 0,
+			superseded: 1,
+			requeued: 0,
+			runs: [
+				{
+					fingerprint: "fp_mixed_reviews",
+					status: "superseded",
+					supersededByReviewId: 4304929065,
+					retrySessionId: null,
+				},
+			],
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_mixed_reviews", {
+			sessionId: "sesn_mixed_reviews",
+			status: "superseded",
+			error: expect.stringContaining("4304929065"),
+		});
+	});
+
 	it("requeues a stale completed session when the newer managed review is for an older head", async () => {
 		mocks.listStartedPrReviewRuns.mockResolvedValue([
 			{

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -1008,9 +1008,12 @@ export async function processPendingPrReviewRuns(
 			const supersedingReview = supersedingReviews[0] ?? null;
 			if (supersedingReview) {
 				let retrySessionId: string | null = null;
-				const reviewedCurrentHead = supersedingReviews.some((review) =>
-					currentHeadAlreadyReviewed(review, run, payload),
-				);
+				const currentHeadReview =
+					supersedingReviews.find((review) =>
+						currentHeadAlreadyReviewed(review, run, payload),
+					) ?? null;
+				const reviewedCurrentHead = currentHeadReview !== null;
+				const referenceReview = currentHeadReview ?? supersedingReview;
 				if (!reviewedCurrentHead) {
 					try {
 						retrySessionId = await triggerPrReview(payload, {
@@ -1024,10 +1027,10 @@ export async function processPendingPrReviewRuns(
 				}
 
 				const error = reviewedCurrentHead
-					? `Superseded by managed review ${supersedingReview.id} on the same head.`
+					? `Superseded by managed review ${referenceReview.id} on the same head.`
 					: retrySessionId
-						? `Superseded by managed review ${supersedingReview.id}; retry session ${retrySessionId} started.`
-						: `Superseded by managed review ${supersedingReview.id}; retry session was not started.`;
+						? `Superseded by managed review ${referenceReview.id}; retry session ${retrySessionId} started.`
+						: `Superseded by managed review ${referenceReview.id}; retry session was not started.`;
 				await recordRunResult(run.fingerprint, {
 					sessionId: run.sessionId,
 					status: "superseded",
@@ -1041,7 +1044,7 @@ export async function processPendingPrReviewRuns(
 					prNumber: run.prNumber,
 					status: "superseded",
 					error,
-					supersededByReviewId: supersedingReview.id,
+					supersededByReviewId: referenceReview.id,
 					retrySessionId,
 				});
 				console.log(


### PR DESCRIPTION
## Summary

- Add a regression test for the managed-reviewer broker stale-session guard.
- Cover the case where multiple late managed reviews exist and one of them already covers the current head.
- Keep the broker from starting an unnecessary `superseded_retry` when current-head review coverage already exists.

## Mergeability

- Surface: web managed PR reviewer tests / stale-session broker logic.
- User-facing behavior changed: none directly; this pins down broker behavior added in #490.
- Non-happy paths considered: mixed late-review ordering where the newest late review is older-head but another late review covers the current head.
- Release/ops preconditions: none beyond the existing managed-reviewer deployment configuration.
- Residual risk or follow-up: this PR is intentionally small so we can observe whether the managed PR reviewer runs on a fresh useful PR.

## Validation

- [x] Other checks run:
  - pnpm exec vitest run src/lib/agent-runtime/__tests__/pr-review.test.ts
  - mise -C web run web:check
  - git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check

## Performance

- [x] Not a performance-sensitive change

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![managed-reviewer-current-head-test](https://evidence.cloudcompute.com/workspaces/pr-492/20260518-031103-managed-reviewer-current-head-test.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
