### PR TITLE
fix: machine-agnostic Claude hook + status-line commands (stop ~/.claude drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Write machine-agnostic Claude Code hook and status-line commands: both forwarders extract to a stable, space-free dir (`~/.local/share/workspaces/hook-forwarders/`) and `settings.json` carries a tilde-relative, unquoted path identical on every machine. This keeps the committed dotclaude config matching runtime so `~/.claude` stops going dirty and the auto-deploy no longer silently skips. Opted-in users migrate off the older `Application Support` / `.build` bundle paths on next launch. See `docs/decisions/hook-forwarder-command-shape.md`.
+
 ## [0.17.0] - 2026-06-05
 
 ### Added

--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -41,10 +41,10 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
             )
         }
 
-        let statusLinePath = ClaudeIntegrationLifecycle.bundledStatusLineForwarderPath()
+        let statusLinePath = ClaudeIntegrationLifecycle.extractStatusLineForwarderScript()
         if statusLinePath == nil {
             NSLog(
-                "[ClaudeIntegration] statusline.sh not found in bundle; skipping Channel 2 contribution"
+                "[ClaudeIntegration] statusline.sh extraction failed; skipping Channel 2 contribution"
             )
         }
 
@@ -52,13 +52,6 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
             eventForwarderScriptPath: eventForwarderPath,
             statusLineForwarderPath: statusLinePath
         )
-    }
-
-    /// Locate the Channel 2 status-line forwarder shell shipped alongside the app.
-    /// Returns nil if the bundle was assembled without it — caller logs and
-    /// proceeds without registering Channel 2.
-    nonisolated static func bundledStatusLineForwarderPath() -> String? {
-        bundledHookForwarderURL(named: "statusline")?.path
     }
 
     /// Locate the sourceable zsh command-status producer shipped alongside the app.
@@ -146,37 +139,58 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
     }
 
     /// Copy the bundled `event-forwarder.sh` (Channel 1 hook event forwarder) to a
-    /// stable location under Application Support and chmod it executable. Returns
-    /// the destination path, or nil if extraction failed — the contribution then
-    /// declines to register, and Channel 1 stays dormant for this session.
+    /// stable location and chmod it executable. Returns the destination path, or
+    /// nil if extraction failed — the contribution then declines to register, and
+    /// Channel 1 stays dormant for this session.
     nonisolated static func extractEventForwarderScript() -> String? {
         extractHookForwarderScript(named: "event-forwarder")
     }
 
-    /// Generic helper used by the event-forwarder extractor:
-    /// copies `<name>.sh` from the bundle's `HookForwarders/` resource directory
-    /// to `~/Library/Application Support/<bundle-id>/HookForwarders/<name>.sh`,
-    /// chmods it 0o755, returns the destination path. Nil on any failure.
-    nonisolated private static func extractHookForwarderScript(named name: String) -> String? {
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first
-        guard let appSupport else { return nil }
-        let dir =
-            appSupport
-            .appendingPathComponent(bundleID, isDirectory: true)
-            .appendingPathComponent("HookForwarders", isDirectory: true)
+    /// Copy the bundled `statusline.sh` (Channel 2 status-line forwarder) to the
+    /// same stable extraction dir as Channel 1, symmetric with the event
+    /// forwarder. Returns the destination path, or nil if extraction failed.
+    nonisolated static func extractStatusLineForwarderScript() -> String? {
+        extractHookForwarderScript(named: "statusline")
+    }
+
+    /// Stable, space-free directory the app extracts hook/status forwarders into.
+    /// Honors `XDG_DATA_HOME`, defaulting to `~/.local/share`. Deliberately kept
+    /// out of `~/.claude` so an extracted script never dirties the dotclaude git
+    /// tree, and space-free so the command the installer writes to
+    /// `settings.json` stays a clean, unquoted, machine-agnostic tilde path.
+    nonisolated static func hookForwarderInstallDirectory() -> URL {
+        let dataHome: URL
+        if let xdg = ProcessInfo.processInfo.environment["XDG_DATA_HOME"], !xdg.isEmpty {
+            dataHome = URL(fileURLWithPath: xdg)
+        } else {
+            dataHome = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".local", isDirectory: true)
+                .appendingPathComponent("share", isDirectory: true)
+        }
+        return
+            dataHome
+            .appendingPathComponent("workspaces", isDirectory: true)
+            .appendingPathComponent("hook-forwarders", isDirectory: true)
+    }
+
+    /// Generic helper used by the forwarder extractors: copies `<name>.<ext>` from
+    /// the bundle's `HookForwarders/` resource directory to
+    /// `hookForwarderInstallDirectory()/<name>.<ext>`, chmods it 0o755, and returns
+    /// the destination path. Nil on any failure.
+    nonisolated private static func extractHookForwarderScript(
+        named name: String,
+        fileExtension: String = "sh"
+    ) -> String? {
+        let dir = hookForwarderInstallDirectory()
         try? FileManager.default.createDirectory(
             at: dir, withIntermediateDirectories: true
         )
-        let dest = dir.appendingPathComponent("\(name).sh")
+        let dest = dir.appendingPathComponent("\(name).\(fileExtension)")
 
-        // Source: bundled .sh file. Packaged apps expose flattened resources
+        // Source: bundled resource file. Packaged apps expose flattened resources
         // through Bundle.main; SwiftPM builds expose them through a sibling
         // WorkspaceManager_WorkspaceManager.bundle.
-        let bundleURL = bundledHookForwarderURL(named: name)
+        let bundleURL = bundledHookForwarderURL(named: name, fileExtension: fileExtension)
         guard let bundleURL else {
             return nil
         }

--- a/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeSettingsInstaller.swift
@@ -196,12 +196,15 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         var hooks = (current["hooks"]?.value as? [String: Any]) ?? [:]
 
         if let eventForwarderScriptPath {
-            let eventForwarder = CommandContribution(rawPath: eventForwarderScriptPath)
+            let eventForwarder = CommandContribution(
+                rawPath: homeRelativeCommand(eventForwarderScriptPath)
+            )
             var addedEvents: [String] = []
             var normalizedEvents: [String] = []
             var scrubbedLegacyEvents: [String] = []
             var scrubbedTitleEvents: [String] = []
             var scrubbedUnescapedForwarderEvents: [String] = []
+            var scrubbedLegacyForwarderEvents: [String] = []
 
             for name in Self.hookEventNames {
                 let rawEntries = (hooks[name] as? [Any]) ?? []
@@ -227,6 +230,14 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                 groups = unescapedForwarderResult.groups
                 if unescapedForwarderResult.removedCount > 0 {
                     scrubbedUnescapedForwarderEvents.append(name)
+                }
+
+                let legacyForwarderResult = scrubHandlers(in: groups) { handler in
+                    isLegacyWorkspacesEventForwarderHook(handler, contribution: eventForwarder)
+                }
+                groups = legacyForwarderResult.groups
+                if legacyForwarderResult.removedCount > 0 {
+                    scrubbedLegacyForwarderEvents.append(name)
                 }
 
                 let eventForwarderPresent = groups.contains { group in
@@ -268,6 +279,11 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
                     "replace unescaped WorkSpaces event-forwarder command in \(scrubbedUnescapedForwarderEvents.count) events"
                 )
             }
+            if !scrubbedLegacyForwarderEvents.isEmpty {
+                lines.append(
+                    "replace machine-specific WorkSpaces event-forwarder path in \(scrubbedLegacyForwarderEvents.count) events"
+                )
+            }
             if !normalizedEvents.isEmpty {
                 lines.append(
                     "normalize legacy hook group shape for \(normalizedEvents.joined(separator: ", "))"
@@ -282,7 +298,9 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         }
 
         if let statusLineForwarderPath {
-            let statusLineCommand = CommandContribution(rawPath: statusLineForwarderPath).command
+            let statusLineCommand = CommandContribution(
+                rawPath: homeRelativeCommand(statusLineForwarderPath)
+            ).command
             var block = (current["statusLine"]?.value as? [String: Any]) ?? [:]
             let oldCommand = block["command"] as? String
             let oldInterval = block["refreshInterval"] as? Int
@@ -426,6 +444,47 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
         return command == contribution.rawPath
     }
 
+    /// Recognizes a stale, machine-specific WorkSpaces event-forwarder command —
+    /// any prior shape extracted to a `HookForwarders/` directory (an
+    /// `Application Support` path, a `.build` bundle path, quoted or unquoted) —
+    /// so it can be replaced with the canonical machine-agnostic tilde command.
+    /// The canonical command is excluded so an already-installed entry is kept.
+    private func isLegacyWorkspacesEventForwarderHook(
+        _ handler: [String: Any],
+        contribution: CommandContribution
+    ) -> Bool {
+        guard (handler["type"] as? String) == "command" else { return false }
+        guard let command = handler["command"] as? String else { return false }
+        guard command != contribution.command else { return false }
+        let unquoted = unquoteSingleQuotedCommand(command)
+        return unquoted.hasSuffix("/HookForwarders/event-forwarder.sh")
+    }
+
+    /// Strip a single layer of POSIX single quotes (and `'\''` escapes) so a
+    /// quoted command path can be suffix-matched. Returns the input unchanged when
+    /// it is not single-quoted.
+    private func unquoteSingleQuotedCommand(_ command: String) -> String {
+        guard command.count >= 2, command.hasPrefix("'"), command.hasSuffix("'") else {
+            return command
+        }
+        let inner = command.dropFirst().dropLast()
+        return inner.replacingOccurrences(of: "'\\''", with: "'")
+    }
+
+    /// Rewrite an absolute path under the installer's home directory to a
+    /// `~/...` tilde path so the command written to `settings.json` is identical
+    /// on every machine. Tilde expansion is not subject to field splitting, so the
+    /// result stays unquoted even when the home directory contains a space. Paths
+    /// outside the home directory are returned unchanged.
+    private func homeRelativeCommand(_ absolutePath: String) -> String {
+        let home = homeDirectory.standardizedFileURL.path
+        let normalizedHome = home.hasSuffix("/") ? String(home.dropLast()) : home
+        if absolutePath == normalizedHome { return "~" }
+        let prefix = normalizedHome + "/"
+        guard absolutePath.hasPrefix(prefix) else { return absolutePath }
+        return "~/" + absolutePath.dropFirst(prefix.count)
+    }
+
     private struct CommandContribution {
         let rawPath: String
         let command: String
@@ -437,8 +496,13 @@ public actor ClaudeSettingsInstaller: ClaudeSettingsInstalling {
     }
 
     private static func shellEscapedCommand(_ raw: String) -> String {
+        // `~` is in the safe set so a clean home-relative path
+        // (`~/.local/share/workspaces/hook-forwarders/event-forwarder.sh`) stays
+        // unquoted — quoting would defeat tilde expansion. A tilde path that also
+        // contains a space or other unsafe scalar still falls through to quoting;
+        // it cannot occur for the controlled extraction dir, but the guard holds.
         let safeScalars = CharacterSet(
-            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_@%+=:,./-"
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_@%+=:,./-~"
         )
         if raw.unicodeScalars.allSatisfy({ safeScalars.contains($0) }) {
             return raw

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerHomeRelativeCommandTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerHomeRelativeCommandTests.swift
@@ -1,0 +1,207 @@
+//
+//  ClaudeSettingsInstallerHomeRelativeCommandTests.swift
+//  WorkspaceManagerTests
+//
+//  Verifies the installer emits machine-agnostic, tilde-relative, unquoted hook
+//  and status-line commands, and migrates opted-in users off the older
+//  machine-specific absolute paths. Keeping committed-form == runtime-form is what
+//  stops `~/.claude` from going dirty and silently skipping the auto-deploy.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("ClaudeSettingsInstaller home-relative command")
+struct ClaudeSettingsInstallerHomeRelativeCommandTests {
+    private static let eventForwarderRelative =
+        ".local/share/workspaces/hook-forwarders/event-forwarder.sh"
+    private static let statusLineRelative =
+        ".local/share/workspaces/hook-forwarders/statusline.sh"
+    private static let expectedEventCommand =
+        "~/.local/share/workspaces/hook-forwarders/event-forwarder.sh"
+    private static let expectedStatusCommand =
+        "~/.local/share/workspaces/hook-forwarders/statusline.sh"
+
+    private func makeTempHome() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wm-tilde-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func installer(home: URL) -> ClaudeSettingsInstaller {
+        ClaudeSettingsInstaller(
+            homeDirectory: home,
+            eventForwarderScriptPath:
+                home.appendingPathComponent(Self.eventForwarderRelative).path,
+            statusLineForwarderPath:
+                home.appendingPathComponent(Self.statusLineRelative).path
+        )
+    }
+
+    private func settingsURL(home: URL) -> URL {
+        home.appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("settings.json")
+    }
+
+    private func seedSettings(_ object: [String: Any], home: URL) throws {
+        let claudeDir = home.appendingPathComponent(".claude", isDirectory: true)
+        try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted])
+            .write(to: settingsURL(home: home))
+    }
+
+    private func readJSON(_ url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+    }
+
+    private func eventHandlers(in updated: [String: Any], event: String) -> [[String: Any]] {
+        let hooks = updated["hooks"] as? [String: Any] ?? [:]
+        let groups = hooks[event] as? [[String: Any]] ?? []
+        return groups.flatMap { ($0["hooks"] as? [[String: Any]]) ?? [] }
+    }
+
+    private func eventCommands(in updated: [String: Any], event: String) -> [String] {
+        eventHandlers(in: updated, event: event).compactMap { $0["command"] as? String }
+    }
+
+    @Test("Emitted event-forwarder command is the tilde path with no leading /Users and no quotes")
+    func emitsTildeEventCommand() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let installer = installer(home: home)
+        try await installer.install()
+
+        let updated = try readJSON(settingsURL(home: home))
+        let commands = eventCommands(in: updated, event: "Stop")
+        #expect(commands.contains(Self.expectedEventCommand))
+        #expect(commands.allSatisfy { !$0.hasPrefix("/Users/") })
+        #expect(commands.allSatisfy { !$0.hasPrefix("'") })
+    }
+
+    @Test("Emitted statusLine command is the tilde path, unquoted")
+    func emitsTildeStatusLineCommand() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let installer = installer(home: home)
+        try await installer.install()
+
+        let block = try readJSON(settingsURL(home: home))["statusLine"] as? [String: Any] ?? [:]
+        #expect(block["command"] as? String == Self.expectedStatusCommand)
+    }
+
+    @Test("Installing twice is byte-identical and reports isInstalled")
+    func idempotentNoDrift() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let installer = installer(home: home)
+        try await installer.install()
+        let first = try Data(contentsOf: settingsURL(home: home))
+        try await installer.install()
+        let second = try Data(contentsOf: settingsURL(home: home))
+
+        #expect(first == second)
+        #expect(await installer.isInstalled())
+    }
+
+    @Test("Settings already carrying the generic command report isInstalled without a write")
+    func preinstalledGenericCommandIsClean() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        // Produce the canonical file once, then assert a fresh installer sees it
+        // as already-installed (the property that keeps the dotclaude tree clean).
+        try await installer(home: home).install()
+        let canonical = try Data(contentsOf: settingsURL(home: home))
+
+        let fresh = installer(home: home)
+        #expect(await fresh.isInstalled())
+        #expect(try Data(contentsOf: settingsURL(home: home)) == canonical)
+    }
+
+    @Test("Migrates quoted and unquoted Application Support event-forwarder paths to the tilde command")
+    func migratesLegacyApplicationSupportPaths() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let unquoted =
+            "/Users/test/Library/Application Support/com.cloudcompute.workspaces/HookForwarders/event-forwarder.sh"
+        let quoted = "'\(unquoted)'"
+        try seedSettings(
+            [
+                "hooks": [
+                    "PreToolUse": [
+                        ["hooks": [["type": "command", "command": quoted, "async": true]]]
+                    ],
+                    "Stop": [
+                        ["hooks": [["type": "command", "command": unquoted, "async": true]]]
+                    ],
+                ]
+            ],
+            home: home
+        )
+
+        let installer = installer(home: home)
+        try await installer.install()
+
+        let updated = try readJSON(settingsURL(home: home))
+        for event in ["PreToolUse", "Stop"] {
+            let commands = eventCommands(in: updated, event: event)
+            #expect(commands.contains(Self.expectedEventCommand))
+            #expect(commands.contains(quoted) == false)
+            #expect(commands.contains(unquoted) == false)
+        }
+        #expect(await installer.isInstalled())
+    }
+
+    @Test("Migrates a stale .build bundle statusline path to the tilde command")
+    func migratesLegacyBuildStatusLinePath() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let buildStatusLine =
+            "/Users/fairchild/.codex/worktrees/6954/.build/arm64-apple-macosx/debug/WorkspaceManager_WorkspaceManager.bundle/HookForwarders/statusline.sh"
+        try seedSettings(
+            ["statusLine": ["type": "command", "command": buildStatusLine, "refreshInterval": 5000]],
+            home: home
+        )
+
+        let installer = installer(home: home)
+        try await installer.install()
+
+        let block = try readJSON(settingsURL(home: home))["statusLine"] as? [String: Any] ?? [:]
+        #expect(block["command"] as? String == Self.expectedStatusCommand)
+        #expect(await installer.isInstalled())
+    }
+
+    @Test("Preserves a user-owned event-forwarder.sh outside the HookForwarders convention")
+    func preservesUnrelatedUserForwarder() async throws {
+        let home = makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let userHook = "/Users/test/bin/event-forwarder.sh"
+        try seedSettings(
+            [
+                "hooks": [
+                    "Stop": [
+                        ["hooks": [["type": "command", "command": userHook, "async": true]]]
+                    ]
+                ]
+            ],
+            home: home
+        )
+
+        let installer = installer(home: home)
+        try await installer.install()
+
+        let commands = eventCommands(in: try readJSON(settingsURL(home: home)), event: "Stop")
+        #expect(commands.contains(userHook))
+        #expect(commands.contains(Self.expectedEventCommand))
+    }
+}

--- a/docs/decisions/hook-forwarder-command-shape.md
+++ b/docs/decisions/hook-forwarder-command-shape.md
@@ -1,0 +1,47 @@
+---
+status: decided
+date: 2026-06-06
+decision: tilde-relative-unquoted-stable-dir
+related:
+  - docs/development/claude-code-integration.md
+---
+
+# Hook / Status-Line Forwarder Command Shape
+
+## Decision
+
+**Any hook or `statusLine` command the WorkSpaces app writes into `~/.claude/settings.json` must be machine-agnostic: a tilde-relative, unquoted path, extracted to a stable, space-free directory.** The canonical dir is `~/.local/share/workspaces/hook-forwarders/` (honoring `XDG_DATA_HOME`), deliberately outside `~/.claude` so an extracted script never dirties the dotclaude git tree.
+
+Concretely, both channels emit:
+
+```text
+~/.local/share/workspaces/hook-forwarders/event-forwarder.sh
+~/.local/share/workspaces/hook-forwarders/statusline.sh
+```
+
+— no leading `/Users/...`, no surrounding quotes, identical bytes on every machine.
+
+## The problem it solves
+
+The app writes machine-specific absolute paths into a globally-synced file and rewrites them at every launch, so the committed config in the `dotclaude` repo can never match the runtime config. That permanent mismatch keeps `~/.claude` dirty, which makes the `SessionStart` auto-deploy fast-forward silently skip. Two drift axes existed, both rooted in machine-specific absolute paths:
+
+1. **Hooks** — `event-forwarder.sh` extracted under `~/Library/Application Support/.../HookForwarders/`. The space in `Application Support` forced single-quoting, so committed-unquoted ≠ runtime-quoted.
+2. **Status line** — `statusLine.command` pointed straight at the build bundle path, a dev-worktree `.build` artifact that does not exist on a fresh machine and changes with every build location.
+
+## Why tilde-relative + unquoted
+
+- `~/...` is identical bytes for every user, so it is committable and never drifts.
+- Tilde expansion is **not** subject to field splitting, so the path expands cleanly even when the home directory contains a space. That removes the very quoting need that caused the original bug — a space-free dir under `~` never has to be quoted.
+- The cheap `exit 0` no-op stays bash; these hooks fire on every tool call in every Claude session machine-wide, so a CLI subcommand or per-call AppKit cold-start would tax every session. Zero PATH dependency.
+
+## Why not the alternatives
+
+- **Quote the absolute path** (the original symptom fix): keeps the machine-specific prefix, so the committed/runtime forms still differ — drift continues.
+- **A CLI subcommand** (`workspaces hook forward`): adds a PATH dependency and a heavier per-tool-call no-op for a path that runs on every event in every session.
+- **A daemon**: off-target. The in-app `NWListener` is already a daemon-while-running; the command string is just how Claude reaches it.
+
+## Implementation notes
+
+- `shellEscapedCommand` keeps a clean tilde path verbatim — `~` is in the safe-scalar set — and still quotes anything carrying a space or other unsafe scalar. A tilde path with a space would still be quoted (and would break expansion), but that cannot occur for the controlled, space-free extraction dir; the guard holds regardless.
+- The installer migrates opted-in users by scrubbing any prior machine-specific event-forwarder command (an `Application Support` path or a `.build` bundle path, quoted or unquoted, ending in `HookForwarders/event-forwarder.sh`) and overwriting any prior `statusLine.command`, so everyone converges to the generic command on next launch.
+- Idempotency is the property that actually keeps the tree clean: installing twice produces byte-identical `settings.json`, and a file already carrying the generic command reports `isInstalled() == true` with no write.

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -103,14 +103,29 @@ X-WorkSpaces-Host-Session-ID: <uuid>
 The listener decodes with `ClaudeHookTranslator.decodeAgentEvent(from:)` and
 applies the resulting `AgentEvent` to the registry with origin `.hook`.
 
+The app extracts `event-forwarder.sh` to a stable, space-free directory —
+`~/.local/share/workspaces/hook-forwarders/` (honoring `XDG_DATA_HOME`) — and
+writes a tilde-relative, unquoted command into `settings.json`. The path is
+identical on every machine, so the committed dotclaude config matches the runtime
+config and `~/.claude` stops going dirty. See § "Settings Installer" for why the
+command shape matters and `docs/decisions/hook-forwarder-command-shape.md` for the
+rule.
+
 The old `type: "http"` plus `http+unix://...` transport is not used. Real Claude
 Code does not speak that URL scheme. The installer still scrubs only the old
 WorkSpaces-owned `http+unix://.../hooks-<pid>.sock/event` handlers so opted-in
-users self-heal without deleting user-owned Unix-socket hooks.
+users self-heal without deleting user-owned Unix-socket hooks. It also replaces
+any prior machine-specific event-forwarder command (an `Application Support` path
+or a `.build` bundle path, quoted or unquoted, ending in
+`HookForwarders/event-forwarder.sh`) with the generic tilde command.
 
 ## Channel 2: Status-Line Forwarder
 
-Script: `Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh`.
+Script: `Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh`,
+extracted to the same `~/.local/share/workspaces/hook-forwarders/` directory as
+Channel 1 and written to `statusLine.command` as the same tilde-relative,
+unquoted shape. The installer overwrites any prior status-line command, so a
+stale bundle or `.build` path converges to the generic command on next launch.
 
 Claude Code runs it as `statusLine.command`. The script posts status JSON to
 `/statusline` and prints a single space so Claude's own status row stays visually
@@ -188,6 +203,22 @@ owns the complete WorkSpaces patch:
 - `preferredNotifChannel: "iterm2"`
 - migration scrub for old WorkSpaces `http+unix://...hooks-<pid>.sock/event`
 - migration removal for old WorkSpaces `title-emit.sh` hooks
+- migration replacement of machine-specific event-forwarder/status-line paths with
+  the generic tilde command
+
+Both commands the app writes to `~/.claude/settings.json` are **machine-agnostic**:
+the extracted script lives in a stable, space-free dir
+(`~/.local/share/workspaces/hook-forwarders/`) and the command is emitted as a
+tilde-relative, **unquoted** path
+(`~/.local/share/workspaces/hook-forwarders/event-forwarder.sh`). Tilde expansion
+is not subject to field splitting, so the path expands cleanly even if the home
+directory contains a space — which removes the quoting that an absolute
+`Application Support` path needed. `shellEscapedCommand` keeps a clean tilde path
+verbatim (it is in the safe-scalar set) and still quotes anything carrying a space
+or other unsafe scalar. Because the committed and runtime forms are byte-identical
+on every machine, `~/.claude` no longer goes dirty from per-launch rewrites and the
+dotclaude auto-deploy stops silently skipping. The rule is captured in
+`docs/decisions/hook-forwarder-command-shape.md`.
 
 The public UI-facing protocol remains:
 
@@ -222,7 +253,10 @@ listener starts dormant and logs that ownership decision. A dormant listener doe
 not remove the owner socket on shutdown.
 
 This avoids pid-scoped socket churn, per-launch settings rewrites, and stale
-paths synced through `~/.claude/`.
+paths synced through `~/.claude/`. The forwarder **commands** the installer writes
+get the same machine-agnostic treatment — a stable, space-free extraction dir plus
+a tilde-relative unquoted path — so the same drift sources cannot reappear through
+`statusLine.command` or the hook command strings. See § "Settings Installer".
 
 ## Production Wiring
 


### PR DESCRIPTION
## What

The app extracted hook forwarders to `~/Library/Application Support/.../HookForwarders/` and wrote **machine-specific absolute paths** into `~/.claude/settings.json`, rewriting them at every launch. The space in `Application Support` forced single-quoting, and `statusLine.command` pointed straight at the build-bundle path (a dev-worktree `.build` artifact). Both made the committed `dotclaude` config diverge from runtime, keeping `~/.claude` permanently dirty so the `SessionStart` auto-deploy fast-forward silently skipped.

This makes both forwarder commands **machine-agnostic**:

- Extract `event-forwarder.sh` **and** `statusline.sh` to a stable, space-free dir — `~/.local/share/workspaces/hook-forwarders/` (honoring `XDG_DATA_HOME`), deliberately outside `~/.claude`.
- Emit a **tilde-relative, unquoted** command for both channels (`~/.local/share/workspaces/hook-forwarders/event-forwarder.sh`). Tilde expansion is not subject to field splitting, so the path stays clean even when the home dir contains a space — removing the quoting that caused the original bug. `~` joins the `shellEscapedCommand` safe set so a clean tilde path is written verbatim.
- **Self-heal:** opted-in users converge on next launch — any prior `Application Support` / `.build` event-forwarder path (quoted or unquoted, ending in `HookForwarders/event-forwarder.sh`) is scrubbed, and the status-line command is overwritten.

Committed form now equals runtime form on every machine, so `~/.claude` stops going dirty and the auto-deploy resumes.

This supersedes the symptom fix in `fairchild/dotclaude#207` (which quoted the absolute path, fixing only Channel 1). After this ships and the updated app rewrites `settings.json`, committing the generic tilde form to dotclaude permanently ends both drift axes.

## Why this shape

See the new ADR `docs/decisions/hook-forwarder-command-shape.md` — tilde-relative + unquoted + stable space-free dir, with the field-splitting and no-op-perf rationale (not a CLI subcommand, not a daemon).

## Changes

- `ClaudeIntegrationLifecycle.swift` — extraction dir → `hookForwarderInstallDirectory()`; `extractStatusLineForwarderScript()` makes Channel 2 symmetric with Channel 1.
- `ClaudeSettingsInstaller.swift` — `homeRelativeCommand()`, tilde-aware `shellEscapedCommand`, legacy event-forwarder scrub for both channels.
- Tests, docs (`claude-code-integration.md`), ADR, CHANGELOG.

## Mergeability

- Surface: desktop (macOS app, Claude Code settings installer) + docs
- User-facing behavior changed: No visible UI change. Opted-in Claude-integration users get machine-agnostic, tilde-relative commands in `~/.claude/settings.json` and forwarder scripts relocated to `~/.local/share/workspaces/hook-forwarders/` on next launch via a self-healing migration; non-opted-in users see nothing.
- Non-happy paths considered: extraction failure leaves the channel dormant (existing behavior, logged); legacy quoted and unquoted `Application Support` paths plus stale `.build` status-line paths are scrubbed and migrated; home dirs containing spaces are handled by unquoted tilde expansion; unrelated user-owned forwarder hooks are preserved; install is idempotent (byte-identical settings.json on re-run, so `~/.claude` stays clean).
- Release/ops preconditions: None — no release-sensitive files touched.
- Residual risk or follow-up: Low risk; the socket transport is unchanged and the migration/idempotency paths are covered by the new test suite. Follow-up: once this ships and the updated app rewrites `settings.json`, commit the generic tilde form to `dotclaude` to supersede `#207` and close both drift axes.

## Tests

- New suite `ClaudeSettingsInstaller home-relative command`: tilde emission for both channels, idempotency/no-drift, migration from quoted + unquoted `Application Support` paths and a `.build` bundle status-line path, preservation of unrelated user forwarders.
- Full suite: **801 tests / 131 suites pass**. `swift build` clean. `swift-format lint --strict` clean.

## Evidence

Logic/config-only change with no UI surface — evidence is the test summary (build + lint + 802-test suite + the new home-relative-command suite):

![hook-forwarder-generic-path](https://evidence.cloudcompute.com/workspaces/pr-621/20260607-041824-hook-forwarder-generic-path.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
