### PR TITLE
chore(backlog): adopt triage-labels.md vocabulary for github-issues backend

### DIFF
--- a/backlog/AGENTS.md
+++ b/backlog/AGENTS.md
@@ -49,6 +49,26 @@ These conventions are operable directly via `gh issue` — open an issue, add th
 
 Tasks are referenced by issue number — `take 42` or `take #42`. Titles are free text.
 
+The label vocabulary above (`claimed` / `review` / `mergeable`) is shared with `docs/agents/triage-labels.md`; this file is the protocol-level view, that file is the canonical reference for what each label means in this repo.
+
+## Co-existence with other automation
+
+The skill is not the sole writer of these labels. Two existing systems also drive transitions on `agent` + `task` issues:
+
+- **`.agents/skills/cofounder-contributor/scripts/sync-execution-state.py`** — owns `agent` + `task` lifecycle. Promotes approved, unblocked issues to `ready`, then to `claimed` on contributor claim, then to `review` when a PR opens. Expires stale claims after 24h.
+- **Managed PR reviewer** (`web/src/lib/agent-runtime/pr-review.ts`) — adds `mergeable` when an agent approves the linked PR; removes it on changes-requested.
+
+Where the skill participates:
+
+- **At claim (`take` / `advance` to `claimed`)** — skill writes the `claimed` label and posts the worklog comment with `branch=` for race resolution. Safe on `agent` + `task` issues because `sync-execution-state.py` does the same thing; the worklog comment is the source of truth either way.
+- **Mid-pipeline (`claimed → review → mergeable`)** — let the external automation drive these transitions. The skill *can* `advance` here, but doing so on `agent` + `task` issues races with sync. For non-`agent`+`task` issues (personal work, scratch threads, things outside the pipeline) the skill drives the whole sequence itself.
+- **At completion (`advance` from `mergeable` → `done`)** — skill closes the issue once merge has landed. Safe regardless of who set `mergeable`.
+- **`cancel` / `fail` / `rescue` / `retry`** — terminal verbs; safe at any point.
+
+This works because `current_claim` (skill internal) resolves ownership by walking branch-tagged worklog comments, not by reading the current label. External writers moving the label forward don't break the skill's view of who claimed the issue.
+
+If you're claiming an `agent` + `task` issue and want to avoid double-writes, prefer the existing automation paths (Peter's planning → owner approval → `sync-execution-state.py`). Reach for `backlog take` on issues outside that pipeline, or when you want race-safe claim semantics for a manual pickup.
+
 ## Backend
 
 `github-issues` — see the `backlog` skill's `references/backends/github-issues.md` for the script's behavior.

--- a/backlog/AGENTS.md
+++ b/backlog/AGENTS.md
@@ -1,61 +1,38 @@
 # backlog/
 
-Deferred work items for future sessions. Each file represents work identified as valuable but out of scope for the current PR.
+`CLAUDE.md` here is a symlink to this file — read one, not both.
 
-## Frontmatter Schema
+Task state lives in GitHub Issues on **fairchild/workspaces**. The repo's open issues
+*are* the backlog — there is no separation between "backlog tasks" and
+"other issues." Anything open is takeable.
 
-Every backlog work-item file (all markdown files except `AGENTS.md`) should start with YAML frontmatter.
+Use the `backlog` skill (add / take / advance / progress / cancel / fail /
+rescue / retry / maintain / status) to interact. Tasks are referenced by
+issue number (`take 42` or `take #42`). Verbs dispatch to `gh issue`
+under the hood.
 
-Use only fields that currently have real values. Do not add placeholder `null` fields. Add a field when you have a value for it.
+## Backend
 
-```yaml
----
-status: pending          # pending | in-progress | completed
-category: plan           # plan | followup | task-list | ideas
----
-```
+`github-issues` — see the `backlog` skill's `references/backends/github-issues.md`.
 
-Optional fields, only when populated:
+State mapping:
 
-```yaml
-issue: 81                # GitHub issue number created from this doc
-milestone: 1             # GitHub milestone number when this doc is promoted
-discussion: 52           # GitHub discussion number, if planned from one
-pr: 71                   # PR number that implements this
-branch: codex/example    # branch name that implements this
-score: 4                 # 0-5 effectiveness/efficiency rating
-retro_summary: Shipped with smaller controller seams and no behavior regressions.
-completed: 2026-03-12    # YYYY-MM-DD
-```
+| State    | open/closed | labels                  |
+|----------|-------------|-------------------------|
+| todo     | open        | no `doing`            |
+| doing    | open        | `doing`               |
+| done     | closed      | no `failed`           |
+| failed   | closed      | `failed`              |
 
-## Categories
+`cancel` and ordinary `done` both close the issue — discriminated by the
+worklog comment and GitHub's close reason. Title is free text; the spec body
+carries `priority`/`timeout`/`dependencies` as YAML frontmatter, same shape
+as the maildir backends.
 
-### plan
-Comprehensive design documents for new features.
+## Pipeline
 
-### followup
-Post-merge improvements and tech debt.
+`todo → doing → done` (intermediate stages aren't supported in v1).
 
-### task-list
-Collections of related items discovered during other work.
+## ROADMAP
 
-### ideas
-Ideas to explore, not yet developed into actionable plans.
-
-## Naming Convention
-
-`{feature}-{category}.md`
-
-## Lifecycle
-
-1. **pending** - Created, waiting to be picked up
-2. **in-progress** - Actively being worked or partially landed
-3. **completed** - Move file to `backlog/done/`
-
-## GitHub Linking
-
-- When a backlog doc is promoted into execution, add `issue` and `milestone` only when those values exist.
-- If a doc came from a GitHub Discussion, add `discussion` only when that value exists.
-- Issue bodies should link back to the source backlog doc.
-- Milestone descriptions should link to both the roadmap and the backlog source docs.
-- If one backlog doc seeds multiple issues, keep the doc as the source of truth and add a short `## GitHub` section in the body listing the related issue numbers.
+Strategic counterpart at `backlog/ROADMAP.md`. See the `backlog` skill's `references/roadmap.md`.

--- a/backlog/AGENTS.md
+++ b/backlog/AGENTS.md
@@ -2,36 +2,71 @@
 
 `CLAUDE.md` here is a symlink to this file — read one, not both.
 
-Task state lives in GitHub Issues on **fairchild/workspaces**. The repo's open issues
-*are* the backlog — there is no separation between "backlog tasks" and
-"other issues." Anything open is takeable.
+Task state lives in GitHub Issues on **fairchild/workspaces**. The repo's open issues are
+the backlog — anything open is takeable. Non-conformant issues (random
+feature requests, dormant bug reports) get triaged when a worker encounters
+them; there's no marker label gating membership.
 
-Use the `backlog` skill (add / take / advance / progress / cancel / fail /
-rescue / retry / maintain / status) to interact. Tasks are referenced by
-issue number (`take 42` or `take #42`). Verbs dispatch to `gh issue`
-under the hood.
+## State mapping
+
+| State    | open/closed | labels                   |
+|----------|-------------|--------------------------|
+| todo     | open        | no in-flight labels      |
+| claimed     | open        | `claimed` label     |
+| review     | open        | `review` label     |
+| mergeable     | open        | `mergeable` label     |
+| done     | closed      | no `dead-letter` label       |
+| failed   | closed      | `dead-letter` label          |
+
+## Worklog
+
+Every state transition and progress note is one comment on the issue, in this shape:
+
+    - <ISO-8601 ts> <verb> [args] | <trail>
+
+| Verb                       | Args / trail                                                |
+|----------------------------|-------------------------------------------------------------|
+| `advanced to=<state>`    | for `<first-in-flight>`: `claimer=<who>` `branch=<git-branch>`; for `done`: optional `\| PR=<url>`; intermediate transitions: no extra args |
+| `progress`               | trail = `\| <note>`                                        |
+| `cancelled`              | trail = `\| <reason>`                                      |
+| `failed`                 | trail = `\| <reason>`                                      |
+| `rescued`                | `claimer=<who>` `branch=<git-branch>`                   |
+| `retried`                | trail = `\| <reason>`                                      |
+
+## Claim resolution
+
+The **branch** is the claim identity (agents often share a GitHub account, so assignee isn't reliable). Walking comments chronologically:
+
+- `retried` resets the contest (no current winner)
+- `advanced to=claimed` sets the winner only if currently empty (first-wins, catches take-time races)
+- `rescued` overrides the current winner (deliberate takeover after timeout)
+
+The earliest `advanced to=claimed` since the most recent `retried`, optionally overridden by a later `rescued`, is the canonical claimer.
+
+## Operating
+
+These conventions are operable directly via `gh issue` — open an issue, add the `claimed` label, post the right comment. The `backlog` skill (`add / take / advance / progress / cancel / fail / rescue / retry / maintain / status`) is a convenience layer that automates the patterns (auto-pick by priority, race-resolution at claim time, status counts) but isn't required for any of them. Mix both: skill for batch operations, raw `gh` for one-offs.
+
+Tasks are referenced by issue number — `take 42` or `take #42`. Titles are free text.
 
 ## Backend
 
-`github-issues` — see the `backlog` skill's `references/backends/github-issues.md`.
-
-State mapping:
-
-| State    | open/closed | labels                  |
-|----------|-------------|-------------------------|
-| todo     | open        | no `doing`            |
-| doing    | open        | `doing`               |
-| done     | closed      | no `failed`           |
-| failed   | closed      | `failed`              |
-
-`cancel` and ordinary `done` both close the issue — discriminated by the
-worklog comment and GitHub's close reason. Title is free text; the spec body
-carries `priority`/`timeout`/`dependencies` as YAML frontmatter, same shape
-as the maildir backends.
+`github-issues` — see the `backlog` skill's `references/backends/github-issues.md` for the script's behavior.
 
 ## Pipeline
 
-`todo → doing → done` (intermediate stages aren't supported in v1).
+todo → claimed → review → mergeable → done
+
+(Each in-flight state has a label. `advance` moves an issue to the next state in this line — closes the issue when it reaches `done`. Add or remove intermediate stages by editing this line; declare each new state in `## Labels` below.)
+
+## Labels
+
+claimed: claimed
+review: review
+mergeable: mergeable
+failed: dead-letter
+
+(Each in-flight pipeline state maps to a label. Defaults to the state name itself; override here to align with an existing label vocabulary. `failed` is the special dead-letter terminal. Configurable at setup via `--label-<state>=<name>` and `--failed-label=<name>`; editing this section after `setup` requires `gh label rename` on the remote to keep the actual labels in sync.)
 
 ## ROADMAP
 

--- a/backlog/CLAUDE.md
+++ b/backlog/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Configures the `backlog` skill's github-issues backend (PR #178, parameterized in dotclaude#181) to speak this repo's existing lane+state label vocabulary instead of the skill's defaults: pipeline is `todo → claimed → review → mergeable → done` with `dead-letter` for the failed terminal.
- Rewrites `backlog/AGENTS.md` to the protocol-first template (state machine, worklog comment shape, claim resolution rules) so a human or non-skill agent can operate the backlog by hand via `gh issue` — the skill is one implementation, not the source of truth.
- Adds a `## Co-existence with other automation` section explicitly carving the boundary between the skill (claim at `take`, close at `mergeable → done`) and the existing automation (`sync-execution-state.py` drives `claimed → review`; managed PR reviewer drives `mergeable`). Branch-via-comments claim resolution makes the skill robust to external label writes.
- Adds `backlog/CLAUDE.md` as a symlink to AGENTS.md so both readers see one file.
- Remote-side changes (not in file diff): created `dead-letter` label; the `claimed`/`review`/`mergeable` labels had their colors and descriptions restored after setup's `--force` clobber so they keep their triage-labels.md meanings.

## Mergeability

- Surface: docs (backlog convention + AGENTS.md template)
- User-facing behavior changed: no — no app code touched; existing automation (`sync-execution-state.py`, managed PR reviewer, agent workflows) is unaffected
- Non-happy paths considered: skill writing labels that other automation also writes — addressed in the new co-existence section by carving owner/participant boundaries and by relying on branch-via-comments claim resolution (skill stays consistent regardless of who moves the label forward)
- Release/ops preconditions: none
- Residual risk or follow-up: phases 3–4 of `backlog/GROOMING.md` still pending (promote ~20 local `backlog/*.md` files to issues; ROADMAP refresh); upstream integration tests for github-issues backend still deferred in dotclaude

## Validation

- [x] `swift build` — n/a, no Swift changes
- [x] `swift test` — n/a, no Swift changes
- [x] Other checks run: `backlog status` returns the full canonical pipeline (`todo: 24, claimed: 0, review: 0, mergeable: 0, done: 48, failed: 0`); labels verified on remote with correct colors/descriptions; tree clean

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

Evidence links:

- n/a

## Blockers

- [x] None