### PR TITLE
docs(backlog): groom backlog against GitHub Issues + CD-failure sweep

### DIFF
--- a/backlog/GROOMING.md
+++ b/backlog/GROOMING.md
@@ -1,0 +1,163 @@
+# Backlog Grooming — 2026-05-24
+
+Reconciliation pass before we adopt GitHub Issues as the canonical backlog backend. The `backlog` skill ships only `maildir-git` and `maildir-shared` today; a `github-issues` backend is in flight. This doc lines up local `backlog/*.md` against `fairchild/workspaces` Issues so the cutover lands clean: no duplicates, no drift, no orphans.
+
+## Frame
+
+- **Source of truth, today** — split: strategic plans live in `backlog/*.md`, execution tickets live in GH Issues. Most local files predate the lane-label workflow (`agent`/`human`, `ready`/`claimed`/`review`/`mergeable`) and don't reference an issue at all.
+- **Source of truth, after migration** — GH Issues for every actionable item. Local `backlog/*.md` shrinks to ROADMAP-adjacent planning docs (multi-issue plans, design briefs) or disappears entirely.
+- **Goal of this grooming** — for every local file, decide: *open issue / link issue / archive to done / keep as repo doc*. For every open issue, decide: *keep / close / re-triage*. Output is a reconciled state we can then either freeze (single backend = maildir) or migrate (single backend = GH Issues).
+
+## Inventory
+
+### Local backlog
+
+| Bucket | Count | Notes |
+|---|---|---|
+| `backlog/*.md` (top-level "pending") | 25 | Mixed schema — some have `status:`/`category:`, some only `topic:`/`priority:`/`description:`, two have no frontmatter at all |
+| `backlog/done/` | 16 | Settled work; mostly has `pr:` / `completed:` |
+| `backlog/AGENTS.md` | 1 | Old schema documentation (status/category/issue/pr) — predates the maildir model and the lane-label scheme |
+| `backlog/ROADMAP.md` | 1 | 31KB, in active use; left untouched by this pass |
+
+### GitHub Issues (fairchild/workspaces)
+
+| Bucket | Count | Notes |
+|---|---|---|
+| Open, milestone #7 (Web Dashboard) | 12 | Phase 2/3/4/5 features; one has `mergeable` label (#226) |
+| Open, no milestone | ~13 | Includes 3 auto-opened CD-failure issues, several future-labeled MVP-deferred items, and a handful of agent-platform tasks |
+| Closed since 2026-03-01 | 40+ | Includes issues #81/82/83/84 (referenced by local files — see drift below) |
+
+### Label taxonomy in use
+
+Lanes: `agent`, `human`. Lifecycle: `ready` → `claimed` → `review` → `mergeable`. Blockers: `blocked`, `needs-human`, `needs-info`, `needs-triage`, `decision`. Approvals: `safe-to-run-agent`, `privileged-agent-patch`. Areas: `area: ui`, `area: isolation`, `area: distribution`, `area: platform`, `web`. Priorities: `priority:p0`/`p1`/`p2`. Quality: `bug`, `enhancement`, `documentation`, `quality`, `security`, `devEx`, `future`. Operational: `cd-failure`, `cd-failure:playwright`, `cd-failure:lighthouse`, `cd-failure:prod`, `auto-opened`, `urgent`.
+
+This is the schema the GH-issues backend will inherit — significantly richer than the maildir frontmatter, and already in use across the agent automation. No reason to invent a parallel taxonomy.
+
+## State drift — fix immediately
+
+Three local files claim "pending" but reference issues GitHub already closed in March:
+
+| File | Issue | GH status | Correction |
+|---|---|---|---|
+| `backlog/ghostty-appearance-hardening_followup.md` | [#84](https://github.com/fairchild/workspaces/issues/84) | Closed 2026-03-13 | File frontmatter already says `status: completed` — just `git mv` to `backlog/done/` |
+| `backlog/main-window-sidebar-maintainability_followup.md` | [#81](https://github.com/fairchild/workspaces/issues/81) | Closed 2026-03-13 | File says `status: in-progress` with a `retro_summary` and "Remaining work is incremental…" — split: archive the closed scope, open a fresh issue for the residual ContentView/SidebarView/GhosttySurfaceView shrinkage, or move to `done/` if the residual is now covered elsewhere |
+| `backlog/shared-desktop-focus-contention-followup.md` | [#82](https://github.com/fairchild/workspaces/issues/82) | Closed 2026-03-13 | File says `status: phase-1-complete` — same call: phase-2 either becomes a new issue or moves to `done/` with a resolution note |
+
+These three are mechanical fixes; no decisions needed beyond "is the residual scope still real?"
+
+## Reconciliation table — local files
+
+For each file in `backlog/*.md`, the proposal. **Action** column is the recommended next move; **rationale** explains the call.
+
+### Strategic plans worth promoting to GH Issues (or a tracking issue)
+
+| File | Action | Rationale |
+|---|---|---|
+| `daytona-native-swift-api-plan.md` | Open issue, label `enhancement`+`area: isolation`+`task` | Replaces Python CLI bridge; needs scheduling + claim semantics |
+| `desktop-continuity_plan.md` | Open issue, label `enhancement`+`area: ui`+`priority:p1` | Marked active, P1, has a branch — should be visible in Issues |
+| `dev-build-warning-cleanup-and-mise-tasks_plan.md` | Open issue, label `devEx`+`area: platform` | Discrete cleanup, good agent task |
+| `lume-runtime-architecture-followups_followup.md` | Open tracking issue + per-item child issues | Multiple distinct items; one tracking issue links the rest |
+| `managed-pr-reviewer-continuous-reruns_plan.md` | Open issue, label `agent`+`enhancement`+`priority:p1` | Already tagged P1; concrete |
+| `notification-client-catchup-plan.md` | Open issue, label `area: ui` | Plan exists; needs to enter the queue |
+| `pr-reviewer-narration-eval-skill_plan.md` | Open issue, label `agent`+`enhancement` | Discrete skill work |
+| `pre-release-deployment-smoke_plan.md` | Open issue, label `area: platform`+`web` | Smoke lane; one PR |
+| `remote-runtime-expansion-plan.md` | Open tracking issue | Plan spans multiple runtimes; tracking issue + per-runtime children |
+| `signing-host-runner_followup.md` | Open issue, label `area: distribution`+`area: platform` | Operational; runner provisioning |
+| `spaces-agent-discovery-dashboard-plan.md` | **Link to existing #174** (`feat(web): wire GitHub adapter in Chat SDK bot`) and/or open milestone-7 child issues | Likely overlaps with the Web Dashboard milestone work |
+| `terminal-architecture-followups.md` | Open tracking issue, label `area: ui`+`enhancement` | Multi-item; each line becomes a child |
+| `terminal-polish-followup.md` | Open issue, label `area: ui`+`enhancement` | Discrete polish items, each one PR |
+| `terminal-pty-relay-plan.md` | Open issue, label `area: ui`+`area: platform`+`enhancement` | Sandcastle PTY relay — concrete enough to track |
+| `tmux-support_plan.md` | Open issue, label `area: ui`+`priority:p1` | Active, P1, tied to a decision doc |
+| `vz-tahoe-execution-brief-plan.md` | Open tracking issue | Large execution brief; split into phased issues |
+| `web-api-authorization-hardening-followup.md` | Open issue, label `web`+`security` | Already references PR #342; trivial to issue-ify |
+| `web-dashboard-component-regression-tests_followup.md` | Open issue, label `web`+`quality` | Testing harness; one PR |
+| `web-dashboard-phase3-followups.md` | Open child issues under milestone #7 Phase 3 | Multiple items in one file → split |
+| `workspace-creation-hang-root-cause_followup.md` | Open issue, label `bug`+`area: ui`+`priority:p1` | Hang/root-cause work; needs visibility |
+
+### Discrete, smaller items
+
+| File | Action | Rationale |
+|---|---|---|
+| `detail-pane-sticky-width-followup.md` | Open issue, label `area: ui`+`enhancement` | One-PR polish |
+| `headless-claude-programmatic-runner.md` | **Triage first** — no frontmatter, no description visible; read body before deciding | May be a sketch rather than a plan |
+| `agent-event-log-recovery.md` | **Triage first** — no frontmatter; read body | Same |
+| `swift-dev-skills-task-list.md` | Open tracking issue, label `devEx` | Task list → tracking issue + children |
+
+### Active/in-flight (do not duplicate)
+
+| File | Action | Rationale |
+|---|---|---|
+| `sparkle-autoupdate-plan.md` | Confirm not already covered by closed #2 (`Add Sparkle auto-update`, closed 2026-05-09); if residual work remains, open follow-up issue; else move to `done/` | The umbrella issue closed two weeks ago; this file may now be archival |
+
+## Reconciliation table — open GH issues
+
+| Issue | Title | Action | Rationale |
+|---|---|---|---|
+| [#509](https://github.com/fairchild/workspaces/issues/509) | Prod regression on 69e1e79 | Triage now (urgent, just opened today) | Live CD-failure |
+| [#357](https://github.com/fairchild/workspaces/issues/357) | CD: lighthouse failures on main | Close as stale (auto-opened 2026-04-19, no movement) or reopen against current SHA | Auto-opened issues against a long-stale SHA usually want closing + re-running |
+| [#356](https://github.com/fairchild/workspaces/issues/356) | CD: playwright failures on main | Same — close-as-stale or rerun against current main | Has `needs-human` label, last touched 2026-05-14 |
+| [#472](https://github.com/fairchild/workspaces/issues/472) | Check agent label migration after scheduled agent runs | Verify against current label state; close if migration completed | `blocked` label suggests a dep that may have shipped |
+| [#231](https://github.com/fairchild/workspaces/issues/231) | chore(web): deploy chat and agent dispatch to production | Verify deployed; close if shipped | Milestone #7 |
+| [#230, #229, #228](https://github.com/fairchild/workspaces/issues/230) | qa(web): verify * | Run the verification or pull into the QA loop | These are claim-ready agent tasks |
+| [#227, #225, #224](https://github.com/fairchild/workspaces/issues/227) | feat(web): chat UI / dispatch / tab nav | Cross-check against `web/src/app/dashboard/`; close any already shipped | Several pre-March milestone-7 items may be stale |
+| [#226](https://github.com/fairchild/workspaces/issues/226) | feat(web): chat API route | `mergeable` label set — confirm a PR exists and merge | Already past `claimed`/`review` |
+| [#219](https://github.com/fairchild/workspaces/issues/219) | verify webhooks to spaces | Run verification or close | No labels, no milestone — needs triage |
+| [#196](https://github.com/fairchild/workspaces/issues/196) | PR review workshop preset | Decide: keep as enhancement or close | Older enhancement, no recent movement |
+| [#184](https://github.com/fairchild/workspaces/issues/184) | tracking: Web Dashboard Phase 2 dependency graph | Close (Phase 2 complete per `backlog/done/landing-page.md`) | Tracking issue for completed phase |
+| [#182, #181, #179, #174](https://github.com/fairchild/workspaces/issues/174) | Phase 4/5 web features | Keep in milestone #7; re-prioritize against current focus | Future-phase work |
+| [#159](https://github.com/fairchild/workspaces/issues/159) | Contributor runtime typed boundaries follow-up | Keep — clean enhancement, agent-claimable | `agent`+`task`+`enhancement`+`area: platform` |
+| [#107](https://github.com/fairchild/workspaces/issues/107) | Per-step snapshot timeout | Keep — `claimed` (active) | In flight |
+| [#7, #6, #5, #4, #3, #1](https://github.com/fairchild/workspaces/issues/1) | `future`-labeled MVP-deferred items | Leave as backlog floor; revisit at next milestone-set | These are the long-tail wishlist |
+
+## GitHub-backend migration plan
+
+When the `backlog` skill ships its `github-issues` backend, the cutover wants to look like this:
+
+1. **Don't double-write.** As soon as the backend exists in the skill, stop adding new `backlog/*.md` files for trackable work. New tracking goes straight to `gh issue create` with the lane + state labels.
+2. **Preserve plans, not tickets.** Keep `backlog/ROADMAP.md` (strategy) and large multi-issue planning docs (e.g. `vz-tahoe-execution-brief-plan.md`) as repo documents — they're the thing GH Issues *can't* hold well. Each plan links to its issues; each issue links back to the plan.
+3. **Migrate done/.** Once the reconciliation in this doc is complete, `backlog/done/` becomes archival. New `done` state lives in GH Issues (closed + the lifecycle labels).
+4. **Replace `backlog/AGENTS.md`.** When the new backend lands, AGENTS.md gets rewritten to point at `gh issue list --label …` recipes instead of the local-file schema. This is also the moment to drop `category:`/`status:` from any remaining frontmatter.
+5. **The `arc:` linkage from ROADMAP still works.** Both backends honor `arc: <name>` for grouping; in GH Issues it becomes a label (`arc:<name>`) or a milestone, depending on what the skill chooses.
+
+**Open questions before cutover** (don't need answers now; flag them for the skill author):
+
+- Does the GH backend treat **milestones** as arcs, or as a separate concept? Either is fine; consistency matters.
+- Does **claim** map to assigning the issue + setting the `claimed` label, or to one of those alone? The local agent automation already uses the label, so label-based claim is the lower-friction choice.
+- **Cross-worktree race avoidance** — the whole reason `maildir-shared` exists — comes free with GH Issues (server-side atomic). Worth confirming the backend uses HTTP PATCH-with-precondition rather than read-modify-write.
+- **Offline behavior** — what happens when an agent is air-gapped or rate-limited? Maildir doesn't have this problem.
+
+## Action sequence
+
+Sized for one grooming session per phase. Each phase ends in a commit.
+
+### Phase 1 — fix state drift (15 min)
+1. For #81, #82, #84 closed-issue files: decide residual scope, either `git mv` to `done/` or open a fresh issue capturing what's left.
+2. Read the two no-frontmatter files (`agent-event-log-recovery.md`, `headless-claude-programmatic-runner.md`) and either delete (if obsolete) or move into the open-an-issue queue.
+3. Commit: `chore(backlog): correct state drift against closed issues`.
+
+### Phase 2 — close GH-side noise (15 min)
+1. Triage the three auto-opened CD-failure issues (#357, #356, #509). Close the stale, leave the live, label `needs-human` if blocked.
+2. Close #184 (tracking issue for completed Phase 2).
+3. Verify #226 (`mergeable`) and #107 (`claimed`) are still actively owned; un-label or merge as appropriate.
+
+### Phase 3 — open issues for promotable local files (30–60 min)
+1. Walk the "promote to issue" rows of the reconciliation table top-to-bottom.
+2. For each: `gh issue create` with the proposed labels + a body that quotes the local file's frontmatter + description (or just links to the file at the SHA), then `git mv backlog/<file> backlog/done/` with a `linked_issue:` line in frontmatter.
+3. For multi-item files (`web-dashboard-phase3-followups.md`, `lume-runtime-architecture-followups_followup.md`, `terminal-architecture-followups.md`): open one tracking issue + child issues, link with `Tracked in #N` / `Part of #N`.
+4. Commit each chunk separately so the history shows the reconciliation as a series of small moves, not one massive sweep.
+
+### Phase 4 — ROADMAP refresh (30 min)
+1. Re-read `backlog/ROADMAP.md` against the now-true GH Issues queue.
+2. Update Current Focus to match the actively-claimed items.
+3. Add `arc:` labels in GH for each named arc in ROADMAP so the linkage works after cutover.
+
+### Phase 5 — cutover (when the GH backend ships)
+1. Replace `backlog/AGENTS.md` with the github-issues version (per skill docs).
+2. Delete or freeze `backlog/{todo,doing,done}/` (don't yet exist as such; effectively means delete `backlog/done/`).
+3. Keep `backlog/ROADMAP.md` and any surviving planning docs.
+4. Single commit: `chore(backlog): migrate to github-issues backend`.
+
+## Notes
+
+- This doc is itself a working artifact, not a permanent fixture. Once Phases 1–4 are done it can move to `backlog/done/GROOMING-2026-05-24.md` or just be deleted. Once Phase 5 is done it's definitely deleted.
+- Nothing in this doc has been *executed* yet — it's the plan, not the change. Each phase wants explicit confirmation before running.

--- a/backlog/GROOMING.md
+++ b/backlog/GROOMING.md
@@ -1,6 +1,14 @@
 # Backlog Grooming — 2026-05-24
 
-Reconciliation pass before we adopt GitHub Issues as the canonical backlog backend. The `backlog` skill ships only `maildir-git` and `maildir-shared` today; a `github-issues` backend is in flight. This doc lines up local `backlog/*.md` against `fairchild/workspaces` Issues so the cutover lands clean: no duplicates, no drift, no orphans.
+Reconciliation pass before we adopt GitHub Issues as the canonical backlog backend. The `backlog` skill's `github-issues` backend shipped in skill PR #178 (`~/.claude/skills/backlog/` HEAD `e5e632a`). This doc lines up local `backlog/*.md` against `fairchild/workspaces` Issues so the cutover lands clean: no duplicates, no drift, no orphans.
+
+## Progress
+
+- **Phase 1 — state drift** ✅ done in [PR #512](https://github.com/fairchild/workspaces/pull/512) (2026-05-25). Five files archived to `backlog/done/`; queue went from 25 → 20 active.
+- **Phase 2 — GH-side noise** ✅ done 2026-05-25 (actions logged in [Outcomes](#outcomes) below). Three issues closed (#357, #356, #184), `needs-human` added to live one (#509), two stale labels removed (#226 `mergeable`, #107 `claimed`).
+- **Phase 3 — promote local files to issues** pending.
+- **Phase 4 — ROADMAP refresh** pending.
+- **Phase 5 — cutover to `github-issues` backend** pending (now possible — backend shipped).
 
 ## Frame
 
@@ -157,7 +165,42 @@ Sized for one grooming session per phase. Each phase ends in a commit.
 3. Keep `backlog/ROADMAP.md` and any surviving planning docs.
 4. Single commit: `chore(backlog): migrate to github-issues backend`.
 
+## Outcomes
+
+### Phase 1 — 2026-05-25 ([PR #512](https://github.com/fairchild/workspaces/pull/512))
+
+Five files moved to `backlog/done/` with frontmatter updates:
+
+| File | Issue | Resolution |
+|---|---|---|
+| `ghostty-appearance-hardening_followup.md` | #84 | Closed 2026-03-13; frontmatter normalized |
+| `main-window-sidebar-maintainability_followup.md` | #81 | Closed 2026-03-13; `residual:` note for incremental ContentView/SidebarView/GhosttySurfaceView work |
+| `shared-desktop-focus-contention-followup.md` | #82 | Closed 2026-03-13; `residual:` note for self-deferred Phase 2 (capture handshake, separate user, VM-backed lane) |
+| `agent-event-log-recovery.md` | — | `resolution: deferred-design`; design notes preserved |
+| `headless-claude-programmatic-runner.md` | — | `resolution: deferred-design`; design notes preserved |
+
+### Phase 2 — 2026-05-25
+
+GitHub-side cleanup. Six issues actioned:
+
+| Issue | Action | Reason |
+|---|---|---|
+| [#357](https://github.com/fairchild/workspaces/issues/357) | Closed (`not planned`) | Stale lighthouse failure; SHA `04f5fc82` 5+ weeks superseded |
+| [#356](https://github.com/fairchild/workspaces/issues/356) | Closed (`not planned`) with cluster summary | Aggregated 3 distinct Playwright failure clusters (landing, api-authorization, docs); summary captured in close comment for future reference |
+| [#509](https://github.com/fairchild/workspaces/issues/509) | Added `needs-human` label | Live prod regression on `69e1e79` (current main); managed reviewer ingress canary HTTP 503; likely related to recent PRs #504/#506/#508. Owner decision: rollback vs roll forward |
+| [#184](https://github.com/fairchild/workspaces/issues/184) | Closed (`completed`) | Tracking issue for Phase 2 Web Dashboard; all linked deps #167–#178 closed |
+| [#226](https://github.com/fairchild/workspaces/issues/226) | Removed `mergeable` label, commented | PR #232 "Closes #226" was closed-not-merged on 2026-05-10. Issue left open for re-triage on whether GitHub Discussion bridge is still wanted |
+| [#107](https://github.com/fairchild/workspaces/issues/107) | Removed `claimed` label, commented | April's claim branch `codex/april-clearwater-issue-107-...` deleted on remote, no PR materialized — orphaned claim. Issue left open as `agent`+`enhancement` for fresh claim |
+
+Net effect on the open-issue queue: ~28 → ~25 open issues; the two truly live items (#509 prod, #107 fresh claim) are now properly tagged; the recurring noise generators (#356, #357) are gone.
+
+### Remaining
+
+- **Phase 3** — promote ~20 remaining local files to issues per the reconciliation table above. Two-triage-first files (`agent-event-log-recovery.md`, `headless-claude-programmatic-runner.md`) already resolved in Phase 1.
+- **Phase 4** — ROADMAP refresh against the post-grooming queue.
+- **Phase 5** — cutover to `github-issues` backend (now actually possible; backend doc: `~/.claude/skills/backlog/references/backends/github-issues.md`).
+
 ## Notes
 
 - This doc is itself a working artifact, not a permanent fixture. Once Phases 1–4 are done it can move to `backlog/done/GROOMING-2026-05-24.md` or just be deleted. Once Phase 5 is done it's definitely deleted.
-- Nothing in this doc has been *executed* yet — it's the plan, not the change. Each phase wants explicit confirmation before running.
+- The `github-issues` backend is simpler than originally speculated in this doc's earlier draft: only two labels (`doing`, `failed`), no `slug:`/`category:`/`arc:` labels, claim discrimination via branch+comment ordering. Every open GH issue is a backlog candidate — no marker label gating membership. Worth re-reading `github-issues.md` before Phase 5.

--- a/backlog/auto-opened-cd-failure-sweep_followup.md
+++ b/backlog/auto-opened-cd-failure-sweep_followup.md
@@ -1,0 +1,54 @@
+---
+status: pending
+category: followup
+topic: cd-automation
+priority: 2
+relates_to: backlog/GROOMING.md
+description: Sweep accumulating auto-opened CD-failure issues and add a stale-close policy so the auto-opener stops piling up dead tickets against long-stale SHAs.
+---
+
+# Sweep accumulating auto-opened CD-failure issues
+
+Surfaced in `backlog/GROOMING.md` (2026-05-24).
+
+## Problem
+
+The CD auto-opener creates GitHub issues per failed run, tagged `auto-opened`+`cd-failure`+`cd-failure:<kind>`, and dispatches an agent (April) to investigate. When the agent doesn't close the loop — or when the underlying SHA is superseded by later commits — the issue lingers indefinitely. Currently 3 open:
+
+- [#357](https://github.com/fairchild/workspaces/issues/357) — `cd-failure:lighthouse`, opened 2026-04-19 against commit `04f5fc82`, no movement since. April was dispatched once (attempt 1/2) and never returned. SHA is 5+ weeks stale.
+- [#356](https://github.com/fairchild/workspaces/issues/356) — `cd-failure:playwright`, opened 2026-04-19, last touched 2026-05-14, carries `needs-human`. SHA also 5+ weeks stale.
+- [#509](https://github.com/fairchild/workspaces/issues/509) — `cd-failure:prod`+`urgent`, opened 2026-05-25 (today) against commit `69e1e79`. Live; needs triage now.
+
+The pattern: each commit-pinned failure spawns its own issue with no dedup, no stale-close, no rerun-against-current-SHA flow. The queue grows monotonically.
+
+## Sweep (immediate)
+
+1. **#509** — triage. If reproducible on current `main`, leave open with `needs-human`; otherwise rerun CD and close on green.
+2. **#357** — close as `wontfix` with a comment noting SHA staleness; rerun lighthouse against current `main` separately, and if it still fails, let the auto-opener file a fresh issue.
+3. **#356** — same close-as-stale path; the `needs-human` label suggests a real signal was found but not actioned, so capture any hypothesis from the issue comments in a new ticket before closing if there's anything load-bearing.
+
+## Policy (durable fix)
+
+Decide and implement one of:
+
+- **Stale-close action** — a scheduled GH Action that closes `auto-opened`+`cd-failure` issues with no comment activity for 14 days, leaving a comment that says "closed as stale; rerun CD will reopen if still broken". Lowest mechanism, prevents accumulation.
+- **Auto-rerun before re-filing** — modify the auto-opener to first search for an existing open issue with the same `cd-failure:<kind>` label; if one exists, comment on it with the new SHA + run URL instead of opening a fresh issue. Higher fidelity, more code.
+- **Both** — stale-close handles abandonment; dedup handles same-kind re-occurrence.
+
+Recommendation: start with stale-close (single workflow file, low risk), add dedup only if accumulation continues after stale-close lands.
+
+## Acceptance
+
+- The three current issues are resolved (closed or actioned).
+- A stale-close workflow exists for `label:auto-opened label:cd-failure` issues with N-day inactivity threshold (proposed: 14 days, configurable).
+- Workflow has run once successfully against the queue.
+- AGENTS.md or CI docs mention the policy so future auto-opener tweaks don't fight it.
+
+## Dependencies
+
+None blocking. Worth doing before the GitHub-issues backend cutover (Phase 5 of grooming) so the queue is clean at handover.
+
+## Notes
+
+- The auto-opener itself likely lives in a `.github/workflows/*.yml` and a Python or TS script under `scripts/` or `web/`. Find it first; it'll inform the dedup option's feasibility.
+- The April-dispatch comment pattern suggests the agent was supposed to close the loop. If April is the right place to add "close as stale if rerun is green" logic, that's a third option.


### PR DESCRIPTION
## Summary

- `backlog/GROOMING.md` — reconciliation report lining up local `backlog/*.md` against open issues in `fairchild/workspaces`. Inventories both sides, flags 3 state-drift cases (local "pending" files referencing closed issues #81/#82/#84), proposes per-file actions (open issue / link / archive / triage), and sketches a 5-phase sequence toward the `backlog` skill's new `github-issues` backend (shipped in skill PR #178).
- `backlog/auto-opened-cd-failure-sweep_followup.md` — focused followup for the immediate CD-failure issue accumulation (#357 from April, #356 from April, #509 today) plus a durable stale-close policy proposal.

Both files are planning artifacts under `backlog/`. No code changes, no behavior changes, no public API touched.

## Mergeability

- Surface: docs
- User-facing behavior changed: no
- Non-happy paths considered: n/a — pure planning documents
- Release/ops preconditions: none
- Residual risk or follow-up: the grooming report itself is a working artifact and may move to `backlog/done/` once Phases 1–4 are complete; the CD-failure followup will be executed and closed in a separate change

## Validation

- [x] Not a testable change (docs-only)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None