### PR TITLE
feat: add WorkspaceEvent + WorkspaceJournal read API (M4 prep)

### DIFF
--- a/Sources/WorkspaceManagerCore/Models/WorkspaceEvent.swift
+++ b/Sources/WorkspaceManagerCore/Models/WorkspaceEvent.swift
@@ -1,0 +1,47 @@
+//
+//  WorkspaceEvent.swift
+//  WorkspaceManagerCore
+//
+//  Value-type domain model over rows in the SQLite `agent_status_events`
+//  table. The Timeline inspector consumes these via `WorkspaceJournal`; the
+//  shape collapses the storage event_name / run_state pair into a small set
+//  of cases keyed for display.
+//
+//  New cases must be additive — never rename or repurpose without a
+//  migration. Mapping from raw rows lives in `WorkspaceJournal.map(rows:)`.
+//
+
+import Foundation
+
+public struct WorkspaceEvent: Sendable, Equatable, Identifiable {
+    public enum Kind: Sendable, Equatable {
+        case started
+        case stateTransition(from: AgentRunState?, to: AgentRunState)
+        case toolRun(name: String)
+        case error(category: AgentErrorCategory, message: String?)
+        case completed
+    }
+
+    public let workspaceID: UUID
+    public let hostSessionID: UUID
+    public let timestamp: Date
+    public let kind: Kind
+    /// Stable identifier for the underlying `agent_status_events` row.
+    public let rowID: String
+
+    public init(
+        workspaceID: UUID,
+        hostSessionID: UUID,
+        timestamp: Date,
+        kind: Kind,
+        rowID: String
+    ) {
+        self.workspaceID = workspaceID
+        self.hostSessionID = hostSessionID
+        self.timestamp = timestamp
+        self.kind = kind
+        self.rowID = rowID
+    }
+
+    public var id: String { rowID }
+}

--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -438,6 +438,33 @@ public actor LocalStateStore {
             ])
     }
 
+    /// Fetch the most recent `agent_status_events` rows for one host session,
+    /// returned newest first. Returns `[]` for unknown sessions.
+    public func fetchAgentStatusEvents(
+        hostSessionID: UUID,
+        limit: Int = 200
+    ) async throws -> [AgentStatusEventRow] {
+        let sessionIDString = hostSessionID.uuidString
+        let cappedLimit = max(0, limit)
+        return try await dbPool.read { db -> [AgentStatusEventRow] in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT id, host_session_id, agent_session_id, agent_kind, origin,
+                           origin_detail, event_name, run_state, cwd, tool_name,
+                           tool_detail, awaiting_reason, error_category, error_message,
+                           model_display_name, event_at
+                    FROM agent_status_events
+                    WHERE host_session_id = ?
+                    ORDER BY event_at DESC, id DESC
+                    LIMIT ?
+                    """,
+                arguments: [sessionIDString, cappedLimit]
+            )
+            return rows.compactMap(AgentStatusEventRow.init(row:))
+        }
+    }
+
     public func recordDiagnosticEvent(
         metric: String,
         durationMs: Double,
@@ -861,6 +888,108 @@ public actor LocalStateStore {
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(value)
         return String(decoding: data, as: UTF8.self)
+    }
+}
+
+/// Read-side projection of one `agent_status_events` row. Strings are kept
+/// verbatim from the table — mapping to a richer domain type (e.g.
+/// `WorkspaceEvent`) is a caller concern, so the store stays the single owner
+/// of the SQL contract.
+public struct AgentStatusEventRow: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let hostSessionID: UUID
+    public let agentSessionID: String?
+    public let agentKind: String
+    public let origin: String
+    public let originDetail: String?
+    public let eventName: String
+    public let runState: String
+    public let cwd: String
+    public let toolName: String?
+    public let toolDetail: String?
+    public let awaitingReason: String?
+    public let errorCategory: String?
+    public let errorMessage: String?
+    public let modelDisplayName: String?
+    public let eventAt: Date
+
+    public init(
+        id: String,
+        hostSessionID: UUID,
+        agentSessionID: String?,
+        agentKind: String,
+        origin: String,
+        originDetail: String?,
+        eventName: String,
+        runState: String,
+        cwd: String,
+        toolName: String?,
+        toolDetail: String?,
+        awaitingReason: String?,
+        errorCategory: String?,
+        errorMessage: String?,
+        modelDisplayName: String?,
+        eventAt: Date
+    ) {
+        self.id = id
+        self.hostSessionID = hostSessionID
+        self.agentSessionID = agentSessionID
+        self.agentKind = agentKind
+        self.origin = origin
+        self.originDetail = originDetail
+        self.eventName = eventName
+        self.runState = runState
+        self.cwd = cwd
+        self.toolName = toolName
+        self.toolDetail = toolDetail
+        self.awaitingReason = awaitingReason
+        self.errorCategory = errorCategory
+        self.errorMessage = errorMessage
+        self.modelDisplayName = modelDisplayName
+        self.eventAt = eventAt
+    }
+
+    init?(row: Row) {
+        guard let id = row["id"] as String?,
+            let hostSessionIDString = row["host_session_id"] as String?,
+            let hostSessionID = UUID(uuidString: hostSessionIDString),
+            let agentKind = row["agent_kind"] as String?,
+            let origin = row["origin"] as String?,
+            let eventName = row["event_name"] as String?,
+            let runState = row["run_state"] as String?,
+            let cwd = row["cwd"] as String?,
+            let eventAtRaw = row["event_at"] as String?,
+            let eventAt = AgentStatusEventRow.parseISODate(eventAtRaw)
+        else {
+            return nil
+        }
+
+        self.init(
+            id: id,
+            hostSessionID: hostSessionID,
+            agentSessionID: row["agent_session_id"] as String?,
+            agentKind: agentKind,
+            origin: origin,
+            originDetail: row["origin_detail"] as String?,
+            eventName: eventName,
+            runState: runState,
+            cwd: cwd,
+            toolName: row["tool_name"] as String?,
+            toolDetail: row["tool_detail"] as String?,
+            awaitingReason: row["awaiting_reason"] as String?,
+            errorCategory: row["error_category"] as String?,
+            errorMessage: row["error_message"] as String?,
+            modelDisplayName: row["model_display_name"] as String?,
+            eventAt: eventAt
+        )
+    }
+
+    private static func parseISODate(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceJournal.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceJournal.swift
@@ -1,0 +1,133 @@
+//
+//  WorkspaceJournal.swift
+//  WorkspaceManagerCore
+//
+//  Read-side repository over `agent_status_events`, exposing a per-workspace
+//  list of `WorkspaceEvent` values ordered newest first. The Timeline inspector
+//  observes this; refresh is explicit so views can scope SQL load to the
+//  active workspace.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+public final class WorkspaceJournal: ObservableObject {
+    /// Per-workspace event lists, newest first.
+    @Published public private(set) var events: [UUID: [WorkspaceEvent]] = [:]
+
+    private let store: LocalStateStore?
+
+    public init(store: LocalStateStore?) {
+        self.store = store
+    }
+
+    /// Fetch the latest events for `workspaceID` keyed off `hostSessionID`,
+    /// then publish them newest first. No-op when no backing store is wired.
+    public func refresh(
+        workspaceID: UUID,
+        hostSessionID: UUID,
+        limit: Int = 200
+    ) async {
+        guard let store else { return }
+        do {
+            let rows = try await store.fetchAgentStatusEvents(
+                hostSessionID: hostSessionID,
+                limit: limit
+            )
+            let mapped = Self.map(rows: rows, workspaceID: workspaceID)
+            if events[workspaceID] != mapped {
+                events[workspaceID] = mapped
+            }
+        } catch {
+            // Read errors are non-fatal for the journal; surface empty rather
+            // than crashing the UI.
+            if events[workspaceID] != nil {
+                events[workspaceID] = []
+            }
+        }
+    }
+
+    public func events(for workspaceID: UUID) -> [WorkspaceEvent] {
+        events[workspaceID] ?? []
+    }
+
+    /// Pure mapping from rows (any order) to ordered `WorkspaceEvent`s, newest
+    /// first. Public for testability; callers should normally go through
+    /// `refresh(workspaceID:hostSessionID:limit:)`.
+    public nonisolated static func map(
+        rows: [AgentStatusEventRow],
+        workspaceID: UUID
+    ) -> [WorkspaceEvent] {
+        let chronological = rows.sorted { lhs, rhs in
+            if lhs.eventAt != rhs.eventAt { return lhs.eventAt < rhs.eventAt }
+            return lhs.id < rhs.id
+        }
+        var result: [WorkspaceEvent] = []
+        result.reserveCapacity(chronological.count)
+        var previousRunState: AgentRunState?
+        for row in chronological {
+            let runState = Self.parseRunState(row)
+            let kind = Self.kind(for: row, runState: runState, previousRunState: previousRunState)
+            previousRunState = runState
+            result.append(
+                WorkspaceEvent(
+                    workspaceID: workspaceID,
+                    hostSessionID: row.hostSessionID,
+                    timestamp: row.eventAt,
+                    kind: kind,
+                    rowID: row.id
+                )
+            )
+        }
+        return result.reversed()
+    }
+
+    private nonisolated static func kind(
+        for row: AgentStatusEventRow,
+        runState: AgentRunState,
+        previousRunState: AgentRunState?
+    ) -> WorkspaceEvent.Kind {
+        switch row.eventName {
+        case "session_start":
+            return .started
+        case "stopped":
+            return .completed
+        case "errored", "tool_failed":
+            let category =
+                row.errorCategory.flatMap(AgentErrorCategory.init(rawValue:))
+                ?? .unknown
+            return .error(category: category, message: row.errorMessage)
+        case "tool_start":
+            let name = row.toolName ?? "unknown"
+            return .toolRun(name: name)
+        default:
+            return .stateTransition(from: previousRunState, to: runState)
+        }
+    }
+
+    private nonisolated static func parseRunState(_ row: AgentStatusEventRow) -> AgentRunState {
+        switch row.runState {
+        case "idle":
+            return .idle
+        case "thinking":
+            return .thinking
+        case "running_tool":
+            return .runningTool(name: row.toolName ?? "unknown", detail: row.toolDetail)
+        case "awaiting_input":
+            let reason =
+                row.awaitingReason.flatMap(AwaitingReason.init(rawValue:))
+                ?? .custom
+            return .awaitingInput(reason: reason)
+        case "complete":
+            return .complete
+        case "errored":
+            let category =
+                row.errorCategory.flatMap(AgentErrorCategory.init(rawValue:))
+                ?? .unknown
+            return .errored(category: category, message: row.errorMessage)
+        default:
+            return .idle
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/WorkspaceEventTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceEventTests.swift
@@ -1,0 +1,235 @@
+//
+//  WorkspaceEventTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("WorkspaceEvent")
+struct WorkspaceEventTests {
+    private let workspaceID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+    private let hostSessionID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+
+    private func row(
+        id: String,
+        eventName: String,
+        runState: String,
+        toolName: String? = nil,
+        awaitingReason: String? = nil,
+        errorCategory: String? = nil,
+        errorMessage: String? = nil,
+        at offset: TimeInterval
+    ) -> AgentStatusEventRow {
+        AgentStatusEventRow(
+            id: id,
+            hostSessionID: hostSessionID,
+            agentSessionID: "agent-1",
+            agentKind: "claudeCode",
+            origin: "hook",
+            originDetail: nil,
+            eventName: eventName,
+            runState: runState,
+            cwd: "/tmp/w",
+            toolName: toolName,
+            toolDetail: nil,
+            awaitingReason: awaitingReason,
+            errorCategory: errorCategory,
+            errorMessage: errorMessage,
+            modelDisplayName: "Claude",
+            eventAt: Date(timeIntervalSince1970: 1_700_000_000 + offset)
+        )
+    }
+
+    @Test("Empty input yields empty output")
+    func emptyMapping() {
+        let mapped = WorkspaceJournal.map(rows: [], workspaceID: workspaceID)
+        #expect(mapped.isEmpty)
+    }
+
+    @Test("session_start row maps to .started")
+    func sessionStartMaps() {
+        let mapped = WorkspaceJournal.map(
+            rows: [row(id: "a", eventName: "session_start", runState: "idle", at: 0)],
+            workspaceID: workspaceID
+        )
+        #expect(mapped.count == 1)
+        #expect(mapped[0].kind == .started)
+        #expect(mapped[0].workspaceID == workspaceID)
+        #expect(mapped[0].hostSessionID == hostSessionID)
+        #expect(mapped[0].rowID == "a")
+    }
+
+    @Test("tool_start row maps to .toolRun with the tool name")
+    func toolStartMaps() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(
+                    id: "a",
+                    eventName: "tool_start",
+                    runState: "running_tool",
+                    toolName: "Bash",
+                    at: 0
+                )
+            ],
+            workspaceID: workspaceID
+        )
+        #expect(mapped[0].kind == .toolRun(name: "Bash"))
+    }
+
+    @Test("errored row maps to .error with category + message")
+    func erroredMaps() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(
+                    id: "a",
+                    eventName: "errored",
+                    runState: "errored",
+                    errorCategory: "rateLimit",
+                    errorMessage: "slow down",
+                    at: 0
+                )
+            ],
+            workspaceID: workspaceID
+        )
+        #expect(mapped[0].kind == .error(category: .rateLimit, message: "slow down"))
+    }
+
+    @Test("tool_failed row maps to .error using toolFailure-style category")
+    func toolFailedMaps() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(
+                    id: "a",
+                    eventName: "tool_failed",
+                    runState: "thinking",
+                    toolName: "Bash",
+                    errorCategory: "toolFailure",
+                    errorMessage: "exit 1",
+                    at: 0
+                )
+            ],
+            workspaceID: workspaceID
+        )
+        #expect(mapped[0].kind == .error(category: .toolFailure, message: "exit 1"))
+    }
+
+    @Test("Unknown error category falls back to .unknown")
+    func unknownErrorCategoryFallback() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(
+                    id: "a",
+                    eventName: "errored",
+                    runState: "errored",
+                    errorCategory: "what-is-this",
+                    errorMessage: nil,
+                    at: 0
+                )
+            ],
+            workspaceID: workspaceID
+        )
+        #expect(mapped[0].kind == .error(category: .unknown, message: nil))
+    }
+
+    @Test("stopped row maps to .completed")
+    func stoppedMaps() {
+        let mapped = WorkspaceJournal.map(
+            rows: [row(id: "a", eventName: "stopped", runState: "complete", at: 0)],
+            workspaceID: workspaceID
+        )
+        #expect(mapped[0].kind == .completed)
+    }
+
+    @Test("Other rows map to .stateTransition with previous run state")
+    func stateTransitionUsesPriorRun() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(id: "a", eventName: "session_start", runState: "idle", at: 0),
+                row(
+                    id: "b",
+                    eventName: "awaiting_input",
+                    runState: "awaiting_input",
+                    awaitingReason: "permissionPrompt",
+                    at: 1
+                ),
+            ],
+            workspaceID: workspaceID
+        )
+        // Newest first
+        #expect(mapped[0].rowID == "b")
+        #expect(mapped[1].rowID == "a")
+        #expect(mapped[0].kind == .stateTransition(from: .idle, to: .awaitingInput(reason: .permissionPrompt)))
+        #expect(mapped[1].kind == .started)
+    }
+
+    @Test("First stateTransition has nil from")
+    func firstStateTransitionFromIsNil() {
+        let mapped = WorkspaceJournal.map(
+            rows: [row(id: "a", eventName: "status_fields", runState: "thinking", at: 0)],
+            workspaceID: workspaceID
+        )
+        #expect(mapped[0].kind == .stateTransition(from: nil, to: .thinking))
+    }
+
+    @Test("running_tool transitions carry the tool name in the new state")
+    func runningToolTransitionCarriesToolName() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(
+                    id: "a",
+                    eventName: "tool_end",
+                    runState: "running_tool",
+                    toolName: "Read",
+                    at: 0
+                )
+            ],
+            workspaceID: workspaceID
+        )
+        if case .stateTransition(_, .runningTool(let name, _)) = mapped[0].kind {
+            #expect(name == "Read")
+        } else {
+            Issue.record("expected stateTransition to runningTool, got \(mapped[0].kind)")
+        }
+    }
+
+    @Test("Events come out newest first regardless of input ordering")
+    func newestFirstOrdering() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(id: "newest", eventName: "session_start", runState: "idle", at: 100),
+                row(id: "oldest", eventName: "session_start", runState: "idle", at: 0),
+                row(id: "middle", eventName: "session_start", runState: "idle", at: 50),
+            ],
+            workspaceID: workspaceID
+        )
+        #expect(mapped.map(\.rowID) == ["newest", "middle", "oldest"])
+    }
+
+    @Test("Ties on timestamp break by id ascending so ordering is deterministic")
+    func tiebreakerByID() {
+        let mapped = WorkspaceJournal.map(
+            rows: [
+                row(id: "b", eventName: "session_start", runState: "idle", at: 0),
+                row(id: "a", eventName: "session_start", runState: "idle", at: 0),
+            ],
+            workspaceID: workspaceID
+        )
+        // Same timestamp, so we sort chronologically by id ASC then reverse.
+        #expect(mapped.map(\.rowID) == ["b", "a"])
+    }
+
+    @Test("WorkspaceEvent id matches the row id")
+    func identifiableStableAcrossInstances() {
+        let event = WorkspaceEvent(
+            workspaceID: workspaceID,
+            hostSessionID: hostSessionID,
+            timestamp: Date(timeIntervalSince1970: 0),
+            kind: .started,
+            rowID: "row-1"
+        )
+        #expect(event.id == "row-1")
+    }
+}

--- a/Tests/WorkspaceManagerTests/WorkspaceJournalTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceJournalTests.swift
@@ -64,11 +64,12 @@ struct WorkspaceJournalTests {
 
         let events = journal.events(for: workspaceID)
         #expect(events.count == 3)
-        #expect(events.map(\.kind) == [
-            .completed,
-            .toolRun(name: "Bash"),
-            .started,
-        ])
+        #expect(
+            events.map(\.kind) == [
+                .completed,
+                .toolRun(name: "Bash"),
+                .started,
+            ])
         #expect(events.allSatisfy { $0.workspaceID == workspaceID })
         #expect(events.allSatisfy { $0.hostSessionID == hostSessionID })
     }

--- a/Tests/WorkspaceManagerTests/WorkspaceJournalTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceJournalTests.swift
@@ -1,0 +1,217 @@
+//
+//  WorkspaceJournalTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("WorkspaceJournal")
+struct WorkspaceJournalTests {
+    @Test("Empty store yields no events for any workspace")
+    func emptyStore() async throws {
+        let fixture = try JournalFixture()
+        defer { fixture.cleanup() }
+        let workspaceID = UUID()
+        let journal = WorkspaceJournal(store: fixture.store)
+
+        await journal.refresh(workspaceID: workspaceID, hostSessionID: UUID())
+
+        #expect(journal.events(for: workspaceID).isEmpty)
+        #expect(journal.events(for: UUID()).isEmpty)
+    }
+
+    @Test("Nil store is a safe no-op")
+    func nilStoreNoOp() async {
+        let journal = WorkspaceJournal(store: nil)
+        await journal.refresh(workspaceID: UUID(), hostSessionID: UUID())
+        #expect(journal.events.isEmpty)
+    }
+
+    @Test("Refresh publishes events newest first for the requested workspace")
+    func refreshOrdersNewestFirst() async throws {
+        let fixture = try JournalFixture()
+        defer { fixture.cleanup() }
+        let workspaceID = UUID()
+        let hostSessionID = UUID()
+
+        try await fixture.recordSequence(
+            hostSessionID: hostSessionID,
+            entries: [
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    event: .sessionStart(agentSessionID: "a", cwd: "/tmp/w", kind: .claudeCode),
+                    run: .idle
+                ),
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_001),
+                    event: .toolStart(name: "Bash", detail: nil),
+                    run: .runningTool(name: "Bash", detail: nil)
+                ),
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_002),
+                    event: .stopped(error: nil),
+                    run: .complete
+                ),
+            ]
+        )
+
+        let journal = WorkspaceJournal(store: fixture.store)
+        await journal.refresh(workspaceID: workspaceID, hostSessionID: hostSessionID)
+
+        let events = journal.events(for: workspaceID)
+        #expect(events.count == 3)
+        #expect(events.map(\.kind) == [
+            .completed,
+            .toolRun(name: "Bash"),
+            .started,
+        ])
+        #expect(events.allSatisfy { $0.workspaceID == workspaceID })
+        #expect(events.allSatisfy { $0.hostSessionID == hostSessionID })
+    }
+
+    @Test("Different workspaces stay isolated in the published map")
+    func multiWorkspaceIsolation() async throws {
+        let fixture = try JournalFixture()
+        defer { fixture.cleanup() }
+        let workspaceA = UUID()
+        let workspaceB = UUID()
+        let hostA = UUID()
+        let hostB = UUID()
+
+        try await fixture.recordSequence(
+            hostSessionID: hostA,
+            entries: [
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    event: .sessionStart(agentSessionID: "a", cwd: "/tmp/a", kind: .claudeCode),
+                    run: .idle
+                )
+            ]
+        )
+        try await fixture.recordSequence(
+            hostSessionID: hostB,
+            entries: [
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_010),
+                    event: .sessionStart(agentSessionID: "b", cwd: "/tmp/b", kind: .claudeCode),
+                    run: .idle
+                ),
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_011),
+                    event: .errored(category: .server, message: "boom"),
+                    run: .errored(category: .server, message: "boom")
+                ),
+            ]
+        )
+
+        let journal = WorkspaceJournal(store: fixture.store)
+        await journal.refresh(workspaceID: workspaceA, hostSessionID: hostA)
+        await journal.refresh(workspaceID: workspaceB, hostSessionID: hostB)
+
+        #expect(journal.events(for: workspaceA).count == 1)
+        #expect(journal.events(for: workspaceB).count == 2)
+        #expect(journal.events(for: workspaceA).first?.hostSessionID == hostA)
+        #expect(journal.events(for: workspaceB).first?.hostSessionID == hostB)
+    }
+
+    @Test("Limit caps the number of returned events")
+    func respectsLimit() async throws {
+        let fixture = try JournalFixture()
+        defer { fixture.cleanup() }
+        let workspaceID = UUID()
+        let hostSessionID = UUID()
+
+        var entries: [JournalFixture.Entry] = []
+        for index in 0..<10 {
+            entries.append(
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_000 + TimeInterval(index)),
+                    event: .userPrompt(prompt: nil),
+                    run: .thinking
+                )
+            )
+        }
+        try await fixture.recordSequence(hostSessionID: hostSessionID, entries: entries)
+
+        let journal = WorkspaceJournal(store: fixture.store)
+        await journal.refresh(
+            workspaceID: workspaceID,
+            hostSessionID: hostSessionID,
+            limit: 3
+        )
+
+        #expect(journal.events(for: workspaceID).count == 3)
+    }
+
+    @Test("Refresh against an unknown host session publishes an empty array")
+    func unknownHostSession() async throws {
+        let fixture = try JournalFixture()
+        defer { fixture.cleanup() }
+        let workspaceID = UUID()
+        let knownHost = UUID()
+
+        try await fixture.recordSequence(
+            hostSessionID: knownHost,
+            entries: [
+                .init(
+                    occurredAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    event: .sessionStart(agentSessionID: "x", cwd: "/tmp/x", kind: .claudeCode),
+                    run: .idle
+                )
+            ]
+        )
+
+        let journal = WorkspaceJournal(store: fixture.store)
+        await journal.refresh(workspaceID: workspaceID, hostSessionID: UUID())
+
+        #expect(journal.events(for: workspaceID).isEmpty)
+    }
+}
+
+private struct JournalFixture {
+    struct Entry {
+        let occurredAt: Date
+        let event: AgentEvent
+        let run: AgentRunState
+    }
+
+    let directory: URL
+    let store: LocalStateStore
+
+    init() throws {
+        self.directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceJournalTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let databaseURL = directory.appendingPathComponent("state.sqlite")
+        self.store = try LocalStateStore(databaseURL: databaseURL)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func recordSequence(hostSessionID: UUID, entries: [Entry]) async throws {
+        for entry in entries {
+            let status = AgentSessionStatus(
+                hostSessionID: hostSessionID,
+                agentSessionID: "agent-\(hostSessionID.uuidString.prefix(8))",
+                kind: .claudeCode,
+                cwd: "/tmp/w",
+                run: entry.run,
+                lastEventAt: entry.occurredAt,
+                createdAt: entry.occurredAt
+            )
+            try await store.recordAgentEvents(
+                [entry.event],
+                hostSessionID: hostSessionID,
+                origin: .hook,
+                status: status,
+                occurredAt: entry.occurredAt
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Prep refactor for **M4.chg** (Timeline tab in the workspace inspector). Adds the read API the upcoming view will consume; persistence is the existing `agent_status_events` table so no schema migration.

- `WorkspaceEvent` — value-type domain enum over agent state transitions persisted in `agent_status_events`. Names follow `CONTEXT.md` (avoids bare "Session", which is flagged ambiguous in the glossary).
- `WorkspaceJournal` — `@MainActor` `ObservableObject` that reads events keyed by workspace UUID. Mirrors the `WorkspaceStatusAggregator` injection shape from #496 so M4.chg can subscribe via `@EnvironmentObject`.
- No view files touched. Production code does not consume the journal yet; M4.chg adds a `.timeline` case to `RightPaneView.Tab` and renders from `WorkspaceJournal.events(for:)`.

Touches `LocalStateStore` (reads `agent_status_events` via a new selector). The handoff plan called for verifying no concurrent activity on that file — confirmed clean via `git log --since=2026-05-23 -- Sources/WorkspaceManagerCore/Services/LocalStateStore.swift` (no commits).

Part of the prep/change rollout cadence established in PR #496. Unblocks M4.chg once merged.

## Mergeability

- Surface: desktop
- User-facing behavior changed: no (pure prep — no consumer yet)
- Non-happy paths considered: empty journal returns `[]`; UUID lookup for non-existent workspaces returns `[]`; tests cover decode + ordering edge cases
- Release/ops preconditions: none — `agent_status_events` table already exists
- Residual risk or follow-up: M4.chg picks this up; the open product question (workspace-vs-repo scope) is captured in the handoff doc and defaults to workspace-scoped first

## Validation

- [x] `swift build`
- [x] `swift test` — 712 tests in 121 suites passed (+19 vs main for the new `WorkspaceJournal` + `WorkspaceEvent` suite)
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/` exits 0
- One small `style:` follow-up commit applies a `[AddLines]` swift-format fix surfaced by the current toolchain version (same pattern as recent `5f2ac28f`)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Backend-only — `swift test` is the proof. Test summary screenshot linked below.

Evidence links:

- [Test summary screenshot](https://evidence.cloudcompute.com/workspaces/pr-500/20260523-200032-m4-prep-test-summary.png)

## Blockers

- [x] None
