### PR TITLE
feat: terminal color theme switcher

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,14 @@ _Avoid_: Log, history, activity feed, audit trail
 The last shell command observed in a **Terminal Session** — its exit code, duration, and whether it is still running. Sourced from OSC 133 prompt marks or an equivalent shell hook.
 _Avoid_: Exit status, shell result, return code
 
+**Terminal Theme**:
+The color scheme applied to **Terminal Sessions**, expressed as a light/dark pair of named Ghostty themes. The active half follows the macOS appearance.
+_Avoid_: Color scheme (ambiguous with macOS appearance), palette, skin
+
+**Command Palette**:
+WorkSpaces' own keyboard-driven command/finder overlay — the Cmd+P switcher and the Cmd+Shift+P command runner. Distinct from Ghostty's native palette, which WorkSpaces does not render.
+_Avoid_: Quick open, launcher, Ghostty palette
+
 **Diff**:
 A unified `git diff` for a single file in a **Workspace**, structured as hunks of context / added / removed lines. The Changes tab of the **Detail Pane** renders it inline.
 _Avoid_: Patch, changeset, edit

--- a/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
+++ b/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
@@ -28,6 +28,7 @@ enum AppChromeShortcut: CaseIterable {
     case openInEditor
     case settings
     case workspaceSwitcher
+    case commandRunner
 
     private var definition: AppChromeShortcutDefinition {
         switch self {
@@ -56,6 +57,12 @@ enum AppChromeShortcut: CaseIterable {
             return AppChromeShortcutDefinition(keyString: ",", modifiers: [.command], defaultRoute: .appChrome)
         case .workspaceSwitcher:
             return AppChromeShortcutDefinition(keyString: "p", modifiers: [.command], defaultRoute: .appChrome)
+        case .commandRunner:
+            return AppChromeShortcutDefinition(
+                keyString: "p",
+                modifiers: [.command, .shift],
+                defaultRoute: .appChrome
+            )
         }
     }
 

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -211,6 +211,15 @@ struct WorkspaceManagerApp: App {
                     modifiers: AppChromeShortcut.workspaceSwitcher.eventModifiers
                 )
                 .disabled(!appCommandState.mainWindowAvailability.canOpenCommandPalette)
+
+                Button("Terminal Theme...") {
+                    appCommandState.perform(.openCommandRunner)
+                }
+                .keyboardShortcut(
+                    AppChromeShortcut.commandRunner.keyEquivalent,
+                    modifiers: AppChromeShortcut.commandRunner.eventModifiers
+                )
+                .disabled(!appCommandState.mainWindowAvailability.canOpenCommandRunner)
             }
 
             SidebarCommands()
@@ -641,6 +650,7 @@ struct MainWindowFocusedActions {
     var revealInFinder: Action? = nil
     var copyPath: Action? = nil
     var openCommandPalette: Action? = nil
+    var openCommandRunner: Action? = nil
 
     @MainActor static let empty = MainWindowFocusedActions()
 }
@@ -660,6 +670,7 @@ struct MainWindowCommandAvailability: Equatable {
     let canRevealInFinder: Bool
     let canCopyPath: Bool
     let canOpenCommandPalette: Bool
+    let canOpenCommandRunner: Bool
 
     static let empty = MainWindowCommandAvailability(
         canToggleSidebar: false,
@@ -675,7 +686,8 @@ struct MainWindowCommandAvailability: Equatable {
         canOpenDesktop: false,
         canRevealInFinder: false,
         canCopyPath: false,
-        canOpenCommandPalette: false
+        canOpenCommandPalette: false,
+        canOpenCommandRunner: false
     )
 }
 
@@ -694,6 +706,7 @@ enum MainWindowCommand {
     case revealInFinder
     case copyPath
     case openCommandPalette
+    case openCommandRunner
 }
 
 @MainActor
@@ -758,6 +771,8 @@ final class AppCommandState: ObservableObject {
             mainWindowActions.copyPath?()
         case .openCommandPalette:
             mainWindowActions.openCommandPalette?()
+        case .openCommandRunner:
+            mainWindowActions.openCommandRunner?()
         }
     }
 }

--- a/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
@@ -37,6 +37,12 @@ final class GhosttyAppManager: NSObject {
     private var initialized = false
     private var currentColorScheme: ghostty_color_scheme_e?
 
+    /// Live surfaces, weakly held, so a Terminal Theme change can be broadcast
+    /// to every open terminal via `ghostty_surface_update_config`. Weak objects
+    /// drop automatically when a `GhosttySurfaceView` deallocates, so a stale
+    /// entry can never be visited.
+    private let surfaceViews = NSHashTable<GhosttySurfaceView>.weakObjects()
+
     private override init() {
         super.init()
     }
@@ -69,12 +75,10 @@ final class GhosttyAppManager: NSObject {
             return
         }
 
-        guard let config = ghostty_config_new() else {
-            NSLog("[GhosttyAppManager] ghostty_config_new failed")
+        guard let config = makeConfig(for: GhosttyThemePersistence.load()) else {
+            NSLog("[GhosttyAppManager] failed to build initial Ghostty config")
             return
         }
-
-        ghostty_config_finalize(config)
         self.config = config
 
         var runtimeConfig = GhosttyRuntimeConfigFactory.make(userdata: Unmanaged.passUnretained(self).toOpaque())
@@ -115,6 +119,64 @@ final class GhosttyAppManager: NSObject {
 
         ghostty_app_set_color_scheme(app, colorSchemeToApply)
         currentColorScheme = colorSchemeToApply
+    }
+
+    // MARK: Surface registry
+
+    func registerSurface(_ view: GhosttySurfaceView) {
+        surfaceViews.add(view)
+    }
+
+    func unregisterSurface(_ view: GhosttySurfaceView) {
+        surfaceViews.remove(view)
+    }
+
+    // MARK: Terminal Theme
+
+    /// Apply a light/dark Terminal Theme pair to the app and every live surface
+    /// without recreating surfaces (scrollback is preserved). Mirrors the real
+    /// Ghostty reload-config path: rebuild a fresh config from the app-owned
+    /// file, broadcast it via `ghostty_app_update_config` /
+    /// `ghostty_surface_update_config`, then free the previous config.
+    ///
+    /// Callers persist the selection separately; this only drives the live
+    /// apply, so it serves both committed changes and transient previews.
+    func applyTheme(lightTheme: String, darkTheme: String) {
+        guard initialized, let app else { return }
+        let pair = GhosttyThemePersistence.Pair(lightTheme: lightTheme, darkTheme: darkTheme)
+        guard let newConfig = makeConfig(for: pair) else { return }
+
+        ghostty_app_update_config(app, newConfig)
+        for view in surfaceViews.allObjects {
+            guard let surface = view.surface else { continue }
+            ghostty_surface_update_config(surface, newConfig)
+        }
+
+        if let previous = config {
+            ghostty_config_free(previous)
+        }
+        config = newConfig
+    }
+
+    /// Build a finalized `ghostty_config_t` for the given theme pair. When a
+    /// theme is selected, the app-owned config file is (re)written and loaded;
+    /// when nothing is selected, a bare config preserves Ghostty's default.
+    private func makeConfig(for pair: GhosttyThemePersistence.Pair) -> ghostty_config_t? {
+        guard let config = ghostty_config_new() else {
+            NSLog("[GhosttyAppManager] ghostty_config_new failed")
+            return nil
+        }
+
+        let writeResult = try? GhosttyThemeConfig.writeConfigFile(
+            lightTheme: pair.lightTheme,
+            darkTheme: pair.darkTheme
+        )
+        if let url = writeResult.flatMap({ $0 }) {
+            ghostty_config_load_file(config, url.path)
+        }
+
+        ghostty_config_finalize(config)
+        return config
     }
 
     @objc private func keyboardSelectionDidChange(_ notification: Notification) {

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -85,6 +85,8 @@ final class GhosttySurfaceView: NSView {
 
     deinit {
         MainActor.assumeIsolated {
+            GhosttyAppManager.shared.unregisterSurface(self)
+
             if let eventMonitor {
                 NSEvent.removeMonitor(eventMonitor)
                 self.eventMonitor = nil
@@ -287,6 +289,7 @@ final class GhosttySurfaceView: NSView {
         }
 
         surface = createdSurface
+        GhosttyAppManager.shared.registerSurface(self)
         updateScaleAndSize()
         applySystemColorSchemeIfNeeded(force: true)
         readinessDiagnostics.markSurfaceCreateSucceeded()

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemeCatalog.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemeCatalog.swift
@@ -37,7 +37,7 @@ enum GhosttyThemeCatalog {
         "Nightfox",
         "Dayfox",
         "Ayu Light",
-        "Snazzy"
+        "Snazzy",
     ]
 
     /// Built-in fallback used to fill an unspecified slot so the dual
@@ -68,7 +68,8 @@ enum GhosttyThemeCatalog {
                 .filter { !$0.isEmpty && !$0.hasPrefix(".") }
         )
 
-        return names
+        return
+            names
             .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             .map(GhosttyTheme.init(name:))
     }
@@ -77,7 +78,8 @@ enum GhosttyThemeCatalog {
     /// not actually present.
     static func featured(in all: [GhosttyTheme]) -> [GhosttyTheme] {
         let present = Set(all.map(\.name))
-        return featuredNames
+        return
+            featuredNames
             .filter { present.contains($0) }
             .map(GhosttyTheme.init(name:))
     }
@@ -106,7 +108,8 @@ enum GhosttyThemeCatalog {
             return (theme, 1)
         }
 
-        return scored
+        return
+            scored
             .sorted { lhs, rhs in
                 if lhs.tier != rhs.tier { return lhs.tier < rhs.tier }
                 return lhs.theme.name.localizedCaseInsensitiveCompare(rhs.theme.name) == .orderedAscending

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemeCatalog.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemeCatalog.swift
@@ -1,0 +1,151 @@
+//
+//  GhosttyThemeCatalog.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+/// A bundled Ghostty color theme. The file name *is* the value Ghostty accepts
+/// for its `theme = ` config key, so `name` doubles as the stable identifier.
+struct GhosttyTheme: Identifiable, Hashable, Sendable {
+    let name: String
+    var id: String { name }
+}
+
+/// Enumerates the iTerm2-derived themes Ghostty bundles under
+/// `<resources>/ghostty/themes/`, with a curated **Featured** set pinned on top.
+///
+/// Pure and directory-injectable: enumeration takes an explicit directory so it
+/// can be tested against a fixture without the app bundle. Ranking mirrors the
+/// command palette's `SwitchableIndex` philosophy (prefix > substring > other)
+/// but sorts alphabetically within a tier, which reads better for a name list.
+enum GhosttyThemeCatalog {
+    /// Curated, ordered short list surfaced first in pickers. Only entries that
+    /// exist on disk are shown, so this may name themes liberally — a missing
+    /// name is silently skipped rather than rendered as a dead row.
+    static let featuredNames: [String] = [
+        "Catppuccin Mocha",
+        "Catppuccin Latte",
+        "Nord",
+        "Dracula",
+        "Gruvbox Dark",
+        "Gruvbox Light",
+        "tokyonight",
+        "Solarized Dark Higher Contrast",
+        "GitHub Dark",
+        "Kanagawa Wave",
+        "Nightfox",
+        "Dayfox",
+        "Ayu Light",
+        "Snazzy"
+    ]
+
+    /// Built-in fallback used to fill an unspecified slot so the dual
+    /// `light:…,dark:…` form stays valid (Ghostty rejects a single-sided pair).
+    static let defaultLightName = "Builtin Light"
+    static let defaultDarkName = "Builtin Dark"
+
+    /// All themes found in `themesDirectory`, de-duplicated and sorted
+    /// case-insensitively by name. Hidden/dot files are ignored.
+    static func themes(
+        in themesDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [GhosttyTheme] {
+        guard
+            let entries = try? fileManager.contentsOfDirectory(
+                at: themesDirectory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            return []
+        }
+
+        let names = Set(
+            entries
+                .filter { (try? $0.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true }
+                .map { $0.lastPathComponent }
+                .filter { !$0.isEmpty && !$0.hasPrefix(".") }
+        )
+
+        return names
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            .map(GhosttyTheme.init(name:))
+    }
+
+    /// The featured subset of `all`, in curated order, omitting any that are
+    /// not actually present.
+    static func featured(in all: [GhosttyTheme]) -> [GhosttyTheme] {
+        let present = Set(all.map(\.name))
+        return featuredNames
+            .filter { present.contains($0) }
+            .map(GhosttyTheme.init(name:))
+    }
+
+    /// Case-insensitive substring match against the theme name.
+    static func matches(_ theme: GhosttyTheme, query: String) -> Bool {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        return theme.name.localizedCaseInsensitiveContains(trimmed)
+    }
+
+    /// Filter `themes` by `query` and rank: title-prefix matches first, then
+    /// substring matches, then any remaining matches; alphabetical within each
+    /// tier. An empty query returns every theme alphabetically.
+    static func rank(_ themes: [GhosttyTheme], query: String) -> [GhosttyTheme] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return themes }
+
+        let lowerQuery = trimmed.lowercased()
+        let scored: [(theme: GhosttyTheme, tier: Int)] = themes.compactMap { theme in
+            let lowerName = theme.name.lowercased()
+            guard lowerName.contains(lowerQuery) else { return nil }
+            if lowerName.hasPrefix(lowerQuery) {
+                return (theme, 0)
+            }
+            return (theme, 1)
+        }
+
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.tier != rhs.tier { return lhs.tier < rhs.tier }
+                return lhs.theme.name.localizedCaseInsensitiveCompare(rhs.theme.name) == .orderedAscending
+            }
+            .map(\.theme)
+    }
+
+    /// Resolve `<resources>/ghostty/themes` using the same locator that feeds
+    /// terminfo, so dev (env var) and release (bundled) share one resolution.
+    static func resolvedThemesDirectory(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        GhosttyResourcesLocator.resolvedResourcesDirectory(
+            existingEnvironmentValue: environment[GhosttyResourcesLocator.environmentVariableName],
+            resourcesURL: bundle.resourceURL,
+            fileManager: fileManager
+        )?
+        .appendingPathComponent("themes", isDirectory: true)
+    }
+
+    /// Convenience: all bundled themes resolved via `resolvedThemesDirectory`.
+    /// Returns an empty list when resources are unavailable (e.g. a dev build
+    /// launched without `GHOSTTY_RESOURCES_DIR`).
+    static func bundledThemes(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) -> [GhosttyTheme] {
+        guard
+            let directory = resolvedThemesDirectory(
+                environment: environment,
+                bundle: bundle,
+                fileManager: fileManager
+            )
+        else {
+            return []
+        }
+        return themes(in: directory, fileManager: fileManager)
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemeConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemeConfig.swift
@@ -1,0 +1,93 @@
+//
+//  GhosttyThemeConfig.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+/// Generates and writes the app-owned Ghostty config file that carries the
+/// Terminal Theme. The file is isolated from the user's `~/.config/ghostty`
+/// (we never load that) and contains only a `theme = light:…,dark:…` line.
+///
+/// String generation is pure so it can be unit-tested; file placement follows
+/// the `WORKSPACES_DATA_DIR` convention, falling back to the app support dir.
+enum GhosttyThemeConfig {
+    static let configFileName = "workspaces.config"
+
+    /// The value for Ghostty's `theme` key, or nil when neither slot is set.
+    ///
+    /// An unset slot is filled with the built-in fallback so the dual
+    /// `light:…,dark:…` form stays valid — Ghostty rejects a single-sided pair
+    /// such as `light:foo` with `error.InvalidValue`.
+    static func themeValue(lightTheme: String, darkTheme: String) -> String? {
+        let light = lightTheme.trimmingCharacters(in: .whitespacesAndNewlines)
+        let dark = darkTheme.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !(light.isEmpty && dark.isEmpty) else { return nil }
+        let resolvedLight = light.isEmpty ? GhosttyThemeCatalog.defaultLightName : light
+        let resolvedDark = dark.isEmpty ? GhosttyThemeCatalog.defaultDarkName : dark
+        return "light:\(resolvedLight),dark:\(resolvedDark)"
+    }
+
+    /// The full contents of the app-owned config file, or nil when nothing is
+    /// selected (so the caller can preserve Ghostty's bare default behavior).
+    static func configContents(lightTheme: String, darkTheme: String) -> String? {
+        guard let value = themeValue(lightTheme: lightTheme, darkTheme: darkTheme) else { return nil }
+        return "theme = \(value)\n"
+    }
+
+    /// `<dataDir>/ghostty/<configFileName>` — app-owned and isolated.
+    static func configFileURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try resolveDataDirectory(environment: environment, fileManager: fileManager)
+            .appendingPathComponent("ghostty", isDirectory: true)
+            .appendingPathComponent(configFileName, isDirectory: false)
+    }
+
+    /// Write (or clear) the app-owned config file for the given pair.
+    ///
+    /// Returns the file URL when a theme line was written, or nil when nothing
+    /// is selected — in which case any stale file is removed so a later bare
+    /// config rebuild reflects the cleared selection. The parent directory is
+    /// created on demand.
+    @discardableResult
+    static func writeConfigFile(
+        lightTheme: String,
+        darkTheme: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) throws -> URL? {
+        let url = try configFileURL(environment: environment, fileManager: fileManager)
+        guard let contents = configContents(lightTheme: lightTheme, darkTheme: darkTheme) else {
+            try? fileManager.removeItem(at: url)
+            return nil
+        }
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private static func resolveDataDirectory(
+        environment: [String: String],
+        fileManager: FileManager
+    ) throws -> URL {
+        if let raw = environment["WORKSPACES_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        {
+            let expanded = (raw as NSString).expandingTildeInPath
+            return URL(fileURLWithPath: expanded, isDirectory: true)
+        }
+
+        let appSupport = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return appSupport.appendingPathComponent("WorkspaceManager", isDirectory: true)
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemePersistence.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemePersistence.swift
@@ -1,0 +1,38 @@
+//
+//  GhosttyThemePersistence.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+/// UserDefaults-backed storage of the selected light/dark Terminal Theme pair.
+///
+/// Pure read/write helpers so `GhosttyThemeStore` (the observable both entry
+/// points bind to) and `GhosttyAppManager` (which builds the initial config at
+/// startup) share one source of truth without a dependency cycle. An empty
+/// string means "no selection" for that slot.
+enum GhosttyThemePersistence {
+    static let lightThemeKey = "terminalThemeLight"
+    static let darkThemeKey = "terminalThemeDark"
+
+    struct Pair: Equatable, Sendable {
+        var lightTheme: String
+        var darkTheme: String
+
+        static let empty = Pair(lightTheme: "", darkTheme: "")
+
+        var hasSelection: Bool { !lightTheme.isEmpty || !darkTheme.isEmpty }
+    }
+
+    static func load(from defaults: UserDefaults = .standard) -> Pair {
+        Pair(
+            lightTheme: defaults.string(forKey: lightThemeKey) ?? "",
+            darkTheme: defaults.string(forKey: darkThemeKey) ?? ""
+        )
+    }
+
+    static func save(_ pair: Pair, to defaults: UserDefaults = .standard) {
+        defaults.set(pair.lightTheme, forKey: lightThemeKey)
+        defaults.set(pair.darkTheme, forKey: darkThemeKey)
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemePersistence.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemePersistence.swift
@@ -14,6 +14,7 @@ import Foundation
 enum GhosttyThemePersistence {
     static let lightThemeKey = "terminalThemeLight"
     static let darkThemeKey = "terminalThemeDark"
+    static let recentsKey = "terminalThemeRecents"
 
     struct Pair: Equatable, Sendable {
         var lightTheme: String
@@ -34,5 +35,14 @@ enum GhosttyThemePersistence {
     static func save(_ pair: Pair, to defaults: UserDefaults = .standard) {
         defaults.set(pair.lightTheme, forKey: lightThemeKey)
         defaults.set(pair.darkTheme, forKey: darkThemeKey)
+    }
+
+    /// Recently committed theme names, most-recent-first.
+    static func loadRecents(from defaults: UserDefaults = .standard) -> [String] {
+        defaults.stringArray(forKey: recentsKey) ?? []
+    }
+
+    static func saveRecents(_ recents: [String], to defaults: UserDefaults = .standard) {
+        defaults.set(recents, forKey: recentsKey)
     }
 }

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemeStore.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemeStore.swift
@@ -19,12 +19,16 @@ final class GhosttyThemeStore: ObservableObject {
     @Published private(set) var lightTheme: String
     /// Committed dark theme name. Empty means "no selection" (Ghostty default).
     @Published private(set) var darkTheme: String
+    /// Recently committed theme names, most-recent-first, for quick re-selection.
+    @Published private(set) var recentThemes: [String]
 
     private let defaults: UserDefaults
     private let apply: @MainActor (_ light: String, _ dark: String) -> Void
     /// Debounce window for highlight-driven previews (~40 ms): long enough to
     /// coalesce key-repeat, short enough to feel live. `.zero` applies inline.
     private let debounce: Duration
+    /// How many recently-used themes to remember.
+    private let maxRecents = 8
     private var previewTask: Task<Void, Never>?
     private var isPreviewing = false
 
@@ -41,6 +45,7 @@ final class GhosttyThemeStore: ObservableObject {
         let pair = GhosttyThemePersistence.load(from: defaults)
         self.lightTheme = pair.lightTheme
         self.darkTheme = pair.darkTheme
+        self.recentThemes = GhosttyThemePersistence.loadRecents(from: defaults)
     }
 
     var committedPair: GhosttyThemePersistence.Pair {
@@ -49,14 +54,18 @@ final class GhosttyThemeStore: ObservableObject {
 
     func setLightTheme(_ name: String) {
         commit(GhosttyThemePersistence.Pair(lightTheme: name, darkTheme: darkTheme))
+        recordRecent(name)
     }
 
     func setDarkTheme(_ name: String) {
         commit(GhosttyThemePersistence.Pair(lightTheme: lightTheme, darkTheme: name))
+        recordRecent(name)
     }
 
     func setPair(lightTheme: String, darkTheme: String) {
         commit(GhosttyThemePersistence.Pair(lightTheme: lightTheme, darkTheme: darkTheme))
+        recordRecent(lightTheme)
+        recordRecent(darkTheme)
     }
 
     /// Transiently apply a pair without persisting. Debounced, so arrowing
@@ -96,5 +105,19 @@ final class GhosttyThemeStore: ObservableObject {
         darkTheme = pair.darkTheme
         GhosttyThemePersistence.save(pair, to: defaults)
         apply(pair.lightTheme, pair.darkTheme)
+    }
+
+    /// Move a committed theme to the front of the recents list (deduped, capped).
+    /// The empty "Ghostty Default" sentinel is not a recent.
+    private func recordRecent(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var updated = recentThemes.filter { $0 != trimmed }
+        updated.insert(trimmed, at: 0)
+        if updated.count > maxRecents {
+            updated = Array(updated.prefix(maxRecents))
+        }
+        recentThemes = updated
+        GhosttyThemePersistence.saveRecents(updated, to: defaults)
     }
 }

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemeStore.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemeStore.swift
@@ -1,0 +1,100 @@
+//
+//  GhosttyThemeStore.swift
+//  WorkspaceManager
+//
+
+import Foundation
+
+/// Single backing store for the Terminal Theme, shared by the Settings pickers
+/// and the Cmd+Shift+P command overlay.
+///
+/// Holds the committed light/dark pair (persisted in `UserDefaults`), drives the
+/// live apply through `GhosttyAppManager`, and supports transient, debounced
+/// previews that revert to the committed pair on demand.
+@MainActor
+final class GhosttyThemeStore: ObservableObject {
+    static let shared = GhosttyThemeStore()
+
+    /// Committed light theme name. Empty means "no selection" (Ghostty default).
+    @Published private(set) var lightTheme: String
+    /// Committed dark theme name. Empty means "no selection" (Ghostty default).
+    @Published private(set) var darkTheme: String
+
+    private let defaults: UserDefaults
+    private let apply: @MainActor (_ light: String, _ dark: String) -> Void
+    /// Debounce window for highlight-driven previews (~40 ms): long enough to
+    /// coalesce key-repeat, short enough to feel live. `.zero` applies inline.
+    private let debounce: Duration
+    private var previewTask: Task<Void, Never>?
+    private var isPreviewing = false
+
+    init(
+        defaults: UserDefaults = .standard,
+        debounce: Duration = .milliseconds(40),
+        apply: @escaping @MainActor (_ light: String, _ dark: String) -> Void = { light, dark in
+            GhosttyAppManager.shared.applyTheme(lightTheme: light, darkTheme: dark)
+        }
+    ) {
+        self.defaults = defaults
+        self.debounce = debounce
+        self.apply = apply
+        let pair = GhosttyThemePersistence.load(from: defaults)
+        self.lightTheme = pair.lightTheme
+        self.darkTheme = pair.darkTheme
+    }
+
+    var committedPair: GhosttyThemePersistence.Pair {
+        GhosttyThemePersistence.Pair(lightTheme: lightTheme, darkTheme: darkTheme)
+    }
+
+    func setLightTheme(_ name: String) {
+        commit(GhosttyThemePersistence.Pair(lightTheme: name, darkTheme: darkTheme))
+    }
+
+    func setDarkTheme(_ name: String) {
+        commit(GhosttyThemePersistence.Pair(lightTheme: lightTheme, darkTheme: name))
+    }
+
+    func setPair(lightTheme: String, darkTheme: String) {
+        commit(GhosttyThemePersistence.Pair(lightTheme: lightTheme, darkTheme: darkTheme))
+    }
+
+    /// Transiently apply a pair without persisting. Debounced, so arrowing
+    /// through a long theme list rebuilds the config at most once per window.
+    func preview(lightTheme: String, darkTheme: String) {
+        isPreviewing = true
+        previewTask?.cancel()
+        previewTask = nil
+
+        guard debounce > .zero else {
+            apply(lightTheme, darkTheme)
+            return
+        }
+
+        previewTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: debounce)
+            guard !Task.isCancelled else { return }
+            self.apply(lightTheme, darkTheme)
+        }
+    }
+
+    /// Revert any in-flight or applied preview back to the committed pair.
+    func endPreview() {
+        guard isPreviewing else { return }
+        isPreviewing = false
+        previewTask?.cancel()
+        previewTask = nil
+        apply(lightTheme, darkTheme)
+    }
+
+    private func commit(_ pair: GhosttyThemePersistence.Pair) {
+        previewTask?.cancel()
+        previewTask = nil
+        isPreviewing = false
+        lightTheme = pair.lightTheme
+        darkTheme = pair.darkTheme
+        GhosttyThemePersistence.save(pair, to: defaults)
+        apply(pair.lightTheme, pair.darkTheme)
+    }
+}

--- a/Sources/WorkspaceManager/Views/CommandPalette/CommandPaletteView.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/CommandPaletteView.swift
@@ -9,16 +9,28 @@
 import SwiftUI
 import WorkspaceManagerCore
 
+/// A non-navigational command surfaced in the palette (e.g. "Change Terminal
+/// Theme…"). Seeds the switcher with actions, distinct from items you switch to.
+private struct CommandPaletteAction: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let perform: () -> Void
+}
+
 private enum PaletteRow: SwitchableItem {
     case workspace(WorkspaceSwitchableItem)
     case repo(RepoSwitchableItem)
     case web(WebSourceSwitchableItem)
+    case command(CommandPaletteAction)
 
     var id: String {
         switch self {
         case .workspace(let item): return "ws-\(item.id.uuidString)"
         case .repo(let item): return "repo-\(item.id.uuidString)"
         case .web(let item): return "web-\(item.id.uuidString)"
+        case .command(let action): return "cmd-\(action.id)"
         }
     }
 
@@ -27,6 +39,7 @@ private enum PaletteRow: SwitchableItem {
         case .workspace(let item): return item.title
         case .repo(let item): return item.title
         case .web(let item): return item.title
+        case .command(let action): return action.title
         }
     }
 
@@ -35,6 +48,7 @@ private enum PaletteRow: SwitchableItem {
         case .workspace(let item): return item.subtitle
         case .repo(let item): return item.subtitle
         case .web(let item): return item.subtitle
+        case .command(let action): return action.subtitle
         }
     }
 
@@ -43,6 +57,7 @@ private enum PaletteRow: SwitchableItem {
         case .workspace(let item): return item.indicator
         case .repo(let item): return item.indicator
         case .web(let item): return item.indicator
+        case .command: return .inactive
         }
     }
 
@@ -51,6 +66,8 @@ private enum PaletteRow: SwitchableItem {
         case .workspace(let item): return item.sortKey
         case .repo(let item): return item.sortKey
         case .web(let item): return item.sortKey
+        // Pin commands above recency-sorted items on an empty query.
+        case .command: return .distantFuture
         }
     }
 
@@ -59,6 +76,10 @@ private enum PaletteRow: SwitchableItem {
         case .workspace(let item): return item.matches(query)
         case .repo(let item): return item.matches(query)
         case .web(let item): return item.matches(query)
+        case .command(let action):
+            guard !query.isEmpty else { return true }
+            return action.title.localizedCaseInsensitiveContains(query)
+                || action.subtitle.localizedCaseInsensitiveContains(query)
         }
     }
 
@@ -67,6 +88,7 @@ private enum PaletteRow: SwitchableItem {
         case .workspace(let item): item.activate(context)
         case .repo(let item): item.activate(context)
         case .web(let item): item.activate(context)
+        case .command(let action): action.perform()
         }
     }
 }
@@ -81,6 +103,7 @@ struct CommandPaletteView: View {
     let onSelectRepo: (Repo) -> Void
     let onSelectWebSource: (WebSource) -> Void
     let onDismiss: () -> Void
+    let onOpenThemeSwitcher: () -> Void
 
     @State private var query = ""
     @State private var highlightedIndex = 0
@@ -218,6 +241,7 @@ struct CommandPaletteView: View {
         case .workspace: return "terminal"
         case .repo: return "folder"
         case .web: return "globe"
+        case .command(let action): return action.systemImage
         }
     }
 
@@ -244,7 +268,18 @@ struct CommandPaletteView: View {
         let webRows: [PaletteRow] = webSources.map { source in
             .web(WebSourceSwitchableItem(source: source))
         }
-        return SwitchableIndex.rank(workspaceRows + repoRows + webRows, query: query)
+        let commandRows: [PaletteRow] = [
+            .command(
+                CommandPaletteAction(
+                    id: "change-terminal-theme",
+                    title: "Change Terminal Theme…",
+                    subtitle: "Command · ⇧⌘P",
+                    systemImage: "paintpalette",
+                    perform: onOpenThemeSwitcher
+                )
+            )
+        ]
+        return SwitchableIndex.rank(commandRows + workspaceRows + repoRows + webRows, query: query)
     }
 
     private func waitingDescriptor(for state: AgentRunState?) -> String? {

--- a/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeListView.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeListView.swift
@@ -1,0 +1,270 @@
+//
+//  TerminalThemeListView.swift
+//  WorkspaceManager
+//
+//  Searchable theme list shared by the Settings pickers and the Cmd+Shift+P
+//  command overlay. Featured themes are pinned on top when the query is empty;
+//  typing collapses the list into a single ranked result set. Highlighting a
+//  row previews it live (the host debounces); Enter commits, Esc cancels.
+//
+
+import SwiftUI
+
+struct TerminalThemeListView: View {
+    let allThemes: [GhosttyTheme]
+    let featuredThemes: [GhosttyTheme]
+    /// Currently committed name for the slot being edited ("" = Ghostty default).
+    let currentSelectionName: String
+    /// Whether to offer a "Ghostty Default" row that clears the slot.
+    let showsDefaultRow: Bool
+    /// Live preview of a candidate ("" = default). Called as the highlight moves.
+    let onPreview: (String) -> Void
+    /// Commit a candidate ("" = default).
+    let onCommit: (String) -> Void
+    /// Revert any preview and dismiss without committing.
+    let onCancel: () -> Void
+
+    @State private var query = ""
+    @State private var highlightedID: String?
+    @FocusState private var searchFocused: Bool
+
+    private static let defaultEntryID = "__ghostty_default__"
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchField
+            Divider()
+            resultsList
+        }
+        .onAppear {
+            searchFocused = true
+            highlightedID = initialHighlightID
+        }
+    }
+
+    // MARK: Search field
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search themes", text: $query)
+                .textFieldStyle(.plain)
+                .font(.body)
+                .focused($searchFocused)
+                .onSubmit { commitHighlighted() }
+                .onKeyPress(.downArrow) {
+                    moveHighlight(by: 1)
+                    return .handled
+                }
+                .onKeyPress(.upArrow) {
+                    moveHighlight(by: -1)
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    onCancel()
+                    return .handled
+                }
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .onChange(of: query) { _, _ in
+            highlightedID = orderedSelectableIDs.first
+            previewHighlighted()
+        }
+    }
+
+    // MARK: Results
+
+    @ViewBuilder
+    private var resultsList: some View {
+        let sections = displaySections
+        if sections.allSatisfy({ $0.themes.isEmpty }) && !sections.contains(where: { $0.includesDefault }) {
+            emptyState
+        } else {
+            ScrollViewReader { proxy in
+                List {
+                    ForEach(sections) { section in
+                        Section {
+                            if section.includesDefault {
+                                themeRow(
+                                    id: Self.defaultEntryID,
+                                    title: "Ghostty Default",
+                                    systemImage: "circle.dashed",
+                                    isCurrent: currentSelectionName.isEmpty,
+                                    name: ""
+                                )
+                            }
+                            ForEach(section.themes) { theme in
+                                themeRow(
+                                    id: theme.id,
+                                    title: theme.name,
+                                    systemImage: "paintpalette",
+                                    isCurrent: theme.name == currentSelectionName,
+                                    name: theme.name
+                                )
+                            }
+                        } header: {
+                            if let title = section.header {
+                                Text(title)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .onChange(of: highlightedID) { _, newValue in
+                    guard let newValue else { return }
+                    proxy.scrollTo(newValue, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "paintpalette")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("No themes match “\(query)”")
+                .foregroundStyle(.secondary)
+                .font(.callout)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    @ViewBuilder
+    private func themeRow(
+        id: String,
+        title: String,
+        systemImage: String,
+        isCurrent: Bool,
+        name: String
+    ) -> some View {
+        let isHighlighted = id == highlightedID
+        HStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .foregroundStyle(isHighlighted ? .primary : .secondary)
+                .frame(width: 18)
+            Text(title)
+                .font(.callout.weight(isHighlighted ? .semibold : .regular))
+            Spacer(minLength: 8)
+            if isCurrent {
+                Image(systemName: "checkmark")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .contentShape(Rectangle())
+        .id(id)
+        .onTapGesture {
+            highlightedID = id
+            onCommit(name)
+        }
+        .onHover { hovering in
+            if hovering, highlightedID != id {
+                highlightedID = id
+                onPreview(name)
+            }
+        }
+        .listRowSeparator(.hidden)
+        .listRowBackground(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHighlighted ? Color.accentColor.opacity(0.18) : Color.clear)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+        )
+    }
+
+    // MARK: Section model
+
+    private struct DisplaySection: Identifiable {
+        let id: String
+        let header: String?
+        let includesDefault: Bool
+        let themes: [GhosttyTheme]
+    }
+
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var displaySections: [DisplaySection] {
+        guard trimmedQuery.isEmpty else {
+            return [
+                DisplaySection(
+                    id: "results",
+                    header: nil,
+                    includesDefault: false,
+                    themes: GhosttyThemeCatalog.rank(allThemes, query: query)
+                )
+            ]
+        }
+
+        let featuredNames = Set(featuredThemes.map(\.name))
+        let rest = allThemes.filter { !featuredNames.contains($0.name) }
+        var sections: [DisplaySection] = []
+        sections.append(
+            DisplaySection(id: "featured", header: "Featured", includesDefault: showsDefaultRow, themes: featuredThemes)
+        )
+        sections.append(
+            DisplaySection(id: "all", header: "All Themes", includesDefault: false, themes: rest)
+        )
+        return sections
+    }
+
+    /// Selectable row IDs in display order — drives arrow navigation.
+    private var orderedSelectableIDs: [String] {
+        displaySections.flatMap { section -> [String] in
+            (section.includesDefault ? [Self.defaultEntryID] : []) + section.themes.map(\.id)
+        }
+    }
+
+    private var initialHighlightID: String? {
+        if !currentSelectionName.isEmpty,
+            orderedSelectableIDs.contains(currentSelectionName)
+        {
+            return currentSelectionName
+        }
+        if currentSelectionName.isEmpty, showsDefaultRow {
+            return Self.defaultEntryID
+        }
+        return orderedSelectableIDs.first
+    }
+
+    private func name(forID id: String) -> String {
+        id == Self.defaultEntryID ? "" : id
+    }
+
+    // MARK: Navigation
+
+    private func moveHighlight(by delta: Int) {
+        let ids = orderedSelectableIDs
+        guard !ids.isEmpty else { return }
+        let currentIndex = highlightedID.flatMap { ids.firstIndex(of: $0) } ?? 0
+        let nextIndex = max(0, min(ids.count - 1, currentIndex + delta))
+        highlightedID = ids[nextIndex]
+        previewHighlighted()
+    }
+
+    private func previewHighlighted() {
+        guard let highlightedID else { return }
+        onPreview(name(forID: highlightedID))
+    }
+
+    private func commitHighlighted() {
+        guard let highlightedID else { return }
+        onCommit(name(forID: highlightedID))
+    }
+}

--- a/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeListView.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeListView.swift
@@ -13,6 +13,9 @@ import SwiftUI
 struct TerminalThemeListView: View {
     let allThemes: [GhosttyTheme]
     let featuredThemes: [GhosttyTheme]
+    /// Recently committed theme names, most-recent-first. Pinned in a "Recent"
+    /// section above Featured so the last-used themes are an arrow-key away.
+    var recentThemes: [String] = []
     /// Currently committed name for the slot being edited ("" = Ghostty default).
     let currentSelectionName: String
     /// Whether to offer a "Ghostty Default" row that clears the slot.
@@ -212,11 +215,29 @@ struct TerminalThemeListView: View {
             ]
         }
 
-        let featuredNames = Set(featuredThemes.map(\.name))
-        let rest = allThemes.filter { !featuredNames.contains($0.name) }
+        // Recent first (most-recent-first), then Featured, then everything else.
+        // A theme appears in exactly one section so row IDs stay unique.
+        let byName = Dictionary(allThemes.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        var recent: [GhosttyTheme] = []
+        var recentSeen = Set<String>()
+        for name in recentThemes {
+            guard let theme = byName[name], !recentSeen.contains(name) else { continue }
+            recentSeen.insert(name)
+            recent.append(theme)
+        }
+
+        let featured = featuredThemes.filter { !recentSeen.contains($0.name) }
+        let excluded = recentSeen.union(featured.map(\.name))
+        let rest = allThemes.filter { !excluded.contains($0.name) }
+
         var sections: [DisplaySection] = []
+        if !recent.isEmpty {
+            sections.append(
+                DisplaySection(id: "recent", header: "Recent", includesDefault: false, themes: recent)
+            )
+        }
         sections.append(
-            DisplaySection(id: "featured", header: "Featured", includesDefault: showsDefaultRow, themes: featuredThemes)
+            DisplaySection(id: "featured", header: "Featured", includesDefault: showsDefaultRow, themes: featured)
         )
         sections.append(
             DisplaySection(id: "all", header: "All Themes", includesDefault: false, themes: rest)
@@ -232,15 +253,18 @@ struct TerminalThemeListView: View {
     }
 
     private var initialHighlightID: String? {
-        if !currentSelectionName.isEmpty,
-            orderedSelectableIDs.contains(currentSelectionName)
-        {
+        let ids = orderedSelectableIDs
+        // Prefer the most-recently-used theme so it's a single arrow press away.
+        if let firstRecent = ids.first(where: { recentThemes.contains($0) }) {
+            return firstRecent
+        }
+        if !currentSelectionName.isEmpty, ids.contains(currentSelectionName) {
             return currentSelectionName
         }
         if currentSelectionName.isEmpty, showsDefaultRow {
             return Self.defaultEntryID
         }
-        return orderedSelectableIDs.first
+        return ids.first
     }
 
     private func name(forID id: String) -> String {

--- a/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeOverlay.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeOverlay.swift
@@ -1,0 +1,123 @@
+//
+//  TerminalThemeOverlay.swift
+//  WorkspaceManager
+//
+//  Cmd+Shift+P command overlay, seeded with the Terminal Theme commands. Built
+//  on the same palette pattern as the Cmd+P switcher and structured to grow
+//  into a fuller command runner later. Pick the light or dark slot, search,
+//  preview live on highlight, commit on Enter, revert on Esc.
+//
+
+import AppKit
+import SwiftUI
+
+/// Which half of the light/dark Terminal Theme pair is being edited.
+enum TerminalThemeSlot: String, CaseIterable, Identifiable {
+    case light, dark
+    var id: String { rawValue }
+    var title: String { self == .light ? "Light" : "Dark" }
+}
+
+struct TerminalThemeOverlay: View {
+    @ObservedObject var store: GhosttyThemeStore
+    let onDismiss: () -> Void
+
+    @State private var slot: TerminalThemeSlot = .dark
+    @State private var allThemes: [GhosttyTheme] = []
+    @State private var featuredThemes: [GhosttyTheme] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            TerminalThemeListView(
+                allThemes: allThemes,
+                featuredThemes: featuredThemes,
+                currentSelectionName: currentSelectionName,
+                showsDefaultRow: true,
+                onPreview: preview(_:),
+                onCommit: commit(_:),
+                onCancel: cancel
+            )
+            .id(slot)
+        }
+        .frame(width: 520, height: 460)
+        .background(.thinMaterial)
+        .onAppear {
+            slot = currentAppearanceSlot()
+            loadThemes()
+        }
+        .onChange(of: slot) { _, _ in
+            store.endPreview()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "paintpalette")
+                    .foregroundStyle(.secondary)
+                Text("Terminal Theme")
+                    .font(.headline)
+                Spacer()
+                Picker("Slot", selection: $slot) {
+                    ForEach(TerminalThemeSlot.allCases) { slot in
+                        Text(slot.title).tag(slot)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 150)
+            }
+            Text(slotDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    private var currentSelectionName: String {
+        slot == .light ? store.lightTheme : store.darkTheme
+    }
+
+    private var slotDescription: String {
+        let current = currentSelectionName.isEmpty ? "Ghostty Default" : currentSelectionName
+        var description = "Editing \(slot.title.lowercased()) appearance · current: \(current)"
+        if slot != currentAppearanceSlot() {
+            description += " · preview shows in \(slot.title.lowercased()) mode"
+        }
+        return description
+    }
+
+    private func preview(_ name: String) {
+        switch slot {
+        case .light: store.preview(lightTheme: name, darkTheme: store.darkTheme)
+        case .dark: store.preview(lightTheme: store.lightTheme, darkTheme: name)
+        }
+    }
+
+    private func commit(_ name: String) {
+        switch slot {
+        case .light: store.setLightTheme(name)
+        case .dark: store.setDarkTheme(name)
+        }
+        onDismiss()
+    }
+
+    private func cancel() {
+        store.endPreview()
+        onDismiss()
+    }
+
+    private func currentAppearanceSlot() -> TerminalThemeSlot {
+        let match = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
+        return match == .darkAqua ? .dark : .light
+    }
+
+    private func loadThemes() {
+        let all = GhosttyThemeCatalog.bundledThemes()
+        allThemes = all
+        featuredThemes = GhosttyThemeCatalog.featured(in: all)
+    }
+}

--- a/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeOverlay.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/TerminalThemeOverlay.swift
@@ -33,6 +33,7 @@ struct TerminalThemeOverlay: View {
             TerminalThemeListView(
                 allThemes: allThemes,
                 featuredThemes: featuredThemes,
+                recentThemes: store.recentThemes,
                 currentSelectionName: currentSelectionName,
                 showsDefaultRow: true,
                 onPreview: preview(_:),

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -326,7 +326,8 @@ struct ContentView: View {
             openDesktop: openDesktopFocusedAction,
             revealInFinder: revealInFinderFocusedAction,
             copyPath: copyPathFocusedAction,
-            openCommandPalette: { viewState.isShowingCommandPalette = true }
+            openCommandPalette: { viewState.isShowingCommandPalette = true },
+            openCommandRunner: { viewState.isShowingThemeOverlay = true }
         )
     }
 
@@ -345,7 +346,8 @@ struct ContentView: View {
             canOpenDesktop: openDesktopFocusedAction != nil,
             canRevealInFinder: revealInFinderFocusedAction != nil,
             canCopyPath: copyPathFocusedAction != nil,
-            canOpenCommandPalette: true
+            canOpenCommandPalette: true,
+            canOpenCommandRunner: true
         )
     }
 
@@ -833,7 +835,17 @@ struct ContentView: View {
                     },
                     onDismiss: {
                         viewState.isShowingCommandPalette = false
+                    },
+                    onOpenThemeSwitcher: {
+                        viewState.isShowingCommandPalette = false
+                        viewState.isShowingThemeOverlay = true
                     }
+                )
+            }
+            .sheet(isPresented: $viewState.isShowingThemeOverlay) {
+                TerminalThemeOverlay(
+                    store: .shared,
+                    onDismiss: { viewState.isShowingThemeOverlay = false }
                 )
             }
             .alert(

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
@@ -62,6 +62,7 @@ struct MainWindowViewState {
     var connectingWorkspaceID: UUID?
     var terminalCloseConfirmation: TerminalCloseConfirmation?
     var isShowingCommandPalette = false
+    var isShowingThemeOverlay = false
 }
 
 enum MainWindowOpenInEditorContextKey: Equatable {

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @Environment(\.lumeRuntimeService) private var lumeRuntimeService
     @Environment(\.claudeSettingsInstaller) private var claudeSettingsInstaller
     @EnvironmentObject private var modelStoreStatusController: ModelStoreStatusController
+    @ObservedObject private var terminalThemeStore = GhosttyThemeStore.shared
 
     @AppStorage("workspacesRoot") private var workspacesRootPath: String = ""
     @AppStorage(TerminalMultiplexingMode.storageKey)
@@ -240,6 +241,11 @@ struct SettingsView: View {
                     Text(terminalMultiplexingMode.summary)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    Divider()
+                        .padding(.vertical, 4)
+
+                    TerminalThemeSettingsSection(store: terminalThemeStore)
                 }
             } header: {
                 Text("Terminal")

--- a/Sources/WorkspaceManager/Views/TerminalThemeSettingsSection.swift
+++ b/Sources/WorkspaceManager/Views/TerminalThemeSettingsSection.swift
@@ -74,6 +74,7 @@ private struct TerminalThemeSlotField: View {
                 TerminalThemeListView(
                     allThemes: allThemes,
                     featuredThemes: featuredThemes,
+                    recentThemes: store.recentThemes,
                     currentSelectionName: committedName,
                     showsDefaultRow: true,
                     onPreview: preview(_:),

--- a/Sources/WorkspaceManager/Views/TerminalThemeSettingsSection.swift
+++ b/Sources/WorkspaceManager/Views/TerminalThemeSettingsSection.swift
@@ -1,0 +1,118 @@
+//
+//  TerminalThemeSettingsSection.swift
+//  WorkspaceManager
+//
+//  Settings → Terminal: light + dark theme pickers. Each opens the same
+//  searchable theme list used by the Cmd+Shift+P overlay, and edits live via
+//  the shared GhosttyThemeStore.
+//
+
+import SwiftUI
+
+struct TerminalThemeSettingsSection: View {
+    @ObservedObject var store: GhosttyThemeStore
+
+    @State private var allThemes: [GhosttyTheme] = []
+    @State private var featuredThemes: [GhosttyTheme] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Terminal Theme")
+                .font(.headline)
+
+            Text("Pick a light and dark color theme for your terminals. The active theme follows the macOS appearance.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            slotRow(.light)
+            slotRow(.dark)
+        }
+        .onAppear(perform: loadThemes)
+    }
+
+    private func slotRow(_ slot: TerminalThemeSlot) -> some View {
+        TerminalThemeSlotField(
+            slot: slot,
+            store: store,
+            allThemes: allThemes,
+            featuredThemes: featuredThemes
+        )
+    }
+
+    private func loadThemes() {
+        let all = GhosttyThemeCatalog.bundledThemes()
+        allThemes = all
+        featuredThemes = GhosttyThemeCatalog.featured(in: all)
+    }
+}
+
+private struct TerminalThemeSlotField: View {
+    let slot: TerminalThemeSlot
+    @ObservedObject var store: GhosttyThemeStore
+    let allThemes: [GhosttyTheme]
+    let featuredThemes: [GhosttyTheme]
+
+    @State private var isShowingPicker = false
+
+    var body: some View {
+        HStack {
+            Text("\(slot.title) theme")
+                .font(.callout)
+            Spacer()
+            Button {
+                isShowingPicker = true
+            } label: {
+                HStack(spacing: 6) {
+                    Text(displayName)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .popover(isPresented: $isShowingPicker, arrowEdge: .trailing) {
+                TerminalThemeListView(
+                    allThemes: allThemes,
+                    featuredThemes: featuredThemes,
+                    currentSelectionName: committedName,
+                    showsDefaultRow: true,
+                    onPreview: preview(_:),
+                    onCommit: { name in
+                        commit(name)
+                        isShowingPicker = false
+                    },
+                    onCancel: {
+                        store.endPreview()
+                        isShowingPicker = false
+                    }
+                )
+                .frame(width: 360, height: 420)
+            }
+            .onChange(of: isShowingPicker) { _, isShowing in
+                if !isShowing { store.endPreview() }
+            }
+        }
+    }
+
+    private var committedName: String {
+        slot == .light ? store.lightTheme : store.darkTheme
+    }
+
+    private var displayName: String {
+        committedName.isEmpty ? "Ghostty Default" : committedName
+    }
+
+    private func preview(_ name: String) {
+        switch slot {
+        case .light: store.preview(lightTheme: name, darkTheme: store.darkTheme)
+        case .dark: store.preview(lightTheme: store.lightTheme, darkTheme: name)
+        }
+    }
+
+    private func commit(_ name: String) {
+        switch slot {
+        case .light: store.setLightTheme(name)
+        case .dark: store.setDarkTheme(name)
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
@@ -51,7 +51,8 @@ struct AppCommandStateTests {
             canOpenDesktop: false,
             canRevealInFinder: false,
             canCopyPath: false,
-            canOpenCommandPalette: true
+            canOpenCommandPalette: true,
+            canOpenCommandRunner: true
         )
 
         state.setMainWindowActions(

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemeCatalogTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemeCatalogTests.swift
@@ -1,0 +1,108 @@
+//
+//  GhosttyThemeCatalogTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyThemeCatalog")
+struct GhosttyThemeCatalogTests {
+    private struct ThemesFixture {
+        let directory: URL
+
+        init(themeNames: [String]) throws {
+            directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            for name in themeNames {
+                FileManager.default.createFile(
+                    atPath: directory.appendingPathComponent(name, isDirectory: false).path,
+                    contents: Data("background = #000000\n".utf8)
+                )
+            }
+        }
+
+        func addHiddenFile(_ name: String) {
+            FileManager.default.createFile(
+                atPath: directory.appendingPathComponent(name, isDirectory: false).path,
+                contents: Data()
+            )
+        }
+
+        func addSubdirectory(_ name: String) throws {
+            try FileManager.default.createDirectory(
+                at: directory.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    @Test("Enumerates regular theme files, sorted alphabetically, skipping hidden files and subdirectories")
+    func enumeratesThemeFiles() throws {
+        let fixture = try ThemesFixture(themeNames: ["Nord", "Dracula", "Catppuccin Mocha", "Owlet", "Light Owl"])
+        defer { fixture.cleanup() }
+        fixture.addHiddenFile(".DS_Store")
+        try fixture.addSubdirectory("nested")
+
+        let themes = GhosttyThemeCatalog.themes(in: fixture.directory)
+
+        #expect(themes.map(\.name) == ["Catppuccin Mocha", "Dracula", "Light Owl", "Nord", "Owlet"])
+    }
+
+    @Test("Missing themes directory yields an empty list rather than throwing")
+    func missingDirectoryYieldsEmpty() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        #expect(GhosttyThemeCatalog.themes(in: missing).isEmpty)
+    }
+
+    @Test("Featured returns curated themes that exist, in curated order")
+    func featuredOrdering() throws {
+        let fixture = try ThemesFixture(themeNames: ["Nord", "Dracula", "Catppuccin Mocha", "Owlet"])
+        defer { fixture.cleanup() }
+
+        let all = GhosttyThemeCatalog.themes(in: fixture.directory)
+        let featured = GhosttyThemeCatalog.featured(in: all)
+
+        // Curated order from featuredNames: Catppuccin Mocha < Nord < Dracula.
+        #expect(featured.map(\.name) == ["Catppuccin Mocha", "Nord", "Dracula"])
+        #expect(!featured.map(\.name).contains("Owlet"))
+    }
+
+    @Test("Ranking puts prefix matches above substring matches")
+    func rankingPrefixThenSubstring() throws {
+        let fixture = try ThemesFixture(themeNames: ["Owlet", "Light Owl", "Nord"])
+        defer { fixture.cleanup() }
+
+        let all = GhosttyThemeCatalog.themes(in: fixture.directory)
+        let ranked = GhosttyThemeCatalog.rank(all, query: "owl")
+
+        #expect(ranked.map(\.name) == ["Owlet", "Light Owl"])
+    }
+
+    @Test("Empty query returns every theme alphabetically")
+    func emptyQueryReturnsAll() throws {
+        let fixture = try ThemesFixture(themeNames: ["Nord", "Dracula"])
+        defer { fixture.cleanup() }
+
+        let all = GhosttyThemeCatalog.themes(in: fixture.directory)
+        #expect(GhosttyThemeCatalog.rank(all, query: "").map(\.name) == ["Dracula", "Nord"])
+        #expect(GhosttyThemeCatalog.rank(all, query: "   ").map(\.name) == ["Dracula", "Nord"])
+    }
+
+    @Test("matches is case-insensitive and treats empty query as a match")
+    func matchesSemantics() {
+        let theme = GhosttyTheme(name: "Catppuccin Mocha")
+        #expect(GhosttyThemeCatalog.matches(theme, query: ""))
+        #expect(GhosttyThemeCatalog.matches(theme, query: "MOCHA"))
+        #expect(GhosttyThemeCatalog.matches(theme, query: "ppucc"))
+        #expect(!GhosttyThemeCatalog.matches(theme, query: "dracula"))
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemeConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemeConfigTests.swift
@@ -1,0 +1,87 @@
+//
+//  GhosttyThemeConfigTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyThemeConfig")
+struct GhosttyThemeConfigTests {
+    @Test("No selection produces no theme value")
+    func emptyPairHasNoValue() {
+        #expect(GhosttyThemeConfig.themeValue(lightTheme: "", darkTheme: "") == nil)
+        #expect(GhosttyThemeConfig.configContents(lightTheme: "", darkTheme: "") == nil)
+    }
+
+    @Test("Both slots set produce the dual light/dark value")
+    func bothSlotsSet() {
+        #expect(
+            GhosttyThemeConfig.themeValue(lightTheme: "Catppuccin Latte", darkTheme: "Dracula")
+                == "light:Catppuccin Latte,dark:Dracula"
+        )
+        #expect(
+            GhosttyThemeConfig.configContents(lightTheme: "Nord", darkTheme: "Dracula")
+                == "theme = light:Nord,dark:Dracula\n"
+        )
+    }
+
+    @Test("An unset slot is filled with the built-in fallback to keep the dual form valid")
+    func unsetSlotFallsBackToBuiltin() {
+        #expect(
+            GhosttyThemeConfig.themeValue(lightTheme: "", darkTheme: "Dracula")
+                == "light:Builtin Light,dark:Dracula"
+        )
+        #expect(
+            GhosttyThemeConfig.themeValue(lightTheme: "Catppuccin Latte", darkTheme: "")
+                == "light:Catppuccin Latte,dark:Builtin Dark"
+        )
+    }
+
+    @Test("Whitespace around theme names is trimmed")
+    func trimsWhitespace() {
+        #expect(
+            GhosttyThemeConfig.themeValue(lightTheme: "  Nord  ", darkTheme: " Dracula ")
+                == "light:Nord,dark:Dracula"
+        )
+    }
+
+    @Test("Config file lives under <dataDir>/ghostty/workspaces.config")
+    func configFileURLLayout() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let url = try GhosttyThemeConfig.configFileURL(
+            environment: ["WORKSPACES_DATA_DIR": dataDir.path]
+        )
+        #expect(url.lastPathComponent == "workspaces.config")
+        #expect(url.deletingLastPathComponent().lastPathComponent == "ghostty")
+        #expect(url.path.hasPrefix(dataDir.path))
+    }
+
+    @Test("Writing a selected pair persists the config file; clearing removes it")
+    func writeAndClearConfigFile() throws {
+        let dataDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dataDir) }
+        let environment = ["WORKSPACES_DATA_DIR": dataDir.path]
+
+        let writtenURL = try GhosttyThemeConfig.writeConfigFile(
+            lightTheme: "Nord",
+            darkTheme: "Dracula",
+            environment: environment
+        )
+        let url = try #require(writtenURL)
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        #expect(contents == "theme = light:Nord,dark:Dracula\n")
+
+        let cleared = try GhosttyThemeConfig.writeConfigFile(
+            lightTheme: "",
+            darkTheme: "",
+            environment: environment
+        )
+        #expect(cleared == nil)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemePersistenceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemePersistenceTests.swift
@@ -41,4 +41,13 @@ struct GhosttyThemePersistenceTests {
         let lightOnly = GhosttyThemePersistence.Pair(lightTheme: "Nord", darkTheme: "")
         #expect(lightOnly.hasSelection)
     }
+
+    @Test("Recents are empty by default and round-trip in order")
+    func recentsRoundTrip() {
+        let defaults = makeDefaults()
+        #expect(GhosttyThemePersistence.loadRecents(from: defaults).isEmpty)
+
+        GhosttyThemePersistence.saveRecents(["Dracula", "Nord", "Gruvbox Dark"], to: defaults)
+        #expect(GhosttyThemePersistence.loadRecents(from: defaults) == ["Dracula", "Nord", "Gruvbox Dark"])
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemePersistenceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemePersistenceTests.swift
@@ -1,0 +1,44 @@
+//
+//  GhosttyThemePersistenceTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyThemePersistence")
+struct GhosttyThemePersistenceTests {
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "GhosttyThemePersistenceTests-\(UUID().uuidString)")!
+    }
+
+    @Test("Absent values load as an empty pair")
+    func emptyByDefault() {
+        let defaults = makeDefaults()
+        let pair = GhosttyThemePersistence.load(from: defaults)
+        #expect(pair == .empty)
+        #expect(!pair.hasSelection)
+    }
+
+    @Test("Saved pair round-trips through UserDefaults")
+    func roundTrip() {
+        let defaults = makeDefaults()
+        let pair = GhosttyThemePersistence.Pair(lightTheme: "Catppuccin Latte", darkTheme: "Dracula")
+        GhosttyThemePersistence.save(pair, to: defaults)
+
+        let loaded = GhosttyThemePersistence.load(from: defaults)
+        #expect(loaded == pair)
+        #expect(loaded.hasSelection)
+    }
+
+    @Test("A single populated slot still counts as a selection")
+    func partialSelection() {
+        let darkOnly = GhosttyThemePersistence.Pair(lightTheme: "", darkTheme: "Dracula")
+        #expect(darkOnly.hasSelection)
+
+        let lightOnly = GhosttyThemePersistence.Pair(lightTheme: "Nord", darkTheme: "")
+        #expect(lightOnly.hasSelection)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemeStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemeStoreTests.swift
@@ -1,0 +1,78 @@
+//
+//  GhosttyThemeStoreTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("GhosttyThemeStore")
+struct GhosttyThemeStoreTests {
+    /// Records every applied pair so tests can assert what reached the terminal.
+    private final class ApplyRecorder {
+        private(set) var applied: [(light: String, dark: String)] = []
+        func record(_ light: String, _ dark: String) { applied.append((light, dark)) }
+        var last: (light: String, dark: String)? { applied.last }
+    }
+
+    /// Zero debounce so previews apply inline — deterministic under parallel
+    /// suite execution (a timed debounce flakes when the main actor is busy).
+    private func makeStore() -> (store: GhosttyThemeStore, defaults: UserDefaults, recorder: ApplyRecorder) {
+        let defaults = UserDefaults(suiteName: "GhosttyThemeStoreTests-\(UUID().uuidString)")!
+        let recorder = ApplyRecorder()
+        let store = GhosttyThemeStore(defaults: defaults, debounce: .zero) { light, dark in
+            recorder.record(light, dark)
+        }
+        return (store, defaults, recorder)
+    }
+
+    @Test("Setting a slot persists it and applies the new pair")
+    func setPersistsAndApplies() {
+        let (store, defaults, recorder) = makeStore()
+
+        store.setDarkTheme("Dracula")
+
+        #expect(store.darkTheme == "Dracula")
+        #expect(GhosttyThemePersistence.load(from: defaults).darkTheme == "Dracula")
+        #expect(recorder.last?.dark == "Dracula")
+    }
+
+    @Test("Initial values reflect previously persisted selection")
+    func loadsPersistedSelection() {
+        let defaults = UserDefaults(suiteName: "GhosttyThemeStoreTests-\(UUID().uuidString)")!
+        GhosttyThemePersistence.save(
+            GhosttyThemePersistence.Pair(lightTheme: "Catppuccin Latte", darkTheme: "Nord"),
+            to: defaults
+        )
+        let store = GhosttyThemeStore(defaults: defaults) { _, _ in }
+
+        #expect(store.lightTheme == "Catppuccin Latte")
+        #expect(store.darkTheme == "Nord")
+    }
+
+    @Test("Preview applies live without persisting")
+    func previewDoesNotPersist() {
+        let (store, defaults, recorder) = makeStore()
+
+        store.preview(lightTheme: "", darkTheme: "Nord")
+
+        #expect(recorder.last?.dark == "Nord")
+        #expect(GhosttyThemePersistence.load(from: defaults).darkTheme == "")
+    }
+
+    @Test("Ending a preview reverts to the committed pair")
+    func endPreviewReverts() {
+        let (store, _, recorder) = makeStore()
+
+        store.setDarkTheme("Dracula")
+        store.preview(lightTheme: "", darkTheme: "Nord")
+        #expect(recorder.last?.dark == "Nord")
+
+        store.endPreview()
+        #expect(recorder.last?.dark == "Dracula")
+        #expect(store.darkTheme == "Dracula")
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemeStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemeStoreTests.swift
@@ -75,4 +75,52 @@ struct GhosttyThemeStoreTests {
         #expect(recorder.last?.dark == "Dracula")
         #expect(store.darkTheme == "Dracula")
     }
+
+    @Test("Committing themes records them most-recent-first, deduped")
+    func recordsRecentsMostRecentFirst() {
+        let (store, defaults, _) = makeStore()
+
+        store.setDarkTheme("Nord")
+        store.setLightTheme("Catppuccin Latte")
+        store.setDarkTheme("Dracula")
+        store.setDarkTheme("Nord")  // re-use moves it to front, no duplicate
+
+        #expect(store.recentThemes == ["Nord", "Dracula", "Catppuccin Latte"])
+        #expect(GhosttyThemePersistence.loadRecents(from: defaults) == store.recentThemes)
+    }
+
+    @Test("The Ghostty Default (empty) selection is not recorded as a recent")
+    func emptySelectionNotRecorded() {
+        let (store, _, _) = makeStore()
+
+        store.setDarkTheme("Dracula")
+        store.setLightTheme("")  // clear the light slot
+
+        #expect(store.recentThemes == ["Dracula"])
+    }
+
+    @Test("Recents are capped at the most recent eight")
+    func recentsAreCapped() {
+        let (store, _, _) = makeStore()
+
+        for index in 1...10 {
+            store.setDarkTheme("Theme \(index)")
+        }
+
+        #expect(store.recentThemes.count == 8)
+        #expect(store.recentThemes.first == "Theme 10")
+        #expect(store.recentThemes.last == "Theme 3")
+        #expect(!store.recentThemes.contains("Theme 1"))
+    }
+
+    @Test("Recents reload from persistence in a new store")
+    func recentsReloadFromPersistence() {
+        let defaults = UserDefaults(suiteName: "GhosttyThemeStoreTests-\(UUID().uuidString)")!
+        let first = GhosttyThemeStore(defaults: defaults, debounce: .zero) { _, _ in }
+        first.setDarkTheme("Dracula")
+        first.setLightTheme("Nord")
+
+        let reloaded = GhosttyThemeStore(defaults: defaults, debounce: .zero) { _, _ in }
+        #expect(reloaded.recentThemes == ["Nord", "Dracula"])
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/ShortcutRoutingPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ShortcutRoutingPolicyTests.swift
@@ -48,6 +48,17 @@ struct ShortcutRoutingPolicyTests {
         #expect(AppChromeShortcutCatalog.appOwnedDefaults.contains(.settings))
     }
 
+    @Test("Command runner (Cmd+Shift+P) is app-owned so it no longer falls through to Ghostty")
+    func commandRunnerRoutesToAppChrome() {
+        policy.clearOverrides()
+
+        let chord = AppChromeShortcut.commandRunner.chord
+        #expect(chord == ShortcutChord(key: "p", modifiers: [.command, .shift]))
+        #expect(chord != AppChromeShortcut.workspaceSwitcher.chord)
+        #expect(policy.route(for: chord) == .appChrome)
+        #expect(AppChromeShortcutCatalog.appOwnedDefaults.contains(.commandRunner))
+    }
+
     @Test("Non-reserved shortcuts route to Ghostty by default")
     func nonReservedShortcutsRouteToGhostty() {
         policy.clearOverrides()

--- a/docs/decisions/ghostty-theme-config.md
+++ b/docs/decisions/ghostty-theme-config.md
@@ -1,0 +1,67 @@
+---
+status: decided
+date: 2026-06-06
+decision: app-owned-theme-config-applied-live
+related:
+  - docs/development/libghostty-integration.md
+  - docs/development/shortcut-routing.md
+---
+
+# App-owned Ghostty config carries the Terminal Theme, applied live
+
+## Decision
+
+**WorkSpaces manages the Terminal Theme through a small, app-owned Ghostty
+config file that it generates and loads itself, and applies live via
+`ghostty_app_update_config` / `ghostty_surface_update_config`.** The file holds
+only a `theme = light:<L>,dark:<D>` line and lives under the
+`WORKSPACES_DATA_DIR` convention (`<dataDir>/ghostty/workspaces.config`),
+separate from the bundled resources directory that supplies terminfo and the
+theme catalog.
+
+This was chosen over two alternatives the generic "libghostty" guidance steers
+toward — driving colors with OSC escape sequences, or recreating surfaces to
+pick up a new theme.
+
+## Why this works here
+
+The repo embeds Ghostty via the **apprt** C API (the same surface the official
+Ghostty.app uses), not libghostty-vt. The pinned header (ghostty
+`332b2aefc6`) exposes the real reload path:
+
+- `ghostty_config_new()` → `ghostty_config_load_file(path)` → `ghostty_config_finalize()`
+- `ghostty_app_update_config(app, cfg)` and `ghostty_surface_update_config(surface, cfg)`
+  push a new config — including `theme = …` — to **live** surfaces with no
+  recreation and no lost scrollback.
+
+So a theme change is: rewrite the file, rebuild a fresh `ghostty_config_t`,
+broadcast it to the app and every registered surface, then free the previous
+config. This mirrors how reload-config works in the real app and gives us all
+~460 bundled iTerm2 themes by name plus native dual light/dark, where the active
+half follows the macOS appearance via the existing `set_color_scheme` path.
+
+## Tradeoffs
+
+- **Empirical dependency.** The live recolor relies on `surface_update_config`
+  re-theming an existing surface in this exact pinned build. Confidence is high
+  (it is the official reload path), but it is verified end-to-end before each
+  release-relevant change; the fallback — rebuilding the surface — loses
+  scrollback and is avoided unless forced.
+- **Isolated from `~/.config/ghostty`.** We deliberately do **not** load the
+  user's Ghostty config. That keeps the shortcut-routing / keybind contract
+  intact (see `docs/development/shortcut-routing.md`) at the cost of not
+  inheriting a user's personal Ghostty theme automatically.
+- **Config lifetime.** Exactly one `ghostty_config_t` is owned at a time; the
+  previous one is freed after each `update_config` broadcast to avoid leaks.
+- **Single-sided pairs are invalid.** Ghostty rejects `theme = light:foo`
+  without a `dark:` peer, so an unset slot is filled with `Builtin Light` /
+  `Builtin Dark`. When neither slot is set, no theme line is written and the
+  bare default behavior is preserved.
+
+## Surface registry
+
+Because the broadcast must reach every open terminal, `GhosttyAppManager` keeps
+a weak set of live `GhosttySurfaceView`s (`NSHashTable.weakObjects()`). Surfaces
+register on successful `ghostty_surface_new` and drop automatically on
+deallocation, so a theme change reaches all of them and a stale surface can
+never be visited.

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -171,6 +171,10 @@ Contract:
   `setDarkTheme`, persisted). The active half follows the macOS appearance via
   the existing `set_color_scheme` path, so a slot only previews live while its
   matching appearance is active.
+- **Recents**: committed themes are remembered (`recentThemes`, persisted under
+  `terminalThemeRecents`, most-recent-first, capped at 8) and pinned in a
+  "Recent" section above Featured. The picker's initial highlight lands on the
+  most recent theme, so re-selecting a recent is a single arrow press away.
 
 ## Appearance Sync
 

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -146,8 +146,12 @@ Contract:
 - **Catalog**: themes are enumerated at runtime from `<resources>/ghostty/themes/`
   via `GhosttyResourcesLocator.resolvedResourcesDirectory()` — each filename *is*
   the `theme =` value. `GhosttyThemeCatalog` exposes `all`, `featured`, and fuzzy
-  `rank`. In a dev build this needs `GHOSTTY_RESOURCES_DIR` pointed at a Ghostty
-  share dir (release bundles the resources); without it the catalog is empty.
+  `rank`. Release bundles the resources; dev builds do not, so the catalog is
+  empty unless `GHOSTTY_RESOURCES_DIR` points at a Ghostty share dir.
+  `launch-dev.sh` auto-resolves one from the pinned checkout
+  (`~/.cache/workspacemanager/ghostty/zig-out/share/ghostty`), so a plain
+  `./scripts/launch-dev.sh` shows themes; a direct-binary launch still needs the
+  env var set by hand.
 - **Startup**: `initializeIfNeeded()` builds the initial `ghostty_config_t` from
   the persisted pair (`GhosttyThemePersistence`, `UserDefaults`). With no
   selection it stays a bare default; with a selection it writes the file and

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -53,6 +53,8 @@ Behavior:
 - `ghostty_app_new/free/tick`
 - app-wide focus sync via `ghostty_app_set_focus(...)`
 - clipboard callbacks + app-level color-scheme synchronization
+- the live Terminal Theme apply (`applyTheme(lightTheme:darkTheme:)`) and a weak
+  registry of live `GhosttySurfaceView`s to broadcast it to (see "Terminal Theme")
 
 Registered callbacks in `ghostty_runtime_config_s`:
 - `wakeup_cb`: schedules `ghostty_app_tick` on main queue
@@ -125,10 +127,46 @@ Current migration uses surface/runtime config only:
 - `font_size`
 
 Not configured yet (by design in this migration):
-- app-owned color palette / theme overrides
 - app-owned font-family override
 
-Reason: keep integration on stable C fields and avoid config file management in v1.
+Reason: keep integration on stable C fields. The Terminal Theme (below) is the
+one app-owned config-file key we manage.
+
+## Terminal Theme (app-owned config + live update)
+
+WorkSpaces sets the terminal color theme through a small, app-owned config file
+applied live — never via OSC escapes or surface recreation. See the ADR
+`docs/decisions/ghostty-theme-config.md` for the rationale.
+
+Contract:
+
+- **Config file**: `<dataDir>/ghostty/workspaces.config` (the `WORKSPACES_DATA_DIR`
+  convention, else the app support dir), isolated from `~/.config/ghostty`, which
+  we never load. It contains only `theme = light:<L>,dark:<D>`.
+- **Catalog**: themes are enumerated at runtime from `<resources>/ghostty/themes/`
+  via `GhosttyResourcesLocator.resolvedResourcesDirectory()` — each filename *is*
+  the `theme =` value. `GhosttyThemeCatalog` exposes `all`, `featured`, and fuzzy
+  `rank`. In a dev build this needs `GHOSTTY_RESOURCES_DIR` pointed at a Ghostty
+  share dir (release bundles the resources); without it the catalog is empty.
+- **Startup**: `initializeIfNeeded()` builds the initial `ghostty_config_t` from
+  the persisted pair (`GhosttyThemePersistence`, `UserDefaults`). With no
+  selection it stays a bare default; with a selection it writes the file and
+  `ghostty_config_load_file`s it before `ghostty_app_new`, so the first surfaces
+  inherit the theme.
+- **Live change**: `applyTheme(lightTheme:darkTheme:)` rewrites the file, rebuilds
+  a fresh config, broadcasts via `ghostty_app_update_config(app, cfg)` and
+  `ghostty_surface_update_config(surface, cfg)` over the weak surface registry,
+  then frees the previous config. Scrollback is preserved; new splits/tabs
+  inherit the theme from the updated app config.
+- **Dual form is required**: Ghostty rejects a single-sided `theme = light:foo`,
+  so an unset slot is filled with `Builtin Light` / `Builtin Dark`; both unset
+  writes no theme line (bare default).
+- **Preview/commit**: `GhosttyThemeStore` (the observable both the Settings
+  pickers and the Cmd+Shift+P overlay bind to) drives debounced previews
+  (`preview`/`endPreview`, no persistence) and commits (`setLightTheme` /
+  `setDarkTheme`, persisted). The active half follows the macOS appearance via
+  the existing `set_color_scheme` path, so a slot only previews live while its
+  matching appearance is active.
 
 ## Appearance Sync
 

--- a/scripts/launch-dev.sh
+++ b/scripts/launch-dev.sh
@@ -348,6 +348,36 @@ configure_launch_behavior() {
     fi
 }
 
+# Dev builds don't bundle Ghostty's themes/terminfo (only release does), so the
+# in-app GhosttyResourcesLocator finds nothing unless GHOSTTY_RESOURCES_DIR
+# points at a Ghostty share dir. Resolve one from the pinned checkout so the
+# theme catalog + terminfo work in dev without an explicit flag. Mirrors
+# build-release.sh's share-dir resolution; honors a user-provided value.
+configure_ghostty_resources() {
+    # Respect an explicit --env override or an inherited value.
+    local entry
+    for entry in "${ENV_VARS[@]}"; do
+        [[ "$entry" == GHOSTTY_RESOURCES_DIR=* ]] && return
+    done
+    [[ -n "${GHOSTTY_RESOURCES_DIR:-}" ]] && return
+
+    local -a share_candidates=()
+    [[ -n "${GHOSTTY_SHARE_DIR:-}" ]] && share_candidates+=("$(expand_home_prefix "$GHOSTTY_SHARE_DIR")")
+    [[ -n "${GHOSTTY_DIR:-}" ]] && share_candidates+=("$(expand_home_prefix "$GHOSTTY_DIR")/zig-out/share")
+    share_candidates+=("$HOME/.cache/workspacemanager/ghostty/zig-out/share")
+
+    local share
+    for share in "${share_candidates[@]}"; do
+        if [[ -d "$share/ghostty/themes" && -f "$share/terminfo/78/xterm-ghostty" ]]; then
+            ENV_VARS+=("GHOSTTY_RESOURCES_DIR=$share/ghostty")
+            log "Using Ghostty resources: $share/ghostty"
+            return
+        fi
+    done
+
+    log "Ghostty resources dir not found; terminal themes/terminfo may be unavailable in this dev launch."
+}
+
 prepare_log_path() {
     mkdir -p "$LOG_DIR"
     LOG_PATH="$LOG_DIR/launch-dev-$(date +%Y%m%d-%H%M%S).log"
@@ -575,6 +605,7 @@ main() {
     configure_data_root
     configure_fixture_mode
     configure_launch_behavior
+    configure_ghostty_resources
     prepare_log_path
     print_launch_plan
 


### PR DESCRIPTION
## Summary

Adds a **Terminal Theme** switcher for the embedded Ghostty terminal. You pick a light theme and a dark theme from all ~460 bundled iTerm2 themes (a curated **Featured** group pinned on top); the active half follows the macOS appearance. Changes apply **live** to every open terminal with no surface recreation and no lost scrollback.

Two entry points share one backing store (`GhosttyThemeStore`):

- **Settings → Terminal** — searchable Light/Dark pickers (discoverability + persistence).
- **Cmd+Shift+P** — a command overlay (the chord was previously inert in our embedding) with a Light/Dark slot toggle, live preview on highlight, commit on Enter, revert on Esc. **Cmd+P** also gains a "Change Terminal Theme…" row.

The mechanism is the real apprt reload path the official Ghostty.app uses, not OSC escapes or surface recreation: write a small app-owned config file (`theme = light:L,dark:D`), rebuild a `ghostty_config_t`, and broadcast it via `ghostty_app_update_config` / `ghostty_surface_update_config` over a weak surface registry, freeing the previous config. The file lives under `<dataDir>/ghostty/workspaces.config`, isolated from the user's `~/.config/ghostty` (which we never load) so the keybind/routing contract stays intact. See `docs/decisions/ghostty-theme-config.md`.

**Follow-ups in this PR (later commits):**

- **Recently-used pinned on top** — committed themes are remembered (most-recent-first, deduped, capped at 8) in a "Recent" section above Featured, and the picker's initial highlight lands on the most-recent theme, so re-selecting a recent is a single arrow press.
- **Dev launches show themes without a flag** — dev builds don't bundle Ghostty's theme/terminfo resources (only release does), so the picker came up empty under a plain `launch-dev`. `launch-dev.sh` now auto-resolves `GHOSTTY_RESOURCES_DIR` from the pinned checkout (honoring an explicit value).

## Mergeability

- Surface: desktop
- User-facing behavior changed: yes — new Settings pickers, a new Cmd+Shift+P overlay, and a Cmd+P command row. No change when no theme is selected (bare Ghostty default preserved).
- Non-happy paths considered: both slots unset → no theme line written (current behavior); a single slot set → the other is filled with `Builtin Light`/`Builtin Dark`, because Ghostty rejects a single-sided `light:foo` pair; resources unavailable (dev without `GHOSTTY_RESOURCES_DIR`) → empty catalog, no crash; preview reverts on Esc / picker dismiss; the previous config is freed after each broadcast.
- Release/ops preconditions: none. Release bundles the Ghostty theme resources already; dev needs `GHOSTTY_RESOURCES_DIR` for the catalog (same locator that feeds terminfo).
- Residual risk or follow-up: the live recolor relies on `surface_update_config` re-theming an existing surface in this pinned build — confirmed visually below. Swatch previews in the picker were intentionally deferred (noted in the plan as optional).

## Validation

- [x] `swift build`
- [x] `swift test` — 814 tests in 134 suites passed
- [x] Other checks run: launched the debug build (`launch-dev.sh --no-activate`) and confirmed a live terminal recolors to the selected theme.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (test output)
- [x] UI evidence attached (screenshot from the exact commit under review)

Evidence links:

- [swift test — 814 passed](https://evidence.cloudcompute.com/workspaces/pr-622/20260607-071230-theme-tests.png)

  ![theme tests](https://evidence.cloudcompute.com/workspaces/pr-622/20260607-071230-theme-tests.png)
- [Live terminal recolor — before/after](https://evidence.cloudcompute.com/workspaces/pr-622/20260607-071230-theme-before-after.png)

  ![before after](https://evidence.cloudcompute.com/workspaces/pr-622/20260607-071230-theme-before-after.png)

The before/after shows the host terminal in the bare default scheme, then recolored to `light:Catppuccin Latte,dark:Dracula` — macOS in light mode, so the live surface picks the light slot (Catppuccin Latte). This confirms the app-owned config applies to a live surface in the pinned build (the plan's one empirical risk).

Reproduce the full interactive flow on a non-shared session:

```bash
./scripts/build-ghosttykit.sh && swift build
./scripts/launch-dev.sh --no-build --env GHOSTTY_RESOURCES_DIR=$HOME/.cache/workspacemanager/ghostty/zig-out/share/ghostty
# Cmd+Shift+P → arrow through themes (live preview) → Enter to commit, Esc to revert
# Settings → Terminal → Light/Dark pickers; flip macOS appearance to see the slot switch
```

## Blockers

- [x] None

