### PR TITLE
feat: tile-tree Phase 2 — protocol Surface seam + SurfaceStore

### DIFF
--- a/Sources/WorkspaceManager/Surface/Surface.swift
+++ b/Sources/WorkspaceManager/Surface/Surface.swift
@@ -1,0 +1,44 @@
+import AppKit
+import WorkspaceManagerCore
+
+/// The seam between the generic tile-tree layout and the concrete content a tile renders.
+///
+/// A `Surface` is a renderable main-content unit of one kind (Terminal / Web), bound 1:1 to a
+/// `TileID`. It vends an AppKit `NSView` (both current leaves are AppKit views wrapped in
+/// `NSViewRepresentable`, so an `NSView` preserves the store-owned, reused-across-update persistence
+/// the terminal and web paths already rely on). Kind-specific coupling — agent registry, OSC routing,
+/// command status, local state for terminals — lives inside the conformer, never on this protocol;
+/// that asymmetry (a `WebSurface` carries none of it) is what validates the abstraction.
+@MainActor
+protocol Surface: AnyObject {
+    var kind: SurfaceKind { get }
+    var tileID: TileID { get }
+
+    /// The content view to mount for this tile. Store-owned and reused across render updates, so
+    /// repeated calls return the same instance.
+    func makeContentView() -> NSView
+
+    /// Human-readable title for tab strips / window subtitles.
+    var displayTitle: String { get }
+
+    /// Make this surface's content the first responder.
+    func focus()
+
+    /// Relinquish first-responder if currently held.
+    func resignFocus()
+
+    /// USER intent to close (Cmd+W / close button). The terminal honors its close-confirmation /
+    /// process-alive checks here; this is distinct from `tearDown`, which is unconditional eviction.
+    func requestClose()
+
+    /// STORE eviction: the surface is being removed from the tree. The terminal releases its
+    /// libghostty surface; the web view releases per its deferred-release policy. Conflating this
+    /// with `requestClose` would skip the terminal close confirmation or leak the surface.
+    func tearDown()
+}
+
+/// The kind of content a `Surface` renders. `repoOverview` arrives with main-content unification.
+enum SurfaceKind: Equatable, Sendable {
+    case terminal
+    case web
+}

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -1,0 +1,147 @@
+import AppKit
+import WorkspaceManagerCore
+
+/// Owns the live `Surface` for each `TileID` in a tile tree: a `[TileID: any Surface]` map plus the
+/// resolver behavior the legacy `HostTerminalSurfaceStore` provided (surface-view → session lookup,
+/// create/invalidate callbacks, display titles).
+///
+/// This is the generalized, `TileID`-keyed successor to `HostTerminalSurfaceStore`. It is not yet on
+/// the live render path — Phase 3 swaps the renderer onto it, and Phase 5 makes `sync` the single
+/// surface-eviction authority. Built and tested ahead of those flips so the wiring lands against a
+/// proven store.
+@MainActor
+final class SurfaceStore {
+    private var surfaces: [TileID: any Surface] = [:]
+
+    /// Forwarded to terminal surfaces at creation so libghostty can reach the agent hook socket.
+    var hooksSocketPath: String?
+
+    /// Fired when a surface is first created for a tile (drives focus-coordinator readiness).
+    var onSurfaceCreated: (@MainActor (TileID) -> Void)?
+    /// Fired when a surface is evicted for a tile (process exit, close, or `sync` diff).
+    var onSurfaceInvalidated: (@MainActor (TileID) -> Void)?
+
+    // MARK: - Access
+
+    func surface(for tileID: TileID) -> (any Surface)? {
+        surfaces[tileID]
+    }
+
+    /// The tiles that currently hold a live surface. Drives lifecycle assertions and `sync` diffs.
+    var retainedTileIDs: Set<TileID> {
+        Set(surfaces.keys)
+    }
+
+    // MARK: - Terminal
+
+    /// Get-or-create the terminal surface bound to `tileID`. On reuse the per-render callbacks are
+    /// refreshed; on creation `onSurfaceCreated` fires. The process-exit callback is wrapped to evict
+    /// the surface before invoking the caller's handler, matching the legacy store.
+    @discardableResult
+    func terminalSurface(
+        for tileID: TileID,
+        session: HostTerminalSession,
+        onProcessExit: (() -> Void)? = nil,
+        onCloseConfirmationRequired: (() -> Void)? = nil,
+        contextMenuProvider: (() -> NSMenu?)? = nil
+    ) -> TerminalSurface {
+        let wrappedOnProcessExit: () -> Void = { [weak self] in
+            Task { @MainActor in
+                self?.invalidate(tileID: tileID)
+                onProcessExit?()
+            }
+        }
+
+        if let existing = surfaces[tileID] as? TerminalSurface {
+            existing.update(
+                onProcessExit: wrappedOnProcessExit,
+                onCloseConfirmationRequired: onCloseConfirmationRequired,
+                contextMenuProvider: contextMenuProvider
+            )
+            return existing
+        }
+
+        let created = TerminalSurface(
+            tileID: tileID,
+            session: session,
+            hooksSocketPath: hooksSocketPath,
+            onProcessExit: wrappedOnProcessExit,
+            onCloseConfirmationRequired: onCloseConfirmationRequired,
+            contextMenuProvider: contextMenuProvider
+        )
+        surfaces[tileID] = created
+        onSurfaceCreated?(tileID)
+        return created
+    }
+
+    // MARK: - Web
+
+    /// Get-or-create the web surface bound to `tileID`. Reuse refreshes the blocked-navigation hook.
+    @discardableResult
+    func webSurface(
+        for tileID: TileID,
+        source: WebSource,
+        onBlockedNavigation: ((URL) -> Void)? = nil
+    ) -> WebSurface {
+        if let existing = surfaces[tileID] as? WebSurface {
+            existing.onBlockedNavigation = onBlockedNavigation
+            return existing
+        }
+
+        let created = WebSurface(
+            tileID: tileID,
+            source: source,
+            onBlockedNavigation: onBlockedNavigation
+        )
+        surfaces[tileID] = created
+        onSurfaceCreated?(tileID)
+        return created
+    }
+
+    // MARK: - Resolver
+
+    /// The terminal surface whose libghostty view is `view`, if any. Backs OSC / split routing that
+    /// arrive holding a `GhosttySurfaceView` and need the owning tile or agent session.
+    func terminalSurface(owning view: GhosttySurfaceView) -> TerminalSurface? {
+        surfaces.values
+            .lazy
+            .compactMap { $0 as? TerminalSurface }
+            .first { $0.surfaceView === view }
+    }
+
+    /// The agent-domain session id for `view` — the value OSC routing resolves against the registry.
+    func sessionID(for view: GhosttySurfaceView) -> UUID? {
+        terminalSurface(owning: view)?.session.id
+    }
+
+    /// The layout tile id for `view`.
+    func tileID(for view: GhosttySurfaceView) -> TileID? {
+        terminalSurface(owning: view)?.tileID
+    }
+
+    /// The display title for `tileID`'s surface, or `nil` when no surface exists yet (the caller
+    /// supplies its own fallback — e.g. a session's directory name — before the surface mounts).
+    func displayTitle(for tileID: TileID) -> String? {
+        surfaces[tileID]?.displayTitle
+    }
+
+    // MARK: - Eviction
+
+    /// Evict the surface for `tileID`: tear it down and fire `onSurfaceInvalidated`. No-op if absent.
+    func invalidate(tileID: TileID) {
+        guard let surface = surfaces.removeValue(forKey: tileID) else { return }
+        surface.tearDown()
+        onSurfaceInvalidated?(tileID)
+    }
+
+    /// Retain only the surfaces whose tiles are still live leaves; tear down the rest. A pure
+    /// present-vs-retained diff — the eviction authority Phase 5 routes all teardown through, in place
+    /// of today's scattered `invalidate` calls in `HostTerminalStateStore`.
+    func sync(activeLeafIDs: [TileID]) {
+        let active = Set(activeLeafIDs)
+        let stale = surfaces.keys.filter { !active.contains($0) }
+        for tileID in stale {
+            invalidate(tileID: tileID)
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -52,7 +52,7 @@ final class SurfaceStore {
             }
         }
 
-        if let existing = surfaces[tileID] as? TerminalSurface {
+        if let existing = surfaces[tileID] as? TerminalSurface, existing.session.id == session.id {
             existing.update(
                 onProcessExit: wrappedOnProcessExit,
                 onCloseConfirmationRequired: onCloseConfirmationRequired,
@@ -60,6 +60,10 @@ final class SurfaceStore {
             )
             return existing
         }
+
+        // A stale binding (tile rebound to a different session) or a mismatched/absent surface: evict
+        // before recreating so `sessionID(for:)` never reports the previous session's identity.
+        invalidate(tileID: tileID)
 
         let created = TerminalSurface(
             tileID: tileID,
@@ -83,10 +87,13 @@ final class SurfaceStore {
         source: WebSource,
         onBlockedNavigation: ((URL) -> Void)? = nil
     ) -> WebSurface {
-        if let existing = surfaces[tileID] as? WebSurface {
+        if let existing = surfaces[tileID] as? WebSurface, existing.source.id == source.id {
             existing.onBlockedNavigation = onBlockedNavigation
             return existing
         }
+
+        // Stale/mismatched binding: evict before rebinding the tile to a different source.
+        invalidate(tileID: tileID)
 
         let created = WebSurface(
             tileID: tileID,
@@ -128,6 +135,11 @@ final class SurfaceStore {
     // MARK: - Eviction
 
     /// Evict the surface for `tileID`: tear it down and fire `onSurfaceInvalidated`. No-op if absent.
+    ///
+    /// Deliberate parity delta from the legacy `HostTerminalSurfaceStore.invalidate(sessionID:)`, which
+    /// fired `onSurfaceInvalidated` unconditionally: here an absent tile is a silent no-op, so listeners
+    /// see invalidations only for surfaces that actually existed. Phase 5 routes all teardown through
+    /// `sync`, so this guard is what keeps that flip from emitting phantom invalidations.
     func invalidate(tileID: TileID) {
         guard let surface = surfaces.removeValue(forKey: tileID) else { return }
         surface.tearDown()

--- a/Sources/WorkspaceManager/Surface/TerminalSurface.swift
+++ b/Sources/WorkspaceManager/Surface/TerminalSurface.swift
@@ -1,0 +1,92 @@
+import AppKit
+import WorkspaceManagerCore
+
+/// `Surface` conformer backing a terminal tile with one libghostty `GhosttySurfaceView`.
+///
+/// Owns the view's lifecycle (create, focus, close, teardown) and holds the `HostTerminalSession`
+/// binding that ties this layout tile to its agent-domain identity. The agent registry, OSC routing,
+/// command status, and local-state coupling deliberately stay *outside* this type — they remain
+/// orchestrated by `HostTerminalStateStore` until Phase 5 moves eviction authority into the store —
+/// so the seam carries only what a generic surface needs.
+@MainActor
+final class TerminalSurface: Surface {
+    let kind: SurfaceKind = .terminal
+    let tileID: TileID
+
+    /// Agent-domain identity for this tile's terminal (registry / OSC / command status / local state).
+    let session: HostTerminalSession
+
+    let surfaceView: GhosttySurfaceView
+
+    init(
+        tileID: TileID,
+        session: HostTerminalSession,
+        hooksSocketPath: String?,
+        onProcessExit: (() -> Void)? = nil,
+        onCloseConfirmationRequired: (() -> Void)? = nil,
+        contextMenuProvider: (() -> NSMenu?)? = nil
+    ) {
+        self.tileID = tileID
+        self.session = session
+
+        if let customCommand = session.customCommand {
+            self.surfaceView = GhosttySurfaceView(
+                customCommand: customCommand,
+                onProcessExit: onProcessExit,
+                onCloseConfirmationRequired: onCloseConfirmationRequired
+            )
+        } else {
+            self.surfaceView = GhosttySurfaceView(
+                workingDirectory: session.directoryURL,
+                hostSessionID: session.id,
+                hooksSocketPath: hooksSocketPath,
+                onProcessExit: onProcessExit,
+                onCloseConfirmationRequired: onCloseConfirmationRequired
+            )
+        }
+        self.surfaceView.contextMenuProvider = contextMenuProvider
+    }
+
+    /// Refresh the per-render callbacks on surface reuse, mirroring the legacy store's reuse path.
+    func update(
+        onProcessExit: (() -> Void)?,
+        onCloseConfirmationRequired: (() -> Void)?,
+        contextMenuProvider: (() -> NSMenu?)?
+    ) {
+        surfaceView.onProcessExit = onProcessExit
+        surfaceView.onCloseConfirmationRequired = onCloseConfirmationRequired
+        surfaceView.contextMenuProvider = contextMenuProvider
+    }
+
+    func makeContentView() -> NSView {
+        surfaceView
+    }
+
+    var displayTitle: String {
+        let title = surfaceView.terminalTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !title.isEmpty {
+            return title
+        }
+        let fallback = session.directoryURL.lastPathComponent
+        return fallback.isEmpty ? "Terminal" : fallback
+    }
+
+    func focus() {
+        TerminalFocusManager.shared.requestFocus(for: surfaceView)
+    }
+
+    func resignFocus() {
+        guard let window = surfaceView.window, window.firstResponder === surfaceView else { return }
+        window.makeFirstResponder(nil)
+    }
+
+    func requestClose() {
+        surfaceView.requestClose()
+    }
+
+    func tearDown() {
+        // Detach the view; the libghostty C handle frees via ARC/`deinit`, matching the legacy
+        // `HostTerminalSurfaceStore.invalidate` eviction path (no explicit free exists today).
+        surfaceView.removeFromSuperview()
+    }
+}

--- a/Sources/WorkspaceManager/Surface/WebSurface.swift
+++ b/Sources/WorkspaceManager/Surface/WebSurface.swift
@@ -1,0 +1,67 @@
+import AppKit
+import WebKit
+import WorkspaceManagerCore
+
+/// `Surface` conformer backing a web tile with a `WKWebView` managed by `WebSurfaceStore`.
+///
+/// Carries none of the agent-domain coupling a `TerminalSurface` does — no registry, OSC, command
+/// status, or local state — which is the asymmetry that proves the seam is genuinely generic. Web
+/// eviction is *deferred* (`releaseInactiveSurface`) rather than the terminal's immediate free, so a
+/// tab the user flips back to need not reload; `SurfaceStore.sync` honors that per-conformer policy.
+@MainActor
+final class WebSurface: Surface {
+    let kind: SurfaceKind = .web
+    let tileID: TileID
+    let source: WebSource
+
+    private let surfaceStore: WebSurfaceStore
+    var onBlockedNavigation: ((URL) -> Void)?
+
+    init(
+        tileID: TileID,
+        source: WebSource,
+        surfaceStore: WebSurfaceStore? = nil,
+        onBlockedNavigation: ((URL) -> Void)? = nil
+    ) {
+        self.tileID = tileID
+        self.source = source
+        self.surfaceStore = surfaceStore ?? WebSurfaceStore()
+        self.onBlockedNavigation = onBlockedNavigation
+    }
+
+    func makeContentView() -> NSView {
+        surfaceStore.ensureSurface(for: source, onBlockedNavigation: onBlockedNavigation)
+    }
+
+    var displayTitle: String {
+        let name = source.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty {
+            return name
+        }
+        return source.allowedHost.isEmpty ? "Web" : source.allowedHost
+    }
+
+    func focus() {
+        let webView = surfaceStore.ensureSurface(for: source, onBlockedNavigation: onBlockedNavigation)
+        webView.window?.makeFirstResponder(webView)
+    }
+
+    func resignFocus() {
+        guard surfaceStore.hasActiveSurface else { return }
+        let webView = surfaceStore.ensureSurface(for: source, onBlockedNavigation: onBlockedNavigation)
+        if let window = webView.window, window.firstResponder === webView {
+            window.makeFirstResponder(nil)
+        }
+    }
+
+    func requestClose() {
+        // Web has no close-confirmation gate (unlike the terminal), so user-intent close and
+        // unconditional teardown coincide. Issuing the tree `.close` for a web tile lands with
+        // main-content unification (Phase 6); here we simply release the view.
+        tearDown()
+    }
+
+    func tearDown() {
+        surfaceStore.releaseInactiveSurface()
+    }
+}

--- a/Sources/WorkspaceManager/Surface/WebSurface.swift
+++ b/Sources/WorkspaceManager/Surface/WebSurface.swift
@@ -5,9 +5,11 @@ import WorkspaceManagerCore
 /// `Surface` conformer backing a web tile with a `WKWebView` managed by `WebSurfaceStore`.
 ///
 /// Carries none of the agent-domain coupling a `TerminalSurface` does — no registry, OSC, command
-/// status, or local state — which is the asymmetry that proves the seam is genuinely generic. Web
-/// eviction is *deferred* (`releaseInactiveSurface`) rather than the terminal's immediate free, so a
-/// tab the user flips back to need not reload; `SurfaceStore.sync` honors that per-conformer policy.
+/// status, or local state — which is the asymmetry that proves the seam is genuinely generic.
+/// `tearDown` releases the web view immediately (`releaseInactiveSurface`). Because each `WebSurface`
+/// privately owns its `WebSurfaceStore`, an evicted web tile reloads when reopened; whether to keep a
+/// shared store-per-source (reuse the view, defer release) is an explicit Phase 6 decision (PR #633
+/// review), not wired here.
 @MainActor
 final class WebSurface: Surface {
     let kind: SurfaceKind = .web
@@ -42,6 +44,9 @@ final class WebSurface: Surface {
     }
 
     func focus() {
+        // No-op until the tile has mounted its web view: focusing should not be what instantiates a
+        // WKWebView and starts a page load (that is `makeContentView`'s job). Mirrors `resignFocus`.
+        guard surfaceStore.hasActiveSurface else { return }
         let webView = surfaceStore.ensureSurface(for: source, onBlockedNavigation: onBlockedNavigation)
         webView.window?.makeFirstResponder(webView)
     }

--- a/Tests/WorkspaceManagerAppTests/SurfaceStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SurfaceStoreTests.swift
@@ -1,0 +1,160 @@
+import AppKit
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("SurfaceStore")
+struct SurfaceStoreTests {
+    @Test("Creating a terminal surface retains it by tile and fires onSurfaceCreated once")
+    func createTerminalSurfaceRetainsAndNotifies() {
+        let store = SurfaceStore()
+        var created: [TileID] = []
+        store.onSurfaceCreated = { created.append($0) }
+
+        let tile = TileID()
+        let surface = store.terminalSurface(for: tile, session: makeSession())
+
+        #expect(store.retainedTileIDs == [tile])
+        #expect(created == [tile])
+        #expect(store.surface(for: tile) === surface)
+    }
+
+    @Test("Requesting the same tile reuses the surface without re-notifying")
+    func reuseSameTileReturnsSameInstance() {
+        let store = SurfaceStore()
+        var created: [TileID] = []
+        store.onSurfaceCreated = { created.append($0) }
+
+        let tile = TileID()
+        let session = makeSession()
+        let first = store.terminalSurface(for: tile, session: session)
+        let second = store.terminalSurface(for: tile, session: session)
+
+        #expect(first === second)
+        #expect(created == [tile])
+    }
+
+    @Test("Resolver maps a surface view back to its session and tile")
+    func resolverMapsViewToSessionAndTile() {
+        let store = SurfaceStore()
+        let tile = TileID()
+        let session = makeSession()
+        let surface = store.terminalSurface(for: tile, session: session)
+
+        #expect(store.sessionID(for: surface.surfaceView) == session.id)
+        #expect(store.tileID(for: surface.surfaceView) == tile)
+
+        let unknownView = GhosttySurfaceView(workingDirectory: URL(fileURLWithPath: "/tmp"))
+        #expect(store.sessionID(for: unknownView) == nil)
+        #expect(store.tileID(for: unknownView) == nil)
+    }
+
+    @Test("Invalidate evicts the surface and fires onSurfaceInvalidated")
+    func invalidateEvictsAndNotifies() {
+        let store = SurfaceStore()
+        var invalidated: [TileID] = []
+        store.onSurfaceInvalidated = { invalidated.append($0) }
+
+        let tile = TileID()
+        store.terminalSurface(for: tile, session: makeSession())
+        store.invalidate(tileID: tile)
+
+        #expect(store.retainedTileIDs.isEmpty)
+        #expect(invalidated == [tile])
+        #expect(store.surface(for: tile) == nil)
+
+        // Second invalidate of an absent tile is a no-op (no duplicate notification).
+        store.invalidate(tileID: tile)
+        #expect(invalidated == [tile])
+    }
+
+    @Test("sync retains live leaves and tears down the rest")
+    func syncRetainsLiveLeavesEvictsStale() {
+        let store = SurfaceStore()
+        var invalidated: Set<TileID> = []
+        store.onSurfaceInvalidated = { invalidated.insert($0) }
+
+        let keep = TileID()
+        let dropA = TileID()
+        let dropB = TileID()
+        store.terminalSurface(for: keep, session: makeSession(path: "/Users/test/keep"))
+        store.terminalSurface(for: dropA, session: makeSession(path: "/Users/test/a"))
+        store.terminalSurface(for: dropB, session: makeSession(path: "/Users/test/b"))
+
+        store.sync(activeLeafIDs: [keep])
+
+        #expect(store.retainedTileIDs == [keep])
+        #expect(invalidated == [dropA, dropB])
+    }
+
+    @Test("displayTitle falls back to the session directory, nil for an unknown tile")
+    func displayTitleDirectoryFallback() {
+        let store = SurfaceStore()
+        let tile = TileID()
+        store.terminalSurface(for: tile, session: makeSession(path: "/Users/test/myrepo"))
+
+        #expect(store.displayTitle(for: tile) == "myrepo")
+        #expect(store.displayTitle(for: TileID()) == nil)
+    }
+
+    private func makeSession(path: String = "/Users/test/repo") -> HostTerminalSession {
+        HostTerminalSession(key: .repoPath(path), directory: URL(fileURLWithPath: path))
+    }
+}
+
+@MainActor
+@Suite("Surface conformers")
+struct SurfaceConformerTests {
+    @Test("TerminalSurface vends its libghostty view and reports terminal kind")
+    func terminalSurfaceShape() {
+        let tile = TileID()
+        let session = HostTerminalSession(
+            key: .repoPath("/Users/test/proj"),
+            directory: URL(fileURLWithPath: "/Users/test/proj")
+        )
+        let surface = TerminalSurface(tileID: tile, session: session, hooksSocketPath: nil)
+
+        #expect(surface.kind == .terminal)
+        #expect(surface.tileID == tile)
+        #expect(surface.makeContentView() === surface.surfaceView)
+        #expect(surface.displayTitle == "proj")
+    }
+
+    @Test("TerminalSurface tearDown detaches the view from its superview")
+    func terminalSurfaceTearDownDetachesView() {
+        let tile = TileID()
+        let session = HostTerminalSession(
+            key: .repoPath("/Users/test/proj"),
+            directory: URL(fileURLWithPath: "/Users/test/proj")
+        )
+        let surface = TerminalSurface(tileID: tile, session: session, hooksSocketPath: nil)
+
+        let container = NSView()
+        container.addSubview(surface.surfaceView)
+        #expect(surface.surfaceView.superview === container)
+
+        surface.tearDown()
+        #expect(surface.surfaceView.superview == nil)
+    }
+
+    @Test("WebSurface carries no agent coupling and titles from its source")
+    func webSurfaceShape() {
+        let tile = TileID()
+        let source = WebSource(
+            name: "Docs",
+            baseURLString: "https://docs.example.com",
+            allowedHost: "docs.example.com"
+        )
+        let surface = WebSurface(tileID: tile, source: source)
+
+        #expect(surface.kind == .web)
+        #expect(surface.tileID == tile)
+        #expect(surface.displayTitle == "Docs")
+
+        // tearDown is safe before any web view has been instantiated.
+        surface.tearDown()
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SurfaceStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SurfaceStoreTests.swift
@@ -37,6 +37,28 @@ struct SurfaceStoreTests {
         #expect(created == [tile])
     }
 
+    @Test("Rebinding a tile to a new session evicts the old surface and rebinds the resolver")
+    func rebindTileToNewSessionReplacesSurface() {
+        let store = SurfaceStore()
+        var invalidated: [TileID] = []
+        store.onSurfaceInvalidated = { invalidated.append($0) }
+
+        let tile = TileID()
+        let firstSession = makeSession(path: "/Users/test/first")
+        let secondSession = makeSession(path: "/Users/test/second")
+
+        let firstSurface = store.terminalSurface(for: tile, session: firstSession)
+        let firstView = firstSurface.surfaceView
+        let secondSurface = store.terminalSurface(for: tile, session: secondSession)
+
+        #expect(secondSurface !== firstSurface)
+        #expect(invalidated == [tile])
+        #expect(store.retainedTileIDs == [tile])
+        #expect(store.sessionID(for: secondSurface.surfaceView) == secondSession.id)
+        // The old view's identity must no longer resolve — the reason the guard exists.
+        #expect(store.sessionID(for: firstView) == nil)
+    }
+
     @Test("Resolver maps a surface view back to its session and tile")
     func resolverMapsViewToSessionAndTile() {
         let store = SurfaceStore()


### PR DESCRIPTION
## Summary

Phase 2 of the tile-tree + Surface abstraction epic (#627), stacked on #625 (Phase 0–1).

Introduces the `Surface` seam — the abstraction the recursive renderer (Phase 4) and
tree-as-source-of-truth (Phase 3) will sit on — as a **parallel, unit-tested layer**. The live
two-pane render path stays on the existing session-keyed `HostTerminalSurfaceStore`, so this phase
is **zero-regression by construction**; Phase 3 flips the renderer/routing/focus onto `SurfaceStore`.

New `Sources/WorkspaceManager/Surface/`:

- `protocol Surface` (`kind` / `tileID` / `makeContentView() -> NSView` / `displayTitle` / `focus` /
  `resignFocus` / `requestClose` / `tearDown`) + `SurfaceKind{.terminal,.web}`
- `TerminalSurface` — wraps one `GhosttySurfaceView` bound to a `HostTerminalSession`
- `WebSurface` — wraps a `WKWebView` via `WebSurfaceStore`, carrying **no** agent coupling (the
  asymmetry that validates the seam)
- `SurfaceStore` — the `TileID`-keyed `[TileID: any Surface]` owner with the resolver
  (`sessionID` / `tileID` for a `GhosttySurfaceView`), `onSurfaceCreated/Invalidated`, `displayTitle`,
  and a pure `sync(activeLeafIDs:)` present-vs-retained diff

`requestClose` (user intent; the terminal honors its close confirmation) stays distinct from
`tearDown` (unconditional eviction). The agent-registry / OSC / command-status / local-state teardown
fold stays in `HostTerminalStateStore` until Phase 5 makes `SurfaceStore.sync` the single eviction
authority (the plan's gated risk). `sync` is built and tested now so Phase 5 flips authority against a
proven method.

## Mergeability

- Surface: desktop
- User-facing behavior changed: no — internal abstraction; live two-pane render path untouched
- Non-happy paths considered: surface eviction (process exit / close / sync diff), reuse, unknown-view resolver miss
- Release/ops preconditions: none
- Residual risk or follow-up: Phase 3 swaps the render path onto `SurfaceStore` (the registry-parity-sensitive flip)

## Validation

- [x] `swift build`
- [x] `swift test` — 871 tests / 139 suites, all passing
- [x] Other checks run: `swift-format lint --strict --recursive Sources/ Tests/` (clean)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

Evidence links:

- [Test summary — 871 tests / 139 suites passing](https://evidence.cloudcompute.com/workspaces/pr-633/20260610-014143-phase2-test-summary.png)

![phase2-test-summary](https://evidence.cloudcompute.com/workspaces/pr-633/20260610-014143-phase2-test-summary.png)

## Blockers

- [x] None
