### PR TITLE
Classify managed review trigger relevance

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -321,7 +321,11 @@ The reviewer is **continuous**: it reruns on meaningful PR updates and carries
 its own prior review state into each rerun so it can revise (or approve) a
 stale `REQUEST_CHANGES` instead of repeating itself.
 
-`parsePrReviewTrigger()` in `web/src/app/api/webhooks/github/route.ts` accepts:
+`classifyPrReviewTrigger()` in
+`web/src/lib/agent-runtime/pr-review-trigger.ts` classifies webhook activity
+before any ReviewRun claim or active-run coalescing happens. Only material
+classifications become `parsePrReviewTrigger()` results and start or coalesce a
+managed review run:
 
 | Event | Action | Behavior |
 |-------|--------|----------|
@@ -329,8 +333,12 @@ stale `REQUEST_CHANGES` instead of repeating itself.
 | `pull_request` | `reopened` | Rerun (skip drafts) |
 | `pull_request` | `ready_for_review` | Rerun even when previous state was draft |
 | `pull_request` | `synchronize` | Rerun on new head SHA (skip drafts) |
-| `pull_request` | `edited` | Rerun when `changes.body` or `changes.base` is present — base retargets materially change the diff (skip drafts) |
-| `issue_comment` | `created` | Rerun when the comment is on a PR thread, the sender is a non-bot, and the body matches an evidence signal: `evidence.cloudcompute.com`, `Evidence:`, `swift test`, `playwright`, `screenshot`, `recording`, `validation` |
+| `pull_request` | `edited` | Rerun when `changes.body` or `changes.base` is present; title-only and other metadata edits do not start sessions |
+| `pull_request` | `labeled`, `unlabeled` | Metadata only; no managed-review session |
+| `pull_request` | `closed` | Terminal PR activity; no managed-review session |
+| `issue_comment` | `created` with evidence | Rerun when the comment is on a PR thread, the sender is a non-bot, and the body matches an evidence signal: `evidence.cloudcompute.com`, `Evidence:`, `swift test`, `playwright`, `screenshot`, `recording`, `validation` |
+| `issue_comment` | `created` without evidence | Metadata only; no managed-review session |
+| `pull_request_review_comment`, `pull_request_review` | any | Metadata only; no managed-review session |
 
 Loop guards skip events from any `*[bot]` sender (including the reviewer
 itself) and from `Bot`-typed senders.
@@ -361,10 +369,13 @@ Effects:
 
 - Webhook redeliveries for the same trigger are no-ops.
 - A new commit changes `headSha` → new fingerprint → rerun.
-- Distinct evidence comments on the same head produce distinct
-  `triggerSourceId` values. If no same-config run is active, each runs once. If
-  a run is active, they coalesce into that run and the broker starts one
-  follow-up against the latest PR state.
+- Distinct body edits and evidence comments on the same head produce distinct
+  `triggerSourceId` values. If no same-config run is active, each material
+  trigger runs once. If a run is active, material triggers coalesce into that
+  run and the broker starts one follow-up against the latest PR state.
+- Metadata-only activity such as title edits, label changes, non-evidence
+  comments, review comments, and PR closure does not create or coalesce managed
+  review runs.
 - A reviewer prompt or model change rotates `reviewerConfigHash`, allowing a
   re-evaluation of the same head without manual intervention.
 

--- a/web/src/app/api/webhooks/github/route.test.ts
+++ b/web/src/app/api/webhooks/github/route.test.ts
@@ -1,5 +1,10 @@
 import crypto from "node:crypto";
 import { PR_REVIEW_WEBHOOK_CONTRACT_CASES } from "@/lib/agent-runtime/__tests__/pr-review-trigger-fixtures";
+import {
+	type PrReviewTriggerClassification,
+	type PrReviewTriggerClassificationKind,
+	classifyPrReviewTrigger,
+} from "@/lib/agent-runtime/pr-review-trigger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -24,6 +29,36 @@ vi.mock("@/lib/events", () => ({
 	pushEvent: mocks.pushEvent,
 }));
 
+function makePullRequestPayload(
+	action: string,
+	overrides: {
+		pull_request?: Record<string, unknown>;
+		changes?: Record<string, unknown>;
+		sender?: Record<string, unknown>;
+	} = {},
+): Record<string, unknown> {
+	return {
+		action,
+		sender: overrides.sender ?? { login: "fairchild", type: "User" },
+		repository: {
+			full_name: "fairchild/workspaces",
+			html_url: "https://github.com/fairchild/workspaces",
+			name: "workspaces",
+		},
+		pull_request: {
+			number: 123,
+			title: "Fix review kickoff",
+			html_url: "https://github.com/fairchild/workspaces/pull/123",
+			body: "## Evidence\n- [x] Test evidence attached",
+			head: { ref: "codex-fix-review-kickoff", sha: "abc123def456" },
+			base: { ref: "main" },
+			draft: false,
+			...overrides.pull_request,
+		},
+		...(overrides.changes ? { changes: overrides.changes } : {}),
+	};
+}
+
 function makePullRequestRequest(
 	action: string,
 	overrides: {
@@ -38,27 +73,45 @@ function makePullRequestRequest(
 			"x-github-delivery": `delivery-${action}`,
 			"x-github-event": "pull_request",
 		},
-		body: JSON.stringify({
-			action,
-			sender: overrides.sender ?? { login: "fairchild", type: "User" },
-			repository: {
-				full_name: "fairchild/workspaces",
-				html_url: "https://github.com/fairchild/workspaces",
-				name: "workspaces",
-			},
-			pull_request: {
-				number: 123,
-				title: "Fix review kickoff",
-				html_url: "https://github.com/fairchild/workspaces/pull/123",
-				body: "## Evidence\n- [x] Test evidence attached",
-				head: { ref: "codex-fix-review-kickoff", sha: "abc123def456" },
-				base: { ref: "main" },
-				draft: false,
-				...overrides.pull_request,
-			},
-			...(overrides.changes ? { changes: overrides.changes } : {}),
-		}),
+		body: JSON.stringify(makePullRequestPayload(action, overrides)),
 	});
+}
+
+function makeIssueCommentPayload(
+	body: string,
+	overrides: {
+		sender?: Record<string, unknown>;
+		comment_id?: number;
+		issue_overrides?: Record<string, unknown>;
+	} = {},
+): Record<string, unknown> {
+	return {
+		action: "created",
+		sender: overrides.sender ?? { login: "fairchild", type: "User" },
+		repository: {
+			full_name: "fairchild/workspaces",
+			html_url: "https://github.com/fairchild/workspaces",
+			name: "workspaces",
+		},
+		issue: {
+			number: 123,
+			title: "Fix review kickoff",
+			html_url: "https://github.com/fairchild/workspaces/pull/123",
+			pull_request: {
+				html_url: "https://github.com/fairchild/workspaces/pull/123",
+			},
+			body: "PR description",
+			...overrides.issue_overrides,
+		},
+		comment: {
+			id: overrides.comment_id ?? 9001,
+			body,
+			html_url:
+				"https://github.com/fairchild/workspaces/pull/123#issuecomment-9001",
+			created_at: "2026-05-09T12:00:00Z",
+			user: { login: "fairchild" },
+		},
+	};
 }
 
 function makeIssueCommentRequest(
@@ -75,34 +128,60 @@ function makeIssueCommentRequest(
 			"x-github-delivery": "delivery-comment",
 			"x-github-event": "issue_comment",
 		},
-		body: JSON.stringify({
-			action: "created",
-			sender: overrides.sender ?? { login: "fairchild", type: "User" },
-			repository: {
-				full_name: "fairchild/workspaces",
-				html_url: "https://github.com/fairchild/workspaces",
-				name: "workspaces",
-			},
-			issue: {
-				number: 123,
-				title: "Fix review kickoff",
-				html_url: "https://github.com/fairchild/workspaces/pull/123",
-				pull_request: {
-					html_url: "https://github.com/fairchild/workspaces/pull/123",
-				},
-				body: "PR description",
-				...overrides.issue_overrides,
-			},
-			comment: {
-				id: overrides.comment_id ?? 9001,
-				body,
-				html_url:
-					"https://github.com/fairchild/workspaces/pull/123#issuecomment-9001",
-				created_at: "2026-05-09T12:00:00Z",
-				user: { login: "fairchild" },
-			},
-		}),
+		body: JSON.stringify(makeIssueCommentPayload(body, overrides)),
 	});
+}
+
+function makeReviewCommentPayload(): Record<string, unknown> {
+	return {
+		action: "created",
+		sender: { login: "fairchild", type: "User" },
+		repository: {
+			full_name: "fairchild/workspaces",
+			html_url: "https://github.com/fairchild/workspaces",
+			name: "workspaces",
+		},
+		pull_request: {
+			number: 123,
+			html_url: "https://github.com/fairchild/workspaces/pull/123",
+		},
+		comment: {
+			id: 9201,
+			body: "Could this helper be smaller?",
+			html_url:
+				"https://github.com/fairchild/workspaces/pull/123#discussion_r9201",
+		},
+	};
+}
+
+function expectTrigger(
+	classification: PrReviewTriggerClassification,
+	kind: PrReviewTriggerClassificationKind,
+) {
+	expect(classification).toMatchObject({
+		decision: "trigger_review",
+		relevance: "material",
+		kind,
+	});
+	if (classification.decision !== "trigger_review") {
+		throw new Error(`expected ${kind} to trigger review`);
+	}
+	return classification.trigger;
+}
+
+function expectSkip(
+	classification: PrReviewTriggerClassification,
+	kind: PrReviewTriggerClassificationKind,
+	relevance: "metadata" | "terminal" | "ignored",
+) {
+	expect(classification).toMatchObject({
+		decision: "skip_review",
+		kind,
+		relevance,
+	});
+	if (classification.decision !== "skip_review") {
+		throw new Error(`expected ${kind} to skip review`);
+	}
 }
 
 function pullRequestOpenedRequest(): Request {
@@ -134,6 +213,210 @@ function signedWebhookRequest(
 		body,
 	});
 }
+
+describe("PR review trigger relevance classifier", () => {
+	it("classifies material review triggers explicitly", () => {
+		const opened = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"opened",
+				makePullRequestPayload("opened"),
+			),
+			"opened",
+		);
+		expect(opened.context.kind).toBe("opened");
+
+		const synchronize = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"synchronize",
+				makePullRequestPayload("synchronize", {
+					pull_request: { head: { ref: "feature/x", sha: "head-new" } },
+				}),
+			),
+			"synchronize",
+		);
+		expect(synchronize.context).toMatchObject({
+			kind: "synchronize",
+			triggerSourceId: "head-new",
+		});
+
+		const bodyEdit = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { body: "Updated evidence and summary" },
+					changes: { body: { from: "old body" } },
+				}),
+			),
+			"body_edit",
+		);
+		expect(bodyEdit.context.kind).toBe("edited");
+		expect(bodyEdit.context.triggerSourceId).toMatch(/^body-/);
+
+		const baseEdit = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { base: { ref: "release/2026-05" } },
+					changes: { base: { ref: { from: "main" } } },
+				}),
+			),
+			"base_edit",
+		);
+		expect(baseEdit.context.triggerSourceId).toBe(
+			"base-release/2026-05-abc123def456",
+		);
+
+		const evidenceComment = expectTrigger(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload(
+					"Evidence: https://evidence.cloudcompute.com/pr-123.png",
+				),
+			),
+			"evidence_comment",
+		);
+		expect(evidenceComment.context).toMatchObject({
+			kind: "evidence_comment",
+			triggerSourceId: "comment-9001",
+		});
+	});
+
+	it("classifies metadata and terminal events without managed-review sessions", () => {
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					changes: { title: { from: "old title" } },
+				}),
+			),
+			"metadata_edit",
+			"metadata",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload("looks good, ship it"),
+			),
+			"non_evidence_comment",
+			"metadata",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request_review_comment",
+				"created",
+				makeReviewCommentPayload(),
+			),
+			"review_comment",
+			"metadata",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"labeled",
+				makePullRequestPayload("labeled"),
+			),
+			"label",
+			"metadata",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"closed",
+				makePullRequestPayload("closed"),
+			),
+			"closed",
+			"terminal",
+		);
+	});
+
+	it("keeps repeated body edits and evidence comments idempotent by source id", () => {
+		const firstBody = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { body: "body version one" },
+					changes: { body: { from: "old body" } },
+				}),
+			),
+			"body_edit",
+		);
+		const redeliveredBody = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { body: "body version one" },
+					changes: { body: { from: "old body" } },
+				}),
+			),
+			"body_edit",
+		);
+		const updatedBody = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { body: "body version two" },
+					changes: { body: { from: "body version one" } },
+				}),
+			),
+			"body_edit",
+		);
+
+		expect(redeliveredBody.context.triggerSourceId).toBe(
+			firstBody.context.triggerSourceId,
+		);
+		expect(updatedBody.context.triggerSourceId).not.toBe(
+			firstBody.context.triggerSourceId,
+		);
+
+		const firstEvidence = expectTrigger(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload("Evidence: validation attached", {
+					comment_id: 9101,
+				}),
+			),
+			"evidence_comment",
+		);
+		const redeliveredEvidence = expectTrigger(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload("Evidence: validation attached", {
+					comment_id: 9101,
+				}),
+			),
+			"evidence_comment",
+		);
+		const nextEvidence = expectTrigger(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload("Evidence: validation attached", {
+					comment_id: 9102,
+				}),
+			),
+			"evidence_comment",
+		);
+
+		expect(redeliveredEvidence.context.triggerSourceId).toBe(
+			firstEvidence.context.triggerSourceId,
+		);
+		expect(nextEvidence.context.triggerSourceId).not.toBe(
+			firstEvidence.context.triggerSourceId,
+		);
+	});
+});
 
 describe("/api/webhooks/github POST", () => {
 	beforeEach(() => {
@@ -264,6 +547,46 @@ describe("/api/webhooks/github POST", () => {
 				}),
 			);
 			expect(mocks.triggerPrReview).not.toHaveBeenCalled();
+		});
+
+		it("does not start review sessions for metadata-only PR events", async () => {
+			const { POST } = await import("./route");
+			await POST(makePullRequestRequest("labeled"));
+			await POST(makePullRequestRequest("unlabeled"));
+			await POST(makePullRequestRequest("closed"));
+			await POST(
+				makePullRequestRequest("edited", {
+					changes: { title: { from: "old title" } },
+				}),
+			);
+			expect(mocks.triggerPrReview).not.toHaveBeenCalled();
+		});
+
+		it("routes mixed metadata and material triggers without metadata sessions", async () => {
+			const { POST } = await import("./route");
+			await POST(makePullRequestRequest("labeled"));
+			await POST(
+				makePullRequestRequest("synchronize", {
+					pull_request: {
+						head: { ref: "feature/x", sha: "materialsha123" },
+					},
+				}),
+			);
+			await POST(
+				makeIssueCommentRequest("Evidence: tests uploaded", {
+					comment_id: 9002,
+				}),
+			);
+
+			expect(mocks.triggerPrReview).toHaveBeenCalledTimes(2);
+			expect(mocks.triggerPrReview.mock.calls[0][1]).toMatchObject({
+				kind: "synchronize",
+				triggerSourceId: "materialsha123",
+			});
+			expect(mocks.triggerPrReview.mock.calls[1][1]).toMatchObject({
+				kind: "evidence_comment",
+				triggerSourceId: "comment-9002",
+			});
 		});
 
 		it("triggers when the PR base branch is retargeted", async () => {

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -26,6 +26,8 @@ const SUPPORTED_EVENTS = new Set<string>([
 	"push",
 	"issues",
 	"issue_comment",
+	"pull_request_review",
+	"pull_request_review_comment",
 	"workflow_run",
 ]);
 

--- a/web/src/app/dashboard/components/event-utils.ts
+++ b/web/src/app/dashboard/components/event-utils.ts
@@ -13,6 +13,8 @@ export const TYPE_LABEL: Record<WebhookEventType, string> = {
 	push: "PUSH",
 	issues: "ISSUE",
 	issue_comment: "ISSUE",
+	pull_request_review: "PR",
+	pull_request_review_comment: "PR",
 	workflow_run: "CI",
 };
 
@@ -25,5 +27,7 @@ export const TYPE_COLOR: Record<WebhookEventType, ColorKey> = {
 	push: "push",
 	issues: "issue",
 	issue_comment: "issue",
+	pull_request_review: "pr",
+	pull_request_review_comment: "pr",
 	workflow_run: "ci",
 };

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -86,6 +86,48 @@ describe("recordRunStart", () => {
 		expect(row?.coalescedAt).toEqual(expect.any(String));
 	});
 
+	it("keeps only the latest synchronize trigger while a run is active", async () => {
+		const { getPrReviewRunByFingerprint, recordRunStart } = await loadModule();
+		const active = makeInput({
+			fingerprint: "fp_active_sync",
+			headSha: "head-a",
+			triggerKind: "opened",
+			triggerSourceId: "head-a",
+		});
+		const firstPush = makeInput({
+			fingerprint: "fp_sync_head_b",
+			headSha: "head-b",
+			triggerKind: "synchronize",
+			triggerSourceId: "head-b",
+		});
+		const secondPush = makeInput({
+			fingerprint: "fp_sync_head_c",
+			headSha: "head-c",
+			triggerKind: "synchronize",
+			triggerSourceId: "head-c",
+		});
+
+		await expect(recordRunStart(active)).resolves.toEqual({ inserted: true });
+		await expect(recordRunStart(firstPush)).resolves.toMatchObject({
+			inserted: false,
+			coalesced: true,
+			activeFingerprint: active.fingerprint,
+		});
+		await expect(recordRunStart(secondPush)).resolves.toMatchObject({
+			inserted: false,
+			coalesced: true,
+			activeFingerprint: active.fingerprint,
+		});
+
+		await expect(
+			getPrReviewRunByFingerprint(active.fingerprint),
+		).resolves.toMatchObject({
+			coalescedHeadSha: "head-c",
+			coalescedTriggerKind: "synchronize",
+			coalescedTriggerSourceId: "head-c",
+		});
+	});
+
 	it("clears the active claim when a run reaches a terminal state", async () => {
 		const { recordRunStart, recordRunResult } = await loadModule();
 		const first = makeInput({

--- a/web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts
@@ -1,4 +1,7 @@
-export type PrReviewContractEventType = "pull_request" | "issue_comment";
+export type PrReviewContractEventType =
+	| "pull_request"
+	| "issue_comment"
+	| "pull_request_review_comment";
 
 export type ExpectedPrReviewTriggerKind =
 	| "opened"
@@ -84,6 +87,25 @@ function issueCommentPayload(
 			created_at: "2026-05-13T12:00:00Z",
 			user: humanSender,
 			...overrides.comment,
+		},
+	};
+}
+
+function reviewCommentPayload(number: number): Record<string, unknown> {
+	return {
+		action: "created",
+		sender: humanSender,
+		repository: repo,
+		pull_request: {
+			number,
+			html_url: `https://github.com/fairchild/workspaces/pull/${number}`,
+		},
+		comment: {
+			id: 910000 + number,
+			body: "Could this be simpler?",
+			html_url: `https://github.com/fairchild/workspaces/pull/${number}#discussion_r${910000 + number}`,
+			created_at: "2026-05-13T12:00:00Z",
+			user: humanSender,
 		},
 	};
 }
@@ -177,6 +199,22 @@ export const PR_REVIEW_WEBHOOK_CONTRACT_CASES: PrReviewWebhookContractCase[] = [
 		expectedTriggerKind: null,
 	},
 	{
+		name: "PR label added",
+		deliveryId: "contract-pr-labeled",
+		eventType: "pull_request",
+		payload: pullRequestPayload("labeled", 8114),
+		expectedForwarded: false,
+		expectedTriggerKind: null,
+	},
+	{
+		name: "PR closed",
+		deliveryId: "contract-pr-closed",
+		eventType: "pull_request",
+		payload: pullRequestPayload("closed", 8115),
+		expectedForwarded: false,
+		expectedTriggerKind: null,
+	},
+	{
 		name: "reviewer bot synchronized",
 		deliveryId: "contract-pr-bot-sender",
 		eventType: "pull_request",
@@ -212,6 +250,14 @@ export const PR_REVIEW_WEBHOOK_CONTRACT_CASES: PrReviewWebhookContractCase[] = [
 		payload: issueCommentPayload(8113, "Evidence: attached", {
 			issue: { pull_request: undefined },
 		}),
+		expectedForwarded: false,
+		expectedTriggerKind: null,
+	},
+	{
+		name: "PR review comment created",
+		deliveryId: "contract-pr-review-comment",
+		eventType: "pull_request_review_comment",
+		payload: reviewCommentPayload(8116),
 		expectedForwarded: false,
 		expectedTriggerKind: null,
 	},

--- a/web/src/lib/agent-runtime/pr-review-trigger.ts
+++ b/web/src/lib/agent-runtime/pr-review-trigger.ts
@@ -6,6 +6,50 @@ export interface ParsedPrTrigger {
 	context: PrReviewTrigger;
 }
 
+export type PrReviewTriggerClassificationKind =
+	| "opened"
+	| "reopened"
+	| "ready_for_review"
+	| "synchronize"
+	| "body_edit"
+	| "base_edit"
+	| "metadata_edit"
+	| "evidence_comment"
+	| "non_evidence_comment"
+	| "review_comment"
+	| "label"
+	| "closed"
+	| "draft"
+	| "bot_sender"
+	| "malformed"
+	| "unsupported";
+
+type PrReviewTriggerSkipRelevance = "metadata" | "terminal" | "ignored";
+
+interface BasePrReviewTriggerClassification {
+	eventType: string;
+	action: string;
+	kind: PrReviewTriggerClassificationKind;
+	reason: string;
+}
+
+export interface PrReviewTriggerMaterialClassification
+	extends BasePrReviewTriggerClassification {
+	decision: "trigger_review";
+	relevance: "material";
+	trigger: ParsedPrTrigger;
+}
+
+export interface PrReviewTriggerSkipClassification
+	extends BasePrReviewTriggerClassification {
+	decision: "skip_review";
+	relevance: PrReviewTriggerSkipRelevance;
+}
+
+export type PrReviewTriggerClassification =
+	| PrReviewTriggerMaterialClassification
+	| PrReviewTriggerSkipClassification;
+
 const EVIDENCE_SIGNAL =
 	/(evidence\.cloudcompute\.com|^Evidence:|swift test|playwright|screenshot|recording|validation)/im;
 const PR_REVIEWER_BOT_LOGIN = "workspaces-claude-pr-reviewer[bot]";
@@ -40,117 +84,284 @@ function buildReviewPayloadFromPr(
 	};
 }
 
-export function parsePrReviewTrigger(
+function skipClassification(input: {
+	eventType: string;
+	action: string;
+	kind: PrReviewTriggerClassificationKind;
+	relevance?: PrReviewTriggerSkipRelevance;
+	reason: string;
+}): PrReviewTriggerSkipClassification {
+	return {
+		eventType: input.eventType,
+		action: input.action,
+		kind: input.kind,
+		decision: "skip_review",
+		relevance: input.relevance ?? "ignored",
+		reason: input.reason,
+	};
+}
+
+function materialClassification(input: {
+	eventType: string;
+	action: string;
+	kind: PrReviewTriggerClassificationKind;
+	reason: string;
+	reviewPayload: PrReviewPayload;
+	context: PrReviewTrigger;
+}): PrReviewTriggerMaterialClassification {
+	return {
+		eventType: input.eventType,
+		action: input.action,
+		kind: input.kind,
+		decision: "trigger_review",
+		relevance: "material",
+		reason: input.reason,
+		trigger: {
+			reviewPayload: input.reviewPayload,
+			context: input.context,
+		},
+	};
+}
+
+export function classifyPrReviewTrigger(
 	eventType: string,
 	action: string,
 	payload: Record<string, unknown>,
-): ParsedPrTrigger | null {
-	if (isBotSender(payload)) return null;
+): PrReviewTriggerClassification {
+	if (isBotSender(payload)) {
+		return skipClassification({
+			eventType,
+			action,
+			kind: "bot_sender",
+			reason: "Bot-originated webhook events do not trigger managed reviews",
+		});
+	}
 
 	if (eventType === "pull_request") {
 		const pr = payload.pull_request as Record<string, unknown> | undefined;
 		const repoObj = payload.repository as Record<string, unknown> | undefined;
-		if (!pr || !repoObj) return null;
+		if (!pr || !repoObj) {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "malformed",
+				reason: "Pull request webhook is missing pull_request or repository",
+			});
+		}
 		const reviewPayload = buildReviewPayloadFromPr(pr, repoObj);
-		if (!reviewPayload) return null;
+		if (!reviewPayload) {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "malformed",
+				reason: "Pull request webhook is missing a PR number",
+			});
+		}
 
 		const isDraft = Boolean(pr.draft);
+		const draftSkip = (
+			kind: PrReviewTriggerClassificationKind,
+			reason: string,
+		) =>
+			skipClassification({
+				eventType,
+				action,
+				kind,
+				reason,
+			});
 
 		if (action === "opened") {
-			if (isDraft) return null;
-			return {
+			if (isDraft) return draftSkip("draft", "Draft PR opened");
+			return materialClassification({
+				eventType,
+				action,
+				kind: "opened",
+				reason: "PR opened",
 				reviewPayload,
 				context: {
 					kind: "opened",
 					triggerSourceId: reviewPayload.headSha || reviewPayload.headRef,
 					reason: "PR opened",
 				},
-			};
+			});
 		}
 		if (action === "reopened") {
-			if (isDraft) return null;
-			return {
+			if (isDraft) return draftSkip("draft", "Draft PR reopened");
+			return materialClassification({
+				eventType,
+				action,
+				kind: "reopened",
+				reason: "PR reopened",
 				reviewPayload,
 				context: {
 					kind: "reopened",
 					triggerSourceId: reviewPayload.headSha || reviewPayload.headRef,
 					reason: "PR reopened",
 				},
-			};
+			});
 		}
 		if (action === "ready_for_review") {
-			return {
+			return materialClassification({
+				eventType,
+				action,
+				kind: "ready_for_review",
+				reason: "PR moved from draft to ready for review",
 				reviewPayload,
 				context: {
 					kind: "ready_for_review",
 					triggerSourceId: reviewPayload.headSha || reviewPayload.headRef,
 					reason: "PR moved from draft to ready for review",
 				},
-			};
+			});
 		}
 		if (action === "synchronize") {
-			if (isDraft) return null;
-			if (!reviewPayload.headSha) return null;
-			return {
+			if (isDraft) return draftSkip("draft", "Draft PR synchronized");
+			if (!reviewPayload.headSha) {
+				return skipClassification({
+					eventType,
+					action,
+					kind: "malformed",
+					reason: "Synchronize webhook is missing head SHA",
+				});
+			}
+			return materialClassification({
+				eventType,
+				action,
+				kind: "synchronize",
+				reason: `New commit pushed (head ${reviewPayload.headSha.slice(0, 8)})`,
 				reviewPayload,
 				context: {
 					kind: "synchronize",
 					triggerSourceId: reviewPayload.headSha,
 					reason: `New commit pushed (head ${reviewPayload.headSha.slice(0, 8)})`,
 				},
-			};
+			});
 		}
 		if (action === "edited") {
-			if (isDraft) return null;
+			if (isDraft) return draftSkip("draft", "Draft PR edited");
 			const changes = payload.changes as Record<string, unknown> | undefined;
-			if (!changes) return null;
+			if (!changes) {
+				return skipClassification({
+					eventType,
+					action,
+					kind: "metadata_edit",
+					relevance: "metadata",
+					reason: "PR edited without changed fields",
+				});
+			}
 			const baseChange = changes.base as Record<string, unknown> | undefined;
 			if (baseChange !== undefined) {
 				// Base-branch retarget materially changes the diff being reviewed,
 				// so a new review must be produced. Source ID combines new base ref
 				// and head SHA so a webhook retry is deduped but a real retarget
 				// still reruns.
-				return {
+				return materialClassification({
+					eventType,
+					action,
+					kind: "base_edit",
+					reason: `PR base branch changed to ${reviewPayload.baseRef}`,
 					reviewPayload,
 					context: {
 						kind: "edited",
 						triggerSourceId: `base-${reviewPayload.baseRef}-${reviewPayload.headSha}`,
 						reason: `PR base branch changed to ${reviewPayload.baseRef}`,
 					},
-				};
+				});
 			}
 			if (changes.body !== undefined) {
 				const bodyHash = createHash("sha256")
 					.update(reviewPayload.body)
 					.digest("hex")
 					.slice(0, 16);
-				return {
+				return materialClassification({
+					eventType,
+					action,
+					kind: "body_edit",
+					reason: "PR description edited",
 					reviewPayload,
 					context: {
 						kind: "edited",
 						triggerSourceId: `body-${bodyHash}`,
 						reason: "PR description edited",
 					},
-				};
+				});
 			}
-			return null;
+			return skipClassification({
+				eventType,
+				action,
+				kind: "metadata_edit",
+				relevance: "metadata",
+				reason: "PR metadata edited without body or base changes",
+			});
 		}
-		return null;
+		if (action === "labeled" || action === "unlabeled") {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "label",
+				relevance: "metadata",
+				reason: "PR label metadata changed",
+			});
+		}
+		if (action === "closed") {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "closed",
+				relevance: "terminal",
+				reason: "PR closed",
+			});
+		}
+		return skipClassification({
+			eventType,
+			action,
+			kind: "unsupported",
+			reason: `Unsupported pull_request action: ${action}`,
+		});
 	}
 
 	if (eventType === "issue_comment" && action === "created") {
 		const issue = payload.issue as Record<string, unknown> | undefined;
 		const comment = payload.comment as Record<string, unknown> | undefined;
 		const repoObj = payload.repository as Record<string, unknown> | undefined;
-		if (!issue || !comment || !repoObj) return null;
+		if (!issue || !comment || !repoObj) {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "malformed",
+				reason:
+					"Issue comment webhook is missing issue, comment, or repository",
+			});
+		}
 		// Only PR comments — issue.pull_request is present on PR threads.
-		if (!issue.pull_request) return null;
+		if (!issue.pull_request) {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "unsupported",
+				reason: "Issue comment is not on a PR thread",
+			});
+		}
 		const body = String(comment.body ?? "");
-		if (!body.trim()) return null;
-		if (!EVIDENCE_SIGNAL.test(body)) return null;
+		if (!body.trim() || !EVIDENCE_SIGNAL.test(body)) {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "non_evidence_comment",
+				relevance: "metadata",
+				reason: "PR comment does not contain evidence signals",
+			});
+		}
 
 		const number = Number(issue.number ?? 0);
-		if (!number) return null;
+		if (!number) {
+			return skipClassification({
+				eventType,
+				action,
+				kind: "malformed",
+				reason: "Issue comment webhook is missing a PR number",
+			});
+		}
 		const prHead = issue.pull_request as Record<string, unknown> | undefined;
 		// issue.pull_request from issue_comment payloads carries only URLs; the head
 		// SHA is not present, so we accept the empty-SHA case and let the runtime
@@ -171,17 +382,49 @@ export function parsePrReviewTrigger(
 		const sender = payload.sender as Record<string, unknown> | undefined;
 		const senderLogin = String(sender?.login ?? "unknown");
 		const commentId = String(comment.id ?? Date.now());
-		return {
+		return materialClassification({
+			eventType,
+			action,
+			kind: "evidence_comment",
+			reason: `Evidence-bearing PR comment by ${senderLogin}`,
 			reviewPayload,
 			context: {
 				kind: "evidence_comment",
 				triggerSourceId: `comment-${commentId}`,
 				reason: `Evidence-bearing PR comment by ${senderLogin}`,
 			},
-		};
+		});
 	}
 
-	return null;
+	if (
+		eventType === "pull_request_review_comment" ||
+		eventType === "pull_request_review"
+	) {
+		return skipClassification({
+			eventType,
+			action,
+			kind: "review_comment",
+			relevance: "metadata",
+			reason: "PR review comments do not change the reviewed head",
+		});
+	}
+
+	return skipClassification({
+		eventType,
+		action,
+		kind: "unsupported",
+		reason: `Unsupported webhook event for managed review: ${eventType}`,
+	});
+}
+
+export function parsePrReviewTrigger(
+	eventType: string,
+	action: string,
+	payload: Record<string, unknown>,
+): ParsedPrTrigger | null {
+	const classification = classifyPrReviewTrigger(eventType, action, payload);
+	if (classification.decision !== "trigger_review") return null;
+	return classification.trigger;
 }
 
 // Internal export for tests / future operator paths.

--- a/web/src/lib/event-source.ts
+++ b/web/src/lib/event-source.ts
@@ -22,6 +22,10 @@ export function getSourceUrl(
 			return str((p.issue as Nested)?.html_url) || null;
 		case "issue_comment":
 			return str((p.comment as Nested)?.html_url) || null;
+		case "pull_request_review":
+			return str((p.review as Nested)?.html_url) || null;
+		case "pull_request_review_comment":
+			return str((p.comment as Nested)?.html_url) || null;
 		case "push":
 			return str(p.compare) || null;
 		case "check_run":

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -54,6 +54,8 @@ export type WebhookEventType =
 	| "push"
 	| "issues"
 	| "issue_comment"
+	| "pull_request_review"
+	| "pull_request_review_comment"
 	| "workflow_run";
 
 export const WORKSPACE_STATUS_LABELS: Record<WorkspaceStatus, string> = {
@@ -72,6 +74,8 @@ export const WEBHOOK_EVENT_ICONS: Record<WebhookEventType, string> = {
 	push: "git-commit",
 	issues: "circle-dot",
 	issue_comment: "message-circle",
+	pull_request_review: "message-square",
+	pull_request_review_comment: "message-circle",
 	workflow_run: "play-circle",
 };
 


### PR DESCRIPTION
## Summary

- add an explicit managed-review trigger classifier before ReviewRun claim/coalescing
- distinguish material triggers from metadata, terminal, ignored, malformed, and unsupported activity
- record PR review webhook event types without starting managed-review sessions for review comments
- document which PR activities are expected to trigger fresh reviews

Closes #586

## Mergeability

- Surface: web / agent-runtime / docs
- User-facing behavior changed: managed-review triggers become explicit and metadata-only PR activity no longer creates managed-review sessions.
- Non-happy paths considered: malformed webhooks, bot senders, draft PRs, closed PRs, review comments, non-evidence comments, repeated body edits, repeated evidence comments, and active-run coalescing.
- Release/ops preconditions: none beyond normal web deployment.
- Residual risk or follow-up: follow-up ReviewRun lifecycle and projection work continues in the milestone.

## Validation

- [ ] swift build
- [ ] swift test
- [x] Other checks run: mise -C web run web:check; ./scripts/tests/test_security_hardening.py; git diff --check

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![validation](https://evidence.cloudcompute.com/workspaces/pr-595/20260531-213703-validation.png)

## Blockers

- [x] None
- [ ] Blocked on evidence