### PR TITLE
release: embed changelog notes in Sparkle appcast

### DIFF
--- a/Tests/WorkspaceManagerAppTests/SparkleAppcastScriptTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SparkleAppcastScriptTests.swift
@@ -13,6 +13,7 @@ struct SparkleAppcastScriptTests {
                 "--dmg", fixture.dmg.path,
                 "--app", fixture.app.path,
                 "--tag", "v9.9.9",
+                "--changelog", fixture.changelog.path,
                 "--output", fixture.output.path,
             ],
             environment: [:]
@@ -31,6 +32,7 @@ struct SparkleAppcastScriptTests {
                 "--app", fixture.app.path,
                 "--tag", "v9.9.9",
                 "--repo", "fairchild/workspaces",
+                "--changelog", fixture.changelog.path,
                 "--output", fixture.output.path,
             ],
             environment: ["SPARKLE_PRIVATE_KEY": testPrivateKey]
@@ -47,15 +49,52 @@ struct SparkleAppcastScriptTests {
         #expect(xml.contains(dmgURL))
         #expect(xml.contains("sparkle:edSignature="))
         #expect(xml.contains("length=\"4\""))
+        let fullReleaseNotesLink =
+            "<sparkle:fullReleaseNotesLink>"
+            + "https://github.com/fairchild/workspaces/blob/v9.9.9/CHANGELOG.md"
+            + "</sparkle:fullReleaseNotesLink>"
+        #expect(xml.contains(fullReleaseNotesLink))
+        #expect(xml.contains("<h2>WorkSpaces 9.9.9</h2>"))
+        #expect(xml.contains("<h3>Added</h3>"))
+        #expect(xml.contains("<li>show changelog notes in Sparkle update checks</li>"))
+        #expect(xml.contains("<h3>Fixed</h3>"))
+        #expect(xml.contains("<li>escape &lt;markup&gt; &amp; quotes &quot;safely&quot;</li>"))
+        #expect(!xml.contains("See the GitHub release notes"))
     }
 
-    private func makeFixture() throws -> (app: URL, dmg: URL, output: URL) {
+    @Test("Missing changelog entry fails clearly")
+    func missingChangelogEntryFailsClearly() throws {
+        let fixture = try makeFixture(includeChangelogEntry: false)
+        let result = runAppcastScript(
+            arguments: [
+                "--dmg", fixture.dmg.path,
+                "--app", fixture.app.path,
+                "--tag", "v9.9.9",
+                "--changelog", fixture.changelog.path,
+                "--output", fixture.output.path,
+            ],
+            environment: ["SPARKLE_PRIVATE_KEY": testPrivateKey]
+        )
+
+        #expect(result.exitCode == 1)
+        #expect(result.stderr.contains("CHANGELOG.md does not contain release notes for WorkSpaces 9.9.9"))
+    }
+
+    private func makeFixture(
+        includeChangelogEntry: Bool = true
+    ) throws -> (
+        app: URL,
+        dmg: URL,
+        output: URL,
+        changelog: URL
+    ) {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("SparkleAppcastScriptTests-\(UUID().uuidString)", isDirectory: true)
         let app = root.appendingPathComponent("WorkSpaces.app", isDirectory: true)
         let contents = app.appendingPathComponent("Contents", isDirectory: true)
         let dmg = root.appendingPathComponent("WorkSpaces-9.9.9.dmg")
         let output = root.appendingPathComponent("appcast.xml")
+        let changelog = root.appendingPathComponent("CHANGELOG.md")
 
         try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
         let plist: [String: Any] = [
@@ -67,7 +106,32 @@ struct SparkleAppcastScriptTests {
         try data.write(to: contents.appendingPathComponent("Info.plist"))
         try Data("test".utf8).write(to: dmg)
 
-        return (app, dmg, output)
+        let changelogEntry: String
+        if includeChangelogEntry {
+            changelogEntry = """
+                ## [9.9.9] - 2099-09-09
+
+                ### Added
+                - show changelog notes in Sparkle update checks
+
+                ### Fixed
+                - escape <markup> & quotes "safely"
+
+                """
+        } else {
+            changelogEntry = ""
+        }
+        let changelogContent = """
+            # Changelog
+
+            \(changelogEntry)## [9.9.8] - 2099-09-08
+
+            ### Fixed
+            - older release notes should not be embedded
+            """
+        try changelogContent.write(to: changelog, atomically: true, encoding: .utf8)
+
+        return (app, dmg, output, changelog)
     }
 
     private func runAppcastScript(

--- a/backlog/sparkle-appcast-release-notes-followups_followup.md
+++ b/backlog/sparkle-appcast-release-notes-followups_followup.md
@@ -1,0 +1,61 @@
+---
+topic: sparkle-appcast-release-notes
+relates_to: after:sparkle-autoupdate-plan
+priority: 2
+description: Capture release runbook and appcast script hardening follow-ups from PR #497 review.
+---
+
+# Sparkle Appcast Release Notes Follow-ups
+
+## Problem Statement
+
+PR #497 made generated Sparkle appcasts depend on a version-matched `CHANGELOG.md` entry. That is the right release artifact contract, but it creates a new hard release precondition that should be easy for future release operators and agents to see before the protected release workflow reaches appcast signing.
+
+The PR review also called out a safe-but-implicit script assumption: `scripts/generate-sparkle-appcast.sh` interpolates `$REPO` and `$TAG` into XML and release URLs directly. In the current release workflow those values come from controlled repository metadata and a validated release tag, so this is not a blocker. If the script is reused more broadly, that assumption should either be documented in code or hardened.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Release precondition | Document `CHANGELOG.md` entry before appcast generation | Missing notes now fail the release before signing, so the runbook should state the requirement explicitly. |
+| Script reuse assumption | Start with a local comment, harden only if inputs become less controlled | The current workflow controls `GITHUB_REPOSITORY` and tag inputs; validation work is only needed if the script becomes a general-purpose appcast generator. |
+
+## Implementation Phases
+
+### Phase 1: Release Runbook Note
+
+**Files to modify:**
+- `RELEASING.md` - add the appcast release-notes precondition near the `prepare-release.sh` / changelog flow.
+- `backlog/sparkle-autoupdate-plan.md` - add the same note under Release Integration so the Sparkle update plan stays current.
+
+**Acceptance criteria:**
+- [ ] Release docs state that `CHANGELOG.md` must contain `## [CFBundleShortVersionString] - <date>` before `scripts/generate-sparkle-appcast.sh` runs.
+- [ ] Docs mention that the generated appcast embeds that section in `<description>` and fails if it is missing or empty.
+
+### Phase 2: Appcast Script Assumption Comment
+
+**Files to modify:**
+- `scripts/generate-sparkle-appcast.sh` - add a short comment near `DOWNLOAD_URL`, `RELEASE_URL`, and `CHANGELOG_URL` explaining that `$REPO` comes from `GITHUB_REPOSITORY` and `$TAG` is validated by release preparation before the release workflow runs.
+
+**Acceptance criteria:**
+- [ ] The comment makes the trust boundary explicit without adding noisy escaping code for the current release-only use case.
+- [ ] If future work allows arbitrary `--repo` or `--tag` values from untrusted callers, the follow-up either constrains those values or escapes them before XML interpolation.
+
+## Verification Commands
+
+```bash
+bash -n scripts/generate-sparkle-appcast.sh
+swift test --filter SparkleAppcastScript
+rg -n "CHANGELOG.md|generate-sparkle-appcast|fullReleaseNotesLink" RELEASING.md backlog/sparkle-autoupdate-plan.md scripts/generate-sparkle-appcast.sh
+```
+
+## Rollback Plan
+
+Remove the added documentation/comment-only changes. Do not weaken the appcast generator guard introduced in PR #497 unless the release process gets a replacement source for signed release notes.
+
+## References
+
+- PR #497: `release: embed changelog notes in Sparkle appcast`
+- `scripts/generate-sparkle-appcast.sh`
+- `Tests/WorkspaceManagerAppTests/SparkleAppcastScriptTests.swift`
+- `backlog/sparkle-autoupdate-plan.md`

--- a/scripts/generate-sparkle-appcast.sh
+++ b/scripts/generate-sparkle-appcast.sh
@@ -12,8 +12,96 @@ PLIST_BUDDY="/usr/libexec/PlistBuddy"
 DMG_PATH=""
 APP_BUNDLE="$PROJECT_DIR/build/WorkSpaces.app"
 OUTPUT_PATH="$PROJECT_DIR/build/appcast.xml"
+CHANGELOG_PATH="$PROJECT_DIR/CHANGELOG.md"
 REPO="${GITHUB_REPOSITORY:-fairchild/workspaces}"
 TAG=""
+
+fail() {
+    echo "[generate-sparkle-appcast] ERROR: $*" >&2
+    exit 1
+}
+
+html_escape() {
+    sed \
+        -e 's/&/\&amp;/g' \
+        -e 's/</\&lt;/g' \
+        -e 's/>/\&gt;/g' \
+        -e 's/"/\&quot;/g'
+}
+
+extract_changelog_section() {
+    local version="$1"
+
+    awk -v version="$version" '
+        /^## \[/ {
+            if (found) {
+                exit 0
+            }
+            if (index($0, "## [" version "] - ") == 1) {
+                found = 1
+                next
+            }
+        }
+        found {
+            print
+        }
+        END {
+            if (!found) {
+                exit 42
+            }
+        }
+    ' "$CHANGELOG_PATH"
+}
+
+render_release_notes_html() {
+    local short_version="$1"
+    local line=""
+    local escaped=""
+    local in_list=false
+
+    printf '        <h2>WorkSpaces %s</h2>\n' "$(printf '%s' "$short_version" | html_escape)"
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$line" =~ ^###[[:space:]]+(.+)$ ]]; then
+            if [[ "$in_list" == true ]]; then
+                printf '        </ul>\n'
+                in_list=false
+            fi
+            escaped="$(printf '%s' "${BASH_REMATCH[1]}" | html_escape)"
+            printf '        <h3>%s</h3>\n' "$escaped"
+            continue
+        fi
+
+        if [[ "$line" =~ ^-[[:space:]]+(.+)$ ]]; then
+            if [[ "$in_list" == false ]]; then
+                printf '        <ul>\n'
+                in_list=true
+            fi
+            escaped="$(printf '%s' "${BASH_REMATCH[1]}" | html_escape)"
+            printf '          <li>%s</li>\n' "$escaped"
+            continue
+        fi
+
+        if [[ -z "${line//[[:space:]]/}" ]]; then
+            if [[ "$in_list" == true ]]; then
+                printf '        </ul>\n'
+                in_list=false
+            fi
+            continue
+        fi
+
+        if [[ "$in_list" == true ]]; then
+            printf '        </ul>\n'
+            in_list=false
+        fi
+        escaped="$(printf '%s' "$line" | html_escape)"
+        printf '        <p>%s</p>\n' "$escaped"
+    done
+
+    if [[ "$in_list" == true ]]; then
+        printf '        </ul>\n'
+    fi
+}
 
 usage() {
     cat <<'EOF'
@@ -23,6 +111,7 @@ Usage:
 Options:
   --app <path>       App bundle used for version metadata (default: build/WorkSpaces.app)
   --output <path>    Output appcast path (default: build/appcast.xml)
+  --changelog <path> Changelog used for embedded release notes (default: CHANGELOG.md)
   --repo <owner/repo> GitHub repository for release asset URLs (default: GITHUB_REPOSITORY or fairchild/workspaces)
   --help            Show this help
 
@@ -45,6 +134,10 @@ while [[ $# -gt 0 ]]; do
             OUTPUT_PATH="${2:-}"
             shift 2
             ;;
+        --changelog)
+            CHANGELOG_PATH="${2:-}"
+            shift 2
+            ;;
         --repo)
             REPO="${2:-}"
             shift 2
@@ -65,23 +158,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-[[ -n "$DMG_PATH" ]] || { echo "Missing required --dmg path" >&2; exit 2; }
-[[ -n "$TAG" ]] || { echo "Missing required --tag" >&2; exit 2; }
-[[ -f "$DMG_PATH" ]] || { echo "DMG not found: $DMG_PATH" >&2; exit 1; }
-[[ -d "$APP_BUNDLE" ]] || { echo "App bundle not found: $APP_BUNDLE" >&2; exit 1; }
+[[ -n "$DMG_PATH" ]] || fail "Missing required --dmg path"
+[[ -n "$TAG" ]] || fail "Missing required --tag"
+[[ -f "$DMG_PATH" ]] || fail "DMG not found: $DMG_PATH"
+[[ -d "$APP_BUNDLE" ]] || fail "App bundle not found: $APP_BUNDLE"
+[[ -f "$CHANGELOG_PATH" ]] || fail "CHANGELOG.md not found: $CHANGELOG_PATH"
 [[ -n "${SPARKLE_PRIVATE_KEY:-}" ]] || {
-    echo "SPARKLE_PRIVATE_KEY is required to sign Sparkle update archives" >&2
-    exit 1
+    fail "SPARKLE_PRIVATE_KEY is required to sign Sparkle update archives"
 }
 
 SIGN_UPDATE="$PROJECT_DIR/.build/artifacts/sparkle/Sparkle/bin/sign_update"
-[[ -x "$SIGN_UPDATE" ]] || {
-    echo "Sparkle sign_update tool not found at $SIGN_UPDATE; run swift package resolve" >&2
-    exit 1
-}
 
 INFO_PLIST="$APP_BUNDLE/Contents/Info.plist"
-[[ -f "$INFO_PLIST" ]] || { echo "Info.plist not found in app bundle: $INFO_PLIST" >&2; exit 1; }
+[[ -f "$INFO_PLIST" ]] || fail "Info.plist not found in app bundle: $INFO_PLIST"
 
 VERSION="$("$PLIST_BUDDY" -c "Print :CFBundleVersion" "$INFO_PLIST")"
 SHORT_VERSION="$("$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$INFO_PLIST")"
@@ -89,7 +178,20 @@ MIN_SYSTEM_VERSION="$("$PLIST_BUDDY" -c "Print :LSMinimumSystemVersion" "$INFO_P
 DMG_BASENAME="$(basename "$DMG_PATH")"
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$DMG_BASENAME"
 RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
+CHANGELOG_URL="https://github.com/$REPO/blob/$TAG/CHANGELOG.md"
 PUB_DATE="$(LC_ALL=C date -u "+%a, %d %b %Y %H:%M:%S +0000")"
+
+if ! CHANGELOG_ENTRY="$(extract_changelog_section "$SHORT_VERSION")"; then
+    fail "CHANGELOG.md does not contain release notes for WorkSpaces $SHORT_VERSION"
+fi
+if [[ -z "${CHANGELOG_ENTRY//[[:space:]]/}" ]]; then
+    fail "CHANGELOG.md release notes for WorkSpaces $SHORT_VERSION are empty"
+fi
+RELEASE_NOTES_HTML="$(printf '%s\n' "$CHANGELOG_ENTRY" | render_release_notes_html "$SHORT_VERSION")"
+
+[[ -x "$SIGN_UPDATE" ]] || {
+    fail "Sparkle sign_update tool not found at $SIGN_UPDATE; run swift package resolve"
+}
 
 SIGNATURE_ATTRIBUTES="$(
     printf "%s" "$SPARKLE_PRIVATE_KEY" \
@@ -108,13 +210,14 @@ cat >"$OUTPUT_PATH" <<XML
     <item>
       <title>WorkSpaces $SHORT_VERSION</title>
       <link>$RELEASE_URL</link>
+      <sparkle:fullReleaseNotesLink>$CHANGELOG_URL</sparkle:fullReleaseNotesLink>
       <sparkle:version>$VERSION</sparkle:version>
       <sparkle:shortVersionString>$SHORT_VERSION</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>$MIN_SYSTEM_VERSION</sparkle:minimumSystemVersion>
       <pubDate>$PUB_DATE</pubDate>
       <enclosure url="$DOWNLOAD_URL" $SIGNATURE_ATTRIBUTES type="application/octet-stream" />
       <description><![CDATA[
-        <p>See the GitHub release notes for WorkSpaces $SHORT_VERSION.</p>
+$RELEASE_NOTES_HTML
       ]]></description>
     </item>
   </channel>


### PR DESCRIPTION
## Summary

- Embed the matching CHANGELOG.md release entry into generated Sparkle appcasts.
- Add a tag-stable full release notes link to the appcast item.
- Fail appcast generation clearly when release notes for the app version are missing.

## Mergeability

- Surface: desktop release tooling
- User-facing behavior changed: Sparkle update prompts can show version-specific release notes from the appcast.
- Non-happy paths considered: missing changelog entry now fails appcast generation before signing.
- Release/ops preconditions: release CHANGELOG.md must contain the CFBundleShortVersionString entry before appcast generation.
- Residual risk or follow-up: None known.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `bash -n scripts/generate-sparkle-appcast.sh`; `swift-format lint --strict --recursive Sources/ Tests/`; `swift test --filter SparkleAppcastScript`; hosted evidence uploaded for the rebased head.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![sparkle-appcast-notes-rebased](https://evidence.cloudcompute.com/workspaces/pr-497/20260524-164026-sparkle-appcast-notes-rebased.svg)
- Rebased focused validation passed: `swift test --filter SparkleAppcastScript` completed with 3 tests passed in 1 suite.
- Formatter validation passed: `swift-format lint --strict --recursive Sources/ Tests/`.
- Shell syntax validation passed: `bash -n scripts/generate-sparkle-appcast.sh`.

## Blockers

- [x] None
- [ ] Blocked on evidence
