### PR TITLE
fix: isolate managed review broker status concurrency

### DIFF
--- a/.github/workflows/managed-reviewer-broker.yml
+++ b/.github/workflows/managed-reviewer-broker.yml
@@ -35,7 +35,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: managed-reviewer-broker-${{ github.event_name }}-${{ github.event.sha || github.run_id }}
+  group: managed-reviewer-broker-${{ github.event_name }}-${{ github.event.sha || github.run_id }}-${{ github.event.context || 'none' }}-${{ github.event.state || 'none' }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -141,6 +141,11 @@ The same workflow remains the manual repair path and script smoke test. Manual
 `workflow_dispatch` runs `scripts/pr-reviewer-broker.py` against the broker
 route once by default, or for a caller-provided number of attempts.
 
+When the workflow runs for ordinary `pull_request` changes, the
+`Reconcile completed managed reviews` job is expected to show as skipped. That
+job is intentionally limited to `status` events for the pending managed-review
+context and to manual `workflow_dispatch` repair runs.
+
 A broker failure means a completed ReviewRun could not be published or marked
 superseded.
 
@@ -166,8 +171,8 @@ Production CD requires `WORKSPACES_WEBHOOK_CANARY_SECRET`, runs the ingress
 canary before promotion, then repeats it in `validate-prod` after promotion
 before the production Playwright smoke. That canary proves only relay delivery,
 route HMAC validation, canary-secret validation, and dry-run trigger selection.
-It does not broker completed runs or report queue health; the scheduled broker
-and health workflows own live reviewer reconciliation failures.
+It does not broker completed runs or report queue health; the broker and health
+workflows own live reviewer reconciliation failures.
 
 The scheduled ingress workflow is a contract probe. It does not reconcile
 completed runs and does not report queue health.
@@ -303,7 +308,7 @@ If using the GitHub App: check that `PR_REVIEWER_APP_ID`, `PR_REVIEWER_PRIVATE_K
 
 Check the session events for the final fenced `json` review intent, then check
 Vercel logs for `[pr-review] broker failed`. Common causes:
-- `WORKSPACES_WEBHOOK_CANARY_SECRET` is missing, so scheduled broker calls are not authenticated
+- `WORKSPACES_WEBHOOK_CANARY_SECRET` is missing, so broker calls are not authenticated
 - GitHub App token exchange failed — check Vercel logs for `[pr-review] GitHub App token failed`
 - `PR_REVIEWER_ENABLED=0` is set
 - the managed agent did not return valid fenced JSON with `event`, `body`, and `labels`

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -482,6 +482,8 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertNotIn("schedule:", broker_workflow)
         self.assertIn("github.event.context == 'WorkSpaces Managed Review'", broker_workflow)
         self.assertIn("github.event.state == 'pending'", broker_workflow)
+        self.assertIn("github.event.context || 'none'", broker_workflow)
+        self.assertIn("github.event.state || 'none'", broker_workflow)
         self.assertIn("ref: main", broker_workflow)
         self.assertIn("persist-credentials: false", broker_workflow)
         self.assertIn("github.event_name == 'status' && '30'", broker_workflow)


### PR DESCRIPTION
## Summary

- Include status context/state in the managed reviewer broker concurrency key so a success status event cannot cancel the pending-status broker run that just published it.
- Clarify that the broker workflow's reconcile job is expected to be skipped on ordinary `pull_request` runs.
- Remove stale "scheduled broker" wording from the reviewer docs.

## Mergeability

- Surface: agent-runtime / infra / docs
- User-facing behavior changed: Managed review broker runs should no longer appear cancelled immediately after successfully publishing a review/status.
- Non-happy paths considered: Pending status broker runs still cancel older pending broker runs for the same SHA/context/state, while success status events get their own skipped concurrency lane.
- Release/ops preconditions: None.
- Residual risk or follow-up: Re-run the live PR e2e after this update: pending managed review status should trigger broker, broker should poll until apply, and the broker run should finish success instead of cancelled.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `uv run --script scripts/tests/test_security_hardening.py` passed: 29 tests
  - `python3 scripts/pr-reviewer-broker.py --help` passed
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check` passed

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [managed review e2e concurrency](https://evidence.cloudcompute.com/workspaces/pr-612/20260604-070544-managed-review-e2e-concurrency.svg)
- [original docs e2e evidence](https://evidence.cloudcompute.com/workspaces/pr-612/20260604-070050-managed-review-e2e-doc.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence