### PR TITLE
Simplify managed review run projection state

### DIFF
--- a/scripts/pr-reviewer-runs.py
+++ b/scripts/pr-reviewer-runs.py
@@ -14,11 +14,12 @@ prints the current queue in operator terms:
 - ``starting``: a ReviewRun row exists, but the managed-agent session id has not
   been recorded yet. Briefly normal immediately after pickup.
 - ``stuckStarting``: a starting row is old enough to need attention.
-- ``executing``: a managed-agent session exists and is still inside the normal
-  projection window.
-- ``needsProjection``: a session exists, but the row is old enough that the
-  broker should have posted the GitHub review or failure status.
-- ``failed``: the ReviewRun reached a terminal failure and stored a reason.
+- ``executing``: a managed-agent session exists and its GitHub projection is
+  still inside the normal window.
+- ``needsProjection``: the agent run is old enough that the broker should have
+  posted a GitHub review or failure status by now.
+- ``failed``: either the agent lifecycle or GitHub projection failed and stored
+  a reason.
 - ``terminal``: completed or superseded rows. These are counted, but omitted
   from the terse text output unless ``--json`` is used.
 
@@ -141,15 +142,23 @@ def print_run_bucket(label: str, runs: list[dict[str, Any]]) -> None:
         pr_number = run.get("prNumber", "?")
         short_sha = run.get("shortHeadSha", "-")
         age = run.get("ageMinutes", "?")
-        status = run.get("status", "-")
+        agent_status = run.get("agentStatus", run.get("status", "-"))
+        projection_status = run.get("projectionStatus", "-")
         state = run.get("state", "-")
         session_id = run.get("sessionId")
         details_url = run.get("detailsUrl")
-        print(f"  - PR #{pr_number} {short_sha} {state} ({status}), age {age}m")
+        print(
+            f"  - PR #{pr_number} {short_sha} {state} "
+            f"(agent={agent_status}, projection={projection_status}), age {age}m"
+        )
         if session_id:
             print(f"    session: {session_id}")
+        if run.get("githubReviewId"):
+            print(f"    github review: {run['githubReviewId']}")
         if details_url:
             print(f"    details: {details_url}")
+        if run.get("projectionError") and run.get("projectionError") != run.get("error"):
+            print(f"    projection error: {run['projectionError']}")
         if run.get("error"):
             print(f"    error: {run['error']}")
 

--- a/web/docs/pr-reviewer.md
+++ b/web/docs/pr-reviewer.md
@@ -146,10 +146,11 @@ uv run --script scripts/pr-reviewer-runs.py
 
 Use the report as the first read of production health. `missingRuns` means a
 reviewer-eligible webhook did not create a `managed_pr_review_runs` row.
-`executing` means the managed-agent session has been created and is still inside
-the normal projection window. `needsProjection` means the row is old enough that
-the broker should have posted the GitHub review or failure status. `failed`
-shows terminal run failures with the stored reason and a details URL.
+`executing` means the managed-agent session has been created and the GitHub
+projection is still inside the normal window. `needsProjection` means the row is
+old enough that the broker should have posted the GitHub review or failure
+status. `failed` shows agent or projection failures with the stored reason and a
+details URL.
 
 The Worker requires `WORKSPACES_WEBHOOK_CANARY_SECRET`, signs a canonical
 reviewer-eligible PR payload with `GITHUB_WEBHOOK_SECRET`, forwards it to the
@@ -173,7 +174,9 @@ curl --fail-with-body -sS \
 
 The broker inspects `started` rows in `managed_pr_review_runs`, skips sessions
 that are still running, validates completed review-intent JSON, and posts the
-review with the GitHub App token. Before posting, it re-checks current managed
+review with the GitHub App token. The row keeps two lifecycle fields: `status`
+for the managed-agent run and `projection_status` for the GitHub-facing review
+or failure projection. Before posting, the broker re-checks current managed
 reviews on the PR; if another managed review was submitted after the session
 started, the stale session is marked `superseded`. If the superseding review is
 for an older head, the broker starts a fresh follow-up session so the newer-head
@@ -320,11 +323,14 @@ itself) and from `Bot`-typed senders.
 
 Every dispatch computes a fingerprint over
 `(repo, pr, headSha, triggerKind, triggerSourceId, reviewerConfigHash)` and
-inserts a row into `managed_pr_review_runs` (created on first use). The skip
-decision honors the prior run's status so failed/crashed dispatches stay
-retriable:
+inserts a row into `managed_pr_review_runs` (created on first use). The row is
+the source of truth for both lifecycles: `status` tracks the managed agent, while
+`projection_status` tracks whether the broker has projected the result back to
+GitHub. The skip decision honors the prior run's agent status so failed/crashed
+dispatches stay retriable:
 
 - `completed` → skip; the previous run already produced a review.
+- `superseded` → skip; a later managed review intentionally covered this run.
 - `failed` → reset and proceed; lets a redelivery (or a follow-on event with
   the same fingerprint) recover from a transient session-create failure.
 - fresh `started` → skip (in-flight).

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
@@ -58,9 +58,14 @@ function runRow(
 		createdAt: string;
 		updatedAt: string;
 		error: string | null;
+		projectionStatus: "pending" | "projected" | "failed" | "superseded";
+		projectionUpdatedAt: string;
+		projectionError: string | null;
+		githubReviewId: string | null;
 	}> = {},
 ) {
 	const now = new Date().toISOString();
+	const status = overrides.status ?? "started";
 	return {
 		fingerprint: "fp_monitor_test",
 		repoFullName: "fairchild/workspaces",
@@ -68,11 +73,26 @@ function runRow(
 		headSha: "abc8101def456",
 		triggerKind: "opened",
 		triggerSourceId: "abc8101def456",
-		status: "started" as const,
+		status,
 		sessionId: "sesn_123",
 		createdAt: now,
 		updatedAt: now,
 		error: null,
+		projectionStatus:
+			overrides.projectionStatus ??
+			(status === "completed"
+				? "projected"
+				: status === "failed"
+					? "failed"
+					: status === "superseded"
+						? "superseded"
+						: "pending"),
+		projectionUpdatedAt:
+			overrides.projectionUpdatedAt ?? overrides.updatedAt ?? now,
+		projectionError:
+			overrides.projectionError ??
+			(status === "failed" ? (overrides.error ?? null) : null),
+		githubReviewId: null,
 		...overrides,
 	};
 }
@@ -238,6 +258,8 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 					{
 						fingerprint: "fp_needs_projection",
 						state: "needs_projection",
+						agentStatus: "started",
+						projectionStatus: "pending",
 						detailsUrl:
 							"http://localhost/dashboard/review-runs/fp_needs_projection",
 					},
@@ -246,6 +268,7 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 					{
 						fingerprint: "fp_failed",
 						state: "failed",
+						projectionStatus: "failed",
 						error: "review intent parse failed",
 					},
 				],

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
@@ -35,6 +35,11 @@ interface OperatorRunItem {
 	triggerKind: string;
 	triggerSourceId: string;
 	status: string;
+	agentStatus: string;
+	projectionStatus: string;
+	projectionUpdatedAt: string;
+	projectionError?: string;
+	githubReviewId?: string;
 	state: string;
 	sessionId: string | null;
 	ageMinutes: number;
@@ -107,6 +112,9 @@ function operatorRunItem(
 		triggerKind: run.triggerKind,
 		triggerSourceId: run.triggerSourceId,
 		status: run.status,
+		agentStatus: run.status,
+		projectionStatus: run.projectionStatus,
+		projectionUpdatedAt: run.projectionUpdatedAt,
 		state: run.state,
 		sessionId: run.sessionId,
 		ageMinutes: run.ageMinutes,
@@ -114,6 +122,8 @@ function operatorRunItem(
 		updatedAt: run.updatedAt,
 		detailsUrl: reviewRunDetailsUrl(requestUrl, run.fingerprint),
 		...(run.error ? { error: run.error } : {}),
+		...(run.projectionError ? { projectionError: run.projectionError } : {}),
+		...(run.githubReviewId ? { githubReviewId: run.githubReviewId } : {}),
 	};
 }
 

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -33,7 +33,9 @@ export default async function ReviewRunPage({
 		owner && repo
 			? `/dashboard/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}?tab=terminal&agent=pr-reviewer`
 			: "/dashboard";
-	const statusClass = styles[`status-${run.status}`] ?? "";
+	const effectiveStatus =
+		run.projectionStatus === "failed" ? "failed" : run.status;
+	const statusClass = styles[`status-${effectiveStatus}`] ?? "";
 	const projectionError =
 		run.projectionError && run.projectionError !== run.error
 			? run.projectionError

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -34,6 +34,10 @@ export default async function ReviewRunPage({
 			? `/dashboard/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}?tab=terminal&agent=pr-reviewer`
 			: "/dashboard";
 	const statusClass = styles[`status-${run.status}`] ?? "";
+	const projectionError =
+		run.projectionError && run.projectionError !== run.error
+			? run.projectionError
+			: null;
 
 	return (
 		<main className={styles.page}>
@@ -44,7 +48,9 @@ export default async function ReviewRunPage({
 						{run.repoFullName}#{run.prNumber}
 					</h1>
 				</div>
-				<span className={`${styles.status} ${statusClass}`}>{run.status}</span>
+				<span className={`${styles.status} ${statusClass}`}>
+					{run.status} / {run.projectionStatus}
+				</span>
 			</div>
 
 			<section className={styles.summary}>
@@ -66,6 +72,19 @@ export default async function ReviewRunPage({
 					<span>Updated</span>
 					<strong>{new Date(run.updatedAt).toLocaleString()}</strong>
 				</div>
+				<div>
+					<span>Projection</span>
+					<strong>
+						{run.projectionStatus} /{" "}
+						{new Date(run.projectionUpdatedAt).toLocaleString()}
+					</strong>
+				</div>
+				{run.githubReviewId && (
+					<div>
+						<span>GitHub review</span>
+						<strong>{run.githubReviewId}</strong>
+					</div>
+				)}
 			</section>
 
 			<nav className={styles.links} aria-label="Run links">
@@ -75,6 +94,9 @@ export default async function ReviewRunPage({
 			</nav>
 
 			{run.error && <pre className={styles.errorBlock}>{run.error}</pre>}
+			{projectionError && (
+				<pre className={styles.errorBlock}>{projectionError}</pre>
+			)}
 
 			<ReviewRunTranscript
 				fingerprint={run.fingerprint}

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -176,53 +176,66 @@ describe("bucketPrReviewRuns", () => {
 			triggerSourceId: "abc123",
 			createdAt: "2026-05-24T11:00:00.000Z",
 			error: null,
+			projectionError: null,
+			githubReviewId: null,
 		};
+		const pendingRun = (overrides: {
+			fingerprint: string;
+			status: "started" | "completed" | "failed";
+			sessionId: string | null;
+			updatedAt: string;
+			error?: string | null;
+			projectionStatus?: "pending" | "projected" | "failed";
+			projectionError?: string | null;
+		}) => ({
+			...base,
+			projectionStatus: overrides.projectionStatus ?? ("pending" as const),
+			projectionUpdatedAt: overrides.updatedAt,
+			...overrides,
+		});
 
 		const buckets = bucketPrReviewRuns(
 			[
-				{
-					...base,
+				pendingRun({
 					fingerprint: "fp_starting",
 					status: "started" as const,
 					sessionId: null,
 					updatedAt: "2026-05-24T11:59:00.000Z",
-				},
-				{
-					...base,
+				}),
+				pendingRun({
 					fingerprint: "fp_stuck_starting",
 					status: "started" as const,
 					sessionId: null,
 					updatedAt: "2026-05-24T11:50:00.000Z",
-				},
-				{
-					...base,
+				}),
+				pendingRun({
 					fingerprint: "fp_executing",
 					status: "started" as const,
 					sessionId: "sesn_executing",
 					updatedAt: "2026-05-24T11:40:00.000Z",
-				},
-				{
-					...base,
+				}),
+				pendingRun({
 					fingerprint: "fp_needs_projection",
 					status: "started" as const,
 					sessionId: "sesn_projection",
 					updatedAt: "2026-05-24T11:20:00.000Z",
-				},
-				{
-					...base,
+				}),
+				pendingRun({
 					fingerprint: "fp_failed",
 					status: "failed" as const,
 					sessionId: "sesn_failed",
 					updatedAt: "2026-05-24T11:58:00.000Z",
 					error: "review intent parse failed",
-				},
-				{
-					...base,
+					projectionStatus: "failed",
+					projectionError: "review intent parse failed",
+				}),
+				pendingRun({
 					fingerprint: "fp_completed",
 					status: "completed" as const,
 					sessionId: "sesn_completed",
 					updatedAt: "2026-05-24T11:58:00.000Z",
-				},
+					projectionStatus: "projected",
+				}),
 			],
 			{
 				now,
@@ -281,6 +294,8 @@ describe("run detail lookups", () => {
 			sessionId: "sesn_details",
 			status: "failed",
 			error: "review intent parse failed",
+			projectionStatus: "failed",
+			projectionError: "review intent parse failed",
 		});
 		expect(bySession).toEqual(byFingerprint);
 	});

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -857,7 +857,15 @@ describe("processPendingPrReviewRuns", () => {
 			sessionId: "sesn_stale",
 			status: "superseded",
 			error: expect.stringContaining("same head"),
+			projectionStatus: "projected",
 			githubReviewId: "4304929065",
+		});
+		const statusPost = mocks.fetch.mock.calls.find(([url]) =>
+			String(url).includes("/statuses/same-head"),
+		);
+		expect(JSON.parse(String(statusPost?.[1]?.body))).toMatchObject({
+			state: "success",
+			description: "Managed review posted.",
 		});
 	});
 
@@ -924,6 +932,9 @@ describe("processPendingPrReviewRuns", () => {
 					],
 				};
 			}
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
+			}
 			throw new Error(`Unexpected fetch URL: ${url}`);
 		});
 
@@ -949,6 +960,7 @@ describe("processPendingPrReviewRuns", () => {
 			sessionId: "sesn_mixed_reviews",
 			status: "superseded",
 			error: expect.stringContaining("4304929065"),
+			projectionStatus: "projected",
 			githubReviewId: "4304929065",
 		});
 	});
@@ -1056,6 +1068,7 @@ describe("processPendingPrReviewRuns", () => {
 			sessionId: "sesn_new_head_stale",
 			status: "superseded",
 			error: expect.stringContaining("retry session sesn_01 started"),
+			projectionStatus: "superseded",
 			githubReviewId: "4304929065",
 		});
 		const [, params] = mocks.sendEvent.mock.calls[0];

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -599,7 +599,11 @@ describe("processPendingPrReviewRuns", () => {
 						event: "COMMENT",
 						body: expect.stringContaining("No blocking issues found"),
 					});
-					return { ok: true, text: async () => "", json: async () => ({}) };
+					return {
+						ok: true,
+						text: async () => "",
+						json: async () => ({ id: 4304929701 }),
+					};
 				}
 				if (url.endsWith("/issues/486/labels")) {
 					expect(options?.method).toBe("POST");
@@ -626,6 +630,7 @@ describe("processPendingPrReviewRuns", () => {
 		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_486", {
 			sessionId: "sesn_486",
 			status: "completed",
+			githubReviewId: "4304929701",
 		});
 		const statusPost = mocks.fetch.mock.calls.find(([url]) =>
 			String(url).includes("/statuses/head-sha"),
@@ -852,6 +857,7 @@ describe("processPendingPrReviewRuns", () => {
 			sessionId: "sesn_stale",
 			status: "superseded",
 			error: expect.stringContaining("same head"),
+			githubReviewId: "4304929065",
 		});
 	});
 
@@ -943,6 +949,7 @@ describe("processPendingPrReviewRuns", () => {
 			sessionId: "sesn_mixed_reviews",
 			status: "superseded",
 			error: expect.stringContaining("4304929065"),
+			githubReviewId: "4304929065",
 		});
 	});
 
@@ -1049,6 +1056,7 @@ describe("processPendingPrReviewRuns", () => {
 			sessionId: "sesn_new_head_stale",
 			status: "superseded",
 			error: expect.stringContaining("retry session sesn_01 started"),
+			githubReviewId: "4304929065",
 		});
 		const [, params] = mocks.sendEvent.mock.calls[0];
 		const message = params.events[0].content[0].text;

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -7,6 +7,12 @@ export type PrReviewRunStatus =
 	| "failed"
 	| "superseded";
 
+export type PrReviewProjectionStatus =
+	| "pending"
+	| "projected"
+	| "failed"
+	| "superseded";
+
 export interface PrReviewRunFingerprintInput {
 	repoFullName: string;
 	prNumber: number;
@@ -40,7 +46,26 @@ async function ensureRunsTable(): Promise<void> {
 		.addColumn("created_at", "text", (c) => c.notNull())
 		.addColumn("updated_at", "text", (c) => c.notNull())
 		.addColumn("error", "text")
+		.addColumn("projection_status", "text")
+		.addColumn("projection_updated_at", "text")
+		.addColumn("projection_error", "text")
+		.addColumn("github_review_id", "text")
 		.execute();
+	for (const [column, type] of [
+		["projection_status", "text"],
+		["projection_updated_at", "text"],
+		["projection_error", "text"],
+		["github_review_id", "text"],
+	] as const) {
+		try {
+			await db.schema
+				.alterTable("managed_pr_review_runs")
+				.addColumn(column, type)
+				.execute();
+		} catch {
+			// Column already exists.
+		}
+	}
 	await db.schema
 		.createIndex("idx_managed_pr_review_runs_pr")
 		.ifNotExists()
@@ -71,6 +96,36 @@ export interface RecordRunStartResult {
 
 /** Treat a `started` row older than this as crashed and eligible for retry. */
 const STALE_STARTED_MS = 15 * 60 * 1000;
+
+function projectionStatusForRunStatus(
+	status: PrReviewRunStatus,
+): PrReviewProjectionStatus {
+	switch (status) {
+		case "completed":
+			return "projected";
+		case "failed":
+			return "failed";
+		case "superseded":
+			return "superseded";
+		case "started":
+			return "pending";
+	}
+}
+
+function normalizeProjectionStatus(
+	projectionStatus: string | null,
+	runStatus: PrReviewRunStatus,
+): PrReviewProjectionStatus {
+	if (
+		projectionStatus === "pending" ||
+		projectionStatus === "projected" ||
+		projectionStatus === "failed" ||
+		projectionStatus === "superseded"
+	) {
+		return projectionStatus;
+	}
+	return projectionStatusForRunStatus(runStatus);
+}
 
 /**
  * Claim a run slot for the fingerprint. Returns `inserted: true` when the
@@ -111,6 +166,10 @@ export async function recordRunStart(
 			created_at: now,
 			updated_at: now,
 			error: null,
+			projection_status: "pending",
+			projection_updated_at: now,
+			projection_error: null,
+			github_review_id: null,
 		})
 		.onConflict((oc) => oc.column("fingerprint").doNothing())
 		.executeTakeFirst();
@@ -141,6 +200,10 @@ export async function recordRunStart(
 				created_at: now,
 				updated_at: now,
 				error: null,
+				projection_status: "pending",
+				projection_updated_at: now,
+				projection_error: null,
+				github_review_id: null,
 			})
 			.execute();
 		return { inserted: true };
@@ -166,6 +229,10 @@ export async function recordRunStart(
 			session_id: null,
 			error: null,
 			updated_at: now,
+			projection_status: "pending",
+			projection_updated_at: now,
+			projection_error: null,
+			github_review_id: null,
 		})
 		.where("fingerprint", "=", input.fingerprint)
 		.execute();
@@ -176,6 +243,9 @@ export interface RecordRunResultInput {
 	sessionId: string | null;
 	status: PrReviewRunStatus;
 	error?: string | null;
+	projectionStatus?: PrReviewProjectionStatus;
+	projectionError?: string | null;
+	githubReviewId?: string | null;
 }
 
 export async function recordRunResult(
@@ -183,13 +253,25 @@ export async function recordRunResult(
 	input: RecordRunResultInput,
 ): Promise<void> {
 	await ensureRunsTable();
+	const now = new Date().toISOString();
+	const projectionStatus =
+		input.projectionStatus ?? projectionStatusForRunStatus(input.status);
 	await getDb()
 		.updateTable("managed_pr_review_runs")
 		.set({
 			session_id: input.sessionId,
 			status: input.status,
 			error: input.error ?? null,
-			updated_at: new Date().toISOString(),
+			updated_at: now,
+			projection_status: projectionStatus,
+			projection_updated_at: now,
+			projection_error:
+				input.projectionError !== undefined
+					? input.projectionError
+					: projectionStatus === "failed"
+						? (input.error ?? null)
+						: null,
+			github_review_id: input.githubReviewId ?? null,
 		})
 		.where("fingerprint", "=", fingerprint)
 		.execute();
@@ -207,6 +289,10 @@ export interface PrReviewRunSummary {
 	createdAt: string;
 	updatedAt: string;
 	error: string | null;
+	projectionStatus: PrReviewProjectionStatus;
+	projectionUpdatedAt: string;
+	projectionError: string | null;
+	githubReviewId: string | null;
 }
 
 export interface PrReviewRunDetails extends PrReviewRunSummary {
@@ -238,7 +324,12 @@ function mapRunDetails(row: {
 	created_at: string;
 	updated_at: string;
 	error: string | null;
+	projection_status: string | null;
+	projection_updated_at: string | null;
+	projection_error: string | null;
+	github_review_id: string | null;
 }): PrReviewRunDetails {
+	const status = row.status as PrReviewRunStatus;
 	return {
 		fingerprint: row.fingerprint,
 		repoFullName: row.repo_full_name,
@@ -247,11 +338,16 @@ function mapRunDetails(row: {
 		triggerKind: row.trigger_kind,
 		triggerSourceId: row.trigger_source_id,
 		reviewerConfigHash: row.reviewer_config_hash,
-		status: row.status as PrReviewRunStatus,
+		status,
 		sessionId: row.session_id,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		error: row.error,
+		projectionStatus: normalizeProjectionStatus(row.projection_status, status),
+		projectionUpdatedAt: row.projection_updated_at ?? row.updated_at,
+		projectionError:
+			row.projection_error ?? (status === "failed" ? row.error : null),
+		githubReviewId: row.github_review_id,
 	};
 }
 
@@ -300,24 +396,39 @@ export async function listRecentPrReviewRuns(input: {
 			"created_at",
 			"updated_at",
 			"error",
+			"projection_status",
+			"projection_updated_at",
+			"projection_error",
+			"github_review_id",
 		])
 		.where("created_at", ">=", input.sinceIso)
 		.where("repo_full_name", "=", input.repoFullName)
 		.execute();
 
-	return rows.map((row) => ({
-		fingerprint: row.fingerprint,
-		repoFullName: row.repo_full_name,
-		prNumber: row.pr_number,
-		headSha: row.head_sha,
-		triggerKind: row.trigger_kind,
-		triggerSourceId: row.trigger_source_id,
-		status: row.status as PrReviewRunStatus,
-		sessionId: row.session_id,
-		createdAt: row.created_at,
-		updatedAt: row.updated_at,
-		error: row.error,
-	}));
+	return rows.map((row) => {
+		const status = row.status as PrReviewRunStatus;
+		return {
+			fingerprint: row.fingerprint,
+			repoFullName: row.repo_full_name,
+			prNumber: row.pr_number,
+			headSha: row.head_sha,
+			triggerKind: row.trigger_kind,
+			triggerSourceId: row.trigger_source_id,
+			status,
+			sessionId: row.session_id,
+			createdAt: row.created_at,
+			updatedAt: row.updated_at,
+			error: row.error,
+			projectionStatus: normalizeProjectionStatus(
+				row.projection_status,
+				status,
+			),
+			projectionUpdatedAt: row.projection_updated_at ?? row.updated_at,
+			projectionError:
+				row.projection_error ?? (status === "failed" ? row.error : null),
+			githubReviewId: row.github_review_id,
+		};
+	});
 }
 
 export type PrReviewRunOperatorState =
@@ -362,26 +473,34 @@ export function classifyPrReviewRun(
 	},
 ): ClassifiedPrReviewRun {
 	const now = options.now ?? new Date();
-	const ageMinutes = elapsedMinutes(run.updatedAt, now);
+	let ageSource = run.updatedAt;
 	let state: PrReviewRunOperatorState;
 
-	if (run.status === "failed") {
+	if (run.status === "failed" || run.projectionStatus === "failed") {
 		state = "failed";
-	} else if (run.status === "completed" || run.status === "superseded") {
+	} else if (
+		run.status === "completed" ||
+		run.status === "superseded" ||
+		run.projectionStatus === "projected" ||
+		run.projectionStatus === "superseded"
+	) {
 		state = "terminal";
 	} else if (!run.sessionId) {
+		const ageMinutes = elapsedMinutes(ageSource, now);
 		state =
 			ageMinutes >= options.thresholds.startingTimeoutMinutes
 				? "stuck_starting"
 				: "starting";
 	} else {
+		ageSource = run.projectionUpdatedAt;
+		const ageMinutes = elapsedMinutes(ageSource, now);
 		state =
 			ageMinutes >= options.thresholds.projectionTimeoutMinutes
 				? "needs_projection"
 				: "executing";
 	}
 
-	return { ...run, state, ageMinutes };
+	return { ...run, state, ageMinutes: elapsedMinutes(ageSource, now) };
 }
 
 export function bucketPrReviewRuns(

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -492,6 +492,8 @@ export function classifyPrReviewRun(
 				? "stuck_starting"
 				: "starting";
 	} else {
+		// Once a session exists, age reports projection staleness rather than
+		// wall-clock run age so operators can see when the broker is overdue.
 		ageSource = run.projectionUpdatedAt;
 		const ageMinutes = elapsedMinutes(ageSource, now);
 		state =

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -1134,10 +1134,19 @@ export async function processPendingPrReviewRuns(
 					: retrySessionId
 						? `Superseded by managed review ${referenceReview.id}; retry session ${retrySessionId} started.`
 						: `Superseded by managed review ${referenceReview.id}; retry session was not started.`;
+				if (reviewedCurrentHead) {
+					await postManagedReviewStatus(
+						githubToken,
+						statusPayload,
+						"success",
+						"Managed review posted.",
+					);
+				}
 				await recordRunResult(run.fingerprint, {
 					sessionId: run.sessionId,
 					status: "superseded",
 					error,
+					projectionStatus: reviewedCurrentHead ? "projected" : "superseded",
 					githubReviewId: String(referenceReview.id),
 				});
 				result.superseded += 1;

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -723,7 +723,7 @@ async function postGitHubReviewIntent(
 	githubToken: string,
 	payload: PrReviewPayload,
 	intent: PrReviewIntent,
-): Promise<void> {
+): Promise<{ reviewId: string | null }> {
 	const [owner, repo] = payload.repoFullName.split("/");
 	if (!owner || !repo) {
 		throw new Error("Repository owner/name was unavailable.");
@@ -748,8 +748,15 @@ async function postGitHubReviewIntent(
 			`GitHub review post failed ${reviewRes.status}: ${await reviewRes.text()}`,
 		);
 	}
+	const reviewJson = (await reviewRes.json().catch(() => null)) as {
+		id?: unknown;
+	} | null;
+	const reviewId =
+		reviewJson?.id !== undefined && reviewJson.id !== null
+			? String(reviewJson.id)
+			: null;
 
-	if (intent.labels.length === 0) return;
+	if (intent.labels.length === 0) return { reviewId };
 
 	const labelRes = await fetch(
 		`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${payload.number}/labels`,
@@ -764,6 +771,7 @@ async function postGitHubReviewIntent(
 			`[pr-review] label post skipped/failed ${labelRes.status}: ${await labelRes.text()}`,
 		);
 	}
+	return { reviewId };
 }
 
 const FAILED_REVIEW_OUTPUT_LIMIT = 8000;
@@ -1130,6 +1138,7 @@ export async function processPendingPrReviewRuns(
 					sessionId: run.sessionId,
 					status: "superseded",
 					error,
+					githubReviewId: String(referenceReview.id),
 				});
 				result.superseded += 1;
 				if (retrySessionId) result.requeued += 1;
@@ -1156,17 +1165,29 @@ export async function processPendingPrReviewRuns(
 				collected.output,
 				narrativeContext.availableLabels.map((label) => label.name),
 			);
-			await postGitHubReviewIntent(githubToken, payload, intent);
+			const postedReview = await postGitHubReviewIntent(
+				githubToken,
+				payload,
+				intent,
+			);
 			await postManagedReviewStatus(
 				githubToken,
 				statusPayload,
 				"success",
 				"Managed review posted.",
 			);
-			await recordRunResult(run.fingerprint, {
-				sessionId: run.sessionId,
-				status: "completed",
-			});
+			if (postedReview.reviewId) {
+				await recordRunResult(run.fingerprint, {
+					sessionId: run.sessionId,
+					status: "completed",
+					githubReviewId: postedReview.reviewId,
+				});
+			} else {
+				await recordRunResult(run.fingerprint, {
+					sessionId: run.sessionId,
+					status: "completed",
+				});
+			}
 			result.completed += 1;
 			result.runs.push({
 				fingerprint: run.fingerprint,

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -1185,18 +1185,11 @@ export async function processPendingPrReviewRuns(
 				"success",
 				"Managed review posted.",
 			);
-			if (postedReview.reviewId) {
-				await recordRunResult(run.fingerprint, {
-					sessionId: run.sessionId,
-					status: "completed",
-					githubReviewId: postedReview.reviewId,
-				});
-			} else {
-				await recordRunResult(run.fingerprint, {
-					sessionId: run.sessionId,
-					status: "completed",
-				});
-			}
+			await recordRunResult(run.fingerprint, {
+				sessionId: run.sessionId,
+				status: "completed",
+				githubReviewId: postedReview.reviewId,
+			});
 			result.completed += 1;
 			result.runs.push({
 				fingerprint: run.fingerprint,

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -85,6 +85,10 @@ export interface ManagedPrReviewRunsTable {
 	created_at: string;
 	updated_at: string;
 	error: string | null;
+	projection_status: string | null;
+	projection_updated_at: string | null;
+	projection_error: string | null;
+	github_review_id: string | null;
 }
 
 interface Database {


### PR DESCRIPTION
## Summary

- split ReviewRun tracking into managed-agent status and GitHub projection status
- surface projection status, projection errors, and GitHub review ids in the monitor, script, API, and run detail page
- document the ReviewRun row as the source of truth for both lifecycles

## Mergeability

- Surface: web / agent-runtime / docs
- User-facing behavior changed: PR review run detail pages and operator reports now show both agent and projection state.
- Non-happy paths considered: existing rows without projection columns are normalized from their legacy run status; failed and superseded rows retain reasons.
- Release/ops preconditions: none beyond normal web deploy.
- Residual risk or follow-up: the production DB migration is lazy on first access, matching the existing ReviewRun table bootstrap pattern.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `mise -C web run web:check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- `mise -C web run web:check` passed locally:
  - typecheck: `tsc --noEmit`
  - lint: `biome check .` checked 177 files
  - tests: 28 files passed, 277 tests passed
- Evidence upload could not be completed because `EVIDENCE_UPLOAD_TOKEN` is not present in this worktree or the main checkout environment; `./scripts/evidence.sh --pr 510 --name web-check --file /tmp/workspaces-pr-510-web-check.svg` exited before upload.

## Blockers

- [x] None
- [ ] Blocked on evidence

## Notes

- `web/docs/architecture.md` has an unrelated local change and is intentionally not part of this PR.
