### PR TITLE
Observe workspace-agents contributor review association

### DIFF
--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - ".agents/**"
       - ".github/workflows/ci-agents.yml"
+      - "scripts/agent-triage-request.py"
+      - "scripts/tests/test_agent_triage.py"
+      - "scripts/tests/test_run_contributor.py"
   pull_request:
     branches: [main]
     paths:
       - ".agents/**"
       - ".github/workflows/ci-agents.yml"
+      - "scripts/agent-triage-request.py"
+      - "scripts/tests/test_agent_triage.py"
+      - "scripts/tests/test_run_contributor.py"
   workflow_dispatch:
 
 permissions:
@@ -38,3 +44,9 @@ jobs:
 
       - name: Run gh-discuss tests
         run: uv run .agents/skills/gh-discuss/scripts/test_gh_discuss.py
+
+      - name: Run public agent triage tests
+        run: uv run --script scripts/tests/test_agent_triage.py
+
+      - name: Run contributor runner policy tests
+        run: uv run --script scripts/tests/test_run_contributor.py

--- a/.github/workflows/managed-reviewer-broker.yml
+++ b/.github/workflows/managed-reviewer-broker.yml
@@ -9,12 +9,12 @@ on:
     paths:
       - ".github/workflows/managed-reviewer-broker.yml"
       - "scripts/pr-reviewer-broker.py"
-      - "scripts/test_security_hardening.py"
+      - "scripts/tests/test_security_hardening.py"
   pull_request:
     paths:
       - ".github/workflows/managed-reviewer-broker.yml"
       - "scripts/pr-reviewer-broker.py"
-      - "scripts/test_security_hardening.py"
+      - "scripts/tests/test_security_hardening.py"
   workflow_dispatch:
     inputs:
       limit:

--- a/.github/workflows/managed-reviewer-health.yml
+++ b/.github/workflows/managed-reviewer-health.yml
@@ -6,12 +6,12 @@ on:
     paths:
       - ".github/workflows/managed-reviewer-health.yml"
       - "scripts/pr-review-health.py"
-      - "scripts/test_pr_review_health.py"
+      - "scripts/tests/test_pr_review_health.py"
   pull_request:
     paths:
       - ".github/workflows/managed-reviewer-health.yml"
       - "scripts/pr-review-health.py"
-      - "scripts/test_pr_review_health.py"
+      - "scripts/tests/test_pr_review_health.py"
   workflow_dispatch:
     inputs:
       updated_within_hours:
@@ -48,7 +48,7 @@ jobs:
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Run health script unit tests
-        run: uv run --script scripts/test_pr_review_health.py
+        run: uv run --script scripts/tests/test_pr_review_health.py
 
   health:
     name: Summarize managed reviewer coverage

--- a/.github/workflows/mise-security.yml
+++ b/.github/workflows/mise-security.yml
@@ -11,7 +11,7 @@ on:
       - "scripts/setup"
       - "scripts/build-ghosttykit.sh"
       - "scripts/verify-mise-security.sh"
-      - "scripts/test_security_hardening.py"
+      - "scripts/tests/test_security_hardening.py"
       - "docs/development/mise-security.md"
       - "web/src/lib/agent-runtime/vercel-sandbox.ts"
   pull_request:
@@ -23,7 +23,7 @@ on:
       - "scripts/setup"
       - "scripts/build-ghosttykit.sh"
       - "scripts/verify-mise-security.sh"
-      - "scripts/test_security_hardening.py"
+      - "scripts/tests/test_security_hardening.py"
       - "docs/development/mise-security.md"
       - "web/src/lib/agent-runtime/vercel-sandbox.ts"
   workflow_dispatch:

--- a/.github/workflows/perf-validation.yml
+++ b/.github/workflows/perf-validation.yml
@@ -17,7 +17,7 @@ on:
       - scripts/perf_schema.py
       - scripts/perf-compare.py
       - scripts/new-workspace-perf.sh
-      - scripts/test_perf_tools.py
+      - scripts/tests/test_perf_tools.py
       - scripts/launch-installed-diagnostics.sh
       - scripts/verify-installed-perf.sh
       - Sources/**
@@ -170,7 +170,7 @@ jobs:
         run: swift build
 
       - name: Validate perf tooling
-        run: python3 scripts/test_perf_tools.py
+        run: uv run --script scripts/tests/test_perf_tools.py
 
       - name: Capture perf baseline
         run: ./scripts/perf-baseline.sh 3 6 --record --assert-budget

--- a/docs/development/codespaces-claude-worker.md
+++ b/docs/development/codespaces-claude-worker.md
@@ -89,7 +89,7 @@ Inside the Codespace, Claude artifacts live under `.context/codespaces-claude-wo
 Quick local checks for the control-plane scripts:
 
 ```bash
-uv run --script ./scripts/test_codespaces_claude_launch.py
+uv run --script ./scripts/tests/test_codespaces_claude_launch.py
 uv run --script ./scripts/codespaces-claude-launch.py --help
 bash -n ./scripts/codespaces-claude-worker.sh
 ```

--- a/docs/development/github-app-identities.md
+++ b/docs/development/github-app-identities.md
@@ -58,6 +58,8 @@ To make another app a contributing bot:
 5. Run a disposable PR with that app token and verify the PR author and commit attribution resolve to the bot.
 6. After a bot-authored commit lands in the default branch history, verify a later review from that bot reports `authorAssociation: CONTRIBUTOR`.
 
+When seeding contributor status through a PR, merge with a merge commit. Squash or rebase merging can remove the bot-authored commit from default-branch history and invalidate the contributor evidence.
+
 Do not repeat this process for `workspaces-claude-pr-reviewer`. That app is intentionally review-only.
 
 ## Verification Checklist

--- a/docs/development/security-critical-path.md
+++ b/docs/development/security-critical-path.md
@@ -63,7 +63,7 @@ not a broad public security stance.
 Run these before merging security/release changes:
 
 ```bash
-uv run --script scripts/test_security_hardening.py
+uv run --script scripts/tests/test_security_hardening.py
 uv run --script scripts/audit-security-posture.py --local-only --strict
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,7 +62,7 @@ Run `mise tasks` from the repo root for the current catalog. Web dashboard tasks
 
 - `uv run --script ./scripts/codespaces-claude-launch.py --help`
   - Shows the runner-side CLI that creates a Codespace, uploads a request file, and launches the repo's in-Codespace Claude worker.
-- `uv run --script ./scripts/test_codespaces_claude_launch.py`
+- `uv run --script ./scripts/tests/test_codespaces_claude_launch.py`
   - Runs stdlib tests for the launcher path.
 - `./scripts/codespaces-claude-worker.sh --help`
   - Shows the Codespace-side Claude runner contract.
@@ -79,6 +79,22 @@ Run `mise tasks` from the repo root for the current catalog. Web dashboard tasks
   - Fails if `terminal_first_output` / `first_prompt_ready` are missing or if known Ghostty resource warnings appear.
   - Requires an interactive display-capable macOS session; it is not valid in headless AppKit environments.
   - `--allow-skip-noninteractive` converts only the known display-session limitation into a recorded skip for release automation.
+
+## Script Test Harnesses
+
+Standalone script tests live in `./scripts/tests/`. Keep those files executable
+UV scripts with module docstrings that explain intent, not just mechanics. That
+directory is for lightweight harnesses around scripts in `./scripts/`; tests for
+repo-owned agent skills stay with the skill or under `.agents/scripts/`.
+
+Common examples:
+
+- `uv run --script ./scripts/tests/test_agent_triage.py`
+  - Public GitHub mention triage and approval-gate policy tests.
+- `uv run --script ./scripts/tests/test_run_contributor.py`
+  - Contributor runner policy tests, including app-bot git identity selection.
+- `uv run --script ./scripts/tests/test_security_hardening.py`
+  - Workflow, setup, Lume, CODEOWNERS, and open-source automation hardening tests.
 
 ## Performance Contract
 

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,17 @@
+# Script Tests
+
+This directory contains executable UV test harnesses for standalone scripts in
+`../`. The split is intentional: operational entry points stay in `scripts/`,
+while their local stdlib or fixture tests live here.
+
+Each test file should keep a module docstring that states:
+
+- the policy or operational surface it protects
+- why the test exists, not only which functions it imports
+- whether it is safe to run without network, secrets, UI access, or live GitHub
+  mutations
+
+Use this directory for root script tests such as release gates, PR readiness,
+security hardening, setup, Codespaces worker launch, performance tooling, and
+managed-reviewer health. Keep tests for `.agents/` skill internals next to those
+skills unless the test is explicitly validating a root `scripts/` entry point.

--- a/scripts/tests/test_agent_triage.py
+++ b/scripts/tests/test_agent_triage.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Unit tests for structured agent triage and approval helpers."""
+"""Policy tests for public agent mention triage.
+
+Intent: keep the GitHub comment/review triage path safe for an open-source
+repo by proving public mentions are sanitized, approval labels gate execution,
+and April automation only responds to the public `@april-clearwater` app slug.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +21,7 @@ import unittest
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURES_DIR = REPO_ROOT / ".agents" / "scripts" / "fixtures"
 
 

--- a/scripts/tests/test_codespaces_claude_launch.py
+++ b/scripts/tests/test_codespaces_claude_launch.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Stdlib tests for the Codespaces Claude launcher."""
+"""Launcher tests for the Codespaces Claude worker.
+
+Intent: protect the runner-side script that provisions a Codespace and starts
+the in-Codespace Claude worker. These are stdlib-only unit tests so GitHub
+workflow jobs can run them without installing the full app dependency stack.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +19,7 @@ import unittest
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "codespaces-claude-launch.py"
 
 

--- a/scripts/tests/test_migrate_agent_labels.py
+++ b/scripts/tests/test_migrate_agent_labels.py
@@ -3,7 +3,11 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Stdlib tests for agent label migration helpers."""
+"""Migration tests for GitHub agent label cleanup.
+
+Intent: keep one-off label migration helpers deterministic and reviewable.
+These tests exercise API payload handling without calling the live GitHub API.
+"""
 
 from __future__ import annotations
 
@@ -16,7 +20,7 @@ from pathlib import Path
 from unittest import mock
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def load_module(name: str, path: Path):

--- a/scripts/tests/test_ops_report.py
+++ b/scripts/tests/test_ops_report.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Stdlib tests for the ops reporting script."""
+"""Fixture tests for the ops reporting script.
+
+Intent: protect the live-ops report generator using checked-in fixtures so
+cooldown, breach selection, and report rendering behavior can be validated
+without writing real ops snapshots or mutating GitHub state.
+"""
 
 from __future__ import annotations
 
@@ -19,9 +24,10 @@ from pathlib import Path
 from unittest import mock
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURES_DIR = REPO_ROOT / "fixtures" / "ops-report"
 SCRIPT_PATH = REPO_ROOT / "scripts" / "ops-report.py"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 
 def load_module(name: str, path: Path):

--- a/scripts/tests/test_perf_tools.py
+++ b/scripts/tests/test_perf_tools.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Fixture tests for the Workspaces performance contract and summary tooling."""
+"""Fixture tests for the Workspaces performance contract.
+
+Intent: keep perf summary parsing, budget evaluation, and diagnostic report
+helpers aligned with `config/performance/contract.json` using small local
+fixtures instead of launching the app or requiring a performance runner.
+"""
 
 from __future__ import annotations
 
@@ -15,10 +20,12 @@ import unittest
 import zipfile
 from pathlib import Path
 
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
 from perf_schema import evaluate_budgets, load_contract
 
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
 SUMMARIZE_PERF_LOG = (
     REPO_ROOT
     / ".agents"

--- a/scripts/tests/test_pr_readiness.py
+++ b/scripts/tests/test_pr_readiness.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Tests for scripts/pr-readiness.py."""
+"""Policy tests for the PR readiness workflow helper.
+
+Intent: make the mergeability gate predictable by proving the script accepts
+the PR body sections this repo requires and reports missing evidence or policy
+sections in a form GitHub Actions can surface cleanly.
+"""
 
 from __future__ import annotations
 
@@ -13,7 +18,7 @@ import unittest
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "pr-readiness.py"
 
 spec = importlib.util.spec_from_file_location("pr_readiness", SCRIPT_PATH)

--- a/scripts/tests/test_pr_review_health.py
+++ b/scripts/tests/test_pr_review_health.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Tests for scripts/pr-review-health.py."""
+"""Health tests for the managed PR reviewer monitor.
+
+Intent: keep the scheduled reviewer-health check focused on stale or missing
+managed reviews while avoiding false failures for drafts, inactive PRs, or
+ordinary review states that do not need operator intervention.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "pr-review-health.py"
 
 spec = importlib.util.spec_from_file_location("pr_review_health", SCRIPT_PATH)

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Stdlib tests for run-contributor evidence reconciliation."""
+"""Policy tests for the cofounder contributor runner.
+
+Intent: protect the automation that lets trusted GitHub Apps commit and open
+PRs. These tests cover app-bot git identity selection, sensitive path gates,
+and PR evidence reconciliation without running an actual agent.
+"""
 
 from __future__ import annotations
 
@@ -18,7 +23,7 @@ from pathlib import Path
 from unittest import mock
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / ".agents" / "skills" / "cofounder-contributor" / "scripts" / "run-contributor.py"
 
 

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Regression tests for the workflow and Lume security hardening."""
+"""Security policy tests for workflows, setup, and local runner surfaces.
+
+Intent: keep open-source repo automation fail-closed by checking public
+trigger secret isolation, GitHub App identity routing, CODEOWNERS ownership,
+Lume password handling, pinned actions, and setup/mise trust boundaries.
+"""
 
 from __future__ import annotations
 
@@ -20,7 +25,7 @@ import unittest
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class SecurityHardeningTests(unittest.TestCase):

--- a/scripts/tests/test_setup_env_linking.py
+++ b/scripts/tests/test_setup_env_linking.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Tests for scripts/setup env-file linking behavior."""
+"""Setup tests for local environment-file linking.
+
+Intent: protect the bootstrap path that links private local env files between
+worktrees without copying secrets into the repository or overwriting deliberate
+checkout-local configuration.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +20,7 @@ import unittest
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SETUP_SCRIPT = REPO_ROOT / "scripts" / "setup"
 
 

--- a/scripts/tests/test_validate_release_changes.py
+++ b/scripts/tests/test_validate_release_changes.py
@@ -3,7 +3,12 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Tests for scripts/validate-release-changes.py."""
+"""Release-gate tests for validating release-sensitive diffs.
+
+Intent: keep release automation honest by classifying release metadata changes
+and ensuring the workflow reports actionable validation failures before tags,
+appcast updates, or package publishing proceed.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +17,7 @@ import unittest
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "validate-release-changes.py"
 
 spec = importlib.util.spec_from_file_location("validate_release_changes", SCRIPT_PATH)


### PR DESCRIPTION
## Summary

- Adds a docs note that contributor-status seed PRs should use merge commits.
- Moves root `scripts/test_*.py` harnesses into `scripts/tests/` with a directory README and intent-focused module docstrings.
- Updates workflow and docs references to the new test locations; CI agent checks now run the public triage and contributor runner policy harnesses directly.

## Mergeability

- Surface: infra / docs / scripts
- User-facing behavior changed: none; this is documentation and harness organization only.
- Non-happy paths considered: moved UV scripts now resolve `REPO_ROOT` from `scripts/tests/`; imports that rely on `scripts/` are covered by explicit `sys.path` setup; stale root-level test references were checked with `rg`.
- Release/ops preconditions: none; this does not change release packaging, deployment, runner credentials, or production app behavior.
- Residual risk or follow-up: the intended observation completed on this PR; branch-protection policy can now be tested separately with human/code-owner approval if needed.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `uv run --script scripts/tests/test_agent_triage.py` — 8 tests passed.
  - `uv run --script scripts/tests/test_run_contributor.py` — 36 tests passed.
  - `uv run --script scripts/tests/test_security_hardening.py` — 29 tests passed.
  - `uv run --script scripts/tests/test_codespaces_claude_launch.py` — 9 tests passed.
  - `uv run --script scripts/tests/test_migrate_agent_labels.py` — 4 tests passed.
  - `uv run --script scripts/tests/test_ops_report.py` — 22 tests passed.
  - `uv run --script scripts/tests/test_perf_tools.py` — 8 tests passed.
  - `uv run --script scripts/tests/test_pr_readiness.py` — 9 tests passed.
  - `uv run --script scripts/tests/test_pr_review_health.py` — 14 tests passed.
  - `uv run --script scripts/tests/test_setup_env_linking.py` — 1 test passed.
  - `uv run --script scripts/tests/test_validate_release_changes.py` — 2 tests passed.
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Local command evidence listed in Validation; CI checks are running on this PR head.
- [GitHub App Review Smoke #26434178302](https://github.com/fairchild/workspaces/actions/runs/26434178302) succeeded for `workspace-agents` on PR #568 after rebasing onto `origin/main`.
- PR review API evidence: `workspace-agents[bot]` review at commit `5f3e446eb91ebee80f238ef4fc3c741dc68e5e4b` has `state: APPROVED` and `author_association: CONTRIBUTOR`.

## Observed Result

After PR #563 landed a `workspace-agents[bot]` authored commit on `main`, a fresh `workspace-agents` app approval on this PR reports `authorAssociation: CONTRIBUTOR`. That confirms the mechanism we expected: the merged default-branch commit, not merely `contents:write`, is what changes GitHub review association.

## Blockers

- [x] None
- [ ] Blocked on evidence