### PR TITLE
chore(backlog): promote web dashboard files to GitHub issues

### DIFF
--- a/backlog/done/pre-release-deployment-smoke_plan.md
+++ b/backlog/done/pre-release-deployment-smoke_plan.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 543
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: web-cd
 priority: 2
 description: Add a remote-safe, skippable Playwright smoke lane for CD preview and prod validation.

--- a/backlog/done/spaces-agent-discovery-dashboard-plan.md
+++ b/backlog/done/spaces-agent-discovery-dashboard-plan.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 542
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: spaces-web
 priority: 2
 description: Build the agent discovery dashboard into the Next.js app at spaces.cloudcompute.com

--- a/backlog/done/web-api-authorization-hardening-followup.md
+++ b/backlog/done/web-api-authorization-hardening-followup.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 535
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: web
 priority: 2
 description: Add cross-tenant Playwright coverage for the read-API authorization checks landed in PR #342.

--- a/backlog/done/web-dashboard-component-regression-tests_followup.md
+++ b/backlog/done/web-dashboard-component-regression-tests_followup.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 536
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: web-dashboard-testing
 priority: 2
 description: Add a lightweight component-test harness for dashboard regressions like hook-order violations and stale repo-switch fetches.

--- a/backlog/done/web-dashboard-phase3-followups.md
+++ b/backlog/done/web-dashboard-phase3-followups.md
@@ -1,5 +1,9 @@
 ---
-status: pending
+status: done
+issue: 537
+children: [538, 539, 540, 541]
+completed: 2026-05-25
+resolution: promoted-to-github-issues
 category: followup
 pr: null
 branch: null


### PR DESCRIPTION
## Summary

Chunk 3 of phase 3 backlog grooming (`backlog/GROOMING.md`): promote five web-dashboard files.

| File → done/ | GitHub Issue(s) |
|---|---|
| `web-api-authorization-hardening-followup.md` | **#535** (cross-tenant Playwright coverage for PR #342) |
| `web-dashboard-component-regression-tests_followup.md` | **#536** (DOM Vitest lane) |
| `web-dashboard-phase3-followups.md` | tracking **#537** + children **#538–#541** under milestone #7 |
| `spaces-agent-discovery-dashboard-plan.md` | **#542** (distinct scope from #174) |
| `pre-release-deployment-smoke_plan.md` | **#543** (remote-safe Playwright lane; references rolling tracker #356) |

Notes:

- The phase-3 tracking issue and all four children land in milestone #7 (Web Dashboard). The spaces-discovery issue (#542) is also milestone #7.
- After inspection, **#174** (`feat(web): wire GitHub adapter in Chat SDK bot`) covers a different scope from `spaces-agent-discovery-dashboard-plan.md`: #174 is bot/webhook plumbing, #542 is the dashboard UX + repo-discovery surface. No overlap — both stay open.
- **#356** (rolling CD Playwright tracker) is referenced from #543 rather than reopened.

Independent of PRs #531 and #534 — branch base is `origin/main`.

## Mergeability

- Surface: docs
- User-facing behavior changed: No — backlog/ archival + new GH issues + milestone-7 assignments only
- Non-happy paths considered: N/A. Verified #174 is OPEN and covers a distinct scope from #542 before filing separately (rather than linking).
- Residual risk or follow-up: None. The phase-3 children (#538–#541) reference parent #537 in their bodies; parent links them back as a checklist.

## Evidence

- [x] Not a testable change (docs-only, config)

Verified locally:

- `git status` shows only the five file moves + frontmatter additions
- New issues #535–#543 open with the documented labels and bodies
- Phase 3 children (#538–#541) all reference `Part of #537` and #537's body lists them as a checklist

## Test plan

- [ ] Reviewer confirms five files removed from `backlog/` top level and visible under `backlog/done/`
- [ ] Reviewer confirms milestone #7 covers #537 / #538 / #539 / #540 / #541 / #542
- [ ] No collision with #174 — spaces-discovery (#542) calls out the boundary in its body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
