### PR TITLE
chore(backlog): promote agents + planning files to GitHub issues

### DIFF
--- a/backlog/done/desktop-continuity_plan.md
+++ b/backlog/done/desktop-continuity_plan.md
@@ -1,5 +1,8 @@
 ---
-status: active
+status: done
+issue: 548
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 category: plan
 priority: P1
 created: 2026-04-23

--- a/backlog/done/managed-pr-reviewer-continuous-reruns_plan.md
+++ b/backlog/done/managed-pr-reviewer-continuous-reruns_plan.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 545
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: pr-reviewer
 priority: 1
 description: Make the managed PR reviewer run again on meaningful PR updates while carrying forward prior review context and avoiding review loops.

--- a/backlog/done/notification-client-catchup-plan.md
+++ b/backlog/done/notification-client-catchup-plan.md
@@ -1,11 +1,13 @@
 ---
-status: pending
+status: done
+issue: 547
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 category: plan
 pr: null
 branch: null
 score: null
 retro_summary: null
-completed: null
 ---
 
 # Per-Client Notification Catch-Up

--- a/backlog/done/pr-reviewer-narration-eval-skill_plan.md
+++ b/backlog/done/pr-reviewer-narration-eval-skill_plan.md
@@ -1,4 +1,8 @@
 ---
+status: done
+issue: 546
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 topic: pr-reviewer
 priority: 2
 description: Convert the recent PR reviewer narration analysis into a small skill-backed preference eval harness for fine-tuning narrative, evidence, and label behavior.

--- a/backlog/done/tmux-support_plan.md
+++ b/backlog/done/tmux-support_plan.md
@@ -1,5 +1,8 @@
 ---
-status: active
+status: done
+issue: 549
+completed: 2026-05-25
+resolution: promoted-to-github-issue
 category: plan
 priority: P1
 chosen_by: docs/decisions/terminal-multiplexing.md
@@ -8,7 +11,6 @@ pr: null
 branch: null
 score: null
 retro_summary: null
-completed: null
 ---
 
 > **Promoted 2026-04-23.** Chosen as the desktop multiplexing model in `docs/decisions/terminal-multiplexing.md`. Implementation runs against this plan. Continuity work is paired but tracked separately in `backlog/desktop-continuity_plan.md`.


### PR DESCRIPTION
## Summary

Chunk 4 of phase 3 backlog grooming (`backlog/GROOMING.md`): promote five agent + planning files.

| File → done/ | GitHub Issue |
|---|---|
| `managed-pr-reviewer-continuous-reruns_plan.md` | **#545** (P1) — rerun on `synchronize`, body edits, evidence comments; durable run fingerprints; same-PR review history; manual rerun path |
| `pr-reviewer-narration-eval-skill_plan.md` | **#546** — skill-backed pairwise eval harness for narrative/evidence/label tuning (lab only; deployed reviewer keeps server-fetched context) |
| `notification-client-catchup-plan.md` | **#547** — per-client cursor (one row per `client_id` per owner DO); `X-Client-ID` header; ACK protocol |
| `desktop-continuity_plan.md` | **#548** (P1) — hybrid tmux + restore manifest; first-phase contract for same-OS-session continuity |
| `tmux-support_plan.md` | **#549** (P1) — promote partial `tmux_per_session` to full product path with mode transitions, availability UX, dual-mode shortcut policy |

Pairings noted in PR titles + issue bodies:

- **#545 + #546** — runtime path (continuous reruns) vs lab/eval (narration). Separated per the original plan files' guidance about not folding eval tooling into runtime work.
- **#548 + #549** — both reference `docs/decisions/terminal-multiplexing.md`. Continuity (#548) is paired with tmux support (#549) but tracked separately because tmux primary alone doesn't deliver across-session continuity.

All five issues carry `agent` + `task` + `needs-triage` (per `backlog/AGENTS.md` for items entering bypassing Peter's planning flow). Three carry `priority:p1`.

The largest source file (`tmux-support_plan.md`, ~14k) is condensed in the issue body; full plan including shortcut tables and architectural diagrams stays in `backlog/done/tmux-support_plan.md`.

## Mergeability

- Surface: docs
- User-facing behavior changed: No — backlog/ archival + new GH issues only
- Non-happy paths considered: N/A. Pairings between #545/#546 and #548/#549 are cross-referenced in both directions so dropping either issue's history doesn't orphan the other.
- Residual risk or follow-up: None. Full plan bodies remain in done/ for any reviewer who needs the deeper detail (esp. the 14k tmux plan).

## Evidence

- [x] Not a testable change (docs-only, config)

Verified locally:

- `git status` shows only five file moves + frontmatter additions
- New issues #545–#549 open with the documented labels and bodies
- Cross-references between #545/#546 and #548/#549 are present in both directions

## Test plan

- [ ] Reviewer confirms five files removed from `backlog/` top level and visible under `backlog/done/`
- [ ] Reviewer confirms #545, #548, #549 carry `priority:p1`
- [ ] Reviewer confirms `agent` + `task` + `needs-triage` on all five

🤖 Generated with [Claude Code](https://claude.com/claude-code)
