### PR TITLE
fix: paginate release preflight check runs

### DIFF
--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -70,29 +70,51 @@ print_header() {
     echo ""
 }
 
-# Return the latest check-run state for this release SHA:
+# Return the latest check-run state for this release SHA.
+#
+# GitHub can attach many check-runs to busy release commits, so collect every
+# paginated page and choose the newest matching check by timestamp.
+#
 # - terminal conclusions such as success, failure, cancelled
 # - queued or in_progress while GitHub Actions is still running
 # - not_found when no matching check run exists on the commit
 check_workflow_state() {
     local workflow_name="$1"
-    local jq_filter
-    local state
+    local check_runs
+    local name
+    local status
+    local conclusion
+    local timestamp
+    local latest_state="not_found"
+    local latest_timestamp="0000-00-00T00:00:00Z"
 
-    jq_filter=".check_runs
-        | map(select(.name == \"$workflow_name\"))
-        | sort_by(.started_at // .created_at // \"\")
-        | last
-        | if . == null then empty
-          elif .status == \"completed\" then .conclusion
-          else .status
-          end"
+    if ! check_runs=$(gh api \
+	--paginate \
+	"repos/$REPO/commits/$SHA/check-runs?per_page=100" \
+	--jq '.check_runs[] | [.name, .status, (.conclusion // "__no_conclusion__"), (.started_at // .created_at // "0000-00-00T00:00:00Z")] | @tsv' \
+	2>/dev/null); then
+	echo "not_found"
+	return
+    fi
 
-    state=$(gh api \
-        "repos/$REPO/commits/$SHA/check-runs" \
-        --jq "$jq_filter" \
-        2>/dev/null)
-    echo "${state:-not_found}"
+    while IFS=$'\t' read -r name status conclusion timestamp; do
+	[[ -n "${name:-}" ]] || continue
+	[[ "$name" == "$workflow_name" ]] || continue
+	[[ "$timestamp" > "$latest_timestamp" ]] || continue
+
+	latest_timestamp="$timestamp"
+	if [[ "$status" == "completed" ]]; then
+	    if [[ "$conclusion" == "__no_conclusion__" ]]; then
+		latest_state="completed"
+	    else
+		latest_state="$conclusion"
+	    fi
+	else
+	    latest_state="${status:-not_found}"
+	fi
+    done <<<"$check_runs"
+
+    echo "$latest_state"
 }
 
 check_any_workflow() {

--- a/scripts/tests/test_release_preflight.py
+++ b/scripts/tests/test_release_preflight.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Release-preflight tests for GitHub check-run lookup reliability.
+
+These tests run without network, secrets, UI access, or live GitHub mutation.
+They protect the release gate that verifies CI on the exact SHA being
+published, especially when GitHub check-runs spill past the first API page.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "release-preflight.sh"
+
+
+class ReleasePreflightTests(unittest.TestCase):
+    def test_paginated_check_run_lookup_uses_latest_matching_run(self) -> None:
+        with ReleasePreflightFixture() as fixture:
+            result = fixture.run()
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("CI (build-and-test): PASS", result.stdout)
+        self.assertNotIn("FAIL (failure)", result.stdout)
+
+    def test_absent_required_ci_stays_readable_in_dry_run(self) -> None:
+        with ReleasePreflightFixture(no_required_ci=True) as fixture:
+            result = fixture.run()
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("CI (build-and-test): NOT FOUND (dry-run: continuing)", result.stdout)
+        self.assertIn("Preflight passed.", result.stdout)
+
+
+class ReleasePreflightFixture:
+    def __init__(self, *, no_required_ci: bool = False) -> None:
+        self.no_required_ci = no_required_ci
+        self.root = Path(tempfile.mkdtemp(prefix="ReleasePreflightTests-"))
+
+    def __enter__(self) -> "ReleasePreflightFixture":
+        fake_bin = self.root / "bin"
+        fake_bin.mkdir()
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                args=" $* "
+
+                case "$args" in
+                    *"/commits/test-sha/check-runs"* )
+                        if [ "${FAKE_RELEASE_PREFLIGHT_NO_REQUIRED_CI:-}" = "1" ]; then
+                            printf '%s\\t%s\\t%s\\t%s\\n' "lint" "completed" "success" "2026-06-06T10:00:00Z"
+                            exit 0
+                        fi
+
+                        case "$args" in
+                            *" --paginate "*"per_page=100"* )
+                                printf '%s\\t%s\\t%s\\t%s\\n' "build-and-test" "completed" "failure" "2026-06-06T10:00:00Z"
+                                printf '%s\\t%s\\t%s\\t%s\\n' "lint" "completed" "success" "2026-06-06T10:01:00Z"
+                                printf '%s\\t%s\\t%s\\t%s\\n' "build-and-test" "completed" "success" "2026-06-06T10:02:00Z"
+                                printf '%s\\t%s\\t%s\\t%s\\n' "perf-validation" "completed" "success" "2026-06-06T10:03:00Z"
+                                ;;
+                            * )
+                                printf '%s\\t%s\\t%s\\t%s\\n' "build-and-test" "completed" "failure" "2026-06-06T10:00:00Z"
+                                ;;
+                        esac
+                        ;;
+                    *"/commits/test-sha "* )
+                        printf '%s\\n' "Sources/App.swift"
+                        ;;
+                    * )
+                        printf 'unexpected gh invocation: %s\\n' "$*" >&2
+                        exit 64
+                        ;;
+                esac
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        shutil.rmtree(self.root)
+
+    def run(self) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["PATH"] = f"{self.root / 'bin'}:{environment['PATH']}"
+        environment["FAKE_RELEASE_PREFLIGHT_NO_REQUIRED_CI"] = "1" if self.no_required_ci else ""
+
+        return subprocess.run(
+            ["/bin/bash", str(SCRIPT_PATH), "--dry-run", "test-sha", "fairchild/workspaces"],
+            check=False,
+            cwd=REPO_ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Paginate release-preflight commit check-run lookup with `gh api --paginate` and `per_page=100`.
- Select the newest matching workflow state across all returned pages by `started_at` / `created_at` so busy release SHAs find the latest `build-and-test` result.
- Add an executable UV script test that covers a required CI check appearing after the first page and the readable dry-run output for genuinely absent CI.

Closes #615.

## Mergeability

- Surface: infra
- User-facing behavior changed: release operators get accurate CI gating on busy release commits instead of false `not_found` results from the first check-run page.
- Non-happy paths considered: `gh api` errors still report `not_found`; dry-run absent required CI remains readable and non-blocking.
- Release/ops preconditions: no secrets or operator steps required.
- Residual risk or follow-up: none identified; check-run names are still matched exactly as before.

## Validation

- [ ] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/tests/test_release_preflight.py` -> `Ran 2 tests ... OK`
  - `./scripts/release-preflight.sh --dry-run 55c3390d17a5ef54180622623c2509e1fea9abd9 fairchild/workspaces` -> `CI (build-and-test): PASS`; `Preflight passed.`
  - `git diff --check`
  - `bash -n scripts/release-preflight.sh`
  - `uv run --script scripts/validate-release-changes.py --changed-files /tmp/workspaces-pr-619-changed-files.json` -> `Release change validation passed.`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![release-preflight-validation](https://evidence.cloudcompute.com/workspaces/pr-619/20260606-231948-release-preflight-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
