### PR TITLE
refactor(web): consolidate schema bootstrap into one tracked-migration seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,19 @@ mise run web:deps:remove -- <pkg>           # pnpm remove + auto-fix formatting
 | PR reviewer status script | scripts/pr-reviewer-status.py |
 | Web architecture doc | web/docs/architecture.md |
 
+## File Purpose Blocks
+
+Where a file's purpose isn't obvious from its name, it opens with a short (≈2–4 line)
+top-of-file doc block stating **what it does and why** — present tense (what the file
+is, not the history of how it got there). Add one when creating or substantially
+editing such a file; skip self-evident utils and tests.
+
+This doubles as a fast index when exploring: `head` a file (the block is the first
+thing) or `rg` a shared phrase to summarize a whole family without opening them —
+e.g. `rg -n "^ \* Persistence for"` lists every persistence module with its one-liner.
+Lean on this before reading files in explore mode, and keep the blocks accurate so it
+stays trustworthy.
+
 ## Key Patterns
 
 1. **URL Storage**: SwiftData can't store URLs directly. Store as String, access via computed property:

--- a/backlog/web-pr-review-runs-split_plan.md
+++ b/backlog/web-pr-review-runs-split_plan.md
@@ -1,0 +1,93 @@
+# Plan: split `web/src/lib/agent-runtime/pr-review-runs.ts` into domain / store / lifecycle
+
+> Part 2 of a two-part architecture-deepening pass on `web/`. Part 1 (the schema
+> seam) shipped in PR #624. This plan is self-contained — a fresh session can
+> execute it without prior context.
+
+## Context
+
+`web/src/lib/agent-runtime/pr-review-runs.ts` is a ~2,100-line module with ~51
+exports doing five jobs at once: row CRUD, the projection ledger, the run-status
+state machine, coalescing, and failure classification. (Its table DDL already moved
+out in Part 1 — it now calls `ensureSchema()` and owns no schema.) The interface is
+nearly as large as the implementation; `pr-review.ts` imports 18 symbols and must
+sequence them correctly, and the legal state transitions are encoded only in that
+call order, stated nowhere.
+
+The deepening: separate the **pure domain**, the **persistence** (reads + low-level
+row writes), and the **lifecycle** (the verbs that encode legal transitions), behind
+a **barrel** so every existing consumer and test keeps working unchanged.
+
+**Decision already made (do not re-litigate):** a 3-module split with a stable barrel
+and **no** test-injection / fakeable-`PrReviewRunStore`-interface refactor. The point
+is locality + pure-domain testability now; collapsing `pr-review.ts`'s 18-symbol
+import and introducing an injectable store interface are explicitly deferred.
+
+## Target structure
+
+Convert the file into a folder `web/src/lib/agent-runtime/pr-review-runs/` with a
+barrel. The six consumers import the path `pr-review-runs` and must keep working
+untouched: `pr-review.ts`, `app/api/webhooks/github/pr-reviewer-monitor/route.ts`,
+`app/api/pr-review-runs/[fingerprint]/route.ts`, `app/api/managed-agents/transcript/route.ts`,
+`app/dashboard/review-runs/[fingerprint]/page.tsx`, `…/review-run-recovery-action.tsx`.
+
+- **`domain.ts`** — pure, no `getDb`/`getTurso` import:
+  - Type unions: `PrReviewRunStatus`, `PrReviewProjectionStatus`, `PrReviewProjectionType`,
+    `PrReviewProjectionLedgerState`, `PrReviewProjectionErrorKind`, `PrReviewFailureKind`,
+    `PrReviewExecutionState`, `PrReviewRunOperatorState`, `PrReviewRunRecoveryAction`.
+  - Interfaces (data shapes): `PrReviewRunReviewIntent`, `PrReviewRunFingerprintInput`,
+    `PrReviewRunRecordInput`, `RecordRunStartResult`, `PrReviewProjectionRecord`,
+    `BeginPrReviewProjectionAttemptInput`, `BeginPrReviewProjectionAttemptResult`,
+    `RecordRunResultInput`, `PrReviewRunSummary`, `PrReviewRunDetails`, `StartedPrReviewRun`,
+    `BrokerPrReviewRun`, `PrReviewRunRecoveryAvailability`, `ActivePrReviewRunSuccessor`,
+    `PrReviewRunSuccessor`, `PrReviewRunStateThresholds`, `ClassifiedPrReviewRun`,
+    `PrReviewRunStateBuckets`.
+  - Pure functions: `computeRunFingerprint`, `classifyPrReviewProjectionError`,
+    `classifyPrReviewRun`, `bucketPrReviewRuns`. Add `domain.test.ts` (these are
+    trivially testable in isolation — the immediate win).
+- **`store.ts`** — persistence reads + low-level row mutations; calls `ensureSchema()`;
+  owns no DDL:
+  - `getPrReviewRunByFingerprint`, `getPrReviewRunBySessionId`, `getActivePrReviewRunSuccessor`,
+    `getNewerCurrentHeadPrReviewRun`, `getPrReviewRunByTrigger`, `listRecentPrReviewRuns`,
+    `listPrReviewRunsForBroker`, `listStartedPrReviewRuns`, `listPrReviewProjectionsForRun`,
+    plus the private row-mapper helpers and any low-level insert/update used by lifecycle.
+- **`lifecycle.ts`** — the transition verbs (the state machine), orchestrating `store` + `domain`:
+  - `recordRunStart` (the coalescing logic), `recordRunResult`, `markRunSessionStarted`,
+    `markRunCompleted`, `markRunFailed`, `markRunSuperseded`, `beginPrReviewProjectionAttempt`,
+    `recordPrReviewProjectionSuccess`, `recordPrReviewProjectionFailure`, `releaseRunActiveClaim`.
+- **`index.ts`** (barrel) — `export * from "./domain"; export * from "./store"; export * from "./lifecycle";`
+  and re-export `__resetPrReviewRunsForTests` (it currently delegates to `resetSchemaForTests()`).
+
+## Guidance / gotchas
+
+- **Keep each function whole** — don't split one function across modules. The store/lifecycle
+  boundary is fuzzy for `recordRunStart` (it reads, applies domain logic, and writes during
+  coalescing); keep it in `lifecycle.ts` and let it call `store` reads + its own writes.
+- **Behavior-preserving.** No logic changes — pure relocation. If a circular import appears
+  (lifecycle→store→domain is fine; avoid store→lifecycle), move the shared helper down to
+  `domain.ts` or `store.ts`.
+- **`Database` is exported from `../db`** (Part 1) — use `Kysely<Database>` typing as needed.
+- Do **not** introduce an injectable store interface or touch the big test files' mocking
+  strategy.
+
+## Verification
+
+- `mise -C web run web:check` (typecheck + Biome + Vitest) must be green.
+- The two large suites must stay green **unchanged**: `__tests__/pr-review-runs.test.ts`
+  (910 lines, real `:memory:` DB, imports via the barrel) and `__tests__/pr-review.test.ts`
+  (2,237 lines, mocks `pr-review-runs` via the barrel path). If either needs edits beyond
+  import paths, the split changed behavior — back out and re-do.
+- Confirm zero remaining imports of the old single-file path resolve incorrectly (the barrel
+  at `pr-review-runs/index.ts` keeps `from ".../pr-review-runs"` working).
+- New: `domain.ts` unit tests for the four pure functions.
+- Evidence + PR per `web/docs/schema-management.md` siblings and the repo evidence gate
+  (`./scripts/evidence.sh`); see also `docs/development/evidence.md`.
+
+## How to start
+
+1. Ensure PR #624 (Part 1) is merged to `main`, then branch off the updated `main`
+   (Part 2 depends on `ensureSchema()` and the baseline owning the two `pr_review` tables).
+   If #624 is not yet merged, base this branch on `c-web-architecture-review` instead and
+   retarget to `main` after the merge.
+2. Read `web/docs/schema-management.md` for how persistence/schema works post-Part-1.
+3. Execute the split, run verification, open a separate PR.

--- a/backlog/web-pr-review-runs-split_plan.md
+++ b/backlog/web-pr-review-runs-split_plan.md
@@ -58,6 +58,9 @@ untouched: `pr-review.ts`, `app/api/webhooks/github/pr-reviewer-monitor/route.ts
 - **`index.ts`** (barrel) — `export * from "./domain"; export * from "./store"; export * from "./lifecycle";`
   and re-export `__resetPrReviewRunsForTests` (it currently delegates to `resetSchemaForTests()`).
 
+Give each of `domain.ts`, `store.ts`, `lifecycle.ts` a short (2–4 line) top-of-file doc
+block stating what it is and why, present-tense.
+
 ## Guidance / gotchas
 
 - **Keep each function whole** — don't split one function across modules. The store/lifecycle

--- a/docs/decisions/web-schema-toolchain.md
+++ b/docs/decisions/web-schema-toolchain.md
@@ -1,0 +1,61 @@
+---
+status: decided
+date: 2026-06-07
+decision: kysely-with-tracked-migrations
+related:
+  - web/docs/architecture.md
+---
+
+# Web Schema Toolchain: Kysely + Tracked Migrations (Drizzle Deferred)
+
+## Decision
+
+**The `web/` app stays on Kysely for queries and gains a centralized, tracked
+versioned-migration runner (`ensureSchema()` + a `schema_migrations` table).
+Drizzle is deliberately not adopted now.** A future move to Drizzle (typed schema +
+generated migrations) remains open as its own ADR'd change, but is out of scope for
+the schema-deepening work.
+
+## Context
+
+Schema bootstrap was copy-pasted across nine persistence modules — each with a
+module-local `migrated` flag, an `ensure*Table()` doing `createTable().ifNotExists()`
+plus best-effort `alterTable().addColumn()` in a swallowed `try/catch`, inline
+indexes, and a bespoke `__reset*ForTests()`. The deepening consolidates this behind
+one `ensureSchema()` seam with an ordered, tracked migration list. While planning it,
+we asked whether to adopt Drizzle for schema management instead.
+
+## Why not Drizzle (now)
+
+A spike (`.context/drizzle-spike.md`, throwaway) settled the two questions that drove
+the choice:
+
+- **The custom `libsql-dialect.ts` is not a burden.** It is 81 trivial lines bridging
+  the official `@libsql/client` into Kysely, reusing Kysely's stock `SqliteAdapter`,
+  `SqliteIntrospector`, and `SqliteQueryCompiler`. No embedded-replica logic, nothing
+  bespoke. The "large custom dialect to maintain" argument — the strongest reason to
+  switch — was based on a wrong line count and does not hold. (Introspection works, so
+  the baseline migration's add-missing-columns step can use
+  `db.introspection.getTables()`.)
+- **Drizzle's migrate model is an operational change we don't want bundled here.**
+  Today the app has no build-time DB step: schema bootstraps at request time,
+  once per warm serverless instance, idempotently. Drizzle's clean path
+  (`drizzle-kit migrate` at deploy) adds a deploy step with prod Turso credentials in
+  CI and a new failure mode; its runtime `migrate()` needs migration files bundled
+  into the Next.js function (known friction) and reads `__drizzle_migrations` on each
+  cold start. The Kysely plan keeps the existing operational model untouched while
+  still delivering tracked versioned migrations (~60 lines).
+- **Adoption cost is real and orthogonal to the deepening.** Drizzle means a
+  query-layer rewrite across ~7 Kysely modules, reconciling the two raw-SQL modules
+  (`repos.ts`, `terminal-tickets.ts`) that bypass Kysely via `getTurso()`, and
+  baseline-against-prod reconciliation. None of it helps the parallel `pr-review-runs`
+  split, which is ORM-agnostic.
+
+## Consequences
+
+- The deepening centralizes schema behind a single `ensureSchema()` seam, which also
+  **de-risks** any future Drizzle adoption: one seam to replace instead of nine
+  scattered `ensure*Table()` functions, with the dialect question already answered.
+- If typed schema and generated migrations become desirable as a platform choice, the
+  remaining decision is mostly query-layer rewrite cost plus the build-time-migrate
+  operational shift — to be recorded in its own ADR at that time.

--- a/web/docs/architecture.md
+++ b/web/docs/architecture.md
@@ -65,6 +65,18 @@
 | Deployment | Vercel | Hosting, serverless functions |
 | Infrastructure | Cloudflare Workers | Webhook relay, evidence store, terminal proxy |
 
+## Database & Schema
+
+The schema is defined in one ordered migration list (`src/lib/schema/migrations.ts`)
+and applied by `ensureSchema()` (`src/lib/schema/index.ts`), which every persistence
+query awaits before touching the database. It runs at request time, once per warm
+serverless instance, tracked via a `schema_migrations` table. The typed row shapes
+live in the `Database` interface in `src/lib/db.ts`.
+
+See [`schema-management.md`](./schema-management.md) for where each piece lives, how
+to add a migration, and the design tradeoffs; the Kysely-vs-Drizzle decision is in
+[`docs/decisions/web-schema-toolchain.md`](../../docs/decisions/web-schema-toolchain.md).
+
 ## Agent Runtime
 
 The agent runtime executes Claude Code through the `ComputeProviderRegistry` at `src/lib/agent-runtime/provider-registry.ts`. The registry loads Vercel Sandbox, Daytona, GitHub Actions, and Anthropic Managed Agents providers by default; Daytona and GitHub Actions are registered stubs that currently report unavailable. `MOCK_AGENT=1` adds the test-only mock provider and makes it the default.

--- a/web/docs/schema-management.md
+++ b/web/docs/schema-management.md
@@ -44,18 +44,18 @@ getDb()/getTurso() ─▶ one libsql client (Turso remote in prod; file: in dev;
 
 `ensureSchema()`:
 
-1. memoizes a single in-flight promise, so concurrent serverless callers share one bootstrap (and a failure clears the memo so a later request retries);
+1. memoizes a single in-flight promise inside one warm serverless instance, so same-process callers share one bootstrap (and a failure clears the memo so a later request retries);
 2. ensures the `schema_migrations` bookkeeping table exists;
 3. reads which migration ids have already run;
 4. runs each pending migration's `up()` in order, recording its id only after it succeeds.
 
-It runs **at request time, once per warm serverless instance** — there is no separate build- or deploy-time DB step. The first query after a cold start triggers the bootstrap; every call after that is a cached no-op.
+It runs **at request time, once per warm serverless instance** — there is no separate build- or deploy-time DB step. The first query after a cold start triggers the bootstrap; every call after that is a cached no-op. Separate cold starts can overlap, so migrations are written to tolerate another instance making the same DDL change first and the migration record insert is idempotent.
 
 ## Changing the schema
 
 - **Append** a new migration to `MIGRATIONS`: `{ id: "0002_add_thing", up: async (db) => { … } }`. Use a zero-padded, ordered id.
 - **Never edit a migration that has shipped.** It's already recorded in `schema_migrations` on production and will not re-run. Add a new migration instead.
-- **Keep `up()` idempotent**: `createTable().ifNotExists()`, `createIndex().ifNotExists()`, introspection-guarded column adds (see `addMissingColumns`), idempotent data `UPDATE`s. The runner records a migration only after `up()` succeeds; a partial failure is re-run from the top on the next request.
+- **Keep `up()` idempotent**: `createTable().ifNotExists()`, `createIndex().ifNotExists()`, introspection-guarded column adds (see `addMissingColumns`), idempotent data `UPDATE`s. The runner records a migration only after `up()` succeeds; a partial failure is re-run from the top on the next request, and overlapping cold starts can run the same pending `up()` at the same time.
 - **Put data migrations** (backfills, renames) in a migration, not in a query module. The `terminal`→`shell` rename and `owner_id` backfill live in `0001_baseline` for exactly this reason.
 - **Add the row type** to the `Database` interface in `db.ts` for typed Kysely access. Two tables — `user_repos` and `terminal_access_tickets` — are instead queried via raw `getTurso()` SQL; their DDL still lives in the baseline so *all* schema stays in one place.
 

--- a/web/docs/schema-management.md
+++ b/web/docs/schema-management.md
@@ -1,0 +1,80 @@
+# Web Schema Management
+
+The web app's database (LibSQL/Turso, queried through Kysely) follows one rule:
+**one place defines the schema, one function applies it, and every query goes
+through that function.** This doc says where each of those lives, the model that
+runs them, and the tradeoffs behind the design.
+
+> Not the desktop schema. `docs/schema.sql` is the **macOS app's** local SQLite
+> sidecar (`LocalStateStore`) — a different database. The web schema described
+> here lives in code (`src/lib/schema/migrations.ts`), not in `docs/schema.sql`.
+
+## Where things live
+
+| You want… | Read | What it is |
+|-----------|------|------------|
+| What tables exist + their columns/indexes | `src/lib/schema/migrations.ts` | The ordered `MIGRATIONS` list. `0001_baseline` defines every table, index, and data migration — the **source of truth for the schema**. |
+| The typed row shapes | `src/lib/db.ts` (`Database` interface) | The TypeScript contract Kysely queries are checked against. |
+| What runs the schema | `src/lib/schema/index.ts` | `ensureSchema()` applies pending migrations once; `resetSchemaForTests()` for tests. |
+| The connection | `src/lib/db.ts` | `getTurso()` (raw libsql client) and `getDb()` (Kysely over the same client). |
+
+Short version: **schema is defined in `migrations.ts`; it is run by `ensureSchema()` in `schema/index.ts`.**
+
+## How it runs
+
+Every persistence query awaits `ensureSchema()` before touching the database:
+
+```ts
+export async function getEvents(/* … */) {
+  await ensureSchema();
+  const db = getDb();
+  // … query
+}
+```
+
+```
+query() ─ await ensureSchema() ─┬─ first call ──▶ runMigrations()
+                                │                    ├─ CREATE TABLE schema_migrations (if absent)
+                                │                    ├─ read already-applied ids
+                                │                    └─ for each pending migration: up(getDb()); record id
+                                └─ later calls ──▶ the cached promise (a no-op)
+
+getDb()/getTurso() ─▶ one libsql client (Turso remote in prod; file: in dev; :memory: in tests)
+```
+
+`ensureSchema()`:
+
+1. memoizes a single in-flight promise, so concurrent serverless callers share one bootstrap (and a failure clears the memo so a later request retries);
+2. ensures the `schema_migrations` bookkeeping table exists;
+3. reads which migration ids have already run;
+4. runs each pending migration's `up()` in order, recording its id only after it succeeds.
+
+It runs **at request time, once per warm serverless instance** — there is no separate build- or deploy-time DB step. The first query after a cold start triggers the bootstrap; every call after that is a cached no-op.
+
+## Changing the schema
+
+- **Append** a new migration to `MIGRATIONS`: `{ id: "0002_add_thing", up: async (db) => { … } }`. Use a zero-padded, ordered id.
+- **Never edit a migration that has shipped.** It's already recorded in `schema_migrations` on production and will not re-run. Add a new migration instead.
+- **Keep `up()` idempotent**: `createTable().ifNotExists()`, `createIndex().ifNotExists()`, introspection-guarded column adds (see `addMissingColumns`), idempotent data `UPDATE`s. The runner records a migration only after `up()` succeeds; a partial failure is re-run from the top on the next request.
+- **Put data migrations** (backfills, renames) in a migration, not in a query module. The `terminal`→`shell` rename and `owner_id` backfill live in `0001_baseline` for exactly this reason.
+- **Add the row type** to the `Database` interface in `db.ts` for typed Kysely access. Two tables — `user_repos` and `terminal_access_tickets` — are instead queried via raw `getTurso()` SQL; their DDL still lives in the baseline so *all* schema stays in one place.
+
+## Principles
+
+- **One ordered source.** The schema is the migration list, read top to bottom — not assembled from scattered per-module bootstraps.
+- **Append-only and tracked.** `schema_migrations` records what has run; migrations are never edited after shipping.
+- **Idempotent, so re-runs are safe.** Cold starts and partial failures re-enter `up()` without harm.
+- **Reconcile, don't assume.** `0001_baseline` introspects (`PRAGMA table_info`) and adds only missing columns — no swallowed `try/catch` — so it is safe against the existing production database, which predates `schema_migrations`.
+
+## Tradeoffs (and what we did not do)
+
+The decision record is `docs/decisions/web-schema-toolchain.md`. In short:
+
+- **Kysely + an in-code tracked-migration runner, not Drizzle.** The custom libsql dialect is a trivial 81-line bridge, so it isn't a maintenance burden worth escaping; Drizzle would add a deploy-time migrate model this app doesn't have, plus a query-layer rewrite, for no gain on this work. Revisiting Drizzle is its own future ADR.
+- **Request-time bootstrap, not build/deploy-time migration.** Keeps deploys free of a DB step and prod credentials out of CI; the cost is a small idempotent check on the first request per warm instance.
+- **One baseline, not re-derived history.** We don't need the old per-deploy column-add history. The baseline reconciles any existing database; future changes are clean append-only migrations.
+
+## Testing
+
+- Tests run against an in-memory libsql DB (`TURSO_DATABASE_URL=:memory:`) with `vi.resetModules()` so each gets a fresh schema; `resetSchemaForTests()` forgets the memo between runs.
+- `src/lib/schema/__tests__/schema.test.ts` is the cutover-safety suite: fresh build, idempotent re-run, and reconciliation of a pre-migration database that has real rows and no `schema_migrations` entry.

--- a/web/src/lib/agent-runtime/managed-agents-cache.ts
+++ b/web/src/lib/agent-runtime/managed-agents-cache.ts
@@ -3,6 +3,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 import type { BetaManagedAgentsAgentToolset20260401Params } from "@anthropic-ai/sdk/resources/beta/agents/agents";
 import type { BetaCloudConfigParams } from "@anthropic-ai/sdk/resources/beta/environments";
 import { getDb } from "../db";
+import { ensureSchema, resetSchemaForTests } from "../schema";
 
 /**
  * In-process + durable cache of Managed Agents `agent` and `environment`
@@ -17,28 +18,6 @@ type Kind = "agent" | "environment";
 
 const memoryCache = new Map<string, string>();
 
-let migrated = false;
-async function ensureCacheTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("managed_agents_cache")
-		.ifNotExists()
-		.addColumn("kind", "text", (c) => c.notNull())
-		.addColumn("hash", "text", (c) => c.notNull())
-		.addColumn("remote_id", "text", (c) => c.notNull())
-		.addColumn("created_at", "text", (c) => c.notNull())
-		.addColumn("metadata", "text")
-		.execute();
-	await db.schema
-		.createIndex("idx_managed_agents_cache_key")
-		.ifNotExists()
-		.on("managed_agents_cache")
-		.columns(["kind", "hash"])
-		.execute();
-	migrated = true;
-}
-
 function sha16(input: string): string {
 	return createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
@@ -50,7 +29,7 @@ function cacheKey(kind: Kind, hash: string): string {
 async function readCache(kind: Kind, hash: string): Promise<string | null> {
 	const hit = memoryCache.get(cacheKey(kind, hash));
 	if (hit) return hit;
-	await ensureCacheTable();
+	await ensureSchema();
 	const row = await getDb()
 		.selectFrom("managed_agents_cache")
 		.select("remote_id")
@@ -70,7 +49,7 @@ async function writeCache(
 	remoteId: string,
 	metadata?: Record<string, unknown>,
 ): Promise<void> {
-	await ensureCacheTable();
+	await ensureSchema();
 	memoryCache.set(cacheKey(kind, hash), remoteId);
 	await getDb()
 		.insertInto("managed_agents_cache")
@@ -171,5 +150,5 @@ function stableStringify(value: unknown): unknown {
 /** Test-only hook. */
 export function __resetCacheForTests(): void {
 	memoryCache.clear();
-	migrated = false;
+	resetSchemaForTests();
 }

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { getDb } from "../db";
+import { ensureSchema, resetSchemaForTests } from "../schema";
 
 export type PrReviewRunStatus =
 	| "started"
@@ -65,140 +66,9 @@ export interface PrReviewRunRecordInput extends PrReviewRunFingerprintInput {
 	fingerprint: string;
 }
 
-let migrated = false;
-let projectionsMigrated = false;
-
-async function ensureRunsTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("managed_pr_review_runs")
-		.ifNotExists()
-		.addColumn("fingerprint", "text", (c) => c.primaryKey())
-		.addColumn("repo_full_name", "text", (c) => c.notNull())
-		.addColumn("pr_number", "integer", (c) => c.notNull())
-		.addColumn("head_sha", "text", (c) => c.notNull())
-		.addColumn("trigger_kind", "text", (c) => c.notNull())
-		.addColumn("trigger_source_id", "text", (c) => c.notNull())
-		.addColumn("reviewer_config_hash", "text", (c) => c.notNull())
-		.addColumn("session_id", "text")
-		.addColumn("status", "text", (c) => c.notNull())
-		.addColumn("created_at", "text", (c) => c.notNull())
-		.addColumn("updated_at", "text", (c) => c.notNull())
-		.addColumn("error", "text")
-		.addColumn("failure_kind", "text")
-		.addColumn("failure_message", "text")
-		.addColumn("failure_retryable", "integer")
-		.addColumn("failed_at", "text")
-		.addColumn("projection_status", "text")
-		.addColumn("projection_updated_at", "text")
-		.addColumn("projection_error", "text")
-		.addColumn("github_review_id", "text")
-		.addColumn("review_intent_event", "text")
-		.addColumn("review_intent_body", "text")
-		.addColumn("review_intent_labels", "text")
-		.addColumn("review_intent_recorded_at", "text")
-		.addColumn("active_claim_key", "text")
-		.addColumn("coalesced_head_sha", "text")
-		.addColumn("coalesced_trigger_kind", "text")
-		.addColumn("coalesced_trigger_source_id", "text")
-		.addColumn("coalesced_at", "text")
-		.execute();
-	for (const [column, type] of [
-		["failure_kind", "text"],
-		["failure_message", "text"],
-		["failure_retryable", "integer"],
-		["failed_at", "text"],
-		["projection_status", "text"],
-		["projection_updated_at", "text"],
-		["projection_error", "text"],
-		["github_review_id", "text"],
-		["review_intent_event", "text"],
-		["review_intent_body", "text"],
-		["review_intent_labels", "text"],
-		["review_intent_recorded_at", "text"],
-		["active_claim_key", "text"],
-		["coalesced_head_sha", "text"],
-		["coalesced_trigger_kind", "text"],
-		["coalesced_trigger_source_id", "text"],
-		["coalesced_at", "text"],
-	] as const) {
-		try {
-			await db.schema
-				.alterTable("managed_pr_review_runs")
-				.addColumn(column, type)
-				.execute();
-		} catch {
-			// Column already exists.
-		}
-	}
-	await db.schema
-		.createIndex("idx_managed_pr_review_runs_pr")
-		.ifNotExists()
-		.on("managed_pr_review_runs")
-		.columns(["repo_full_name", "pr_number"])
-		.execute();
-	// New rows hold this nullable unique value only while active. Existing
-	// pre-migration `started` rows are intentionally not backfilled; they age out
-	// through the normal stale-started path rather than risking a broad migration.
-	await db.schema
-		.createIndex("ux_managed_pr_review_runs_active_claim")
-		.ifNotExists()
-		.on("managed_pr_review_runs")
-		.column("active_claim_key")
-		.unique()
-		.execute();
-	migrated = true;
-}
-
-async function ensureProjectionLedgerTable(): Promise<void> {
-	await ensureRunsTable();
-	if (projectionsMigrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("managed_pr_review_projections")
-		.ifNotExists()
-		.addColumn("projection_id", "text", (c) => c.primaryKey())
-		.addColumn("run_fingerprint", "text", (c) => c.notNull())
-		.addColumn("projection_type", "text", (c) => c.notNull())
-		.addColumn("projection_key", "text", (c) => c.notNull())
-		.addColumn("desired_payload_hash", "text", (c) => c.notNull())
-		.addColumn("desired_payload", "text", (c) => c.notNull())
-		.addColumn("state", "text", (c) => c.notNull())
-		.addColumn("attempts", "integer", (c) => c.notNull().defaultTo(0))
-		.addColumn("last_attempted_at", "text")
-		.addColumn("observed_external_id", "text")
-		.addColumn("error_kind", "text")
-		.addColumn("error_text", "text")
-		.addColumn("created_at", "text", (c) => c.notNull())
-		.addColumn("updated_at", "text", (c) => c.notNull())
-		.execute();
-	await db.schema
-		.createIndex("ux_managed_pr_review_projections_desired")
-		.ifNotExists()
-		.on("managed_pr_review_projections")
-		.columns([
-			"run_fingerprint",
-			"projection_type",
-			"projection_key",
-			"desired_payload_hash",
-		])
-		.unique()
-		.execute();
-	await db.schema
-		.createIndex("idx_managed_pr_review_projections_run")
-		.ifNotExists()
-		.on("managed_pr_review_projections")
-		.column("run_fingerprint")
-		.execute();
-	await db.schema
-		.createIndex("idx_managed_pr_review_projections_state")
-		.ifNotExists()
-		.on("managed_pr_review_projections")
-		.columns(["state", "updated_at"])
-		.execute();
-	projectionsMigrated = true;
-}
+// Schema for managed_pr_review_runs + managed_pr_review_projections lives in
+// the baseline migration (web/src/lib/schema/migrations.ts). Queries below call
+// ensureSchema() before touching the database.
 
 export function computeRunFingerprint(
 	input: PrReviewRunFingerprintInput,
@@ -729,7 +599,7 @@ async function coalesceIntoActiveRun(input: {
 export async function recordRunStart(
 	input: PrReviewRunRecordInput,
 ): Promise<RecordRunStartResult> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const now = new Date().toISOString();
 	const db = getDb();
 	const claimKey = activeClaimKey(input);
@@ -957,7 +827,7 @@ function mapProjectionRecord(row: {
 export async function beginPrReviewProjectionAttempt(
 	input: BeginPrReviewProjectionAttemptInput,
 ): Promise<BeginPrReviewProjectionAttemptResult> {
-	await ensureProjectionLedgerTable();
+	await ensureSchema();
 	const now = new Date().toISOString();
 	const { desiredPayloadHash, boundedPayloadJson } = prepareProjectionPayload(
 		input.desiredPayload,
@@ -1039,7 +909,7 @@ export async function recordPrReviewProjectionSuccess(
 	projectionId: string,
 	input: { observedExternalId?: string | null } = {},
 ): Promise<void> {
-	await ensureProjectionLedgerTable();
+	await ensureSchema();
 	const now = new Date().toISOString();
 	const updates = {
 		state: "projected" as const,
@@ -1065,7 +935,7 @@ export async function recordPrReviewProjectionFailure(
 		errorText: string;
 	},
 ): Promise<void> {
-	await ensureProjectionLedgerTable();
+	await ensureSchema();
 	const now = new Date().toISOString();
 	await getDb()
 		.updateTable("managed_pr_review_projections")
@@ -1082,7 +952,7 @@ export async function recordPrReviewProjectionFailure(
 export async function listPrReviewProjectionsForRun(
 	runFingerprint: string,
 ): Promise<PrReviewProjectionRecord[]> {
-	await ensureProjectionLedgerTable();
+	await ensureSchema();
 	const rows = await getDb()
 		.selectFrom("managed_pr_review_projections")
 		.selectAll()
@@ -1161,7 +1031,7 @@ async function updateRunLifecycle(
 	fingerprint: string,
 	input: RunLifecycleUpdateInput,
 ): Promise<void> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const now = new Date().toISOString();
 	await assertTransitionAllowed(fingerprint, input.status);
 	const projectionStatus =
@@ -1339,7 +1209,7 @@ export async function recordRunResult(
 export async function releaseRunActiveClaim(
 	fingerprint: string,
 ): Promise<void> {
-	await ensureRunsTable();
+	await ensureSchema();
 	await getDb()
 		.updateTable("managed_pr_review_runs")
 		.set({ active_claim_key: null })
@@ -1634,7 +1504,7 @@ function mapRunDetails(row: {
 export async function getPrReviewRunByFingerprint(
 	fingerprint: string,
 ): Promise<PrReviewRunDetails | null> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const row = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.selectAll()
@@ -1652,7 +1522,7 @@ export async function getPrReviewRunByFingerprint(
 export async function getPrReviewRunBySessionId(
 	sessionId: string,
 ): Promise<PrReviewRunDetails | null> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const row = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.selectAll()
@@ -1673,7 +1543,7 @@ export async function getActivePrReviewRunSuccessor(input: {
 	prNumber: number;
 	createdAt: string;
 }): Promise<ActivePrReviewRunSuccessor | null> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const row = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select([
@@ -1711,7 +1581,7 @@ export async function getNewerCurrentHeadPrReviewRun(input: {
 	headSha: string;
 	createdAt: string;
 }): Promise<PrReviewRunSuccessor | null> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const row = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select([
@@ -1753,7 +1623,7 @@ export async function getPrReviewRunByTrigger(input: {
 	triggerKind: string;
 	triggerSourceId: string;
 }): Promise<PrReviewRunDetails | null> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const row = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.selectAll()
@@ -1775,7 +1645,7 @@ export async function listRecentPrReviewRuns(input: {
 	sinceIso: string;
 	repoFullName: string;
 }): Promise<PrReviewRunSummary[]> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const rows = await getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select([
@@ -2142,7 +2012,7 @@ export async function listPrReviewRunsForBroker(
 		repoFullName?: string;
 	} = {},
 ): Promise<BrokerPrReviewRun[]> {
-	await ensureRunsTable();
+	await ensureSchema();
 	const limit = input.limit ?? 10;
 	let startedQuery = getDb()
 		.selectFrom("managed_pr_review_runs")
@@ -2192,7 +2062,7 @@ export async function listStartedPrReviewRuns(
 		repoFullName?: string;
 	} = {},
 ): Promise<StartedPrReviewRun[]> {
-	await ensureRunsTable();
+	await ensureSchema();
 	let query = getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select([
@@ -2240,6 +2110,5 @@ export async function listStartedPrReviewRuns(
 
 /** Test-only hook so per-test in-memory DBs re-run table creation. */
 export function __resetPrReviewRunsForTests(): void {
-	migrated = false;
-	projectionsMigrated = false;
+	resetSchemaForTests();
 }

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -1,3 +1,10 @@
+/**
+ * Persistence and lifecycle for managed PR review runs and their GitHub projection
+ * ledger (`managed_pr_review_runs`, `managed_pr_review_projections`): the run state
+ * machine, coalescing of redundant triggers, failure classification, and the
+ * broker/monitor queries. Consumed by pr-review.ts and the reviewer webhook routes.
+ */
+
 import { createHash } from "node:crypto";
 import { getDb } from "../db";
 import { ensureSchema, resetSchemaForTests } from "../schema";

--- a/web/src/lib/agent-sessions.ts
+++ b/web/src/lib/agent-sessions.ts
@@ -1,73 +1,10 @@
 import { getDb } from "./db";
+import { ensureSchema } from "./schema";
 import type {
 	AgentSession,
 	AgentSessionStatus,
 	ComputeBackendId,
 } from "./types";
-
-let migrated = false;
-
-async function ensureSessionTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("agent_sessions")
-		.ifNotExists()
-		.addColumn("id", "text", (c) => c.primaryKey())
-		.addColumn("user_id", "text", (c) => c.notNull())
-		.addColumn("repo", "text", (c) => c.notNull())
-		.addColumn("agent_name", "text", (c) => c.notNull())
-		.addColumn("compute_backend", "text", (c) => c.notNull())
-		.addColumn("compute_instance_id", "text")
-		.addColumn("thread_id", "text", (c) => c.notNull())
-		.addColumn("discussion_id", "text")
-		.addColumn("status", "text", (c) => c.notNull())
-		.addColumn("created_at", "text", (c) => c.notNull())
-		.addColumn("last_activity_at", "text", (c) => c.notNull())
-		.addColumn("snapshot_id", "text")
-		.addColumn("claude_session_id", "text")
-		.execute();
-	await db.schema
-		.createIndex("idx_agent_sessions_thread")
-		.ifNotExists()
-		.on("agent_sessions")
-		.columns(["repo", "agent_name", "thread_id"])
-		.execute();
-	// Migrate: add columns if table already existed without them
-	for (const col of ["snapshot_id", "claude_session_id", "user_id"] as const) {
-		try {
-			await db.schema
-				.alterTable("agent_sessions")
-				.addColumn(col, "text")
-				.execute();
-		} catch {
-			// Column already exists
-		}
-	}
-	await db.schema
-		.createIndex("idx_agent_sessions_user_thread")
-		.ifNotExists()
-		.on("agent_sessions")
-		.columns(["user_id", "repo", "agent_name", "thread_id"])
-		.execute();
-	// Migrate: rename the synthetic terminal slot from "terminal" to "shell".
-	// PR #299 changed the default fallback from "terminal" to "shell" but
-	// existing rows weren't updated. Without this, those rows are orphaned —
-	// the UI shows them as "shell" via the display alias but the Stop button
-	// sends agentName="shell" which doesn't match. One-shot rename so the DB
-	// matches the new vocabulary.
-	try {
-		await db
-			.updateTable("agent_sessions")
-			.set({ agent_name: "shell" })
-			.where("agent_name", "=", "terminal")
-			.where("status", "in", ["active", "streaming", "snapshotted"] as never[])
-			.execute();
-	} catch {
-		// Best-effort — don't block startup if the migration fails
-	}
-	migrated = true;
-}
 
 function rowToSession(r: {
 	id: string;
@@ -102,7 +39,7 @@ function rowToSession(r: {
 }
 
 export async function createSession(session: AgentSession): Promise<void> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.insertInto("agent_sessions")
@@ -126,7 +63,7 @@ export async function createSession(session: AgentSession): Promise<void> {
 }
 
 export async function getSession(id: string): Promise<AgentSession | null> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("agent_sessions")
@@ -140,7 +77,7 @@ export async function getSessionByInstanceId(
 	userId: string,
 	instanceId: string,
 ): Promise<AgentSession | null> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("agent_sessions")
@@ -159,7 +96,7 @@ export async function getActiveSessionForThread(
 	agentName: string,
 	threadId: string,
 ): Promise<AgentSession | null> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("agent_sessions")
@@ -179,7 +116,7 @@ export async function updateSessionStatus(
 	id: string,
 	status: AgentSessionStatus,
 ): Promise<void> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.updateTable("agent_sessions")
@@ -192,7 +129,7 @@ export async function updateComputeInstance(
 	id: string,
 	computeInstanceId: string,
 ): Promise<void> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.updateTable("agent_sessions")
@@ -205,7 +142,7 @@ export async function updateSnapshotId(
 	id: string,
 	snapshotId: string,
 ): Promise<void> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.updateTable("agent_sessions")
@@ -222,7 +159,7 @@ export async function updateSnapshotId(
  * Returns true if this caller won the race (status transitioned snapshotted → streaming).
  */
 export async function claimSnapshotSession(id: string): Promise<boolean> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const result = await db
 		.updateTable("agent_sessions")
@@ -238,7 +175,7 @@ export async function getActiveSessionForRepo(
 	userId: string,
 	repo: string,
 ): Promise<AgentSession | null> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("agent_sessions")
@@ -262,7 +199,7 @@ export async function getSessionsForRepo(
 	userId: string,
 	repo: string,
 ): Promise<AgentSession[]> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const rows = await db
 		.selectFrom("agent_sessions")
@@ -297,7 +234,7 @@ export async function getSessionForAgent(
 	repo: string,
 	agentName: string,
 ): Promise<AgentSession | null> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("agent_sessions")
@@ -320,7 +257,7 @@ export async function getSnapshotSessionForThread(
 	agentName: string,
 	threadId: string,
 ): Promise<AgentSession | null> {
-	await ensureSessionTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("agent_sessions")

--- a/web/src/lib/agent-sessions.ts
+++ b/web/src/lib/agent-sessions.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistence for `agent_sessions` — the per-(user, repo, agent, thread) compute
+ * sessions behind agent chat and terminals. Tracks lifecycle status and the
+ * snapshot/restore claim used to resume a session.
+ */
+
 import { getDb } from "./db";
 import { ensureSchema } from "./schema";
 import type {

--- a/web/src/lib/base-snapshots.ts
+++ b/web/src/lib/base-snapshots.ts
@@ -1,28 +1,12 @@
 import { getDb } from "./db";
-
-let migrated = false;
-
-async function ensureTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("base_snapshots")
-		.ifNotExists()
-		.addColumn("provider", "text", (c) => c.notNull())
-		.addColumn("version", "text", (c) => c.notNull())
-		.addColumn("snapshot_id", "text", (c) => c.notNull())
-		.addColumn("created_at", "text", (c) => c.notNull())
-		.addPrimaryKeyConstraint("base_snapshots_pk", ["provider", "version"])
-		.execute();
-	migrated = true;
-}
+import { ensureSchema } from "./schema";
 
 /** Look up the snapshot ID for a given provider + version. */
 export async function getBaseSnapshotId(
 	provider: string,
 	version: string,
 ): Promise<string | null> {
-	await ensureTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("base_snapshots")
@@ -39,7 +23,7 @@ export async function recordBaseSnapshot(
 	version: string,
 	snapshotId: string,
 ): Promise<void> {
-	await ensureTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.insertInto("base_snapshots")

--- a/web/src/lib/base-snapshots.ts
+++ b/web/src/lib/base-snapshots.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistence for `base_snapshots` — the provider base-image snapshot id for each
+ * (provider, version), so a new sandbox restores a prepared base instead of
+ * rebuilding it.
+ */
+
 import { getDb } from "./db";
 import { ensureSchema } from "./schema";
 

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -1,4 +1,5 @@
 import { getDb } from "./db";
+import { ensureSchema } from "./schema";
 import type {
 	AuthorType,
 	ChatMessage,
@@ -6,35 +7,8 @@ import type {
 	WebhookEventType,
 } from "./types";
 
-let migrated = false;
-
-async function ensureChatTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("chat_messages")
-		.ifNotExists()
-		.addColumn("id", "text", (c) => c.primaryKey())
-		.addColumn("repo", "text", (c) => c.notNull())
-		.addColumn("author", "text", (c) => c.notNull())
-		.addColumn("author_type", "text", (c) => c.notNull())
-		.addColumn("content", "text", (c) => c.notNull())
-		.addColumn("agent_target", "text")
-		.addColumn("discussion_id", "text")
-		.addColumn("discussion_url", "text")
-		.addColumn("timestamp", "text", (c) => c.notNull())
-		.execute();
-	await db.schema
-		.createIndex("idx_chat_messages_repo_ts")
-		.ifNotExists()
-		.on("chat_messages")
-		.columns(["repo", "timestamp desc"])
-		.execute();
-	migrated = true;
-}
-
 export async function pushChatMessage(msg: ChatMessage): Promise<void> {
-	await ensureChatTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.insertInto("chat_messages")
@@ -58,7 +32,7 @@ export async function getChatMessages(
 	limit = 50,
 	since?: string,
 ): Promise<ChatMessage[]> {
-	await ensureChatTable();
+	await ensureSchema();
 	const db = getDb();
 	let query = db
 		.selectFrom("chat_messages")
@@ -87,7 +61,7 @@ export async function updateChatMessageContent(
 	id: string,
 	content: string,
 ): Promise<void> {
-	await ensureChatTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.updateTable("chat_messages")
@@ -99,7 +73,7 @@ export async function updateChatMessageContent(
 export async function getChatMessageByDiscussionId(
 	discussionId: string,
 ): Promise<ChatMessage | null> {
-	await ensureChatTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("chat_messages")
@@ -128,7 +102,7 @@ export async function getMixedTimeline(
 	limit = 50,
 	since?: string,
 ): Promise<TimelineEntry[]> {
-	await ensureChatTable();
+	await ensureSchema();
 	const db = getDb();
 
 	let eventsQuery = db

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistence for `chat_messages` — dispatch and agent chat history, plus
+ * `getMixedTimeline`, which merges chat messages with webhook events into one
+ * time-ordered feed for the dashboard.
+ */
+
 import { getDb } from "./db";
 import { ensureSchema } from "./schema";
 import type {

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -121,7 +121,7 @@ export interface ManagedPrReviewProjectionsTable {
 	updated_at: string;
 }
 
-interface Database {
+export interface Database {
 	webhook_events: EventsTable;
 	chat_messages: ChatMessagesTable;
 	workspaces: WorkspacesTable;

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistence for `webhook_events` — the GitHub webhook activity stream behind the
+ * dashboard's event feed and stats card. Stores incoming events and serves the
+ * repo-scoped, time-ordered reads the poll endpoints hit.
+ */
+
 import { getDb } from "./db";
 import { ensureSchema } from "./schema";
 import type { WebhookEvent, WebhookEventType } from "./types";

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -1,61 +1,9 @@
 import { getDb } from "./db";
+import { ensureSchema } from "./schema";
 import type { WebhookEvent, WebhookEventType } from "./types";
 
-let migrated = false;
-
-async function ensureEventsTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("webhook_events")
-		.ifNotExists()
-		.addColumn("id", "text", (c) => c.primaryKey())
-		.addColumn("type", "text", (c) => c.notNull())
-		.addColumn("action", "text", (c) => c.notNull().defaultTo(""))
-		.addColumn("summary", "text", (c) => c.notNull().defaultTo(""))
-		.addColumn("repo", "text", (c) => c.notNull().defaultTo("unknown"))
-		.addColumn("timestamp", "text", (c) => c.notNull())
-		.addColumn("payload", "text", (c) => c.notNull().defaultTo("{}"))
-		.execute();
-	// Ensure payload column exists on tables created before this migration
-	try {
-		await db.schema
-			.alterTable("webhook_events")
-			.addColumn("payload", "text", (c) => c.notNull().defaultTo("{}"))
-			.execute();
-	} catch {
-		/* column already exists */
-	}
-	await db.schema
-		.createIndex("idx_webhook_events_timestamp")
-		.ifNotExists()
-		.on("webhook_events")
-		.column("timestamp desc")
-		.execute();
-	await db.schema
-		.createIndex("idx_webhook_events_repo")
-		.ifNotExists()
-		.on("webhook_events")
-		.column("repo")
-		.execute();
-	// Composite index for `WHERE repo = ? ORDER BY timestamp DESC LIMIT N`.
-	// Without this, that query scans every event for the repo — the chat
-	// panel and activity feed poll endpoints hit this path every 5-10s
-	// and blew through 500M Turso row-reads in a single month for one
-	// user. The separate single-column indexes above are not enough; the
-	// planner needs a composite that matches the filter + order.
-	// See docs/development/agent-chat-sandbox.md § "DB query volume".
-	await db.schema
-		.createIndex("idx_webhook_events_repo_ts")
-		.ifNotExists()
-		.on("webhook_events")
-		.columns(["repo", "timestamp desc"])
-		.execute();
-	migrated = true;
-}
-
 export async function pushEvent(event: WebhookEvent): Promise<void> {
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	await db
 		.insertInto("webhook_events")
@@ -76,7 +24,7 @@ export async function getEvents(
 	limit = 50,
 	repo?: string | null,
 ): Promise<WebhookEvent[]> {
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	let query = db
 		.selectFrom("webhook_events")
@@ -102,7 +50,7 @@ export async function getEventsForRepos(
 	limit = 50,
 ): Promise<WebhookEvent[]> {
 	if (repos.length === 0) return [];
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	const rows = await db
 		.selectFrom("webhook_events")
@@ -122,7 +70,7 @@ export async function getEventsForRepos(
 }
 
 export async function getEvent(id: string): Promise<WebhookEvent | null> {
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("webhook_events")
@@ -142,7 +90,7 @@ export async function getEvent(id: string): Promise<WebhookEvent | null> {
 }
 
 export async function getLastEventTime(repo: string): Promise<string | null> {
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	const row = await db
 		.selectFrom("webhook_events")
@@ -177,7 +125,7 @@ export async function getEventStats(): Promise<EventStats> {
 		return cachedEventStats.value;
 	}
 
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	const today = new Date();
 	today.setHours(0, 0, 0, 0);
@@ -210,7 +158,7 @@ export async function getEventStatsForRepos(
 ): Promise<EventStats> {
 	if (repos.length === 0) return { eventsToday: 0, repos: [] };
 
-	await ensureEventsTable();
+	await ensureSchema();
 	const db = getDb();
 	const today = new Date();
 	today.setHours(0, 0, 0, 0);

--- a/web/src/lib/repos.ts
+++ b/web/src/lib/repos.ts
@@ -1,27 +1,9 @@
 import { getTurso } from "./db";
+import { ensureSchema } from "./schema";
 import type { SelectedRepo } from "./types";
 
-let tableReady: Promise<void> | undefined;
-
-function ensureTable(): Promise<void> {
-	if (!tableReady) {
-		tableReady = getTurso()
-			.execute(`
-			CREATE TABLE IF NOT EXISTS user_repos (
-				user_id TEXT NOT NULL,
-				owner TEXT NOT NULL,
-				repo TEXT NOT NULL,
-				added_at TEXT NOT NULL DEFAULT (datetime('now')),
-				PRIMARY KEY (user_id, owner, repo)
-			)
-		`)
-			.then(() => {});
-	}
-	return tableReady;
-}
-
 export async function getUserRepos(userId: string): Promise<SelectedRepo[]> {
-	await ensureTable();
+	await ensureSchema();
 	const result = await getTurso().execute({
 		sql: "SELECT owner, repo, added_at FROM user_repos WHERE user_id = ? ORDER BY added_at",
 		args: [userId],
@@ -37,7 +19,7 @@ export async function setUserRepos(
 	userId: string,
 	repos: Array<{ owner: string; repo: string }>,
 ): Promise<void> {
-	await ensureTable();
+	await ensureSchema();
 	const db = getTurso();
 	await db.execute({
 		sql: "DELETE FROM user_repos WHERE user_id = ?",
@@ -54,7 +36,7 @@ export async function setUserRepos(
 }
 
 export async function hasUserRepos(userId: string): Promise<boolean> {
-	await ensureTable();
+	await ensureSchema();
 	const result = await getTurso().execute({
 		sql: "SELECT 1 FROM user_repos WHERE user_id = ? LIMIT 1",
 		args: [userId],
@@ -68,7 +50,7 @@ export async function isRepoOwnedByUser(
 ): Promise<boolean> {
 	const [owner, name] = repo.split("/");
 	if (!owner || !name) return false;
-	await ensureTable();
+	await ensureSchema();
 	const result = await getTurso().execute({
 		sql: "SELECT 1 FROM user_repos WHERE user_id = ? AND owner = ? AND repo = ? LIMIT 1",
 		args: [userId, owner, name],

--- a/web/src/lib/repos.ts
+++ b/web/src/lib/repos.ts
@@ -1,3 +1,9 @@
+/**
+ * Persistence for `user_repos` — the per-user allow-list of selected repos. Backs
+ * `isRepoOwnedByUser`, the gate every repo-scoped API route authorizes against.
+ * Queries run as raw libsql (`getTurso`); the table's DDL lives in the baseline migration.
+ */
+
 import { getTurso } from "./db";
 import { ensureSchema } from "./schema";
 import type { SelectedRepo } from "./types";

--- a/web/src/lib/schema/__tests__/schema.test.ts
+++ b/web/src/lib/schema/__tests__/schema.test.ts
@@ -1,3 +1,4 @@
+import type { InArgs, InStatement } from "@libsql/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Fresh in-memory libsql DB per test so the bootstrap runs against a real
@@ -64,6 +65,45 @@ describe("ensureSchema", () => {
 			"SELECT id FROM schema_migrations",
 		);
 		expect(applied.rows).toHaveLength(1);
+	});
+
+	it("tolerates another bootstrap adding a missing column after introspection", async () => {
+		const { ensureSchema, getTurso } = await load();
+		const turso = getTurso();
+		await turso.execute(
+			"CREATE TABLE webhook_events (id TEXT PRIMARY KEY, type TEXT NOT NULL, action TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', repo TEXT NOT NULL DEFAULT 'unknown', timestamp TEXT NOT NULL)",
+		);
+
+		const originalExecute = turso.execute.bind(turso) as (
+			statement: InStatement | string,
+			args?: InArgs,
+		) => ReturnType<typeof turso.execute>;
+		let raced = false;
+		vi.spyOn(turso, "execute").mockImplementation(
+			async (statement: InStatement | string, args?: InArgs) => {
+				const sqlText =
+					typeof statement === "string" ? statement : statement.sql;
+				if (!raced && sqlText === 'PRAGMA table_info("webhook_events")') {
+					raced = true;
+					const result = await originalExecute(statement, args);
+					await originalExecute(
+						"ALTER TABLE webhook_events ADD COLUMN payload TEXT NOT NULL DEFAULT '{}'",
+					);
+					return result;
+				}
+				return originalExecute(statement, args);
+			},
+		);
+
+		await expect(ensureSchema()).resolves.toBeUndefined();
+		expect(raced).toBe(true);
+
+		const eventColumns = await turso.execute(
+			'PRAGMA table_info("webhook_events")',
+		);
+		expect(eventColumns.rows.map((r) => String(r.name))).toContain("payload");
+		const applied = await turso.execute("SELECT id FROM schema_migrations");
+		expect(applied.rows.map((r) => String(r.id))).toEqual(["0001_baseline"]);
 	});
 
 	it("converges an existing database with a narrower schema without losing data", async () => {

--- a/web/src/lib/schema/__tests__/schema.test.ts
+++ b/web/src/lib/schema/__tests__/schema.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Fresh in-memory libsql DB per test so the bootstrap runs against a real
+// engine without persisting between runs.
+beforeEach(() => {
+	vi.stubEnv("TURSO_DATABASE_URL", ":memory:");
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.resetModules();
+});
+
+// db + schema must come from the same fresh module graph so getTurso() in the
+// test shares the singleton client ensureSchema() bootstraps.
+async function load() {
+	vi.resetModules();
+	const db = await import("../../db");
+	const schema = await import("../index");
+	return { ...db, ...schema };
+}
+
+describe("ensureSchema", () => {
+	it("builds every table on a fresh database and records the baseline", async () => {
+		const { ensureSchema, getTurso } = await load();
+		await ensureSchema();
+
+		const tables = await getTurso().execute(
+			"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+		);
+		const names = tables.rows.map((r) => String(r.name));
+		for (const expected of [
+			"agent_sessions",
+			"base_snapshots",
+			"chat_messages",
+			"managed_agents_cache",
+			"managed_pr_review_projections",
+			"managed_pr_review_runs",
+			"schema_migrations",
+			"terminal_access_tickets",
+			"user_repos",
+			"webhook_events",
+			"workspaces",
+		]) {
+			expect(names).toContain(expected);
+		}
+
+		const applied = await getTurso().execute(
+			"SELECT id FROM schema_migrations",
+		);
+		expect(applied.rows.map((r) => String(r.id))).toEqual(["0001_baseline"]);
+	});
+
+	it("re-running the migration runner is a no-op (idempotent skip, no duplicate record)", async () => {
+		const { ensureSchema, resetSchemaForTests, getTurso } = await load();
+		await ensureSchema();
+
+		// Forget the memoized promise so the runner actually executes again; it
+		// must see the baseline already applied and skip it rather than re-run.
+		resetSchemaForTests();
+		await expect(ensureSchema()).resolves.toBeUndefined();
+
+		const applied = await getTurso().execute(
+			"SELECT id FROM schema_migrations",
+		);
+		expect(applied.rows).toHaveLength(1);
+	});
+
+	it("reconciles an existing pre-migration database without losing data", async () => {
+		const { ensureSchema, getTurso } = await load();
+		const turso = getTurso();
+
+		// Simulate a production DB created by the old ifNotExists path: tables
+		// missing later-added columns, real rows, and no schema_migrations row.
+		await turso.execute(
+			"CREATE TABLE webhook_events (id TEXT PRIMARY KEY, type TEXT NOT NULL, action TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', repo TEXT NOT NULL DEFAULT 'unknown', timestamp TEXT NOT NULL)",
+		);
+		await turso.execute(
+			"INSERT INTO webhook_events (id, type, timestamp) VALUES ('e1', 'push', '2026-01-01T00:00:00Z')",
+		);
+		await turso.execute(
+			"CREATE TABLE agent_sessions (id TEXT PRIMARY KEY, repo TEXT NOT NULL, agent_name TEXT NOT NULL, compute_backend TEXT NOT NULL, thread_id TEXT NOT NULL, status TEXT NOT NULL, created_at TEXT NOT NULL, last_activity_at TEXT NOT NULL)",
+		);
+		await turso.execute(
+			"INSERT INTO agent_sessions (id, repo, agent_name, compute_backend, thread_id, status, created_at, last_activity_at) VALUES ('s1', 'o/r', 'terminal', 'vercel', 't1', 'active', '2026-01-01', '2026-01-01')",
+		);
+		await turso.execute(
+			"CREATE TABLE workspaces (id TEXT PRIMARY KEY, name TEXT NOT NULL, path TEXT NOT NULL, created_at TEXT NOT NULL, last_accessed_at TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'stopped', backend_identifier TEXT NOT NULL DEFAULT 'local', synced_at TEXT NOT NULL)",
+		);
+		await turso.execute(
+			"INSERT INTO workspaces (id, name, path, created_at, last_accessed_at, synced_at) VALUES ('w1', 'ws', '/p', '2026-01-01', '2026-01-01', '2026-01-01')",
+		);
+
+		await expect(ensureSchema()).resolves.toBeUndefined();
+
+		// Missing column added with its default; existing row preserved + backfilled.
+		const ev = await turso.execute(
+			"SELECT id, payload FROM webhook_events WHERE id = 'e1'",
+		);
+		expect(ev.rows).toHaveLength(1);
+		expect(String(ev.rows[0].payload)).toBe("{}");
+
+		// New columns added; the terminal→shell data migration applied.
+		const sess = await turso.execute(
+			"SELECT agent_name, user_id, snapshot_id FROM agent_sessions WHERE id = 's1'",
+		);
+		expect(String(sess.rows[0].agent_name)).toBe("shell");
+		expect(sess.rows[0].user_id).toBeNull();
+
+		// owner_id added and backfilled to the default owner.
+		const ws = await turso.execute(
+			"SELECT owner_id FROM workspaces WHERE id = 'w1'",
+		);
+		expect(String(ws.rows[0].owner_id)).toBe("default");
+
+		const applied = await turso.execute("SELECT id FROM schema_migrations");
+		expect(applied.rows.map((r) => String(r.id))).toContain("0001_baseline");
+	});
+});

--- a/web/src/lib/schema/__tests__/schema.test.ts
+++ b/web/src/lib/schema/__tests__/schema.test.ts
@@ -66,12 +66,12 @@ describe("ensureSchema", () => {
 		expect(applied.rows).toHaveLength(1);
 	});
 
-	it("reconciles an existing pre-migration database without losing data", async () => {
+	it("converges an existing database with a narrower schema without losing data", async () => {
 		const { ensureSchema, getTurso } = await load();
 		const turso = getTurso();
 
-		// Simulate a production DB created by the old ifNotExists path: tables
-		// missing later-added columns, real rows, and no schema_migrations row.
+		// A database that already holds some tables with a narrower column set,
+		// real rows, and no schema_migrations entry.
 		await turso.execute(
 			"CREATE TABLE webhook_events (id TEXT PRIMARY KEY, type TEXT NOT NULL, action TEXT NOT NULL DEFAULT '', summary TEXT NOT NULL DEFAULT '', repo TEXT NOT NULL DEFAULT 'unknown', timestamp TEXT NOT NULL)",
 		);

--- a/web/src/lib/schema/index.ts
+++ b/web/src/lib/schema/index.ts
@@ -8,9 +8,9 @@ import { getDb, getTurso } from "../db";
 import { MIGRATIONS } from "./migrations";
 
 /**
- * Single in-flight bootstrap promise so concurrent callers (one warm serverless
- * instance serves many requests) await one run rather than racing — a plain boolean
- * would flip before its async body finished. Cleared on failure so a later call retries.
+ * Single in-flight bootstrap promise so concurrent callers in one warm serverless
+ * instance await one run rather than racing — a plain boolean would flip before its
+ * async body finished. Cleared on failure so a later call retries.
  */
 let schemaReady: Promise<void> | undefined;
 
@@ -42,7 +42,7 @@ async function runMigrations(): Promise<void> {
 		if (applied.has(migration.id)) continue;
 		await migration.up(db);
 		await turso.execute({
-			sql: "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+			sql: "INSERT OR IGNORE INTO schema_migrations (id, applied_at) VALUES (?, ?)",
 			args: [migration.id, new Date().toISOString()],
 		});
 	}

--- a/web/src/lib/schema/index.ts
+++ b/web/src/lib/schema/index.ts
@@ -1,0 +1,54 @@
+import { getDb, getTurso } from "../db";
+import { MIGRATIONS } from "./migrations";
+
+/**
+ * Single in-flight bootstrap promise. Concurrent callers (serverless handles
+ * many requests per warm instance) await the same run instead of racing — an
+ * improvement over the per-module boolean flags this replaces, which raced on
+ * their async body. Cleared on failure so a later call retries.
+ */
+let schemaReady: Promise<void> | undefined;
+
+/**
+ * Ensure every table the app reads/writes exists and is up to date. Idempotent
+ * and cheap after the first call (a boolean check on the cached promise). Every
+ * persistence query awaits this before touching the database; it is the single
+ * seam that replaces nine per-module `ensure*Table()` functions.
+ */
+export function ensureSchema(): Promise<void> {
+	if (!schemaReady) {
+		schemaReady = runMigrations().catch((err) => {
+			schemaReady = undefined;
+			throw err;
+		});
+	}
+	return schemaReady;
+}
+
+async function runMigrations(): Promise<void> {
+	const turso = getTurso();
+	await turso.execute(
+		"CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL)",
+	);
+	const appliedRows = await turso.execute("SELECT id FROM schema_migrations");
+	const applied = new Set(appliedRows.rows.map((r) => String(r.id)));
+
+	const db = getDb();
+	for (const migration of MIGRATIONS) {
+		if (applied.has(migration.id)) continue;
+		await migration.up(db);
+		await turso.execute({
+			sql: "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+			args: [migration.id, new Date().toISOString()],
+		});
+	}
+}
+
+/**
+ * Test-only: forget the cached bootstrap so the next `ensureSchema()` re-runs
+ * against a fresh in-memory database. Replaces the schema-bootstrap half of the
+ * former per-module `__reset*ForTests()` helpers.
+ */
+export function resetSchemaForTests(): void {
+	schemaReady = undefined;
+}

--- a/web/src/lib/schema/index.ts
+++ b/web/src/lib/schema/index.ts
@@ -2,18 +2,16 @@ import { getDb, getTurso } from "../db";
 import { MIGRATIONS } from "./migrations";
 
 /**
- * Single in-flight bootstrap promise. Concurrent callers (serverless handles
- * many requests per warm instance) await the same run instead of racing — an
- * improvement over the per-module boolean flags this replaces, which raced on
- * their async body. Cleared on failure so a later call retries.
+ * Single in-flight bootstrap promise so concurrent callers (one warm serverless
+ * instance serves many requests) await one run rather than racing — a plain boolean
+ * would flip before its async body finished. Cleared on failure so a later call retries.
  */
 let schemaReady: Promise<void> | undefined;
 
 /**
- * Ensure every table the app reads/writes exists and is up to date. Idempotent
- * and cheap after the first call (a boolean check on the cached promise). Every
- * persistence query awaits this before touching the database; it is the single
- * seam that replaces nine per-module `ensure*Table()` functions.
+ * Ensure every table the app reads/writes exists and is current. Every persistence
+ * query awaits this before its first database access. Idempotent and cheap after the
+ * first call — subsequent calls await the already-resolved promise.
  */
 export function ensureSchema(): Promise<void> {
 	if (!schemaReady) {
@@ -46,8 +44,7 @@ async function runMigrations(): Promise<void> {
 
 /**
  * Test-only: forget the cached bootstrap so the next `ensureSchema()` re-runs
- * against a fresh in-memory database. Replaces the schema-bootstrap half of the
- * former per-module `__reset*ForTests()` helpers.
+ * against a fresh in-memory database.
  */
 export function resetSchemaForTests(): void {
 	schemaReady = undefined;

--- a/web/src/lib/schema/index.ts
+++ b/web/src/lib/schema/index.ts
@@ -1,3 +1,9 @@
+/**
+ * The schema runner. Applies the migrations defined in ./migrations to the database
+ * and records which have run. `ensureSchema()` is the entry point every persistence
+ * query awaits before its first database access.
+ */
+
 import { getDb, getTurso } from "../db";
 import { MIGRATIONS } from "./migrations";
 

--- a/web/src/lib/schema/migrations.ts
+++ b/web/src/lib/schema/migrations.ts
@@ -4,8 +4,9 @@
  * The schema is an ordered, append-only list of migrations (`MIGRATIONS`). Each has
  * a stable `id` and an idempotent `up(db)` that brings a database to the state that
  * migration describes. `ensureSchema()` (in ./index) runs the pending migrations in
- * order and records each `id` in the `schema_migrations` table, so any given
- * migration runs at most once per database.
+ * order and records each `id` in the `schema_migrations` table. A concurrent cold
+ * start may enter the same pending migration before another instance records it, so
+ * `up` functions must stay idempotent and tolerate benign DDL races.
  *
  * Changing the schema:
  *  - Append a new migration with the next ordered id; never edit one that has
@@ -14,8 +15,8 @@
  *  - Keep `up` idempotent: `createTable().ifNotExists()`, `createIndex().ifNotExists()`,
  *    `addMissingColumns()` for added columns, and data writes guarded by a WHERE
  *    clause. The runner records a migration only after `up` resolves, so a failure
- *    partway through re-runs `up` from the top on the next call — `up` must tolerate
- *    that.
+ *    partway through re-runs `up` from the top on the next call. A second cold-start
+ *    runner can also overlap the first — `up` must tolerate both cases.
  *  - Add the table's row type to the `Database` interface in ../db for typed access.
  *    (Raw-libsql tables like `user_repos`/`terminal_access_tickets` are the exception;
  *    their DDL still lives here so all schema is in one place.)
@@ -65,8 +66,20 @@ async function addMissingColumns(
 				if (col.defaultTo !== undefined) built = built.defaultTo(col.defaultTo);
 				return built;
 			})
-			.execute();
+			.execute()
+			.catch((err: unknown) => {
+				if (isDuplicateColumnError(err, col.name)) return;
+				throw err;
+			});
 	}
+}
+
+function isDuplicateColumnError(err: unknown, column: string): boolean {
+	const message = err instanceof Error ? err.message : String(err);
+	return (
+		message.toLowerCase().includes("duplicate column name") &&
+		message.includes(column)
+	);
 }
 
 /**

--- a/web/src/lib/schema/migrations.ts
+++ b/web/src/lib/schema/migrations.ts
@@ -1,11 +1,33 @@
+/**
+ * Schema definition for the web database.
+ *
+ * The schema is an ordered, append-only list of migrations (`MIGRATIONS`). Each has
+ * a stable `id` and an idempotent `up(db)` that brings a database to the state that
+ * migration describes. `ensureSchema()` (in ./index) runs the pending migrations in
+ * order and records each `id` in the `schema_migrations` table, so any given
+ * migration runs at most once per database.
+ *
+ * Changing the schema:
+ *  - Append a new migration with the next ordered id; never edit one that has
+ *    shipped — it is already recorded and will not run again, so add a follow-up
+ *    migration instead.
+ *  - Keep `up` idempotent: `createTable().ifNotExists()`, `createIndex().ifNotExists()`,
+ *    `addMissingColumns()` for added columns, and data writes guarded by a WHERE
+ *    clause. The runner records a migration only after `up` resolves, so a failure
+ *    partway through re-runs `up` from the top on the next call — `up` must tolerate
+ *    that.
+ *  - Add the table's row type to the `Database` interface in ../db for typed access.
+ *    (Raw-libsql tables like `user_repos`/`terminal_access_tickets` are the exception;
+ *    their DDL still lives here so all schema is in one place.)
+ *
+ * Design rationale and tradeoffs: web/docs/schema-management.md and
+ * docs/decisions/web-schema-toolchain.md.
+ */
+
 import { type Kysely, sql } from "kysely";
 import { type Database, getTurso } from "../db";
 
-/**
- * A tracked, ordered schema migration. `id` is recorded in `schema_migrations`
- * once `up` succeeds; migrations are applied in array order and each must be
- * idempotent (safe to re-run if a prior attempt failed before being recorded).
- */
+/** One tracked migration: a stable `id` and an idempotent `up`. */
 export interface Migration {
 	id: string;
 	up(db: Kysely<Database>): Promise<void>;
@@ -19,10 +41,11 @@ interface MissingColumn {
 }
 
 /**
- * Add columns that are missing from a table that already exists. Introspection-
- * driven and idempotent — no swallowed try/catch. Reconciles databases created
- * before a column was introduced (the prod DB predates `schema_migrations`).
- * Table names are internal constants, so interpolation into PRAGMA is safe.
+ * Add the listed columns that aren't already on `table`. Reads the live columns
+ * (`PRAGMA table_info`) and adds only the missing ones, so a table that exists with
+ * a narrower set of columns converges to the target shape — idempotent, with no
+ * blind try/catch. Table names are internal constants, so interpolating into the
+ * PRAGMA is safe.
  */
 async function addMissingColumns(
 	db: Kysely<Database>,
@@ -47,11 +70,10 @@ async function addMissingColumns(
 }
 
 /**
- * Baseline: the union of the nine former per-module `ensure*Table()` bodies.
- * On a fresh database it builds the full schema; against an existing production
- * database (tables created by the old ifNotExists path, no `schema_migrations`
- * row) it reconciles missing columns and re-applies the idempotent data
- * migrations, leaving existing rows intact.
+ * Baseline schema: every table, index, and data normalization the app needs.
+ * Idempotent and reconciling — it creates missing tables, adds missing columns, and
+ * normalizes data through guarded writes, converging any database (empty or partial)
+ * to this schema without disturbing existing rows.
  */
 const baseline: Migration = {
 	id: "0001_baseline",
@@ -148,8 +170,8 @@ const baseline: Migration = {
 			.on("agent_sessions")
 			.columns(["user_id", "repo", "agent_name", "thread_id"])
 			.execute();
-		// One-shot rename of the synthetic terminal slot "terminal" → "shell"
-		// (PR #299 changed the default fallback but left existing rows behind).
+		// Synthetic terminal sessions use the canonical name "shell"; normalize any
+		// rows that still hold the non-canonical "terminal".
 		await db
 			.updateTable("agent_sessions")
 			.set({ agent_name: "shell" })
@@ -161,8 +183,8 @@ const baseline: Migration = {
 		await db.schema
 			.createTable("workspaces")
 			.ifNotExists()
-			// Kept literal ("default") rather than importing
-			// DEFAULT_WORKSPACE_OWNER_ID to avoid a migrations→module dependency.
+			// Literal rather than importing DEFAULT_WORKSPACE_OWNER_ID, to keep
+			// migrations free of app-module imports.
 			.addColumn("owner_id", "text", (c) => c.notNull().defaultTo("default"))
 			.addColumn("id", "text", (c) => c.primaryKey())
 			.addColumn("name", "text", (c) => c.notNull())
@@ -280,9 +302,9 @@ const baseline: Migration = {
 			.on("managed_pr_review_runs")
 			.columns(["repo_full_name", "pr_number"])
 			.execute();
-		// Nullable unique value held only while a run is active. Pre-migration
-		// `started` rows are intentionally not backfilled; they age out via the
-		// stale-started path rather than risk a broad migration.
+		// active_claim_key is unique but nullable; SQLite permits many NULLs, so the
+		// constraint binds only runs currently holding a claim. Idle/completed runs
+		// (NULL) age out through the stale-started path.
 		await db.schema
 			.createIndex("ux_managed_pr_review_runs_active_claim")
 			.ifNotExists()

--- a/web/src/lib/schema/migrations.ts
+++ b/web/src/lib/schema/migrations.ts
@@ -1,0 +1,374 @@
+import { type Kysely, sql } from "kysely";
+import { type Database, getTurso } from "../db";
+
+/**
+ * A tracked, ordered schema migration. `id` is recorded in `schema_migrations`
+ * once `up` succeeds; migrations are applied in array order and each must be
+ * idempotent (safe to re-run if a prior attempt failed before being recorded).
+ */
+export interface Migration {
+	id: string;
+	up(db: Kysely<Database>): Promise<void>;
+}
+
+interface MissingColumn {
+	name: string;
+	type: "text" | "integer";
+	notNull?: boolean;
+	defaultTo?: string;
+}
+
+/**
+ * Add columns that are missing from a table that already exists. Introspection-
+ * driven and idempotent — no swallowed try/catch. Reconciles databases created
+ * before a column was introduced (the prod DB predates `schema_migrations`).
+ * Table names are internal constants, so interpolation into PRAGMA is safe.
+ */
+async function addMissingColumns(
+	db: Kysely<Database>,
+	table: string,
+	columns: MissingColumn[],
+): Promise<void> {
+	const info = await getTurso().execute(`PRAGMA table_info("${table}")`);
+	if (info.rows.length === 0) return; // fresh DB — createTable already built it in full
+	const present = new Set(info.rows.map((r) => String(r.name)));
+	for (const col of columns) {
+		if (present.has(col.name)) continue;
+		await db.schema
+			.alterTable(table)
+			.addColumn(col.name, col.type, (c) => {
+				let built = c;
+				if (col.notNull) built = built.notNull();
+				if (col.defaultTo !== undefined) built = built.defaultTo(col.defaultTo);
+				return built;
+			})
+			.execute();
+	}
+}
+
+/**
+ * Baseline: the union of the nine former per-module `ensure*Table()` bodies.
+ * On a fresh database it builds the full schema; against an existing production
+ * database (tables created by the old ifNotExists path, no `schema_migrations`
+ * row) it reconciles missing columns and re-applies the idempotent data
+ * migrations, leaving existing rows intact.
+ */
+const baseline: Migration = {
+	id: "0001_baseline",
+	async up(db) {
+		// --- webhook_events ---
+		await db.schema
+			.createTable("webhook_events")
+			.ifNotExists()
+			.addColumn("id", "text", (c) => c.primaryKey())
+			.addColumn("type", "text", (c) => c.notNull())
+			.addColumn("action", "text", (c) => c.notNull().defaultTo(""))
+			.addColumn("summary", "text", (c) => c.notNull().defaultTo(""))
+			.addColumn("repo", "text", (c) => c.notNull().defaultTo("unknown"))
+			.addColumn("timestamp", "text", (c) => c.notNull())
+			.addColumn("payload", "text", (c) => c.notNull().defaultTo("{}"))
+			.execute();
+		await addMissingColumns(db, "webhook_events", [
+			{ name: "payload", type: "text", notNull: true, defaultTo: "{}" },
+		]);
+		await db.schema
+			.createIndex("idx_webhook_events_timestamp")
+			.ifNotExists()
+			.on("webhook_events")
+			.column("timestamp desc")
+			.execute();
+		await db.schema
+			.createIndex("idx_webhook_events_repo")
+			.ifNotExists()
+			.on("webhook_events")
+			.column("repo")
+			.execute();
+		// Composite index for `WHERE repo = ? ORDER BY timestamp DESC LIMIT N`,
+		// the chat/activity poll path. The single-column indexes are not enough.
+		await db.schema
+			.createIndex("idx_webhook_events_repo_ts")
+			.ifNotExists()
+			.on("webhook_events")
+			.columns(["repo", "timestamp desc"])
+			.execute();
+
+		// --- chat_messages ---
+		await db.schema
+			.createTable("chat_messages")
+			.ifNotExists()
+			.addColumn("id", "text", (c) => c.primaryKey())
+			.addColumn("repo", "text", (c) => c.notNull())
+			.addColumn("author", "text", (c) => c.notNull())
+			.addColumn("author_type", "text", (c) => c.notNull())
+			.addColumn("content", "text", (c) => c.notNull())
+			.addColumn("agent_target", "text")
+			.addColumn("discussion_id", "text")
+			.addColumn("discussion_url", "text")
+			.addColumn("timestamp", "text", (c) => c.notNull())
+			.execute();
+		await db.schema
+			.createIndex("idx_chat_messages_repo_ts")
+			.ifNotExists()
+			.on("chat_messages")
+			.columns(["repo", "timestamp desc"])
+			.execute();
+
+		// --- agent_sessions ---
+		await db.schema
+			.createTable("agent_sessions")
+			.ifNotExists()
+			.addColumn("id", "text", (c) => c.primaryKey())
+			.addColumn("user_id", "text", (c) => c.notNull())
+			.addColumn("repo", "text", (c) => c.notNull())
+			.addColumn("agent_name", "text", (c) => c.notNull())
+			.addColumn("compute_backend", "text", (c) => c.notNull())
+			.addColumn("compute_instance_id", "text")
+			.addColumn("thread_id", "text", (c) => c.notNull())
+			.addColumn("discussion_id", "text")
+			.addColumn("status", "text", (c) => c.notNull())
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("last_activity_at", "text", (c) => c.notNull())
+			.addColumn("snapshot_id", "text")
+			.addColumn("claude_session_id", "text")
+			.execute();
+		await addMissingColumns(db, "agent_sessions", [
+			{ name: "snapshot_id", type: "text" },
+			{ name: "claude_session_id", type: "text" },
+			{ name: "user_id", type: "text" },
+		]);
+		await db.schema
+			.createIndex("idx_agent_sessions_thread")
+			.ifNotExists()
+			.on("agent_sessions")
+			.columns(["repo", "agent_name", "thread_id"])
+			.execute();
+		await db.schema
+			.createIndex("idx_agent_sessions_user_thread")
+			.ifNotExists()
+			.on("agent_sessions")
+			.columns(["user_id", "repo", "agent_name", "thread_id"])
+			.execute();
+		// One-shot rename of the synthetic terminal slot "terminal" → "shell"
+		// (PR #299 changed the default fallback but left existing rows behind).
+		await db
+			.updateTable("agent_sessions")
+			.set({ agent_name: "shell" })
+			.where("agent_name", "=", "terminal")
+			.where("status", "in", ["active", "streaming", "snapshotted"])
+			.execute();
+
+		// --- workspaces ---
+		await db.schema
+			.createTable("workspaces")
+			.ifNotExists()
+			// Kept literal ("default") rather than importing
+			// DEFAULT_WORKSPACE_OWNER_ID to avoid a migrations→module dependency.
+			.addColumn("owner_id", "text", (c) => c.notNull().defaultTo("default"))
+			.addColumn("id", "text", (c) => c.primaryKey())
+			.addColumn("name", "text", (c) => c.notNull())
+			.addColumn("path", "text", (c) => c.notNull())
+			.addColumn("repo_id", "text")
+			.addColumn("repo_name", "text")
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("last_accessed_at", "text", (c) => c.notNull())
+			.addColumn("status", "text", (c) => c.notNull().defaultTo("stopped"))
+			.addColumn("git_branch", "text")
+			.addColumn("backend_identifier", "text", (c) =>
+				c.notNull().defaultTo("local"),
+			)
+			.addColumn("synced_at", "text", (c) => c.notNull())
+			.execute();
+		await addMissingColumns(db, "workspaces", [
+			{ name: "owner_id", type: "text" },
+		]);
+		await db
+			.updateTable("workspaces")
+			.set({ owner_id: "default" })
+			.where("owner_id", "is", null)
+			.execute();
+		await db.schema
+			.createIndex("idx_workspaces_owner")
+			.ifNotExists()
+			.on("workspaces")
+			.column("owner_id")
+			.execute();
+
+		// --- base_snapshots ---
+		await db.schema
+			.createTable("base_snapshots")
+			.ifNotExists()
+			.addColumn("provider", "text", (c) => c.notNull())
+			.addColumn("version", "text", (c) => c.notNull())
+			.addColumn("snapshot_id", "text", (c) => c.notNull())
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addPrimaryKeyConstraint("base_snapshots_pk", ["provider", "version"])
+			.execute();
+
+		// --- managed_agents_cache ---
+		await db.schema
+			.createTable("managed_agents_cache")
+			.ifNotExists()
+			.addColumn("kind", "text", (c) => c.notNull())
+			.addColumn("hash", "text", (c) => c.notNull())
+			.addColumn("remote_id", "text", (c) => c.notNull())
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("metadata", "text")
+			.execute();
+		await db.schema
+			.createIndex("idx_managed_agents_cache_key")
+			.ifNotExists()
+			.on("managed_agents_cache")
+			.columns(["kind", "hash"])
+			.execute();
+
+		// --- managed_pr_review_runs ---
+		await db.schema
+			.createTable("managed_pr_review_runs")
+			.ifNotExists()
+			.addColumn("fingerprint", "text", (c) => c.primaryKey())
+			.addColumn("repo_full_name", "text", (c) => c.notNull())
+			.addColumn("pr_number", "integer", (c) => c.notNull())
+			.addColumn("head_sha", "text", (c) => c.notNull())
+			.addColumn("trigger_kind", "text", (c) => c.notNull())
+			.addColumn("trigger_source_id", "text", (c) => c.notNull())
+			.addColumn("reviewer_config_hash", "text", (c) => c.notNull())
+			.addColumn("session_id", "text")
+			.addColumn("status", "text", (c) => c.notNull())
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("updated_at", "text", (c) => c.notNull())
+			.addColumn("error", "text")
+			.addColumn("failure_kind", "text")
+			.addColumn("failure_message", "text")
+			.addColumn("failure_retryable", "integer")
+			.addColumn("failed_at", "text")
+			.addColumn("projection_status", "text")
+			.addColumn("projection_updated_at", "text")
+			.addColumn("projection_error", "text")
+			.addColumn("github_review_id", "text")
+			.addColumn("review_intent_event", "text")
+			.addColumn("review_intent_body", "text")
+			.addColumn("review_intent_labels", "text")
+			.addColumn("review_intent_recorded_at", "text")
+			.addColumn("active_claim_key", "text")
+			.addColumn("coalesced_head_sha", "text")
+			.addColumn("coalesced_trigger_kind", "text")
+			.addColumn("coalesced_trigger_source_id", "text")
+			.addColumn("coalesced_at", "text")
+			.execute();
+		await addMissingColumns(db, "managed_pr_review_runs", [
+			{ name: "failure_kind", type: "text" },
+			{ name: "failure_message", type: "text" },
+			{ name: "failure_retryable", type: "integer" },
+			{ name: "failed_at", type: "text" },
+			{ name: "projection_status", type: "text" },
+			{ name: "projection_updated_at", type: "text" },
+			{ name: "projection_error", type: "text" },
+			{ name: "github_review_id", type: "text" },
+			{ name: "review_intent_event", type: "text" },
+			{ name: "review_intent_body", type: "text" },
+			{ name: "review_intent_labels", type: "text" },
+			{ name: "review_intent_recorded_at", type: "text" },
+			{ name: "active_claim_key", type: "text" },
+			{ name: "coalesced_head_sha", type: "text" },
+			{ name: "coalesced_trigger_kind", type: "text" },
+			{ name: "coalesced_trigger_source_id", type: "text" },
+			{ name: "coalesced_at", type: "text" },
+		]);
+		await db.schema
+			.createIndex("idx_managed_pr_review_runs_pr")
+			.ifNotExists()
+			.on("managed_pr_review_runs")
+			.columns(["repo_full_name", "pr_number"])
+			.execute();
+		// Nullable unique value held only while a run is active. Pre-migration
+		// `started` rows are intentionally not backfilled; they age out via the
+		// stale-started path rather than risk a broad migration.
+		await db.schema
+			.createIndex("ux_managed_pr_review_runs_active_claim")
+			.ifNotExists()
+			.on("managed_pr_review_runs")
+			.column("active_claim_key")
+			.unique()
+			.execute();
+
+		// --- managed_pr_review_projections ---
+		await db.schema
+			.createTable("managed_pr_review_projections")
+			.ifNotExists()
+			.addColumn("projection_id", "text", (c) => c.primaryKey())
+			.addColumn("run_fingerprint", "text", (c) => c.notNull())
+			.addColumn("projection_type", "text", (c) => c.notNull())
+			.addColumn("projection_key", "text", (c) => c.notNull())
+			.addColumn("desired_payload_hash", "text", (c) => c.notNull())
+			.addColumn("desired_payload", "text", (c) => c.notNull())
+			.addColumn("state", "text", (c) => c.notNull())
+			.addColumn("attempts", "integer", (c) => c.notNull().defaultTo(0))
+			.addColumn("last_attempted_at", "text")
+			.addColumn("observed_external_id", "text")
+			.addColumn("error_kind", "text")
+			.addColumn("error_text", "text")
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("updated_at", "text", (c) => c.notNull())
+			.execute();
+		await db.schema
+			.createIndex("ux_managed_pr_review_projections_desired")
+			.ifNotExists()
+			.on("managed_pr_review_projections")
+			.columns([
+				"run_fingerprint",
+				"projection_type",
+				"projection_key",
+				"desired_payload_hash",
+			])
+			.unique()
+			.execute();
+		await db.schema
+			.createIndex("idx_managed_pr_review_projections_run")
+			.ifNotExists()
+			.on("managed_pr_review_projections")
+			.column("run_fingerprint")
+			.execute();
+		await db.schema
+			.createIndex("idx_managed_pr_review_projections_state")
+			.ifNotExists()
+			.on("managed_pr_review_projections")
+			.columns(["state", "updated_at"])
+			.execute();
+
+		// --- terminal_access_tickets (queried via raw libsql in terminal-tickets.ts) ---
+		await db.schema
+			.createTable("terminal_access_tickets")
+			.ifNotExists()
+			.addColumn("ticket_hash", "text", (c) => c.primaryKey())
+			.addColumn("user_id", "text", (c) => c.notNull())
+			.addColumn("repo", "text", (c) => c.notNull())
+			.addColumn("session_id", "text", (c) => c.notNull())
+			.addColumn("compute_instance_id", "text", (c) => c.notNull())
+			.addColumn("compute_backend", "text", (c) => c.notNull())
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("expires_at", "text", (c) => c.notNull())
+			.addColumn("redeemed_at", "text")
+			.execute();
+		await db.schema
+			.createIndex("idx_terminal_access_tickets_session")
+			.ifNotExists()
+			.on("terminal_access_tickets")
+			.columns(["user_id", "repo", "session_id", "expires_at"])
+			.execute();
+
+		// --- user_repos (queried via raw libsql in repos.ts) ---
+		await db.schema
+			.createTable("user_repos")
+			.ifNotExists()
+			.addColumn("user_id", "text", (c) => c.notNull())
+			.addColumn("owner", "text", (c) => c.notNull())
+			.addColumn("repo", "text", (c) => c.notNull())
+			.addColumn("added_at", "text", (c) =>
+				c.notNull().defaultTo(sql`(datetime('now'))`),
+			)
+			.addPrimaryKeyConstraint("user_repos_pk", ["user_id", "owner", "repo"])
+			.execute();
+	},
+};
+
+export const MIGRATIONS: Migration[] = [baseline];

--- a/web/src/lib/terminal-tickets.ts
+++ b/web/src/lib/terminal-tickets.ts
@@ -1,3 +1,10 @@
+/**
+ * Single-use, short-TTL terminal access tickets (`terminal_access_tickets`): issued
+ * per request and redeemed exactly once, scoped to a user + session, so a client can
+ * authorize a ttyd connection without carrying a long-lived credential. Queries run
+ * as raw libsql (`getTurso`); the table's DDL lives in the baseline migration.
+ */
+
 import crypto from "node:crypto";
 import { getTurso } from "./db";
 import { ensureSchema } from "./schema";

--- a/web/src/lib/terminal-tickets.ts
+++ b/web/src/lib/terminal-tickets.ts
@@ -1,9 +1,8 @@
 import crypto from "node:crypto";
 import { getTurso } from "./db";
+import { ensureSchema } from "./schema";
 
 export const TERMINAL_TICKET_TTL_MS = 30_000;
-
-let migrated = false;
 
 export interface IssuedTerminalTicket {
 	ticket: string;
@@ -27,29 +26,6 @@ export type ConsumeTerminalTicketResult =
 			reason: "invalid" | "wrong-user" | "expired" | "redeemed";
 	  };
 
-async function ensureTerminalTicketsTable(): Promise<void> {
-	if (migrated) return;
-	const db = getTurso();
-	await db.execute(`
-		CREATE TABLE IF NOT EXISTS terminal_access_tickets (
-			ticket_hash TEXT PRIMARY KEY,
-			user_id TEXT NOT NULL,
-			repo TEXT NOT NULL,
-			session_id TEXT NOT NULL,
-			compute_instance_id TEXT NOT NULL,
-			compute_backend TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			expires_at TEXT NOT NULL,
-			redeemed_at TEXT
-		)
-	`);
-	await db.execute(`
-		CREATE INDEX IF NOT EXISTS idx_terminal_access_tickets_session
-		ON terminal_access_tickets (user_id, repo, session_id, expires_at)
-	`);
-	migrated = true;
-}
-
 function ticketHash(ticket: string): string {
 	return crypto.createHash("sha256").update(ticket, "utf8").digest("hex");
 }
@@ -71,7 +47,7 @@ export async function issueTerminalTicket(
 	},
 	now = new Date(),
 ): Promise<IssuedTerminalTicket> {
-	await ensureTerminalTicketsTable();
+	await ensureSchema();
 
 	const ticket = crypto.randomBytes(32).toString("base64url");
 	const createdAt = now.toISOString();
@@ -110,7 +86,7 @@ export async function consumeTerminalTicket(
 	userId: string,
 	now = new Date(),
 ): Promise<ConsumeTerminalTicketResult> {
-	await ensureTerminalTicketsTable();
+	await ensureSchema();
 
 	const nowIso = now.toISOString();
 	const hash = ticketHash(ticket);

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -1,3 +1,8 @@
+/**
+ * Persistence for `workspaces` — the workspace list mirrored from the desktop app
+ * via sync, scoped per owner, plus the Markdown status-card formatter.
+ */
+
 import { getDb } from "./db";
 import { ensureSchema } from "./schema";
 import { formatRelativeTime } from "./timeline-utils";

--- a/web/src/lib/workspaces.ts
+++ b/web/src/lib/workspaces.ts
@@ -1,55 +1,9 @@
 import { getDb } from "./db";
+import { ensureSchema } from "./schema";
 import { formatRelativeTime } from "./timeline-utils";
 import type { Workspace, WorkspaceStatus } from "./types";
 
 export const DEFAULT_WORKSPACE_OWNER_ID = "default";
-
-let migrated = false;
-
-async function ensureWorkspacesTable(): Promise<void> {
-	if (migrated) return;
-	const db = getDb();
-	await db.schema
-		.createTable("workspaces")
-		.ifNotExists()
-		.addColumn("owner_id", "text", (c) =>
-			c.notNull().defaultTo(DEFAULT_WORKSPACE_OWNER_ID),
-		)
-		.addColumn("id", "text", (c) => c.primaryKey())
-		.addColumn("name", "text", (c) => c.notNull())
-		.addColumn("path", "text", (c) => c.notNull())
-		.addColumn("repo_id", "text")
-		.addColumn("repo_name", "text")
-		.addColumn("created_at", "text", (c) => c.notNull())
-		.addColumn("last_accessed_at", "text", (c) => c.notNull())
-		.addColumn("status", "text", (c) => c.notNull().defaultTo("stopped"))
-		.addColumn("git_branch", "text")
-		.addColumn("backend_identifier", "text", (c) =>
-			c.notNull().defaultTo("local"),
-		)
-		.addColumn("synced_at", "text", (c) => c.notNull())
-		.execute();
-	try {
-		await db.schema
-			.alterTable("workspaces")
-			.addColumn("owner_id", "text")
-			.execute();
-	} catch {
-		// Column already exists.
-	}
-	await db
-		.updateTable("workspaces")
-		.set({ owner_id: DEFAULT_WORKSPACE_OWNER_ID })
-		.where("owner_id", "is", null)
-		.execute();
-	await db.schema
-		.createIndex("idx_workspaces_owner")
-		.ifNotExists()
-		.on("workspaces")
-		.column("owner_id")
-		.execute();
-	migrated = true;
-}
 
 export interface SyncWorkspaceInput {
 	id: string;
@@ -68,7 +22,7 @@ export async function syncWorkspaces(
 	ownerId: string,
 	workspaces: SyncWorkspaceInput[],
 ): Promise<number> {
-	await ensureWorkspacesTable();
+	await ensureSchema();
 	const db = getDb();
 	const now = new Date().toISOString();
 
@@ -115,7 +69,7 @@ export async function getWorkspaces(
 	ownerId: string,
 	repo?: string | null,
 ): Promise<Workspace[]> {
-	await ensureWorkspacesTable();
+	await ensureSchema();
 	const db = getDb();
 	let query = db
 		.selectFrom("workspaces")


### PR DESCRIPTION
## Summary

Part 1 of 2 from an architecture-deepening pass on `web/` (`/improve-codebase-architecture`). This PR deepens the persistence layer's schema bootstrap into a single seam.

- Nine persistence modules each carried a `migrated` flag, an `ensure*Table()` with inline DDL, and swallowed-`try/catch` column adds. All of it is replaced by a single `ensureSchema()` backed by an **ordered, tracked migration list** and a `schema_migrations` table.
- `0001_baseline` is the faithful union of the former bodies; it is **idempotent against existing production databases** (introspection-driven column reconciliation — no swallowed try/catch — plus the relocated data migrations: `terminal`→`shell` rename and `owner_id` backfill).
- ~59 per-query `ensure*Table()` calls now `await ensureSchema()`; per-module test resets delegate to `resetSchemaForTests()`.
- Decision recorded in `docs/decisions/web-schema-toolchain.md` (Kysely + tracked migrations; Drizzle deferred — the custom libsql dialect is a trivial 81-line bridge, and Drizzle would add a deploy-time migrate model this app doesn't have).
- **Contributor docs:** `web/docs/schema-management.md` explains where the schema is defined (`schema/migrations.ts`), what runs it (`ensureSchema()` in `schema/index.ts`), the request-time bootstrap model, how to add a migration, and the principles/tradeoffs — linked from `web/docs/architecture.md` (new *Database & Schema* section).

Follow-up (Part 2): split `pr-review-runs.ts` into domain / store / lifecycle modules behind a barrel — self-contained plan committed at `backlog/web-pr-review-runs-split_plan.md` for a fresh session.

## Mergeability

- Surface: web
- User-facing behavior changed: no — schema bootstrap is internal and behavior-preserving
- Non-happy paths considered: existing pre-migration prod DB (missing columns, no `schema_migrations` row) is reconciled and covered by a cutover-safety test; concurrent serverless callers share one in-flight bootstrap promise; a failed bootstrap clears the memo so a later request retries
- Release/ops preconditions: none — the request-time, run-once-per-warm-instance bootstrap model is unchanged; no build/deploy DB step introduced
- Residual risk or follow-up: baseline idempotency against the real prod DB (mitigated by introspection + test); Part 2 is the follow-up

## Validation

- [ ] `swift build` (N/A — web-only)
- [ ] `swift test` (N/A — web-only)
- [x] Other checks run: `mise -C web run web:check` (typecheck + Biome + Vitest)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (test output)
- [ ] UI evidence attached (N/A — no UI change)

Command: `mise -C web run web:check` → `tsc --noEmit` clean, `biome check .` clean (182 files), `vitest run` **30 files / 343 tests passed** (includes the new `schema.test.ts` cutover-safety suite: fresh-build, idempotent re-run, and pre-migration-DB reconciliation).

Evidence links:

- [web:check — typecheck + Biome + 343 tests passing](https://evidence.cloudcompute.com/workspaces/pr-624/20260607-175140-part1-web-check.png)

![web:check evidence](https://evidence.cloudcompute.com/workspaces/pr-624/20260607-175140-part1-web-check.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
