### PR TITLE
Align GitHub app identities and code ownership

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/execution.py
+++ b/.agents/skills/cofounder-contributor/scripts/execution.py
@@ -59,6 +59,34 @@ from github_state import (
 
 _label_cache: set[str] | None = None
 
+APP_BOT_GIT_IDENTITIES = {
+    # PR authorship comes from the GitHub App token; commit/contributor
+    # attribution comes from this git identity. Keep reviewer-only apps out of
+    # this table so they cannot accidentally seed CONTRIBUTOR status.
+    "april-clearwater": {
+        "login": "april-clearwater[bot]",
+        "email": "268297116+april-clearwater[bot]@users.noreply.github.com",
+    },
+    "workspace-agents": {
+        "login": "workspace-agents[bot]",
+        "email": "266434718+workspace-agents[bot]@users.noreply.github.com",
+    },
+}
+
+
+def app_bot_git_identity(env: dict[str, str], persona: str, bot_login: str) -> tuple[str, str]:
+    app_slug = env.get("GH_APP_SLUG", "").strip()
+    if not app_slug:
+        return bot_login or short_persona_name(persona), f"{persona_slug(persona)}@users.noreply.github.com"
+
+    identity = APP_BOT_GIT_IDENTITIES.get(app_slug)
+    if identity is None:
+        raise RuntimeError(
+            f"GH_APP_SLUG={app_slug!r} does not have an approved commit identity. "
+            "Add it to APP_BOT_GIT_IDENTITIES only for apps that are allowed to push commits."
+        )
+    return identity["login"], identity["email"]
+
 
 def _dismiss_own_blocking_reviews(pr_number: int, bot_login: str, env: dict[str, str]) -> None:
     """Dismiss prior CHANGES_REQUESTED reviews from this bot before approving."""
@@ -192,8 +220,7 @@ def build_execution_summary_body(
 
 
 def set_git_identity(env: dict[str, str], persona: str, bot_login: str) -> None:
-    user_name = bot_login or short_persona_name(persona)
-    user_email = f"{persona_slug(persona)}@users.noreply.github.com"
+    user_name, user_email = app_bot_git_identity(env, persona, bot_login)
     run_checked(["git", "config", "user.name", user_name], timeout=GITHUB_API_TIMEOUT, cwd=REPO_ROOT, env=env)
     run_checked(["git", "config", "user.email", user_email], timeout=GITHUB_API_TIMEOUT, cwd=REPO_ROOT, env=env)
 

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -194,8 +194,10 @@ from triage import (  # noqa: E402, F401
 )
 
 from execution import (  # noqa: E402, F401
+    APP_BOT_GIT_IDENTITIES,
     _update_mergeable_label,
     _write_github_outputs,
+    app_bot_git_identity,
     build_body,
     build_execution_summary_body,
     claim_marker,

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# fairchild is the global code owner so branch protection can require the
+# owner's approval separately from an app/bot approval.
+* @fairchild
+
+# Keep repository-control policy owned by fairchild even if future ownership
+# exceptions are added below.
+/.github/ @fairchild

--- a/.github/workflows/agent-executor.yml
+++ b/.github/workflows/agent-executor.yml
@@ -47,7 +47,7 @@ jobs:
 
   april-check-runner:
     needs: claim
-    if: needs.claim.outputs.matched == 'true' && needs.claim.outputs.requested_agent == 'april'
+    if: needs.claim.outputs.matched == 'true' && needs.claim.outputs.requested_agent == 'april-clearwater'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -77,7 +77,7 @@ jobs:
 
   april:
     needs: [claim, april-check-runner]
-    if: needs.claim.outputs.matched == 'true' && needs.claim.outputs.requested_agent == 'april'
+    if: needs.claim.outputs.matched == 'true' && needs.claim.outputs.requested_agent == 'april-clearwater'
     runs-on: ${{ fromJSON(needs.april-check-runner.outputs.runner) }}
     timeout-minutes: 30
     concurrency:
@@ -143,7 +143,7 @@ jobs:
 
   april-evidence:
     needs: [claim, april-check-runner, april]
-    if: needs.claim.outputs.matched == 'true' && needs.claim.outputs.requested_agent == 'april' && needs.april-check-runner.outputs.is_macos == 'false' && needs.april.outputs.needs_macos_evidence == 'true'
+    if: needs.claim.outputs.matched == 'true' && needs.claim.outputs.requested_agent == 'april-clearwater' && needs.april-check-runner.outputs.is_macos == 'false' && needs.april.outputs.needs_macos_evidence == 'true'
     uses: ./.github/workflows/_evidence.yml
     with:
       pr_branch: ${{ needs.april.outputs.pr_branch }}

--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -21,19 +21,19 @@ jobs:
       vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
       !endsWith(github.event.sender.login, '[bot]') && (
         ((github.event_name == 'issue_comment') && (
-          contains(github.event.comment.body || '', '@april') ||
+          contains(github.event.comment.body || '', '@april-clearwater') ||
           contains(github.event.comment.body || '', '@plat') ||
           contains(github.event.comment.body || '', '@peter') ||
           contains(github.event.comment.body || '', '@claude')
         )) ||
         ((github.event_name == 'pull_request_review_comment') && (
-          contains(github.event.comment.body || '', '@april') ||
+          contains(github.event.comment.body || '', '@april-clearwater') ||
           contains(github.event.comment.body || '', '@plat') ||
           contains(github.event.comment.body || '', '@peter') ||
           contains(github.event.comment.body || '', '@claude')
         )) ||
         ((github.event_name == 'pull_request_review') && (
-          contains(github.event.review.body || '', '@april') ||
+          contains(github.event.review.body || '', '@april-clearwater') ||
           contains(github.event.review.body || '', '@plat') ||
           contains(github.event.review.body || '', '@peter') ||
           contains(github.event.review.body || '', '@claude')

--- a/.github/workflows/app-review-smoke.yml
+++ b/.github/workflows/app-review-smoke.yml
@@ -26,6 +26,14 @@ on:
         description: "Review body text"
         type: string
         required: true
+      content_write_probe:
+        description: "Before reviewing, push an empty probe commit to a disposable branch with the selected app token"
+        type: boolean
+        default: false
+      probe_branch:
+        description: "Optional branch name for the content-write probe"
+        type: string
+        default: ""
 
 permissions:
   # This workflow validates GitHub App review capability. These permissions only
@@ -89,6 +97,83 @@ jobs:
           echo "::add-mask::$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
           echo "expected_login=$expected_login" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout for content-write probe
+        if: inputs.content_write_probe
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 1
+          token: ${{ steps.resolve.outputs.token }}
+
+      - name: Push app-authored content-write probe commit
+        if: inputs.content_write_probe
+        env:
+          GH_TOKEN: ${{ steps.resolve.outputs.token }}
+          APP_SLUG: ${{ inputs.app_slug }}
+          EXPECTED_LOGIN: ${{ steps.resolve.outputs.expected_login }}
+          PROBE_BRANCH: ${{ inputs.probe_branch }}
+        run: |
+          set -euo pipefail
+          unset GITHUB_TOKEN || true
+
+          case "$APP_SLUG" in
+            april-clearwater)
+              expected_email="268297116+april-clearwater[bot]@users.noreply.github.com"
+              ;;
+            workspace-agents)
+              expected_email="266434718+workspace-agents[bot]@users.noreply.github.com"
+              ;;
+            *)
+              echo "Unsupported app slug for content-write probe: $APP_SLUG" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$PROBE_BRANCH" ]; then
+            PROBE_BRANCH="codex/${APP_SLUG}-content-write-smoke-${GITHUB_RUN_ID}"
+          fi
+
+          git config user.name "$EXPECTED_LOGIN"
+          git config user.email "$expected_email"
+          git checkout -B "$PROBE_BRANCH"
+          git commit --allow-empty -m "chore: ${APP_SLUG} content-write smoke ${GITHUB_RUN_ID}"
+          commit_sha=$(git rev-parse HEAD)
+          git push origin "HEAD:refs/heads/$PROBE_BRANCH"
+
+          commit_author_name=$(gh api "repos/$GITHUB_REPOSITORY/commits/$commit_sha" --jq '.commit.author.name')
+          commit_author_email=$(gh api "repos/$GITHUB_REPOSITORY/commits/$commit_sha" --jq '.commit.author.email')
+          linked_author_login=$(gh api "repos/$GITHUB_REPOSITORY/commits/$commit_sha" --jq '.author.login // ""')
+
+          echo "probe_branch=$PROBE_BRANCH"
+          echo "commit_sha=$commit_sha"
+          echo "commit_author_name=$commit_author_name"
+          echo "commit_author_email=$commit_author_email"
+          echo "linked_author_login=$linked_author_login"
+
+          if [ "$commit_author_name" != "$EXPECTED_LOGIN" ]; then
+            echo "Unexpected commit author name: expected $EXPECTED_LOGIN, got $commit_author_name" >&2
+            exit 1
+          fi
+
+          if [ "$commit_author_email" != "$expected_email" ]; then
+            echo "Unexpected commit author email: expected $expected_email, got $commit_author_email" >&2
+            exit 1
+          fi
+
+          if [ "$linked_author_login" != "$EXPECTED_LOGIN" ]; then
+            echo "Unexpected linked GitHub author: expected $EXPECTED_LOGIN, got $linked_author_login" >&2
+            exit 1
+          fi
+
+          {
+            echo "### GitHub App Content-Write Smoke"
+            echo ""
+            echo "- app: \`$APP_SLUG\`"
+            echo "- pushed branch: \`$PROBE_BRANCH\`"
+            echo "- commit: \`$commit_sha\`"
+            echo "- commit author: \`$commit_author_name <$commit_author_email>\`"
+            echo "- linked GitHub author: \`$linked_author_login\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Submit app-native review
         env:
@@ -179,6 +264,8 @@ jobs:
 
           echo "review_author=$review_author"
           echo "review_state=$review_state"
+          review_author_association=$(printf '%s' "$reviews_json" | jq -r --arg marker "$marker" 'map(select((.body // "") | contains($marker))) | last | .author_association // empty')
+          echo "review_author_association=$review_author_association"
 
           if [ "$review_author" != "$EXPECTED_LOGIN" ]; then
             echo "Unexpected review author: expected $EXPECTED_LOGIN, got $review_author" >&2
@@ -202,6 +289,7 @@ jobs:
             echo "- viewer: \`$viewer\`"
             echo "- review author: \`$review_author\`"
             echo "- review state: \`$review_state\`"
+            echo "- review author association: \`$review_author_association\`"
             echo "- pull request: \`#$PR_NUMBER\`"
             echo "- marker: \`$marker\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/app-review-smoke.yml
+++ b/.github/workflows/app-review-smoke.yml
@@ -31,7 +31,7 @@ on:
         type: boolean
         default: false
       probe_branch:
-        description: "Optional branch name for the content-write probe"
+        description: "Optional codex-prefixed branch name for the content-write probe"
         type: string
         default: ""
 
@@ -132,6 +132,18 @@ jobs:
           if [ -z "$PROBE_BRANCH" ]; then
             PROBE_BRANCH="codex/${APP_SLUG}-content-write-smoke-${GITHUB_RUN_ID}"
           fi
+          if ! git check-ref-format --branch "$PROBE_BRANCH" >/dev/null; then
+            echo "Invalid probe branch name: $PROBE_BRANCH" >&2
+            exit 1
+          fi
+          case "$PROBE_BRANCH" in
+            codex/*|codex-*)
+              ;;
+            *)
+              echo "Content-write probe branches must start with codex/ or codex-." >&2
+              exit 1
+              ;;
+          esac
 
           git config user.name "$EXPECTED_LOGIN"
           git config user.email "$expected_email"

--- a/.github/workflows/app-review-smoke.yml
+++ b/.github/workflows/app-review-smoke.yml
@@ -31,7 +31,7 @@ on:
         type: boolean
         default: false
       probe_branch:
-        description: "Optional codex-prefixed branch name for the content-write probe"
+        description: "Optional branch name for the content-write probe"
         type: string
         default: ""
 
@@ -137,10 +137,8 @@ jobs:
             exit 1
           fi
           case "$PROBE_BRANCH" in
-            codex/*|codex-*)
-              ;;
-            *)
-              echo "Content-write probe branches must start with codex/ or codex-." >&2
+            main|release/*|releases/*)
+              echo "Content-write probes must not target main or release branches." >&2
               exit 1
               ;;
           esac

--- a/docs/design/chat-tab-wireframes.md
+++ b/docs/design/chat-tab-wireframes.md
@@ -9,12 +9,13 @@ Selected layout: **Chat as tab in main panel** alongside Overview and Agents tab
 ```
 ┌──────────┬──────────────────────────────────┬───────────────┐
 │ Repos    │                                  │ All Activity  │
-│          │  Select a repo to start chatting  │               │
+│          │  Select a repo to start chatting │               │
 │   works… │                                  │ [CI] 3 commits│
 │   beads  │  or type a message to dispatch   │ [PR] #243     │
 │   bread  │  an agent across any repo:       │ [PUSH] beads  │
 │   jrnl…  │                                  │               │
-│          │  @april-clearwater repo:workspaces fix #234  │               │
+│          │  @april-clearwater               │               │
+│          │  repo:workspaces fix #234        │               │
 │          │                                  │               │
 │          │                                  │               │
 │          │                                  │               │
@@ -67,10 +68,11 @@ System events are compact; human/agent messages get full treatment.
 │   beads  │ ── Today ──────────────────────  │ [PR] #243     │
 │          │                                  │               │
 │          │  10:12  PUSH  3 commits to main  │               │
-│          │  10:14  CI    ✗ tests failed      │               │
+│          │  10:14  CI    ✗ tests failed     │               │
 │          │                                  │               │
 │          │  10:16  you                      │               │
-│          │  @april-clearwater the test_workspace_crud  │               │
+│          │  @april-clearwater               │               │
+│          │  the test_workspace_crud         │               │
 │          │  test is flaky again. Fix it     │               │
 │          │  and make sure CI is green.      │               │
 │          │                                  │               │
@@ -86,10 +88,10 @@ System events are compact; human/agent messages get full treatment.
 │          │  setup. Opened PR #245.          │               │
 │          │                                  │               │
 │          │  10:23  PR  opened #245          │               │
-│          │  10:24  CI  ✓ all checks passed   │               │
+│          │  10:24  CI  ✓ all checks passed  │               │
 │          │                                  │               │
 │          ├──────────────────────────────────┤               │
-│          │ [@april-clearwater] ...              [Send] │               │
+│          │ [@april-clearwater] ... [Send]   │               │
 └──────────┴──────────────────────────────────┴───────────────┘
 ```
 
@@ -139,7 +141,7 @@ After submitting a message with an @mention:
 
 ```
 │          │                                  │
-│          │  @april-clearwater fix the flaky test #234  │
+│          │  @april-clearwater fix #234      │
 │          │                                  │
 │          │ ┌─ Confirm dispatch ───────────┐ │
 │          │ │                              │ │
@@ -155,7 +157,7 @@ After submitting a message with an @mention:
 │          │ └──────────────────────────────┘ │
 │          │                                  │
 │          ├──────────────────────────────────┤
-│          │ [@april-clearwater] ...              [Send] │
+│          │ [@april-clearwater] ... [Send]   │
 └──────────┴──────────────────────────────────┘
 ```
 
@@ -230,12 +232,12 @@ Asking `@spaces` or `@status` returns info without dispatching:
 ## Compose Bar Details
 
 ```
-┌─────────────────────────────────────────────────────┐
-│ [@april-clearwater ▼]  Type a message...               [Send]  │
+┌──────────────────────────────────────────────────────┐
+│ [@april-clearwater ▼] Message...       [Send]        │
 │              ↑                                ↑      │
-│         agent picker               Enter or click   │
+│         agent picker               Enter or click    │
 │         (click to change)          Cmd+Enter = send  │
-└─────────────────────────────────────────────────────┘
+└──────────────────────────────────────────────────────┘
 ```
 
 - **Agent picker** (left): shows currently targeted agent, click to change or clear
@@ -263,12 +265,13 @@ Clicking an event in the right-side activity feed can jump to Chat tab:
 
 ```
 Activity panel:                    Main panel switches to Chat:
-┌───────────────┐                 ┌──────────────────────────┐
-│ [CI] ✗ failed │ ← click →      │ [Overview] [Agents] [Chat]
-│               │                 │                          │
-│               │                 │ Re: CI failure on main   │
-│               │                 │ [@april-clearwater] ...      [Send] │
-└───────────────┘                 └──────────────────────────┘
+┌───────────────┐                 ┌───────────────────────────┐
+│ [CI] ✗ failed │ ← click →      │ [Overview] [Agents] [Chat] │
+│               │                 │                           │
+│               │                 │ Re: CI failure on main    │
+│               │                 │ [@april-clearwater]       │
+│               │                 │ ... [Send]                │
+└───────────────┘                 └───────────────────────────┘
 ```
 
 This bridges the read-only activity feed with the interactive chat.

--- a/docs/design/chat-tab-wireframes.md
+++ b/docs/design/chat-tab-wireframes.md
@@ -14,7 +14,7 @@ Selected layout: **Chat as tab in main panel** alongside Overview and Agents tab
 │   beads  │  or type a message to dispatch   │ [PR] #243     │
 │   bread  │  an agent across any repo:       │ [PUSH] beads  │
 │   jrnl…  │                                  │               │
-│          │  @april repo:workspaces fix #234  │               │
+│          │  @april-clearwater repo:workspaces fix #234  │               │
 │          │                                  │               │
 │          │                                  │               │
 │          │                                  │               │
@@ -70,7 +70,7 @@ System events are compact; human/agent messages get full treatment.
 │          │  10:14  CI    ✗ tests failed      │               │
 │          │                                  │               │
 │          │  10:16  you                      │               │
-│          │  @april the test_workspace_crud  │               │
+│          │  @april-clearwater the test_workspace_crud  │               │
 │          │  test is flaky again. Fix it     │               │
 │          │  and make sure CI is green.      │               │
 │          │                                  │               │
@@ -89,7 +89,7 @@ System events are compact; human/agent messages get full treatment.
 │          │  10:24  CI  ✓ all checks passed   │               │
 │          │                                  │               │
 │          ├──────────────────────────────────┤               │
-│          │ [@april] ...              [Send] │               │
+│          │ [@april-clearwater] ...              [Send] │               │
 └──────────┴──────────────────────────────────┴───────────────┘
 ```
 
@@ -139,7 +139,7 @@ After submitting a message with an @mention:
 
 ```
 │          │                                  │
-│          │  @april fix the flaky test #234  │
+│          │  @april-clearwater fix the flaky test #234  │
 │          │                                  │
 │          │ ┌─ Confirm dispatch ───────────┐ │
 │          │ │                              │ │
@@ -155,7 +155,7 @@ After submitting a message with an @mention:
 │          │ └──────────────────────────────┘ │
 │          │                                  │
 │          ├──────────────────────────────────┤
-│          │ [@april] ...              [Send] │
+│          │ [@april-clearwater] ...              [Send] │
 └──────────┴──────────────────────────────────┘
 ```
 
@@ -231,7 +231,7 @@ Asking `@spaces` or `@status` returns info without dispatching:
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│ [@april ▼]  Type a message...               [Send]  │
+│ [@april-clearwater ▼]  Type a message...               [Send]  │
 │              ↑                                ↑      │
 │         agent picker               Enter or click   │
 │         (click to change)          Cmd+Enter = send  │
@@ -267,7 +267,7 @@ Activity panel:                    Main panel switches to Chat:
 │ [CI] ✗ failed │ ← click →      │ [Overview] [Agents] [Chat]
 │               │                 │                          │
 │               │                 │ Re: CI failure on main   │
-│               │                 │ [@april] ...      [Send] │
+│               │                 │ [@april-clearwater] ...      [Send] │
 └───────────────┘                 └──────────────────────────┘
 ```
 

--- a/docs/design/product_overview.md
+++ b/docs/design/product_overview.md
@@ -5,7 +5,7 @@
 You have a fleet of AI coding agents defined in `.agents/` directories across your repos. Today, dispatching them requires terminal access — SSH into a machine, run `kanban task start`, or trigger a GitHub workflow manually. There's no way to:
 
 - **Talk to agents** from a browser — ask for status, request work, review output
-- **Dispatch agents by name** — `@april go fix the flaky test in #234`
+- **Dispatch agents by name** — `@april-clearwater go fix the flaky test in #234`
 - **See the conversation** — what did the agent do, what did it produce, what's it working on now
 - **React to repo events conversationally** — a PR fails CI, you want to say "retry" or "fix it"
 
@@ -25,7 +25,7 @@ The Chat SDK (`@chat-adapter/github`) handles the GitHub side (mentions in Discu
 ## Core Capabilities
 
 - **Web chat panel** — persistent chat UI in the dashboard, scoped per-repo or global
-- **@mention dispatch** — type `@april`, `@peter-planner`, or any agent name to route a message
+- **@mention dispatch** — type `@april-clearwater`, `@peter-planner`, or any agent name to route a message
 - **GitHub Discussion bridge** — messages posted in the web chat can create/reply to GitHub Discussions, and vice versa
 - **Agent status in chat** — when an agent is dispatched, its progress appears as chat messages (task created, PR opened, review ready)
 - **Webhook events as chat context** — CI failures, PR merges, and other events appear inline so you can react to them conversationally

--- a/docs/design/product_overview.md
+++ b/docs/design/product_overview.md
@@ -25,7 +25,7 @@ The Chat SDK (`@chat-adapter/github`) handles the GitHub side (mentions in Discu
 ## Core Capabilities
 
 - **Web chat panel** — persistent chat UI in the dashboard, scoped per-repo or global
-- **@mention dispatch** — type `@april-clearwater`, `@peter-planner`, or any agent name to route a message
+- **@mention dispatch** — type `@april-clearwater`, `@peter-planner`, or another discovered agent name to route a message
 - **GitHub Discussion bridge** — messages posted in the web chat can create/reply to GitHub Discussions, and vice versa
 - **Agent status in chat** — when an agent is dispatched, its progress appears as chat messages (task created, PR opened, review ready)
 - **Webhook events as chat context** — CI failures, PR merges, and other events appear inline so you can react to them conversationally

--- a/docs/design/user-stories.md
+++ b/docs/design/user-stories.md
@@ -51,8 +51,8 @@ sequenceDiagram
 │          │ │ 10:32 CI failed on main     │  │               │
 │          │ │                             │  │               │
 │          │ │ 10:34 you                   │  │               │
-│          │ │ @april-clearwater fix the flaky test   │  │               │
-│          │ │ in #234                     │  │               │
+│          │ │ @april-clearwater           │  │               │
+│          │ │ fix flaky test in #234      │  │               │
 │          │ │                             │  │               │
 │          │ │ 10:34 april                 │  │               │
 │          │ │ On it. Investigating...     │  │               │
@@ -61,7 +61,7 @@ sequenceDiagram
 │          │ │ PR #245 ready for review    │  │               │
 │          │ │                             │  │               │
 │          │ └─────────────────────────────┘  │               │
-│          │ [@april-clearwater] fix the flaky test...   │               │
+│          │ [@april-clearwater] fix flaky... │               │
 │          │ [Send]                           │               │
 └──────────┴──────────────────────────────────┴───────────────┘
 ```
@@ -117,7 +117,8 @@ sequenceDiagram
 │ Activity                                              │
 │                                                       │
 │ [CI] ✗ Tests failed on main           2m ago          │
-│       └─ [Reply: @april-clearwater fix this] [Retry]             │
+│       └─ [Reply: @april-clearwater]                   │
+│          fix this                         [Retry]     │
 │                                                       │
 │ [PR] opened #243: feat(web)...        5m ago          │
 │ [PUSH] 3 commits to main             12m ago          │
@@ -162,7 +163,8 @@ sequenceDiagram
 ┌─────────────────────────────────────────┐
 │ Chat — fairchild/workspaces             │
 │                                         │
-│ [you] @april-clearwater status                     │
+│ [you] @april-clearwater                 │
+│       status                             │
 │                                         │
 │ [spaces] april — Active                 │
 │ ┌─────────────────────────────────────┐ │
@@ -172,7 +174,7 @@ sequenceDiagram
 │ │ Last activity: 3m ago               │ │
 │ └─────────────────────────────────────┘ │
 │                                         │
-│ [@april-clearwater] ...                    [Send]  │
+│ [@april-clearwater] ...      [Send]     │
 └─────────────────────────────────────────┘
 ```
 
@@ -199,7 +201,8 @@ sequenceDiagram
 │          │                                  │               │
 │   works… │ Recent conversations:            │ [PR] #243     │
 │   beads  │                                  │ [CI] ✗ main   │
-│   bread  │ workspaces — @april-clearwater fixing #234  │ [PUSH] beads  │
+│   bread  │ workspaces — @april-clearwater   │ [PUSH] beads  │
+│          │ fixing #234                      │               │
 │   jrnl…  │ beads — @peter planning sprint   │               │
 │          │                                  │               │
 │          │ Quick dispatch:                  │               │
@@ -237,7 +240,7 @@ sequenceDiagram
 │                                         │
 │ After selecting april:                  │
 │                                         │
-│ [@april-clearwater] fix the flaky test in #234     │
+│ [@april-clearwater] fix flaky #234      │
 │                                         │
 │ ┌─ Dispatch confirmation ────────────┐  │
 │ │ Agent: april (● active)            │  │

--- a/docs/design/user-stories.md
+++ b/docs/design/user-stories.md
@@ -22,7 +22,7 @@ sequenceDiagram
     participant GH as GitHub Discussions
     participant Agent as Agent (Claude Code)
 
-    User->>Dashboard: Types "@april fix the flaky test in #234"
+    User->>Dashboard: Types "@april-clearwater fix the flaky test in #234"
     Dashboard->>API: POST message
     API->>GH: Create/reply to Discussion
     GH-->>API: Webhook: discussion_comment
@@ -51,7 +51,7 @@ sequenceDiagram
 │          │ │ 10:32 CI failed on main     │  │               │
 │          │ │                             │  │               │
 │          │ │ 10:34 you                   │  │               │
-│          │ │ @april fix the flaky test   │  │               │
+│          │ │ @april-clearwater fix the flaky test   │  │               │
 │          │ │ in #234                     │  │               │
 │          │ │                             │  │               │
 │          │ │ 10:34 april                 │  │               │
@@ -61,7 +61,7 @@ sequenceDiagram
 │          │ │ PR #245 ready for review    │  │               │
 │          │ │                             │  │               │
 │          │ └─────────────────────────────┘  │               │
-│          │ [@april] fix the flaky test...   │               │
+│          │ [@april-clearwater] fix the flaky test...   │               │
 │          │ [Send]                           │               │
 └──────────┴──────────────────────────────────┴───────────────┘
 ```
@@ -104,7 +104,7 @@ sequenceDiagram
     Note over Feed: CI failure event appears
     User->>Feed: Clicks CI failure event
     Feed->>Chat: Pre-fills context: "Re: CI failure on main"
-    User->>Chat: Types "@april fix this"
+    User->>Chat: Types "@april-clearwater fix this"
     Chat->>API: POST with event context
     API->>GH: Creates Discussion referencing the failure
     API-->>Chat: "Dispatching april with CI context..."
@@ -117,7 +117,7 @@ sequenceDiagram
 │ Activity                                              │
 │                                                       │
 │ [CI] ✗ Tests failed on main           2m ago          │
-│       └─ [Reply: @april fix this] [Retry]             │
+│       └─ [Reply: @april-clearwater fix this] [Retry]             │
 │                                                       │
 │ [PR] opened #243: feat(web)...        5m ago          │
 │ [PUSH] 3 commits to main             12m ago          │
@@ -149,7 +149,7 @@ sequenceDiagram
     participant Bot as Spaces Bot
     participant GH as GitHub API
 
-    User->>Chat: "@april status"
+    User->>Chat: "@april-clearwater status"
     Chat->>Bot: Route to status handler
     Bot->>GH: Check agent's recent activity
     GH-->>Bot: Open PRs, recent commits, Discussion replies
@@ -162,7 +162,7 @@ sequenceDiagram
 ┌─────────────────────────────────────────┐
 │ Chat — fairchild/workspaces             │
 │                                         │
-│ [you] @april status                     │
+│ [you] @april-clearwater status                     │
 │                                         │
 │ [spaces] april — Active                 │
 │ ┌─────────────────────────────────────┐ │
@@ -172,13 +172,13 @@ sequenceDiagram
 │ │ Last activity: 3m ago               │ │
 │ └─────────────────────────────────────┘ │
 │                                         │
-│ [@april] ...                    [Send]  │
+│ [@april-clearwater] ...                    [Send]  │
 └─────────────────────────────────────────┘
 ```
 
 ### Steps
 
-1. **User types** `@april status` or `@status` for all agents
+1. **User types** `@april-clearwater status` or `@status` for all agents
 2. **Bot queries** GitHub API for agent's recent activity
 3. **Bot responds** with structured status card inline in chat
 4. **No agent dispatched** — this is a bot query, not a task
@@ -199,7 +199,7 @@ sequenceDiagram
 │          │                                  │               │
 │   works… │ Recent conversations:            │ [PR] #243     │
 │   beads  │                                  │ [CI] ✗ main   │
-│   bread  │ workspaces — @april fixing #234  │ [PUSH] beads  │
+│   bread  │ workspaces — @april-clearwater fixing #234  │ [PUSH] beads  │
 │   jrnl…  │ beads — @peter planning sprint   │               │
 │          │                                  │               │
 │          │ Quick dispatch:                  │               │
@@ -237,7 +237,7 @@ sequenceDiagram
 │                                         │
 │ After selecting april:                  │
 │                                         │
-│ [@april] fix the flaky test in #234     │
+│ [@april-clearwater] fix the flaky test in #234     │
 │                                         │
 │ ┌─ Dispatch confirmation ────────────┐  │
 │ │ Agent: april (● active)            │  │

--- a/docs/development/agent-owner-protocol.md
+++ b/docs/development/agent-owner-protocol.md
@@ -10,7 +10,7 @@ Use it when you want to remember:
 - how to redirect or stop agents
 - what signals the agents actually listen to
 
-For the implementation details behind this protocol, see [agent-team.md](/Users/fairchild/.codex/worktrees/7a0f/workspaces/docs/development/agent-team.md).
+For the implementation details behind this protocol, see [agent-team.md](agent-team.md). For GitHub App identity, contributor attribution, reviewer isolation, and code-owner approval policy, see [github-app-identities.md](github-app-identities.md).
 
 ## Core Rule
 
@@ -23,6 +23,8 @@ The current control points are:
 3. You approve execution by reacting with 👍 on Peter's planning summary comment.
 4. April and Plat pick up approved work on their next wake-up.
 5. You review and merge PRs yourself.
+
+The intended merge gate is two approvals: one from the contributing app bot and one from you as `@fairchild`, the sole global code owner in `.github/CODEOWNERS`. Branch protection or rulesets must enable required code-owner review for CODEOWNERS to become a merge gate.
 
 ## Quick Reference
 
@@ -76,6 +78,13 @@ Internally, the next contributor wake-up converts that discussion approval into 
 There is no agent merge signal.
 
 You merge the PR yourself when it is ready.
+
+When branch protection is configured for this policy, wait for both approval signals:
+
+- the contributing app bot approval
+- your `@fairchild` code-owner approval
+
+Do not treat `workspaces-claude-pr-reviewer[bot]` as the contributing bot approval. That app is review-only and must not be seeded with commit history.
 
 ## Recommended Workflow
 
@@ -191,7 +200,8 @@ Good examples:
 ## If Native App Reviews Break
 
 - Workflow `permissions:` only affect the built-in `GITHUB_TOKEN`. They do not grant pull request review authority to GitHub App installation tokens.
-- Update the affected GitHub App in GitHub settings so the repository permissions include `pull_requests: write`, `contents: write`, `issues: write`, `discussions: write`, and `metadata: read`.
+- For contributing apps such as `april-clearwater` and `workspace-agents`, update the affected GitHub App in GitHub settings so repository permissions include `contents: write`, `pull_requests: write`, and `metadata: read`.
+- For `workspaces-claude-pr-reviewer`, keep the app review-only: `contents: read`, `pull_requests: write`, `statuses: write`, and `metadata: read`. Do not grant it `contents: write`.
 - After saving the permission change, re-approve the app installation for `fairchild/workspaces`. Existing installations do not pick up new permissions until you do.
 - Run the manual `GitHub App Review Smoke` workflow against a disposable PR before relying on app-native reviews again.
 

--- a/docs/development/agent-team.md
+++ b/docs/development/agent-team.md
@@ -2,7 +2,7 @@
 
 Workspaces has a founding team of AI agents that propose improvements, review each other's work, plan approved ideas into actionable issues, and now pick up explicitly approved issues into PRs. The goal is autonomous development with human approval gating — the repo advances itself, guided by the owner.
 
-If you need the operator-facing runbook for how to interact with and manage the agents, start with [agent-owner-protocol.md](/Users/fairchild/.codex/worktrees/7a0f/workspaces/docs/development/agent-owner-protocol.md).
+If you need the operator-facing runbook for how to interact with and manage the agents, start with [agent-owner-protocol.md](agent-owner-protocol.md). For GitHub App identity, commit attribution, and code-owner approval policy, see [github-app-identities.md](github-app-identities.md).
 
 ## Team
 
@@ -86,10 +86,12 @@ Oliver Obever runs separately once a week on Monday at 13:30 UTC to evaluate loo
 
 Mention an agent by name in any issue or PR comment to queue a maintainer-approved request:
 
-- `@april` — April Clearwater responds with her Application/UI perspective
+- `@april-clearwater` — April Clearwater responds with her Application/UI perspective
 - `@plat` — Plat Ironwood responds with his Platform/CI perspective
 - `@peter` — Peter Planner redirects to Discussions (his planning workflow operates there)
 - `@claude` — Claude Code handles one-off repo tasks after maintainer approval
+
+Do not use `@april` for Workspaces automation. That is a different real GitHub user. Public GitHub-triggered April runs use only `@april-clearwater`.
 
 Public mention requests now run in two phases:
 
@@ -157,6 +159,7 @@ Prompt, runtime, and compatibility responsibilities now split cleanly:
 | `.agents/scripts/validate-agent-output.py` | Compatibility shim for shared validation |
 | `.agents/skills/drive/SKILL.md` | Manual milestone execution workflow after planning |
 | `docs/development/agent-owner-protocol.md` | Owner-facing protocol for approving, steering, and merging agent work |
+| `docs/development/github-app-identities.md` | GitHub App identity, commit attribution, reviewer isolation, and code-owner approval runbook |
 | `scripts/ops-report.py` | Deterministic GitHub + perf reporting for the ops loop |
 | `fixtures/ops-report/` | Checked-in replay packs for Oliver Obever dry runs and tests |
 | `docs/ops/` | Checked-in ops timeline, snapshot JSON, and dashboard |

--- a/docs/development/github-app-identities.md
+++ b/docs/development/github-app-identities.md
@@ -1,0 +1,71 @@
+# GitHub App Identities
+
+This repo uses three separate GitHub App identities for agent work. They are intentionally not interchangeable.
+
+| App | Bot login | Commit role | Required permissions |
+|-----|-----------|-------------|----------------------|
+| `april-clearwater` | `april-clearwater[bot]` | Contributor that may open PRs and push commits as April | `contents:write`, `pull_requests:write`, `metadata:read` |
+| `workspace-agents` | `workspace-agents[bot]` | Contributor that may open PRs and push commits for shared agent execution | `contents:write`, `pull_requests:write`, `metadata:read` |
+| `workspaces-claude-pr-reviewer` | `workspaces-claude-pr-reviewer[bot]` | Review-only app; must not push commits | `contents:read`, `pull_requests:write`, `statuses:write`, `metadata:read` |
+
+## Mechanism
+
+GitHub shows three related but distinct identities:
+
+1. PR author: the GitHub App token that creates the PR.
+2. Commit author: the local git `user.name` and `user.email` used before `git commit`.
+3. Review author association: GitHub's relationship between the reviewer and this repository.
+
+`contents:write` only lets an app push branches and commits. It does not by itself make the bot a contributor. A bot becomes `CONTRIBUTOR` after GitHub sees an attributed commit from that bot in the repository history.
+
+Contributor runs set `GH_APP_SLUG` and use the approved identity table in `.agents/skills/cofounder-contributor/scripts/execution.py`. The table maps app slugs to canonical bot noreply addresses:
+
+- `april-clearwater` uses `268297116+april-clearwater[bot]@users.noreply.github.com`
+- `workspace-agents` uses `266434718+workspace-agents[bot]@users.noreply.github.com`
+
+If a workflow sets an unknown `GH_APP_SLUG`, contributor execution fails before committing. This is deliberate: adding a commit identity is a security decision.
+
+## Public Mentions
+
+Use `@april-clearwater` for April in GitHub issues, PRs, and review comments. Do not use `@april`; that is a different real GitHub user and must not queue Workspaces automation.
+
+Local persona aliases are separate from public GitHub mentions. `/become april` may stay as local operator shorthand because it does not notify or dispatch a GitHub user.
+
+## Code Owner Gate
+
+`.github/CODEOWNERS` lists `@fairchild` as the global code owner:
+
+```text
+* @fairchild
+/.github/ @fairchild
+```
+
+Branch protection or a repository ruleset can then require:
+
+- two approving reviews
+- code owner review
+
+With only `@fairchild` listed as code owner, one required approval must come from `fairchild`. The second approval may come from the intended contributor bot only after live GitHub evidence proves that required-review protection counts that app-bot approval.
+
+## Repeating The Contributor Setup
+
+To make another app a contributing bot:
+
+1. Grant the GitHub App `contents:write`, `pull_requests:write`, and `metadata:read`.
+2. Re-approve the app installation on `fairchild/workspaces`; existing installations do not receive new permissions automatically.
+3. Look up the bot account ID with `gh api users/<bot-login>%5Bbot%5D --jq '{login,id}'`.
+4. Add the app slug, bot login, and canonical noreply email to the approved identity table.
+5. Run a disposable PR with that app token and verify the PR author and commit attribution resolve to the bot.
+6. Verify a later review from that bot reports `authorAssociation: CONTRIBUTOR`.
+
+Do not repeat this process for `workspaces-claude-pr-reviewer`. That app is intentionally review-only.
+
+## Verification Checklist
+
+Before relying on the approval policy:
+
+1. Confirm `@april-clearwater` queues triage and `@april` does not.
+2. Confirm `april-clearwater[bot]` can open a PR as itself.
+3. After `workspace-agents` receives `contents:write`, confirm it can push an attributed commit as `workspace-agents[bot]`.
+4. Confirm `workspaces-claude-pr-reviewer[bot]` still lacks `contents:write` and has no commits in repo history.
+5. On a disposable PR, confirm GitHub branch protection counts one app-bot approval plus one `@fairchild` code-owner approval before requiring that policy on `main`.

--- a/docs/development/github-app-identities.md
+++ b/docs/development/github-app-identities.md
@@ -16,7 +16,7 @@ GitHub shows three related but distinct identities:
 2. Commit author: the local git `user.name` and `user.email` used before `git commit`.
 3. Review author association: GitHub's relationship between the reviewer and this repository.
 
-`contents:write` only lets an app push branches and commits. It does not by itself make the bot a contributor. A bot becomes `CONTRIBUTOR` after GitHub sees an attributed commit from that bot in the repository history.
+`contents:write` only lets an app push branches and commits. It does not by itself make the bot a contributor. Treat `CONTRIBUTOR` status as proven only after a live review reports that association; a linked bot-authored commit on an unmerged PR branch is not enough evidence.
 
 Contributor runs set `GH_APP_SLUG` and use the approved identity table in `.agents/skills/cofounder-contributor/scripts/execution.py`. The table maps app slugs to canonical bot noreply addresses:
 
@@ -56,7 +56,7 @@ To make another app a contributing bot:
 3. Look up the bot account ID with `gh api users/<bot-login>%5Bbot%5D --jq '{login,id}'`.
 4. Add the app slug, bot login, and canonical noreply email to the approved identity table.
 5. Run a disposable PR with that app token and verify the PR author and commit attribution resolve to the bot.
-6. Verify a later review from that bot reports `authorAssociation: CONTRIBUTOR`.
+6. After a bot-authored commit lands in the default branch history, verify a later review from that bot reports `authorAssociation: CONTRIBUTOR`.
 
 Do not repeat this process for `workspaces-claude-pr-reviewer`. That app is intentionally review-only.
 

--- a/scripts/agent-triage-request.py
+++ b/scripts/agent-triage-request.py
@@ -32,10 +32,10 @@ APPROVAL_LABEL = "safe-to-run-agent"
 PRIVILEGED_PATCH_LABEL = "privileged-agent-patch"
 TRIAGE_COMMENT_AUTHOR = "github-actions[bot]"
 TRIAGE_MARKER_RE = re.compile(r"<!-- agent-triage-request:v1:([A-Za-z0-9_\-=]+) -->")
-SUPPORTED_AGENTS = ("april", "plat", "peter", "claude")
+SUPPORTED_AGENTS = ("april-clearwater", "plat", "peter", "claude")
 ISSUE_BODY_AGENTS = ("claude",)
 MENTION_PATTERNS = {
-    agent: re.compile(rf"(^|\s|[^a-z0-9])@{agent}(\s|[^a-z0-9]|$)", re.IGNORECASE)
+    agent: re.compile(rf"(?<![A-Za-z0-9_-])@{re.escape(agent)}(?![A-Za-z0-9_-])", re.IGNORECASE)
     for agent in SUPPORTED_AGENTS
 }
 UNSAFE_SUMMARY_PATTERNS = (
@@ -225,7 +225,7 @@ def render_conflict_comment(context: EventContext, agents: list[str]) -> str:
             "Agent request not queued.",
             "",
             f"- Reason: public requests must mention exactly one agent, but this request mentioned {mentions}.",
-            f"- Fix: edit or repost the request with exactly one of `@april`, `@plat`, `@peter`, or `@claude`, then apply `{APPROVAL_LABEL}` after triage posts the request summary.",
+            f"- Fix: edit or repost the request with exactly one of `@april-clearwater`, `@plat`, `@peter`, or `@claude`, then apply `{APPROVAL_LABEL}` after triage posts the request summary.",
             f"- Source URL: {context.source_url}",
         ]
     )

--- a/scripts/test_agent_triage.py
+++ b/scripts/test_agent_triage.py
@@ -42,7 +42,7 @@ class AgentTriageTests(unittest.TestCase):
             "version": 1,
             "status": status,
             "request_id": request_id,
-            "requested_agent": "april",
+            "requested_agent": "april-clearwater",
             "target_type": "pull_request",
             "target_number": 212,
             "source_type": "issue_comment",
@@ -173,6 +173,48 @@ class AgentTriageTests(unittest.TestCase):
         )
 
         self.assertIn(triage.PRIVILEGED_PATCH_LABEL, names)
+
+    def test_public_april_mention_uses_full_app_slug_only(self) -> None:
+        context = triage.EventContext(
+            event_name="issue_comment",
+            action="created",
+            target_type="pull_request",
+            target_number=212,
+            source_type="issue_comment",
+            source_id="issue_comment:1",
+            source_url="https://github.com/fairchild/workspaces/pull/212#issuecomment-1",
+            author_login="fairchild",
+            author_association="OWNER",
+            source_text="@april-clearwater please review the status colors",
+            requested_at="2026-03-24T16:00:00Z",
+        )
+
+        self.assertEqual(triage.find_requested_agents(context), ["april-clearwater"])
+
+        short_context = triage.EventContext(
+            **{
+                **context.__dict__,
+                "source_text": "@april please review the status colors",
+            }
+        )
+        self.assertEqual(triage.find_requested_agents(short_context), [])
+
+    def test_april_clearwater_mention_requires_exact_slug_boundary(self) -> None:
+        context = triage.EventContext(
+            event_name="issue_comment",
+            action="created",
+            target_type="pull_request",
+            target_number=212,
+            source_type="issue_comment",
+            source_id="issue_comment:1",
+            source_url="https://github.com/fairchild/workspaces/pull/212#issuecomment-1",
+            author_login="fairchild",
+            author_association="OWNER",
+            source_text="@april-clearwater-extra is a different mention",
+            requested_at="2026-03-24T16:00:00Z",
+        )
+
+        self.assertEqual(triage.find_requested_agents(context), [])
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_contributor.py
+++ b/scripts/test_run_contributor.py
@@ -68,6 +68,44 @@ class RunContributorEvidenceTests(unittest.TestCase):
             ],
         )
 
+    def test_app_bot_git_identity_uses_canonical_bot_noreply_addresses(self) -> None:
+        self.assertEqual(
+            run_contributor.app_bot_git_identity(
+                {"GH_APP_SLUG": "april-clearwater"},
+                "April Clearwater",
+                "april-clearwater[bot]",
+            ),
+            (
+                "april-clearwater[bot]",
+                "268297116+april-clearwater[bot]@users.noreply.github.com",
+            ),
+        )
+        self.assertEqual(
+            run_contributor.app_bot_git_identity(
+                {"GH_APP_SLUG": "workspace-agents"},
+                "Plat Ironwood",
+                "workspace-agents[bot]",
+            ),
+            (
+                "workspace-agents[bot]",
+                "266434718+workspace-agents[bot]@users.noreply.github.com",
+            ),
+        )
+
+    def test_app_bot_git_identity_rejects_unknown_app_slug(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "does not have an approved commit identity"):
+            run_contributor.app_bot_git_identity(
+                {"GH_APP_SLUG": "workspaces-claude-pr-reviewer"},
+                "Claude Reviewer",
+                "workspaces-claude-pr-reviewer[bot]",
+            )
+
+    def test_non_app_git_identity_keeps_persona_fallback(self) -> None:
+        self.assertEqual(
+            run_contributor.app_bot_git_identity({}, "April Clearwater", ""),
+            ("April Clearwater", "april-clearwater@users.noreply.github.com"),
+        )
+
     def test_agent_patch_policy_requires_privileged_label_or_override(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -85,6 +85,9 @@ class SecurityHardeningTests(unittest.TestCase):
         for trigger in ("issue_comment:", "pull_request_review_comment:", "pull_request_review:", "issues:"):
             self.assertIn(trigger, on_block)
         self.assertIn("runs-on: ubuntu-latest", workflow)
+        self.assertIn("@april-clearwater", workflow)
+        self.assertNotIn("@april')", workflow)
+        self.assertNotIn("@april' )", workflow)
         for secret_name in (
             "CLAUDE_CODE_OAUTH_TOKEN",
             "APRIL_PRIVATE_KEY",
@@ -92,6 +95,11 @@ class SecurityHardeningTests(unittest.TestCase):
             "EVIDENCE_UPLOAD_TOKEN",
         ):
             self.assertNotIn(secret_name, workflow)
+
+    def test_codeowners_requires_fairchild_for_repo_and_control_paths(self) -> None:
+        codeowners = (REPO_ROOT / ".github/CODEOWNERS").read_text()
+        self.assertRegex(codeowners, r"(?m)^\*\s+@fairchild$")
+        self.assertRegex(codeowners, r"(?m)^/\.github/\s+@fairchild$")
 
     def test_claude_workflow_is_manual_dispatch_only(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/claude.yml").read_text()
@@ -115,6 +123,8 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("safe-to-run-agent", workflow)
         self.assertIn("privileged_patch_approved:", workflow)
         self.assertIn("--allow-privileged-patches", workflow)
+        self.assertIn("requested_agent == 'april-clearwater'", workflow)
+        self.assertNotIn("requested_agent == 'april'", workflow)
 
     def test_codespaces_claude_worker_is_break_glass_ref_gated(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/codespaces-claude-worker.yml").read_text()

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -104,8 +104,8 @@ class SecurityHardeningTests(unittest.TestCase):
     def test_app_review_smoke_limits_content_write_probe_branches(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/app-review-smoke.yml").read_text()
         self.assertIn("git check-ref-format --branch", workflow)
-        self.assertIn("codex/*|codex-*)", workflow)
-        self.assertIn("Content-write probe branches must start with codex/ or codex-.", workflow)
+        self.assertIn("main|release/*|releases/*", workflow)
+        self.assertIn("Content-write probes must not target main or release branches.", workflow)
 
     def test_claude_workflow_is_manual_dispatch_only(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/claude.yml").read_text()

--- a/scripts/test_security_hardening.py
+++ b/scripts/test_security_hardening.py
@@ -101,6 +101,12 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertRegex(codeowners, r"(?m)^\*\s+@fairchild$")
         self.assertRegex(codeowners, r"(?m)^/\.github/\s+@fairchild$")
 
+    def test_app_review_smoke_limits_content_write_probe_branches(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/app-review-smoke.yml").read_text()
+        self.assertIn("git check-ref-format --branch", workflow)
+        self.assertIn("codex/*|codex-*)", workflow)
+        self.assertIn("Content-write probe branches must start with codex/ or codex-.", workflow)
+
     def test_claude_workflow_is_manual_dispatch_only(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/claude.yml").read_text()
         on_block, _ = workflow.split("\njobs:\n", 1)

--- a/web/src/app/api/chat/dispatch/route.ts
+++ b/web/src/app/api/chat/dispatch/route.ts
@@ -1,8 +1,14 @@
 import crypto from "node:crypto";
+import { resolvePersona } from "@/lib/agent-runtime/persona-loader";
 import { authorizeRepoAccess, unauthorizedResponse } from "@/lib/api-auth";
 import { getDevBypassToken, getSession } from "@/lib/auth-server";
 import { pushChatMessage } from "@/lib/chat";
-import { formatDispatchBody, parseIssueRef } from "@/lib/chat-utils";
+import {
+	findForbiddenPublicAgentMention,
+	formatDispatchBody,
+	parseIssueRef,
+	validatePublicAgentTarget,
+} from "@/lib/chat-utils";
 import { createDiscussion, getGitHubToken } from "@/lib/github";
 import type { ChatMessage, DispatchMetadata } from "@/lib/types";
 
@@ -56,6 +62,33 @@ export async function POST(request: Request): Promise<Response> {
 	const taskId = crypto.randomUUID().slice(0, 8);
 	const timestamp = new Date().toISOString();
 	const issueRef = body.issueRef ?? parseIssueRef(body.task);
+	// Dispatch targets become GitHub @mentions; validate server-side so direct
+	// API calls cannot notify unrelated real users such as @april.
+	const targetError = validatePublicAgentTarget(body.agentName, {
+		allowSpaces: false,
+	});
+	if (targetError) {
+		return Response.json({ error: targetError }, { status: 400 });
+	}
+	const forbiddenMention = findForbiddenPublicAgentMention(body.task);
+	if (forbiddenMention) {
+		return Response.json(
+			{
+				error: `Use @april-clearwater instead of ${forbiddenMention}; @april is a different GitHub user.`,
+			},
+			{ status: 400 },
+		);
+	}
+	const persona = await resolvePersona(token, owner, repo, body.agentName);
+	if (!persona) {
+		return Response.json(
+			{
+				error:
+					"Unknown agent target. Use a discovered repo persona such as @april-clearwater.",
+			},
+			{ status: 400 },
+		);
+	}
 
 	const title = `@${body.agentName}: ${body.task.slice(0, 100)}`;
 	const discussionBody = formatDispatchBody(

--- a/web/src/app/api/chat/messages/route.ts
+++ b/web/src/app/api/chat/messages/route.ts
@@ -7,7 +7,12 @@ import { resolvePersona } from "@/lib/agent-runtime/persona-loader";
 import { authorizeRepoAccess, unauthorizedResponse } from "@/lib/api-auth";
 import { getDevBypassToken, getSession } from "@/lib/auth-server";
 import { getMixedTimeline, pushChatMessage } from "@/lib/chat";
-import { handleBotCommand, parseAgentMention } from "@/lib/chat-utils";
+import {
+	findForbiddenPublicAgentMention,
+	handleBotCommand,
+	parseAgentMention,
+	validatePublicAgentTarget,
+} from "@/lib/chat-utils";
 import { getEventStats } from "@/lib/events";
 import {
 	addDiscussionComment,
@@ -69,7 +74,25 @@ export async function POST(request: Request): Promise<Response> {
 	let discussionUrl: string | null = null;
 
 	const explicitTarget = body.agentName ?? parseAgentMention(body.message);
+	// Explicit targets become GitHub @mentions in Discussion titles, so reject
+	// unsafe aliases before publishing user text to a public repo.
+	const targetError = validatePublicAgentTarget(explicitTarget, {
+		allowSpaces: true,
+	});
+	if (targetError) {
+		return Response.json({ error: targetError }, { status: 400 });
+	}
+	const forbiddenMention = findForbiddenPublicAgentMention(body.message);
+	if (forbiddenMention) {
+		return Response.json(
+			{
+				error: `Use @april-clearwater instead of ${forbiddenMention}; @april is a different GitHub user.`,
+			},
+			{ status: 400 },
+		);
+	}
 	const agentTarget = explicitTarget ?? DEFAULT_AGENT;
+	let resolvedExplicitPersona = false;
 
 	// Bot commands only for explicit @mentions (not default agent fallback)
 	const botResponse = await handleBotCommand({
@@ -86,40 +109,57 @@ export async function POST(request: Request): Promise<Response> {
 
 	// Check if the mention targets a known agent persona (restricted to allowed users).
 	if (agentTarget && agentTarget !== "spaces") {
+		const persona = await resolvePersona(token, owner, repo, agentTarget);
+		resolvedExplicitPersona = explicitTarget !== null && persona !== null;
 		const login = getDevBypassToken()
 			? "fairchild"
 			: await fetchGitHubLogin(token);
-		if (ALLOWED_AGENT_LOGINS.has(login)) {
-			const persona = await resolvePersona(token, owner, repo, agentTarget);
-			if (persona) {
-				const chatMessage: ChatMessage = {
-					id: messageId,
-					repo: body.repo,
-					author: session.user.name ?? session.user.email ?? "you",
-					authorType: "user",
-					content: body.message,
-					agentTarget,
-					discussionId: null,
-					discussionUrl: null,
-					timestamp,
-				};
-				await pushChatMessage(chatMessage);
+		if (persona && ALLOWED_AGENT_LOGINS.has(login)) {
+			const chatMessage: ChatMessage = {
+				id: messageId,
+				repo: body.repo,
+				author: session.user.name ?? session.user.email ?? "you",
+				authorType: "user",
+				content: body.message,
+				agentTarget,
+				discussionId: null,
+				discussionUrl: null,
+				timestamp,
+			};
+			await pushChatMessage(chatMessage);
 
-				return Response.json({
-					messageId,
-					agentSession: {
-						agentName: agentTarget,
-						streamUrl: "/api/chat/agent-stream",
-						threadId: body.parentDiscussionId ?? messageId,
-					},
-				});
-			}
-			// Persona not found — fall through to Discussion creation
+			return Response.json({
+				messageId,
+				agentSession: {
+					agentName: agentTarget,
+					streamUrl: "/api/chat/agent-stream",
+					threadId: body.parentDiscussionId ?? messageId,
+				},
+			});
 		}
 	}
 
 	// Use explicit target (not default fallback) for Discussion titles
 	const effectiveTarget = explicitTarget;
+	if (
+		effectiveTarget &&
+		effectiveTarget !== "spaces" &&
+		!resolvedExplicitPersona
+	) {
+		return Response.json(
+			{
+				error:
+					"Unknown agent target. Use a discovered repo persona such as @april-clearwater.",
+			},
+			{ status: 400 },
+		);
+	}
+	if (effectiveTarget === "spaces") {
+		return Response.json(
+			{ error: "Unknown @spaces command." },
+			{ status: 400 },
+		);
+	}
 	const title = effectiveTarget
 		? `@${effectiveTarget}: ${body.message.slice(0, 100)}`
 		: body.message.slice(0, 100);

--- a/web/src/lib/__tests__/chat-utils.test.ts
+++ b/web/src/lib/__tests__/chat-utils.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	findForbiddenPublicAgentMention,
 	formatDispatchBody,
 	handleBotCommand,
 	parseAgentMention,
 	parseIssueRef,
 	stripMention,
+	validatePublicAgentTarget,
 } from "../chat-utils";
 import type { EventStats } from "../events";
 
@@ -31,6 +33,50 @@ describe("parseAgentMention", () => {
 
 	it("returns null for text without mention", () => {
 		expect(parseAgentMention("no mention here")).toBeNull();
+	});
+});
+
+describe("validatePublicAgentTarget", () => {
+	it("allows canonical April Clearwater public target", () => {
+		expect(validatePublicAgentTarget("april-clearwater")).toBeNull();
+	});
+
+	it("rejects the short April alias because it is a real GitHub user", () => {
+		expect(validatePublicAgentTarget("april")).toContain(
+			"Use @april-clearwater instead of @april",
+		);
+	});
+
+	it("rejects malformed target names before they become GitHub mentions", () => {
+		expect(validatePublicAgentTarget("octo/agent")).toContain(
+			"Agent names may contain only",
+		);
+	});
+
+	it("can reject spaces where an agent target is required", () => {
+		expect(validatePublicAgentTarget("spaces")).toBeNull();
+		expect(
+			validatePublicAgentTarget("spaces", { allowSpaces: false }),
+		).toContain("not a dispatchable agent");
+	});
+});
+
+describe("findForbiddenPublicAgentMention", () => {
+	it("finds @april in GitHub-bound text", () => {
+		expect(findForbiddenPublicAgentMention("@april please handle this")).toBe(
+			"@april",
+		);
+		expect(findForbiddenPublicAgentMention("please ask @april")).toBe("@april");
+	});
+
+	it("does not flag canonical April Clearwater or longer names", () => {
+		expect(
+			findForbiddenPublicAgentMention("@april-clearwater status"),
+		).toBeNull();
+		expect(findForbiddenPublicAgentMention("@april_extra status")).toBeNull();
+		expect(
+			findForbiddenPublicAgentMention("@april-clearwater-extra"),
+		).toBeNull();
 	});
 });
 

--- a/web/src/lib/__tests__/chat-utils.test.ts
+++ b/web/src/lib/__tests__/chat-utils.test.ts
@@ -72,8 +72,13 @@ describe("parseIssueRef", () => {
 
 describe("formatDispatchBody", () => {
 	it("formats body with issue ref", () => {
-		const body = formatDispatchBody("april", "fix the bug", "#42", "abc12345");
-		expect(body).toContain("**Agent:** @april");
+		const body = formatDispatchBody(
+			"april-clearwater",
+			"fix the bug",
+			"#42",
+			"abc12345",
+		);
+		expect(body).toContain("**Agent:** @april-clearwater");
 		expect(body).toContain("**Task:** fix the bug");
 		expect(body).toContain("**Task ID:** `abc12345`");
 		expect(body).toContain("**Issue:** #42");
@@ -135,12 +140,12 @@ describe("handleBotCommand", () => {
 	});
 
 	it("@agent status returns agent status placeholder", async () => {
-		const params = makeParams("april", "@april status");
+		const params = makeParams("april-clearwater", "@april-clearwater status");
 		const result = await handleBotCommand(params);
 		expect(result).not.toBeNull();
 		expect(params.pushChatMessage).toHaveBeenCalledTimes(2);
 		const botMsg = params.pushChatMessage.mock.calls[1][0];
-		expect(botMsg.content).toContain("@april");
+		expect(botMsg.content).toContain("@april-clearwater");
 		expect(botMsg.content).toContain("No active dispatches");
 	});
 
@@ -152,7 +157,10 @@ describe("handleBotCommand", () => {
 	});
 
 	it("@agent with task body returns null (falls through to dispatch)", async () => {
-		const params = makeParams("april", "@april fix the bug in auth");
+		const params = makeParams(
+			"april-clearwater",
+			"@april-clearwater fix the bug in auth",
+		);
 		const result = await handleBotCommand(params);
 		expect(result).toBeNull();
 		expect(params.pushChatMessage).not.toHaveBeenCalled();

--- a/web/src/lib/chat-utils.ts
+++ b/web/src/lib/chat-utils.ts
@@ -2,6 +2,34 @@ import crypto from "node:crypto";
 import type { EventStats } from "./events";
 import type { ChatMessage } from "./types";
 
+const FORBIDDEN_PUBLIC_AGENT_MENTION_RE =
+	/(^|[^A-Za-z0-9_-])@(april)(?![A-Za-z0-9_-])/i;
+const PUBLIC_AGENT_TARGET_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+export function findForbiddenPublicAgentMention(text: string): string | null {
+	const match = text.match(FORBIDDEN_PUBLIC_AGENT_MENTION_RE);
+	return match ? `@${match[2]}` : null;
+}
+
+export function validatePublicAgentTarget(
+	target: string | null | undefined,
+	options: { allowSpaces?: boolean } = {},
+): string | null {
+	if (!target) return null;
+	if (!PUBLIC_AGENT_TARGET_RE.test(target)) {
+		return "Agent names may contain only letters, numbers, underscores, and hyphens.";
+	}
+	if (target.toLowerCase() === "spaces") {
+		return options.allowSpaces === false
+			? "@spaces is a bot command target, not a dispatchable agent."
+			: null;
+	}
+	if (target.toLowerCase() === "april") {
+		return "Use @april-clearwater instead of @april; @april is a different GitHub user.";
+	}
+	return null;
+}
+
 export async function handleBotCommand(params: {
 	target: string | null;
 	message: string;


### PR DESCRIPTION
## Summary
- Add .github/CODEOWNERS with @fairchild as global owner, including explicit .github/ ownership.
- Switch public April GitHub mention routing from @april to @april-clearwater and update executor conditions/docs/examples.
- Add an approved app-bot git identity table for april-clearwater and workspace-agents; unknown app slugs now fail before commit attribution.
- Harden web chat and dispatch APIs so direct calls cannot publish @april or unknown explicit agent targets into GitHub Discussions.
- Document app-token PR authorship, git commit attribution, CONTRIBUTOR mechanics, reviewer-only isolation, and the repeatable setup checklist.
- Extend the manual GitHub App review smoke workflow with a content-write probe that rejects main and release branches, pushes an app-authored empty commit, and verifies linked commit attribution.

## Mergeability
- Surface: agent-runtime / GitHub Actions / web chat API / docs
- User-facing behavior changed: Public GitHub-triggered April routing now uses only @april-clearwater; web chat and dispatch APIs reject @april and unknown explicit agent targets before publishing GitHub Discussions.
- Non-happy paths considered: Unknown GH_APP_SLUG fails before commit attribution; reviewer-only app remains excluded from commit identity mapping; content-write smoke refuses main and release branch probes; @spaces remains bot-command only for chat messages.
- Residual risk or follow-up: Do not enable the final two-approval + code-owner branch protection policy until a follow-up disposable PR proves GitHub counts the intended bot approval after workspace-agents has a merged default-branch commit.

## Evidence
- uv run --script scripts/test_agent_triage.py
- uv run --script scripts/test_run_contributor.py
- uv run --script scripts/test_security_hardening.py
- pnpm test -- src/lib/__tests__/chat-utils.test.ts (Vitest ran all 28 web test files: 283 tests passed)
- pnpm typecheck
- pnpm lint
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check
- [Web CI passed](https://github.com/fairchild/workspaces/actions/runs/26433022574/job/77809914245)
- [Mise Security passed](https://github.com/fairchild/workspaces/actions/runs/26433022596/job/77809914432)
- [Agent Scripts CI passed](https://github.com/fairchild/workspaces/actions/runs/26433022593/job/77809914327)
- [Managed Reviewer Broker passed](https://github.com/fairchild/workspaces/actions/runs/26433022598/job/77809914467)
- [April app review smoke passed](https://github.com/fairchild/workspaces/actions/runs/26430254685): review author april-clearwater[bot], state APPROVED, author_association CONTRIBUTOR.
- [workspace-agents app review smoke passed](https://github.com/fairchild/workspaces/actions/runs/26430254706): review author workspace-agents[bot], state APPROVED, author_association NONE.
- [workspace-agents disposable-branch content-write smoke passed](https://github.com/fairchild/workspaces/actions/runs/26431215172): pushed branch codex/workspace-agents-content-write-smoke-563 with commit 1d0bd1922daffa619253d6a5c29f20fec5119d03 authored as workspace-agents[bot] <266434718+workspace-agents[bot]@users.noreply.github.com> and linked by GitHub to workspace-agents[bot].
- [workspace-agents PR-branch content-write smoke passed](https://github.com/fairchild/workspaces/actions/runs/26431596816): pushed commit d8325a47f1d71df8dd5082924f1cd65143add66d directly to this PR branch, authored as workspace-agents[bot] <266434718+workspace-agents[bot]@users.noreply.github.com>, linked by GitHub to workspace-agents[bot].

## Live GitHub State Checked
- april-clearwater bot id: 268297116; app permissions include contents:write, pull_requests:write, metadata:read.
- workspace-agents bot id: 266434718; app permissions now include contents:write, pull_requests:write, metadata:read.
- workspaces-claude-pr-reviewer bot id: 279358706; local gh-apps inspection shows contents:read, pull_requests:write, statuses:write, metadata:read.
- fairchild repository permission: admin.
- main branch protection currently has required_approving_review_count: 0 and require_code_owner_reviews: false.

## Remaining External Gates
- This PR intentionally does not change branch protection yet. The documented policy says to enable two required approvals plus code-owner review only after live evidence proves GitHub counts the intended app-bot approval with @fairchild code-owner approval.
- The content-write smokes prove workspace-agents can push and GitHub links its commit attribution, including on this PR branch. Its review immediately after the PR-branch commit still reports author_association NONE, so contributor status likely requires the bot-authored commit to land in main or for GitHub association to refresh after a merged commit.
- Reviewer isolation remains intact: workspaces-claude-pr-reviewer is documented and verified as review-only, not a commit-writing app.
