### PR TITLE
docs: clarify broker status event skips

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -145,6 +145,9 @@ When the workflow runs for ordinary `pull_request` changes, the
 `Reconcile completed managed reviews` job is expected to show as skipped. That
 job is intentionally limited to `status` events for the pending managed-review
 context and to manual `workflow_dispatch` repair runs.
+Non-pending status events can also create skipped workflow runs, but the
+workflow concurrency key includes status context and state so those skipped runs
+do not cancel an active pending-status broker poll.
 
 A broker failure means a completed ReviewRun could not be published or marked
 superseded.


### PR DESCRIPTION
## Summary

- Document that non-pending status events can create skipped broker workflow runs.
- Clarify that those skipped runs should not cancel an active pending-status broker poll because the concurrency key includes status context and state.
- Use this PR as the post-#612 live e2e probe for the fixed status-event broker path.

## Mergeability

- Surface: docs / agent-runtime
- User-facing behavior changed: No product behavior change; operator docs better explain expected status-event workflow noise.
- Non-happy paths considered: This explicitly documents the success-status/skipped-run case found during #612 validation.
- Release/ops preconditions: None.
- Residual risk or follow-up: Verify this PR's managed review is picked up, brokered automatically, and the status-event broker run finishes success rather than cancelled.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check` passed

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [x] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [managed review final e2e](https://evidence.cloudcompute.com/workspaces/pr-613/20260604-071035-managed-review-final-e2e.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence