### PR TITLE
fix: point managed review status to run details

### DIFF
--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -85,6 +85,10 @@ posts the final GitHub review, it updates the same status context to `success`;
 if broker processing fails before a review is posted, it updates the context to
 `failure`.
 
+The status details URL points to `/dashboard/review-runs/<fingerprint>`. That
+authenticated page authorizes access to the stored repo, shows run metadata, and
+streams the managed-agent transcript once the run records a session id.
+
 The status is best-effort: a status API failure is logged but does not block the
 review session or broker. A `403` on this request means the GitHub App is missing
 the `statuses:write` permission.

--- a/web/src/app/api/managed-agents/transcript/route.ts
+++ b/web/src/app/api/managed-agents/transcript/route.ts
@@ -1,3 +1,4 @@
+import { getPrReviewRunBySessionId } from "@/lib/agent-runtime/pr-review-runs";
 import { getSessionByInstanceId } from "@/lib/agent-sessions";
 import { authorizeRepoAccess } from "@/lib/api-auth";
 import { getSession } from "@/lib/auth-server";
@@ -23,13 +24,14 @@ export async function GET(request: Request): Promise<Response> {
 	}
 
 	const agentSession = await getSessionByInstanceId(authed.user.id, sessionId);
-	if (!agentSession) {
+	const reviewRun = agentSession
+		? null
+		: await getPrReviewRunBySessionId(sessionId);
+	const repo = agentSession?.repo ?? reviewRun?.repoFullName ?? null;
+	if (!repo) {
 		return new Response("session not found", { status: 404 });
 	}
-	const unauthorized = await authorizeRepoAccess(
-		authed.user.id,
-		agentSession.repo,
-	);
+	const unauthorized = await authorizeRepoAccess(authed.user.id, repo);
 	if (unauthorized) return unauthorized;
 
 	if (!process.env.ANTHROPIC_API_KEY) {

--- a/web/src/app/api/pr-review-runs/[fingerprint]/route.ts
+++ b/web/src/app/api/pr-review-runs/[fingerprint]/route.ts
@@ -1,0 +1,27 @@
+import { getPrReviewRunByFingerprint } from "@/lib/agent-runtime/pr-review-runs";
+import { authorizeRepoAccess, unauthorizedResponse } from "@/lib/api-auth";
+import { getSession } from "@/lib/auth-server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+	_request: Request,
+	{ params }: { params: Promise<{ fingerprint: string }> },
+): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) return unauthorizedResponse();
+
+	const { fingerprint } = await params;
+	const run = await getPrReviewRunByFingerprint(fingerprint);
+	if (!run) {
+		return Response.json({ error: "review run not found" }, { status: 404 });
+	}
+
+	const unauthorized = await authorizeRepoAccess(
+		session.user.id,
+		run.repoFullName,
+	);
+	if (unauthorized) return unauthorized;
+
+	return Response.json({ run });
+}

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
@@ -1,0 +1,176 @@
+.page {
+	display: flex;
+	flex-direction: column;
+	gap: 18px;
+	min-height: calc(100vh - 56px);
+	padding: 24px;
+	background: #f7f7f5;
+	color: #171717;
+}
+
+.header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.eyebrow {
+	margin: 0 0 4px;
+	color: #6b7280;
+	font-size: 12px;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+.header h1 {
+	margin: 0;
+	font-size: 24px;
+	line-height: 1.2;
+}
+
+.status {
+	border: 1px solid #d1d5db;
+	border-radius: 999px;
+	padding: 4px 10px;
+	background: #ffffff;
+	color: #374151;
+	font-size: 12px;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+.status-started {
+	border-color: #93c5fd;
+	background: #eff6ff;
+	color: #1d4ed8;
+}
+
+.status-completed {
+	border-color: #86efac;
+	background: #f0fdf4;
+	color: #15803d;
+}
+
+.status-failed {
+	border-color: #fca5a5;
+	background: #fef2f2;
+	color: #b91c1c;
+}
+
+.status-superseded {
+	border-color: #facc15;
+	background: #fefce8;
+	color: #854d0e;
+}
+
+.summary {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	gap: 1px;
+	overflow: hidden;
+	border: 1px solid #e5e7eb;
+	border-radius: 8px;
+	background: #e5e7eb;
+}
+
+.summary div {
+	min-width: 0;
+	padding: 12px;
+	background: #ffffff;
+}
+
+.summary span {
+	display: block;
+	margin-bottom: 4px;
+	color: #6b7280;
+	font-size: 12px;
+}
+
+.summary strong {
+	display: block;
+	overflow-wrap: anywhere;
+	font-size: 13px;
+}
+
+.links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.links a {
+	border: 1px solid #d1d5db;
+	border-radius: 6px;
+	padding: 7px 10px;
+	background: #ffffff;
+	color: #111827;
+	font-size: 13px;
+	font-weight: 600;
+	text-decoration: none;
+}
+
+.links a:hover {
+	border-color: #9ca3af;
+	background: #f9fafb;
+}
+
+.transcriptCard {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-height: 360px;
+	overflow: hidden;
+	border: 1px solid #d1d5db;
+	border-radius: 8px;
+	background: #ffffff;
+}
+
+.transcriptCard h2 {
+	margin: 0;
+	padding: 12px 14px;
+	border-bottom: 1px solid #e5e7eb;
+	font-size: 15px;
+}
+
+.transcriptHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	border-bottom: 1px solid #e5e7eb;
+}
+
+.transcriptHeader h2 {
+	border-bottom: 0;
+}
+
+.sessionId {
+	margin-right: 14px;
+	color: #6b7280;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 12px;
+}
+
+.transcriptFrame {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+}
+
+.muted {
+	margin: 12px 14px;
+	color: #6b7280;
+	font-size: 13px;
+}
+
+.errorBlock {
+	margin: 0;
+	overflow: auto;
+	border: 1px solid #fecaca;
+	border-radius: 8px;
+	padding: 12px;
+	background: #fef2f2;
+	color: #991b1b;
+	white-space: pre-wrap;
+}

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -1,0 +1,87 @@
+import { getPrReviewRunByFingerprint } from "@/lib/agent-runtime/pr-review-runs";
+import { authorizeRepoAccess } from "@/lib/api-auth";
+import { getSession } from "@/lib/auth-server";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import styles from "./page.module.css";
+import { ReviewRunTranscript } from "./review-run-transcript";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReviewRunPage({
+	params,
+}: {
+	params: Promise<{ fingerprint: string }>;
+}) {
+	const session = await getSession();
+	if (!session?.user) redirect("/sign-in");
+
+	const { fingerprint } = await params;
+	const run = await getPrReviewRunByFingerprint(fingerprint);
+	if (!run) notFound();
+
+	const unauthorized = await authorizeRepoAccess(
+		session.user.id,
+		run.repoFullName,
+	);
+	if (unauthorized) notFound();
+
+	const [owner, repo] = run.repoFullName.split("/");
+	const prUrl = `https://github.com/${run.repoFullName}/pull/${run.prNumber}`;
+	const commitUrl = `https://github.com/${run.repoFullName}/commit/${run.headSha}`;
+	const dashboardUrl =
+		owner && repo
+			? `/dashboard/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}?tab=terminal&agent=pr-reviewer`
+			: "/dashboard";
+	const statusClass = styles[`status-${run.status}`] ?? "";
+
+	return (
+		<main className={styles.page}>
+			<div className={styles.header}>
+				<div>
+					<p className={styles.eyebrow}>Managed PR Review</p>
+					<h1>
+						{run.repoFullName}#{run.prNumber}
+					</h1>
+				</div>
+				<span className={`${styles.status} ${statusClass}`}>{run.status}</span>
+			</div>
+
+			<section className={styles.summary}>
+				<div>
+					<span>Run</span>
+					<strong>{run.fingerprint}</strong>
+				</div>
+				<div>
+					<span>Trigger</span>
+					<strong>
+						{run.triggerKind} / {run.triggerSourceId}
+					</strong>
+				</div>
+				<div>
+					<span>Head</span>
+					<strong>{run.headSha.slice(0, 12)}</strong>
+				</div>
+				<div>
+					<span>Updated</span>
+					<strong>{new Date(run.updatedAt).toLocaleString()}</strong>
+				</div>
+			</section>
+
+			<nav className={styles.links} aria-label="Run links">
+				<Link href={prUrl}>Open PR</Link>
+				<Link href={commitUrl}>Open commit</Link>
+				<Link href={dashboardUrl}>Open terminal tab</Link>
+			</nav>
+
+			{run.error && <pre className={styles.errorBlock}>{run.error}</pre>}
+
+			<ReviewRunTranscript
+				fingerprint={run.fingerprint}
+				initialSessionId={run.sessionId}
+				initialStatus={run.status}
+				initialError={run.error}
+			/>
+		</main>
+	);
+}

--- a/web/src/app/dashboard/review-runs/[fingerprint]/review-run-transcript.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/review-run-transcript.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { TranscriptTerminal } from "../../components/transcript-terminal";
+import styles from "./page.module.css";
+
+interface ReviewRunTranscriptProps {
+	fingerprint: string;
+	initialSessionId: string | null;
+	initialStatus: string;
+	initialError: string | null;
+}
+
+interface ReviewRunResponse {
+	run?: {
+		sessionId: string | null;
+		status: string;
+		error: string | null;
+	};
+}
+
+export function ReviewRunTranscript({
+	fingerprint,
+	initialSessionId,
+	initialStatus,
+	initialError,
+}: ReviewRunTranscriptProps) {
+	const [sessionId, setSessionId] = useState(initialSessionId);
+	const [status, setStatus] = useState(initialStatus);
+	const [error, setError] = useState(initialError);
+
+	useEffect(() => {
+		if (sessionId) return;
+
+		const poll = async () => {
+			const response = await fetch(
+				`/api/pr-review-runs/${encodeURIComponent(fingerprint)}`,
+			);
+			if (!response.ok) return;
+			const data = (await response.json()) as ReviewRunResponse;
+			if (!data.run) return;
+			setSessionId(data.run.sessionId);
+			setStatus(data.run.status);
+			setError(data.run.error);
+		};
+
+		void poll();
+		const interval = window.setInterval(() => void poll(), 2500);
+		return () => window.clearInterval(interval);
+	}, [fingerprint, sessionId]);
+
+	if (!sessionId) {
+		return (
+			<section className={styles.transcriptCard}>
+				<h2>Transcript</h2>
+				<p className={styles.muted}>
+					Managed review status: <strong>{status}</strong>
+				</p>
+				{error ? (
+					<pre className={styles.errorBlock}>{error}</pre>
+				) : (
+					<p className={styles.muted}>
+						Waiting for the managed-agent session id.
+					</p>
+				)}
+			</section>
+		);
+	}
+
+	return (
+		<section className={styles.transcriptCard}>
+			<div className={styles.transcriptHeader}>
+				<h2>Transcript</h2>
+				<span className={styles.sessionId}>{sessionId}</span>
+			</div>
+			<div className={styles.transcriptFrame}>
+				<TranscriptTerminal
+					sessionId={sessionId}
+					agentName="pr-reviewer"
+					active={true}
+				/>
+			</div>
+		</section>
+	);
+}

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -163,3 +163,36 @@ describe("listStartedPrReviewRuns", () => {
 		});
 	});
 });
+
+describe("run detail lookups", () => {
+	it("returns run details by fingerprint and session id", async () => {
+		const {
+			getPrReviewRunByFingerprint,
+			getPrReviewRunBySessionId,
+			recordRunStart,
+			recordRunResult,
+		} = await loadModule();
+		const input = makeInput({ fingerprint: "fp_details", prNumber: 42 });
+
+		await recordRunStart(input);
+		await recordRunResult(input.fingerprint, {
+			sessionId: "sesn_details",
+			status: "failed",
+			error: "review intent parse failed",
+		});
+
+		await expect(getPrReviewRunByFingerprint("missing")).resolves.toBeNull();
+		const byFingerprint = await getPrReviewRunByFingerprint(input.fingerprint);
+		const bySession = await getPrReviewRunBySessionId("sesn_details");
+
+		expect(byFingerprint).toMatchObject({
+			fingerprint: "fp_details",
+			repoFullName: "fairchild/workspaces",
+			prNumber: 42,
+			sessionId: "sesn_details",
+			status: "failed",
+			error: "review intent parse failed",
+		});
+		expect(bySession).toEqual(byFingerprint);
+	});
+});

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -216,6 +216,7 @@ beforeEach(() => {
 	vi.stubEnv("PR_REVIEWER_APP_ID", "123");
 	vi.stubEnv("PR_REVIEWER_PRIVATE_KEY", "private-key");
 	vi.stubEnv("PR_REVIEWER_INSTALLATION_ID", "456");
+	vi.stubEnv("WORKSPACES_WEB_BASE_URL", "https://spaces.cloudcompute.com");
 	mocks.createSession.mockReset();
 	mocks.listEvents.mockReset();
 	mocks.sendEvent.mockReset();
@@ -606,7 +607,8 @@ describe("processPendingPrReviewRuns", () => {
 			state: "success",
 			context: "WorkSpaces Managed Review",
 			description: "Managed review posted.",
-			target_url: "https://github.com/fairchild/workspaces/pull/486",
+			target_url:
+				"https://spaces.cloudcompute.com/dashboard/review-runs/fp_486",
 		});
 	});
 
@@ -975,7 +977,8 @@ describe("triggerPrReview", () => {
 			state: "pending",
 			context: "WorkSpaces Managed Review",
 			description: "Managed reviewer picked up this PR.",
-			target_url: "https://github.com/fairchild/workspaces/pull/9",
+			target_url:
+				"https://spaces.cloudcompute.com/dashboard/review-runs/fp_test",
 		});
 		const statusOrder = mocks.fetch.mock.invocationCallOrder[statusCallIndex];
 		expect(statusOrder).toBeGreaterThan(

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -208,6 +208,11 @@ export interface PrReviewRunSummary {
 	updatedAt: string;
 }
 
+export interface PrReviewRunDetails extends PrReviewRunSummary {
+	reviewerConfigHash: string;
+	error: string | null;
+}
+
 export interface StartedPrReviewRun {
 	fingerprint: string;
 	repoFullName: string;
@@ -218,6 +223,62 @@ export interface StartedPrReviewRun {
 	sessionId: string;
 	createdAt: string;
 	updatedAt: string;
+}
+
+function mapRunDetails(row: {
+	fingerprint: string;
+	repo_full_name: string;
+	pr_number: number;
+	head_sha: string;
+	trigger_kind: string;
+	trigger_source_id: string;
+	reviewer_config_hash: string;
+	status: string;
+	session_id: string | null;
+	created_at: string;
+	updated_at: string;
+	error: string | null;
+}): PrReviewRunDetails {
+	return {
+		fingerprint: row.fingerprint,
+		repoFullName: row.repo_full_name,
+		prNumber: row.pr_number,
+		headSha: row.head_sha,
+		triggerKind: row.trigger_kind,
+		triggerSourceId: row.trigger_source_id,
+		reviewerConfigHash: row.reviewer_config_hash,
+		status: row.status as PrReviewRunStatus,
+		sessionId: row.session_id,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+		error: row.error,
+	};
+}
+
+export async function getPrReviewRunByFingerprint(
+	fingerprint: string,
+): Promise<PrReviewRunDetails | null> {
+	await ensureRunsTable();
+	const row = await getDb()
+		.selectFrom("managed_pr_review_runs")
+		.selectAll()
+		.where("fingerprint", "=", fingerprint)
+		.executeTakeFirst();
+
+	return row ? mapRunDetails(row) : null;
+}
+
+export async function getPrReviewRunBySessionId(
+	sessionId: string,
+): Promise<PrReviewRunDetails | null> {
+	await ensureRunsTable();
+	const row = await getDb()
+		.selectFrom("managed_pr_review_runs")
+		.selectAll()
+		.where("session_id", "=", sessionId)
+		.executeTakeFirst();
+
+	return row ? mapRunDetails(row) : null;
 }
 
 export async function listRecentPrReviewRuns(input: {

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -770,6 +770,22 @@ interface ManagedReviewStatusPayload {
 	number: number;
 	headSha: string;
 	htmlUrl: string;
+	fingerprint?: string;
+}
+
+function getManagedReviewStatusBaseUrl(): string {
+	const explicit =
+		process.env.WORKSPACES_WEB_BASE_URL ?? process.env.BETTER_AUTH_URL;
+	if (explicit) return explicit.replace(/\/+$/, "");
+	if (process.env.NODE_ENV === "development") return "http://localhost:3000";
+	return "https://spaces.cloudcompute.com";
+}
+
+function buildManagedReviewStatusTargetUrl(
+	payload: ManagedReviewStatusPayload,
+): string {
+	if (!payload.fingerprint) return payload.htmlUrl;
+	return `${getManagedReviewStatusBaseUrl()}/dashboard/review-runs/${encodeURIComponent(payload.fingerprint)}`;
 }
 
 async function postManagedReviewStatus(
@@ -801,7 +817,7 @@ async function postManagedReviewStatus(
 					state,
 					context: MANAGED_REVIEW_STATUS_CONTEXT,
 					description,
-					target_url: payload.htmlUrl,
+					target_url: buildManagedReviewStatusTargetUrl(payload),
 				}),
 			},
 		);
@@ -967,6 +983,7 @@ export async function processPendingPrReviewRuns(
 			number: run.prNumber,
 			headSha: run.headSha,
 			htmlUrl: `https://github.com/${run.repoFullName}/pull/${run.prNumber}`,
+			fingerprint: run.fingerprint,
 		};
 		try {
 			const collected = await collectCompletedReviewIntentText(
@@ -995,6 +1012,7 @@ export async function processPendingPrReviewRuns(
 				number: payload.number,
 				headSha: payload.headSha,
 				htmlUrl: payload.htmlUrl,
+				fingerprint: run.fingerprint,
 			};
 
 			const currentReviewHistory = await fetchCurrentPrReviewHistory(
@@ -1197,6 +1215,7 @@ export async function triggerPrReview(
 			number: resolvedPayload.number,
 			headSha: resolvedPayload.headSha,
 			htmlUrl: resolvedPayload.htmlUrl,
+			fingerprint,
 		},
 		"pending",
 		"Managed reviewer picked up this PR.",
@@ -1380,6 +1399,7 @@ In "## Project Thread", include a short label rationale using the first applicab
 				number: resolvedPayload.number,
 				headSha: resolvedPayload.headSha,
 				htmlUrl: resolvedPayload.htmlUrl,
+				fingerprint,
 			},
 			"failure",
 			"Managed reviewer failed to start.",


### PR DESCRIPTION
## Summary
- Point the WorkSpaces Managed Review status details URL at an authenticated run-details page keyed by the managed-review fingerprint instead of looping back to the PR.
- Add a protected run details API/page that shows run metadata and streams the managed-agent transcript once the session id is recorded.
- Allow the transcript route to authorize managed PR review sessions through repo access, and document the new status details behavior.

## Mergeability
- Surface: web managed reviewer / GitHub status projection.
- User-facing behavior changed: clicking Details on the managed-review status should open the run details/transcript page instead of the PR.
- Non-happy paths considered: pending run without a session id, failed run with stored error, unauthorized repo access, missing run.
- Release/ops preconditions: none; WORKSPACES_WEB_BASE_URL can override the status details host, otherwise production falls back to https://spaces.cloudcompute.com.
- Residual risk or follow-up: managed-review statuses created before this deploy still point at the PR until a later status projection rewrites them.

## Validation
- [x] mise -C web run web:check
- [x] pnpm test -- src/lib/agent-runtime/__tests__/pr-review.test.ts src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
- [x] git diff --check

## Performance
- [x] Not a performance-sensitive change

## Evidence
- [Verification artifact](https://evidence.cloudcompute.com/workspaces/pr-506/20260524-213209-managed-review-details.svg)

## Blockers
- [x] None