### PR TITLE
Tighten managed review evidence comment detection

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -354,7 +354,7 @@ managed review run:
 | `pull_request` | `edited` | Rerun when `changes.body` or `changes.base` is present; title-only and other metadata edits do not start sessions |
 | `pull_request` | `labeled`, `unlabeled` | Metadata only; no managed-review session |
 | `pull_request` | `closed` | Terminal PR activity; no managed-review session |
-| `issue_comment` | `created` with evidence | Rerun when the comment is on a PR thread, the sender is a non-bot, and the body matches an evidence signal: `evidence.cloudcompute.com`, `Evidence:`, `swift test`, `playwright`, `screenshot`, `recording`, `validation` |
+| `issue_comment` | `created` with evidence | Rerun when the comment is on a PR thread, the sender is a non-bot, and the body matches an evidence signal: `evidence.cloudcompute.com`, `Evidence:`, `Validation:`, `swift test`, `playwright`, `screenshot`, or `recording`. Plain status comments that merely mention validation do not rerun review. |
 | `issue_comment` | `created` without evidence | Metadata only; no managed-review session |
 | `pull_request_review_comment`, `pull_request_review` | any | Metadata only; no managed-review session |
 

--- a/web/src/app/api/webhooks/github/route.test.ts
+++ b/web/src/app/api/webhooks/github/route.test.ts
@@ -284,6 +284,24 @@ describe("PR review trigger relevance classifier", () => {
 			kind: "evidence_comment",
 			triggerSourceId: "comment-9001",
 		});
+
+		const validationComment = expectTrigger(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload(
+					"Validation: mise -C web run web:check passed",
+					{
+						comment_id: 9002,
+					},
+				),
+			),
+			"evidence_comment",
+		);
+		expect(validationComment.context).toMatchObject({
+			kind: "evidence_comment",
+			triggerSourceId: "comment-9002",
+		});
 	});
 
 	it("classifies metadata and terminal events without managed-review sessions", () => {
@@ -303,6 +321,17 @@ describe("PR review trigger relevance classifier", () => {
 				"issue_comment",
 				"created",
 				makeIssueCommentPayload("looks good, ship it"),
+			),
+			"non_evidence_comment",
+			"metadata",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload(
+					"Managed review approved with no requested changes. Local and CI validation are green.",
+				),
 			),
 			"non_evidence_comment",
 			"metadata",
@@ -671,6 +700,11 @@ describe("/api/webhooks/github POST", () => {
 		it("does not trigger on a comment without evidence signals", async () => {
 			const { POST } = await import("./route");
 			await POST(makeIssueCommentRequest("looks good, ship it"));
+			await POST(
+				makeIssueCommentRequest(
+					"Managed review approved with no requested changes. Local and CI validation are green.",
+				),
+			);
 			expect(mocks.triggerPrReview).not.toHaveBeenCalled();
 		});
 

--- a/web/src/lib/agent-runtime/pr-review-trigger.ts
+++ b/web/src/lib/agent-runtime/pr-review-trigger.ts
@@ -51,7 +51,7 @@ export type PrReviewTriggerClassification =
 	| PrReviewTriggerSkipClassification;
 
 const EVIDENCE_SIGNAL =
-	/(evidence\.cloudcompute\.com|^Evidence:|swift test|playwright|screenshot|recording|validation)/im;
+	/(evidence\.cloudcompute\.com|^\s*(?:Evidence|Validation):|\bswift test\b|\bplaywright\b|\bscreenshot\b|\brecording\b)/im;
 const PR_REVIEWER_BOT_LOGIN = "workspaces-claude-pr-reviewer[bot]";
 
 function isBotSender(payload: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary
- Tighten PR-comment evidence detection so explicit Evidence:/Validation:/artifact/test/screenshot signals still rerun review.
- Prevent plain review-acknowledgement comments that merely mention validation from starting another managed review on the same head.
- Update the managed reviewer trigger docs to match.

## Mergeability
- Surface: web / agent-runtime / docs
- User-facing behavior changed: no product UI; managed reviewer operator behavior only
- Non-happy paths considered: explicit validation evidence still triggers; plain validation status comments do not; bot comments remain skipped
- Release/ops preconditions: None
- Residual risk or follow-up: validate on this PR that review-response comments no longer create a redundant managed-review loop

## Validation
- [x] `mise -C web run web:check`
- [x] `uv run --script scripts/tests/test_security_hardening.py`
- [x] `git diff --check`

## Performance
- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence
- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![web-check](https://evidence.cloudcompute.com/workspaces/pr-605/20260601-035436-web-check.svg)

## Blockers
- [x] None
- [ ] Blocked on evidence

Part of #593.