### PR TITLE
feat: GitService extensions for diff/stage/discard + branches (M5+M8 prep)

### DIFF
--- a/Sources/WorkspaceManagerCore/Models/UnifiedDiff.swift
+++ b/Sources/WorkspaceManagerCore/Models/UnifiedDiff.swift
@@ -1,0 +1,185 @@
+//
+//  UnifiedDiff.swift
+//  WorkspaceManagerCore
+//
+//  Structured representation of a single-file unified diff.
+//
+
+import Foundation
+
+public struct UnifiedDiff: Equatable, Sendable {
+    public let path: String
+    public let oldPath: String?
+    public let hunks: [Hunk]
+    public let addedLines: Int
+    public let removedLines: Int
+
+    public init(path: String, oldPath: String? = nil, hunks: [Hunk]) {
+        self.path = path
+        self.oldPath = oldPath
+        self.hunks = hunks
+        self.addedLines = hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .added }.count }
+        self.removedLines = hunks.reduce(0) { $0 + $1.lines.filter { $0.kind == .removed }.count }
+    }
+
+    public struct Hunk: Equatable, Sendable {
+        public let oldStart: Int
+        public let oldCount: Int
+        public let newStart: Int
+        public let newCount: Int
+        public let lines: [Line]
+
+        public init(oldStart: Int, oldCount: Int, newStart: Int, newCount: Int, lines: [Line]) {
+            self.oldStart = oldStart
+            self.oldCount = oldCount
+            self.newStart = newStart
+            self.newCount = newCount
+            self.lines = lines
+        }
+    }
+
+    public struct Line: Equatable, Sendable {
+        public enum Kind: Sendable {
+            case context
+            case added
+            case removed
+        }
+
+        public let kind: Kind
+        public let content: String
+
+        public init(kind: Kind, content: String) {
+            self.kind = kind
+            self.content = content
+        }
+    }
+
+    public enum ParseError: LocalizedError {
+        case malformedHunkHeader(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .malformedHunkHeader(let header):
+                return "Malformed hunk header: \(header)"
+            }
+        }
+    }
+
+    /// Parse the output of `git diff --no-color <file>` for a single file.
+    public static func parse(_ raw: String, path: String) throws -> UnifiedDiff {
+        var oldPath: String? = nil
+        var hunks: [Hunk] = []
+
+        var currentHeader: (oldStart: Int, oldCount: Int, newStart: Int, newCount: Int)? = nil
+        var currentLines: [Line] = []
+
+        func flushHunk() {
+            guard let h = currentHeader else { return }
+            hunks.append(
+                Hunk(
+                    oldStart: h.oldStart,
+                    oldCount: h.oldCount,
+                    newStart: h.newStart,
+                    newCount: h.newCount,
+                    lines: currentLines
+                )
+            )
+            currentHeader = nil
+            currentLines = []
+        }
+
+        let rawLines = raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        for line in rawLines {
+            // File headers (before any hunk)
+            if currentHeader == nil {
+                if line.hasPrefix("rename from ") {
+                    oldPath = String(line.dropFirst("rename from ".count))
+                    continue
+                }
+                if line.hasPrefix("--- a/") {
+                    let candidate = String(line.dropFirst("--- a/".count))
+                    if candidate != path, oldPath == nil {
+                        oldPath = candidate
+                    }
+                    continue
+                }
+                if line.hasPrefix("--- ") || line.hasPrefix("+++ ") || line.hasPrefix("diff --git")
+                    || line.hasPrefix("index ") || line.hasPrefix("new file") || line.hasPrefix("deleted file")
+                    || line.hasPrefix("similarity ") || line.hasPrefix("rename to ")
+                {
+                    continue
+                }
+            }
+
+            if line.hasPrefix("@@") {
+                flushHunk()
+                currentHeader = try parseHunkHeader(line)
+                continue
+            }
+
+            guard currentHeader != nil else {
+                continue
+            }
+
+            if line.hasPrefix("+") {
+                currentLines.append(Line(kind: .added, content: String(line.dropFirst())))
+            } else if line.hasPrefix("-") {
+                currentLines.append(Line(kind: .removed, content: String(line.dropFirst())))
+            } else if line.hasPrefix(" ") {
+                currentLines.append(Line(kind: .context, content: String(line.dropFirst())))
+            } else if line.hasPrefix("\\") {
+                // "\ No newline at end of file" — ignore.
+                continue
+            } else if line.isEmpty {
+                // Empty line within a hunk is a context line with empty content.
+                currentLines.append(Line(kind: .context, content: ""))
+            }
+        }
+
+        flushHunk()
+
+        return UnifiedDiff(path: path, oldPath: oldPath, hunks: hunks)
+    }
+
+    private static func parseHunkHeader(
+        _ header: String
+    ) throws -> (oldStart: Int, oldCount: Int, newStart: Int, newCount: Int) {
+        // Format: @@ -oldStart[,oldCount] +newStart[,newCount] @@ optional-context
+        guard let openRange = header.range(of: "@@"),
+            let closeRange = header.range(of: "@@", range: openRange.upperBound..<header.endIndex)
+        else {
+            throw ParseError.malformedHunkHeader(header)
+        }
+        let inner = header[openRange.upperBound..<closeRange.lowerBound]
+            .trimmingCharacters(in: .whitespaces)
+
+        let parts = inner.split(separator: " ")
+        guard parts.count == 2 else {
+            throw ParseError.malformedHunkHeader(header)
+        }
+        let old = String(parts[0])
+        let new = String(parts[1])
+        guard old.hasPrefix("-"), new.hasPrefix("+") else {
+            throw ParseError.malformedHunkHeader(header)
+        }
+
+        let (oldStart, oldCount) = try parseRange(String(old.dropFirst()), header: header)
+        let (newStart, newCount) = try parseRange(String(new.dropFirst()), header: header)
+        return (oldStart, oldCount, newStart, newCount)
+    }
+
+    private static func parseRange(_ spec: String, header: String) throws -> (Int, Int) {
+        let parts = spec.split(separator: ",")
+        guard let start = Int(parts[0]) else {
+            throw ParseError.malformedHunkHeader(header)
+        }
+        if parts.count == 1 {
+            return (start, 1)
+        }
+        guard parts.count == 2, let count = Int(parts[1]) else {
+            throw ParseError.malformedHunkHeader(header)
+        }
+        return (start, count)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -76,6 +76,42 @@ public actor GitService: GitServiceProtocol {
         _ = try await runGit(["checkout", name], at: path)
     }
 
+    /// List local and `origin/*` remote branches. Sorted locals-first, current at top.
+    public func branches(at path: URL) async throws -> [BranchName] {
+        let current = try await getCurrentBranch(at: path) ?? ""
+
+        let output = try await runGit(
+            [
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/heads",
+                "refs/remotes/origin",
+            ],
+            at: path
+        )
+
+        var locals: [BranchName] = []
+        var remotes: [BranchName] = []
+
+        for raw in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let ref = String(raw)
+            if let name = ref.dropPrefix("refs/heads/") {
+                locals.append(BranchName(name: name, isCurrent: name == current, isRemote: false))
+            } else if let name = ref.dropPrefix("refs/remotes/origin/") {
+                if name == "HEAD" { continue }
+                remotes.append(BranchName(name: name, isCurrent: false, isRemote: true))
+            }
+        }
+
+        locals.sort { lhs, rhs in
+            if lhs.isCurrent != rhs.isCurrent { return lhs.isCurrent }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+        remotes.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        return locals + remotes
+    }
+
     // MARK: - Diff / Stage / Unstage / Discard
 
     /// Structured working-tree-vs-index diff for a single file.
@@ -224,6 +260,27 @@ public actor GitService: GitServiceProtocol {
             return .modified
         }
         return .modified
+    }
+}
+
+// MARK: - Value Types
+
+public struct BranchName: Hashable, Sendable {
+    public let name: String
+    public let isCurrent: Bool
+    public let isRemote: Bool
+
+    public init(name: String, isCurrent: Bool, isRemote: Bool) {
+        self.name = name
+        self.isCurrent = isCurrent
+        self.isRemote = isRemote
+    }
+}
+
+extension String {
+    fileprivate func dropPrefix(_ prefix: String) -> String? {
+        guard hasPrefix(prefix) else { return nil }
+        return String(dropFirst(prefix.count))
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -76,6 +76,28 @@ public actor GitService: GitServiceProtocol {
         _ = try await runGit(["checkout", name], at: path)
     }
 
+    // MARK: - Diff / Stage / Unstage / Discard
+
+    /// Structured working-tree-vs-index diff for a single file.
+    public func diff(file: String, at path: URL) async throws -> UnifiedDiff {
+        let output = try await runGit(["diff", "--no-color", "--", file], at: path)
+        return try UnifiedDiff.parse(output, path: file)
+    }
+
+    public func stage(file: String, at path: URL) async throws {
+        _ = try await runGit(["add", "--", file], at: path)
+    }
+
+    public func unstage(file: String, at path: URL) async throws {
+        _ = try await runGit(["reset", "HEAD", "--", file], at: path)
+    }
+
+    /// Discard working-tree changes for `file`, restoring HEAD contents.
+    /// Destructive: unstaged edits are lost without recovery.
+    public func discard(file: String, at path: URL) async throws {
+        _ = try await runGit(["checkout", "--", file], at: path)
+    }
+
     // MARK: - File Tree
 
     public func getFileTree(at path: URL, maxDepth: Int = 4) async throws -> FileNode {

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -90,6 +90,10 @@ public protocol GitServiceProtocol: Sendable {
     func createBranch(_ name: String, at path: URL) async throws
     func checkoutBranch(_ name: String, at path: URL) async throws
     func getFileTree(at path: URL, maxDepth: Int) async throws -> FileNode
+    func diff(file: String, at path: URL) async throws -> UnifiedDiff
+    func stage(file: String, at path: URL) async throws
+    func unstage(file: String, at path: URL) async throws
+    func discard(file: String, at path: URL) async throws
 }
 
 extension GitServiceProtocol {

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -94,6 +94,7 @@ public protocol GitServiceProtocol: Sendable {
     func stage(file: String, at path: URL) async throws
     func unstage(file: String, at path: URL) async throws
     func discard(file: String, at path: URL) async throws
+    func branches(at path: URL) async throws -> [BranchName]
 }
 
 extension GitServiceProtocol {

--- a/Tests/WorkspaceManagerTests/GitServiceBranchesTests.swift
+++ b/Tests/WorkspaceManagerTests/GitServiceBranchesTests.swift
@@ -1,0 +1,91 @@
+//
+//  GitServiceBranchesTests.swift
+//  WorkspaceManagerTests
+//
+//  Integration tests for GitService.branches(at:).
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("GitService branches")
+struct GitServiceBranchesTests {
+
+    @Test("Single branch is returned and flagged current")
+    func singleBranchIsCurrent() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "x")
+        try repo.commit(message: "init")
+
+        let branches = try await GitService.shared.branches(at: repo.url)
+        #expect(branches.count == 1)
+        #expect(branches[0].isCurrent)
+        #expect(branches[0].isRemote == false)
+    }
+
+    @Test("Multiple local branches sorted with current first")
+    func multipleLocalBranchesSorted() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "x")
+        try repo.commit(message: "init")
+        try run(["git", "branch", "alpha"], at: repo.url)
+        try run(["git", "branch", "zulu"], at: repo.url)
+        try run(["git", "checkout", "alpha"], at: repo.url)
+
+        let branches = try await GitService.shared.branches(at: repo.url)
+        let names = branches.filter { !$0.isRemote }.map(\.name)
+        #expect(names.first == "alpha")
+        #expect(branches.first(where: { $0.isCurrent })?.name == "alpha")
+        let onlyOneCurrent = branches.filter(\.isCurrent).count
+        #expect(onlyOneCurrent == 1)
+        #expect(Set(names).isSuperset(of: ["alpha", "zulu"]))
+    }
+
+    @Test("Remote branches are included and flagged")
+    func remoteBranchesIncluded() async throws {
+        // Origin repo
+        let origin = try TestGitRepository.create()
+        defer { origin.cleanup() }
+        try origin.createFile("a.txt", content: "x")
+        try origin.commit(message: "init")
+        try run(["git", "branch", "feature/one"], at: origin.url)
+
+        // Clone into a working repo so it gets refs/remotes/origin/*
+        let workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceManagerTests-clone-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: workDir) }
+        try run(["git", "clone", origin.url.path, workDir.path], at: FileManager.default.temporaryDirectory)
+        try run(["git", "config", "user.email", "t@e.com"], at: workDir)
+        try run(["git", "config", "user.name", "T"], at: workDir)
+
+        let branches = try await GitService.shared.branches(at: workDir)
+        let remotes = branches.filter(\.isRemote).map(\.name)
+        #expect(remotes.contains("feature/one"))
+        #expect(!remotes.contains("HEAD"), "origin/HEAD pointer should be filtered out")
+
+        // Locals come before remotes.
+        let firstRemoteIndex = branches.firstIndex(where: { $0.isRemote }) ?? branches.endIndex
+        let lastLocalIndex = branches.lastIndex(where: { !$0.isRemote }) ?? -1
+        #expect(lastLocalIndex < firstRemoteIndex)
+    }
+
+    private func run(_ args: [String], at directory: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = args
+        process.currentDirectoryURL = directory
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw TestGitRepository.TestError.commandFailed(args.joined(separator: " "))
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
+++ b/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
@@ -1,0 +1,98 @@
+//
+//  GitServiceDiffTests.swift
+//  WorkspaceManagerTests
+//
+//  Integration tests for GitService diff / stage / unstage / discard.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("GitService diff/stage/unstage/discard")
+struct GitServiceDiffTests {
+
+    @Test("diff returns hunks for modified file")
+    func diffReturnsHunksForModifiedFile() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "one\ntwo\nthree\n")
+        try repo.commit(message: "init")
+        try repo.modifyFile("a.txt", content: "one\nTWO\nthree\n")
+
+        let diff = try await GitService.shared.diff(file: "a.txt", at: repo.url)
+        #expect(diff.path == "a.txt")
+        #expect(diff.hunks.count == 1)
+        #expect(diff.addedLines == 1)
+        #expect(diff.removedLines == 1)
+        #expect(diff.hunks[0].lines.contains(.init(kind: .added, content: "TWO")))
+        #expect(diff.hunks[0].lines.contains(.init(kind: .removed, content: "two")))
+    }
+
+    @Test("diff on clean file is empty")
+    func diffOnCleanFileIsEmpty() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "hello\n")
+        try repo.commit(message: "init")
+
+        let diff = try await GitService.shared.diff(file: "a.txt", at: repo.url)
+        #expect(diff.hunks.isEmpty)
+    }
+
+    @Test("stage moves modification into index and clears working-tree diff")
+    func stageMovesIntoIndex() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "x\n")
+        try repo.commit(message: "init")
+        try repo.modifyFile("a.txt", content: "y\n")
+
+        try await GitService.shared.stage(file: "a.txt", at: repo.url)
+
+        let diff = try await GitService.shared.diff(file: "a.txt", at: repo.url)
+        #expect(diff.hunks.isEmpty, "working-tree diff should be empty after staging")
+
+        let status = try await GitService.shared.getStatus(at: repo.url)
+        #expect(status.contains(where: { $0.path == "a.txt" }))
+    }
+
+    @Test("unstage moves staged change back to working tree")
+    func unstageMovesBackToWorkingTree() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "x\n")
+        try repo.commit(message: "init")
+        try repo.modifyFile("a.txt", content: "y\n")
+        try await GitService.shared.stage(file: "a.txt", at: repo.url)
+        try await GitService.shared.unstage(file: "a.txt", at: repo.url)
+
+        let diff = try await GitService.shared.diff(file: "a.txt", at: repo.url)
+        #expect(!diff.hunks.isEmpty, "working-tree diff should reappear after unstage")
+        #expect(diff.addedLines == 1)
+        #expect(diff.removedLines == 1)
+    }
+
+    @Test("discard restores HEAD contents")
+    func discardRestoresHeadContents() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "original\n")
+        try repo.commit(message: "init")
+        try repo.modifyFile("a.txt", content: "garbage\n")
+
+        try await GitService.shared.discard(file: "a.txt", at: repo.url)
+
+        let restored = try String(contentsOf: repo.url.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(restored == "original\n")
+
+        let diff = try await GitService.shared.diff(file: "a.txt", at: repo.url)
+        #expect(diff.hunks.isEmpty)
+    }
+}

--- a/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
@@ -74,4 +74,12 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     func discard(file: String, at path: URL) async throws {
         discardCalls.append((file: file, path: path))
     }
+
+    // MARK: - Branches (M8 prep)
+
+    var branchesResult: [BranchName] = []
+
+    func branches(at path: URL) async throws -> [BranchName] {
+        branchesResult
+    }
 }

--- a/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
@@ -51,4 +51,27 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     func getFileTree(at path: URL, maxDepth: Int) async throws -> FileNode {
         fileTreeResult
     }
+
+    // MARK: - Diff / Stage / Unstage / Discard (M5 prep)
+
+    var diffResult: UnifiedDiff = UnifiedDiff(path: "", hunks: [])
+    var stageCalls: [(file: String, path: URL)] = []
+    var unstageCalls: [(file: String, path: URL)] = []
+    var discardCalls: [(file: String, path: URL)] = []
+
+    func diff(file: String, at path: URL) async throws -> UnifiedDiff {
+        diffResult
+    }
+
+    func stage(file: String, at path: URL) async throws {
+        stageCalls.append((file: file, path: path))
+    }
+
+    func unstage(file: String, at path: URL) async throws {
+        unstageCalls.append((file: file, path: path))
+    }
+
+    func discard(file: String, at path: URL) async throws {
+        discardCalls.append((file: file, path: path))
+    }
 }

--- a/Tests/WorkspaceManagerTests/UnifiedDiffTests.swift
+++ b/Tests/WorkspaceManagerTests/UnifiedDiffTests.swift
@@ -1,0 +1,180 @@
+//
+//  UnifiedDiffTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("UnifiedDiff")
+struct UnifiedDiffTests {
+
+    @Test("Parses single-hunk modification")
+    func parsesSingleHunkModification() throws {
+        let raw = """
+            diff --git a/file.txt b/file.txt
+            index 1234567..89abcde 100644
+            --- a/file.txt
+            +++ b/file.txt
+            @@ -1,3 +1,3 @@
+             line1
+            -old
+            +new
+             line3
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "file.txt")
+        #expect(diff.path == "file.txt")
+        #expect(diff.oldPath == nil)
+        #expect(diff.hunks.count == 1)
+        #expect(diff.addedLines == 1)
+        #expect(diff.removedLines == 1)
+
+        let hunk = diff.hunks[0]
+        #expect(hunk.oldStart == 1)
+        #expect(hunk.oldCount == 3)
+        #expect(hunk.newStart == 1)
+        #expect(hunk.newCount == 3)
+        #expect(hunk.lines.count == 4)
+        #expect(hunk.lines[0] == .init(kind: .context, content: "line1"))
+        #expect(hunk.lines[1] == .init(kind: .removed, content: "old"))
+        #expect(hunk.lines[2] == .init(kind: .added, content: "new"))
+        #expect(hunk.lines[3] == .init(kind: .context, content: "line3"))
+    }
+
+    @Test("Parses added file")
+    func parsesAddedFile() throws {
+        let raw = """
+            diff --git a/new.txt b/new.txt
+            new file mode 100644
+            index 0000000..abcdef0
+            --- /dev/null
+            +++ b/new.txt
+            @@ -0,0 +1,2 @@
+            +alpha
+            +beta
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "new.txt")
+        #expect(diff.hunks.count == 1)
+        #expect(diff.addedLines == 2)
+        #expect(diff.removedLines == 0)
+        #expect(diff.hunks[0].oldStart == 0)
+        #expect(diff.hunks[0].oldCount == 0)
+        #expect(diff.hunks[0].newStart == 1)
+        #expect(diff.hunks[0].newCount == 2)
+    }
+
+    @Test("Parses removed file")
+    func parsesRemovedFile() throws {
+        let raw = """
+            diff --git a/gone.txt b/gone.txt
+            deleted file mode 100644
+            index abcdef0..0000000
+            --- a/gone.txt
+            +++ /dev/null
+            @@ -1,2 +0,0 @@
+            -alpha
+            -beta
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "gone.txt")
+        #expect(diff.hunks.count == 1)
+        #expect(diff.removedLines == 2)
+        #expect(diff.addedLines == 0)
+        #expect(diff.hunks[0].newStart == 0)
+        #expect(diff.hunks[0].newCount == 0)
+    }
+
+    @Test("Parses multiple hunks")
+    func parsesMultipleHunks() throws {
+        let raw = """
+            diff --git a/big.txt b/big.txt
+            index 1111111..2222222 100644
+            --- a/big.txt
+            +++ b/big.txt
+            @@ -1,3 +1,3 @@
+             a
+            -b
+            +B
+             c
+            @@ -10,3 +10,4 @@
+             x
+             y
+            +Y
+             z
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "big.txt")
+        #expect(diff.hunks.count == 2)
+        #expect(diff.addedLines == 2)
+        #expect(diff.removedLines == 1)
+        #expect(diff.hunks[0].oldStart == 1)
+        #expect(diff.hunks[1].oldStart == 10)
+        #expect(diff.hunks[1].newCount == 4)
+    }
+
+    @Test("Parses rename and captures oldPath")
+    func parsesRename() throws {
+        let raw = """
+            diff --git a/old.txt b/new.txt
+            similarity index 90%
+            rename from old.txt
+            rename to new.txt
+            index 1111111..2222222 100644
+            --- a/old.txt
+            +++ b/new.txt
+            @@ -1,2 +1,2 @@
+             keep
+            -was
+            +is
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "new.txt")
+        #expect(diff.oldPath == "old.txt")
+        #expect(diff.hunks.count == 1)
+        #expect(diff.addedLines == 1)
+        #expect(diff.removedLines == 1)
+    }
+
+    @Test("Single-line hunk default count is 1")
+    func singleLineHunkDefaultCount() throws {
+        let raw = """
+            diff --git a/f.txt b/f.txt
+            --- a/f.txt
+            +++ b/f.txt
+            @@ -5 +5 @@
+            -old
+            +new
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "f.txt")
+        #expect(diff.hunks.count == 1)
+        #expect(diff.hunks[0].oldStart == 5)
+        #expect(diff.hunks[0].oldCount == 1)
+        #expect(diff.hunks[0].newStart == 5)
+        #expect(diff.hunks[0].newCount == 1)
+    }
+
+    @Test("Empty diff produces no hunks")
+    func emptyDiffProducesNoHunks() throws {
+        let diff = try UnifiedDiff.parse("", path: "file.txt")
+        #expect(diff.hunks.isEmpty)
+        #expect(diff.addedLines == 0)
+        #expect(diff.removedLines == 0)
+    }
+
+    @Test("Ignores no-newline marker")
+    func ignoresNoNewlineMarker() throws {
+        let raw = """
+            diff --git a/f.txt b/f.txt
+            --- a/f.txt
+            +++ b/f.txt
+            @@ -1 +1 @@
+            -hello
+            \\ No newline at end of file
+            +hello!
+            \\ No newline at end of file
+            """
+        let diff = try UnifiedDiff.parse(raw, path: "f.txt")
+        #expect(diff.hunks.count == 1)
+        #expect(diff.addedLines == 1)
+        #expect(diff.removedLines == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Two prep refactors on one branch — both extend `GitService` so the matching change PRs can land as thin view-layer additions. Per the handoff plan, M5 and M8 sit on the same branch by design (close-by surface area, no test interactions); one combined PR avoids artificial splitting.

**M5 prep — `feat: extend GitService with diff + stage/unstage/discard`** (commit 1, `0a7d4517`)
- `UnifiedDiff` value type with a single-file parser for `git diff --no-color` output (hunks, line kinds, added/removed counts, rename `oldPath` capture).
- `GitService.diff/stage/unstage/discard` built on the existing `runGit` subprocess pattern. `discard` uses `git checkout --` to match existing style and is documented as destructive.
- `MockGitService` gains the new methods with call tracking.
- 8 parser unit tests + 5 integration tests against `TestGitRepository`.

**M8 prep — `feat: extend GitService with branches(at:)`** (commit 2, `c6af50c5`)
- Single call returning local + `origin/*` remote branches so the upcoming new-workspace branch picker reads from one place.
- `BranchName` is a small `Hashable`/`Sendable` value type with `isCurrent` + `isRemote`; locals come first with the current branch on top.
- `origin/HEAD` pointer is filtered out.
- `MockGitService` gains a configurable `branchesResult`.
- 3 integration tests: single branch, multi-branch ordering, clone+remote.

Together: +16 tests, no view files touched.

Unlocks: **M5.chg** (inline diff in Changes tab) and **M8.chg** (branch picker in `NewWorkspaceSheet`). Part of the prep/change rollout cadence established in PR #496.

## Mergeability

- Surface: desktop
- User-facing behavior changed: no (pure service-layer prep — no call sites yet)
- Non-happy paths considered: parser tested against renames, multi-hunk diffs, empty diffs; `discard` documented as destructive; `branches(at:)` filters `origin/HEAD`
- Release/ops preconditions: none — additive `GitService` surface, mock parity maintained
- Residual risk or follow-up: M5.chg + M8.chg consume these in subsequent PRs

## Validation

- [x] `swift build`
- [x] `swift test` — 709 tests in 122 suites passed (+16 vs main)
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/` exits 0

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Backend-only — `swift test` is the proof. Test summary screenshot linked below.

Evidence links:

- [Test summary screenshot](https://evidence.cloudcompute.com/workspaces/pr-499/20260523-195826-m5m8-prep-test-summary.png)

## Blockers

- [x] None
