### PR TITLE
Improve managed review timing observability

### DIFF
--- a/.github/workflows/managed-reviewer-broker.yml
+++ b/.github/workflows/managed-reviewer-broker.yml
@@ -35,7 +35,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: managed-reviewer-broker-${{ github.event_name }}-${{ github.event.sha || github.run_id }}-${{ github.event.context || 'none' }}-${{ github.event.state || 'none' }}
+  # Status-triggered broker passes poll the repo-wide ReviewRun queue, not a
+  # single SHA. Coalesce pending status bursts into one loop while still keeping
+  # non-pending status events from canceling an active pending pass.
+  group: managed-reviewer-broker-${{ github.event_name }}-${{ github.repository }}-${{ github.event_name == 'status' && (github.event.context || 'none') || github.ref || github.run_id }}-${{ github.event_name == 'status' && (github.event.state || 'none') || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/assets/operator-index.js
+++ b/docs/assets/operator-index.js
@@ -64,6 +64,8 @@
 
     let currentDocs = [];
     let renderRequestId = 0;
+    let renderTimer = 0;
+    const searchDebounceMs = 120;
 
     function escapeHtml(value) {
       return String(value || "")
@@ -242,6 +244,16 @@
       }
     }
 
+    function renderImmediately() {
+      window.clearTimeout(renderTimer);
+      render();
+    }
+
+    function scheduleRender() {
+      window.clearTimeout(renderTimer);
+      renderTimer = window.setTimeout(render, searchDebounceMs);
+    }
+
     function renderAutocomplete(docs, active) {
       const shouldShow = Boolean(active.q) && docs.length > 0;
       elements.autocomplete.classList.toggle("active", shouldShow);
@@ -354,9 +366,9 @@
 
     elements.routeForm.addEventListener("submit", (event) => {
       event.preventDefault();
-      render();
+      renderImmediately();
     });
-    elements.routeInput.addEventListener("input", render);
+    elements.routeInput.addEventListener("input", scheduleRender);
     elements.routeShowAll.addEventListener("click", clearFilters);
     elements.openAll.addEventListener("click", clearFilters);
     elements.routeGrid.addEventListener("click", handleFilterClick);

--- a/docs/pr-review/review-run-schema.sql
+++ b/docs/pr-review/review-run-schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE managed_pr_review_runs (
   -- started | completed | failed | superseded
   status text NOT NULL,
   session_id text,
+  session_started_at text,
 
   created_at text NOT NULL,
   updated_at text NOT NULL,

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.test.ts
@@ -80,6 +80,7 @@ function runRow(
 		triggerSourceId: string;
 		status: "started" | "completed" | "failed" | "superseded";
 		sessionId: string | null;
+		sessionStartedAt: string | null;
 		createdAt: string;
 		updatedAt: string;
 		error: string | null;
@@ -119,6 +120,9 @@ function runRow(
 		triggerSourceId: "abc8101def456",
 		status,
 		sessionId,
+		sessionStartedAt: sessionId
+			? (overrides.sessionStartedAt ?? overrides.updatedAt ?? now)
+			: null,
 		createdAt: now,
 		updatedAt: now,
 		error: null,

--- a/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
+++ b/web/src/app/api/webhooks/github/pr-reviewer-monitor/route.ts
@@ -69,6 +69,7 @@ interface OperatorRunItem {
 	githubReviewId?: string;
 	state: string;
 	sessionId: string | null;
+	sessionStartedAt: string | null;
 	ageMinutes: number;
 	pickupLatencyMinutes: number | null;
 	executionDurationMinutes: number | null;
@@ -77,6 +78,10 @@ interface OperatorRunItem {
 	createdAt: string;
 	updatedAt: string;
 	detailsUrl: string;
+	coalescedAt?: string;
+	coalescedHeadSha?: string | null;
+	coalescedTriggerKind?: string | null;
+	coalescedTriggerSourceId?: string | null;
 	error?: string;
 }
 
@@ -148,6 +153,7 @@ function operatorRunItem(
 		projectionUpdatedAt: run.projectionUpdatedAt,
 		state: run.state,
 		sessionId: run.sessionId,
+		sessionStartedAt: run.sessionStartedAt,
 		ageMinutes: run.ageMinutes,
 		pickupLatencyMinutes: run.pickupLatencyMinutes,
 		executionDurationMinutes: run.executionDurationMinutes,
@@ -156,6 +162,14 @@ function operatorRunItem(
 		createdAt: run.createdAt,
 		updatedAt: run.updatedAt,
 		detailsUrl: reviewRunDetailsUrl(requestUrl, run.fingerprint),
+		...(run.coalescedAt
+			? {
+					coalescedAt: run.coalescedAt,
+					coalescedHeadSha: run.coalescedHeadSha,
+					coalescedTriggerKind: run.coalescedTriggerKind,
+					coalescedTriggerSourceId: run.coalescedTriggerSourceId,
+				}
+			: {}),
 		...(run.error ? { error: run.error } : {}),
 		...(run.projectionError ? { projectionError: run.projectionError } : {}),
 		...(run.githubReviewId ? { githubReviewId: run.githubReviewId } : {}),

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -73,6 +73,16 @@ export default async function ReviewRunPage({
 					<strong>{run.executionState}</strong>
 				</div>
 				<div>
+					<span>Created</span>
+					<strong>{new Date(run.createdAt).toLocaleString()}</strong>
+				</div>
+				{run.sessionStartedAt && (
+					<div>
+						<span>Session started</span>
+						<strong>{new Date(run.sessionStartedAt).toLocaleString()}</strong>
+					</div>
+				)}
+				<div>
 					<span>Target head</span>
 					<strong>{run.headSha.slice(0, 12)}</strong>
 				</div>
@@ -84,6 +94,16 @@ export default async function ReviewRunPage({
 					<span>Updated</span>
 					<strong>{new Date(run.updatedAt).toLocaleString()}</strong>
 				</div>
+				{run.coalescedAt && (
+					<div>
+						<span>Coalesced trigger</span>
+						<strong>
+							{run.coalescedTriggerKind ?? "trigger"} /{" "}
+							{run.coalescedHeadSha?.slice(0, 12) ?? "same head"} /{" "}
+							{new Date(run.coalescedAt).toLocaleString()}
+						</strong>
+					</div>
+				)}
 				<div>
 					<span>Projection</span>
 					<strong>

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -814,6 +814,7 @@ describe("bucketPrReviewRuns", () => {
 			fingerprint: string;
 			status: "started" | "completed" | "failed" | "superseded";
 			sessionId: string | null;
+			sessionStartedAt?: string | null;
 			createdAt: string;
 			updatedAt: string;
 			error?: string | null;
@@ -840,6 +841,7 @@ describe("bucketPrReviewRuns", () => {
 			nextAction: "",
 			projectionStatus: overrides.projectionStatus ?? ("pending" as const),
 			projectionUpdatedAt: overrides.projectionUpdatedAt ?? overrides.updatedAt,
+			sessionStartedAt: overrides.sessionStartedAt ?? null,
 			...overrides,
 		});
 
@@ -864,6 +866,7 @@ describe("bucketPrReviewRuns", () => {
 					status: "started" as const,
 					sessionId: "sesn_running",
 					createdAt: "2026-05-24T11:35:00.000Z",
+					sessionStartedAt: "2026-05-24T11:40:00.000Z",
 					updatedAt: "2026-05-24T11:40:00.000Z",
 				}),
 				pendingRun({
@@ -871,6 +874,7 @@ describe("bucketPrReviewRuns", () => {
 					status: "started" as const,
 					sessionId: "sesn_slow",
 					createdAt: "2026-05-24T11:00:00.000Z",
+					sessionStartedAt: "2026-05-24T11:20:00.000Z",
 					updatedAt: "2026-05-24T11:20:00.000Z",
 				}),
 				pendingRun({
@@ -966,6 +970,60 @@ describe("bucketPrReviewRuns", () => {
 			ageMinutes: 15,
 			projectionLatencyMinutes: 15,
 			sloBreached: false,
+		});
+	});
+
+	it("does not reset running age when a newer trigger coalesces", async () => {
+		const { bucketPrReviewRuns } = await loadModule();
+		const buckets = bucketPrReviewRuns(
+			[
+				{
+					fingerprint: "fp_coalesced_slow",
+					repoFullName: "fairchild/workspaces",
+					prNumber: 1,
+					headSha: "abc123",
+					triggerKind: "opened",
+					triggerSourceId: "abc123",
+					status: "started" as const,
+					sessionId: "sesn_slow",
+					sessionStartedAt: "2026-05-24T11:05:00.000Z",
+					createdAt: "2026-05-24T11:00:00.000Z",
+					updatedAt: "2026-05-24T11:59:00.000Z",
+					error: null,
+					executionState: "running_session" as const,
+					latestKnownHeadSha: "def456",
+					failureKind: null,
+					failureMessage: null,
+					failureRetryable: null,
+					failedAt: null,
+					nextAction: "",
+					projectionStatus: "pending" as const,
+					projectionUpdatedAt: "2026-05-24T11:00:00.000Z",
+					projectionError: null,
+					githubReviewId: null,
+					coalescedHeadSha: "def456",
+					coalescedTriggerKind: "synchronize",
+					coalescedTriggerSourceId: "def456",
+					coalescedAt: "2026-05-24T11:59:00.000Z",
+				},
+			],
+			{
+				now: new Date("2026-05-24T12:00:00.000Z"),
+				thresholds: {
+					startingTimeoutMinutes: 5,
+					runningTimeoutMinutes: 30,
+					projectionTimeoutMinutes: 30,
+				},
+			},
+		);
+
+		expect(buckets.running).toEqual([]);
+		expect(buckets.runningTooLong[0]).toMatchObject({
+			fingerprint: "fp_coalesced_slow",
+			ageMinutes: 55,
+			pickupLatencyMinutes: 5,
+			executionDurationMinutes: 55,
+			sloBreached: true,
 		});
 	});
 });

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -621,6 +621,7 @@ export async function recordRunStart(
 			trigger_source_id: input.triggerSourceId,
 			reviewer_config_hash: input.reviewerConfigHash,
 			session_id: null,
+			session_started_at: null,
 			status: "started",
 			created_at: now,
 			updated_at: now,
@@ -677,6 +678,7 @@ export async function recordRunStart(
 				trigger_source_id: input.triggerSourceId,
 				reviewer_config_hash: input.reviewerConfigHash,
 				session_id: null,
+				session_started_at: null,
 				status: "started",
 				created_at: now,
 				updated_at: now,
@@ -731,6 +733,7 @@ export async function recordRunStart(
 		.set({
 			status: "started",
 			session_id: null,
+			session_started_at: null,
 			error: null,
 			failure_kind: null,
 			failure_message: null,
@@ -1069,6 +1072,9 @@ async function updateRunLifecycle(
 			: {};
 	const updates = {
 		session_id: input.sessionId,
+		...(input.status === "started"
+			? { session_started_at: input.sessionId ? now : null }
+			: {}),
 		status: input.status,
 		error: sanitizedError,
 		failure_kind: failureKind,
@@ -1233,6 +1239,7 @@ export interface PrReviewRunSummary {
 	triggerSourceId: string;
 	status: PrReviewRunStatus;
 	sessionId: string | null;
+	sessionStartedAt: string | null;
 	createdAt: string;
 	updatedAt: string;
 	error: string | null;
@@ -1268,6 +1275,7 @@ export interface StartedPrReviewRun {
 	triggerKind: string;
 	triggerSourceId: string;
 	sessionId: string;
+	sessionStartedAt: string | null;
 	createdAt: string;
 	updatedAt: string;
 	coalescedHeadSha: string | null;
@@ -1310,6 +1318,7 @@ export interface ActivePrReviewRunSuccessor {
 	triggerKind: string;
 	triggerSourceId: string;
 	sessionId: string | null;
+	sessionStartedAt: string | null;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -1423,6 +1432,7 @@ function mapRunDetails(row: {
 	reviewer_config_hash: string;
 	status: string;
 	session_id: string | null;
+	session_started_at: string | null;
 	created_at: string;
 	updated_at: string;
 	error: string | null;
@@ -1470,6 +1480,7 @@ function mapRunDetails(row: {
 		reviewerConfigHash: row.reviewer_config_hash,
 		status,
 		sessionId: row.session_id,
+		sessionStartedAt: row.session_started_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		error: failureMessage,
@@ -1559,6 +1570,7 @@ export async function getActivePrReviewRunSuccessor(input: {
 			"trigger_kind",
 			"trigger_source_id",
 			"session_id",
+			"session_started_at",
 			"created_at",
 			"updated_at",
 		])
@@ -1576,6 +1588,7 @@ export async function getActivePrReviewRunSuccessor(input: {
 		triggerKind: row.trigger_kind,
 		triggerSourceId: row.trigger_source_id,
 		sessionId: row.session_id,
+		sessionStartedAt: row.session_started_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -1599,6 +1612,7 @@ export async function getNewerCurrentHeadPrReviewRun(input: {
 			"status",
 			"projection_status",
 			"session_id",
+			"session_started_at",
 			"created_at",
 			"updated_at",
 		])
@@ -1619,6 +1633,7 @@ export async function getNewerCurrentHeadPrReviewRun(input: {
 		status,
 		projectionStatus: normalizeProjectionStatus(row.projection_status, status),
 		sessionId: row.session_id,
+		sessionStartedAt: row.session_started_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -1664,6 +1679,7 @@ export async function listRecentPrReviewRuns(input: {
 			"trigger_source_id",
 			"status",
 			"session_id",
+			"session_started_at",
 			"created_at",
 			"updated_at",
 			"error",
@@ -1707,6 +1723,7 @@ export async function listRecentPrReviewRuns(input: {
 			triggerSourceId: row.trigger_source_id,
 			status,
 			sessionId: row.session_id,
+			sessionStartedAt: row.session_started_at,
 			createdAt: row.created_at,
 			updatedAt: row.updated_at,
 			error: sanitizeFailureMessage(row.failure_message ?? row.error),
@@ -1805,16 +1822,18 @@ function runLatencies(
 	| "executionDurationMinutes"
 	| "projectionLatencyMinutes"
 > {
+	const sessionStartedAt =
+		run.sessionStartedAt ?? (run.sessionId ? run.createdAt : null);
 	const pickupLatencyMinutes =
 		run.status !== "started"
 			? null
 			: run.sessionId
-				? elapsedMinutesBetween(run.createdAt, run.updatedAt)
+				? elapsedMinutesBetween(run.createdAt, sessionStartedAt)
 				: elapsedMinutesBetween(run.createdAt, now);
 	const executionDurationMinutes = run.sessionId
 		? run.status === "started"
-			? elapsedMinutesBetween(run.updatedAt, now)
-			: elapsedMinutesBetween(run.createdAt, run.updatedAt)
+			? elapsedMinutesBetween(sessionStartedAt, now)
+			: elapsedMinutesBetween(sessionStartedAt, run.updatedAt)
 		: null;
 	const projectionLatencyMinutes =
 		run.status === "completed" && run.projectionStatus !== "projected"
@@ -1874,7 +1893,7 @@ export function classifyPrReviewRun(
 			state = "starting";
 		}
 	} else {
-		ageSource = run.updatedAt;
+		ageSource = run.sessionStartedAt ?? run.createdAt;
 		const ageMinutes = elapsedMinutes(ageSource, now);
 		if (ageMinutes >= runningTimeoutMinutes) {
 			state = "running_too_long";
@@ -1957,6 +1976,7 @@ function mapBrokerRun(row: {
 	trigger_source_id: string;
 	status: string;
 	session_id: string | null;
+	session_started_at: string | null;
 	github_review_id: string | null;
 	created_at: string;
 	updated_at: string;
@@ -1980,6 +2000,7 @@ function mapBrokerRun(row: {
 		status,
 		projectionStatus: normalizeProjectionStatus(row.projection_status, status),
 		sessionId: row.session_id,
+		sessionStartedAt: row.session_started_at,
 		githubReviewId: row.github_review_id,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -2000,6 +2021,7 @@ const BROKER_RUN_COLUMNS = [
 	"trigger_source_id",
 	"status",
 	"session_id",
+	"session_started_at",
 	"github_review_id",
 	"created_at",
 	"updated_at",
@@ -2080,6 +2102,7 @@ export async function listStartedPrReviewRuns(
 			"trigger_kind",
 			"trigger_source_id",
 			"session_id",
+			"session_started_at",
 			"created_at",
 			"updated_at",
 			"coalesced_head_sha",
@@ -2106,6 +2129,7 @@ export async function listStartedPrReviewRuns(
 			triggerKind: row.trigger_kind,
 			triggerSourceId: row.trigger_source_id,
 			sessionId: row.session_id as string,
+			sessionStartedAt: row.session_started_at,
 			createdAt: row.created_at,
 			updatedAt: row.updated_at,
 			coalescedHeadSha: row.coalesced_head_sha,

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -1361,6 +1361,7 @@ function brokerRunFromDetails(run: PrReviewRunDetails): BrokerPrReviewRun {
 		status: run.status,
 		projectionStatus: run.projectionStatus,
 		sessionId: run.sessionId,
+		sessionStartedAt: run.sessionStartedAt,
 		githubReviewId: run.githubReviewId,
 		createdAt: run.createdAt,
 		updatedAt: run.updatedAt,

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -81,6 +81,7 @@ export interface ManagedPrReviewRunsTable {
 	trigger_source_id: string;
 	reviewer_config_hash: string;
 	session_id: string | null;
+	session_started_at: string | null;
 	status: string;
 	created_at: string;
 	updated_at: string;

--- a/web/src/lib/schema/__tests__/schema.test.ts
+++ b/web/src/lib/schema/__tests__/schema.test.ts
@@ -12,6 +12,11 @@ afterEach(() => {
 	vi.resetModules();
 });
 
+const EXPECTED_MIGRATIONS = [
+	"0001_baseline",
+	"0002_managed_pr_review_run_session_started_at",
+];
+
 // db + schema must come from the same fresh module graph so getTurso() in the
 // test shares the singleton client ensureSchema() bootstraps.
 async function load() {
@@ -49,7 +54,7 @@ describe("ensureSchema", () => {
 		const applied = await getTurso().execute(
 			"SELECT id FROM schema_migrations",
 		);
-		expect(applied.rows.map((r) => String(r.id))).toEqual(["0001_baseline"]);
+		expect(applied.rows.map((r) => String(r.id))).toEqual(EXPECTED_MIGRATIONS);
 	});
 
 	it("re-running the migration runner is a no-op (idempotent skip, no duplicate record)", async () => {
@@ -64,7 +69,7 @@ describe("ensureSchema", () => {
 		const applied = await getTurso().execute(
 			"SELECT id FROM schema_migrations",
 		);
-		expect(applied.rows).toHaveLength(1);
+		expect(applied.rows).toHaveLength(EXPECTED_MIGRATIONS.length);
 	});
 
 	it("tolerates another bootstrap adding a missing column after introspection", async () => {
@@ -103,7 +108,34 @@ describe("ensureSchema", () => {
 		);
 		expect(eventColumns.rows.map((r) => String(r.name))).toContain("payload");
 		const applied = await turso.execute("SELECT id FROM schema_migrations");
-		expect(applied.rows.map((r) => String(r.id))).toEqual(["0001_baseline"]);
+		expect(applied.rows.map((r) => String(r.id))).toEqual(EXPECTED_MIGRATIONS);
+	});
+
+	it("applies the ReviewRun session-start migration after the baseline is already recorded", async () => {
+		const { ensureSchema, getTurso } = await load();
+		const turso = getTurso();
+		await turso.execute(
+			"CREATE TABLE schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL)",
+		);
+		await turso.execute(
+			"INSERT INTO schema_migrations (id, applied_at) VALUES ('0001_baseline', '2026-01-01T00:00:00Z')",
+		);
+		await turso.execute(
+			"CREATE TABLE managed_pr_review_runs (fingerprint TEXT PRIMARY KEY, session_id TEXT)",
+		);
+
+		await expect(ensureSchema()).resolves.toBeUndefined();
+
+		const columns = await turso.execute(
+			'PRAGMA table_info("managed_pr_review_runs")',
+		);
+		expect(columns.rows.map((r) => String(r.name))).toContain(
+			"session_started_at",
+		);
+		const applied = await turso.execute(
+			"SELECT id FROM schema_migrations ORDER BY id",
+		);
+		expect(applied.rows.map((r) => String(r.id))).toEqual(EXPECTED_MIGRATIONS);
 	});
 
 	it("converges an existing database with a narrower schema without losing data", async () => {

--- a/web/src/lib/schema/migrations.ts
+++ b/web/src/lib/schema/migrations.ts
@@ -406,4 +406,16 @@ const baseline: Migration = {
 	},
 };
 
-export const MIGRATIONS: Migration[] = [baseline];
+const managedPrReviewRunSessionStartedAt: Migration = {
+	id: "0002_managed_pr_review_run_session_started_at",
+	async up(db) {
+		await addMissingColumns(db, "managed_pr_review_runs", [
+			{ name: "session_started_at", type: "text" },
+		]);
+	},
+};
+
+export const MIGRATIONS: Migration[] = [
+	baseline,
+	managedPrReviewRunSessionStartedAt,
+];


### PR DESCRIPTION
## Summary

- Add an explicit ReviewRun session_started_at timestamp and append-only schema migration so active execution age is not reset by coalesced triggers.
- Surface session start and coalesced trigger details on the ReviewRun page and monitor JSON.
- Coalesce status-triggered broker workflow bursts by repo/context/state instead of spawning one repo-wide polling loop per PR SHA.
- Debounce local docs operator-index search so rapid typing does not strand the autocomplete behind stale requests.

## Mergeability

- Surface: web / agent-runtime / infra / docs
- User-facing behavior changed: ReviewRun detail pages now show created time, session start time, and coalesced trigger information; local docs search waits briefly during rapid typing before fetching; managed-review behavior is otherwise unchanged.
- Non-happy paths considered: Existing production DBs with 0001 already recorded get a 0002 add-column migration; pre-migration rows fall back conservatively when session_started_at is absent; coalesced active runs keep accurate execution age; docs search form submission still renders immediately.
- Residual risk or follow-up: Existing active runs created before deployment may only have conservative fallback timing until their next transition; no data backfill is required.

## Validation

- [mise -C web run web:check](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)
- [mise -C web exec -- pnpm run test:e2e:docs-local](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)
- [mise -C web exec -- pnpm run docs:check](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)
- [node --check docs/assets/operator-index.js](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)
- [PYTHONPYCACHEPREFIX=/tmp/workspaces-pycache python3 -m py_compile docs/server.py scripts/docs_catalog.py scripts/docs-server-smoke.py](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)
- [git diff --check](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)
- [UV_CACHE_DIR=/tmp/uv-cache-pr-646 uv run --with pytest python -m pytest scripts/tests/test_security_hardening.py scripts/tests/test_pr_reviewer_runs.py](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-034224-validation-summary.svg)

## Performance

- Reduces redundant broker polling during managed-review bursts by allowing one pending-status broker loop per repo/context/state.
- Fixes SLO/reporting accuracy by anchoring active execution duration to session_started_at instead of mutable updated_at.
- Reduces local docs live-search request bursts during rapid typing.

## Evidence

![validation-summary-2](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-035708-validation-summary-2.svg)

![validation-summary](https://evidence.cloudcompute.com/workspaces/pr-646/20260610-034224-validation-summary.svg)

## Blockers

- None.
