### PR TITLE
chore(backlog): promote lume + isolation files to GitHub issues

### DIFF
--- a/backlog/done/daytona-native-swift-api-plan.md
+++ b/backlog/done/daytona-native-swift-api-plan.md
@@ -1,5 +1,8 @@
 ---
-status: pending
+status: done
+issue: 532
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 category: plan
 topic: daytona
 relates_to: after:vz-tahoe-execution-brief-plan

--- a/backlog/done/lume-runtime-architecture-followups_followup.md
+++ b/backlog/done/lume-runtime-architecture-followups_followup.md
@@ -1,5 +1,8 @@
 ---
-status: pending
+status: done
+issues: [87, 88, 89]
+completed: 2026-05-25
+resolution: covered-by-prior-issues
 category: followup
 topic: lume-runtime
 priority: 2

--- a/backlog/done/vz-tahoe-execution-brief-plan.md
+++ b/backlog/done/vz-tahoe-execution-brief-plan.md
@@ -1,11 +1,13 @@
 ---
-status: pending
+status: done
+issue: 533
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 category: plan
 pr: null
 branch: null
 score: null
 retro_summary: null
-completed: null
 ---
 
 # Tahoe VZ Backend Execution Brief (Terminal-First Defaults)


### PR DESCRIPTION
## Summary

Chunk 2 of phase 3 backlog grooming (`backlog/GROOMING.md`): promote three lume/isolation files.

| File → done/ | GitHub Issue(s) |
|---|---|
| `lume-runtime-architecture-followups_followup.md` | already covered by closed **#87, #88, #89** — no new issue |
| `daytona-native-swift-api-plan.md` | **#532** (native Swift HTTP client replacing Python bridge) |
| `vz-tahoe-execution-brief-plan.md` | tracking **#533** (M2–M6; M1 done) |

Frontmatter notes:

- The lume followup carries `resolution: covered-by-prior-issues` + `issues: [87, 88, 89]` since those three PR-#54 follow-up issues all closed.
- The VZ tracking issue references the archived file at `backlog/done/vz-tahoe-execution-brief-plan.md` for full plan body rather than inlining 6.5k (per the issue-body-length gotcha in the plan).
- The daytona issue notes the existing `relates_to: after:vz-tahoe-execution-brief-plan` sequencing.

Chunk depends on PR #531 (terminal) only in that it shares the same branch base (`origin/main`); the two PRs are independent and either can land first.

## Mergeability

- Surface: docs
- User-facing behavior changed: No — backlog/ archival + new GH issues only
- Non-happy paths considered: N/A — file moves + frontmatter additions only. Verified the lume follow-up's referenced issues (#87, #88, #89) are all CLOSED before archiving.
- Residual risk or follow-up: None. The closed-issue verification means no work was silently dropped.

## Evidence

- [x] Not a testable change (docs-only, config)

Verified locally:

- `git status` shows only the three file moves + frontmatter additions
- New GH issues #532 and #533 open with the documented labels and bodies
- Closed issues #87/#88/#89 are referenced in the lume followup frontmatter

## Test plan

- [ ] Reviewer confirms three files removed from `backlog/` top level and visible under `backlog/done/`
- [ ] Reviewer confirms issues #532 and #533 carry `agent` + `task` + `needs-triage` + `area: isolation` + `enhancement`
- [ ] Lume followup frontmatter correctly references closed #87/#88/#89 (no new issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
