### PR TITLE
Fix Claude hook command paths with spaces

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -184,7 +184,7 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         var hooks = (current["hooks"]?.value as? [String: Any]) ?? [:]
 
         if let eventForwarderScriptPath {
-            let eventForwarderCommand = Self.shellEscapedCommand(eventForwarderScriptPath)
+            let eventForwarder = CommandContribution(rawPath: eventForwarderScriptPath)
             var addedEvents: [String] = []
             var normalizedEvents: [String] = []
             var scrubbedLegacyEvents: [String] = []
@@ -201,65 +201,36 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 }
 
                 var groups = normalizedClaudeHookGroups(from: hooks[name])
-                let beforeLegacyCount = countHandlers(in: groups, where: isWorkspacesLegacyHTTPUnixHook)
-                let beforeTitleCount = countHandlers(in: groups, where: isWorkspacesTitleEmitHook)
-                let beforeUnescapedForwarderCount = countHandlers(in: groups) { handler in
-                    isWorkspacesUnescapedEventForwarderHook(
-                        handler,
-                        rawPath: eventForwarderScriptPath,
-                        escapedCommand: eventForwarderCommand
-                    )
+                let legacyHTTPResult = scrubHandlers(in: groups, where: isWorkspacesLegacyHTTPUnixHook)
+                groups = legacyHTTPResult.groups
+                if legacyHTTPResult.removedCount > 0 { scrubbedLegacyEvents.append(name) }
+
+                let titleEmitResult = scrubHandlers(in: groups, where: isWorkspacesTitleEmitHook)
+                groups = titleEmitResult.groups
+                if titleEmitResult.removedCount > 0 { scrubbedTitleEvents.append(name) }
+
+                let unescapedForwarderResult = scrubHandlers(in: groups) { handler in
+                    isUnescapedWorkspacesCommandHook(handler, contribution: eventForwarder)
                 }
-                groups = scrubHandlers(in: groups) { handler in
-                    isWorkspacesLegacyHTTPUnixHook(handler) || isWorkspacesTitleEmitHook(handler)
-                        || isWorkspacesUnescapedEventForwarderHook(
-                            handler,
-                            rawPath: eventForwarderScriptPath,
-                            escapedCommand: eventForwarderCommand
-                        )
-                }
-                if countHandlers(in: groups, where: isWorkspacesLegacyHTTPUnixHook) < beforeLegacyCount {
-                    scrubbedLegacyEvents.append(name)
-                }
-                if countHandlers(in: groups, where: isWorkspacesTitleEmitHook) < beforeTitleCount {
-                    scrubbedTitleEvents.append(name)
-                }
-                let afterUnescapedForwarderCount = countHandlers(in: groups) { handler in
-                    isWorkspacesUnescapedEventForwarderHook(
-                        handler,
-                        rawPath: eventForwarderScriptPath,
-                        escapedCommand: eventForwarderCommand
-                    )
-                }
-                if afterUnescapedForwarderCount < beforeUnescapedForwarderCount {
+                groups = unescapedForwarderResult.groups
+                if unescapedForwarderResult.removedCount > 0 {
                     scrubbedUnescapedForwarderEvents.append(name)
                 }
 
                 let eventForwarderPresent = groups.contains { group in
                     claudeGroupContainsHandler(group) { handler in
-                        (handler["type"] as? String) == "command"
-                            && (handler["command"] as? String) == eventForwarderCommand
+                        isCanonicalWorkspacesCommandHook(handler, contribution: eventForwarder)
                     }
                 }
 
                 if !eventForwarderPresent {
-                    let integrationGroupIndex =
-                        groups.firstIndex { group in
-                            claudeGroupContainsHandler(group) { handler in
-                                (handler["type"] as? String) == "command"
-                                    && (handler["command"] as? String) == eventForwarderCommand
-                            }
-                        }
-                        ?? {
-                            groups.append(["hooks": [[String: Any]]()])
-                            return groups.index(before: groups.endIndex)
-                        }()
-
+                    groups.append(["hooks": [[String: Any]]()])
+                    let integrationGroupIndex = groups.index(before: groups.endIndex)
                     var integrationGroup = groups[integrationGroupIndex]
                     var integrationHandlers = claudeHookHandlers(in: integrationGroup)
                     integrationHandlers.append([
                         "type": "command",
-                        "command": eventForwarderCommand,
+                        "command": eventForwarder.command,
                         "async": true,
                     ])
                     integrationGroup["hooks"] = integrationHandlers
@@ -292,13 +263,13 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
             }
             if !addedEvents.isEmpty {
                 lines.append(
-                    "add command hook for \(addedEvents.count) events using \(eventForwarderCommand)"
+                    "add command hook for \(addedEvents.count) events using \(eventForwarder.command)"
                 )
             }
         }
 
         if let statusLineForwarderPath {
-            let statusLineCommand = Self.shellEscapedCommand(statusLineForwarderPath)
+            let statusLineCommand = CommandContribution(rawPath: statusLineForwarderPath).command
             var block = (current["statusLine"]?.value as? [String: Any]) ?? [:]
             let oldCommand = block["command"] as? String
             let oldInterval = block["refreshInterval"] as? Int
@@ -390,14 +361,18 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
     private func scrubHandlers(
         in groups: [[String: Any]],
         where shouldRemove: ([String: Any]) -> Bool
-    ) -> [[String: Any]] {
-        groups.compactMap { group in
+    ) -> (groups: [[String: Any]], removedCount: Int) {
+        var removedCount = 0
+        let scrubbedGroups = groups.compactMap { group -> [String: Any]? in
             var next = group
-            let kept = claudeHookHandlers(in: next).filter { !shouldRemove($0) }
+            let handlers = claudeHookHandlers(in: next)
+            let kept = handlers.filter { !shouldRemove($0) }
+            removedCount += handlers.count - kept.count
             if kept.isEmpty { return nil }
             next["hooks"] = kept
             return next
         }
+        return (scrubbedGroups, removedCount)
     }
 
     private func isWorkspacesLegacyHTTPUnixHook(_ handler: [String: Any]) -> Bool {
@@ -419,15 +394,33 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
             && command.contains("/Application Support/")
     }
 
-    private func isWorkspacesUnescapedEventForwarderHook(
+    private func isCanonicalWorkspacesCommandHook(
         _ handler: [String: Any],
-        rawPath: String,
-        escapedCommand: String
+        contribution: CommandContribution
     ) -> Bool {
-        guard escapedCommand != rawPath else { return false }
         guard (handler["type"] as? String) == "command" else { return false }
         guard let command = handler["command"] as? String else { return false }
-        return command == rawPath
+        return command == contribution.command
+    }
+
+    private func isUnescapedWorkspacesCommandHook(
+        _ handler: [String: Any],
+        contribution: CommandContribution
+    ) -> Bool {
+        guard contribution.command != contribution.rawPath else { return false }
+        guard (handler["type"] as? String) == "command" else { return false }
+        guard let command = handler["command"] as? String else { return false }
+        return command == contribution.rawPath
+    }
+
+    private struct CommandContribution {
+        let rawPath: String
+        let command: String
+
+        init(rawPath: String) {
+            self.rawPath = rawPath
+            command = ClaudeSettingsInstaller.shellEscapedCommand(rawPath)
+        }
     }
 
     private static func shellEscapedCommand(_ raw: String) -> String {

--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -184,10 +184,12 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         var hooks = (current["hooks"]?.value as? [String: Any]) ?? [:]
 
         if let eventForwarderScriptPath {
+            let eventForwarderCommand = Self.shellEscapedCommand(eventForwarderScriptPath)
             var addedEvents: [String] = []
             var normalizedEvents: [String] = []
             var scrubbedLegacyEvents: [String] = []
             var scrubbedTitleEvents: [String] = []
+            var scrubbedUnescapedForwarderEvents: [String] = []
 
             for name in Self.hookEventNames {
                 let rawEntries = (hooks[name] as? [Any]) ?? []
@@ -201,8 +203,20 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 var groups = normalizedClaudeHookGroups(from: hooks[name])
                 let beforeLegacyCount = countHandlers(in: groups, where: isWorkspacesLegacyHTTPUnixHook)
                 let beforeTitleCount = countHandlers(in: groups, where: isWorkspacesTitleEmitHook)
+                let beforeUnescapedForwarderCount = countHandlers(in: groups) { handler in
+                    isWorkspacesUnescapedEventForwarderHook(
+                        handler,
+                        rawPath: eventForwarderScriptPath,
+                        escapedCommand: eventForwarderCommand
+                    )
+                }
                 groups = scrubHandlers(in: groups) { handler in
                     isWorkspacesLegacyHTTPUnixHook(handler) || isWorkspacesTitleEmitHook(handler)
+                        || isWorkspacesUnescapedEventForwarderHook(
+                            handler,
+                            rawPath: eventForwarderScriptPath,
+                            escapedCommand: eventForwarderCommand
+                        )
                 }
                 if countHandlers(in: groups, where: isWorkspacesLegacyHTTPUnixHook) < beforeLegacyCount {
                     scrubbedLegacyEvents.append(name)
@@ -210,11 +224,21 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 if countHandlers(in: groups, where: isWorkspacesTitleEmitHook) < beforeTitleCount {
                     scrubbedTitleEvents.append(name)
                 }
+                let afterUnescapedForwarderCount = countHandlers(in: groups) { handler in
+                    isWorkspacesUnescapedEventForwarderHook(
+                        handler,
+                        rawPath: eventForwarderScriptPath,
+                        escapedCommand: eventForwarderCommand
+                    )
+                }
+                if afterUnescapedForwarderCount < beforeUnescapedForwarderCount {
+                    scrubbedUnescapedForwarderEvents.append(name)
+                }
 
                 let eventForwarderPresent = groups.contains { group in
                     claudeGroupContainsHandler(group) { handler in
                         (handler["type"] as? String) == "command"
-                            && (handler["command"] as? String) == eventForwarderScriptPath
+                            && (handler["command"] as? String) == eventForwarderCommand
                     }
                 }
 
@@ -223,7 +247,7 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                         groups.firstIndex { group in
                             claudeGroupContainsHandler(group) { handler in
                                 (handler["type"] as? String) == "command"
-                                    && (handler["command"] as? String) == eventForwarderScriptPath
+                                    && (handler["command"] as? String) == eventForwarderCommand
                             }
                         }
                         ?? {
@@ -235,7 +259,7 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                     var integrationHandlers = claudeHookHandlers(in: integrationGroup)
                     integrationHandlers.append([
                         "type": "command",
-                        "command": eventForwarderScriptPath,
+                        "command": eventForwarderCommand,
                         "async": true,
                     ])
                     integrationGroup["hooks"] = integrationHandlers
@@ -256,6 +280,11 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                     "remove deprecated title-emit hooks from \(scrubbedTitleEvents.count) events"
                 )
             }
+            if !scrubbedUnescapedForwarderEvents.isEmpty {
+                lines.append(
+                    "replace unescaped WorkSpaces event-forwarder command in \(scrubbedUnescapedForwarderEvents.count) events"
+                )
+            }
             if !normalizedEvents.isEmpty {
                 lines.append(
                     "normalize legacy hook group shape for \(normalizedEvents.joined(separator: ", "))"
@@ -263,22 +292,23 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
             }
             if !addedEvents.isEmpty {
                 lines.append(
-                    "add command hook for \(addedEvents.count) events using \(eventForwarderScriptPath)"
+                    "add command hook for \(addedEvents.count) events using \(eventForwarderCommand)"
                 )
             }
         }
 
         if let statusLineForwarderPath {
+            let statusLineCommand = Self.shellEscapedCommand(statusLineForwarderPath)
             var block = (current["statusLine"]?.value as? [String: Any]) ?? [:]
             let oldCommand = block["command"] as? String
             let oldInterval = block["refreshInterval"] as? Int
             block["type"] = "command"
-            block["command"] = statusLineForwarderPath
+            block["command"] = statusLineCommand
             block["refreshInterval"] = statusLineRefreshInterval
             dict["statusLine"] = AnyCodable(block)
-            if oldCommand != statusLineForwarderPath || oldInterval != statusLineRefreshInterval {
+            if oldCommand != statusLineCommand || oldInterval != statusLineRefreshInterval {
                 lines.append(
-                    "set statusLine command to \(statusLineForwarderPath) every \(statusLineRefreshInterval)ms"
+                    "set statusLine command to \(statusLineCommand) every \(statusLineRefreshInterval)ms"
                 )
             }
         }
@@ -387,6 +417,27 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         guard let command = handler["command"] as? String else { return false }
         return command.hasSuffix("/HookForwarders/title-emit.sh")
             && command.contains("/Application Support/")
+    }
+
+    private func isWorkspacesUnescapedEventForwarderHook(
+        _ handler: [String: Any],
+        rawPath: String,
+        escapedCommand: String
+    ) -> Bool {
+        guard escapedCommand != rawPath else { return false }
+        guard (handler["type"] as? String) == "command" else { return false }
+        guard let command = handler["command"] as? String else { return false }
+        return command == rawPath
+    }
+
+    private static func shellEscapedCommand(_ raw: String) -> String {
+        let safeScalars = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_@%+=:,./-"
+        )
+        if raw.unicodeScalars.allSatisfy({ safeScalars.contains($0) }) {
+            return raw
+        }
+        return "'" + raw.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     // MARK: - Filesystem helpers

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
@@ -250,8 +250,8 @@ struct ClaudeSettingsInstallerTests {
         let spacedEventForwarder =
             "/Users/test/Library/Application Support/com.cloudcompute.workspaces/HookForwarders/event-forwarder.sh"
         let escapedEventForwarder = "'\(spacedEventForwarder)'"
-        let spacedStatusline = "/tmp/Status Line/statusline.sh"
-        let escapedStatusline = "'\(spacedStatusline)'"
+        let spacedStatusline = "/tmp/Status Line/O'Brien/statusline.sh"
+        let escapedStatusline = "'/tmp/Status Line/O'\\''Brien/statusline.sh'"
         let userHook = "/Users/test/Library/Application Support/user-hook.sh"
         let existing: [String: Any] = [
             "hooks": [

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
@@ -239,6 +239,55 @@ struct ClaudeSettingsInstallerTests {
         #expect(handlers.contains { ($0["command"] as? String) == eventForwarder })
     }
 
+    @Test("Install shell-escapes WorkSpaces commands with spaces")
+    func shellEscapesCommandsWithSpaces() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let settingsURL = claudeDir.appendingPathComponent("settings.json")
+        let spacedEventForwarder =
+            "/Users/test/Library/Application Support/com.cloudcompute.workspaces/HookForwarders/event-forwarder.sh"
+        let escapedEventForwarder = "'\(spacedEventForwarder)'"
+        let spacedStatusline = "/tmp/Status Line/statusline.sh"
+        let escapedStatusline = "'\(spacedStatusline)'"
+        let userHook = "/Users/test/Library/Application Support/user-hook.sh"
+        let existing: [String: Any] = [
+            "hooks": [
+                "Notification": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": spacedEventForwarder, "async": true],
+                            ["type": "command", "command": userHook, "async": true],
+                        ]
+                    ]
+                ]
+            ],
+            "statusLine": ["type": "command", "command": spacedStatusline],
+        ]
+        try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted])
+            .write(to: settingsURL)
+
+        let installer = ClaudeSettingsInstaller(
+            homeDirectory: home,
+            eventForwarderScriptPath: spacedEventForwarder,
+            statusLineForwarderPath: spacedStatusline
+        )
+        try await installer.install()
+
+        let updated = try readJSON(settingsURL)
+        let handlers = hookGroups(named: "Notification", in: updated)
+            .flatMap { hookHandlers(in: $0) }
+        #expect(handlers.contains { ($0["command"] as? String) == spacedEventForwarder } == false)
+        #expect(handlers.contains { ($0["command"] as? String) == escapedEventForwarder })
+        #expect(handlers.contains { ($0["command"] as? String) == userHook })
+
+        let block = updated["statusLine"] as? [String: Any] ?? [:]
+        #expect(block["command"] as? String == escapedStatusline)
+        #expect(await installer.isInstalled())
+    }
+
     @Test("renderPreview describes pending concrete changes")
     func renderPreviewDescribesChanges() async throws {
         let home = makeTempHome()


### PR DESCRIPTION
## Summary

- Shell-escape Claude Code hook/statusline command paths before writing `~/.claude/settings.json`.
- Replace old unescaped WorkSpaces-owned `event-forwarder.sh` entries when the canonical path requires quoting.
- Add installer coverage for command paths containing spaces while preserving user-owned hooks.

## Mergeability

- Surface: desktop
- User-facing behavior changed: opted-in Claude Code integration now repairs the event-forwarder command to a shell-safe quoted path, so real Claude command hooks run when the path contains `Application Support`.
- Non-happy paths considered: existing user hooks with spaces are preserved; old unescaped WorkSpaces-owned forwarder entries are replaced; idempotent install still avoids duplicate hooks/backups.
- Release/ops preconditions: none beyond normal CI/review; real smoke used a safe temp-file delete in the debug app.
- Residual risk or follow-up: managed review is still pending; local unit tests, full suite, and real embedded-Claude smoke are green.

## Validation

- [x] `swift build` — covered by `swift test` build and debug app relaunch from the rebuilt binary
- [x] `swift test`
- [x] Other checks run:
  - `swift-format lint --strict Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift`
  - `swift test --filter ClaudeSettingsInstaller`
  - `./scripts/launch-dev.sh --no-build`
  - Real embedded Claude smoke verified `origin=hook` rows for `session_start`, `user_prompt`, `tool_start`, `awaiting_input(permissionPrompt)`, `tool_end`, and `stopped` after settings repair wrote the quoted event-forwarder path.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![claude-channel1-quoted-hook-real-session](https://evidence.cloudcompute.com/workspaces/pr-513/20260525-165100-claude-channel1-quoted-hook-real-session.png)
- ![claude-channel1-permission-hook-events](https://evidence.cloudcompute.com/workspaces/pr-513/20260525-165100-claude-channel1-permission-hook-events.png)
- ![claude-channel1-event-store-proof](https://evidence.cloudcompute.com/workspaces/pr-513/20260525-165100-claude-channel1-event-store-proof.png)
- ![claude-channel1-quote-fix-verification](https://evidence.cloudcompute.com/workspaces/pr-513/20260525-165100-claude-channel1-quote-fix-verification.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
