### PR TITLE
feat: add defaultAgentCommand fields + DefaultAgentResolver (M7 prep)

### DIFF
--- a/Sources/WorkspaceManagerCore/Models/Models.swift
+++ b/Sources/WorkspaceManagerCore/Models/Models.swift
@@ -18,6 +18,10 @@ public final class Repo {
     public var addedAt: Date
     public var lastAccessedAt: Date = Date()
 
+    /// Repo-level default agent command (e.g. `claude --resume`). Overrides the
+    /// global default; overridden by a workspace's own `defaultAgentCommand`.
+    public var defaultAgentCommand: String?
+
     @Relationship(deleteRule: .cascade, inverse: \Workspace.sourceRepo)
     public var workspaces: [Workspace] = []
 
@@ -34,7 +38,8 @@ public final class Repo {
         localPath: URL,
         remoteURL: String? = nil,
         addedAt: Date = Date(),
-        lastAccessedAt: Date = Date()
+        lastAccessedAt: Date = Date(),
+        defaultAgentCommand: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -42,6 +47,7 @@ public final class Repo {
         self.remoteURL = remoteURL
         self.addedAt = addedAt
         self.lastAccessedAt = lastAccessedAt
+        self.defaultAgentCommand = defaultAgentCommand
     }
 }
 
@@ -283,6 +289,10 @@ public final class Workspace {
     public var statusRaw: String
     public var gitBranch: String?
 
+    /// Workspace-level default agent command (e.g. `claude --resume`). Most
+    /// specific tier — overrides both the repo and global defaults.
+    public var defaultAgentCommand: String?
+
     /// Isolation backend identifier ("local", "daytona", etc.)
     public var backendIdentifier: String = "local"
 
@@ -410,6 +420,7 @@ public final class Workspace {
         lastAccessedAt: Date = Date(),
         status: WorkspaceStatus = .active,
         gitBranch: String? = nil,
+        defaultAgentCommand: String? = nil,
         backendIdentifier: String = "local",
         remoteId: String? = nil,
         sessionRoutingID: String? = nil,
@@ -424,6 +435,7 @@ public final class Workspace {
         self.lastAccessedAt = lastAccessedAt
         self.statusRaw = status.rawValue
         self.gitBranch = gitBranch
+        self.defaultAgentCommand = defaultAgentCommand
         self.backendIdentifier = backendIdentifier
         self.remoteId = remoteId
         self.sessionRoutingID = sessionRoutingID

--- a/Sources/WorkspaceManagerCore/Services/DefaultAgentResolver.swift
+++ b/Sources/WorkspaceManagerCore/Services/DefaultAgentResolver.swift
@@ -1,0 +1,46 @@
+//
+//  DefaultAgentResolver.swift
+//  WorkspaceManagerCore
+//
+//  Resolves the agent command a workspace should auto-spawn after provision,
+//  walking the precedence chain: workspace override → repo default → global
+//  default. Centralized so callers (provisioners, terminal launchers, UI hints)
+//  don't reimplement the walk.
+//
+
+import Foundation
+
+/// Shared keys for the global default-agent setting. The Settings UI and the
+/// terminal launcher both read/write the same UserDefaults key.
+public enum DefaultAgentDefaults {
+    /// Project-wide fallback agent command (e.g. `claude --resume`). Empty or
+    /// whitespace-only values are treated as unset by `DefaultAgentResolver`.
+    public static let globalCommandKey = "workspaces.defaultAgentCommand"
+}
+
+public struct DefaultAgentResolver: Sendable {
+    public init() {}
+
+    /// Resolve the agent command for a workspace, walking the precedence chain:
+    /// workspace override → repo default → global default → `nil`.
+    ///
+    /// Empty and whitespace-only strings are treated as unset at every tier, so
+    /// a workspace can't accidentally suppress its repo/global default by
+    /// holding an empty string. Non-empty values are trimmed before being
+    /// returned.
+    public func resolve(
+        workspaceCommand: String?,
+        repoCommand: String?,
+        globalCommand: String?
+    ) -> String? {
+        Self.normalize(workspaceCommand)
+            ?? Self.normalize(repoCommand)
+            ?? Self.normalize(globalCommand)
+    }
+
+    private static func normalize(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Tests/WorkspaceManagerTests/DefaultAgentResolverTests.swift
+++ b/Tests/WorkspaceManagerTests/DefaultAgentResolverTests.swift
@@ -1,0 +1,103 @@
+//
+//  DefaultAgentResolverTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("DefaultAgentResolver")
+struct DefaultAgentResolverTests {
+    private let resolver = DefaultAgentResolver()
+
+    @Test("All nil → nil")
+    func allNil() {
+        #expect(resolver.resolve(workspaceCommand: nil, repoCommand: nil, globalCommand: nil) == nil)
+    }
+
+    @Test("Only global set → returns global")
+    func globalOnly() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: nil,
+                repoCommand: nil,
+                globalCommand: "claude --resume"
+            ) == "claude --resume"
+        )
+    }
+
+    @Test("Repo overrides global")
+    func repoOverridesGlobal() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: nil,
+                repoCommand: "codex",
+                globalCommand: "claude --resume"
+            ) == "codex"
+        )
+    }
+
+    @Test("Workspace overrides repo and global")
+    func workspaceOverridesAll() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: "aider",
+                repoCommand: "codex",
+                globalCommand: "claude --resume"
+            ) == "aider"
+        )
+    }
+
+    @Test("Empty string is treated as nil and falls through")
+    func emptyFallsThrough() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: "",
+                repoCommand: "",
+                globalCommand: "claude"
+            ) == "claude"
+        )
+        #expect(
+            resolver.resolve(
+                workspaceCommand: "",
+                repoCommand: "codex",
+                globalCommand: nil
+            ) == "codex"
+        )
+    }
+
+    @Test("Whitespace-only is treated as nil and falls through")
+    func whitespaceFallsThrough() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: "   ",
+                repoCommand: "\t\n",
+                globalCommand: "claude"
+            ) == "claude"
+        )
+    }
+
+    @Test("Non-empty values are trimmed of surrounding whitespace")
+    func trimsSurroundingWhitespace() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: "  claude --resume  \n",
+                repoCommand: nil,
+                globalCommand: nil
+            ) == "claude --resume"
+        )
+    }
+
+    @Test("Internal whitespace is preserved")
+    func preservesInternalWhitespace() {
+        #expect(
+            resolver.resolve(
+                workspaceCommand: "claude --resume --model opus",
+                repoCommand: nil,
+                globalCommand: nil
+            ) == "claude --resume --model opus"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Prep refactor for **M7.chg** (auto-spawn agent after workspace provision). Adds the storage + resolver so the change side can land as a thin view-layer PR.

- `defaultAgentCommand: String?` on `Workspace` and `Repo` SwiftData models.
- `DefaultAgentDefaults.globalCommandKey` for `@AppStorage` (global scope).
- `DefaultAgentResolver` value type — walks workspace → repo → global precedence.
- No view files touched. Production code does not call the resolver yet; M7.chg wires it into `SidebarView.createWorkspaceAfterSetup`.

Part of the prep/change rollout cadence established in PR #496. The matching change PR (M7.chg) is unblocked once this merges.

## Mergeability

- Surface: desktop
- User-facing behavior changed: no (pure prep — no call sites yet)
- Non-happy paths considered: precedence walk has explicit unit coverage; nil-at-every-scope returns nil cleanly
- Release/ops preconditions: SwiftData schema gains two optional `String?` columns (additive, no migration needed)
- Residual risk or follow-up: M7.chg picks this up and adds the call site + settings UI

## Validation

- [x] `swift build`
- [x] `swift test` — 701 tests in 120 suites passed (8 new tests for `DefaultAgentResolver`)
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/` exits 0

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

This is a backend/value-type addition — `swift test` is the proof. Test summary screenshot will be uploaded shortly and linked below.

Evidence links:

- [Test summary screenshot](https://evidence.cloudcompute.com/workspaces/pr-498/20260523-195701-m7-prep-test-summary.png)

## Blockers

- [x] None
