### PR TITLE
Fix Claude hook install churn

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -25,6 +25,7 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
     /// Maximum number of `*.workspaces-backup-*` files to retain per settings file.
     /// Older backups beyond this count are deleted on each `install()` call.
     public static let maxBackupsPerFile: Int = 5
+    public static let defaultBundleIdentifier = "com.cloudcompute.workspaces"
 
     private enum Target: CaseIterable {
         case userSettingsJSON
@@ -50,6 +51,7 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
     private let eventForwarderScriptPath: String?
     private let statusLineForwarderPath: String?
     private let statusLineRefreshInterval: Int
+    private let backupDirectory: URL
     private let preferredNotifChannel = "iterm2"
     private var lastBackupPath: String?
 
@@ -57,12 +59,16 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
         eventForwarderScriptPath: String? = nil,
         statusLineForwarderPath: String? = nil,
-        statusLineRefreshInterval: Int = 5000
+        statusLineRefreshInterval: Int = 5000,
+        backupDirectory: URL? = nil
     ) {
         self.homeDirectory = homeDirectory
         self.eventForwarderScriptPath = eventForwarderScriptPath
         self.statusLineForwarderPath = statusLineForwarderPath
         self.statusLineRefreshInterval = statusLineRefreshInterval
+        self.backupDirectory =
+            backupDirectory
+            ?? Self.defaultBackupDirectory(homeDirectory: homeDirectory)
     }
 
     public func userSettingsURL() -> URL {
@@ -125,13 +131,21 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 options: [.prettyPrinted, .sortedKeys]
             )
 
+            if areJSONEqual(current, next) {
+                continue
+            }
+
             if let originalData, originalData == mergedData {
                 continue
             }
 
             if let originalData {
-                let backupURL = url.appendingPathExtension(
-                    "workspaces-backup-\(Self.iso8601Timestamp())"
+                try FileManager.default.createDirectory(
+                    at: backupDirectory,
+                    withIntermediateDirectories: true
+                )
+                let backupURL = backupDirectory.appendingPathComponent(
+                    "\(url.lastPathComponent).workspaces-backup-\(Self.iso8601Timestamp())"
                 )
                 try originalData.write(to: backupURL)
                 if target == .userSettingsJSON {
@@ -446,6 +460,14 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         }
     }
 
+    public nonisolated static func defaultBackupDirectory(homeDirectory: URL) -> URL {
+        homeDirectory
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent(defaultBundleIdentifier, isDirectory: true)
+            .appendingPathComponent("ClaudeSettingsBackups", isDirectory: true)
+    }
+
     private func ensureParentExists(for url: URL) throws {
         let parent = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(
@@ -460,12 +482,11 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
     }
 
     private func rotateBackups(forSettingsFile url: URL) {
-        let parent = url.deletingLastPathComponent()
         let baseName = url.lastPathComponent
         let prefix = "\(baseName).workspaces-backup-"
         let entries =
             (try? FileManager.default.contentsOfDirectory(
-                at: parent,
+                at: backupDirectory,
                 includingPropertiesForKeys: [.contentModificationDateKey],
                 options: []
             )) ?? []

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerBackupRotationTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerBackupRotationTests.swift
@@ -22,6 +22,10 @@ struct ClaudeSettingsInstallerBackupRotationTests {
         return url
     }
 
+    private func backupDirectory(for home: URL) -> URL {
+        ClaudeSettingsInstaller.defaultBackupDirectory(homeDirectory: home)
+    }
+
     @Test("Seven sequential installs leave exactly five settings.json backups")
     func sevenInstallsLeaveFiveBackups() async throws {
         let home = makeTempHome()
@@ -47,8 +51,14 @@ struct ClaudeSettingsInstallerBackupRotationTests {
             try await Task.sleep(nanoseconds: 12_000_000)
         }
 
+        let legacyEntries = try FileManager.default.contentsOfDirectory(
+            at: claudeDir,
+            includingPropertiesForKeys: nil
+        )
+        #expect(legacyEntries.contains { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") } == false)
+
         let entries = try FileManager.default.contentsOfDirectory(
-            at: claudeDir, includingPropertiesForKeys: nil
+            at: backupDirectory(for: home), includingPropertiesForKeys: nil
         )
         let backups = entries.filter {
             $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-")
@@ -75,7 +85,7 @@ struct ClaudeSettingsInstallerBackupRotationTests {
         }
 
         let entries = try FileManager.default.contentsOfDirectory(
-            at: home, includingPropertiesForKeys: nil
+            at: backupDirectory(for: home), includingPropertiesForKeys: nil
         )
         let backups = entries.filter {
             $0.lastPathComponent.hasPrefix(".claude.json.workspaces-backup-")
@@ -106,8 +116,15 @@ struct ClaudeSettingsInstallerBackupRotationTests {
             try await Task.sleep(nanoseconds: 25_000_000)
         }
 
+        let legacyEntries = try FileManager.default.contentsOfDirectory(
+            at: claudeDir,
+            includingPropertiesForKeys: nil
+        )
+        #expect(legacyEntries.contains { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") } == false)
+
         let entries = try FileManager.default.contentsOfDirectory(
-            at: claudeDir, includingPropertiesForKeys: [.contentModificationDateKey]
+            at: backupDirectory(for: home),
+            includingPropertiesForKeys: [.contentModificationDateKey]
         )
         let backups = entries.filter {
             $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-")

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerTests.swift
@@ -44,6 +44,10 @@ struct ClaudeSettingsInstallerTests {
         return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
     }
 
+    private func backupDirectory(for home: URL) -> URL {
+        ClaudeSettingsInstaller.defaultBackupDirectory(homeDirectory: home)
+    }
+
     @Test("Non-destructive merge preserves unrelated keys and user hooks")
     func nonDestructiveMerge() async throws {
         let home = makeTempHome()
@@ -131,8 +135,14 @@ struct ClaudeSettingsInstallerTests {
         let installer = installer(home: home)
         try await installer.install()
 
-        let backups = try FileManager.default.contentsOfDirectory(
+        let legacyBackups = try FileManager.default.contentsOfDirectory(
             at: claudeDir,
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
+        #expect(legacyBackups.isEmpty)
+
+        let backups = try FileManager.default.contentsOfDirectory(
+            at: backupDirectory(for: home),
             includingPropertiesForKeys: nil
         ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
         #expect(backups.count == 1)
@@ -164,12 +174,82 @@ struct ClaudeSettingsInstallerTests {
         }
         #expect(eventForwarderEntries.count == 1)
 
-        let backups = try FileManager.default.contentsOfDirectory(
+        let legacyBackups = try FileManager.default.contentsOfDirectory(
             at: claudeDir,
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
+        #expect(legacyBackups.isEmpty)
+
+        let backups = try FileManager.default.contentsOfDirectory(
+            at: backupDirectory(for: home),
             includingPropertiesForKeys: nil
         ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
         #expect(backups.count == 1)
         #expect(await installer.isInstalled())
+    }
+
+    @Test("Install skips byte rewrite for semantically equivalent hook settings")
+    func equivalentHookSettingsDoNotRewrite() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        let settingsURL = claudeDir.appendingPathComponent("settings.json")
+        let hookEvents = [
+            "SessionStart",
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolUse",
+            "PostToolBatch",
+            "PostToolUseFailure",
+            "PermissionRequest",
+            "Notification",
+            "Stop",
+            "StopFailure",
+            "TaskCreated",
+            "TaskCompleted",
+        ]
+        let handler: [String: Any] = [
+            "type": "command",
+            "command": eventForwarder,
+            "async": true,
+        ]
+        var hooks: [String: Any] = [:]
+        for event in hookEvents {
+            hooks[event] = [["hooks": [handler]]]
+        }
+        let originalData = try JSONSerialization.data(
+            withJSONObject: [
+                "statusLine": [
+                    "refreshInterval": 5000,
+                    "command": statusline,
+                    "type": "command",
+                ],
+                "hooks": hooks,
+            ],
+            options: []
+        )
+        try originalData.write(to: settingsURL)
+
+        let installer = installer(home: home)
+        try await installer.install()
+
+        #expect(try Data(contentsOf: settingsURL) == originalData)
+        #expect(await installer.isInstalled())
+
+        let legacyBackups = try FileManager.default.contentsOfDirectory(
+            at: claudeDir,
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("settings.json.workspaces-backup-") }
+        #expect(legacyBackups.isEmpty)
+
+        let externalBackups =
+            (try? FileManager.default.contentsOfDirectory(
+                at: backupDirectory(for: home),
+                includingPropertiesForKeys: nil
+            )) ?? []
+        #expect(externalBackups.isEmpty)
     }
 
     @Test("Re-install scrubs legacy WorkSpaces http+unix hooks only")

--- a/Tests/WorkspaceManagerTests/Perf/PerfChannel1Tests.swift
+++ b/Tests/WorkspaceManagerTests/Perf/PerfChannel1Tests.swift
@@ -502,7 +502,7 @@ struct PerfChannel1Tests {
 
         let entries =
             (try? FileManager.default.contentsOfDirectory(
-                at: homeDir.appendingPathComponent(".claude"),
+                at: ClaudeSettingsInstaller.defaultBackupDirectory(homeDirectory: homeDir),
                 includingPropertiesForKeys: nil
             )) ?? []
         let backups = entries.filter { $0.path.contains("workspaces-backup-") }

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -198,9 +198,11 @@ The public UI-facing protocol remains:
 - `mostRecentBackupPath()`
 - `userSettingsModificationDate()`
 
-`install()` compares the merged JSON bytes with the file on disk. If nothing
-changes, it skips both the write and backup creation. When it does write, it
-keeps at most five `*.workspaces-backup-*` files per settings file.
+`install()` compares the merged JSON semantically with the file on disk. If
+nothing changes, it skips both the write and backup creation, preserving the
+user's formatting. When it does write, backups go under
+`~/Library/Application Support/com.cloudcompute.workspaces/ClaudeSettingsBackups`
+and rotation keeps at most five `*.workspaces-backup-*` files per settings file.
 
 `ClaudeIntegrationLifecycle.start(registry:)` publishes the installer, starts the
 stable socket listener, and repairs settings only when the user has opted in and


### PR DESCRIPTION
## Summary
- skip Claude settings writes when the planned WorkSpaces hook/status changes are already semantically present
- keep shell-safe hook commands while preserving equivalent user formatting
- move WorkSpaces settings backups out of ~/.claude into the app support backup directory and rotate them there
- update focused installer tests and the Claude integration doc

Fixes #617.

## Validation
- ./scripts/build-ghosttykit.sh
- swift test --filter ClaudeSettingsInstaller
- swift test
- git diff --check (ran; local core.whitespace flags Swift indentation spaces as indent-with-non-tab)
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check

## Evidence
- Code-only Swift settings installer change; no UI screenshot needed.
- [Focused ClaudeSettingsInstaller test evidence](https://evidence.cloudcompute.com/workspaces/pr-620/20260607-024421-claude-settings-installer-tests.svg)

## Mergeability
- Surface: desktop
- User-facing behavior changed: Claude hook settings installs avoid formatting-only rewrites and write WorkSpaces backups under app support instead of ~/.claude.
- Non-happy paths considered: malformed settings still back up before repair; unescaped WorkSpaces command hooks are still scrubbed; backup rotation now runs in the external backup directory.
- Residual risk or follow-up: existing legacy backup files already in ~/.claude are not migrated or deleted by this slice.