### PR TITLE
Make managed review health ReviewRun-first

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -98,13 +98,32 @@ the `statuses:write` permission.
 
 ### Health monitoring
 
-Managed-reviewer coverage is summarized by
+ReviewRun rows are the source of truth for managed-reviewer health. Start with
+`scripts/pr-reviewer-runs.py` or the protected
+`/api/webhooks/github/pr-reviewer-monitor` route when diagnosing the queue. The
+report groups rows into `starting`, `stuckStarting`, `running`,
+`runningTooLong`, `completedAwaitingProjection`, `failedExecution`,
+`projectionFailed`, `superseded`, and `published`, and includes pickup,
+execution, and projection latency signals where the row has enough timestamps.
+
+Interpret the ReviewRun report as:
+
+- `healthy`: no missing coalesced ReviewRun keys and no row has breached an SLO
+  or stored a failure.
+- `degraded`: ReviewRuns are present and within SLO, but at least one completed
+  run is awaiting GitHub projection.
+- `unhealthy`: a coalesced ReviewRun key is missing, pickup/execution/projection
+  SLOs have been breached, or an execution/projection failure is stored.
+
+GitHub-facing projection drift is audited separately by
 `scripts/pr-review-health.py` and `.github/workflows/managed-reviewer-health.yml`.
-The workflow runs on a schedule and can be dispatched manually. It checks recent
-open PRs for the `WorkSpaces Managed Review` status, stale pending pickup,
+That workflow runs on a schedule and can be dispatched manually. It checks recent
+open PRs for the `WorkSpaces Managed Review` status, stale pending status,
 failure statuses, and success statuses that do not have a current-head managed
 review. Older or draft PRs are reported but skipped by default so pre-indicator
-branches do not keep the health job red forever.
+branches do not keep the projection-audit job red forever. Do not treat a green
+projection audit as proof that ReviewRun ingestion, session execution, or broker
+projection is healthy.
 
 The Cloudflare relay forwards only managed-review trigger candidates:
 `pull_request.opened`, `reopened`, `ready_for_review`, `synchronize`, eligible
@@ -170,12 +189,14 @@ uv run --script scripts/pr-reviewer-runs.py
 ```
 
 Use the report as the first read of production health. `missingRuns` means a
-reviewer-eligible webhook did not create a `managed_pr_review_runs` row.
-`executing` means the managed-agent session has been created and the GitHub
-projection is still inside the normal window. `needsProjection` means the row is
-old enough that the broker should have posted the GitHub review or failure
-status. `failed` shows agent or projection failures with the stored reason and a
-details URL.
+coalesced reviewer-eligible key did not create a `managed_pr_review_runs` row.
+`running` means the managed-agent session has been created and remains inside
+the execution SLO. `runningTooLong` means the session exceeded the execution
+SLO. `completedAwaitingProjection` means the broker still needs to publish or
+repair GitHub projection for a completed run. `failedExecution` and
+`projectionFailed` separate managed-agent failures from GitHub projection
+failures. Actionable run rows include details URLs for inspecting the stored
+metadata and transcript.
 
 The Worker requires `WORKSPACES_WEBHOOK_CANARY_SECRET`, signs a canonical
 reviewer-eligible PR payload with `GITHUB_WEBHOOK_SECRET`, forwards it to the
@@ -197,11 +218,10 @@ marks that run `superseded`, and starts exactly one follow-up session against th
 latest PR state. If the superseding review is for an older head, the broker
 starts a fresh follow-up session so the newer-head review includes the prior
 review context. The run report compares recent
-reviewer-eligible rows in `webhook_events` with `managed_pr_review_runs`
-records and classifies ReviewRun rows into starting, executing,
-needs-projection, failed, and terminal buckets. Broker and report routes return
-only run metadata, details URLs, stored failure reasons, and missing event
-identifiers, not raw payloads or secrets.
+reviewer-eligible rows in `webhook_events` with coalesced ReviewRun keys from
+`managed_pr_review_runs` records and classifies rows into source-of-truth health
+buckets. Broker and report routes return only run metadata, details URLs, stored
+failure reasons, and missing event identifiers, not raw payloads or secrets.
 
 ## Observing Sessions
 

--- a/scripts/pr-review-health.py
+++ b/scripts/pr-review-health.py
@@ -3,10 +3,11 @@
 # requires-python = ">=3.11"
 # dependencies = []
 # ///
-"""Summarize managed PR reviewer health across recent open pull requests.
+"""Audit managed PR reviewer GitHub projection drift on recent open PRs.
 
-This is an operational monitor for the WorkSpaces managed PR reviewer, not a
-general "all open PRs are mergeable" gate.
+This is a GitHub-facing projection audit for the WorkSpaces managed PR
+reviewer, not the source-of-truth ReviewRun health report and not a general "all
+open PRs are mergeable" gate.
 
 Use ``scripts/pr-reviewer-runs.py`` when you need the ReviewRun database view:
 trigger rows, executing sessions, projection-due rows, and stored failures. This
@@ -342,8 +343,10 @@ def result_summary(result: PullRequestResult) -> str:
 
 def render_markdown(report: HealthReport, *, updated_within: timedelta, pending_timeout: timedelta) -> str:
     lines = [
-        "## Managed Reviewer Health",
+        "## Managed Reviewer GitHub Projection Audit",
         "",
+        "- Source of truth: ReviewRun health comes from `scripts/pr-reviewer-runs.py`",
+        "- This audit checks GitHub status/review drift on open PRs",
         f"- Scope: open PRs updated within {format_timedelta(updated_within)}",
         f"- Pending timeout: {format_timedelta(pending_timeout)}",
         f"- Active PRs checked: {len(report.active_results)}",

--- a/scripts/pr-reviewer-runs.py
+++ b/scripts/pr-reviewer-runs.py
@@ -14,19 +14,25 @@ prints the current queue in operator terms:
 - ``starting``: a ReviewRun row exists, but the managed-agent session id has not
   been recorded yet. Briefly normal immediately after pickup.
 - ``stuckStarting``: a starting row is old enough to need attention.
-- ``executing``: a managed-agent session exists and its GitHub projection is
-  still inside the normal window.
-- ``needsProjection``: the agent run is old enough that the broker should have
-  posted a GitHub review or failure status by now.
-- ``failed``: either the agent lifecycle or GitHub projection failed and stored
-  a reason.
-- ``terminal``: completed or superseded rows. These are counted, but omitted
-  from the terse text output unless ``--json`` is used.
+- ``running``: a managed-agent session exists and is still inside the execution
+  SLO.
+- ``runningTooLong``: a managed-agent session has exceeded the execution SLO.
+- ``completedAwaitingProjection``: the agent completed and the broker still
+  needs to publish or repair the GitHub projection.
+- ``failedExecution``: the agent/session lifecycle failed and stored a reason.
+- ``projectionFailed``: the ReviewRun completed, but GitHub projection failed.
+- ``superseded``: a newer run or managed review intentionally replaced this row.
+- ``published``: the ReviewRun has been projected to GitHub.
+
+GitHub status/review drift is intentionally separate. Run
+``scripts/pr-review-health.py`` when you need the GitHub-facing projection audit
+for open PRs.
 
 The script is read-only. It does not run the broker, create sessions, or post
-GitHub statuses. Exit code 0 means the monitor reported healthy, 1 means the
-monitor returned attention-needed state, and 2 means the report could not be
-fetched or parsed.
+GitHub statuses. Exit code 0 means the monitor reported no unhealthy
+attention-needed state (healthy or degraded), 1 means the monitor returned
+unhealthy attention-needed state, and 2 means the report could not be fetched or
+parsed.
 """
 
 from __future__ import annotations
@@ -121,6 +127,10 @@ def as_int(payload: dict[str, Any], key: str) -> int:
     return value if isinstance(value, int) else 0
 
 
+def format_optional_minutes(value: object) -> str:
+    return f"{value}m" if isinstance(value, int) else "-"
+
+
 def run_buckets(payload: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     runs = payload.get("runs")
     if not isinstance(runs, dict):
@@ -147,10 +157,22 @@ def print_run_bucket(label: str, runs: list[dict[str, Any]]) -> None:
         state = run.get("state", "-")
         session_id = run.get("sessionId")
         details_url = run.get("detailsUrl")
+        latencies = []
+        for label_key, run_key in (
+            ("pickup", "pickupLatencyMinutes"),
+            ("execution", "executionDurationMinutes"),
+            ("projection", "projectionLatencyMinutes"),
+        ):
+            value = run.get(run_key)
+            if isinstance(value, int):
+                latencies.append(f"{label_key}={value}m")
+        latency_text = f", {' '.join(latencies)}" if latencies else ""
         print(
             f"  - PR #{pr_number} {short_sha} {state} "
-            f"(agent={agent_status}, projection={projection_status}), age {age}m"
+            f"(agent={agent_status}, projection={projection_status}), age {age}m{latency_text}"
         )
+        if run.get("sloBreached") is True:
+            print("    slo: breached")
         if session_id:
             print(f"    session: {session_id}")
         if run.get("githubReviewId"):
@@ -164,47 +186,85 @@ def print_run_bucket(label: str, runs: list[dict[str, Any]]) -> None:
 
 
 def print_report(status: int, payload: dict[str, Any]) -> None:
-    health = "healthy" if payload.get("ok") is True else "attention needed"
+    health = str(
+        payload.get("health")
+        or ("healthy" if payload.get("ok") is True else "attention needed")
+    )
     repo = payload.get("repo", "unknown repo")
     window = payload.get("windowMinutes", "?")
     print(f"ReviewRun report for {repo} over {window}m: {health} (HTTP {status})")
     print(
         "events "
         f"eligible={as_int(payload, 'eligibleEvents')} "
-        f"missing={as_int(payload, 'missingRuns')} "
+        f"run_keys={as_int(payload, 'eligibleRunKeys')} "
+        f"missing_keys={as_int(payload, 'missingRunKeys') or as_int(payload, 'missingRuns')} "
         f"attention={as_int(payload, 'attentionRequired')}"
     )
     print(
         "runs "
         f"starting={as_int(payload, 'starting')} "
         f"stuckStarting={as_int(payload, 'stuckStarting')} "
-        f"executing={as_int(payload, 'executing')} "
-        f"needsProjection={as_int(payload, 'needsProjection')} "
-        f"failed={as_int(payload, 'failed')} "
-        f"terminal={as_int(payload, 'terminal')}"
+        f"running={as_int(payload, 'running')} "
+        f"runningTooLong={as_int(payload, 'runningTooLong')} "
+        f"completedAwaitingProjection={as_int(payload, 'completedAwaitingProjection')} "
+        f"failedExecution={as_int(payload, 'failedExecution')} "
+        f"projectionFailed={as_int(payload, 'projectionFailed')} "
+        f"superseded={as_int(payload, 'superseded')} "
+        f"published={as_int(payload, 'published')}"
     )
+    print(
+        "signals "
+        f"failedRuns={as_int(payload, 'failedRunCount')} "
+        f"projectionFailed={as_int(payload, 'projectionFailedCount')} "
+        f"staleOrSuperseded={as_int(payload, 'staleOrSupersededCount')}"
+    )
+    slo = payload.get("slo")
+    if isinstance(slo, dict):
+        print(
+            "slo "
+            f"pickup<={format_optional_minutes(slo.get('pickupTimeoutMinutes'))} "
+            f"execution<={format_optional_minutes(slo.get('runningTimeoutMinutes'))} "
+            f"projection<={format_optional_minutes(slo.get('projectionTimeoutMinutes'))} "
+            f"maxPickup={format_optional_minutes(slo.get('maxPickupLatencyMinutes'))} "
+            f"maxExecution={format_optional_minutes(slo.get('maxExecutionDurationMinutes'))} "
+            f"maxProjection={format_optional_minutes(slo.get('maxProjectionLatencyMinutes'))}"
+        )
+    projection_audit = payload.get("githubProjectionAudit")
+    if isinstance(projection_audit, dict):
+        print(
+            "github projection audit: "
+            f"{projection_audit.get('status', 'not_checked')} "
+            f"({projection_audit.get('script', 'scripts/pr-review-health.py')})"
+        )
 
     missing = payload.get("missing")
     if isinstance(missing, list) and missing:
-        print("\nMissing run rows:")
+        print("\nMissing ReviewRun keys:")
         for item in missing:
             if not isinstance(item, dict):
                 continue
             print(
                 "  - "
-                f"event={item.get('eventId', '?')} "
+                f"key={item.get('key', '?')} "
+                f"events={item.get('eventCount', '?')} "
                 f"PR #{item.get('prNumber', '?')} "
                 f"{item.get('triggerKind', '?')} "
                 f"{str(item.get('headSha', ''))[:7] or '-'}"
             )
 
     buckets = run_buckets(payload)
-    # Print attention buckets before normal progress buckets; terminal rows stay
+    # Print attention buckets before normal progress buckets; published rows stay
     # available in --json without making the default report noisy.
     print_run_bucket("Stuck starting", buckets.get("stuckStarting", []))
-    print_run_bucket("Needs projection", buckets.get("needsProjection", []))
-    print_run_bucket("Failed", buckets.get("failed", []))
-    print_run_bucket("Executing", buckets.get("executing", []))
+    print_run_bucket("Running too long", buckets.get("runningTooLong", []))
+    print_run_bucket(
+        "Completed awaiting projection",
+        buckets.get("completedAwaitingProjection", []),
+    )
+    print_run_bucket("Failed execution", buckets.get("failedExecution", []))
+    print_run_bucket("Projection failed", buckets.get("projectionFailed", []))
+    print_run_bucket("Superseded", buckets.get("superseded", []))
+    print_run_bucket("Running", buckets.get("running", []))
     print_run_bucket("Starting", buckets.get("starting", []))
 
 

--- a/scripts/tests/test_pr_review_health.py
+++ b/scripts/tests/test_pr_review_health.py
@@ -183,6 +183,8 @@ class PRReviewHealthTests(unittest.TestCase):
             pending_timeout=timedelta(minutes=30),
         )
 
+        self.assertIn("## Managed Reviewer GitHub Projection Audit", rendered)
+        self.assertIn("ReviewRun health comes from `scripts/pr-reviewer-runs.py`", rendered)
         self.assertIn("pending within timeout; PR merge state is blocked", rendered)
 
     def test_render_markdown_does_not_treat_skipped_prs_as_global_health(self) -> None:

--- a/scripts/tests/test_pr_reviewer_runs.py
+++ b/scripts/tests/test_pr_reviewer_runs.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for the ReviewRun operator report renderer."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pr-reviewer-runs.py"
+
+spec = importlib.util.spec_from_file_location("pr_reviewer_runs", SCRIPT_PATH)
+assert spec and spec.loader
+pr_reviewer_runs = importlib.util.module_from_spec(spec)
+sys.modules["pr_reviewer_runs"] = pr_reviewer_runs
+spec.loader.exec_module(pr_reviewer_runs)
+
+
+class PRReviewerRunsTests(unittest.TestCase):
+    def test_print_report_uses_reviewrun_buckets_and_separate_projection_audit(self) -> None:
+        payload = {
+            "ok": False,
+            "health": "unhealthy",
+            "repo": "fairchild/workspaces",
+            "windowMinutes": 90,
+            "eligibleEvents": 3,
+            "eligibleRunKeys": 2,
+            "missingRunKeys": 1,
+            "attentionRequired": 2,
+            "starting": 0,
+            "stuckStarting": 0,
+            "running": 0,
+            "runningTooLong": 1,
+            "completedAwaitingProjection": 1,
+            "failedExecution": 0,
+            "projectionFailed": 1,
+            "superseded": 1,
+            "published": 4,
+            "failedRunCount": 0,
+            "projectionFailedCount": 1,
+            "staleOrSupersededCount": 2,
+            "slo": {
+                "pickupTimeoutMinutes": 5,
+                "runningTimeoutMinutes": 45,
+                "projectionTimeoutMinutes": 30,
+                "maxPickupLatencyMinutes": 4,
+                "maxExecutionDurationMinutes": 53,
+                "maxProjectionLatencyMinutes": 31,
+            },
+            "githubProjectionAudit": {
+                "status": "not_checked",
+                "script": "scripts/pr-review-health.py",
+            },
+            "missing": [
+                {
+                    "key": "fairchild/workspaces|590|abc123",
+                    "eventCount": 2,
+                    "prNumber": 590,
+                    "triggerKind": "synchronize",
+                    "headSha": "abc123456",
+                }
+            ],
+            "runs": {
+                "runningTooLong": [
+                    {
+                        "prNumber": 590,
+                        "shortHeadSha": "abc1234",
+                        "state": "running_too_long",
+                        "agentStatus": "started",
+                        "projectionStatus": "pending",
+                        "ageMinutes": 53,
+                        "executionDurationMinutes": 53,
+                        "sloBreached": True,
+                        "sessionId": "sesn_slow",
+                        "detailsUrl": "https://spaces.cloudcompute.com/dashboard/review-runs/fp_slow",
+                    }
+                ],
+                "completedAwaitingProjection": [],
+                "projectionFailed": [],
+                "superseded": [],
+            },
+        }
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            pr_reviewer_runs.print_report(503, payload)
+
+        rendered = output.getvalue()
+        self.assertIn("ReviewRun report for fairchild/workspaces over 90m: unhealthy", rendered)
+        self.assertIn("events eligible=3 run_keys=2 missing_keys=1 attention=2", rendered)
+        self.assertIn("projectionFailed=1", rendered)
+        self.assertIn("github projection audit: not_checked (scripts/pr-review-health.py)", rendered)
+        self.assertIn("Missing ReviewRun keys:", rendered)
+        self.assertIn("key=fairchild/workspaces|590|abc123 events=2", rendered)
+        self.assertIn("Running too long:", rendered)
+        self.assertIn("details: https://spaces.cloudcompute.com/dashboard/review-runs/fp_slow", rendered)
+        self.assertIn("slo: breached", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
@@ -62,19 +62,38 @@ function runRow(
 		projectionUpdatedAt: string;
 		projectionError: string | null;
 		githubReviewId: string | null;
+		executionState:
+			| "waiting_for_session"
+			| "running_session"
+			| "completed"
+			| "failed"
+			| "superseded";
+		latestKnownHeadSha: string;
+		failureKind: string | null;
+		failureMessage: string | null;
+		failureRetryable: boolean | null;
+		failedAt: string | null;
+		nextAction: string;
+		coalescedHeadSha: string | null;
+		coalescedTriggerKind: string | null;
+		coalescedTriggerSourceId: string | null;
+		coalescedAt: string | null;
 	}> = {},
 ) {
 	const now = new Date().toISOString();
 	const status = overrides.status ?? "started";
+	const headSha = overrides.headSha ?? "abc8101def456";
+	const sessionId =
+		overrides.sessionId === undefined ? "sesn_123" : overrides.sessionId;
 	return {
 		fingerprint: "fp_monitor_test",
 		repoFullName: "fairchild/workspaces",
 		prNumber: 8101,
-		headSha: "abc8101def456",
+		headSha,
 		triggerKind: "opened",
 		triggerSourceId: "abc8101def456",
 		status,
-		sessionId: "sesn_123",
+		sessionId,
 		createdAt: now,
 		updatedAt: now,
 		error: null,
@@ -93,6 +112,28 @@ function runRow(
 			overrides.projectionError ??
 			(status === "failed" ? (overrides.error ?? null) : null),
 		githubReviewId: null,
+		executionState:
+			overrides.executionState ??
+			(status === "completed"
+				? "completed"
+				: status === "failed"
+					? "failed"
+					: status === "superseded"
+						? "superseded"
+						: sessionId
+							? "running_session"
+							: "waiting_for_session"),
+		latestKnownHeadSha:
+			overrides.latestKnownHeadSha ?? overrides.coalescedHeadSha ?? headSha,
+		failureKind: null,
+		failureMessage: null,
+		failureRetryable: null,
+		failedAt: null,
+		nextAction: "",
+		coalescedHeadSha: null,
+		coalescedTriggerKind: null,
+		coalescedTriggerSourceId: null,
+		coalescedAt: null,
 		...overrides,
 	};
 }
@@ -154,8 +195,11 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 			ok: true,
 			checked: 1,
 			eligibleEvents: 1,
+			eligibleRunKeys: 1,
 			missingRuns: 0,
-			executing: 1,
+			missingRunKeys: 0,
+			health: "healthy",
+			running: 1,
 			missing: [],
 		});
 	});
@@ -189,11 +233,12 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 		await expect(response.json()).resolves.toMatchObject({
 			ok: true,
 			checked: 1,
+			eligibleRunKeys: 1,
 			missing: [],
 		});
 	});
 
-	it("returns 503 with metadata when an eligible webhook has no run row", async () => {
+	it("returns 503 with metadata when an eligible run key has no run row", async () => {
 		const opened = PR_REVIEW_WEBHOOK_CONTRACT_CASES[0];
 		mocks.executeWebhookQuery.mockResolvedValue([
 			webhookRowFromContractCase(opened),
@@ -208,11 +253,17 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 		expect(response.status).toBe(503);
 		await expect(response.json()).resolves.toMatchObject({
 			ok: false,
+			health: "unhealthy",
 			checked: 1,
+			eligibleEvents: 1,
+			eligibleRunKeys: 1,
 			missingRuns: 1,
+			missingRunKeys: 1,
 			missing: [
 				{
-					eventId: "contract-pr-opened",
+					key: "fairchild/workspaces|8101|abc8101def456",
+					eventIds: ["contract-pr-opened"],
+					eventCount: 1,
 					repoFullName: "fairchild/workspaces",
 					prNumber: 8101,
 					triggerKind: "opened",
@@ -222,14 +273,79 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 		});
 	});
 
+	it("deduplicates missing run checks by coalesced PR head key", async () => {
+		const opened = PR_REVIEW_WEBHOOK_CONTRACT_CASES[0];
+		mocks.executeWebhookQuery.mockResolvedValue([
+			webhookRowFromContractCase(opened),
+			{
+				...webhookRowFromContractCase(opened),
+				id: "contract-pr-opened-redelivery",
+			},
+		]);
+		mocks.listRecentPrReviewRuns.mockResolvedValue([]);
+
+		const { GET } = await import("./route");
+		const response = await GET(
+			monitorRequest({ "x-workspace-webhook-canary": MONITOR_SECRET }),
+		);
+
+		expect(response.status).toBe(503);
+		await expect(response.json()).resolves.toMatchObject({
+			eligibleEvents: 2,
+			checked: 1,
+			eligibleRunKeys: 1,
+			missingRunKeys: 1,
+			missing: [
+				{
+					eventIds: ["contract-pr-opened", "contract-pr-opened-redelivery"],
+					eventCount: 2,
+				},
+			],
+		});
+	});
+
+	it("accepts a coalesced ReviewRun as covering a newer webhook head", async () => {
+		const synchronize = PR_REVIEW_WEBHOOK_CONTRACT_CASES.find(
+			(testCase) => testCase.expectedTriggerKind === "synchronize",
+		);
+		if (!synchronize) throw new Error("missing synchronize fixture");
+		mocks.executeWebhookQuery.mockResolvedValue([
+			webhookRowFromContractCase(synchronize),
+		]);
+		mocks.listRecentPrReviewRuns.mockResolvedValue([
+			runRow({
+				fingerprint: "fp_coalesced",
+				prNumber: 8105,
+				headSha: "older-head",
+				coalescedHeadSha: "newsha8105abc",
+				coalescedTriggerKind: "synchronize",
+				coalescedTriggerSourceId: "newsha8105abc",
+				coalescedAt: new Date().toISOString(),
+			}),
+		]);
+
+		const { GET } = await import("./route");
+		const response = await GET(
+			monitorRequest({ "x-workspace-webhook-canary": MONITOR_SECRET }),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			ok: true,
+			checked: 1,
+			missingRunKeys: 0,
+			missing: [],
+		});
+	});
+
 	it("fails the operator report when existing runs need attention", async () => {
 		mocks.executeWebhookQuery.mockResolvedValue([]);
 		const oldStamp = new Date(Date.now() - 45 * 60 * 1000).toISOString();
 		mocks.listRecentPrReviewRuns.mockResolvedValue([
 			runRow({
-				fingerprint: "fp_needs_projection",
+				fingerprint: "fp_running_too_long",
 				prNumber: 9001,
-				sessionId: "sesn_projection",
+				sessionId: "sesn_slow",
 				updatedAt: oldStamp,
 			}),
 			runRow({
@@ -238,6 +354,15 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 				status: "failed",
 				sessionId: "sesn_failed",
 				error: "review intent parse failed",
+				updatedAt: oldStamp,
+			}),
+			runRow({
+				fingerprint: "fp_projection_failed",
+				prNumber: 9003,
+				status: "completed",
+				sessionId: "sesn_projection_failed",
+				projectionStatus: "failed",
+				projectionError: "GitHub status update failed 503",
 				updatedAt: oldStamp,
 			}),
 		]);
@@ -250,26 +375,100 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 		expect(response.status).toBe(503);
 		await expect(response.json()).resolves.toMatchObject({
 			ok: false,
-			attentionRequired: 2,
-			needsProjection: 1,
-			failed: 1,
+			health: "unhealthy",
+			attentionRequired: 3,
+			runningTooLong: 1,
+			failedExecution: 1,
+			projectionFailed: 1,
+			failedRunCount: 1,
+			projectionFailedCount: 1,
+			githubProjectionAudit: {
+				status: "not_checked",
+				script: "scripts/pr-review-health.py",
+			},
 			runs: {
-				needsProjection: [
+				runningTooLong: [
 					{
-						fingerprint: "fp_needs_projection",
-						state: "needs_projection",
+						fingerprint: "fp_running_too_long",
+						state: "running_too_long",
 						agentStatus: "started",
 						projectionStatus: "pending",
 						detailsUrl:
-							"http://localhost/dashboard/review-runs/fp_needs_projection",
+							"http://localhost/dashboard/review-runs/fp_running_too_long",
 					},
 				],
-				failed: [
+				failedExecution: [
 					{
 						fingerprint: "fp_failed",
-						state: "failed",
+						state: "failed_execution",
 						projectionStatus: "failed",
 						error: "review intent parse failed",
+					},
+				],
+				projectionFailed: [
+					{
+						fingerprint: "fp_projection_failed",
+						state: "projection_failed",
+						projectionStatus: "failed",
+						projectionError: "GitHub status update failed 503",
+					},
+				],
+			},
+		});
+	});
+
+	it("reports stale projection and superseded runs without collapsing them into GitHub drift", async () => {
+		mocks.executeWebhookQuery.mockResolvedValue([]);
+		const projectionStamp = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+		mocks.listRecentPrReviewRuns.mockResolvedValue([
+			runRow({
+				fingerprint: "fp_awaiting_projection",
+				status: "completed",
+				sessionId: "sesn_completed",
+				projectionStatus: "pending",
+				projectionUpdatedAt: projectionStamp,
+			}),
+			runRow({
+				fingerprint: "fp_superseded",
+				status: "superseded",
+				sessionId: "sesn_superseded",
+				projectionStatus: "superseded",
+			}),
+		]);
+
+		const { GET } = await import("./route");
+		const response = await GET(
+			monitorRequest({ authorization: `Bearer ${MONITOR_SECRET}` }),
+		);
+
+		expect(response.status).toBe(503);
+		await expect(response.json()).resolves.toMatchObject({
+			completedAwaitingProjection: 1,
+			superseded: 1,
+			staleRunCount: 1,
+			supersededRunCount: 1,
+			staleOrSupersededCount: 2,
+			reviewRunHealth: {
+				status: "unhealthy",
+				staleRunCount: 1,
+				supersededRunCount: 1,
+			},
+			githubProjectionAudit: {
+				status: "not_checked",
+			},
+			runs: {
+				completedAwaitingProjection: [
+					{
+						fingerprint: "fp_awaiting_projection",
+						state: "completed_awaiting_projection",
+						projectionLatencyMinutes: expect.any(Number),
+						sloBreached: true,
+					},
+				],
+				superseded: [
+					{
+						fingerprint: "fp_superseded",
+						state: "superseded",
 					},
 				],
 			},

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import {
 	type ClassifiedPrReviewRun,
+	type PrReviewRunSummary,
 	bucketPrReviewRuns,
 	listRecentPrReviewRuns,
 } from "@/lib/agent-runtime/pr-review-runs";
@@ -13,12 +14,26 @@ const SECRET_HEADER = "x-workspace-webhook-canary";
 const DEFAULT_REPO = "fairchild/workspaces";
 const DEFAULT_WINDOW_MINUTES = 90;
 const DEFAULT_STARTING_TIMEOUT_MINUTES = 5;
+const DEFAULT_RUNNING_TIMEOUT_MINUTES = 45;
 const DEFAULT_PROJECTION_TIMEOUT_MINUTES = 30;
 const MAX_WINDOW_MINUTES = 24 * 60;
 
 interface ExpectedRun {
 	eventId: string;
 	timestamp: string;
+	repoFullName: string;
+	prNumber: number;
+	headSha: string;
+	triggerKind: string;
+	triggerSourceId: string;
+}
+
+interface ExpectedRunGroup {
+	key: string;
+	eventIds: string[];
+	eventCount: number;
+	firstTimestamp: string;
+	lastTimestamp: string;
 	repoFullName: string;
 	prNumber: number;
 	headSha: string;
@@ -43,6 +58,10 @@ interface OperatorRunItem {
 	state: string;
 	sessionId: string | null;
 	ageMinutes: number;
+	pickupLatencyMinutes: number | null;
+	executionDurationMinutes: number | null;
+	projectionLatencyMinutes: number | null;
+	sloBreached: boolean;
 	createdAt: string;
 	updatedAt: string;
 	detailsUrl: string;
@@ -118,6 +137,10 @@ function operatorRunItem(
 		state: run.state,
 		sessionId: run.sessionId,
 		ageMinutes: run.ageMinutes,
+		pickupLatencyMinutes: run.pickupLatencyMinutes,
+		executionDurationMinutes: run.executionDurationMinutes,
+		projectionLatencyMinutes: run.projectionLatencyMinutes,
+		sloBreached: run.sloBreached,
 		createdAt: run.createdAt,
 		updatedAt: run.updatedAt,
 		detailsUrl: reviewRunDetailsUrl(requestUrl, run.fingerprint),
@@ -125,6 +148,75 @@ function operatorRunItem(
 		...(run.projectionError ? { projectionError: run.projectionError } : {}),
 		...(run.githubReviewId ? { githubReviewId: run.githubReviewId } : {}),
 	};
+}
+
+function expectedRunGroupKey(expected: ExpectedRun): string {
+	return [
+		expected.repoFullName,
+		String(expected.prNumber),
+		expected.headSha || "*",
+	].join("|");
+}
+
+function groupExpectedRuns(expectedRuns: ExpectedRun[]): ExpectedRunGroup[] {
+	const groups = new Map<string, ExpectedRunGroup>();
+	for (const expected of [...expectedRuns].sort((a, b) =>
+		a.timestamp.localeCompare(b.timestamp),
+	)) {
+		const key = expectedRunGroupKey(expected);
+		const existing = groups.get(key);
+		if (existing) {
+			existing.eventIds.push(expected.eventId);
+			existing.eventCount += 1;
+			existing.lastTimestamp = expected.timestamp;
+			existing.triggerKind = expected.triggerKind;
+			existing.triggerSourceId = expected.triggerSourceId;
+			continue;
+		}
+		groups.set(key, {
+			key,
+			eventIds: [expected.eventId],
+			eventCount: 1,
+			firstTimestamp: expected.timestamp,
+			lastTimestamp: expected.timestamp,
+			repoFullName: expected.repoFullName,
+			prNumber: expected.prNumber,
+			headSha: expected.headSha,
+			triggerKind: expected.triggerKind,
+			triggerSourceId: expected.triggerSourceId,
+		});
+	}
+	return [...groups.values()];
+}
+
+function runCoversExpectedGroup(
+	run: PrReviewRunSummary,
+	expected: ExpectedRunGroup,
+): boolean {
+	if (
+		run.repoFullName !== expected.repoFullName ||
+		run.prNumber !== expected.prNumber
+	) {
+		return false;
+	}
+	if (!expected.headSha) return true;
+	return (
+		run.headSha === expected.headSha ||
+		run.latestKnownHeadSha === expected.headSha ||
+		run.coalescedHeadSha === expected.headSha
+	);
+}
+
+function maxMetric(values: Array<number | null>): number | null {
+	const present = values.filter((value): value is number => value !== null);
+	return present.length ? Math.max(...present) : null;
+}
+
+function runItems(
+	requestUrl: URL,
+	runs: ClassifiedPrReviewRun[],
+): OperatorRunItem[] {
+	return runs.map((run) => operatorRunItem(requestUrl, run));
 }
 
 function expectedRunFromWebhookEvent(row: {
@@ -165,30 +257,65 @@ export async function GET(request: Request): Promise<Response> {
 			disabled: true,
 			checked: 0,
 			eligibleEvents: 0,
+			eligibleRunKeys: 0,
 			missingRuns: 0,
+			missingRunKeys: 0,
 			attentionRequired: 0,
+			health: "disabled",
 			starting: 0,
 			stuckStarting: 0,
-			executing: 0,
-			needsProjection: 0,
-			failed: 0,
-			terminal: 0,
+			running: 0,
+			runningTooLong: 0,
+			completedAwaitingProjection: 0,
+			failedExecution: 0,
+			projectionFailed: 0,
+			superseded: 0,
+			published: 0,
+			failedRunCount: 0,
+			projectionFailedCount: 0,
+			staleRunCount: 0,
+			supersededRunCount: 0,
+			staleOrSupersededCount: 0,
 			runStates: {
 				starting: 0,
 				stuckStarting: 0,
-				executing: 0,
-				needsProjection: 0,
-				failed: 0,
-				terminal: 0,
+				running: 0,
+				runningTooLong: 0,
+				completedAwaitingProjection: 0,
+				failedExecution: 0,
+				projectionFailed: 0,
+				superseded: 0,
+				published: 0,
+			},
+			slo: {
+				pickupTimeoutMinutes: DEFAULT_STARTING_TIMEOUT_MINUTES,
+				runningTimeoutMinutes: DEFAULT_RUNNING_TIMEOUT_MINUTES,
+				projectionTimeoutMinutes: DEFAULT_PROJECTION_TIMEOUT_MINUTES,
+				maxPickupLatencyMinutes: null,
+				maxExecutionDurationMinutes: null,
+				maxProjectionLatencyMinutes: null,
+			},
+			reviewRunHealth: {
+				status: "disabled",
+				missingRunKeys: 0,
+				unhealthyRunCount: 0,
+				degradedRunCount: 0,
+			},
+			githubProjectionAudit: {
+				status: "not_checked",
+				script: "scripts/pr-review-health.py",
 			},
 			missing: [],
 			runs: {
 				starting: [],
 				stuckStarting: [],
-				executing: [],
-				needsProjection: [],
-				failed: [],
-				terminal: [],
+				running: [],
+				runningTooLong: [],
+				completedAwaitingProjection: [],
+				failedExecution: [],
+				projectionFailed: [],
+				superseded: [],
+				published: [],
 			},
 		});
 	}
@@ -200,6 +327,11 @@ export async function GET(request: Request): Promise<Response> {
 		url,
 		"startingTimeoutMinutes",
 		DEFAULT_STARTING_TIMEOUT_MINUTES,
+	);
+	const runningTimeoutMinutes = timeoutMinutesFromUrl(
+		url,
+		"runningTimeoutMinutes",
+		DEFAULT_RUNNING_TIMEOUT_MINUTES,
 	);
 	const projectionTimeoutMinutes = timeoutMinutesFromUrl(
 		url,
@@ -219,68 +351,143 @@ export async function GET(request: Request): Promise<Response> {
 	const expectedRuns = webhookRows
 		.map(expectedRunFromWebhookEvent)
 		.filter((entry): entry is ExpectedRun => Boolean(entry));
+	const expectedRunGroups = groupExpectedRuns(expectedRuns);
 
 	const runs = await listRecentPrReviewRuns({ sinceIso, repoFullName });
 	const runBuckets = bucketPrReviewRuns(runs, {
-		thresholds: { startingTimeoutMinutes, projectionTimeoutMinutes },
+		thresholds: {
+			startingTimeoutMinutes,
+			runningTimeoutMinutes,
+			projectionTimeoutMinutes,
+		},
 	});
-	const missing = expectedRuns.filter(
-		(expected) =>
-			!runs.some(
-				(run) =>
-					run.repoFullName === expected.repoFullName &&
-					run.prNumber === expected.prNumber &&
-					(!expected.headSha || run.headSha === expected.headSha) &&
-					run.triggerKind === expected.triggerKind &&
-					run.triggerSourceId === expected.triggerSourceId,
-			),
+	const missing = expectedRunGroups.filter(
+		(expected) => !runs.some((run) => runCoversExpectedGroup(run, expected)),
 	);
-	const attentionRequired =
-		missing.length +
+	const staleCompletedAwaitingProjection =
+		runBuckets.completedAwaitingProjection.filter((run) => run.sloBreached);
+	const unhealthyRunCount =
 		runBuckets.stuckStarting.length +
-		runBuckets.needsProjection.length +
-		runBuckets.failed.length;
-	const ok = attentionRequired === 0;
+		runBuckets.runningTooLong.length +
+		runBuckets.failedExecution.length +
+		runBuckets.projectionFailed.length +
+		staleCompletedAwaitingProjection.length;
+	const degradedRunCount =
+		runBuckets.completedAwaitingProjection.length -
+		staleCompletedAwaitingProjection.length;
+	const attentionRequired = missing.length + unhealthyRunCount;
+	const health =
+		attentionRequired > 0
+			? "unhealthy"
+			: degradedRunCount > 0
+				? "degraded"
+				: "healthy";
+	const ok = health !== "unhealthy";
+	const allClassifiedRuns = [
+		...runBuckets.starting,
+		...runBuckets.stuckStarting,
+		...runBuckets.running,
+		...runBuckets.runningTooLong,
+		...runBuckets.completedAwaitingProjection,
+		...runBuckets.failedExecution,
+		...runBuckets.projectionFailed,
+		...runBuckets.superseded,
+		...runBuckets.published,
+	];
+	const staleRunCount =
+		runBuckets.stuckStarting.length +
+		runBuckets.runningTooLong.length +
+		staleCompletedAwaitingProjection.length;
+	const supersededRunCount = runBuckets.superseded.length;
 
 	return Response.json(
 		{
 			ok,
 			disabled: false,
+			health,
 			repo: repoFullName,
 			windowMinutes,
 			startingTimeoutMinutes,
+			runningTimeoutMinutes,
 			projectionTimeoutMinutes,
 			since: sinceIso,
-			checked: expectedRuns.length,
+			checked: expectedRunGroups.length,
 			eligibleEvents: expectedRuns.length,
+			eligibleRunKeys: expectedRunGroups.length,
 			missingRuns: missing.length,
+			missingRunKeys: missing.length,
 			attentionRequired,
 			starting: runBuckets.starting.length,
 			stuckStarting: runBuckets.stuckStarting.length,
-			executing: runBuckets.executing.length,
-			needsProjection: runBuckets.needsProjection.length,
-			failed: runBuckets.failed.length,
-			terminal: runBuckets.terminal.length,
+			running: runBuckets.running.length,
+			runningTooLong: runBuckets.runningTooLong.length,
+			completedAwaitingProjection:
+				runBuckets.completedAwaitingProjection.length,
+			failedExecution: runBuckets.failedExecution.length,
+			projectionFailed: runBuckets.projectionFailed.length,
+			superseded: runBuckets.superseded.length,
+			published: runBuckets.published.length,
+			failedRunCount: runBuckets.failedExecution.length,
+			projectionFailedCount: runBuckets.projectionFailed.length,
+			staleRunCount,
+			supersededRunCount,
+			staleOrSupersededCount: staleRunCount + supersededRunCount,
 			runStates: {
 				starting: runBuckets.starting.length,
 				stuckStarting: runBuckets.stuckStarting.length,
-				executing: runBuckets.executing.length,
-				needsProjection: runBuckets.needsProjection.length,
-				failed: runBuckets.failed.length,
-				terminal: runBuckets.terminal.length,
+				running: runBuckets.running.length,
+				runningTooLong: runBuckets.runningTooLong.length,
+				completedAwaitingProjection:
+					runBuckets.completedAwaitingProjection.length,
+				failedExecution: runBuckets.failedExecution.length,
+				projectionFailed: runBuckets.projectionFailed.length,
+				superseded: runBuckets.superseded.length,
+				published: runBuckets.published.length,
+			},
+			slo: {
+				pickupTimeoutMinutes: startingTimeoutMinutes,
+				runningTimeoutMinutes,
+				projectionTimeoutMinutes,
+				maxPickupLatencyMinutes: maxMetric(
+					allClassifiedRuns.map((run) => run.pickupLatencyMinutes),
+				),
+				maxExecutionDurationMinutes: maxMetric(
+					allClassifiedRuns.map((run) => run.executionDurationMinutes),
+				),
+				maxProjectionLatencyMinutes: maxMetric(
+					allClassifiedRuns.map((run) => run.projectionLatencyMinutes),
+				),
+			},
+			reviewRunHealth: {
+				status: health,
+				missingRunKeys: missing.length,
+				unhealthyRunCount,
+				degradedRunCount,
+				failedRunCount: runBuckets.failedExecution.length,
+				projectionFailedCount: runBuckets.projectionFailed.length,
+				staleRunCount,
+				supersededRunCount,
+				staleOrSupersededCount: staleRunCount + supersededRunCount,
+			},
+			githubProjectionAudit: {
+				status: "not_checked",
+				script: "scripts/pr-review-health.py",
+				note: "GitHub status/review drift is audited separately from ReviewRun source-of-truth health.",
 			},
 			missing,
 			runs: {
-				starting: runBuckets.starting.map((run) => operatorRunItem(url, run)),
-				stuckStarting: runBuckets.stuckStarting.map((run) =>
-					operatorRunItem(url, run),
+				starting: runItems(url, runBuckets.starting),
+				stuckStarting: runItems(url, runBuckets.stuckStarting),
+				running: runItems(url, runBuckets.running),
+				runningTooLong: runItems(url, runBuckets.runningTooLong),
+				completedAwaitingProjection: runItems(
+					url,
+					runBuckets.completedAwaitingProjection,
 				),
-				executing: runBuckets.executing.map((run) => operatorRunItem(url, run)),
-				needsProjection: runBuckets.needsProjection.map((run) =>
-					operatorRunItem(url, run),
-				),
-				failed: runBuckets.failed.map((run) => operatorRunItem(url, run)),
-				terminal: runBuckets.terminal.map((run) => operatorRunItem(url, run)),
+				failedExecution: runItems(url, runBuckets.failedExecution),
+				projectionFailed: runItems(url, runBuckets.projectionFailed),
+				superseded: runItems(url, runBuckets.superseded),
+				published: runItems(url, runBuckets.published),
 			},
 		},
 		{ status: ok ? 200 : 503 },

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -632,7 +632,7 @@ describe("projection ledger", () => {
 });
 
 describe("bucketPrReviewRuns", () => {
-	it("separates runs that are starting, executing, due for projection, failed, and terminal", async () => {
+	it("separates ReviewRun health by execution and projection state with SLO latencies", async () => {
 		const { bucketPrReviewRuns } = await loadModule();
 		const now = new Date("2026-05-24T12:00:00.000Z");
 		const base = {
@@ -641,7 +641,6 @@ describe("bucketPrReviewRuns", () => {
 			headSha: "abc123",
 			triggerKind: "opened",
 			triggerSourceId: "abc123",
-			createdAt: "2026-05-24T11:00:00.000Z",
 			error: null,
 			projectionError: null,
 			githubReviewId: null,
@@ -653,11 +652,13 @@ describe("bucketPrReviewRuns", () => {
 		};
 		const pendingRun = (overrides: {
 			fingerprint: string;
-			status: "started" | "completed" | "failed";
+			status: "started" | "completed" | "failed" | "superseded";
 			sessionId: string | null;
+			createdAt: string;
 			updatedAt: string;
 			error?: string | null;
-			projectionStatus?: "pending" | "projected" | "failed";
+			projectionStatus?: "pending" | "projected" | "failed" | "superseded";
+			projectionUpdatedAt?: string;
 			projectionError?: string | null;
 		}) => ({
 			...base,
@@ -666,9 +667,11 @@ describe("bucketPrReviewRuns", () => {
 					? ("completed" as const)
 					: overrides.status === "failed"
 						? ("failed" as const)
-						: overrides.sessionId
-							? ("running_session" as const)
-							: ("waiting_for_session" as const),
+						: overrides.status === "superseded"
+							? ("superseded" as const)
+							: overrides.sessionId
+								? ("running_session" as const)
+								: ("waiting_for_session" as const),
 			latestKnownHeadSha: base.headSha,
 			failureKind: null,
 			failureMessage: null,
@@ -676,7 +679,7 @@ describe("bucketPrReviewRuns", () => {
 			failedAt: null,
 			nextAction: "",
 			projectionStatus: overrides.projectionStatus ?? ("pending" as const),
-			projectionUpdatedAt: overrides.updatedAt,
+			projectionUpdatedAt: overrides.projectionUpdatedAt ?? overrides.updatedAt,
 			...overrides,
 		});
 
@@ -686,39 +689,71 @@ describe("bucketPrReviewRuns", () => {
 					fingerprint: "fp_starting",
 					status: "started" as const,
 					sessionId: null,
+					createdAt: "2026-05-24T11:59:00.000Z",
 					updatedAt: "2026-05-24T11:59:00.000Z",
 				}),
 				pendingRun({
 					fingerprint: "fp_stuck_starting",
 					status: "started" as const,
 					sessionId: null,
+					createdAt: "2026-05-24T11:50:00.000Z",
 					updatedAt: "2026-05-24T11:50:00.000Z",
 				}),
 				pendingRun({
-					fingerprint: "fp_executing",
+					fingerprint: "fp_running",
 					status: "started" as const,
-					sessionId: "sesn_executing",
+					sessionId: "sesn_running",
+					createdAt: "2026-05-24T11:35:00.000Z",
 					updatedAt: "2026-05-24T11:40:00.000Z",
 				}),
 				pendingRun({
-					fingerprint: "fp_needs_projection",
+					fingerprint: "fp_running_too_long",
 					status: "started" as const,
-					sessionId: "sesn_projection",
+					sessionId: "sesn_slow",
+					createdAt: "2026-05-24T11:00:00.000Z",
 					updatedAt: "2026-05-24T11:20:00.000Z",
+				}),
+				pendingRun({
+					fingerprint: "fp_completed_awaiting_projection",
+					status: "completed" as const,
+					sessionId: "sesn_completed",
+					createdAt: "2026-05-24T11:00:00.000Z",
+					updatedAt: "2026-05-24T11:35:00.000Z",
+					projectionStatus: "pending",
+					projectionUpdatedAt: "2026-05-24T11:45:00.000Z",
 				}),
 				pendingRun({
 					fingerprint: "fp_failed",
 					status: "failed" as const,
 					sessionId: "sesn_failed",
+					createdAt: "2026-05-24T11:50:00.000Z",
 					updatedAt: "2026-05-24T11:58:00.000Z",
 					error: "review intent parse failed",
 					projectionStatus: "failed",
 					projectionError: "review intent parse failed",
 				}),
 				pendingRun({
-					fingerprint: "fp_completed",
+					fingerprint: "fp_projection_failed",
 					status: "completed" as const,
-					sessionId: "sesn_completed",
+					sessionId: "sesn_projection_failed",
+					createdAt: "2026-05-24T11:10:00.000Z",
+					updatedAt: "2026-05-24T11:40:00.000Z",
+					projectionStatus: "failed",
+					projectionError: "GitHub status update failed 503",
+				}),
+				pendingRun({
+					fingerprint: "fp_superseded",
+					status: "superseded" as const,
+					sessionId: "sesn_superseded",
+					createdAt: "2026-05-24T11:05:00.000Z",
+					updatedAt: "2026-05-24T11:55:00.000Z",
+					projectionStatus: "superseded",
+				}),
+				pendingRun({
+					fingerprint: "fp_published",
+					status: "completed" as const,
+					sessionId: "sesn_published",
+					createdAt: "2026-05-24T11:05:00.000Z",
 					updatedAt: "2026-05-24T11:58:00.000Z",
 					projectionStatus: "projected",
 				}),
@@ -727,6 +762,7 @@ describe("bucketPrReviewRuns", () => {
 				now,
 				thresholds: {
 					startingTimeoutMinutes: 5,
+					runningTimeoutMinutes: 30,
 					projectionTimeoutMinutes: 30,
 				},
 			},
@@ -738,17 +774,39 @@ describe("bucketPrReviewRuns", () => {
 		expect(buckets.stuckStarting.map((run) => run.fingerprint)).toEqual([
 			"fp_stuck_starting",
 		]);
-		expect(buckets.executing.map((run) => run.fingerprint)).toEqual([
-			"fp_executing",
+		expect(buckets.running.map((run) => run.fingerprint)).toEqual([
+			"fp_running",
 		]);
-		expect(buckets.needsProjection.map((run) => run.fingerprint)).toEqual([
-			"fp_needs_projection",
+		expect(buckets.runningTooLong.map((run) => run.fingerprint)).toEqual([
+			"fp_running_too_long",
 		]);
-		expect(buckets.failed.map((run) => run.fingerprint)).toEqual(["fp_failed"]);
-		expect(buckets.terminal.map((run) => run.fingerprint)).toEqual([
-			"fp_completed",
+		expect(
+			buckets.completedAwaitingProjection.map((run) => run.fingerprint),
+		).toEqual(["fp_completed_awaiting_projection"]);
+		expect(buckets.failedExecution.map((run) => run.fingerprint)).toEqual([
+			"fp_failed",
 		]);
-		expect(buckets.needsProjection[0].ageMinutes).toBe(40);
+		expect(buckets.projectionFailed.map((run) => run.fingerprint)).toEqual([
+			"fp_projection_failed",
+		]);
+		expect(buckets.superseded.map((run) => run.fingerprint)).toEqual([
+			"fp_superseded",
+		]);
+		expect(buckets.published.map((run) => run.fingerprint)).toEqual([
+			"fp_published",
+		]);
+		expect(buckets.runningTooLong[0]).toMatchObject({
+			ageMinutes: 40,
+			pickupLatencyMinutes: 20,
+			executionDurationMinutes: 40,
+			projectionLatencyMinutes: null,
+			sloBreached: true,
+		});
+		expect(buckets.completedAwaitingProjection[0]).toMatchObject({
+			ageMinutes: 15,
+			projectionLatencyMinutes: 15,
+			sloBreached: false,
+		});
 	});
 });
 

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -1618,28 +1618,39 @@ export async function listRecentPrReviewRuns(input: {
 export type PrReviewRunOperatorState =
 	| "starting"
 	| "stuck_starting"
-	| "executing"
-	| "needs_projection"
-	| "failed"
-	| "terminal";
+	| "running"
+	| "running_too_long"
+	| "failed_execution"
+	| "completed_awaiting_projection"
+	| "projection_failed"
+	| "superseded"
+	| "published";
 
 export interface PrReviewRunStateThresholds {
 	startingTimeoutMinutes: number;
+	runningTimeoutMinutes?: number;
 	projectionTimeoutMinutes: number;
 }
 
 export interface ClassifiedPrReviewRun extends PrReviewRunSummary {
 	state: PrReviewRunOperatorState;
 	ageMinutes: number;
+	pickupLatencyMinutes: number | null;
+	executionDurationMinutes: number | null;
+	projectionLatencyMinutes: number | null;
+	sloBreached: boolean;
 }
 
 export interface PrReviewRunStateBuckets {
 	starting: ClassifiedPrReviewRun[];
 	stuckStarting: ClassifiedPrReviewRun[];
-	executing: ClassifiedPrReviewRun[];
-	needsProjection: ClassifiedPrReviewRun[];
-	failed: ClassifiedPrReviewRun[];
-	terminal: ClassifiedPrReviewRun[];
+	running: ClassifiedPrReviewRun[];
+	runningTooLong: ClassifiedPrReviewRun[];
+	failedExecution: ClassifiedPrReviewRun[];
+	completedAwaitingProjection: ClassifiedPrReviewRun[];
+	projectionFailed: ClassifiedPrReviewRun[];
+	superseded: ClassifiedPrReviewRun[];
+	published: ClassifiedPrReviewRun[];
 }
 
 function elapsedMinutes(sinceIso: string, now: Date): number {
@@ -1647,6 +1658,48 @@ function elapsedMinutes(sinceIso: string, now: Date): number {
 	const nowMs = now.getTime();
 	if (!Number.isFinite(sinceMs) || !Number.isFinite(nowMs)) return 0;
 	return Math.max(0, Math.floor((nowMs - sinceMs) / (60 * 1000)));
+}
+
+function elapsedMinutesBetween(
+	startIso: string | null | undefined,
+	endIso: string | Date | null | undefined,
+): number | null {
+	if (!startIso || !endIso) return null;
+	const startMs = Date.parse(startIso);
+	const endMs = endIso instanceof Date ? endIso.getTime() : Date.parse(endIso);
+	if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return null;
+	return Math.max(0, Math.floor((endMs - startMs) / (60 * 1000)));
+}
+
+function runLatencies(
+	run: PrReviewRunSummary,
+	now: Date,
+): Pick<
+	ClassifiedPrReviewRun,
+	| "pickupLatencyMinutes"
+	| "executionDurationMinutes"
+	| "projectionLatencyMinutes"
+> {
+	const pickupLatencyMinutes =
+		run.status !== "started"
+			? null
+			: run.sessionId
+				? elapsedMinutesBetween(run.createdAt, run.updatedAt)
+				: elapsedMinutesBetween(run.createdAt, now);
+	const executionDurationMinutes = run.sessionId
+		? run.status === "started"
+			? elapsedMinutesBetween(run.updatedAt, now)
+			: elapsedMinutesBetween(run.createdAt, run.updatedAt)
+		: null;
+	const projectionLatencyMinutes =
+		run.status === "completed" && run.projectionStatus !== "projected"
+			? elapsedMinutesBetween(run.projectionUpdatedAt, now)
+			: null;
+	return {
+		pickupLatencyMinutes,
+		executionDurationMinutes,
+		projectionLatencyMinutes,
+	};
 }
 
 export function classifyPrReviewRun(
@@ -1659,34 +1712,60 @@ export function classifyPrReviewRun(
 	const now = options.now ?? new Date();
 	let ageSource = run.updatedAt;
 	let state: PrReviewRunOperatorState;
+	let sloBreached = false;
+	const runningTimeoutMinutes =
+		options.thresholds.runningTimeoutMinutes ??
+		options.thresholds.projectionTimeoutMinutes;
 
-	if (run.status === "failed" || run.projectionStatus === "failed") {
-		state = "failed";
+	if (run.status === "failed") {
+		state = "failed_execution";
+		ageSource = run.failedAt ?? run.updatedAt;
+	} else if (run.projectionStatus === "failed") {
+		state = "projection_failed";
+		ageSource = run.projectionUpdatedAt;
 	} else if (
-		run.status === "completed" ||
 		run.status === "superseded" ||
-		run.projectionStatus === "projected" ||
 		run.projectionStatus === "superseded"
 	) {
-		state = "terminal";
+		state = "superseded";
+		ageSource = run.updatedAt;
+	} else if (run.status === "completed") {
+		if (run.projectionStatus === "projected") {
+			state = "published";
+			ageSource = run.projectionUpdatedAt;
+		} else {
+			state = "completed_awaiting_projection";
+			ageSource = run.projectionUpdatedAt;
+			sloBreached =
+				elapsedMinutes(ageSource, now) >=
+				options.thresholds.projectionTimeoutMinutes;
+		}
 	} else if (!run.sessionId) {
 		const ageMinutes = elapsedMinutes(ageSource, now);
-		state =
-			ageMinutes >= options.thresholds.startingTimeoutMinutes
-				? "stuck_starting"
-				: "starting";
+		if (ageMinutes >= options.thresholds.startingTimeoutMinutes) {
+			state = "stuck_starting";
+			sloBreached = true;
+		} else {
+			state = "starting";
+		}
 	} else {
-		// Once a session exists, age reports projection staleness rather than
-		// wall-clock run age so operators can see when the broker is overdue.
-		ageSource = run.projectionUpdatedAt;
+		ageSource = run.updatedAt;
 		const ageMinutes = elapsedMinutes(ageSource, now);
-		state =
-			ageMinutes >= options.thresholds.projectionTimeoutMinutes
-				? "needs_projection"
-				: "executing";
+		if (ageMinutes >= runningTimeoutMinutes) {
+			state = "running_too_long";
+			sloBreached = true;
+		} else {
+			state = "running";
+		}
 	}
 
-	return { ...run, state, ageMinutes: elapsedMinutes(ageSource, now) };
+	return {
+		...run,
+		state,
+		ageMinutes: elapsedMinutes(ageSource, now),
+		...runLatencies(run, now),
+		sloBreached,
+	};
 }
 
 export function bucketPrReviewRuns(
@@ -1699,10 +1778,13 @@ export function bucketPrReviewRuns(
 	const buckets: PrReviewRunStateBuckets = {
 		starting: [],
 		stuckStarting: [],
-		executing: [],
-		needsProjection: [],
-		failed: [],
-		terminal: [],
+		running: [],
+		runningTooLong: [],
+		failedExecution: [],
+		completedAwaitingProjection: [],
+		projectionFailed: [],
+		superseded: [],
+		published: [],
 	};
 
 	for (const run of runs) {
@@ -1714,17 +1796,26 @@ export function bucketPrReviewRuns(
 			case "stuck_starting":
 				buckets.stuckStarting.push(classified);
 				break;
-			case "executing":
-				buckets.executing.push(classified);
+			case "running":
+				buckets.running.push(classified);
 				break;
-			case "needs_projection":
-				buckets.needsProjection.push(classified);
+			case "running_too_long":
+				buckets.runningTooLong.push(classified);
 				break;
-			case "failed":
-				buckets.failed.push(classified);
+			case "failed_execution":
+				buckets.failedExecution.push(classified);
 				break;
-			case "terminal":
-				buckets.terminal.push(classified);
+			case "completed_awaiting_projection":
+				buckets.completedAwaitingProjection.push(classified);
+				break;
+			case "projection_failed":
+				buckets.projectionFailed.push(classified);
+				break;
+			case "superseded":
+				buckets.superseded.push(classified);
+				break;
+			case "published":
+				buckets.published.push(classified);
 				break;
 		}
 	}


### PR DESCRIPTION
## Summary

- make the managed reviewer monitor classify health from ReviewRun state first, with healthy/degraded/unhealthy output and SLO buckets
- update `scripts/pr-reviewer-runs.py` as the primary operator health command and keep `scripts/pr-review-health.py` focused on GitHub projection drift
- add monitor/script tests for coalesced expected run keys, stale pickup, long-running sessions, projection failures, and CLI output

Closes #590.

## Mergeability

- Surface: web agent-runtime monitor, ReviewRun helpers, operator scripts, docs
- User-facing behavior changed: Maintainers see ReviewRun-first health states and SLO signals from the monitor and `scripts/pr-reviewer-runs.py`.
- Non-happy paths considered: Stuck pickup, long-running sessions, completed runs awaiting projection, failed projections, failed executions, superseded runs, and duplicate webhook deliveries are covered by tests.
- Residual risk or follow-up: Latency values remain best-effort until ReviewRun lifecycle-specific timestamps exist; the monitor reports them only where current persisted fields support a meaningful signal.

## Validation

- `pnpm --dir web exec vitest run src/lib/agent-runtime/__tests__/pr-review-runs.test.ts src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts`
- `mise -C web run web:check`
- `UV_CACHE_DIR=/tmp/uv-cache ./scripts/tests/test_security_hardening.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --script scripts/tests/test_pr_review_health.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --script scripts/tests/test_pr_reviewer_runs.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`

## Evidence

- ![validation](https://evidence.cloudcompute.com/workspaces/pr-599/20260531-235310-validation.png)