### PR TITLE
Fix evidence env discovery in worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ Evidence is a merge gate. Do not create a PR without it. Follow these steps in o
 mise run evidence -- --pr <number> --name <slug>
 ```
 
-The script auto-sources `.env` for `EVIDENCE_UPLOAD_TOKEN`. Uploads go to `https://evidence.cloudcompute.com/`. See `docs/development/evidence.md` for the full guide.
+The script auto-sources `.env` for `EVIDENCE_UPLOAD_TOKEN` and falls back to shared worktree env files. If a worktree is missing `.env`, run `./scripts/setup --env-only` before claiming evidence is blocked. Uploads go to `https://evidence.cloudcompute.com/`. See `docs/development/evidence.md` for the full guide.
 
 ### Evidence rules
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env 2>/dev/null || true; bash ./scripts/setup --fast",
+    "setup": "bash ./scripts/setup --fast",
     "archive": "cd \"$CONDUCTOR_ROOT_PATH\" && git fetch origin"
   }
 }

--- a/docs/development/evidence.md
+++ b/docs/development/evidence.md
@@ -25,6 +25,14 @@ Add `EVIDENCE_UPLOAD_TOKEN` to your `.env` (gitignored):
 EVIDENCE_UPLOAD_TOKEN=<value>
 ```
 
+Fresh linked worktrees can symlink the checked-out secret file with:
+
+```bash
+./scripts/setup --env-only
+```
+
+`scripts/evidence.sh` also searches the canonical checkout and sibling worktrees for `.env` or `.env.local` before failing, so evidence upload should not be marked blocked just because the current worktree is missing its symlink.
+
 The token value is stored in [GitHub repo secrets](https://github.com/fairchild/workspaces/settings/secrets/actions). To rotate it across all three locations:
 
 ```bash
@@ -83,7 +91,7 @@ Three layers, from gentlest to strongest:
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `EVIDENCE_UPLOAD_TOKEN not set` | Token missing from `.env` | Add it — see [Setup](#setup) |
+| `EVIDENCE_UPLOAD_TOKEN not set` | Token missing from this checkout and no sibling checkout has it | Run `./scripts/setup --env-only`, or add it — see [Setup](#setup) |
 | `401 unauthorized` on upload | Token mismatch | Rotate token across Worker + GitHub + `.env` |
 | Auth redirect on localhost | Web middleware requires session | Use `DEV_BYPASS_AUTH=1 pnpm dev` |
 | `screencapture` fails | No display (headless/SSH) | Use `--file` with an existing screenshot |

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -16,13 +16,77 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Source .env for EVIDENCE_UPLOAD_TOKEN if not already set
-if [[ -z "${EVIDENCE_UPLOAD_TOKEN:-}" ]] && [[ -f "$REPO_ROOT/.env" ]]; then
+source_env_file() {
+  local env_path="$1"
+  [[ -f "$env_path" ]] || return 1
+
   set -a
   # shellcheck disable=SC1091
-  source "$REPO_ROOT/.env"
+  source "$env_path"
   set +a
-fi
+}
+
+env_source_for() {
+  local envfile="$1"
+  local candidate=""
+  local git_common=""
+  local worktree_path=""
+
+  if [[ -n "${CONDUCTOR_ROOT_PATH:-}" ]]; then
+    candidate="$CONDUCTOR_ROOT_PATH/$envfile"
+    [[ "$candidate" != "$REPO_ROOT/$envfile" && -f "$candidate" ]] && { printf '%s\n' "$candidate"; return 0; }
+  fi
+
+  candidate="$HOME/code/$(basename "$REPO_ROOT")/$envfile"
+  if [[ "$candidate" != "$REPO_ROOT/$envfile" && -f "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  git_common="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  if [[ -n "$git_common" ]]; then
+    [[ "$git_common" == /* ]] || git_common="$REPO_ROOT/$git_common"
+    if [[ "$git_common" == */.git ]]; then
+      candidate="${git_common%/.git}/$envfile"
+      [[ "$candidate" != "$REPO_ROOT/$envfile" && -f "$candidate" ]] && { printf '%s\n' "$candidate"; return 0; }
+    fi
+  fi
+
+  while IFS= read -r line; do
+    [[ "$line" == worktree\ * ]] || continue
+    worktree_path="${line#worktree }"
+    if [[ "$worktree_path" != "$REPO_ROOT" && -f "$worktree_path/$envfile" ]]; then
+      printf '%s\n' "$worktree_path/$envfile"
+      return 0
+    fi
+  done < <(git worktree list --porcelain 2>/dev/null)
+
+  return 1
+}
+
+load_evidence_env() {
+  local envfile=""
+  local env_source=""
+
+  [[ -n "${EVIDENCE_UPLOAD_TOKEN:-}" ]] && return 0
+
+  for envfile in .env .env.local; do
+    if [[ -f "$REPO_ROOT/$envfile" ]]; then
+      source_env_file "$REPO_ROOT/$envfile"
+      [[ -n "${EVIDENCE_UPLOAD_TOKEN:-}" ]] && return 0
+    fi
+  done
+
+  for envfile in .env .env.local; do
+    env_source="$(env_source_for "$envfile" || true)"
+    if [[ -n "$env_source" ]]; then
+      source_env_file "$env_source"
+      [[ -n "${EVIDENCE_UPLOAD_TOKEN:-}" ]] && return 0
+    fi
+  done
+}
+
+load_evidence_env
 
 PR=""
 NAME=""
@@ -64,7 +128,7 @@ fi
 
 if [[ -z "${EVIDENCE_UPLOAD_TOKEN:-}" ]]; then
   echo "error: EVIDENCE_UPLOAD_TOKEN not set." >&2
-  echo "  Add it to $REPO_ROOT/.env or export it directly." >&2
+  echo "  Add it to $REPO_ROOT/.env, run ./scripts/setup --env-only to symlink it from an existing checkout, or export it directly." >&2
   echo "  The token value is stored in GitHub repo secrets." >&2
   exit 1
 fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -83,8 +83,14 @@ fi
 # any sibling worktree that actually has the env file.
 env_source_for() {
   local envfile="$1"
+  local conductor_source="${CONDUCTOR_ROOT_PATH:-}"
   local preferred_source="$HOME/code/$(basename "$REPO_ROOT")/$envfile"
   local worktree_path=""
+
+  if [[ -n "$conductor_source" && "$conductor_source/$envfile" != "$REPO_ROOT/$envfile" && -f "$conductor_source/$envfile" ]]; then
+    printf '%s\n' "$conductor_source/$envfile"
+    return 0
+  fi
 
   if [[ "$preferred_source" != "$REPO_ROOT/$envfile" && -f "$preferred_source" ]]; then
     printf '%s\n' "$preferred_source"
@@ -113,6 +119,11 @@ link_env_from_main() {
   [[ "$git_common" != "$git_dir" ]] || return 0  # not a worktree
 
   for envfile in .env .env.local; do
+    if [[ -L "$REPO_ROOT/$envfile" && ! -e "$REPO_ROOT/$envfile" ]]; then
+      echo "=> Replacing broken $envfile symlink"
+      rm "$REPO_ROOT/$envfile"
+    fi
+
     if [[ ! -e "$REPO_ROOT/$envfile" && ! -L "$REPO_ROOT/$envfile" ]]; then
       env_source="$(env_source_for "$envfile" || true)"
       if [[ -n "$env_source" ]]; then

--- a/scripts/test_evidence_env_loading.py
+++ b/scripts/test_evidence_env_loading.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for scripts/evidence.sh env-file discovery."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_SCRIPT = REPO_ROOT / "scripts" / "evidence.sh"
+
+
+class EvidenceEnvLoadingTests(unittest.TestCase):
+    def assert_success(self, result: subprocess.CompletedProcess[str]) -> None:
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"command failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def run_command(
+        self,
+        args: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        merged_env = {**os.environ, **(env or {})}
+        merged_env.pop("EVIDENCE_UPLOAD_TOKEN", None)
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            env=merged_env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def create_repo_with_evidence_script(self, repo_path: Path) -> None:
+        repo_path.mkdir()
+        self.assert_success(self.run_command(["git", "init"], cwd=repo_path))
+        self.assert_success(
+            self.run_command(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=repo_path,
+            )
+        )
+        self.assert_success(
+            self.run_command(
+                ["git", "config", "user.name", "Test User"],
+                cwd=repo_path,
+            )
+        )
+
+        scripts_dir = repo_path / "scripts"
+        scripts_dir.mkdir()
+        shutil.copy2(EVIDENCE_SCRIPT, scripts_dir / "evidence.sh")
+        (repo_path / "README.md").write_text("test repo\n", encoding="utf-8")
+
+        self.assert_success(
+            self.run_command(["git", "add", "README.md", "scripts/evidence.sh"], cwd=repo_path)
+        )
+        self.assert_success(self.run_command(["git", "commit", "-m", "initial"], cwd=repo_path))
+
+    def add_worktree(self, repo_path: Path, branch: str, worktree_path: Path) -> None:
+        self.assert_success(
+            self.run_command(
+                ["git", "worktree", "add", "-b", branch, str(worktree_path)],
+                cwd=repo_path,
+            )
+        )
+
+    def write_fake_uv(self, bin_dir: Path, expected_token: str) -> None:
+        bin_dir.mkdir()
+        fake_uv = bin_dir / "uv"
+        fake_uv.write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env bash",
+                    "set -euo pipefail",
+                    f'if [[ "${{EVIDENCE_UPLOAD_TOKEN:-}}" != "{expected_token}" ]]; then',
+                    '  echo "missing expected token" >&2',
+                    "  exit 42",
+                    "fi",
+                    'echo "https://evidence.example/workspaces/pr-1/test.png"',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        fake_uv.chmod(fake_uv.stat().st_mode | stat.S_IXUSR)
+
+    def test_evidence_sources_token_from_sibling_worktree_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            main = tmp_path / "repo"
+            source = tmp_path / "source-worktree"
+            target = tmp_path / "target-worktree"
+            fake_bin = tmp_path / "bin"
+            isolated_home = tmp_path / "home"
+
+            self.create_repo_with_evidence_script(main)
+            self.add_worktree(main, "env-source", source)
+            (source / ".env").write_text("EVIDENCE_UPLOAD_TOKEN=test-token\n", encoding="utf-8")
+            self.add_worktree(main, "env-target", target)
+            self.write_fake_uv(fake_bin, "test-token")
+
+            evidence_file = target / "test.png"
+            evidence_file.write_bytes(b"not a real png; fake uv does not inspect it\n")
+
+            result = self.run_command(
+                [
+                    "./scripts/evidence.sh",
+                    "--pr",
+                    "1",
+                    "--name",
+                    "test",
+                    "--file",
+                    str(evidence_file),
+                ],
+                cwd=target,
+                env={
+                    "HOME": str(isolated_home),
+                    "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+                },
+            )
+
+            self.assert_success(result)
+            self.assertEqual(
+                result.stdout.strip(),
+                "https://evidence.example/workspaces/pr-1/test.png",
+            )
+            self.assertFalse((target / ".env").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_setup_env_linking.py
+++ b/scripts/test_setup_env_linking.py
@@ -118,6 +118,60 @@ class SetupEnvLinkingTests(unittest.TestCase):
             self.assertEqual(linked_env.resolve(), source_env.resolve())
             self.assertIn("Symlinking .env", result.stdout)
 
+    def test_env_only_prefers_conductor_root_path_env_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            main = tmp_path / "repo"
+            target = tmp_path / "target-worktree"
+            conductor_root = tmp_path / "conductor-root"
+
+            self.create_repo_with_setup_script(main)
+            self.add_worktree(main, "env-target", target)
+            conductor_root.mkdir()
+            conductor_env = conductor_root / ".env"
+            conductor_env.write_text("EVIDENCE_UPLOAD_TOKEN=test-token\n", encoding="utf-8")
+
+            isolated_home = tmp_path / "home"
+            result = self.run_command(
+                ["./scripts/setup", "--env-only"],
+                cwd=target,
+                env={"HOME": str(isolated_home), "CONDUCTOR_ROOT_PATH": str(conductor_root)},
+            )
+
+            self.assert_success(result)
+            linked_env = target / ".env"
+            self.assertTrue(linked_env.is_symlink())
+            self.assertEqual(linked_env.resolve(), conductor_env.resolve())
+            self.assertIn("Symlinking .env", result.stdout)
+
+    def test_env_only_replaces_broken_env_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            main = tmp_path / "repo"
+            source = tmp_path / "source-worktree"
+            target = tmp_path / "target-worktree"
+
+            self.create_repo_with_setup_script(main)
+            self.add_worktree(main, "env-source", source)
+            source_env = source / ".env"
+            source_env.write_text("EVIDENCE_UPLOAD_TOKEN=test-token\n", encoding="utf-8")
+            self.add_worktree(main, "env-target", target)
+            (target / ".env").symlink_to(tmp_path / "missing-env")
+
+            isolated_home = tmp_path / "home"
+            result = self.run_command(
+                ["./scripts/setup", "--env-only"],
+                cwd=target,
+                env={"HOME": str(isolated_home)},
+            )
+
+            self.assert_success(result)
+            linked_env = target / ".env"
+            self.assertTrue(linked_env.is_symlink())
+            self.assertEqual(linked_env.resolve(), source_env.resolve())
+            self.assertIn("Replacing broken .env symlink", result.stdout)
+            self.assertIn("Symlinking .env", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Make `scripts/evidence.sh` load `EVIDENCE_UPLOAD_TOKEN` from the current checkout, `CONDUCTOR_ROOT_PATH`, canonical `~/code/workspaces`, git-common-dir checkout, or sibling worktrees.
- Route Conductor setup through `scripts/setup --fast`, and make setup replace broken `.env` symlinks before linking a real secret file.
- Document the worktree env fallback in AGENTS and evidence docs.

## Mergeability

- Surface: agent tooling / docs
- User-facing behavior changed: agents should no longer mark hosted evidence blocked solely because the worktree is missing `.env`.
- Non-happy paths considered: missing token, missing env file, broken `.env` symlink, conductor root available outside git worktree, sibling worktree only.
- Release/ops preconditions: none.
- Residual risk or follow-up: raw evidence upload still requires a valid token in at least one env source.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `uv run --script scripts/test_evidence_env_loading.py`
  - `uv run --script scripts/test_setup_env_linking.py`
  - `uv run --script scripts/test_security_hardening.py`
  - `bash -n scripts/evidence.sh scripts/setup`
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Validation artifact](https://evidence.cloudcompute.com/workspaces/pr-567/20260526-051520-env-fallback-validation-rebased.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence