### PR TITLE
Docs: add managed reviewer understanding guide and quiz

### DIFF
--- a/docs/pr-review/README.md
+++ b/docs/pr-review/README.md
@@ -4,10 +4,13 @@ This directory is the entry point for the WorkSpaces managed PR reviewer.
 
 Start with [`architecture.md`](architecture.md) when you need the current
 ReviewRun model, lifecycle vocabulary, diagrams, and operator triage surfaces.
-Use [`pr-reviewer.md`](pr-reviewer.md) for runtime configuration, webhook
-ingress, broker scheduling, canaries, and debugging commands. The current
-storage reference in [`review-run-schema.sql`](review-run-schema.sql) mirrors
-the ReviewRun-centered tables used by the web runtime.
+Use [`understanding-guide.md`](understanding-guide.md) and
+[`scripts/pr-reviewer-quiz.py`](../../scripts/pr-reviewer-quiz.py) when someone
+needs to learn the system through scenarios before operating or changing it. Use
+[`pr-reviewer.md`](pr-reviewer.md) for runtime configuration, webhook ingress,
+broker scheduling, canaries, and debugging commands. The current storage
+reference in [`review-run-schema.sql`](review-run-schema.sql) mirrors the
+ReviewRun-centered tables used by the web runtime.
 
 The operational rule is simple: **ReviewRun rows are the source of truth**.
 GitHub commit statuses, GitHub reviews, dashboard pages, and health reports are

--- a/docs/pr-review/architecture.md
+++ b/docs/pr-review/architecture.md
@@ -6,6 +6,13 @@ broker projects the completed run back to GitHub. Operator surfaces read from
 the same run record so a missing, pending, failed, or stale review can be
 diagnosed from one vocabulary.
 
+If you are learning the system or checking that a docs change still teaches the
+right operator decisions, use the scenario-based
+[`understanding-guide.md`](understanding-guide.md) and offline quiz:
+[`uv run --script scripts/pr-reviewer-quiz.py --check-answer-key`](../../scripts/pr-reviewer-quiz.py).
+They exercise the vocabulary here without requiring network access or
+production secrets.
+
 ## Vocabulary
 
 | Term | Meaning |

--- a/docs/pr-review/understanding-guide.md
+++ b/docs/pr-review/understanding-guide.md
@@ -1,0 +1,128 @@
+# Managed Reviewer Understanding Guide
+
+Use this guide when you need to explain or verify the current managed reviewer
+system from behavior instead of table names. For the canonical component model,
+state machine, and operator surfaces, keep
+[`architecture.md`](architecture.md) as the source of truth. For operational
+configuration and production runbooks, use [`pr-reviewer.md`](pr-reviewer.md).
+
+The companion quiz is offline and deterministic:
+
+```bash
+uv run --script scripts/pr-reviewer-quiz.py
+uv run --script scripts/pr-reviewer-quiz.py --check-answer-key
+```
+
+Run the quiz after reading this page, after changing managed-reviewer docs, or
+when onboarding someone who needs the reviewer vocabulary before touching the
+runtime.
+
+## The Mental Model
+
+The managed reviewer is a ReviewRun pipeline:
+
+1. A material GitHub trigger creates or coalesces a ReviewRun.
+2. The managed agent executes and returns a validated review intent.
+3. The broker projects the completed ReviewRun to GitHub.
+4. Health and dashboard surfaces explain the same run record.
+
+Keep two lifecycle questions separate:
+
+| Question | Field | Meaning |
+|----------|-------|---------|
+| Did the managed agent produce usable review intent? | `status` | `started`, `completed`, `failed`, or `superseded` |
+| Did GitHub receive the review/status projection? | `projection_status` | `pending`, `projected`, `failed`, or `superseded` |
+
+That split is the fastest way to avoid the wrong recovery action. Retry
+execution only when there is no valid review intent and the run is still safe to
+retry. Repair projection when the ReviewRun is already completed and the stored
+intent only needs to be applied to GitHub.
+
+## Scenario Walkthroughs
+
+### 1. Pickup Is Visible Before A Review Exists
+
+A PR opens and the `WorkSpaces Managed Review` status appears as pending on the
+new head. That status means the webhook route accepted a material trigger,
+created a ReviewRun, and published the first GitHub-facing indicator. It does
+not mean the managed agent has finished or that the broker has posted a review.
+
+If an operator sees no review yet, the first check is the ReviewRun report:
+`uv run --script scripts/pr-reviewer-runs.py`. A healthy early row may be
+`starting` or `running`. A problem row may be `missingRuns`, `stuckStarting`, or
+`runningTooLong`.
+
+### 2. Coalescing Prevents Parallel Reviews
+
+A PR receives two pushes while the first review is still active. The system does
+not start three independent agents for the same reviewer config. It records the
+latest trigger and latest head on the active run's coalesced fields. The broker
+then suppresses stale output and starts one follow-up run for the latest PR
+state.
+
+The key vocabulary is active coalescing: one active run, latest known head
+recorded, older output retired, one follow-up review for the current state.
+
+### 3. Stale Output Is Suppressed, Not Published Late
+
+A managed-agent session may complete successfully for a head that is no longer
+current. If a newer run or managed review covers the PR, the broker marks the
+older run superseded. A superseded run is terminal and should not be retried.
+
+This is intentional. The system prefers no review from an old head over a
+confusing late review that appears authoritative on outdated code.
+
+### 4. Failed Execution Means No Valid Intent Exists
+
+An execution failure happens before usable review intent is stored: session
+creation failed, session output could not be read, PR metadata was unavailable,
+or the returned intent failed validation. The run records a failure kind,
+retryability, and a sanitized message.
+
+Safe retry is limited. Retry execution only when the failure is retryable and
+the run still targets the current PR head. If the PR moved on, the safer action
+is a fresh run for the current head, not reviving stale execution.
+
+### 5. Failed Projection Means The Intent Already Exists
+
+A completed run can still fail to update GitHub. For example, the broker may
+store validated review intent but fail while posting the GitHub review or final
+status. That is `status=completed` with `projection_status=failed`.
+
+Do not rerun the managed agent in this case. Repair projection from the stored
+ReviewRun intent. The repair sweep is designed for this path: re-apply missing
+or failed GitHub effects without spending another agent run.
+
+### 6. Health Output Has Two Lenses
+
+The ReviewRun report is the source-of-truth health lens for pickup, execution,
+coalescing, failure, supersession, and projection due rows. It uses buckets such
+as `missingRuns`, `runningTooLong`, `completedAwaitingProjection`,
+`failedExecution`, `projectionFailed`, `superseded`, and `published`.
+
+The GitHub projection audit is a drift lens for open PRs: statuses, pending
+timeouts, failures, and whether a current-head managed review exists. A green
+projection audit is useful, but it does not prove ingestion, session execution,
+or broker projection is healthy.
+
+## Choosing The Next Action
+
+| Observation | Interpret As | First Action |
+|-------------|--------------|--------------|
+| No ReviewRun row for an eligible trigger | Pickup or ingestion gap | Inspect ReviewRun report for `missingRuns`; then check ingress/trigger classification. |
+| Pending status just appeared | Pickup succeeded; execution or projection may still be in progress | Wait inside SLO or open the details URL for run state. |
+| Active run has coalesced fields | Newer material trigger arrived during execution | Let the broker suppress older output and create one follow-up run. |
+| Completed run has failed projection | Valid intent exists, GitHub projection failed | Repair projection or let a repair sweep re-apply effects. |
+| Failed run has retryable execution failure on current head | No valid intent exists, but retry is safe | Retry execution from the run details surface. |
+| Failed run targets an older head | Retry would revive stale work | Start or wait for a current-head run instead. |
+| Superseded run | Newer work intentionally replaced it | Do not retry; use the covering current-head run. |
+
+## Boundaries To Preserve
+
+- Do not include raw webhook payloads, secrets, tokens, or transcript dumps in
+  learning materials.
+- Do not teach production-only emergency steps as the default path.
+- Do not collapse execution failure and projection failure into one "reviewer
+  failed" bucket.
+- Do not treat an old successful review as proof that the current PR head is
+  covered.

--- a/scripts/pr-reviewer-quiz.py
+++ b/scripts/pr-reviewer-quiz.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Offline managed reviewer scenario quiz.
+
+The quiz teaches the ReviewRun vocabulary used by docs/pr-review/architecture.md.
+It does not call GitHub, Vercel, Anthropic, or production services.
+
+Usage:
+  uv run --script scripts/pr-reviewer-quiz.py
+  uv run --script scripts/pr-reviewer-quiz.py --check-answer-key
+  uv run --script scripts/pr-reviewer-quiz.py --answers A,B,C
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+
+
+REQUIRED_TOPICS = {
+    "pickup",
+    "active-coalescing",
+    "stale-output",
+    "superseded-output",
+    "failed-execution",
+    "failed-projection",
+    "repair-sweep",
+    "health-output",
+    "safe-retry",
+}
+
+VOCABULARY = {
+    "ReviewRun",
+    "coalesced",
+    "current head",
+    "superseded",
+    "status",
+    "projection_status",
+    "review intent",
+    "repair sweep",
+    "WorkSpaces Managed Review",
+}
+
+
+@dataclass(frozen=True)
+class Question:
+    id: str
+    topic: str
+    prompt: str
+    choices: tuple[str, str, str, str]
+    answer: str
+    explanation: str
+
+
+QUESTIONS: tuple[Question, ...] = (
+    Question(
+        id="pickup-pending-status",
+        topic="pickup",
+        prompt=(
+            "A PR is opened and the `WorkSpaces Managed Review` status appears "
+            "as pending on the PR head, but no GitHub review has been posted yet. "
+            "What has the system proved so far?"
+        ),
+        choices=(
+            "The broker posted the managed review and GitHub is only slow to render it.",
+            "A material trigger created a ReviewRun and the first GitHub-facing "
+            "pickup indicator was projected.",
+            "The managed agent completed and stored a validated review intent.",
+            "The projection ledger has already marked every GitHub effect projected.",
+        ),
+        answer="B",
+        explanation=(
+            "Pending `WorkSpaces Managed Review` proves pickup: a material trigger "
+            "created a ReviewRun and a pending status. It does not prove completed "
+            "execution, review intent, or final projection."
+        ),
+    ),
+    Question(
+        id="pickup-missing-run",
+        topic="pickup",
+        prompt=(
+            "An eligible synchronize event happened, but the ReviewRun report "
+            "shows the PR key under `missingRuns`. Where should triage start?"
+        ),
+        choices=(
+            "Repair projection, because a completed run must already exist.",
+            "Retry execution from the run details page.",
+            "Investigate ingress and trigger classification before looking for agent output.",
+            "Mark the last successful run superseded.",
+        ),
+        answer="C",
+        explanation=(
+            "`missingRuns` means the source-of-truth ReviewRun row is absent for "
+            "an eligible trigger. Triage pickup, ingress, and trigger classification "
+            "before execution or projection paths."
+        ),
+    ),
+    Question(
+        id="active-coalescing-burst",
+        topic="active-coalescing",
+        prompt=(
+            "A same-config run is active when two newer commits are pushed to the "
+            "PR. What should happen?"
+        ),
+        choices=(
+            "Start a parallel managed-agent session for every push.",
+            "Cancel all managed review activity until a human restarts it.",
+            "Record the latest coalesced head/trigger on the active ReviewRun, "
+            "then create one follow-up run for the latest state.",
+            "Post the active run's output even if it reviewed the first head.",
+        ),
+        answer="C",
+        explanation=(
+            "Active coalescing keeps one active ReviewRun, records the latest "
+            "coalesced current head, suppresses stale output, and follows up once "
+            "for the latest PR state."
+        ),
+    ),
+    Question(
+        id="stale-output-after-newer-review",
+        topic="stale-output",
+        prompt=(
+            "A managed-agent session returns valid review intent for an older head, "
+            "but a newer managed review already covers the current head. What should "
+            "the broker do with the older run?"
+        ),
+        choices=(
+            "Post the older review so every session has a visible GitHub review.",
+            "Mark the older run superseded and avoid publishing stale output.",
+            "Retry execution until it produces the same findings for the newer head.",
+            "Convert the older review intent into a health audit failure.",
+        ),
+        answer="B",
+        explanation=(
+            "Stale output should be suppressed. A superseded ReviewRun is terminal "
+            "because newer current-head work intentionally replaced it."
+        ),
+    ),
+    Question(
+        id="superseded-retry",
+        topic="superseded-output",
+        prompt=(
+            "A details page shows `status=superseded` for a run after newer PR "
+            "activity was reviewed. Which action is safe?"
+        ),
+        choices=(
+            "Retry the superseded run so the old transcript is not wasted.",
+            "Repair projection for the superseded run.",
+            "Do not retry it; inspect the covering current-head run instead.",
+            "Change the projection status to pending by hand.",
+        ),
+        answer="C",
+        explanation=(
+            "Superseded runs are terminal. Retrying or repairing them can revive "
+            "outdated output; use the newer ReviewRun that covers the current head."
+        ),
+    ),
+    Question(
+        id="failed-execution-no-intent",
+        topic="failed-execution",
+        prompt=(
+            "A run has `status=failed`, `projection_status=pending`, and no stored "
+            "review intent because session output could not be read. What kind of "
+            "failure is this?"
+        ),
+        choices=(
+            "Failed execution.",
+            "Failed projection.",
+            "Successful projection with delayed status update.",
+            "Superseded output.",
+        ),
+        answer="A",
+        explanation=(
+            "Failed execution happens before validated review intent exists. "
+            "`status` owns the agent/session lifecycle; projection repair is not "
+            "available until a completed ReviewRun has intent to project."
+        ),
+    ),
+    Question(
+        id="failed-projection-has-intent",
+        topic="failed-projection",
+        prompt=(
+            "A run has `status=completed`, validated review intent, and "
+            "`projection_status=failed` after GitHub rejected a review post. What "
+            "is the correct recovery shape?"
+        ),
+        choices=(
+            "Rerun the managed agent from scratch.",
+            "Repair projection using the stored ReviewRun intent.",
+            "Mark the run failed execution.",
+            "Ignore it because completed status means GitHub was updated.",
+        ),
+        answer="B",
+        explanation=(
+            "A completed ReviewRun already has review intent. Failed projection is "
+            "recovered by repairing GitHub effects from the stored intent, not by "
+            "rerunning execution."
+        ),
+    ),
+    Question(
+        id="repair-sweep-purpose",
+        topic="repair-sweep",
+        prompt=(
+            "What is the repair sweep designed to do?"
+        ),
+        choices=(
+            "Re-run all managed agents whose reviews were unflattering.",
+            "Apply or re-apply missing GitHub projection for completed ReviewRuns "
+            "without rerunning the agent.",
+            "Replay raw webhook payloads from production logs.",
+            "Delete superseded runs from the database.",
+        ),
+        answer="B",
+        explanation=(
+            "A repair sweep is a projection recovery path. It reuses completed "
+            "ReviewRun intent and the projection ledger to apply missing or failed "
+            "GitHub effects."
+        ),
+    ),
+    Question(
+        id="health-run-report-vs-projection-audit",
+        topic="health-output",
+        prompt=(
+            "The GitHub projection audit is green for active PRs. Which statement "
+            "is still true?"
+        ),
+        choices=(
+            "It proves ReviewRun ingestion, execution, and broker projection are "
+            "all healthy.",
+            "It only checks GitHub-facing drift; use the ReviewRun report for "
+            "source-of-truth queue health.",
+            "It means there are no superseded runs.",
+            "It means retrying all failed execution rows is safe.",
+        ),
+        answer="B",
+        explanation=(
+            "Health has two lenses. The projection audit checks GitHub statuses and "
+            "reviews; the ReviewRun report is the source of truth for pickup, "
+            "execution, coalescing, failures, and projection-due rows."
+        ),
+    ),
+    Question(
+        id="health-bucket-completed-awaiting-projection",
+        topic="health-output",
+        prompt=(
+            "The ReviewRun report lists a run under `completedAwaitingProjection`. "
+            "What does that bucket mean?"
+        ),
+        choices=(
+            "The managed agent has no session id yet.",
+            "The run has completed review intent and the broker still needs to "
+            "publish or repair GitHub projection.",
+            "The run is too old to retry and must be superseded immediately.",
+            "The webhook relay rejected the event before creating a row.",
+        ),
+        answer="B",
+        explanation=(
+            "`completedAwaitingProjection` is between execution and GitHub effects: "
+            "the ReviewRun has completed intent, while projection_status or ledger "
+            "work still needs the broker or repair sweep."
+        ),
+    ),
+    Question(
+        id="safe-retry-current-head",
+        topic="safe-retry",
+        prompt=(
+            "A failed execution row is retryable and still targets the current PR "
+            "head. What is the safe action?"
+        ),
+        choices=(
+            "Retry execution from the run details surface.",
+            "Repair projection even though no review intent exists.",
+            "Mark the run superseded before trying again.",
+            "Run the GitHub projection audit and ignore the ReviewRun failure.",
+        ),
+        answer="A",
+        explanation=(
+            "Safe retry requires a retryable execution failure on the current head. "
+            "Because no review intent exists, retry execution is the right recovery."
+        ),
+    ),
+    Question(
+        id="safe-retry-older-head",
+        topic="safe-retry",
+        prompt=(
+            "A failed execution row is marked retryable, but the PR has since moved "
+            "to a newer head. What should an operator avoid?"
+        ),
+        choices=(
+            "Starting or waiting for a current-head ReviewRun.",
+            "Checking whether newer activity coalesced into an active run.",
+            "Retrying the older-head run as though it still represented current code.",
+            "Using ReviewRun health output to understand coverage.",
+        ),
+        answer="C",
+        explanation=(
+            "Retryability is not enough. Safe retry also requires current-head "
+            "coverage; retrying an older-head ReviewRun can produce stale output."
+        ),
+    ),
+)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--answers",
+        help=(
+            "Comma-separated answers for non-interactive grading. "
+            "Example: --answers A,B,C,D"
+        ),
+    )
+    parser.add_argument(
+        "--check-answer-key",
+        action="store_true",
+        help="Validate quiz data and grade the embedded answer key.",
+    )
+    parser.add_argument(
+        "--show-answer-key",
+        action="store_true",
+        help="Print question ids and correct answers.",
+    )
+    return parser.parse_args(argv)
+
+
+def normalized_answers(raw: str) -> list[str]:
+    return [part.strip().upper() for part in raw.split(",") if part.strip()]
+
+
+def answer_key() -> list[str]:
+    return [question.answer for question in QUESTIONS]
+
+
+def validate_questions() -> list[str]:
+    errors: list[str] = []
+    ids: set[str] = set()
+    topics = {question.topic for question in QUESTIONS}
+
+    if len(QUESTIONS) < 10:
+        errors.append("quiz must include at least ten questions")
+
+    missing_topics = REQUIRED_TOPICS - topics
+    if missing_topics:
+        errors.append(f"missing required topics: {', '.join(sorted(missing_topics))}")
+
+    for index, question in enumerate(QUESTIONS, start=1):
+        if question.id in ids:
+            errors.append(f"duplicate question id: {question.id}")
+        ids.add(question.id)
+
+        if len(question.choices) != 4:
+            errors.append(f"{question.id}: expected exactly four choices")
+
+        if question.answer not in {"A", "B", "C", "D"}:
+            errors.append(f"{question.id}: answer must be A, B, C, or D")
+        elif ord(question.answer) - ord("A") >= len(question.choices):
+            errors.append(f"{question.id}: answer points past available choices")
+
+        if not question.prompt.strip():
+            errors.append(f"{question.id}: prompt is empty")
+
+        if len(question.explanation.split()) < 12:
+            errors.append(f"{question.id}: explanation is too short")
+
+        if not any(term in question.explanation for term in VOCABULARY):
+            errors.append(f"{question.id}: explanation should use managed reviewer vocabulary")
+
+        if question.id != question.id.strip().lower():
+            errors.append(f"question {index}: id must be lowercase and trimmed")
+
+    return errors
+
+
+def grade(answers: list[str], *, quiet: bool = False) -> int:
+    if len(answers) != len(QUESTIONS):
+        raise ValueError(f"expected {len(QUESTIONS)} answers, got {len(answers)}")
+
+    correct = 0
+    for index, (question, answer) in enumerate(
+        zip(QUESTIONS, answers, strict=True),
+        start=1,
+    ):
+        normalized = answer.upper()
+        if normalized not in {"A", "B", "C", "D"}:
+            raise ValueError(f"answer {index} must be A, B, C, or D")
+        is_correct = normalized == question.answer
+        correct += int(is_correct)
+        if quiet:
+            continue
+        result = (
+            "correct"
+            if is_correct
+            else f"incorrect; correct answer is {question.answer}"
+        )
+        print(f"{index}. {question.id}: {result}")
+        print(f"   {question.explanation}")
+
+    if not quiet:
+        print()
+        print(f"Score: {correct}/{len(QUESTIONS)} ({correct / len(QUESTIONS):.0%})")
+    return correct
+
+
+def run_interactive() -> int:
+    answers: list[str] = []
+    for index, question in enumerate(QUESTIONS, start=1):
+        print(f"\n{index}. {question.prompt}")
+        for offset, choice in enumerate(question.choices):
+            letter = chr(ord("A") + offset)
+            print(f"   {letter}. {choice}")
+        while True:
+            answer = input("Answer [A-D]: ").strip().upper()
+            if answer in {"A", "B", "C", "D"}:
+                answers.append(answer)
+                break
+            print("Please enter A, B, C, or D.")
+
+    print()
+    grade(answers)
+    return 0
+
+
+def check_answer_key() -> int:
+    errors = validate_questions()
+    if errors:
+        for error in errors:
+            print(f"answer-key check failed: {error}", file=sys.stderr)
+        return 1
+
+    correct = grade(answer_key(), quiet=True)
+    if correct != len(QUESTIONS):
+        print("answer-key check failed: embedded key did not score 100%", file=sys.stderr)
+        return 1
+
+    print(f"answer-key check passed: {correct}/{len(QUESTIONS)} questions")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    if args.show_answer_key:
+        for question in QUESTIONS:
+            print(f"{question.id}: {question.answer}")
+        return 0
+
+    if args.check_answer_key:
+        return check_answer_key()
+
+    if args.answers:
+        answers = normalized_answers(args.answers)
+        try:
+            correct = grade(answers)
+        except ValueError as error:
+            print(error, file=sys.stderr)
+            return 2
+        return 0 if correct == len(QUESTIONS) else 1
+
+    return run_interactive()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Add a scenario-based managed reviewer understanding guide focused on current ReviewRun behavior and operator decisions.
- Add an offline stdlib-only UV quiz with 12 scenario questions, grading, explanations, and a deterministic answer-key check.
- Link the guide and quiz from the PR-review README and architecture guide.

Closes #592

## Mergeability

- Surface: docs
- User-facing behavior changed: no app behavior change; docs and offline learning script only
- Non-happy paths considered: quiz covers failed execution, failed projection, stale/superseded output, repair sweep behavior, health output, and safe retry
- Release/ops preconditions: none
- Residual risk or follow-up: wording may need future updates if managed reviewer vocabulary changes

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `git diff --check`
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`
  - `uv run --script scripts/pr-reviewer-quiz.py --check-answer-key`
  - `uv run --script scripts/pr-reviewer-quiz.py --answers B,C,C,B,C,A,B,B,B,B,A,C`
  - `env PYTHONPYCACHEPREFIX=/tmp/workspaces-592-pycache python3 -m py_compile scripts/pr-reviewer-quiz.py`

Notes:

- `pnpm --dir web docs:check` was attempted, but this fresh worker tree has no generated `web/public/docs` sync output, so the command reported the entire public docs tree missing. The new `docs/pr-review/*` pages are not in `web/scripts/docs-sync-manifest.json`.
- Plain `git diff --check origin/main...HEAD` is affected by this machine's `core.whitespace=indent-with-non-tab` setting and reports normal Python space indentation. The committed range passes the trailing-whitespace check above.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [x] Not a testable change (docs-only, config)
- [ ] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- n/a; docs/offline script change validated by commands above

## Blockers

- [x] None
- [ ] Blocked on evidence
