### PR TITLE
fix: harden ProcessRunner against subprocess hang classes

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/ProcessRunner.swift
+++ b/Sources/WorkspaceManagerCore/Services/ProcessRunner.swift
@@ -2,31 +2,60 @@
 //  ProcessRunner.swift
 //  WorkspaceManager
 //
-//  Shared async process execution with non-blocking stdout/stderr draining.
+//  Shared async process execution with non-blocking stdout/stderr draining,
+//  a bounded post-exit pipe-drain grace (so backgrounded children that inherit
+//  the pipes cannot starve EOF and hang the caller), and an optional timeout
+//  that kills the child and throws.
 //
 
 import Foundation
+
+enum ProcessRunnerError: Error, LocalizedError, Equatable {
+    case timedOut(executable: String, arguments: [String], timeout: TimeInterval)
+
+    var errorDescription: String? {
+        switch self {
+        case .timedOut(let executable, let arguments, let timeout):
+            let command = ([executable] + arguments).joined(separator: " ")
+            return "Command timed out after \(timeout)s: \(command)"
+        }
+    }
+}
 
 enum ProcessRunner {
     private final class State: @unchecked Sendable {
         private let lock = NSLock()
 
-        private var stdoutData: Data?
-        private var stderrData: Data?
+        private var stdoutData = Data()
+        private var stderrData = Data()
+        private var stdoutEOF = false
+        private var stderrEOF = false
         private var exitCode: Int32?
         private var didResume = false
 
-        func completeStdout(_ data: Data) -> ProcessResult? {
+        func appendStdout(_ data: Data) {
             lock.lock()
-            stdoutData = data
+            stdoutData.append(data)
+            lock.unlock()
+        }
+
+        func appendStderr(_ data: Data) {
+            lock.lock()
+            stderrData.append(data)
+            lock.unlock()
+        }
+
+        func completeStdout() -> ProcessResult? {
+            lock.lock()
+            stdoutEOF = true
             let result = makeResultIfReadyLocked()
             lock.unlock()
             return result
         }
 
-        func completeStderr(_ data: Data) -> ProcessResult? {
+        func completeStderr() -> ProcessResult? {
             lock.lock()
-            stderrData = data
+            stderrEOF = true
             let result = makeResultIfReadyLocked()
             lock.unlock()
             return result
@@ -40,7 +69,19 @@ enum ProcessRunner {
             return result
         }
 
-        func markFailed() -> Bool {
+        /// Resume with the output captured so far, even though a pipe never reached
+        /// EOF — the exit code is already known, so the result is complete except for
+        /// whatever a backgrounded child might still write into the inherited pipe.
+        func finalizeAfterGrace() -> ProcessResult? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didResume, let exitCode else { return nil }
+            didResume = true
+            return makeResultLocked(exitCode: exitCode)
+        }
+
+        /// Claim the single resume slot for a throwing path (launch failure, timeout).
+        func takeResumeSlot() -> Bool {
             lock.lock()
             defer { lock.unlock() }
             guard !didResume else { return false }
@@ -49,15 +90,13 @@ enum ProcessRunner {
         }
 
         private func makeResultIfReadyLocked() -> ProcessResult? {
-            guard
-                !didResume,
-                let exitCode,
-                let stdoutData,
-                let stderrData
-            else { return nil }
-
+            guard !didResume, let exitCode, stdoutEOF, stderrEOF else { return nil }
             didResume = true
-            return ProcessResult(
+            return makeResultLocked(exitCode: exitCode)
+        }
+
+        private func makeResultLocked(exitCode: Int32) -> ProcessResult {
+            ProcessResult(
                 exitCode: exitCode,
                 stdout: String(data: stdoutData, encoding: .utf8) ?? String(decoding: stdoutData, as: UTF8.self),
                 stderr: String(data: stderrData, encoding: .utf8) ?? String(decoding: stderrData, as: UTF8.self)
@@ -65,11 +104,23 @@ enum ProcessRunner {
         }
     }
 
+    /// Run `executable` and capture stdout/stderr until exit.
+    ///
+    /// - Parameters:
+    ///   - timeout: When set, the child is terminated (SIGTERM, escalating to SIGKILL
+    ///     after one second) once the interval elapses and the call throws
+    ///     `ProcessRunnerError.timedOut`. `nil` waits indefinitely for exit.
+    ///   - pipeDrainGracePeriod: How long to keep draining stdout/stderr after the
+    ///     child exits when a pipe has not reached EOF — the case where a backgrounded
+    ///     grandchild inherited the write end. After the grace the call returns with
+    ///     the output captured so far instead of waiting on a pipe that may never close.
     static func run(
         executable: String,
         arguments: [String] = [],
         currentDirectory: URL? = nil,
-        environment: [String: String]? = nil
+        environment: [String: String]? = nil,
+        timeout: TimeInterval? = nil,
+        pipeDrainGracePeriod: TimeInterval = 2.0
     ) async throws -> ProcessResult {
         try await withCheckedThrowingContinuation { continuation in
             let process = Process()
@@ -87,33 +138,88 @@ enum ProcessRunner {
             let stderrHandle = stderrPipe.fileHandleForReading
             let state = State()
 
-            DispatchQueue.global(qos: .userInitiated).async {
-                let data = stdoutHandle.readDataToEndOfFile()
-                if let result = state.completeStdout(data) {
-                    continuation.resume(returning: result)
+            let stopDraining: @Sendable () -> Void = {
+                stdoutHandle.readabilityHandler = nil
+                stderrHandle.readabilityHandler = nil
+            }
+
+            stdoutHandle.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                    if let result = state.completeStdout() {
+                        stopDraining()
+                        continuation.resume(returning: result)
+                    }
+                } else {
+                    state.appendStdout(data)
                 }
             }
 
-            DispatchQueue.global(qos: .userInitiated).async {
-                let data = stderrHandle.readDataToEndOfFile()
-                if let result = state.completeStderr(data) {
-                    continuation.resume(returning: result)
+            stderrHandle.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                    if let result = state.completeStderr() {
+                        stopDraining()
+                        continuation.resume(returning: result)
+                    }
+                } else {
+                    state.appendStderr(data)
                 }
             }
 
             process.terminationHandler = { process in
                 if let result = state.markTerminated(exitCode: process.terminationStatus) {
+                    stopDraining()
                     continuation.resume(returning: result)
+                    return
+                }
+                // Exit is recorded but a pipe is still open — typically a backgrounded
+                // child inherited the write end. Drain for the bounded grace, then
+                // finish with what was captured.
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                    deadline: .now() + pipeDrainGracePeriod
+                ) {
+                    if let result = state.finalizeAfterGrace() {
+                        stopDraining()
+                        continuation.resume(returning: result)
+                    }
                 }
             }
 
             do {
                 try process.run()
             } catch {
+                stopDraining()
                 try? stdoutHandle.close()
                 try? stderrHandle.close()
-                if state.markFailed() {
+                if state.takeResumeSlot() {
                     continuation.resume(throwing: error)
+                }
+                return
+            }
+
+            if let timeout {
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
+                    guard state.takeResumeSlot() else { return }
+                    stopDraining()
+                    if process.isRunning {
+                        process.terminate()
+                    }
+                    let pid = process.processIdentifier
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1.0) {
+                        if process.isRunning {
+                            kill(pid, SIGKILL)
+                        }
+                    }
+                    continuation.resume(
+                        throwing: ProcessRunnerError.timedOut(
+                            executable: executable,
+                            arguments: arguments,
+                            timeout: timeout
+                        )
+                    )
                 }
             }
         }

--- a/Tests/WorkspaceManagerTests/ProcessRunnerTests.swift
+++ b/Tests/WorkspaceManagerTests/ProcessRunnerTests.swift
@@ -72,4 +72,53 @@ struct ProcessRunnerTests {
             #expect(result.stdout.contains(token))
         }
     }
+
+    @Test("Returns after exit when a backgrounded child holds the pipes open")
+    func returnsWhenBackgroundedChildHoldsPipes() async throws {
+        let start = ContinuousClock.now
+        let command = [
+            "echo before-background",
+            "sleep 30 &",
+            "exit 0",
+        ].joined(separator: "\n")
+
+        let result = try await ProcessRunner.run(
+            executable: "/bin/bash",
+            arguments: ["-c", command],
+            pipeDrainGracePeriod: 0.5
+        )
+        let elapsed = ContinuousClock.now - start
+
+        #expect(result.success)
+        #expect(result.stdout.contains("before-background"))
+        #expect(elapsed < .seconds(10))
+    }
+
+    @Test("Throws timedOut for a child that never exits")
+    func timesOutHungChild() async throws {
+        let start = ContinuousClock.now
+
+        await #expect(throws: ProcessRunnerError.self) {
+            _ = try await ProcessRunner.run(
+                executable: "/bin/bash",
+                arguments: ["-c", "sleep 30"],
+                timeout: 0.5
+            )
+        }
+
+        let elapsed = ContinuousClock.now - start
+        #expect(elapsed < .seconds(10))
+    }
+
+    @Test("Timeout leaves a process that completes in time untouched")
+    func timeoutUnusedForFastProcess() async throws {
+        let result = try await ProcessRunner.run(
+            executable: "/bin/echo",
+            arguments: ["fast-enough"],
+            timeout: 30
+        )
+
+        #expect(result.success)
+        #expect(result.stdout.contains("fast-enough"))
+    }
 }


### PR DESCRIPTION
## Summary

Closes #634. Hardens `ProcessRunner.run` — the shared subprocess seam for 12 services (GitService, WorkspaceService lifecycle scripts, WorkspaceMaterializer, LumeCLIRunner, SSHBackend, …) — against the two hang classes identified in the 2026-06-09 reliability review:

1. **EOF starvation (deterministic).** Reads previously blocked in `readDataToEndOfFile()`, so a lifecycle script that backgrounded a child (`sleep 30 &`, a dev server) kept the pipe write-ends alive and hung the caller *forever* after the script exited — workspace creation stuck at "Running setup...". Reads are now incremental via `readabilityHandler`, and process termination starts a bounded pipe-drain grace (default 2s), after which the call returns with the output captured so far. Default-on; no call-site changes needed.
2. **No deadline.** New optional `timeout:` parameter — on expiry the child gets SIGTERM (SIGKILL after 1s) and the call throws `ProcessRunnerError.timedOut` naming the exact command. Defaults to `nil`, so existing call sites are unchanged; per-call-site adoption (git ops seconds-scale, lifecycle scripts minutes-scale) is deliberately a follow-up to keep this PR small.

Single-resume safety is preserved by the same locked-state pattern as before (`didResume` slot; all paths funnel through `State` under one lock).

Relation to #554: this does **not** claim to fix the reported "Finishing workspace..." hang (that maps to `.finished`, after the setup script returns — live-repro gate stands). It removes an adjacent deterministic hang class and makes any future subprocess hang diagnosable. See the [hypothesis comment](https://github.com/fairchild/workspaces/issues/554#issuecomment-4665718604).

## Mergeability

- Surface: desktop (WorkspaceManagerCore)
- User-facing behavior changed: only in previously-hanging cases — creation against a backgrounding setup script now completes ~2s after script exit instead of hanging
- Non-happy paths considered: backgrounded grandchild holding pipes, never-exiting child, launch failure, rapid exits, large output, double-resume races
- Release/ops preconditions: none
- Residual risk or follow-up: per-call-site `timeout:` adoption (follow-up); output written by a backgrounded child *after* the grace window is not captured (by design)

## Validation

- [x] `swift test` — 865 tests / 137 suites passing (targeted ProcessRunner suite: 7/7, backgrounding case returns in 0.53s)
- [x] `swift-format lint --strict` clean on changed files
- Note: one unrelated test flaked in a single early full run and did not reproduce across two subsequent full runs.

## Performance

- [x] Not a performance-sensitive change (readabilityHandler vs blocking reads; same data volume, no main-thread work)

## Evidence

- [Test summary — ProcessRunner suite + full run](https://evidence.cloudcompute.com/workspaces/pr-640/20260610-021232-processrunner-hang-tests.png)

![processrunner-hang-tests](https://evidence.cloudcompute.com/workspaces/pr-640/20260610-021232-processrunner-hang-tests.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)