### PR TITLE
ci: make managed reviewer ingress canary ingress-only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -339,7 +339,7 @@ jobs:
           WORKSPACES_WEBHOOK_CANARY_SECRET: ${{ secrets.WORKSPACES_WEBHOOK_CANARY_SECRET }}
         run: |
           set +e
-          python3 ../scripts/managed-reviewer-ingress-canary.py --skip-broker --advisory-monitor > managed-reviewer-ingress-canary.log 2>&1
+          python3 ../scripts/managed-reviewer-ingress-canary.py > managed-reviewer-ingress-canary.log 2>&1
           CANARY_EXIT=$?
           cat managed-reviewer-ingress-canary.log
           if [ "$CANARY_EXIT" -ne 0 ]; then

--- a/.github/workflows/managed-reviewer-ingress.yml
+++ b/.github/workflows/managed-reviewer-ingress.yml
@@ -1,7 +1,7 @@
 # Managed reviewer ingress is the contract gate between GitHub webhook delivery,
 # the Cloudflare relay, and the Vercel route that decides whether to start a
-# managed PR review. Keep this workflow narrow and required for changes that can
-# break either side of that cross-service handoff.
+# managed PR review. It should not broker completed reviews or report run
+# health; those are separate managed-reviewer surfaces.
 name: Managed Reviewer Ingress
 
 on:
@@ -9,17 +9,19 @@ on:
     branches: [main]
     paths:
       - "infra/cloudflare-webhook-relay/**"
-      - "web/src/app/api/webhooks/github/**"
-      - "web/src/lib/agent-runtime/pr-review*.ts"
-      - "web/src/lib/agent-runtime/__tests__/pr-review*.ts"
+      - "web/src/app/api/webhooks/github/route.ts"
+      - "web/src/app/api/webhooks/github/route.test.ts"
+      - "web/src/lib/agent-runtime/pr-review-trigger.ts"
+      - "web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts"
       - "scripts/managed-reviewer-ingress-canary.py"
       - ".github/workflows/managed-reviewer-ingress.yml"
   pull_request:
     paths:
       - "infra/cloudflare-webhook-relay/**"
-      - "web/src/app/api/webhooks/github/**"
-      - "web/src/lib/agent-runtime/pr-review*.ts"
-      - "web/src/lib/agent-runtime/__tests__/pr-review*.ts"
+      - "web/src/app/api/webhooks/github/route.ts"
+      - "web/src/app/api/webhooks/github/route.test.ts"
+      - "web/src/lib/agent-runtime/pr-review-trigger.ts"
+      - "web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts"
       - "scripts/managed-reviewer-ingress-canary.py"
       - ".github/workflows/managed-reviewer-ingress.yml"
   workflow_dispatch:
@@ -81,6 +83,24 @@ jobs:
 
       - name: Validate Worker bundle
         run: bun run --bun wrangler deploy --dry-run
+
+  canary-script-smoke:
+    name: Ingress canary script smoke
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Check ingress canary script help
+        run: python3 scripts/managed-reviewer-ingress-canary.py --help
+
+      - name: Check ingress canary script secret gate
+        run: |
+          if python3 scripts/managed-reviewer-ingress-canary.py --timeout 0.1 2>canary.err; then
+            echo "::error::canary script succeeded without WORKSPACES_WEBHOOK_CANARY_SECRET"
+            exit 1
+          fi
+          grep -q "WORKSPACES_WEBHOOK_CANARY_SECRET is required" canary.err
 
   production-canary:
     name: Production ingress canary

--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -125,12 +125,13 @@ completed ReviewRun could not be published or marked superseded.
 
 Reviewer ingress is covered by `.github/workflows/managed-reviewer-ingress.yml`.
 The workflow runs when either side of the Cloudflare-to-Vercel contract changes:
-the Worker relay, the web webhook route, the reviewer trigger/runtime files, or
-the shared trigger fixtures. It runs:
+the Worker relay, the web webhook route, the reviewer trigger parser, the shared
+trigger fixtures, the ingress canary script, or the workflow itself. It runs:
 
 - `pnpm exec vitest run src/app/api/webhooks/github/route.test.ts`
 - `cd infra/cloudflare-webhook-relay && bun run test:e2e`
 - `cd infra/cloudflare-webhook-relay && bun run --bun wrangler deploy --dry-run`
+- `python3 scripts/managed-reviewer-ingress-canary.py --help`
 
 The shared trigger fixture matrix lives in
 `web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts` and is
@@ -138,16 +139,15 @@ imported by both the Vercel route tests and the Cloudflare relay e2e harness.
 This is the regression guard for drift between "forward this webhook" and
 "start the reviewer".
 
-Production CD requires `WORKSPACES_WEBHOOK_CANARY_SECRET`. Before promotion it
-runs the ingress canary, broker, and monitor as a strict gate so a known-broken
-reviewer does not get papered over by a deploy. After promotion, `validate-prod`
-checks the ingress canary again before the production Playwright smoke, skips
-the mutating broker, and reports monitor attention as advisory queue health. The
-scheduled broker and health workflows remain the source of truth for live
-reviewer reconciliation failures.
+Production CD requires `WORKSPACES_WEBHOOK_CANARY_SECRET`, runs the ingress
+canary before promotion, then repeats it in `validate-prod` after promotion
+before the production Playwright smoke. That canary proves only relay delivery,
+route HMAC validation, canary-secret validation, and dry-run trigger selection.
+It does not broker completed runs or report queue health; the scheduled broker
+and health workflows own live reviewer reconciliation failures.
 
-The scheduled ingress workflow is a contract probe, not the normal broker
-driver. Use `Managed Reviewer Broker` to reconcile completed runs on demand.
+The scheduled ingress workflow is a contract probe. It does not reconcile
+completed runs and does not report queue health.
 
 Production canary:
 
@@ -155,6 +155,12 @@ Production canary:
 curl --fail-with-body -sS -X POST \
   https://webhooks.cloudcompute.com/canary/pr-review-ingress \
   -H "X-Workspace-Webhook-Canary: $WORKSPACES_WEBHOOK_CANARY_SECRET"
+```
+
+Broker reconciliation:
+
+```bash
+uv run --script scripts/pr-reviewer-broker.py --limit 5
 ```
 
 Operator run report:
@@ -179,18 +185,6 @@ route verifies the GitHub-style HMAC and the canary secret before returning the
 dry-run result, and returns before `pushEvent()` or `triggerPrReview()` so no
 managed-agent session or GitHub review is created.
 
-The same workflow also calls:
-
-```bash
-curl --fail-with-body -sS -X POST \
-  "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-broker?limit=5" \
-  -H "X-Workspace-Webhook-Canary: $WORKSPACES_WEBHOOK_CANARY_SECRET"
-
-curl --fail-with-body -sS \
-  "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-monitor?windowMinutes=90" \
-  -H "X-Workspace-Webhook-Canary: $WORKSPACES_WEBHOOK_CANARY_SECRET"
-```
-
 The broker inspects `started` rows in `managed_pr_review_runs`, skips sessions
 that are still running, validates completed review-intent JSON, and posts the
 review with the GitHub App token. The row keeps two lifecycle fields: `status`
@@ -199,12 +193,12 @@ or failure projection. Before posting, the broker re-checks current managed
 reviews on the PR; if another managed review was submitted after the session
 started, the stale session is marked `superseded`. If the superseding review is
 for an older head, the broker starts a fresh follow-up session so the newer-head
-review includes the prior review context. The monitor then compares recent
+review includes the prior review context. The run report compares recent
 reviewer-eligible rows in `webhook_events` with `managed_pr_review_runs`
-records and classifies the current ReviewRun rows into starting, executing,
-needs-projection, failed, and terminal buckets. These routes return only run
-metadata, details URLs, stored failure reasons, and missing event identifiers,
-not raw payloads or secrets.
+records and classifies ReviewRun rows into starting, executing,
+needs-projection, failed, and terminal buckets. Broker and report routes return
+only run metadata, details URLs, stored failure reasons, and missing event
+identifiers, not raw payloads or secrets.
 
 ## Observing Sessions
 

--- a/scripts/managed-reviewer-ingress-canary.py
+++ b/scripts/managed-reviewer-ingress-canary.py
@@ -3,13 +3,11 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Run the production managed-reviewer ingress canary, broker, and monitor.
+"""Run the production managed-reviewer ingress canary.
 
 The canary proves the deployed Cloudflare relay can forward a signed,
-reviewer-eligible webhook to the Vercel route in dry-run mode. The broker then
-posts any completed managed-agent review intents, and the monitor checks that
-recent eligible production webhook activity has matching managed_pr_review_runs
-rows.
+reviewer-eligible webhook to the Vercel route in dry-run mode. It does not run
+the broker or monitor; those are separate managed-reviewer surfaces.
 """
 
 from __future__ import annotations
@@ -19,16 +17,12 @@ import json
 import os
 import sys
 import urllib.error
-import urllib.parse
 import urllib.request
 from typing import Any
 
 
 CANARY_HEADER = "X-Workspace-Webhook-Canary"
 DEFAULT_CANARY_URL = "https://webhooks.cloudcompute.com/canary/pr-review-ingress"
-DEFAULT_MONITOR_URL = "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-monitor"
-DEFAULT_BROKER_URL = "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-broker"
-DEFAULT_REPO = "fairchild/workspaces"
 SAFE_RESPONSE_KEYS = (
     "ok",
     "canary",
@@ -37,39 +31,8 @@ SAFE_RESPONSE_KEYS = (
     "eventType",
     "action",
     "repo",
-    "windowMinutes",
-    "eligibleEvents",
-    "missingRuns",
-    "attentionRequired",
-    "starting",
-    "stuckStarting",
-    "executing",
-    "needsProjection",
-    "terminal",
-    "checked",
-    "completed",
-    "failed",
-    "skippedRunning",
-    "superseded",
-    "requeued",
     "error",
 )
-SAFE_RUN_KEYS = (
-    "prNumber",
-    "shortHeadSha",
-    "triggerKind",
-    "status",
-    "agentStatus",
-    "projectionStatus",
-    "state",
-    "ageMinutes",
-    "detailsUrl",
-    "error",
-    "projectionError",
-    "githubReviewId",
-    "supersededByReviewId",
-)
-SAFE_MISSING_KEYS = ("eventId", "prNumber", "triggerKind", "headSha")
 
 
 class CanaryError(RuntimeError):
@@ -79,20 +42,7 @@ class CanaryError(RuntimeError):
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--canary-url", default=DEFAULT_CANARY_URL)
-    parser.add_argument("--monitor-url", default=DEFAULT_MONITOR_URL)
-    parser.add_argument("--broker-url", default=DEFAULT_BROKER_URL)
-    parser.add_argument("--repo", default=DEFAULT_REPO)
-    parser.add_argument("--window-minutes", type=int, default=90)
-    parser.add_argument("--broker-limit", type=int, default=5)
     parser.add_argument("--timeout", type=float, default=20)
-    parser.add_argument("--skip-canary", action="store_true")
-    parser.add_argument("--skip-broker", action="store_true")
-    parser.add_argument("--skip-monitor", action="store_true")
-    parser.add_argument(
-        "--advisory-monitor",
-        action="store_true",
-        help="Print monitor attention as a warning instead of failing the ingress canary.",
-    )
     return parser.parse_args()
 
 
@@ -103,68 +53,10 @@ def require_secret() -> str:
     return secret
 
 
-def url_with_query_defaults(base_url: str, defaults: dict[str, str]) -> str:
-    parsed = urllib.parse.urlparse(base_url)
-    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
-    existing = {key for key, _ in query}
-    query.extend(
-        (key, value) for key, value in defaults.items() if key not in existing
-    )
-    return urllib.parse.urlunparse(
-        parsed._replace(query=urllib.parse.urlencode(query))
-    )
-
-
-def monitor_url(base_url: str, repo: str, window_minutes: int) -> str:
-    return url_with_query_defaults(
-        base_url,
-        {"repo": repo, "windowMinutes": str(window_minutes)},
-    )
-
-
-def broker_url(base_url: str, repo: str, limit: int) -> str:
-    return url_with_query_defaults(base_url, {"repo": repo, "limit": str(limit)})
-
-
-def safe_run(item: object) -> dict[str, object]:
-    if not isinstance(item, dict):
-        return {"error": "non_object_run"}
-    return {key: item[key] for key in SAFE_RUN_KEYS if key in item}
-
-
-def safe_runs(value: object) -> object:
-    if isinstance(value, list):
-        return [safe_run(item) for item in value]
-    if isinstance(value, dict):
-        return {
-            key: [safe_run(item) for item in items]
-            for key, items in value.items()
-            if isinstance(items, list)
-        }
-    return {"error": "non_object_runs"}
-
-
-def safe_missing(item: object) -> dict[str, object]:
-    if not isinstance(item, dict):
-        return {"error": "non_object_missing"}
-    return {key: item[key] for key in SAFE_MISSING_KEYS if key in item}
-
-
-def safe_missing_list(value: object) -> object:
-    if not isinstance(value, list):
-        return {"error": "non_list_missing"}
-    return [safe_missing(item) for item in value]
-
-
 def safe_payload(payload: object) -> dict[str, object]:
     if not isinstance(payload, dict):
         return {"error": "non_object_response"}
-    safe = {key: payload[key] for key in SAFE_RESPONSE_KEYS if key in payload}
-    if "runs" in payload:
-        safe["runs"] = safe_runs(payload["runs"])
-    if "missing" in payload:
-        safe["missing"] = safe_missing_list(payload["missing"])
-    return safe
+    return {key: payload[key] for key in SAFE_RESPONSE_KEYS if key in payload}
 
 
 def payload_for_error(raw: bytes) -> dict[str, object]:
@@ -190,8 +82,6 @@ def request_json(
     url: str,
     secret: str,
     timeout: float,
-    *,
-    allow_http_error_json: bool = False,
 ) -> dict[str, Any]:
     request = urllib.request.Request(
         url,
@@ -208,8 +98,6 @@ def request_json(
             raw = response.read(64 * 1024)
     except urllib.error.HTTPError as error:
         raw = error.read(64 * 1024)
-        if allow_http_error_json:
-            return decode_payload(label, raw)
         raise CanaryError(
             f"{label} returned HTTP {error.code}: "
             f"{json.dumps(payload_for_error(raw), sort_keys=True)}"
@@ -227,76 +115,29 @@ def validate_canary(payload: dict[str, Any]) -> None:
         or payload.get("wouldTrigger") is not True
         or payload.get("triggerKind") != "opened"
     ):
-        raise CanaryError(f"unexpected canary response: {json.dumps(safe_payload(payload), sort_keys=True)}")
-
-
-def validate_monitor(payload: dict[str, Any]) -> None:
-    if payload.get("ok") is not True:
-        raise CanaryError(f"reviewer run monitor failed: {json.dumps(safe_payload(payload), sort_keys=True)}")
+        raise CanaryError(
+            f"unexpected canary response: "
+            f"{json.dumps(safe_payload(payload), sort_keys=True)}"
+        )
 
 
 def main() -> int:
     args = parse_args()
 
-    if args.skip_canary and args.skip_broker and args.skip_monitor:
-        print("No managed reviewer ingress checks requested.")
-        return 0
-
     try:
         secret = require_secret()
-
-        if not args.skip_canary:
-            payload = request_json(
-                "managed reviewer ingress canary",
-                "POST",
-                args.canary_url,
-                secret,
-                args.timeout,
-            )
-            validate_canary(payload)
-            print(
-                "managed reviewer ingress canary ok: "
-                f"{json.dumps(safe_payload(payload), sort_keys=True)}"
-            )
-
-        if not args.skip_broker:
-            payload = request_json(
-                "managed reviewer broker",
-                "POST",
-                broker_url(args.broker_url, args.repo, args.broker_limit),
-                secret,
-                args.timeout,
-            )
-            if payload.get("ok") is not True:
-                raise CanaryError(
-                    "managed reviewer broker failed: "
-                    f"{json.dumps(safe_payload(payload), sort_keys=True)}"
-                )
-            print(
-                "managed reviewer broker ok: "
-                f"{json.dumps(safe_payload(payload), sort_keys=True)}"
-            )
-
-        if not args.skip_monitor:
-            payload = request_json(
-                "managed reviewer run monitor",
-                "GET",
-                monitor_url(args.monitor_url, args.repo, args.window_minutes),
-                secret,
-                args.timeout,
-                allow_http_error_json=args.advisory_monitor,
-            )
-            try:
-                validate_monitor(payload)
-            except CanaryError as error:
-                if not args.advisory_monitor:
-                    raise
-                print(f"::warning::{error}", file=sys.stderr)
-            else:
-                print(
-                    "managed reviewer run monitor ok: "
-                    f"{json.dumps(safe_payload(payload), sort_keys=True)}"
-                )
+        payload = request_json(
+            "managed reviewer ingress canary",
+            "POST",
+            args.canary_url,
+            secret,
+            args.timeout,
+        )
+        validate_canary(payload)
+        print(
+            "managed reviewer ingress canary ok: "
+            f"{json.dumps(safe_payload(payload), sort_keys=True)}"
+        )
     except CanaryError as error:
         print(f"::error::{error}", file=sys.stderr)
         return 1

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -427,9 +427,24 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("managed_pr_review_runs", runs)
         self.assertIn("listRecentPrReviewRuns", monitor)
         self.assertIn("processPendingPrReviewRuns", broker)
-        self.assertIn("pr-reviewer-broker", canary_script)
-        self.assertIn("pr-reviewer-monitor", canary_script)
+        self.assertIn("/canary/pr-review-ingress", canary_script)
+        self.assertNotIn("pr-reviewer-broker", canary_script)
+        self.assertNotIn("pr-reviewer-monitor", canary_script)
+        self.assertNotIn("DEFAULT_BROKER_URL", canary_script)
+        self.assertNotIn("DEFAULT_MONITOR_URL", canary_script)
+        self.assertNotIn("--skip-broker", canary_script)
+        self.assertNotIn("--skip-monitor", canary_script)
+        self.assertNotIn("windowMinutes", canary_script)
         self.assertIn("scripts/managed-reviewer-ingress-canary.py", workflow)
+        self.assertIn("web/src/lib/agent-runtime/pr-review-trigger.ts", workflow)
+        self.assertIn(
+            "web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts",
+            workflow,
+        )
+        self.assertNotIn("web/src/lib/agent-runtime/pr-review*.ts", workflow)
+        self.assertNotIn("web/src/lib/agent-runtime/__tests__/pr-review*.ts", workflow)
+        self.assertIn("Check ingress canary script help", workflow)
+        self.assertIn("WORKSPACES_WEBHOOK_CANARY_SECRET is required", workflow)
         self.assertIn("scripts/managed-reviewer-ingress-canary.py", cd_workflow)
         self.assertNotIn("python3 - <<", workflow)
         self.assertNotIn("python3 - <<", cd_workflow)
@@ -437,7 +452,9 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("canary-secret-preflight", cd_workflow)
         self.assertIn("managed-reviewer-canary-preflight", cd_workflow)
         self.assertIn("Managed reviewer ingress canary before promotion", cd_workflow)
-        self.assertIn("--skip-broker --advisory-monitor", cd_workflow)
+        self.assertNotIn("--skip-broker", cd_workflow)
+        self.assertNotIn("--skip-monitor", cd_workflow)
+        self.assertNotIn("--advisory-monitor", cd_workflow)
         self.assertIn("pre-prod-managed-reviewer-ingress-findings", cd_workflow)
         self.assertIn(
             "WORKSPACES_WEBHOOK_CANARY_SECRET is required before production promotion",
@@ -448,10 +465,10 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("wrangler deploy --dry-run", workflow)
         self.assertIn("urllib.request", canary_script)
         self.assertIn("SAFE_RESPONSE_KEYS", canary_script)
-        self.assertIn("SAFE_RUN_KEYS", canary_script)
-        self.assertIn("def safe_runs", canary_script)
-        self.assertIn("--advisory-monitor", canary_script)
-        self.assertIn("def broker_url", canary_script)
+        self.assertNotIn("SAFE_RUN_KEYS", canary_script)
+        self.assertNotIn("def safe_runs", canary_script)
+        self.assertNotIn("--advisory-monitor", canary_script)
+        self.assertNotIn("def broker_url", canary_script)
         self.assertIn("scripts/pr-reviewer-broker.py", broker_workflow)
         self.assertIn("schedule:", broker_workflow)
         self.assertNotIn("scripts/managed-reviewer-ingress-canary.py", broker_workflow)
@@ -462,9 +479,13 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertNotIn("canary/pr-review-ingress", broker_script)
 
         result = subprocess.run(
-            ["python3", "scripts/managed-reviewer-ingress-canary.py", "--skip-monitor"],
+            ["python3", "scripts/managed-reviewer-ingress-canary.py"],
             cwd=REPO_ROOT,
-            env={key: value for key, value in os.environ.items() if key != "WORKSPACES_WEBHOOK_CANARY_SECRET"},
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key != "WORKSPACES_WEBHOOK_CANARY_SECRET"
+            },
             capture_output=True,
             text=True,
             check=False,


### PR DESCRIPTION
## Summary
- keep the managed reviewer ingress canary focused on the relay-to-route dry-run contract
- remove broker/monitor flags and CD usage from the ingress canary path
- tighten ingress workflow path filters and add script smoke coverage
- update hardening tests and reviewer docs so ingress cannot quietly regain broker/monitor responsibility

## Verification
- `python3 scripts/managed-reviewer-ingress-canary.py --help`
- `env -u WORKSPACES_WEBHOOK_CANARY_SECRET python3 scripts/managed-reviewer-ingress-canary.py --timeout 0.1`
- `env PYTHONPYCACHEPREFIX=/private/tmp/python-pycache python3 -m py_compile scripts/managed-reviewer-ingress-canary.py scripts/pr-reviewer-broker.py scripts/pr-reviewer-runs.py scripts/tests/test_security_hardening.py`
- `uv run --script scripts/tests/test_security_hardening.py`
- `mise -C web run web:check`
- `bun run test:e2e` in `infra/cloudflare-webhook-relay`
- `bun run --bun wrangler deploy --dry-run` in `infra/cloudflare-webhook-relay`
- `git -c core.whitespace=space-before-tab,trailing-space diff --check`

## Evidence
- ![managed-reviewer-ingress-only-validation](https://evidence.cloudcompute.com/workspaces/pr-575/20260526-065723-managed-reviewer-ingress-only-validation.svg)

## Mergeability
- Surface: CI / managed reviewer ingress / production CD canary / docs
- User-facing behavior changed: no direct app UI change; operator behavior changes because ingress canary and CD canary no longer run broker or monitor checks.
- Non-happy paths considered: missing canary secret remains a hard failure; malformed or unexpected canary responses still fail with bounded safe payload output.
- Residual risk or follow-up: production live canary could not be run locally because no local `WORKSPACES_WEBHOOK_CANARY_SECRET` was available; GitHub workflow uses the configured repository secret.
