### PR TITLE
feat: adopt ProcessRunner timeout: at non-Lume call sites

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -257,7 +257,8 @@ public actor GitService: GitServiceProtocol {
         try await ProcessRunner.run(
             executable: "/usr/bin/git",
             arguments: args,
-            currentDirectory: path
+            currentDirectory: path,
+            timeout: 30
         )
     }
 
@@ -266,7 +267,8 @@ public actor GitService: GitServiceProtocol {
         let result = try await ProcessRunner.run(
             executable: "/usr/bin/git",
             arguments: args,
-            currentDirectory: path
+            currentDirectory: path,
+            timeout: 30
         )
 
         if result.exitCode == 0 {

--- a/Sources/WorkspaceManagerCore/Services/LocalBackend.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalBackend.swift
@@ -79,7 +79,8 @@ public actor LocalBackend {
             executable: executableURL.path,
             arguments: Array(command.dropFirst()),
             currentDirectory: workDir,
-            environment: env
+            environment: env,
+            timeout: 600
         )
     }
 
@@ -98,7 +99,8 @@ public actor LocalBackend {
     private func resolveExecutable(_ name: String) async throws -> String {
         let result = try await ProcessRunner.run(
             executable: "/usr/bin/which",
-            arguments: [name]
+            arguments: [name],
+            timeout: 5
         )
 
         let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
+++ b/Sources/WorkspaceManagerCore/Services/RuntimeDiagnostics.swift
@@ -251,11 +251,13 @@ public struct LiveRuntimeProcessSnapshotProvider: RuntimeProcessSnapshotProvidin
     public func processes() async throws -> [RuntimeProcessSample] {
         async let processOutput = ProcessRunner.run(
             executable: "/bin/ps",
-            arguments: ["-axo", "pid=,ppid=,pcpu=,rss=,time=,comm=,args="]
+            arguments: ["-axo", "pid=,ppid=,pcpu=,rss=,time=,comm=,args="],
+            timeout: 10
         )
         async let cwdOutput = ProcessRunner.run(
             executable: "/usr/sbin/lsof",
-            arguments: ["-d", "cwd", "-F", "pcn"]
+            arguments: ["-d", "cwd", "-F", "pcn"],
+            timeout: 10
         )
 
         let processResult = try await processOutput

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
@@ -55,7 +55,8 @@ enum WorkspaceDirectoryRemover {
             let result = try await ProcessRunner.run(
                 executable: "/usr/bin/git",
                 arguments: removalArguments,
-                currentDirectory: workspaceURL.deletingLastPathComponent()
+                currentDirectory: workspaceURL.deletingLastPathComponent(),
+                timeout: 30
             )
 
             guard result.success else {
@@ -71,7 +72,8 @@ enum WorkspaceDirectoryRemover {
                 do {
                     let branchDeletionResult = try await ProcessRunner.run(
                         executable: "/usr/bin/git",
-                        arguments: branchDeletionArguments
+                        arguments: branchDeletionArguments,
+                        timeout: 30
                     )
                     if !branchDeletionResult.success {
                         let reason = branchDeletionResult.stderr.isEmpty ? "Unknown error" : branchDeletionResult.stderr
@@ -106,7 +108,8 @@ enum WorkspaceDirectoryRemover {
         let result = try await ProcessRunner.run(
             executable: "/usr/bin/git",
             arguments: ["branch", "--show-current"],
-            currentDirectory: workspaceURL
+            currentDirectory: workspaceURL,
+            timeout: 30
         )
         guard result.success else {
             let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
@@ -120,7 +123,8 @@ enum WorkspaceDirectoryRemover {
         let result = try await ProcessRunner.run(
             executable: "/usr/bin/git",
             arguments: ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-            currentDirectory: workspaceURL
+            currentDirectory: workspaceURL,
+            timeout: 30
         )
         guard result.success else {
             let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceMaterializer.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceMaterializer.swift
@@ -85,7 +85,8 @@ struct GitCloneWorkspaceMaterializer: WorkspaceMaterializer {
         let cloneResult = try await ProcessRunner.run(
             executable: "/usr/bin/git",
             arguments: cloneArguments,
-            currentDirectory: sourceRepository.deletingLastPathComponent()
+            currentDirectory: sourceRepository.deletingLastPathComponent(),
+            timeout: 30
         )
         guard cloneResult.success else {
             let reason = cloneResult.stderr.isEmpty ? "Unknown error" : cloneResult.stderr

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -311,7 +311,8 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
             executable: "/bin/bash",
             arguments: [scriptPath.path],
             currentDirectory: directory,
-            environment: env
+            environment: env,
+            timeout: 600
         )
 
         return ScriptResult(


### PR DESCRIPTION
## What

Adopts the `timeout:` parameter introduced in PR #640 at every `ProcessRunner.run` call site where a bounded deadline makes sense. Lume/SSH/Daytona paths are left untimed — they already carry outer deadlines at their respective protocol layers.

| Call site | Timeout | Rationale |
|-----------|---------|-----------|
| `GitService` (2 calls) | 30s | git ops are seconds-scale |
| `WorkspaceDirectoryRemover` (4 calls) | 30s | git worktree/branch ops |
| `WorkspaceMaterializer` (1 call) | 30s | local `--no-hardlinks` clone |
| `WorkspaceService.runScript` | 600s | lifecycle scripts are minutes-scale |
| `LocalBackend.execute` | 600s | same — arbitrary workspace commands |
| `LocalBackend.resolveExecutable` (`which`) | 5s | tool lookup, never slow |
| `RuntimeDiagnostics` ps + lsof | 10s | diagnostic snapshots |
| `SSHBackend`, `DaytonaBackend`, all Lume paths | untimed | outer deadlines already present |

No new tests: the timeout mechanism is covered by `ProcessRunnerTests`. Service-level timeout integration tests would need a `MockProcessRunner` or real hanging processes — that's infrastructure for a follow-up.

## Evidence

✔ Test run with 888 tests in 140 suites passed after 8.923 seconds.

![test-summary](https://evidence.cloudcompute.com/workspaces/pr-999/20260610-040253-timeout-call-sites.png)

## Mergeability

- Surface: core services (ProcessRunner call sites only — no UI, web, or infra changes)
- User-facing behavior changed: No — timeout ceilings are internal; all call sites already surfaced subprocess errors to callers
- Non-happy paths considered: `ProcessRunnerError.timedOut` propagates through git call sites as `GitError`, through lifecycle script sites as thrown errors from `WorkspaceService`/`LocalBackend`; ps/lsof timeout surfaces as `RuntimeDiagnosticsError.commandFailed`
- Residual risk or follow-up: 30s clone ceiling could be tight for unexpectedly large local repos — elevate if reports come in

🤖 Generated with [Claude Code](https://claude.com/claude-code)