### PR TITLE
Dedup and close prod CD failure issues

### DIFF
--- a/.github/workflows/cd-prod-alert.js
+++ b/.github/workflows/cd-prod-alert.js
@@ -1,0 +1,147 @@
+// Owns the production CD issue policy for cd.yml: one open issue per prod
+// surface while failing, and close auto-opened prod issues once prod validates.
+
+import nodeFs from "node:fs";
+
+const prodSurfaceLabel = "cd-failure:prod";
+const marker = `<!-- ${prodSurfaceLabel} -->`;
+const prodUrl = "https://spaces.cloudcompute.com";
+const failureLabels = ["cd-failure", prodSurfaceLabel, "urgent", "auto-opened"];
+
+function runUrl(context) {
+	return `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+}
+
+function openProdIssueParams(context) {
+	return {
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		state: "open",
+		labels: `auto-opened,cd-failure,${prodSurfaceLabel}`,
+		sort: "updated",
+		direction: "desc",
+	};
+}
+
+async function listOpenProdIssues(github, context, perPage = 50) {
+	const found = await github.rest.issues.listForRepo({
+		...openProdIssueParams(context),
+		per_page: perPage,
+	});
+	return found.data;
+}
+
+function readFindings(fs) {
+	return fs.existsSync("findings.md")
+		? fs.readFileSync("findings.md", "utf8")
+		: "_No findings file produced._";
+}
+
+function alertBody(context, env, findings) {
+	return [
+		marker,
+		`**Commit:** ${context.sha}`,
+		`**Run:** ${runUrl(context)}`,
+		`**Prod URL:** ${env.PROD_URL || prodUrl}`,
+		"",
+		"## Findings",
+		findings,
+		"",
+		"## Manual rollback runbook",
+		"",
+		"**Vercel - instant alias swap:**",
+		"```bash",
+		"vercel rollback                    # interactive picker",
+		"# or:",
+		"vercel ls --prod | head -5",
+		"vercel promote <previous-prod-url>",
+		"```",
+		"",
+		"**Workers - re-deploy from previous good SHA:**",
+		"```bash",
+		"git checkout <previous-good-sha>",
+		"cd infra/<worker> && npx wrangler@4 deploy",
+		"git checkout main",
+		"```",
+		"",
+		"## Decide: rollback vs roll forward",
+		"- [ ] Rolled back (note which surfaces): ",
+		"- [ ] Rolling forward (link the fix PR): ",
+		"",
+		"@fairchild",
+	].join("\n");
+}
+
+export async function postProdAlert({
+	github,
+	context,
+	core,
+	env = process.env,
+	fs = nodeFs,
+}) {
+	const findings = readFindings(fs);
+	const body = alertBody(context, env, findings);
+	const existing = (await listOpenProdIssues(github, context, 1))[0];
+
+	if (existing) {
+		await github.rest.issues.addLabels({
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: existing.number,
+			labels: ["urgent"],
+		});
+		await github.rest.issues.createComment({
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: existing.number,
+			body,
+		});
+		core.notice(`Updated prod alert issue #${existing.number}`);
+		return { issueNumber: existing.number, created: false };
+	}
+
+	const shortSha = context.sha.slice(0, 7);
+	const created = await github.rest.issues.create({
+		owner: context.repo.owner,
+		repo: context.repo.repo,
+		title: `Prod regression on ${shortSha}`,
+		body,
+		labels: failureLabels,
+	});
+	core.notice(`Opened prod alert issue #${created.data.number}`);
+	return { issueNumber: created.data.number, created: true };
+}
+
+export async function closeResolvedProdAlerts({ github, context, core }) {
+	const issues = await listOpenProdIssues(github, context);
+	const body = [
+		marker,
+		`Prod validation is green for \`${context.sha}\` in ${runUrl(context)}.`,
+		"",
+		`Closing this auto-opened \`${prodSurfaceLabel}\` issue. The CD auto-opener will update an open surface issue or create a new one if production regresses again.`,
+	].join("\n");
+
+	for (const issue of issues) {
+		await github.rest.issues.createComment({
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: issue.number,
+			body,
+		});
+		await github.rest.issues.update({
+			owner: context.repo.owner,
+			repo: context.repo.repo,
+			issue_number: issue.number,
+			state: "closed",
+			state_reason: "completed",
+		});
+	}
+
+	const numbers = issues.map((issue) => issue.number);
+	core.notice(
+		numbers.length
+			? `Closed resolved prod alert issues: ${numbers.join(", ")}`
+			: "No open prod alert issues to close",
+	);
+	return { closed: numbers };
+}

--- a/.github/workflows/cd-prod-alert.test.js
+++ b/.github/workflows/cd-prod-alert.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { closeResolvedProdAlerts, postProdAlert } from "./cd-prod-alert.js";
+
+function makeContext() {
+	return {
+		serverUrl: "https://github.com",
+		repo: { owner: "fairchild", repo: "workspaces" },
+		runId: 123,
+		sha: "abc1234def5678",
+	};
+}
+
+function makeGithub(searchItems) {
+	const calls = [];
+	return {
+		calls,
+		rest: {
+			issues: {
+				addLabels: async (params) => calls.push(["addLabels", params]),
+				create: async (params) => {
+					calls.push(["create", params]);
+					return { data: { number: 700 } };
+				},
+				createComment: async (params) => calls.push(["createComment", params]),
+				listForRepo: async (params) => {
+					calls.push(["listForRepo", params]);
+					return { data: searchItems };
+				},
+				update: async (params) => calls.push(["update", params]),
+			},
+		},
+	};
+}
+
+const core = { notice() {} };
+const fs = {
+	existsSync: () => true,
+	readFileSync: () => "prod failure details",
+};
+
+test("postProdAlert updates the existing open prod issue", async () => {
+	const github = makeGithub([{ number: 630 }]);
+
+	const result = await postProdAlert({
+		github,
+		context: makeContext(),
+		core,
+		env: { PROD_URL: "https://spaces.cloudcompute.com" },
+		fs,
+	});
+
+	assert.deepEqual(result, { issueNumber: 630, created: false });
+	assert.equal(github.calls.some(([name]) => name === "create"), false);
+	assert.deepEqual(github.calls[0], [
+		"listForRepo",
+		{
+			owner: "fairchild",
+			repo: "workspaces",
+			state: "open",
+			labels: "auto-opened,cd-failure,cd-failure:prod",
+			sort: "updated",
+			direction: "desc",
+			per_page: 1,
+		},
+	]);
+	assert.equal(github.calls[1][0], "addLabels");
+	assert.equal(github.calls[1][1].issue_number, 630);
+	assert.deepEqual(github.calls[1][1].labels, ["urgent"]);
+	assert.equal(github.calls[2][0], "createComment");
+	assert.match(github.calls[2][1].body, /<!-- cd-failure:prod -->/);
+	assert.match(github.calls[2][1].body, /prod failure details/);
+});
+
+test("postProdAlert opens the first prod issue for a failing surface", async () => {
+	const github = makeGithub([]);
+
+	const result = await postProdAlert({
+		github,
+		context: makeContext(),
+		core,
+		env: { PROD_URL: "https://spaces.cloudcompute.com" },
+		fs,
+	});
+
+	assert.deepEqual(result, { issueNumber: 700, created: true });
+	const create = github.calls.find(([name]) => name === "create");
+	assert.deepEqual(create[1].labels, [
+		"cd-failure",
+		"cd-failure:prod",
+		"urgent",
+		"auto-opened",
+	]);
+});
+
+test("closeResolvedProdAlerts comments and closes all open prod issues", async () => {
+	const github = makeGithub([{ number: 630 }, { number: 640 }]);
+
+	const result = await closeResolvedProdAlerts({
+		github,
+		context: makeContext(),
+		core,
+	});
+
+	assert.deepEqual(result, { closed: [630, 640] });
+	const updates = github.calls.filter(([name]) => name === "update");
+	assert.deepEqual(
+		updates.map(([, params]) => ({
+			issue_number: params.issue_number,
+			state: params.state,
+			state_reason: params.state_reason,
+		})),
+		[
+			{ issue_number: 630, state: "closed", state_reason: "completed" },
+			{ issue_number: 640, state: "closed", state_reason: "completed" },
+		],
+	);
+	const comments = github.calls.filter(([name]) => name === "createComment");
+	assert.equal(comments.length, 2);
+	assert.match(comments[0][1].body, /Prod validation is green/);
+});

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -403,6 +403,7 @@ jobs:
     if: failure() && !cancelled() && needs.validate-prod.result == 'failure'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: prod-validate-findings
@@ -412,52 +413,23 @@ jobs:
           PROD_URL: https://spaces.cloudcompute.com
         with:
           script: |
-            const fs = require('fs');
-            const findings = fs.existsSync('findings.md')
-              ? fs.readFileSync('findings.md', 'utf8')
-              : '_No findings file produced._';
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const abs = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/cd-prod-alert.js');
+            const { postProdAlert } = await import(pathToFileURL(abs).href);
+            await postProdAlert({ github, context, core });
 
-            const shortSha = context.sha.slice(0, 7);
-            const title = `🚨 Prod regression on ${shortSha}`;
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            const body = [
-              `**Commit:** ${context.sha}`,
-              `**Run:** ${runUrl}`,
-              `**Prod URL:** ${process.env.PROD_URL}`,
-              '',
-              '## Findings',
-              findings,
-              '',
-              '## Manual rollback runbook',
-              '',
-              '**Vercel — instant alias swap:**',
-              '```bash',
-              'vercel rollback                    # interactive picker',
-              '# or:',
-              'vercel ls --prod | head -5',
-              'vercel promote <previous-prod-url>',
-              '```',
-              '',
-              '**Workers — re-deploy from previous good SHA:**',
-              '```bash',
-              'git checkout <previous-good-sha>',
-              'cd infra/<worker> && npx wrangler@4 deploy',
-              'git checkout main',
-              '```',
-              '',
-              '## Decide: rollback vs roll forward',
-              '- [ ] Rolled back (note which surfaces): ',
-              '- [ ] Rolling forward (link the fix PR): ',
-              '',
-              '@fairchild',
-            ].join('\n');
-
-            const created = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['cd-failure', 'cd-failure:prod', 'urgent', 'auto-opened'],
-            });
-            core.notice(`Opened prod alert issue #${created.data.number}`);
+  resolve-prod-alert:
+    needs: [promote, validate-prod]
+    if: success() && needs.validate-prod.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const abs = path.join(process.env.GITHUB_WORKSPACE, '.github/workflows/cd-prod-alert.js');
+            const { closeResolvedProdAlerts } = await import(pathToFileURL(abs).href);
+            await closeResolvedProdAlerts({ github, context, core });

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -21,7 +21,7 @@ After: every push to `main` produces a preview deployment, gets validated agains
 
 **"Validated artifact ships" invariant.** `vercel promote <preview-url>` re-points the production alias to the existing preview deployment without rebuilding. The bytes you tested are the bytes that go live. This is the single most important property of the design — see [`backlog/`](../../backlog/) for the analysis of Deploy Hooks vs. CLI promote.
 
-**Rolling failure issues, not per-failure issues.** One issue per validator (`CD: playwright failures on main`, `CD: lighthouse failures on main`), identified by hidden HTML markers. New failures append a comment; the issue auto-reopens if closed. Avoids issue-tracker flooding during a regression burst.
+**Rolling failure issues, not per-failure issues.** One issue per validator (`CD: playwright failures on main`, `CD: lighthouse failures on main`), identified by hidden HTML markers. New failures append a comment; the issue auto-reopens if closed. Production validation uses one open `cd-failure:prod` issue for the prod surface, and the next green prod validation comments on and closes open auto-opened prod failure issues. Avoids issue-tracker flooding during a regression burst.
 
 **Configuration as code.** The Vercel Git auto-deploy guard lives in `web/vercel.json` (`git.deploymentEnabled = false`), not in dashboard settings. Vercel stays connected for metadata, while GitHub Actions owns PR previews and production promotion.
 
@@ -72,7 +72,8 @@ After: every push to `main` produces a preview deployment, gets validated agains
 
 | File | What it does |
 |---|---|
-| `.github/workflows/cd.yml` | The 7-job CD pipeline: preview-web, preview-workers, playwright-validate, lighthouse, promote, fail-notify-{playwright,lighthouse}. |
+| `.github/workflows/cd.yml` | The CD pipeline: preview-web, preview-workers, validation, promotion, failure notification, and prod alert resolution. |
+| `.github/workflows/cd-prod-alert.js` | Shared prod alert issue policy: dedup failed prod validation into one open issue and close auto-opened prod issues after green validation. |
 | `.github/workflows/web-preview.yml` | Path-filtered PR preview deployment for `web/**`, with a single updated PR comment. |
 | `scripts/cd/bootstrap-preview.py` | Interactive setup wizard for first-time configuration. Prompts for tokens, writes secrets to GitHub + Cloudflare, generates `web/vercel.json`. |
 | `scripts/cd/config.toml` | Declarative manifest. Workers, preview health URLs, secret names, GitHub Actions secrets. **Add a worker = one TOML block.** |
@@ -129,7 +130,7 @@ What still requires you (no API exists for these):
 
 **`--only STEP`** runs a single phase (`prereq | vercel | cloudflare | github | validate`). Useful when one step fails and you want to retry just that one.
 
-**Failure issue dedup.** Failures from the same validator update one rolling issue rather than spamming. Close the issue when you've handled it; the next failure reopens it.
+**Failure issue dedup.** Failures from the same validator update one rolling issue rather than spamming. Prod failures update the newest open `auto-opened` + `cd-failure:prod` issue instead of opening a new urgent issue. Close the issue when you've handled it; the next failure reopens or recreates the surface issue.
 
 **Workflow trigger.** `cd.yml` runs on `push: branches: [main]` and `workflow_dispatch:` (so you can dispatch test runs from the Actions tab without merging).
 


### PR DESCRIPTION
*Codex*

## Summary
- Factor prod CD alert issue handling into `.github/workflows/cd-prod-alert.js`.
- Dedup repeat prod validation failures into the newest open `auto-opened` + `cd-failure:prod` issue instead of opening another urgent issue.
- Add `resolve-prod-alert` so green `validate-prod` runs comment on and close open auto-opened prod failure issues for the prod surface.
- Document the prod dedup/green-close policy in `scripts/cd/README.md`.

## Mergeability
- Surface: CD workflow automation and documentation
- User-facing behavior changed: No app UI change. Operational behavior changes so prod CD failures dedup into one open issue and green prod validation closes prior auto-opened prod failure issues.
- Non-happy paths considered: Missing findings files still render fallback text; repeated failures update the existing prod issue; multiple stale prod issues are all closed on the next green validation.
- Residual risk or follow-up: The new policy depends on `auto-opened`, `cd-failure`, and `cd-failure:prod` labels remaining the ownership/surface markers.

## Verification
- [Evidence: local command output](https://evidence.cloudcompute.com/workspaces/pr-649/20260610-040740-cd-prod-alert-policy.svg)
- `node --test .github/workflows/cd-prod-alert.test.js`
- `node --check .github/workflows/cd-prod-alert.js`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/cd.yml")'`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`
- `uv run python -m unittest scripts.tests.test_security_hardening` fails on existing mise expectation mismatch: test expects `MISE_EXPECTED_VERSION="v2026.6.0"`, checked-in `scripts/verify-mise-security.sh` has `v2026.6.1`.

Closes #557

<!-- contributor:issue=557;agent=codex -->