### PR TITLE
docs: close sparkle appcast release notes follow-up

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -253,6 +253,7 @@ The recommended method for production releases.
    - fetches `origin/main` and fast-forwards local `main` before mutating
    - updates `Info.plist` version/build metadata
    - prepends a changelog entry from commits since the latest `v*` tag
+   - ensures `CHANGELOG.md` contains `## [<CFBundleShortVersionString>] - <date>` for the release version before `scripts/generate-sparkle-appcast.sh` runs
    - creates commit `release: v0.3.1`
    - creates lightweight tag `v0.3.1`
    - pushes `main` first, then pushes the tag
@@ -294,6 +295,10 @@ The recommended method for production releases.
      - Publish or refresh a GitHub release with artifacts via `gh`
      - Download the published assets on hosted macOS and re-check appcast XML,
        DMG identity, stapling, and Gatekeeper assessment
+   - Appcast release notes:
+     - `scripts/generate-sparkle-appcast.sh` embeds the matching
+       `CHANGELOG.md` section in the item `<description>`
+     - appcast generation fails if the matching section is missing or empty
 
 4. **Release Tag and Assets**
 

--- a/backlog/done/sparkle-appcast-release-notes-followups_followup.md
+++ b/backlog/done/sparkle-appcast-release-notes-followups_followup.md
@@ -3,9 +3,19 @@ topic: sparkle-appcast-release-notes
 relates_to: after:sparkle-autoupdate-plan
 priority: 2
 description: Capture release runbook and appcast script hardening follow-ups from PR #497 review.
+completed: 2026-05-24
 ---
 
 # Sparkle Appcast Release Notes Follow-ups
+
+## Outcome
+
+Implemented the release-note precondition in `RELEASING.md`, kept the Sparkle autoupdate plan aligned, and documented the trusted release-workflow boundary around appcast URL interpolation in `scripts/generate-sparkle-appcast.sh`.
+
+Verification:
+- `bash -n scripts/generate-sparkle-appcast.sh`
+- `swift test --filter SparkleAppcastScript`
+- `rg -n "CHANGELOG.md|generate-sparkle-appcast|fullReleaseNotesLink" RELEASING.md backlog/sparkle-autoupdate-plan.md scripts/generate-sparkle-appcast.sh`
 
 ## Problem Statement
 
@@ -29,8 +39,8 @@ The PR review also called out a safe-but-implicit script assumption: `scripts/ge
 - `backlog/sparkle-autoupdate-plan.md` - add the same note under Release Integration so the Sparkle update plan stays current.
 
 **Acceptance criteria:**
-- [ ] Release docs state that `CHANGELOG.md` must contain `## [CFBundleShortVersionString] - <date>` before `scripts/generate-sparkle-appcast.sh` runs.
-- [ ] Docs mention that the generated appcast embeds that section in `<description>` and fails if it is missing or empty.
+- [x] Release docs state that `CHANGELOG.md` must contain `## [CFBundleShortVersionString] - <date>` before `scripts/generate-sparkle-appcast.sh` runs.
+- [x] Docs mention that the generated appcast embeds that section in `<description>` and fails if it is missing or empty.
 
 ### Phase 2: Appcast Script Assumption Comment
 
@@ -38,8 +48,8 @@ The PR review also called out a safe-but-implicit script assumption: `scripts/ge
 - `scripts/generate-sparkle-appcast.sh` - add a short comment near `DOWNLOAD_URL`, `RELEASE_URL`, and `CHANGELOG_URL` explaining that `$REPO` comes from `GITHUB_REPOSITORY` and `$TAG` is validated by release preparation before the release workflow runs.
 
 **Acceptance criteria:**
-- [ ] The comment makes the trust boundary explicit without adding noisy escaping code for the current release-only use case.
-- [ ] If future work allows arbitrary `--repo` or `--tag` values from untrusted callers, the follow-up either constrains those values or escapes them before XML interpolation.
+- [x] The comment makes the trust boundary explicit without adding noisy escaping code for the current release-only use case.
+- [x] If future work allows arbitrary `--repo` or `--tag` values from untrusted callers, the follow-up either constrains those values or escapes them before XML interpolation.
 
 ## Verification Commands
 

--- a/backlog/sparkle-autoupdate-plan.md
+++ b/backlog/sparkle-autoupdate-plan.md
@@ -51,11 +51,15 @@ Info.plist defaults:
 
 Release builds bundle `Sparkle.framework` into `Contents/Frameworks` and sign it with the rest of the app bundle. The release workflow requires `SPARKLE_PRIVATE_KEY`, generates `build/appcast.xml` after the DMG is created, and uploads the appcast beside the DMG assets.
 
+Before appcast generation, `CHANGELOG.md` must contain a version-matched `## [<CFBundleShortVersionString>] - <date>` section. The appcast generator embeds that section in the item `<description>` and fails if the section is missing or empty, so release notes are part of the signed release artifact contract.
+
 The generated appcast uses:
 
 - `CFBundleVersion` for `sparkle:version`
 - `CFBundleShortVersionString` for `sparkle:shortVersionString`
 - `LSMinimumSystemVersion` for `sparkle:minimumSystemVersion`
+- the matching `CHANGELOG.md` section for the item `<description>`
+- the tagged `CHANGELOG.md` URL for `sparkle:fullReleaseNotesLink`
 - Sparkle `sign_update` output for `sparkle:edSignature` and `length`
 - the tagged GitHub Release DMG URL as the enclosure URL
 

--- a/scripts/generate-sparkle-appcast.sh
+++ b/scripts/generate-sparkle-appcast.sh
@@ -176,6 +176,9 @@ VERSION="$("$PLIST_BUDDY" -c "Print :CFBundleVersion" "$INFO_PLIST")"
 SHORT_VERSION="$("$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$INFO_PLIST")"
 MIN_SYSTEM_VERSION="$("$PLIST_BUDDY" -c "Print :LSMinimumSystemVersion" "$INFO_PLIST")"
 DMG_BASENAME="$(basename "$DMG_PATH")"
+# In the release workflow, REPO comes from GITHUB_REPOSITORY and TAG has passed
+# release-version validation. Constrain or XML-escape arbitrary --repo/--tag
+# inputs before broadening this script beyond trusted release automation.
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$DMG_BASENAME"
 RELEASE_URL="https://github.com/$REPO/releases/tag/$TAG"
 CHANGELOG_URL="https://github.com/$REPO/blob/$TAG/CHANGELOG.md"


### PR DESCRIPTION
## Summary

- document the `CHANGELOG.md` release-note precondition for Sparkle appcast generation
- align the Sparkle autoupdate backlog plan with the signed appcast release-note contract
- document the trusted release-workflow boundary for `$REPO`/`$TAG` URL interpolation and close the follow-up backlog item

## Mergeability

- Surface: docs / release tooling
- User-facing behavior changed: no runtime behavior change; this documents the release artifact contract added in PR #497
- Non-happy paths considered: missing or empty changelog sections are already handled by `scripts/generate-sparkle-appcast.sh`; this PR makes that operator-visible
- Release/ops preconditions: release docs now state the required `## [<CFBundleShortVersionString>] - <date>` changelog section before appcast generation
- Residual risk or follow-up: none

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:

```bash
bash -n scripts/generate-sparkle-appcast.sh
swift test --filter SparkleAppcastScript
rg -n "CHANGELOG.md|generate-sparkle-appcast|fullReleaseNotesLink" RELEASING.md backlog/sparkle-autoupdate-plan.md scripts/generate-sparkle-appcast.sh
git diff --check
git diff --cached --check
```

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- N/A: docs/comment-only PR; local command output is summarized in Validation.

## Blockers

- [x] None
- [ ] Blocked on evidence
