### PR TITLE
Coalesce active managed reviewer runs

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -12,7 +12,7 @@ GitHub PR opened
 → Cloudflare webhook relay
 → signed forward to web/api/webhooks/github (webhook route)
 → triggerPrReview() (fire-and-forget)
-→ record new run and post pending `WorkSpaces Managed Review` commit status
+→ record new run or coalesce into the active run, then post pending `WorkSpaces Managed Review` commit status
 → getOrCreateAgent/Environment (idempotent, DB-cached)
 → sessions.create (mounts repo at PR branch)
 → events.send (kickoff message)
@@ -191,9 +191,12 @@ review with the GitHub App token. The row keeps two lifecycle fields: `status`
 for the managed-agent run and `projection_status` for the GitHub-facing review
 or failure projection. Before posting, the broker re-checks current managed
 reviews on the PR; if another managed review was submitted after the session
-started, the stale session is marked `superseded`. If the superseding review is
-for an older head, the broker starts a fresh follow-up session so the newer-head
-review includes the prior review context. The run report compares recent
+started, the stale session is marked `superseded`. If a newer PR update was
+coalesced into the active run, the broker suppresses the older completed output,
+marks that run `superseded`, and starts exactly one follow-up session against the
+latest PR state. If the superseding review is for an older head, the broker
+starts a fresh follow-up session so the newer-head review includes the prior
+review context. The run report compares recent
 reviewer-eligible rows in `webhook_events` with `managed_pr_review_runs`
 records and classifies ReviewRun rows into starting, executing,
 needs-projection, failed, and terminal buckets. Broker and report routes return
@@ -336,11 +339,15 @@ itself) and from `Bot`-typed senders.
 
 Every dispatch computes a fingerprint over
 `(repo, pr, headSha, triggerKind, triggerSourceId, reviewerConfigHash)` and
-inserts a row into `managed_pr_review_runs` (created on first use). The row is
-the source of truth for both lifecycles: `status` tracks the managed agent, while
-`projection_status` tracks whether the broker has projected the result back to
-GitHub. The skip decision honors the prior run's agent status so failed/crashed
-dispatches stay retriable:
+inserts a row into `managed_pr_review_runs` (created on first use). The exact
+fingerprint is still the idempotency key. Automatic triggers also claim one
+active slot per `(repo, pr, reviewerConfigHash)` so body edits, evidence
+comments, or new commits arriving while a same-config session is already active
+update the active row's coalesced trigger fields instead of creating another
+managed-agent session. The row is the source of truth for both lifecycles:
+`status` tracks the managed agent, while `projection_status` tracks whether the
+broker has projected the result back to GitHub. The skip decision honors the
+prior run's agent status so failed/crashed dispatches stay retriable:
 
 - `completed` → skip; the previous run already produced a review.
 - `superseded` → skip; a later managed review intentionally covered this run.
@@ -355,7 +362,9 @@ Effects:
 - Webhook redeliveries for the same trigger are no-ops.
 - A new commit changes `headSha` → new fingerprint → rerun.
 - Distinct evidence comments on the same head produce distinct
-  `triggerSourceId` values → each runs once.
+  `triggerSourceId` values. If no same-config run is active, each runs once. If
+  a run is active, they coalesce into that run and the broker starts one
+  follow-up against the latest PR state.
 - A reviewer prompt or model change rotates `reviewerConfigHash`, allowing a
   re-evaluation of the same head without manual intervention.
 

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -53,6 +53,130 @@ describe("recordRunStart", () => {
 		expect(second.inserted).toBe(false);
 	});
 
+	it("coalesces a different active fingerprint for the same PR and reviewer config", async () => {
+		const { getPrReviewRunByFingerprint, recordRunStart } = await loadModule();
+		const active = makeInput({
+			fingerprint: "fp_active",
+			headSha: "head-a",
+			triggerKind: "synchronize",
+			triggerSourceId: "head-a",
+		});
+		const newer = makeInput({
+			fingerprint: "fp_newer",
+			headSha: "head-b",
+			triggerKind: "edited",
+			triggerSourceId: "body-new",
+		});
+
+		await expect(recordRunStart(active)).resolves.toEqual({ inserted: true });
+		const coalesced = await recordRunStart(newer);
+
+		expect(coalesced).toMatchObject({
+			inserted: false,
+			coalesced: true,
+			activeFingerprint: "fp_active",
+			priorStatus: "started",
+		});
+		const row = await getPrReviewRunByFingerprint("fp_active");
+		expect(row).toMatchObject({
+			coalescedHeadSha: "head-b",
+			coalescedTriggerKind: "edited",
+			coalescedTriggerSourceId: "body-new",
+		});
+		expect(row?.coalescedAt).toEqual(expect.any(String));
+	});
+
+	it("clears the active claim when a run reaches a terminal state", async () => {
+		const { recordRunStart, recordRunResult } = await loadModule();
+		const first = makeInput({
+			fingerprint: "fp_first",
+			headSha: "head-a",
+			triggerSourceId: "head-a",
+		});
+		const second = makeInput({
+			fingerprint: "fp_second",
+			headSha: "head-b",
+			triggerSourceId: "head-b",
+		});
+
+		await recordRunStart(first);
+		await recordRunResult(first.fingerprint, {
+			sessionId: "sesn_first",
+			status: "completed",
+		});
+
+		const next = await recordRunStart(second);
+		expect(next).toEqual({ inserted: true });
+	});
+
+	it("can release an active claim without changing the run status", async () => {
+		const { releaseRunActiveClaim, recordRunStart } = await loadModule();
+		const active = makeInput({
+			fingerprint: "fp_claim_release",
+			headSha: "head-a",
+			triggerSourceId: "head-a",
+		});
+		const followUp = makeInput({
+			fingerprint: "fp_after_release",
+			headSha: "head-b",
+			triggerSourceId: "head-b",
+		});
+
+		await recordRunStart(active);
+		await releaseRunActiveClaim(active.fingerprint);
+
+		await expect(recordRunStart(followUp)).resolves.toEqual({
+			inserted: true,
+		});
+	});
+
+	it("does not coalesce across different reviewer config hashes", async () => {
+		const { recordRunStart } = await loadModule();
+		const first = makeInput({
+			fingerprint: "fp_cfg_a",
+			reviewerConfigHash: "cfg-a",
+		});
+		const second = makeInput({
+			fingerprint: "fp_cfg_b",
+			reviewerConfigHash: "cfg-b",
+		});
+
+		await expect(recordRunStart(first)).resolves.toEqual({ inserted: true });
+		await expect(recordRunStart(second)).resolves.toEqual({ inserted: true });
+	});
+
+	it("releases a stale active claim so a newer fingerprint can start", async () => {
+		const { getPrReviewRunByFingerprint, recordRunStart } = await loadModule();
+		const stale = makeInput({
+			fingerprint: "fp_stale_active",
+			headSha: "head-a",
+			triggerSourceId: "head-a",
+		});
+		const newer = makeInput({
+			fingerprint: "fp_after_stale",
+			headSha: "head-b",
+			triggerSourceId: "head-b",
+		});
+
+		await recordRunStart(stale);
+		const { getDb } = await import("../../db");
+		const oldStamp = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+		await getDb()
+			.updateTable("managed_pr_review_runs")
+			.set({ updated_at: oldStamp })
+			.where("fingerprint", "=", stale.fingerprint)
+			.execute();
+
+		await expect(recordRunStart(newer)).resolves.toEqual({ inserted: true });
+		await expect(
+			getPrReviewRunByFingerprint(stale.fingerprint),
+		).resolves.toMatchObject({
+			status: "superseded",
+			projectionStatus: "superseded",
+			error: expect.stringContaining("active claim became stale"),
+		});
+	});
+
 	it("treats a completed prior run as a permanent skip", async () => {
 		const { recordRunStart, recordRunResult } = await loadModule();
 		const input = makeInput();
@@ -98,6 +222,44 @@ describe("recordRunStart", () => {
 		const retry = await recordRunStart(input);
 		expect(retry.inserted).toBe(true);
 		expect(retry.priorStatus).toBe("failed");
+	});
+
+	it("coalesces a failed exact-fingerprint retry if a different run is already active", async () => {
+		const { getPrReviewRunByFingerprint, recordRunStart, recordRunResult } =
+			await loadModule();
+		const failed = makeInput({
+			fingerprint: "fp_failed_exact",
+			headSha: "head-a",
+			triggerSourceId: "head-a",
+		});
+		const active = makeInput({
+			fingerprint: "fp_active_other",
+			headSha: "head-b",
+			triggerSourceId: "head-b",
+		});
+
+		await recordRunStart(failed);
+		await recordRunResult(failed.fingerprint, {
+			sessionId: null,
+			status: "failed",
+			error: "session failed before kickoff",
+		});
+		await expect(recordRunStart(active)).resolves.toEqual({ inserted: true });
+
+		const retry = await recordRunStart(failed);
+
+		expect(retry).toMatchObject({
+			inserted: false,
+			coalesced: true,
+			activeFingerprint: active.fingerprint,
+			priorStatus: "started",
+		});
+		await expect(
+			getPrReviewRunByFingerprint(active.fingerprint),
+		).resolves.toMatchObject({
+			coalescedHeadSha: "head-a",
+			coalescedTriggerSourceId: "head-a",
+		});
 	});
 
 	it("retries when a prior `started` row is stale (likely crashed)", async () => {
@@ -178,6 +340,10 @@ describe("bucketPrReviewRuns", () => {
 			error: null,
 			projectionError: null,
 			githubReviewId: null,
+			coalescedHeadSha: null,
+			coalescedTriggerKind: null,
+			coalescedTriggerSourceId: null,
+			coalescedAt: null,
 		};
 		const pendingRun = (overrides: {
 			fingerprint: string;

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
 	fetch: vi.fn(),
 	recordRunStart: vi.fn(),
 	recordRunResult: vi.fn(),
+	releaseRunActiveClaim: vi.fn(),
 	listStartedPrReviewRuns: vi.fn(),
 	computeRunFingerprint: vi.fn(),
 }));
@@ -47,6 +48,7 @@ vi.mock("../pr-review-runs", () => ({
 	listStartedPrReviewRuns: mocks.listStartedPrReviewRuns,
 	recordRunStart: mocks.recordRunStart,
 	recordRunResult: mocks.recordRunResult,
+	releaseRunActiveClaim: mocks.releaseRunActiveClaim,
 }));
 
 vi.stubGlobal("fetch", mocks.fetch);
@@ -227,6 +229,7 @@ beforeEach(() => {
 	mocks.fetch.mockReset();
 	mocks.recordRunStart.mockReset();
 	mocks.recordRunResult.mockReset();
+	mocks.releaseRunActiveClaim.mockReset();
 	mocks.listStartedPrReviewRuns.mockReset();
 	mocks.computeRunFingerprint.mockReset();
 
@@ -239,6 +242,7 @@ beforeEach(() => {
 	mocks.computeRunFingerprint.mockReturnValue("fp_test");
 	mocks.recordRunStart.mockResolvedValue({ inserted: true });
 	mocks.recordRunResult.mockResolvedValue(undefined);
+	mocks.releaseRunActiveClaim.mockResolvedValue(undefined);
 	mocks.listStartedPrReviewRuns.mockResolvedValue([]);
 });
 
@@ -771,6 +775,119 @@ describe("processPendingPrReviewRuns", () => {
 			skippedRunning: 1,
 		});
 		expect(mocks.recordRunResult).not.toHaveBeenCalled();
+	});
+
+	it("suppresses stale completed output when a newer trigger was coalesced", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_coalesced_old",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 486,
+				headSha: "old-head",
+				triggerKind: "synchronize",
+				triggerSourceId: "old-head",
+				sessionId: "sesn_old",
+				createdAt: "2026-05-17T06:24:27Z",
+				updatedAt: "2026-05-17T06:24:27Z",
+				coalescedHeadSha: "new-head",
+				coalescedTriggerKind: "edited",
+				coalescedTriggerSourceId: "body-new",
+				coalescedAt: "2026-05-17T06:25:00Z",
+			},
+		]);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [
+						{
+							type: "text",
+							text: `Stale review output.
+
+\`\`\`json
+{"event":"APPROVE","body":"Old output should not post","labels":[]}
+\`\`\``,
+						},
+					],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(
+			async (url: string, options?: RequestInit) => {
+				if (url.endsWith("/pulls/486")) {
+					return {
+						ok: true,
+						json: async () =>
+							githubPr(486, {
+								title: "Refactor main window orchestration",
+								html_url: "https://github.com/fairchild/workspaces/pull/486",
+								body: "Updated PR body",
+								head: { ref: "codex/main-window", sha: "new-head" },
+								base: { ref: "main" },
+							}),
+					};
+				}
+				if (url.includes("/pulls?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/labels?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/issues/486/comments?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/pulls/486/reviews?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.endsWith("/pulls/486/reviews")) {
+					throw new Error("stale review output should not be posted");
+				}
+				if (isManagedReviewStatusUrl(url)) {
+					expect(options?.method).toBe("POST");
+					return okResponse();
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			},
+		);
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			superseded: 1,
+			requeued: 1,
+		});
+		expect(mocks.createSession).toHaveBeenCalledTimes(1);
+		expect(mocks.releaseRunActiveClaim).toHaveBeenCalledWith(
+			"fp_coalesced_old",
+		);
+		expect(mocks.recordRunResult).toHaveBeenLastCalledWith(
+			"fp_coalesced_old",
+			expect.objectContaining({
+				sessionId: "sesn_old",
+				status: "superseded",
+				projectionStatus: "superseded",
+				error: expect.stringContaining("Follow-up session sesn_01 started"),
+			}),
+		);
+		expect(mocks.recordRunStart).toHaveBeenCalledWith(
+			expect.objectContaining({
+				triggerKind: "superseded_retry",
+				triggerSourceId: "coalesced-2026-05-17T06:25:00Z-head-new-head",
+			}),
+		);
+		expect(
+			mocks.fetch.mock.calls.some(
+				([url, options]) =>
+					String(url).endsWith("/pulls/486/reviews") &&
+					options?.method === "POST",
+			),
+		).toBe(false);
 	});
 
 	it("supersedes a completed session when a newer managed review already covers the same head", async () => {
@@ -1363,6 +1480,41 @@ describe("triggerPrReview rerun behavior", () => {
 
 		expect(mocks.createSession).not.toHaveBeenCalled();
 		expect(mocks.sendEvent).not.toHaveBeenCalled();
+	});
+
+	it("updates the PR status when a trigger coalesces into an active run", async () => {
+		mockPrList([githubPr(9), githubPr(8)]);
+		mocks.recordRunStart.mockResolvedValueOnce({
+			inserted: false,
+			priorStatus: "started",
+			coalesced: true,
+			activeFingerprint: "fp_active",
+		});
+
+		await expect(
+			triggerPrReview(payload(), {
+				kind: "edited",
+				triggerSourceId: "body-new",
+				reason: "PR body changed",
+			}),
+		).resolves.toBeNull();
+
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.sendEvent).not.toHaveBeenCalled();
+		const statusPost = mocks.fetch.mock.calls.find(([url]) =>
+			String(url).includes(
+				"/statuses/deadbeefcafebabe1234567890abcdef12345678",
+			),
+		);
+		expect(statusPost?.[1]).toMatchObject({ method: "POST" });
+		expect(JSON.parse(String(statusPost?.[1]?.body))).toMatchObject({
+			state: "pending",
+			context: "WorkSpaces Managed Review",
+			description:
+				"Managed reviewer already running; latest trigger coalesced.",
+			target_url:
+				"https://spaces.cloudcompute.com/dashboard/review-runs/fp_active",
+		});
 	});
 
 	it("includes prior managed reviews in the kickoff for reruns", async () => {

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -50,12 +50,22 @@ async function ensureRunsTable(): Promise<void> {
 		.addColumn("projection_updated_at", "text")
 		.addColumn("projection_error", "text")
 		.addColumn("github_review_id", "text")
+		.addColumn("active_claim_key", "text")
+		.addColumn("coalesced_head_sha", "text")
+		.addColumn("coalesced_trigger_kind", "text")
+		.addColumn("coalesced_trigger_source_id", "text")
+		.addColumn("coalesced_at", "text")
 		.execute();
 	for (const [column, type] of [
 		["projection_status", "text"],
 		["projection_updated_at", "text"],
 		["projection_error", "text"],
 		["github_review_id", "text"],
+		["active_claim_key", "text"],
+		["coalesced_head_sha", "text"],
+		["coalesced_trigger_kind", "text"],
+		["coalesced_trigger_source_id", "text"],
+		["coalesced_at", "text"],
 	] as const) {
 		try {
 			await db.schema
@@ -71,6 +81,16 @@ async function ensureRunsTable(): Promise<void> {
 		.ifNotExists()
 		.on("managed_pr_review_runs")
 		.columns(["repo_full_name", "pr_number"])
+		.execute();
+	// New rows hold this nullable unique value only while active. Existing
+	// pre-migration `started` rows are intentionally not backfilled; they age out
+	// through the normal stale-started path rather than risking a broad migration.
+	await db.schema
+		.createIndex("ux_managed_pr_review_runs_active_claim")
+		.ifNotExists()
+		.on("managed_pr_review_runs")
+		.column("active_claim_key")
+		.unique()
 		.execute();
 	migrated = true;
 }
@@ -92,6 +112,8 @@ export function computeRunFingerprint(
 export interface RecordRunStartResult {
 	inserted: boolean;
 	priorStatus?: PrReviewRunStatus;
+	coalesced?: boolean;
+	activeFingerprint?: string;
 }
 
 /** Treat a `started` row older than this as crashed and eligible for retry. */
@@ -127,13 +149,81 @@ function normalizeProjectionStatus(
 	return projectionStatusForRunStatus(runStatus);
 }
 
+function activeClaimKey(input: {
+	repoFullName: string;
+	prNumber: number;
+	reviewerConfigHash: string;
+}): string {
+	return [
+		input.repoFullName,
+		String(input.prNumber),
+		input.reviewerConfigHash,
+	].join("|");
+}
+
+async function coalesceIntoActiveRun(input: {
+	activeClaimKey: string;
+	headSha: string;
+	triggerKind: string;
+	triggerSourceId: string;
+	now: string;
+}): Promise<RecordRunStartResult | null> {
+	const db = getDb();
+	const active = await db
+		.selectFrom("managed_pr_review_runs")
+		.select(["fingerprint", "status", "updated_at"])
+		.where("active_claim_key", "=", input.activeClaimKey)
+		.executeTakeFirst();
+	if (!active || active.status !== "started") return null;
+
+	const updatedMs = Date.parse(active.updated_at);
+	const ageMs = Number.isFinite(updatedMs) ? Date.now() - updatedMs : 0;
+	if (ageMs >= STALE_STARTED_MS) {
+		await db
+			.updateTable("managed_pr_review_runs")
+			.set({
+				status: "superseded",
+				error:
+					"Superseded by a newer trigger after the active claim became stale.",
+				updated_at: input.now,
+				projection_status: "superseded",
+				projection_updated_at: input.now,
+				active_claim_key: null,
+			})
+			.where("fingerprint", "=", active.fingerprint)
+			.execute();
+		return null;
+	}
+
+	await db
+		.updateTable("managed_pr_review_runs")
+		.set({
+			coalesced_head_sha: input.headSha,
+			coalesced_trigger_kind: input.triggerKind,
+			coalesced_trigger_source_id: input.triggerSourceId,
+			coalesced_at: input.now,
+			updated_at: input.now,
+		})
+		.where("fingerprint", "=", active.fingerprint)
+		.execute();
+
+	return {
+		inserted: false,
+		priorStatus: "started",
+		coalesced: true,
+		activeFingerprint: active.fingerprint,
+	};
+}
+
 /**
- * Claim a run slot for the fingerprint. Returns `inserted: true` when the
- * caller should proceed with the session; `inserted: false` when this run
- * should be treated as an idempotent skip.
+ * Claim a run slot. Exact fingerprint idempotency is preserved, and automatic
+ * PR-level bursts coalesce behind one active `(repo, PR, reviewer config)` run.
+ * Returns `inserted: true` when the caller should proceed with a new session.
  *
  * The semantics are:
- * - no row → insert and proceed.
+ * - no row and no active claim → insert and proceed.
+ * - no exact row, but a fresh active claim exists → record the latest trigger
+ *   on the active row and skip creating another session.
  * - row with `completed` → skip; the previous run already produced a review.
  * - row with `superseded` → skip; a later broker pass intentionally retired
  *   that run because a newer managed review was already visible.
@@ -151,6 +241,7 @@ export async function recordRunStart(
 	await ensureRunsTable();
 	const now = new Date().toISOString();
 	const db = getDb();
+	const claimKey = activeClaimKey(input);
 	const insert = await db
 		.insertInto("managed_pr_review_runs")
 		.values({
@@ -170,8 +261,13 @@ export async function recordRunStart(
 			projection_updated_at: now,
 			projection_error: null,
 			github_review_id: null,
+			active_claim_key: claimKey,
+			coalesced_head_sha: null,
+			coalesced_trigger_kind: null,
+			coalesced_trigger_source_id: null,
+			coalesced_at: null,
 		})
-		.onConflict((oc) => oc.column("fingerprint").doNothing())
+		.onConflict((oc) => oc.doNothing())
 		.executeTakeFirst();
 	if (Number(insert?.numInsertedOrUpdatedRows ?? 0) > 0) {
 		return { inserted: true };
@@ -183,8 +279,17 @@ export async function recordRunStart(
 		.where("fingerprint", "=", input.fingerprint)
 		.executeTakeFirst();
 	if (!existing) {
-		// Race: row vanished between insert attempt and select. Try insert again
-		// without doNothing() to surface any real error to the caller.
+		const coalesced = await coalesceIntoActiveRun({
+			activeClaimKey: claimKey,
+			headSha: input.headSha,
+			triggerKind: input.triggerKind,
+			triggerSourceId: input.triggerSourceId,
+			now,
+		});
+		if (coalesced) return coalesced;
+
+		// Race: the conflicting active row vanished between insert attempt and
+		// lookup. Try insert again without doNothing() to surface any real error.
 		await db
 			.insertInto("managed_pr_review_runs")
 			.values({
@@ -204,6 +309,11 @@ export async function recordRunStart(
 				projection_updated_at: now,
 				projection_error: null,
 				github_review_id: null,
+				active_claim_key: claimKey,
+				coalesced_head_sha: null,
+				coalesced_trigger_kind: null,
+				coalesced_trigger_source_id: null,
+				coalesced_at: null,
 			})
 			.execute();
 		return { inserted: true };
@@ -220,6 +330,16 @@ export async function recordRunStart(
 			return { inserted: false, priorStatus };
 		}
 	}
+	if (priorStatus === "failed") {
+		const coalesced = await coalesceIntoActiveRun({
+			activeClaimKey: claimKey,
+			headSha: input.headSha,
+			triggerKind: input.triggerKind,
+			triggerSourceId: input.triggerSourceId,
+			now,
+		});
+		if (coalesced) return coalesced;
+	}
 
 	// failed, or stale started — reset and proceed.
 	await db
@@ -233,6 +353,11 @@ export async function recordRunStart(
 			projection_updated_at: now,
 			projection_error: null,
 			github_review_id: null,
+			active_claim_key: claimKey,
+			coalesced_head_sha: null,
+			coalesced_trigger_kind: null,
+			coalesced_trigger_source_id: null,
+			coalesced_at: null,
 		})
 		.where("fingerprint", "=", input.fingerprint)
 		.execute();
@@ -256,23 +381,44 @@ export async function recordRunResult(
 	const now = new Date().toISOString();
 	const projectionStatus =
 		input.projectionStatus ?? projectionStatusForRunStatus(input.status);
+	const updates = {
+		session_id: input.sessionId,
+		status: input.status,
+		error: input.error ?? null,
+		updated_at: now,
+		projection_status: projectionStatus,
+		projection_updated_at: now,
+		projection_error:
+			input.projectionError !== undefined
+				? input.projectionError
+				: projectionStatus === "failed"
+					? (input.error ?? null)
+					: null,
+		github_review_id: input.githubReviewId ?? null,
+		...(input.status === "started"
+			? {}
+			: {
+					active_claim_key: null,
+					coalesced_head_sha: null,
+					coalesced_trigger_kind: null,
+					coalesced_trigger_source_id: null,
+					coalesced_at: null,
+				}),
+	};
 	await getDb()
 		.updateTable("managed_pr_review_runs")
-		.set({
-			session_id: input.sessionId,
-			status: input.status,
-			error: input.error ?? null,
-			updated_at: now,
-			projection_status: projectionStatus,
-			projection_updated_at: now,
-			projection_error:
-				input.projectionError !== undefined
-					? input.projectionError
-					: projectionStatus === "failed"
-						? (input.error ?? null)
-						: null,
-			github_review_id: input.githubReviewId ?? null,
-		})
+		.set(updates)
+		.where("fingerprint", "=", fingerprint)
+		.execute();
+}
+
+export async function releaseRunActiveClaim(
+	fingerprint: string,
+): Promise<void> {
+	await ensureRunsTable();
+	await getDb()
+		.updateTable("managed_pr_review_runs")
+		.set({ active_claim_key: null })
 		.where("fingerprint", "=", fingerprint)
 		.execute();
 }
@@ -293,6 +439,10 @@ export interface PrReviewRunSummary {
 	projectionUpdatedAt: string;
 	projectionError: string | null;
 	githubReviewId: string | null;
+	coalescedHeadSha: string | null;
+	coalescedTriggerKind: string | null;
+	coalescedTriggerSourceId: string | null;
+	coalescedAt: string | null;
 }
 
 export interface PrReviewRunDetails extends PrReviewRunSummary {
@@ -309,6 +459,10 @@ export interface StartedPrReviewRun {
 	sessionId: string;
 	createdAt: string;
 	updatedAt: string;
+	coalescedHeadSha: string | null;
+	coalescedTriggerKind: string | null;
+	coalescedTriggerSourceId: string | null;
+	coalescedAt: string | null;
 }
 
 function mapRunDetails(row: {
@@ -328,6 +482,10 @@ function mapRunDetails(row: {
 	projection_updated_at: string | null;
 	projection_error: string | null;
 	github_review_id: string | null;
+	coalesced_head_sha: string | null;
+	coalesced_trigger_kind: string | null;
+	coalesced_trigger_source_id: string | null;
+	coalesced_at: string | null;
 }): PrReviewRunDetails {
 	const status = row.status as PrReviewRunStatus;
 	return {
@@ -348,6 +506,10 @@ function mapRunDetails(row: {
 		projectionError:
 			row.projection_error ?? (status === "failed" ? row.error : null),
 		githubReviewId: row.github_review_id,
+		coalescedHeadSha: row.coalesced_head_sha,
+		coalescedTriggerKind: row.coalesced_trigger_kind,
+		coalescedTriggerSourceId: row.coalesced_trigger_source_id,
+		coalescedAt: row.coalesced_at,
 	};
 }
 
@@ -400,6 +562,10 @@ export async function listRecentPrReviewRuns(input: {
 			"projection_updated_at",
 			"projection_error",
 			"github_review_id",
+			"coalesced_head_sha",
+			"coalesced_trigger_kind",
+			"coalesced_trigger_source_id",
+			"coalesced_at",
 		])
 		.where("created_at", ">=", input.sinceIso)
 		.where("repo_full_name", "=", input.repoFullName)
@@ -427,6 +593,10 @@ export async function listRecentPrReviewRuns(input: {
 			projectionError:
 				row.projection_error ?? (status === "failed" ? row.error : null),
 			githubReviewId: row.github_review_id,
+			coalescedHeadSha: row.coalesced_head_sha,
+			coalescedTriggerKind: row.coalesced_trigger_kind,
+			coalescedTriggerSourceId: row.coalesced_trigger_source_id,
+			coalescedAt: row.coalesced_at,
 		};
 	});
 }
@@ -567,6 +737,10 @@ export async function listStartedPrReviewRuns(
 			"session_id",
 			"created_at",
 			"updated_at",
+			"coalesced_head_sha",
+			"coalesced_trigger_kind",
+			"coalesced_trigger_source_id",
+			"coalesced_at",
 		])
 		.where("status", "=", "started")
 		.where("session_id", "is not", null)
@@ -589,6 +763,10 @@ export async function listStartedPrReviewRuns(
 			sessionId: row.session_id as string,
 			createdAt: row.created_at,
 			updatedAt: row.updated_at,
+			coalescedHeadSha: row.coalesced_head_sha,
+			coalescedTriggerKind: row.coalesced_trigger_kind,
+			coalescedTriggerSourceId: row.coalesced_trigger_source_id,
+			coalescedAt: row.coalesced_at,
 		}));
 }
 

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -12,6 +12,7 @@ import {
 	listStartedPrReviewRuns,
 	recordRunResult,
 	recordRunStart,
+	releaseRunActiveClaim,
 } from "./pr-review-runs";
 
 const MANAGED_REVIEWER_LOGIN = "workspaces-claude-pr-reviewer[bot]";
@@ -956,6 +957,7 @@ async function collectCompletedReviewIntentText(
 async function payloadFromStartedRun(
 	githubToken: string,
 	run: StartedPrReviewRun,
+	options: { preferCurrentHead?: boolean } = {},
 ): Promise<PrReviewPayload | null> {
 	const [owner, repo] = run.repoFullName.split("/");
 	if (!owner || !repo) return null;
@@ -971,7 +973,9 @@ async function payloadFromStartedRun(
 		htmlUrl: fetched.htmlUrl,
 		body: fetched.body,
 		headRef: fetched.headRef,
-		headSha: run.headSha || fetched.headSha,
+		headSha: options.preferCurrentHead
+			? fetched.headSha
+			: run.headSha || fetched.headSha,
 		baseRef: fetched.baseRef,
 		repoUrl: `https://github.com/${run.repoFullName}`,
 		repoFullName: run.repoFullName,
@@ -1099,6 +1103,48 @@ export async function processPendingPrReviewRuns(
 				htmlUrl: payload.htmlUrl,
 				fingerprint: run.fingerprint,
 			};
+
+			if (run.coalescedAt) {
+				const latestPayload =
+					(await payloadFromStartedRun(githubToken, run, {
+						preferCurrentHead: true,
+					})) ?? payload;
+				const retryReason = `New ${run.coalescedTriggerKind ?? "PR"} trigger arrived while session ${run.sessionId} was active; re-running against the latest PR state.`;
+				let retrySessionId: string | null = null;
+				await releaseRunActiveClaim(run.fingerprint);
+				try {
+					retrySessionId = await triggerPrReview(latestPayload, {
+						kind: "superseded_retry",
+						triggerSourceId: `coalesced-${run.coalescedAt}-head-${latestPayload.headSha || run.coalescedHeadSha || run.headSha}`,
+						reason: retryReason,
+					});
+				} catch (err) {
+					console.error("[pr-review] coalesced retry failed:", err);
+				}
+				const error = retrySessionId
+					? `${retryReason} Follow-up session ${retrySessionId} started.`
+					: `${retryReason} Follow-up session was not started.`;
+				await recordRunResult(run.fingerprint, {
+					sessionId: run.sessionId,
+					status: "superseded",
+					error,
+					projectionStatus: "superseded",
+				});
+				result.superseded += 1;
+				if (retrySessionId) result.requeued += 1;
+				result.runs.push({
+					fingerprint: run.fingerprint,
+					sessionId: run.sessionId,
+					prNumber: run.prNumber,
+					status: "superseded",
+					error,
+					retrySessionId,
+				});
+				console.log(
+					`[pr-review] Broker superseded coalesced run for PR #${run.prNumber} (fingerprint=${run.fingerprint}): ${run.sessionId}`,
+				);
+				continue;
+			}
 
 			const currentReviewHistory = await fetchCurrentPrReviewHistory(
 				githubToken,
@@ -1313,6 +1359,24 @@ export async function triggerPrReview(
 		reviewerConfigHash,
 	});
 	if (!start.inserted) {
+		if (start.coalesced && start.activeFingerprint) {
+			await postManagedReviewStatus(
+				githubToken,
+				{
+					repoFullName: resolvedPayload.repoFullName,
+					number: resolvedPayload.number,
+					headSha: resolvedPayload.headSha,
+					htmlUrl: resolvedPayload.htmlUrl,
+					fingerprint: start.activeFingerprint,
+				},
+				"pending",
+				"Managed reviewer already running; latest trigger coalesced.",
+			);
+			console.log(
+				`[pr-review] coalesced run for PR #${resolvedPayload.number} into active fingerprint ${start.activeFingerprint}`,
+			);
+			return null;
+		}
 		console.log(
 			`[pr-review] skipping duplicate run for PR #${resolvedPayload.number} (fingerprint=${fingerprint})`,
 		);

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -89,6 +89,11 @@ export interface ManagedPrReviewRunsTable {
 	projection_updated_at: string | null;
 	projection_error: string | null;
 	github_review_id: string | null;
+	active_claim_key: string | null;
+	coalesced_head_sha: string | null;
+	coalesced_trigger_kind: string | null;
+	coalesced_trigger_source_id: string | null;
+	coalesced_at: string | null;
 }
 
 interface Database {


### PR DESCRIPTION
## Summary
- add an active run claim for managed PR reviews keyed by repo, PR, and reviewer config
- coalesce PR update bursts into the active run instead of starting duplicate managed-agent sessions
- suppress stale completed output and start one follow-up run against the latest PR state
- update the managed reviewer operations doc for the new coalescing contract

## Mergeability
- Surface: web managed reviewer runtime, ReviewRun storage, broker reconciliation, docs
- User-facing behavior changed: yes — PR update bursts should show one active managed-review run instead of starting duplicate managed-agent sessions.
- Non-happy paths considered: stale active claims are superseded and released, terminal states clear the claim, different reviewer configs do not coalesce, failed exact-fingerprint retries coalesce when another run is active, and stale completed output is not posted to GitHub.
- Residual risk or follow-up: live coalescing cannot be production-validated until this code is merged and deployed; the projection-ledger work remains the next larger simplification slice.

## Evidence
- ![managed-reviewer-coalesce-active-validation](https://evidence.cloudcompute.com/workspaces/pr-580/20260526-151216-managed-reviewer-coalesce-active-validation.svg)

## Validation
- mise -C web run web:check (28 files / 291 tests passed)
- uv run --script scripts/tests/test_security_hardening.py (29 tests passed)
- git diff --check