### PR TITLE
docs: add managed reviewer architecture guide

### DIFF
--- a/docs/pr-review/README.md
+++ b/docs/pr-review/README.md
@@ -1,112 +1,15 @@
 # Managed PR Review
 
-This directory is the home for managed PR reviewer design and operations docs.
+This directory is the entry point for the WorkSpaces managed PR reviewer.
 
-- [`pr-reviewer.md`](pr-reviewer.md): deployed runtime, webhook ingress,
-  broker, health checks, and debugging.
-- [`review-run-schema.sql`](review-run-schema.sql): commented Postgres DDL
-  sketch for the target `ReviewRun` source-of-truth model, with example rows.
+Start with [`architecture.md`](architecture.md) when you need the current
+ReviewRun model, lifecycle vocabulary, diagrams, and operator triage surfaces.
+Use [`pr-reviewer.md`](pr-reviewer.md) for runtime configuration, webhook
+ingress, broker scheduling, canaries, and debugging commands. The current
+storage reference in [`review-run-schema.sql`](review-run-schema.sql) mirrors
+the ReviewRun-centered tables used by the web runtime.
 
-The model should stay simple: a `ReviewRun` row is the durable source of truth.
-GitHub statuses, reviews, labels, diagnostic comments, health checks, and
-dashboard pages are projections that can be recreated or repaired from that row.
-
-## Source Of Truth
-
-```
-GitHub webhook / manual retry
-|
-v
-+-------------------------+
-| ReviewRun               |
-|-------------------------|
-| repo + PR + head        |
-| trigger + fingerprint   |
-| state + timestamps      |
-| agent session id        |
-| validated intent        |
-| error details           |
-+-----------+-------------+
-|
-| desired external state
-v
-+-------------------------+
-| ReviewRunProjection     |
-|-------------------------|
-| github status           |
-| github review           |
-| github labels           |
-| diagnostic comment      |
-+-----------+-------------+
-|
-| apply / observe / repair
-v
-+-------------------------+
-| GitHub                  |
-|-------------------------|
-| WorkSpaces status       |
-| PR review               |
-| labels/comments         |
-+-------------------------+
-```
-
-This removes ambiguity. Operators should ask "what does the run say?" first,
-then ask whether GitHub matches it.
-
-## State Machine
-
-```
-+--------+    session starts    +---------+
-| queued | -------------------> | running |
-+---+----+                      +----+----+
-|                                |
-| setup failure                  | valid review intent
-v                                v
-+--------+   parse/apply    +-----------+   projections   +-----------+
-| failed | <--------------- | completed | --------------> | published |
-+--------+     failure      +-----+-----+     applied     +-----------+
-^                                |
-| projection drift               | newer head/config
-|                                v
-|                          +------------+
-+--------------------------| superseded |
-+------------+
-```
-
-The state field should stay small. Retry counters, reconcile timestamps, and
-projection status are operational metadata, not extra run states.
-
-## Relationships
-
-```
-review_runs
-id PK
-fingerprint UNIQUE
-repo_full_name, pr_number, head_sha
-state
-anthropic_session_id
-intent_event, intent_body, intent_json
-error_code, error_message
-|
-| 1-to-many
-v
-review_run_projections
-run_id FK
-kind: github_status | github_review | github_issue_comment | github_labels
-projection_key
-state: missing | applying | applied | failed | drifted | not_needed
-desired_payload
-observed_payload
-
-review_runs
-|
-| 1-to-many
-v
-review_run_transitions
-run_id FK
-from_state, to_state
-event_name, actor, reason
-```
-
-The transition table is an audit log. The projection table is a repair ledger.
-Neither should replace the current state on `review_runs`.
+The operational rule is simple: **ReviewRun rows are the source of truth**.
+GitHub commit statuses, GitHub reviews, dashboard pages, and health reports are
+derived surfaces that should be checked against the run record when behavior
+looks inconsistent.

--- a/docs/pr-review/architecture.md
+++ b/docs/pr-review/architecture.md
@@ -1,0 +1,140 @@
+# Managed Reviewer Architecture
+
+The managed PR reviewer is a ReviewRun-centered system. GitHub activity starts
+or coalesces a durable run, the managed agent produces a review intent, and the
+broker projects the completed run back to GitHub. Operator surfaces read from
+the same run record so a missing, pending, failed, or stale review can be
+diagnosed from one vocabulary.
+
+## Vocabulary
+
+| Term | Meaning |
+|------|---------|
+| ReviewRun | The durable row in `managed_pr_review_runs` for one reviewer attempt. It stores the PR, head SHA, trigger, reviewer config hash, managed-agent session id, execution status, review intent, projection status, failure metadata, coalesced trigger fields, and details-page fingerprint. |
+| Trigger | A material GitHub event that should review or re-review a PR: PR opened, reopened, ready for review, synchronize, eligible body/base edits, or evidence-bearing PR comments. Metadata-only events are ignored. |
+| Coalesced state | A burst state where a new material trigger arrives while a same-repo, same-PR, same-reviewer-config run is active. The active run keeps executing, records the latest coalesced head and trigger fields, and the broker starts one follow-up run for the latest PR state after retiring the older active run. |
+| Current head | The latest PR head SHA known to the reviewer system for the PR. A run's `head_sha` is the head it started from; `coalesced_head_sha` becomes the latest known head when later activity coalesces into the run. |
+| Superseded run | A run intentionally retired because newer review activity covers it. Superseded runs are terminal and should not be retried. |
+| Completed run | A run whose managed-agent execution finished and stored a validated review intent. Completion is not the same as publication; `projection_status` shows whether GitHub has been updated. |
+| Projection | A GitHub-facing effect derived from a ReviewRun, currently the `WorkSpaces Managed Review` commit status and the posted GitHub PR review. Projections are tracked on the run and in `managed_pr_review_projections`. |
+| Repair sweep | A broker or operator-initiated pass that re-applies missing or failed GitHub projection from a completed ReviewRun without rerunning the agent. |
+| Health audit | A read-only check of ReviewRun coverage, SLOs, failures, and projection drift. The first operator command is [`uv run --script scripts/pr-reviewer-runs.py`](../../scripts/pr-reviewer-runs.py); the GitHub-facing projection audit remains [`scripts/pr-review-health.py`](../../scripts/pr-review-health.py). |
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Started: material trigger
+    Started --> Started: coalesced trigger recorded
+    Started --> Completed: validated review intent
+    Started --> Failed: session start/output failure
+    Completed --> Projected: status and review projected
+    Completed --> ProjectionFailed: GitHub projection failed
+    Completed --> Superseded: newer review/run covers output
+    ProjectionFailed --> Projected: repair sweep succeeds
+    ProjectionFailed --> Failed: repair cannot continue
+    Started --> Superseded: stale active claim retired
+    Failed --> Started: retry execution
+    Superseded --> [*]
+    Projected --> [*]
+```
+
+`status` tracks managed-agent execution: `started`, `completed`, `failed`, or
+`superseded`. `projection_status` tracks GitHub projection: `pending`,
+`projected`, `failed`, or `superseded`. The projection ledger adds per-effect
+states: `pending`, `projecting`, `projected`, `failed`, and `superseded`.
+
+## Relationships
+
+```mermaid
+flowchart LR
+    Trigger["GitHub trigger<br/>PR event or evidence comment"]
+    Run["ReviewRun<br/>managed_pr_review_runs"]
+    Session["Managed agent session<br/>session id + transcript"]
+    Ledger["Projection ledger<br/>managed_pr_review_projections"]
+    GitHub["GitHub artifacts<br/>status + PR review"]
+    Health["Operator surfaces<br/>run report + details page"]
+
+    Trigger -->|"create or coalesce"| Run
+    Run -->|"starts / records"| Session
+    Session -->|"validated review intent"| Run
+    Run -->|"desired effects"| Ledger
+    Ledger -->|"apply / repair"| GitHub
+    GitHub -->|"observed review/status"| Ledger
+    Run -->|"details URL"| GitHub
+    Run -->|"source of truth"| Health
+    Ledger -->|"projection attempts"| Health
+```
+
+The run fingerprint is the stable id for details URLs and idempotency. The
+projection ledger is a repair record, not a second source of truth.
+
+## Runtime Paths
+
+### Happy Path
+
+1. GitHub sends a material trigger through the Cloudflare relay to the Vercel
+   webhook route.
+2. The route verifies the webhook, classifies the trigger, inserts a ReviewRun,
+   and posts a pending `WorkSpaces Managed Review` commit status whose details
+   URL points to `/dashboard/review-runs/<fingerprint>`.
+3. The runtime starts a managed-agent session and stores its session id on the
+   run.
+4. The broker reads the completed session, validates the review-intent JSON,
+   stores the intent, posts the GitHub PR review, and updates the status to
+   success.
+5. The run becomes `status=completed` and `projection_status=projected`.
+
+### Stale Or Superseded Path
+
+When a material trigger arrives while a same-config run is active, the system
+updates the active run's coalesced fields instead of starting parallel work.
+The broker suppresses the older output, marks the older run superseded, and
+starts one follow-up run against the latest known PR state. If a completed
+session is already covered by a newer managed review, the broker also marks it
+superseded instead of posting stale output.
+
+### Failed Execution Path
+
+Execution failures happen before a validated review intent exists: session
+creation failed, session output could not be read, PR metadata was unavailable,
+or the returned intent was invalid. The run records `status=failed`, a
+`failure_kind`, retryability, and a sanitized failure message. Retry execution
+from the run details surface only when the run still targets the current PR
+head and the failure is retryable.
+
+### Failed Projection Path
+
+Projection failures happen after the run has a validated review intent but
+GitHub could not be updated. The run stays completed, records
+`projection_status=failed`, and stores projection errors on the run and ledger.
+Repair projection from the run details surface reuses the stored intent and
+does not rerun the managed agent.
+
+## Operator Triage
+
+Use this order when a PR looks wrong:
+
+| PR symptom | First surface | What to check |
+|------------|---------------|---------------|
+| No review | [`uv run --script scripts/pr-reviewer-runs.py`](../../scripts/pr-reviewer-runs.py) | Look for `missingRuns`, `starting`, `stuckStarting`, or `runningTooLong`. If a run exists, open its details URL. |
+| Pending `WorkSpaces Managed Review` | Run details page from the status details URL | Check execution state, session id, transcript, coalesced fields, and whether the run is still inside the execution/projection SLO. |
+| Failed status | Run details page from the status details URL | Separate `failedExecution` from `projectionFailed`. Retry execution only for retryable execution failures; repair projection for completed runs with failed projection. |
+| Stale review | [`uv run --script scripts/pr-reviewer-runs.py`](../../scripts/pr-reviewer-runs.py) | Confirm whether the current head was picked up, coalesced, superseded, or projected. Use [`scripts/pr-review-health.py`](../../scripts/pr-review-health.py) when the ReviewRun report is healthy but GitHub status/review drift is suspected. |
+
+The authenticated run details page is
+`/dashboard/review-runs/<fingerprint>` (implemented by the
+[review-run details route](../../web/src/app/dashboard/review-runs/%5Bfingerprint%5D/page.tsx)).
+It shows run metadata, latest known head, projection records, recovery
+availability, and the managed-agent transcript when a session id exists.
+
+## Boundaries
+
+- The webhook route decides whether activity is material and either creates a
+  run or coalesces it into the active run.
+- The managed agent reads the PR and returns review intent; it does not post to
+  GitHub.
+- The broker is the only component that publishes managed review output to
+  GitHub or repairs completed-run projection.
+- Health commands and dashboard pages are read surfaces unless an explicit
+  retry or repair action is invoked from the run details page.

--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -5,24 +5,10 @@ on Anthropic's infrastructure, reads the diff, explores surrounding code, runs
 tests, and returns a structured review intent. The web server validates that
 intent and posts the GitHub review with the PR reviewer GitHub App token.
 
-## Architecture
-
-```
-GitHub PR opened
-→ Cloudflare webhook relay
-→ signed forward to web/api/webhooks/github (webhook route)
-→ triggerPrReview() (fire-and-forget)
-→ record new run or coalesce into the active run, then post pending `WorkSpaces Managed Review` commit status
-→ getOrCreateAgent/Environment (idempotent, DB-cached)
-→ sessions.create (mounts repo at PR branch)
-→ events.send (kickoff message)
-→ Agent runs autonomously on Anthropic → returns review-intent JSON
-→ scheduled/protected broker route validates intent → posts GitHub review
-→ commit status flips to success or failure
-```
-
-For the target source-of-truth model and schema sketch, see
-[`README.md`](README.md) and [`review-run-schema.sql`](review-run-schema.sql).
+For the current ReviewRun architecture, lifecycle vocabulary, diagrams, and
+operator triage surfaces, start with [`architecture.md`](architecture.md). This
+file is the runtime and operations reference: configuration, ingress canaries,
+broker scheduling, and debugging commands.
 
 ## Key Files
 

--- a/docs/pr-review/review-run-schema.sql
+++ b/docs/pr-review/review-run-schema.sql
@@ -1,553 +1,102 @@
--- Postgres design sketch for the managed PR reviewer state machine.
+-- Current managed PR reviewer storage reference.
 --
--- This file is intentionally documentation, not a production migration. The
--- deployed web app currently uses LibSQL/Kysely, but the normalized Postgres
--- shape below is the target model: ReviewRun is the source of truth, while
--- GitHub statuses, GitHub reviews, labels, and diagnostic comments are
--- projections that can be repaired from ReviewRun state.
+-- This file documents the ReviewRun-centered shape used by the web runtime.
+-- The production app creates these tables through Kysely/LibSQL helpers in
+-- web/src/lib/agent-runtime/pr-review-runs.ts. Treat this file as an operator
+-- and architecture reference, not as a migration.
 --
--- Start with docs/pr-review/README.md for the operational model and diagrams.
+-- Start with docs/pr-review/README.md, then docs/pr-review/architecture.md for
+-- diagrams, vocabulary, lifecycle paths, and triage surfaces.
 
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-
-CREATE SCHEMA IF NOT EXISTS managed_review;
-
-COMMENT ON SCHEMA managed_review IS
-  'Durable state for managed PR review runs. GitHub state is a projection of these rows.';
-
-DO $$
-BEGIN
-  CREATE TYPE managed_review.review_run_state AS ENUM (
-    'queued',
-    'running',
-    'completed',
-    'published',
-    'failed',
-    'superseded'
-  );
-EXCEPTION WHEN duplicate_object THEN
-  NULL;
-END $$;
-
-COMMENT ON TYPE managed_review.review_run_state IS
-  'Small state machine for one managed review attempt.';
-
-DO $$
-BEGIN
-  CREATE TYPE managed_review.review_trigger_kind AS ENUM (
-    'pr_opened',
-    'pr_reopened',
-    'pr_ready_for_review',
-    'pr_synchronized',
-    'pr_body_edited',
-    'pr_base_edited',
-    'evidence_comment',
-    'manual_retry',
-    'superseded_retry'
-  );
-EXCEPTION WHEN duplicate_object THEN
-  NULL;
-END $$;
-
-COMMENT ON TYPE managed_review.review_trigger_kind IS
-  'External or operator event that asked for a managed review run.';
-
-DO $$
-BEGIN
-  CREATE TYPE managed_review.review_intent_event AS ENUM (
-    'approve',
-    'request_changes',
-    'comment'
-  );
-EXCEPTION WHEN duplicate_object THEN
-  NULL;
-END $$;
-
-COMMENT ON TYPE managed_review.review_intent_event IS
-  'Validated GitHub review event requested by the managed agent.';
-
-DO $$
-BEGIN
-  CREATE TYPE managed_review.review_projection_kind AS ENUM (
-    'github_status',
-    'github_review',
-    'github_issue_comment',
-    'github_labels'
-  );
-EXCEPTION WHEN duplicate_object THEN
-  NULL;
-END $$;
-
-COMMENT ON TYPE managed_review.review_projection_kind IS
-  'Kind of external GitHub object projected from a ReviewRun.';
-
-DO $$
-BEGIN
-  CREATE TYPE managed_review.review_projection_state AS ENUM (
-    'missing',
-    'applying',
-    'applied',
-    'failed',
-    'drifted',
-    'not_needed'
-  );
-EXCEPTION WHEN duplicate_object THEN
-  NULL;
-END $$;
-
-COMMENT ON TYPE managed_review.review_projection_state IS
-  'Observed state of one GitHub projection for a ReviewRun.';
-
-CREATE TABLE IF NOT EXISTS managed_review.review_runs (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-
-  -- Idempotency key for the logical run. This is usually a hash of repo, PR,
-  -- head SHA, trigger kind/source, and reviewer config hash.
-  fingerprint text NOT NULL UNIQUE,
+CREATE TABLE managed_pr_review_runs (
+  fingerprint text PRIMARY KEY,
 
   repo_full_name text NOT NULL,
-  pr_number integer NOT NULL CHECK (pr_number > 0),
-  head_sha text NOT NULL CHECK (head_sha ~ '^[0-9a-f]{40}$'),
-  head_ref text NOT NULL,
-  base_ref text NOT NULL,
+  pr_number integer NOT NULL,
+  head_sha text NOT NULL,
+  trigger_kind text NOT NULL,
+  trigger_source_id text NOT NULL,
   reviewer_config_hash text NOT NULL,
 
-  -- The only state field operators should need to reason about.
-  state managed_review.review_run_state NOT NULL DEFAULT 'queued',
+  -- Managed-agent execution lifecycle:
+  -- started | completed | failed | superseded
+  status text NOT NULL,
+  session_id text,
 
-  trigger_kind managed_review.review_trigger_kind NOT NULL,
-  trigger_source_id text NOT NULL,
-  trigger_delivery_id text,
-  trigger_url text,
+  created_at text NOT NULL,
+  updated_at text NOT NULL,
 
-  -- Retry/supersession relationships keep manual repair explicit instead of
-  -- reusing rows or hiding history.
-  retry_of_run_id uuid REFERENCES managed_review.review_runs(id),
-  superseded_by_run_id uuid REFERENCES managed_review.review_runs(id),
+  -- Execution failure summary. Messages are sanitized and bounded before
+  -- storage.
+  error text,
+  failure_kind text,
+  failure_message text,
+  failure_retryable integer,
+  failed_at text,
 
-  -- Managed-agent execution identity. This is present once the run is running.
-  anthropic_session_id text UNIQUE,
-  agent_id text,
-  environment_id text,
-  model text NOT NULL DEFAULT 'claude-opus-4-6',
-
-  -- Validated review intent captured from the completed managed-agent session.
-  intent_event managed_review.review_intent_event,
-  intent_body text,
-  intent_labels text[] NOT NULL DEFAULT '{}',
-  intent_json jsonb,
-
-  -- Diagnostic material from the managed-agent final output. Keep this
-  -- bounded in application code and treat it as untrusted text when rendering.
-  diagnostic_output text,
-
-  -- GitHub review projection summary. The detailed projection rows below are
-  -- the repair ledger; these columns make the common success path easy to read.
+  -- GitHub projection lifecycle:
+  -- pending | projected | failed | superseded
+  projection_status text,
+  projection_updated_at text,
+  projection_error text,
   github_review_id text,
-  github_review_url text,
 
-  -- Lifecycle timestamps answer "where did this run stop?" without requiring
-  -- operators to reconstruct timing from GitHub status or agent logs.
-  queued_at timestamptz NOT NULL DEFAULT now(),
-  started_at timestamptz,
-  completed_at timestamptz,
-  published_at timestamptz,
-  failed_at timestamptz,
-  superseded_at timestamptz,
+  -- Validated review intent captured from the completed managed-agent output.
+  review_intent_event text,
+  review_intent_body text,
+  review_intent_labels text,
+  review_intent_recorded_at text,
 
-  -- Reconcile fields are scheduler inputs. The broker advances runs and updates
-  -- projections, then sets the next due time for retry or health reporting.
-  next_reconcile_at timestamptz NOT NULL DEFAULT now(),
-  last_reconcile_at timestamptz,
-  reconcile_attempts integer NOT NULL DEFAULT 0 CHECK (reconcile_attempts >= 0),
-
-  -- Error fields carry the operator-facing reason a run failed or needs manual
-  -- attention; projection-specific failures live in review_run_projections.
-  error_code text,
-  error_message text,
-  error_detail jsonb NOT NULL DEFAULT '{}'::jsonb,
-
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now(),
-
-  CONSTRAINT review_runs_repo_full_name_shape
-    CHECK (repo_full_name ~ '^[^/]+/[^/]+$'),
-  CONSTRAINT review_runs_retry_not_self
-    CHECK (retry_of_run_id IS NULL OR retry_of_run_id <> id),
-  CONSTRAINT review_runs_superseded_not_self
-    CHECK (superseded_by_run_id IS NULL OR superseded_by_run_id <> id),
-  CONSTRAINT review_runs_running_has_session
-    CHECK (state <> 'running' OR (anthropic_session_id IS NOT NULL AND started_at IS NOT NULL)),
-  CONSTRAINT review_runs_completed_has_intent
-    CHECK (state NOT IN ('completed', 'published') OR (intent_event IS NOT NULL AND intent_body IS NOT NULL AND completed_at IS NOT NULL)),
-  CONSTRAINT review_runs_published_has_review
-    CHECK (state <> 'published' OR (github_review_url IS NOT NULL AND published_at IS NOT NULL)),
-  CONSTRAINT review_runs_failed_has_error
-    CHECK (state <> 'failed' OR (failed_at IS NOT NULL AND error_code IS NOT NULL)),
-  CONSTRAINT review_runs_superseded_has_target
-    CHECK (state <> 'superseded' OR (superseded_at IS NOT NULL AND superseded_by_run_id IS NOT NULL))
+  -- Active-run coalescing. active_claim_key is unique while a run is active
+  -- for one repo, PR, and reviewer config.
+  active_claim_key text,
+  coalesced_head_sha text,
+  coalesced_trigger_kind text,
+  coalesced_trigger_source_id text,
+  coalesced_at text
 );
 
-COMMENT ON TABLE managed_review.review_runs IS
-  'One durable managed reviewer attempt. This row, not GitHub, is the source of truth.';
-COMMENT ON COLUMN managed_review.review_runs.fingerprint IS
-  'Stable idempotency key for a trigger/config/head combination.';
-COMMENT ON COLUMN managed_review.review_runs.state IS
-  'Current state-machine state. Valid transitions should happen in application code and be audited in review_run_transitions.';
-COMMENT ON COLUMN managed_review.review_runs.trigger_source_id IS
-  'Webhook delivery id, comment id, head SHA, or operator retry id that caused this run.';
-COMMENT ON COLUMN managed_review.review_runs.retry_of_run_id IS
-  'Previous failed or superseded run when this row is an explicit retry.';
-COMMENT ON COLUMN managed_review.review_runs.superseded_by_run_id IS
-  'Newer run that made this run obsolete.';
-COMMENT ON COLUMN managed_review.review_runs.intent_json IS
-  'Raw validated structured intent, stored for replay/debugging.';
-COMMENT ON COLUMN managed_review.review_runs.diagnostic_output IS
-  'Untrusted managed-agent output excerpt for failure comments and operator diagnosis.';
-COMMENT ON COLUMN managed_review.review_runs.next_reconcile_at IS
-  'Scheduler hint for the reconciler; not semantic state.';
-COMMENT ON COLUMN managed_review.review_runs.error_detail IS
-  'Structured failure metadata, such as HTTP status, parser reason, or projection payload hash.';
+CREATE INDEX idx_managed_pr_review_runs_pr
+  ON managed_pr_review_runs (repo_full_name, pr_number);
 
--- Prevent two active runs from competing to publish a review for the same PR
--- head/config. Terminal states may coexist for history and retries.
-CREATE UNIQUE INDEX IF NOT EXISTS review_runs_one_active_per_head
-  ON managed_review.review_runs (repo_full_name, pr_number, head_sha, reviewer_config_hash)
-  WHERE state IN ('queued', 'running', 'completed');
+CREATE UNIQUE INDEX ux_managed_pr_review_runs_active_claim
+  ON managed_pr_review_runs (active_claim_key);
 
-CREATE INDEX IF NOT EXISTS review_runs_reconcile_queue
-  ON managed_review.review_runs (next_reconcile_at, state)
-  WHERE state IN ('queued', 'running', 'completed', 'failed');
+CREATE TABLE managed_pr_review_projections (
+  projection_id text PRIMARY KEY,
+  run_fingerprint text NOT NULL,
 
-CREATE INDEX IF NOT EXISTS review_runs_pr_lookup
-  ON managed_review.review_runs (repo_full_name, pr_number, created_at DESC);
-
-CREATE TABLE IF NOT EXISTS managed_review.review_run_transitions (
-  id bigserial PRIMARY KEY,
-  run_id uuid NOT NULL REFERENCES managed_review.review_runs(id) ON DELETE CASCADE,
-  from_state managed_review.review_run_state,
-  to_state managed_review.review_run_state NOT NULL,
-  event_name text NOT NULL,
-  actor text NOT NULL DEFAULT 'system',
-  reason text,
-  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
-  created_at timestamptz NOT NULL DEFAULT now()
-);
-
-COMMENT ON TABLE managed_review.review_run_transitions IS
-  'Append-only audit log of ReviewRun state changes.';
-COMMENT ON COLUMN managed_review.review_run_transitions.event_name IS
-  'Domain event, such as trigger.accepted, session.started, intent.completed, projection.published, or run.failed.';
-COMMENT ON COLUMN managed_review.review_run_transitions.actor IS
-  'Component or operator responsible for the transition.';
-COMMENT ON COLUMN managed_review.review_run_transitions.metadata IS
-  'Small structured context for diagnosis; never store secrets.';
-
-CREATE INDEX IF NOT EXISTS review_run_transitions_run_time
-  ON managed_review.review_run_transitions (run_id, created_at);
-
-CREATE TABLE IF NOT EXISTS managed_review.review_run_projections (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  run_id uuid NOT NULL REFERENCES managed_review.review_runs(id) ON DELETE CASCADE,
-  kind managed_review.review_projection_kind NOT NULL,
-
-  -- Stable per-run key. Examples: WorkSpaces Managed Review, final-review,
-  -- diagnostic-comment, labels.
+  -- Current projection types:
+  -- github_status | github_review
+  projection_type text NOT NULL,
   projection_key text NOT NULL,
-  state managed_review.review_projection_state NOT NULL DEFAULT 'missing',
 
-  desired_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
-  desired_payload_hash text,
+  desired_payload_hash text NOT NULL,
+  desired_payload text NOT NULL,
 
-  github_id text,
-  github_url text,
-  observed_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  -- Ledger state:
+  -- pending | projecting | projected | failed | superseded
+  state text NOT NULL,
+  attempts integer NOT NULL DEFAULT 0,
+  last_attempted_at text,
+  observed_external_id text,
+  error_kind text,
+  error_text text,
 
-  applied_at timestamptz,
-  observed_at timestamptz,
-  last_error_code text,
-  last_error_message text,
-
-  created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now(),
-
-  CONSTRAINT review_run_projections_failed_has_error
-    CHECK (state <> 'failed' OR last_error_code IS NOT NULL),
-  CONSTRAINT review_run_projections_applied_has_observation
-    CHECK (state <> 'applied' OR (applied_at IS NOT NULL AND observed_at IS NOT NULL))
+  created_at text NOT NULL,
+  updated_at text NOT NULL
 );
 
-COMMENT ON TABLE managed_review.review_run_projections IS
-  'GitHub objects derived from ReviewRun state. The reconciler can recreate or repair these rows.';
-COMMENT ON COLUMN managed_review.review_run_projections.projection_key IS
-  'Human-stable key that distinguishes projections of the same kind for one run.';
-COMMENT ON COLUMN managed_review.review_run_projections.desired_payload IS
-  'Canonical payload the reconciler wants GitHub to have.';
-COMMENT ON COLUMN managed_review.review_run_projections.observed_payload IS
-  'Last GitHub state observed by the reconciler.';
-COMMENT ON COLUMN managed_review.review_run_projections.state IS
-  'Projection health relative to ReviewRun state: missing, applied, failed, drifted, or not needed.';
-
-CREATE UNIQUE INDEX IF NOT EXISTS review_run_projections_one_key
-  ON managed_review.review_run_projections (run_id, kind, projection_key);
-
-CREATE INDEX IF NOT EXISTS review_run_projections_repair
-  ON managed_review.review_run_projections (state, updated_at)
-  WHERE state IN ('missing', 'failed', 'drifted');
-
--- Health should become a view over unreconciled ReviewRuns, not a scrape of
--- GitHub statuses first. GitHub checks are projection verification only.
-CREATE OR REPLACE VIEW managed_review.review_run_health AS
-SELECT
-  r.id,
-  r.repo_full_name,
-  r.pr_number,
-  r.head_sha,
-  r.state,
-  r.error_code,
-  r.error_message,
-  r.next_reconcile_at,
-  r.last_reconcile_at,
-  count(p.id) FILTER (WHERE p.state IN ('missing', 'failed', 'drifted')) AS unhealthy_projection_count,
-  max(p.updated_at) FILTER (WHERE p.state IN ('missing', 'failed', 'drifted')) AS last_unhealthy_projection_at
-FROM managed_review.review_runs r
-LEFT JOIN managed_review.review_run_projections p ON p.run_id = r.id
-WHERE r.state IN ('queued', 'running', 'completed', 'failed')
-GROUP BY
-  r.id,
-  r.repo_full_name,
-  r.pr_number,
-  r.head_sha,
-  r.state,
-  r.error_code,
-  r.error_message,
-  r.next_reconcile_at,
-  r.last_reconcile_at;
-
-COMMENT ON VIEW managed_review.review_run_health IS
-  'Operator-facing queue of runs that still need reconciliation or explicit attention.';
-
--- ---------------------------------------------------------------------------
--- Example rows
--- ---------------------------------------------------------------------------
--- The examples are executable against an empty database. They are not seed data.
-
--- Example 1: a completed and published approval. GitHub can be repaired from
--- this run because the validated intent and projection payloads are durable.
-INSERT INTO managed_review.review_runs (
-  id,
-  fingerprint,
-  repo_full_name,
-  pr_number,
-  head_sha,
-  head_ref,
-  base_ref,
-  reviewer_config_hash,
-  state,
-  trigger_kind,
-  trigger_source_id,
-  trigger_url,
-  anthropic_session_id,
-  agent_id,
-  environment_id,
-  intent_event,
-  intent_body,
-  intent_labels,
-  intent_json,
-  github_review_id,
-  github_review_url,
-  queued_at,
-  started_at,
-  completed_at,
-  published_at
-) VALUES (
-  '11111111-1111-4111-8111-111111111111',
-  'sha256:f4a7-review-run-published-example',
-  'fairchild/workspaces',
-  504,
-  '1454644ee9f36f802206d305b2c58f9b2b36415a',
-  'codex-managed-review-parser',
-  'main',
-  'reviewer-config:claude-opus-4-6:2026-05-24',
-  'published',
-  'pr_ready_for_review',
-  'head-1454644ee9f36f802206d305b2c58f9b2b36415a',
-  'https://github.com/fairchild/workspaces/pull/504',
-  'sesn_01examplepublished',
-  'agent_pr_reviewer',
-  'env_pr_reviewer',
-  'approve',
-  'Approve - parser hardening is focused and covered by regression tests.',
-  ARRAY['area: platform', 'web'],
-  '{"event":"APPROVE","labels":["area: platform","web"]}'::jsonb,
-  'PRR_kwDOExampleReview',
-  'https://github.com/fairchild/workspaces/pull/504#pullrequestreview-1',
-  '2026-05-24T06:07:46Z',
-  '2026-05-24T06:07:47Z',
-  '2026-05-24T06:12:30Z',
-  '2026-05-24T06:13:00Z'
-);
-
-INSERT INTO managed_review.review_run_projections (
-  run_id,
-  kind,
-  projection_key,
-  state,
-  desired_payload,
-  desired_payload_hash,
-  github_id,
-  github_url,
-  observed_payload,
-  applied_at,
-  observed_at
-) VALUES
-  (
-    '11111111-1111-4111-8111-111111111111',
-    'github_status',
-    'WorkSpaces Managed Review',
-    'applied',
-    '{"state":"success","context":"WorkSpaces Managed Review","description":"Managed review posted."}'::jsonb,
-    'sha256:status-success-example',
-    'status:1454644:WorkSpaces Managed Review',
-    'https://github.com/fairchild/workspaces/pull/504',
-    '{"state":"success","context":"WorkSpaces Managed Review"}'::jsonb,
-    '2026-05-24T06:13:00Z',
-    '2026-05-24T06:13:01Z'
-  ),
-  (
-    '11111111-1111-4111-8111-111111111111',
-    'github_review',
-    'final-review',
-    'applied',
-    '{"event":"APPROVE","body":"Approve - parser hardening is focused and covered by regression tests."}'::jsonb,
-    'sha256:review-approve-example',
-    'PRR_kwDOExampleReview',
-    'https://github.com/fairchild/workspaces/pull/504#pullrequestreview-1',
-    '{"state":"APPROVED","commit_id":"1454644ee9f36f802206d305b2c58f9b2b36415a"}'::jsonb,
-    '2026-05-24T06:13:00Z',
-    '2026-05-24T06:13:01Z'
+CREATE UNIQUE INDEX ux_managed_pr_review_projections_desired
+  ON managed_pr_review_projections (
+    run_fingerprint,
+    projection_type,
+    projection_key,
+    desired_payload_hash
   );
 
-INSERT INTO managed_review.review_run_transitions (
-  run_id,
-  from_state,
-  to_state,
-  event_name,
-  actor,
-  reason,
-  metadata
-) VALUES
-  ('11111111-1111-4111-8111-111111111111', NULL, 'queued', 'trigger.accepted', 'webhook', 'PR moved to ready for review', '{}'::jsonb),
-  ('11111111-1111-4111-8111-111111111111', 'queued', 'running', 'session.started', 'reconciler', 'Managed-agent session created', '{"session_id":"sesn_01examplepublished"}'::jsonb),
-  ('11111111-1111-4111-8111-111111111111', 'running', 'completed', 'intent.completed', 'reconciler', 'Validated APPROVE intent captured', '{}'::jsonb),
-  ('11111111-1111-4111-8111-111111111111', 'completed', 'published', 'projection.published', 'reconciler', 'GitHub review and status applied', '{}'::jsonb);
+CREATE INDEX idx_managed_pr_review_projections_run
+  ON managed_pr_review_projections (run_fingerprint);
 
--- Example 2: a completed session whose output could not be converted into a
--- final GitHub review. The failed run plus status/comment projections make the
--- problem explicit; operators do not have to infer it from GitHub status alone.
-INSERT INTO managed_review.review_runs (
-  id,
-  fingerprint,
-  repo_full_name,
-  pr_number,
-  head_sha,
-  head_ref,
-  base_ref,
-  reviewer_config_hash,
-  state,
-  trigger_kind,
-  trigger_source_id,
-  trigger_url,
-  anthropic_session_id,
-  intent_json,
-  diagnostic_output,
-  queued_at,
-  started_at,
-  completed_at,
-  failed_at,
-  error_code,
-  error_message,
-  error_detail
-) VALUES (
-  '22222222-2222-4222-8222-222222222222',
-  'sha256:8db1-review-run-failed-example',
-  'fairchild/workspaces',
-  504,
-  '1454644ee9f36f802206d305b2c58f9b2b36415a',
-  'codex-managed-review-parser',
-  'main',
-  'reviewer-config:claude-opus-4-6:2026-05-24',
-  'failed',
-  'manual_retry',
-  'comment-4527593416',
-  'https://github.com/fairchild/workspaces/pull/504#issuecomment-4527593416',
-  'sesn_01examplefailed',
-  '{"raw":"agent returned a review intent that production could not parse"}'::jsonb,
-  'The managed reviewer completed, but the production parser stopped at an embedded fenced-code marker.',
-  '2026-05-24T06:21:56Z',
-  '2026-05-24T06:21:58Z',
-  '2026-05-24T06:28:40Z',
-  '2026-05-24T06:28:58Z',
-  'intent_json_parse_failed',
-  'No valid PR review intent JSON found: unterminated string in JSON body',
-  '{"parser":"legacy_lazy_fence_regex","repair":"deploy line-delimited fence parser"}'::jsonb
-);
-
-INSERT INTO managed_review.review_run_projections (
-  run_id,
-  kind,
-  projection_key,
-  state,
-  desired_payload,
-  desired_payload_hash,
-  github_id,
-  github_url,
-  observed_payload,
-  applied_at,
-  observed_at,
-  last_error_code,
-  last_error_message
-) VALUES
-  (
-    '22222222-2222-4222-8222-222222222222',
-    'github_status',
-    'WorkSpaces Managed Review',
-    'applied',
-    '{"state":"failure","context":"WorkSpaces Managed Review","description":"Managed review failed before posting."}'::jsonb,
-    'sha256:status-failure-example',
-    'status:1454644:WorkSpaces Managed Review',
-    'https://github.com/fairchild/workspaces/pull/504',
-    '{"state":"failure","context":"WorkSpaces Managed Review"}'::jsonb,
-    '2026-05-24T06:28:58Z',
-    '2026-05-24T06:28:59Z',
-    NULL,
-    NULL
-  ),
-  (
-    '22222222-2222-4222-8222-222222222222',
-    'github_issue_comment',
-    'diagnostic-comment',
-    'applied',
-    '{"body":"Managed review publication failed. See escaped diagnostic output."}'::jsonb,
-    'sha256:diagnostic-comment-example',
-    'IC_kwDOExampleDiagnostic',
-    'https://github.com/fairchild/workspaces/pull/504#issuecomment-operator-note',
-    '{"body_prefix":"Managed review publication failed"}'::jsonb,
-    '2026-05-24T06:28:58Z',
-    '2026-05-24T06:28:59Z',
-    NULL,
-    NULL
-  );
-
-INSERT INTO managed_review.review_run_transitions (
-  run_id,
-  from_state,
-  to_state,
-  event_name,
-  actor,
-  reason,
-  metadata
-) VALUES
-  ('22222222-2222-4222-8222-222222222222', NULL, 'queued', 'trigger.accepted', 'operator', 'Manual retry requested after failed projection', '{"comment_id":"4527593416"}'::jsonb),
-  ('22222222-2222-4222-8222-222222222222', 'queued', 'running', 'session.started', 'reconciler', 'Managed-agent session created', '{"session_id":"sesn_01examplefailed"}'::jsonb),
-  ('22222222-2222-4222-8222-222222222222', 'running', 'failed', 'run.failed', 'reconciler', 'Completed output could not be parsed by deployed broker', '{"error_code":"intent_json_parse_failed"}'::jsonb);
+CREATE INDEX idx_managed_pr_review_projections_state
+  ON managed_pr_review_projections (state, updated_at);


### PR DESCRIPTION
## Summary

- Add `docs/pr-review/architecture.md` as the current ReviewRun architecture guide for issue #591
- Make `docs/pr-review/README.md` the single entry point and point `pr-reviewer.md` to the guide for architecture
- Replace the stale target-state schema sketch with a concise current storage reference for runs and projections

Fixes #591.

## Mergeability

- Surface: docs
- User-facing behavior changed: no runtime behavior changes
- Non-happy paths considered: documented stale/superseded runs, failed execution, and failed projection handling
- Release/ops preconditions: none
- Residual risk or follow-up: Mermaid rendering depends on the Markdown viewer; the diagrams are also readable from their labels and surrounding text

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `git diff --check`
  - `node web/scripts/docs-sync.mjs`
  - `node web/scripts/docs-sync.mjs --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Docs-only validation: `git diff --check`; `node web/scripts/docs-sync.mjs`; `node web/scripts/docs-sync.mjs --check`

## Blockers

- [x] None
- [ ] Blocked on evidence
