### PR TITLE
Coordinate workspace deletion cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ Continuous improvement of `AGENTS.md` is important to the health and longevity o
 
 Issues and PRDs live in GitHub Issues for `fairchild/workspaces`. See `docs/agents/issue-tracker.md`.
 
+When the user asks to work a GitHub issue, or gives an issue link/number, treat it as a backlog claim even if the `backlog` skill was not named.
+Before implementation, read the issue, apply the `claimed` label, remove `ready` if present, and post a claim comment naming the active Codex thread title/name and session ID.
+If either identifier is unavailable, say so explicitly in the comment instead of omitting it.
+Then continue through the issue lifecycle in `backlog/AGENTS.md`.
+
 ### Triage labels
 
 Use lane + state labels: `agent`/`human` for ownership, `ready`/`claimed`/`review`/`mergeable` for lifecycle, and `needs-human` only for human intervention blockers. See `docs/agents/triage-labels.md`.

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -242,6 +242,17 @@ final class GhosttySurfaceView: NSView {
         ghostty_surface_request_close(surface)
     }
 
+    func forceCloseForSessionRetirement() {
+        onCloseConfirmationRequired = nil
+        onProcessExit = nil
+        didProcessExit = true
+
+        guard let surface else { return }
+        GhosttyAppManager.shared.unregisterSurface(self)
+        ghostty_surface_free(surface)
+        self.surface = nil
+    }
+
     // MARK: - Local event monitor
 
     private func setupEventMonitor() {

--- a/Sources/WorkspaceManager/Views/Components/TerminalView.swift
+++ b/Sources/WorkspaceManager/Views/Components/TerminalView.swift
@@ -116,6 +116,19 @@ final class HostTerminalSurfaceStore {
         }
         onSurfaceInvalidated?(sessionID)
     }
+
+    @discardableResult
+    func retire(sessionID: UUID) -> Bool {
+        guard let removed = surfaces.removeValue(forKey: sessionID) else {
+            onSurfaceInvalidated?(sessionID)
+            return false
+        }
+
+        sessionIDsBySurfaceIdentity.removeValue(forKey: ObjectIdentifier(removed))
+        removed.forceCloseForSessionRetirement()
+        onSurfaceInvalidated?(sessionID)
+        return true
+    }
 }
 
 struct TerminalContainerView: View {

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -478,6 +478,9 @@ struct ContentView: View {
                     webSourceCreationTarget = target
                 },
                 onWorkspaceCreated: handleWorkspaceCreated,
+                retireTerminalSessions: { key in
+                    await retireTerminalSessions(inScope: key)
+                },
                 workspaceProviderSetupCoordinator: workspaceProviderSetupCoordinator,
                 hostLumeSmokeAutomation: hostLumeSmokeAutomation
             )
@@ -1429,7 +1432,10 @@ struct ContentView: View {
         let controller = SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: workspaceProviderRegistry
+            workspaceProviderRegistry: workspaceProviderRegistry,
+            retireTerminalSessions: { key in
+                await retireTerminalSessions(inScope: key)
+            }
         )
         let workspace = try await controller.createWorkspace(
             from: repo,
@@ -1453,7 +1459,10 @@ struct ContentView: View {
         let controller = SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: workspaceProviderRegistry
+            workspaceProviderRegistry: workspaceProviderRegistry,
+            retireTerminalSessions: { key in
+                await retireTerminalSessions(inScope: key)
+            }
         )
         do {
             try await controller.archive(workspace)
@@ -1551,6 +1560,14 @@ struct ContentView: View {
             )
         else { return }
         applyTerminalSessionResult(result)
+    }
+
+    @MainActor
+    private func retireTerminalSessions(inScope scopeKey: HostTerminalSessionKey) async {
+        let retiredSessionIDs = hostTerminalState.retireSessions(inScope: scopeKey)
+        guard !retiredSessionIDs.isEmpty else { return }
+
+        terminalFocusCoordinator.cancelPendingFocusRequest(reason: "workspace_lifecycle_retired_sessions")
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -264,6 +264,32 @@ final class HostTerminalStateStore: ObservableObject {
     }
 
     @discardableResult
+    func retireSessions(inScope scopeKey: HostTerminalSessionKey) -> [UUID] {
+        let primarySessionIDs = coordinator.sessions(inScope: scopeKey).map(\.id)
+        guard !primarySessionIDs.isEmpty else { return [] }
+
+        var retiredSessionIDs: [UUID] = []
+        for primarySessionID in primarySessionIDs {
+            if let splitSession = splitSessionsByPrimaryID.removeValue(forKey: primarySessionID) {
+                retireTerminalSession(splitSession.id)
+                retiredSessionIDs.append(splitSession.id)
+            }
+            splitLayoutsByPrimaryID.removeValue(forKey: primarySessionID)
+            splitFractionsByPrimaryID.removeValue(forKey: primarySessionID)
+
+            guard coordinator.remove(sessionID: primarySessionID) != nil else { continue }
+            retireTerminalSession(primarySessionID)
+            tabTitleOverridesBySessionID.removeValue(forKey: primarySessionID)
+            retiredSessionIDs.append(primarySessionID)
+        }
+
+        if !retiredSessionIDs.isEmpty {
+            publishSnapshot()
+        }
+        return retiredSessionIDs
+    }
+
+    @discardableResult
     func handleProcessExit(for sessionID: UUID) -> Bool {
         var removed = false
 
@@ -545,6 +571,16 @@ final class HostTerminalStateStore: ObservableObject {
         }
         splitLayoutsByPrimaryID.removeValue(forKey: primarySessionID)
         splitFractionsByPrimaryID.removeValue(forKey: primarySessionID)
+    }
+
+    private func retireTerminalSession(_ sessionID: UUID) {
+        surfaceStore.retire(sessionID: sessionID)
+        if registeredAgentSessionIDs.contains(sessionID) {
+            agentSessionRegistry?.deregister(hostSessionID: sessionID)
+            lastCommandStatusRegistry?.clear(terminalSessionID: sessionID)
+            recordTerminalSessionEnded(sessionID)
+            registeredAgentSessionIDs.remove(sessionID)
+        }
     }
 
     private func recordTerminalSession(_ session: HostTerminalSession, isActive: Bool) {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -54,6 +54,7 @@ struct SidebarView: View {
     let onWebSourceSelected: (WebSource) -> Void
     let onRequestWebSourceCreation: (WebSourceCreationTarget) -> Void
     let onWorkspaceCreated: () -> Void
+    let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async -> Void
     let workspaceProviderSetupCoordinator: WorkspaceProviderSetupCoordinator
     let hostLumeSmokeAutomation: HostLumeSmokeAutomationController
 
@@ -95,7 +96,8 @@ struct SidebarView: View {
         SidebarWorkspaceController(
             modelContext: modelContext,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: workspaceProviderRegistry
+            workspaceProviderRegistry: workspaceProviderRegistry,
+            retireTerminalSessions: retireTerminalSessions
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -31,6 +31,19 @@ struct SidebarWorkspaceController {
     let modelContext: ModelContext
     let workspaceService: any WorkspaceServiceProtocol
     let workspaceProviderRegistry: WorkspaceProviderRegistry
+    let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async -> Void
+
+    init(
+        modelContext: ModelContext,
+        workspaceService: any WorkspaceServiceProtocol,
+        workspaceProviderRegistry: WorkspaceProviderRegistry,
+        retireTerminalSessions: @escaping @MainActor (HostTerminalSessionKey) async -> Void = { _ in }
+    ) {
+        self.modelContext = modelContext
+        self.workspaceService = workspaceService
+        self.workspaceProviderRegistry = workspaceProviderRegistry
+        self.retireTerminalSessions = retireTerminalSessions
+    }
 
     nonisolated static func preferredRepoForNewWorkspace(
         selectedWorkspace: Workspace?,
@@ -152,6 +165,8 @@ struct SidebarWorkspaceController {
 
     func deleteWorkspace(_ workspace: Workspace, deleteFiles: Bool) async throws {
         let workspaceURL = workspace.workspaceURL
+        let sessionKey = try terminalSessionKey(for: workspace)
+        await retireTerminalSessions(sessionKey)
 
         if workspace.backend == .local {
             try await workspaceService.deleteWorkspace(at: workspaceURL, deleteFiles: deleteFiles)
@@ -182,6 +197,9 @@ struct SidebarWorkspaceController {
     }
 
     func archive(_ workspace: Workspace) async throws {
+        let sessionKey = try terminalSessionKey(for: workspace)
+        await retireTerminalSessions(sessionKey)
+
         if workspace.backend == .local {
             try await workspaceService.archiveWorkspace(at: workspace.workspaceURL)
         } else {
@@ -223,6 +241,15 @@ struct SidebarWorkspaceController {
         }
 
         try saveModelContext(action: "save workspace")
+    }
+
+    private func terminalSessionKey(for workspace: Workspace) throws -> HostTerminalSessionKey {
+        let target = WorkspaceProviderTarget(workspace)
+        if workspace.backend == .local {
+            return LocalWorkspaceProvider().sessionKey(for: target)
+        }
+
+        return try provider(for: workspace).sessionKey(for: target)
     }
 
     private func reserveWorkspaceName(

--- a/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import os.log
+
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "LumeWorkspaceProvider")
 
 public struct LumeWorkspaceMetadata: Codable, Sendable, Equatable {
     public let vmName: String
@@ -255,14 +258,18 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
             return finalResult
         } catch {
             if let vmName {
-                try? await deleteVM(
+                await deleteVMBestEffort(
                     named: vmName,
                     storagePath: vmStoragePath,
-                    guestOS: guestOS
+                    guestOS: guestOS,
+                    context: "createWorkspace failure"
                 )
             }
             if let localInfo {
-                try? await WorkspaceDirectoryRemover.remove(at: localInfo.path)
+                await removeLocalWorkspaceBestEffort(
+                    at: localInfo.path,
+                    context: "createWorkspace failure"
+                )
             }
             throw error
         }
@@ -521,7 +528,11 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
             await progressMessage?(
                 "Lume's background service could not provision macOS directly. Retrying with the Lume CLI..."
             )
-            try? await deleteVMWithCLI(named: vmName, storagePath: storagePath)
+            await deleteVMWithCLIBestEffort(
+                named: vmName,
+                storagePath: storagePath,
+                context: "macOS provisioning HTTP fallback"
+            )
             try await createMacOSVMWithCLI(
                 named: vmName,
                 hostProfile: hostProfile,
@@ -663,6 +674,21 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
         )
     }
 
+    private func deleteVMBestEffort(
+        named vmName: String,
+        storagePath: String?,
+        guestOS: WorkspaceGuestOS,
+        context: String
+    ) async {
+        do {
+            try await deleteVM(named: vmName, storagePath: storagePath, guestOS: guestOS)
+        } catch {
+            log.warning(
+                "Failed best-effort Lume VM cleanup after \(context) for \(vmName): \(error.localizedDescription)"
+            )
+        }
+    }
+
     private func stopVMWithCLI(named vmName: String, storagePath: String?) async throws {
         var arguments = ["stop", vmName]
         if let storagePath {
@@ -684,6 +710,26 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
 
         guard result.success else {
             throw WorkspaceProviderError.unavailable("Failed to delete macOS VM '\(vmName)'.")
+        }
+    }
+
+    private func deleteVMWithCLIBestEffort(named vmName: String, storagePath: String?, context: String) async {
+        do {
+            try await deleteVMWithCLI(named: vmName, storagePath: storagePath)
+        } catch {
+            log.warning(
+                "Failed best-effort Lume CLI VM cleanup after \(context) for \(vmName): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func removeLocalWorkspaceBestEffort(at workspaceURL: URL, context: String) async {
+        do {
+            try await WorkspaceDirectoryRemover.remove(at: workspaceURL)
+        } catch {
+            log.warning(
+                "Failed best-effort Lume local workspace cleanup after \(context) at \(workspaceURL.path): \(error.localizedDescription)"
+            )
         }
     }
 

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import os.log
+
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "WorkspaceDirectoryRemover")
 
 enum WorkspaceDirectoryRemover {
     static func remove(at workspaceURL: URL) async throws {
@@ -16,10 +19,28 @@ enum WorkspaceDirectoryRemover {
         }
 
         if isLinkedGitWorktree(at: workspaceURL, fileManager: fileManager) {
-            let branchName = try? await currentBranchName(at: workspaceURL)
-            let commonGitDirectory = try? await commonGitDirectory(at: workspaceURL)
+            let branchName: String?
+            do {
+                branchName = try await currentBranchName(at: workspaceURL)
+            } catch {
+                branchName = nil
+                log.warning(
+                    "Failed to read current branch for workspace cleanup at \(workspaceURL.path): \(error.localizedDescription)"
+                )
+            }
+
+            let commonGitDirectoryURL: URL?
+            do {
+                commonGitDirectoryURL = try await commonGitDirectory(at: workspaceURL)
+            } catch {
+                commonGitDirectoryURL = nil
+                log.warning(
+                    "Failed to read common git directory for workspace cleanup at \(workspaceURL.path): \(error.localizedDescription)"
+                )
+            }
+
             let removalArguments: [String]
-            if let commonGitDirectory {
+            if let commonGitDirectory = commonGitDirectoryURL {
                 removalArguments = [
                     "--git-dir",
                     commonGitDirectory.path,
@@ -44,12 +65,25 @@ enum WorkspaceDirectoryRemover {
 
             if let branchName,
                 branchName.hasPrefix("workspace/"),
-                let commonGitDirectory
+                let commonGitDirectory = commonGitDirectoryURL
             {
-                _ = try? await ProcessRunner.run(
-                    executable: "/usr/bin/git",
-                    arguments: ["--git-dir", commonGitDirectory.path, "branch", "-D", branchName]
-                )
+                let branchDeletionArguments = ["--git-dir", commonGitDirectory.path, "branch", "-D", branchName]
+                do {
+                    let branchDeletionResult = try await ProcessRunner.run(
+                        executable: "/usr/bin/git",
+                        arguments: branchDeletionArguments
+                    )
+                    if !branchDeletionResult.success {
+                        let reason = branchDeletionResult.stderr.isEmpty ? "Unknown error" : branchDeletionResult.stderr
+                        log.warning(
+                            "Failed best-effort workspace branch cleanup for \(branchName) at \(commonGitDirectory.path): \(reason)"
+                        )
+                    }
+                } catch {
+                    log.warning(
+                        "Failed best-effort workspace branch cleanup for \(branchName) at \(commonGitDirectory.path): \(error.localizedDescription)"
+                    )
+                }
             }
         } else {
             try fileManager.removeItem(at: workspaceURL)
@@ -74,7 +108,10 @@ enum WorkspaceDirectoryRemover {
             arguments: ["branch", "--show-current"],
             currentDirectory: workspaceURL
         )
-        guard result.success else { return nil }
+        guard result.success else {
+            let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
+            throw GitError.commandFailed(args: ["branch", "--show-current"], stderr: reason)
+        }
         let branchName = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return branchName.isEmpty ? nil : branchName
     }
@@ -85,17 +122,30 @@ enum WorkspaceDirectoryRemover {
             arguments: ["rev-parse", "--path-format=absolute", "--git-common-dir"],
             currentDirectory: workspaceURL
         )
-        guard result.success else { return nil }
+        guard result.success else {
+            let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
+            throw GitError.commandFailed(
+                args: ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+                stderr: reason
+            )
+        }
         let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return path.isEmpty ? nil : URL(fileURLWithPath: path)
     }
 
     private static func cleanupEmptyParent(of workspaceURL: URL, fileManager: FileManager) {
         let parentDir = workspaceURL.deletingLastPathComponent()
-        if let contents = try? fileManager.contentsOfDirectory(atPath: parentDir.path),
-            contents.isEmpty
-        {
-            try? fileManager.removeItem(at: parentDir)
+        guard fileManager.fileExists(atPath: parentDir.path) else { return }
+
+        do {
+            let contents = try fileManager.contentsOfDirectory(atPath: parentDir.path)
+            if contents.isEmpty {
+                try fileManager.removeItem(at: parentDir)
+            }
+        } catch {
+            log.warning(
+                "Failed best-effort empty parent cleanup at \(parentDir.path): \(error.localizedDescription)"
+            )
         }
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -10,10 +10,23 @@ import os.log
 
 private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "WorkspaceService")
 
+struct WorkspaceCleanupFailure: Sendable, Equatable {
+    let context: String
+    let targetPath: String
+    let errorDescription: String
+}
+
+private let defaultCleanupFailureReporter: @Sendable (WorkspaceCleanupFailure) -> Void = { failure in
+    log.warning(
+        "Failed best-effort workspace cleanup after \(failure.context) at \(failure.targetPath): \(failure.errorDescription)"
+    )
+}
+
 public actor WorkspaceService: WorkspaceServiceProtocol {
     public static let shared = WorkspaceService()
 
     private let materializer: any WorkspaceMaterializer
+    private let cleanupFailureReporter: @Sendable (WorkspaceCleanupFailure) -> Void
 
     // MARK: - Workspace Root Configuration
 
@@ -43,8 +56,12 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
         self.init(materializer: GitWorktreeWorkspaceMaterializer(gitService: gitService))
     }
 
-    init(materializer: any WorkspaceMaterializer) {
+    init(
+        materializer: any WorkspaceMaterializer,
+        cleanupFailureReporter: @escaping @Sendable (WorkspaceCleanupFailure) -> Void = defaultCleanupFailureReporter
+    ) {
         self.materializer = materializer
+        self.cleanupFailureReporter = cleanupFailureReporter
         Self.ensureDefaultWorkspacesRootExists()
     }
 
@@ -105,14 +122,14 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
                 from: repoLocalURL
             )
         } catch {
-            try? await materializer.removeWorkspace(at: workspaceDir)
+            await cleanupMaterializedWorkspace(at: workspaceDir, context: "materialization failure")
             throw WorkspaceError.materializationFailed(
                 operation: materializer.failureOperationDescription,
                 reason: error.localizedDescription
             )
         }
         guard FileManager.default.fileExists(atPath: workspaceDir.path) else {
-            try? await materializer.removeWorkspace(at: workspaceDir)
+            await cleanupMaterializedWorkspace(at: workspaceDir, context: "missing workspace directory")
             throw WorkspaceError.materializationFailed(
                 operation: materializer.failureOperationDescription,
                 reason: "Materializer did not create workspace directory at \(workspaceDir.path)"
@@ -141,8 +158,22 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
                 warnings: warnings
             )
         } catch {
-            try? await materializer.removeWorkspace(at: workspaceDir)
+            await cleanupMaterializedWorkspace(at: workspaceDir, context: "setup lifecycle failure")
             throw error
+        }
+    }
+
+    private func cleanupMaterializedWorkspace(at workspaceURL: URL, context: String) async {
+        do {
+            try await materializer.removeWorkspace(at: workspaceURL)
+        } catch {
+            cleanupFailureReporter(
+                WorkspaceCleanupFailure(
+                    context: context,
+                    targetPath: workspaceURL.path,
+                    errorDescription: error.localizedDescription
+                )
+            )
         }
     }
 

--- a/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
@@ -453,6 +453,46 @@ struct HostTerminalStateStoreTests {
         #expect(commandStatusRegistry.statusByTerminalSession[pre.id] == nil)
     }
 
+    @Test("Retiring a workspace scope removes primary tabs, splits, and registry state")
+    func retiringWorkspaceScopeRemovesSessionsAndRegistryState() throws {
+        let store = HostTerminalStateStore()
+        let defaultHome = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        let workspaceURL = URL(fileURLWithPath: "/Users/test/code/repo/workspaces/feature-a")
+        let firstWorkspaceTab = store.activateSession(
+            key: .hostPath(workspaceURL.path),
+            directory: workspaceURL
+        ).session
+        let secondWorkspaceTab = try #require(store.createTab())
+        let split = try #require(store.ensureSplit(forPrimarySessionID: firstWorkspaceTab.id))
+
+        let registry = AgentSessionRegistry()
+        let commandStatusRegistry = LastCommandStatusRegistry()
+        store.attach(
+            agentSessionRegistry: registry,
+            localStateStore: nil,
+            hooksSocketPath: nil,
+            lastCommandStatusRegistry: commandStatusRegistry
+        )
+        commandStatusRegistry.ingest(markers: [.commandStart], for: firstWorkspaceTab.id, commandLine: "make")
+        commandStatusRegistry.ingest(markers: [.commandStart], for: split.id, commandLine: "claude")
+
+        let retired = store.retireSessions(inScope: .hostPath(workspaceURL.path))
+
+        #expect(Set(retired) == Set([split.id, firstWorkspaceTab.id, secondWorkspaceTab.id]))
+        #expect(store.sessions.map(\.id) == [defaultHome.id])
+        #expect(store.activeSessionID == defaultHome.id)
+        #expect(store.splitSession(for: firstWorkspaceTab.id) == nil)
+        #expect(registry.statuses[firstWorkspaceTab.id] == nil)
+        #expect(registry.statuses[secondWorkspaceTab.id] == nil)
+        #expect(registry.statuses[split.id] == nil)
+        #expect(registry.statuses[defaultHome.id] != nil)
+        #expect(commandStatusRegistry.statusByTerminalSession[firstWorkspaceTab.id] == nil)
+        #expect(commandStatusRegistry.statusByTerminalSession[split.id] == nil)
+    }
+
     @Test("Process exit helper returns active fallback session when others remain")
     func processExitHelperReturnsRemainingActiveSession() throws {
         let store = HostTerminalStateStore()

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -7,6 +7,18 @@ import WorkspaceManagerCore
 
 @Suite("SidebarWorkspaceControllerBehavior")
 struct SidebarWorkspaceControllerBehaviorTests {
+    actor OperationRecorder {
+        private var events: [String] = []
+
+        func record(_ event: String) {
+            events.append(event)
+        }
+
+        func snapshot() -> [String] {
+            events
+        }
+    }
+
     @Test("Local request routes through WorkspaceService")
     @MainActor
     func localRequestRoutesThroughWorkspaceService() async throws {
@@ -327,6 +339,42 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(workspaceService.deleteWorkspaceCalls.first?.deleteFiles == true)
     }
 
+    @Test("Deleting local workspace retires terminal sessions before service cleanup")
+    @MainActor
+    func deletingLocalWorkspaceRetiresTerminalSessionsBeforeServiceCleanup() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: workspaceURL,
+            sourceRepo: repo,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let recorder = OperationRecorder()
+        let workspaceService = MockWorkspaceService()
+        workspaceService.deleteWorkspaceWillRun = {
+            await recorder.record("delete")
+        }
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()],
+            retireTerminalSessions: { key in
+                await recorder.record("retire:\(key.debugDescription)")
+            }
+        )
+
+        try await controller.deleteWorkspace(workspace, deleteFiles: true)
+
+        #expect(await recorder.snapshot() == ["retire:hostPath(\(workspaceURL.path))", "delete"])
+    }
+
     @Test("Deleting remote workspace preserves the record when provider deletion fails")
     @MainActor
     func deletingRemoteWorkspacePreservesRecordWhenProviderDeletionFails() async throws {
@@ -507,6 +555,44 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(workspace.status == .archived)
     }
 
+    @Test("Archiving local workspace retires terminal sessions before service lifecycle")
+    @MainActor
+    func archivingLocalWorkspaceRetiresTerminalSessionsBeforeServiceLifecycle() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: workspaceURL,
+            sourceRepo: repo,
+            status: .active,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let recorder = OperationRecorder()
+        let workspaceService = MockWorkspaceService()
+        workspaceService.archiveWorkspaceWillRun = {
+            await recorder.record("archive")
+        }
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()],
+            retireTerminalSessions: { key in
+                await recorder.record("retire:\(key.debugDescription)")
+            }
+        )
+
+        try await controller.archive(workspace)
+
+        #expect(await recorder.snapshot() == ["retire:hostPath(\(workspaceURL.path))", "archive"])
+        #expect(workspace.status == .archived)
+    }
+
     @Test("Managed lifecycle operations fail closed when remote identifier is missing")
     @MainActor
     func managedLifecycleOperationsFailClosedWhenRemoteIdentifierIsMissing() async throws {
@@ -575,12 +661,14 @@ struct SidebarWorkspaceControllerBehaviorTests {
     private func makeController(
         context: ModelContext,
         workspaceService: MockWorkspaceService,
-        providers: [any WorkspaceProviderProtocol]
+        providers: [any WorkspaceProviderProtocol],
+        retireTerminalSessions: @escaping @MainActor (HostTerminalSessionKey) async -> Void = { _ in }
     ) -> SidebarWorkspaceController {
         SidebarWorkspaceController(
             modelContext: context,
             workspaceService: workspaceService,
-            workspaceProviderRegistry: WorkspaceProviderRegistry(providers: providers)
+            workspaceProviderRegistry: WorkspaceProviderRegistry(providers: providers),
+            retireTerminalSessions: retireTerminalSessions
         )
     }
 
@@ -615,6 +703,8 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
     var archiveWorkspaceCalls: [URL] = []
     var deleteWorkspaceCalls: [(workspaceURL: URL, deleteFiles: Bool)] = []
     var createWorkspaceDelay: @Sendable () async -> Void = {}
+    var archiveWorkspaceWillRun: @Sendable () async -> Void = {}
+    var deleteWorkspaceWillRun: @Sendable () async -> Void = {}
 
     func createWorkspace(
         repoName: String,
@@ -642,10 +732,12 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
     }
 
     func archiveWorkspace(at workspaceURL: URL) async throws {
+        await archiveWorkspaceWillRun()
         archiveWorkspaceCalls.append(workspaceURL)
     }
 
     func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws {
+        await deleteWorkspaceWillRun()
         deleteWorkspaceCalls.append((workspaceURL, deleteFiles))
     }
 

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -24,10 +24,32 @@ struct WorkspaceServiceTests {
         }
     }
 
+    final class CleanupFailureRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var failures: [WorkspaceCleanupFailure] = []
+
+        func record(_ failure: WorkspaceCleanupFailure) {
+            lock.lock()
+            defer { lock.unlock() }
+            failures.append(failure)
+        }
+
+        func snapshot() -> [WorkspaceCleanupFailure] {
+            lock.lock()
+            defer { lock.unlock() }
+            return failures
+        }
+    }
+
+    struct CleanupError: LocalizedError {
+        let errorDescription: String? = "cleanup failed"
+    }
+
     final class RecordingWorkspaceMaterializer: WorkspaceMaterializer, @unchecked Sendable {
         var materializeCalls: [(sanitizedName: String, destination: URL, source: URL)] = []
         var removeCalls: [URL] = []
         var materializeError: Error?
+        var removeError: Error?
         var resultBranch = "workspace/recorded"
         var createsDestination = false
 
@@ -52,6 +74,9 @@ struct WorkspaceServiceTests {
 
         func removeWorkspace(at workspaceURL: URL) async throws {
             removeCalls.append(workspaceURL)
+            if let removeError {
+                throw removeError
+            }
             try? await WorkspaceDirectoryRemover.remove(at: workspaceURL)
         }
     }
@@ -349,6 +374,39 @@ struct WorkspaceServiceTests {
             .appendingPathComponent("test-ws", isDirectory: true)
         #expect(materializer.removeCalls == [workspaceDir])
         #expect(!FileManager.default.fileExists(atPath: workspaceDir.path))
+    }
+
+    @Test("createWorkspace reports failed best-effort materializer cleanup")
+    func createWorkspaceReportsFailedMaterializerCleanup() async throws {
+        let materializer = RecordingWorkspaceMaterializer()
+        materializer.createsDestination = true
+        materializer.materializeError = GitError.commandFailed(args: ["worktree", "add"], stderr: "already exists")
+        materializer.removeError = CleanupError()
+        let cleanupFailures = CleanupFailureRecorder()
+        let service = WorkspaceService(
+            materializer: materializer,
+            cleanupFailureReporter: { failure in
+                cleanupFailures.record(failure)
+            }
+        )
+        let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        await #expect(throws: WorkspaceError.self) {
+            _ = try await service.createWorkspace(repoName: "test-repo", repoLocalURL: repoDir, name: "test-ws")
+        }
+
+        let workspaceDir =
+            wsRoot
+            .appendingPathComponent("test-repo", isDirectory: true)
+            .appendingPathComponent("test-ws", isDirectory: true)
+        let failure = try #require(cleanupFailures.snapshot().first)
+        #expect(materializer.removeCalls == [workspaceDir])
+        #expect(failure.context == "materialization failure")
+        #expect(failure.targetPath == workspaceDir.path)
+        #expect(failure.errorDescription == "cleanup failed")
     }
 
     @Test("createWorkspace throws when directory already exists")


### PR DESCRIPTION
## Summary
- Retire host terminal sessions for a workspace before archive/delete cleanup runs.
- Release retained Ghostty surfaces during session retirement so deleted workspaces do not leave live terminal surfaces behind.
- Log best-effort cleanup failures for workspace materializer cleanup, git worktree metadata cleanup, and Lume VM/local cleanup paths.
- Document the GitHub issue claim workflow in `AGENTS.md`.

Closes #635

## Mergeability
- Surface: desktop / docs
- User-facing behavior changed: Deleting or archiving a workspace now retires its WorkSpaces-owned terminal sessions before provider/filesystem cleanup; no visible UI copy change.
- Non-happy paths considered: Provider identifier lookup still fails closed, provider deletion failures still preserve records, and best-effort cleanup failures are logged instead of swallowed.
- Residual risk or follow-up: GhosttyKit currently exposes request-close/free surface APIs, not a session PID kill API, so this patch retires WorkSpaces-owned host-session state and frees retained surfaces before cleanup.

## Validation
- `./scripts/build-ghosttykit.sh`
- `swift build`
- `swift test` — 879 tests in 139 suites passed from clean worktree at `cb1355e765bad0000216f11bfa9d9031c7c1197c`
- `swift test --disable-sandbox --filter 'HostTerminalStateStoreTests|SidebarWorkspaceControllerBehaviorTests|WorkspaceServiceTests'` — 73 tests in 3 suites passed; used only to capture uploadable transcript because piping plain `swift test` triggers SwiftPM `sandbox-exec` under the Codex sandbox
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`

## Evidence
- ![workspace-deletion-cleanup-current-head](https://evidence.cloudcompute.com/workspaces/pr-644/20260610-031501-workspace-deletion-cleanup-current-head.svg)
