### PR TITLE
Coalesce ReviewRun health expectations

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -101,6 +101,13 @@ Interpret the ReviewRun report as:
 - `unhealthy`: a coalesced ReviewRun key is missing, pickup/execution/projection
   SLOs have been breached, or an execution/projection failure is stored.
 
+The report intentionally separates raw event volume from actionable keys.
+`candidateRunKeys` is the raw reviewer-eligible webhook history grouped by
+PR/head. `eligibleRunKeys` is the current actionable set after closed PRs and
+older material triggers for the same PR are removed. `terminalRunKeys` and
+`supersededTriggerRunKeys` explain why historical webhook rows are not treated
+as missing work.
+
 `.github/workflows/managed-reviewer-health.yml` runs the same split on a
 schedule and can be dispatched manually. Its first job calls
 `scripts/pr-reviewer-runs.py` with the protected canary secret and fails on
@@ -178,7 +185,8 @@ uv run --script scripts/pr-reviewer-runs.py
 ```
 
 Use the report as the first read of production health. `missingRuns` means a
-coalesced reviewer-eligible key did not create a `managed_pr_review_runs` row.
+current actionable reviewer-eligible key did not create a
+`managed_pr_review_runs` row.
 `running` means the managed-agent session has been created and remains inside
 the execution SLO. `runningTooLong` means the session exceeded the execution
 SLO. `completedAwaitingProjection` means the broker still needs to publish or
@@ -207,10 +215,11 @@ marks that run `superseded`, and starts exactly one follow-up session against th
 latest PR state. If the superseding review is for an older head, the broker
 starts a fresh follow-up session so the newer-head review includes the prior
 review context. The run report compares recent
-reviewer-eligible rows in `webhook_events` with coalesced ReviewRun keys from
-`managed_pr_review_runs` records and classifies rows into source-of-truth health
-buckets. Broker and report routes return only run metadata, details URLs, stored
-failure reasons, and missing event identifiers, not raw payloads or secrets.
+reviewer-eligible rows in `webhook_events` with current actionable ReviewRun
+keys from `managed_pr_review_runs` records and classifies rows into
+source-of-truth health buckets. Broker and report routes return only run
+metadata, details URLs, stored failure reasons, and missing event identifiers,
+not raw payloads or secrets.
 
 ## Observing Sessions
 

--- a/scripts/pr-reviewer-runs.py
+++ b/scripts/pr-reviewer-runs.py
@@ -9,8 +9,12 @@ This is the first command to run when the managed PR reviewer looks stuck. It
 asks the protected production monitor route for the ReviewRun database view and
 prints the current queue in operator terms:
 
-- ``missingRuns``: a reviewer-eligible webhook exists, but no ReviewRun row was
-  created. Investigate trigger/ingress.
+- ``candidateRunKeys``: reviewer-eligible webhook deliveries grouped by PR/head
+  before terminal or superseded history is removed.
+- ``eligibleRunKeys``: the current actionable keys after closed PRs and older
+  triggers for the same PR are coalesced away.
+- ``missingRuns``: an actionable key exists, but no ReviewRun row was created.
+  Investigate trigger/ingress.
 - ``starting``: a ReviewRun row exists, but the managed-agent session id has not
   been recorded yet. Briefly normal immediately after pickup.
 - ``stuckStarting``: a starting row is old enough to need attention.
@@ -196,7 +200,10 @@ def print_report(status: int, payload: dict[str, Any]) -> None:
     print(
         "events "
         f"eligible={as_int(payload, 'eligibleEvents')} "
+        f"candidate_keys={as_int(payload, 'candidateRunKeys')} "
         f"run_keys={as_int(payload, 'eligibleRunKeys')} "
+        f"terminal_keys={as_int(payload, 'terminalRunKeys')} "
+        f"superseded_keys={as_int(payload, 'supersededTriggerRunKeys')} "
         f"missing_keys={as_int(payload, 'missingRunKeys') or as_int(payload, 'missingRuns')} "
         f"attention={as_int(payload, 'attentionRequired')}"
     )

--- a/scripts/tests/test_pr_reviewer_runs.py
+++ b/scripts/tests/test_pr_reviewer_runs.py
@@ -33,7 +33,10 @@ class PRReviewerRunsTests(unittest.TestCase):
             "repo": "fairchild/workspaces",
             "windowMinutes": 90,
             "eligibleEvents": 3,
+            "candidateRunKeys": 3,
             "eligibleRunKeys": 2,
+            "terminalRunKeys": 1,
+            "supersededTriggerRunKeys": 0,
             "missingRunKeys": 1,
             "attentionRequired": 2,
             "starting": 0,
@@ -96,7 +99,10 @@ class PRReviewerRunsTests(unittest.TestCase):
 
         rendered = output.getvalue()
         self.assertIn("ReviewRun report for fairchild/workspaces over 90m: unhealthy", rendered)
-        self.assertIn("events eligible=3 run_keys=2 missing_keys=1 attention=2", rendered)
+        self.assertIn(
+            "events eligible=3 candidate_keys=3 run_keys=2 terminal_keys=1 superseded_keys=0 missing_keys=1 attention=2",
+            rendered,
+        )
         self.assertIn("projectionFailed=1", rendered)
         self.assertIn("github projection audit: not_checked (scripts/pr-review-health.py)", rendered)
         self.assertIn("Missing ReviewRun keys:", rendered)

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
@@ -27,15 +27,40 @@ const MONITOR_SECRET = "monitor-secret";
 
 function webhookRowFromContractCase(
 	testCase: (typeof PR_REVIEW_WEBHOOK_CONTRACT_CASES)[number],
+	overrides: Partial<{
+		id: string;
+		timestamp: string;
+		payload: Record<string, unknown>;
+	}> = {},
 ) {
-	const payload = testCase.payload as { action?: string };
+	const payload = (overrides.payload ?? testCase.payload) as {
+		action?: string;
+	};
 	return {
-		id: testCase.deliveryId,
+		id: overrides.id ?? testCase.deliveryId,
 		type: testCase.eventType,
 		action: String(payload.action ?? ""),
-		timestamp: new Date().toISOString(),
-		payload: JSON.stringify(testCase.payload),
+		timestamp: overrides.timestamp ?? new Date().toISOString(),
+		payload: JSON.stringify(payload),
 	};
+}
+
+function pullRequestPayloadFor(
+	testCase: (typeof PR_REVIEW_WEBHOOK_CONTRACT_CASES)[number],
+	prNumber: number,
+	headSha: string,
+): Record<string, unknown> {
+	const payload = JSON.parse(JSON.stringify(testCase.payload)) as Record<
+		string,
+		unknown
+	>;
+	const pullRequest = payload.pull_request as Record<string, unknown>;
+	pullRequest.number = prNumber;
+	pullRequest.head = {
+		...(pullRequest.head as Record<string, unknown>),
+		sha: headSha,
+	};
+	return payload;
 }
 
 function monitorRequest(headers: Record<string, string> = {}): Request {
@@ -299,6 +324,92 @@ describe("/api/webhooks/github/pr-reviewer-monitor GET", () => {
 				{
 					eventIds: ["contract-pr-opened", "contract-pr-opened-redelivery"],
 					eventCount: 2,
+				},
+			],
+		});
+	});
+
+	it("does not report missing run keys for PRs closed after eligible triggers", async () => {
+		const edited = PR_REVIEW_WEBHOOK_CONTRACT_CASES.find(
+			(testCase) => testCase.deliveryId === "contract-pr-edited-body",
+		);
+		const closed = PR_REVIEW_WEBHOOK_CONTRACT_CASES.find(
+			(testCase) => testCase.deliveryId === "contract-pr-closed",
+		);
+		if (!edited || !closed) throw new Error("missing PR fixtures");
+		mocks.executeWebhookQuery.mockResolvedValue([
+			webhookRowFromContractCase(edited, {
+				id: "contract-pr-edited-before-close",
+				timestamp: "2026-06-01T03:00:00.000Z",
+				payload: pullRequestPayloadFor(edited, 8120, "terminalsha8120"),
+			}),
+			webhookRowFromContractCase(closed, {
+				id: "contract-pr-closed-after-edit",
+				timestamp: "2026-06-01T03:01:00.000Z",
+				payload: pullRequestPayloadFor(closed, 8120, "terminalsha8120"),
+			}),
+		]);
+		mocks.listRecentPrReviewRuns.mockResolvedValue([]);
+
+		const { GET } = await import("./route");
+		const response = await GET(
+			monitorRequest({ "x-workspace-webhook-canary": MONITOR_SECRET }),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			ok: true,
+			health: "healthy",
+			eligibleEvents: 1,
+			candidateRunKeys: 1,
+			eligibleRunKeys: 0,
+			terminalRunKeys: 1,
+			supersededTriggerRunKeys: 0,
+			missingRunKeys: 0,
+			missing: [],
+		});
+	});
+
+	it("reports only the latest missing trigger key for a still-open PR", async () => {
+		const opened = PR_REVIEW_WEBHOOK_CONTRACT_CASES[0];
+		const synchronize = PR_REVIEW_WEBHOOK_CONTRACT_CASES.find(
+			(testCase) => testCase.expectedTriggerKind === "synchronize",
+		);
+		if (!synchronize) throw new Error("missing synchronize fixture");
+		mocks.executeWebhookQuery.mockResolvedValue([
+			webhookRowFromContractCase(opened, {
+				timestamp: "2026-06-01T03:00:00.000Z",
+				payload: pullRequestPayloadFor(opened, 8121, "oldsha8121"),
+			}),
+			webhookRowFromContractCase(synchronize, {
+				timestamp: "2026-06-01T03:02:00.000Z",
+				payload: pullRequestPayloadFor(synchronize, 8121, "newsha8121"),
+			}),
+		]);
+		mocks.listRecentPrReviewRuns.mockResolvedValue([]);
+
+		const { GET } = await import("./route");
+		const response = await GET(
+			monitorRequest({ "x-workspace-webhook-canary": MONITOR_SECRET }),
+		);
+
+		expect(response.status).toBe(503);
+		await expect(response.json()).resolves.toMatchObject({
+			ok: false,
+			health: "unhealthy",
+			eligibleEvents: 2,
+			candidateRunKeys: 2,
+			eligibleRunKeys: 1,
+			supersededTriggerRunKeys: 1,
+			missingRunKeys: 1,
+			missing: [
+				{
+					key: "fairchild/workspaces|8121|newsha8121",
+					eventIds: ["contract-pr-synchronize"],
+					eventCount: 1,
+					prNumber: 8121,
+					triggerKind: "synchronize",
+					headSha: "newsha8121",
 				},
 			],
 		});

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
@@ -41,6 +41,18 @@ interface ExpectedRunGroup {
 	triggerSourceId: string;
 }
 
+interface TerminalPullRequest {
+	repoFullName: string;
+	prNumber: number;
+	timestamp: string;
+}
+
+interface CoalescedExpectedRunGroups {
+	actionable: ExpectedRunGroup[];
+	terminal: ExpectedRunGroup[];
+	superseded: ExpectedRunGroup[];
+}
+
 interface OperatorRunItem {
 	fingerprint: string;
 	repoFullName: string;
@@ -158,6 +170,12 @@ function expectedRunGroupKey(expected: ExpectedRun): string {
 	].join("|");
 }
 
+function expectedRunPrKey(
+	expected: Pick<ExpectedRun, "repoFullName" | "prNumber">,
+): string {
+	return [expected.repoFullName, String(expected.prNumber)].join("|");
+}
+
 function groupExpectedRuns(expectedRuns: ExpectedRun[]): ExpectedRunGroup[] {
 	const groups = new Map<string, ExpectedRunGroup>();
 	for (const expected of [...expectedRuns].sort((a, b) =>
@@ -187,6 +205,51 @@ function groupExpectedRuns(expectedRuns: ExpectedRun[]): ExpectedRunGroup[] {
 		});
 	}
 	return [...groups.values()];
+}
+
+function coalesceExpectedRunGroups(
+	groups: ExpectedRunGroup[],
+	terminalPrs: TerminalPullRequest[],
+): CoalescedExpectedRunGroups {
+	const terminalByPr = new Map<string, string>();
+	for (const terminal of terminalPrs) {
+		const key = expectedRunPrKey(terminal);
+		const priorTimestamp = terminalByPr.get(key);
+		if (!priorTimestamp || priorTimestamp < terminal.timestamp) {
+			terminalByPr.set(key, terminal.timestamp);
+		}
+	}
+
+	const terminal: ExpectedRunGroup[] = [];
+	const openGroupsByPr = new Map<string, ExpectedRunGroup[]>();
+	for (const group of groups) {
+		const key = expectedRunPrKey(group);
+		const terminalTimestamp = terminalByPr.get(key);
+		if (terminalTimestamp && terminalTimestamp >= group.lastTimestamp) {
+			terminal.push(group);
+			continue;
+		}
+		const existing = openGroupsByPr.get(key);
+		if (existing) {
+			existing.push(group);
+		} else {
+			openGroupsByPr.set(key, [group]);
+		}
+	}
+
+	const actionable: ExpectedRunGroup[] = [];
+	const superseded: ExpectedRunGroup[] = [];
+	for (const prGroups of openGroupsByPr.values()) {
+		const sorted = [...prGroups].sort((a, b) =>
+			a.lastTimestamp.localeCompare(b.lastTimestamp),
+		);
+		const latest = sorted.at(-1);
+		if (!latest) continue;
+		superseded.push(...sorted.slice(0, -1));
+		actionable.push(latest);
+	}
+
+	return { actionable, terminal, superseded };
 }
 
 function runCoversExpectedGroup(
@@ -247,6 +310,35 @@ function expectedRunFromWebhookEvent(row: {
 	};
 }
 
+function terminalPrFromWebhookEvent(row: {
+	type: string;
+	action: string;
+	timestamp: string;
+	payload: string;
+}): TerminalPullRequest | null {
+	if (row.type !== "pull_request" || row.action !== "closed") return null;
+
+	let payload: Record<string, unknown>;
+	try {
+		payload = JSON.parse(row.payload) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+
+	const pr = payload.pull_request as Record<string, unknown> | undefined;
+	const repo = payload.repository as Record<string, unknown> | undefined;
+	const repoFullName =
+		typeof repo?.full_name === "string" ? repo.full_name : "";
+	const prNumber = Number(pr?.number);
+	if (!repoFullName || !Number.isInteger(prNumber)) return null;
+
+	return {
+		repoFullName,
+		prNumber,
+		timestamp: row.timestamp,
+	};
+}
+
 export async function GET(request: Request): Promise<Response> {
 	const authFailure = authenticate(request);
 	if (authFailure) return authFailure;
@@ -257,7 +349,10 @@ export async function GET(request: Request): Promise<Response> {
 			disabled: true,
 			checked: 0,
 			eligibleEvents: 0,
+			candidateRunKeys: 0,
 			eligibleRunKeys: 0,
+			terminalRunKeys: 0,
+			supersededTriggerRunKeys: 0,
 			missingRuns: 0,
 			missingRunKeys: 0,
 			attentionRequired: 0,
@@ -352,6 +447,13 @@ export async function GET(request: Request): Promise<Response> {
 		.map(expectedRunFromWebhookEvent)
 		.filter((entry): entry is ExpectedRun => Boolean(entry));
 	const expectedRunGroups = groupExpectedRuns(expectedRuns);
+	const terminalPrs = webhookRows
+		.map(terminalPrFromWebhookEvent)
+		.filter((entry): entry is TerminalPullRequest => Boolean(entry));
+	const expectedWork = coalesceExpectedRunGroups(
+		expectedRunGroups,
+		terminalPrs,
+	);
 
 	const runs = await listRecentPrReviewRuns({ sinceIso, repoFullName });
 	const runBuckets = bucketPrReviewRuns(runs, {
@@ -361,7 +463,7 @@ export async function GET(request: Request): Promise<Response> {
 			projectionTimeoutMinutes,
 		},
 	});
-	const missing = expectedRunGroups.filter(
+	const missing = expectedWork.actionable.filter(
 		(expected) => !runs.some((run) => runCoversExpectedGroup(run, expected)),
 	);
 	const staleCompletedAwaitingProjection =
@@ -411,9 +513,12 @@ export async function GET(request: Request): Promise<Response> {
 			runningTimeoutMinutes,
 			projectionTimeoutMinutes,
 			since: sinceIso,
-			checked: expectedRunGroups.length,
+			checked: expectedWork.actionable.length,
 			eligibleEvents: expectedRuns.length,
-			eligibleRunKeys: expectedRunGroups.length,
+			candidateRunKeys: expectedRunGroups.length,
+			eligibleRunKeys: expectedWork.actionable.length,
+			terminalRunKeys: expectedWork.terminal.length,
+			supersededTriggerRunKeys: expectedWork.superseded.length,
 			missingRuns: missing.length,
 			missingRunKeys: missing.length,
 			attentionRequired,

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -1803,7 +1803,13 @@ export async function listRecentPrReviewRuns(input: {
 			"coalesced_trigger_source_id",
 			"coalesced_at",
 		])
-		.where("created_at", ">=", input.sinceIso)
+		.where((eb) =>
+			eb.or([
+				eb("created_at", ">=", input.sinceIso),
+				eb("updated_at", ">=", input.sinceIso),
+				eb("coalesced_at", ">=", input.sinceIso),
+			]),
+		)
 		.where("repo_full_name", "=", input.repoFullName)
 		.execute();
 


### PR DESCRIPTION
## Summary
- Make ReviewRun health compare only current actionable expected run keys.
- Ignore closed PR history and older material triggers for the same still-open PR when reporting missing runs.
- Surface candidate, terminal, and superseded trigger-key counts in the operator report.

## Mergeability

- Surface: web agent-runtime / PR reviewer monitor / operator scripts / docs
- User-facing behavior changed: No product UI change. Operator health output now explains candidate, terminal, and superseded trigger-key counts.
- Non-happy paths considered: Covered closed PRs after eligible triggers, older triggers superseded by later PR activity, and runs updated/coalesced inside the report window.
- Release/ops preconditions: None.
- Residual risk or follow-up: After merge, rerun the production ReviewRun health workflow to confirm historical missing-key noise drops as expected.

## Validation

- [x] `mise -C web run web:check`
- [x] `uv run --script scripts/tests/test_pr_reviewer_runs.py`
- [x] `uv run --script scripts/tests/test_security_hardening.py`
- [x] `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-604/20260601-033045-web-check.svg

## Blockers

- [x] None
- [ ] Blocked on evidence

Part of #593.