### PR TITLE
Use git worktrees for local workspace creation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,7 @@
 │                 │                      │                            │
 │  • getStatus()  │  • createWorkspace() │    LocalBackend            │
 │  • getFileTree()│  • deleteWorkspace() │    DaytonaBackend          │
-│  • getBranch()  │  • copyRepo()        │                            │
+│  • getBranch()  │  • createWorktree()  │                            │
 └─────────────────┴──────────────────────┴────────────────────────────┘
                               │
                               ▼
@@ -319,9 +319,7 @@ User right-clicks repo → "New Workspace..."
          │
          ├─→ Create directory in workspaces root
          │
-         ├─→ Copy repo with `ditto`
-         │
-         ├─→ Create git branch (optional)
+         ├─→ Create git worktree and workspace branch
          │
          ├─→ Run setup.sh if exists (show output in terminal)
          │

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -58,10 +58,8 @@ struct SidebarWorkspaceController {
         switch phase {
         case .preparing:
             return "Preparing workspace..."
-        case .copyingRepository:
-            return "Copying repository..."
-        case .creatingBranch:
-            return "Creating branch..."
+        case .creatingWorktree:
+            return "Creating git worktree..."
         case .runningSetupScript:
             return "Running setup script..."
         case .finished:

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceEnvironmentOptionsController.swift
@@ -419,7 +419,7 @@ struct WorkspaceEnvironmentOptionsController {
 
         return WorkspaceEnvironmentSheetOption(
             title: "Local",
-            subtitle: "Create a local workspace copy on this Mac",
+            subtitle: "Create a git worktree workspace on this Mac",
             description: descriptor.description,
             iconName: "plus.rectangle.on.folder.fill",
             providerID: LocalWorkspaceProvider.identifier,

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -72,6 +72,20 @@ public actor GitService: GitServiceProtocol {
         _ = try await runGit(["checkout", "-b", name], at: path)
     }
 
+    public func createWorktree(branchName: String, at destination: URL, from source: URL) async throws {
+        if try await localBranchExists(branchName, at: source) {
+            throw GitError.branchAlreadyExists(name: branchName)
+        }
+
+        let args = ["worktree", "add", "-b", branchName, destination.path, "HEAD"]
+        let result = try await runGitResult(args, at: source)
+        guard result.success else {
+            try? await deleteLocalBranchIfExists(branchName, at: source)
+            let stderr = result.stderr.isEmpty ? "Unknown error" : result.stderr
+            throw GitError.commandFailed(args: args, stderr: stderr)
+        }
+    }
+
     public func checkoutBranch(_ name: String, at path: URL) async throws {
         _ = try await runGit(["checkout", name], at: path)
     }
@@ -229,11 +243,7 @@ public actor GitService: GitServiceProtocol {
     // MARK: - Run Git Command
 
     private func runGit(_ args: [String], at path: URL) async throws -> String {
-        let result = try await ProcessRunner.run(
-            executable: "/usr/bin/git",
-            arguments: args,
-            currentDirectory: path
-        )
+        let result = try await runGitResult(args, at: path)
 
         if result.exitCode != 0 {
             let stderr = result.stderr.isEmpty ? "Unknown error" : result.stderr
@@ -241,6 +251,44 @@ public actor GitService: GitServiceProtocol {
         }
 
         return result.stdout
+    }
+
+    private func runGitResult(_ args: [String], at path: URL) async throws -> ProcessResult {
+        try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: args,
+            currentDirectory: path
+        )
+    }
+
+    private func localBranchExists(_ name: String, at path: URL) async throws -> Bool {
+        let args = ["show-ref", "--verify", "--quiet", "refs/heads/\(name)"]
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: args,
+            currentDirectory: path
+        )
+
+        if result.exitCode == 0 {
+            return true
+        }
+        if result.exitCode == 1 {
+            return false
+        }
+
+        let stderr = result.stderr.isEmpty ? "Unknown error" : result.stderr
+        throw GitError.commandFailed(args: args, stderr: stderr)
+    }
+
+    private func deleteLocalBranchIfExists(_ name: String, at path: URL) async throws {
+        guard try await localBranchExists(name, at: path) else { return }
+        let args = ["branch", "-D", name]
+        let result = try await runGitResult(args, at: path)
+
+        if result.exitCode != 0 {
+            let stderr = result.stderr.isEmpty ? "Unknown error" : result.stderr
+            throw GitError.commandFailed(args: args, stderr: stderr)
+        }
     }
 
     private func mapStatus(from porcelainCode: String) -> GitStatus {
@@ -289,6 +337,7 @@ extension String {
 public enum GitError: LocalizedError {
     case commandFailed(args: [String], stderr: String)
     case notARepository
+    case branchAlreadyExists(name: String)
 
     public var errorDescription: String? {
         switch self {
@@ -296,6 +345,8 @@ public enum GitError: LocalizedError {
             return "Git command failed: git \(args.joined(separator: " "))\n\(stderr)"
         case .notARepository:
             return "Not a git repository"
+        case .branchAlreadyExists(let name):
+            return "A branch named '\(name)' already exists"
         }
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/LocalWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalWorkspaceProvider.swift
@@ -12,7 +12,7 @@ public struct LocalWorkspaceProvider: WorkspaceProviderProtocol {
     public static let providerDescriptor = WorkspaceProviderDescriptor(
         id: LocalWorkspaceProvider.identifier,
         displayName: "Local",
-        description: "Create a normal workspace on the host filesystem.",
+        description: "Create a git worktree workspace on this Mac.",
         sheetStatusPolicy: .immediate,
         usesHostWorkspaceFiles: true
     )
@@ -68,10 +68,8 @@ public struct LocalWorkspaceProvider: WorkspaceProviderProtocol {
         switch phase {
         case .preparing:
             return "Preparing workspace..."
-        case .copyingRepository:
-            return "Copying repository..."
-        case .creatingBranch:
-            return "Creating branch..."
+        case .creatingWorktree:
+            return "Creating git worktree..."
         case .runningSetupScript:
             return "Running setup script..."
         case .finished:

--- a/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
@@ -262,7 +262,7 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
                 )
             }
             if let localInfo {
-                cleanupWorkspaceDirectory(localInfo.path)
+                try? await WorkspaceDirectoryRemover.remove(at: localInfo.path)
             }
             throw error
         }
@@ -902,17 +902,6 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
             )
         } catch {
             throw WorkspaceProviderError.unavailable(error.localizedDescription)
-        }
-    }
-
-    private func cleanupWorkspaceDirectory(_ workspaceURL: URL) {
-        try? fileManager.removeItem(at: workspaceURL)
-
-        let parentDirectory = workspaceURL.deletingLastPathComponent()
-        if let contents = try? fileManager.contentsOfDirectory(atPath: parentDirectory.path),
-            contents.isEmpty
-        {
-            try? fileManager.removeItem(at: parentDirectory)
         }
     }
 

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -14,7 +14,7 @@ public struct NewWorkspaceInfo: Sendable {
     public let name: String
     public let path: URL
     public let gitBranch: String
-    /// Non-fatal issues encountered during creation (e.g. branch creation failed, setup script non-zero).
+    /// Non-fatal issues encountered during creation (e.g. setup script non-zero).
     public let warnings: [String]
 
     public init(name: String, path: URL, gitBranch: String, warnings: [String] = []) {
@@ -75,8 +75,7 @@ public struct LocalWorkspaceContext: Sendable, Equatable {
 
 public enum WorkspaceCreationPhase: String, CaseIterable, Sendable {
     case preparing
-    case copyingRepository
-    case creatingBranch
+    case creatingWorktree
     case runningSetupScript
     case finished
 }
@@ -88,6 +87,7 @@ public protocol GitServiceProtocol: Sendable {
     func getRemoteURL(at path: URL) async throws -> String?
     func getCurrentBranch(at path: URL) async throws -> String?
     func createBranch(_ name: String, at path: URL) async throws
+    func createWorktree(branchName: String, at destination: URL, from source: URL) async throws
     func checkoutBranch(_ name: String, at path: URL) async throws
     func getFileTree(at path: URL, maxDepth: Int) async throws -> FileNode
     func diff(file: String, at path: URL) async throws -> UnifiedDiff

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
@@ -1,0 +1,88 @@
+//
+//  WorkspaceDirectoryRemover.swift
+//  WorkspaceManager
+//
+//  Removes host workspace directories while preserving git worktree metadata.
+//
+
+import Foundation
+
+enum WorkspaceDirectoryRemover {
+    static func remove(at workspaceURL: URL) async throws {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: workspaceURL.path) else {
+            cleanupEmptyParent(of: workspaceURL, fileManager: fileManager)
+            return
+        }
+
+        if isLinkedGitWorktree(at: workspaceURL, fileManager: fileManager) {
+            let branchName = try? await currentBranchName(at: workspaceURL)
+            let commonGitDirectory = try? await commonGitDirectory(at: workspaceURL)
+            let result = try await ProcessRunner.run(
+                executable: "/usr/bin/git",
+                arguments: ["worktree", "remove", "--force", workspaceURL.path],
+                currentDirectory: workspaceURL
+            )
+
+            guard result.success else {
+                let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
+                throw WorkspaceError.deletionFailed(reason: reason)
+            }
+
+            if let branchName,
+                branchName.hasPrefix("workspace/"),
+                let commonGitDirectory
+            {
+                _ = try? await ProcessRunner.run(
+                    executable: "/usr/bin/git",
+                    arguments: ["--git-dir", commonGitDirectory.path, "branch", "-D", branchName]
+                )
+            }
+        } else {
+            try fileManager.removeItem(at: workspaceURL)
+        }
+
+        cleanupEmptyParent(of: workspaceURL, fileManager: fileManager)
+    }
+
+    private static func isLinkedGitWorktree(at workspaceURL: URL, fileManager: FileManager) -> Bool {
+        let gitFileURL = workspaceURL.appendingPathComponent(".git")
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: gitFileURL.path, isDirectory: &isDirectory) else {
+            return false
+        }
+
+        return !isDirectory.boolValue
+    }
+
+    private static func currentBranchName(at workspaceURL: URL) async throws -> String? {
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: ["branch", "--show-current"],
+            currentDirectory: workspaceURL
+        )
+        guard result.success else { return nil }
+        let branchName = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return branchName.isEmpty ? nil : branchName
+    }
+
+    private static func commonGitDirectory(at workspaceURL: URL) async throws -> URL? {
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+            currentDirectory: workspaceURL
+        )
+        guard result.success else { return nil }
+        let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : URL(fileURLWithPath: path)
+    }
+
+    private static func cleanupEmptyParent(of workspaceURL: URL, fileManager: FileManager) {
+        let parentDir = workspaceURL.deletingLastPathComponent()
+        if let contents = try? fileManager.contentsOfDirectory(atPath: parentDir.path),
+            contents.isEmpty
+        {
+            try? fileManager.removeItem(at: parentDir)
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -2,7 +2,7 @@
 //  WorkspaceService.swift
 //  WorkspaceManager
 //
-//  Workspace creation, copying, lifecycle hooks, and management
+//  Workspace creation, git worktree materialization, lifecycle hooks, and management
 //
 
 import Foundation
@@ -85,55 +85,47 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
         )
 
         await progress?(.preparing)
-        await progress?(.copyingRepository)
-        try await copyRepository(from: repoLocalURL, to: workspaceDir)
 
         var warnings: [String] = []
 
         let branchName = "workspace/\(sanitizedName)"
-        await progress?(.creatingBranch)
+        await progress?(.creatingWorktree)
         do {
-            try await gitService.createBranch(branchName, at: workspaceDir)
+            try await gitService.createWorktree(
+                branchName: branchName,
+                at: workspaceDir,
+                from: repoLocalURL
+            )
         } catch {
-            let msg = "Could not create branch '\(branchName)': \(error)"
-            log.warning("\(msg)")
-            warnings.append(msg)
+            try? await WorkspaceDirectoryRemover.remove(at: workspaceDir)
+            throw WorkspaceError.worktreeCreationFailed(reason: error.localizedDescription)
         }
 
-        let currentBranch = try? await gitService.getCurrentBranch(at: workspaceDir)
+        do {
+            let currentBranch = try? await gitService.getCurrentBranch(at: workspaceDir)
 
-        await progress?(.runningSetupScript)
-        let setupResult = try await runLifecycleScript("setup.sh", in: workspaceDir)
-        if !setupResult.stdout.isEmpty {
-            log.info("setup.sh output: \(setupResult.stdout)")
-        }
-        if setupResult.exitCode != 0 {
-            let msg = "setup.sh exited with code \(setupResult.exitCode): \(setupResult.stderr)"
-            log.warning("\(msg)")
-            warnings.append(msg)
-        }
+            await progress?(.runningSetupScript)
+            let setupResult = try await runLifecycleScript("setup.sh", in: workspaceDir)
+            if !setupResult.stdout.isEmpty {
+                log.info("setup.sh output: \(setupResult.stdout)")
+            }
+            if setupResult.exitCode != 0 {
+                let msg = "setup.sh exited with code \(setupResult.exitCode): \(setupResult.stderr)"
+                log.warning("\(msg)")
+                warnings.append(msg)
+            }
 
-        await progress?(.finished)
+            await progress?(.finished)
 
-        return NewWorkspaceInfo(
-            name: name,
-            path: workspaceDir,
-            gitBranch: currentBranch ?? branchName,
-            warnings: warnings
-        )
-    }
-
-    // MARK: - Copy Repository
-
-    private func copyRepository(from source: URL, to destination: URL) async throws {
-        let result = try await ProcessRunner.run(
-            executable: "/usr/bin/ditto",
-            arguments: ["--rsrc", source.path, destination.path]
-        )
-
-        guard result.success else {
-            let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
-            throw WorkspaceError.copyFailed(reason: reason)
+            return NewWorkspaceInfo(
+                name: name,
+                path: workspaceDir,
+                gitBranch: currentBranch ?? branchName,
+                warnings: warnings
+            )
+        } catch {
+            try? await WorkspaceDirectoryRemover.remove(at: workspaceDir)
+            throw error
         }
     }
 
@@ -155,14 +147,7 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
         _ = try await runLifecycleScript("archive.sh", in: workspaceURL)
 
         if deleteFiles {
-            try FileManager.default.removeItem(at: workspaceURL)
-
-            let parentDir = workspaceURL.deletingLastPathComponent()
-            if let contents = try? FileManager.default.contentsOfDirectory(atPath: parentDir.path),
-                contents.isEmpty
-            {
-                try? FileManager.default.removeItem(at: parentDir)
-            }
+            try await WorkspaceDirectoryRemover.remove(at: workspaceURL)
         }
     }
 
@@ -296,7 +281,7 @@ public enum WorkspaceError: LocalizedError {
     case notAGitRepo
     case alreadyExists(name: String)
     case invalidName(name: String)
-    case copyFailed(reason: String)
+    case worktreeCreationFailed(reason: String)
     case deletionFailed(reason: String)
 
     public var errorDescription: String? {
@@ -307,8 +292,8 @@ public enum WorkspaceError: LocalizedError {
             return "A workspace named '\(name)' already exists"
         case .invalidName(let name):
             return "Workspace name '\(name)' is not valid"
-        case .copyFailed(let reason):
-            return "Failed to copy repository: \(reason)"
+        case .worktreeCreationFailed(let reason):
+            return "Failed to create git worktree: \(reason)"
         case .deletionFailed(let reason):
             return "Failed to delete workspace: \(reason)"
         }

--- a/Tests/WorkspaceManagerAppTests/SidebarViewTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarViewTests.swift
@@ -75,8 +75,7 @@ struct SidebarViewTests {
     @Test("Local creation message matches progress phase")
     func localCreationMessageMatchesPhase() {
         #expect(SidebarWorkspaceController.localCreationMessage(for: .preparing) == "Preparing workspace...")
-        #expect(SidebarWorkspaceController.localCreationMessage(for: .copyingRepository) == "Copying repository...")
-        #expect(SidebarWorkspaceController.localCreationMessage(for: .creatingBranch) == "Creating branch...")
+        #expect(SidebarWorkspaceController.localCreationMessage(for: .creatingWorktree) == "Creating git worktree...")
         #expect(SidebarWorkspaceController.localCreationMessage(for: .runningSetupScript) == "Running setup script...")
         #expect(SidebarWorkspaceController.localCreationMessage(for: .finished) == "Finishing workspace...")
     }

--- a/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
@@ -14,6 +14,7 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     // MARK: - Call Tracking
 
     var createBranchCalls: [(name: String, path: URL)] = []
+    var createWorktreeCalls: [(branchName: String, destination: URL, source: URL)] = []
     var getCurrentBranchCalls: [URL] = []
 
     // MARK: - Configurable Returns
@@ -23,6 +24,7 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     var currentBranchResult: String? = "main"
     var fileTreeResult: FileNode = FileNode(name: "root", path: "", isDirectory: true, children: [])
     var createBranchError: Error? = nil
+    var createWorktreeError: Error? = nil
 
     // MARK: - Protocol Conformance
 
@@ -42,6 +44,13 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     func createBranch(_ name: String, at path: URL) async throws {
         createBranchCalls.append((name: name, path: path))
         if let error = createBranchError {
+            throw error
+        }
+    }
+
+    func createWorktree(branchName: String, at destination: URL, from source: URL) async throws {
+        createWorktreeCalls.append((branchName: branchName, destination: destination, source: source))
+        if let error = createWorktreeError {
             throw error
         }
     }

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -67,6 +67,66 @@ struct WorkspaceServiceTests {
         return dir
     }
 
+    private func makeGitWorkspaceFixture() throws -> (testRoot: URL, repoDir: URL, wsRoot: URL) {
+        let testRoot = try makeTempDir()
+        let repoDir = testRoot.appendingPathComponent("repos/test-repo", isDirectory: true)
+        let wsRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: wsRoot, withIntermediateDirectories: true)
+
+        _ = try runGit(["init"], at: repoDir)
+        _ = try runGit(["config", "user.email", "test@example.com"], at: repoDir)
+        _ = try runGit(["config", "user.name", "Test User"], at: repoDir)
+        try "root file\n".write(to: repoDir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        _ = try runGit(["add", "-A"], at: repoDir)
+        _ = try runGit(["commit", "-m", "initial commit"], at: repoDir)
+
+        return (testRoot, repoDir, wsRoot)
+    }
+
+    private func runGit(_ args: [String], at directory: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = directory
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: stdoutData, encoding: .utf8) ?? ""
+        let errorOutput = String(data: stderrData, encoding: .utf8) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            throw TestGitCommandError(args: args, stderr: errorOutput)
+        }
+
+        return output
+    }
+
+    private func branchExists(_ name: String, at directory: URL) throws -> Bool {
+        let output = try runGit(["branch", "--list", name], at: directory)
+        return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func worktreeList(_ output: String, contains url: URL) -> Bool {
+        if output.contains("worktree \(url.path)") {
+            return true
+        }
+        if url.path.hasPrefix("/var/"),
+            output.contains("worktree /private\(url.path)")
+        {
+            return true
+        }
+        return false
+    }
+
     // MARK: - runLifecycleScript Tests
 
     @Test("Returns success when script is missing")
@@ -192,8 +252,8 @@ struct WorkspaceServiceTests {
 
     // MARK: - createWorkspace Tests
 
-    @Test("createWorkspace calls git createBranch with correct name")
-    func createWorkspaceCallsCreateBranch() async throws {
+    @Test("createWorkspace calls git createWorktree with correct branch and path")
+    func createWorkspaceCallsCreateWorktree() async throws {
         let mockGit = MockGitService()
         let service = WorkspaceService(gitService: mockGit)
         let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
@@ -203,22 +263,35 @@ struct WorkspaceServiceTests {
 
         _ = try await service.createWorkspace(repoName: "test-repo", repoLocalURL: repoDir, name: "my-feature")
 
-        #expect(mockGit.createBranchCalls.count == 1)
-        #expect(mockGit.createBranchCalls[0].name == "workspace/my-feature")
+        let workspaceDir =
+            wsRoot
+            .appendingPathComponent("test-repo", isDirectory: true)
+            .appendingPathComponent("my-feature", isDirectory: true)
+        #expect(mockGit.createWorktreeCalls.count == 1)
+        #expect(mockGit.createWorktreeCalls[0].branchName == "workspace/my-feature")
+        #expect(mockGit.createWorktreeCalls[0].destination == workspaceDir)
+        #expect(mockGit.createWorktreeCalls[0].source == repoDir)
     }
 
-    @Test("createWorkspace continues when branch creation fails")
-    func createWorkspaceContinuesWhenBranchFails() async throws {
+    @Test("createWorkspace fails clearly when worktree creation fails")
+    func createWorkspaceFailsWhenWorktreeCreationFails() async throws {
         let mockGit = MockGitService()
-        mockGit.createBranchError = GitError.commandFailed(args: ["checkout", "-b"], stderr: "already exists")
+        mockGit.createWorktreeError = GitError.commandFailed(args: ["worktree", "add"], stderr: "already exists")
         let service = WorkspaceService(gitService: mockGit)
         let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
         defer { try? FileManager.default.removeItem(at: testRoot) }
         let originalRoot = setWorkspacesRoot(wsRoot)
         defer { restoreWorkspacesRoot(originalRoot) }
 
-        let info = try await service.createWorkspace(repoName: "test-repo", repoLocalURL: repoDir, name: "test-ws")
-        #expect(info.name == "test-ws")
+        await #expect(throws: WorkspaceError.self) {
+            _ = try await service.createWorkspace(repoName: "test-repo", repoLocalURL: repoDir, name: "test-ws")
+        }
+
+        let workspaceDir =
+            wsRoot
+            .appendingPathComponent("test-repo", isDirectory: true)
+            .appendingPathComponent("test-ws", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: workspaceDir.path))
     }
 
     @Test("createWorkspace throws when directory already exists")
@@ -289,12 +362,13 @@ struct WorkspaceServiceTests {
         )
 
         let phases = await recorder.snapshot()
-        #expect(phases == [.preparing, .copyingRepository, .creatingBranch, .runningSetupScript, .finished])
+        #expect(phases == [.preparing, .creatingWorktree, .runningSetupScript, .finished])
     }
 
     @Test("createWorkspace stops progress at failing phase")
     func createWorkspaceStopsProgressAtFailingPhase() async throws {
         let mockGit = MockGitService()
+        mockGit.createWorktreeError = GitError.commandFailed(args: ["worktree", "add"], stderr: "failed")
         let service = WorkspaceService(gitService: mockGit)
         let tempRoot = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempRoot) }
@@ -316,7 +390,145 @@ struct WorkspaceServiceTests {
         }
 
         let phases = await recorder.snapshot()
-        #expect(phases == [.preparing, .copyingRepository])
+        #expect(phases == [.preparing, .creatingWorktree])
+    }
+
+    @Test("createWorkspace materializes a git worktree")
+    func createWorkspaceMaterializesGitWorktree() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "feature-a"
+        )
+
+        #expect(info.gitBranch == "workspace/feature-a")
+        #expect(FileManager.default.fileExists(atPath: info.path.appendingPathComponent("README.md").path))
+
+        var gitPathIsDirectory: ObjCBool = false
+        #expect(
+            FileManager.default.fileExists(
+                atPath: info.path.appendingPathComponent(".git").path,
+                isDirectory: &gitPathIsDirectory
+            )
+        )
+        #expect(!gitPathIsDirectory.boolValue)
+
+        let currentBranch = try runGit(["branch", "--show-current"], at: info.path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(currentBranch == "workspace/feature-a")
+
+        let worktreeList = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
+        #expect(self.worktreeList(worktreeList, contains: info.path))
+    }
+
+    @Test("createWorkspace can materialize from a linked worktree source")
+    func createWorkspaceMaterializesFromLinkedWorktreeSource() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let sourceWorktree = testRoot.appendingPathComponent("source-worktree", isDirectory: true)
+        _ = try runGit(
+            ["worktree", "add", "-b", "source-linked", sourceWorktree.path, "HEAD"],
+            at: repoDir
+        )
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: sourceWorktree,
+            name: "from-linked"
+        )
+
+        let currentBranch = try runGit(["branch", "--show-current"], at: info.path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(currentBranch == "workspace/from-linked")
+
+        let worktreeList = try runGit(["worktree", "list", "--porcelain"], at: sourceWorktree)
+        #expect(self.worktreeList(worktreeList, contains: info.path))
+    }
+
+    @Test("createWorkspace cleans up when workspace branch already exists")
+    func createWorkspaceCleansUpWhenWorkspaceBranchExists() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+        _ = try runGit(["branch", "workspace/conflict"], at: repoDir)
+
+        await #expect(throws: WorkspaceError.self) {
+            _ = try await service.createWorkspace(
+                repoName: "test-repo",
+                repoLocalURL: repoDir,
+                name: "conflict"
+            )
+        }
+
+        let workspaceDir =
+            wsRoot
+            .appendingPathComponent("test-repo", isDirectory: true)
+            .appendingPathComponent("conflict", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: workspaceDir.path))
+        #expect(!FileManager.default.fileExists(atPath: workspaceDir.deletingLastPathComponent().path))
+        let preexistingBranchStillExists = try branchExists("workspace/conflict", at: repoDir)
+        #expect(preexistingBranchStillExists)
+    }
+
+    @Test("deleteWorkspace removes linked worktree metadata and branch")
+    func deleteWorkspaceRemovesLinkedWorktreeMetadataAndBranch() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "delete-me"
+        )
+
+        try await service.deleteWorkspace(at: info.path, deleteFiles: true)
+
+        #expect(!FileManager.default.fileExists(atPath: info.path.path))
+        let worktreeList = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
+        #expect(!self.worktreeList(worktreeList, contains: info.path))
+        let deletedBranchExists = try branchExists("workspace/delete-me", at: repoDir)
+        #expect(!deletedBranchExists)
+    }
+
+    @Test("createWorkspace keeps setup.sh warning behavior")
+    func createWorkspaceKeepsSetupWarningBehavior() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+        let setupPath = repoDir.appendingPathComponent("setup.sh")
+        try """
+        #!/bin/bash
+        echo setup failed >&2
+        exit 7
+        """.write(to: setupPath, atomically: true, encoding: .utf8)
+        _ = try runGit(["add", "setup.sh"], at: repoDir)
+        _ = try runGit(["commit", "-m", "add failing setup"], at: repoDir)
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "setup-warning"
+        )
+
+        #expect(FileManager.default.fileExists(atPath: info.path.path))
+        #expect(info.warnings.contains { $0.contains("setup.sh exited with code 7") })
     }
 
     // MARK: - deleteWorkspace Tests
@@ -445,5 +657,14 @@ struct WorkspaceServiceTests {
 
         let size = try await service.getWorkspaceSize(at: tempDir)
         #expect(size == 0)
+    }
+}
+
+private struct TestGitCommandError: Error, CustomStringConvertible {
+    let args: [String]
+    let stderr: String
+
+    var description: String {
+        "git \(args.joined(separator: " ")) failed: \(stderr)"
     }
 }

--- a/docs/design/design-brief.html
+++ b/docs/design/design-brief.html
@@ -511,7 +511,7 @@
         </div>
         <div class="solution">
           <h4>Our Solution</h4>
-          <p>WorkSpaces creates <strong>isolated copies of repos with embedded terminal support</strong>. Each workspace runs setup.sh automatically, giving you a clean slate for every AI coding session. Think of it as <strong>git worktrees with a terminal-first UI</strong>.</p>
+          <p>WorkSpaces creates <strong>isolated git worktrees with embedded terminal support</strong>. Each workspace runs setup.sh automatically, giving you a clean slate for every AI coding session.</p>
         </div>
       </div>
     </section>

--- a/docs/development/lume-validation.md
+++ b/docs/development/lume-validation.md
@@ -301,7 +301,7 @@ The smoke path:
 - auto-confirms Lume setup or repair if needed
 - waits for `workspace_active`
 - runs a host-side `lume ssh <vmName>` probe
-- cleans up the disposable repo, workspace copy, and VM on success
+- cleans up the disposable repo, host workspace, and VM on success
 - preserves all artifacts on failure
 
 Artifacts are written to:

--- a/docs/original_spec.md
+++ b/docs/original_spec.md
@@ -472,15 +472,15 @@ actor WorkspaceService {
 1. Sanitize name for filesystem
 2. Create directory path: `{workspacesRoot}/{repo.name}/{sanitizedName}`
 3. Check doesn't already exist
-4. Copy repo using `ditto --rsrc`
-5. Create git branch `workspace/{name}` (best effort, don't fail if git fails)
+4. Create git worktree at that path with branch `workspace/{name}`
+5. Fail clearly and clean up if branch or worktree creation fails
 6. **Run `setup.sh` if exists** (capture output, show in terminal)
 7. Return Workspace model (caller inserts into SwiftData)
 
 **Workspace Archive/Delete Steps**:
 1. **Run `archive.sh` if exists** (capture output, show in terminal)
 2. Update status to archived OR delete from SwiftData
-3. Optionally delete workspace directory from disk
+3. Optionally remove the workspace directory/worktree from disk
 
 **Lifecycle Script Execution**:
 ```swift

--- a/docs/product_overview.md
+++ b/docs/product_overview.md
@@ -22,8 +22,8 @@ Think of it as **a terminal session manager for your code portfolio, with worksp
 - **Repo Overview Launcher**: Clicking a repo opens an overview with workspace and web-view actions
 - **Persistent Terminal Sessions**: Repo and workspace terminals resume instead of restarting from scratch
 - **Scoped Web Views**: Global, repo-owned, and workspace-owned web views live alongside terminal contexts
-- **Workspace Creation**: Create isolated workspace copies per repo
-- **Inline Workspace Progress**: Repo rows show coarse creation progress while a workspace copy/setup is in flight
+- **Workspace Creation**: Create isolated git worktree workspaces per repo
+- **Inline Workspace Progress**: Repo rows show coarse creation progress while worktree creation/setup is in flight
 - **Lifecycle Hooks**: `setup.sh` runs after creation, `archive.sh` runs on close
 - **Embedded Terminal**: GhosttyKit (`libghostty`) terminal as the primary interface
 - **Two-Pane Split Control**: Ghostty split actions can create, focus, resize, and equalize the current two-pane stack

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -160,8 +160,8 @@ sequenceDiagram
     User->>App: Right-click repo → "New Workspace..."
     App-->>User: Name input sheet
     User->>App: Enters "approach-b"
-    App->>FS: Copy repo to ~/workspaces/project/approach-b
-    FS-->>App: Copy complete
+    App->>FS: Create git worktree at ~/workspaces/project/approach-b
+    FS-->>App: Worktree ready
     App->>FS: Run setup.sh
     FS-->>App: Setup output
     App-->>User: New workspace selected
@@ -184,11 +184,11 @@ sequenceDiagram
 └──────────────────┘
 
 ~/workspaces/my-api/
-├── approach-a/     ← Independent copy
-│   ├── .git/
+├── approach-a/     ← Independent worktree
+│   ├── .git
 │   └── src/
-└── approach-b/     ← Independent copy
-    ├── .git/
+└── approach-b/     ← Independent worktree
+    ├── .git
     └── src/
 ```
 
@@ -196,7 +196,7 @@ sequenceDiagram
 
 1. **Right-click repo** — Context menu appears with "New Workspace..." option
 2. **Name workspace** — User enters descriptive name like "approach-b"
-3. **Copy created** — Full repo copy made to workspaces directory
+3. **Worktree created** — Git worktree made in the workspaces directory
 4. **Setup runs** — If setup.sh exists, it runs automatically
 5. **Workspace ready** — New workspace selected, terminal opens there
 


### PR DESCRIPTION
## Summary

- Replace local workspace materialization with `git worktree add` from the existing Local provider path.
- Add cleanup that removes failed or deleted linked worktrees, including Workspace-owned `workspace/*` branches.
- Update local workspace progress/copy from repository copying to git worktree creation, and refresh stale docs.
- Add real temporary git repository integration coverage for normal, linked-worktree source, conflict cleanup, deletion cleanup, and `setup.sh` warning behavior.

## Mergeability

- Surface: desktop
- User-facing behavior changed: local workspace creation now creates a git worktree instead of copying the repository; progress text says `Creating git worktree...`.
- Non-happy paths considered: existing target directories, pre-existing workspace branches, failed `git worktree add`, linked-worktree cleanup, and non-zero `setup.sh` warnings.
- Release/ops preconditions: git must be available for Local workspace creation, matching the existing git-backed app assumptions.
- Residual risk or follow-up: existing workspaces created by the old copy path still delete via filesystem fallback; new linked worktrees delete through git metadata-aware cleanup.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - [x] `./scripts/build-ghosttykit.sh`
  - [x] `swift-format lint --strict --recursive Sources/ Tests/`
  - [x] `swift test --filter WorkspaceServiceTests`
  - [x] `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![git-worktree-local-workspaces](https://evidence.cloudcompute.com/workspaces/pr-606/20260601-035521-git-worktree-local-workspaces.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
