### PR TITLE
[codex] Scope host terminal tabs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,12 @@ An isolated working copy or provider-backed environment created from a repositor
 _Avoid_: Session, tab, branch
 
 **Terminal Session**:
-A resumable terminal context attached to a repository or workspace.
+A resumable terminal context attached to Home, a repository, or a workspace.
 _Avoid_: Shell, pane, console
+
+**Terminal Scope**:
+The owner of a single tab collection — exactly one of Home, a Repository, or a Workspace.
+_Avoid_: Tab group, session group, context
 
 **Surface**:
 The currently selected main content target, such as a repo overview, repository terminal, workspace terminal, or web view.
@@ -70,7 +74,9 @@ _Avoid_: Notifications, alerts, warnings, tasks
 - A **Repository** owns zero or more repo-scoped **Web Sources**.
 - A **Workspace** belongs to exactly one **Repository**.
 - A **Workspace** owns zero or more workspace-scoped **Web Sources**.
-- A **Terminal Session** attaches to either a **Repository** or a **Workspace**.
+- A **Terminal Session** belongs to exactly one **Terminal Scope**: Home, a **Repository**, or a **Workspace**.
+- A **Terminal Scope** owns an ordered collection of **Terminal Sessions** and one active tab.
+- **Home** is the app-level **Terminal Scope** rooted at `~/code`, owned by neither a **Repository** nor a **Workspace**.
 - A **Surface** is one selected **Repo Overview**, repository **Terminal Session**, workspace **Terminal Session**, or **Web Source**.
 - The **Detail Pane** follows the selected **Surface** when that surface has repository or workspace context.
 - An **Agent** runs inside a **Terminal Session** and emits **Workspace Events** that the **Workspace Journal** persists.

--- a/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
@@ -27,6 +27,9 @@ struct TerminalContinuityManifest: Codable, Equatable {
         }
 
         func restoredSession(fileManager: FileManager = .default) -> HostTerminalSession? {
+            guard isSafeForDirectRestore else {
+                return nil
+            }
             guard Self.isExistingDirectory(directoryPath, fileManager: fileManager) else {
                 return nil
             }
@@ -37,6 +40,12 @@ struct TerminalContinuityManifest: Codable, Equatable {
                 directory: URL(fileURLWithPath: directoryPath, isDirectory: true),
                 customCommand: customCommand
             )
+        }
+
+        private var isSafeForDirectRestore: Bool {
+            guard customCommand == nil else { return false }
+            guard case .backendSession = key else { return true }
+            return false
         }
 
         private static func isExistingDirectory(_ path: String, fileManager: FileManager) -> Bool {

--- a/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
@@ -4,14 +4,63 @@
 //
 
 import Foundation
+import WorkspaceManagerCore
 
 struct TerminalContinuityManifest: Codable, Equatable {
     enum TargetKind: String, Codable {
+        case home
         case repo
         case workspace
     }
 
+    struct SessionRecord: Codable, Equatable {
+        let id: UUID
+        let key: HostTerminalSessionKey
+        let directoryPath: String
+        let customCommand: String?
+
+        init(session: HostTerminalSession) {
+            self.id = session.id
+            self.key = session.key
+            self.directoryPath = session.directoryPath
+            self.customCommand = session.customCommand
+        }
+
+        func restoredSession(fileManager: FileManager = .default) -> HostTerminalSession? {
+            guard Self.isExistingDirectory(directoryPath, fileManager: fileManager) else {
+                return nil
+            }
+
+            return HostTerminalSession(
+                id: id,
+                key: key,
+                directory: URL(fileURLWithPath: directoryPath, isDirectory: true),
+                customCommand: customCommand
+            )
+        }
+
+        private static func isExistingDirectory(_ path: String, fileManager: FileManager) -> Bool {
+            var isDirectory = ObjCBool(false)
+            guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory) else {
+                return false
+            }
+            return isDirectory.boolValue
+        }
+    }
+
+    struct ScopeActiveRecord: Codable, Equatable {
+        let scopeKey: HostTerminalSessionKey
+        let sessionID: UUID
+    }
+
+    struct HostSessionSnapshot: Equatable {
+        let sessions: [HostTerminalSession]
+        let activeSessionID: UUID?
+        let activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID]
+    }
+
     static let storageKey = "terminalContinuity.manifest.v1"
+    static let homeTargetID = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
 
     let version: Int
     let targetKind: TargetKind
@@ -21,6 +70,9 @@ struct TerminalContinuityManifest: Codable, Equatable {
     let terminalMode: TerminalMultiplexingMode
     let tmuxSessionName: String
     let updatedAt: Date
+    let sessionRecords: [SessionRecord]
+    let activeSessionID: UUID?
+    let activeSessionIDsByScope: [ScopeActiveRecord]
 
     init(
         targetKind: TargetKind,
@@ -28,12 +80,15 @@ struct TerminalContinuityManifest: Codable, Equatable {
         rootURL: URL,
         launchURL: URL,
         terminalMode: TerminalMultiplexingMode,
+        sessions: [HostTerminalSession] = [],
+        activeSessionID: UUID? = nil,
+        activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID] = [:],
         updatedAt: Date = Date()
     ) {
         let normalizedRoot = Self.normalizedPath(for: rootURL)
         let normalizedLaunch = Self.normalizedPath(for: launchURL)
 
-        self.version = 1
+        self.version = 2
         self.targetKind = targetKind
         self.targetID = targetID
         self.rootPath = normalizedRoot
@@ -43,6 +98,59 @@ struct TerminalContinuityManifest: Codable, Equatable {
             for: URL(fileURLWithPath: normalizedLaunch, isDirectory: true)
         )
         self.updatedAt = updatedAt
+        self.sessionRecords = sessions.map(SessionRecord.init(session:))
+        self.activeSessionID = activeSessionID
+        self.activeSessionIDsByScope = activeSessionIDByScopeKey.map { scopeKey, sessionID in
+            ScopeActiveRecord(scopeKey: scopeKey, sessionID: sessionID)
+        }
+        .sorted { lhs, rhs in
+            lhs.scopeKey.debugDescription < rhs.scopeKey.debugDescription
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case targetKind
+        case targetID
+        case rootPath
+        case launchPath
+        case terminalMode
+        case tmuxSessionName
+        case updatedAt
+        case sessionRecords
+        case activeSessionID
+        case activeSessionIDsByScope
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = try container.decode(Int.self, forKey: .version)
+        targetKind = try container.decode(TargetKind.self, forKey: .targetKind)
+        targetID = try container.decode(UUID.self, forKey: .targetID)
+        rootPath = try container.decode(String.self, forKey: .rootPath)
+        launchPath = try container.decode(String.self, forKey: .launchPath)
+        terminalMode = try container.decode(TerminalMultiplexingMode.self, forKey: .terminalMode)
+        tmuxSessionName = try container.decode(String.self, forKey: .tmuxSessionName)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        sessionRecords = try container.decodeIfPresent([SessionRecord].self, forKey: .sessionRecords) ?? []
+        activeSessionID = try container.decodeIfPresent(UUID.self, forKey: .activeSessionID)
+        activeSessionIDsByScope =
+            try container.decodeIfPresent([ScopeActiveRecord].self, forKey: .activeSessionIDsByScope) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(targetKind, forKey: .targetKind)
+        try container.encode(targetID, forKey: .targetID)
+        try container.encode(rootPath, forKey: .rootPath)
+        try container.encode(launchPath, forKey: .launchPath)
+        try container.encode(terminalMode, forKey: .terminalMode)
+        try container.encode(tmuxSessionName, forKey: .tmuxSessionName)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encode(sessionRecords, forKey: .sessionRecords)
+        try container.encodeIfPresent(activeSessionID, forKey: .activeSessionID)
+        try container.encode(activeSessionIDsByScope, forKey: .activeSessionIDsByScope)
     }
 
     var rawValue: String {
@@ -56,8 +164,72 @@ struct TerminalContinuityManifest: Codable, Equatable {
         guard let manifest = try? JSONDecoder().decode(TerminalContinuityManifest.self, from: data) else {
             return nil
         }
-        guard manifest.version == 1 else { return nil }
+        guard manifest.version == 1 || manifest.version == 2 else { return nil }
         return manifest
+    }
+
+    static func snapshot(
+        previous: TerminalContinuityManifest?,
+        defaultHomeURL: URL,
+        terminalMode: TerminalMultiplexingMode,
+        sessions: [HostTerminalSession],
+        activeSessionID: UUID?,
+        activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID],
+        updatedAt: Date = Date()
+    ) -> TerminalContinuityManifest {
+        let rootURL = URL(
+            fileURLWithPath: previous?.rootPath ?? Self.normalizedPath(for: defaultHomeURL),
+            isDirectory: true
+        )
+        let launchURL = URL(
+            fileURLWithPath: previous?.launchPath ?? Self.normalizedPath(for: defaultHomeURL),
+            isDirectory: true
+        )
+
+        return TerminalContinuityManifest(
+            targetKind: previous?.targetKind ?? .home,
+            targetID: previous?.targetID ?? Self.homeTargetID,
+            rootURL: rootURL,
+            launchURL: launchURL,
+            terminalMode: terminalMode,
+            sessions: sessions,
+            activeSessionID: activeSessionID,
+            activeSessionIDByScopeKey: activeSessionIDByScopeKey,
+            updatedAt: updatedAt
+        )
+    }
+
+    func hostSessionSnapshot(fileManager: FileManager = .default) -> HostSessionSnapshot? {
+        let restoredSessions = sessionRecords.compactMap {
+            $0.restoredSession(fileManager: fileManager)
+        }
+        guard !restoredSessions.isEmpty else { return nil }
+
+        let validSessionIDs = Set(restoredSessions.map(\.id))
+        var activeByScope: [HostTerminalSessionKey: UUID] = [:]
+        for record in activeSessionIDsByScope
+        where validSessionIDs.contains(record.sessionID)
+            && restoredSessions.contains(where: { $0.id == record.sessionID && $0.key == record.scopeKey })
+        {
+            activeByScope[record.scopeKey] = record.sessionID
+        }
+
+        for session in restoredSessions where activeByScope[session.key] == nil {
+            activeByScope[session.key] = session.id
+        }
+
+        let restoredActiveSessionID: UUID?
+        if let activeSessionID, validSessionIDs.contains(activeSessionID) {
+            restoredActiveSessionID = activeSessionID
+        } else {
+            restoredActiveSessionID = restoredSessions.last?.id
+        }
+
+        return HostSessionSnapshot(
+            sessions: restoredSessions,
+            activeSessionID: restoredActiveSessionID,
+            activeSessionIDByScopeKey: activeByScope
+        )
     }
 
     func launchDirectory(

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1265,7 +1265,7 @@ struct ContentView: View {
         let providerTarget = WorkspaceProviderTarget(workspace)
         let sessionKey = provider.sessionKey(for: providerTarget)
         if workspace.status == .active,
-            let existing = hostTerminalState.sessions.first(where: { $0.key == sessionKey })
+            let existing = hostTerminalState.activeSession(inScope: sessionKey)
         {
             abandonPendingRemoteConnection(reason: "remote_workspace_reused_existing_session")
             markAccessed(workspace: workspace)

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -337,8 +337,8 @@ struct ContentView: View {
             canToggleTerminalPanel: true,
             canCreateTerminalTab: hostTerminalState.hasSessions,
             canCloseTerminalTab: hostTerminalState.hasSessions,
-            canSelectNextTerminalTab: hostTerminalState.sessions.count > 1,
-            canSelectPreviousTerminalTab: hostTerminalState.sessions.count > 1,
+            canSelectNextTerminalTab: hostTerminalState.scopedSessions.count > 1,
+            canSelectPreviousTerminalTab: hostTerminalState.scopedSessions.count > 1,
             canOpenInEditor: openInEditorFocusedAction != nil,
             canOpenInBrowser: openInBrowserFocusedAction != nil,
             canReloadWebSource: reloadWebSourceFocusedAction != nil,
@@ -380,6 +380,7 @@ struct ContentView: View {
             selectedRepo: selectedRepoForInspector,
             activeHostSession: activeHostSession,
             hostTerminalSessions: hostTerminalState.sessions,
+            visibleHostTerminalSessions: hostTerminalState.scopedSessions,
             activeHostTerminalSessionID: hostTerminalState.activeSessionID,
             activeSplitHostSession: hostTerminalState.splitSession(for: hostTerminalState.activeSessionID),
             activeSplitLayout: hostTerminalState.splitLayout(for: hostTerminalState.activeSessionID),
@@ -395,6 +396,7 @@ struct ContentView: View {
                     forPrimarySessionID: activeSessionID
                 )
             },
+            onOpenRepoOverview: handleRepoSelection,
             onSelectTerminalTab: selectTerminalTab(sessionID:),
             onCloseTerminalTab: closeTerminalTab(sessionID:),
             onTerminalCloseConfirmationRequired: requestCloseConfirmationForTerminalTab(sessionID:),
@@ -557,6 +559,10 @@ struct ContentView: View {
             }
             .onChange(of: hostTerminalState.sessions) { _, _ in
                 refreshWorkspaceStatusAggregator()
+                persistTerminalContinuitySnapshot()
+            }
+            .onChange(of: hostTerminalState.activeSessionID) { _, _ in
+                persistTerminalContinuitySnapshot()
             }
             .task {
                 await performDeferredStartupWorkspaceStatusSync()
@@ -1820,6 +1826,18 @@ struct ContentView: View {
 
     @MainActor
     private func ensureInitialHostSession() {
+        if !hostTerminalState.hasSessions,
+            let snapshot = TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue)?
+                .hostSessionSnapshot()
+        {
+            hostTerminalState.restoreSessions(
+                snapshot.sessions,
+                activeSessionID: snapshot.activeSessionID,
+                activeSessionIDByScopeKey: snapshot.activeSessionIDByScopeKey
+            )
+            return
+        }
+
         terminalSessionController.ensureInitialHostSession(
             hostTerminalState: hostTerminalState,
             defaultHomeDirectory: resolvedDefaultHostDirectory,
@@ -1994,7 +2012,10 @@ struct ContentView: View {
             targetID: targetID,
             rootURL: rootURL,
             launchURL: launchURL,
-            terminalMode: terminalMultiplexingMode
+            terminalMode: terminalMultiplexingMode,
+            sessions: hostTerminalState.sessions,
+            activeSessionID: hostTerminalState.activeSessionID,
+            activeSessionIDByScopeKey: hostTerminalState.activeSessionIDByScopeKey
         )
         terminalContinuityManifestRawValue = manifest.rawValue
         NSLog(
@@ -2006,6 +2027,18 @@ struct ContentView: View {
             manifest.tmuxSessionName,
             manifest.terminalMode.rawValue
         )
+    }
+
+    private func persistTerminalContinuitySnapshot() {
+        let manifest = TerminalContinuityManifest.snapshot(
+            previous: TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue),
+            defaultHomeURL: resolvedDefaultHostDirectory,
+            terminalMode: terminalMultiplexingMode,
+            sessions: hostTerminalState.sessions,
+            activeSessionID: hostTerminalState.activeSessionID,
+            activeSessionIDByScopeKey: hostTerminalState.activeSessionIDByScopeKey
+        )
+        terminalContinuityManifestRawValue = manifest.rawValue
     }
 
     private func restoredLaunchDirectory(for repo: Repo) -> URL? {
@@ -2291,6 +2324,7 @@ struct MainTerminalDetailView: View {
     let selectedRepo: Repo?
     let activeHostSession: HostTerminalSession?
     let hostTerminalSessions: [HostTerminalSession]
+    let visibleHostTerminalSessions: [HostTerminalSession]
     let activeHostTerminalSessionID: UUID?
     let activeSplitHostSession: HostTerminalSession?
     let activeSplitLayout: HostTerminalStateStore.SplitPaneLayout?
@@ -2300,6 +2334,7 @@ struct MainTerminalDetailView: View {
     let agentStatuses: [AgentSessionStatus]
     let terminalContextMenuProvider: (HostTerminalSession) -> NSMenu?
     let onSplitFractionChanged: (CGFloat) -> Void
+    let onOpenRepoOverview: (Repo) -> Void
     var onSelectTerminalTab: ((UUID) -> Void)?
     var onCloseTerminalTab: ((UUID) -> Void)?
     var onTerminalCloseConfirmationRequired: ((UUID) -> Void)?
@@ -2374,6 +2409,14 @@ struct MainTerminalDetailView: View {
 
     @ViewBuilder
     private var previewAndTerminalPanel: some View {
+        VStack(spacing: 0) {
+            repoTerminalBreadcrumb
+            previewAndTerminalPanelContent
+        }
+    }
+
+    @ViewBuilder
+    private var previewAndTerminalPanelContent: some View {
         if let selectedCodePreview {
             if isTerminalPanelVisible {
                 VSplitView {
@@ -2409,9 +2452,47 @@ struct MainTerminalDetailView: View {
         }
     }
 
+    @ViewBuilder
+    private var repoTerminalBreadcrumb: some View {
+        if selectedWorkspace == nil, let selectedRepo {
+            HStack(spacing: 8) {
+                Button {
+                    onOpenRepoOverview(selectedRepo)
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 11, weight: .semibold))
+                        Image(systemName: "folder")
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(selectedRepo.name)
+                                .font(.callout.weight(.semibold))
+                                .lineLimit(1)
+                            Text(selectedRepo.localPath)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Open Repo Overview")
+
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .overlay(alignment: .bottom) {
+                Divider()
+            }
+        }
+    }
+
     private var hostTerminalPanel: some View {
         HostTerminalSessionStack(
-            sessions: hostTerminalSessions,
+            sessions: visibleHostTerminalSessions,
             activeSessionID: activeHostTerminalSessionID,
             splitSession: activeSplitHostSession,
             splitLayout: activeSplitLayout,

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -24,6 +24,7 @@ final class HostTerminalStateStore: ObservableObject {
     private static let splitResizeStep: CGFloat = 0.05
 
     @Published private(set) var sessions: [HostTerminalSession] = []
+    @Published private(set) var scopedSessions: [HostTerminalSession] = []
     @Published private(set) var activeSessionID: UUID?
     @Published private(set) var splitSessionsByPrimaryID: [UUID: HostTerminalSession] = [:]
     @Published private(set) var splitLayoutsByPrimaryID: [UUID: SplitPaneLayout] = [:]
@@ -83,6 +84,18 @@ final class HostTerminalStateStore: ObservableObject {
         !sessions.isEmpty
     }
 
+    var activeScopeKey: HostTerminalSessionKey? {
+        coordinator.activeScopeKey
+    }
+
+    var activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID] {
+        coordinator.activeSessionIDByScopeKey
+    }
+
+    func sessions(inScope scopeKey: HostTerminalSessionKey?) -> [HostTerminalSession] {
+        coordinator.sessions(inScope: scopeKey)
+    }
+
     @discardableResult
     func activateSession(
         key: HostTerminalSessionKey,
@@ -96,13 +109,23 @@ final class HostTerminalStateStore: ObservableObject {
 
     @discardableResult
     func activateExistingSession(sessionID: UUID) -> Bool {
-        guard let session = coordinator.sessions.first(where: { $0.id == sessionID }) else {
-            return false
-        }
-
-        _ = coordinator.activate(key: session.key, directory: session.directoryURL)
+        guard coordinator.activate(sessionID: sessionID) != nil else { return false }
         publishSnapshot()
         return true
+    }
+
+    func restoreSessions(
+        _ sessions: [HostTerminalSession],
+        activeSessionID: UUID?,
+        activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID]
+    ) {
+        guard !sessions.isEmpty else { return }
+        coordinator = HostTerminalSessionCoordinator(
+            sessions: sessions,
+            activeSessionID: activeSessionID,
+            activeSessionIDByScopeKey: activeSessionIDByScopeKey
+        )
+        publishSnapshot()
     }
 
     @discardableResult
@@ -156,8 +179,13 @@ final class HostTerminalStateStore: ObservableObject {
 
     func tabIDsForClose(mode: GhosttyAppManager.TabCloseMode, sourceSessionID: UUID?) -> [UUID] {
         guard let primarySessionID = resolvedPrimarySessionID(sourceSessionID),
-            let primaryIndex = coordinator.sessions.firstIndex(where: { $0.id == primarySessionID })
+            let primarySession = coordinator.sessions.first(where: { $0.id == primarySessionID })
         else {
+            return []
+        }
+
+        let scopedSessions = coordinator.sessions(inScope: primarySession.key)
+        guard let primaryIndex = scopedSessions.firstIndex(where: { $0.id == primarySessionID }) else {
             return []
         }
 
@@ -165,11 +193,11 @@ final class HostTerminalStateStore: ObservableObject {
         case .this:
             return [primarySessionID]
         case .other:
-            return coordinator.sessions.map(\.id).filter { $0 != primarySessionID }
+            return scopedSessions.map(\.id).filter { $0 != primarySessionID }
         case .right:
-            let rightStart = coordinator.sessions.index(after: primaryIndex)
-            guard rightStart < coordinator.sessions.endIndex else { return [] }
-            return coordinator.sessions[rightStart...].map(\.id)
+            let rightStart = scopedSessions.index(after: primaryIndex)
+            guard rightStart < scopedSessions.endIndex else { return [] }
+            return scopedSessions[rightStart...].map(\.id)
         }
     }
 
@@ -434,6 +462,7 @@ final class HostTerminalStateStore: ObservableObject {
 
     private func publishSnapshot() {
         sessions = coordinator.sessions
+        scopedSessions = coordinator.sessions(inScope: coordinator.activeScopeKey)
         activeSessionID = coordinator.activeSessionID
         sessionPresentation = coordinator.presentation
 
@@ -446,7 +475,10 @@ final class HostTerminalStateStore: ObservableObject {
         syncRegistry()
 
         for session in sessions {
-            recordTerminalSession(session, isActive: session.id == activeSessionID)
+            recordTerminalSession(
+                session,
+                isActive: coordinator.activeSessionIDByScopeKey[session.key] == session.id
+            )
         }
         for splitSession in splitSessionsByPrimaryID.values {
             recordTerminalSession(splitSession, isActive: false)
@@ -472,7 +504,10 @@ final class HostTerminalStateStore: ObservableObject {
                 kind: kind
             )
             registeredAgentSessionIDs.insert(session.id)
-            recordTerminalSession(session, isActive: session.id == activeSessionID)
+            recordTerminalSession(
+                session,
+                isActive: coordinator.activeSessionIDByScopeKey[session.key] == session.id
+            )
         }
 
         // Deregister sessions that have left the coordinator.

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -96,6 +96,19 @@ final class HostTerminalStateStore: ObservableObject {
         coordinator.sessions(inScope: scopeKey)
     }
 
+    func activeSession(inScope scopeKey: HostTerminalSessionKey) -> HostTerminalSession? {
+        let scopedSessions = coordinator.sessions(inScope: scopeKey)
+        guard !scopedSessions.isEmpty else { return nil }
+
+        if let activeSessionID = coordinator.activeSessionIDByScopeKey[scopeKey.normalized()],
+            let activeSession = scopedSessions.first(where: { $0.id == activeSessionID })
+        {
+            return activeSession
+        }
+
+        return scopedSessions.first
+    }
+
     @discardableResult
     func activateSession(
         key: HostTerminalSessionKey,

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -440,7 +440,11 @@ struct SidebarView: View {
                 if !isRepoExpanded(repo) {
                     expansionController.expandRepo(repo.id)
                 }
-                onRepoSelected(repo)
+                if paneCount(for: repoSessionKey) > 0 {
+                    onRepoTerminalSelected(repo)
+                } else {
+                    onRepoSelected(repo)
+                }
             },
             onNewWorkspace: {
                 Task { @MainActor in

--- a/Sources/WorkspaceManagerCore/Services/HostTerminalSessionCoordinator.swift
+++ b/Sources/WorkspaceManagerCore/Services/HostTerminalSessionCoordinator.swift
@@ -48,6 +48,59 @@ public enum HostTerminalSessionKey: Hashable, Sendable, CustomDebugStringConvert
     }
 }
 
+extension HostTerminalSessionKey: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case path
+        case providerID
+        case instanceID
+    }
+
+    private enum Kind: String, Codable {
+        case defaultHome
+        case repoPath
+        case hostPath
+        case backendSession
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+
+        switch kind {
+        case .defaultHome:
+            self = .defaultHome
+        case .repoPath:
+            self = .repoPath(try container.decode(String.self, forKey: .path))
+        case .hostPath:
+            self = .hostPath(try container.decode(String.self, forKey: .path))
+        case .backendSession:
+            self = .backendSession(
+                providerID: try container.decode(String.self, forKey: .providerID),
+                instanceID: try container.decode(String.self, forKey: .instanceID)
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .defaultHome:
+            try container.encode(Kind.defaultHome, forKey: .kind)
+        case .repoPath(let path):
+            try container.encode(Kind.repoPath, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case .hostPath(let path):
+            try container.encode(Kind.hostPath, forKey: .kind)
+            try container.encode(path, forKey: .path)
+        case .backendSession(let providerID, let instanceID):
+            try container.encode(Kind.backendSession, forKey: .kind)
+            try container.encode(providerID, forKey: .providerID)
+            try container.encode(instanceID, forKey: .instanceID)
+        }
+    }
+}
+
 public struct HostTerminalSession: Identifiable, Hashable, Sendable {
     public let id: UUID
     public let key: HostTerminalSessionKey
@@ -103,13 +156,47 @@ public struct HostTerminalSessionPresentation: Sendable, Equatable {
 public struct HostTerminalSessionCoordinator: Sendable {
     public private(set) var sessions: [HostTerminalSession]
     public private(set) var activeSessionID: UUID?
+    public private(set) var activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID]
 
     public init(
         sessions: [HostTerminalSession] = [],
-        activeSessionID: UUID? = nil
+        activeSessionID: UUID? = nil,
+        activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID] = [:]
     ) {
         self.sessions = sessions
-        self.activeSessionID = activeSessionID
+        self.activeSessionID = nil
+        self.activeSessionIDByScopeKey = [:]
+
+        let validSessionIDs = Set(sessions.map(\.id))
+        for (scopeKey, sessionID) in activeSessionIDByScopeKey
+        where validSessionIDs.contains(sessionID)
+            && sessions.contains(where: { $0.id == sessionID && $0.key == scopeKey.normalized() })
+        {
+            self.activeSessionIDByScopeKey[scopeKey.normalized()] = sessionID
+        }
+
+        let restoredScopeKeys = Set(self.activeSessionIDByScopeKey.keys)
+        for session in sessions where !restoredScopeKeys.contains(session.key) {
+            self.activeSessionIDByScopeKey[session.key] = session.id
+        }
+
+        if let activeSessionID, validSessionIDs.contains(activeSessionID) {
+            setActiveSessionID(activeSessionID)
+        } else {
+            self.activeSessionID = sessions.last?.id
+            if let activeSessionID = self.activeSessionID {
+                setActiveSessionID(activeSessionID)
+            }
+        }
+    }
+
+    public var activeScopeKey: HostTerminalSessionKey? {
+        activeSessionID.flatMap(session(withID:))?.key
+    }
+
+    public func sessions(inScope scopeKey: HostTerminalSessionKey?) -> [HostTerminalSession] {
+        guard let normalizedScopeKey = scopeKey?.normalized() else { return [] }
+        return sessions.filter { $0.key == normalizedScopeKey }
     }
 
     @discardableResult
@@ -122,8 +209,13 @@ public struct HostTerminalSessionCoordinator: Sendable {
         let normalizedPath = normalizedDirectory.path
         let normalizedKey = key.normalized()
 
+        if let activeScopeSession = activeSessionIDByScopeKey[normalizedKey].flatMap(session(withID:)) {
+            setActiveSessionID(activeScopeSession.id)
+            return HostTerminalSessionActivationResult(session: activeScopeSession, created: false)
+        }
+
         if let existing = sessions.first(where: { $0.key == normalizedKey }) {
-            activeSessionID = existing.id
+            setActiveSessionID(existing.id)
             return HostTerminalSessionActivationResult(session: existing, created: false)
         }
 
@@ -132,7 +224,7 @@ public struct HostTerminalSessionCoordinator: Sendable {
                 shouldReuseByDirectoryPath(for: $0.key) && $0.directoryPath == normalizedPath
             })
         {
-            activeSessionID = existing.id
+            setActiveSessionID(existing.id)
             return HostTerminalSessionActivationResult(session: existing, created: false)
         }
 
@@ -142,8 +234,15 @@ public struct HostTerminalSessionCoordinator: Sendable {
             customCommand: customCommand
         )
         sessions.append(session)
-        activeSessionID = session.id
+        setActiveSessionID(session.id)
         return HostTerminalSessionActivationResult(session: session, created: true)
+    }
+
+    @discardableResult
+    public mutating func activate(sessionID: UUID) -> HostTerminalSession? {
+        guard let session = session(withID: sessionID) else { return nil }
+        setActiveSessionID(session.id)
+        return session
     }
 
     @discardableResult
@@ -154,53 +253,71 @@ public struct HostTerminalSessionCoordinator: Sendable {
             customCommand: source.customCommand
         )
         sessions.append(session)
-        activeSessionID = session.id
+        setActiveSessionID(session.id)
         return session
     }
 
     @discardableResult
     public mutating func activateAdjacent(to sessionID: UUID, offset: Int) -> HostTerminalSession? {
-        guard !sessions.isEmpty,
-            let currentIndex = sessions.firstIndex(where: { $0.id == sessionID })
+        guard let currentSession = session(withID: sessionID) else {
+            return nil
+        }
+
+        let scopedSessions = sessions(inScope: currentSession.key)
+        guard !scopedSessions.isEmpty,
+            let currentIndex = scopedSessions.firstIndex(where: { $0.id == sessionID })
         else {
             return nil
         }
 
-        let nextIndex = wrappedIndex(currentIndex + offset, count: sessions.count)
-        let session = sessions[nextIndex]
-        activeSessionID = session.id
+        let nextIndex = wrappedIndex(currentIndex + offset, count: scopedSessions.count)
+        let session = scopedSessions[nextIndex]
+        setActiveSessionID(session.id)
         return session
     }
 
     @discardableResult
     public mutating func activateTab(atOneBasedIndex index: Int) -> HostTerminalSession? {
-        guard !sessions.isEmpty else { return nil }
-        let clampedIndex = min(max(index - 1, 0), sessions.count - 1)
-        let session = sessions[clampedIndex]
-        activeSessionID = session.id
+        let scopedSessions = sessions(inScope: activeScopeKey)
+        guard !scopedSessions.isEmpty else { return nil }
+        let clampedIndex = min(max(index - 1, 0), scopedSessions.count - 1)
+        let session = scopedSessions[clampedIndex]
+        setActiveSessionID(session.id)
         return session
     }
 
     @discardableResult
     public mutating func activateLastTab() -> HostTerminalSession? {
-        guard let session = sessions.last else { return nil }
-        activeSessionID = session.id
+        guard let session = sessions(inScope: activeScopeKey).last else { return nil }
+        setActiveSessionID(session.id)
         return session
     }
 
     @discardableResult
     public mutating func moveTab(sessionID: UUID, offset: Int) -> Bool {
-        guard sessions.count > 1,
+        guard let currentSession = session(withID: sessionID) else { return false }
+
+        let scopedIndices = sessions.indices.filter { sessions[$0].key == currentSession.key }
+        guard scopedIndices.count > 1,
             offset != 0,
-            let currentIndex = sessions.firstIndex(where: { $0.id == sessionID })
+            let currentGlobalIndex = sessions.firstIndex(where: { $0.id == sessionID }),
+            let currentScopedIndex = scopedIndices.firstIndex(of: currentGlobalIndex)
         else {
             return false
         }
 
-        let session = sessions.remove(at: currentIndex)
-        let nextIndex = wrappedIndex(currentIndex + offset, count: sessions.count + 1)
-        sessions.insert(session, at: nextIndex)
-        activeSessionID = session.id
+        let nextScopedIndex = wrappedIndex(currentScopedIndex + offset, count: scopedIndices.count)
+        let session = sessions.remove(at: currentGlobalIndex)
+        let remainingScopeIndices = sessions.indices.filter { sessions[$0].key == currentSession.key }
+        let insertionIndex: Int
+        if nextScopedIndex >= remainingScopeIndices.count {
+            insertionIndex = remainingScopeIndices.last.map { sessions.index(after: $0) } ?? sessions.endIndex
+        } else {
+            insertionIndex = remainingScopeIndices[nextScopedIndex]
+        }
+
+        sessions.insert(session, at: insertionIndex)
+        setActiveSessionID(session.id)
         return true
     }
 
@@ -239,7 +356,11 @@ public struct HostTerminalSessionCoordinator: Sendable {
         sessions.removeAll { removedSet.contains($0.id) }
 
         if let activeSessionID, removedSet.contains(activeSessionID) {
-            self.activeSessionID = sessions.last?.id
+            setActiveSessionID(sessions.last?.id)
+        }
+
+        for sessionID in removedIDs {
+            removeActiveScopeReference(for: sessionID)
         }
 
         return removedIDs
@@ -253,8 +374,10 @@ public struct HostTerminalSessionCoordinator: Sendable {
 
         let removed = sessions.remove(at: index)
         if activeSessionID == sessionID {
-            activeSessionID = sessions.last?.id
+            let sameScopeFallback = sessions.last(where: { $0.key == removed.key })
+            setActiveSessionID(sameScopeFallback?.id ?? sessions.last?.id)
         }
+        removeActiveScopeReference(for: sessionID, removedScopeKey: removed.key)
 
         return removed
     }
@@ -287,5 +410,38 @@ public struct HostTerminalSessionCoordinator: Sendable {
             hasDefaultHomeSession: hasDefaultHomeSession,
             isDefaultHomeSessionActive: isDefaultHomeSessionActive
         )
+    }
+
+    private func session(withID sessionID: UUID) -> HostTerminalSession? {
+        sessions.first(where: { $0.id == sessionID })
+    }
+
+    private mutating func setActiveSessionID(_ sessionID: UUID?) {
+        activeSessionID = sessionID
+        guard let sessionID, let session = session(withID: sessionID) else { return }
+        activeSessionIDByScopeKey[session.key] = sessionID
+    }
+
+    private mutating func removeActiveScopeReference(
+        for sessionID: UUID,
+        removedScopeKey: HostTerminalSessionKey? = nil
+    ) {
+        let affectedScopeKeys = activeSessionIDByScopeKey.compactMap { scopeKey, activeSessionID in
+            activeSessionID == sessionID ? scopeKey : nil
+        }
+
+        for scopeKey in affectedScopeKeys {
+            activeSessionIDByScopeKey.removeValue(forKey: scopeKey)
+            if let fallbackSession = sessions.last(where: { $0.key == scopeKey }) {
+                activeSessionIDByScopeKey[scopeKey] = fallbackSession.id
+            }
+        }
+
+        if let removedScopeKey,
+            activeSessionIDByScopeKey[removedScopeKey] == nil,
+            let fallbackSession = sessions.last(where: { $0.key == removedScopeKey })
+        {
+            activeSessionIDByScopeKey[removedScopeKey] = fallbackSession.id
+        }
     }
 }

--- a/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
@@ -89,6 +89,53 @@ struct HostTerminalStateStoreTests {
         #expect(store.tabIDsForClose(mode: .right, sourceSessionID: second.id) == [third.id])
     }
 
+    @Test("Scoped sessions follow the active terminal scope")
+    func scopedSessionsFollowActiveScope() throws {
+        let store = HostTerminalStateStore()
+        let home = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        let secondHomeTab = try #require(store.createTab())
+        let repoURL = URL(fileURLWithPath: "/Users/test/code/repo")
+        let repo = store.activateSession(
+            key: .repoPath(repoURL.path),
+            directory: repoURL
+        ).session
+        let secondRepoTab = try #require(store.createTab())
+
+        #expect(store.scopedSessions.map(\.id) == [repo.id, secondRepoTab.id])
+
+        #expect(store.activateExistingSession(sessionID: secondHomeTab.id))
+        #expect(store.scopedSessions.map(\.id) == [home.id, secondHomeTab.id])
+    }
+
+    @Test("Close other and right candidates stay within the source scope")
+    func closeCandidatesStayWithinSourceScope() throws {
+        let store = HostTerminalStateStore()
+        _ =
+            store.activateSession(
+                key: .defaultHome,
+                directory: URL(fileURLWithPath: "/Users/test")
+            ).session
+        _ = try #require(store.createTab())
+
+        let repoURL = URL(fileURLWithPath: "/Users/test/code/repo")
+        let firstRepoTab = store.activateSession(
+            key: .repoPath(repoURL.path),
+            directory: repoURL
+        ).session
+        let secondRepoTab = try #require(store.createTab())
+        let thirdRepoTab = try #require(store.createTab())
+
+        #expect(
+            store.tabIDsForClose(mode: .other, sourceSessionID: secondRepoTab.id) == [
+                firstRepoTab.id,
+                thirdRepoTab.id,
+            ])
+        #expect(store.tabIDsForClose(mode: .right, sourceSessionID: secondRepoTab.id) == [thirdRepoTab.id])
+    }
+
     @Test("ensureSplit stores preferred top-bottom layout")
     func ensureSplitStoresPreferredLayout() {
         let store = HostTerminalStateStore()

--- a/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
@@ -110,6 +110,30 @@ struct HostTerminalStateStoreTests {
         #expect(store.scopedSessions.map(\.id) == [home.id, secondHomeTab.id])
     }
 
+    @Test("Active session lookup restores the active backend scope tab")
+    func activeSessionLookupRestoresActiveBackendScopeTab() throws {
+        let store = HostTerminalStateStore()
+        let backendKey = HostTerminalSessionKey.backendSession(providerID: "lume", instanceID: "vm-123")
+        _ =
+            store.activateSession(
+                key: backendKey,
+                directory: URL(fileURLWithPath: "/tmp/workspaces/vm-123"),
+                customCommand: "/usr/local/bin/lume ssh vm-123"
+            ).session
+        let secondBackendTab = try #require(store.createTab())
+        _ =
+            store.activateSession(
+                key: .defaultHome,
+                directory: URL(fileURLWithPath: "/Users/test")
+            ).session
+
+        let activeBackendTab = try #require(store.activeSession(inScope: backendKey))
+
+        #expect(activeBackendTab.id == secondBackendTab.id)
+        #expect(store.activateExistingSession(sessionID: activeBackendTab.id))
+        #expect(store.activeSessionID == secondBackendTab.id)
+    }
+
     @Test("Close other and right candidates stay within the source scope")
     func closeCandidatesStayWithinSourceScope() throws {
         let store = HostTerminalStateStore()

--- a/Tests/WorkspaceManagerAppTests/MainWindowTerminalSessionControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowTerminalSessionControllerTests.swift
@@ -43,10 +43,11 @@ struct MainWindowTerminalSessionControllerTests {
             key: .defaultHome,
             directory: URL(fileURLWithPath: "/Users/test")
         )
-        let workspaceSession = store.activateSession(
+        let firstWorkspaceSession = store.activateSession(
             key: .hostPath(fixture.workspace.path),
             directory: fixture.workspace.workspaceURL
         ).session
+        let secondWorkspaceSession = try #require(store.createTab())
 
         let result = try #require(
             controller.selectAdjacentTab(
@@ -57,18 +58,18 @@ struct MainWindowTerminalSessionControllerTests {
             )
         )
 
-        #expect(result.focusSessionID != workspaceSession.id)
-        #expect(result.syncedWorkspace == nil)
+        #expect(result.focusSessionID == firstWorkspaceSession.id)
+        #expect(result.syncedWorkspace?.id == fixture.workspace.id)
 
         let workspaceResult = try #require(
             controller.selectTab(
-                sessionID: workspaceSession.id,
+                sessionID: secondWorkspaceSession.id,
                 hostTerminalState: store,
                 repos: [fixture.repo],
                 normalizePath: normalizePath
             )
         )
-        #expect(workspaceResult.focusSessionID == workspaceSession.id)
+        #expect(workspaceResult.focusSessionID == secondWorkspaceSession.id)
         #expect(workspaceResult.syncedWorkspace?.id == fixture.workspace.id)
     }
 

--- a/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
@@ -150,6 +150,40 @@ struct TerminalContinuityManifestTests {
         #expect(snapshot.activeSessionIDByScopeKey[.repoPath(repo.path)] == secondRepoSession.id)
     }
 
+    @Test("Host session snapshot skips provider-backed command sessions")
+    func hostSessionSnapshotSkipsProviderBackedCommandSessions() throws {
+        let home = try temporaryDirectory()
+        let remoteWorkingDirectory = try temporaryDirectory()
+        let homeSession = HostTerminalSession(key: .defaultHome, directory: home)
+        let remoteSession = HostTerminalSession(
+            key: .backendSession(providerID: "lume", instanceID: "vm-123"),
+            directory: remoteWorkingDirectory,
+            customCommand: "/usr/local/bin/lume ssh vm-123"
+        )
+
+        let manifest = TerminalContinuityManifest(
+            targetKind: .workspace,
+            targetID: UUID(),
+            rootURL: home,
+            launchURL: home,
+            terminalMode: .ghosttyManagedSplits,
+            sessions: [homeSession, remoteSession],
+            activeSessionID: remoteSession.id,
+            activeSessionIDByScopeKey: [
+                .defaultHome: homeSession.id,
+                .backendSession(providerID: "lume", instanceID: "vm-123"): remoteSession.id,
+            ],
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let snapshot = try #require(manifest.hostSessionSnapshot())
+
+        #expect(snapshot.sessions.map(\.id) == [homeSession.id])
+        #expect(snapshot.activeSessionID == homeSession.id)
+        #expect(snapshot.activeSessionIDByScopeKey[.defaultHome] == homeSession.id)
+        #expect(snapshot.activeSessionIDByScopeKey[.backendSession(providerID: "lume", instanceID: "vm-123")] == nil)
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("TerminalContinuityManifestTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Testing
+import WorkspaceManagerCore
 
 @testable import WorkspaceManager
 
@@ -115,6 +116,38 @@ struct TerminalContinuityManifestTests {
         )
 
         #expect(restored.path == root.path)
+    }
+
+    @Test("Host session snapshot restores tabs and active tab by scope")
+    func hostSessionSnapshotRestoresTabsByScope() throws {
+        let home = try temporaryDirectory()
+        let repo = try temporaryDirectory()
+        let homeSession = HostTerminalSession(key: .defaultHome, directory: home)
+        let repoSession = HostTerminalSession(key: .repoPath(repo.path), directory: repo)
+        let secondRepoSession = HostTerminalSession(key: .repoPath(repo.path), directory: repo)
+
+        let manifest = TerminalContinuityManifest(
+            targetKind: .repo,
+            targetID: UUID(),
+            rootURL: repo,
+            launchURL: repo,
+            terminalMode: .ghosttyManagedSplits,
+            sessions: [homeSession, repoSession, secondRepoSession],
+            activeSessionID: secondRepoSession.id,
+            activeSessionIDByScopeKey: [
+                .defaultHome: homeSession.id,
+                .repoPath(repo.path): secondRepoSession.id,
+            ],
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let decoded = try #require(TerminalContinuityManifest.decode(from: manifest.rawValue))
+        let snapshot = try #require(decoded.hostSessionSnapshot())
+
+        #expect(snapshot.sessions.map(\.id) == [homeSession.id, repoSession.id, secondRepoSession.id])
+        #expect(snapshot.activeSessionID == secondRepoSession.id)
+        #expect(snapshot.activeSessionIDByScopeKey[.defaultHome] == homeSession.id)
+        #expect(snapshot.activeSessionIDByScopeKey[.repoPath(repo.path)] == secondRepoSession.id)
     }
 
     private func temporaryDirectory() throws -> URL {

--- a/Tests/WorkspaceManagerTests/HostTerminalSessionCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerTests/HostTerminalSessionCoordinatorTests.swift
@@ -230,6 +230,63 @@ struct HostTerminalSessionCoordinatorTests {
         #expect(coordinator.activeSessionID == workspaceSession.id)
     }
 
+    @Test("Scope activation restores the last active tab for that scope")
+    func scopeActivationRestoresLastActiveTab() throws {
+        var coordinator = HostTerminalSessionCoordinator()
+        let homeURL = URL(fileURLWithPath: "/Users/test/code")
+        let repoURL = URL(fileURLWithPath: "/Users/test/code/repo-a")
+
+        let home = coordinator.activate(key: .defaultHome, directory: homeURL).session
+        let secondHomeTab = coordinator.createTab(from: home)
+        let repo = coordinator.activate(key: .repoPath(repoURL.path), directory: repoURL).session
+        let secondRepoTab = coordinator.createTab(from: repo)
+
+        _ = coordinator.activate(key: .defaultHome, directory: homeURL)
+        #expect(coordinator.activeSessionID == secondHomeTab.id)
+
+        let restoredRepo = coordinator.activate(key: .repoPath(repoURL.path), directory: repoURL)
+        #expect(!restoredRepo.created)
+        #expect(restoredRepo.session.id == secondRepoTab.id)
+        #expect(coordinator.activeSessionID == secondRepoTab.id)
+    }
+
+    @Test("Tab navigation stays within the active scope")
+    func tabNavigationStaysWithinActiveScope() throws {
+        var coordinator = HostTerminalSessionCoordinator()
+        let homeURL = URL(fileURLWithPath: "/Users/test/code")
+        let repoURL = URL(fileURLWithPath: "/Users/test/code/repo-a")
+
+        let home = coordinator.activate(key: .defaultHome, directory: homeURL).session
+        let secondHomeTab = coordinator.createTab(from: home)
+        let repo = coordinator.activate(key: .repoPath(repoURL.path), directory: repoURL).session
+        let secondRepoTab = coordinator.createTab(from: repo)
+
+        #expect(coordinator.activateAdjacent(to: secondRepoTab.id, offset: 1)?.id == repo.id)
+        #expect(coordinator.activateAdjacent(to: repo.id, offset: -1)?.id == secondRepoTab.id)
+        #expect(coordinator.activateTab(atOneBasedIndex: 1)?.id == repo.id)
+        #expect(coordinator.activateLastTab()?.id == secondRepoTab.id)
+
+        _ = coordinator.activate(key: .defaultHome, directory: homeURL)
+        #expect(coordinator.activateAdjacent(to: secondHomeTab.id, offset: 1)?.id == home.id)
+    }
+
+    @Test("Moving tabs reorders only the source scope")
+    func movingTabsReordersOnlySourceScope() throws {
+        var coordinator = HostTerminalSessionCoordinator()
+        let homeURL = URL(fileURLWithPath: "/Users/test/code")
+        let repoURL = URL(fileURLWithPath: "/Users/test/code/repo-a")
+
+        let home = coordinator.activate(key: .defaultHome, directory: homeURL).session
+        let secondHomeTab = coordinator.createTab(from: home)
+        let repo = coordinator.activate(key: .repoPath(repoURL.path), directory: repoURL).session
+        let secondRepoTab = coordinator.createTab(from: repo)
+
+        let didMoveRepoTab = coordinator.moveTab(sessionID: secondRepoTab.id, offset: -1)
+        #expect(didMoveRepoTab)
+        #expect(coordinator.sessions(inScope: .repoPath(repoURL.path)).map(\.id) == [secondRepoTab.id, repo.id])
+        #expect(coordinator.sessions(inScope: .defaultHome).map(\.id) == [home.id, secondHomeTab.id])
+    }
+
     @Test("Canonical-path-equivalent selections do not duplicate sessions")
     func canonicalEquivalentSelectionsDoNotDuplicateSessions() throws {
         var coordinator = HostTerminalSessionCoordinator()

--- a/docs/decisions/terminal-tab-scopes.md
+++ b/docs/decisions/terminal-tab-scopes.md
@@ -1,0 +1,44 @@
+# Terminal Tab Scopes
+
+## Status
+
+Accepted
+
+## Context
+
+Host terminal tabs were stored in one flat list and rendered globally. That kept
+terminals alive across navigation, but it meant a workspace surface could show tabs
+from Home, another workspace, and the repository root at the same time.
+
+The repo-root terminal is easy to mistake for a workspace because it has terminal
+tabs and can run agents. It is not a workspace: a workspace is an isolated copy or
+provider-backed environment created from a repository for a single work stream.
+
+## Decision
+
+Treat terminal tabs as collections owned by a **Terminal Scope**. A scope is exactly
+one of:
+
+- Home (`~/code`)
+- a Repository
+- a Workspace
+
+`HostTerminalSessionKey` is the scope identity. Tabs remain in the coordinator's flat
+session list, but tab rendering, tab navigation, tab reordering, and close-other /
+close-right operations filter by the active scope key.
+
+The repo-root terminal remains a Repository-scoped Terminal Session. It is reached
+from the Repo Overview, and when repository tabs already exist the sidebar repository
+row resumes that terminal collection directly. The repo-terminal header provides the
+breadcrumb back to the Repo Overview.
+
+## Consequences
+
+- We preserve the invariant that workspaces are isolated copies or remote
+  environments, not the repository root.
+- Terminal processes can stay alive globally while the visible tab strip remains
+  local to the current Home, Repository, or Workspace scope.
+- There is no new tab-group data model. The ordered flat list remains the source of
+  truth, with `HostTerminalSessionKey` providing the grouping boundary.
+- Launch continuity must persist both the flat tab list and the active tab for each
+  scope, otherwise a restored repository row could not resume the same tab collection.

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -65,6 +65,8 @@ CREATE TABLE IF NOT EXISTS terminal_sessions (
     custom_command_present INTEGER NOT NULL DEFAULT 0
         CHECK (custom_command_present IN (0, 1)),
     hooks_socket_path TEXT,
+    -- Active tab for this terminal scope; more than one row can be active
+    -- globally when they belong to different Home/Repository/Workspace scopes.
     is_active INTEGER NOT NULL DEFAULT 0
         CHECK (is_active IN (0, 1)),
     created_at TEXT NOT NULL,

--- a/prototypes/terminal-tab-scopes/index.html
+++ b/prototypes/terminal-tab-scopes/index.html
@@ -1,0 +1,410 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Per-Scope Terminal Tab Collections — Prototype</title>
+<style>
+  :root {
+    --bg: #1c1c1e;
+    --sidebar-bg: #252527;
+    --sidebar-bg2: #202022;
+    --row-sel: #3a3a3d;
+    --row-hover: #2e2e30;
+    --main-bg: #1a1a1c;
+    --header-bg: #232325;
+    --tabbar-bg: #202022;
+    --tab-active: #2c2c2f;
+    --tab-inactive: transparent;
+    --border: #38383b;
+    --border-soft: #2c2c2f;
+    --text: #e8e8ea;
+    --text-dim: #98989d;
+    --text-faint: #6a6a6e;
+    --accent: #2f6bff;
+    --accent-soft: #3b82f6;
+    --term-green: #7ee787;
+    --term-dim: #5a5a5e;
+    --good: #34c759;
+    --radius: 7px;
+    --mono: ui-monospace, "SF Mono", Menlo, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #0d0d0f;
+    color: var(--text);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 20px 56px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+  }
+  .intro { max-width: 1040px; width: 100%; }
+  .intro h1 { font-size: 19px; font-weight: 600; letter-spacing: -0.01em; }
+  .intro p { color: var(--text-dim); font-size: 13.5px; line-height: 1.55; margin-top: 7px; }
+  .intro code { font-family: var(--mono); font-size: 12px; background: #2a2a2d; padding: 1px 5px; border-radius: 4px; color: #d0d0d4; }
+
+  .controls {
+    display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+    max-width: 1040px; width: 100%; font-size: 12.5px; color: var(--text-dim);
+  }
+  .toggle {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    background: #232326; border: 1px solid var(--border); padding: 6px 11px; border-radius: 20px;
+    user-select: none;
+  }
+  .toggle .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--term-dim); transition: background .15s; }
+  .toggle.on .dot { background: var(--good); }
+  .toggle .label { color: var(--text); font-size: 12px; }
+
+  /* ---- App window ---- */
+  .window {
+    width: 1040px; height: 600px; background: var(--bg);
+    border-radius: 12px; overflow: hidden; display: flex; flex-direction: column;
+    box-shadow: 0 24px 70px rgba(0,0,0,.55), 0 0 0 1px rgba(255,255,255,.04);
+  }
+  .titlebar {
+    height: 38px; flex: none; display: flex; align-items: center;
+    background: var(--header-bg); border-bottom: 1px solid var(--border-soft);
+    padding: 0 14px; gap: 8px;
+  }
+  .lights { display: flex; gap: 8px; }
+  .light { width: 12px; height: 12px; border-radius: 50%; }
+  .light.r { background: #ff5f57; } .light.y { background: #febc2e; } .light.g { background: #28c840; }
+  .titlebar .spacer { flex: 1; }
+  .pill-btn {
+    display: inline-flex; align-items: center; gap: 5px; height: 23px; padding: 0 9px;
+    background: #303034; border: 1px solid #3d3d41; border-radius: 6px;
+    color: var(--text); font-size: 12px; cursor: pointer;
+  }
+  .icon-btn { color: var(--text-dim); font-size: 15px; padding: 2px 5px; cursor: pointer; }
+
+  .body { flex: 1; display: flex; min-height: 0; }
+
+  /* ---- Sidebar ---- */
+  .sidebar {
+    width: 244px; flex: none; background: var(--sidebar-bg);
+    border-right: 1px solid var(--border-soft); display: flex; flex-direction: column;
+  }
+  .sb-head {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 11px 14px 7px; color: var(--text-faint);
+    font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;
+  }
+  .sb-scroll { overflow-y: auto; padding: 2px 8px 12px; flex: 1; }
+  .row {
+    display: flex; align-items: center; gap: 8px; height: 30px; padding: 0 8px;
+    border-radius: 6px; cursor: pointer; color: var(--text); font-size: 13px;
+    position: relative; user-select: none;
+  }
+  .row:hover { background: var(--row-hover); }
+  .row.sel { background: var(--row-sel); }
+  .row .ico { width: 17px; text-align: center; font-size: 13px; color: var(--text-dim); flex: none; }
+  .row.sel .ico, .row.live .ico { color: var(--accent-soft); }
+  .row .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .row .live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); flex: none; }
+  .row.child { margin-left: 16px; }
+  .row.child2 { margin-left: 30px; }
+  .disclosure { width: 12px; font-size: 9px; color: var(--text-faint); flex: none; text-align: center; }
+  .hint {
+    font-size: 10.5px; color: var(--text-faint); margin: 1px 0 6px 34px;
+    font-style: italic; line-height: 1.3;
+  }
+
+  /* ---- Main pane ---- */
+  .main { flex: 1; min-width: 0; background: var(--main-bg); display: flex; flex-direction: column; }
+  .main-head {
+    height: 46px; flex: none; display: flex; align-items: center; gap: 8px;
+    padding: 0 16px; border-bottom: 1px solid var(--border-soft); background: var(--header-bg);
+  }
+  .crumb { display: flex; align-items: center; gap: 6px; font-size: 14px; font-weight: 600; }
+  .crumb .back {
+    color: var(--accent-soft); cursor: pointer; font-weight: 500; font-size: 13px;
+    display: inline-flex; align-items: center; gap: 4px;
+  }
+  .crumb .back:hover { text-decoration: underline; }
+  .crumb .sep { color: var(--text-faint); font-weight: 400; }
+  .main-head .spacer { flex: 1; }
+  .scope-badge {
+    font-size: 10.5px; color: var(--text-faint); border: 1px solid var(--border);
+    border-radius: 5px; padding: 2px 7px; font-family: var(--mono);
+  }
+
+  /* tab strip */
+  .tabbar {
+    height: 36px; flex: none; display: flex; align-items: center; gap: 4px;
+    padding: 0 8px; background: var(--tabbar-bg); border-bottom: 1px solid var(--border-soft);
+    overflow-x: auto;
+  }
+  .tab {
+    display: inline-flex; align-items: center; gap: 7px; height: 25px; padding: 0 9px;
+    border-radius: 6px; font-size: 12px; color: var(--text-dim); cursor: pointer;
+    white-space: nowrap; flex: none;
+  }
+  .tab:hover { background: #2a2a2d; }
+  .tab.active { background: var(--tab-active); color: var(--text); }
+  .tab .tico { font-size: 11px; opacity: .8; }
+  .tab .x { color: var(--text-faint); font-size: 13px; opacity: 0; }
+  .tab:hover .x, .tab.active .x { opacity: .7; }
+  .tab .x:hover { color: var(--text); }
+  .tab-new { color: var(--text-faint); font-size: 16px; padding: 0 9px; cursor: pointer; flex: none; }
+  .tab-new:hover { color: var(--text); }
+
+  /* terminal canvas */
+  .term { flex: 1; min-height: 0; padding: 16px 18px; font-family: var(--mono); font-size: 12.5px; line-height: 1.65; overflow: hidden; }
+  .term .dim { color: var(--term-dim); }
+  .term .grn { color: var(--term-green); }
+  .term .cwd { color: #79b8ff; }
+  .term .cursor { display: inline-block; width: 7px; height: 14px; background: var(--text); vertical-align: -2px; animation: blink 1.1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  /* overview */
+  .overview { flex: 1; min-height: 0; overflow-y: auto; padding: 20px 22px; }
+  .ov-top { display: flex; align-items: center; gap: 12px; margin-bottom: 22px; }
+  .ov-folder { width: 42px; height: 42px; border-radius: 9px; background: #303034; display: grid; place-items: center; font-size: 19px; }
+  .ov-title { font-size: 15px; font-weight: 600; }
+  .ov-sub { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
+  .ov-actions { margin-left: auto; display: flex; gap: 9px; }
+  .ov-btn { height: 30px; padding: 0 13px; border-radius: 7px; font-size: 12.5px; display: inline-flex; align-items: center; gap: 6px; cursor: pointer; border: 1px solid #3d3d41; background: #2c2c30; color: var(--text); }
+  .ov-btn.primary { background: var(--accent); border-color: var(--accent); }
+  .ov-sec-h { font-size: 12px; font-weight: 600; color: var(--text-dim); margin: 6px 0 11px; }
+  .ov-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 26px; }
+  .ws-card { border: 1px solid var(--border-soft); border-radius: 9px; padding: 13px; background: #202023; cursor: pointer; }
+  .ws-card:hover { border-color: #4a4a4f; }
+  .ws-card.new { display: grid; place-items: center; color: var(--text-faint); border-style: dashed; min-height: 92px; gap: 6px; }
+  .ws-card .ws-name { font-size: 13px; font-weight: 600; display: flex; justify-content: space-between; align-items: center; }
+  .ws-card .ws-active { font-size: 10px; color: var(--good); font-weight: 600; }
+  .ws-card .ws-branch { font-size: 11px; color: var(--text-dim); margin-top: 10px; font-family: var(--mono); }
+  .ov-web { border: 1px solid var(--border-soft); border-radius: 9px; padding: 12px 14px; display: flex; align-items: center; gap: 10px; background: #202023; }
+  .ov-web .gl { font-size: 15px; }
+  .ov-web .wt { font-size: 13px; font-weight: 500; }
+  .ov-web .wu { font-size: 11px; color: var(--text-dim); }
+
+  .annot { max-width: 1040px; width: 100%; font-size: 12.5px; color: var(--text-dim); line-height: 1.55; display:flex; gap:18px; flex-wrap:wrap; }
+  .annot .k { color: var(--accent-soft); font-weight: 600; }
+  .legend { display:flex; gap:7px; align-items:flex-start; flex:1; min-width: 280px; }
+  .legend .b { color: var(--text); font-weight:600; }
+</style>
+</head>
+<body>
+
+<div class="intro">
+  <h1>Per-Scope Terminal Tab Collections</h1>
+  <p>Each <b>Terminal Scope</b> — Home (<code>~/code</code>), a Repository's root terminal, or a Workspace — owns its own tab strip. Selecting one in the sidebar shows <i>only</i> that scope's tabs. The repo-root terminal is <b>not</b> a Workspace; it's reached from the Overview, and once it has live tabs the folder row resumes it directly. Click around — it's live.</p>
+</div>
+
+<div class="controls">
+  <div class="toggle on" id="liveToggle" onclick="toggleLive()">
+    <span class="dot"></span>
+    <span class="label">Repo “workspaces” has live root-terminal tabs</span>
+  </div>
+  <span>← toggle to see the folder-row behavior change between <b>resume terminal</b> and <b>show Overview</b></span>
+</div>
+
+<div class="window">
+  <div class="titlebar">
+    <div class="lights"><span class="light r"></span><span class="light y"></span><span class="light g"></span></div>
+    <div class="spacer"></div>
+    <div class="pill-btn">＋ <span style="font-size:9px;opacity:.7">▾</span></div>
+    <div class="icon-btn">▭</div>
+  </div>
+  <div class="body">
+    <!-- Sidebar -->
+    <div class="sidebar">
+      <div class="sb-head"><span>Repositories</span><span style="font-size:13px">⇅</span></div>
+      <div class="sb-scroll" id="sidebar"></div>
+    </div>
+    <!-- Main -->
+    <div class="main" id="main"></div>
+  </div>
+</div>
+
+<div class="annot">
+  <div class="legend"><span class="b">Folder row&nbsp;</span><span>resumes the repo-root terminal when it has live tabs, otherwise opens the Overview. The repo name in the terminal header is a breadcrumb back to the Overview — its only entry once the row resumes the terminal.</span></div>
+</div>
+
+<script>
+const state = { repoLive: true, sel: 'ws:brisk-sparrow' };
+
+// ---- model ----
+const scopes = {
+  'home': {
+    kind: 'terminal', title: '~/code', badge: 'scope: Home',
+    cwd: '~/code',
+    tabs: [{ico:'❯_', name:'code'}],
+  },
+  'repo:workspaces': {
+    kind: 'terminal', title: 'workspaces', badge: 'scope: Repository · workspaces',
+    cwd: '~/code/workspaces', crumb: true,
+    tabs: [{ico:'❯_', name:'main'}, {ico:'⚙', name:'build'}, {ico:'≣', name:'logs'}],
+  },
+  'overview:workspaces': { kind: 'overview' },
+  'ws:brisk-sparrow': {
+    kind: 'terminal', title: 'brisk-sparrow', badge: 'scope: Workspace · brisk-sparrow',
+    cwd: '~/workspaces/brisk-sparrow', branch: 'workspace/brisk-sparrow',
+    tabs: [{ico:'❯_', name:'zsh'}, {ico:'✦', name:'claude'}],
+  },
+  'ws:brisk-trail': {
+    kind: 'terminal', title: 'brisk-trail', badge: 'scope: Workspace · brisk-trail',
+    cwd: '~/workspaces/brisk-trail', branch: 'workspace/brisk-trail',
+    tabs: [{ico:'❯_', name:'zsh'}],
+  },
+  'ws:zesty-comet': {
+    kind: 'terminal', title: 'zesty-comet', badge: 'scope: Workspace · zesty-comet',
+    cwd: '~/workspaces/zesty-comet', branch: 'workspace/zesty-comet',
+    tabs: [{ico:'❯_', name:'zsh'}, {ico:'▶', name:'server'}],
+  },
+};
+const activeTab = { 'home':0, 'repo:workspaces':0, 'ws:brisk-sparrow':1, 'ws:brisk-trail':0, 'ws:zesty-comet':1 };
+
+// ---- sidebar ----
+function renderSidebar() {
+  const live = state.repoLive;
+  const rows = [];
+  rows.push(repoRow());
+  rows.push(`<div class="hint">${live
+    ? 'has live tabs → clicking resumes the root terminal'
+    : 'no live tabs → clicking opens the Overview'}</div>`);
+  rows.push(wsRow('spaces', '🌐', 'web', 'web:spaces', false));
+  rows.push(wsRow('brisk-sparrow', '❯_', 'ws:brisk-sparrow'));
+  rows.push(wsRow('brisk-trail', '❯_', 'ws:brisk-trail'));
+  rows.push(wsRow('zesty-comet', '❯_', 'ws:zesty-comet'));
+  // a couple of sibling repos for context
+  rows.push(plainRepo('keep'));
+  rows.push(plainRepo('dotclaude'));
+  rows.push(plainRepo('voxcode'));
+  document.getElementById('sidebar').innerHTML = rows.join('');
+}
+function repoRow() {
+  const live = state.repoLive;
+  const isSel = state.sel === 'repo:workspaces' || state.sel === 'overview:workspaces';
+  const cls = ['row']; if (isSel) cls.push('sel'); if (live) cls.push('live');
+  return `<div class="${cls.join(' ')}" onclick="clickRepo()">
+    <span class="disclosure">▾</span>
+    <span class="ico">📁</span>
+    <span class="name">workspaces</span>
+    ${live ? '<span class="live-dot"></span>' : ''}
+  </div>`;
+}
+function wsRow(name, ico, sel, isWeb) {
+  const k = sel.startsWith('ws') ? sel : sel;
+  const id = arguments.length >= 4 ? arguments[3] : sel; // handle web overload
+  const realSel = (typeof isWeb === 'string') ? isWeb : sel;
+  const selId = (sel === 'web') ? 'web:spaces' : sel;
+  // normalize
+  const target = (ico === '🌐') ? null : sel;
+  const active = state.sel === sel;
+  const cls = ['row','child']; if (active) cls.push('sel');
+  const onclick = target ? `onclick="select('${sel}')"` : '';
+  return `<div class="${cls.join(' ')}" ${onclick}>
+    <span class="ico">${ico}</span>
+    <span class="name">${name}</span>
+    ${(ico !== '🌐') ? '<span class="live-dot"></span>' : ''}
+  </div>`;
+}
+function plainRepo(name) {
+  return `<div class="row" style="opacity:.78"><span class="disclosure"></span><span class="ico">📁</span><span class="name">${name}</span></div>`;
+}
+
+// ---- interactions ----
+function clickRepo() {
+  state.sel = state.repoLive ? 'repo:workspaces' : 'overview:workspaces';
+  render();
+}
+function select(id) { state.sel = id; render(); }
+function gotoOverview() { state.sel = 'overview:workspaces'; render(); }
+function gotoRepoTerminal() { state.sel = 'repo:workspaces'; state.repoLive = true; syncToggle(); render(); }
+function toggleLive() {
+  state.repoLive = !state.repoLive;
+  if (!state.repoLive && state.sel === 'repo:workspaces') state.sel = 'overview:workspaces';
+  syncToggle(); render();
+}
+function syncToggle(){ document.getElementById('liveToggle').classList.toggle('on', state.repoLive); }
+function setTab(scopeId, i){ activeTab[scopeId] = i; render(); }
+
+// ---- main pane ----
+function renderMain() {
+  const id = state.sel;
+  const scope = scopes[id];
+  const main = document.getElementById('main');
+  if (!scope || scope.kind === 'overview') { main.innerHTML = overviewHTML(); return; }
+  main.innerHTML = terminalHTML(id, scope);
+}
+
+function terminalHTML(id, s) {
+  const ai = activeTab[id] ?? 0;
+  const tabs = s.tabs.map((t,i) =>
+    `<div class="tab ${i===ai?'active':''}" onclick="setTab('${id}',${i})">
+       <span class="tico">${t.ico}</span><span>${t.name}</span><span class="x">×</span>
+     </div>`).join('');
+  const header = s.crumb
+    ? `<div class="crumb"><span class="back" onclick="gotoOverview()">‹ workspaces</span><span class="sep">/</span><span>Terminal</span></div>`
+    : `<div class="crumb"><span>${s.title}</span></div>`;
+  const tabName = s.tabs[ai].name;
+  return `
+    <div class="main-head">
+      ${header}
+      <div class="spacer"></div>
+      <span class="scope-badge">${s.badge}</span>
+    </div>
+    <div class="tabbar">
+      ${tabs}
+      <span class="tab-new">＋</span>
+    </div>
+    <div class="term">
+      <div class="dim">Last login: Sat Jun  7 23:35 on ttys00${ai+1}</div>
+      <div style="height:8px"></div>
+      <div><span class="grn">${s.title}</span> <span class="cwd">${s.cwd}</span> <span class="dim">— ${tabName}</span></div>
+      <div>›&nbsp;<span class="cursor"></span></div>
+    </div>`;
+}
+
+function overviewHTML() {
+  return `
+    <div class="main-head"><div class="crumb"><span>workspaces</span></div></div>
+    <div class="overview">
+      <div class="ov-top">
+        <div class="ov-folder">📁</div>
+        <div>
+          <div class="ov-title">~/code/workspaces</div>
+          <div class="ov-sub">3 workspaces</div>
+        </div>
+        <div class="ov-actions">
+          <div class="ov-btn" onclick="gotoRepoTerminal()">❯_ Terminal</div>
+          <div class="ov-btn primary">＋ New Workspace</div>
+        </div>
+      </div>
+      <div class="ov-sec-h">Workspaces</div>
+      <div class="ov-grid">
+        ${wsCard('brisk-sparrow','workspace/brisk-…','ws:brisk-sparrow')}
+        ${wsCard('brisk-trail','workspace/brisk-tr…','ws:brisk-trail')}
+        ${wsCard('zesty-comet','workspace/zesty-c…','ws:zesty-comet')}
+        <div class="ws-card new"><div style="font-size:20px">＋</div><div>New Workspace</div></div>
+      </div>
+      <div class="ov-sec-h">Web Views</div>
+      <div class="ov-web"><span class="gl">🌐</span><div><div class="wt">spaces</div><div class="wu">spaces.cloudcompute.com</div></div></div>
+    </div>`;
+}
+function wsCard(name, branch, sel) {
+  return `<div class="ws-card" onclick="select('${sel}')">
+    <div class="ws-name">${name} <span class="ws-active">Active</span></div>
+    <div class="ws-branch">⑂ ${branch}</div>
+  </div>`;
+}
+
+function render(){ renderSidebar(); renderMain(); }
+// optional deep-link for screenshots: #repo, #overview, #home, #ws:zesty-comet
+if (location.hash) {
+  const h = location.hash.slice(1);
+  if (h === 'repo') { state.sel = 'repo:workspaces'; }
+  else if (h === 'overview') { state.sel = 'overview:workspaces'; }
+  else if (h === 'home') { state.sel = 'home'; }
+  else if (scopes[h]) { state.sel = h; }
+}
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Scope host terminal tab collections by `HostTerminalSessionKey` while keeping the flat coordinator session list alive.
- Render only the active scope's tabs, keep tab navigation/reordering/close-other scoped, and make repo rows resume live repo terminal tabs.
- Extend terminal continuity to restore saved tab collections plus active tab per Home/Repository/Workspace scope, and document the Terminal Scope decision.
- Address review findings by skipping provider/custom-command sessions during direct continuity restore and by reselecting the active provider-backed tab for remote workspace scopes.

## Mergeability

- Surface: desktop
- User-facing behavior changed: terminal tab strips now show only the selected Home, Repository, or Workspace scope; repository rows with live terminal tabs resume the repo terminal, with a breadcrumb back to the Repo Overview.
- Non-happy paths considered: missing restored launch directories fall back to the scope root, stale local session directories are skipped, provider/custom-command sessions are not directly restored before provider setup, canonical path reuse avoids duplicate scopes, active provider-backed tabs are remembered on reselect, and close-other/close-right operations stay within the active scope.
- Release/ops preconditions: not applicable
- Residual risk or follow-up: live provider-backed workspace smoke was not run locally; the restore/reselect paths are covered by focused regression tests.

## Validation

- [x] `./scripts/build-ghosttykit.sh`
- [x] `swift-format lint --strict --recursive Sources/ Tests/`
- [x] `swift build`
- [x] `swift test`
- [x] `swift test --filter 'TerminalContinuityManifest|HostTerminalStateStore|HostTerminalSessionCoordinator|MainWindowTerminalSessionController'`
- [x] `swift-format lint --strict Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift Sources/WorkspaceManager/Views/MainWindow/ContentView.swift Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift`
- [x] `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`
- [x] `./scripts/dev-smoke.sh --no-build`
- [x] `./scripts/launch-dev.sh --no-build --no-activate`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: not applicable
- Before Summary: not applicable
- After Summary: not applicable
- Delta Summary: not applicable

Performance comparison notes:

- Exact commands used: not applicable
- Workload / environment context: not applicable

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Review-fix focused test evidence](https://evidence.cloudcompute.com/workspaces/pr-623/20260607-081710-terminal-scope-review-fixes.svg)
- [Dev smoke screenshot](https://evidence.cloudcompute.com/workspaces/pr-623/20260607-074329-terminal-tab-scopes.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

## Notes

- `./scripts/launch-dev.sh --no-build --no-activate` verified the debug executable path and visible window. A follow-up `./scripts/capture-window.sh` found the process had already exited; the launch log showed a healthy startup through first prompt, not a startup crash.
