### PR TITLE
docs: add Claude Code integration changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.16.0] - 2026-05-26
 
 ### Added
+- Add opt-in Claude Code integration for live agent-session signal in the host app: sidebar status, macOS notifications, status-line fields, and conversation-log context. Enable in Settings -> Agents; see `docs/development/claude-code-integration.md` (#443, #451, #452, #454, #455, #466, #473, #477, #513)
 - Report Claude command status from prompt markers through a new parser, registry, and hook forwarder (#501, #566)
 - Add workspace event/journal read APIs and default-agent command resolution foundations (#498, #500)
 - Add GitService diff, staging, discard, and branch APIs for upcoming workspace actions (#499)


### PR DESCRIPTION
## Summary

- Add the missing user-facing 0.16.0 changelog entry for the opt-in Claude Code integration.
- Reference the canonical operational doc and shipped PR sequence from issue #519.

## Mergeability

- Surface: docs
- User-facing behavior changed: yes, release notes now advertise the shipped Claude Code integration.
- Non-happy paths considered: kept the entry high level and out of internal channel/listener details.
- Release/ops preconditions: none.
- Residual risk or follow-up: README/docs-index discovery remains separate from this changelog entry.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run: `git diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [x] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![changelog-claude-code-integration-validation](https://evidence.cloudcompute.com/workspaces/pr-582/20260527-142054-changelog-claude-code-integration-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence

Closes #519
