### PR TITLE
feat: tile-tree core model + reducer (Phase 0–1)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTree.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTree.swift
@@ -152,6 +152,15 @@ public enum TileTreeLayout {
 
     /// Clamp a proposed `first`-child ratio into `[minimumRatio, maximumRatio]`.
     public static func clampRatio(_ ratio: Double) -> Double {
-        min(max(ratio, minimumRatio), maximumRatio)
+        if ratio.isNaN {
+            return defaultRatio
+        }
+        if ratio == .infinity {
+            return maximumRatio
+        }
+        if ratio == -.infinity {
+            return minimumRatio
+        }
+        return min(max(ratio, minimumRatio), maximumRatio)
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTree.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTree.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+// MARK: - Identity
+
+/// Layout identity for a leaf region (a *Tile*) in a `TileTree`.
+///
+/// Distinct from `HostTerminalSession.id`, which is the agent-domain identity used by the
+/// session registry, OSC routing, command status, and local state. A terminal tile binds one
+/// `TileID` to one `HostTerminalSession.id` in the app layer; keeping the types separate stops
+/// the generic arrangement layer from leaking into the agent subsystems.
+public struct TileID: Hashable, Codable, Sendable, CustomStringConvertible {
+    public let rawValue: UUID
+
+    public init(_ rawValue: UUID = UUID()) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { "Tile(\(rawValue.uuidString.prefix(8)))" }
+}
+
+/// Identity for an internal *Split* node dividing space between exactly two children.
+public struct SplitID: Hashable, Codable, Sendable, CustomStringConvertible {
+    public let rawValue: UUID
+
+    public init(_ rawValue: UUID = UUID()) {
+        self.rawValue = rawValue
+    }
+
+    public var description: String { "Split(\(rawValue.uuidString.prefix(8)))" }
+}
+
+// MARK: - Axis
+
+/// The axis along which a `Split` divides its space.
+///
+/// Mirrors the geometry of the legacy two-pane `SplitPaneLayout.Axis` so the depth-1 mapping
+/// is a direct translation: `first` is the leading child (left / top), `second` the trailing.
+public enum SplitAxis: String, Codable, Sendable {
+    /// Children laid out left → right; `ratio` is the fraction of *width* given to `first`.
+    case leadingTrailing
+    /// Children laid out top → bottom; `ratio` is the fraction of *height* given to `first`.
+    case topBottom
+}
+
+// MARK: - Tile tree
+
+/// The recursive arrangement of Splits and Tiles filling the main column.
+///
+/// A pure topology value type: it carries only `TileID`s, `SplitID`s, axes, and ratios — never a
+/// surface, session, or view. The `TileID ↔ Surface` binding lives in the app layer (`SurfaceStore`),
+/// so the reducer and its tests stay free of SwiftUI, AppKit, and `HostTerminalSession`.
+public indirect enum TileTree: Equatable, Codable, Sendable {
+    /// A leaf region hosting exactly one Surface (identified in the app layer by `TileID`).
+    case tile(TileID)
+    /// An internal node dividing space between `first` and `second` along `axis`.
+    /// `ratio` is `first`'s fraction of the split's length, clamped to
+    /// `[TileTreeLayout.minimumRatio, TileTreeLayout.maximumRatio]`.
+    case split(id: SplitID, axis: SplitAxis, ratio: Double, first: TileTree, second: TileTree)
+}
+
+extension TileTree {
+    /// All tile IDs in depth-first, leading-before-trailing order. Drives relative focus cycling
+    /// and the `SurfaceStore.sync` leaf-set diff.
+    public var leafIDs: [TileID] {
+        switch self {
+        case .tile(let id):
+            return [id]
+        case .split(_, _, _, let first, let second):
+            return first.leafIDs + second.leafIDs
+        }
+    }
+
+    /// All split IDs anywhere in the subtree.
+    public var splitIDs: [SplitID] {
+        switch self {
+        case .tile:
+            return []
+        case .split(let id, _, _, let first, let second):
+            return [id] + first.splitIDs + second.splitIDs
+        }
+    }
+
+    /// Whether `tileID` appears as a leaf anywhere in the subtree.
+    public func contains(_ tileID: TileID) -> Bool {
+        switch self {
+        case .tile(let id):
+            return id == tileID
+        case .split(_, _, _, let first, let second):
+            return first.contains(tileID) || second.contains(tileID)
+        }
+    }
+
+    /// The first (leading-most) leaf of the subtree — used to resolve a focus target when a
+    /// collapse removes the focused tile.
+    public var firstLeafID: TileID {
+        switch self {
+        case .tile(let id):
+            return id
+        case .split(_, _, _, let first, _):
+            return first.firstLeafID
+        }
+    }
+
+    /// The last (trailing-most) leaf of the subtree.
+    public var lastLeafID: TileID {
+        switch self {
+        case .tile(let id):
+            return id
+        case .split(_, _, _, _, let second):
+            return second.lastLeafID
+        }
+    }
+}
+
+// MARK: - State
+
+/// A `TileTree` paired with the single focused tile. The reducer maintains the invariant that
+/// `focusedTileID` always references a live leaf of `root`.
+public struct TileTreeState: Equatable, Codable, Sendable {
+    public var root: TileTree
+    public var focusedTileID: TileID
+
+    public init(root: TileTree, focusedTileID: TileID) {
+        self.root = root
+        self.focusedTileID = focusedTileID
+    }
+
+    /// A single-tile tree with that tile focused — the depth-0 starting shape (and the re-seed
+    /// shape after the last tile closes).
+    public init(singleTile tileID: TileID) {
+        self.root = .tile(tileID)
+        self.focusedTileID = tileID
+    }
+
+    public var leafIDs: [TileID] { root.leafIDs }
+    public var splitIDs: [SplitID] { root.splitIDs }
+}
+
+// MARK: - Layout constants
+
+/// Shared split-ratio constants. Mirrors the legacy `HostTerminalStateStore` fractions so the
+/// depth-1 two-pane case clamps and steps identically.
+public enum TileTreeLayout {
+    /// Smallest fraction a child may occupy. The complementary child is bounded by `maximumRatio`.
+    public static let minimumRatio: Double = 0.2
+    /// Default `first`-child fraction for a freshly created split (an even divide).
+    public static let defaultRatio: Double = 0.5
+    /// Largest fraction a child may occupy (`1 - minimumRatio`).
+    public static var maximumRatio: Double { 1 - minimumRatio }
+    /// Ratio delta applied per keyboard resize step.
+    public static let resizeStep: Double = 0.05
+
+    /// Clamp a proposed `first`-child ratio into `[minimumRatio, maximumRatio]`.
+    public static func clampRatio(_ ratio: Double) -> Double {
+        min(max(ratio, minimumRatio), maximumRatio)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeAction.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeAction.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Geometric focus directions for `goto_split`-style navigation.
+public enum TileFocusDirection: Sendable, Equatable {
+    case up
+    case down
+    case left
+    case right
+}
+
+/// Order-based focus navigation (cycles the depth-first leaf order, wrapping at the ends).
+public enum TileFocusOrder: Sendable, Equatable {
+    case previous
+    case next
+}
+
+/// The closed set of mutations the `TileTreeReducer` understands.
+///
+/// Every action is payload-free: it moves `TileID`s / `SplitID`s and split ratios only. The
+/// `TileID ↔ Surface` binding lives entirely in the app layer.
+public enum TileTreeAction: Sendable, Equatable {
+    /// Split the leaf `parent` along `axis`, inserting a fresh tile before or after it. The new
+    /// tile becomes focused. No-op if `parent` is not a live leaf.
+    case split(parent: TileID, axis: SplitAxis, insertNewBefore: Bool)
+
+    /// Close the leaf `tile`, collapsing its parent split into the surviving sibling. Closing the
+    /// last remaining tile re-seeds a fresh single tile (the tree is never empty). If the closed
+    /// tile held focus, focus moves into the surviving sibling subtree.
+    case close(TileID)
+
+    /// Move focus geometrically from `from` toward `direction`. No-op when there is no neighbor.
+    case focusDirectional(from: TileID, direction: TileFocusDirection)
+
+    /// Move focus to the previous/next leaf in depth-first order, wrapping at the ends.
+    case focusRelative(from: TileID, order: TileFocusOrder)
+
+    /// Add `ratioDelta` to `split`'s `first`-child ratio, clamped to the legal range.
+    case resize(split: SplitID, ratioDelta: Double)
+
+    /// Set `split`'s `first`-child ratio to `ratio`, clamped to the legal range.
+    case setRatio(split: SplitID, ratio: Double)
+
+    /// Reset every split ratio to `TileTreeLayout.defaultRatio`. `subtreeRoot == nil` equalizes the
+    /// whole tree (matching Ghostty's `equalize_splits`); a `SplitID` equalizes only that subtree.
+    case equalize(subtreeRoot: SplitID?)
+
+    /// Focus `tile` directly. No-op if it is not a live leaf.
+    case setFocus(TileID)
+}

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeInvariants.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeInvariants.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// A structural invariant a `TileTreeState` must satisfy after every reducer action. Surfaced as a
+/// value (not a trap) so tests can assert the exhaustive set and the reducer can `assert` in DEBUG.
+public enum TileTreeInvariantViolation: Equatable, CustomStringConvertible {
+    /// The same `TileID` appears on more than one leaf.
+    case duplicateTileID(TileID)
+    /// The same `SplitID` appears on more than one split node.
+    case duplicateSplitID(SplitID)
+    /// A split's `first`-child ratio is outside `[minimumRatio, maximumRatio]`.
+    case ratioOutOfRange(SplitID, ratio: Double)
+    /// A split's ratio is not finite (NaN / infinite).
+    case ratioNotFinite(SplitID)
+    /// `focusedTileID` does not reference any live leaf.
+    case focusedTileMissing(TileID)
+
+    public var description: String {
+        switch self {
+        case .duplicateTileID(let id): return "duplicate tile id \(id)"
+        case .duplicateSplitID(let id): return "duplicate split id \(id)"
+        case .ratioOutOfRange(let id, let ratio): return "ratio \(ratio) out of range for \(id)"
+        case .ratioNotFinite(let id): return "non-finite ratio for \(id)"
+        case .focusedTileMissing(let id): return "focused tile \(id) is not a live leaf"
+        }
+    }
+}
+
+public enum TileTreeInvariants {
+    /// Every violation in `state`, in a stable order. Empty means the state is well-formed.
+    ///
+    /// Connectedness and acyclicity are guaranteed by the value-type structure (a `TileTree` is a
+    /// finite tree by construction) and so are covered by the uniqueness checks rather than a
+    /// separate graph walk. Likewise "every split has exactly two children" and "no empty tree" are
+    /// enforced by the enum shape itself (`.split` always carries `first` and `second`; the root is
+    /// always a `.tile` or `.split`).
+    public static func violations(in state: TileTreeState) -> [TileTreeInvariantViolation] {
+        var result: [TileTreeInvariantViolation] = []
+
+        var seenTiles: Set<TileID> = []
+        for leafID in state.root.leafIDs {
+            if !seenTiles.insert(leafID).inserted {
+                result.append(.duplicateTileID(leafID))
+            }
+        }
+
+        var seenSplits: Set<SplitID> = []
+        collectSplitViolations(state.root, seenSplits: &seenSplits, into: &result)
+
+        if !seenTiles.contains(state.focusedTileID) {
+            result.append(.focusedTileMissing(state.focusedTileID))
+        }
+
+        return result
+    }
+
+    /// Convenience: whether `state` satisfies every invariant.
+    public static func isValid(_ state: TileTreeState) -> Bool {
+        violations(in: state).isEmpty
+    }
+
+    private static func collectSplitViolations(
+        _ node: TileTree,
+        seenSplits: inout Set<SplitID>,
+        into result: inout [TileTreeInvariantViolation]
+    ) {
+        guard case .split(let id, _, let ratio, let first, let second) = node else { return }
+
+        if !seenSplits.insert(id).inserted {
+            result.append(.duplicateSplitID(id))
+        }
+        if !ratio.isFinite {
+            result.append(.ratioNotFinite(id))
+        } else if ratio < TileTreeLayout.minimumRatio || ratio > TileTreeLayout.maximumRatio {
+            result.append(.ratioOutOfRange(id, ratio: ratio))
+        }
+
+        collectSplitViolations(first, seenSplits: &seenSplits, into: &result)
+        collectSplitViolations(second, seenSplits: &seenSplits, into: &result)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeReducer.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeReducer.swift
@@ -1,0 +1,306 @@
+import Foundation
+
+/// Pure, payload-free reducer over `TileTreeState`.
+///
+/// Every action returns a fresh state; the reducer never mutates surfaces, sessions, or views. New
+/// `TileID`s / `SplitID`s come from injectable generators so callers (and tests) control identity —
+/// the defaults mint UUIDs. After `split`, the new tile becomes `focusedTileID`; after `close`, focus
+/// moves into the surviving sibling. Callers drive `SurfaceStore.sync` by diffing `state.leafIDs`
+/// before and after, so the reducer need not surface created/removed IDs explicitly.
+public struct TileTreeReducer {
+    private let makeTileID: () -> TileID
+    private let makeSplitID: () -> SplitID
+
+    public init(
+        makeTileID: @escaping () -> TileID = { TileID() },
+        makeSplitID: @escaping () -> SplitID = { SplitID() }
+    ) {
+        self.makeTileID = makeTileID
+        self.makeSplitID = makeSplitID
+    }
+
+    public func reduce(_ state: TileTreeState, _ action: TileTreeAction) -> TileTreeState {
+        let next: TileTreeState
+        switch action {
+        case .split(let parent, let axis, let insertNewBefore):
+            next = applySplit(state, parent: parent, axis: axis, insertNewBefore: insertNewBefore)
+        case .close(let tile):
+            next = applyClose(state, target: tile)
+        case .focusDirectional(let from, let direction):
+            next = applyFocus(state, to: directionalTarget(from: from, direction: direction, in: state.root))
+        case .focusRelative(let from, let order):
+            next = applyFocus(state, to: relativeTarget(from: from, order: order, in: state.root))
+        case .resize(let split, let ratioDelta):
+            next = applyRatio(state, split: split) { $0 + ratioDelta }
+        case .setRatio(let split, let ratio):
+            next = applyRatio(state, split: split) { _ in ratio }
+        case .equalize(let subtreeRoot):
+            next = applyEqualize(state, subtreeRoot: subtreeRoot)
+        case .setFocus(let tile):
+            next = applyFocus(state, to: state.root.contains(tile) ? tile : nil)
+        }
+
+        assert(
+            TileTreeInvariants.isValid(next),
+            "TileTreeReducer produced an invalid state for \(action): "
+                + "\(TileTreeInvariants.violations(in: next))"
+        )
+        return next
+    }
+
+    // MARK: - Split
+
+    private func applySplit(
+        _ state: TileTreeState,
+        parent: TileID,
+        axis: SplitAxis,
+        insertNewBefore: Bool
+    ) -> TileTreeState {
+        guard state.root.contains(parent) else { return state }
+
+        let newTile = makeTileID()
+        let parentLeaf = TileTree.tile(parent)
+        let newLeaf = TileTree.tile(newTile)
+        let (first, second) = insertNewBefore ? (newLeaf, parentLeaf) : (parentLeaf, newLeaf)
+        let replacement = TileTree.split(
+            id: makeSplitID(),
+            axis: axis,
+            ratio: TileTreeLayout.defaultRatio,
+            first: first,
+            second: second
+        )
+        let newRoot = replacingLeaf(state.root, parent, with: replacement)
+        return TileTreeState(root: newRoot, focusedTileID: newTile)
+    }
+
+    // MARK: - Close
+
+    private func applyClose(_ state: TileTreeState, target: TileID) -> TileTreeState {
+        // A single-tile tree: closing the only tile re-seeds a fresh one (the tree is never empty).
+        if case .tile(let id) = state.root {
+            guard id == target else { return state }
+            return TileTreeState(singleTile: makeTileID())
+        }
+
+        guard state.root.contains(target), let newRoot = removingLeaf(state.root, target) else {
+            return state
+        }
+
+        let newFocus: TileID
+        if state.focusedTileID != target, newRoot.contains(state.focusedTileID) {
+            newFocus = state.focusedTileID
+        } else {
+            newFocus = focusReplacement(forClosing: target, in: state.root) ?? newRoot.firstLeafID
+        }
+        return TileTreeState(root: newRoot, focusedTileID: newFocus)
+    }
+
+    // MARK: - Focus
+
+    private func applyFocus(_ state: TileTreeState, to target: TileID?) -> TileTreeState {
+        guard let target, target != state.focusedTileID else { return state }
+        var next = state
+        next.focusedTileID = target
+        return next
+    }
+
+    /// Recursive ancestor walk: rise from `from` to the root and take the first split whose axis
+    /// matches `direction` and where `from` sits on the side you can move away from, then descend
+    /// into the other child toward the entering edge. Reproduces the legacy two-pane `splitFocusTarget`
+    /// exactly at depth 1; the deeper-than-1 traversal is a deliberate not-hardened fallback.
+    private func directionalTarget(
+        from: TileID,
+        direction: TileFocusDirection,
+        in root: TileTree
+    ) -> TileID? {
+        guard let frames = ancestors(of: from, in: root) else { return nil }
+
+        let requiredAxis: SplitAxis
+        let requiredSide: ChildSide
+        let descendToLastLeaf: Bool
+        switch direction {
+        case .right:
+            (requiredAxis, requiredSide, descendToLastLeaf) = (.leadingTrailing, .first, false)
+        case .left:
+            (requiredAxis, requiredSide, descendToLastLeaf) = (.leadingTrailing, .second, true)
+        case .down:
+            (requiredAxis, requiredSide, descendToLastLeaf) = (.topBottom, .first, false)
+        case .up:
+            (requiredAxis, requiredSide, descendToLastLeaf) = (.topBottom, .second, true)
+        }
+
+        for frame in frames.reversed() where frame.axis == requiredAxis && frame.side == requiredSide {
+            let otherChild = requiredSide == .first ? frame.second : frame.first
+            return descendToLastLeaf ? otherChild.lastLeafID : otherChild.firstLeafID
+        }
+        return nil
+    }
+
+    private func relativeTarget(
+        from: TileID,
+        order: TileFocusOrder,
+        in root: TileTree
+    ) -> TileID? {
+        let leaves = root.leafIDs
+        guard leaves.count > 1, let index = leaves.firstIndex(of: from) else { return nil }
+        let count = leaves.count
+        let target = order == .next ? (index + 1) % count : (index - 1 + count) % count
+        return leaves[target]
+    }
+
+    // MARK: - Ratio
+
+    private func applyRatio(
+        _ state: TileTreeState,
+        split: SplitID,
+        transform: (Double) -> Double
+    ) -> TileTreeState {
+        var next = state
+        next.root = updatingSplit(state.root, split, transform: transform)
+        return next
+    }
+
+    private func applyEqualize(_ state: TileTreeState, subtreeRoot: SplitID?) -> TileTreeState {
+        var next = state
+        if let subtreeRoot {
+            next.root = equalizingSubtree(state.root, root: subtreeRoot)
+        } else {
+            next.root = equalizingAll(state.root)
+        }
+        return next
+    }
+
+    // MARK: - Tree transforms
+
+    private func replacingLeaf(_ node: TileTree, _ target: TileID, with replacement: TileTree) -> TileTree {
+        switch node {
+        case .tile(let id):
+            return id == target ? replacement : node
+        case .split(let id, let axis, let ratio, let first, let second):
+            return .split(
+                id: id,
+                axis: axis,
+                ratio: ratio,
+                first: replacingLeaf(first, target, with: replacement),
+                second: replacingLeaf(second, target, with: replacement)
+            )
+        }
+    }
+
+    private func removingLeaf(_ node: TileTree, _ target: TileID) -> TileTree? {
+        guard case .split(let id, let axis, let ratio, let first, let second) = node else {
+            return nil
+        }
+        if first == .tile(target) { return second }
+        if second == .tile(target) { return first }
+        if first.contains(target), let newFirst = removingLeaf(first, target) {
+            return .split(id: id, axis: axis, ratio: ratio, first: newFirst, second: second)
+        }
+        if second.contains(target), let newSecond = removingLeaf(second, target) {
+            return .split(id: id, axis: axis, ratio: ratio, first: first, second: newSecond)
+        }
+        return nil
+    }
+
+    /// The leaf to focus when `target` is removed: the neighbor across the collapsing split, biased
+    /// to the side nearest where `target` sat.
+    private func focusReplacement(forClosing target: TileID, in node: TileTree) -> TileID? {
+        guard case .split(_, _, _, let first, let second) = node else { return nil }
+        if first == .tile(target) { return second.firstLeafID }
+        if second == .tile(target) { return first.lastLeafID }
+        if first.contains(target) { return focusReplacement(forClosing: target, in: first) }
+        if second.contains(target) { return focusReplacement(forClosing: target, in: second) }
+        return nil
+    }
+
+    private func updatingSplit(
+        _ node: TileTree,
+        _ target: SplitID,
+        transform: (Double) -> Double
+    ) -> TileTree {
+        switch node {
+        case .tile:
+            return node
+        case .split(let id, let axis, let ratio, let first, let second):
+            if id == target {
+                return .split(
+                    id: id,
+                    axis: axis,
+                    ratio: TileTreeLayout.clampRatio(transform(ratio)),
+                    first: first,
+                    second: second
+                )
+            }
+            return .split(
+                id: id,
+                axis: axis,
+                ratio: ratio,
+                first: updatingSplit(first, target, transform: transform),
+                second: updatingSplit(second, target, transform: transform)
+            )
+        }
+    }
+
+    private func equalizingAll(_ node: TileTree) -> TileTree {
+        switch node {
+        case .tile:
+            return node
+        case .split(let id, let axis, _, let first, let second):
+            return .split(
+                id: id,
+                axis: axis,
+                ratio: TileTreeLayout.defaultRatio,
+                first: equalizingAll(first),
+                second: equalizingAll(second)
+            )
+        }
+    }
+
+    private func equalizingSubtree(_ node: TileTree, root target: SplitID) -> TileTree {
+        switch node {
+        case .tile:
+            return node
+        case .split(let id, let axis, let ratio, let first, let second):
+            if id == target {
+                return equalizingAll(node)
+            }
+            return .split(
+                id: id,
+                axis: axis,
+                ratio: ratio,
+                first: equalizingSubtree(first, root: target),
+                second: equalizingSubtree(second, root: target)
+            )
+        }
+    }
+
+    // MARK: - Ancestor path
+
+    private enum ChildSide: Equatable {
+        case first
+        case second
+    }
+
+    private struct AncestorFrame {
+        let axis: SplitAxis
+        let first: TileTree
+        let second: TileTree
+        let side: ChildSide
+    }
+
+    /// Ancestors of `target` from the root down to its parent split, or `nil` if `target` is absent.
+    private func ancestors(of target: TileID, in node: TileTree) -> [AncestorFrame]? {
+        switch node {
+        case .tile(let id):
+            return id == target ? [] : nil
+        case .split(_, let axis, _, let first, let second):
+            if let deeper = ancestors(of: target, in: first) {
+                return [AncestorFrame(axis: axis, first: first, second: second, side: .first)] + deeper
+            }
+            if let deeper = ancestors(of: target, in: second) {
+                return [AncestorFrame(axis: axis, first: first, second: second, side: .second)] + deeper
+            }
+            return nil
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
@@ -1,0 +1,150 @@
+//
+//  TileTreePropertyTests.swift
+//  WorkspaceManagerTests
+//
+//  Randomized operation-sequence tests: the reducer must keep every tree invariant after each
+//  action, and `close` must remove exactly the closed leaf (the property that makes
+//  `SurfaceStore.sync(activeLeafIDs:)` correct).
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("TileTreeProperty")
+struct TileTreePropertyTests {
+    /// Deterministic SplitMix64 so a failing seed reproduces exactly.
+    private struct SeededGenerator: RandomNumberGenerator {
+        private var state: UInt64
+        init(seed: UInt64) { state = seed }
+
+        mutating func next() -> UInt64 {
+            state = state &+ 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+    }
+
+    private final class IDGen {
+        private var tiles = 0
+        private var splits = 0
+        func tile() -> TileID {
+            tiles += 1
+            return TileID(UUID(uuidString: "10000000-0000-0000-0000-\(Self.tail(tiles))")!)
+        }
+        func split() -> SplitID {
+            splits += 1
+            return SplitID(UUID(uuidString: "20000000-0000-0000-0000-\(Self.tail(splits))")!)
+        }
+        private static func tail(_ n: Int) -> String { String(format: "%012d", n) }
+    }
+
+    private func randomAction(
+        for state: TileTreeState,
+        using rng: inout SeededGenerator
+    ) -> TileTreeAction {
+        let leaves = state.leafIDs
+        let splits = state.splitIDs
+        let axes: [SplitAxis] = [.leadingTrailing, .topBottom]
+        let directions: [TileFocusDirection] = [.up, .down, .left, .right]
+        let deltas: [Double] = [-0.4, -0.05, 0.05, 0.4]
+
+        switch Int.random(in: 0..<8, using: &rng) {
+        case 0:
+            return .split(
+                parent: leaves.randomElement(using: &rng)!,
+                axis: axes.randomElement(using: &rng)!,
+                insertNewBefore: Bool.random(using: &rng)
+            )
+        case 1:
+            return .close(leaves.randomElement(using: &rng)!)
+        case 2:
+            return .focusDirectional(
+                from: leaves.randomElement(using: &rng)!,
+                direction: directions.randomElement(using: &rng)!
+            )
+        case 3:
+            return .focusRelative(
+                from: leaves.randomElement(using: &rng)!,
+                order: Bool.random(using: &rng) ? .next : .previous
+            )
+        case 4 where !splits.isEmpty:
+            return .resize(split: splits.randomElement(using: &rng)!, ratioDelta: deltas.randomElement(using: &rng)!)
+        case 5 where !splits.isEmpty:
+            return .setRatio(split: splits.randomElement(using: &rng)!, ratio: Double.random(in: -0.5...1.5, using: &rng))
+        case 6:
+            return .equalize(subtreeRoot: splits.randomElement(using: &rng))
+        default:
+            return .setFocus(leaves.randomElement(using: &rng)!)
+        }
+    }
+
+    @Test("Invariants hold and IDs stay unique across randomized sequences", arguments: 0..<64)
+    func invariantsUnderRandomSequences(seed: Int) {
+        var rng = SeededGenerator(seed: UInt64(seed) &+ 1)
+        let gen = IDGen()
+        let reducer = TileTreeReducer(makeTileID: gen.tile, makeSplitID: gen.split)
+        var state = TileTreeState(singleTile: gen.tile())
+
+        for step in 0..<80 {
+            let action = randomAction(for: state, using: &rng)
+            let leavesBefore = state.leafIDs
+            state = reducer.reduce(state, action)
+
+            let violations = TileTreeInvariants.violations(in: state)
+            #expect(violations.isEmpty, "seed=\(seed) step=\(step) action=\(action) violations=\(violations)")
+            #expect(Set(state.leafIDs).count == state.leafIDs.count)
+            #expect(Set(state.splitIDs).count == state.splitIDs.count)
+            #expect(state.leafIDs.contains(state.focusedTileID))
+
+            // close on a multi-leaf tree removes exactly the target leaf.
+            if case .close(let target) = action, leavesBefore.count > 1, leavesBefore.contains(target) {
+                #expect(Set(state.leafIDs) == Set(leavesBefore).subtracting([target]))
+            }
+        }
+    }
+
+    @Test("Split grows the leaf set by exactly one and focuses the new tile", arguments: 0..<32)
+    func splitAddsOneLeaf(seed: Int) {
+        var rng = SeededGenerator(seed: UInt64(seed) &+ 1000)
+        let gen = IDGen()
+        let reducer = TileTreeReducer(makeTileID: gen.tile, makeSplitID: gen.split)
+        var state = TileTreeState(singleTile: gen.tile())
+
+        // Grow to a few leaves with random splits, checking the +1 property each time.
+        for _ in 0..<12 {
+            let leavesBefore = Set(state.leafIDs)
+            let parent = state.leafIDs.randomElement(using: &rng)!
+            state = reducer.reduce(
+                state,
+                .split(
+                    parent: parent,
+                    axis: [SplitAxis.leadingTrailing, .topBottom].randomElement(using: &rng)!,
+                    insertNewBefore: Bool.random(using: &rng)
+                )
+            )
+            let leavesAfter = Set(state.leafIDs)
+            #expect(leavesAfter.count == leavesBefore.count + 1)
+            #expect(leavesBefore.isSubset(of: leavesAfter))
+            let added = leavesAfter.subtracting(leavesBefore)
+            #expect(added.count == 1)
+            #expect(state.focusedTileID == added.first)
+        }
+    }
+
+    @Test("Codable round-trips preserve the tree and focus")
+    func codableRoundTrip() {
+        let gen = IDGen()
+        let reducer = TileTreeReducer(makeTileID: gen.tile, makeSplitID: gen.split)
+        var state = TileTreeState(singleTile: gen.tile())
+        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
+        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .topBottom, insertNewBefore: true))
+
+        let data = try! JSONEncoder().encode(state)
+        let decoded = try! JSONDecoder().decode(TileTreeState.self, from: data)
+        #expect(decoded == state)
+    }
+}

--- a/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
@@ -74,7 +74,8 @@ struct TileTreePropertyTests {
         case 4 where !splits.isEmpty:
             return .resize(split: splits.randomElement(using: &rng)!, ratioDelta: deltas.randomElement(using: &rng)!)
         case 5 where !splits.isEmpty:
-            return .setRatio(split: splits.randomElement(using: &rng)!, ratio: Double.random(in: -0.5...1.5, using: &rng))
+            return .setRatio(
+                split: splits.randomElement(using: &rng)!, ratio: Double.random(in: -0.5...1.5, using: &rng))
         case 6:
             return .equalize(subtreeRoot: splits.randomElement(using: &rng))
         default:
@@ -140,7 +141,8 @@ struct TileTreePropertyTests {
         let gen = IDGen()
         let reducer = TileTreeReducer(makeTileID: gen.tile, makeSplitID: gen.split)
         var state = TileTreeState(singleTile: gen.tile())
-        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
+        state = reducer.reduce(
+            state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
         state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .topBottom, insertNewBefore: true))
 
         let data = try! JSONEncoder().encode(state)

--- a/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
@@ -325,6 +325,27 @@ struct TileTreeReducerTests {
         #expect(ratio(of: low.root) == TileTreeLayout.minimumRatio)
     }
 
+    @Test("Non-finite ratios resolve to valid split fractions")
+    func nonFiniteRatiosStayValid() {
+        let (state, reducer, _, _) = twoPane(axis: .leadingTrailing)
+        guard case .split(let splitID, _, _, _, _) = state.root else {
+            Issue.record("expected a split")
+            return
+        }
+
+        let nan = reducer.reduce(state, .setRatio(split: splitID, ratio: .nan))
+        #expect(ratio(of: nan.root) == TileTreeLayout.defaultRatio)
+        #expect(TileTreeInvariants.isValid(nan))
+
+        let high = reducer.reduce(state, .setRatio(split: splitID, ratio: .infinity))
+        #expect(ratio(of: high.root) == TileTreeLayout.maximumRatio)
+        #expect(TileTreeInvariants.isValid(high))
+
+        let low = reducer.reduce(state, .resize(split: splitID, ratioDelta: -.infinity))
+        #expect(ratio(of: low.root) == TileTreeLayout.minimumRatio)
+        #expect(TileTreeInvariants.isValid(low))
+    }
+
     @Test("Resize on an unknown split is a no-op")
     func resizeUnknownNoOp() {
         let (state, reducer, _, _) = twoPane(axis: .leadingTrailing)

--- a/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
@@ -274,10 +274,10 @@ struct TileTreeReducerTests {
         #expect(s.focusedTileID == second)
 
         s = reducer.reduce(s, .focusRelative(from: second, order: .next))
-        #expect(s.focusedTileID == first) // wraps
+        #expect(s.focusedTileID == first)  // wraps
 
         s = reducer.reduce(s, .focusRelative(from: first, order: .previous))
-        #expect(s.focusedTileID == second) // wraps backward
+        #expect(s.focusedTileID == second)  // wraps backward
     }
 
     @Test("Relative focus on a single tile is a no-op")
@@ -359,7 +359,8 @@ struct TileTreeReducerTests {
         let reducer = makeReducer(gen)
         var state = TileTreeState(singleTile: gen.tile())
         // Build two nested splits and skew their ratios.
-        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
+        state = reducer.reduce(
+            state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
         state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .topBottom, insertNewBefore: false))
         for splitID in state.root.splitIDs {
             state = reducer.reduce(state, .setRatio(split: splitID, ratio: 0.75))
@@ -375,7 +376,8 @@ struct TileTreeReducerTests {
         let gen = IDGen()
         let reducer = makeReducer(gen)
         var state = TileTreeState(singleTile: gen.tile())
-        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
+        state = reducer.reduce(
+            state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
         let outerSplit = state.root.splitIDs[0]
         state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .topBottom, insertNewBefore: false))
         let innerSplit = state.root.splitIDs.first { $0 != outerSplit }!
@@ -384,7 +386,7 @@ struct TileTreeReducerTests {
         state = reducer.reduce(state, .setRatio(split: innerSplit, ratio: 0.7))
 
         let equalized = reducer.reduce(state, .equalize(subtreeRoot: innerSplit))
-        #expect(ratioOfSplit(equalized.root, outerSplit) == 0.7) // untouched
+        #expect(ratioOfSplit(equalized.root, outerSplit) == 0.7)  // untouched
         #expect(ratioOfSplit(equalized.root, innerSplit) == TileTreeLayout.defaultRatio)
     }
 

--- a/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
@@ -1,0 +1,376 @@
+//
+//  TileTreeReducerTests.swift
+//  WorkspaceManagerTests
+//
+//  Deterministic per-action coverage for the pure tile-tree reducer, plus the depth-1 two-pane
+//  cases that must stay identical to the legacy `splitFocusTarget` / split-fraction behavior.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("TileTreeReducer")
+struct TileTreeReducerTests {
+    // MARK: - Fixtures
+
+    /// Mints sequential, deterministic IDs so failures are reproducible.
+    private final class IDGen {
+        private var tiles = 0
+        private var splits = 0
+
+        func tile() -> TileID {
+            tiles += 1
+            return TileID(UUID(uuidString: "10000000-0000-0000-0000-\(Self.tail(tiles))")!)
+        }
+
+        func split() -> SplitID {
+            splits += 1
+            return SplitID(UUID(uuidString: "20000000-0000-0000-0000-\(Self.tail(splits))")!)
+        }
+
+        private static func tail(_ n: Int) -> String { String(format: "%012d", n) }
+    }
+
+    private func makeReducer(_ gen: IDGen) -> TileTreeReducer {
+        TileTreeReducer(makeTileID: gen.tile, makeSplitID: gen.split)
+    }
+
+    /// A depth-1 two-pane state: `first` = original tile, `second` = the split tile, focus on second.
+    private func twoPane(
+        axis: SplitAxis,
+        insertNewBefore: Bool = false
+    ) -> (state: TileTreeState, reducer: TileTreeReducer, original: TileID, added: TileID) {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let original = gen.tile()
+        let initial = TileTreeState(singleTile: original)
+        let state = reducer.reduce(
+            initial,
+            .split(parent: original, axis: axis, insertNewBefore: insertNewBefore)
+        )
+        return (state, reducer, original, state.focusedTileID)
+    }
+
+    // MARK: - Construction & split
+
+    @Test("Single-tile state is well-formed")
+    func singleTileValid() {
+        let gen = IDGen()
+        let t1 = gen.tile()
+        let state = TileTreeState(singleTile: t1)
+        #expect(state.leafIDs == [t1])
+        #expect(state.focusedTileID == t1)
+        #expect(TileTreeInvariants.isValid(state))
+    }
+
+    @Test("Split creates a two-pane tree and focuses the new tile")
+    func splitCreatesTwoPane() {
+        let (state, _, original, added) = twoPane(axis: .leadingTrailing)
+        #expect(state.leafIDs == [original, added])
+        #expect(state.focusedTileID == added)
+        #expect(added != original)
+        #expect(TileTreeInvariants.isValid(state))
+
+        guard case .split(_, let axis, let ratio, .tile(let first), .tile(let second)) = state.root else {
+            Issue.record("expected a single split with two tile children")
+            return
+        }
+        #expect(axis == .leadingTrailing)
+        #expect(ratio == TileTreeLayout.defaultRatio)
+        #expect(first == original)
+        #expect(second == added)
+    }
+
+    @Test("insertNewBefore places the new tile as the leading child")
+    func splitInsertBefore() {
+        let (state, _, original, added) = twoPane(axis: .leadingTrailing, insertNewBefore: true)
+        guard case .split(_, _, _, .tile(let first), .tile(let second)) = state.root else {
+            Issue.record("expected a single split")
+            return
+        }
+        #expect(first == added)
+        #expect(second == original)
+    }
+
+    @Test("Split on an unknown parent is a no-op")
+    func splitUnknownParentNoOp() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let t1 = gen.tile()
+        let state = TileTreeState(singleTile: t1)
+        let stranger = TileID()
+        let next = reducer.reduce(state, .split(parent: stranger, axis: .topBottom, insertNewBefore: false))
+        #expect(next == state)
+    }
+
+    @Test("Repeated splits build three-plus tiles at depth")
+    func recursiveSplitsGrow() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        var state = TileTreeState(singleTile: gen.tile())
+
+        for _ in 0..<4 {
+            // Always split the currently focused leaf, mirroring Cmd+D on the active tile.
+            state = reducer.reduce(
+                state,
+                .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false)
+            )
+            #expect(TileTreeInvariants.isValid(state))
+        }
+        #expect(state.leafIDs.count == 5)
+        #expect(Set(state.leafIDs).count == 5)
+        #expect(state.root.splitIDs.count == 4)
+    }
+
+    // MARK: - Close
+
+    @Test("Closing the trailing tile collapses to the leading sibling and focuses it")
+    func closeTrailingCollapses() {
+        let (state, reducer, original, added) = twoPane(axis: .leadingTrailing)
+        let next = reducer.reduce(state, .close(added))
+        #expect(next.root == .tile(original))
+        #expect(next.focusedTileID == original)
+        #expect(TileTreeInvariants.isValid(next))
+    }
+
+    @Test("Closing the leading tile collapses to the trailing sibling and focuses it")
+    func closeLeadingCollapses() {
+        let (state, reducer, original, added) = twoPane(axis: .leadingTrailing)
+        let next = reducer.reduce(state, .close(original))
+        #expect(next.root == .tile(added))
+        #expect(next.focusedTileID == added)
+    }
+
+    @Test("Closing a non-focused tile preserves the existing focus")
+    func closeNonFocusedKeepsFocus() {
+        // Build three tiles, focus the first, close the last.
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let t1 = gen.tile()
+        var state = TileTreeState(singleTile: t1)
+        state = reducer.reduce(state, .split(parent: t1, axis: .leadingTrailing, insertNewBefore: false))
+        let t2 = state.focusedTileID
+        state = reducer.reduce(state, .split(parent: t2, axis: .leadingTrailing, insertNewBefore: false))
+        let t3 = state.focusedTileID
+        state = reducer.reduce(state, .setFocus(t1))
+        #expect(state.focusedTileID == t1)
+
+        let next = reducer.reduce(state, .close(t3))
+        #expect(next.focusedTileID == t1)
+        #expect(Set(next.leafIDs) == [t1, t2])
+    }
+
+    @Test("Closing the last remaining tile re-seeds a fresh tile")
+    func closeLastReseeds() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let t1 = gen.tile()
+        let state = TileTreeState(singleTile: t1)
+        let next = reducer.reduce(state, .close(t1))
+        #expect(next.leafIDs.count == 1)
+        #expect(next.leafIDs.first != t1)
+        #expect(next.focusedTileID == next.leafIDs.first)
+        #expect(TileTreeInvariants.isValid(next))
+    }
+
+    @Test("Closing an unknown tile is a no-op")
+    func closeUnknownNoOp() {
+        let (state, reducer, _, _) = twoPane(axis: .leadingTrailing)
+        let next = reducer.reduce(state, .close(TileID()))
+        #expect(next == state)
+    }
+
+    // MARK: - Directional focus (depth-1 parity with splitFocusTarget)
+
+    @Test("Directional focus across a leading/trailing split")
+    func directionalLeadingTrailing() {
+        let (state, reducer, left, right) = twoPane(axis: .leadingTrailing)
+        // Focus the left tile first.
+        var s = reducer.reduce(state, .setFocus(left))
+
+        s = reducer.reduce(s, .focusDirectional(from: left, direction: .right))
+        #expect(s.focusedTileID == right)
+
+        s = reducer.reduce(s, .focusDirectional(from: right, direction: .left))
+        #expect(s.focusedTileID == left)
+
+        // No vertical neighbor on a leading/trailing split.
+        let blocked = reducer.reduce(s, .focusDirectional(from: left, direction: .up))
+        #expect(blocked.focusedTileID == left)
+        let blocked2 = reducer.reduce(s, .focusDirectional(from: left, direction: .down))
+        #expect(blocked2.focusedTileID == left)
+    }
+
+    @Test("Directional focus across a top/bottom split")
+    func directionalTopBottom() {
+        let (state, reducer, top, bottom) = twoPane(axis: .topBottom)
+        var s = reducer.reduce(state, .setFocus(top))
+
+        s = reducer.reduce(s, .focusDirectional(from: top, direction: .down))
+        #expect(s.focusedTileID == bottom)
+
+        s = reducer.reduce(s, .focusDirectional(from: bottom, direction: .up))
+        #expect(s.focusedTileID == top)
+
+        let blocked = reducer.reduce(s, .focusDirectional(from: top, direction: .left))
+        #expect(blocked.focusedTileID == top)
+    }
+
+    @Test("Directional focus reproduces splitBeforePrimary=true (new tile leads)")
+    func directionalInsertBefore() {
+        // splitBeforePrimary == true: the new tile is leading (left), original is trailing (right).
+        let (state, reducer, original, added) = twoPane(axis: .leadingTrailing, insertNewBefore: true)
+        var s = reducer.reduce(state, .setFocus(original))
+
+        // From the right (original) moving left lands on the new leading tile.
+        s = reducer.reduce(s, .focusDirectional(from: original, direction: .left))
+        #expect(s.focusedTileID == added)
+
+        // From the leftmost tile there is nothing further left.
+        let blocked = reducer.reduce(s, .focusDirectional(from: added, direction: .left))
+        #expect(blocked.focusedTileID == added)
+    }
+
+    // MARK: - Relative focus
+
+    @Test("Relative focus toggles between two leaves and wraps")
+    func relativeFocusTwoLeaves() {
+        let (state, reducer, first, second) = twoPane(axis: .leadingTrailing)
+        var s = reducer.reduce(state, .setFocus(first))
+
+        s = reducer.reduce(s, .focusRelative(from: first, order: .next))
+        #expect(s.focusedTileID == second)
+
+        s = reducer.reduce(s, .focusRelative(from: second, order: .next))
+        #expect(s.focusedTileID == first) // wraps
+
+        s = reducer.reduce(s, .focusRelative(from: first, order: .previous))
+        #expect(s.focusedTileID == second) // wraps backward
+    }
+
+    @Test("Relative focus on a single tile is a no-op")
+    func relativeFocusSingle() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let t1 = gen.tile()
+        let state = TileTreeState(singleTile: t1)
+        let next = reducer.reduce(state, .focusRelative(from: t1, order: .next))
+        #expect(next == state)
+    }
+
+    // MARK: - Resize / equalize
+
+    @Test("Resize adds the delta and clamps to the legal range")
+    func resizeClamps() {
+        let (state, reducer, _, _) = twoPane(axis: .leadingTrailing)
+        guard case .split(let splitID, _, _, _, _) = state.root else {
+            Issue.record("expected a split")
+            return
+        }
+
+        var s = reducer.reduce(state, .resize(split: splitID, ratioDelta: 0.05))
+        #expect(ratio(of: s.root) == 0.55)
+
+        // Push well past the maximum; it should clamp.
+        s = reducer.reduce(s, .resize(split: splitID, ratioDelta: 1.0))
+        #expect(ratio(of: s.root) == TileTreeLayout.maximumRatio)
+
+        // Push well below the minimum; it should clamp.
+        s = reducer.reduce(s, .resize(split: splitID, ratioDelta: -1.0))
+        #expect(ratio(of: s.root) == TileTreeLayout.minimumRatio)
+    }
+
+    @Test("setRatio clamps to the legal range")
+    func setRatioClamps() {
+        let (state, reducer, _, _) = twoPane(axis: .leadingTrailing)
+        guard case .split(let splitID, _, _, _, _) = state.root else {
+            Issue.record("expected a split")
+            return
+        }
+        let high = reducer.reduce(state, .setRatio(split: splitID, ratio: 0.95))
+        #expect(ratio(of: high.root) == TileTreeLayout.maximumRatio)
+        let low = reducer.reduce(state, .setRatio(split: splitID, ratio: 0.01))
+        #expect(ratio(of: low.root) == TileTreeLayout.minimumRatio)
+    }
+
+    @Test("Resize on an unknown split is a no-op")
+    func resizeUnknownNoOp() {
+        let (state, reducer, _, _) = twoPane(axis: .leadingTrailing)
+        let next = reducer.reduce(state, .resize(split: SplitID(), ratioDelta: 0.1))
+        #expect(next == state)
+    }
+
+    @Test("Equalize resets every split ratio to the default")
+    func equalizeWholeTree() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        var state = TileTreeState(singleTile: gen.tile())
+        // Build two nested splits and skew their ratios.
+        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
+        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .topBottom, insertNewBefore: false))
+        for splitID in state.root.splitIDs {
+            state = reducer.reduce(state, .setRatio(split: splitID, ratio: 0.75))
+        }
+        #expect(allRatios(state.root).allSatisfy { $0 == 0.75 })
+
+        let equalized = reducer.reduce(state, .equalize(subtreeRoot: nil))
+        #expect(allRatios(equalized.root).allSatisfy { $0 == TileTreeLayout.defaultRatio })
+    }
+
+    @Test("Equalize with a subtree root only touches that subtree")
+    func equalizeSubtree() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        var state = TileTreeState(singleTile: gen.tile())
+        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .leadingTrailing, insertNewBefore: false))
+        let outerSplit = state.root.splitIDs[0]
+        state = reducer.reduce(state, .split(parent: state.focusedTileID, axis: .topBottom, insertNewBefore: false))
+        let innerSplit = state.root.splitIDs.first { $0 != outerSplit }!
+
+        state = reducer.reduce(state, .setRatio(split: outerSplit, ratio: 0.7))
+        state = reducer.reduce(state, .setRatio(split: innerSplit, ratio: 0.7))
+
+        let equalized = reducer.reduce(state, .equalize(subtreeRoot: innerSplit))
+        #expect(ratioOfSplit(equalized.root, outerSplit) == 0.7) // untouched
+        #expect(ratioOfSplit(equalized.root, innerSplit) == TileTreeLayout.defaultRatio)
+    }
+
+    // MARK: - setFocus
+
+    @Test("setFocus moves focus to a live leaf and ignores unknown tiles")
+    func setFocusBehavior() {
+        let (state, reducer, original, added) = twoPane(axis: .leadingTrailing)
+        let focused = reducer.reduce(state, .setFocus(original))
+        #expect(focused.focusedTileID == original)
+
+        let ignored = reducer.reduce(focused, .setFocus(TileID()))
+        #expect(ignored.focusedTileID == original)
+        _ = added
+    }
+
+    // MARK: - Helpers
+
+    private func ratio(of node: TileTree) -> Double? {
+        guard case .split(_, _, let ratio, _, _) = node else { return nil }
+        return ratio
+    }
+
+    private func allRatios(_ node: TileTree) -> [Double] {
+        switch node {
+        case .tile: return []
+        case .split(_, _, let ratio, let first, let second):
+            return [ratio] + allRatios(first) + allRatios(second)
+        }
+    }
+
+    private func ratioOfSplit(_ node: TileTree, _ target: SplitID) -> Double? {
+        switch node {
+        case .tile: return nil
+        case .split(let id, _, let ratio, let first, let second):
+            if id == target { return ratio }
+            return ratioOfSplit(first, target) ?? ratioOfSplit(second, target)
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
@@ -182,6 +182,36 @@ struct TileTreeReducerTests {
         #expect(next == state)
     }
 
+    @Test("Closing the only tile with a mismatched target is a no-op")
+    func closeSingleMismatchedTargetNoOp() {
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let t1 = gen.tile()
+        let state = TileTreeState(singleTile: t1)
+        let next = reducer.reduce(state, .close(TileID()))
+        #expect(next == state)
+    }
+
+    @Test("Closing the focused tile in a deeper tree moves focus to the adjacent survivor")
+    func closeFocusedReassignsToNeighbor() {
+        // tree = split(t1, split(t2, t3)); focus the nested middle leaf t2 and close it.
+        let gen = IDGen()
+        let reducer = makeReducer(gen)
+        let t1 = gen.tile()
+        var state = TileTreeState(singleTile: t1)
+        state = reducer.reduce(state, .split(parent: t1, axis: .leadingTrailing, insertNewBefore: false))
+        let t2 = state.focusedTileID
+        state = reducer.reduce(state, .split(parent: t2, axis: .leadingTrailing, insertNewBefore: false))
+        let t3 = state.focusedTileID
+        state = reducer.reduce(state, .setFocus(t2))
+
+        let next = reducer.reduce(state, .close(t2))
+        // The survivor across the collapsing split is t3 (the leaf t2 sat next to).
+        #expect(next.focusedTileID == t3)
+        #expect(Set(next.leafIDs) == [t1, t3])
+        #expect(TileTreeInvariants.isValid(next))
+    }
+
     // MARK: - Directional focus (depth-1 parity with splitFocusTarget)
 
     @Test("Directional focus across a leading/trailing split")


### PR DESCRIPTION
## Summary

First stacked PR of the **Tile Tree + Surface abstraction** branch. Lays the payload-free Core foundation so later phases can host non-Ghostty surfaces (a webview first) in a recursive tile tree, and pays down the two-pane special-case debt — without any app wiring yet.

- `TileTree.swift` — `TileID`, `SplitID`, `SplitAxis`, the recursive `TileTree` node (`.tile | .split`), `TileTreeState{root, focusedTileID}`, and shared ratio constants (min 0.2 / max 0.8 / step 0.05) mirroring the legacy `HostTerminalStateStore` fractions. `Codable`/`Equatable`/`Sendable`; no SwiftUI / AppKit / `HostTerminalSession` dependency.
- `TileTreeAction.swift` — the closed action set: `split`, `close`, `focusDirectional`, `focusRelative`, `resize`, `setRatio`, `equalize`, `setFocus`. Each action moves IDs and ratios only.
- `TileTreeReducer.swift` — pure reducer. Split focuses the new tile; close collapses into the surviving sibling, re-seeds on the last tile, and reassigns focus; directional focus is an ancestor walk that **reproduces the depth-1 `splitFocusTarget` mapping exactly** (deeper traversal is a deliberate not-hardened fallback). DEBUG-asserts invariants after every action.
- `TileTreeInvariants.swift` — unique IDs, ratios in range, exactly one focused live leaf (connectedness / two-children / non-empty are guaranteed by the value-type shape).

The reducer is payload-free: it moves `TileID`s and ratios only. The `TileID ↔ HostTerminalSession` binding for terminal tiles will live in the app layer (`SurfaceStore`) in a later phase, keeping the generic tree out of the agent subsystems.

This is **Phase 0–1 of 8**. Follow-on PRs (each green + evidence-backed): `protocol Surface` + `SurfaceStore` (P2), action mapping / tree-as-source-of-truth (P3), recursive renderer (P4), focus + lifecycle sync (P5), web conformer (P6), renames sweep (P7), docs/ADR + `CONTEXT.md` glossary (P8).

## Mergeability

- Surface: desktop (Core library only)
- User-facing behavior changed: **no** — no app wiring; the two-pane render/routing path is untouched
- Non-happy paths considered: split/close/focus/resize on unknown IDs (no-op), closing the last tile (re-seeds), ratio clamping, focus reassignment after collapse — all covered by tests
- Release/ops preconditions: none
- Residual risk or follow-up: depth ≥ 2 directional focus is new behavior with no legacy baseline (flagged not-hardened); the registry/OSC teardown parity risk lands in Phase 5, gated by tests

## Validation

- [x] `swift build`
- [x] `swift test` — 834 tests in 133 suites pass; 24 new tile-tree tests (incl. 64 randomized property sequences)
- [x] Other checks run: `swift test --filter TileTree`

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

Evidence links:

- ![phase0-1-tiletree-tests](https://evidence.cloudcompute.com/workspaces/pr-625/20260607-182703-phase0-1-tiletree-tests.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)