### PR TITLE
feat: LastCommandStatus + parser + registry (M6 prep — parked, no producer)

### DIFF
--- a/Sources/WorkspaceManagerCore/Models/LastCommandStatus.swift
+++ b/Sources/WorkspaceManagerCore/Models/LastCommandStatus.swift
@@ -1,0 +1,91 @@
+//
+//  LastCommandStatus.swift
+//  WorkspaceManagerCore
+//
+//  Per-terminal-session "last command" record consumed by the upcoming status
+//  sliver UI (M6). Captures what the user can usefully know about the shell
+//  command that just finished — its line, its exit code, when it started and
+//  ended — without forcing the producer to always know all of them.
+//
+//  Producer contract is intentionally tolerant: any field may be unknown, and
+//  `isRunning` is true exactly when `endedAt` is nil. Producers should publish
+//  `started(...)` when they observe the command begin (OSC 133 ;B, shell hook,
+//  or heuristic), and `ended(...)` when they observe the command finish
+//  (OSC 133 ;D, shell hook, idle-prompt return).
+//
+
+import Foundation
+
+public struct LastCommandStatus: Equatable, Sendable {
+    /// Best-effort literal command line as typed at the prompt. `nil` when the
+    /// producer cannot capture it (e.g. an OSC 133 ;D arrives without ;B
+    /// having carried a command, or the heuristic path has no shell hook).
+    public let commandLine: String?
+
+    /// Exit code reported by the shell. `nil` while the command is still
+    /// running, or when the producer can detect "command ended" but not the
+    /// numeric status (heuristic path).
+    public let exitCode: Int?
+
+    /// Wall-clock start time as observed by the producer.
+    public let startedAt: Date
+
+    /// Wall-clock end time. `nil` while running.
+    public let endedAt: Date?
+
+    public init(
+        commandLine: String?,
+        exitCode: Int?,
+        startedAt: Date,
+        endedAt: Date?
+    ) {
+        self.commandLine = commandLine
+        self.exitCode = exitCode
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+    }
+
+    public var duration: TimeInterval? {
+        endedAt.map { $0.timeIntervalSince(startedAt) }
+    }
+
+    public var isRunning: Bool {
+        endedAt == nil
+    }
+
+    /// `true` for exit code 0, `false` for any non-zero exit, `nil` if the
+    /// command is still running or the producer could not capture the code.
+    public var isSuccess: Bool? {
+        exitCode.map { $0 == 0 }
+    }
+
+    /// Convenience constructor for a freshly-started command with no exit
+    /// information yet.
+    public static func started(
+        commandLine: String?,
+        at startedAt: Date
+    ) -> LastCommandStatus {
+        LastCommandStatus(
+            commandLine: commandLine,
+            exitCode: nil,
+            startedAt: startedAt,
+            endedAt: nil
+        )
+    }
+
+    /// Convenience for transitioning a running status into an ended one. If
+    /// `self` is not running this is a no-op transform: the existing end time
+    /// and exit code are preserved.
+    public func ending(
+        exitCode: Int?,
+        at endedAt: Date
+    ) -> LastCommandStatus {
+        guard isRunning else { return self }
+        return LastCommandStatus(
+            commandLine: commandLine,
+            exitCode: exitCode,
+            startedAt: startedAt,
+            endedAt: endedAt
+        )
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/CommandMarkerParser.swift
+++ b/Sources/WorkspaceManagerCore/Services/CommandMarkerParser.swift
@@ -55,7 +55,8 @@ public struct CommandMarkerParser: Sendable {
                 // buffer looks like a partial introducer (ESC, ESC ], …) so we
                 // hold those bytes for the next chunk; drop everything before
                 // the partial prefix.
-                let tailStart = Self.partialIntroducerStart(in: buffer, from: index)
+                let tailStart =
+                    Self.partialIntroducerStart(in: buffer, from: index)
                     ?? buffer.endIndex
                 consumedThrough = tailStart
                 break
@@ -163,12 +164,12 @@ public struct CommandMarkerParser: Sendable {
         var i = start
         while i < data.endIndex {
             let byte = data[i]
-            if byte == 0x07 { // BEL
+            if byte == 0x07 {  // BEL
                 return i..<data.index(after: i)
             }
             if byte == 0x1B {
                 let next = data.index(after: i)
-                if next < data.endIndex, data[next] == 0x5C { // ESC \
+                if next < data.endIndex, data[next] == 0x5C {  // ESC \
                     return i..<data.index(after: next)
                 }
                 // A lone ESC inside an OSC payload is ambiguous; treat as

--- a/Sources/WorkspaceManagerCore/Services/CommandMarkerParser.swift
+++ b/Sources/WorkspaceManagerCore/Services/CommandMarkerParser.swift
@@ -1,0 +1,212 @@
+//
+//  CommandMarkerParser.swift
+//  WorkspaceManagerCore
+//
+//  Pure-function parser for OSC 133 "semantic prompt" escape sequences. This
+//  is the shape libghostty would surface if/when it forwards FinalTerm/iTerm2
+//  prompt marks to the application layer; until then, the parser is also
+//  callable by any future shell-side producer (PROMPT hook script, PTY proxy,
+//  etc.) that wants to emit the same byte protocol over its own transport.
+//
+//  Recognized markers:
+//    ESC ] 133 ; A …          prompt start
+//    ESC ] 133 ; B …          command start (about to execute)
+//    ESC ] 133 ; C …          output start
+//    ESC ] 133 ; D ; <exit>   command end with numeric exit status
+//    ESC ] 133 ; D            command end with no exit status reported
+//
+//  All sequences may terminate with either BEL (0x07) or ST (ESC \).
+//
+//  Anything outside an OSC 133 introducer is ignored — this is not a general
+//  ANSI parser. We tolerate fragmented input: an incomplete marker at the end
+//  of a chunk is buffered and consumed when the next chunk arrives.
+//
+
+import Foundation
+
+public enum CommandMarker: Equatable, Sendable {
+    case promptStart
+    case commandStart
+    case outputStart
+    case commandEnd(exitCode: Int?)
+}
+
+public struct CommandMarkerParser: Sendable {
+    private var pending: Data = Data()
+    private static let maxBufferedBytes = 4096
+
+    public init() {}
+
+    /// Feed a chunk of raw terminal bytes. Returns the markers found in order.
+    /// Bytes that do not participate in a marker are discarded; markers split
+    /// across chunks are reassembled across calls.
+    public mutating func consume(_ chunk: Data) -> [CommandMarker] {
+        var markers: [CommandMarker] = []
+        var buffer = pending
+        buffer.append(chunk)
+
+        var index = buffer.startIndex
+        var consumedThrough = buffer.startIndex
+
+        while index < buffer.endIndex {
+            // Look for ESC ] 133 ;  (5 bytes).
+            guard let escIndex = Self.findIntroducer(in: buffer, from: index) else {
+                // No complete introducer ahead. Check whether the tail of the
+                // buffer looks like a partial introducer (ESC, ESC ], …) so we
+                // hold those bytes for the next chunk; drop everything before
+                // the partial prefix.
+                let tailStart = Self.partialIntroducerStart(in: buffer, from: index)
+                    ?? buffer.endIndex
+                consumedThrough = tailStart
+                break
+            }
+
+            // Bytes before the introducer are not interesting.
+            consumedThrough = escIndex
+
+            let payloadStart = buffer.index(escIndex, offsetBy: Self.introducer.count)
+            guard payloadStart < buffer.endIndex else {
+                // Introducer present but payload not yet arrived.
+                break
+            }
+
+            guard let terminatorRange = Self.findTerminator(in: buffer, from: payloadStart) else {
+                // Wait for more bytes — but bail if the buffer is unbounded.
+                if buffer.distance(from: escIndex, to: buffer.endIndex) > Self.maxBufferedBytes {
+                    // Drop the runaway introducer to avoid unbounded growth.
+                    consumedThrough = payloadStart
+                }
+                break
+            }
+
+            let payload = buffer.subdata(in: payloadStart..<terminatorRange.lowerBound)
+            if let marker = Self.parsePayload(payload) {
+                markers.append(marker)
+            }
+            consumedThrough = terminatorRange.upperBound
+            index = terminatorRange.upperBound
+        }
+
+        if consumedThrough > buffer.startIndex {
+            pending = buffer.subdata(in: consumedThrough..<buffer.endIndex)
+        } else {
+            pending = buffer
+        }
+
+        // Prevent unbounded growth if a malicious stream sends a perpetual
+        // introducer without a terminator.
+        if pending.count > Self.maxBufferedBytes {
+            pending = pending.suffix(Self.maxBufferedBytes)
+        }
+
+        return markers
+    }
+
+    /// Convenience for callers that don't need cross-chunk state.
+    public static func parse(_ chunk: Data) -> [CommandMarker] {
+        var parser = CommandMarkerParser()
+        return parser.consume(chunk)
+    }
+
+    // MARK: - Internals
+
+    /// `ESC ] 1 3 3 ;` — five bytes.
+    private static let introducer: [UInt8] = [0x1B, 0x5D, 0x31, 0x33, 0x33, 0x3B]
+
+    /// Returns the index of the first byte of a prefix-match of `introducer`
+    /// at the buffer tail (i.e. a partial introducer that may complete in a
+    /// future chunk), or `nil` if no such prefix exists. Considers prefixes of
+    /// length 1..<introducer.count.
+    private static func partialIntroducerStart(in data: Data, from start: Data.Index) -> Data.Index? {
+        let maxPrefix = min(introducer.count - 1, data.distance(from: start, to: data.endIndex))
+        guard maxPrefix > 0 else { return nil }
+        // Longest prefix wins.
+        for prefixLen in stride(from: maxPrefix, through: 1, by: -1) {
+            let candidate = data.index(data.endIndex, offsetBy: -prefixLen)
+            var match = true
+            for offset in 0..<prefixLen {
+                if data[data.index(candidate, offsetBy: offset)] != introducer[offset] {
+                    match = false
+                    break
+                }
+            }
+            if match { return candidate }
+        }
+        return nil
+    }
+
+    private static func findIntroducer(in data: Data, from start: Data.Index) -> Data.Index? {
+        guard data.distance(from: start, to: data.endIndex) >= introducer.count else {
+            return nil
+        }
+        var i = start
+        let limit = data.index(data.endIndex, offsetBy: -(introducer.count - 1))
+        while i < limit {
+            if data[i] == introducer[0] {
+                var match = true
+                for offset in 1..<introducer.count {
+                    if data[data.index(i, offsetBy: offset)] != introducer[offset] {
+                        match = false
+                        break
+                    }
+                }
+                if match { return i }
+            }
+            i = data.index(after: i)
+        }
+        return nil
+    }
+
+    /// Locates the terminator (BEL or ST = ESC \) starting from `start`.
+    /// Returns the range covering the terminator bytes themselves.
+    private static func findTerminator(in data: Data, from start: Data.Index) -> Range<Data.Index>? {
+        var i = start
+        while i < data.endIndex {
+            let byte = data[i]
+            if byte == 0x07 { // BEL
+                return i..<data.index(after: i)
+            }
+            if byte == 0x1B {
+                let next = data.index(after: i)
+                if next < data.endIndex, data[next] == 0x5C { // ESC \
+                    return i..<data.index(after: next)
+                }
+                // A lone ESC inside an OSC payload is ambiguous; treat as
+                // terminator boundary at ESC itself so we don't swallow the
+                // following sequence.
+                return i..<i
+            }
+            i = data.index(after: i)
+        }
+        return nil
+    }
+
+    private static func parsePayload(_ payload: Data) -> CommandMarker? {
+        guard let string = String(data: payload, encoding: .utf8), !string.isEmpty else {
+            return nil
+        }
+        // payload examples:
+        //   "A"                  — prompt start
+        //   "A;aid=xyz"          — prompt start with key=value tail
+        //   "B"                  — command start
+        //   "C"                  — output start
+        //   "D"                  — command end, no exit code
+        //   "D;0"                — command end, exit code 0
+        //   "D;137;err=killed"   — command end, exit 137 plus tail
+        let marker = string.first!
+        let tail = string.dropFirst()
+        switch marker {
+        case "A": return .promptStart
+        case "B": return .commandStart
+        case "C": return .outputStart
+        case "D":
+            guard tail.first == ";" else { return .commandEnd(exitCode: nil) }
+            let afterSemi = tail.dropFirst()
+            let code = afterSemi.prefix { $0 != ";" }
+            if code.isEmpty { return .commandEnd(exitCode: nil) }
+            return .commandEnd(exitCode: Int(code))
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/LastCommandStatusRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/LastCommandStatusRegistry.swift
@@ -1,0 +1,106 @@
+//
+//  LastCommandStatusRegistry.swift
+//  WorkspaceManagerCore
+//
+//  Per-terminal-session @Published map of `LastCommandStatus`. The Status Sliver
+//  view (M6.chg) reads this to render the prompt-context bar (✓/✗ + exit +
+//  duration). Mirrors `WorkspaceStatusAggregator`'s @MainActor / ObservableObject
+//  shape so views can subscribe consistently.
+//
+//  This registry does NOT itself read PTY data. Producers (a future libghostty
+//  OSC 133 forwarder, a shell-side PROMPT hook over a socket, or anything else
+//  capable of observing prompt boundaries) call `ingest(markers:for:at:)` with
+//  parsed `CommandMarker`s and a session id. The registry collapses the
+//  prompt → command → end transitions into a single observable
+//  `LastCommandStatus` per session.
+//
+//  Until a producer is wired, this class ships as the public API contract: the
+//  view layer can build against `statusByTerminalSession` today and the producer can
+//  land in a follow-up without touching the view.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+public final class LastCommandStatusRegistry: ObservableObject {
+    @Published public private(set) var statusByTerminalSession: [UUID: LastCommandStatus] = [:]
+
+    private let clock: @Sendable () -> Date
+
+    public init(clock: @escaping @Sendable () -> Date = { Date() }) {
+        self.clock = clock
+    }
+
+    /// Replace the published status for `terminalSessionID`. Use when a producer can
+    /// synthesise a full status in one shot (e.g. shell hook delivers a JSON
+    /// payload with both command and exit).
+    public func setStatus(_ status: LastCommandStatus, for terminalSessionID: UUID) {
+        if statusByTerminalSession[terminalSessionID] != status {
+            statusByTerminalSession[terminalSessionID] = status
+        }
+    }
+
+    /// Feed parsed markers in order. `commandLine` is optional and applies to
+    /// the next started command — producers that only observe OSC 133 cannot
+    /// know the literal line, so they pass `nil`; producers with shell-side
+    /// context (a PROMPT hook) pass the captured line.
+    public func ingest(
+        markers: [CommandMarker],
+        for terminalSessionID: UUID,
+        commandLine: String? = nil,
+        at timestamp: Date? = nil
+    ) {
+        guard !markers.isEmpty else { return }
+        let now = timestamp ?? clock()
+
+        for marker in markers {
+            switch marker {
+            case .promptStart, .outputStart:
+                // ;A and ;C don't change the published status — they're
+                // structural in the OSC 133 dance. A prompt start that arrives
+                // while a previous command is still "running" implies the
+                // shell silently dropped the end; clear it so the UI doesn't
+                // show a phantom in-flight command.
+                if case .promptStart = marker,
+                    let current = statusByTerminalSession[terminalSessionID],
+                    current.isRunning
+                {
+                    statusByTerminalSession[terminalSessionID] = current.ending(exitCode: nil, at: now)
+                }
+
+            case .commandStart:
+                statusByTerminalSession[terminalSessionID] = LastCommandStatus.started(
+                    commandLine: commandLine,
+                    at: now
+                )
+
+            case .commandEnd(let exitCode):
+                if let current = statusByTerminalSession[terminalSessionID], current.isRunning {
+                    statusByTerminalSession[terminalSessionID] = current.ending(exitCode: exitCode, at: now)
+                } else {
+                    // ;D without a preceding ;B — happens on the very first
+                    // prompt of a shell, or with shells that emit only ;D.
+                    // Record a zero-duration ended status so the sliver has
+                    // something to show.
+                    statusByTerminalSession[terminalSessionID] = LastCommandStatus(
+                        commandLine: commandLine,
+                        exitCode: exitCode,
+                        startedAt: now,
+                        endedAt: now
+                    )
+                }
+            }
+        }
+    }
+
+    /// Drop tracking for a session — called from the host terminal session
+    /// store when a session is removed.
+    public func clear(terminalSessionID: UUID) {
+        statusByTerminalSession.removeValue(forKey: terminalSessionID)
+    }
+
+    public func reset() {
+        statusByTerminalSession = [:]
+    }
+}

--- a/Tests/WorkspaceManagerTests/LastCommandStatusTests.swift
+++ b/Tests/WorkspaceManagerTests/LastCommandStatusTests.swift
@@ -1,0 +1,268 @@
+//
+//  LastCommandStatusTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("LastCommandStatus")
+struct LastCommandStatusValueTests {
+    @Test("Running status reports isRunning, no duration, no isSuccess")
+    func runningInvariants() {
+        let started = Date()
+        let s = LastCommandStatus.started(commandLine: "ls", at: started)
+        #expect(s.isRunning == true)
+        #expect(s.endedAt == nil)
+        #expect(s.exitCode == nil)
+        #expect(s.duration == nil)
+        #expect(s.isSuccess == nil)
+        #expect(s.commandLine == "ls")
+    }
+
+    @Test("ending() transitions a running status and computes duration")
+    func endingTransition() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = Date(timeIntervalSince1970: 1_002.5)
+        let running = LastCommandStatus.started(commandLine: "make", at: started)
+        let done = running.ending(exitCode: 0, at: ended)
+        #expect(done.isRunning == false)
+        #expect(done.exitCode == 0)
+        #expect(done.isSuccess == true)
+        #expect(done.duration == 2.5)
+    }
+
+    @Test("Non-zero exit code reports isSuccess == false")
+    func failureCase() {
+        let s = LastCommandStatus(
+            commandLine: "false",
+            exitCode: 1,
+            startedAt: Date(),
+            endedAt: Date()
+        )
+        #expect(s.isSuccess == false)
+    }
+
+    @Test("ending() is a no-op on already-ended status")
+    func endingNoOp() {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = Date(timeIntervalSince1970: 1_001)
+        let later = Date(timeIntervalSince1970: 1_999)
+        let done = LastCommandStatus(
+            commandLine: "x", exitCode: 0, startedAt: started, endedAt: ended
+        )
+        let again = done.ending(exitCode: 1, at: later)
+        #expect(again == done)
+    }
+}
+
+@Suite("CommandMarkerParser")
+struct CommandMarkerParserTests {
+    private static let esc: UInt8 = 0x1B
+    private static let bel: UInt8 = 0x07
+    private static let backslash: UInt8 = 0x5C
+
+    private func seq(_ payload: String, bel terminator: Bool = true) -> Data {
+        var d = Data([Self.esc, 0x5D, 0x31, 0x33, 0x33, 0x3B])
+        d.append(payload.data(using: .utf8)!)
+        if terminator {
+            d.append(Self.bel)
+        } else {
+            d.append(Self.esc)
+            d.append(Self.backslash)
+        }
+        return d
+    }
+
+    @Test("Parses a full OSC 133 cycle with BEL terminator")
+    func fullCycle() {
+        var data = Data()
+        data.append(seq("A"))
+        data.append("$ ls\n".data(using: .utf8)!)
+        data.append(seq("B"))
+        data.append(seq("C"))
+        data.append("a  b  c\n".data(using: .utf8)!)
+        data.append(seq("D;0"))
+        let markers = CommandMarkerParser.parse(data)
+        #expect(markers == [.promptStart, .commandStart, .outputStart, .commandEnd(exitCode: 0)])
+    }
+
+    @Test("ST terminator (ESC \\) is recognised")
+    func stTerminator() {
+        let data = seq("D;42", bel: false)
+        #expect(CommandMarkerParser.parse(data) == [.commandEnd(exitCode: 42)])
+    }
+
+    @Test("Command end without exit code parses to nil")
+    func endWithoutExit() {
+        #expect(CommandMarkerParser.parse(seq("D")) == [.commandEnd(exitCode: nil)])
+        #expect(CommandMarkerParser.parse(seq("D;")) == [.commandEnd(exitCode: nil)])
+    }
+
+    @Test("Tail key=value after exit code is tolerated")
+    func tolerantTail() {
+        let data = seq("D;137;err=killed")
+        #expect(CommandMarkerParser.parse(data) == [.commandEnd(exitCode: 137)])
+    }
+
+    @Test("Plain text without markers yields no events")
+    func plainText() {
+        let data = "hello world\n".data(using: .utf8)!
+        #expect(CommandMarkerParser.parse(data) == [])
+    }
+
+    @Test("Unknown marker letters are ignored, surrounding markers still parse")
+    func unknownMarker() {
+        var data = Data()
+        data.append(seq("A"))
+        data.append(seq("Z;ignored"))
+        data.append(seq("B"))
+        let markers = CommandMarkerParser.parse(data)
+        #expect(markers == [.promptStart, .commandStart])
+    }
+
+    @Test("Markers split across chunks reassemble correctly")
+    func splitAcrossChunks() {
+        let full = seq("D;0")
+        let mid = full.count / 2
+        let first = full.prefix(mid)
+        let second = full.suffix(from: mid)
+        var parser = CommandMarkerParser()
+        let firstMarkers = parser.consume(Data(first))
+        #expect(firstMarkers == [])
+        let secondMarkers = parser.consume(Data(second))
+        #expect(secondMarkers == [.commandEnd(exitCode: 0)])
+    }
+
+    @Test("Trailing partial introducer is held until next chunk")
+    func partialIntroducerHeld() {
+        var parser = CommandMarkerParser()
+        // Send "noise" + ESC ] 1   (introducer truncated before "33;")
+        var chunk = "noise".data(using: .utf8)!
+        chunk.append(Data([0x1B, 0x5D, 0x31]))
+        let first = parser.consume(chunk)
+        #expect(first == [])
+
+        // Now send the rest: "33;B" + BEL.
+        var rest = Data([0x33, 0x33, 0x3B])
+        rest.append("B".data(using: .utf8)!)
+        rest.append(0x07)
+        let second = parser.consume(rest)
+        #expect(second == [.commandStart])
+    }
+
+    @Test("Prompt start prefix tail (A;aid=...) parses as promptStart")
+    func promptStartWithTail() {
+        let data = seq("A;aid=42;cl=m")
+        #expect(CommandMarkerParser.parse(data) == [.promptStart])
+    }
+}
+
+@MainActor
+@Suite("LastCommandStatusRegistry")
+struct LastCommandStatusRegistryTests {
+    private final class FakeClock: @unchecked Sendable {
+        var now: Date
+        init(_ start: Date) { self.now = start }
+    }
+
+    private func makeRegistry(start: Date = Date(timeIntervalSince1970: 1_000))
+        -> (LastCommandStatusRegistry, FakeClock)
+    {
+        let clock = FakeClock(start)
+        let registry = LastCommandStatusRegistry(clock: { clock.now })
+        return (registry, clock)
+    }
+
+    @Test("Ingesting commandStart publishes a running status")
+    func startedThenRunning() {
+        let session = UUID()
+        let (registry, clock) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "make test")
+        let s = registry.statusByTerminalSession[session]
+        #expect(s?.isRunning == true)
+        #expect(s?.commandLine == "make test")
+        #expect(s?.startedAt == clock.now)
+    }
+
+    @Test("Start → end with exit 0 records duration and success")
+    func startedToSuccess() {
+        let session = UUID()
+        let (registry, clock) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "ls")
+        clock.now = clock.now.addingTimeInterval(1.25)
+        registry.ingest(markers: [.commandEnd(exitCode: 0)], for: session)
+        let s = registry.statusByTerminalSession[session]
+        #expect(s?.isRunning == false)
+        #expect(s?.isSuccess == true)
+        #expect(s?.duration == 1.25)
+    }
+
+    @Test("Start → end with non-zero exit records failure")
+    func startedToFailure() {
+        let session = UUID()
+        let (registry, _) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "false")
+        registry.ingest(markers: [.commandEnd(exitCode: 1)], for: session)
+        #expect(registry.statusByTerminalSession[session]?.isSuccess == false)
+        #expect(registry.statusByTerminalSession[session]?.exitCode == 1)
+    }
+
+    @Test("Sequential commands replace the prior status")
+    func sequentialCommands() {
+        let session = UUID()
+        let (registry, clock) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "first")
+        registry.ingest(markers: [.commandEnd(exitCode: 0)], for: session)
+        clock.now = clock.now.addingTimeInterval(5)
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "second")
+        let s = registry.statusByTerminalSession[session]
+        #expect(s?.commandLine == "second")
+        #expect(s?.isRunning == true)
+    }
+
+    @Test("promptStart while a previous command is running ends it with nil exit")
+    func orphanedRunningClosed() {
+        let session = UUID()
+        let (registry, clock) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "stray")
+        clock.now = clock.now.addingTimeInterval(0.5)
+        registry.ingest(markers: [.promptStart], for: session)
+        let s = registry.statusByTerminalSession[session]
+        #expect(s?.isRunning == false)
+        #expect(s?.exitCode == nil)
+    }
+
+    @Test("commandEnd without a preceding start records a zero-duration ended status")
+    func endWithoutStart() {
+        let session = UUID()
+        let (registry, _) = makeRegistry()
+        registry.ingest(markers: [.commandEnd(exitCode: 0)], for: session)
+        let s = registry.statusByTerminalSession[session]
+        #expect(s?.isRunning == false)
+        #expect(s?.duration == 0)
+    }
+
+    @Test("Sessions are tracked independently")
+    func sessionsAreIndependent() {
+        let a = UUID()
+        let b = UUID()
+        let (registry, _) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: a, commandLine: "a")
+        registry.ingest(markers: [.commandStart, .commandEnd(exitCode: 2)], for: b, commandLine: "b")
+        #expect(registry.statusByTerminalSession[a]?.isRunning == true)
+        #expect(registry.statusByTerminalSession[b]?.isRunning == false)
+        #expect(registry.statusByTerminalSession[b]?.exitCode == 2)
+    }
+
+    @Test("clear(terminalSessionID:) drops tracking")
+    func clearDrops() {
+        let session = UUID()
+        let (registry, _) = makeRegistry()
+        registry.ingest(markers: [.commandStart], for: session, commandLine: "x")
+        registry.clear(terminalSessionID: session)
+        #expect(registry.statusByTerminalSession[session] == nil)
+    }
+}

--- a/Tests/WorkspaceManagerTests/LastCommandStatusTests.swift
+++ b/Tests/WorkspaceManagerTests/LastCommandStatusTests.swift
@@ -168,7 +168,9 @@ struct LastCommandStatusRegistryTests {
         init(_ start: Date) { self.now = start }
     }
 
-    private func makeRegistry(start: Date = Date(timeIntervalSince1970: 1_000))
+    private func makeRegistry(
+        start: Date = Date(timeIntervalSince1970: 1_000)
+    )
         -> (LastCommandStatusRegistry, FakeClock)
     {
         let clock = FakeClock(start)


### PR DESCRIPTION
## Summary

**⚠️ Parked prep — no live producer.** This ships the M6 status-sliver public API contract so the consumer side can be reviewed independently, but the registry has no feeder until the M6 producer side-track lands. Merging this alone has zero user-visible effect; the registry simply stays empty.

- `LastCommandStatus` value type (`commandLine`, `exitCode`, `startedAt`, `endedAt`, derived `duration` / `isRunning` / `isSuccess`).
- `CommandMarkerParser` — pure OSC 133 parser, tolerant of BEL+ST terminators, `key=value` tails, and chunk boundaries.
- `LastCommandStatusRegistry` — `@MainActor` `ObservableObject` keyed by `terminalSessionID` (CONTEXT.md vocabulary).
- No view files touched; no call sites added.

### Producer status

libghostty's runtime-action callback does not surface OSC 133 prompt marks, so we have no source for the parser yet. Two paths (handoff doc § "M6 producer — the OSC 133 question"):

1. **libghostty patch** surfacing OSC 133 to the runtime callback.
2. **Shell-side PROMPT hook** emitting OSC-shaped JSON to the existing `AgentHookListener` Unix socket (Claude-Code hook transport). **Recommended** — no libghostty changes, lives in user-controlled rcs.

Until one of those lands, **M6.chg (the status-sliver view) shouldn't ship** — an always-empty sliver is worse than no sliver.

Unlocks: M6.chg, once the producer is also in. Opening parked so the contract is reviewable in isolation.

## Mergeability

- Surface: desktop
- User-facing behavior changed: no (registry has no producer; views don't read it)
- Non-happy paths considered: parser tested against BEL+ST terminators, partial chunks, malformed tails; registry handles unknown terminal-session keys cleanly
- Release/ops preconditions: none (no consumer wired)
- Residual risk or follow-up: M6 producer + M6.chg view land on top; this PR is safe to hold if you'd rather sequence producer first

## Validation

- [x] `swift build`
- [x] `swift test` — 714 tests in 122 suites passed (+21 vs main for parser + registry suites)
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/` exits 0
- Carries a follow-up `style:` commit applying current-toolchain swift-format fixes (`[AddLines]` / `[Spacing]`) — same pattern as `5f2ac28f`

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Backend contract — `swift test` is the proof. Test summary screenshot linked below.

Evidence links:

- [Test summary screenshot](https://evidence.cloudcompute.com/workspaces/pr-501/20260523-214144-m6-prep-test-summary.png)

## Blockers

- [x] None — but reviewer should note the "no producer" state above; safe to merge or hold per producer sequencing preference
