### PR TITLE
Clarify release performance gate

### DIFF
--- a/.agents/skills/workspaces-performance-system/SKILL.md
+++ b/.agents/skills/workspaces-performance-system/SKILL.md
@@ -18,7 +18,7 @@ Use `workspaces-optimization` instead when the task is root-cause investigation 
 
 ## Quick Start
 
-Run one canonical scenario and assert budgets:
+Run one canonical debug scenario and assert budgets:
 
 ```bash
 ./scripts/perf-runner.sh --scenario debug_no_activate --assert-budget
@@ -30,10 +30,10 @@ Compare before and after summaries:
 ./scripts/perf-compare.py before-summary.json after-summary.json
 ```
 
-Verify release-bundle installed-build parity:
+Verify release-bundle performance signoff on the packaged app:
 
 ```bash
-./scripts/verify-installed-perf.sh build/WorkspaceManager.app
+./scripts/verify-installed-perf.sh build/WorkSpaces.app
 ```
 
 ## Core Workflow
@@ -67,9 +67,9 @@ Use these scenario ids exactly:
 
 Guidance:
 
-- Use `debug_no_activate` for low-variance local branch comparisons.
+- Use `debug_no_activate` for low-variance local branch comparisons and trend history, not release signoff.
 - Use `debug_activate` for interactive local validation.
-- Use `installed_clean_shell` to isolate app and terminal surface cost.
+- Use `installed_clean_shell` to isolate app and terminal surface cost; this is the packaged-app release signoff scenario.
 - Use `installed_login_shell` to include shell-init overhead.
 - Use `installed_input_short_capture` only for short interactive focused typing captures.
 
@@ -119,6 +119,10 @@ Installed validation must confirm:
 - logs do not contain missing-resource warnings
 
 If the verifier fails because the machine is headless or lacks a real display session, classify that as an environment limitation, not a product perf result. Release automation may use `./scripts/verify-installed-perf.sh --allow-skip-noninteractive` for that one case only.
+
+Debug scenario failures are useful branch-trend evidence. They do not block a
+release by themselves when the packaged app verifier passes and the debug
+environment difference is explicitly classified.
 
 ### 6. Separate infra failures from perf regressions
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,10 +23,17 @@
 - [ ] Before and after evidence came from a like-for-like workload and environment
 - [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below
 
-For performance-sensitive work, capture canonical evidence with:
+For performance-sensitive work, capture canonical evidence with the scenario
+that matches the changed surface:
 
 ```bash
+# Debug-build UI/runtime branch deltas:
 ./scripts/prepare-perf-evidence.sh --scenario debug_no_activate
+
+# Release, packaging, shell, or bundled Ghostty resource changes:
+./scripts/build-release.sh --no-sign
+./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-installed-perf-verify-<slug>
+./scripts/perf-runner.sh --scenario installed_login_shell --app build/WorkSpaces.app
 ```
 
 If this PR has the `performance-sensitive` label, fill all fields below. The `PR Perf Evidence` workflow enforces them.

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Build (debug)
         run: swift build
 
+      - name: Validate perf tooling
+        run: python3 scripts/test_perf_tools.py
+
       - name: Capture perf baseline
         run: ./scripts/perf-baseline.sh 3 6 --record --assert-budget
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Verify signed app bundle
         run: ./scripts/verify-release-bundle.sh build/WorkSpaces.app
 
-      - name: Verify installed-build perf parity
+      - name: Verify installed-build release performance
         run: ./scripts/verify-installed-perf.sh --allow-skip-noninteractive build/WorkSpaces.app build/release-installed-perf
 
       - name: Upload installed-build perf verification artifact

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -132,7 +132,7 @@ Run a local unsigned build first to confirm the toolchain works:
 
 ```bash
 ./scripts/build-release.sh --no-sign
-open build/WorkSpaces.app
+./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-installed-perf-verify-<date>
 ```
 
 Then test signing:
@@ -141,8 +141,10 @@ Then test signing:
 ./scripts/build-release.sh
 ./scripts/verify-app-keychain-signing.sh build/WorkSpaces.app
 ./scripts/verify-release-bundle.sh build/WorkSpaces.app
+./scripts/verify-installed-perf.sh build/WorkSpaces.app build/release-installed-perf
 # Should confirm the embedded provisioning profile, keychain access group,
-# and Developer ID signing across nested code objects
+# Developer ID signing across nested code objects, bundled Ghostty resources,
+# and installed-app terminal readiness metrics
 ```
 
 ### GitHub Actions Setup (for CI/CD)
@@ -418,6 +420,12 @@ xcrun stapler validate build/WorkSpaces-0.3.1.dmg
 # Should say "The validate action worked!"
 ```
 
+### Installed Performance
+```bash
+./scripts/verify-installed-perf.sh build/WorkSpaces.app build/release-installed-perf
+# Should report launch_to_first_prompt, terminal_first_output, and first_prompt_ready
+```
+
 ### Clean Mac Test
 
 Download the DMG from GitHub Releases onto a Mac that has never seen the app:
@@ -476,6 +484,7 @@ security find-identity -v -p codesigning
 | `scripts/build-release.sh` | Build app bundle from SPM |
 | `scripts/verify-app-keychain-signing.sh` | Verify embedded provisioning profile and signed keychain entitlements |
 | `scripts/verify-release-bundle.sh` | Verify Developer ID signing across bundled code objects before notarization |
+| `scripts/verify-installed-perf.sh` | Verify packaged Ghostty resources and installed-app terminal readiness metrics |
 | `scripts/prepare-release.sh` | Update release metadata, create the release commit, and tag/push the release |
 | `scripts/notarize.sh` | Create DMG and notarize |
 | `scripts/setup-release-secrets.sh` | Configure GitHub Actions release secrets/variables from a verified `.p12` and provisioning profile |

--- a/config/performance/contract.json
+++ b/config/performance/contract.json
@@ -22,13 +22,19 @@
     "main_scheduled": {
       "self_hosted_perf_required": true,
       "self_hosted_perf_condition": "after_7_day_lane_stability"
+    },
+    "release": {
+      "installed_build_verification_required": true,
+      "release_signoff_scenario": "installed_clean_shell",
+      "debug_scenarios_block_release": false,
+      "debug_scenarios_use": "branch_delta_and_trend"
     }
   },
   "scenarios": [
     {
       "id": "debug_no_activate",
       "build_kind": "debug",
-      "description": "Debug binary launched without activation for reproducible local startup and switch timing."
+      "description": "Raw SwiftPM debug binary launched without activation for reproducible local branch-delta and trend timing; not the release signoff scenario."
     },
     {
       "id": "debug_activate",
@@ -38,7 +44,7 @@
     {
       "id": "installed_clean_shell",
       "build_kind": "installed",
-      "description": "Installed app launched with clean shell profiles to isolate app and terminal surface cost."
+      "description": "Packaged app launched with clean shell profiles to isolate app and terminal surface cost; primary release performance signoff scenario."
     },
     {
       "id": "installed_login_shell",

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -25,9 +25,41 @@ swift build
 
 This ensures perf changes are not hiding functional regressions.
 
+## Release performance signoff
+
+Release performance is validated against the packaged app, not the raw SwiftPM
+debug binary. The installed verifier is the release gate because it confirms the
+bundle contains the Ghostty runtime resources and emits the installed-only
+terminal readiness metrics.
+
+Local prerelease check:
+
+```bash
+./scripts/build-release.sh --no-sign
+./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-installed-perf-verify-<date>
+```
+
+Signed release automation runs the same gate after `./scripts/verify-release-bundle.sh`:
+
+```bash
+./scripts/verify-installed-perf.sh --allow-skip-noninteractive build/WorkSpaces.app build/release-installed-perf
+```
+
+Use `--allow-skip-noninteractive` only on release runners that may lack an
+interactive Aqua session. On a developer Mac with a real display session, a
+missing installed perf result is a validation failure to diagnose before
+signoff.
+
 ## PR evidence contract
 
-Performance-sensitive PRs must carry canonical before/after evidence in the PR body. The expected workflow is:
+Performance-sensitive PRs must carry canonical before/after evidence in the PR
+body. Pick the scenario that matches the surface under review:
+
+- Use `debug_no_activate` for debug-build UI/runtime branch deltas.
+- Use `installed_clean_shell` or `installed_login_shell` for package, release,
+  shell, Ghostty resource, or installed-app startup changes.
+
+The expected debug-build workflow is:
 
 ```bash
 ./scripts/pr-evidence.sh --pr <N> --profile performance --scenario debug_no_activate
@@ -47,6 +79,15 @@ The lower-level helper remains available when you only need local Markdown field
 ./scripts/prepare-perf-evidence.sh --scenario debug_no_activate
 ```
 
+For release or packaging-sensitive PRs, include the installed verifier output
+and the exact packaged-app scenario used:
+
+```bash
+./scripts/build-release.sh --no-sign
+./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-installed-perf-verify-<slug>
+./scripts/perf-runner.sh --scenario installed_login_shell --app build/WorkSpaces.app
+```
+
 The PR evidence wrapper runs the canonical scenario, captures `before` and `after` summaries, compares them with `./scripts/perf-compare.py`, writes local PR-ready Markdown, and uploads an SVG delta summary through `./scripts/evidence.sh`.
 
 Required PR fields for `performance-sensitive` work:
@@ -58,15 +99,21 @@ Required PR fields for `performance-sensitive` work:
 
 When the PR has the `performance-sensitive` label, `.github/workflows/pr-perf-evidence.yml` fails if those fields are missing. Use scenarios from `config/performance/contract.json` and keep the machine, launch mode, and workload comparable across captures.
 
-## Standard benchmark workflow (recommended)
+## Debug benchmark workflow
 
-Use the scripted baseline runner:
+Use the scripted baseline runner for branch-to-branch debug comparisons and
+dashboard trend updates:
 
 ```bash
 ./scripts/perf-baseline.sh 5 8
 ./scripts/perf-baseline.sh 5 8 --launch-mode activate
 ./scripts/perf-runner.sh --scenario debug_no_activate --assert-budget
 ```
+
+This is not the release signoff path. The raw debug binary may carry debug-build
+overhead or miss packaged Ghostty resources that the release app bundles
+correctly. Compare debug captures only against debug captures from the same
+machine, launch mode, and workload shape.
 
 To persist results and generate a visual trend dashboard:
 
@@ -119,8 +166,8 @@ The dedicated GitHub Actions workflow is `.github/workflows/perf-validation.yml`
 Use the canonical installed-build wrapper when validating packaged or installed apps:
 
 ```bash
-./scripts/perf-runner.sh --scenario installed_clean_shell --app /Applications/WorkSpaces.app/Contents/MacOS/WorkspaceManager
-./scripts/perf-runner.sh --scenario installed_login_shell --app /Applications/WorkSpaces.app/Contents/MacOS/WorkspaceManager
+./scripts/perf-runner.sh --scenario installed_clean_shell --app build/WorkSpaces.app
+./scripts/perf-runner.sh --scenario installed_login_shell --app build/WorkSpaces.app
 ./scripts/perf-runner.sh --scenario installed_input_short_capture --capture-seconds 15
 ./scripts/verify-installed-perf.sh build/WorkSpaces.app
 ```
@@ -129,6 +176,8 @@ These runs use the same summary schema as the debug baseline, so before/after co
 
 Notes:
 
+- `perf-runner.sh --app` accepts either a `.app` bundle or the
+  `Contents/MacOS/WorkspaceManager` executable for installed scenarios.
 - `installed_input_short_capture` is intentionally interactive. The app activates and you must type in the focused terminal during the capture window.
 - `verify-installed-perf.sh --allow-skip-noninteractive` is reserved for release automation on runners that may lack an interactive Aqua session.
 
@@ -192,24 +241,40 @@ Recommended evidence loop for this startup-probing work:
 
 For PR submission, prefer `./scripts/prepare-perf-evidence.sh` over ad hoc notes so the evidence format stays consistent with the repo gate.
 
-## Installed-build validation workflow
+## Installed-build release validation workflow
 
-Use an installed app pass as validation evidence after the local repeated runs:
+Use the installed verifier as the primary quantitative source of truth for
+release readiness:
 
 ```bash
-./scripts/install-local.sh --no-open
+./scripts/build-release.sh --no-sign
+./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-installed-perf-verify-<date>
 ```
 
-Then launch the installed app and capture local logs:
+For a signed release artifact, the full release sequence is:
 
 ```bash
-log stream --style compact --predicate 'eventMessage CONTAINS "[Perf]"'
+./scripts/build-release.sh
+./scripts/verify-release-bundle.sh build/WorkSpaces.app
+./scripts/verify-installed-perf.sh build/WorkSpaces.app build/release-installed-perf
+```
+
+When you need the login-shell view of the same packaged app, run:
+
+```bash
+./scripts/perf-runner.sh --scenario installed_login_shell --app build/WorkSpaces.app
 ```
 
 Notes:
 
-- Treat the installed run as a spot check, not the main statistical baseline.
-- If local unsigned installs do not expose the expected `[Perf]` lines through unified logging, record that limitation explicitly in the report instead of fabricating timing data. The repeated local debug-run benchmarks remain the primary quantitative source of truth.
+- `verify-installed-perf.sh` must produce `terminal_first_output` and
+  `first_prompt_ready` in addition to `launch_to_first_prompt`.
+- Release signoff uses the installed scenario budgets in
+  `config/performance/contract.json`; do not apply debug `250ms` expectations to
+  the packaged release app.
+- If a debug run fails but the installed verifier passes, classify the debug
+  result as branch-trend evidence or a debug-environment issue, not a release
+  blocker.
 
 ## Manual benchmark workflow (optional)
 

--- a/docs/performance/metrics-reference.md
+++ b/docs/performance/metrics-reference.md
@@ -10,9 +10,9 @@ Canonical scenarios:
 
 | Scenario | Build Kind | Purpose |
 |---|---|---|
-| `debug_no_activate` | `debug` | Low-variance local startup and switch timing without app activation |
+| `debug_no_activate` | `debug` | Raw SwiftPM debug startup and switch timing without app activation; use for branch deltas and trend history, not release signoff |
 | `debug_activate` | `debug` | Interactive debug startup timing with normal activation |
-| `installed_clean_shell` | `installed` | Installed-app startup with shell init bypassed |
+| `installed_clean_shell` | `installed` | Packaged-app release signoff with shell init bypassed and bundled Ghostty resources verified |
 | `installed_login_shell` | `installed` | Installed-app startup with normal login shell cost included |
 | `installed_input_short_capture` | `installed` | Short focused typing capture for input event age and handler timing |
 
@@ -28,6 +28,8 @@ Start event:
 
 End event:
 - `PerformanceSignposts.endLaunchToFirstPromptIfNeeded(trigger: "terminal_focus")` when focus manager successfully sets terminal first responder.
+- Installed no-activation captures may also end when terminal prompt readiness is
+  observed through the terminal title path before foreground focus is possible.
 
 Why it matters:
 - This is the “is the app immediately usable?” number.
@@ -262,6 +264,9 @@ Rules:
 - median is the gating statistic
 - p95 is diagnostic and should trigger investigation even when median still passes
 - existing `[Perf]` metric names remain the raw telemetry source; contract logic sits above them
+- debug scenario budgets are release-advisory only; a debug failure does not
+  block a release when installed-build verification passes and the difference is
+  classified in the release notes or PR context
 
 Enforcement points:
 
@@ -269,10 +274,14 @@ Enforcement points:
 - `./scripts/perf-runner.sh --scenario <id> --assert-budget`
 - `.github/workflows/perf-validation.yml`
 
-Installed-build parity is verified separately in the release path:
+Release signoff uses installed-build verification:
 
 - `./scripts/verify-release-bundle.sh`
 - `./scripts/verify-installed-perf.sh`
+
+`verify-installed-perf.sh` must confirm bundled Ghostty resources, bundled
+terminfo, `terminal_first_output`, and `first_prompt_ready`. These installed
+metrics are the release-relevant signal for packaged app startup.
 
 ## Interpreting Dashboard Changes
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,7 @@ Run `mise tasks` from the repo root for the current catalog. Web dashboard tasks
 
 - `./scripts/perf-runner.sh --scenario <id>`
   - Runs one canonical scenario and writes a canonical summary artifact.
+  - Installed scenarios accept either a `.app` bundle path or the bundled executable path.
 - `./scripts/perf-compare.py before.json after.json`
   - Compares two canonical summaries and prints metric deltas plus gate status.
 - `./scripts/pr-evidence.sh --pr <N> --profile performance`

--- a/scripts/perf-runner.sh
+++ b/scripts/perf-runner.sh
@@ -95,6 +95,20 @@ if [[ -z "$OUTPUT_DIR" ]]; then
 fi
 mkdir -p "$OUTPUT_DIR"
 
+normalize_installed_app_path() {
+    local candidate="${1%/}"
+    if [[ -d "$candidate" && "$candidate" == *.app ]]; then
+        local binary="$candidate/Contents/MacOS/WorkspaceManager"
+        if [[ ! -x "$binary" ]]; then
+            echo "App bundle binary not found or not executable: $binary" >&2
+            exit 1
+        fi
+        printf '%s\n' "$binary"
+        return
+    fi
+    printf '%s\n' "$candidate"
+}
+
 run_debug() {
     local launch_mode="$1"
     local latest_before=""
@@ -122,13 +136,15 @@ run_installed() {
     local shell_mode_flag="$1"
     local activate_mode="${2:-no-activate}"
     shift 2
+    local resolved_app_path
+    resolved_app_path="$(normalize_installed_app_path "$APP_PATH")"
     local log_file="$OUTPUT_DIR/$SCENARIO.log"
     local summary_json="$OUTPUT_DIR/summary.json"
     local summary_txt="$OUTPUT_DIR/summary.txt"
     mkdir -p "$OUTPUT_DIR/app-data"
 
     local launch_args=(
-        --app "$APP_PATH"
+        --app "$resolved_app_path"
         "$shell_mode_flag"
         --capture-seconds "$CAPTURE_SECONDS"
         --log-file "$log_file"
@@ -141,25 +157,26 @@ run_installed() {
         "${launch_args[@]}" \
         "$@"
 
-    summarize_installed_log "$log_file" "$summary_json" "$summary_txt"
+    summarize_installed_log "$log_file" "$summary_json" "$summary_txt" "$resolved_app_path"
 }
 
 summarize_installed_log() {
     local log_file="$1"
     local summary_json="$2"
     local summary_txt="$3"
+    local app_path="$4"
 
     "$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
         --json \
         --scenario "$SCENARIO" \
         --build-kind installed \
-        --app-path "$APP_PATH" \
+        --app-path "$app_path" \
         "$log_file" >"$summary_json"
 
     "$ROOT_DIR/.agents/skills/workspaces-optimization/scripts/summarize_perf_log.py" \
         --scenario "$SCENARIO" \
         --build-kind installed \
-        --app-path "$APP_PATH" \
+        --app-path "$app_path" \
         "$log_file" >"$summary_txt"
 
     echo "summary_json=$summary_json"
@@ -174,6 +191,8 @@ run_installed_input_short_capture() {
         exit 1
     fi
 
+    local resolved_app_path
+    resolved_app_path="$(normalize_installed_app_path "$APP_PATH")"
     local log_file="$OUTPUT_DIR/$SCENARIO.log"
     local summary_json="$OUTPUT_DIR/summary.json"
     local summary_txt="$OUTPUT_DIR/summary.txt"
@@ -183,13 +202,13 @@ run_installed_input_short_capture() {
     echo "Type in the focused terminal during that window to produce input metrics."
 
     WORKSPACES_DATA_DIR="$OUTPUT_DIR/app-data" "$ROOT_DIR/scripts/launch-installed-diagnostics.sh" \
-        --app "$APP_PATH" \
+        --app "$resolved_app_path" \
         --login-shell \
         --with-input-diagnostics \
         --capture-seconds "$CAPTURE_SECONDS" \
         --log-file "$log_file"
 
-    summarize_installed_log "$log_file" "$summary_json" "$summary_txt"
+    summarize_installed_log "$log_file" "$summary_json" "$summary_txt" "$resolved_app_path"
 
     python3 - "$summary_json" <<'PY'
 import json

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -8,7 +8,8 @@
 #
 # Checks:
 #   - build-and-test (CI) must have passed on <sha>       → hard gate
-#   - perf-validation passing is advisory                 → warning only
+#   - scheduled debug perf-validation is advisory          → warning only
+#   - packaged-app perf signoff runs later in release.yml  → hard gate
 #
 # Exit codes:
 #   0  all required checks passed

--- a/scripts/test_perf_tools.py
+++ b/scripts/test_perf_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import tempfile
 import unittest
 import zipfile
@@ -58,9 +59,26 @@ class PerfContractTests(unittest.TestCase):
         self.assertEqual(result["launch_to_first_prompt"]["diagnostic_threshold_ms"], 390)
         self.assertEqual(result["launch_to_first_prompt"]["status"], "pass")
 
+    def test_release_policy_uses_installed_signoff(self) -> None:
+        contract = load_contract()
+        release_policy = contract["gate_policy"]["release"]
+        self.assertTrue(release_policy["installed_build_verification_required"])
+        self.assertEqual(release_policy["release_signoff_scenario"], "installed_clean_shell")
+        self.assertFalse(release_policy["debug_scenarios_block_release"])
+
+
+class PerfRunnerScriptTests(unittest.TestCase):
+    def test_installed_scenario_normalizes_app_bundle_path(self) -> None:
+        script = (REPO_ROOT / "scripts" / "perf-runner.sh").read_text(encoding="utf-8")
+        self.assertIn("normalize_installed_app_path", script)
+        self.assertIn("Contents/MacOS/WorkspaceManager", script)
+        self.assertIn('--app "$resolved_app_path"', script)
+
 
 class PerfSummarizerTests(unittest.TestCase):
     def run_json(self, command: list[str]) -> dict:
+        if command and Path(command[0]).suffix == ".py":
+            command = [sys.executable, *command]
         result = subprocess.run(
             command,
             cwd=REPO_ROOT,

--- a/scripts/verify-installed-perf.sh
+++ b/scripts/verify-installed-perf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Verify installed-build performance parity and resource packaging for a packaged app.
+# Verify packaged-app performance and resource packaging for release signoff.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Make packaged installed-app verification the release performance gate and classify raw debug captures as branch-trend evidence.
- Update release docs, PR template, performance contract, and the performance-system skill to point release signoff at `verify-installed-perf.sh`.
- Let `perf-runner.sh` installed scenarios accept a `.app` bundle path, then validate that behavior in perf tooling tests and the perf workflow.

## Mergeability

- Surface: docs / infra / release / perf tooling
- User-facing behavior changed: no app runtime behavior change
- Non-happy paths considered: headless release runners still use `--allow-skip-noninteractive`; debug perf failures no longer imply release failure when packaged verification passes
- Release/ops preconditions: release workflow still verifies signing before installed perf and uploads the installed perf artifact
- Residual risk or follow-up: no numeric budget rebaseline in this PR

## Validation

- [x] `python3 scripts/test_perf_tools.py` passed, 8 tests passed
- [x] `bash -n scripts/perf-runner.sh`
- [x] `bash -n scripts/verify-installed-perf.sh`
- [x] `bash -n scripts/release-preflight.sh`
- [x] `python3 -m json.tool config/performance/contract.json`
- [x] `ruby -e "require \"yaml\"; ARGV.each { |path| YAML.load_file(path); puts path }" .github/workflows/perf-validation.yml .github/workflows/release.yml`
- [x] `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main`
- [x] `./scripts/perf-runner.sh --scenario installed_clean_shell --app build/WorkSpaces.app --output-dir /tmp/workspaces-perf-runner-bundle-smoke-20260525-223000 --capture-seconds 12`

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `config/performance/contract.json`
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: `installed_clean_shell`
- Before Summary: process-only change; no runtime before/after delta expected
- After Summary: `launch_to_first_prompt=121.36ms`, `terminal_first_output=95.31ms`, `first_prompt_ready=95.31ms`; all gated installed metrics passed
- Delta Summary: not applicable, no app runtime change

Performance comparison notes:

- Exact commands used: see Validation
- Workload / environment context: packaged `build/WorkSpaces.app`, clean shell, no-activate installed scenario, 12 second capture

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Release perf bundle smoke](https://evidence.cloudcompute.com/workspaces/pr-565/20260526-050326-release-perf-bundle-smoke.svg)
- [CI build-and-test passed](https://github.com/fairchild/workspaces/actions/runs/26433010999/job/77809881771)
- [Web CI passed](https://github.com/fairchild/workspaces/actions/runs/26433010996/job/77809881707)
- [Agent script tests passed](https://github.com/fairchild/workspaces/actions/runs/26433011001/job/77809881711)

## Blockers

- [x] None
- [ ] Blocked on evidence
