### PR TITLE
ci: cache Playwright browsers in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -157,7 +157,22 @@ jobs:
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install chromium --with-deps
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm exec playwright --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --with-deps
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
       - name: Run Playwright fast against preview
         env:
           PLAYWRIGHT_BASE_URL: ${{ needs.preview-web.outputs.preview_url }}
@@ -322,7 +337,22 @@ jobs:
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install chromium --with-deps
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm exec playwright --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --with-deps
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
       - name: Settle CDN cache
         run: |
           for i in 1 2 3 4 5; do


### PR DESCRIPTION
## Summary

- Reuse the existing version-keyed Playwright browser cache in CD preview validation.
- Apply the same cache/deps split to production validation so promotion does not depend on a fresh browser download every run.
- Add a 15 minute bound to cold browser installs so CD fails clearly instead of staying stuck indefinitely.

## Mergeability

- Surface: infra
- User-facing behavior changed: none
- Non-happy paths considered: cache miss still installs Chromium, but now the install is bounded; cache hit installs only system deps.
- Release/ops preconditions: after merge, cancel or let the currently stuck old CD run finish, then allow the next main CD run to validate with the cache path.
- Residual risk or follow-up: first cache miss can still fail if upstream Playwright download/extract is broken; the existing web-ci cache key should usually avoid that path.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `mise -C web run web:check` passed
  - `uv run --script scripts/tests/test_security_hardening.py` passed
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check` passed

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID:
- Before Summary:
- After Summary:
- Delta Summary:

Performance comparison notes:

- Exact commands used:
- Workload / environment context:

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![cd-playwright-cache](https://evidence.cloudcompute.com/workspaces/pr-607/20260601-043408-cd-playwright-cache.png)

## Blockers

- [x] None
- [ ] Blocked on evidence