### PR TITLE
release: v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.18.0] - 2026-06-07
+
+### Added
+- terminal color theme switcher (#622)
+
+### Fixed
+- paginate release preflight check runs (#619)
+- write machine-agnostic Claude hook + status-line commands (#621)
+
+### Other
+- refresh roadmap after v0.17.0 (#618)
+- fix claude hook install churn (#620)
+- [codex] Scope host terminal tabs (#623)
+- consolidate schema bootstrap into one tracked-migration seam (#624)
+
 ## [Unreleased]
 
 ### Fixed

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.17.0</string>
+	<string>0.18.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

- Prepare WorkSpaces `v0.18.0` release metadata.
- Bump `CFBundleShortVersionString` to `0.18.0` and `CFBundleVersion` to `23`.
- Add the `0.18.0` changelog section generated from `v0.17.0..HEAD`.

## Mergeability

- Surface: desktop release metadata / docs
- User-facing behavior changed: release version shown by the app and release notes consumed by Sparkle appcast generation.
- Non-happy paths considered: direct `main` push is blocked by repository rules, so this release prep is using the PR path. The `v0.18.0` tag remains local and must not be pushed until this PR lands on `main`.
- Release/ops preconditions: after merge, push `v0.18.0` from the merged release commit so `.github/workflows/release.yml` can build, sign, notarize, publish, and validate assets.
- Residual risk or follow-up: raw debug `debug_no_activate` budget is still above the configured advisory gate; packaged installed release benchmarks pass and remain the release gate per `config/performance/contract.json`.

## Validation

- [x] `swift build` covered by `./scripts/build-release.sh --no-sign`
- [x] `swift test`
- [x] Other checks run:
  - `./scripts/build-ghosttykit.sh`
  - `./scripts/prepare-release.sh --version 0.18.0 --dry-run`
  - `./scripts/prepare-release.sh --version 0.18.0 --no-push`
  - `./scripts/build-release.sh --no-sign`
  - `./scripts/verify-installed-perf.sh build/WorkSpaces.app build/release-installed-perf`
  - `./scripts/perf-runner.sh --scenario installed_login_shell --app build/WorkSpaces.app --output-dir build/release-installed-login-perf`
  - `./scripts/perf-baseline.sh 5 8 --launch-mode no-activate --assert-budget`

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `config/performance/contract.json`
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: `installed_clean_shell`
- Before Summary: release gate uses installed scenario budget, not branch delta
- After Summary: `launch_to_first_prompt` 135.90ms <= 800ms; `terminal_first_output` 116.55ms <= 675ms; `first_prompt_ready` 116.55ms <= 675ms
- Delta Summary: all installed clean-shell release-gate metrics passed

Performance comparison notes:

- Exact commands used:
  - `./scripts/verify-installed-perf.sh build/WorkSpaces.app build/release-installed-perf`
  - `./scripts/perf-runner.sh --scenario installed_login_shell --app build/WorkSpaces.app --output-dir build/release-installed-login-perf`
  - `./scripts/perf-baseline.sh 5 8 --launch-mode no-activate --assert-budget`
- Workload / environment context:
  - Packaged `installed_clean_shell`: pass; `terminal_first_output` and `first_prompt_ready` were present.
  - Packaged `installed_login_shell`: pass; `launch_to_first_prompt` 312.11ms <= 1125ms, `terminal_first_output`/`first_prompt_ready` 285.65ms <= 875ms.
  - Advisory raw debug `debug_no_activate`: fail; `launch_to_first_prompt` median 601.80ms > 250ms. Logs show `Ghostty resources dir unavailable` for the raw debug binary, while the packaged app verified bundled Ghostty resources and passed both installed scenarios. This is called out as advisory, not a packaged-release blocker under the current performance contract.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![release-v0.18.0-validation](https://evidence.cloudcompute.com/workspaces/pr-629/20260608-041128-release-v0.18.0-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence

Release tag status: local `v0.18.0` tag exists in the release-prep clone only; remote tag was intentionally not pushed before PR merge.
