### PR TITLE
Clarify managed review run lifecycle

### DIFF
--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
@@ -115,6 +115,30 @@
 	background: #f9fafb;
 }
 
+.actionCard {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	border: 1px solid #d1d5db;
+	border-radius: 8px;
+	padding: 12px;
+	background: #ffffff;
+}
+
+.actionCard span {
+	color: #6b7280;
+	font-size: 12px;
+}
+
+.actionCard strong {
+	font-size: 14px;
+}
+
+.actionCard small {
+	color: #6b7280;
+	font-size: 12px;
+}
+
 .transcriptCard {
 	display: flex;
 	flex: 1;

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -29,6 +29,7 @@ export default async function ReviewRunPage({
 	const [owner, repo] = run.repoFullName.split("/");
 	const prUrl = `https://github.com/${run.repoFullName}/pull/${run.prNumber}`;
 	const commitUrl = `https://github.com/${run.repoFullName}/commit/${run.headSha}`;
+	const latestCommitUrl = `https://github.com/${run.repoFullName}/commit/${run.latestKnownHeadSha}`;
 	const dashboardUrl =
 		owner && repo
 			? `/dashboard/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}?tab=terminal&agent=pr-reviewer`
@@ -67,8 +68,16 @@ export default async function ReviewRunPage({
 					</strong>
 				</div>
 				<div>
-					<span>Head</span>
+					<span>Execution</span>
+					<strong>{run.executionState}</strong>
+				</div>
+				<div>
+					<span>Target head</span>
 					<strong>{run.headSha.slice(0, 12)}</strong>
+				</div>
+				<div>
+					<span>Latest known head</span>
+					<strong>{run.latestKnownHeadSha.slice(0, 12)}</strong>
 				</div>
 				<div>
 					<span>Updated</span>
@@ -87,15 +96,42 @@ export default async function ReviewRunPage({
 						<strong>{run.githubReviewId}</strong>
 					</div>
 				)}
+				{run.failureKind && (
+					<div>
+						<span>Failure</span>
+						<strong>{run.failureKind}</strong>
+					</div>
+				)}
+				{run.failureRetryable !== null && (
+					<div>
+						<span>Retryable</span>
+						<strong>{run.failureRetryable ? "yes" : "no"}</strong>
+					</div>
+				)}
 			</section>
 
 			<nav className={styles.links} aria-label="Run links">
 				<Link href={prUrl}>Open PR</Link>
 				<Link href={commitUrl}>Open commit</Link>
+				{run.latestKnownHeadSha !== run.headSha && (
+					<Link href={latestCommitUrl}>Open latest known commit</Link>
+				)}
 				<Link href={dashboardUrl}>Open terminal tab</Link>
 			</nav>
 
-			{run.error && <pre className={styles.errorBlock}>{run.error}</pre>}
+			<section className={styles.actionCard}>
+				<span>Next action</span>
+				<strong>{run.nextAction}</strong>
+				{run.failedAt && (
+					<small>
+						Failure recorded {new Date(run.failedAt).toLocaleString()}
+					</small>
+				)}
+			</section>
+
+			{run.failureMessage && (
+				<pre className={styles.errorBlock}>{run.failureMessage}</pre>
+			)}
 			{projectionError && (
 				<pre className={styles.errorBlock}>{projectionError}</pre>
 			)}

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -355,6 +355,20 @@ describe("bucketPrReviewRuns", () => {
 			projectionError?: string | null;
 		}) => ({
 			...base,
+			executionState:
+				overrides.status === "completed"
+					? ("completed" as const)
+					: overrides.status === "failed"
+						? ("failed" as const)
+						: overrides.sessionId
+							? ("running_session" as const)
+							: ("waiting_for_session" as const),
+			latestKnownHeadSha: base.headSha,
+			failureKind: null,
+			failureMessage: null,
+			failureRetryable: null,
+			failedAt: null,
+			nextAction: "",
 			projectionStatus: overrides.projectionStatus ?? ("pending" as const),
 			projectionUpdatedAt: overrides.updatedAt,
 			...overrides,
@@ -433,6 +447,83 @@ describe("bucketPrReviewRuns", () => {
 });
 
 describe("run detail lookups", () => {
+	it("uses transition helpers for valid lifecycle transitions", async () => {
+		const {
+			getPrReviewRunByFingerprint,
+			markRunCompleted,
+			markRunSessionStarted,
+			recordRunStart,
+		} = await loadModule();
+		const input = makeInput({ fingerprint: "fp_lifecycle", prNumber: 44 });
+
+		await recordRunStart(input);
+		await markRunSessionStarted(input.fingerprint, {
+			sessionId: "sesn_lifecycle",
+		});
+		await markRunCompleted(input.fingerprint, {
+			sessionId: "sesn_lifecycle",
+			githubReviewId: "9876",
+		});
+
+		await expect(
+			getPrReviewRunByFingerprint(input.fingerprint),
+		).resolves.toMatchObject({
+			status: "completed",
+			executionState: "completed",
+			projectionStatus: "projected",
+			githubReviewId: "9876",
+			failureKind: null,
+			nextAction:
+				"No action needed; the ReviewRun has been published to GitHub.",
+		});
+	});
+
+	it("blocks lifecycle transitions away from a terminal state", async () => {
+		const { markRunCompleted, markRunFailed, recordRunStart } =
+			await loadModule();
+		const input = makeInput({ fingerprint: "fp_terminal_guard" });
+
+		await recordRunStart(input);
+		await markRunCompleted(input.fingerprint, {
+			sessionId: "sesn_terminal",
+		});
+
+		await expect(
+			markRunFailed(input.fingerprint, {
+				sessionId: "sesn_terminal",
+				error: "late failure",
+			}),
+		).rejects.toThrow("is terminal");
+	});
+
+	it("persists bounded user-safe failure details", async () => {
+		const { getPrReviewRunByFingerprint, markRunFailed, recordRunStart } =
+			await loadModule();
+		const input = makeInput({ fingerprint: "fp_failure_details" });
+		const secret = `github_pat_${"a".repeat(40)}`;
+		const longError = `review intent parse failed with ${secret} ${"x".repeat(900)}`;
+
+		await recordRunStart(input);
+		await markRunFailed(input.fingerprint, {
+			sessionId: "sesn_failure",
+			error: longError,
+		});
+
+		const run = await getPrReviewRunByFingerprint(input.fingerprint);
+		expect(run).toMatchObject({
+			status: "failed",
+			executionState: "failed",
+			failureKind: "review_intent_invalid",
+			failureRetryable: false,
+			projectionStatus: "failed",
+		});
+		expect(run?.failedAt).toEqual(expect.any(String));
+		expect(run?.failureMessage).not.toContain(secret);
+		expect(run?.failureMessage).toContain("[redacted]");
+		expect(run?.failureMessage?.length).toBeLessThanOrEqual(602);
+		expect(run?.nextAction).toBe("Manual inspection required before retry.");
+	});
+
 	it("returns run details by fingerprint and session id", async () => {
 		const {
 			getPrReviewRunByFingerprint,
@@ -460,6 +551,12 @@ describe("run detail lookups", () => {
 			sessionId: "sesn_details",
 			status: "failed",
 			error: "review intent parse failed",
+			executionState: "failed",
+			latestKnownHeadSha: "abc123",
+			failureKind: "review_intent_invalid",
+			failureMessage: "review intent parse failed",
+			failureRetryable: false,
+			failedAt: expect.any(String),
 			projectionStatus: "failed",
 			projectionError: "review intent parse failed",
 		});

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -13,6 +13,23 @@ export type PrReviewProjectionStatus =
 	| "failed"
 	| "superseded";
 
+export type PrReviewFailureKind =
+	| "session_start_failed"
+	| "session_output_failed"
+	| "review_intent_invalid"
+	| "pr_metadata_unavailable"
+	| "github_projection_failed"
+	| "broker_failed"
+	| "stale_active_claim"
+	| "unknown";
+
+export type PrReviewExecutionState =
+	| "waiting_for_session"
+	| "running_session"
+	| "completed"
+	| "failed"
+	| "superseded";
+
 export interface PrReviewRunFingerprintInput {
 	repoFullName: string;
 	prNumber: number;
@@ -46,6 +63,10 @@ async function ensureRunsTable(): Promise<void> {
 		.addColumn("created_at", "text", (c) => c.notNull())
 		.addColumn("updated_at", "text", (c) => c.notNull())
 		.addColumn("error", "text")
+		.addColumn("failure_kind", "text")
+		.addColumn("failure_message", "text")
+		.addColumn("failure_retryable", "integer")
+		.addColumn("failed_at", "text")
 		.addColumn("projection_status", "text")
 		.addColumn("projection_updated_at", "text")
 		.addColumn("projection_error", "text")
@@ -57,6 +78,10 @@ async function ensureRunsTable(): Promise<void> {
 		.addColumn("coalesced_at", "text")
 		.execute();
 	for (const [column, type] of [
+		["failure_kind", "text"],
+		["failure_message", "text"],
+		["failure_retryable", "integer"],
+		["failed_at", "text"],
 		["projection_status", "text"],
 		["projection_updated_at", "text"],
 		["projection_error", "text"],
@@ -118,6 +143,140 @@ export interface RecordRunStartResult {
 
 /** Treat a `started` row older than this as crashed and eligible for retry. */
 const STALE_STARTED_MS = 15 * 60 * 1000;
+const MAX_FAILURE_MESSAGE_LENGTH = 600;
+
+const TOKEN_REDACTIONS: RegExp[] = [
+	/ghp_[A-Za-z0-9_]{20,}/g,
+	/github_pat_[A-Za-z0-9_]{20,}/g,
+	/(?:sk|sk-ant|sk-proj)-[A-Za-z0-9_-]{20,}/g,
+	/\bBearer\s+[A-Za-z0-9._-]{20,}/gi,
+	/\btoken["'\s:=]+[A-Za-z0-9._-]{20,}/gi,
+	/\bsecret["'\s:=]+[A-Za-z0-9._-]{20,}/gi,
+];
+
+function sanitizeFailureMessage(
+	message: string | null | undefined,
+): string | null {
+	if (!message) return null;
+	let sanitized = message;
+	for (const pattern of TOKEN_REDACTIONS) {
+		sanitized = sanitized.replace(pattern, "[redacted]");
+	}
+	sanitized = sanitized.replace(/\s+$/g, "");
+	if (sanitized.length <= MAX_FAILURE_MESSAGE_LENGTH) return sanitized;
+	return `${sanitized.slice(0, MAX_FAILURE_MESSAGE_LENGTH - 1)}...`;
+}
+
+function classifyFailureKind(
+	status: PrReviewRunStatus,
+	message: string | null | undefined,
+): PrReviewFailureKind | null {
+	if (status !== "failed") return null;
+	const lower = String(message ?? "").toLowerCase();
+	if (
+		lower.includes("review intent") ||
+		lower.includes("invalid intent") ||
+		lower.includes("json")
+	) {
+		return "review_intent_invalid";
+	}
+	if (
+		lower.includes("could not resolve pr metadata") ||
+		lower.includes("could not resolve head metadata")
+	) {
+		return "pr_metadata_unavailable";
+	}
+	if (
+		lower.includes("github") ||
+		lower.includes("status") ||
+		/\b(?:401|403|404|422|500|502|503)\b/.test(lower)
+	) {
+		return "github_projection_failed";
+	}
+	if (lower.includes("session") || lower.includes("managed agent")) {
+		return "session_output_failed";
+	}
+	return "broker_failed";
+}
+
+function defaultRetryable(kind: PrReviewFailureKind | null): boolean | null {
+	switch (kind) {
+		case null:
+			return null;
+		case "review_intent_invalid":
+			return false;
+		case "github_projection_failed":
+		case "pr_metadata_unavailable":
+		case "session_output_failed":
+		case "session_start_failed":
+		case "broker_failed":
+		case "stale_active_claim":
+		case "unknown":
+			return true;
+	}
+}
+
+function normalizeFailureRetryable(value: boolean | null): number | null {
+	if (value === null) return null;
+	return value ? 1 : 0;
+}
+
+function normalizeFailureKind(kind: string | null): PrReviewFailureKind | null {
+	if (
+		kind === "session_start_failed" ||
+		kind === "session_output_failed" ||
+		kind === "review_intent_invalid" ||
+		kind === "pr_metadata_unavailable" ||
+		kind === "github_projection_failed" ||
+		kind === "broker_failed" ||
+		kind === "stale_active_claim" ||
+		kind === "unknown"
+	) {
+		return kind;
+	}
+	return null;
+}
+
+function executionStateForRun(input: {
+	status: PrReviewRunStatus;
+	sessionId: string | null;
+}): PrReviewExecutionState {
+	if (input.status === "completed") return "completed";
+	if (input.status === "failed") return "failed";
+	if (input.status === "superseded") return "superseded";
+	return input.sessionId ? "running_session" : "waiting_for_session";
+}
+
+function nextActionForRun(input: {
+	status: PrReviewRunStatus;
+	sessionId: string | null;
+	projectionStatus: PrReviewProjectionStatus;
+	failureRetryable: boolean | null;
+	coalescedAt: string | null;
+}): string {
+	if (input.coalescedAt && input.status === "started") {
+		return "Broker will supersede this run and start one follow-up review for the latest PR state.";
+	}
+	if (input.status === "started" && !input.sessionId) {
+		return "Waiting for the managed-agent session to be created.";
+	}
+	if (input.status === "started") {
+		return "Waiting for the broker to collect completed managed-agent output.";
+	}
+	if (input.status === "completed" && input.projectionStatus === "projected") {
+		return "No action needed; the ReviewRun has been published to GitHub.";
+	}
+	if (input.status === "completed") {
+		return "Broker or repair tooling should publish the completed ReviewRun projection to GitHub.";
+	}
+	if (input.status === "superseded") {
+		return "No action needed for this run; a newer run or review replaced it.";
+	}
+	if (input.failureRetryable) {
+		return "Retry is allowed after confirming this run still targets the current PR head.";
+	}
+	return "Manual inspection required before retry.";
+}
 
 function projectionStatusForRunStatus(
 	status: PrReviewRunStatus,
@@ -185,6 +344,11 @@ async function coalesceIntoActiveRun(input: {
 				status: "superseded",
 				error:
 					"Superseded by a newer trigger after the active claim became stale.",
+				failure_kind: "stale_active_claim",
+				failure_message:
+					"Superseded by a newer trigger after the active claim became stale.",
+				failure_retryable: 1,
+				failed_at: input.now,
 				updated_at: input.now,
 				projection_status: "superseded",
 				projection_updated_at: input.now,
@@ -257,6 +421,10 @@ export async function recordRunStart(
 			created_at: now,
 			updated_at: now,
 			error: null,
+			failure_kind: null,
+			failure_message: null,
+			failure_retryable: null,
+			failed_at: null,
 			projection_status: "pending",
 			projection_updated_at: now,
 			projection_error: null,
@@ -305,6 +473,10 @@ export async function recordRunStart(
 				created_at: now,
 				updated_at: now,
 				error: null,
+				failure_kind: null,
+				failure_message: null,
+				failure_retryable: null,
+				failed_at: null,
 				projection_status: "pending",
 				projection_updated_at: now,
 				projection_error: null,
@@ -348,6 +520,10 @@ export async function recordRunStart(
 			status: "started",
 			session_id: null,
 			error: null,
+			failure_kind: null,
+			failure_message: null,
+			failure_retryable: null,
+			failed_at: null,
 			updated_at: now,
 			projection_status: "pending",
 			projection_updated_at: now,
@@ -368,32 +544,87 @@ export interface RecordRunResultInput {
 	sessionId: string | null;
 	status: PrReviewRunStatus;
 	error?: string | null;
+	failureKind?: PrReviewFailureKind | null;
+	failureRetryable?: boolean | null;
 	projectionStatus?: PrReviewProjectionStatus;
 	projectionError?: string | null;
 	githubReviewId?: string | null;
 }
 
-export async function recordRunResult(
+const TERMINAL_RUN_STATUSES = new Set<PrReviewRunStatus>([
+	"completed",
+	"failed",
+	"superseded",
+]);
+
+async function assertTransitionAllowed(
 	fingerprint: string,
-	input: RecordRunResultInput,
+	nextStatus: PrReviewRunStatus,
+): Promise<void> {
+	const current = await getDb()
+		.selectFrom("managed_pr_review_runs")
+		.select(["status"])
+		.where("fingerprint", "=", fingerprint)
+		.executeTakeFirst();
+	if (!current) {
+		throw new Error(`ReviewRun ${fingerprint} does not exist`);
+	}
+	const currentStatus = current.status as PrReviewRunStatus;
+	if (
+		TERMINAL_RUN_STATUSES.has(currentStatus) &&
+		currentStatus !== nextStatus
+	) {
+		throw new Error(
+			`ReviewRun ${fingerprint} is terminal (${currentStatus}); cannot mark ${nextStatus}`,
+		);
+	}
+}
+
+interface RunLifecycleUpdateInput {
+	sessionId: string | null;
+	status: PrReviewRunStatus;
+	error?: string | null;
+	failureKind?: PrReviewFailureKind | null;
+	failureRetryable?: boolean | null;
+	projectionStatus?: PrReviewProjectionStatus;
+	projectionError?: string | null;
+	githubReviewId?: string | null;
+}
+
+async function updateRunLifecycle(
+	fingerprint: string,
+	input: RunLifecycleUpdateInput,
 ): Promise<void> {
 	await ensureRunsTable();
 	const now = new Date().toISOString();
+	await assertTransitionAllowed(fingerprint, input.status);
 	const projectionStatus =
 		input.projectionStatus ?? projectionStatusForRunStatus(input.status);
+	const failureKind =
+		input.failureKind ?? classifyFailureKind(input.status, input.error);
+	const sanitizedError = sanitizeFailureMessage(input.error);
+	const failureMessage =
+		input.status === "failed" || failureKind ? sanitizedError : null;
+	const failureRetryable =
+		input.failureRetryable ?? defaultRetryable(failureKind);
+	const projectionError =
+		input.projectionError !== undefined
+			? sanitizeFailureMessage(input.projectionError)
+			: projectionStatus === "failed"
+				? failureMessage
+				: null;
 	const updates = {
 		session_id: input.sessionId,
 		status: input.status,
-		error: input.error ?? null,
+		error: sanitizedError,
+		failure_kind: failureKind,
+		failure_message: failureMessage,
+		failure_retryable: normalizeFailureRetryable(failureRetryable),
+		failed_at: failureKind ? now : null,
 		updated_at: now,
 		projection_status: projectionStatus,
 		projection_updated_at: now,
-		projection_error:
-			input.projectionError !== undefined
-				? input.projectionError
-				: projectionStatus === "failed"
-					? (input.error ?? null)
-					: null,
+		projection_error: projectionError,
 		github_review_id: input.githubReviewId ?? null,
 		...(input.status === "started"
 			? {}
@@ -410,6 +641,104 @@ export async function recordRunResult(
 		.set(updates)
 		.where("fingerprint", "=", fingerprint)
 		.execute();
+}
+
+export async function markRunSessionStarted(
+	fingerprint: string,
+	input: { sessionId: string },
+): Promise<void> {
+	await updateRunLifecycle(fingerprint, {
+		sessionId: input.sessionId,
+		status: "started",
+		projectionStatus: "pending",
+	});
+}
+
+export async function markRunCompleted(
+	fingerprint: string,
+	input: { sessionId: string | null; githubReviewId?: string | null },
+): Promise<void> {
+	await updateRunLifecycle(fingerprint, {
+		sessionId: input.sessionId,
+		status: "completed",
+		githubReviewId: input.githubReviewId ?? null,
+	});
+}
+
+export async function markRunFailed(
+	fingerprint: string,
+	input: {
+		sessionId: string | null;
+		error: string;
+		failureKind?: PrReviewFailureKind | null;
+		failureRetryable?: boolean | null;
+		projectionError?: string | null;
+	},
+): Promise<void> {
+	await updateRunLifecycle(fingerprint, {
+		sessionId: input.sessionId,
+		status: "failed",
+		error: input.error,
+		failureKind: input.failureKind,
+		failureRetryable: input.failureRetryable,
+		projectionStatus: "failed",
+		projectionError: input.projectionError,
+	});
+}
+
+export async function markRunSuperseded(
+	fingerprint: string,
+	input: {
+		sessionId: string | null;
+		reason: string;
+		projectionStatus?: PrReviewProjectionStatus;
+		githubReviewId?: string | null;
+	},
+): Promise<void> {
+	await updateRunLifecycle(fingerprint, {
+		sessionId: input.sessionId,
+		status: "superseded",
+		error: input.reason,
+		projectionStatus: input.projectionStatus ?? "superseded",
+		githubReviewId: input.githubReviewId ?? null,
+	});
+}
+
+export async function recordRunResult(
+	fingerprint: string,
+	input: RecordRunResultInput,
+): Promise<void> {
+	switch (input.status) {
+		case "started":
+			if (!input.sessionId) {
+				throw new Error("ReviewRun session start requires a session id");
+			}
+			await markRunSessionStarted(fingerprint, { sessionId: input.sessionId });
+			return;
+		case "completed":
+			await markRunCompleted(fingerprint, {
+				sessionId: input.sessionId,
+				githubReviewId: input.githubReviewId,
+			});
+			return;
+		case "failed":
+			await markRunFailed(fingerprint, {
+				sessionId: input.sessionId,
+				error: input.error ?? "Managed review failed.",
+				failureKind: input.failureKind,
+				failureRetryable: input.failureRetryable,
+				projectionError: input.projectionError,
+			});
+			return;
+		case "superseded":
+			await markRunSuperseded(fingerprint, {
+				sessionId: input.sessionId,
+				reason: input.error ?? "Managed review was superseded.",
+				projectionStatus: input.projectionStatus,
+				githubReviewId: input.githubReviewId,
+			});
+			return;
+	}
 }
 
 export async function releaseRunActiveClaim(
@@ -435,6 +764,13 @@ export interface PrReviewRunSummary {
 	createdAt: string;
 	updatedAt: string;
 	error: string | null;
+	executionState: PrReviewExecutionState;
+	latestKnownHeadSha: string;
+	failureKind: PrReviewFailureKind | null;
+	failureMessage: string | null;
+	failureRetryable: boolean | null;
+	failedAt: string | null;
+	nextAction: string;
 	projectionStatus: PrReviewProjectionStatus;
 	projectionUpdatedAt: string;
 	projectionError: string | null;
@@ -478,6 +814,10 @@ function mapRunDetails(row: {
 	created_at: string;
 	updated_at: string;
 	error: string | null;
+	failure_kind: string | null;
+	failure_message: string | null;
+	failure_retryable: number | null;
+	failed_at: string | null;
 	projection_status: string | null;
 	projection_updated_at: string | null;
 	projection_error: string | null;
@@ -488,6 +828,22 @@ function mapRunDetails(row: {
 	coalesced_at: string | null;
 }): PrReviewRunDetails {
 	const status = row.status as PrReviewRunStatus;
+	const projectionStatus = normalizeProjectionStatus(
+		row.projection_status,
+		status,
+	);
+	const latestKnownHeadSha = row.coalesced_head_sha ?? row.head_sha;
+	const failureKind = normalizeFailureKind(row.failure_kind);
+	const failureMessage = sanitizeFailureMessage(
+		row.failure_message ?? row.error,
+	);
+	const projectionError = sanitizeFailureMessage(
+		row.projection_error ?? (status === "failed" ? row.error : null),
+	);
+	const executionState = executionStateForRun({
+		status,
+		sessionId: row.session_id,
+	});
 	return {
 		fingerprint: row.fingerprint,
 		repoFullName: row.repo_full_name,
@@ -500,11 +856,25 @@ function mapRunDetails(row: {
 		sessionId: row.session_id,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
-		error: row.error,
-		projectionStatus: normalizeProjectionStatus(row.projection_status, status),
+		error: failureMessage,
+		executionState,
+		latestKnownHeadSha,
+		failureKind,
+		failureMessage,
+		failureRetryable:
+			row.failure_retryable === null ? null : row.failure_retryable === 1,
+		failedAt: row.failed_at,
+		nextAction: nextActionForRun({
+			status,
+			sessionId: row.session_id,
+			projectionStatus,
+			failureRetryable:
+				row.failure_retryable === null ? null : row.failure_retryable === 1,
+			coalescedAt: row.coalesced_at,
+		}),
+		projectionStatus,
 		projectionUpdatedAt: row.projection_updated_at ?? row.updated_at,
-		projectionError:
-			row.projection_error ?? (status === "failed" ? row.error : null),
+		projectionError,
 		githubReviewId: row.github_review_id,
 		coalescedHeadSha: row.coalesced_head_sha,
 		coalescedTriggerKind: row.coalesced_trigger_kind,
@@ -558,6 +928,10 @@ export async function listRecentPrReviewRuns(input: {
 			"created_at",
 			"updated_at",
 			"error",
+			"failure_kind",
+			"failure_message",
+			"failure_retryable",
+			"failed_at",
 			"projection_status",
 			"projection_updated_at",
 			"projection_error",
@@ -573,6 +947,12 @@ export async function listRecentPrReviewRuns(input: {
 
 	return rows.map((row) => {
 		const status = row.status as PrReviewRunStatus;
+		const projectionStatus = normalizeProjectionStatus(
+			row.projection_status,
+			status,
+		);
+		const failureRetryable =
+			row.failure_retryable === null ? null : row.failure_retryable === 1;
 		return {
 			fingerprint: row.fingerprint,
 			repoFullName: row.repo_full_name,
@@ -584,14 +964,28 @@ export async function listRecentPrReviewRuns(input: {
 			sessionId: row.session_id,
 			createdAt: row.created_at,
 			updatedAt: row.updated_at,
-			error: row.error,
-			projectionStatus: normalizeProjectionStatus(
-				row.projection_status,
+			error: sanitizeFailureMessage(row.failure_message ?? row.error),
+			executionState: executionStateForRun({
 				status,
-			),
+				sessionId: row.session_id,
+			}),
+			latestKnownHeadSha: row.coalesced_head_sha ?? row.head_sha,
+			failureKind: normalizeFailureKind(row.failure_kind),
+			failureMessage: sanitizeFailureMessage(row.failure_message ?? row.error),
+			failureRetryable,
+			failedAt: row.failed_at,
+			nextAction: nextActionForRun({
+				status,
+				sessionId: row.session_id,
+				projectionStatus,
+				failureRetryable,
+				coalescedAt: row.coalesced_at,
+			}),
+			projectionStatus,
 			projectionUpdatedAt: row.projection_updated_at ?? row.updated_at,
-			projectionError:
+			projectionError: sanitizeFailureMessage(
 				row.projection_error ?? (status === "failed" ? row.error : null),
+			),
 			githubReviewId: row.github_review_id,
 			coalescedHeadSha: row.coalesced_head_sha,
 			coalescedTriggerKind: row.coalesced_trigger_kind,

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -85,6 +85,10 @@ export interface ManagedPrReviewRunsTable {
 	created_at: string;
 	updated_at: string;
 	error: string | null;
+	failure_kind: string | null;
+	failure_message: string | null;
+	failure_retryable: number | null;
+	failed_at: string | null;
 	projection_status: string | null;
 	projection_updated_at: string | null;
 	projection_error: string | null;


### PR DESCRIPTION
## Summary

- add explicit ReviewRun execution state, failure kind, retryability, failure timestamp, latest known head, and next-action fields
- persist bounded, user-safe failure details while keeping ReviewRun as the source of truth
- route lifecycle updates through transition-named helpers with terminal-state protection
- update the run details page to separate execution state, projection state, target head, latest known head, and operator action

Closes #585

## Mergeability

- Surface: web / agent-runtime
- User-facing behavior changed: review-run details now explain run execution state, failure details, retryability, and next action instead of only showing raw status/error text.
- Non-happy paths considered: malformed/secret-like failure strings, overlong failure output, failed runs, superseded stale active claims, terminal-state transition attempts, completed runs awaiting projection, and coalesced latest-head state.
- Release/ops preconditions: deploy web after normal checks pass; schema is additive and compatibility reads are preserved.
- Residual risk or follow-up: projection ledger and completion-primary projection are still separate milestone issues.

## Validation

- [ ] swift build
- [ ] swift test
- [x] Other checks run: mise -C web run web:check; UV_CACHE_DIR=/tmp/uv-cache ./scripts/tests/test_security_hardening.py; git diff --check

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from config/performance/contract.json
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![validation](https://evidence.cloudcompute.com/workspaces/pr-596/20260531-214340-validation.png)

## Blockers

- [x] None
- [ ] Blocked on evidence