### PR TITLE
chore(backlog): correct state drift against closed issues (GROOMING phase 1)

### DIFF
--- a/backlog/done/agent-event-log-recovery.md
+++ b/backlog/done/agent-event-log-recovery.md
@@ -1,3 +1,12 @@
+---
+status: done
+category: plan
+resolution: deferred-design
+topic: agent-runtime
+priority: 3
+description: Design notes for a host-owned AgentEvent log used for cold-start state recovery. Deferred — the architecture intentionally keeps transcripts as transcript data only. Revisit if cold-start recovery becomes necessary.
+---
+
 # Agent Event Log Recovery
 
 Status: Deferred

--- a/backlog/done/ghostty-appearance-hardening_followup.md
+++ b/backlog/done/ghostty-appearance-hardening_followup.md
@@ -1,7 +1,8 @@
 ---
-status: completed
+status: done
 category: followup
 issue: 84
+issue_closed: 2026-03-13
 milestone: 1
 completed_prs: [379, 383]
 ---

--- a/backlog/done/headless-claude-programmatic-runner.md
+++ b/backlog/done/headless-claude-programmatic-runner.md
@@ -1,3 +1,12 @@
+---
+status: done
+category: plan
+resolution: deferred-design
+topic: agent-runtime
+priority: 3
+description: Design notes for a host-owned `claude -p` runner (workspace warm-up, scheduled tasks, sidebar quick actions). Removed from the shipped integration; preserved here as a design doc. Revisit when there's a concrete UI/automation surface, a clear permission model, and a product decision on headless-vs-interactive history.
+---
+
 # Headless Claude Programmatic Runner
 
 Status: Deferred

--- a/backlog/done/main-window-sidebar-maintainability_followup.md
+++ b/backlog/done/main-window-sidebar-maintainability_followup.md
@@ -1,11 +1,13 @@
 ---
-status: in-progress
+status: done
 category: followup
 issue: 81
+issue_closed: 2026-03-13
 milestone: 1
 completed_prs: [36, 387, 394]
 branch: codex/apple-native-main-window-redesign-backlog
 retro_summary: Main-window state, navigation transitions, launch-surface resolution, and remote-workspace selection now have dedicated controller seams; sidebar sorting also moved into a small pure controller. Ghostty runtime callback config and callback userdata/main-thread bridging now have focused seams. Remaining work is incremental integration-file shrinkage, especially ContentView/SidebarView hotspots and the GhosttySurfaceView AppKit lifecycle boundary.
+residual: ContentView/SidebarView orchestration extraction and GhosttySurfaceView AppKit lifecycle boundary remain available as incremental quality work. No deadline; promote to a fresh issue if a concrete regression or refactor lands that benefits from it.
 ---
 
 # Main Window + Sidebar Maintainability Pass

--- a/backlog/done/shared-desktop-focus-contention-followup.md
+++ b/backlog/done/shared-desktop-focus-contention-followup.md
@@ -1,8 +1,12 @@
 ---
-status: phase-1-complete
+status: done
 category: followup
 issue: 82
+issue_closed: 2026-03-13
 milestone: 1
+completed_prs: [374]
+retro_summary: Phase 1 shipped — `AppActivationPolicy` (PR #374) and `scripts/capture-window.sh` give the agent-driven launch/capture loop a no-foreground-activation path on shared desktops.
+residual: Phase 2 items (capture handshake protocol, separate macOS user account, VM-backed CI execution lane) remain deferred at P2 per the file body. Promote when a concrete daily-driver scenario forces the issue.
 ---
 
 # Shared Desktop Focus Contention Hardening


### PR DESCRIPTION
## Summary

Phase 1 of [`backlog/GROOMING.md`](https://github.com/fairchild/workspaces/pull/511) — archive five local `backlog/*.md` files that were drifting from their actual state.

- Three files referenced GitHub issues already closed in March (#81, #82, #84) but lived in the active "pending" pile.
- Two files (`agent-event-log-recovery.md`, `headless-claude-programmatic-runner.md`) had no frontmatter and bodies marked "Status: Deferred" — design docs intentionally preserved but not active work.

All five move to `backlog/done/` with one-line frontmatter additions to reflect actual state (`status: done`, `issue_closed:` for the GH-referenced ones, `resolution: deferred-design` for the two deferred design docs, and `residual:` notes where genuine future work remains uncommitted to a deadline).

No fresh GH issues were opened — residual scope in the two larger followups (#81, #82) is incremental quality work that can be promoted later if a concrete driver lands.

## Mergeability

- Surface: docs
- User-facing behavior changed: no
- Non-happy paths considered: n/a — file moves + frontmatter only
- Release/ops preconditions: none
- Residual risk or follow-up: residual scope captured in frontmatter; no immediate action required

## Validation

- [x] Not a testable change (docs-only)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None