### PR TITLE
chore(backlog): promote terminal files to GitHub issues

### DIFF
--- a/backlog/done/detail-pane-sticky-width-followup.md
+++ b/backlog/done/detail-pane-sticky-width-followup.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 530
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: runtime-diagnostics
 priority: 2
 description: Preserve the user's preferred Detail Pane width across tab changes, including the wider Diagnostics tab.

--- a/backlog/done/terminal-architecture-followups.md
+++ b/backlog/done/terminal-architecture-followups.md
@@ -1,4 +1,9 @@
 ---
+status: done
+issue: 520
+children: [521, 522, 523, 524, 525, 526, 527]
+completed: 2026-05-25
+resolution: promoted-to-github-issues
 priority: 2
 description: Larger terminal architecture items that need design discussion before implementation. Small polish items live in terminal-polish-followup.md.
 ---

--- a/backlog/done/terminal-polish-followup.md
+++ b/backlog/done/terminal-polish-followup.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 528
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 priority: 2
 description: Small terminal polish items — each fits in one PR and needs no architectural decision. Larger items live in terminal-architecture-followups.md.
 ---

--- a/backlog/done/terminal-pty-relay-plan.md
+++ b/backlog/done/terminal-pty-relay-plan.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 529
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 priority: 2
 description: Upgrade terminal tab from command-per-line SSE to Sandcastle-style PTY relay with persistent sessions and WebSocket reconnection
 ---


### PR DESCRIPTION
## Summary

Phase 3 of the backlog grooming (see `backlog/GROOMING.md`): promote the four terminal-related local plans/follow-ups to GitHub Issues so workers picking up the queue can see them.

| File → done/ | GitHub Issue(s) |
|---|---|
| `terminal-architecture-followups.md` | tracking #520 + children #521–#527 |
| `terminal-polish-followup.md` | #528 (8 polish items as body checklist) |
| `terminal-pty-relay-plan.md` | #529 (ttyd PTY relay upgrade) |
| `detail-pane-sticky-width-followup.md` | #530 |

Each archived file carries `status: done`, `issue:` / `children:`, `completed: 2026-05-25`, `resolution: promoted-to-github-issue(s)` in frontmatter so the lineage is traceable. Issues use `agent` + `task` + `needs-triage` labels per `backlog/AGENTS.md` so they land in the maintainer queue rather than auto-claimed.

This is chunk 1 of 6 chunks; the remaining chunks (Lume + isolation, web dashboard, agents/planning, platform/devEx, cleanup/sweep) plus phase 4 (ROADMAP refresh) and the GROOMING archive ship as separate PRs.

## Mergeability

- Surface: docs
- User-facing behavior changed: No — backlog/ archival only; no code, schema, runtime, or CI behavior touched
- Non-happy paths considered: N/A — file moves + frontmatter additions only; verified `git status` shows only renames + small frontmatter inserts
- Residual risk or follow-up: None for this PR. Follow-up PRs (#534, #544, #550, #556, #558, #559, #560) carry the rest of the grooming arc.

## Evidence

- [x] Not a testable change (docs-only, config)

Verified locally:

- `git status` shows only the four file moves + frontmatter additions
- Each new GH issue (#520–#530) opens with the documented labels and body
- Tracking issue #520 body links each child by number

## Test plan

- [ ] Reviewer confirms the four files are removed from `backlog/` top level and visible under `backlog/done/`
- [ ] Reviewer confirms issues #520–#530 carry the labels claimed in the table above
- [ ] No new `backlog/*.md` left without GH coverage (still ~20 to go in subsequent chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
