### PR TITLE
[codex] Feed command status from prompt markers

### DIFF
--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -61,6 +61,12 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         bundledHookForwarderURL(named: "statusline")?.path
     }
 
+    /// Locate the sourceable zsh command-status producer shipped alongside the app.
+    /// Returns nil when the bundle was assembled without the producer resource.
+    nonisolated static func bundledCommandStatusHookPath() -> String? {
+        bundledHookForwarderURL(named: "command-status", fileExtension: "zsh")?.path
+    }
+
     private init() {}
 
     /// Test seam: swap the UserDefaults instance and the installer construction so
@@ -79,12 +85,16 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         self.socketPath = nil
     }
 
-    func start(registry: AgentSessionRegistry) {
+    func start(registry: AgentSessionRegistry, commandStatusRegistry: LastCommandStatusRegistry? = nil) {
         guard !didStart else { return }
         didStart = true
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
-        let listener = AgentHookListener(bundleIdentifier: bundleID, registry: registry)
+        let listener = AgentHookListener(
+            bundleIdentifier: bundleID,
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry
+        )
         self.listener = listener
         self.socketPath = listener.socketPath
         self.notificationPoster = AgentNotificationPoster(registry: registry)
@@ -183,9 +193,10 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         }
     }
 
-    nonisolated static func bundledHookForwarderURL(named name: String) -> URL? {
+    nonisolated static func bundledHookForwarderURL(named name: String, fileExtension: String = "sh") -> URL? {
         bundledHookForwarderURL(
             named: name,
+            fileExtension: fileExtension,
             mainBundle: .main,
             swiftPMResourceBundle: { Bundle.module }
         )
@@ -193,11 +204,16 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
 
     nonisolated static func bundledHookForwarderURL(
         named name: String,
+        fileExtension: String = "sh",
         mainBundle: Bundle,
         swiftPMResourceBundle: () -> Bundle?
     ) -> URL? {
         let appResourceBundles = hookForwarderResourceBundles(mainBundle: mainBundle)
-        if let url = hookForwarderURL(named: name, resourceBundles: appResourceBundles) {
+        if let url = hookForwarderURL(
+            named: name,
+            fileExtension: fileExtension,
+            resourceBundles: appResourceBundles
+        ) {
             return url
         }
 
@@ -207,20 +223,25 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
 
         return hookForwarderURL(
             named: name,
+            fileExtension: fileExtension,
             resourceBundles: [swiftPMBundle]
         )
     }
 
-    nonisolated static func hookForwarderURL(named name: String, resourceBundles: [Bundle]) -> URL? {
+    nonisolated static func hookForwarderURL(
+        named name: String,
+        fileExtension: String = "sh",
+        resourceBundles: [Bundle]
+    ) -> URL? {
         for bundle in resourceBundles {
             if let url = bundle.url(
                 forResource: name,
-                withExtension: "sh",
+                withExtension: fileExtension,
                 subdirectory: "HookForwarders"
             ) {
                 return url
             }
-            if let url = bundle.url(forResource: name, withExtension: "sh") {
+            if let url = bundle.url(forResource: name, withExtension: fileExtension) {
                 return url
             }
         }

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -18,6 +18,7 @@ struct WorkspaceManagerApp: App {
     @StateObject private var modelStoreStatusController: ModelStoreStatusController
     @StateObject private var softwareUpdateController: SoftwareUpdateController
     @StateObject private var agentSessionRegistry: AgentSessionRegistry
+    @StateObject private var lastCommandStatusRegistry: LastCommandStatusRegistry
     @StateObject private var workspaceStatusAggregator = WorkspaceStatusAggregator()
     @StateObject private var claudeIntegrationLifecycle: ClaudeIntegrationLifecycle
     private let appRuntimeDependencies = AppRuntimeDependencies.resolved()
@@ -48,7 +49,9 @@ struct WorkspaceManagerApp: App {
         _softwareUpdateController = StateObject(wrappedValue: SoftwareUpdateController())
         _claudeIntegrationLifecycle = StateObject(wrappedValue: ClaudeIntegrationLifecycle.shared)
         let registry = AgentSessionRegistry(localStateStore: localStateBootstrap.store)
+        let commandStatusRegistry = LastCommandStatusRegistry()
         _agentSessionRegistry = StateObject(wrappedValue: registry)
+        _lastCommandStatusRegistry = StateObject(wrappedValue: commandStatusRegistry)
         self.sharedModelContainer = bootstrap.container
         self.localStateStore = localStateBootstrap.store
 
@@ -56,7 +59,10 @@ struct WorkspaceManagerApp: App {
         // The listener binds to a Unix socket under Application Support keyed by pid.
         // Disabled in CI to avoid cluttering the runner's filesystem.
         if ProcessInfo.processInfo.environment["CI"] == nil {
-            ClaudeIntegrationLifecycle.shared.start(registry: registry)
+            ClaudeIntegrationLifecycle.shared.start(
+                registry: registry,
+                commandStatusRegistry: commandStatusRegistry
+            )
         }
     }
 
@@ -73,8 +79,10 @@ struct WorkspaceManagerApp: App {
             )
             .environmentObject(modelStoreStatusController)
             .environmentObject(agentSessionRegistry)
+            .environmentObject(lastCommandStatusRegistry)
             .environmentObject(workspaceStatusAggregator)
             .environment(\.agentSessionRegistry, agentSessionRegistry)
+            .environment(\.lastCommandStatusRegistry, lastCommandStatusRegistry)
             .environment(\.localStateStore, localStateStore)
             .frame(minWidth: 1000, minHeight: 700)
             .onAppear {
@@ -252,7 +260,9 @@ struct WorkspaceManagerApp: App {
                 .environment(\.claudeSettingsInstaller, claudeIntegrationLifecycle.settingsInstaller)
                 .environmentObject(modelStoreStatusController)
                 .environmentObject(agentSessionRegistry)
+                .environmentObject(lastCommandStatusRegistry)
                 .environment(\.agentSessionRegistry, agentSessionRegistry)
+                .environment(\.lastCommandStatusRegistry, lastCommandStatusRegistry)
         }
     }
 }
@@ -303,6 +313,7 @@ private struct MainWindowRootView: View {
 /// agent-state seeder so deterministic screenshots can land at specific run states.
 private struct AgentSessionRegistryAttacher: ViewModifier {
     @EnvironmentObject private var registry: AgentSessionRegistry
+    @EnvironmentObject private var commandStatusRegistry: LastCommandStatusRegistry
     @Environment(\.localStateStore) private var localStateStore
     @Environment(\.modelContext) private var modelContext
     let hostTerminalState: HostTerminalStateStore
@@ -312,7 +323,8 @@ private struct AgentSessionRegistryAttacher: ViewModifier {
             hostTerminalState.attach(
                 agentSessionRegistry: registry,
                 localStateStore: localStateStore,
-                hooksSocketPath: ClaudeIntegrationLifecycle.shared.socketPath
+                hooksSocketPath: ClaudeIntegrationLifecycle.shared.socketPath,
+                lastCommandStatusRegistry: commandStatusRegistry
             )
             if ProcessInfo.processInfo.environment["WORKSPACES_UI_FIXTURE"] == "1" {
                 UIFixtureSeeder.seedAgentStatesIfNeeded(
@@ -542,6 +554,10 @@ private struct AgentSessionRegistryKey: EnvironmentKey {
     static let defaultValue: AgentSessionRegistry? = nil
 }
 
+private struct LastCommandStatusRegistryKey: EnvironmentKey {
+    static let defaultValue: LastCommandStatusRegistry? = nil
+}
+
 private struct LocalStateStoreKey: EnvironmentKey {
     static let defaultValue: LocalStateStore? = nil
 }
@@ -584,6 +600,11 @@ extension EnvironmentValues {
     var agentSessionRegistry: AgentSessionRegistry? {
         get { self[AgentSessionRegistryKey.self] }
         set { self[AgentSessionRegistryKey.self] = newValue }
+    }
+
+    var lastCommandStatusRegistry: LastCommandStatusRegistry? {
+        get { self[LastCommandStatusRegistryKey.self] }
+        set { self[LastCommandStatusRegistryKey.self] = newValue }
     }
 
     var localStateStore: LocalStateStore? {

--- a/Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh
@@ -1,0 +1,66 @@
+# command-status.zsh — sourceable zsh producer for WorkSpaces command status.
+#
+# Usage:
+#   source "$WORKSPACES_COMMAND_STATUS_ZSH"
+#
+# The hook emits OSC-133-shaped command lifecycle markers through the existing
+# WorkSpaces Unix-socket listener. It is opt-in and safe to source from .zshrc:
+# missing socket/session env, missing curl, or a stopped host app all degrade to
+# no-op behavior.
+
+if [[ -z "${ZSH_VERSION:-}" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+if [[ -n "${WORKSPACES_COMMAND_STATUS_ZSH_LOADED:-}" ]]; then
+    return 0
+fi
+typeset -g WORKSPACES_COMMAND_STATUS_ZSH_LOADED=1
+typeset -g __workspaces_command_status_started=0
+
+__workspaces_post_command_marker() {
+    emulate -L zsh
+    setopt no_unset
+
+    local socket="${WORKSPACES_HOOKS_SOCKET:-}"
+    local host_session_id="${WORKSPACES_HOST_SESSION_ID:-}"
+    local payload="$1"
+
+    [[ -n "$socket" && -S "$socket" ]] || return 0
+    [[ -n "$host_session_id" ]] || return 0
+    [[ -x /usr/bin/curl ]] || return 0
+
+    builtin printf '%b' "$payload" | /usr/bin/curl \
+        --silent \
+        --show-error \
+        --max-time 1 \
+        --unix-socket "$socket" \
+        -X POST \
+        -H 'Content-Type: application/octet-stream' \
+        -H "X-WorkSpaces-Host-Session-ID: $host_session_id" \
+        --data-binary @- \
+        'http://localhost/command-markers' \
+        >/dev/null 2>&1 || true
+}
+
+__workspaces_command_status_preexec() {
+    emulate -L zsh
+    typeset -g __workspaces_command_status_started=1
+    __workspaces_post_command_marker $'\033]133;B\a'
+}
+
+__workspaces_command_status_precmd() {
+    local exit_code=$?
+    emulate -L zsh
+
+    if [[ "${__workspaces_command_status_started:-0}" != "1" ]]; then
+        return 0
+    fi
+
+    typeset -g __workspaces_command_status_started=0
+    __workspaces_post_command_marker $'\033]133;D;'"${exit_code}"$'\a'
+}
+
+autoload -Uz add-zsh-hook 2>/dev/null || return 0
+add-zsh-hook preexec __workspaces_command_status_preexec 2>/dev/null || true
+add-zsh-hook precmd __workspaces_command_status_precmd 2>/dev/null || true

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -54,6 +54,9 @@ struct GhosttyTerminalConfig {
         if let hooksSocketPath, let hostSessionID {
             environment["WORKSPACES_HOOKS_SOCKET"] = hooksSocketPath
             environment["WORKSPACES_HOST_SESSION_ID"] = hostSessionID.uuidString
+            if let commandStatusHookPath = ClaudeIntegrationLifecycle.bundledCommandStatusHookPath() {
+                environment["WORKSPACES_COMMAND_STATUS_ZSH"] = commandStatusHookPath
+            }
         }
 
         if let path = environment["PATH"] {

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -37,6 +37,7 @@ final class HostTerminalStateStore: ObservableObject {
     /// Agent session registry attached at scene mount. Optional because previews and
     /// fixtures construct stores without an app-scoped registry.
     private weak var agentSessionRegistry: AgentSessionRegistry?
+    private weak var lastCommandStatusRegistry: LastCommandStatusRegistry?
     private var localStateStore: LocalStateStore?
     /// Stub probe used to seed `kind` on register; PR #1 ships a fail-safe
     /// `.claudeCode` default. Replace with the real probe in a Channel 3 follow-up.
@@ -56,9 +57,11 @@ final class HostTerminalStateStore: ObservableObject {
     func attach(
         agentSessionRegistry: AgentSessionRegistry,
         localStateStore: LocalStateStore?,
-        hooksSocketPath: String?
+        hooksSocketPath: String?,
+        lastCommandStatusRegistry: LastCommandStatusRegistry? = nil
     ) {
         self.localStateStore = localStateStore
+        self.lastCommandStatusRegistry = lastCommandStatusRegistry
         self.surfaceStore.hooksSocketPath = hooksSocketPath
         guard self.agentSessionRegistry !== agentSessionRegistry else {
             syncRegistry()
@@ -476,6 +479,7 @@ final class HostTerminalStateStore: ObservableObject {
         let removed = registeredAgentSessionIDs.subtracting(liveIDs)
         for sessionID in removed {
             registry.deregister(hostSessionID: sessionID)
+            lastCommandStatusRegistry?.clear(terminalSessionID: sessionID)
             recordTerminalSessionEnded(sessionID)
         }
         registeredAgentSessionIDs.subtract(removed)
@@ -486,6 +490,7 @@ final class HostTerminalStateStore: ObservableObject {
             surfaceStore.invalidate(sessionID: splitSession.id)
             if registeredAgentSessionIDs.contains(splitSession.id) {
                 agentSessionRegistry?.deregister(hostSessionID: splitSession.id)
+                lastCommandStatusRegistry?.clear(terminalSessionID: splitSession.id)
                 recordTerminalSessionEnded(splitSession.id)
                 registeredAgentSessionIDs.remove(splitSession.id)
             }

--- a/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
@@ -9,6 +9,8 @@
 //    POST /event       — hook event, decoded via ClaudeHookTranslator
 //    POST /statusline  — Channel 2 status-line forwarder; decodes StatusLinePayload
 //                        and applies status fields for the header-routed session
+//    POST /command-markers
+//                      — raw OSC 133 command markers for LastCommandStatusRegistry
 //    GET  /healthz     — 200 OK "OK"
 //
 //  Framing: minimal HTTP/1.1 — request line, headers, body. We respond 200 OK
@@ -33,11 +35,13 @@ public actor AgentHookListener {
         public var unsupportedRoutes: Int = 0
         public var ingestedEvents: Int = 0
         public var statusLineUpdates: Int = 0
+        public var commandMarkerUpdates: Int = 0
     }
 
     private let socketURL: URL
     private let lockURL: URL
     private let registry: any AgentSessionRegistryProtocol
+    private let commandStatusRegistry: LastCommandStatusRegistry?
     private let logger: @Sendable (String) -> Void
     private var listener: NWListener?
     private var lockFileDescriptor: Int32?
@@ -46,10 +50,12 @@ public actor AgentHookListener {
     public init(
         bundleIdentifier: String,
         registry: any AgentSessionRegistryProtocol,
+        commandStatusRegistry: LastCommandStatusRegistry? = nil,
         socketURLOverride: URL? = nil,
         logger: @escaping @Sendable (String) -> Void = { NSLog("[AgentHookListener] %@", $0) }
     ) {
         self.registry = registry
+        self.commandStatusRegistry = commandStatusRegistry
         self.logger = logger
         if let override = socketURLOverride {
             self.socketURL = override
@@ -204,6 +210,8 @@ public actor AgentHookListener {
             return (200, Data())
         case ("POST", "/statusline"):
             return (200, Data())
+        case ("POST", "/command-markers"):
+            return (200, Data())
         default:
             return (200, Data())
         }
@@ -215,6 +223,8 @@ public actor AgentHookListener {
             await processEvent(request: request)
         case ("POST", "/statusline"):
             await processStatusLine(request: request)
+        case ("POST", "/command-markers"):
+            await processCommandMarkers(request: request)
         default:
             break
         }
@@ -265,6 +275,39 @@ public actor AgentHookListener {
             registry.apply(events: [.statusFields(fields)], for: hostSessionID, origin: .statusLine)
         }
         statistics.statusLineUpdates += 1
+    }
+
+    private func processCommandMarkers(request: HTTPRequest) async {
+        guard let hostSessionID = Self.hostSessionID(from: request.headers) else {
+            logger("dropping command markers without valid host session header")
+            return
+        }
+        guard await isRegisteredHostSession(hostSessionID) else {
+            logger("dropping command markers for unregistered host session \(hostSessionID.uuidString)")
+            return
+        }
+        guard !request.body.isEmpty else {
+            statistics.decodeFailures += 1
+            logger("command marker decode failed: empty body")
+            return
+        }
+
+        let markers = CommandMarkerParser.parse(request.body)
+        guard !markers.isEmpty else {
+            statistics.decodeFailures += 1
+            logger("command marker decode failed: no OSC 133 markers")
+            return
+        }
+
+        guard let commandStatusRegistry else {
+            logger("dropping command markers; command status registry unavailable")
+            return
+        }
+
+        await MainActor.run { [commandStatusRegistry, markers] in
+            commandStatusRegistry.ingest(markers: markers, for: hostSessionID)
+        }
+        statistics.commandMarkerUpdates += 1
     }
 
     private func isRegisteredHostSession(_ hostSessionID: UUID) async -> Bool {

--- a/Tests/WorkspaceManagerAppTests/ClaudeIntegrationLifecycleTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ClaudeIntegrationLifecycleTests.swift
@@ -126,9 +126,16 @@ struct ClaudeIntegrationLifecycleTests {
             ClaudeIntegrationLifecycle.bundledHookForwarderURL(named: "event-forwarder"))
         let statusLine = try #require(
             ClaudeIntegrationLifecycle.bundledHookForwarderURL(named: "statusline"))
+        let commandStatus = try #require(
+            ClaudeIntegrationLifecycle.bundledHookForwarderURL(
+                named: "command-status",
+                fileExtension: "zsh"
+            ))
 
         #expect(FileManager.default.fileExists(atPath: eventForwarder.path))
         #expect(FileManager.default.fileExists(atPath: statusLine.path))
+        #expect(FileManager.default.fileExists(atPath: commandStatus.path))
+        #expect(ClaudeIntegrationLifecycle.bundledCommandStatusHookPath() == commandStatus.path)
     }
 
     @Test("packaged app hook forwarder resources resolve from flattened app resources")

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -150,6 +150,11 @@ struct GhosttyTerminalConfigTests {
 
         #expect(config.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == hostSessionID.uuidString)
         #expect(config.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == "/tmp/workspaces-hooks.sock")
+        let commandStatusHook = config.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"]
+        #expect(commandStatusHook?.hasSuffix("command-status.zsh") == true)
+        if let commandStatusHook {
+            #expect(FileManager.default.fileExists(atPath: commandStatusHook))
+        }
     }
 
     @Test("host session hook context is omitted unless complete")
@@ -178,8 +183,10 @@ struct GhosttyTerminalConfigTests {
 
         #expect(missingSocket.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == nil)
         #expect(missingSocket.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == nil)
+        #expect(missingSocket.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
         #expect(missingHostID.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == nil)
         #expect(missingHostID.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == nil)
+        #expect(missingHostID.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
     }
 
     @Test("tmux mode respects clean shell override")

--- a/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
@@ -351,7 +351,13 @@ struct HostTerminalStateStoreTests {
         let pre = store.activateSession(key: .repoPath(repoURL.path), directory: repoURL).session
 
         let registry = AgentSessionRegistry()
-        store.attach(agentSessionRegistry: registry)
+        let commandStatusRegistry = LastCommandStatusRegistry()
+        store.attach(
+            agentSessionRegistry: registry,
+            localStateStore: nil,
+            hooksSocketPath: nil,
+            lastCommandStatusRegistry: commandStatusRegistry
+        )
 
         // Backfill: pre-existing session is registered on attach.
         #expect(registry.statuses[pre.id] != nil)
@@ -366,10 +372,14 @@ struct HostTerminalStateStoreTests {
         #expect(registry.statuses[next.id] != nil)
         #expect(registry.statuses[pre.id] != nil)
 
+        commandStatusRegistry.ingest(markers: [.commandStart], for: pre.id, commandLine: "make")
+        #expect(commandStatusRegistry.statusByTerminalSession[pre.id] != nil)
+
         // Process exit deregisters.
         _ = store.handleProcessExit(for: pre.id)
         #expect(registry.statuses[pre.id] == nil)
         #expect(registry.statuses[next.id] != nil)
+        #expect(commandStatusRegistry.statusByTerminalSession[pre.id] == nil)
     }
 
     @Test("Process exit helper returns active fallback session when others remain")

--- a/Tests/WorkspaceManagerTests/AgentHookListenerTests.swift
+++ b/Tests/WorkspaceManagerTests/AgentHookListenerTests.swift
@@ -64,6 +64,13 @@ struct AgentHookListenerTests {
         return process.terminationStatus
     }
 
+    private static func osc133(_ payload: String) -> Data {
+        var data = Data([0x1B, 0x5D, 0x31, 0x33, 0x33, 0x3B])
+        data.append(payload.data(using: .utf8)!)
+        data.append(0x07)
+        return data
+    }
+
     @MainActor
     private final class TestRegistry: AgentSessionRegistryProtocol {
         var statuses: [UUID: AgentSessionStatus] = [:]
@@ -537,6 +544,131 @@ struct AgentHookListenerTests {
         try await Task.sleep(nanoseconds: 300_000_000)
         let runAfter = await registry.statuses[registeredID]?.modelDisplayName
         #expect(runAfter == runBefore)
+
+        await listener.stop()
+    }
+
+    @Test("command-markers POST updates last command status by host session header")
+    func commandMarkersUpdateLastCommandStatusByHostSessionHeader() async throws {
+        let cwd = "/tmp/hook-test-\(UUID().uuidString.prefix(6))"
+        try? FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: cwd) }
+
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: cwd)
+        let registeredID = registry.registeredID
+        await MainActor.run {
+            registry.register(hostSessionID: UUID(), cwd: "/tmp/other", kind: .claudeCode)
+        }
+        let commandStatusRegistry = await MainActor.run { LastCommandStatusRegistry() }
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        var body = Data()
+        body.append(Self.osc133("B"))
+        body.append(Self.osc133("D;7"))
+        let status = await Self.curlPost(
+            socket: socket,
+            path: "/command-markers",
+            body: body,
+            hostSessionID: registeredID
+        )
+        #expect(status == 0)
+
+        let reached = await waitUntil {
+            await MainActor.run {
+                commandStatusRegistry.statusByTerminalSession[registeredID]?.exitCode == 7
+            }
+        }
+        #expect(reached)
+        let live = await MainActor.run {
+            commandStatusRegistry.statusByTerminalSession[registeredID]
+        }
+        #expect(live?.isRunning == false)
+        #expect(live?.isSuccess == false)
+
+        let stats = await listener.currentStatistics()
+        #expect(stats.commandMarkerUpdates == 1)
+
+        await listener.stop()
+    }
+
+    @Test("command-markers POST drops missing and unregistered sessions")
+    func commandMarkersDropMissingAndUnregisteredSessions() async throws {
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: "/tmp")
+        let registeredID = registry.registeredID
+        let commandStatusRegistry = await MainActor.run { LastCommandStatusRegistry() }
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        _ = await Self.curlPost(
+            socket: socket,
+            path: "/command-markers",
+            body: Self.osc133("B")
+        )
+        _ = await Self.curlPost(
+            socket: socket,
+            path: "/command-markers",
+            body: Self.osc133("D;0"),
+            hostSessionID: UUID()
+        )
+
+        try await Task.sleep(nanoseconds: 400_000_000)
+        let status = await MainActor.run {
+            commandStatusRegistry.statusByTerminalSession[registeredID]
+        }
+        #expect(status == nil)
+
+        await listener.stop()
+    }
+
+    @Test("command-markers POST with malformed body records decode failure")
+    func commandMarkersMalformedBodyRecordsDecodeFailure() async throws {
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: "/tmp")
+        let registeredID = registry.registeredID
+        let commandStatusRegistry = await MainActor.run { LastCommandStatusRegistry() }
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let status = await Self.curlPost(
+            socket: socket,
+            path: "/command-markers",
+            body: Data("not an osc marker".utf8),
+            hostSessionID: registeredID
+        )
+        #expect(status == 0)
+
+        let reached = await waitUntil {
+            await listener.currentStatistics().decodeFailures == 1
+        }
+        #expect(reached)
+        let commandStatus = await MainActor.run {
+            commandStatusRegistry.statusByTerminalSession[registeredID]
+        }
+        #expect(commandStatus == nil)
 
         await listener.stop()
     }

--- a/Tests/WorkspaceManagerTests/HookForwarderScriptTests.swift
+++ b/Tests/WorkspaceManagerTests/HookForwarderScriptTests.swift
@@ -57,6 +57,41 @@ struct HookForwarderScriptTests {
         return (process.terminationStatus, stdout, stderr)
     }
 
+    private static func runZshCommandStatusHook(
+        socket: URL,
+        hostSessionID: UUID
+    ) throws -> (status: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [
+            "-f",
+            "-c",
+            """
+            source "$WORKSPACES_COMMAND_STATUS_ZSH"
+            __workspaces_command_status_preexec "false"
+            false
+            __workspaces_command_status_precmd
+            """,
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["WORKSPACES_HOOKS_SOCKET"] = socket.path
+        environment["WORKSPACES_HOST_SESSION_ID"] = hostSessionID.uuidString
+        environment["WORKSPACES_COMMAND_STATUS_ZSH"] = hookForwarder(named: "command-status.zsh").path
+        process.environment = environment
+
+        let output = Pipe()
+        let error = Pipe()
+        process.standardOutput = output
+        process.standardError = error
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, stdout, stderr)
+    }
+
     @Test("event-forwarder posts hook JSON with host-session header")
     @MainActor
     func eventForwarderPostsHookJSONWithHostSessionHeader() async throws {
@@ -131,5 +166,39 @@ struct HookForwarderScriptTests {
         }
         #expect(reached)
         #expect(registry.statuses[hostSessionID]?.costUSD == 0.42)
+    }
+
+    @Test("command-status zsh hook posts command markers with host-session header")
+    @MainActor
+    func commandStatusZshHookPostsCommandMarkersWithHostSessionHeader() async throws {
+        let socket = Self.makeTempSocketURL()
+        let registry = AgentSessionRegistry()
+        let commandStatusRegistry = LastCommandStatusRegistry()
+        let hostSessionID = UUID()
+        registry.register(hostSessionID: hostSessionID, cwd: "/tmp", kind: .claudeCode)
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+
+        let result = try Self.runZshCommandStatusHook(
+            socket: socket,
+            hostSessionID: hostSessionID
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.isEmpty)
+        let reached = await waitUntil {
+            await MainActor.run {
+                commandStatusRegistry.statusByTerminalSession[hostSessionID]?.exitCode == 1
+            }
+        }
+        #expect(reached)
+        #expect(commandStatusRegistry.statusByTerminalSession[hostSessionID]?.isSuccess == false)
     }
 }

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -10,15 +10,17 @@ Claude work is tracked separately in `backlog/headless-claude-programmatic-runne
 
 ## Shipped Channels
 
-Only the first three channels feed `AgentSessionRegistry`. Channel 4 is a
-transcript reader for the conversation log UI; it is not a state recovery path.
+The first, second, and fourth channels feed `AgentSessionRegistry`. Channel 3
+feeds `LastCommandStatusRegistry`. Channel 5 is a transcript reader for the
+conversation log UI; it is not a state recovery path.
 
 | Channel | Role | Registry input |
 |---|---|---|
 | 1. Command hook forwarder | Primary event stream: tool start/end, awaiting input, complete, errored | Yes |
 | 2. Status-line forwarder | Model, cost, context fill, rate-limit headroom | Yes |
-| 3. libghostty OSC/BEL | Fallback attention signal for unhooked or degraded sessions | Yes |
-| 4. Transcript JSONL | Conversation replay/audit view | No |
+| 3. Command-status producer | Last shell command start/end and exit status | LastCommandStatusRegistry |
+| 4. libghostty OSC/BEL | Fallback attention signal for unhooked or degraded sessions | Yes |
+| 5. Transcript JSONL | Conversation replay/audit view | No |
 
 ```text
                  +------------------------------------+
@@ -32,7 +34,8 @@ transcript reader for the conversation log UI; it is not a state recovery path.
            |                                               |
            v                                               v
     Hook/status listener                              OSC router
-    /event, /statusline                               libghostty actions
+    /event, /statusline,                              libghostty actions
+    /command-markers
            |
            v
     SwiftUI observers
@@ -53,7 +56,8 @@ transcript reader for the conversation log UI; it is not a state recovery path.
 - `Sources/WorkspaceManagerCore/Services/AgentEventTranslators.swift` contains
   the concrete Claude hook translator and OSC mapper. There is no adapter
   protocol until a second rich hook-speaking agent exists.
-- `AgentHookListener` exposes `/event`, `/statusline`, and `/healthz`.
+- `AgentHookListener` exposes `/event`, `/statusline`, `/command-markers`,
+  and `/healthz`.
 
 The registry write surface is deliberately small:
 
@@ -71,6 +75,7 @@ Routing is explicit. Every persistent host terminal created from a
 
 - `WORKSPACES_HOOKS_SOCKET`
 - `WORKSPACES_HOST_SESSION_ID`
+- `WORKSPACES_COMMAND_STATUS_ZSH` when the bundled zsh producer is available
 
 The bundled shell forwarders include
 `X-WorkSpaces-Host-Session-ID: <uuid>` on every POST. The listener accepts the
@@ -116,7 +121,29 @@ it through the same registry write surface.
 Status-line ticks never change `AgentRunState`; they only update display fields
 such as model, cost, context used, and five-hour limit state.
 
-## Channel 3: libghostty OSC/BEL
+## Channel 3: Command-Status Producer
+
+Script: `Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh`.
+
+Local zsh sessions can opt in by sourcing the bundled path exported in the
+terminal environment:
+
+```zsh
+source "$WORKSPACES_COMMAND_STATUS_ZSH"
+```
+
+The sourceable hook uses `preexec` to POST `OSC 133 ; B` to
+`/command-markers`, then uses `precmd` to POST `OSC 133 ; D ; <exit>` after the
+command returns. Payloads are raw OSC bytes with
+`X-WorkSpaces-Host-Session-ID: <uuid>`, so the listener can parse them with
+`CommandMarkerParser` and update `LastCommandStatusRegistry` for the matching
+host terminal only.
+
+The app does not mutate shell profiles automatically. Missing socket/session
+environment, missing `curl`, stopped host listeners, and malformed payloads
+drop quietly with diagnostics.
+
+## Channel 4: libghostty OSC/BEL
 
 `GhosttyRuntimeActionBridge` recognizes:
 
@@ -136,7 +163,7 @@ Notification channel selection is concrete installer behavior: `~/.claude.json`
 is patched to `preferredNotifChannel: "iterm2"` because OSC 9 is the reliable
 path libghostty surfaces today.
 
-## Channel 4: Transcript JSONL
+## Channel 5: Transcript JSONL
 
 `Sources/WorkspaceManagerCore/Services/TranscriptReader.swift` reads Claude Code
 transcripts for `ConversationLogView`.


### PR DESCRIPTION
## Summary

- Add `/command-markers` to `AgentHookListener` for raw OSC 133 command lifecycle payloads.
- Wire an app-scoped `LastCommandStatusRegistry` into the listener and host terminal cleanup path.
- Bundle a sourceable zsh producer and expose it as `WORKSPACES_COMMAND_STATUS_ZSH` for local terminals.
- Document the opt-in producer flow and cover listener, script, env export, and cleanup behavior.

Closes #564.

## Mergeability

- Surface: desktop / agent-runtime
- User-facing behavior changed: local terminals now expose an opt-in zsh hook path that can feed last-command status; no status-sliver UI is shipped.
- Non-happy paths considered: missing host-session headers, unregistered sessions, empty or malformed marker payloads, missing socket/session env, missing curl, and session removal cleanup.
- Release/ops preconditions: none beyond existing GhosttyKit build prerequisite.
- Residual risk or follow-up: bash support and automatic shell-profile installation remain out of scope.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `./scripts/build-ghosttykit.sh`
  - `/bin/zsh -n Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh`
  - `swift test --filter AgentHookListener`
  - `swift test --filter HookForwarderScriptTests`
  - `swift test --filter GhosttyTerminalConfig`
  - `swift test --filter ClaudeIntegrationLifecycle`
  - `swift test --filter HostTerminalStateStore`
  - `swift test --filter LastCommandStatus`
  - `env MISE_TRUSTED_CONFIG_PATHS=/Users/fairchild/.codex/worktrees/997c/workspaces ./scripts/launch-dev.sh --no-build --no-activate`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Terminal status producer verification](https://evidence.cloudcompute.com/workspaces/pr-566/20260526-050453-terminal-status-producer.svg)

No status-sliver UI is shipped in this PR. The evidence covers test output and
the no-activate debug launch smoke, including the launcher-verified visible
window check.

## Blockers

- [x] None
- [ ] Blocked on evidence
