### PR TITLE
fix: exempt docs-only PRs from the readiness evidence gate

### DIFF
--- a/scripts/pr-readiness.py
+++ b/scripts/pr-readiness.py
@@ -18,6 +18,8 @@ from typing import Any
 
 
 DEFAULT_SURFACE = "desktop / web / agent-runtime / infra / docs"
+DOC_EVIDENCE_EXEMPT_SUFFIXES = (".md", ".mdx", ".markdown", ".txt")
+DOC_EVIDENCE_EXEMPT_PREFIXES = ("docs/", "backlog/")
 RELEASE_PATHS = {
     ".github/workflows/release.yml",
     "scripts/build-release.sh",
@@ -105,6 +107,14 @@ def changed_release_files(files: list[str]) -> list[str]:
     return [path for path in files if path in RELEASE_PATHS]
 
 
+def is_docs_only(files: list[str]) -> bool:
+    return bool(files) and all(
+        path.endswith(DOC_EVIDENCE_EXEMPT_SUFFIXES)
+        or path.startswith(DOC_EVIDENCE_EXEMPT_PREFIXES)
+        for path in files
+    )
+
+
 def evaluate(pr: dict[str, Any], files: list[str]) -> Result:
     body = pr.get("body") or ""
     title = pr.get("title") or ""
@@ -141,7 +151,7 @@ def evaluate(pr: dict[str, Any], files: list[str]) -> Result:
     if re.search(r"(?i)\bdo not merge(?:\s+this\s+pr|\s+until|\b)", f"{title}\n{body}"):
         failures.append("PR text contains a merge-stop instruction.")
 
-    if not has_any_evidence(body):
+    if not has_any_evidence(body) and not is_docs_only(files):
         failures.append("No test/evidence signal found in PR body.")
 
     release_files = changed_release_files(files)

--- a/scripts/tests/test_pr_readiness.py
+++ b/scripts/tests/test_pr_readiness.py
@@ -109,6 +109,24 @@ class PRReadinessTests(unittest.TestCase):
             result.failures,
         )
 
+    def test_docs_only_pr_without_evidence_passes(self) -> None:
+        body = GOOD_BODY.replace(
+            "- ![tests](https://evidence.cloudcompute.com/workspaces/pr-1/tests.svg)",
+            "- Docs-only change; no test or screenshot evidence applicable.",
+        )
+        result = pr_readiness.evaluate(pr(body), ["backlog/ROADMAP.md"])
+        self.assertEqual(result.failures, [])
+
+    def test_mixed_docs_and_code_still_requires_evidence(self) -> None:
+        body = GOOD_BODY.replace(
+            "- ![tests](https://evidence.cloudcompute.com/workspaces/pr-1/tests.svg)",
+            "- Docs-only change; no test or screenshot evidence applicable.",
+        )
+        result = pr_readiness.evaluate(
+            pr(body), ["backlog/ROADMAP.md", "Sources/WorkspaceManager/Foo.swift"]
+        )
+        self.assertIn("No test/evidence signal found in PR body.", result.failures)
+
     def test_draft_pr_is_advisory(self) -> None:
         result = pr_readiness.evaluate(pr("", draft=True), [".github/workflows/release.yml"])
         self.assertEqual(result.failures, [])


### PR DESCRIPTION
## Summary

Makes the `PR Readiness` evidence gate stop false-failing on docs-only PRs.

PR #639 (roadmap refresh) was mergeable in every respect but blocked by `readiness`:

> No test/evidence signal found in PR body.

`has_any_evidence()` recognizes only four signals — an `evidence.cloudcompute.com`
URL, an embedded image, a "tests passed" string, or a **checked** `- [x] Not a
testable change` box. A docs-only author who writes prose in the Evidence section
instead of checking that exact box gets blocked; the regex can't read prose.

This derives the docs-only exemption from the **changed-file list** (ground truth),
reusing the file-list mechanism already trusted for release-file detection, instead
of fragile body wording.

- Pure-docs PRs (`.md`/`.mdx`/`.markdown`/`.txt`, `docs/`, `backlog/`) skip the
  evidence requirement.
- Any **mixed** docs+code PR still requires evidence (`all()` over a non-empty list).
- Empty file list falls back to require-evidence (`bool(files)` guard).
- The manual `- [x] Not a testable change` box stays as the override for config-only
  or other genuinely-untestable non-docs changes — no existing behavior removed.

## Mergeability

- Surface: infra (CI readiness gate)
- User-facing behavior changed: no
- Non-happy paths considered: mixed docs+code still gated; empty file list falls back to require-evidence; release-file detection path untouched
- Release/ops preconditions: none
- Residual risk or follow-up: none

## Validation

- [x] Other checks run: `uv run --script scripts/tests/test_pr_readiness.py` — 11 passed (2 new)
- [x] Reproduced #639 locally against the patched script: docs-only file list passes with a prose (no-checkbox) body; adding a `Sources/**` path fails as expected

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

Evidence links:

- [11 unit tests passed](https://evidence.cloudcompute.com/workspaces/pr-641/20260610-023301-docs-exempt-tests.png)

![docs-exempt-tests](https://evidence.cloudcompute.com/workspaces/pr-641/20260610-023301-docs-exempt-tests.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
