### PR TITLE
M6.chg Terminal Status Sliver

### DIFF
--- a/.claude/skills/release-screenshot/SKILL.md
+++ b/.claude/skills/release-screenshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-screenshot
-description: Capture deterministic screenshots of the WorkSpaces macOS app in a known UI state. Use when the user asks to "capture a release screenshot", "screenshot the app", "show the Phase 1 state", or wants evidence for a PR / release notes / design brief. Wraps the fixture-mode env vars (WORKSPACES_UI_FIXTURE + WORKSPACES_UI_FIXTURE_AGENT_STATES) and the existing scripts/sidebar-capture.sh capture pipeline. Triggers on "release screenshot", "screenshot the app", "capture the app", "fixture screenshot", "ui evidence", "/release-screenshot".
+description: Capture deterministic screenshots of the WorkSpaces macOS app in a known UI state. Use when the user asks to "capture a release screenshot", "screenshot the app", "show the Phase 1 state", or wants evidence for a PR / release notes / design brief. Wraps the fixture-mode env vars (WORKSPACES_UI_FIXTURE, WORKSPACES_UI_FIXTURE_AGENT_STATES, and WORKSPACES_UI_FIXTURE_COMMAND_STATUSES) and the existing scripts/sidebar-capture.sh capture pipeline. Triggers on "release screenshot", "screenshot the app", "capture the app", "fixture screenshot", "ui evidence", "/release-screenshot".
 ---
 
 # release-screenshot
@@ -9,7 +9,7 @@ Project skill for producing deterministic, reproducible screenshots of the WorkS
 
 ## Overview
 
-The skill orchestrates `WORKSPACES_UI_FIXTURE=1` plus `WORKSPACES_UI_FIXTURE_AGENT_STATES=<scenario value>` and the existing `scripts/lib/ui-test-common.sh` helpers to launch the debug build, drive the sidebar into a chosen run-state configuration, capture the window, and quit. The bundled script `scripts/capture.sh` is the single entry point.
+The skill orchestrates `WORKSPACES_UI_FIXTURE=1` plus named scenario env vars and the existing `scripts/lib/ui-test-common.sh` helpers to launch the debug build, drive the app into a chosen fixture state, capture the window, and quit. Scenarios may set agent run states, terminal command statuses, or both. The bundled script `scripts/capture.sh` is the single entry point.
 
 Default output: `output/release-screenshots/<scenario>-<iso8601>.png`. Override with `--output`.
 
@@ -31,6 +31,7 @@ Flags:
 | Scenario | Visible |
 |----------|---------|
 | `phase-1-release` | Bertram-chat repo expanded with `feature-auth` selected (blue thinking), `bugfix-422` yellow (awaiting input), `refactor-state` idle; `bread-builder` collapsed with red bubbled errored dot; toolbar pill reads "2 need you". Matches `.context/ux-review/release-screenshot.png`. |
+| `m6-status-sliver` | `feature-auth` selected with a compact terminal sliver showing a failed `swift test` command, exit `1`, and duration. |
 | `attention-only` | A single workspace (`bugfix-422`) in `awaitingInput` — useful when only the toolbar pill matters. |
 | `clean` | No agent states applied — baseline sidebar, no dots. |
 
@@ -55,7 +56,7 @@ See `references/extending.md`. Two-step: add a `case` arm to `scripts/capture.sh
 - **Build fails / GhosttyKit out of date:** `./scripts/build-ghosttykit.sh` once, then retry.
 - **Permission prompts (`cliclick`, `screencapture`):** open System Settings → Privacy & Security and grant Accessibility + Screen Recording to the terminal you're running from.
 - **App launches but no fixture data:** verify the env var made it through with `ps aux | rg WORKSPACES_UI_FIXTURE`. If absent, you launched the installed `/Applications/WorkSpaces.app` by accident — `pkill -f WorkspaceManager` first.
-- **Status dots don't match what you expected:** scenarios drive the agent registry via synthetic events; check the env-var value in `references/scenarios.md` matches your mental model.
+- **Status dots or slivers don't match what you expected:** scenarios drive the agent registry and command-status registry via synthetic events; check the env-var values in `references/scenarios.md` match your mental model.
 
 ## Known limits
 

--- a/.claude/skills/release-screenshot/references/scenarios.md
+++ b/.claude/skills/release-screenshot/references/scenarios.md
@@ -1,14 +1,15 @@
 # Scenarios
 
-Each named scenario maps to one literal value of `WORKSPACES_UI_FIXTURE_AGENT_STATES`. The script `scripts/capture.sh` is the single source of truth — this table mirrors its `case` arm. If you edit one, edit both.
+Each named scenario maps to literal UI fixture env vars. The script `scripts/capture.sh` is the single source of truth — this table mirrors its `case` arm. If you edit one, edit both.
 
 ## Named scenarios
 
-| Scenario id | `WORKSPACES_UI_FIXTURE_AGENT_STATES` | Expected visual |
-|-------------|--------------------------------------|-----------------|
-| `phase-1-release` | `feature-auth:thinking,bugfix-422:awaitingInput,refactor-runtime:errored` | `bertram-chat` expanded with `feature-auth` selected (blue thinking dot), `bugfix-422` yellow (awaiting input), `refactor-state` no dot (idle); `bread-builder` collapsed with red bubbled errored dot from `refactor-runtime`; toolbar pill reads "2 need you". Matches `.context/ux-review/release-screenshot.png`. |
-| `attention-only` | `bugfix-422:awaitingInput` | Only `bugfix-422` shows a yellow dot; toolbar pill reads "1 needs you". |
-| `clean` | *(unset)* | Baseline sidebar with no agent-state dots; toolbar pill hidden. |
+| Scenario id | `WORKSPACES_UI_FIXTURE_AGENT_STATES` | `WORKSPACES_UI_FIXTURE_COMMAND_STATUSES` | Expected visual |
+|-------------|--------------------------------------|----------------------------------------------------|-----------------|
+| `phase-1-release` | `feature-auth:thinking,bugfix-422:awaitingInput,refactor-runtime:errored` | *(unset)* | `bertram-chat` expanded with `feature-auth` selected (blue thinking dot), `bugfix-422` yellow (awaiting input), `refactor-state` no dot (idle); `bread-builder` collapsed with red bubbled errored dot from `refactor-runtime`; toolbar pill reads "2 need you". Matches `.context/ux-review/release-screenshot.png`. |
+| `m6-status-sliver` | *(unset)* | `feature-auth:failed` | `feature-auth` selected with a compact terminal sliver showing a failed `swift test` command, exit `1`, and duration. |
+| `attention-only` | `bugfix-422:awaitingInput` | *(unset)* | Only `bugfix-422` shows a yellow dot; toolbar pill reads "1 needs you". |
+| `clean` | *(unset)* | *(unset)* | Baseline sidebar with no agent-state dots; toolbar pill hidden. |
 
 ## Inline form
 
@@ -32,6 +33,17 @@ The string after `inline:` becomes `WORKSPACES_UI_FIXTURE_AGENT_STATES` verbatim
 | `awaitingInput` | `.awaitingInput(reason: .permissionPrompt)` | Yellow dot (contributes to attention count) |
 | `errored` | `.errored(category: .toolFailure, message: "Tool failed")` | Red dot (contributes to attention count) |
 | `complete` | `.complete` | No dot |
+
+## Supported command statuses
+
+`WORKSPACES_UI_FIXTURE_COMMAND_STATUSES` uses the same comma-separated `workspaceName:status` shape. It creates or activates the matching host terminal session and publishes a synthetic `LastCommandStatus` for the terminal sliver.
+
+| Token | Resulting command status | Visual |
+|-------|--------------------------|--------|
+| `success` | `swift build`, exit `0` | Green success sliver |
+| `failed` | `swift test`, exit `1` | Red failed sliver |
+| `running` | running `swift test` | Running sliver |
+| `finished` | `git status`, unknown exit code | Neutral finished sliver |
 
 ## Available fixture workspaces
 

--- a/.claude/skills/release-screenshot/scripts/capture.sh
+++ b/.claude/skills/release-screenshot/scripts/capture.sh
@@ -24,6 +24,7 @@ Usage: capture.sh <scenario> [--output PATH] [--no-build] [--keep-running]
 
 Scenarios:
   phase-1-release   Matches .context/ux-review/release-screenshot.png
+  m6-status-sliver  Shows the terminal command-status sliver
   attention-only    Single workspace awaiting input
   clean             Baseline — no agent states
   inline:<env>      Pass <env> directly as WORKSPACES_UI_FIXTURE_AGENT_STATES
@@ -73,17 +74,25 @@ fi
 
 if [[ "$scenario" == inline:* ]]; then
     agent_states="${scenario#inline:}"
+    command_statuses=""
     scenario_id="inline"
 else
     case "$scenario" in
         phase-1-release)
             agent_states="feature-auth:thinking,bugfix-422:awaitingInput,refactor-runtime:errored"
+            command_statuses=""
+            ;;
+        m6-status-sliver)
+            agent_states=""
+            command_statuses="feature-auth:failed"
             ;;
         attention-only)
             agent_states="bugfix-422:awaitingInput"
+            command_statuses=""
             ;;
         clean)
             agent_states=""
+            command_statuses=""
             ;;
         *)
             echo "ERROR: unknown scenario '$scenario'." >&2
@@ -115,6 +124,12 @@ if [[ -n "$agent_states" ]]; then
     ws_log "WORKSPACES_UI_FIXTURE_AGENT_STATES=${agent_states}"
 else
     unset WORKSPACES_UI_FIXTURE_AGENT_STATES || true
+fi
+if [[ -n "$command_statuses" ]]; then
+    export WORKSPACES_UI_FIXTURE_COMMAND_STATUSES="$command_statuses"
+    ws_log "WORKSPACES_UI_FIXTURE_COMMAND_STATUSES=${command_statuses}"
+else
+    unset WORKSPACES_UI_FIXTURE_COMMAND_STATUSES || true
 fi
 
 if [[ $do_build -eq 1 ]]; then

--- a/Sources/WorkspaceManager/App/UIFixtureSeeder.swift
+++ b/Sources/WorkspaceManager/App/UIFixtureSeeder.swift
@@ -2,8 +2,8 @@
 //  UIFixtureSeeder.swift
 //  WorkspaceManager
 //
-//  Fixture-mode seeding for SwiftData and agent session state. Drives
-//  deterministic screenshots via WORKSPACES_UI_FIXTURE_AGENT_STATES.
+//  Fixture-mode seeding for SwiftData, agent session state, and command status.
+//  Drives deterministic screenshots via WORKSPACES_UI_FIXTURE_* env vars.
 //
 
 import AppKit
@@ -14,10 +14,12 @@ import WorkspaceManagerCore
 @MainActor
 enum UIFixtureSeeder {
     static let agentStatesEnvKey = "WORKSPACES_UI_FIXTURE_AGENT_STATES"
+    static let commandStatusesEnvKey = "WORKSPACES_UI_FIXTURE_COMMAND_STATUSES"
 
     /// Idempotency latch — `seedAgentStatesIfNeeded` may be invoked multiple times
     /// as views re-appear, but the synthetic events should only land once per launch.
     static var hasSeededAgentStates = false
+    static var hasSeededCommandStatuses = false
 
     /// Seeds the in-memory fixture model context with the standard set of repos,
     /// web sources, and workspaces used across screenshots. No-op when the context
@@ -180,9 +182,64 @@ enum UIFixtureSeeder {
         return applied
     }
 
+    /// Reads `WORKSPACES_UI_FIXTURE_COMMAND_STATUSES`, resolves workspace names
+    /// against `context`, ensures a host terminal session exists for each, then
+    /// publishes synthetic command status for the M6 status sliver.
+    @discardableResult
+    static func seedCommandStatusesIfNeeded(
+        from environment: [String: String],
+        in context: ModelContext,
+        commandStatusRegistry: LastCommandStatusRegistry,
+        hostTerminalState: HostTerminalStateStore,
+        now: Date = Date()
+    ) -> Int {
+        guard !hasSeededCommandStatuses else { return 0 }
+        guard let raw = environment[commandStatusesEnvKey],
+            !raw.trimmingCharacters(in: .whitespaces).isEmpty
+        else {
+            return 0
+        }
+        hasSeededCommandStatuses = true
+
+        let entries = parseCommandStatusEntries(raw)
+        guard !entries.isEmpty else { return 0 }
+
+        var applied = 0
+        var firstActivation: (key: HostTerminalSessionKey, directory: URL)?
+        let workspaces = fetchAllWorkspaces(in: context)
+        for entry in entries {
+            guard
+                let workspace = workspaces.first(where: {
+                    $0.name.caseInsensitiveCompare(entry.workspaceName) == .orderedSame
+                })
+            else {
+                NSLog("[UIFixture] No fixture workspace named '%@' — skipping", entry.workspaceName)
+                continue
+            }
+
+            let directory = workspace.workspaceURL.standardizedFileURL.resolvingSymlinksInPath()
+            let key: HostTerminalSessionKey = .hostPath(directory.path)
+            let result = hostTerminalState.activateSession(key: key, directory: directory)
+            if firstActivation == nil {
+                firstActivation = (key, directory)
+            }
+            commandStatusRegistry.setStatus(
+                entry.status.status(at: now),
+                for: result.session.id
+            )
+            applied += 1
+        }
+
+        if let primary = firstActivation {
+            hostTerminalState.activateSession(key: primary.key, directory: primary.directory)
+        }
+        return applied
+    }
+
     /// Test seam — resets the idempotency latch.
     static func resetForTesting() {
         hasSeededAgentStates = false
+        hasSeededCommandStatuses = false
     }
 
     // MARK: - Parsing
@@ -210,6 +267,67 @@ enum UIFixtureSeeder {
                 return nil
             }
             return ParsedEntry(workspaceName: name, run: run)
+        }
+    }
+
+    struct ParsedCommandStatusEntry: Equatable {
+        let workspaceName: String
+        let status: FixtureCommandStatus
+    }
+
+    enum FixtureCommandStatus: Equatable {
+        case success
+        case failed
+        case running
+        case finished
+
+        func status(at now: Date) -> LastCommandStatus {
+            switch self {
+            case .success:
+                return LastCommandStatus(
+                    commandLine: "swift build",
+                    exitCode: 0,
+                    startedAt: now.addingTimeInterval(-1.2),
+                    endedAt: now
+                )
+            case .failed:
+                return LastCommandStatus(
+                    commandLine: "swift test",
+                    exitCode: 1,
+                    startedAt: now.addingTimeInterval(-2.4),
+                    endedAt: now
+                )
+            case .running:
+                return .started(commandLine: "swift test", at: now.addingTimeInterval(-8))
+            case .finished:
+                return LastCommandStatus(
+                    commandLine: "git status",
+                    exitCode: nil,
+                    startedAt: now.addingTimeInterval(-0.4),
+                    endedAt: now
+                )
+            }
+        }
+    }
+
+    static func parseCommandStatusEntries(_ raw: String) -> [ParsedCommandStatusEntry] {
+        raw.split(separator: ",", omittingEmptySubsequences: true).compactMap { fragment in
+            let pair = fragment.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard pair.count == 2 else {
+                NSLog("[UIFixture] Malformed command-status entry '%@' — expected name:status", String(fragment))
+                return nil
+            }
+            let name = pair[0].trimmingCharacters(in: .whitespaces)
+            let stateToken = pair[1].trimmingCharacters(in: .whitespaces)
+            guard !name.isEmpty else {
+                NSLog("[UIFixture] Empty workspace name in '%@' — skipping", String(fragment))
+                return nil
+            }
+            guard let status = commandStatus(for: stateToken) else {
+                NSLog("[UIFixture] Unknown command status '%@' for '%@' — skipping", stateToken, name)
+                return nil
+            }
+            return ParsedCommandStatusEntry(workspaceName: name, status: status)
         }
     }
 
@@ -241,6 +359,21 @@ enum UIFixtureSeeder {
             return [.errored(category: category, message: message)]
         case .complete:
             return [.stopped(error: nil)]
+        }
+    }
+
+    private static func commandStatus(for token: String) -> FixtureCommandStatus? {
+        switch token.lowercased() {
+        case "success", "succeeded", "exit0", "exit-0":
+            return .success
+        case "failed", "failure", "exit1", "exit-1", "nonzero", "non-zero":
+            return .failed
+        case "running", "inflight", "in-flight":
+            return .running
+        case "finished", "unknown", "unknown-exit":
+            return .finished
+        default:
+            return nil
         }
     }
 

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -333,6 +333,12 @@ private struct AgentSessionRegistryAttacher: ViewModifier {
                     registry: registry,
                     hostTerminalState: hostTerminalState
                 )
+                UIFixtureSeeder.seedCommandStatusesIfNeeded(
+                    from: ProcessInfo.processInfo.environment,
+                    in: modelContext,
+                    commandStatusRegistry: commandStatusRegistry,
+                    hostTerminalState: hostTerminalState
+                )
             }
         }
     }

--- a/Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh
@@ -63,4 +63,6 @@ __workspaces_command_status_precmd() {
 
 autoload -Uz add-zsh-hook 2>/dev/null || return 0
 add-zsh-hook preexec __workspaces_command_status_preexec 2>/dev/null || true
-add-zsh-hook precmd __workspaces_command_status_precmd 2>/dev/null || true
+if add-zsh-hook precmd __workspaces_command_status_precmd 2>/dev/null; then
+    precmd_functions=(__workspaces_command_status_precmd ${precmd_functions:#__workspaces_command_status_precmd})
+fi

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalSessionStack.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalSessionStack.swift
@@ -3,6 +3,8 @@ import SwiftUI
 import WorkspaceManagerCore
 
 struct HostTerminalSessionStack: View {
+    @EnvironmentObject private var commandStatusRegistry: LastCommandStatusRegistry
+
     let sessions: [HostTerminalSession]
     let activeSessionID: UUID?
     let splitSession: HostTerminalSession?
@@ -31,19 +33,26 @@ struct HostTerminalSessionStack: View {
         for session: HostTerminalSession,
         axis: HostTerminalStateStore.SplitPaneLayout.Axis
     ) -> some View {
-        PersistentHostTerminalContainerView(
-            session: session,
-            surfaceStore: surfaceStore,
-            onProcessExit: {
-                onTerminalProcessExit?(session.id)
-            },
-            onCloseConfirmationRequired: {
-                onCloseConfirmationRequired?(session.id)
-            },
-            contextMenuProvider: {
-                contextMenuProvider?(session)
-            }
-        )
+        VStack(spacing: 0) {
+            TerminalCommandStatusSliver(
+                status: commandStatusRegistry.statusByTerminalSession[session.id]
+            )
+
+            PersistentHostTerminalContainerView(
+                session: session,
+                surfaceStore: surfaceStore,
+                onProcessExit: {
+                    onTerminalProcessExit?(session.id)
+                },
+                onCloseConfirmationRequired: {
+                    onCloseConfirmationRequired?(session.id)
+                },
+                contextMenuProvider: {
+                    contextMenuProvider?(session)
+                }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
         .frame(
             minWidth: axis == .leadingTrailing ? 240 : nil,
             minHeight: axis == .topBottom ? 160 : nil

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalCommandStatusSliver.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalCommandStatusSliver.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+import WorkspaceManagerCore
+
+struct TerminalCommandStatusSliver: View {
+    let status: LastCommandStatus?
+
+    var body: some View {
+        if let presentation = TerminalCommandStatusSliverPresentation(status: status) {
+            HStack(spacing: 8) {
+                statusGlyph(for: presentation)
+
+                Text(presentation.primaryText)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(.primary)
+                    .layoutPriority(0)
+
+                if let secondaryText = presentation.secondaryText {
+                    Text(secondaryText)
+                        .font(.system(size: 11))
+                        .lineLimit(1)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .layoutPriority(1)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, minHeight: 26, maxHeight: 26, alignment: .leading)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor).opacity(0.8))
+                    .frame(height: 1)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(presentation.accessibilityLabel)
+        }
+    }
+
+    @ViewBuilder
+    private func statusGlyph(for presentation: TerminalCommandStatusSliverPresentation) -> some View {
+        if presentation.isRunning {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 14, height: 14)
+                .accessibilityHidden(true)
+        } else {
+            Image(systemName: presentation.symbolName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(presentation.tint.color)
+                .frame(width: 14, height: 14)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+struct TerminalCommandStatusSliverPresentation: Equatable {
+    enum Tint: Equatable {
+        case running
+        case success
+        case failure
+        case neutral
+
+        var color: Color {
+            switch self {
+            case .running:
+                return Color(nsColor: .controlAccentColor)
+            case .success:
+                return .green
+            case .failure:
+                return .red
+            case .neutral:
+                return .secondary
+            }
+        }
+    }
+
+    let primaryText: String
+    let secondaryText: String?
+    let accessibilityLabel: String
+    let symbolName: String
+    let tint: Tint
+    let isRunning: Bool
+
+    init?(status: LastCommandStatus?) {
+        guard let status else { return nil }
+
+        let commandText = status.commandLine?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayCommand = commandText?.isEmpty == false ? commandText : nil
+        let durationText = status.duration.map(Self.durationText(for:))
+
+        if status.isRunning {
+            primaryText = displayCommand ?? "Running command..."
+            secondaryText = displayCommand == nil ? nil : "Running"
+            accessibilityLabel = displayCommand.map { "Running command, \($0)" } ?? "Running command"
+            symbolName = "circle.dotted"
+            tint = .running
+            isRunning = true
+            return
+        }
+
+        isRunning = false
+
+        switch status.exitCode {
+        case 0?:
+            primaryText = displayCommand ?? "Last command succeeded"
+            secondaryText = Self.joinedMetadata(["Exit 0", durationText])
+            accessibilityLabel = Self.accessibilityLabel(
+                state: "Last command succeeded",
+                command: displayCommand,
+                exitCode: 0,
+                duration: durationText
+            )
+            symbolName = "checkmark.circle.fill"
+            tint = .success
+
+        case let exitCode?:
+            primaryText = displayCommand ?? "Last command failed"
+            secondaryText = Self.joinedMetadata(["Exited \(exitCode)", durationText])
+            accessibilityLabel = Self.accessibilityLabel(
+                state: "Last command failed",
+                command: displayCommand,
+                exitCode: exitCode,
+                duration: durationText
+            )
+            symbolName = "xmark.circle.fill"
+            tint = .failure
+
+        case nil:
+            primaryText = displayCommand ?? "Command finished"
+            secondaryText = Self.joinedMetadata(["Finished", durationText])
+            accessibilityLabel = Self.accessibilityLabel(
+                state: "Command finished",
+                command: displayCommand,
+                exitCode: nil,
+                duration: durationText
+            )
+            symbolName = "checkmark.circle"
+            tint = .neutral
+        }
+    }
+
+    static func durationText(for duration: TimeInterval) -> String {
+        let seconds = max(0, duration)
+        if seconds < 1 {
+            return "<1s"
+        }
+        if seconds < 10 {
+            let tenths = Int((seconds * 10).rounded())
+            if tenths % 10 == 0 {
+                return "\(tenths / 10)s"
+            }
+            return "\(tenths / 10).\(tenths % 10)s"
+        }
+        if seconds < 60 {
+            return "\(Int(seconds.rounded()))s"
+        }
+
+        let wholeSeconds = Int(seconds.rounded())
+        let minutes = wholeSeconds / 60
+        let remainingSeconds = wholeSeconds % 60
+        let paddedSeconds = remainingSeconds < 10 ? "0\(remainingSeconds)" : "\(remainingSeconds)"
+        return "\(minutes)m \(paddedSeconds)s"
+    }
+
+    private static func joinedMetadata(_ values: [String?]) -> String? {
+        let pieces = values.compactMap { value -> String? in
+            guard let value, !value.isEmpty else { return nil }
+            return value
+        }
+        guard !pieces.isEmpty else { return nil }
+        return pieces.joined(separator: " - ")
+    }
+
+    private static func accessibilityLabel(
+        state: String,
+        command: String?,
+        exitCode: Int?,
+        duration: String?
+    ) -> String {
+        var pieces = [state]
+        if let command, !command.isEmpty {
+            pieces.append(command)
+        }
+        if let exitCode {
+            pieces.append("exit code \(exitCode)")
+        }
+        if let duration {
+            pieces.append("duration \(duration)")
+        }
+        return pieces.joined(separator: ", ")
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
@@ -46,6 +46,8 @@ public actor AgentHookListener {
     private var listener: NWListener?
     private var lockFileDescriptor: Int32?
     private var statistics = Statistics()
+    private var commandMarkerRequestQueue: [HTTPRequest] = []
+    private var isDrainingCommandMarkerRequests = false
 
     public init(
         bundleIdentifier: String,
@@ -190,6 +192,10 @@ public actor AgentHookListener {
         let (status, body) = route(request)
         statistics.requestCount += 1
         let response = Self.httpResponse(status: status, body: body)
+        let isCommandMarkerRequest = Self.isCommandMarkerRequest(request)
+        if isCommandMarkerRequest {
+            enqueueCommandMarkerRequest(request)
+        }
         connection.send(
             content: response,
             completion: .contentProcessed { _ in
@@ -197,8 +203,10 @@ public actor AgentHookListener {
             })
 
         // Process payload off the response path so the hook caller never blocks on us.
-        Task { [request] in
-            await self.process(request: request)
+        if !isCommandMarkerRequest {
+            Task { [request] in
+                await self.process(request: request)
+            }
         }
     }
 
@@ -223,11 +231,31 @@ public actor AgentHookListener {
             await processEvent(request: request)
         case ("POST", "/statusline"):
             await processStatusLine(request: request)
-        case ("POST", "/command-markers"):
-            await processCommandMarkers(request: request)
         default:
             break
         }
+    }
+
+    private static func isCommandMarkerRequest(_ request: HTTPRequest) -> Bool {
+        request.method.uppercased() == "POST" && request.path == "/command-markers"
+    }
+
+    private func enqueueCommandMarkerRequest(_ request: HTTPRequest) {
+        commandMarkerRequestQueue.append(request)
+        guard !isDrainingCommandMarkerRequests else { return }
+
+        isDrainingCommandMarkerRequests = true
+        Task {
+            await self.drainCommandMarkerRequests()
+        }
+    }
+
+    private func drainCommandMarkerRequests() async {
+        while !commandMarkerRequestQueue.isEmpty {
+            let request = commandMarkerRequestQueue.removeFirst()
+            await processCommandMarkers(request: request)
+        }
+        isDrainingCommandMarkerRequests = false
     }
 
     private func processEvent(request: HTTPRequest) async {
@@ -282,10 +310,6 @@ public actor AgentHookListener {
             logger("dropping command markers without valid host session header")
             return
         }
-        guard await isRegisteredHostSession(hostSessionID) else {
-            logger("dropping command markers for unregistered host session \(hostSessionID.uuidString)")
-            return
-        }
         guard !request.body.isEmpty else {
             statistics.decodeFailures += 1
             logger("command marker decode failed: empty body")
@@ -304,8 +328,14 @@ public actor AgentHookListener {
             return
         }
 
-        await MainActor.run { [commandStatusRegistry, markers] in
+        let ingested = await MainActor.run { [registry, commandStatusRegistry, markers] in
+            guard registry.statuses[hostSessionID] != nil else { return false }
             commandStatusRegistry.ingest(markers: markers, for: hostSessionID)
+            return true
+        }
+        guard ingested else {
+            logger("dropping command markers for unregistered host session \(hostSessionID.uuidString)")
+            return
         }
         statistics.commandMarkerUpdates += 1
     }

--- a/Tests/WorkspaceManagerAppTests/TerminalCommandStatusSliverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalCommandStatusSliverTests.swift
@@ -1,0 +1,109 @@
+//
+//  TerminalCommandStatusSliverTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+import WorkspaceManagerCore
+
+@Suite("TerminalCommandStatusSliver")
+struct TerminalCommandStatusSliverPresentationTests {
+    @Test("Nil status renders no presentation")
+    func nilStatusIsHidden() {
+        #expect(TerminalCommandStatusSliverPresentation(status: nil) == nil)
+    }
+
+    @Test("Running status without a command uses generic copy")
+    func runningWithoutCommand() throws {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let status = LastCommandStatus.started(commandLine: nil, at: started)
+        let presentation = try #require(TerminalCommandStatusSliverPresentation(status: status))
+
+        #expect(presentation.primaryText == "Running command...")
+        #expect(presentation.secondaryText == nil)
+        #expect(presentation.accessibilityLabel == "Running command")
+        #expect(presentation.tint == .running)
+        #expect(presentation.isRunning == true)
+    }
+
+    @Test("Running status with command shows command and running metadata")
+    func runningWithCommand() throws {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let status = LastCommandStatus.started(commandLine: " swift test ", at: started)
+        let presentation = try #require(TerminalCommandStatusSliverPresentation(status: status))
+
+        #expect(presentation.primaryText == "swift test")
+        #expect(presentation.secondaryText == "Running")
+        #expect(presentation.accessibilityLabel == "Running command, swift test")
+    }
+
+    @Test("Success status without command uses success copy")
+    func successWithoutCommand() throws {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(1.2)
+        let status = LastCommandStatus(
+            commandLine: nil,
+            exitCode: 0,
+            startedAt: started,
+            endedAt: ended
+        )
+        let presentation = try #require(TerminalCommandStatusSliverPresentation(status: status))
+
+        #expect(presentation.primaryText == "Last command succeeded")
+        #expect(presentation.secondaryText == "Exit 0 - 1.2s")
+        #expect(presentation.accessibilityLabel == "Last command succeeded, exit code 0, duration 1.2s")
+        #expect(presentation.symbolName == "checkmark.circle.fill")
+        #expect(presentation.tint == .success)
+        #expect(presentation.isRunning == false)
+    }
+
+    @Test("Failure status shows command, exit code, and duration")
+    func failureWithCommand() throws {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(2.4)
+        let status = LastCommandStatus(
+            commandLine: "swift test",
+            exitCode: 1,
+            startedAt: started,
+            endedAt: ended
+        )
+        let presentation = try #require(TerminalCommandStatusSliverPresentation(status: status))
+
+        #expect(presentation.primaryText == "swift test")
+        #expect(presentation.secondaryText == "Exited 1 - 2.4s")
+        #expect(presentation.accessibilityLabel == "Last command failed, swift test, exit code 1, duration 2.4s")
+        #expect(presentation.symbolName == "xmark.circle.fill")
+        #expect(presentation.tint == .failure)
+    }
+
+    @Test("Completed status with unknown exit code is neutral")
+    func unknownExitCode() throws {
+        let started = Date(timeIntervalSince1970: 1_000)
+        let ended = started.addingTimeInterval(0.4)
+        let status = LastCommandStatus(
+            commandLine: nil,
+            exitCode: nil,
+            startedAt: started,
+            endedAt: ended
+        )
+        let presentation = try #require(TerminalCommandStatusSliverPresentation(status: status))
+
+        #expect(presentation.primaryText == "Command finished")
+        #expect(presentation.secondaryText == "Finished - <1s")
+        #expect(presentation.accessibilityLabel == "Command finished, duration <1s")
+        #expect(presentation.tint == .neutral)
+    }
+
+    @Test("Duration formatting keeps compact terminal chrome")
+    func durationFormatting() {
+        #expect(TerminalCommandStatusSliverPresentation.durationText(for: 0) == "<1s")
+        #expect(TerminalCommandStatusSliverPresentation.durationText(for: 0.99) == "<1s")
+        #expect(TerminalCommandStatusSliverPresentation.durationText(for: 1.24) == "1.2s")
+        #expect(TerminalCommandStatusSliverPresentation.durationText(for: 9.96) == "10s")
+        #expect(TerminalCommandStatusSliverPresentation.durationText(for: 12.2) == "12s")
+        #expect(TerminalCommandStatusSliverPresentation.durationText(for: 65) == "1m 05s")
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/TerminalCommandStatusSliverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalCommandStatusSliverTests.swift
@@ -5,9 +5,9 @@
 
 import Foundation
 import Testing
+import WorkspaceManagerCore
 
 @testable import WorkspaceManager
-import WorkspaceManagerCore
 
 @Suite("TerminalCommandStatusSliver")
 struct TerminalCommandStatusSliverPresentationTests {

--- a/Tests/WorkspaceManagerAppTests/UIFixtureSeederTests.swift
+++ b/Tests/WorkspaceManagerAppTests/UIFixtureSeederTests.swift
@@ -17,6 +17,7 @@ struct UIFixtureSeederTests {
         let container: ModelContainer
         let context: ModelContext
         let registry: AgentSessionRegistry
+        let commandRegistry: LastCommandStatusRegistry
         let store: HostTerminalStateStore
     }
 
@@ -29,13 +30,21 @@ struct UIFixtureSeederTests {
         let context = container.mainContext
         UIFixtureSeeder.seedDataIfNeeded(in: context)
         let registry = AgentSessionRegistry()
+        let commandRegistry = LastCommandStatusRegistry()
         let hostTerminalState = HostTerminalStateStore()
         hostTerminalState.attach(
             agentSessionRegistry: registry,
             localStateStore: nil,
-            hooksSocketPath: nil
+            hooksSocketPath: nil,
+            lastCommandStatusRegistry: commandRegistry
         )
-        return Fixtures(container: container, context: context, registry: registry, store: hostTerminalState)
+        return Fixtures(
+            container: container,
+            context: context,
+            registry: registry,
+            commandRegistry: commandRegistry,
+            store: hostTerminalState
+        )
     }
 
     private func workspace(named name: String, in context: ModelContext) throws -> Workspace {
@@ -48,12 +57,21 @@ struct UIFixtureSeederTests {
     )
         -> AgentSessionStatus?
     {
+        hostSession(for: workspace, in: store).flatMap { registry.statuses[$0.id] }
+    }
+
+    private func commandStatus(
+        for workspace: Workspace,
+        in store: HostTerminalStateStore,
+        registry: LastCommandStatusRegistry
+    ) -> LastCommandStatus? {
+        hostSession(for: workspace, in: store).flatMap { registry.statusByTerminalSession[$0.id] }
+    }
+
+    private func hostSession(for workspace: Workspace, in store: HostTerminalStateStore) -> HostTerminalSession? {
         let normalized = workspace.workspaceURL.standardizedFileURL.resolvingSymlinksInPath().path
         let key: HostTerminalSessionKey = .hostPath(normalized)
-        return
-            store.sessions
-            .first(where: { $0.key == key })
-            .flatMap { registry.statuses[$0.id] }
+        return store.sessions.first(where: { $0.key == key })
     }
 
     @Test("Seed data inserts the expected fixture repos and workspaces")
@@ -225,6 +243,59 @@ struct UIFixtureSeederTests {
         #expect(f.store.activeSessionID == firstSession?.id)
     }
 
+    @Test("Command-status fixture seeds the terminal sliver registry")
+    func commandStatusEntry() throws {
+        let f = try freshFixtures()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let applied = UIFixtureSeeder.seedCommandStatusesIfNeeded(
+            from: [UIFixtureSeeder.commandStatusesEnvKey: "feature-auth:failed"],
+            in: f.context,
+            commandStatusRegistry: f.commandRegistry,
+            hostTerminalState: f.store,
+            now: now
+        )
+        #expect(applied == 1)
+
+        let featureAuth = try workspace(named: "feature-auth", in: f.context)
+        let terminalSession = try #require(hostSession(for: featureAuth, in: f.store))
+        let status = try #require(commandStatus(for: featureAuth, in: f.store, registry: f.commandRegistry))
+        #expect(f.store.activeSessionID == terminalSession.id)
+        #expect(status.commandLine == "swift test")
+        #expect(status.exitCode == 1)
+        #expect(status.isSuccess == false)
+        #expect(abs((status.duration ?? 0) - 2.4) < 0.001)
+    }
+
+    @Test("Every command-status fixture token is producible from the env var")
+    func everyCommandStatusProducible() throws {
+        let f = try freshFixtures()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let raw =
+            "feature-auth:success,bugfix-422:running,refactor-state:finished,refactor-runtime:failed"
+        let applied = UIFixtureSeeder.seedCommandStatusesIfNeeded(
+            from: [UIFixtureSeeder.commandStatusesEnvKey: raw],
+            in: f.context,
+            commandStatusRegistry: f.commandRegistry,
+            hostTerminalState: f.store,
+            now: now
+        )
+        #expect(applied == 4)
+
+        let featureAuth = try workspace(named: "feature-auth", in: f.context)
+        #expect(commandStatus(for: featureAuth, in: f.store, registry: f.commandRegistry)?.exitCode == 0)
+
+        let bugfix = try workspace(named: "bugfix-422", in: f.context)
+        #expect(commandStatus(for: bugfix, in: f.store, registry: f.commandRegistry)?.isRunning == true)
+
+        let refactorState = try workspace(named: "refactor-state", in: f.context)
+        let finished = try #require(commandStatus(for: refactorState, in: f.store, registry: f.commandRegistry))
+        #expect(finished.isRunning == false)
+        #expect(finished.exitCode == nil)
+
+        let refactorRuntime = try workspace(named: "refactor-runtime", in: f.context)
+        #expect(commandStatus(for: refactorRuntime, in: f.store, registry: f.commandRegistry)?.exitCode == 1)
+    }
+
     @Test("Re-invoking the seeder is idempotent once the latch is set")
     func idempotentAfterFirstCall() throws {
         let f = try freshFixtures()
@@ -246,5 +317,27 @@ struct UIFixtureSeederTests {
         let bugfix = try workspace(named: "bugfix-422", in: f.context)
         // The second invocation must not land bugfix-422 in .errored.
         #expect(status(for: bugfix, in: f.store, registry: f.registry) == nil)
+    }
+
+    @Test("Command-status seeder is idempotent once the latch is set")
+    func commandStatusSeederIdempotentAfterFirstCall() throws {
+        let f = try freshFixtures()
+        let first = UIFixtureSeeder.seedCommandStatusesIfNeeded(
+            from: [UIFixtureSeeder.commandStatusesEnvKey: "feature-auth:failed"],
+            in: f.context,
+            commandStatusRegistry: f.commandRegistry,
+            hostTerminalState: f.store
+        )
+        #expect(first == 1)
+        let second = UIFixtureSeeder.seedCommandStatusesIfNeeded(
+            from: [UIFixtureSeeder.commandStatusesEnvKey: "bugfix-422:failed"],
+            in: f.context,
+            commandStatusRegistry: f.commandRegistry,
+            hostTerminalState: f.store
+        )
+        #expect(second == 0)
+
+        let bugfix = try workspace(named: "bugfix-422", in: f.context)
+        #expect(commandStatus(for: bugfix, in: f.store, registry: f.commandRegistry) == nil)
     }
 }

--- a/Tests/WorkspaceManagerTests/AgentHookListenerTests.swift
+++ b/Tests/WorkspaceManagerTests/AgentHookListenerTests.swift
@@ -600,6 +600,56 @@ struct AgentHookListenerTests {
         await listener.stop()
     }
 
+    @Test("command-markers POST preserves start/end order across separate requests")
+    func commandMarkersPreserveOrderAcrossSeparateRequests() async throws {
+        let socket = Self.makeTempSocketURL()
+        let registry = await TestRegistry(cwd: "/tmp")
+        let registeredID = registry.registeredID
+        let commandStatusRegistry = await MainActor.run { LastCommandStatusRegistry() }
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        let startStatus = await Self.curlPost(
+            socket: socket,
+            path: "/command-markers",
+            body: Self.osc133("B"),
+            hostSessionID: registeredID
+        )
+        #expect(startStatus == 0)
+
+        let endStatus = await Self.curlPost(
+            socket: socket,
+            path: "/command-markers",
+            body: Self.osc133("D;0"),
+            hostSessionID: registeredID
+        )
+        #expect(endStatus == 0)
+
+        let reached = await waitUntil {
+            await MainActor.run {
+                commandStatusRegistry.statusByTerminalSession[registeredID]?.exitCode == 0
+                    && commandStatusRegistry.statusByTerminalSession[registeredID]?.isRunning == false
+            }
+        }
+        #expect(reached)
+        let live = await MainActor.run {
+            commandStatusRegistry.statusByTerminalSession[registeredID]
+        }
+        #expect(live?.isSuccess == true)
+
+        let stats = await listener.currentStatistics()
+        #expect(stats.commandMarkerUpdates == 2)
+
+        await listener.stop()
+    }
+
     @Test("command-markers POST drops missing and unregistered sessions")
     func commandMarkersDropMissingAndUnregisteredSessions() async throws {
         let socket = Self.makeTempSocketURL()

--- a/Tests/WorkspaceManagerTests/HookForwarderScriptTests.swift
+++ b/Tests/WorkspaceManagerTests/HookForwarderScriptTests.swift
@@ -92,6 +92,53 @@ struct HookForwarderScriptTests {
         return (process.terminationStatus, stdout, stderr)
     }
 
+    private static func runZshCommandStatusRegisteredHooks(
+        socket: URL,
+        hostSessionID: UUID,
+        installExistingPrecmd: Bool
+    ) throws -> (status: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        let existingPrecmdSetup =
+            installExistingPrecmd
+            ? """
+            autoload -Uz add-zsh-hook
+            __workspaces_test_existing_precmd() { return 0 }
+            add-zsh-hook precmd __workspaces_test_existing_precmd
+            """
+            : ""
+        process.arguments = [
+            "-f",
+            "-c",
+            """
+            \(existingPrecmdSetup)
+            source "$WORKSPACES_COMMAND_STATUS_ZSH"
+            __workspaces_command_status_preexec "false"
+            false
+            for hook in $precmd_functions; do
+                "$hook"
+            done
+            """,
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["WORKSPACES_HOOKS_SOCKET"] = socket.path
+        environment["WORKSPACES_HOST_SESSION_ID"] = hostSessionID.uuidString
+        environment["WORKSPACES_COMMAND_STATUS_ZSH"] = hookForwarder(named: "command-status.zsh").path
+        process.environment = environment
+
+        let output = Pipe()
+        let error = Pipe()
+        process.standardOutput = output
+        process.standardError = error
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, stdout, stderr)
+    }
+
     @Test("event-forwarder posts hook JSON with host-session header")
     @MainActor
     func eventForwarderPostsHookJSONWithHostSessionHeader() async throws {
@@ -188,6 +235,41 @@ struct HookForwarderScriptTests {
         let result = try Self.runZshCommandStatusHook(
             socket: socket,
             hostSessionID: hostSessionID
+        )
+
+        #expect(result.status == 0)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.isEmpty)
+        let reached = await waitUntil {
+            await MainActor.run {
+                commandStatusRegistry.statusByTerminalSession[hostSessionID]?.exitCode == 1
+            }
+        }
+        #expect(reached)
+        #expect(commandStatusRegistry.statusByTerminalSession[hostSessionID]?.isSuccess == false)
+    }
+
+    @Test("command-status zsh hook preserves exit code when existing precmd hooks are installed")
+    @MainActor
+    func commandStatusZshHookRunsBeforeExistingPrecmdHooks() async throws {
+        let socket = Self.makeTempSocketURL()
+        let registry = AgentSessionRegistry()
+        let commandStatusRegistry = LastCommandStatusRegistry()
+        let hostSessionID = UUID()
+        registry.register(hostSessionID: hostSessionID, cwd: "/tmp", kind: .claudeCode)
+        let listener = AgentHookListener(
+            bundleIdentifier: "com.test.workspaces",
+            registry: registry,
+            commandStatusRegistry: commandStatusRegistry,
+            socketURLOverride: socket
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+
+        let result = try Self.runZshCommandStatusRegisteredHooks(
+            socket: socket,
+            hostSessionID: hostSessionID,
+            installExistingPrecmd: true
         )
 
         #expect(result.status == 0)

--- a/docs/development/ui-fixture-mode.md
+++ b/docs/development/ui-fixture-mode.md
@@ -1,6 +1,6 @@
 # UI Fixture Mode
 
-In-memory SwiftData seeding plus deterministic agent-status seeding so the app can launch into a known visual state for screenshots, design review, and visual regression. Scope: the seeded model state is in-memory and no real agents drive the sessions. The rest of the app still does its normal launch IO — outside `CI=1`, `ClaudeIntegrationLifecycle` binds a Unix socket under Application Support keyed by pid (`Sources/WorkspaceManager/App/WorkspaceManagerApp.swift:55-60`), `LocalStateStore` writes SQLite under the dev-data dir, and the synthetic `HostTerminalSession`s spawn real PTYs (which fall back to `$HOME` when the seeded path doesn't exist — see "Known limits"). For a truly hermetic capture environment, set `CI=1` and a dedicated `WORKSPACES_DATA_DIR`.
+In-memory SwiftData seeding plus deterministic agent-status and command-status seeding so the app can launch into a known visual state for screenshots, design review, and visual regression. Scope: the seeded model state is in-memory and no real agents drive the sessions. The rest of the app still does its normal launch IO — outside `CI=1`, `ClaudeIntegrationLifecycle` binds a Unix socket under Application Support keyed by pid (`Sources/WorkspaceManager/App/WorkspaceManagerApp.swift:55-60`), `LocalStateStore` writes SQLite under the dev-data dir, and the synthetic `HostTerminalSession`s spawn real PTYs (which fall back to `$HOME` when the seeded path doesn't exist — see "Known limits"). For a truly hermetic capture environment, set `CI=1` and a dedicated `WORKSPACES_DATA_DIR`.
 
 ## Quick start
 
@@ -12,6 +12,12 @@ WORKSPACES_UI_FIXTURE=1 WORKSPACES_DISABLE_AUTO_IMPORT=1 ./scripts/launch-dev.sh
 WORKSPACES_UI_FIXTURE=1 \
 WORKSPACES_DISABLE_AUTO_IMPORT=1 \
 WORKSPACES_UI_FIXTURE_AGENT_STATES="feature-auth:thinking,bugfix-422:awaitingInput,refactor-runtime:errored" \
+./scripts/launch-dev.sh --no-build
+
+# Terminal command-status sliver
+WORKSPACES_UI_FIXTURE=1 \
+WORKSPACES_DISABLE_AUTO_IMPORT=1 \
+WORKSPACES_UI_FIXTURE_COMMAND_STATUSES="feature-auth:failed" \
 ./scripts/launch-dev.sh --no-build
 ```
 
@@ -28,6 +34,7 @@ For repeatable captures, prefer the wrapper:
 | `WORKSPACES_UI_FIXTURE` | `1` to enable | Seeds an in-memory `ModelContainer` with the canonical fixture repos, web sources, and workspaces. Without this, none of the other vars do anything. |
 | `WORKSPACES_DISABLE_AUTO_IMPORT` | `1` recommended | Stops the app from auto-importing `~/code/*` repos on launch — keeps the sidebar deterministic. |
 | `WORKSPACES_UI_FIXTURE_AGENT_STATES` | optional | Comma-separated `<workspace-name>:<state>` pairs that drive specific workspaces into specific `AgentRunState`s. |
+| `WORKSPACES_UI_FIXTURE_COMMAND_STATUSES` | optional | Comma-separated `<workspace-name>:<status>` pairs that drive specific terminal sessions into synthetic `LastCommandStatus` values. |
 
 ### `WORKSPACES_UI_FIXTURE_AGENT_STATES` grammar
 
@@ -42,6 +49,21 @@ For repeatable captures, prefer the wrapper:
 - Unknown names or unknown state tokens log via `NSLog("[UIFixture] …")` and are skipped — the remaining valid entries still apply. Fixture mode is best-effort and never crashes.
 
 The first listed entry is also used as the foreground tab and active workspace — natural reading order; no separate "primary" flag.
+
+### `WORKSPACES_UI_FIXTURE_COMMAND_STATUSES` grammar
+
+```
+<entry>     := <workspace-name> ":" <status>
+<entries>   := <entry> ("," <entry>)*
+<status>    := "success" | "failed" | "running" | "finished"
+```
+
+- `success` publishes a completed `swift build` status with exit `0`.
+- `failed` publishes a completed `swift test` status with exit `1`.
+- `running` publishes an in-flight `swift test` status.
+- `finished` publishes a completed `git status` status with unknown exit code.
+
+The first listed command-status entry is also used as the foreground tab.
 
 ## Seeded fixture shape
 
@@ -92,6 +114,24 @@ WORKSPACES_UI_FIXTURE_AGENT_STATES env var
                   ▼
   WorkspaceStatusAggregator
        └─▶ sidebar dots, bubbled repo dots, "N need you" toolbar pill
+
+WORKSPACES_UI_FIXTURE_COMMAND_STATUSES env var
+                  │
+                  ▼
+  UIFixtureSeeder.seedCommandStatusesIfNeeded(...)
+                  │
+       per workspace, for each entry:
+                  │
+                  ▼
+  hostTerminalState.activateSession(.hostPath(path), …)
+       └─▶ HostTerminalSession created in coordinator.sessions
+                  │
+                  ▼
+  LastCommandStatusRegistry.setStatus(..., for: session.id)
+                  │
+                  ▼
+  TerminalCommandStatusSliver
+       └─▶ command-state-only sliver above the visible terminal pane
 ```
 
 Why we route through `HostTerminalSession` instead of injecting statuses straight into the aggregator: agent status is *defined* as a property of a terminal session in this app, and `freshestAgentStatus` short-circuits to `nil` when `sessions.isEmpty`. Synthetic statuses on phantom UUIDs would be orphaned in the registry, never surfaced. By driving through the production pipeline, the fixture exercises the same chain real agents do — if the fixture screenshot looks right, production rendering of the same statuses also works. Detailed reasoning is in `docs/development/notifications.md` and the inline comments in `UIFixtureSeeder.swift`.
@@ -101,7 +141,7 @@ Why we route through `HostTerminalSession` instead of injecting statuses straigh
 | When | Where | What |
 |------|-------|------|
 | `WorkspaceManagerApp.init()` | `Sources/WorkspaceManager/App/WorkspaceManagerApp.swift` | Calls `UIFixtureSeeder.seedDataIfNeeded(in:)` — populates SwiftData with the repos/workspaces above. |
-| `MainWindowRootView.body` ▸ `AgentSessionRegistryAttacher.onAppear` | same file | Calls `UIFixtureSeeder.seedAgentStatesIfNeeded(…)` — reads the env var, drives sessions + applies events. Runs after the registry/host store wiring; idempotent via a module-static latch. |
+| `MainWindowRootView.body` ▸ `AgentSessionRegistryAttacher.onAppear` | same file | Calls `UIFixtureSeeder.seedAgentStatesIfNeeded(…)` and `seedCommandStatusesIfNeeded(…)` — reads fixture env vars, drives sessions, and applies synthetic status. Runs after the registry/host store wiring; idempotent via module-static latches. |
 
 The split is structural: the SwiftData seeder runs at app-init time because that's where the model container is created; the agent-state seeder runs at view-attach time because that's where the `HostTerminalStateStore` first becomes reachable. The latch makes the agent-state seeder safe against repeat `onAppear` events.
 
@@ -117,6 +157,10 @@ If you want the new workspace to be the default selection on launch, bump its `l
 
 The env var's `<state>` tokens map to `AgentRunState` values inside `UIFixtureSeeder.runState(for:)`. To add a variant — e.g. `awaitingIdle` for `.awaitingInput(reason: .idlePrompt)` — add a `case` arm there and a row in `.claude/skills/release-screenshot/references/scenarios.md` under "Supported states." The events list in `events(for:)` may also need a new arm if the state requires a different synthetic event shape.
 
+### A new command-status token
+
+The command-status env var's `<status>` tokens map to `UIFixtureSeeder.FixtureCommandStatus` values. To add a variant, add a `case` arm in `commandStatus(for:)`, define the synthetic `LastCommandStatus`, and mirror the token in `.claude/skills/release-screenshot/references/scenarios.md`.
+
 ### A new named release-screenshot scenario
 
 Edit `.claude/skills/release-screenshot/scripts/capture.sh`'s `case` block and mirror the entry in `.claude/skills/release-screenshot/references/scenarios.md`. The script is the source of truth; the doc mirrors it. See `.claude/skills/release-screenshot/references/extending.md` for the full walkthrough.
@@ -124,6 +168,7 @@ Edit `.claude/skills/release-screenshot/scripts/capture.sh`'s `case` block and m
 ## Known limits
 
 - **One tab per agent-state entry.** Every `HostTerminalSession` shows in the tab bar. A three-entry scenario produces three tabs. The first entry is re-activated last so its workspace is the foreground tab; the others sit behind it.
+- **Command-status entries also create tabs.** Every command-status entry activates a `HostTerminalSession`; the first entry is re-activated last so the sliver is visible in the foreground tab.
 - **Tab labels are best-effort.** PTYs spawn into the workspace path or `$HOME` if it doesn't exist; the tab title shows whatever directory the shell actually lands in (often `fairchild` for `$HOME` rather than the workspace name). Create the directory at the seeded path if a clean label matters.
 - **Repo expansion is "expand all" in fixture mode.** `SidebarExpansionStateController.initializeRepoExpansionIfNeeded` force-expands every fixture repo on boot, masking a latent race where the production `.onChange(of: selectedWorkspace?.id)` observer can miss the nil → set transition. Replicating the design mockup's "collapsed repo with bubbled dot" storytelling requires fixing that race first; not in scope for the fixture mode itself.
 - **Terminal scrollback isn't seeded.** Whatever your shell's prompt produces is what you'll capture. Fixture mode is for chrome (sidebar, toolbar, title bar), not for terminal content.


### PR DESCRIPTION

## Summary

- Add a compact command-status sliver above each visible terminal pane when `LastCommandStatus` exists.
- Seed a deterministic `m6-status-sliver` UI fixture and release-screenshot scenario.
- Preserve command-marker ordering across separate hook requests and keep the zsh command-status hook ahead of existing `precmd` hooks.

## Mergeability

- Surface: desktop
- User-facing behavior changed: visible terminal sliver appears only when a terminal session has command status.
- Non-happy paths considered: nil status renders nothing, unknown exit code renders neutral, unregistered command markers are dropped, existing zsh `precmd` hooks preserve the original exit code.
- Release/ops preconditions: none.
- Residual risk or follow-up: tab-strip command badges and command history remain out of scope.

## Validation

- [x] `swift build`
- [x] `swift test` - passed, 783 tests in 130 suites.
- [x] Other checks run: `./scripts/build-ghosttykit.sh`; `./scripts/dev-smoke.sh --no-build`; `.claude/skills/release-screenshot/scripts/capture.sh m6-status-sliver --no-build --output /tmp/m6-status-sliver-current.png`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (pass/fail summary above)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [m6-status-sliver](https://evidence.cloudcompute.com/workspaces/pr-578/20260526-143548-m6-status-sliver.png)
- [dev-smoke](https://evidence.cloudcompute.com/workspaces/pr-578/20260526-143609-dev-smoke.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
