### PR TITLE
Add workspace materializer strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ WorkSpaces gives you a native app that wraps a terminal with some niceties for s
 - Embedded web views with global, repo-owned, and workspace-owned scope
 - File browser and git status view
 - `cmd+o` to open repo in editor, defaulting to zed
-- Lifecycle hooks (`setup.sh` / `archive.sh`)
+- Lifecycle hooks (`scripts/setup`, `scripts/stop`, `scripts/archive`; legacy `setup.sh` / `archive.sh`)
 
 ## Usage
 
@@ -74,7 +74,7 @@ Open Settings (`Cmd+,`) to configure workspace root location.
 WorkSpaces is designed to be forked. There's no plugin system or extension API — instead, the codebase itself is the API. Common customizations:
 
 - **Change the layout**: Edit `ContentView.swift` to rearrange panes
-- **Add lifecycle hooks**: Drop scripts into workspace directories (`setup.sh`, `archive.sh`)
+- **Add lifecycle hooks**: Drop project lifecycle scripts into `scripts/` (`setup`, `stop`, `archive`) or use legacy root hooks (`setup.sh`, `archive.sh`)
 - **Customize repo overview and sidebar behavior**: Start with `RepoLandingView.swift`, `SidebarView.swift`, and `SidebarRows.swift`
 - **Swap the terminal**: The `TerminalView` wrapper abstracts the terminal backend
 - **Adjust keyboard shortcuts**: See `ShortcutRoutingPolicy.swift`

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1432,19 +1432,15 @@ struct ContentView: View {
 
     @MainActor
     private func archiveWorkspaceFromLanding(_ workspace: Workspace) async {
-        if workspace.backend != .local {
-            let controller = SidebarWorkspaceController(
-                modelContext: modelContext,
-                workspaceService: workspaceService,
-                workspaceProviderRegistry: workspaceProviderRegistry
-            )
-            do {
-                try await controller.archive(workspace)
-            } catch {
-                landingErrorMessage = "Failed to archive workspace: \(error.localizedDescription)"
-            }
-        } else {
-            workspace.status = .archived
+        let controller = SidebarWorkspaceController(
+            modelContext: modelContext,
+            workspaceService: workspaceService,
+            workspaceProviderRegistry: workspaceProviderRegistry
+        )
+        do {
+            try await controller.archive(workspace)
+        } catch {
+            landingErrorMessage = "Failed to archive workspace: \(error.localizedDescription)"
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -860,7 +860,7 @@ struct SidebarView: View {
     private func localWorkspaceActions(_ workspace: Workspace) -> some View {
         if workspace.status == .active {
             Button("Archive") {
-                toggleLocalWorkspaceArchive(workspace, archived: true)
+                performArchive(workspace)
             }
         } else {
             Button("Unarchive") {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -297,14 +297,4 @@ struct SidebarWorkspaceController {
         }
     }
 
-    private static func cleanupWorkspaceDirectoryAfterFailedPersistence(_ workspaceURL: URL) {
-        try? FileManager.default.removeItem(at: workspaceURL)
-
-        let parentDirectory = workspaceURL.deletingLastPathComponent()
-        if let contents = try? FileManager.default.contentsOfDirectory(atPath: parentDirectory.path),
-            contents.isEmpty
-        {
-            try? FileManager.default.removeItem(at: parentDirectory)
-        }
-    }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -182,8 +182,12 @@ struct SidebarWorkspaceController {
     }
 
     func archive(_ workspace: Workspace) async throws {
-        let provider = try provider(for: workspace)
-        try await provider.archiveWorkspace(WorkspaceProviderTarget(workspace))
+        if workspace.backend == .local {
+            try await workspaceService.archiveWorkspace(at: workspace.workspaceURL)
+        } else {
+            let provider = try provider(for: workspace)
+            try await provider.archiveWorkspace(WorkspaceProviderTarget(workspace))
+        }
         workspace.status = .archived
         try saveModelContext(action: "archive workspace")
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -61,7 +61,7 @@ struct SidebarWorkspaceController {
         case .creatingWorktree:
             return "Creating git worktree..."
         case .runningSetupScript:
-            return "Running setup script..."
+            return "Running setup..."
         case .finished:
             return "Finishing workspace..."
         }

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -189,7 +189,7 @@ struct SettingsView: View {
 
                     VStack(alignment: .leading, spacing: 4) {
                         Label {
-                            Text("setup.sh")
+                            Text("scripts/setup")
                                 .font(.system(.body, design: .monospaced))
                             Text("— Runs after workspace is created")
                                 .foregroundStyle(.secondary)
@@ -199,9 +199,9 @@ struct SettingsView: View {
                         }
 
                         Label {
-                            Text("archive.sh")
+                            Text("scripts/stop, scripts/archive")
                                 .font(.system(.body, design: .monospaced))
-                            Text("— Runs when workspace is closed")
+                            Text("— Runs before archive or delete")
                                 .foregroundStyle(.secondary)
                         } icon: {
                             Image(systemName: "archivebox")
@@ -210,7 +210,7 @@ struct SettingsView: View {
                     }
                     .font(.callout)
 
-                    Text("Add these scripts to your repository to automate workspace setup and cleanup.")
+                    Text("WorkSpaces also supports legacy setup.sh and archive.sh hooks.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/WorkspaceManagerCore/Services/LocalWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalWorkspaceProvider.swift
@@ -71,7 +71,7 @@ public struct LocalWorkspaceProvider: WorkspaceProviderProtocol {
         case .creatingWorktree:
             return "Creating git worktree..."
         case .runningSetupScript:
-            return "Running setup script..."
+            return "Running setup..."
         case .finished:
             return "Finishing workspace..."
         }

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
@@ -18,10 +18,23 @@ enum WorkspaceDirectoryRemover {
         if isLinkedGitWorktree(at: workspaceURL, fileManager: fileManager) {
             let branchName = try? await currentBranchName(at: workspaceURL)
             let commonGitDirectory = try? await commonGitDirectory(at: workspaceURL)
+            let removalArguments: [String]
+            if let commonGitDirectory {
+                removalArguments = [
+                    "--git-dir",
+                    commonGitDirectory.path,
+                    "worktree",
+                    "remove",
+                    "--force",
+                    workspaceURL.path,
+                ]
+            } else {
+                removalArguments = ["worktree", "remove", "--force", workspaceURL.path]
+            }
             let result = try await ProcessRunner.run(
                 executable: "/usr/bin/git",
-                arguments: ["worktree", "remove", "--force", workspaceURL.path],
-                currentDirectory: workspaceURL
+                arguments: removalArguments,
+                currentDirectory: workspaceURL.deletingLastPathComponent()
             )
 
             guard result.success else {

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceMaterializer.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceMaterializer.swift
@@ -1,0 +1,101 @@
+//
+//  WorkspaceMaterializer.swift
+//  WorkspaceManager
+//
+//  Materializes local workspace directories behind a small strategy interface.
+//
+
+import Foundation
+
+struct MaterializedWorkspace: Sendable {
+    let gitBranch: String
+}
+
+protocol WorkspaceMaterializer: Sendable {
+    var failureOperationDescription: String { get }
+
+    /// Creates a local workspace at `destination` from `sourceRepository`.
+    /// Implementations own their repository mechanics; callers own destination validation and lifecycle hooks.
+    func materializeWorkspace(
+        named sanitizedName: String,
+        at destination: URL,
+        from sourceRepository: URL
+    ) async throws -> MaterializedWorkspace
+
+    func removeWorkspace(at workspaceURL: URL) async throws
+}
+
+extension WorkspaceMaterializer {
+    func removeWorkspace(at workspaceURL: URL) async throws {
+        try await WorkspaceDirectoryRemover.remove(at: workspaceURL)
+    }
+}
+
+struct GitWorktreeWorkspaceMaterializer: WorkspaceMaterializer {
+    let gitService: any GitServiceProtocol
+
+    var failureOperationDescription: String {
+        "create git worktree"
+    }
+
+    init(gitService: any GitServiceProtocol = GitService.shared) {
+        self.gitService = gitService
+    }
+
+    func materializeWorkspace(
+        named sanitizedName: String,
+        at destination: URL,
+        from sourceRepository: URL
+    ) async throws -> MaterializedWorkspace {
+        let branchName = "workspace/\(sanitizedName)"
+        try await gitService.createWorktree(
+            branchName: branchName,
+            at: destination,
+            from: sourceRepository
+        )
+
+        let currentBranch = try? await gitService.getCurrentBranch(at: destination)
+        return MaterializedWorkspace(gitBranch: currentBranch ?? branchName)
+    }
+}
+
+struct GitCloneWorkspaceMaterializer: WorkspaceMaterializer {
+    let gitService: any GitServiceProtocol
+
+    var failureOperationDescription: String {
+        "copy repository"
+    }
+
+    init(gitService: any GitServiceProtocol = GitService.shared) {
+        self.gitService = gitService
+    }
+
+    func materializeWorkspace(
+        named sanitizedName: String,
+        at destination: URL,
+        from sourceRepository: URL
+    ) async throws -> MaterializedWorkspace {
+        let cloneArguments = [
+            "clone",
+            "--local",
+            "--no-hardlinks",
+            sourceRepository.path,
+            destination.path,
+        ]
+        let cloneResult = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: cloneArguments,
+            currentDirectory: sourceRepository.deletingLastPathComponent()
+        )
+        guard cloneResult.success else {
+            let reason = cloneResult.stderr.isEmpty ? "Unknown error" : cloneResult.stderr
+            throw GitError.commandFailed(args: cloneArguments, stderr: reason)
+        }
+
+        let branchName = "workspace/\(sanitizedName)"
+        try await gitService.createBranch(branchName, at: destination)
+        let currentBranch = try? await gitService.getCurrentBranch(at: destination)
+
+        return MaterializedWorkspace(gitBranch: currentBranch ?? branchName)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -121,12 +121,13 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
 
         do {
             await progress?(.runningSetupScript)
-            let setupResult = try await runLifecycleScript("setup.sh", in: workspaceDir)
-            if !setupResult.stdout.isEmpty {
-                log.info("setup.sh output: \(setupResult.stdout)")
+            let setupRun = try await runLifecycleAction(.setup, in: workspaceDir)
+            if !setupRun.result.stdout.isEmpty {
+                log.info("\(setupRun.scriptName ?? "setup") output: \(setupRun.result.stdout)")
             }
-            if setupResult.exitCode != 0 {
-                let msg = "setup.sh exited with code \(setupResult.exitCode): \(setupResult.stderr)"
+            if setupRun.result.exitCode != 0 {
+                let scriptName = setupRun.scriptName ?? "setup"
+                let msg = "\(scriptName) exited with code \(setupRun.result.exitCode): \(setupRun.result.stderr)"
                 log.warning("\(msg)")
                 warnings.append(msg)
             }
@@ -148,19 +149,13 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
     // MARK: - Archive Workspace
 
     public func archiveWorkspace(at workspaceURL: URL) async throws {
-        let archiveResult = try await runLifecycleScript("archive.sh", in: workspaceURL)
-        if !archiveResult.stdout.isEmpty {
-            log.info("archive.sh output: \(archiveResult.stdout)")
-        }
-        if archiveResult.exitCode != 0 {
-            log.warning("archive.sh exited with code \(archiveResult.exitCode): \(archiveResult.stderr)")
-        }
+        try await runTeardownLifecycle(in: workspaceURL)
     }
 
     // MARK: - Delete Workspace
 
     public func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws {
-        _ = try await runLifecycleScript("archive.sh", in: workspaceURL)
+        try await runTeardownLifecycle(in: workspaceURL)
 
         if deleteFiles {
             try await WorkspaceDirectoryRemover.remove(at: workspaceURL)
@@ -185,6 +180,81 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
 
     public func runLifecycleScript(_ scriptName: String, in directory: URL) async throws -> ScriptResult {
         let scriptPath = directory.appendingPathComponent(scriptName)
+        return try await runLifecycleScript(at: scriptPath, in: directory)
+    }
+
+    private struct LifecycleScriptRun: Sendable {
+        let scriptName: String?
+        let result: ScriptResult
+    }
+
+    private enum LifecycleScriptAction: String, Sendable {
+        case setup
+        case stop
+        case archive
+
+        var legacyScriptName: String? {
+            switch self {
+            case .setup:
+                return "setup.sh"
+            case .stop:
+                return nil
+            case .archive:
+                return "archive.sh"
+            }
+        }
+
+        var candidateScriptNames: [String] {
+            var candidates = [
+                "scripts/\(rawValue)",
+                "scripts/\(rawValue).sh",
+            ]
+            if let legacyScriptName {
+                candidates.append(legacyScriptName)
+            }
+            return candidates
+        }
+    }
+
+    private func runLifecycleAction(
+        _ action: LifecycleScriptAction,
+        in directory: URL
+    ) async throws -> LifecycleScriptRun {
+        for scriptName in action.candidateScriptNames {
+            let scriptPath = directory.appendingPathComponent(scriptName)
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: scriptPath.path, isDirectory: &isDirectory),
+                !isDirectory.boolValue
+            else {
+                continue
+            }
+
+            let result = try await runLifecycleScript(at: scriptPath, in: directory)
+            return LifecycleScriptRun(scriptName: scriptName, result: result)
+        }
+
+        return LifecycleScriptRun(
+            scriptName: nil,
+            result: ScriptResult(exitCode: 0, stdout: "", stderr: "")
+        )
+    }
+
+    private func runTeardownLifecycle(in directory: URL) async throws {
+        for action in [LifecycleScriptAction.stop, .archive] {
+            let run = try await runLifecycleAction(action, in: directory)
+            guard let scriptName = run.scriptName else {
+                continue
+            }
+            if !run.result.stdout.isEmpty {
+                log.info("\(scriptName) output: \(run.result.stdout)")
+            }
+            if run.result.exitCode != 0 {
+                log.warning("\(scriptName) exited with code \(run.result.exitCode): \(run.result.stderr)")
+            }
+        }
+    }
+
+    private func runLifecycleScript(at scriptPath: URL, in directory: URL) async throws -> ScriptResult {
 
         guard FileManager.default.fileExists(atPath: scriptPath.path) else {
             return ScriptResult(exitCode: 0, stdout: "", stderr: "")

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -2,7 +2,7 @@
 //  WorkspaceService.swift
 //  WorkspaceManager
 //
-//  Workspace creation, git worktree materialization, lifecycle hooks, and management
+//  Workspace creation, lifecycle hooks, and management
 //
 
 import Foundation
@@ -13,7 +13,7 @@ private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "Wo
 public actor WorkspaceService: WorkspaceServiceProtocol {
     public static let shared = WorkspaceService()
 
-    private let gitService: any GitServiceProtocol
+    private let materializer: any WorkspaceMaterializer
 
     // MARK: - Workspace Root Configuration
 
@@ -40,15 +40,23 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
     }
 
     public init(gitService: any GitServiceProtocol = GitService.shared) {
-        self.gitService = gitService
+        self.init(materializer: GitWorktreeWorkspaceMaterializer(gitService: gitService))
+    }
+
+    init(materializer: any WorkspaceMaterializer) {
+        self.materializer = materializer
+        Self.ensureDefaultWorkspacesRootExists()
+    }
+
+    private static func ensureDefaultWorkspacesRootExists() {
         do {
             try FileManager.default.createDirectory(
-                at: Self.defaultWorkspacesRoot,
+                at: defaultWorkspacesRoot,
                 withIntermediateDirectories: true
             )
         } catch {
             log.warning(
-                "Failed to create default workspaces root at \(Self.defaultWorkspacesRoot.path): \(error.localizedDescription)"
+                "Failed to create default workspaces root at \(defaultWorkspacesRoot.path): \(error.localizedDescription)"
             )
         }
     }
@@ -88,22 +96,30 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
 
         var warnings: [String] = []
 
-        let branchName = "workspace/\(sanitizedName)"
         await progress?(.creatingWorktree)
+        let materializedWorkspace: MaterializedWorkspace
         do {
-            try await gitService.createWorktree(
-                branchName: branchName,
+            materializedWorkspace = try await materializer.materializeWorkspace(
+                named: sanitizedName,
                 at: workspaceDir,
                 from: repoLocalURL
             )
         } catch {
-            try? await WorkspaceDirectoryRemover.remove(at: workspaceDir)
-            throw WorkspaceError.worktreeCreationFailed(reason: error.localizedDescription)
+            try? await materializer.removeWorkspace(at: workspaceDir)
+            throw WorkspaceError.materializationFailed(
+                operation: materializer.failureOperationDescription,
+                reason: error.localizedDescription
+            )
+        }
+        guard FileManager.default.fileExists(atPath: workspaceDir.path) else {
+            try? await materializer.removeWorkspace(at: workspaceDir)
+            throw WorkspaceError.materializationFailed(
+                operation: materializer.failureOperationDescription,
+                reason: "Materializer did not create workspace directory at \(workspaceDir.path)"
+            )
         }
 
         do {
-            let currentBranch = try? await gitService.getCurrentBranch(at: workspaceDir)
-
             await progress?(.runningSetupScript)
             let setupResult = try await runLifecycleScript("setup.sh", in: workspaceDir)
             if !setupResult.stdout.isEmpty {
@@ -120,11 +136,11 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
             return NewWorkspaceInfo(
                 name: name,
                 path: workspaceDir,
-                gitBranch: currentBranch ?? branchName,
+                gitBranch: materializedWorkspace.gitBranch,
                 warnings: warnings
             )
         } catch {
-            try? await WorkspaceDirectoryRemover.remove(at: workspaceDir)
+            try? await materializer.removeWorkspace(at: workspaceDir)
             throw error
         }
     }
@@ -281,7 +297,7 @@ public enum WorkspaceError: LocalizedError {
     case notAGitRepo
     case alreadyExists(name: String)
     case invalidName(name: String)
-    case worktreeCreationFailed(reason: String)
+    case materializationFailed(operation: String, reason: String)
     case deletionFailed(reason: String)
 
     public var errorDescription: String? {
@@ -292,8 +308,8 @@ public enum WorkspaceError: LocalizedError {
             return "A workspace named '\(name)' already exists"
         case .invalidName(let name):
             return "Workspace name '\(name)' is not valid"
-        case .worktreeCreationFailed(let reason):
-            return "Failed to create git worktree: \(reason)"
+        case .materializationFailed(let operation, let reason):
+            return "Failed to \(operation): \(reason)"
         case .deletionFailed(let reason):
             return "Failed to delete workspace: \(reason)"
         }

--- a/Tests/WorkspaceManagerAppTests/SidebarViewTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarViewTests.swift
@@ -76,7 +76,7 @@ struct SidebarViewTests {
     func localCreationMessageMatchesPhase() {
         #expect(SidebarWorkspaceController.localCreationMessage(for: .preparing) == "Preparing workspace...")
         #expect(SidebarWorkspaceController.localCreationMessage(for: .creatingWorktree) == "Creating git worktree...")
-        #expect(SidebarWorkspaceController.localCreationMessage(for: .runningSetupScript) == "Running setup script...")
+        #expect(SidebarWorkspaceController.localCreationMessage(for: .runningSetupScript) == "Running setup...")
         #expect(SidebarWorkspaceController.localCreationMessage(for: .finished) == "Finishing workspace...")
     }
 }

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -476,6 +476,37 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(await provider.archiveCallCount() == 1)
     }
 
+    @Test("Local archive runs WorkspaceService lifecycle before updating status")
+    @MainActor
+    func localArchiveRunsWorkspaceServiceLifecycleBeforeUpdatingStatus() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: workspaceURL,
+            sourceRepo: repo,
+            status: .active,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let workspaceService = MockWorkspaceService()
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()]
+        )
+
+        try await controller.archive(workspace)
+
+        #expect(workspaceService.archiveWorkspaceCalls == [workspaceURL])
+        #expect(workspace.status == .archived)
+    }
+
     @Test("Managed lifecycle operations fail closed when remote identifier is missing")
     @MainActor
     func managedLifecycleOperationsFailClosedWhenRemoteIdentifierIsMissing() async throws {
@@ -581,6 +612,7 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
 
     var createWorkspaceResult: NewWorkspaceInfo?
     var createWorkspaceCalls: [CreateWorkspaceCall] = []
+    var archiveWorkspaceCalls: [URL] = []
     var deleteWorkspaceCalls: [(workspaceURL: URL, deleteFiles: Bool)] = []
     var createWorkspaceDelay: @Sendable () async -> Void = {}
 
@@ -609,7 +641,9 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         )
     }
 
-    func archiveWorkspace(at workspaceURL: URL) async throws {}
+    func archiveWorkspace(at workspaceURL: URL) async throws {
+        archiveWorkspaceCalls.append(workspaceURL)
+    }
 
     func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws {
         deleteWorkspaceCalls.append((workspaceURL, deleteFiles))

--- a/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
@@ -53,6 +53,7 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
         if let error = createWorktreeError {
             throw error
         }
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
     }
 
     func checkoutBranch(_ name: String, at path: URL) async throws {}

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -24,6 +24,38 @@ struct WorkspaceServiceTests {
         }
     }
 
+    final class RecordingWorkspaceMaterializer: WorkspaceMaterializer, @unchecked Sendable {
+        var materializeCalls: [(sanitizedName: String, destination: URL, source: URL)] = []
+        var removeCalls: [URL] = []
+        var materializeError: Error?
+        var resultBranch = "workspace/recorded"
+        var createsDestination = false
+
+        var failureOperationDescription: String {
+            "record workspace materialization"
+        }
+
+        func materializeWorkspace(
+            named sanitizedName: String,
+            at destination: URL,
+            from sourceRepository: URL
+        ) async throws -> MaterializedWorkspace {
+            materializeCalls.append((sanitizedName: sanitizedName, destination: destination, source: sourceRepository))
+            if createsDestination {
+                try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            }
+            if let materializeError {
+                throw materializeError
+            }
+            return MaterializedWorkspace(gitBranch: resultBranch)
+        }
+
+        func removeWorkspace(at workspaceURL: URL) async throws {
+            removeCalls.append(workspaceURL)
+            try? await WorkspaceDirectoryRemover.remove(at: workspaceURL)
+        }
+    }
+
     // MARK: - Helpers
 
     /// Creates a temp directory with a fake repo and a separate workspaces root.
@@ -252,8 +284,31 @@ struct WorkspaceServiceTests {
 
     // MARK: - createWorkspace Tests
 
-    @Test("createWorkspace calls git createWorktree with correct branch and path")
-    func createWorkspaceCallsCreateWorktree() async throws {
+    @Test("createWorkspace delegates directory creation to the injected materializer")
+    func createWorkspaceDelegatesDirectoryCreationToInjectedMaterializer() async throws {
+        let materializer = RecordingWorkspaceMaterializer()
+        materializer.resultBranch = "workspace/my-feature"
+        materializer.createsDestination = true
+        let service = WorkspaceService(materializer: materializer)
+        let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        _ = try await service.createWorkspace(repoName: "test-repo", repoLocalURL: repoDir, name: "my-feature")
+
+        let workspaceDir =
+            wsRoot
+            .appendingPathComponent("test-repo", isDirectory: true)
+            .appendingPathComponent("my-feature", isDirectory: true)
+        #expect(materializer.materializeCalls.count == 1)
+        #expect(materializer.materializeCalls[0].sanitizedName == "my-feature")
+        #expect(materializer.materializeCalls[0].destination == workspaceDir)
+        #expect(materializer.materializeCalls[0].source == repoDir)
+    }
+
+    @Test("default materializer creates a git worktree branch")
+    func defaultMaterializerCreatesGitWorktreeBranch() async throws {
         let mockGit = MockGitService()
         let service = WorkspaceService(gitService: mockGit)
         let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
@@ -273,11 +328,12 @@ struct WorkspaceServiceTests {
         #expect(mockGit.createWorktreeCalls[0].source == repoDir)
     }
 
-    @Test("createWorkspace fails clearly when worktree creation fails")
-    func createWorkspaceFailsWhenWorktreeCreationFails() async throws {
-        let mockGit = MockGitService()
-        mockGit.createWorktreeError = GitError.commandFailed(args: ["worktree", "add"], stderr: "already exists")
-        let service = WorkspaceService(gitService: mockGit)
+    @Test("createWorkspace fails clearly when materialization fails")
+    func createWorkspaceFailsWhenMaterializationFails() async throws {
+        let materializer = RecordingWorkspaceMaterializer()
+        materializer.createsDestination = true
+        materializer.materializeError = GitError.commandFailed(args: ["worktree", "add"], stderr: "already exists")
+        let service = WorkspaceService(materializer: materializer)
         let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
         defer { try? FileManager.default.removeItem(at: testRoot) }
         let originalRoot = setWorkspacesRoot(wsRoot)
@@ -291,6 +347,7 @@ struct WorkspaceServiceTests {
             wsRoot
             .appendingPathComponent("test-repo", isDirectory: true)
             .appendingPathComponent("test-ws", isDirectory: true)
+        #expect(materializer.removeCalls == [workspaceDir])
         #expect(!FileManager.default.fileExists(atPath: workspaceDir.path))
     }
 
@@ -425,6 +482,40 @@ struct WorkspaceServiceTests {
 
         let worktreeList = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
         #expect(self.worktreeList(worktreeList, contains: info.path))
+    }
+
+    @Test("createWorkspace can materialize with repository copy adapter")
+    func createWorkspaceCanMaterializeWithRepositoryCopyAdapter() async throws {
+        let service = WorkspaceService(materializer: GitCloneWorkspaceMaterializer())
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "copy-mode"
+        )
+
+        #expect(info.gitBranch == "workspace/copy-mode")
+        #expect(FileManager.default.fileExists(atPath: info.path.appendingPathComponent("README.md").path))
+
+        var gitPathIsDirectory: ObjCBool = false
+        #expect(
+            FileManager.default.fileExists(
+                atPath: info.path.appendingPathComponent(".git").path,
+                isDirectory: &gitPathIsDirectory
+            )
+        )
+        #expect(gitPathIsDirectory.boolValue)
+
+        let currentBranch = try runGit(["branch", "--show-current"], at: info.path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(currentBranch == "workspace/copy-mode")
+
+        let worktreeList = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
+        #expect(!self.worktreeList(worktreeList, contains: info.path))
     }
 
     @Test("createWorkspace can materialize from a linked worktree source")

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -546,6 +546,40 @@ struct WorkspaceServiceTests {
         #expect(self.worktreeList(worktreeList, contains: info.path))
     }
 
+    @Test("createWorkspace runs project-scripts setup from the new worktree")
+    func createWorkspaceRunsProjectScriptsSetupFromNewWorktree() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let scriptsDir = repoDir.appendingPathComponent("scripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        try """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        pwd > setup.cwd
+        touch setup.marker
+        """.write(to: scriptsDir.appendingPathComponent("setup"), atomically: true, encoding: .utf8)
+        _ = try runGit(["add", "-A"], at: repoDir)
+        _ = try runGit(["commit", "-m", "add project setup script"], at: repoDir)
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "project-setup"
+        )
+
+        #expect(FileManager.default.fileExists(atPath: info.path.appendingPathComponent("setup.marker").path))
+        let setupCWD = try String(contentsOf: info.path.appendingPathComponent("setup.cwd"), encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(
+            URL(fileURLWithPath: setupCWD).standardizedFileURL.resolvingSymlinksInPath()
+                == info.path.standardizedFileURL.resolvingSymlinksInPath()
+        )
+    }
+
     @Test("createWorkspace cleans up when workspace branch already exists")
     func createWorkspaceCleansUpWhenWorkspaceBranchExists() async throws {
         let service = WorkspaceService()
@@ -719,6 +753,62 @@ struct WorkspaceServiceTests {
         try await service.archiveWorkspace(at: tempDir)
 
         #expect(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("archived.marker").path))
+    }
+
+    @Test("archiveWorkspace runs project-scripts stop then archive")
+    func archiveWorkspaceRunsProjectScriptsStopThenArchive() async throws {
+        let mockGit = MockGitService()
+        let service = WorkspaceService(gitService: mockGit)
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let scriptsDir = tempDir.appendingPathComponent("scripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        let orderFile = tempDir.appendingPathComponent("teardown-order.log")
+        try """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf "stop\\n" >> "\(orderFile.path)"
+        """.write(to: scriptsDir.appendingPathComponent("stop"), atomically: true, encoding: .utf8)
+        try """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf "archive\\n" >> "\(orderFile.path)"
+        """.write(to: scriptsDir.appendingPathComponent("archive"), atomically: true, encoding: .utf8)
+
+        try await service.archiveWorkspace(at: tempDir)
+
+        let order = try String(contentsOf: orderFile, encoding: .utf8)
+        #expect(order == "stop\narchive\n")
+    }
+
+    @Test("deleteWorkspace runs project-scripts teardown before removing workspace")
+    func deleteWorkspaceRunsProjectScriptsTeardownBeforeRemovingWorkspace() async throws {
+        let mockGit = MockGitService()
+        let service = WorkspaceService(gitService: mockGit)
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let wsDir = tempDir.appendingPathComponent("test-repo/ws-project-scripts")
+        let scriptsDir = wsDir.appendingPathComponent("scripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
+        let orderFile = tempDir.appendingPathComponent("delete-teardown-order.log")
+        try """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf "stop\\n" >> "\(orderFile.path)"
+        """.write(to: scriptsDir.appendingPathComponent("stop"), atomically: true, encoding: .utf8)
+        try """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf "archive\\n" >> "\(orderFile.path)"
+        """.write(to: scriptsDir.appendingPathComponent("archive"), atomically: true, encoding: .utf8)
+
+        try await service.deleteWorkspace(at: wsDir, deleteFiles: true)
+
+        let order = try String(contentsOf: orderFile, encoding: .utf8)
+        #expect(order == "stop\narchive\n")
+        #expect(!FileManager.default.fileExists(atPath: wsDir.path))
     }
 
     // MARK: - getWorkspaceSize Tests

--- a/docs/product_overview.md
+++ b/docs/product_overview.md
@@ -24,7 +24,7 @@ Think of it as **a terminal session manager for your code portfolio, with worksp
 - **Scoped Web Views**: Global, repo-owned, and workspace-owned web views live alongside terminal contexts
 - **Workspace Creation**: Create isolated git worktree workspaces per repo
 - **Inline Workspace Progress**: Repo rows show coarse creation progress while worktree creation/setup is in flight
-- **Lifecycle Hooks**: `setup.sh` runs after creation, `archive.sh` runs on close
+- **Lifecycle Hooks**: `scripts/setup` runs after creation; `scripts/stop` and `scripts/archive` run before archive/delete. Legacy `setup.sh` and `archive.sh` still work.
 - **Embedded Terminal**: GhosttyKit (`libghostty`) terminal as the primary interface
 - **Two-Pane Split Control**: Ghostty split actions can create, focus, resize, and equalize the current two-pane stack
 - **Ghostty-First Shortcut Routing**: Terminal keybindings should default to Ghostty behavior; app-level shortcuts are for non-overlapping chrome actions

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -43,8 +43,8 @@ sequenceDiagram
     App-->>User: Shows name input sheet
     User->>App: Enters "feature-auth" → Create
     App-->>User: Shows inline progress on repo row
-    App->>App: Copies repo to ~/workspaces/my-project/feature-auth
-    App->>App: Runs setup.sh (if exists)
+    App->>App: Creates git worktree at ~/workspaces/my-project/feature-auth
+    App->>App: Runs setup lifecycle script if present
     App-->>User: Workspace selected, session available
     User->>Terminal: Types "claude" to start AI session
 ```
@@ -162,7 +162,7 @@ sequenceDiagram
     User->>App: Enters "approach-b"
     App->>FS: Create git worktree at ~/workspaces/project/approach-b
     FS-->>App: Worktree ready
-    App->>FS: Run setup.sh
+    App->>FS: Run scripts/setup
     FS-->>App: Setup output
     App-->>User: New workspace selected
 
@@ -197,7 +197,7 @@ sequenceDiagram
 1. **Right-click repo** — Context menu appears with "New Workspace..." option
 2. **Name workspace** — User enters descriptive name like "approach-b"
 3. **Worktree created** — Git worktree made in the workspaces directory
-4. **Setup runs** — If setup.sh exists, it runs automatically
+4. **Setup runs** — If `scripts/setup`, `scripts/setup.sh`, or legacy `setup.sh` exists, it runs automatically
 5. **Workspace ready** — New workspace selected, terminal opens there
 
 ---
@@ -222,8 +222,8 @@ sequenceDiagram
     App-->>User: Confirmation dialog
     Note over User,App: Explicit choice: keep files or remove files
     User->>App: Confirms desired delete mode
-    App->>FS: Run archive.sh (if exists)
-    FS-->>App: Archive output
+    App->>FS: Run scripts/stop and scripts/archive if present
+    FS-->>App: Teardown output
     App->>FS: Delete workspace directory
     FS-->>App: Deleted
     App->>App: Remove from SwiftData
@@ -251,7 +251,7 @@ sequenceDiagram
 1. **Right-click workspace** — Context menu shows Archive and Delete options
 2. **Click Delete** — Confirmation dialog appears
 3. **Choose file handling** — User picks "Delete (Keep Files)" or "Delete and Remove Files"
-4. **archive.sh runs** — If present, cleanup script runs first
+4. **Lifecycle runs** — If present, `scripts/stop` and `scripts/archive` run first. Legacy `archive.sh` still works.
 5. **Workspace removed** — Deleted from list (and optionally from disk)
 
 ---


### PR DESCRIPTION
## Summary

- Add a local `WorkspaceMaterializer` seam with `GitWorktreeWorkspaceMaterializer` as the default adapter and `GitCloneWorkspaceMaterializer` as the copy-style adapter behind the same interface.
- Move branch/materialization details out of `WorkspaceService`, add a guard that materializers must actually create the destination directory, and keep Local creation on git worktrees by default.
- Run local workspace lifecycle through the project-scripts convention: `scripts/setup` / `scripts/setup.sh` on creation, `scripts/stop` then `scripts/archive` on teardown, with legacy `setup.sh` / `archive.sh` fallback.
- Clean up the managed-review follow-up items: remove the dead sidebar persistence cleanup helper and run `git worktree remove` from a stable parent directory with `--git-dir` when available.
- Add focused workspace tests for injected materialization, default worktree behavior, copy-adapter behavior, project-scripts setup/teardown, cleanup, and the existing real-git worktree cases.

## Mergeability

- Surface: desktop
- User-facing behavior changed: Local workspace creation now recognizes `scripts/` lifecycle hooks and the progress copy says `Running setup...`; legacy root hooks still work.
- Non-happy paths considered: failed materialization cleanup, materializers that fail to create a destination, linked-worktree deletion, branch conflict cleanup, project-scripts teardown ordering, missing scripts as no-ops, and setup warning preservation.
- Release/ops preconditions: none new.
- Residual risk or follow-up: the copy adapter is internal and not selected by the UI/default Local path.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - [x] `swift-format lint --strict --recursive Sources/ Tests/`
  - [x] `swift test --filter WorkspaceServiceTests`
  - [x] `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check`
  - [x] `./scripts/pr-evidence.sh --pr 609 --profile swift-unit --filter WorkspaceServiceTests --name project-scripts-lifecycle`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![project-scripts-lifecycle](https://evidence.cloudcompute.com/workspaces/pr-609/20260601-062933-project-scripts-lifecycle.svg)
- ![workspace-materializer-strategies](https://evidence.cloudcompute.com/workspaces/pr-609/20260601-052357-workspace-materializer-strategies.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
