### PR TITLE
Add managed review projection ledger

### DIFF
--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
@@ -139,6 +139,80 @@
 	font-size: 12px;
 }
 
+.projections {
+	overflow: hidden;
+	border: 1px solid #d1d5db;
+	border-radius: 8px;
+	background: #ffffff;
+}
+
+.sectionHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 12px 14px;
+	border-bottom: 1px solid #e5e7eb;
+}
+
+.sectionHeader h2 {
+	margin: 0;
+	font-size: 15px;
+}
+
+.sectionHeader span {
+	color: #6b7280;
+	font-size: 12px;
+	font-weight: 700;
+}
+
+.projectionList {
+	display: flex;
+	flex-direction: column;
+}
+
+.projectionRow {
+	display: grid;
+	grid-template-columns: minmax(180px, 1.4fr) repeat(5, minmax(112px, 1fr));
+	gap: 12px;
+	padding: 12px 14px;
+	border-top: 1px solid #f3f4f6;
+}
+
+.projectionRow:first-child {
+	border-top: 0;
+}
+
+.projectionRow div {
+	min-width: 0;
+}
+
+.projectionRow span {
+	display: block;
+	margin-bottom: 3px;
+	color: #6b7280;
+	font-size: 11px;
+}
+
+.projectionRow strong {
+	display: block;
+	overflow-wrap: anywhere;
+	font-size: 12px;
+}
+
+.projectionError {
+	grid-column: 1 / -1;
+	margin: 0;
+	overflow: auto;
+	border: 1px solid #fecaca;
+	border-radius: 6px;
+	padding: 8px;
+	background: #fef2f2;
+	color: #991b1b;
+	font-size: 12px;
+	white-space: pre-wrap;
+}
+
 .transcriptCard {
 	display: flex;
 	flex: 1;
@@ -197,4 +271,16 @@
 	background: #fef2f2;
 	color: #991b1b;
 	white-space: pre-wrap;
+}
+
+@media (max-width: 900px) {
+	.projectionRow {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 560px) {
+	.projectionRow {
+		grid-template-columns: 1fr;
+	}
 }

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -136,6 +136,67 @@ export default async function ReviewRunPage({
 				<pre className={styles.errorBlock}>{projectionError}</pre>
 			)}
 
+			<section className={styles.projections}>
+				<div className={styles.sectionHeader}>
+					<h2>GitHub projections</h2>
+					<span>{run.projections.length}</span>
+				</div>
+				{run.projections.length === 0 ? (
+					<p className={styles.muted}>No projection records yet.</p>
+				) : (
+					<div className={styles.projectionList}>
+						{run.projections.map((projection) => (
+							<div
+								className={styles.projectionRow}
+								key={projection.projectionId}
+							>
+								<div>
+									<strong>{projection.type}</strong>
+									<span>{projection.projectionKey}</span>
+								</div>
+								<div>
+									<span>State</span>
+									<strong>{projection.state}</strong>
+								</div>
+								<div>
+									<span>Attempts</span>
+									<strong>{projection.attempts}</strong>
+								</div>
+								<div>
+									<span>Last attempt</span>
+									<strong>
+										{projection.lastAttemptedAt
+											? new Date(projection.lastAttemptedAt).toLocaleString()
+											: "none"}
+									</strong>
+								</div>
+								<div>
+									<span>Desired hash</span>
+									<strong>{projection.desiredPayloadHash.slice(0, 16)}</strong>
+								</div>
+								{projection.observedExternalId && (
+									<div>
+										<span>External ID</span>
+										<strong>{projection.observedExternalId}</strong>
+									</div>
+								)}
+								{projection.errorKind && (
+									<div>
+										<span>Error</span>
+										<strong>{projection.errorKind}</strong>
+									</div>
+								)}
+								{projection.errorText && (
+									<pre className={styles.projectionError}>
+										{projection.errorText}
+									</pre>
+								)}
+							</div>
+						))}
+					</div>
+				)}
+			</section>
+
 			<ReviewRunTranscript
 				fingerprint={run.fingerprint}
 				initialSessionId={run.sessionId}

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -368,6 +368,182 @@ describe("listStartedPrReviewRuns", () => {
 	});
 });
 
+describe("projection ledger", () => {
+	it("hashes desired payloads stably and records successful projection state", async () => {
+		const {
+			beginPrReviewProjectionAttempt,
+			listPrReviewProjectionsForRun,
+			recordPrReviewProjectionSuccess,
+		} = await loadModule();
+
+		const first = await beginPrReviewProjectionAttempt({
+			runFingerprint: "fp_projection_hash",
+			type: "github_status",
+			projectionKey: "WorkSpaces Managed Review",
+			desiredPayload: { state: "success", description: "done" },
+		});
+		await recordPrReviewProjectionSuccess(first.projectionId, {
+			observedExternalId: "status-1",
+		});
+		await recordPrReviewProjectionSuccess(first.projectionId);
+		const duplicate = await beginPrReviewProjectionAttempt({
+			runFingerprint: "fp_projection_hash",
+			type: "github_status",
+			projectionKey: "WorkSpaces Managed Review",
+			desiredPayload: { description: "done", state: "success" },
+		});
+
+		expect(duplicate).toMatchObject({
+			projectionId: first.projectionId,
+			desiredPayloadHash: first.desiredPayloadHash,
+			shouldProject: false,
+			attempts: 1,
+			state: "projected",
+			observedExternalId: "status-1",
+		});
+		await expect(
+			listPrReviewProjectionsForRun("fp_projection_hash"),
+		).resolves.toMatchObject([
+			{
+				type: "github_status",
+				state: "projected",
+				attempts: 1,
+				observedExternalId: "status-1",
+			},
+		]);
+	});
+
+	it("retries failed desired projections without creating duplicate records", async () => {
+		const {
+			beginPrReviewProjectionAttempt,
+			listPrReviewProjectionsForRun,
+			recordPrReviewProjectionFailure,
+		} = await loadModule();
+		const input = {
+			runFingerprint: "fp_projection_retry",
+			type: "github_review" as const,
+			projectionKey: "final-review",
+			desiredPayload: { event: "COMMENT", body: "retry me", labels: [] },
+		};
+
+		const first = await beginPrReviewProjectionAttempt(input);
+		await recordPrReviewProjectionFailure(first.projectionId, {
+			errorKind: "transient_api",
+			errorText: "GitHub review post failed 503: temporarily unavailable",
+		});
+		const retry = await beginPrReviewProjectionAttempt(input);
+
+		expect(retry).toMatchObject({
+			projectionId: first.projectionId,
+			shouldProject: true,
+			attempts: 2,
+			state: "projecting",
+		});
+		const records = await listPrReviewProjectionsForRun("fp_projection_retry");
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({
+			state: "projecting",
+			attempts: 2,
+			errorKind: null,
+			errorText: null,
+		});
+	});
+
+	it("stores bounded redacted projection errors with classified context", async () => {
+		const {
+			beginPrReviewProjectionAttempt,
+			classifyPrReviewProjectionError,
+			listPrReviewProjectionsForRun,
+			recordPrReviewProjectionFailure,
+		} = await loadModule();
+		const secret = `ghp_${"a".repeat(40)}`;
+		const attempt = await beginPrReviewProjectionAttempt({
+			runFingerprint: "fp_projection_error",
+			type: "github_status",
+			projectionKey: "WorkSpaces Managed Review",
+			desiredPayload: { state: "failure", description: "failed" },
+		});
+
+		await recordPrReviewProjectionFailure(attempt.projectionId, {
+			errorKind: classifyPrReviewProjectionError({
+				status: 403,
+				message: `forbidden ${secret}`,
+			}),
+			errorText: `GitHub status update failed 403: forbidden ${secret} ${"x".repeat(900)}`,
+		});
+
+		const [record] = await listPrReviewProjectionsForRun("fp_projection_error");
+		expect(record).toMatchObject({
+			state: "failed",
+			attempts: 1,
+			errorKind: "auth",
+		});
+		expect(record.errorText).not.toContain(secret);
+		expect(record.errorText).toContain("[redacted]");
+		expect(record.errorText?.length).toBeLessThanOrEqual(603);
+	});
+
+	it("classifies projection API failures into operator-safe buckets", async () => {
+		const { classifyPrReviewProjectionError } = await loadModule();
+
+		expect(
+			classifyPrReviewProjectionError({ status: 401, message: "bad token" }),
+		).toBe("auth");
+		expect(
+			classifyPrReviewProjectionError({
+				status: 429,
+				message: "secondary rate limit",
+			}),
+		).toBe("rate_limit");
+		expect(
+			classifyPrReviewProjectionError({
+				status: 503,
+				message: "temporarily unavailable",
+			}),
+		).toBe("transient_api");
+		expect(
+			classifyPrReviewProjectionError({
+				status: 422,
+				message: "validation failed",
+			}),
+		).toBe("validation");
+		expect(
+			classifyPrReviewProjectionError({ status: 418, message: "teapot" }),
+		).toBe("unknown");
+	});
+
+	it("does not expose secrets, raw webhook payloads, or unbounded managed output", async () => {
+		const { beginPrReviewProjectionAttempt, listPrReviewProjectionsForRun } =
+			await loadModule();
+		const secret = `github_pat_${"b".repeat(40)}`;
+
+		await beginPrReviewProjectionAttempt({
+			runFingerprint: "fp_projection_security",
+			type: "github_review",
+			projectionKey: "final-review",
+			desiredPayload: {
+				event: "COMMENT",
+				body: `${secret} ${"managed output ".repeat(600)}`,
+				rawWebhookPayload: { token: secret, action: "synchronize" },
+				authorizationToken: secret,
+			},
+		});
+
+		const [record] = await listPrReviewProjectionsForRun(
+			"fp_projection_security",
+		);
+		const serialized = JSON.stringify(record.desiredPayload);
+		expect(serialized).not.toContain(secret);
+		expect(serialized).not.toContain("github_pat_");
+		expect(serialized).not.toContain("synchronize");
+		expect(serialized.length).toBeLessThanOrEqual(4096);
+		expect(
+			String((record.desiredPayload as { body: string }).body).length,
+		).toBeLessThanOrEqual(1002);
+		expect(serialized).toContain("[redacted]");
+	});
+});
+
 describe("bucketPrReviewRuns", () => {
 	it("separates runs that are starting, executing, due for projection, failed, and terminal", async () => {
 		const { bucketPrReviewRuns } = await loadModule();

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -14,6 +14,10 @@ const mocks = vi.hoisted(() => ({
 	releaseRunActiveClaim: vi.fn(),
 	listStartedPrReviewRuns: vi.fn(),
 	computeRunFingerprint: vi.fn(),
+	beginPrReviewProjectionAttempt: vi.fn(),
+	classifyPrReviewProjectionError: vi.fn(),
+	recordPrReviewProjectionFailure: vi.fn(),
+	recordPrReviewProjectionSuccess: vi.fn(),
 }));
 
 vi.mock("@anthropic-ai/sdk", () => {
@@ -44,8 +48,12 @@ vi.mock("../../github-app-auth", () => ({
 }));
 
 vi.mock("../pr-review-runs", () => ({
+	beginPrReviewProjectionAttempt: mocks.beginPrReviewProjectionAttempt,
+	classifyPrReviewProjectionError: mocks.classifyPrReviewProjectionError,
 	computeRunFingerprint: mocks.computeRunFingerprint,
 	listStartedPrReviewRuns: mocks.listStartedPrReviewRuns,
+	recordPrReviewProjectionFailure: mocks.recordPrReviewProjectionFailure,
+	recordPrReviewProjectionSuccess: mocks.recordPrReviewProjectionSuccess,
 	recordRunStart: mocks.recordRunStart,
 	recordRunResult: mocks.recordRunResult,
 	releaseRunActiveClaim: mocks.releaseRunActiveClaim,
@@ -232,6 +240,10 @@ beforeEach(() => {
 	mocks.releaseRunActiveClaim.mockReset();
 	mocks.listStartedPrReviewRuns.mockReset();
 	mocks.computeRunFingerprint.mockReset();
+	mocks.beginPrReviewProjectionAttempt.mockReset();
+	mocks.classifyPrReviewProjectionError.mockReset();
+	mocks.recordPrReviewProjectionFailure.mockReset();
+	mocks.recordPrReviewProjectionSuccess.mockReset();
 
 	mocks.getOrCreateAgent.mockResolvedValue("agent_01");
 	mocks.getOrCreateEnvironment.mockResolvedValue("env_01");
@@ -244,6 +256,19 @@ beforeEach(() => {
 	mocks.recordRunResult.mockResolvedValue(undefined);
 	mocks.releaseRunActiveClaim.mockResolvedValue(undefined);
 	mocks.listStartedPrReviewRuns.mockResolvedValue([]);
+	mocks.beginPrReviewProjectionAttempt.mockImplementation(
+		async (input: { type: string }) => ({
+			projectionId: `proj_${input.type}`,
+			desiredPayloadHash: "hash_01",
+			shouldProject: true,
+			attempts: 1,
+			state: "projecting",
+			observedExternalId: null,
+		}),
+	);
+	mocks.classifyPrReviewProjectionError.mockReturnValue("unknown");
+	mocks.recordPrReviewProjectionFailure.mockResolvedValue(undefined);
+	mocks.recordPrReviewProjectionSuccess.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -636,6 +661,23 @@ describe("processPendingPrReviewRuns", () => {
 			status: "completed",
 			githubReviewId: "4304929701",
 		});
+		expect(mocks.beginPrReviewProjectionAttempt).toHaveBeenCalledWith(
+			expect.objectContaining({
+				runFingerprint: "fp_486",
+				type: "github_review",
+				projectionKey: "final-review",
+				desiredPayload: expect.objectContaining({
+					repoFullName: "fairchild/workspaces",
+					prNumber: 486,
+					event: "COMMENT",
+					labels: ["refactor"],
+				}),
+			}),
+		);
+		expect(mocks.recordPrReviewProjectionSuccess).toHaveBeenCalledWith(
+			"proj_github_review",
+			{ observedExternalId: "4304929701" },
+		);
 		const statusPost = mocks.fetch.mock.calls.find(([url]) =>
 			String(url).includes("/statuses/head-sha"),
 		);
@@ -647,6 +689,112 @@ describe("processPendingPrReviewRuns", () => {
 			target_url:
 				"https://spaces.cloudcompute.com/dashboard/review-runs/fp_486",
 		});
+		expect(mocks.recordPrReviewProjectionSuccess).toHaveBeenCalledWith(
+			"proj_github_status",
+			{ observedExternalId: null },
+		);
+	});
+
+	it("skips duplicate GitHub review posts when the desired projection is already projected", async () => {
+		mocks.listStartedPrReviewRuns.mockResolvedValue([
+			{
+				fingerprint: "fp_duplicate_projection",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 487,
+				headSha: "head-sha",
+				triggerKind: "opened",
+				triggerSourceId: "head-sha",
+				sessionId: "sesn_duplicate_projection",
+				createdAt: "2026-05-17T06:24:27Z",
+				updatedAt: "2026-05-17T06:24:27Z",
+			},
+		]);
+		mocks.beginPrReviewProjectionAttempt.mockImplementation(
+			async (input: { type: string }) => ({
+				projectionId: `proj_${input.type}`,
+				desiredPayloadHash: "hash_01",
+				shouldProject: input.type !== "github_review",
+				attempts: 1,
+				state: input.type === "github_review" ? "projected" : "projecting",
+				observedExternalId:
+					input.type === "github_review" ? "4304929777" : null,
+			}),
+		);
+		mocks.listEvents.mockReturnValue(
+			asyncEvents([
+				{
+					type: "agent.message",
+					content: [
+						{
+							type: "text",
+							text: `Review complete.
+
+\`\`\`json
+{"event":"COMMENT","body":"No duplicate review please.","labels":[]}
+\`\`\``,
+						},
+					],
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "end_turn" },
+				},
+			]),
+		);
+		mocks.fetch.mockImplementation(
+			async (url: string, options?: RequestInit) => {
+				if (url.endsWith("/pulls/487")) {
+					return {
+						ok: true,
+						json: async () =>
+							githubPr(487, {
+								html_url: "https://github.com/fairchild/workspaces/pull/487",
+								head: { ref: "codex/no-duplicate", sha: "head-sha" },
+								base: { ref: "main" },
+							}),
+					};
+				}
+				if (url.includes("/pulls/487/reviews?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/pulls?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.includes("/labels?")) {
+					return { ok: true, json: async () => [] };
+				}
+				if (url.endsWith("/pulls/487/reviews") && options?.method === "POST") {
+					throw new Error("duplicate review post");
+				}
+				if (isManagedReviewStatusUrl(url)) {
+					return okResponse();
+				}
+				throw new Error(`Unexpected fetch URL: ${url}`);
+			},
+		);
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 1,
+			failed: 0,
+		});
+		expect(mocks.recordRunResult).toHaveBeenCalledWith(
+			"fp_duplicate_projection",
+			{
+				sessionId: "sesn_duplicate_projection",
+				status: "completed",
+				githubReviewId: "4304929777",
+			},
+		);
+		expect(
+			mocks.fetch.mock.calls.some(
+				([url, options]) =>
+					String(url).endsWith("/pulls/487/reviews") &&
+					options?.method === "POST",
+			),
+		).toBe(false);
 	});
 
 	it("posts an operator-visible failure comment when a completed intent cannot be published", async () => {

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -13,6 +13,22 @@ export type PrReviewProjectionStatus =
 	| "failed"
 	| "superseded";
 
+export type PrReviewProjectionType = "github_status" | "github_review";
+
+export type PrReviewProjectionLedgerState =
+	| "pending"
+	| "projecting"
+	| "projected"
+	| "failed"
+	| "superseded";
+
+export type PrReviewProjectionErrorKind =
+	| "auth"
+	| "rate_limit"
+	| "transient_api"
+	| "validation"
+	| "unknown";
+
 export type PrReviewFailureKind =
 	| "session_start_failed"
 	| "session_output_failed"
@@ -44,6 +60,7 @@ export interface PrReviewRunRecordInput extends PrReviewRunFingerprintInput {
 }
 
 let migrated = false;
+let projectionsMigrated = false;
 
 async function ensureRunsTable(): Promise<void> {
 	if (migrated) return;
@@ -120,6 +137,55 @@ async function ensureRunsTable(): Promise<void> {
 	migrated = true;
 }
 
+async function ensureProjectionLedgerTable(): Promise<void> {
+	await ensureRunsTable();
+	if (projectionsMigrated) return;
+	const db = getDb();
+	await db.schema
+		.createTable("managed_pr_review_projections")
+		.ifNotExists()
+		.addColumn("projection_id", "text", (c) => c.primaryKey())
+		.addColumn("run_fingerprint", "text", (c) => c.notNull())
+		.addColumn("projection_type", "text", (c) => c.notNull())
+		.addColumn("projection_key", "text", (c) => c.notNull())
+		.addColumn("desired_payload_hash", "text", (c) => c.notNull())
+		.addColumn("desired_payload", "text", (c) => c.notNull())
+		.addColumn("state", "text", (c) => c.notNull())
+		.addColumn("attempts", "integer", (c) => c.notNull().defaultTo(0))
+		.addColumn("last_attempted_at", "text")
+		.addColumn("observed_external_id", "text")
+		.addColumn("error_kind", "text")
+		.addColumn("error_text", "text")
+		.addColumn("created_at", "text", (c) => c.notNull())
+		.addColumn("updated_at", "text", (c) => c.notNull())
+		.execute();
+	await db.schema
+		.createIndex("ux_managed_pr_review_projections_desired")
+		.ifNotExists()
+		.on("managed_pr_review_projections")
+		.columns([
+			"run_fingerprint",
+			"projection_type",
+			"projection_key",
+			"desired_payload_hash",
+		])
+		.unique()
+		.execute();
+	await db.schema
+		.createIndex("idx_managed_pr_review_projections_run")
+		.ifNotExists()
+		.on("managed_pr_review_projections")
+		.column("run_fingerprint")
+		.execute();
+	await db.schema
+		.createIndex("idx_managed_pr_review_projections_state")
+		.ifNotExists()
+		.on("managed_pr_review_projections")
+		.columns(["state", "updated_at"])
+		.execute();
+	projectionsMigrated = true;
+}
+
 export function computeRunFingerprint(
 	input: PrReviewRunFingerprintInput,
 ): string {
@@ -134,6 +200,200 @@ export function computeRunFingerprint(
 	return createHash("sha256").update(payload).digest("hex").slice(0, 32);
 }
 
+function computeProjectionId(input: {
+	runFingerprint: string;
+	type: PrReviewProjectionType;
+	projectionKey: string;
+	desiredPayloadHash: string;
+}): string {
+	return createHash("sha256")
+		.update(
+			[
+				input.runFingerprint,
+				input.type,
+				input.projectionKey,
+				input.desiredPayloadHash,
+			].join("|"),
+		)
+		.digest("hex")
+		.slice(0, 32);
+}
+
+function normalizeProjectionPayload(
+	value: unknown,
+	options: { stringLimit: number | null },
+	depth = 0,
+): unknown {
+	if (value === null || typeof value === "boolean") return value;
+	if (typeof value === "number") return Number.isFinite(value) ? value : null;
+	if (typeof value === "string") {
+		const redacted = redactSensitiveText(value);
+		return options.stringLimit === null
+			? redacted
+			: truncateText(redacted, options.stringLimit);
+	}
+	if (Array.isArray(value)) {
+		if (depth >= MAX_PROJECTION_DEPTH) return "[truncated-depth]";
+		const items = value
+			.slice(0, MAX_PROJECTION_ARRAY_ITEMS)
+			.map((item) => normalizeProjectionPayload(item, options, depth + 1));
+		if (value.length > MAX_PROJECTION_ARRAY_ITEMS) {
+			items.push(
+				`[truncated ${value.length - MAX_PROJECTION_ARRAY_ITEMS} items]`,
+			);
+		}
+		return items;
+	}
+	if (typeof value === "object") {
+		if (depth >= MAX_PROJECTION_DEPTH) return "[truncated-depth]";
+		const input = value as Record<string, unknown>;
+		const output: Record<string, unknown> = {};
+		const keys = Object.keys(input).sort();
+		for (const key of keys.slice(0, MAX_PROJECTION_OBJECT_KEYS)) {
+			const item = input[key];
+			if (item === undefined || typeof item === "function") continue;
+			output[key] = SENSITIVE_PROJECTION_KEY.test(key)
+				? "[redacted]"
+				: normalizeProjectionPayload(item, options, depth + 1);
+		}
+		if (keys.length > MAX_PROJECTION_OBJECT_KEYS) {
+			output.__truncatedKeys = keys.length - MAX_PROJECTION_OBJECT_KEYS;
+		}
+		return output;
+	}
+	return String(value);
+}
+
+function stableProjectionJson(
+	value: unknown,
+	options: { stringLimit: number | null },
+): string {
+	return JSON.stringify(normalizeProjectionPayload(value, options));
+}
+
+function boundProjectionPayloadJson(canonicalJson: string): string {
+	if (canonicalJson.length <= MAX_PROJECTION_PAYLOAD_JSON_LENGTH) {
+		return canonicalJson;
+	}
+	let preview = canonicalJson.slice(0, MAX_PROJECTION_PAYLOAD_JSON_LENGTH);
+	let bounded = "";
+	while (preview.length > 0) {
+		bounded = JSON.stringify({
+			truncated: true,
+			originalLength: canonicalJson.length,
+			preview,
+		});
+		if (bounded.length <= MAX_PROJECTION_PAYLOAD_JSON_LENGTH) return bounded;
+		preview = preview.slice(0, -128);
+	}
+	return JSON.stringify({
+		truncated: true,
+		originalLength: canonicalJson.length,
+		preview: "",
+	});
+}
+
+function sanitizeProjectionError(
+	message: string | null | undefined,
+): string | null {
+	if (!message) return null;
+	return truncateText(
+		redactSensitiveText(message).replace(/\s+$/g, ""),
+		MAX_PROJECTION_ERROR_LENGTH,
+	);
+}
+
+export function classifyPrReviewProjectionError(input: {
+	status?: number | null;
+	message?: string | null;
+}): PrReviewProjectionErrorKind {
+	const status = input.status ?? null;
+	const lower = String(input.message ?? "").toLowerCase();
+	if (status === 401 || status === 403) return "auth";
+	if (
+		lower.includes("bad credentials") ||
+		lower.includes("unauthorized") ||
+		lower.includes("forbidden") ||
+		lower.includes("permission") ||
+		lower.includes("token")
+	) {
+		return "auth";
+	}
+	if (
+		status === 429 ||
+		lower.includes("rate limit") ||
+		lower.includes("secondary rate")
+	) {
+		return "rate_limit";
+	}
+	if (
+		status === 400 ||
+		status === 422 ||
+		lower.includes("validation") ||
+		lower.includes("invalid")
+	) {
+		return "validation";
+	}
+	if (
+		(status !== null && status >= 500) ||
+		lower.includes("timeout") ||
+		lower.includes("temporar") ||
+		lower.includes("econnreset") ||
+		lower.includes("fetch failed")
+	) {
+		return "transient_api";
+	}
+	return "unknown";
+}
+
+function prepareProjectionPayload(desiredPayload: unknown): {
+	desiredPayloadHash: string;
+	boundedPayloadJson: string;
+} {
+	const hashJson = stableProjectionJson(desiredPayload, { stringLimit: null });
+	const storageJson = stableProjectionJson(desiredPayload, {
+		stringLimit: MAX_PROJECTION_STRING_LENGTH,
+	});
+	return {
+		desiredPayloadHash: createHash("sha256").update(hashJson).digest("hex"),
+		boundedPayloadJson: boundProjectionPayloadJson(storageJson),
+	};
+}
+
+function normalizeProjectionLedgerState(
+	state: string,
+): PrReviewProjectionLedgerState {
+	if (
+		state === "pending" ||
+		state === "projecting" ||
+		state === "projected" ||
+		state === "failed" ||
+		state === "superseded"
+	) {
+		return state;
+	}
+	return "pending";
+}
+
+function normalizeProjectionType(type: string): PrReviewProjectionType {
+	return type === "github_review" ? "github_review" : "github_status";
+}
+
+function normalizeProjectionErrorKind(
+	kind: string | null,
+): PrReviewProjectionErrorKind | null {
+	if (
+		kind === "auth" ||
+		kind === "rate_limit" ||
+		kind === "transient_api" ||
+		kind === "validation" ||
+		kind === "unknown"
+	) {
+		return kind;
+	}
+	return null;
+}
+
 export interface RecordRunStartResult {
 	inserted: boolean;
 	priorStatus?: PrReviewRunStatus;
@@ -144,6 +404,12 @@ export interface RecordRunStartResult {
 /** Treat a `started` row older than this as crashed and eligible for retry. */
 const STALE_STARTED_MS = 15 * 60 * 1000;
 const MAX_FAILURE_MESSAGE_LENGTH = 600;
+const MAX_PROJECTION_ERROR_LENGTH = 600;
+const MAX_PROJECTION_STRING_LENGTH = 1000;
+const MAX_PROJECTION_PAYLOAD_JSON_LENGTH = 4096;
+const MAX_PROJECTION_ARRAY_ITEMS = 50;
+const MAX_PROJECTION_OBJECT_KEYS = 50;
+const MAX_PROJECTION_DEPTH = 6;
 
 const TOKEN_REDACTIONS: RegExp[] = [
 	/ghp_[A-Za-z0-9_]{20,}/g,
@@ -154,14 +420,27 @@ const TOKEN_REDACTIONS: RegExp[] = [
 	/\bsecret["'\s:=]+[A-Za-z0-9._-]{20,}/gi,
 ];
 
-function sanitizeFailureMessage(
-	message: string | null | undefined,
-): string | null {
-	if (!message) return null;
+const SENSITIVE_PROJECTION_KEY =
+	/(authorization|token|secret|password|private[_-]?key|raw[_-]?webhook|webhook[_-]?payload)/i;
+
+function redactSensitiveText(message: string): string {
 	let sanitized = message;
 	for (const pattern of TOKEN_REDACTIONS) {
 		sanitized = sanitized.replace(pattern, "[redacted]");
 	}
+	return sanitized;
+}
+
+function truncateText(value: string, limit: number): string {
+	if (value.length <= limit) return value;
+	return `${value.slice(0, limit - 1)}...`;
+}
+
+function sanitizeFailureMessage(
+	message: string | null | undefined,
+): string | null {
+	if (!message) return null;
+	let sanitized = redactSensitiveText(message);
 	sanitized = sanitized.replace(/\s+$/g, "");
 	if (sanitized.length <= MAX_FAILURE_MESSAGE_LENGTH) return sanitized;
 	return `${sanitized.slice(0, MAX_FAILURE_MESSAGE_LENGTH - 1)}...`;
@@ -540,6 +819,220 @@ export async function recordRunStart(
 	return { inserted: true, priorStatus };
 }
 
+export interface PrReviewProjectionRecord {
+	projectionId: string;
+	runFingerprint: string;
+	type: PrReviewProjectionType;
+	projectionKey: string;
+	desiredPayloadHash: string;
+	desiredPayload: unknown;
+	state: PrReviewProjectionLedgerState;
+	attempts: number;
+	lastAttemptedAt: string | null;
+	observedExternalId: string | null;
+	errorKind: PrReviewProjectionErrorKind | null;
+	errorText: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface BeginPrReviewProjectionAttemptInput {
+	runFingerprint: string;
+	type: PrReviewProjectionType;
+	projectionKey: string;
+	desiredPayload: unknown;
+}
+
+export interface BeginPrReviewProjectionAttemptResult {
+	projectionId: string;
+	desiredPayloadHash: string;
+	shouldProject: boolean;
+	attempts: number;
+	state: PrReviewProjectionLedgerState;
+	observedExternalId: string | null;
+}
+
+function parseStoredProjectionPayload(payload: string): unknown {
+	try {
+		return JSON.parse(payload);
+	} catch {
+		return { unparseable: true };
+	}
+}
+
+function mapProjectionRecord(row: {
+	projection_id: string;
+	run_fingerprint: string;
+	projection_type: string;
+	projection_key: string;
+	desired_payload_hash: string;
+	desired_payload: string;
+	state: string;
+	attempts: number;
+	last_attempted_at: string | null;
+	observed_external_id: string | null;
+	error_kind: string | null;
+	error_text: string | null;
+	created_at: string;
+	updated_at: string;
+}): PrReviewProjectionRecord {
+	return {
+		projectionId: row.projection_id,
+		runFingerprint: row.run_fingerprint,
+		type: normalizeProjectionType(row.projection_type),
+		projectionKey: row.projection_key,
+		desiredPayloadHash: row.desired_payload_hash,
+		desiredPayload: parseStoredProjectionPayload(row.desired_payload),
+		state: normalizeProjectionLedgerState(row.state),
+		attempts: Number(row.attempts ?? 0),
+		lastAttemptedAt: row.last_attempted_at,
+		observedExternalId: row.observed_external_id,
+		errorKind: normalizeProjectionErrorKind(row.error_kind),
+		errorText: sanitizeProjectionError(row.error_text),
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export async function beginPrReviewProjectionAttempt(
+	input: BeginPrReviewProjectionAttemptInput,
+): Promise<BeginPrReviewProjectionAttemptResult> {
+	await ensureProjectionLedgerTable();
+	const now = new Date().toISOString();
+	const { desiredPayloadHash, boundedPayloadJson } = prepareProjectionPayload(
+		input.desiredPayload,
+	);
+	const projectionId = computeProjectionId({
+		runFingerprint: input.runFingerprint,
+		type: input.type,
+		projectionKey: input.projectionKey,
+		desiredPayloadHash,
+	});
+	const db = getDb();
+	await db
+		.insertInto("managed_pr_review_projections")
+		.values({
+			projection_id: projectionId,
+			run_fingerprint: input.runFingerprint,
+			projection_type: input.type,
+			projection_key: input.projectionKey,
+			desired_payload_hash: desiredPayloadHash,
+			desired_payload: boundedPayloadJson,
+			state: "pending",
+			attempts: 0,
+			last_attempted_at: null,
+			observed_external_id: null,
+			error_kind: null,
+			error_text: null,
+			created_at: now,
+			updated_at: now,
+		})
+		.onConflict((oc) => oc.doNothing())
+		.executeTakeFirst();
+
+	const existing = await db
+		.selectFrom("managed_pr_review_projections")
+		.select([
+			"state",
+			"attempts",
+			"observed_external_id",
+			"desired_payload_hash",
+		])
+		.where("projection_id", "=", projectionId)
+		.executeTakeFirstOrThrow();
+	const existingState = normalizeProjectionLedgerState(existing.state);
+	if (existingState === "projected") {
+		return {
+			projectionId,
+			desiredPayloadHash: existing.desired_payload_hash,
+			shouldProject: false,
+			attempts: Number(existing.attempts ?? 0),
+			state: existingState,
+			observedExternalId: existing.observed_external_id,
+		};
+	}
+
+	const attempts = Number(existing.attempts ?? 0) + 1;
+	await db
+		.updateTable("managed_pr_review_projections")
+		.set({
+			state: "projecting",
+			attempts,
+			last_attempted_at: now,
+			error_kind: null,
+			error_text: null,
+			updated_at: now,
+		})
+		.where("projection_id", "=", projectionId)
+		.execute();
+	return {
+		projectionId,
+		desiredPayloadHash,
+		shouldProject: true,
+		attempts,
+		state: "projecting",
+		observedExternalId: existing.observed_external_id,
+	};
+}
+
+export async function recordPrReviewProjectionSuccess(
+	projectionId: string,
+	input: { observedExternalId?: string | null } = {},
+): Promise<void> {
+	await ensureProjectionLedgerTable();
+	const now = new Date().toISOString();
+	const updates = {
+		state: "projected" as const,
+		error_kind: null,
+		error_text: null,
+		updated_at: now,
+		// Omitted means "no new GitHub ID", not "erase the known GitHub ID".
+		...(input.observedExternalId !== undefined
+			? { observed_external_id: input.observedExternalId }
+			: {}),
+	};
+	await getDb()
+		.updateTable("managed_pr_review_projections")
+		.set(updates)
+		.where("projection_id", "=", projectionId)
+		.execute();
+}
+
+export async function recordPrReviewProjectionFailure(
+	projectionId: string,
+	input: {
+		errorKind: PrReviewProjectionErrorKind;
+		errorText: string;
+	},
+): Promise<void> {
+	await ensureProjectionLedgerTable();
+	const now = new Date().toISOString();
+	await getDb()
+		.updateTable("managed_pr_review_projections")
+		.set({
+			state: "failed",
+			error_kind: input.errorKind,
+			error_text: sanitizeProjectionError(input.errorText),
+			updated_at: now,
+		})
+		.where("projection_id", "=", projectionId)
+		.execute();
+}
+
+export async function listPrReviewProjectionsForRun(
+	runFingerprint: string,
+): Promise<PrReviewProjectionRecord[]> {
+	await ensureProjectionLedgerTable();
+	const rows = await getDb()
+		.selectFrom("managed_pr_review_projections")
+		.selectAll()
+		.where("run_fingerprint", "=", runFingerprint)
+		.orderBy("created_at", "asc")
+		.orderBy("projection_type", "asc")
+		.execute();
+	return rows.map(mapProjectionRecord);
+}
+
 export interface RecordRunResultInput {
 	sessionId: string | null;
 	status: PrReviewRunStatus;
@@ -783,6 +1276,7 @@ export interface PrReviewRunSummary {
 
 export interface PrReviewRunDetails extends PrReviewRunSummary {
 	reviewerConfigHash: string;
+	projections: PrReviewProjectionRecord[];
 }
 
 export interface StartedPrReviewRun {
@@ -880,6 +1374,7 @@ function mapRunDetails(row: {
 		coalescedTriggerKind: row.coalesced_trigger_kind,
 		coalescedTriggerSourceId: row.coalesced_trigger_source_id,
 		coalescedAt: row.coalesced_at,
+		projections: [],
 	};
 }
 
@@ -893,7 +1388,12 @@ export async function getPrReviewRunByFingerprint(
 		.where("fingerprint", "=", fingerprint)
 		.executeTakeFirst();
 
-	return row ? mapRunDetails(row) : null;
+	if (!row) return null;
+	const run = mapRunDetails(row);
+	return {
+		...run,
+		projections: await listPrReviewProjectionsForRun(run.fingerprint),
+	};
 }
 
 export async function getPrReviewRunBySessionId(
@@ -906,7 +1406,12 @@ export async function getPrReviewRunBySessionId(
 		.where("session_id", "=", sessionId)
 		.executeTakeFirst();
 
-	return row ? mapRunDetails(row) : null;
+	if (!row) return null;
+	const run = mapRunDetails(row);
+	return {
+		...run,
+		projections: await listPrReviewProjectionsForRun(run.fingerprint),
+	};
 }
 
 export async function listRecentPrReviewRuns(input: {
@@ -1167,4 +1672,5 @@ export async function listStartedPrReviewRuns(
 /** Test-only hook so per-test in-memory DBs re-run table creation. */
 export function __resetPrReviewRunsForTests(): void {
 	migrated = false;
+	projectionsMigrated = false;
 }

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -8,8 +8,12 @@ import {
 } from "./managed-agents-cache";
 import {
 	type StartedPrReviewRun,
+	beginPrReviewProjectionAttempt,
+	classifyPrReviewProjectionError,
 	computeRunFingerprint,
 	listStartedPrReviewRuns,
+	recordPrReviewProjectionFailure,
+	recordPrReviewProjectionSuccess,
 	recordRunResult,
 	recordRunStart,
 	releaseRunActiveClaim,
@@ -724,6 +728,7 @@ async function postGitHubReviewIntent(
 	githubToken: string,
 	payload: PrReviewPayload,
 	intent: PrReviewIntent,
+	options: { fingerprint?: string } = {},
 ): Promise<{ reviewId: string | null }> {
 	const [owner, repo] = payload.repoFullName.split("/");
 	if (!owner || !repo) {
@@ -736,18 +741,58 @@ async function postGitHubReviewIntent(
 		"X-GitHub-Api-Version": "2022-11-28",
 		"Content-Type": "application/json",
 	};
-	const reviewRes = await fetch(
-		`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${payload.number}/reviews`,
-		{
-			method: "POST",
-			headers,
-			body: JSON.stringify({ event: intent.event, body: intent.body }),
-		},
-	);
-	if (!reviewRes.ok) {
-		throw new Error(
-			`GitHub review post failed ${reviewRes.status}: ${await reviewRes.text()}`,
+
+	const projection = options.fingerprint
+		? await beginPrReviewProjectionAttempt({
+				runFingerprint: options.fingerprint,
+				type: "github_review",
+				projectionKey: "final-review",
+				desiredPayload: {
+					repoFullName: payload.repoFullName,
+					prNumber: payload.number,
+					event: intent.event,
+					body: intent.body,
+					labels: intent.labels,
+				},
+			})
+		: null;
+	if (projection && !projection.shouldProject) {
+		return { reviewId: projection.observedExternalId };
+	}
+
+	let reviewRes: Response;
+	try {
+		reviewRes = await fetch(
+			`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${payload.number}/reviews`,
+			{
+				method: "POST",
+				headers,
+				body: JSON.stringify({ event: intent.event, body: intent.body }),
+			},
 		);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (projection) {
+			await recordPrReviewProjectionFailure(projection.projectionId, {
+				errorKind: classifyPrReviewProjectionError({ message }),
+				errorText: message,
+			});
+		}
+		throw err;
+	}
+	if (!reviewRes.ok) {
+		const responseText = await reviewRes.text();
+		const message = `GitHub review post failed ${reviewRes.status}: ${responseText}`;
+		if (projection) {
+			await recordPrReviewProjectionFailure(projection.projectionId, {
+				errorKind: classifyPrReviewProjectionError({
+					status: reviewRes.status,
+					message: responseText,
+				}),
+				errorText: message,
+			});
+		}
+		throw new Error(message);
 	}
 	const reviewJson = (await reviewRes.json().catch(() => null)) as {
 		id?: unknown;
@@ -756,6 +801,11 @@ async function postGitHubReviewIntent(
 		reviewJson?.id !== undefined && reviewJson.id !== null
 			? String(reviewJson.id)
 			: null;
+	if (projection) {
+		await recordPrReviewProjectionSuccess(projection.projectionId, {
+			observedExternalId: reviewId,
+		});
+	}
 
 	if (intent.labels.length === 0) return { reviewId };
 
@@ -886,6 +936,26 @@ async function postManagedReviewStatus(
 		return;
 	}
 
+	const statusBody = {
+		state,
+		context: MANAGED_REVIEW_STATUS_CONTEXT,
+		description,
+		target_url: buildManagedReviewStatusTargetUrl(payload),
+	};
+	const projection = payload.fingerprint
+		? await beginPrReviewProjectionAttempt({
+				runFingerprint: payload.fingerprint,
+				type: "github_status",
+				projectionKey: MANAGED_REVIEW_STATUS_CONTEXT,
+				desiredPayload: {
+					repoFullName: payload.repoFullName,
+					headSha: payload.headSha,
+					...statusBody,
+				},
+			})
+		: null;
+	if (projection && !projection.shouldProject) return;
+
 	try {
 		const res = await fetch(
 			`${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/statuses/${encodeURIComponent(payload.headSha)}`,
@@ -897,20 +967,44 @@ async function postManagedReviewStatus(
 					"X-GitHub-Api-Version": "2022-11-28",
 					"Content-Type": "application/json",
 				},
-				body: JSON.stringify({
-					state,
-					context: MANAGED_REVIEW_STATUS_CONTEXT,
-					description,
-					target_url: buildManagedReviewStatusTargetUrl(payload),
-				}),
+				body: JSON.stringify(statusBody),
 			},
 		);
 		if (!res.ok) {
+			const responseText = await res.text();
+			if (projection) {
+				await recordPrReviewProjectionFailure(projection.projectionId, {
+					errorKind: classifyPrReviewProjectionError({
+						status: res.status,
+						message: responseText,
+					}),
+					errorText: `GitHub status update failed ${res.status}: ${responseText}`,
+				});
+			}
 			console.warn(
-				`[pr-review] managed review status update failed ${res.status}: ${await res.text()}`,
+				`[pr-review] managed review status update failed ${res.status}: ${responseText}`,
 			);
+			return;
+		}
+		const statusJson = (await res.json().catch(() => null)) as {
+			id?: unknown;
+		} | null;
+		if (projection) {
+			await recordPrReviewProjectionSuccess(projection.projectionId, {
+				observedExternalId:
+					statusJson?.id !== undefined && statusJson.id !== null
+						? String(statusJson.id)
+						: null,
+			});
 		}
 	} catch (err) {
+		if (projection) {
+			const message = err instanceof Error ? err.message : String(err);
+			await recordPrReviewProjectionFailure(projection.projectionId, {
+				errorKind: classifyPrReviewProjectionError({ message }),
+				errorText: message,
+			});
+		}
 		console.warn(
 			"[pr-review] managed review status update failed:",
 			err instanceof Error ? err.message : err,
@@ -1224,6 +1318,7 @@ export async function processPendingPrReviewRuns(
 				githubToken,
 				payload,
 				intent,
+				{ fingerprint: run.fingerprint },
 			);
 			await postManagedReviewStatus(
 				githubToken,

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -100,6 +100,23 @@ export interface ManagedPrReviewRunsTable {
 	coalesced_at: string | null;
 }
 
+export interface ManagedPrReviewProjectionsTable {
+	projection_id: string;
+	run_fingerprint: string;
+	projection_type: string;
+	projection_key: string;
+	desired_payload_hash: string;
+	desired_payload: string;
+	state: string;
+	attempts: number;
+	last_attempted_at: string | null;
+	observed_external_id: string | null;
+	error_kind: string | null;
+	error_text: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
 interface Database {
 	webhook_events: EventsTable;
 	chat_messages: ChatMessagesTable;
@@ -108,6 +125,7 @@ interface Database {
 	base_snapshots: BaseSnapshotsTable;
 	managed_agents_cache: ManagedAgentsCacheTable;
 	managed_pr_review_runs: ManagedPrReviewRunsTable;
+	managed_pr_review_projections: ManagedPrReviewProjectionsTable;
 }
 
 let _turso: Client | undefined;


### PR DESCRIPTION
## Summary
- Add a durable managed PR review projection ledger for GitHub status and review writes.
- Make GitHub status/review publishing idempotent against recorded desired projections.
- Show projection state on the review-run details page/API without exposing raw webhook payloads or unbounded output.

## Mergeability
- Surface: web / agent-runtime
- User-facing behavior changed: review-run details now include a GitHub projections section; existing PR review/status behavior is intended to remain unchanged.
- Non-happy paths considered: projection failures are persisted with bounded operator-safe error kinds/text, and failed desired projections retry against the same ledger row.
- Release/ops preconditions: none; schema change is additive and created through the existing LibSQL/Kysely runtime table setup.
- Residual risk or follow-up: #589 still needs to make completed ReviewRuns repairable without rerunning the managed agent; this PR only adds the ledger and publishing integration.

Closes #587

## Validation
- [x] `mise -C web run web:check` passed: typecheck, Biome, Vitest 28 files / 309 tests.
- [x] `UV_CACHE_DIR=/tmp/uv-cache ./scripts/tests/test_security_hardening.py` passed: 29 tests.
- [x] `git diff --check origin/main...HEAD` passed.

## Performance
- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence
- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

![validation](https://evidence.cloudcompute.com/workspaces/pr-597/20260531-223116-validation.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
