### PR TITLE
docs: add final release update verification

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -316,6 +316,27 @@ The recommended method for production releases.
       - `WorkSpaces-<version>.dmg`
       - `WorkSpaces-latest.dmg`
 
+5. **Final Download And Update Check**
+
+   After the release workflow passes and the published asset validation is
+   green, finish the release with an operator/user-visible update-path check:
+
+   ```bash
+   gh release download v<X.Y.Z> \
+       --repo fairchild/workspaces \
+       --pattern "WorkSpaces-<X.Y.Z>.dmg" \
+       --dir /tmp/workspaces-release-v<X.Y.Z> \
+       --clobber
+   ```
+
+   - Confirm the versioned DMG downloads from the published GitHub Release; do
+     not stop at seeing the asset listed in the browser.
+   - Ask the user to open the installed app and choose
+     `WorkSpaces > Check for Updates...`.
+   - The user should confirm Sparkle offers the newly published version and
+     shows the matching release notes.
+   - Record that user confirmation in the release handoff/status update.
+
 ### Method 1B: Tag-Driven Release (Main Commit Only)
 
 If you prefer to cut the tag yourself first, you can push a release tag from a `main` commit:


### PR DESCRIPTION
## Summary

- Add a final release-plan step to download the published versioned DMG.
- Require asking the user to run WorkSpaces > Check for Updates... and confirm Sparkle shows the new release.

## Mergeability

- Surface: docs
- User-facing behavior changed: no app behavior changes
- Non-happy paths considered: the release operator is told not to stop at a browser asset listing, and to record user confirmation from Sparkle.
- Release/ops preconditions: applies after the release workflow passes and published asset validation is green.
- Residual risk or follow-up: none

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `git diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- n/a, docs-only release process update

## Blockers

- [x] None
- [ ] Blocked on evidence
