### PR TITLE
docs: add managed reviewer visual guide

### DIFF
--- a/docs/pr-review/README.md
+++ b/docs/pr-review/README.md
@@ -2,9 +2,11 @@
 
 This directory is the entry point for the WorkSpaces managed PR reviewer.
 
-Start with [`architecture.md`](architecture.md) when you need the current
-ReviewRun model, lifecycle vocabulary, diagrams, and operator triage surfaces.
-Use [`understanding-guide.md`](understanding-guide.md) and
+Start with the visual [`index.html`](index.html) when you need a high-level,
+progressive explanation of the system before diving into implementation detail.
+Use [`architecture.md`](architecture.md) when you need the current ReviewRun
+model, lifecycle vocabulary, diagrams, and operator triage surfaces. Use
+[`understanding-guide.md`](understanding-guide.md) and
 [`scripts/pr-reviewer-quiz.py`](../../scripts/pr-reviewer-quiz.py) when someone
 needs to learn the system through scenarios before operating or changing it. Use
 [`pr-reviewer.md`](pr-reviewer.md) for runtime configuration, webhook ingress,

--- a/docs/pr-review/index.html
+++ b/docs/pr-review/index.html
@@ -1,0 +1,1405 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Managed PR Reviewer Visual Guide</title>
+  <meta name="description" content="A progressive visual guide to the WorkSpaces managed PR reviewer, ReviewRun lifecycle, projections, health checks, and operator recovery paths.">
+  <style>
+    :root {
+      color-scheme: light;
+      --page: #f7f8f5;
+      --panel: #ffffff;
+      --panel-soft: #f0f4f1;
+      --ink: #17201d;
+      --muted: #5c6863;
+      --quiet: #7f8984;
+      --line: #d9dfdb;
+      --line-strong: #b9c3bd;
+      --teal: #0f766e;
+      --green: #287a3e;
+      --blue: #315f9f;
+      --amber: #a35f00;
+      --red: #a33b4a;
+      --purple: #6d4a9c;
+      --slate: #344054;
+      --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+      --sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      --radius: 8px;
+      --shadow: 0 16px 38px rgba(31, 43, 37, 0.09);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--page);
+      color: var(--ink);
+      font-family: var(--sans);
+      line-height: 1.55;
+    }
+
+    a {
+      color: var(--teal);
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+    }
+
+    code,
+    pre {
+      font-family: var(--mono);
+    }
+
+    code {
+      font-size: 0.94em;
+      color: #202c28;
+      background: #edf2ef;
+      border: 1px solid #d8e2dd;
+      border-radius: 5px;
+      padding: 0.08rem 0.28rem;
+    }
+
+    pre {
+      margin: 0;
+      padding: 14px 16px;
+      overflow-x: auto;
+      color: #eff7f1;
+      background: #17201d;
+      border-radius: var(--radius);
+      font-size: 0.86rem;
+      line-height: 1.45;
+    }
+
+    pre code {
+      padding: 0;
+      color: inherit;
+      background: transparent;
+      border: 0;
+    }
+
+    .shell {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+    }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: rgba(247, 248, 245, 0.96);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(14px);
+    }
+
+    .topbar-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      min-height: 62px;
+      gap: 20px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+      color: var(--ink);
+      text-decoration: none;
+      font-weight: 740;
+      letter-spacing: 0;
+    }
+
+    .brand-mark {
+      display: grid;
+      place-items: center;
+      flex: 0 0 auto;
+      width: 34px;
+      height: 34px;
+      border-radius: 7px;
+      color: #ffffff;
+      background: #17201d;
+      font-family: var(--mono);
+      font-size: 17px;
+      font-weight: 800;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+    }
+
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: 12px;
+      font-size: 0.9rem;
+    }
+
+    nav a {
+      color: var(--muted);
+      text-decoration: none;
+    }
+
+    nav a:hover,
+    nav a:focus-visible {
+      color: var(--ink);
+      text-decoration: underline;
+    }
+
+    header.hero {
+      padding: 56px 0 34px;
+      border-bottom: 1px solid var(--line);
+      background: #fbfcf9;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 0.95fr) minmax(420px, 1.05fr);
+      gap: 36px;
+      align-items: center;
+    }
+
+    .eyebrow {
+      margin: 0 0 12px;
+      color: var(--teal);
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    h1,
+    h2,
+    h3,
+    p {
+      margin-top: 0;
+    }
+
+    h1 {
+      max-width: 760px;
+      margin-bottom: 16px;
+      font-size: clamp(2.05rem, 4.2vw, 4.4rem);
+      line-height: 0.98;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin-bottom: 10px;
+      font-size: clamp(1.55rem, 2.6vw, 2.45rem);
+      line-height: 1.08;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin-bottom: 8px;
+      font-size: 1rem;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    .lead {
+      max-width: 700px;
+      margin-bottom: 22px;
+      color: var(--muted);
+      font-size: 1.06rem;
+    }
+
+    .hero-actions,
+    .doc-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .button {
+      display: inline-flex;
+      align-items: center;
+      min-height: 40px;
+      padding: 8px 12px;
+      color: #ffffff;
+      background: var(--ink);
+      border: 1px solid var(--ink);
+      border-radius: 7px;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .button.secondary {
+      color: var(--ink);
+      background: transparent;
+      border-color: var(--line-strong);
+    }
+
+    .button:hover,
+    .button:focus-visible {
+      text-decoration: none;
+      box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.14);
+    }
+
+    .summary-panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .summary-panel-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 15px 16px;
+      border-bottom: 1px solid var(--line);
+      background: #f4f7f4;
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      font-weight: 700;
+    }
+
+    .summary-panel-head strong {
+      color: var(--ink);
+    }
+
+    .pipeline {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 1px;
+      background: var(--line);
+    }
+
+    .pipeline-step {
+      position: relative;
+      min-height: 172px;
+      padding: 16px;
+      background: #ffffff;
+    }
+
+    .pipeline-step::after {
+      content: ">";
+      position: absolute;
+      top: 20px;
+      right: -10px;
+      z-index: 1;
+      display: grid;
+      place-items: center;
+      width: 20px;
+      height: 20px;
+      color: var(--quiet);
+      background: #ffffff;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      font-family: var(--mono);
+      font-size: 12px;
+      font-weight: 800;
+    }
+
+    .pipeline-step:last-child::after {
+      content: none;
+    }
+
+    .step-number {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      margin-bottom: 12px;
+      color: #ffffff;
+      background: var(--slate);
+      border-radius: 999px;
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      font-weight: 800;
+    }
+
+    .pipeline-step:nth-child(1) .step-number {
+      background: var(--blue);
+    }
+
+    .pipeline-step:nth-child(2) .step-number {
+      background: var(--teal);
+    }
+
+    .pipeline-step:nth-child(3) .step-number {
+      background: var(--purple);
+    }
+
+    .pipeline-step:nth-child(4) .step-number {
+      background: var(--amber);
+    }
+
+    .pipeline-step:nth-child(5) .step-number {
+      background: var(--green);
+    }
+
+    .pipeline-step p {
+      margin-bottom: 0;
+      color: var(--muted);
+      font-size: 0.93rem;
+    }
+
+    main {
+      padding: 34px 0 68px;
+    }
+
+    section {
+      margin-top: 34px;
+    }
+
+    .section-head {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 16px;
+    }
+
+    .section-head p {
+      max-width: 620px;
+      margin-bottom: 0;
+      color: var(--muted);
+    }
+
+    .kicker {
+      margin-bottom: 8px;
+      color: var(--teal);
+      font-family: var(--mono);
+      font-size: 0.76rem;
+      font-weight: 800;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .rule-card {
+      display: grid;
+      grid-template-columns: minmax(220px, 0.62fr) minmax(0, 1.38fr);
+      gap: 1px;
+      background: var(--line);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .rule-card > div {
+      padding: 22px;
+      background: var(--panel);
+    }
+
+    .rule-card .source {
+      display: grid;
+      place-items: center;
+      min-height: 220px;
+      text-align: center;
+      background: #17201d;
+      color: #ffffff;
+    }
+
+    .source-box {
+      width: min(100%, 260px);
+      padding: 22px 18px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .source-box .label {
+      margin-bottom: 8px;
+      color: #aad6ca;
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+    }
+
+    .source-box strong {
+      display: block;
+      font-size: 1.55rem;
+      line-height: 1.05;
+    }
+
+    .source-box p {
+      margin: 10px 0 0;
+      color: #d5dfda;
+      font-size: 0.92rem;
+    }
+
+    .projection-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .projection {
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fbfcfb;
+    }
+
+    .projection b {
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    .projection p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.94rem;
+    }
+
+    .role-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .role-card,
+    .state-card,
+    .drill-card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: 0 8px 22px rgba(31, 43, 37, 0.05);
+    }
+
+    .role-card {
+      padding: 18px;
+    }
+
+    .role-card p,
+    .state-card p,
+    .drill-card p {
+      color: var(--muted);
+    }
+
+    .tag {
+      display: inline-flex;
+      margin-bottom: 12px;
+      padding: 4px 8px;
+      color: var(--ink);
+      background: var(--panel-soft);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      font-family: var(--mono);
+      font-size: 0.74rem;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+
+    .tag.blue {
+      color: var(--blue);
+      background: #eef4ff;
+      border-color: #cddbf1;
+    }
+
+    .tag.teal {
+      color: var(--teal);
+      background: #eaf6f3;
+      border-color: #c8e5dd;
+    }
+
+    .tag.amber {
+      color: var(--amber);
+      background: #fff4df;
+      border-color: #efd49c;
+    }
+
+    .state-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .state-card {
+      overflow: hidden;
+    }
+
+    .state-card header {
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--line);
+      background: #f6f8f5;
+    }
+
+    .state-card header p {
+      margin: 4px 0 0;
+      font-size: 0.92rem;
+    }
+
+    .state-list {
+      display: grid;
+      gap: 1px;
+      background: var(--line);
+    }
+
+    .state-row {
+      display: grid;
+      grid-template-columns: 140px minmax(0, 1fr);
+      gap: 12px;
+      padding: 13px 16px;
+      background: #ffffff;
+    }
+
+    .state-row span {
+      align-self: start;
+      color: var(--ink);
+      font-family: var(--mono);
+      font-size: 0.82rem;
+      font-weight: 800;
+    }
+
+    .state-row p {
+      margin: 0;
+      font-size: 0.93rem;
+    }
+
+    .timeline {
+      display: grid;
+      gap: 12px;
+      padding-left: 0;
+      list-style: none;
+    }
+
+    .timeline li {
+      position: relative;
+      display: grid;
+      grid-template-columns: 42px minmax(0, 1fr);
+      gap: 14px;
+      align-items: start;
+      min-height: 60px;
+    }
+
+    .timeline li::before {
+      content: "";
+      position: absolute;
+      left: 20px;
+      top: 40px;
+      bottom: -18px;
+      width: 2px;
+      background: var(--line);
+    }
+
+    .timeline li:last-child::before {
+      content: none;
+    }
+
+    .timeline-marker {
+      display: grid;
+      place-items: center;
+      width: 42px;
+      height: 42px;
+      color: #ffffff;
+      background: var(--teal);
+      border-radius: 999px;
+      font-family: var(--mono);
+      font-weight: 800;
+    }
+
+    .timeline li:nth-child(2) .timeline-marker {
+      background: var(--purple);
+    }
+
+    .timeline li:nth-child(3) .timeline-marker {
+      background: var(--amber);
+    }
+
+    .timeline li:nth-child(4) .timeline-marker {
+      background: var(--green);
+    }
+
+    .timeline-copy {
+      padding: 13px 16px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+    }
+
+    .timeline-copy p {
+      margin-bottom: 0;
+      color: var(--muted);
+    }
+
+    .drilldown {
+      display: grid;
+      gap: 12px;
+    }
+
+    details {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: 0 8px 22px rgba(31, 43, 37, 0.04);
+    }
+
+    details[open] {
+      border-color: var(--line-strong);
+    }
+
+    summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px 18px;
+      cursor: pointer;
+      font-weight: 800;
+      list-style: none;
+    }
+
+    summary::-webkit-details-marker {
+      display: none;
+    }
+
+    summary::after {
+      content: "+";
+      display: grid;
+      place-items: center;
+      flex: 0 0 auto;
+      width: 24px;
+      height: 24px;
+      color: var(--muted);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      font-family: var(--mono);
+    }
+
+    details[open] summary::after {
+      content: "-";
+      color: var(--ink);
+    }
+
+    .details-body {
+      padding: 0 18px 18px;
+      color: var(--muted);
+    }
+
+    .details-body p:last-child,
+    .details-body ul:last-child,
+    .details-body ol:last-child {
+      margin-bottom: 0;
+    }
+
+    .mini-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+
+    .mini {
+      padding: 13px;
+      color: var(--muted);
+      background: #fbfcfb;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+    }
+
+    .mini strong {
+      display: block;
+      margin-bottom: 5px;
+      color: var(--ink);
+    }
+
+    .triage-table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: 0 8px 22px rgba(31, 43, 37, 0.04);
+    }
+
+    .triage-table th,
+    .triage-table td {
+      padding: 13px 14px;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .triage-table th {
+      color: var(--ink);
+      background: #f3f6f3;
+      font-size: 0.86rem;
+    }
+
+    .triage-table tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .triage-table td {
+      color: var(--muted);
+      font-size: 0.94rem;
+    }
+
+    .command-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .command-card {
+      display: grid;
+      gap: 12px;
+      padding: 18px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+    }
+
+    .command-card p {
+      margin-bottom: 0;
+      color: var(--muted);
+    }
+
+    .docs-footer {
+      display: grid;
+      grid-template-columns: minmax(0, 0.7fr) minmax(0, 1.3fr);
+      gap: 20px;
+      padding: 22px;
+      background: #17201d;
+      color: #f4fbf7;
+      border-radius: var(--radius);
+    }
+
+    .docs-footer p {
+      color: #cfd9d4;
+    }
+
+    .docs-footer a {
+      color: #9ee4d5;
+    }
+
+    .link-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .link-list a {
+      display: block;
+      padding: 11px 12px;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.11);
+      border-radius: var(--radius);
+      text-decoration: none;
+    }
+
+    .link-list a:hover,
+    .link-list a:focus-visible {
+      background: rgba(255, 255, 255, 0.1);
+      text-decoration: none;
+    }
+
+    @media (max-width: 980px) {
+      .hero-grid,
+      .rule-card,
+      .docs-footer {
+        grid-template-columns: 1fr;
+      }
+
+      .pipeline {
+        grid-template-columns: 1fr;
+      }
+
+      .pipeline-step {
+        min-height: auto;
+      }
+
+      .pipeline-step::after {
+        top: auto;
+        right: auto;
+        left: 24px;
+        bottom: -10px;
+        transform: rotate(90deg);
+      }
+
+      .role-grid,
+      .state-grid,
+      .command-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 680px) {
+      .shell {
+        width: min(100% - 22px, 1180px);
+      }
+
+      .topbar-inner {
+        align-items: flex-start;
+        flex-direction: column;
+        padding: 12px 0;
+      }
+
+      nav {
+        justify-content: flex-start;
+      }
+
+      header.hero {
+        padding: 38px 0 28px;
+      }
+
+      .hero-grid {
+        gap: 22px;
+      }
+
+      h1 {
+        font-size: 2.35rem;
+      }
+
+      .section-head {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .projection-grid,
+      .mini-grid,
+      .link-list {
+        grid-template-columns: 1fr;
+      }
+
+      .state-row {
+        grid-template-columns: 1fr;
+      }
+
+      .triage-table,
+      .triage-table thead,
+      .triage-table tbody,
+      .triage-table th,
+      .triage-table td,
+      .triage-table tr {
+        display: block;
+      }
+
+      .triage-table thead {
+        display: none;
+      }
+
+      .triage-table tr {
+        border-bottom: 1px solid var(--line);
+      }
+
+      .triage-table tr:last-child {
+        border-bottom: 0;
+      }
+
+      .triage-table td {
+        border-bottom: 0;
+      }
+
+      .triage-table td::before {
+        content: attr(data-label);
+        display: block;
+        margin-bottom: 4px;
+        color: var(--ink);
+        font-size: 0.76rem;
+        font-weight: 800;
+        text-transform: uppercase;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="topbar">
+    <div class="shell topbar-inner">
+      <a class="brand" href="./README.md" aria-label="Managed PR Review docs">
+        <span class="brand-mark">R</span>
+        <span>Managed PR Review</span>
+      </a>
+      <nav aria-label="Guide sections">
+        <a href="#model">Model</a>
+        <a href="#source-of-truth">Source of truth</a>
+        <a href="#lifecycle">Lifecycle</a>
+        <a href="#details">Details</a>
+        <a href="#operate">Operate</a>
+      </nav>
+    </div>
+  </div>
+
+  <header class="hero">
+    <div class="shell hero-grid">
+      <div>
+        <p class="eyebrow">Progressive visual guide</p>
+        <h1>Understand the managed reviewer from the outside in.</h1>
+        <p class="lead">
+          The system is simpler when you keep one idea fixed: a
+          <strong>ReviewRun</strong> is the source of truth. GitHub statuses,
+          PR reviews, dashboard pages, and health scripts are projections or
+          read surfaces around that run.
+        </p>
+        <div class="hero-actions">
+          <a class="button" href="#model">Start with the model</a>
+          <a class="button secondary" href="understanding-guide.md">Read scenarios</a>
+        </div>
+      </div>
+
+      <div class="summary-panel" aria-labelledby="pipeline-heading">
+        <div class="summary-panel-head">
+          <strong id="pipeline-heading">One-screen pipeline</strong>
+          <span>trigger -> run -> review -> projection</span>
+        </div>
+        <div class="pipeline" role="list" aria-label="Managed reviewer pipeline">
+          <article class="pipeline-step" role="listitem">
+            <span class="step-number">1</span>
+            <h3>Material trigger</h3>
+            <p>A PR opens, syncs, becomes ready, gets an eligible edit, or receives an evidence comment.</p>
+          </article>
+          <article class="pipeline-step" role="listitem">
+            <span class="step-number">2</span>
+            <h3>ReviewRun</h3>
+            <p>The webhook route creates a durable run or coalesces the trigger into an active run.</p>
+          </article>
+          <article class="pipeline-step" role="listitem">
+            <span class="step-number">3</span>
+            <h3>Managed agent</h3>
+            <p>The agent reviews the PR and returns validated review intent. It does not post to GitHub.</p>
+          </article>
+          <article class="pipeline-step" role="listitem">
+            <span class="step-number">4</span>
+            <h3>Broker</h3>
+            <p>The broker stores completed intent, suppresses stale output, and applies repairable projections.</p>
+          </article>
+          <article class="pipeline-step" role="listitem">
+            <span class="step-number">5</span>
+            <h3>GitHub surfaces</h3>
+            <p>The status, details URL, and PR review reflect the run. Health audits compare those surfaces.</p>
+          </article>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="shell">
+    <section id="model" aria-labelledby="model-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Layer 1</p>
+          <h2 id="model-heading">The mental model</h2>
+        </div>
+        <p>
+          Learn the system in three roles. The PR author watches for a quick
+          pickup indicator. The operator reads ReviewRuns. The maintainer
+          preserves the boundaries that keep the system understandable.
+        </p>
+      </div>
+
+      <div class="role-grid">
+        <article class="role-card">
+          <span class="tag blue">PR author</span>
+          <h3>Did the system pick up my PR?</h3>
+          <p>
+            The fast signal is the <code>WorkSpaces Managed Review</code>
+            status on the current head. Its details URL should open the
+            ReviewRun page, not loop back to the PR.
+          </p>
+        </article>
+        <article class="role-card">
+          <span class="tag teal">Operator</span>
+          <h3>What state is the run in?</h3>
+          <p>
+            Start with <code>scripts/pr-reviewer-runs.py</code>. It reports
+            pickup, active execution, coalescing, completed intent, projection
+            failures, and stale or superseded runs.
+          </p>
+        </article>
+        <article class="role-card">
+          <span class="tag amber">Maintainer</span>
+          <h3>What boundary must stay clean?</h3>
+          <p>
+            The webhook classifies and claims runs. The agent returns intent.
+            The broker projects. Health and dashboard surfaces explain without
+            changing state unless an explicit repair or retry action is used.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section id="source-of-truth" aria-labelledby="truth-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Layer 2</p>
+          <h2 id="truth-heading">ReviewRun is the source of truth</h2>
+        </div>
+        <p>
+          Treat GitHub as the user-facing projection layer. When GitHub and the
+          dashboard disagree, read the ReviewRun and projection ledger first.
+        </p>
+      </div>
+
+      <div class="rule-card">
+        <div class="source">
+          <div class="source-box">
+            <div class="label">Durable record</div>
+            <strong>ReviewRun</strong>
+            <p>One reviewer attempt for one PR head and reviewer config.</p>
+          </div>
+        </div>
+        <div>
+          <h3>Everything else is derived from the run.</h3>
+          <div class="projection-grid">
+            <div class="projection">
+              <b>GitHub status</b>
+              <p>Shows pickup, pending, success, failure, and links to run details.</p>
+            </div>
+            <div class="projection">
+              <b>GitHub PR review</b>
+              <p>The broker posts it from stored review intent after completion.</p>
+            </div>
+            <div class="projection">
+              <b>Dashboard details</b>
+              <p>Explains run metadata, transcript availability, coalescing, and recovery.</p>
+            </div>
+            <div class="projection">
+              <b>Health scripts</b>
+              <p>Report unreconciled runs first, then audit GitHub-facing drift.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="lifecycle" aria-labelledby="lifecycle-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Layer 3</p>
+          <h2 id="lifecycle-heading">Two lifecycle questions</h2>
+        </div>
+        <p>
+          Most confusion comes from treating execution and GitHub projection as
+          one state. They are separate because the right recovery action is
+          different.
+        </p>
+      </div>
+
+      <div class="state-grid">
+        <article class="state-card">
+          <header>
+            <h3>Execution: did the agent produce usable intent?</h3>
+            <p>Stored in <code>status</code>.</p>
+          </header>
+          <div class="state-list">
+            <div class="state-row">
+              <span>started</span>
+              <p>The run exists and execution or collection may still be active.</p>
+            </div>
+            <div class="state-row">
+              <span>completed</span>
+              <p>The run has validated review intent. Publication is tracked separately.</p>
+            </div>
+            <div class="state-row">
+              <span>failed</span>
+              <p>No usable intent exists. Retry only when safe and current-head.</p>
+            </div>
+            <div class="state-row">
+              <span>superseded</span>
+              <p>Newer PR activity replaced this run. Do not retry it.</p>
+            </div>
+          </div>
+        </article>
+
+        <article class="state-card">
+          <header>
+            <h3>Projection: did GitHub receive the effect?</h3>
+            <p>Stored in <code>projection_status</code> and projection records.</p>
+          </header>
+          <div class="state-list">
+            <div class="state-row">
+              <span>pending</span>
+              <p>Projection is not complete yet, usually because execution is still active.</p>
+            </div>
+            <div class="state-row">
+              <span>projected</span>
+              <p>GitHub status and review have been applied for this run.</p>
+            </div>
+            <div class="state-row">
+              <span>failed</span>
+              <p>Intent exists, but GitHub write failed. Repair without rerunning the agent.</p>
+            </div>
+            <div class="state-row">
+              <span>superseded</span>
+              <p>Projection was intentionally skipped because newer work covers the PR.</p>
+            </div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="happy-path-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Layer 4</p>
+          <h2 id="happy-path-heading">Happy path in four moves</h2>
+        </div>
+        <p>
+          These are the normal transitions a healthy PR should show. The early
+          pending status is useful because it proves pickup before the review
+          exists.
+        </p>
+      </div>
+
+      <ol class="timeline">
+        <li>
+          <span class="timeline-marker">1</span>
+          <div class="timeline-copy">
+            <h3>Webhook claims the work</h3>
+            <p>A material trigger creates a ReviewRun and publishes a pending status with a details URL.</p>
+          </div>
+        </li>
+        <li>
+          <span class="timeline-marker">2</span>
+          <div class="timeline-copy">
+            <h3>Managed agent executes</h3>
+            <p>The runtime stores the session id. Health may show the run as starting or running.</p>
+          </div>
+        </li>
+        <li>
+          <span class="timeline-marker">3</span>
+          <div class="timeline-copy">
+            <h3>Broker collects intent</h3>
+            <p>Completed session output becomes validated review intent on the ReviewRun.</p>
+          </div>
+        </li>
+        <li>
+          <span class="timeline-marker">4</span>
+          <div class="timeline-copy">
+            <h3>Broker projects to GitHub</h3>
+            <p>The PR review posts, the status flips success, and the projection ledger records the effects.</p>
+          </div>
+        </li>
+      </ol>
+    </section>
+
+    <section id="details" aria-labelledby="details-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Layer 5</p>
+          <h2 id="details-heading">Drill into the details only when needed</h2>
+        </div>
+        <p>
+          The sections below are ordered from conceptual to operational. Open
+          them as your questions get more specific.
+        </p>
+      </div>
+
+      <div class="drilldown">
+        <details open>
+          <summary>What counts as a material trigger?</summary>
+          <div class="details-body">
+            <p>
+              Material triggers are PR activity that should review or re-review
+              code: opened, reopened, ready for review, synchronize, eligible
+              body or base edits, and evidence-bearing PR comments. Metadata-only
+              noise is ignored before any ReviewRun claim happens.
+            </p>
+          </div>
+        </details>
+
+        <details>
+          <summary>Why coalesce active runs?</summary>
+          <div class="details-body">
+            <p>
+              If a new material trigger arrives while the same PR and reviewer
+              config already has an active run, the system records the latest
+              coalesced trigger and head on the active run instead of starting
+              parallel sessions. When the active run completes, stale output is
+              suppressed and exactly one follow-up run covers the latest state.
+            </p>
+            <div class="mini-grid">
+              <div class="mini">
+                <strong>Good outcome</strong>
+                One active session at a time, latest head recorded, one follow-up if needed.
+              </div>
+              <div class="mini">
+                <strong>Bad outcome avoided</strong>
+                Three overlapping reviews that race to comment on different PR heads.
+              </div>
+            </div>
+          </div>
+        </details>
+
+        <details>
+          <summary>What does the broker own?</summary>
+          <div class="details-body">
+            <p>
+              The broker is the publishing boundary. It collects completed
+              managed-agent output, validates review intent, persists completed
+              ReviewRun state, suppresses stale output, posts GitHub reviews,
+              updates commit statuses, and repairs failed projections from stored
+              intent. The agent does not post directly to GitHub.
+            </p>
+          </div>
+        </details>
+
+        <details>
+          <summary>When do we retry versus repair?</summary>
+          <div class="details-body">
+            <p>
+              Retry execution only when no valid review intent exists, the
+              failure is retryable, and the run still targets the current PR
+              head. Repair projection when <code>status=completed</code> but
+              <code>projection_status=failed</code>; the stored intent should be
+              applied to GitHub without rerunning the agent.
+            </p>
+          </div>
+        </details>
+
+        <details>
+          <summary>What should never be exposed?</summary>
+          <div class="details-body">
+            <p>
+              Do not expose raw webhook payloads, secrets, tokens, or unbounded
+              transcript dumps in learning docs, health output, projection
+              records, or dashboard pages. Operator surfaces should show enough
+              context to debug state without leaking credentials or sensitive
+              session output.
+            </p>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <section id="operate" aria-labelledby="operate-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Layer 6</p>
+          <h2 id="operate-heading">When something looks wrong</h2>
+        </div>
+        <p>
+          Use the ReviewRun report first. Use the GitHub projection audit when
+          the run report is healthy but GitHub appears out of sync.
+        </p>
+      </div>
+
+      <table class="triage-table">
+        <thead>
+          <tr>
+            <th>Observation</th>
+            <th>Interpret as</th>
+            <th>First action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td data-label="Observation">No ReviewRun row for an eligible trigger</td>
+            <td data-label="Interpret as">Pickup or ingestion gap</td>
+            <td data-label="First action">Inspect <code>missingRuns</code>, then check trigger classification.</td>
+          </tr>
+          <tr>
+            <td data-label="Observation">Pending status just appeared</td>
+            <td data-label="Interpret as">Pickup succeeded; execution or projection may still be active</td>
+            <td data-label="First action">Wait inside SLO or open the details URL for run state.</td>
+          </tr>
+          <tr>
+            <td data-label="Observation">Active run has coalesced fields</td>
+            <td data-label="Interpret as">Newer material trigger arrived during execution</td>
+            <td data-label="First action">Let the broker suppress old output and start one follow-up run.</td>
+          </tr>
+          <tr>
+            <td data-label="Observation">Completed run has failed projection</td>
+            <td data-label="Interpret as">Valid intent exists, GitHub projection failed</td>
+            <td data-label="First action">Repair projection or let the repair sweep re-apply effects.</td>
+          </tr>
+          <tr>
+            <td data-label="Observation">Superseded run</td>
+            <td data-label="Interpret as">Newer work intentionally replaced it</td>
+            <td data-label="First action">Do not retry. Use the current-head covering run.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section aria-labelledby="commands-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Operator commands</p>
+          <h2 id="commands-heading">Commands worth memorizing</h2>
+        </div>
+        <p>
+          These are intentionally separate: one reads ReviewRuns, the other
+          audits GitHub projection drift.
+        </p>
+      </div>
+
+      <div class="command-grid">
+        <article class="command-card">
+          <h3>ReviewRun source-of-truth report</h3>
+          <pre><code>uv run --script scripts/pr-reviewer-runs.py</code></pre>
+          <p>
+            Use this first for pickup, active runs, stuck runs, completed runs
+            awaiting projection, failed execution, failed projection, and
+            superseded runs.
+          </p>
+        </article>
+        <article class="command-card">
+          <h3>GitHub projection audit</h3>
+          <pre><code>uv run --script scripts/pr-review-health.py \
+  --repo fairchild/workspaces \
+  --updated-within-hours 72 \
+  --pending-timeout-min 30</code></pre>
+          <p>
+            Use this after the run report when GitHub status or review state
+            appears inconsistent with the ReviewRun source of truth.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="learning-heading">
+      <div class="section-head">
+        <div>
+          <p class="kicker">Understanding check</p>
+          <h2 id="learning-heading">Prove the model before changing the system</h2>
+        </div>
+        <p>
+          The quiz is a small guardrail. It checks the decisions that matter:
+          retry versus repair, stale output suppression, health interpretation,
+          and the ReviewRun source-of-truth boundary.
+        </p>
+      </div>
+
+      <div class="command-grid">
+        <article class="command-card">
+          <h3>Take the quiz</h3>
+          <pre><code>uv run --script scripts/pr-reviewer-quiz.py</code></pre>
+          <p>Use this when onboarding or when you want to verify your operating model.</p>
+        </article>
+        <article class="command-card">
+          <h3>Validate quiz data</h3>
+          <pre><code>uv run --script scripts/pr-reviewer-quiz.py --check-answer-key</code></pre>
+          <p>Run this after editing the quiz, docs, or lifecycle vocabulary.</p>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="next-docs-heading">
+      <div class="docs-footer">
+        <div>
+          <p class="kicker">Next docs</p>
+          <h2 id="next-docs-heading">Go deeper from here</h2>
+          <p>
+            This HTML page is the visual map. The linked Markdown files remain
+            the source for implementation vocabulary, runbooks, storage shape,
+            and closure evidence.
+          </p>
+        </div>
+        <div class="link-list">
+          <a href="architecture.md">Architecture reference</a>
+          <a href="understanding-guide.md">Scenario guide</a>
+          <a href="pr-reviewer.md">Runtime runbook</a>
+          <a href="review-run-schema.sql">ReviewRun schema</a>
+          <a href="milestone-validation.md">Milestone validation</a>
+          <a href="../../scripts/pr-reviewer-quiz.py">Offline quiz script</a>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add a standalone HTML visual guide at `docs/pr-review/index.html` that starts with the managed reviewer pipeline and progressively drills into ReviewRun state, projections, coalescing, recovery, health commands, and the quiz.
- Link the visual guide from `docs/pr-review/README.md` as the first learning entry point.

## Mergeability

- Surface: docs
- User-facing behavior changed: no runtime behavior; docs-only learning artifact
- Non-happy paths considered: covers failed execution, failed projection, stale output, superseded runs, and pickup gaps
- Release/ops preconditions: none
- Residual risk or follow-up: none expected

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `mise -C web run web:check` passed: 29 test files, 340 tests
  - `uv run --script scripts/tests/test_security_hardening.py` passed: 29 tests
  - `git diff --check` passed
  - Python HTML parser accepted `docs/pr-review/index.html`
  - Playwright rendered desktop and mobile local screenshots

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: docs-only

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Managed reviewer visual guide screenshot](https://evidence.cloudcompute.com/workspaces/pr-610/20260601-133846-managed-reviewer-visual-guide.png)

## Blockers

- [x] None
- [ ] Blocked on evidence