### PR TITLE
Add managed review retry and repair controls

### DIFF
--- a/web/src/app/api/pr-review-runs/[fingerprint]/route.test.ts
+++ b/web/src/app/api/pr-review-runs/[fingerprint]/route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	authorizeRepoAccess: vi.fn(),
+	getPrReviewRunByFingerprint: vi.fn(),
+	recoverPrReviewRun: vi.fn(),
+	session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+}));
+
+vi.mock("@/lib/agent-runtime/pr-review-runs", () => ({
+	getPrReviewRunByFingerprint: mocks.getPrReviewRunByFingerprint,
+}));
+
+vi.mock("@/lib/agent-runtime/pr-review", () => ({
+	recoverPrReviewRun: mocks.recoverPrReviewRun,
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+	authorizeRepoAccess: mocks.authorizeRepoAccess,
+	unauthorizedResponse: () =>
+		Response.json({ error: "unauthorized" }, { status: 401 }),
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+	getSession: async () => mocks.session,
+}));
+
+const run = {
+	fingerprint: "fp_route",
+	repoFullName: "fairchild/workspaces",
+};
+
+describe("/api/pr-review-runs/[fingerprint]", () => {
+	beforeEach(() => {
+		mocks.authorizeRepoAccess.mockReset();
+		mocks.authorizeRepoAccess.mockResolvedValue(null);
+		mocks.getPrReviewRunByFingerprint.mockReset();
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(run);
+		mocks.recoverPrReviewRun.mockReset();
+		mocks.recoverPrReviewRun.mockResolvedValue({
+			ok: true,
+			action: "retry_execution",
+			outcome: "execution_retry_started",
+			fingerprint: "fp_route",
+			currentHeadSha: "head-sha",
+			message: "Started.",
+		});
+		mocks.session = { user: { id: "user-1" } };
+	});
+
+	it("requires a signed-in user before exposing run details", async () => {
+		mocks.session = null;
+		const { GET } = await import("./route");
+
+		const response = await GET(new Request("http://localhost"), {
+			params: Promise.resolve({ fingerprint: "fp_route" }),
+		});
+
+		expect(response.status).toBe(401);
+		expect(mocks.getPrReviewRunByFingerprint).not.toHaveBeenCalled();
+	});
+
+	it("requires a signed-in user before retry or repair mutation", async () => {
+		mocks.session = null;
+		const { POST } = await import("./route");
+
+		const response = await POST(
+			new Request("http://localhost", { method: "POST" }),
+			{
+				params: Promise.resolve({ fingerprint: "fp_route" }),
+			},
+		);
+
+		expect(response.status).toBe(401);
+		expect(mocks.getPrReviewRunByFingerprint).not.toHaveBeenCalled();
+		expect(mocks.recoverPrReviewRun).not.toHaveBeenCalled();
+	});
+
+	it("requires repo access before retry or repair mutation", async () => {
+		mocks.authorizeRepoAccess.mockResolvedValue(
+			Response.json({ error: "repo not in your workspace" }, { status: 403 }),
+		);
+		const { POST } = await import("./route");
+
+		const response = await POST(
+			new Request("http://localhost", { method: "POST" }),
+			{
+				params: Promise.resolve({ fingerprint: "fp_route" }),
+			},
+		);
+
+		expect(response.status).toBe(403);
+		expect(mocks.authorizeRepoAccess).toHaveBeenCalledWith(
+			"user-1",
+			"fairchild/workspaces",
+		);
+		expect(mocks.recoverPrReviewRun).not.toHaveBeenCalled();
+	});
+
+	it("delegates authenticated mutations to the recovery helper", async () => {
+		const { POST } = await import("./route");
+
+		const response = await POST(
+			new Request("http://localhost", { method: "POST" }),
+			{
+				params: Promise.resolve({ fingerprint: "fp_route" }),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.recoverPrReviewRun).toHaveBeenCalledWith("fp_route");
+		await expect(response.json()).resolves.toMatchObject({
+			ok: true,
+			outcome: "execution_retry_started",
+		});
+	});
+});

--- a/web/src/app/api/pr-review-runs/[fingerprint]/route.ts
+++ b/web/src/app/api/pr-review-runs/[fingerprint]/route.ts
@@ -1,3 +1,4 @@
+import { recoverPrReviewRun } from "@/lib/agent-runtime/pr-review";
 import { getPrReviewRunByFingerprint } from "@/lib/agent-runtime/pr-review-runs";
 import { authorizeRepoAccess, unauthorizedResponse } from "@/lib/api-auth";
 import { getSession } from "@/lib/auth-server";
@@ -24,4 +25,27 @@ export async function GET(
 	if (unauthorized) return unauthorized;
 
 	return Response.json({ run });
+}
+
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ fingerprint: string }> },
+): Promise<Response> {
+	const session = await getSession();
+	if (!session?.user) return unauthorizedResponse();
+
+	const { fingerprint } = await params;
+	const run = await getPrReviewRunByFingerprint(fingerprint);
+	if (!run) {
+		return Response.json({ error: "review run not found" }, { status: 404 });
+	}
+
+	const unauthorized = await authorizeRepoAccess(
+		session.user.id,
+		run.repoFullName,
+	);
+	if (unauthorized) return unauthorized;
+
+	const result = await recoverPrReviewRun(fingerprint);
+	return Response.json(result, { status: result.ok ? 200 : result.status });
 }

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
@@ -139,6 +139,41 @@
 	font-size: 12px;
 }
 
+.recoveryAction {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 6px 12px;
+	align-items: center;
+	margin-top: 8px;
+	border-top: 1px solid #e5e7eb;
+	padding-top: 10px;
+}
+
+.recoveryAction span,
+.recoveryAction strong,
+.recoveryAction small {
+	grid-column: 1;
+}
+
+.recoveryAction button {
+	grid-row: 1 / span 3;
+	grid-column: 2;
+	border: 1px solid #111827;
+	border-radius: 6px;
+	padding: 7px 10px;
+	background: #111827;
+	color: #ffffff;
+	font-size: 13px;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.recoveryAction button:disabled {
+	border-color: #9ca3af;
+	background: #9ca3af;
+	cursor: progress;
+}
+
 .projections {
 	overflow: hidden;
 	border: 1px solid #d1d5db;
@@ -282,5 +317,15 @@
 @media (max-width: 560px) {
 	.projectionRow {
 		grid-template-columns: 1fr;
+	}
+
+	.recoveryAction {
+		grid-template-columns: 1fr;
+	}
+
+	.recoveryAction button {
+		grid-row: auto;
+		grid-column: 1;
+		justify-self: start;
 	}
 }

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/auth-server";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import styles from "./page.module.css";
+import { ReviewRunRecoveryAction } from "./review-run-recovery-action";
 import { ReviewRunTranscript } from "./review-run-transcript";
 
 export const dynamic = "force-dynamic";
@@ -127,6 +128,10 @@ export default async function ReviewRunPage({
 						Failure recorded {new Date(run.failedAt).toLocaleString()}
 					</small>
 				)}
+				<ReviewRunRecoveryAction
+					fingerprint={run.fingerprint}
+					recovery={run.recovery}
+				/>
 			</section>
 
 			{run.failureMessage && (

--- a/web/src/app/dashboard/review-runs/[fingerprint]/review-run-recovery-action.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/review-run-recovery-action.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { PrReviewRunRecoveryAvailability } from "@/lib/agent-runtime/pr-review-runs";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import styles from "./page.module.css";
+
+interface ReviewRunRecoveryActionProps {
+	fingerprint: string;
+	recovery: PrReviewRunRecoveryAvailability;
+}
+
+interface RecoveryResponse {
+	ok?: boolean;
+	message?: string;
+	error?: string;
+	outcome?: string;
+}
+
+export function ReviewRunRecoveryAction({
+	fingerprint,
+	recovery,
+}: ReviewRunRecoveryActionProps) {
+	const router = useRouter();
+	const [pending, setPending] = useState(false);
+	const [result, setResult] = useState<string | null>(null);
+
+	const recover = async () => {
+		setPending(true);
+		setResult(null);
+		try {
+			const response = await fetch(
+				`/api/pr-review-runs/${encodeURIComponent(fingerprint)}`,
+				{ method: "POST" },
+			);
+			const data = (await response
+				.json()
+				.catch(() => ({}))) as RecoveryResponse;
+			if (!response.ok || data.ok === false) {
+				setResult(data.error ?? `Recovery failed (${response.status}).`);
+				return;
+			}
+			setResult(data.message ?? data.outcome ?? "Recovery request accepted.");
+			router.refresh();
+		} finally {
+			setPending(false);
+		}
+	};
+
+	return (
+		<div className={styles.recoveryAction}>
+			<span>Recovery</span>
+			<strong>{recovery.reason}</strong>
+			{recovery.available && recovery.label ? (
+				<button type="button" onClick={recover} disabled={pending}>
+					{pending ? "Working..." : recovery.label}
+				</button>
+			) : (
+				<small>Unavailable</small>
+			)}
+			{result && <small>{result}</small>}
+		</div>
+	);
+}

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -368,6 +368,166 @@ describe("listStartedPrReviewRuns", () => {
 	});
 });
 
+describe("ReviewRun recovery metadata", () => {
+	it("exposes execution retry availability for retryable failed runs", async () => {
+		const { getPrReviewRunByFingerprint, recordRunStart, recordRunResult } =
+			await loadModule();
+		const failed = makeInput({ fingerprint: "fp_recovery_failed" });
+
+		await recordRunStart(failed);
+		await recordRunResult(failed.fingerprint, {
+			sessionId: "sesn_failed",
+			status: "failed",
+			error: "session output failed",
+		});
+
+		await expect(
+			getPrReviewRunByFingerprint(failed.fingerprint),
+		).resolves.toMatchObject({
+			recovery: {
+				available: true,
+				action: "retry_execution",
+				reasonCode: "execution_failed",
+			},
+		});
+	});
+
+	it("exposes projection repair availability only with persisted intent", async () => {
+		const { getPrReviewRunByFingerprint, recordRunStart, recordRunResult } =
+			await loadModule();
+		const repair = makeInput({ fingerprint: "fp_recovery_repair" });
+
+		await recordRunStart(repair);
+		await recordRunResult(repair.fingerprint, {
+			sessionId: "sesn_repair",
+			status: "completed",
+			projectionStatus: "failed",
+			projectionError: "GitHub status update failed 503",
+			reviewIntent: {
+				event: "COMMENT",
+				body: "Persisted review body.",
+				labels: [],
+			},
+		});
+
+		await expect(
+			getPrReviewRunByFingerprint(repair.fingerprint),
+		).resolves.toMatchObject({
+			recovery: {
+				available: true,
+				action: "repair_projection",
+				reasonCode: "projection_failed",
+			},
+		});
+	});
+
+	it("finds a newer active successor for safe recovery refusal", async () => {
+		const {
+			getActivePrReviewRunSuccessor,
+			getPrReviewRunByFingerprint,
+			recordRunStart,
+			recordRunResult,
+		} = await loadModule();
+		const failed = makeInput({
+			fingerprint: "fp_successor_failed",
+			headSha: "head-a",
+			triggerSourceId: "head-a",
+		});
+		const successor = makeInput({
+			fingerprint: "fp_successor_active",
+			headSha: "head-b",
+			triggerKind: "manual_retry",
+			triggerSourceId: "manual-retry-fp_successor_failed-head-head-b",
+		});
+
+		await recordRunStart(failed);
+		await recordRunResult(failed.fingerprint, {
+			sessionId: "sesn_failed",
+			status: "failed",
+			error: "session output failed",
+		});
+		const { getDb } = await import("../../db");
+		const oldStamp = new Date(Date.now() - 60 * 1000).toISOString();
+		await getDb()
+			.updateTable("managed_pr_review_runs")
+			.set({ created_at: oldStamp })
+			.where("fingerprint", "=", failed.fingerprint)
+			.execute();
+		await recordRunStart(successor);
+
+		const failedRun = await getPrReviewRunByFingerprint(failed.fingerprint);
+		expect(failedRun).not.toBeNull();
+		await expect(
+			getActivePrReviewRunSuccessor({
+				fingerprint: failedRun?.fingerprint ?? "",
+				repoFullName: failedRun?.repoFullName ?? "",
+				prNumber: failedRun?.prNumber ?? 0,
+				createdAt: failedRun?.createdAt ?? "",
+			}),
+		).resolves.toMatchObject({
+			fingerprint: successor.fingerprint,
+			triggerKind: "manual_retry",
+			triggerSourceId: "manual-retry-fp_successor_failed-head-head-b",
+		});
+	});
+
+	it("finds a newer current-head run so old failures are not retried", async () => {
+		const {
+			getNewerCurrentHeadPrReviewRun,
+			getPrReviewRunByFingerprint,
+			recordRunStart,
+			recordRunResult,
+		} = await loadModule();
+		const failed = makeInput({
+			fingerprint: "fp_newer_failed",
+			headSha: "same-head",
+			triggerSourceId: "same-head",
+		});
+		const newer = makeInput({
+			fingerprint: "fp_newer_terminal",
+			headSha: "same-head",
+			triggerKind: "manual_retry",
+			triggerSourceId: "manual-retry-fp_newer_failed-head-same-head",
+		});
+
+		await recordRunStart(failed);
+		await recordRunResult(failed.fingerprint, {
+			sessionId: "sesn_failed",
+			status: "failed",
+			error: "session output failed",
+		});
+		const { getDb } = await import("../../db");
+		const oldStamp = new Date(Date.now() - 60 * 1000).toISOString();
+		await getDb()
+			.updateTable("managed_pr_review_runs")
+			.set({ created_at: oldStamp })
+			.where("fingerprint", "=", failed.fingerprint)
+			.execute();
+		await recordRunStart(newer);
+		await recordRunResult(newer.fingerprint, {
+			sessionId: "sesn_newer",
+			status: "completed",
+			projectionStatus: "projected",
+		});
+
+		const failedRun = await getPrReviewRunByFingerprint(failed.fingerprint);
+		expect(failedRun).not.toBeNull();
+		await expect(
+			getNewerCurrentHeadPrReviewRun({
+				fingerprint: failedRun?.fingerprint ?? "",
+				repoFullName: failedRun?.repoFullName ?? "",
+				prNumber: failedRun?.prNumber ?? 0,
+				headSha: "same-head",
+				createdAt: failedRun?.createdAt ?? "",
+			}),
+		).resolves.toMatchObject({
+			fingerprint: newer.fingerprint,
+			status: "completed",
+			projectionStatus: "projected",
+		});
+	});
+});
+
 describe("listPrReviewRunsForBroker", () => {
 	it("returns active sessions and completed runs that still need projection", async () => {
 		const {

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -12,6 +12,10 @@ const mocks = vi.hoisted(() => ({
 	recordRunStart: vi.fn(),
 	recordRunResult: vi.fn(),
 	releaseRunActiveClaim: vi.fn(),
+	getActivePrReviewRunSuccessor: vi.fn(),
+	getNewerCurrentHeadPrReviewRun: vi.fn(),
+	getPrReviewRunByFingerprint: vi.fn(),
+	getPrReviewRunByTrigger: vi.fn(),
 	listPrReviewRunsForBroker: vi.fn(),
 	computeRunFingerprint: vi.fn(),
 	beginPrReviewProjectionAttempt: vi.fn(),
@@ -52,6 +56,10 @@ vi.mock("../pr-review-runs", () => ({
 	beginPrReviewProjectionAttempt: mocks.beginPrReviewProjectionAttempt,
 	classifyPrReviewProjectionError: mocks.classifyPrReviewProjectionError,
 	computeRunFingerprint: mocks.computeRunFingerprint,
+	getActivePrReviewRunSuccessor: mocks.getActivePrReviewRunSuccessor,
+	getNewerCurrentHeadPrReviewRun: mocks.getNewerCurrentHeadPrReviewRun,
+	getPrReviewRunByFingerprint: mocks.getPrReviewRunByFingerprint,
+	getPrReviewRunByTrigger: mocks.getPrReviewRunByTrigger,
 	listPrReviewProjectionsForRun: mocks.listPrReviewProjectionsForRun,
 	listPrReviewRunsForBroker: mocks.listPrReviewRunsForBroker,
 	recordPrReviewProjectionFailure: mocks.recordPrReviewProjectionFailure,
@@ -71,6 +79,7 @@ import {
 	formatPrNarrativeContext,
 	parseReviewIntentFromText,
 	processPendingPrReviewRuns,
+	recoverPrReviewRun,
 	triggerPrReview,
 } from "../pr-review";
 
@@ -148,6 +157,7 @@ function brokerRun(overrides: Record<string, unknown> = {}) {
 		status: "started",
 		projectionStatus: "pending",
 		sessionId: "sesn_broker",
+		githubReviewId: null,
 		createdAt: "2026-05-17T06:24:27Z",
 		updatedAt: "2026-05-17T06:24:27Z",
 		reviewIntent: null,
@@ -155,6 +165,49 @@ function brokerRun(overrides: Record<string, unknown> = {}) {
 		coalescedTriggerKind: null,
 		coalescedTriggerSourceId: null,
 		coalescedAt: null,
+		...overrides,
+	};
+}
+
+function reviewRunDetails(overrides: Record<string, unknown> = {}) {
+	return {
+		fingerprint: "fp_recovery",
+		repoFullName: "fairchild/workspaces",
+		prNumber: 588,
+		headSha: "current-head",
+		triggerKind: "synchronize",
+		triggerSourceId: "current-head",
+		reviewerConfigHash: "cfg",
+		status: "failed",
+		sessionId: "sesn_failed",
+		createdAt: "2026-05-17T06:24:27Z",
+		updatedAt: "2026-05-17T06:25:27Z",
+		error: "session output failed",
+		executionState: "failed",
+		latestKnownHeadSha: "current-head",
+		failureKind: "session_output_failed",
+		failureMessage: "session output failed",
+		failureRetryable: true,
+		failedAt: "2026-05-17T06:25:27Z",
+		nextAction:
+			"Retry is allowed after confirming this run still targets the current PR head.",
+		projectionStatus: "failed",
+		projectionUpdatedAt: "2026-05-17T06:25:27Z",
+		projectionError: "session output failed",
+		githubReviewId: null,
+		reviewIntent: null,
+		coalescedHeadSha: null,
+		coalescedTriggerKind: null,
+		coalescedTriggerSourceId: null,
+		coalescedAt: null,
+		projections: [],
+		recovery: {
+			available: true,
+			action: "retry_execution",
+			label: "Retry execution",
+			reason: "retry",
+			reasonCode: "execution_failed",
+		},
 		...overrides,
 	};
 }
@@ -242,6 +295,59 @@ function mockNarrativeFetch({
 	});
 }
 
+function mockRecoveryFetch({
+	prNumber = 588,
+	headSha = "current-head",
+	reviewId = 588001,
+}: {
+	prNumber?: number;
+	headSha?: string;
+	reviewId?: number;
+} = {}) {
+	mocks.fetch.mockImplementation(async (url: string, options?: RequestInit) => {
+		if (url.endsWith(`/pulls/${prNumber}`)) {
+			return {
+				ok: true,
+				json: async () =>
+					githubPr(prNumber, {
+						title: "Recover managed reviewer run",
+						html_url: `https://github.com/fairchild/workspaces/pull/${prNumber}`,
+						body: "PR body",
+						head: { ref: "codex/recovery", sha: headSha },
+						base: { ref: "main" },
+					}),
+			};
+		}
+		if (url.includes("/pulls?")) {
+			return { ok: true, json: async () => [] };
+		}
+		if (url.includes("/labels?")) {
+			return { ok: true, json: async () => [] };
+		}
+		if (url.includes(`/issues/${prNumber}/comments?`)) {
+			return { ok: true, json: async () => [] };
+		}
+		if (url.includes(`/pulls/${prNumber}/reviews?`)) {
+			return { ok: true, json: async () => [] };
+		}
+		if (url.endsWith(`/pulls/${prNumber}/reviews`)) {
+			expect(options?.method).toBe("POST");
+			return {
+				ok: true,
+				text: async () => "",
+				json: async () => ({ id: reviewId }),
+			};
+		}
+		if (url.endsWith(`/issues/${prNumber}/labels`)) {
+			return okResponse();
+		}
+		if (isManagedReviewStatusUrl(url)) {
+			return okResponse();
+		}
+		throw new Error(`Unexpected fetch URL: ${url}`);
+	});
+}
+
 beforeEach(() => {
 	vi.stubEnv("ANTHROPIC_API_KEY", "sk-test");
 	vi.stubEnv("GITHUB_TOKEN", "ghp_test");
@@ -262,6 +368,10 @@ beforeEach(() => {
 	mocks.recordRunStart.mockReset();
 	mocks.recordRunResult.mockReset();
 	mocks.releaseRunActiveClaim.mockReset();
+	mocks.getActivePrReviewRunSuccessor.mockReset();
+	mocks.getNewerCurrentHeadPrReviewRun.mockReset();
+	mocks.getPrReviewRunByFingerprint.mockReset();
+	mocks.getPrReviewRunByTrigger.mockReset();
 	mocks.listPrReviewRunsForBroker.mockReset();
 	mocks.computeRunFingerprint.mockReset();
 	mocks.beginPrReviewProjectionAttempt.mockReset();
@@ -280,6 +390,10 @@ beforeEach(() => {
 	mocks.recordRunStart.mockResolvedValue({ inserted: true });
 	mocks.recordRunResult.mockResolvedValue(undefined);
 	mocks.releaseRunActiveClaim.mockResolvedValue(undefined);
+	mocks.getActivePrReviewRunSuccessor.mockResolvedValue(null);
+	mocks.getNewerCurrentHeadPrReviewRun.mockResolvedValue(null);
+	mocks.getPrReviewRunByFingerprint.mockResolvedValue(null);
+	mocks.getPrReviewRunByTrigger.mockResolvedValue(null);
 	mocks.listPrReviewRunsForBroker.mockResolvedValue([]);
 	mocks.beginPrReviewProjectionAttempt.mockImplementation(
 		async (input: { type: string }) => ({
@@ -581,6 +695,283 @@ ${JSON.stringify(reviewIntent, null, 2)}
 				'```json\n{"event":"MERGE","body":"ship it","labels":[]}\n```',
 			),
 		).toThrow(/unsupported review event/);
+	});
+});
+
+describe("recoverPrReviewRun", () => {
+	it("refuses superseded runs before any live retry work", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({
+				fingerprint: "fp_superseded",
+				status: "superseded",
+				projectionStatus: "superseded",
+				recovery: {
+					available: false,
+					action: null,
+					label: null,
+					reason: "superseded",
+					reasonCode: "run_superseded",
+				},
+			}),
+		);
+
+		const result = await recoverPrReviewRun("fp_superseded");
+
+		expect(result).toMatchObject({
+			ok: false,
+			status: 409,
+			reason: "superseded_run",
+		});
+		expect(mocks.fetch).not.toHaveBeenCalled();
+		expect(mocks.createSession).not.toHaveBeenCalled();
+	});
+
+	it("refuses a stale failed run when GitHub reports a newer current head", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({ fingerprint: "fp_stale", headSha: "old-head" }),
+		);
+		mockRecoveryFetch({ headSha: "current-head" });
+
+		const result = await recoverPrReviewRun("fp_stale");
+
+		expect(result).toMatchObject({
+			ok: false,
+			status: 409,
+			reason: "stale_run",
+			currentHeadSha: "current-head",
+		});
+		expect(mocks.getActivePrReviewRunSuccessor).not.toHaveBeenCalled();
+		expect(mocks.createSession).not.toHaveBeenCalled();
+	});
+
+	it("makes duplicate manual retry calls idempotent when the deterministic retry is active", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({ fingerprint: "fp_failed" }),
+		);
+		mocks.getActivePrReviewRunSuccessor.mockResolvedValue({
+			fingerprint: "fp_retry",
+			headSha: "current-head",
+			triggerKind: "manual_retry",
+			triggerSourceId: "manual-retry-fp_failed-head-current-head",
+			sessionId: "sesn_retry",
+			createdAt: "2026-05-17T06:26:00Z",
+			updatedAt: "2026-05-17T06:26:10Z",
+		});
+		mockRecoveryFetch({ headSha: "current-head" });
+
+		const result = await recoverPrReviewRun("fp_failed");
+
+		expect(result).toMatchObject({
+			ok: true,
+			action: "retry_execution",
+			outcome: "execution_retry_already_active",
+			successorFingerprint: "fp_retry",
+			sessionId: "sesn_retry",
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.recordRunStart).not.toHaveBeenCalled();
+	});
+
+	it("refuses a failed run when a different active successor exists", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({ fingerprint: "fp_failed" }),
+		);
+		mocks.getActivePrReviewRunSuccessor.mockResolvedValue({
+			fingerprint: "fp_active_other",
+			headSha: "current-head",
+			triggerKind: "synchronize",
+			triggerSourceId: "current-head",
+			sessionId: "sesn_active_other",
+			createdAt: "2026-05-17T06:26:00Z",
+			updatedAt: "2026-05-17T06:26:10Z",
+		});
+		mockRecoveryFetch({ headSha: "current-head" });
+
+		const result = await recoverPrReviewRun("fp_failed");
+
+		expect(result).toMatchObject({
+			ok: false,
+			status: 409,
+			reason: "active_successor",
+			activeSuccessor: { fingerprint: "fp_active_other" },
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.recordRunStart).not.toHaveBeenCalled();
+	});
+
+	it("refuses an older failed run when a newer current-head run exists", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({ fingerprint: "fp_failed" }),
+		);
+		mocks.getNewerCurrentHeadPrReviewRun.mockResolvedValue({
+			fingerprint: "fp_newer_terminal",
+			headSha: "current-head",
+			triggerKind: "synchronize",
+			triggerSourceId: "current-head",
+			status: "completed",
+			projectionStatus: "projected",
+			sessionId: "sesn_newer",
+			createdAt: "2026-05-17T06:26:00Z",
+			updatedAt: "2026-05-17T06:27:00Z",
+		});
+		mockRecoveryFetch({ headSha: "current-head" });
+
+		const result = await recoverPrReviewRun("fp_failed");
+
+		expect(result).toMatchObject({
+			ok: false,
+			status: 409,
+			reason: "newer_run_exists",
+			successor: { fingerprint: "fp_newer_terminal" },
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.recordRunStart).not.toHaveBeenCalled();
+	});
+
+	it("starts an execution retry with a deterministic manual retry trigger", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({ fingerprint: "fp_failed" }),
+		);
+		mockRecoveryFetch({ headSha: "current-head" });
+
+		const result = await recoverPrReviewRun("fp_failed");
+
+		expect(result).toMatchObject({
+			ok: true,
+			action: "retry_execution",
+			outcome: "execution_retry_started",
+			sessionId: "sesn_01",
+			currentHeadSha: "current-head",
+		});
+		expect(mocks.recordRunStart).toHaveBeenCalledWith(
+			expect.objectContaining({
+				prNumber: 588,
+				headSha: "current-head",
+				triggerKind: "manual_retry",
+				triggerSourceId: "manual-retry-fp_failed-head-current-head",
+			}),
+		);
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_test", {
+			sessionId: "sesn_01",
+			status: "started",
+		});
+	});
+
+	it("repairs projection output from a completed run without rerunning the agent", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({
+				fingerprint: "fp_projection_failed",
+				status: "completed",
+				executionState: "completed",
+				projectionStatus: "failed",
+				projectionError: "GitHub status update failed 503",
+				failureKind: null,
+				failureRetryable: null,
+				reviewIntent: {
+					event: "COMMENT",
+					body: "Repair persisted intent.",
+					labels: [],
+				},
+				recovery: {
+					available: true,
+					action: "repair_projection",
+					label: "Repair GitHub output",
+					reason: "repair",
+					reasonCode: "projection_failed",
+				},
+			}),
+		);
+		mockRecoveryFetch({ headSha: "current-head", reviewId: 588002 });
+
+		const result = await recoverPrReviewRun("fp_projection_failed");
+
+		expect(result).toMatchObject({
+			ok: true,
+			action: "repair_projection",
+			outcome: "projection_repaired",
+			currentHeadSha: "current-head",
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.listEvents).not.toHaveBeenCalled();
+		expect(mocks.recordRunResult).toHaveBeenCalledWith(
+			"fp_projection_failed",
+			expect.objectContaining({
+				status: "completed",
+				projectionStatus: "projected",
+				githubReviewId: "588002",
+			}),
+		);
+	});
+
+	it("refuses projection repair when a newer current-head run exists", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({
+				fingerprint: "fp_projection_failed",
+				status: "completed",
+				executionState: "completed",
+				projectionStatus: "failed",
+				projectionError: "GitHub status update failed 503",
+				failureKind: null,
+				failureRetryable: null,
+				reviewIntent: {
+					event: "COMMENT",
+					body: "Repair persisted intent.",
+					labels: [],
+				},
+			}),
+		);
+		mocks.getNewerCurrentHeadPrReviewRun.mockResolvedValue({
+			fingerprint: "fp_newer_projection",
+			headSha: "current-head",
+			triggerKind: "manual_retry",
+			triggerSourceId: "manual-retry-other-head-current-head",
+			status: "completed",
+			projectionStatus: "projected",
+			sessionId: "sesn_newer_projection",
+			createdAt: "2026-05-17T06:26:00Z",
+			updatedAt: "2026-05-17T06:27:00Z",
+		});
+		mockRecoveryFetch({ headSha: "current-head" });
+
+		const result = await recoverPrReviewRun("fp_projection_failed");
+
+		expect(result).toMatchObject({
+			ok: false,
+			status: 409,
+			reason: "newer_run_exists",
+		});
+		expect(mocks.createSession).not.toHaveBeenCalled();
+		expect(mocks.recordRunResult).not.toHaveBeenCalledWith(
+			"fp_projection_failed",
+			expect.objectContaining({ projectionStatus: "projected" }),
+		);
+	});
+
+	it("returns an idempotent no-op for an already projected completed run", async () => {
+		mocks.getPrReviewRunByFingerprint.mockResolvedValue(
+			reviewRunDetails({
+				fingerprint: "fp_projected",
+				status: "completed",
+				projectionStatus: "projected",
+				recovery: {
+					available: false,
+					action: null,
+					label: null,
+					reason: "published",
+					reasonCode: "already_published",
+				},
+			}),
+		);
+
+		const result = await recoverPrReviewRun("fp_projected");
+
+		expect(result).toMatchObject({
+			ok: true,
+			action: "repair_projection",
+			outcome: "projection_already_projected",
+		});
+		expect(mocks.fetch).not.toHaveBeenCalled();
+		expect(mocks.createSession).not.toHaveBeenCalled();
 	});
 });
 

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -1380,6 +1380,7 @@ export interface PrReviewRunDetails extends PrReviewRunSummary {
 	reviewerConfigHash: string;
 	reviewIntent: PrReviewRunReviewIntent | null;
 	projections: PrReviewProjectionRecord[];
+	recovery: PrReviewRunRecoveryAvailability;
 }
 
 export interface StartedPrReviewRun {
@@ -1404,6 +1405,135 @@ export interface BrokerPrReviewRun
 	projectionStatus: PrReviewProjectionStatus;
 	sessionId: string | null;
 	reviewIntent: PrReviewRunReviewIntent | null;
+	githubReviewId: string | null;
+}
+
+export type PrReviewRunRecoveryAction = "retry_execution" | "repair_projection";
+
+export interface PrReviewRunRecoveryAvailability {
+	available: boolean;
+	action: PrReviewRunRecoveryAction | null;
+	label: string | null;
+	reason: string;
+	reasonCode:
+		| "execution_failed"
+		| "projection_failed"
+		| "failure_not_retryable"
+		| "missing_review_intent"
+		| "run_active"
+		| "run_superseded"
+		| "already_published"
+		| "projection_not_failed"
+		| "unsupported_state";
+}
+
+export interface ActivePrReviewRunSuccessor {
+	fingerprint: string;
+	headSha: string;
+	triggerKind: string;
+	triggerSourceId: string;
+	sessionId: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface PrReviewRunSuccessor extends ActivePrReviewRunSuccessor {
+	status: PrReviewRunStatus;
+	projectionStatus: PrReviewProjectionStatus;
+}
+
+function recoveryAvailabilityForRun(input: {
+	status: PrReviewRunStatus;
+	projectionStatus: PrReviewProjectionStatus;
+	failureRetryable: boolean | null;
+	reviewIntent: PrReviewRunReviewIntent | null;
+}): PrReviewRunRecoveryAvailability {
+	if (input.status === "failed") {
+		if (input.failureRetryable === false) {
+			return {
+				available: false,
+				action: null,
+				label: null,
+				reason: "This failed ReviewRun is marked non-retryable.",
+				reasonCode: "failure_not_retryable",
+			};
+		}
+		return {
+			available: true,
+			action: "retry_execution",
+			label: "Retry execution",
+			reason:
+				"This failed ReviewRun can be retried after live current-head checks pass.",
+			reasonCode: "execution_failed",
+		};
+	}
+
+	if (input.status === "completed") {
+		if (input.projectionStatus === "projected") {
+			return {
+				available: false,
+				action: null,
+				label: null,
+				reason: "This ReviewRun has already been published to GitHub.",
+				reasonCode: "already_published",
+			};
+		}
+		if (input.projectionStatus === "failed") {
+			if (!input.reviewIntent) {
+				return {
+					available: false,
+					action: null,
+					label: null,
+					reason:
+						"This completed ReviewRun has no persisted review intent to repair.",
+					reasonCode: "missing_review_intent",
+				};
+			}
+			return {
+				available: true,
+				action: "repair_projection",
+				label: "Repair GitHub output",
+				reason:
+					"This completed ReviewRun can repair GitHub projection without rerunning the agent.",
+				reasonCode: "projection_failed",
+			};
+		}
+		return {
+			available: false,
+			action: null,
+			label: null,
+			reason: "This completed ReviewRun is not in a failed projection state.",
+			reasonCode: "projection_not_failed",
+		};
+	}
+
+	if (input.status === "started") {
+		return {
+			available: false,
+			action: null,
+			label: null,
+			reason: "This ReviewRun is still active.",
+			reasonCode: "run_active",
+		};
+	}
+
+	if (input.status === "superseded") {
+		return {
+			available: false,
+			action: null,
+			label: null,
+			reason: "This ReviewRun was superseded by newer review activity.",
+			reasonCode: "run_superseded",
+		};
+	}
+
+	return {
+		available: false,
+		action: null,
+		label: null,
+		reason: "This ReviewRun state does not support operator recovery.",
+		reasonCode: "unsupported_state",
+	};
 }
 
 function mapRunDetails(row: {
@@ -1440,6 +1570,7 @@ function mapRunDetails(row: {
 		row.projection_status,
 		status,
 	);
+	const reviewIntent = reviewIntentFromRow(row);
 	const latestKnownHeadSha = row.coalesced_head_sha ?? row.head_sha;
 	const failureKind = normalizeFailureKind(row.failure_kind);
 	const failureMessage = sanitizeFailureMessage(
@@ -1484,12 +1615,19 @@ function mapRunDetails(row: {
 		projectionUpdatedAt: row.projection_updated_at ?? row.updated_at,
 		projectionError,
 		githubReviewId: row.github_review_id,
-		reviewIntent: reviewIntentFromRow(row),
+		reviewIntent,
 		coalescedHeadSha: row.coalesced_head_sha,
 		coalescedTriggerKind: row.coalesced_trigger_kind,
 		coalescedTriggerSourceId: row.coalesced_trigger_source_id,
 		coalescedAt: row.coalesced_at,
 		projections: [],
+		recovery: recoveryAvailabilityForRun({
+			status,
+			projectionStatus,
+			failureRetryable:
+				row.failure_retryable === null ? null : row.failure_retryable === 1,
+			reviewIntent,
+		}),
 	};
 }
 
@@ -1521,6 +1659,110 @@ export async function getPrReviewRunBySessionId(
 		.where("session_id", "=", sessionId)
 		.executeTakeFirst();
 
+	if (!row) return null;
+	const run = mapRunDetails(row);
+	return {
+		...run,
+		projections: await listPrReviewProjectionsForRun(run.fingerprint),
+	};
+}
+
+export async function getActivePrReviewRunSuccessor(input: {
+	fingerprint: string;
+	repoFullName: string;
+	prNumber: number;
+	createdAt: string;
+}): Promise<ActivePrReviewRunSuccessor | null> {
+	await ensureRunsTable();
+	const row = await getDb()
+		.selectFrom("managed_pr_review_runs")
+		.select([
+			"fingerprint",
+			"head_sha",
+			"trigger_kind",
+			"trigger_source_id",
+			"session_id",
+			"created_at",
+			"updated_at",
+		])
+		.where("repo_full_name", "=", input.repoFullName)
+		.where("pr_number", "=", input.prNumber)
+		.where("fingerprint", "!=", input.fingerprint)
+		.where("status", "=", "started")
+		.where("created_at", ">=", input.createdAt)
+		.orderBy("created_at", "desc")
+		.executeTakeFirst();
+	if (!row) return null;
+	return {
+		fingerprint: row.fingerprint,
+		headSha: row.head_sha,
+		triggerKind: row.trigger_kind,
+		triggerSourceId: row.trigger_source_id,
+		sessionId: row.session_id,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export async function getNewerCurrentHeadPrReviewRun(input: {
+	fingerprint: string;
+	repoFullName: string;
+	prNumber: number;
+	headSha: string;
+	createdAt: string;
+}): Promise<PrReviewRunSuccessor | null> {
+	await ensureRunsTable();
+	const row = await getDb()
+		.selectFrom("managed_pr_review_runs")
+		.select([
+			"fingerprint",
+			"head_sha",
+			"trigger_kind",
+			"trigger_source_id",
+			"status",
+			"projection_status",
+			"session_id",
+			"created_at",
+			"updated_at",
+		])
+		.where("repo_full_name", "=", input.repoFullName)
+		.where("pr_number", "=", input.prNumber)
+		.where("head_sha", "=", input.headSha)
+		.where("fingerprint", "!=", input.fingerprint)
+		.where("created_at", ">", input.createdAt)
+		.orderBy("created_at", "desc")
+		.executeTakeFirst();
+	if (!row) return null;
+	const status = row.status as PrReviewRunStatus;
+	return {
+		fingerprint: row.fingerprint,
+		headSha: row.head_sha,
+		triggerKind: row.trigger_kind,
+		triggerSourceId: row.trigger_source_id,
+		status,
+		projectionStatus: normalizeProjectionStatus(row.projection_status, status),
+		sessionId: row.session_id,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+export async function getPrReviewRunByTrigger(input: {
+	repoFullName: string;
+	prNumber: number;
+	triggerKind: string;
+	triggerSourceId: string;
+}): Promise<PrReviewRunDetails | null> {
+	await ensureRunsTable();
+	const row = await getDb()
+		.selectFrom("managed_pr_review_runs")
+		.selectAll()
+		.where("repo_full_name", "=", input.repoFullName)
+		.where("pr_number", "=", input.prNumber)
+		.where("trigger_kind", "=", input.triggerKind)
+		.where("trigger_source_id", "=", input.triggerSourceId)
+		.orderBy("created_at", "desc")
+		.executeTakeFirst();
 	if (!row) return null;
 	const run = mapRunDetails(row);
 	return {
@@ -1832,6 +2074,7 @@ function mapBrokerRun(row: {
 	trigger_source_id: string;
 	status: string;
 	session_id: string | null;
+	github_review_id: string | null;
 	created_at: string;
 	updated_at: string;
 	projection_status: string | null;
@@ -1854,6 +2097,7 @@ function mapBrokerRun(row: {
 		status,
 		projectionStatus: normalizeProjectionStatus(row.projection_status, status),
 		sessionId: row.session_id,
+		githubReviewId: row.github_review_id,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		reviewIntent: reviewIntentFromRow(row),
@@ -1873,6 +2117,7 @@ const BROKER_RUN_COLUMNS = [
 	"trigger_source_id",
 	"status",
 	"session_id",
+	"github_review_id",
 	"created_at",
 	"updated_at",
 	"projection_status",

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -7,11 +7,18 @@ import {
 	getOrCreateEnvironment,
 } from "./managed-agents-cache";
 import {
+	type ActivePrReviewRunSuccessor,
 	type BrokerPrReviewRun,
+	type PrReviewRunDetails,
 	type PrReviewRunReviewIntent,
+	type PrReviewRunSuccessor,
 	beginPrReviewProjectionAttempt,
 	classifyPrReviewProjectionError,
 	computeRunFingerprint,
+	getActivePrReviewRunSuccessor,
+	getNewerCurrentHeadPrReviewRun,
+	getPrReviewRunByFingerprint,
+	getPrReviewRunByTrigger,
 	listPrReviewProjectionsForRun,
 	listPrReviewRunsForBroker,
 	recordPrReviewProjectionFailure,
@@ -115,7 +122,8 @@ export type PrReviewTriggerKind =
 	| "synchronize"
 	| "edited"
 	| "evidence_comment"
-	| "superseded_retry";
+	| "superseded_retry"
+	| "manual_retry";
 
 export interface PrReviewTrigger {
 	kind: PrReviewTriggerKind;
@@ -730,7 +738,7 @@ async function postGitHubReviewIntent(
 	githubToken: string,
 	payload: PrReviewPayload,
 	intent: PrReviewIntent,
-	options: { fingerprint?: string } = {},
+	options: { fingerprint?: string; existingReviewId?: string | null } = {},
 ): Promise<{ reviewId: string | null }> {
 	const [owner, repo] = payload.repoFullName.split("/");
 	if (!owner || !repo) {
@@ -759,7 +767,16 @@ async function postGitHubReviewIntent(
 			})
 		: null;
 	if (projection && !projection.shouldProject) {
-		return { reviewId: projection.observedExternalId };
+		return {
+			reviewId:
+				projection.observedExternalId ?? options.existingReviewId ?? null,
+		};
+	}
+	if (projection && options.existingReviewId) {
+		await recordPrReviewProjectionSuccess(projection.projectionId, {
+			observedExternalId: options.existingReviewId,
+		});
+		return { reviewId: options.existingReviewId };
 	}
 
 	let reviewRes: Response;
@@ -1198,7 +1215,10 @@ async function publishReviewRunIntent(
 			githubToken,
 			payload,
 			intent,
-			{ fingerprint: run.fingerprint },
+			{
+				fingerprint: run.fingerprint,
+				existingReviewId: run.githubReviewId,
+			},
 		);
 		reviewId = postedReview.reviewId;
 		await postManagedReviewStatus(
@@ -1241,6 +1261,432 @@ async function publishReviewRunIntent(
 			retryable,
 		};
 	}
+}
+
+type PrReviewRunRecoveryAction = "retry_execution" | "repair_projection";
+
+export type PrReviewRunRecoveryOutcome =
+	| "execution_retry_started"
+	| "execution_retry_already_active"
+	| "execution_retry_already_exists"
+	| "projection_repaired"
+	| "projection_already_projected";
+
+export type PrReviewRunRecoveryFailureReason =
+	| "not_found"
+	| "reviewer_unavailable"
+	| "current_head_unavailable"
+	| "stale_run"
+	| "superseded_run"
+	| "run_still_active"
+	| "active_successor"
+	| "newer_run_exists"
+	| "failure_not_retryable"
+	| "missing_review_intent"
+	| "unsupported_state"
+	| "retry_not_started"
+	| "projection_repair_failed";
+
+export type PrReviewRunRecoveryResult =
+	| {
+			ok: true;
+			action: PrReviewRunRecoveryAction;
+			outcome: PrReviewRunRecoveryOutcome;
+			fingerprint: string;
+			currentHeadSha: string;
+			message: string;
+			sessionId?: string | null;
+			successorFingerprint?: string;
+			brokerRun?: PrReviewBrokerRunResult;
+	  }
+	| {
+			ok: false;
+			status: number;
+			reason: PrReviewRunRecoveryFailureReason;
+			error: string;
+			currentHeadSha?: string;
+			activeSuccessor?: ActivePrReviewRunSuccessor;
+			successor?: PrReviewRunSuccessor;
+			brokerRun?: PrReviewBrokerRunResult;
+	  };
+
+const MANUAL_RETRY_TRIGGER_KIND = "manual_retry";
+
+function manualRetryTriggerSource(
+	failedFingerprint: string,
+	currentHeadSha: string,
+): string {
+	return `manual-retry-${failedFingerprint}-head-${currentHeadSha}`;
+}
+
+function recoveryFailure(
+	status: number,
+	reason: PrReviewRunRecoveryFailureReason,
+	error: string,
+	extra: Omit<
+		Extract<PrReviewRunRecoveryResult, { ok: false }>,
+		"ok" | "status" | "reason" | "error"
+	> = {},
+): PrReviewRunRecoveryResult {
+	return { ok: false, status, reason, error, ...extra };
+}
+
+function payloadFromRunMetadata(
+	run: Pick<PrReviewRunDetails, "repoFullName" | "prNumber">,
+	metadata: NonNullable<Awaited<ReturnType<typeof fetchPrHeadMetadata>>>,
+): PrReviewPayload {
+	const [, repo] = run.repoFullName.split("/");
+	return {
+		number: run.prNumber,
+		title: metadata.title,
+		htmlUrl: metadata.htmlUrl,
+		body: metadata.body,
+		headRef: metadata.headRef,
+		headSha: metadata.headSha,
+		baseRef: metadata.baseRef,
+		repoUrl: `https://github.com/${run.repoFullName}`,
+		repoFullName: run.repoFullName,
+		repoName: repo ?? "",
+	};
+}
+
+function brokerRunFromDetails(run: PrReviewRunDetails): BrokerPrReviewRun {
+	return {
+		fingerprint: run.fingerprint,
+		repoFullName: run.repoFullName,
+		prNumber: run.prNumber,
+		headSha: run.headSha,
+		triggerKind: run.triggerKind,
+		triggerSourceId: run.triggerSourceId,
+		status: run.status,
+		projectionStatus: run.projectionStatus,
+		sessionId: run.sessionId,
+		githubReviewId: run.githubReviewId,
+		createdAt: run.createdAt,
+		updatedAt: run.updatedAt,
+		reviewIntent: run.reviewIntent,
+		coalescedHeadSha: run.coalescedHeadSha,
+		coalescedTriggerKind: run.coalescedTriggerKind,
+		coalescedTriggerSourceId: run.coalescedTriggerSourceId,
+		coalescedAt: run.coalescedAt,
+	};
+}
+
+function matchingManualRetrySuccessor(
+	successor: ActivePrReviewRunSuccessor | PrReviewRunSuccessor | null,
+	triggerSourceId: string,
+): successor is ActivePrReviewRunSuccessor | PrReviewRunSuccessor {
+	return (
+		successor?.triggerKind === MANUAL_RETRY_TRIGGER_KIND &&
+		successor.triggerSourceId === triggerSourceId
+	);
+}
+
+function retryOutcomeForExistingRun(
+	run: PrReviewRunSuccessor | PrReviewRunDetails,
+): PrReviewRunRecoveryOutcome {
+	return run.status === "started"
+		? "execution_retry_already_active"
+		: "execution_retry_already_exists";
+}
+
+async function fetchLiveCurrentHeadForRecovery(
+	githubToken: string,
+	run: Pick<PrReviewRunDetails, "repoFullName" | "prNumber">,
+): Promise<NonNullable<
+	Awaited<ReturnType<typeof fetchPrHeadMetadata>>
+> | null> {
+	const metadata = await fetchPrHeadMetadata(
+		githubToken,
+		run.repoFullName,
+		run.prNumber,
+	);
+	if (!metadata?.headSha) return null;
+	return metadata;
+}
+
+async function retryFailedReviewRun(
+	run: PrReviewRunDetails,
+	currentPayload: PrReviewPayload,
+	activeSuccessor: ActivePrReviewRunSuccessor | null,
+	newerCurrentHeadRun: PrReviewRunSuccessor | null,
+): Promise<PrReviewRunRecoveryResult> {
+	const triggerSourceId = manualRetryTriggerSource(
+		run.fingerprint,
+		currentPayload.headSha,
+	);
+	if (matchingManualRetrySuccessor(activeSuccessor, triggerSourceId)) {
+		return {
+			ok: true,
+			action: "retry_execution",
+			outcome: "execution_retry_already_active",
+			fingerprint: run.fingerprint,
+			currentHeadSha: currentPayload.headSha,
+			successorFingerprint: activeSuccessor.fingerprint,
+			sessionId: activeSuccessor.sessionId,
+			message: "A deterministic manual retry is already active for this run.",
+		};
+	}
+	if (matchingManualRetrySuccessor(newerCurrentHeadRun, triggerSourceId)) {
+		return {
+			ok: true,
+			action: "retry_execution",
+			outcome: retryOutcomeForExistingRun(newerCurrentHeadRun),
+			fingerprint: run.fingerprint,
+			currentHeadSha: currentPayload.headSha,
+			successorFingerprint: newerCurrentHeadRun.fingerprint,
+			sessionId: newerCurrentHeadRun.sessionId,
+			message: "The deterministic manual retry already exists.",
+		};
+	}
+	if (activeSuccessor) {
+		return recoveryFailure(
+			409,
+			"active_successor",
+			"A newer ReviewRun is already active for this PR.",
+			{ currentHeadSha: currentPayload.headSha, activeSuccessor },
+		);
+	}
+	if (newerCurrentHeadRun) {
+		return recoveryFailure(
+			409,
+			"newer_run_exists",
+			"A newer ReviewRun already exists for the current PR head.",
+			{
+				currentHeadSha: currentPayload.headSha,
+				successor: newerCurrentHeadRun,
+			},
+		);
+	}
+
+	const sessionId = await triggerPrReview(currentPayload, {
+		kind: MANUAL_RETRY_TRIGGER_KIND,
+		triggerSourceId,
+		reason: `Manual operator retry for failed ReviewRun ${run.fingerprint}.`,
+	});
+	if (sessionId) {
+		const successor = await getPrReviewRunByTrigger({
+			repoFullName: run.repoFullName,
+			prNumber: run.prNumber,
+			triggerKind: MANUAL_RETRY_TRIGGER_KIND,
+			triggerSourceId,
+		});
+		return {
+			ok: true,
+			action: "retry_execution",
+			outcome: "execution_retry_started",
+			fingerprint: run.fingerprint,
+			currentHeadSha: currentPayload.headSha,
+			successorFingerprint: successor?.fingerprint,
+			sessionId,
+			message: "Started a manual execution retry for the current PR head.",
+		};
+	}
+
+	const existingRetry = await getPrReviewRunByTrigger({
+		repoFullName: run.repoFullName,
+		prNumber: run.prNumber,
+		triggerKind: MANUAL_RETRY_TRIGGER_KIND,
+		triggerSourceId,
+	});
+	if (existingRetry) {
+		return {
+			ok: true,
+			action: "retry_execution",
+			outcome: retryOutcomeForExistingRun(existingRetry),
+			fingerprint: run.fingerprint,
+			currentHeadSha: currentPayload.headSha,
+			successorFingerprint: existingRetry.fingerprint,
+			sessionId: existingRetry.sessionId,
+			message: "The deterministic manual retry already exists.",
+		};
+	}
+
+	return recoveryFailure(
+		503,
+		"retry_not_started",
+		"Manual retry did not start; reviewer credentials or runtime may be unavailable.",
+		{ currentHeadSha: currentPayload.headSha },
+	);
+}
+
+async function repairCompletedReviewRunProjection(
+	githubToken: string,
+	run: PrReviewRunDetails,
+	currentPayload: PrReviewPayload,
+	activeSuccessor: ActivePrReviewRunSuccessor | null,
+	newerCurrentHeadRun: PrReviewRunSuccessor | null,
+): Promise<PrReviewRunRecoveryResult> {
+	if (activeSuccessor) {
+		return recoveryFailure(
+			409,
+			"active_successor",
+			"A newer ReviewRun is already active for this PR.",
+			{ currentHeadSha: currentPayload.headSha, activeSuccessor },
+		);
+	}
+	if (newerCurrentHeadRun) {
+		return recoveryFailure(
+			409,
+			"newer_run_exists",
+			"A newer ReviewRun already exists for the current PR head.",
+			{
+				currentHeadSha: currentPayload.headSha,
+				successor: newerCurrentHeadRun,
+			},
+		);
+	}
+
+	const intent = persistedReviewIntentForRun(run.reviewIntent);
+	if (!intent) {
+		return recoveryFailure(
+			409,
+			"missing_review_intent",
+			"Completed ReviewRun has no persisted review intent to repair.",
+			{ currentHeadSha: currentPayload.headSha },
+		);
+	}
+
+	const brokerRun = await publishReviewRunIntent(
+		githubToken,
+		brokerRunFromDetails(run),
+		currentPayload,
+		{
+			repoFullName: currentPayload.repoFullName,
+			number: currentPayload.number,
+			headSha: currentPayload.headSha,
+			htmlUrl: currentPayload.htmlUrl,
+			fingerprint: run.fingerprint,
+		},
+		intent,
+	);
+	if (brokerRun.outcome === "applied") {
+		return {
+			ok: true,
+			action: "repair_projection",
+			outcome: "projection_repaired",
+			fingerprint: run.fingerprint,
+			currentHeadSha: currentPayload.headSha,
+			brokerRun,
+			message: "Repaired GitHub projection for the completed ReviewRun.",
+		};
+	}
+
+	return recoveryFailure(
+		brokerRun.outcome === "retryable" ? 503 : 422,
+		"projection_repair_failed",
+		brokerRun.error ?? "Projection repair failed.",
+		{ currentHeadSha: currentPayload.headSha, brokerRun },
+	);
+}
+
+export async function recoverPrReviewRun(
+	fingerprint: string,
+): Promise<PrReviewRunRecoveryResult> {
+	const run = await getPrReviewRunByFingerprint(fingerprint);
+	if (!run) {
+		return recoveryFailure(404, "not_found", "ReviewRun not found.");
+	}
+
+	if (run.status === "superseded") {
+		return recoveryFailure(
+			409,
+			"superseded_run",
+			"Superseded ReviewRuns cannot be retried or repaired.",
+		);
+	}
+	if (run.status === "started") {
+		return recoveryFailure(
+			409,
+			"run_still_active",
+			"Active ReviewRuns cannot be retried or repaired.",
+		);
+	}
+	if (run.status === "completed" && run.projectionStatus === "projected") {
+		return {
+			ok: true,
+			action: "repair_projection",
+			outcome: "projection_already_projected",
+			fingerprint: run.fingerprint,
+			currentHeadSha: run.headSha,
+			message: "ReviewRun is already published; no repair was needed.",
+		};
+	}
+
+	const githubToken = await resolveGitHubToken();
+	if (!githubToken) {
+		return recoveryFailure(
+			503,
+			"reviewer_unavailable",
+			"Missing GitHub App credentials or reviewer is disabled.",
+		);
+	}
+
+	const currentHead = await fetchLiveCurrentHeadForRecovery(githubToken, run);
+	if (!currentHead) {
+		return recoveryFailure(
+			502,
+			"current_head_unavailable",
+			"Could not resolve the current PR head from GitHub.",
+		);
+	}
+	if (run.headSha !== currentHead.headSha) {
+		return recoveryFailure(
+			409,
+			"stale_run",
+			`ReviewRun targets ${run.headSha}; current PR head is ${currentHead.headSha}.`,
+			{ currentHeadSha: currentHead.headSha },
+		);
+	}
+
+	const currentPayload = payloadFromRunMetadata(run, currentHead);
+	const activeSuccessor = await getActivePrReviewRunSuccessor({
+		fingerprint: run.fingerprint,
+		repoFullName: run.repoFullName,
+		prNumber: run.prNumber,
+		createdAt: run.createdAt,
+	});
+	const newerCurrentHeadRun = await getNewerCurrentHeadPrReviewRun({
+		fingerprint: run.fingerprint,
+		repoFullName: run.repoFullName,
+		prNumber: run.prNumber,
+		headSha: currentPayload.headSha,
+		createdAt: run.createdAt,
+	});
+
+	if (run.status === "failed") {
+		if (run.failureRetryable === false) {
+			return recoveryFailure(
+				409,
+				"failure_not_retryable",
+				"This failed ReviewRun is marked non-retryable.",
+				{ currentHeadSha: currentPayload.headSha },
+			);
+		}
+		return retryFailedReviewRun(
+			run,
+			currentPayload,
+			activeSuccessor,
+			newerCurrentHeadRun,
+		);
+	}
+
+	if (run.status === "completed" && run.projectionStatus === "failed") {
+		return repairCompletedReviewRunProjection(
+			githubToken,
+			run,
+			currentPayload,
+			activeSuccessor,
+			newerCurrentHeadRun,
+		);
+	}
+
+	return recoveryFailure(
+		409,
+		"unsupported_state",
+		"This ReviewRun is not failed or projection-failed.",
+		{ currentHeadSha: currentPayload.headSha },
+	);
 }
 
 function countBrokerRun(


### PR DESCRIPTION
## Summary

- add a protected ReviewRun recovery action that retries failed current-head executions or repairs failed GitHub projections
- make recovery refuse stale runs, superseded/published runs, active successors, and newer current-head runs before mutating anything
- expose recovery availability on the ReviewRun API/details page and add a small dashboard action for maintainers
- cover retry idempotency, projection repair without rerunning the agent, refusal cases, and route auth in tests

Closes #588.

## Mergeability

- Surface: web agent-runtime recovery service, ReviewRun details API/page, tests
- User-facing behavior changed: Maintainers can see whether a ReviewRun can be retried or repaired from the run details page and trigger the safe action when available.
- Non-happy paths considered: stale PR heads, superseded/active/published runs, non-retryable failures, missing persisted intents, active successors, newer current-head runs, repeated retry calls, and projection repair failures are covered.
- Residual risk or follow-up: `mise -C web run web:check` could not run in this worker worktree because the local approval layer rejected persistent `mise trust`; the direct equivalent commands passed.

## Validation

- `pnpm --dir web test -- src/lib/agent-runtime/__tests__/pr-review-runs.test.ts src/lib/agent-runtime/__tests__/pr-review.test.ts 'src/app/api/pr-review-runs/[fingerprint]/route.test.ts'` (29 files, 337 tests)
- `pnpm --dir web lint`
- `pnpm --dir web typecheck`
- `pnpm --dir web test` (29 files, 337 tests)
- `UV_CACHE_DIR=/tmp/uv-cache ./scripts/tests/test_security_hardening.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`

## Evidence

- ![validation](https://evidence.cloudcompute.com/workspaces/pr-600/20260601-002535-validation.png)