### PR TITLE
fix: show managed reviewer pickup status

### DIFF
--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -12,11 +12,13 @@ GitHub PR opened
 → Cloudflare webhook relay
 → signed forward to web/api/webhooks/github (webhook route)
 → triggerPrReview() (fire-and-forget)
+→ record new run and post pending `WorkSpaces Managed Review` commit status
 → getOrCreateAgent/Environment (idempotent, DB-cached)
 → sessions.create (mounts repo at PR branch)
 → events.send (kickoff message)
 → Agent runs autonomously on Anthropic → returns review-intent JSON
 → scheduled/protected broker route validates intent → posts GitHub review
+→ commit status flips to success or failure
 ```
 
 ## Key Files
@@ -49,8 +51,8 @@ GitHub PR opened
 Reviews are posted by the `workspaces-pr-reviewer` GitHub App, which gives them a dedicated bot identity instead of being attributed to a personal account. To set up:
 
 1. Create a GitHub App at https://github.com/settings/apps with permissions:
-   `contents:read`, `pull_requests:write`; add `issues:write` if you want the
-   broker to apply validated label suggestions
+   `contents:read`, `pull_requests:write`, `statuses:write`; add
+   `issues:write` if you want the broker to apply validated label suggestions
 2. Install the app on `fairchild/workspaces` and note the installation ID
 3. Set `PR_REVIEWER_APP_ID`, `PR_REVIEWER_PRIVATE_KEY`, and `PR_REVIEWER_INSTALLATION_ID` in Vercel
 4. Confirm the Cloudflare relay has `WEBHOOK_FORWARD_URL` configured and that
@@ -73,6 +75,19 @@ component that posts reviews or labels.
 **Security:** Never print App private keys or installation tokens to logs. Use
 files or secret-manager flows, never standalone `echo`/`print` of credential
 values.
+
+### PR progress status
+
+After the webhook route records a new reviewer run, it posts a pending commit
+status named `WorkSpaces Managed Review` to the PR head SHA. This is the first
+visible PR signal that the managed reviewer picked up the run. When the broker
+posts the final GitHub review, it updates the same status context to `success`;
+if broker processing fails before a review is posted, it updates the context to
+`failure`.
+
+The status is best-effort: a status API failure is logged but does not block the
+review session or broker. A `403` on this request means the GitHub App is missing
+the `statuses:write` permission.
 
 The Cloudflare relay forwards only managed-review trigger candidates:
 `pull_request.opened`, `reopened`, `ready_for_review`, `synchronize`, eligible

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -125,6 +125,14 @@ async function* asyncEvents(events: unknown[]) {
 	}
 }
 
+function isManagedReviewStatusUrl(url: string): boolean {
+	return url.includes("/statuses/");
+}
+
+function okResponse() {
+	return { ok: true, text: async () => "", json: async () => ({}) };
+}
+
 function mockPrList(prs: unknown[]) {
 	mockNarrativeFetch({ prs });
 }
@@ -190,6 +198,10 @@ function mockNarrativeFetch({
 						? [{ user: { login: "workspaces-claude-pr-reviewer[bot]" } }]
 						: [{ user: { login: "fairchild" } }],
 			};
+		}
+
+		if (isManagedReviewStatusUrl(url)) {
+			return okResponse();
 		}
 
 		throw new Error(`Unexpected fetch URL: ${url}`);
@@ -567,6 +579,9 @@ describe("processPendingPrReviewRuns", () => {
 					});
 					return { ok: true, text: async () => "", json: async () => ({}) };
 				}
+				if (isManagedReviewStatusUrl(url)) {
+					return okResponse();
+				}
 				throw new Error(`Unexpected fetch URL: ${url}`);
 			},
 		);
@@ -582,6 +597,16 @@ describe("processPendingPrReviewRuns", () => {
 		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_486", {
 			sessionId: "sesn_486",
 			status: "completed",
+		});
+		const statusPost = mocks.fetch.mock.calls.find(([url]) =>
+			String(url).includes("/statuses/head-sha"),
+		);
+		expect(statusPost?.[1]).toMatchObject({ method: "POST" });
+		expect(JSON.parse(String(statusPost?.[1]?.body))).toMatchObject({
+			state: "success",
+			context: "WorkSpaces Managed Review",
+			description: "Managed review posted.",
+			target_url: "https://github.com/fairchild/workspaces/pull/486",
 		});
 	});
 
@@ -673,6 +698,9 @@ describe("processPendingPrReviewRuns", () => {
 						},
 					],
 				};
+			}
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
 			}
 			throw new Error(`Unexpected fetch URL: ${url}`);
 		});
@@ -767,6 +795,9 @@ describe("processPendingPrReviewRuns", () => {
 			if (url.includes("/issues/489/comments?")) {
 				return { ok: true, json: async () => [] };
 			}
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
+			}
 			throw new Error(`Unexpected fetch URL: ${url}`);
 		});
 
@@ -834,6 +865,34 @@ describe("triggerPrReview", () => {
 			"456",
 		);
 		expect(mocks.createSession).toHaveBeenCalledTimes(1);
+	});
+
+	it("posts a pending PR status after the managed reviewer is kicked off", async () => {
+		mockPrList([githubPr(9), githubPr(8)]);
+
+		await expect(triggerPrReview(payload())).resolves.toBe("sesn_01");
+
+		const statusCallIndex = mocks.fetch.mock.calls.findIndex(([url]) =>
+			String(url).includes(
+				"/statuses/deadbeefcafebabe1234567890abcdef12345678",
+			),
+		);
+		expect(statusCallIndex).toBeGreaterThanOrEqual(0);
+		const [, statusOptions] = mocks.fetch.mock.calls[statusCallIndex];
+		expect(statusOptions).toMatchObject({ method: "POST" });
+		expect(JSON.parse(String(statusOptions?.body))).toMatchObject({
+			state: "pending",
+			context: "WorkSpaces Managed Review",
+			description: "Managed reviewer picked up this PR.",
+			target_url: "https://github.com/fairchild/workspaces/pull/9",
+		});
+		const statusOrder = mocks.fetch.mock.invocationCallOrder[statusCallIndex];
+		expect(statusOrder).toBeGreaterThan(
+			mocks.recordRunStart.mock.invocationCallOrder[0],
+		);
+		expect(statusOrder).toBeLessThan(
+			mocks.createSession.mock.invocationCallOrder[0],
+		);
 	});
 
 	it("does not fall back to GITHUB_TOKEN when GitHub App token exchange fails", async () => {
@@ -1098,6 +1157,9 @@ describe("triggerPrReview rerun behavior", () => {
 			if (/\/pulls\/8\/reviews\?/.test(url)) {
 				return { ok: true, json: async () => [] };
 			}
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
+			}
 			throw new Error(`Unexpected fetch URL: ${url}`);
 		});
 
@@ -1165,6 +1227,9 @@ describe("triggerPrReview rerun behavior", () => {
 			if (/\/pulls\/8\/reviews\?/.test(url)) {
 				return { ok: true, json: async () => [] };
 			}
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
+			}
 			throw new Error(`Unexpected fetch URL: ${url}`);
 		});
 
@@ -1221,6 +1286,9 @@ describe("triggerPrReview rerun behavior", () => {
 			}
 			if (/\/pulls\/\d+\/reviews\?/.test(url)) {
 				return { ok: true, json: async () => [] };
+			}
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
 			}
 			throw new Error(`Unexpected fetch URL: ${url}`);
 		});

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -761,6 +761,63 @@ async function postGitHubReviewIntent(
 	}
 }
 
+type ManagedReviewStatusState = "pending" | "success" | "failure" | "error";
+
+const MANAGED_REVIEW_STATUS_CONTEXT = "WorkSpaces Managed Review";
+
+interface ManagedReviewStatusPayload {
+	repoFullName: string;
+	number: number;
+	headSha: string;
+	htmlUrl: string;
+}
+
+async function postManagedReviewStatus(
+	githubToken: string,
+	payload: ManagedReviewStatusPayload,
+	state: ManagedReviewStatusState,
+	description: string,
+): Promise<void> {
+	const [owner, repo] = payload.repoFullName.split("/");
+	if (!owner || !repo || !payload.headSha) {
+		console.warn(
+			`[pr-review] managed review status skipped for PR #${payload.number}: missing repo or head SHA`,
+		);
+		return;
+	}
+
+	try {
+		const res = await fetch(
+			`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/statuses/${encodeURIComponent(payload.headSha)}`,
+			{
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${githubToken}`,
+					Accept: "application/vnd.github+json",
+					"X-GitHub-Api-Version": "2022-11-28",
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					state,
+					context: MANAGED_REVIEW_STATUS_CONTEXT,
+					description,
+					target_url: payload.htmlUrl,
+				}),
+			},
+		);
+		if (!res.ok) {
+			console.warn(
+				`[pr-review] managed review status update failed ${res.status}: ${await res.text()}`,
+			);
+		}
+	} catch (err) {
+		console.warn(
+			"[pr-review] managed review status update failed:",
+			err instanceof Error ? err.message : err,
+		);
+	}
+}
+
 async function collectCompletedReviewIntentText(
 	client: Anthropic,
 	sessionId: string,
@@ -905,6 +962,12 @@ export async function processPendingPrReviewRuns(
 	};
 
 	for (const run of pendingRuns) {
+		let statusPayload: ManagedReviewStatusPayload = {
+			repoFullName: run.repoFullName,
+			number: run.prNumber,
+			headSha: run.headSha,
+			htmlUrl: `https://github.com/${run.repoFullName}/pull/${run.prNumber}`,
+		};
 		try {
 			const collected = await collectCompletedReviewIntentText(
 				client,
@@ -927,6 +990,12 @@ export async function processPendingPrReviewRuns(
 					`could not resolve PR metadata for ${run.repoFullName}#${run.prNumber}`,
 				);
 			}
+			statusPayload = {
+				repoFullName: payload.repoFullName,
+				number: payload.number,
+				headSha: payload.headSha,
+				htmlUrl: payload.htmlUrl,
+			};
 
 			const currentReviewHistory = await fetchCurrentPrReviewHistory(
 				githubToken,
@@ -990,6 +1059,12 @@ export async function processPendingPrReviewRuns(
 				narrativeContext.availableLabels.map((label) => label.name),
 			);
 			await postGitHubReviewIntent(githubToken, payload, intent);
+			await postManagedReviewStatus(
+				githubToken,
+				statusPayload,
+				"success",
+				"Managed review posted.",
+			);
 			await recordRunResult(run.fingerprint, {
 				sessionId: run.sessionId,
 				status: "completed",
@@ -1006,6 +1081,12 @@ export async function processPendingPrReviewRuns(
 			);
 		} catch (err) {
 			const reason = err instanceof Error ? err.message : String(err);
+			await postManagedReviewStatus(
+				githubToken,
+				statusPayload,
+				"failure",
+				"Managed review failed before posting.",
+			);
 			await recordRunResult(run.fingerprint, {
 				sessionId: run.sessionId,
 				status: "failed",
@@ -1105,6 +1186,18 @@ export async function triggerPrReview(
 		);
 		return null;
 	}
+
+	await postManagedReviewStatus(
+		githubToken,
+		{
+			repoFullName: resolvedPayload.repoFullName,
+			number: resolvedPayload.number,
+			headSha: resolvedPayload.headSha,
+			htmlUrl: resolvedPayload.htmlUrl,
+		},
+		"pending",
+		"Managed reviewer picked up this PR.",
+	);
 
 	try {
 		const isRerun = trigger.kind !== "opened";
@@ -1277,6 +1370,17 @@ In "## Project Thread", include a short label rationale using the first applicab
 		return session.id;
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : String(err);
+		await postManagedReviewStatus(
+			githubToken,
+			{
+				repoFullName: resolvedPayload.repoFullName,
+				number: resolvedPayload.number,
+				headSha: resolvedPayload.headSha,
+				htmlUrl: resolvedPayload.htmlUrl,
+			},
+			"failure",
+			"Managed reviewer failed to start.",
+		);
 		await recordRunResult(fingerprint, {
 			sessionId: null,
 			status: "failed",


### PR DESCRIPTION
## Summary

- post a pending `WorkSpaces Managed Review` commit status as soon as a managed-reviewer run is recorded
- update the same status to success when the broker posts the review, or failure when broker/startup processing fails
- document the status flow and required GitHub App `statuses:write` permission

## Mergeability

- Surface: agent-runtime / web
- User-facing behavior changed: PRs get a visible `WorkSpaces Managed Review` pending status as soon as the managed reviewer accepts a new run.
- Non-happy paths considered: status writes are best-effort and logged on failure; reviewer startup and broker failures flip the same status to failure when possible.
- Release/ops preconditions: the PR reviewer GitHub App needs `statuses:write` for the indicator to appear; a missing permission logs 403 without blocking reviews.
- Residual risk or follow-up: after merge/deploy, confirm a fresh PR shows the pending status and later success/failure transition.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `pnpm exec vitest run src/lib/agent-runtime/__tests__/pr-review.test.ts`; `mise -C web run web:check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![managed-reviewer-start-status](https://evidence.cloudcompute.com/workspaces/pr-494/20260519-023009-managed-reviewer-start-status.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
