### PR TITLE
fix: harden managed review intent publishing

### DIFF
--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -492,6 +492,34 @@ describe("parseReviewIntentFromText", () => {
 		});
 	});
 
+	it("extracts fenced JSON when the review body contains markdown code fences", () => {
+		const reviewIntent = {
+			event: "REQUEST_CHANGES",
+			body: [
+				"🛑 **Request changes** — Branch is superseded.",
+				"",
+				"## Summary",
+				"The current branch is dirty against main.",
+				"",
+				"```swift",
+				"let path = try #require(ClaudeIntegrationLifecycle.extractTitleEmitScript())",
+				"```",
+			].join("\n"),
+			labels: ["bug"],
+		};
+
+		const intent = parseReviewIntentFromText(
+			`I now have a complete picture.
+
+\`\`\`json
+${JSON.stringify(reviewIntent, null, 2)}
+\`\`\``,
+			["bug"],
+		);
+
+		expect(intent).toEqual(reviewIntent);
+	});
+
 	it("rejects unsupported review events", () => {
 		expect(() =>
 			parseReviewIntentFromText(
@@ -609,6 +637,100 @@ describe("processPendingPrReviewRuns", () => {
 			description: "Managed review posted.",
 			target_url:
 				"https://spaces.cloudcompute.com/dashboard/review-runs/fp_486",
+		});
+	});
+
+	it("posts an operator-visible failure comment when a completed intent cannot be published", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_bad_intent",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 486,
+				headSha: "head-sha",
+				triggerKind: "opened",
+				triggerSourceId: "head-sha",
+				sessionId: "sesn_bad_intent",
+				createdAt: "2026-05-17T06:24:27Z",
+				updatedAt: "2026-05-17T06:24:27Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [
+						{
+							type: "text",
+							text: `Review complete.
+
+\`\`\`json
+{"event":"MERGE","body":"ship it","labels":[]}
+\`\`\``,
+						},
+					],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(
+			async (url: string, options?: RequestInit) => {
+				if (url.endsWith("/pulls/486")) {
+					return {
+						ok: true,
+						json: async () =>
+							githubPr(486, {
+								title: "Refactor main window orchestration",
+								html_url: "https://github.com/fairchild/workspaces/pull/486",
+								body: "PR body",
+								head: { ref: "codex/main-window", sha: "head-sha" },
+								base: { ref: "main" },
+							}),
+					};
+				}
+				if (url.includes("/pulls/486/reviews?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/pulls?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/labels?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.endsWith("/issues/486/comments")) {
+					expect(options?.method).toBe("POST");
+					const body = JSON.parse(String(options?.body)).body;
+					expect(body).toContain("Managed review publication failed");
+					expect(body).toContain("unsupported review event");
+					expect(body).toContain("MERGE");
+					return okResponse();
+				}
+				if (isManagedReviewStatusUrl(url)) {
+					expect(JSON.parse(String(options?.body))).toMatchObject({
+						state: "failure",
+						context: "WorkSpaces Managed Review",
+						description: "Managed review failed before posting.",
+					});
+					return okResponse();
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			},
+		);
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			failed: 1,
+			skippedRunning: 0,
+		});
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_bad_intent", {
+			sessionId: "sesn_bad_intent",
+			status: "failed",
+			error: expect.stringContaining("unsupported review event"),
 		});
 	});
 

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -654,9 +654,14 @@ function computeReviewerConfigHash(model: string): string {
 
 function extractJsonCandidates(text: string): string[] {
 	const candidates: string[] = [];
-	const fenced = /```json\s*([\s\S]*?)```/gi;
+	const fenced = /(?:^|\r?\n)[ \t]*```json[ \t]*\r?\n/gi;
 	for (const match of text.matchAll(fenced)) {
-		const body = match[1]?.trim();
+		const bodyStart = (match.index ?? 0) + match[0].length;
+		const closingFence = /(?:^|\r?\n)[ \t]*```[ \t]*(?=\r?\n|$)/g;
+		closingFence.lastIndex = bodyStart;
+		const close = closingFence.exec(text);
+		if (!close) continue;
+		const body = text.slice(bodyStart, close.index).trim();
 		if (body) candidates.push(body);
 	}
 	if (candidates.length > 0) return candidates;
@@ -757,6 +762,76 @@ async function postGitHubReviewIntent(
 	if (!labelRes.ok) {
 		console.warn(
 			`[pr-review] label post skipped/failed ${labelRes.status}: ${await labelRes.text()}`,
+		);
+	}
+}
+
+const FAILED_REVIEW_OUTPUT_LIMIT = 8000;
+const FAILED_REVIEW_REASON_LIMIT = 1000;
+
+function truncateForFailureComment(value: string, limit: number): string {
+	if (value.length <= limit) return value;
+	return `${value.slice(0, limit)}\n\n...[truncated ${value.length - limit} characters]`;
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+async function postManagedReviewFailureComment(
+	githubToken: string,
+	payload: ManagedReviewStatusPayload,
+	reason: string,
+	output: string,
+): Promise<void> {
+	const trimmedOutput = output.trim();
+	if (!trimmedOutput) return;
+
+	const [owner, repo] = payload.repoFullName.split("/");
+	if (!owner || !repo) return;
+
+	const safeReason = escapeHtml(
+		truncateForFailureComment(reason.trim(), FAILED_REVIEW_REASON_LIMIT),
+	);
+	const safeOutput = escapeHtml(
+		truncateForFailureComment(trimmedOutput, FAILED_REVIEW_OUTPUT_LIMIT),
+	);
+	const body = [
+		"⚠️ **Managed review publication failed**",
+		"",
+		"The managed reviewer session reached a final response, but the broker could not publish it as a GitHub review.",
+		"",
+		"Reason:",
+		`<pre><code>${safeReason}</code></pre>`,
+		"",
+		"<details><summary>Unpublished managed reviewer output</summary>",
+		"",
+		`<pre><code>${safeOutput}</code></pre>`,
+		"",
+		"</details>",
+	].join("\n");
+
+	const res = await fetch(
+		`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${payload.number}/comments`,
+		{
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${githubToken}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ body }),
+		},
+	);
+	if (!res.ok) {
+		console.warn(
+			`[pr-review] failure comment skipped/failed ${res.status}: ${await res.text()}`,
 		);
 	}
 }
@@ -978,6 +1053,7 @@ export async function processPendingPrReviewRuns(
 	};
 
 	for (const run of pendingRuns) {
+		let completedOutput = "";
 		let statusPayload: ManagedReviewStatusPayload = {
 			repoFullName: run.repoFullName,
 			number: run.prNumber,
@@ -1000,6 +1076,7 @@ export async function processPendingPrReviewRuns(
 				});
 				continue;
 			}
+			completedOutput = collected.output;
 
 			const payload = await payloadFromStartedRun(githubToken, run);
 			if (!payload) {
@@ -1102,6 +1179,17 @@ export async function processPendingPrReviewRuns(
 			);
 		} catch (err) {
 			const reason = err instanceof Error ? err.message : String(err);
+			await postManagedReviewFailureComment(
+				githubToken,
+				statusPayload,
+				reason,
+				completedOutput,
+			).catch((commentErr) => {
+				console.warn(
+					"[pr-review] failure comment skipped/failed:",
+					commentErr instanceof Error ? commentErr.message : commentErr,
+				);
+			});
 			await postManagedReviewStatus(
 				githubToken,
 				statusPayload,


### PR DESCRIPTION
## Summary

- Parse managed-review JSON fences using line-delimited closing fences so markdown code blocks inside the review body do not truncate the JSON intent.
- Post an operator-visible failure comment with escaped unpublished output when a completed managed-reviewer session still cannot be published.
- Add regression coverage for nested markdown fences and broker failure visibility.

## Mergeability

- Surface: agent-runtime / web
- User-facing behavior changed: managed PR review failures become visible on the PR instead of only in logs; valid review bodies with nested code fences can publish normally.
- Non-happy paths considered: invalid review intents still fail safely, set the managed-review status to failure, and now leave escaped diagnostic output on the PR.
- Release/ops preconditions: deploy web after merge for production broker behavior.
- Residual risk or follow-up: failure comments intentionally expose escaped managed-agent output for operator diagnosis.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `pnpm test -- pr-review.test.ts`; `mise -C web run web:check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [web check output](https://evidence.cloudcompute.com/workspaces/pr-504/20260524-060725-managed-review-parser-web-check.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence