### PR TITLE
fix: harden perf readiness diagnostics

### DIFF
--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -365,6 +365,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var windowObserver: Any?
     private static let appVariantEnvKey = "WORKSPACES_APP_VARIANT"
+    private nonisolated static let disableStateRestorationEnvKey = "WORKSPACES_DISABLE_STATE_RESTORATION"
 
     private enum AppVariant {
         case standard
@@ -391,6 +392,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var isCI: Bool {
         ProcessInfo.processInfo.environment["CI"] != nil
+    }
+
+    private var disablesStateRestoration: Bool {
+        !Self.shouldPreserveState(launchEnvironment: ProcessInfo.processInfo.environment)
+    }
+
+    nonisolated static func shouldPreserveState(launchEnvironment: [String: String]) -> Bool {
+        launchEnvironment[disableStateRestorationEnvKey] != "1"
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -504,6 +513,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Keep the app alive after the last window closes. This avoids
         // unexpected app termination when a user closes a terminal/window.
         return false
+    }
+
+    func application(_ application: NSApplication, shouldSaveSecureApplicationState coder: NSCoder) -> Bool {
+        !disablesStateRestoration
+    }
+
+    func application(_ application: NSApplication, shouldRestoreSecureApplicationState coder: NSCoder) -> Bool {
+        !disablesStateRestoration
+    }
+
+    func application(_ application: NSApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {
+        !disablesStateRestoration
+    }
+
+    func application(_ application: NSApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
+        !disablesStateRestoration
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {

--- a/Sources/WorkspaceManager/Diagnostics/TerminalPromptReadinessSignpostController.swift
+++ b/Sources/WorkspaceManager/Diagnostics/TerminalPromptReadinessSignpostController.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct TerminalPromptReadinessSignpostController {
+    typealias LaunchCompletion = (_ trigger: String) -> Void
+    typealias SessionCompletion = (_ sessionID: UUID, _ outcome: String) -> Void
+
+    private let hostSessionID: UUID?
+    private let completeLaunch: LaunchCompletion
+    private let completeRepoClick: SessionCompletion
+    private let completeWorkspaceClick: SessionCompletion
+    private var didComplete = false
+
+    init(
+        hostSessionID: UUID?,
+        completeLaunch: @escaping LaunchCompletion = PerformanceSignposts.endLaunchToFirstPromptIfNeeded,
+        completeRepoClick: @escaping SessionCompletion = PerformanceSignposts.endRepoClickToFocusedInputIfNeeded,
+        completeWorkspaceClick: @escaping SessionCompletion = PerformanceSignposts
+            .endWorkspaceClickToFocusedInputIfNeeded
+    ) {
+        self.hostSessionID = hostSessionID
+        self.completeLaunch = completeLaunch
+        self.completeRepoClick = completeRepoClick
+        self.completeWorkspaceClick = completeWorkspaceClick
+    }
+
+    mutating func completeIfNeeded(signal: TerminalReadinessDiagnostics.Signal) {
+        guard signal.indicatesPromptReady else { return }
+        guard !didComplete else { return }
+
+        didComplete = true
+        completeLaunch("terminal_\(signal.rawValue)")
+
+        guard let hostSessionID else { return }
+        completeRepoClick(hostSessionID, "prompt_ready")
+        completeWorkspaceClick(hostSessionID, "prompt_ready")
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -27,6 +27,7 @@ final class GhosttySurfaceView: NSView {
     private(set) var terminalTitle: String = ""
     private(set) var currentWorkingDirectory: String?
     private var didProcessExit = false
+    private var promptReadinessSignposts: TerminalPromptReadinessSignpostController
     private var lastScaleAndSize: GhosttySurfaceScaleCalculator.ScaleAndSize?
     private var trackingAreaInstalled = false
     var workingDirectoryPath: String { workingDirectory.path }
@@ -40,6 +41,7 @@ final class GhosttySurfaceView: NSView {
         onCloseConfirmationRequired: (() -> Void)? = nil
     ) {
         self.workingDirectory = workingDirectory
+        self.promptReadinessSignposts = TerminalPromptReadinessSignpostController(hostSessionID: hostSessionID)
         self.onProcessExit = onProcessExit
         self.onCloseConfirmationRequired = onCloseConfirmationRequired
         self.terminalConfig = GhosttyTerminalConfig(
@@ -63,6 +65,7 @@ final class GhosttySurfaceView: NSView {
         onCloseConfirmationRequired: (() -> Void)? = nil
     ) {
         self.workingDirectory = FileManager.default.temporaryDirectory
+        self.promptReadinessSignposts = TerminalPromptReadinessSignpostController(hostSessionID: nil)
         self.onProcessExit = onProcessExit
         self.onCloseConfirmationRequired = onCloseConfirmationRequired
         self.terminalConfig = GhosttyTerminalConfig(customCommand: customCommand)
@@ -174,13 +177,22 @@ final class GhosttySurfaceView: NSView {
     func updateTerminalTitle(_ title: String) {
         terminalTitle = title
         guard !title.isEmpty else { return }
-        readinessDiagnostics.observeShellSignal(.setTitle)
+        observePromptReadinessSignal(.setTitle)
     }
 
     func updateWorkingDirectory(_ path: String?) {
         currentWorkingDirectory = path
         guard let path, !path.isEmpty else { return }
-        readinessDiagnostics.observeShellSignal(.pwd)
+        observePromptReadinessSignal(.pwd)
+    }
+
+    private func observePromptReadinessSignal(_ signal: TerminalReadinessDiagnostics.Signal) {
+        readinessDiagnostics.observeShellSignal(signal)
+        completePromptReadinessSignpostsIfNeeded(signal: signal)
+    }
+
+    private func completePromptReadinessSignpostsIfNeeded(signal: TerminalReadinessDiagnostics.Signal) {
+        promptReadinessSignposts.completeIfNeeded(signal: signal)
     }
 
     /// Channel 3: an OSC 9 / OSC 777 notification from the agent. Forward to the

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -67,7 +67,11 @@ struct GhosttyTerminalConfig {
         }
 
         let shell = environment["SHELL"] ?? "/bin/zsh"
+        let shellName = URL(fileURLWithPath: shell).lastPathComponent.lowercased()
         let shellProfileMode = ShellProfileMode.resolve(from: environment)
+        if shellProfileMode == .clean, environment["WORKSPACES_TERMINAL_DIAGNOSTICS"] == "1" {
+            Self.installDiagnosticPromptMarker(for: shellName, environment: &environment)
+        }
         let mode = terminalMultiplexingMode ?? TerminalMultiplexingMode.resolve()
         let tmuxAvailable =
             isTmuxAvailableOverride
@@ -132,6 +136,21 @@ struct GhosttyTerminalConfig {
             components.append(Self.singleQuoted(command))
         }
         return components.joined(separator: " ")
+    }
+
+    private static func installDiagnosticPromptMarker(
+        for shellName: String,
+        environment: inout [String: String]
+    ) {
+        let titleMarker = "\u{1B}]0;WorkSpaces Ready\u{7}"
+        switch shellName {
+        case "zsh":
+            environment["PROMPT"] = "%{\(titleMarker)%}%# "
+        case "bash":
+            environment["PS1"] = "\\[\(titleMarker)\\]\\$ "
+        default:
+            break
+        }
     }
 
     private static func isExecutableAvailable(_ executable: String, inPath path: String?) -> Bool {

--- a/Tests/WorkspaceManagerAppTests/AppStateRestorationPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppStateRestorationPolicyTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("App state restoration policy")
+struct AppStateRestorationPolicyTests {
+    @Test("preserves state by default")
+    func preservesStateByDefault() {
+        #expect(AppDelegate.shouldPreserveState(launchEnvironment: [:]))
+    }
+
+    @Test("diagnostic launches can disable state restoration")
+    func diagnosticLaunchesCanDisableStateRestoration() {
+        #expect(
+            !AppDelegate.shouldPreserveState(
+                launchEnvironment: ["WORKSPACES_DISABLE_STATE_RESTORATION": "1"]
+            )
+        )
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -76,6 +76,26 @@ struct GhosttyTerminalConfigTests {
         #expect(config.shellProfileModeLabel == "clean")
     }
 
+    @Test("clean zsh diagnostics install prompt readiness marker")
+    func cleanZshDiagnosticsInstallPromptReadinessMarker() throws {
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: [
+                "SHELL": "/bin/zsh",
+                "PATH": "/usr/bin:/bin",
+                "WORKSPACES_SHELL_PROFILE_MODE": "clean",
+                "WORKSPACES_TERMINAL_DIAGNOSTICS": "1",
+            ],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true
+        )
+
+        let prompt = try #require(config.environmentVariables["PROMPT"])
+        #expect(config.command == "/bin/zsh -f")
+        #expect(prompt.contains("\u{1B}]0;WorkSpaces Ready\u{7}"))
+        #expect(prompt.hasPrefix("%{"))
+    }
+
     @Test("clean shell mode uses bash without profile loading")
     func cleanShellModeUsesBareBash() {
         let config = GhosttyTerminalConfig(
@@ -91,6 +111,26 @@ struct GhosttyTerminalConfigTests {
 
         #expect(config.command == "/bin/bash --noprofile --norc")
         #expect(config.shellProfileModeLabel == "clean")
+    }
+
+    @Test("clean bash diagnostics install prompt readiness marker")
+    func cleanBashDiagnosticsInstallPromptReadinessMarker() throws {
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: [
+                "SHELL": "/bin/bash",
+                "PATH": "/usr/bin:/bin",
+                "WORKSPACES_SHELL_PROFILE_MODE": "clean",
+                "WORKSPACES_TERMINAL_DIAGNOSTICS": "1",
+            ],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true
+        )
+
+        let prompt = try #require(config.environmentVariables["PS1"])
+        #expect(config.command == "/bin/bash --noprofile --norc")
+        #expect(prompt.contains("\u{1B}]0;WorkSpaces Ready\u{7}"))
+        #expect(prompt.hasPrefix("\\["))
     }
 
     @Test("host session hook context is exported when both values are available")

--- a/Tests/WorkspaceManagerAppTests/TerminalPromptReadinessSignpostControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalPromptReadinessSignpostControllerTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("TerminalPromptReadinessSignpostController")
+struct TerminalPromptReadinessSignpostControllerTests {
+    @Test("prompt readiness completes launch and focus metrics once")
+    func promptReadinessCompletesMetricsOnce() {
+        let sessionID = UUID()
+        var launchTriggers: [String] = []
+        var repoCompletions: [(UUID, String)] = []
+        var workspaceCompletions: [(UUID, String)] = []
+
+        var controller = TerminalPromptReadinessSignpostController(
+            hostSessionID: sessionID,
+            completeLaunch: { trigger in launchTriggers.append(trigger) },
+            completeRepoClick: { sessionID, outcome in repoCompletions.append((sessionID, outcome)) },
+            completeWorkspaceClick: { sessionID, outcome in workspaceCompletions.append((sessionID, outcome)) }
+        )
+
+        controller.completeIfNeeded(signal: .setTitle)
+        controller.completeIfNeeded(signal: .pwd)
+
+        #expect(launchTriggers == ["terminal_set_title"])
+        #expect(repoCompletions.count == 1)
+        #expect(repoCompletions[0].0 == sessionID)
+        #expect(repoCompletions[0].1 == "prompt_ready")
+        #expect(workspaceCompletions.count == 1)
+        #expect(workspaceCompletions[0].0 == sessionID)
+        #expect(workspaceCompletions[0].1 == "prompt_ready")
+    }
+
+    @Test("prompt readiness without host session still completes launch")
+    func promptReadinessWithoutHostSessionCompletesLaunchOnly() {
+        var launchTriggers: [String] = []
+        var repoCompletionCount = 0
+        var workspaceCompletionCount = 0
+
+        var controller = TerminalPromptReadinessSignpostController(
+            hostSessionID: nil,
+            completeLaunch: { trigger in launchTriggers.append(trigger) },
+            completeRepoClick: { _, _ in repoCompletionCount += 1 },
+            completeWorkspaceClick: { _, _ in workspaceCompletionCount += 1 }
+        )
+
+        controller.completeIfNeeded(signal: .pwd)
+
+        #expect(launchTriggers == ["terminal_pwd"])
+        #expect(repoCompletionCount == 0)
+        #expect(workspaceCompletionCount == 0)
+    }
+}

--- a/scripts/launch-installed-diagnostics.sh
+++ b/scripts/launch-installed-diagnostics.sh
@@ -91,6 +91,11 @@ fi
 ENV_VARS=(
     "WORKSPACES_FOCUS_DIAGNOSTICS=1"
     "WORKSPACES_TERMINAL_DIAGNOSTICS=1"
+    "WORKSPACES_DISABLE_STATE_RESTORATION=1"
+)
+APP_ARGS=(
+    "-ApplePersistenceIgnoreState"
+    "YES"
 )
 
 if [[ "$WITH_INPUT_DIAGNOSTICS" -eq 1 ]]; then
@@ -118,13 +123,17 @@ for entry in "${ENV_VARS[@]}"; do
 done
 echo "  summarize:"
 echo "    ./.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py $LOG_FILE"
+echo "  app_args:"
+for entry in "${APP_ARGS[@]}"; do
+    echo "    $entry"
+done
 if [[ "$CAPTURE_SECONDS" -gt 0 ]]; then
     echo "  capture_seconds: $CAPTURE_SECONDS"
-    env "${ENV_VARS[@]}" "$APP_PATH" > >(tee "$LOG_FILE") 2>&1 &
+    env "${ENV_VARS[@]}" "$APP_PATH" "${APP_ARGS[@]}" > >(tee "$LOG_FILE") 2>&1 &
     APP_PID=$!
     sleep "$CAPTURE_SECONDS"
     kill "$APP_PID" 2>/dev/null || true
     wait "$APP_PID" 2>/dev/null || true
 else
-    env "${ENV_VARS[@]}" "$APP_PATH" 2>&1 | tee "$LOG_FILE"
+    env "${ENV_VARS[@]}" "$APP_PATH" "${APP_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
 fi


### PR DESCRIPTION
## Summary
- complete launch/repo/workspace perf intervals from terminal prompt-readiness signals so no-activate runs emit canonical metrics
- make installed diagnostics launches ignore stale AppKit restoration state so packaged verification reliably opens the main window
- seed clean-shell diagnostics with a deterministic OSC title prompt marker for installed clean-shell readiness capture

## Mergeability
- Surface: desktop / release diagnostics / performance tooling
- User-facing behavior changed: no normal UI behavior change; diagnostic and performance launches now emit canonical readiness metrics more reliably.
- Non-happy paths considered: no-activate launches that intentionally skip focus, stale AppKit window restoration state, and clean-shell diagnostics without user profile prompt hooks.
- Release/ops preconditions: land this PR on main before any release tag; use installed clean-shell perf verification and main CI as the release gate.
- Residual risk or follow-up: debug launch-to-first-prompt remains above the canonical debug host budget on this machine, while installed clean-shell release verification is green.

## Validation
- [x] `swift test` -> 665 tests in 116 suites passed
- [x] `UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/test_perf_tools.py` -> 6 tests passed
- [x] `./scripts/build-release.sh --no-sign` -> built `build/WorkSpaces.app`
- [x] `./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-release-perf-0ac3a15-patched/installed_verify_apple_persistence_arg` -> verified installed clean-shell metrics and resource packaging
- [x] `bash -n scripts/launch-installed-diagnostics.sh`

## Performance
Scenario ID: `debug_no_activate`
Before Summary: current `origin/main` could miss `launch_to_first_prompt` / `repo_click_to_focus` in no-activate runs because focus was intentionally skipped.
After Summary: `/tmp/workspaces-perf-baseline-20260518-180820/summary.json`
Delta Summary: canonical no-activate metrics now emit; `repo_click_to_focus` passed at median 174.30 ms, `repo_hydration` passed at median 1.24 ms. `launch_to_first_prompt` remains over the debug contract on this host at median 393.96 ms, while installed clean-shell release verification passed at 143.74 ms.

## Evidence
- ![release-readiness](https://evidence.cloudcompute.com/workspaces/pr-493/20260519-013042-release-readiness.svg)
- `swift test` -> 665 tests in 116 suites passed
- `UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/test_perf_tools.py` -> 6 tests passed
- `./scripts/build-release.sh --no-sign` -> built `build/WorkSpaces.app`
- `./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-release-perf-0ac3a15-patched/installed_verify_apple_persistence_arg` -> verified installed clean-shell metrics and resource packaging

## Release Readiness
- Current branch is based on `origin/main` at `0ac3a15cd6b30972c1f0899bb82524dffcd7c9ba`.
- Main CI for that SHA passed in run `26013246601`.
- Do not cut the release from this branch; release should target main after this PR lands.
