### PR TITLE
Tighten PR evidence comment triggers

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -354,7 +354,7 @@ managed review run:
 | `pull_request` | `edited` | Rerun when `changes.body` or `changes.base` is present; title-only and other metadata edits do not start sessions |
 | `pull_request` | `labeled`, `unlabeled` | Metadata only; no managed-review session |
 | `pull_request` | `closed` | Terminal PR activity; no managed-review session |
-| `issue_comment` | `created` with evidence | Rerun when the comment is on a PR thread, the sender is a non-bot, and the body matches an evidence signal: `evidence.cloudcompute.com`, `Evidence:`, `Validation:`, `swift test`, `playwright`, `screenshot`, or `recording`. Plain status comments that merely mention validation do not rerun review. |
+| `issue_comment` | `created` with evidence | Rerun when the comment is on a PR thread, the sender is a non-bot, and the body explicitly supplies evidence: `evidence.cloudcompute.com`, `Evidence:`, or `Validation:` at the start of a line. Plain review responses that mention tools, screenshots, recordings, or validation do not rerun review. |
 | `issue_comment` | `created` without evidence | Metadata only; no managed-review session |
 | `pull_request_review_comment`, `pull_request_review` | any | Metadata only; no managed-review session |
 

--- a/infra/cloudflare-webhook-relay/src/index.ts
+++ b/infra/cloudflare-webhook-relay/src/index.ts
@@ -157,7 +157,7 @@ async function handleAuthSession(request: Request, env: Env): Promise<Response> 
 // ---------------------------------------------------------------------------
 
 const EVIDENCE_SIGNAL =
-  /(evidence\.cloudcompute\.com|^Evidence:|swift test|playwright|screenshot|recording|validation)/im;
+  /(evidence\.cloudcompute\.com|^\s*(?:Evidence|Validation):)/im;
 
 function isBotSender(payload: Record<string, unknown>): boolean {
   const sender = payload.sender as Record<string, unknown> | undefined;

--- a/web/src/app/api/webhooks/github/route.test.ts
+++ b/web/src/app/api/webhooks/github/route.test.ts
@@ -338,6 +338,17 @@ describe("PR review trigger relevance classifier", () => {
 		);
 		expectSkip(
 			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload(
+					"Review response: no changes. The Playwright cache path is working as intended.",
+				),
+			),
+			"non_evidence_comment",
+			"metadata",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
 				"pull_request_review_comment",
 				"created",
 				makeReviewCommentPayload(),
@@ -703,6 +714,11 @@ describe("/api/webhooks/github POST", () => {
 			await POST(
 				makeIssueCommentRequest(
 					"Managed review approved with no requested changes. Local and CI validation are green.",
+				),
+			);
+			await POST(
+				makeIssueCommentRequest(
+					"Review response: no changes. The Playwright cache path is working as intended.",
 				),
 			);
 			expect(mocks.triggerPrReview).not.toHaveBeenCalled();

--- a/web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-trigger-fixtures.ts
@@ -244,6 +244,17 @@ export const PR_REVIEW_WEBHOOK_CONTRACT_CASES: PrReviewWebhookContractCase[] = [
 		expectedTriggerKind: null,
 	},
 	{
+		name: "review response mentions validation tool",
+		deliveryId: "contract-pr-review-response-tool-comment",
+		eventType: "issue_comment",
+		payload: issueCommentPayload(
+			8117,
+			"Review response: no changes. The Playwright cache path is working as intended.",
+		),
+		expectedForwarded: false,
+		expectedTriggerKind: null,
+	},
+	{
 		name: "evidence issue comment created",
 		deliveryId: "contract-issue-evidence-comment",
 		eventType: "issue_comment",

--- a/web/src/lib/agent-runtime/pr-review-trigger.ts
+++ b/web/src/lib/agent-runtime/pr-review-trigger.ts
@@ -51,7 +51,7 @@ export type PrReviewTriggerClassification =
 	| PrReviewTriggerSkipClassification;
 
 const EVIDENCE_SIGNAL =
-	/(evidence\.cloudcompute\.com|^\s*(?:Evidence|Validation):|\bswift test\b|\bplaywright\b|\bscreenshot\b|\brecording\b)/im;
+	/(evidence\.cloudcompute\.com|^\s*(?:Evidence|Validation):)/im;
 const PR_REVIEWER_BOT_LOGIN = "workspaces-claude-pr-reviewer[bot]";
 
 function isBotSender(payload: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Summary

- require PR evidence comments to use explicit evidence markers before they retrigger managed review
- keep the Cloudflare relay and web webhook classifier aligned on the same evidence-comment contract
- document that plain review responses mentioning tools, screenshots, recordings, or validation do not rerun review

## Mergeability

- Surface: agent-runtime / infra / docs
- User-facing behavior changed: review-response comments are less likely to start duplicate managed reviews
- Non-happy paths considered: actual evidence links and line-start `Evidence:` / `Validation:` comments still retrigger review
- Release/ops preconditions: deploy through normal web/CD pipeline
- Residual risk or follow-up: relay E2E could not be completed locally because Wrangler started but never served `/health` in this desktop environment; web tests and shared contract fixtures cover the changed trigger rule

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `mise -C web run web:check` passed
  - `uv run --script scripts/tests/test_security_hardening.py` passed
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check` passed
  - `bun run test:e2e` for `infra/cloudflare-webhook-relay` was attempted with escalation; blocked because Wrangler never served `/health` locally

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID:
- Before Summary:
- After Summary:
- Delta Summary:

Performance comparison notes:

- Exact commands used:
- Workload / environment context:

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-608/20260601-045848-trigger-comment-filter.png

## Blockers

- [x] None
- [ ] Blocked on evidence
