### PR TITLE
Make managed review health ReviewRun-first

### DIFF
--- a/.github/workflows/managed-reviewer-health.yml
+++ b/.github/workflows/managed-reviewer-health.yml
@@ -5,21 +5,37 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/managed-reviewer-health.yml"
+      - "scripts/pr-reviewer-runs.py"
       - "scripts/pr-review-health.py"
+      - "scripts/tests/test_pr_reviewer_runs.py"
       - "scripts/tests/test_pr_review_health.py"
   pull_request:
     paths:
       - ".github/workflows/managed-reviewer-health.yml"
+      - "scripts/pr-reviewer-runs.py"
       - "scripts/pr-review-health.py"
+      - "scripts/tests/test_pr_reviewer_runs.py"
       - "scripts/tests/test_pr_review_health.py"
   workflow_dispatch:
     inputs:
+      window_minutes:
+        description: "ReviewRun report window in minutes"
+        default: "180"
+        required: true
+      starting_timeout_minutes:
+        description: "Fail when pickup has no session after this many minutes"
+        default: "5"
+        required: true
+      projection_timeout_minutes:
+        description: "Fail when completed runs await projection after this many minutes"
+        default: "30"
+        required: true
       updated_within_hours:
-        description: "Fail only for non-draft PRs updated within this many hours"
+        description: "Projection audit: fail only for non-draft PRs updated within this many hours"
         default: "72"
         required: true
       pending_timeout_min:
-        description: "Fail when pickup stays pending longer than this many minutes"
+        description: "Projection audit: fail when pickup stays pending longer than this many minutes"
         default: "30"
         required: true
   schedule:
@@ -37,7 +53,7 @@ concurrency:
 
 jobs:
   script-tests:
-    name: Test managed reviewer health script
+    name: Test managed reviewer health scripts
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -47,11 +63,14 @@ jobs:
 
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
-      - name: Run health script unit tests
+      - name: Run ReviewRun health script unit tests
+        run: uv run --script scripts/tests/test_pr_reviewer_runs.py
+
+      - name: Run projection audit script unit tests
         run: uv run --script scripts/tests/test_pr_review_health.py
 
-  health:
-    name: Summarize managed reviewer coverage
+  reviewrun-health:
+    name: Summarize ReviewRun health
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +80,36 @@ jobs:
 
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
-      - name: Check managed reviewer health
+      - name: Check ReviewRun health
+        env:
+          WORKSPACES_WEBHOOK_CANARY_SECRET: ${{ secrets.WORKSPACES_WEBHOOK_CANARY_SECRET }}
+          WINDOW_MINUTES: ${{ github.event.inputs.window_minutes || '180' }}
+          STARTING_TIMEOUT_MINUTES: ${{ github.event.inputs.starting_timeout_minutes || '5' }}
+          PROJECTION_TIMEOUT_MINUTES: ${{ github.event.inputs.projection_timeout_minutes || '30' }}
+        run: |
+          if [ -z "$WORKSPACES_WEBHOOK_CANARY_SECRET" ]; then
+            echo "::error::WORKSPACES_WEBHOOK_CANARY_SECRET is required for ReviewRun health"
+            exit 2
+          fi
+
+          uv run --script scripts/pr-reviewer-runs.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --window-minutes "$WINDOW_MINUTES" \
+            --starting-timeout-minutes "$STARTING_TIMEOUT_MINUTES" \
+            --projection-timeout-minutes "$PROJECTION_TIMEOUT_MINUTES"
+
+  github-projection-audit:
+    name: Audit GitHub projection drift
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
+      - name: Audit GitHub projection drift
         env:
           GITHUB_TOKEN: ${{ github.token }}
           UPDATED_WITHIN_HOURS: ${{ github.event.inputs.updated_within_hours || '72' }}

--- a/.github/workflows/mise-security.yml
+++ b/.github/workflows/mise-security.yml
@@ -54,4 +54,6 @@ jobs:
           mise --version
 
       - name: Verify mise security controls
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: ./scripts/verify-mise-security.sh

--- a/docs/pr-review/README.md
+++ b/docs/pr-review/README.md
@@ -10,7 +10,9 @@ needs to learn the system through scenarios before operating or changing it. Use
 [`pr-reviewer.md`](pr-reviewer.md) for runtime configuration, webhook ingress,
 broker scheduling, canaries, and debugging commands. The current storage
 reference in [`review-run-schema.sql`](review-run-schema.sql) mirrors the
-ReviewRun-centered tables used by the web runtime.
+ReviewRun-centered tables used by the web runtime. Use
+[`milestone-validation.md`](milestone-validation.md) for the latest closure
+evidence and maintainer understanding check.
 
 The operational rule is simple: **ReviewRun rows are the source of truth**.
 GitHub commit statuses, GitHub reviews, dashboard pages, and health reports are

--- a/docs/pr-review/milestone-validation.md
+++ b/docs/pr-review/milestone-validation.md
@@ -1,0 +1,93 @@
+# Managed Reviewer Milestone Validation
+
+Validation date: 2026-06-01 UTC.
+
+This page records the current acceptance evidence for the managed reviewer
+simplification milestone. It is intentionally about the current operating model:
+`ReviewRun` is the source of truth, GitHub status and review are projections,
+and the broker repairs projection from completed runs instead of rerunning the
+agent.
+
+## What Passed
+
+| PR | Evidence | Result |
+|----|----------|--------|
+| [#600](https://github.com/fairchild/workspaces/pull/600) | Details URL: <https://spaces.cloudcompute.com/dashboard/review-runs/54800385ca110467006319c470dd742b> | Retry and repair controls landed after managed review approval; final `WorkSpaces Managed Review` status was `success`. |
+| [#601](https://github.com/fairchild/workspaces/pull/601) | Details URL: <https://spaces.cloudcompute.com/dashboard/review-runs/39e5ca038dfcca55f58bfc2a4e1f22db> | Architecture docs landed after managed review approval; final status was `success`. |
+| [#602](https://github.com/fairchild/workspaces/pull/602) | Details URL: <https://spaces.cloudcompute.com/dashboard/review-runs/93933483670bc23113ace2dc85b1c198> | Understanding guide and quiz landed after managed review approval; final status was `success`. |
+
+The validation covered a successful managed-review path and a repairable
+projection path: completed ReviewRuns were published by the broker from stored
+run state, and the final status details URLs opened ReviewRun details instead
+of looping back to the PR.
+
+## Health Checks
+
+The primary operator health command is:
+
+```bash
+uv run --script scripts/pr-reviewer-runs.py
+```
+
+It reads the protected production monitor and reports ReviewRun buckets such as
+`missingRuns`, `stuckStarting`, `runningTooLong`,
+`completedAwaitingProjection`, `failedExecution`, `projectionFailed`, and
+`published`.
+
+The GitHub projection audit remains separate:
+
+```bash
+uv run --script scripts/pr-review-health.py --repo fairchild/workspaces --updated-within-hours 72 --pending-timeout-min 30
+```
+
+Local projection-audit output during validation:
+
+```text
+Active PRs checked: 1
+Active failures: 0
+Skipped/unassessed PRs: 4
+Queue coverage: incomplete (4 skipped/unassessed PRs)
+```
+
+The scheduled health workflow now mirrors the same split: one job checks
+ReviewRun health through `scripts/pr-reviewer-runs.py`, and a separate job
+audits GitHub projection drift through `scripts/pr-review-health.py`.
+
+## Understanding Check
+
+The offline answer-key check passed:
+
+```bash
+uv run --script scripts/pr-reviewer-quiz.py --check-answer-key
+```
+
+Expected output:
+
+```text
+answer-key check passed: 12/12 questions
+```
+
+A human maintainer should still run or review the quiz before closing the
+milestone:
+
+```bash
+uv run --script scripts/pr-reviewer-quiz.py
+```
+
+If any question is confusing, fix the guide or quiz before treating the
+milestone as complete.
+
+## Remaining Posture
+
+The system is simpler than the starting point because operators can answer the
+important questions from one durable run model:
+
+- Was the trigger picked up?
+- Is an agent still running?
+- Did execution fail before a valid intent existed?
+- Did GitHub projection fail after the intent existed?
+- Was older output superseded by newer PR state?
+- Is the GitHub status/review merely drifting from the source-of-truth run?
+
+Do not expand managed reviewer capabilities until this model stays stable under
+normal PR traffic.

--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -101,15 +101,18 @@ Interpret the ReviewRun report as:
 - `unhealthy`: a coalesced ReviewRun key is missing, pickup/execution/projection
   SLOs have been breached, or an execution/projection failure is stored.
 
-GitHub-facing projection drift is audited separately by
-`scripts/pr-review-health.py` and `.github/workflows/managed-reviewer-health.yml`.
-That workflow runs on a schedule and can be dispatched manually. It checks recent
-open PRs for the `WorkSpaces Managed Review` status, stale pending status,
-failure statuses, and success statuses that do not have a current-head managed
-review. Older or draft PRs are reported but skipped by default so pre-indicator
-branches do not keep the projection-audit job red forever. Do not treat a green
-projection audit as proof that ReviewRun ingestion, session execution, or broker
-projection is healthy.
+`.github/workflows/managed-reviewer-health.yml` runs the same split on a
+schedule and can be dispatched manually. Its first job calls
+`scripts/pr-reviewer-runs.py` with the protected canary secret and fails on
+ReviewRun attention-needed state. Its second job calls
+`scripts/pr-review-health.py` to audit GitHub-facing projection drift.
+
+The projection audit checks recent open PRs for the `WorkSpaces Managed Review`
+status, stale pending status, failure statuses, and success statuses that do not
+have a current-head managed review. Older or draft PRs are reported but skipped
+by default so pre-indicator branches do not keep the projection-audit job red
+forever. Do not treat a green projection audit as proof that ReviewRun
+ingestion, session execution, or broker projection is healthy.
 
 The Cloudflare relay forwards only managed-review trigger candidates:
 `pull_request.opened`, `reopened`, `ready_for_review`, `synchronize`, eligible

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -286,9 +286,10 @@ class SecurityHardeningTests(unittest.TestCase):
 
     def test_mise_invocations_are_locked_and_pinned(self) -> None:
         verify_mise = (REPO_ROOT / "scripts/verify-mise-security.sh").read_text()
-        self.assertIn("MISE_EXPECTED_VERSION=\"v2026.5.15\"", verify_mise)
+        self.assertIn("MISE_EXPECTED_VERSION=\"v2026.5.18\"", verify_mise)
         self.assertIn("verify_locked_zig_exec", verify_mise)
         self.assertIn("github.com/repos/jdx/mise/releases/latest", verify_mise)
+        self.assertIn("Authorization: Bearer $GITHUB_TOKEN", verify_mise)
         self.assertIn("SHASUMS256.txt", verify_mise)
 
         build_ghosttykit = (REPO_ROOT / "scripts/build-ghosttykit.sh").read_text()
@@ -312,9 +313,9 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("enable-global-virtual-store=true", web_npmrc)
 
         sandbox = (REPO_ROOT / "web/src/lib/agent-runtime/vercel-sandbox.ts").read_text()
-        self.assertIn("MISE_VERSION='v2026.5.15'", sandbox)
+        self.assertIn("MISE_VERSION='v2026.5.18'", sandbox)
         self.assertIn(
-            "MISE_SHA256='a86aa65c8ca48a548c3f9904853489383bb8cdebfd8f2cf8ddd18b675e03bbf4'",
+            "MISE_SHA256='cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84'",
             sandbox,
         )
         self.assertIn("sha256sum -c -", sandbox)
@@ -323,6 +324,7 @@ class SecurityHardeningTests(unittest.TestCase):
     def test_mise_security_workflow_runs_for_mise_changes(self) -> None:
         workflow = (REPO_ROOT / ".github/workflows/mise-security.yml").read_text()
         self.assertIn("name: Mise Security", workflow)
+        self.assertIn("GITHUB_TOKEN: ${{ github.token }}", workflow)
         self.assertIn("scripts/verify-mise-security.sh", workflow)
         for expected_path in (
             ".mise.toml",
@@ -395,9 +397,13 @@ class SecurityHardeningTests(unittest.TestCase):
         broker_workflow = (
             REPO_ROOT / ".github/workflows/managed-reviewer-broker.yml"
         ).read_text()
+        health_workflow = (
+            REPO_ROOT / ".github/workflows/managed-reviewer-health.yml"
+        ).read_text()
         cd_workflow = (REPO_ROOT / ".github/workflows/cd.yml").read_text()
         canary_script = (REPO_ROOT / "scripts/managed-reviewer-ingress-canary.py").read_text()
         broker_script = (REPO_ROOT / "scripts/pr-reviewer-broker.py").read_text()
+        runs_script = (REPO_ROOT / "scripts/pr-reviewer-runs.py").read_text()
 
         for source in (
             route,
@@ -406,9 +412,11 @@ class SecurityHardeningTests(unittest.TestCase):
             worker,
             workflow,
             broker_workflow,
+            health_workflow,
             cd_workflow,
             canary_script,
             broker_script,
+            runs_script,
         ):
             self.assertIn("WORKSPACES_WEBHOOK_CANARY_SECRET", source)
 
@@ -477,6 +485,14 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("Authorization", broker_script)
         self.assertNotIn("pr-reviewer-monitor", broker_script)
         self.assertNotIn("canary/pr-review-ingress", broker_script)
+        self.assertIn("scripts/pr-reviewer-runs.py", health_workflow)
+        self.assertIn("scripts/pr-review-health.py", health_workflow)
+        self.assertIn("Check ReviewRun health", health_workflow)
+        self.assertIn("Audit GitHub projection drift", health_workflow)
+        self.assertLess(
+            health_workflow.index("scripts/pr-reviewer-runs.py"),
+            health_workflow.index("scripts/pr-review-health.py"),
+        )
 
         result = subprocess.run(
             ["python3", "scripts/managed-reviewer-ingress-canary.py"],

--- a/scripts/verify-mise-security.sh
+++ b/scripts/verify-mise-security.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
-MISE_EXPECTED_VERSION="v2026.5.15"
-MISE_EXPECTED_LINUX_X64_SHA256="a86aa65c8ca48a548c3f9904853489383bb8cdebfd8f2cf8ddd18b675e03bbf4"
+MISE_EXPECTED_VERSION="v2026.5.18"
+MISE_EXPECTED_LINUX_X64_SHA256="cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84"
 ZIG_VERSION="0.15.2"
 
 fail() {
@@ -16,6 +16,18 @@ fail() {
 
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+curl_github_api() {
+  local url="$1"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl -fsSL \
+      -H "Authorization: Bearer $GITHUB_TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "$url"
+  else
+    curl -fsSL "$url"
+  fi
 }
 
 verify_mise_configs() {
@@ -113,7 +125,7 @@ verify_latest_mise_pin() {
   require_cmd python3
 
   local latest_json latest_tag prerelease draft shasum_line
-  latest_json="$(curl -fsSL https://api.github.com/repos/jdx/mise/releases/latest)"
+  latest_json="$(curl_github_api https://api.github.com/repos/jdx/mise/releases/latest)"
   latest_tag="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])' <<<"$latest_json")"
   prerelease="$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["prerelease"]).lower())' <<<"$latest_json")"
   draft="$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["draft"]).lower())' <<<"$latest_json")"

--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -348,8 +348,8 @@ async function resolveBaseSnapshot(): Promise<string> {
 			"-c",
 			[
 				"set -euo pipefail",
-				"MISE_VERSION='v2026.5.15'",
-				"MISE_SHA256='a86aa65c8ca48a548c3f9904853489383bb8cdebfd8f2cf8ddd18b675e03bbf4'",
+				"MISE_VERSION='v2026.5.18'",
+				"MISE_SHA256='cfac593469d028d7ae5fe36e37bd7c59118b5238e92d8a876209578464f24a84'",
 				'MISE_URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64"',
 				"echo '--- downloading mise ---'",
 				'curl -fsSL "$MISE_URL" -o /tmp/mise',


### PR DESCRIPTION
## Summary

- make the scheduled/manual managed reviewer health workflow run ReviewRun health first
- keep GitHub status/review drift as a separate projection-audit job
- add closure validation notes for the managed reviewer simplification milestone
- update the hosted sandbox `mise` pin to the current verified stable release so the security gate stays green

## Mergeability

- Surface: agent-runtime / infra / docs
- User-facing behavior changed: No product UI change; operator health now starts from ReviewRun state before projection drift.
- Non-happy paths considered: Missing `WORKSPACES_WEBHOOK_CANARY_SECRET` fails the ReviewRun health job explicitly, and projection audit still runs as its own job.
- Residual risk or follow-up: Human maintainer still needs to run or review the understanding quiz before closing #593.

## Validation

- Tests passed: `uv run --script scripts/tests/test_pr_reviewer_runs.py`
- Tests passed: `uv run --script scripts/tests/test_pr_review_health.py`
- Tests passed: `uv run --script scripts/tests/test_security_hardening.py`
- Tests passed: `env PATH=/usr/bin:/bin:/usr/sbin:/sbin ./scripts/verify-mise-security.sh`
- Tests passed: `uv run --script scripts/pr-reviewer-quiz.py --check-answer-key`
- Tests passed: `mise -C web run web:check`
- Workflow syntax passed: `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/managed-reviewer-health.yml\"); puts \"yaml ok\""`
- Projection audit passed: `uv run --script scripts/pr-review-health.py --repo fairchild/workspaces --updated-within-hours 72 --pending-timeout-min 30`

Projection audit result during validation: one active PR checked, zero active failures, four skipped/unassessed older or draft PRs.

Part of #593.
