### PR TITLE
Reconcile orphaned workspace resources on startup

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -57,6 +57,10 @@ struct ContentView: View {
     @State private var landingErrorMessage: String?
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
     @State private var didScheduleInitialWorkspaceStatusSync = false
+    @State private var workspaceOrphanItems: [WorkspaceOrphanItem] = []
+    @State private var dismissedWorkspaceOrphanItemIDs: Set<String> = []
+    @State private var cleaningWorkspaceOrphanItemIDs: Set<String> = []
+    @State private var pendingWorkspaceOrphanCleanup: WorkspaceOrphanItem?
     @State private var accessRecorder = MainWindowAccessRecorder()
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
     @StateObject private var webSurfaceStore = WebSurfaceStore()
@@ -118,6 +122,10 @@ struct ContentView: View {
             workspaceIDs: repos.flatMap(\.workspaces).map(\.id),
             webSourceIDs: webSources.map(\.id)
         )
+    }
+
+    private var visibleWorkspaceOrphanItems: [WorkspaceOrphanItem] {
+        workspaceOrphanItems.filter { !dismissedWorkspaceOrphanItemIDs.contains($0.id) }
     }
 
     private var normalizedRepoPathSnapshot: Set<String> {
@@ -531,6 +539,20 @@ struct ContentView: View {
             if modelStoreStatusController.shouldShowDegradedWarning {
                 ModelStoreDegradedBanner()
             }
+            if !visibleWorkspaceOrphanItems.isEmpty {
+                WorkspaceOrphanReconciliationBanner(
+                    items: visibleWorkspaceOrphanItems,
+                    cleaningItemIDs: cleaningWorkspaceOrphanItemIDs,
+                    onClean: { item in
+                        pendingWorkspaceOrphanCleanup = item
+                    },
+                    onDismiss: {
+                        dismissedWorkspaceOrphanItemIDs.formUnion(
+                            visibleWorkspaceOrphanItems.map(\.id)
+                        )
+                    }
+                )
+            }
             baseSplitView
         }
         .background(
@@ -667,6 +689,26 @@ struct ContentView: View {
                 Button("OK", role: .cancel) { viewState.workspaceOperationErrorMessage = nil }
             } message: {
                 Text(viewState.workspaceOperationErrorMessage ?? "Unknown error.")
+            }
+            .alert(
+                workspaceOrphanCleanupTitle(for: pendingWorkspaceOrphanCleanup),
+                isPresented: Binding(
+                    get: { pendingWorkspaceOrphanCleanup != nil },
+                    set: { if !$0 { pendingWorkspaceOrphanCleanup = nil } }
+                )
+            ) {
+                Button("Clean", role: .destructive) {
+                    guard let item = pendingWorkspaceOrphanCleanup else { return }
+                    pendingWorkspaceOrphanCleanup = nil
+                    Task { @MainActor in
+                        await cleanWorkspaceOrphan(item)
+                    }
+                }
+                Button("Cancel", role: .cancel) {
+                    pendingWorkspaceOrphanCleanup = nil
+                }
+            } message: {
+                Text(workspaceOrphanCleanupMessage(for: pendingWorkspaceOrphanCleanup))
             }
             .alert(
                 "Could Not Complete Provider Setup",
@@ -1756,6 +1798,7 @@ struct ContentView: View {
         guard !Task.isCancelled else { return }
 
         await syncWorkspaceStatuses(trigger: "launch_deferred")
+        await refreshWorkspaceOrphans(trigger: "launch_deferred")
     }
 
     @MainActor
@@ -1837,6 +1880,145 @@ struct ContentView: View {
             changedCount,
             hadFailure ? "partial_failure" : "success"
         )
+    }
+
+    @MainActor
+    private func refreshWorkspaceOrphans(trigger: String) async {
+        let scanStartedAt = Date()
+        let snapshots = workspaceOrphanRepositorySnapshots()
+        let workspacesRoot = await workspaceService.workspacesRoot
+        let lumeWorkspaceStorageURL = await LumeValidatedBaseService.shared.workspaceVMStorageDirectoryURL
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: lumeWorkspaceStorageURL
+        )
+
+        let result = await reconciler.scan(repositories: snapshots)
+        workspaceOrphanItems = result.items
+        let currentIDs = Set(result.items.map(\.id))
+        dismissedWorkspaceOrphanItemIDs = dismissedWorkspaceOrphanItemIDs.intersection(currentIDs)
+
+        NSLog(
+            "[Perf] metric=workspace_orphan_scan duration_ms=%.2f trigger=%@ repo_count=%ld item_count=%ld",
+            Date().timeIntervalSince(scanStartedAt) * 1000,
+            trigger,
+            snapshots.count,
+            result.items.count
+        )
+    }
+
+    @MainActor
+    private func workspaceOrphanRepositorySnapshots() -> [WorkspaceOrphanRepositorySnapshot] {
+        repos.map { repo in
+            WorkspaceOrphanRepositorySnapshot(
+                id: repo.id,
+                name: repo.name,
+                localPath: repo.localPath,
+                workspaces: repo.workspaces.map { workspace in
+                    WorkspaceOrphanWorkspaceSnapshot(
+                        id: workspace.id,
+                        name: workspace.name,
+                        path: workspace.path,
+                        gitBranch: workspace.gitBranch,
+                        backendIdentifier: workspace.backendIdentifier,
+                        remoteId: workspace.remoteId,
+                        backendMetadataRaw: workspace.backendMetadataRaw,
+                        usesHostWorkspaceFiles: workspace.usesHostWorkspaceFiles
+                    )
+                }
+            )
+        }
+    }
+
+    @MainActor
+    private func cleanWorkspaceOrphan(_ item: WorkspaceOrphanItem) async {
+        guard !cleaningWorkspaceOrphanItemIDs.contains(item.id) else { return }
+        cleaningWorkspaceOrphanItemIDs.insert(item.id)
+        defer {
+            cleaningWorkspaceOrphanItemIDs.remove(item.id)
+        }
+
+        let workspacesRoot = await workspaceService.workspacesRoot
+        let lumeWorkspaceStorageURL = await LumeValidatedBaseService.shared.workspaceVMStorageDirectoryURL
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: lumeWorkspaceStorageURL
+        )
+
+        do {
+            switch item.kind {
+            case .gitWorktreeWithoutRecord:
+                try await reconciler.cleanupGitWorktree(item)
+            case .workspaceRecordMissingDirectory:
+                if item.hasPrunableGitMetadata {
+                    try await reconciler.cleanupGitWorktree(item)
+                }
+                try deleteWorkspaceRecord(for: item)
+            case .lumeVMWithoutWorkspace:
+                try await cleanupLumeVMOrphan(item)
+            }
+
+            workspaceOrphanItems.removeAll { $0.id == item.id }
+            dismissedWorkspaceOrphanItemIDs.remove(item.id)
+            await refreshWorkspaceOrphans(trigger: "cleanup")
+        } catch {
+            viewState.workspaceOperationErrorMessage =
+                "Could not clean '\(item.resourceName)': \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func deleteWorkspaceRecord(for item: WorkspaceOrphanItem) throws {
+        guard let workspaceID = item.workspaceID,
+            let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == workspaceID })
+        else {
+            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
+        }
+
+        modelContext.delete(workspace)
+        do {
+            try modelContext.save()
+        } catch {
+            modelContext.rollback()
+            throw error
+        }
+    }
+
+    @MainActor
+    private func cleanupLumeVMOrphan(_ item: WorkspaceOrphanItem) async throws {
+        guard let target = item.lumeCleanupTarget(),
+            let provider = workspaceProviderRegistry.provider(for: LumeWorkspaceProvider.identifier)
+        else {
+            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
+        }
+
+        try await provider.deleteWorkspace(target)
+    }
+
+    private func workspaceOrphanCleanupTitle(for item: WorkspaceOrphanItem?) -> String {
+        guard let item else { return "Clean Workspace Leftover?" }
+        switch item.kind {
+        case .gitWorktreeWithoutRecord:
+            return "Remove Orphaned Worktree?"
+        case .workspaceRecordMissingDirectory:
+            return "Remove Missing Workspace Record?"
+        case .lumeVMWithoutWorkspace:
+            return "Delete Orphaned Lume VM?"
+        }
+    }
+
+    private func workspaceOrphanCleanupMessage(for item: WorkspaceOrphanItem?) -> String {
+        guard let item else { return "" }
+        switch item.kind {
+        case .gitWorktreeWithoutRecord:
+            return
+                "This removes the git worktree '\(item.resourceName)' and its workspace branch when it is a workspace-owned branch."
+        case .workspaceRecordMissingDirectory:
+            return
+                "This removes the workspace record for '\(item.resourceName)'. No workspace directory exists at its saved path."
+        case .lumeVMWithoutWorkspace:
+            return "This deletes the Lume VM '\(item.resourceName)' from workspace VM storage."
+        }
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceOrphanReconciliationBanner.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceOrphanReconciliationBanner.swift
@@ -1,0 +1,162 @@
+//
+//  WorkspaceOrphanReconciliationBanner.swift
+//  WorkspaceManager
+//
+//  Quiet main-window affordance for confirmed cleanup of workspace resources
+//  that no longer match persisted workspace records.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+struct WorkspaceOrphanReconciliationBanner: View {
+    let items: [WorkspaceOrphanItem]
+    let cleaningItemIDs: Set<String>
+    let onClean: (WorkspaceOrphanItem) -> Void
+    let onDismiss: () -> Void
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        isExpanded.toggle()
+                    }
+                } label: {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .help(isExpanded ? "Hide Cleanup Items" : "Show Cleanup Items")
+
+                Image(systemName: "wrench.and.screwdriver")
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Workspace cleanup available")
+                        .font(.callout.weight(.semibold))
+                    Text(summaryText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        isExpanded = true
+                    }
+                } label: {
+                    Label("Review", systemImage: "list.bullet")
+                }
+                .buttonStyle(.bordered)
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .help("Dismiss Workspace Cleanup")
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+
+            if isExpanded {
+                Divider()
+                VStack(spacing: 0) {
+                    ForEach(items) { item in
+                        cleanupRow(for: item)
+                        if item.id != items.last?.id {
+                            Divider()
+                                .padding(.leading, 42)
+                        }
+                    }
+                }
+            }
+        }
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.72))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityIdentifier("workspace-orphan-reconciliation.banner")
+    }
+
+    private var summaryText: String {
+        let count = items.count
+        return "\(count) leftover \(count == 1 ? "item" : "items") found. Nothing will be deleted without confirmation."
+    }
+
+    private func cleanupRow(for item: WorkspaceOrphanItem) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: iconName(for: item.kind))
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(rowTitle(for: item))
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                if let detail = rowDetail(for: item) {
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer()
+
+            Button {
+                onClean(item)
+            } label: {
+                if cleaningItemIDs.contains(item.id) {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label("Clean", systemImage: "trash")
+                }
+            }
+            .buttonStyle(.bordered)
+            .disabled(cleaningItemIDs.contains(item.id))
+            .help("Clean \(item.resourceName)")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .accessibilityIdentifier("workspace-orphan-reconciliation.item.\(item.id)")
+    }
+
+    private func iconName(for kind: WorkspaceOrphanKind) -> String {
+        switch kind {
+        case .gitWorktreeWithoutRecord:
+            return "arrow.triangle.branch"
+        case .workspaceRecordMissingDirectory:
+            return "folder.badge.questionmark"
+        case .lumeVMWithoutWorkspace:
+            return "desktopcomputer"
+        }
+    }
+
+    private func rowTitle(for item: WorkspaceOrphanItem) -> String {
+        switch item.kind {
+        case .gitWorktreeWithoutRecord:
+            return "\(item.resourceName) has no workspace record"
+        case .workspaceRecordMissingDirectory:
+            return "\(item.resourceName) is missing its directory"
+        case .lumeVMWithoutWorkspace:
+            return "\(item.resourceName) has no workspace"
+        }
+    }
+
+    private func rowDetail(for item: WorkspaceOrphanItem) -> String? {
+        switch item.kind {
+        case .gitWorktreeWithoutRecord, .workspaceRecordMissingDirectory:
+            return item.path
+        case .lumeVMWithoutWorkspace:
+            return item.storagePath
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceOrphanReconciler.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceOrphanReconciler.swift
@@ -1,0 +1,587 @@
+//
+//  WorkspaceOrphanReconciler.swift
+//  WorkspaceManagerCore
+//
+//  Detects leftover workspace resources whose persisted records and host
+//  resources have drifted apart after interrupted creation or cleanup.
+//
+
+import Foundation
+import os.log
+
+private let workspaceOrphanLog = Logger(
+    subsystem: "com.cloudcompute.workspaces",
+    category: "WorkspaceOrphanReconciler"
+)
+
+public enum WorkspaceOrphanKind: String, Sendable, Codable {
+    case gitWorktreeWithoutRecord
+    case workspaceRecordMissingDirectory
+    case lumeVMWithoutWorkspace
+}
+
+public struct WorkspaceOrphanWorkspaceSnapshot: Sendable, Equatable {
+    public let id: UUID
+    public let name: String
+    public let path: String
+    public let gitBranch: String?
+    public let backendIdentifier: String
+    public let remoteId: String?
+    public let backendMetadataRaw: String
+    public let usesHostWorkspaceFiles: Bool
+
+    public init(
+        id: UUID,
+        name: String,
+        path: String,
+        gitBranch: String?,
+        backendIdentifier: String,
+        remoteId: String?,
+        backendMetadataRaw: String,
+        usesHostWorkspaceFiles: Bool
+    ) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.gitBranch = gitBranch
+        self.backendIdentifier = backendIdentifier
+        self.remoteId = remoteId
+        self.backendMetadataRaw = backendMetadataRaw
+        self.usesHostWorkspaceFiles = usesHostWorkspaceFiles
+    }
+}
+
+public struct WorkspaceOrphanRepositorySnapshot: Sendable, Equatable {
+    public let id: UUID
+    public let name: String
+    public let localPath: String
+    public let workspaces: [WorkspaceOrphanWorkspaceSnapshot]
+
+    public init(
+        id: UUID,
+        name: String,
+        localPath: String,
+        workspaces: [WorkspaceOrphanWorkspaceSnapshot]
+    ) {
+        self.id = id
+        self.name = name
+        self.localPath = localPath
+        self.workspaces = workspaces
+    }
+
+    public var localURL: URL {
+        URL(fileURLWithPath: localPath, isDirectory: true)
+    }
+}
+
+public struct WorkspaceOrphanItem: Identifiable, Sendable, Equatable, Hashable {
+    public let id: String
+    public let kind: WorkspaceOrphanKind
+    public let repoID: UUID?
+    public let repoName: String?
+    public let repoLocalPath: String?
+    public let workspaceID: UUID?
+    public let workspaceName: String?
+    public let resourceName: String
+    public let path: String?
+    public let storagePath: String?
+    public let gitBranch: String?
+    public let hasPrunableGitMetadata: Bool
+
+    public var pathURL: URL? {
+        path.map { URL(fileURLWithPath: $0) }
+    }
+
+    public var repoLocalURL: URL? {
+        repoLocalPath.map { URL(fileURLWithPath: $0, isDirectory: true) }
+    }
+
+    public func lumeCleanupTarget() -> WorkspaceProviderTarget? {
+        guard kind == .lumeVMWithoutWorkspace,
+            let storagePath
+        else { return nil }
+
+        let metadata = LumeWorkspaceMetadata(
+            vmName: resourceName,
+            storagePath: storagePath,
+            guestOS: .linux,
+            sharedHostPath: ""
+        )
+        guard let data = try? JSONEncoder().encode(metadata),
+            let rawMetadata = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        return WorkspaceProviderTarget(
+            id: UUID(),
+            name: resourceName,
+            path: Workspace.remotePathSentinel,
+            gitBranch: nil,
+            status: .archived,
+            backendIdentifier: LumeWorkspaceProvider.identifier,
+            remoteId: resourceName,
+            sessionRoutingID: nil,
+            backendMetadataRaw: rawMetadata
+        )
+    }
+
+    static func gitWorktreeWithoutRecord(
+        repo: WorkspaceOrphanRepositorySnapshot,
+        entry: GitWorktreeEntry
+    ) -> WorkspaceOrphanItem {
+        let normalizedPath = normalizePath(entry.path)
+        return WorkspaceOrphanItem(
+            id: "git:\(repo.id.uuidString):\(normalizedPath)",
+            kind: .gitWorktreeWithoutRecord,
+            repoID: repo.id,
+            repoName: repo.name,
+            repoLocalPath: repo.localPath,
+            workspaceID: nil,
+            workspaceName: nil,
+            resourceName: URL(fileURLWithPath: normalizedPath).lastPathComponent,
+            path: normalizedPath,
+            storagePath: nil,
+            gitBranch: entry.branch,
+            hasPrunableGitMetadata: entry.isPrunable
+        )
+    }
+
+    static func workspaceRecordMissingDirectory(
+        repo: WorkspaceOrphanRepositorySnapshot,
+        workspace: WorkspaceOrphanWorkspaceSnapshot,
+        prunableEntry: GitWorktreeEntry?
+    ) -> WorkspaceOrphanItem {
+        let normalizedPath = normalizePath(workspace.path)
+        return WorkspaceOrphanItem(
+            id: "record:\(workspace.id.uuidString):\(normalizedPath)",
+            kind: .workspaceRecordMissingDirectory,
+            repoID: repo.id,
+            repoName: repo.name,
+            repoLocalPath: repo.localPath,
+            workspaceID: workspace.id,
+            workspaceName: workspace.name,
+            resourceName: workspace.name,
+            path: normalizedPath,
+            storagePath: nil,
+            gitBranch: prunableEntry?.branch ?? workspace.gitBranch,
+            hasPrunableGitMetadata: prunableEntry != nil
+        )
+    }
+
+    static func lumeVMWithoutWorkspace(
+        vmName: String,
+        vmDirectory: URL,
+        storageURL: URL
+    ) -> WorkspaceOrphanItem {
+        let normalizedPath = normalizePath(vmDirectory.path)
+        return WorkspaceOrphanItem(
+            id: "lume:\(normalizePath(storageURL.path)):\(vmName)",
+            kind: .lumeVMWithoutWorkspace,
+            repoID: nil,
+            repoName: nil,
+            repoLocalPath: nil,
+            workspaceID: nil,
+            workspaceName: nil,
+            resourceName: vmName,
+            path: normalizedPath,
+            storagePath: normalizePath(storageURL.path),
+            gitBranch: nil,
+            hasPrunableGitMetadata: false
+        )
+    }
+}
+
+public struct WorkspaceOrphanScanResult: Sendable, Equatable {
+    public let items: [WorkspaceOrphanItem]
+
+    public init(items: [WorkspaceOrphanItem]) {
+        self.items = items
+    }
+}
+
+public enum WorkspaceOrphanReconciliationError: LocalizedError, Equatable {
+    case unsupportedCleanupItem
+    case gitCommandFailed(args: [String], stderr: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedCleanupItem:
+            return "This cleanup item does not contain enough information to clean safely."
+        case .gitCommandFailed(let args, let stderr):
+            return "git \(args.joined(separator: " ")) failed: \(stderr)"
+        }
+    }
+}
+
+public struct WorkspaceOrphanReconciler: Sendable {
+    private let workspacesRoot: URL
+    private let lumeWorkspaceStorageURL: URL?
+    private let worktreeLister: any WorkspaceOrphanWorktreeListing
+    private let fileSystem: any WorkspaceOrphanFileSystem
+
+    public init(
+        workspacesRoot: URL,
+        lumeWorkspaceStorageURL: URL?
+    ) {
+        self.init(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: lumeWorkspaceStorageURL,
+            worktreeLister: GitPorcelainWorktreeLister(),
+            fileSystem: DefaultWorkspaceOrphanFileSystem()
+        )
+    }
+
+    init(
+        workspacesRoot: URL,
+        lumeWorkspaceStorageURL: URL?,
+        worktreeLister: any WorkspaceOrphanWorktreeListing,
+        fileSystem: any WorkspaceOrphanFileSystem
+    ) {
+        self.workspacesRoot = workspacesRoot
+        self.lumeWorkspaceStorageURL = lumeWorkspaceStorageURL
+        self.worktreeLister = worktreeLister
+        self.fileSystem = fileSystem
+    }
+
+    public func scan(
+        repositories: [WorkspaceOrphanRepositorySnapshot]
+    ) async -> WorkspaceOrphanScanResult {
+        var items: [WorkspaceOrphanItem] = []
+
+        for repository in repositories {
+            do {
+                items.append(contentsOf: try await scan(repository: repository))
+            } catch {
+                workspaceOrphanLog.warning(
+                    "Failed to scan workspace orphans for \(repository.name): \(error.localizedDescription)"
+                )
+            }
+        }
+
+        do {
+            items.append(contentsOf: try scanLumeVMs(repositories: repositories))
+        } catch {
+            workspaceOrphanLog.warning(
+                "Failed to scan Lume workspace VM orphans: \(error.localizedDescription)"
+            )
+        }
+
+        return WorkspaceOrphanScanResult(
+            items: items.sorted { lhs, rhs in
+                if lhs.kind.rawValue != rhs.kind.rawValue {
+                    return lhs.kind.rawValue < rhs.kind.rawValue
+                }
+                return lhs.resourceName.localizedCaseInsensitiveCompare(rhs.resourceName) == .orderedAscending
+            }
+        )
+    }
+
+    public func cleanupGitWorktree(_ item: WorkspaceOrphanItem) async throws {
+        guard let path = item.path,
+            let repoLocalURL = item.repoLocalURL,
+            item.kind == .gitWorktreeWithoutRecord || item.hasPrunableGitMetadata
+        else {
+            throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
+        }
+
+        let arguments = ["worktree", "remove", "--force", path]
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: arguments,
+            currentDirectory: repoLocalURL
+        )
+        guard result.success else {
+            let reason = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw WorkspaceOrphanReconciliationError.gitCommandFailed(
+                args: arguments,
+                stderr: reason.isEmpty ? "Unknown error" : reason
+            )
+        }
+
+        if let branch = item.gitBranch, branch.hasPrefix("workspace/") {
+            await deleteWorkspaceBranchBestEffort(branch, at: repoLocalURL)
+        }
+
+        cleanupEmptyParent(of: URL(fileURLWithPath: path))
+    }
+
+    private func scan(
+        repository: WorkspaceOrphanRepositorySnapshot
+    ) async throws -> [WorkspaceOrphanItem] {
+        let entries = try await worktreeLister.worktrees(for: repository.localURL)
+        let workspaceRoot = workspacesRoot.appendingPathComponent(repository.name, isDirectory: true)
+        let normalizedWorkspaceRoot = normalizePath(workspaceRoot.path)
+        let relevantEntries = entries.filter {
+            isPath(normalizePath($0.path), inside: normalizedWorkspaceRoot)
+        }
+
+        let liveEntries = relevantEntries.filter { !$0.isPrunable }
+        let prunableEntries = relevantEntries.filter(\.isPrunable)
+        let liveEntriesByPath = Dictionary(grouping: liveEntries) { normalizePath($0.path) }
+        let prunableEntriesByPath = Dictionary(grouping: prunableEntries) { normalizePath($0.path) }
+        let liveWorktreePaths = Set(liveEntriesByPath.keys)
+
+        let workspaceRecords = repository.workspaces.filter(\.usesHostWorkspaceFiles)
+        let recordedPaths = Set(workspaceRecords.map { normalizePath($0.path) })
+
+        var items: [WorkspaceOrphanItem] = []
+        for entry in liveEntries where !recordedPaths.contains(normalizePath(entry.path)) {
+            items.append(.gitWorktreeWithoutRecord(repo: repository, entry: entry))
+        }
+        for entry in prunableEntries where !recordedPaths.contains(normalizePath(entry.path)) {
+            items.append(.gitWorktreeWithoutRecord(repo: repository, entry: entry))
+        }
+
+        let canSkipDirectoryChecks =
+            liveWorktreePaths == recordedPaths
+            && prunableEntriesByPath.isEmpty
+        guard !canSkipDirectoryChecks else {
+            return items
+        }
+
+        for workspace in workspaceRecords {
+            let normalizedPath = normalizePath(workspace.path)
+            guard !fileSystem.directoryExists(at: URL(fileURLWithPath: normalizedPath, isDirectory: true)) else {
+                continue
+            }
+
+            items.append(
+                .workspaceRecordMissingDirectory(
+                    repo: repository,
+                    workspace: workspace,
+                    prunableEntry: prunableEntriesByPath[normalizedPath]?.first
+                )
+            )
+        }
+
+        return items
+    }
+
+    private func scanLumeVMs(
+        repositories: [WorkspaceOrphanRepositorySnapshot]
+    ) throws -> [WorkspaceOrphanItem] {
+        guard let storageURL = lumeWorkspaceStorageURL else { return [] }
+
+        let storagePath = normalizePath(storageURL.path)
+        let recordedVMNames = Set(
+            repositories.flatMap(\.workspaces)
+                .filter { $0.backendIdentifier == LumeWorkspaceProvider.identifier }
+                .flatMap { workspace -> [String] in
+                    lumeVMNames(for: workspace, expectedStoragePath: storagePath)
+                }
+        )
+
+        let vmNames = try fileSystem.directoryNames(in: storageURL)
+        return
+            vmNames
+            .filter { !recordedVMNames.contains($0) }
+            .map { vmName in
+                WorkspaceOrphanItem.lumeVMWithoutWorkspace(
+                    vmName: vmName,
+                    vmDirectory: storageURL.appendingPathComponent(vmName, isDirectory: true),
+                    storageURL: storageURL
+                )
+            }
+    }
+
+    private func lumeVMNames(
+        for workspace: WorkspaceOrphanWorkspaceSnapshot,
+        expectedStoragePath: String
+    ) -> [String] {
+        var names: [String] = []
+        if let metadata = decodeLumeMetadata(workspace.backendMetadataRaw) {
+            if let storagePath = metadata.storagePath {
+                if normalizePath(storagePath) == expectedStoragePath {
+                    names.append(metadata.vmName)
+                }
+            } else {
+                names.append(metadata.vmName)
+            }
+        } else if let remoteId = workspace.remoteId?.trimmedNonEmpty {
+            names.append(remoteId)
+        }
+        return names
+    }
+
+    private func decodeLumeMetadata(_ rawValue: String) -> LumeWorkspaceMetadata? {
+        guard let data = rawValue.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(LumeWorkspaceMetadata.self, from: data)
+    }
+
+    private func deleteWorkspaceBranchBestEffort(_ branch: String, at repoURL: URL) async {
+        do {
+            let result = try await ProcessRunner.run(
+                executable: "/usr/bin/git",
+                arguments: ["branch", "-D", branch],
+                currentDirectory: repoURL
+            )
+            if !result.success {
+                let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
+                workspaceOrphanLog.warning(
+                    "Failed best-effort workspace branch cleanup for \(branch) at \(repoURL.path): \(reason)"
+                )
+            }
+        } catch {
+            workspaceOrphanLog.warning(
+                "Failed best-effort workspace branch cleanup for \(branch) at \(repoURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func cleanupEmptyParent(of workspaceURL: URL) {
+        let parentURL = workspaceURL.deletingLastPathComponent()
+        do {
+            guard fileSystem.directoryExists(at: parentURL) else { return }
+            if try fileSystem.directoryNames(in: parentURL).isEmpty {
+                try fileSystem.removeItem(at: parentURL)
+            }
+        } catch {
+            workspaceOrphanLog.warning(
+                "Failed best-effort empty parent cleanup at \(parentURL.path): \(error.localizedDescription)"
+            )
+        }
+    }
+}
+
+protocol WorkspaceOrphanWorktreeListing: Sendable {
+    func worktrees(for repositoryURL: URL) async throws -> [GitWorktreeEntry]
+}
+
+struct GitPorcelainWorktreeLister: WorkspaceOrphanWorktreeListing {
+    func worktrees(for repositoryURL: URL) async throws -> [GitWorktreeEntry] {
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: ["worktree", "list", "--porcelain"],
+            currentDirectory: repositoryURL
+        )
+        guard result.success else {
+            let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
+            throw WorkspaceOrphanReconciliationError.gitCommandFailed(
+                args: ["worktree", "list", "--porcelain"],
+                stderr: reason
+            )
+        }
+        return GitWorktreeEntry.parsePorcelain(result.stdout)
+    }
+}
+
+protocol WorkspaceOrphanFileSystem: Sendable {
+    func directoryExists(at url: URL) -> Bool
+    func directoryNames(in url: URL) throws -> [String]
+    func removeItem(at url: URL) throws
+}
+
+struct DefaultWorkspaceOrphanFileSystem: WorkspaceOrphanFileSystem {
+    func directoryExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return false
+        }
+        return isDirectory.boolValue
+    }
+
+    func directoryNames(in url: URL) throws -> [String] {
+        guard directoryExists(at: url) else { return [] }
+        return try FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        .compactMap { childURL -> String? in
+            let values = try childURL.resourceValues(forKeys: [.isDirectoryKey])
+            guard values.isDirectory == true else { return nil }
+            return childURL.lastPathComponent
+        }
+    }
+
+    func removeItem(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+    }
+}
+
+struct GitWorktreeEntry: Sendable, Equatable {
+    let path: String
+    let branch: String?
+    let isPrunable: Bool
+
+    static func parsePorcelain(_ output: String) -> [GitWorktreeEntry] {
+        var entries: [GitWorktreeEntry] = []
+        var currentPath: String?
+        var currentBranch: String?
+        var isPrunable = false
+
+        func finishEntry() {
+            guard let currentPath else { return }
+            entries.append(
+                GitWorktreeEntry(
+                    path: currentPath,
+                    branch: currentBranch,
+                    isPrunable: isPrunable
+                )
+            )
+        }
+
+        for line in output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init) {
+            if line.isEmpty {
+                finishEntry()
+                currentPath = nil
+                currentBranch = nil
+                isPrunable = false
+                continue
+            }
+
+            if let path = line.dropPrefix("worktree ") {
+                if currentPath != nil {
+                    finishEntry()
+                }
+                currentPath = path
+                currentBranch = nil
+                isPrunable = false
+            } else if let branchRef = line.dropPrefix("branch refs/heads/") {
+                currentBranch = branchRef
+            } else if line.hasPrefix("prunable") {
+                isPrunable = true
+            }
+        }
+
+        finishEntry()
+        return entries
+    }
+}
+
+private func normalizePath(_ path: String) -> String {
+    let resolved = URL(fileURLWithPath: path)
+        .standardizedFileURL
+        .resolvingSymlinksInPath()
+        .path
+    if resolved == "/var" {
+        return "/private/var"
+    }
+    if resolved.hasPrefix("/var/") {
+        return "/private\(resolved)"
+    }
+    if resolved == "/tmp" {
+        return "/private/tmp"
+    }
+    if resolved.hasPrefix("/tmp/") {
+        return "/private\(resolved)"
+    }
+    return resolved
+}
+
+private func isPath(_ path: String, inside directoryPath: String) -> Bool {
+    path.hasPrefix(directoryPath + "/")
+}
+
+extension String {
+    fileprivate var trimmedNonEmpty: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    fileprivate func dropPrefix(_ prefix: String) -> String? {
+        guard hasPrefix(prefix) else { return nil }
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
@@ -1,0 +1,405 @@
+//
+//  WorkspaceOrphanReconcilerTests.swift
+//  WorkspaceManagerTests
+//
+//  Coverage for startup reconciliation of workspace records, git worktrees,
+//  and Lume workspace VM storage.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+private struct OrphanReconcilerGitCommandError: Error, CustomStringConvertible {
+    let args: [String]
+    let stderr: String
+
+    var description: String {
+        "git \(args.joined(separator: " ")) failed: \(stderr)"
+    }
+}
+
+@Suite("WorkspaceOrphanReconciler", .serialized)
+struct WorkspaceOrphanReconcilerTests {
+    final class CountingFileSystem: WorkspaceOrphanFileSystem, @unchecked Sendable {
+        private let fileManager = FileManager.default
+        private let lock = NSLock()
+        private var directoryExistsCallCountStorage = 0
+
+        var directoryExistsCallCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return directoryExistsCallCountStorage
+        }
+
+        func directoryExists(at url: URL) -> Bool {
+            lock.lock()
+            directoryExistsCallCountStorage += 1
+            lock.unlock()
+
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+                return false
+            }
+            return isDirectory.boolValue
+        }
+
+        func directoryNames(in url: URL) throws -> [String] {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                isDirectory.boolValue
+            else { return [] }
+
+            return try fileManager.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            .compactMap { childURL -> String? in
+                let values = try childURL.resourceValues(forKeys: [.isDirectoryKey])
+                guard values.isDirectory == true else { return nil }
+                return childURL.lastPathComponent
+            }
+        }
+
+        func removeItem(at url: URL) throws {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    struct StaticWorktreeLister: WorkspaceOrphanWorktreeListing {
+        let entries: [GitWorktreeEntry]
+
+        func worktrees(for repositoryURL: URL) async throws -> [GitWorktreeEntry] {
+            entries
+        }
+    }
+
+    @Test("Detects git worktrees without SwiftData records")
+    func detectsGitWorktreesWithoutRecords() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+        try repo.createFile("README.md", content: "hello\n")
+        try repo.commit(message: "initial")
+
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspacesRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        let worktreeURL =
+            workspacesRoot
+            .appendingPathComponent("sample-repo", isDirectory: true)
+            .appendingPathComponent("orphan-worktree", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktreeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try runGit(
+            ["worktree", "add", "-b", "workspace/orphan-worktree", worktreeURL.path, "HEAD"],
+            at: repo.url
+        )
+
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: nil
+        )
+        let result = await reconciler.scan(
+            repositories: [
+                repoSnapshot(
+                    name: "sample-repo",
+                    localPath: repo.url.path,
+                    workspaces: []
+                )
+            ]
+        )
+
+        let item = try #require(result.items.first)
+        #expect(result.items.count == 1)
+        #expect(item.kind == .gitWorktreeWithoutRecord)
+        #expect(item.resourceName == "orphan-worktree")
+        #expect(item.gitBranch == "workspace/orphan-worktree")
+    }
+
+    @Test("Detects workspace records whose directory no longer exists")
+    func detectsWorkspaceRecordsWithoutDirectories() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+        try repo.createFile("README.md", content: "hello\n")
+        try repo.commit(message: "initial")
+
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspacesRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        let worktreeURL =
+            workspacesRoot
+            .appendingPathComponent("sample-repo", isDirectory: true)
+            .appendingPathComponent("missing-directory", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktreeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try runGit(
+            ["worktree", "add", "-b", "workspace/missing-directory", worktreeURL.path, "HEAD"],
+            at: repo.url
+        )
+        try FileManager.default.removeItem(at: worktreeURL)
+
+        let workspace = workspaceSnapshot(
+            name: "missing-directory",
+            path: worktreeURL.path,
+            gitBranch: "workspace/missing-directory"
+        )
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: nil
+        )
+        let result = await reconciler.scan(
+            repositories: [
+                repoSnapshot(
+                    name: "sample-repo",
+                    localPath: repo.url.path,
+                    workspaces: [workspace]
+                )
+            ]
+        )
+
+        let item = try #require(result.items.first)
+        #expect(result.items.count == 1)
+        #expect(item.kind == .workspaceRecordMissingDirectory)
+        #expect(item.workspaceID == workspace.id)
+        #expect(item.hasPrunableGitMetadata)
+    }
+
+    @Test("Detects Lume workspace VMs without workspace records")
+    func detectsLumeVMsWithoutWorkspaceRecords() async throws {
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspacesRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        let vmStorageURL =
+            testRoot
+            .appendingPathComponent("LumeStorage", isDirectory: true)
+            .appendingPathComponent("workspace-vms", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: vmStorageURL.appendingPathComponent("recorded-vm", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: vmStorageURL.appendingPathComponent("orphan-vm", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let workspaceDirectory =
+            workspacesRoot
+            .appendingPathComponent("sample-repo", isDirectory: true)
+            .appendingPathComponent("vm", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+
+        let metadata = LumeWorkspaceMetadata(
+            vmName: "recorded-vm",
+            storagePath: vmStorageURL.path,
+            guestOS: .linux,
+            sharedHostPath: workspaceDirectory.path
+        )
+        let metadataRaw = String(data: try JSONEncoder().encode(metadata), encoding: .utf8) ?? ""
+        let workspace = workspaceSnapshot(
+            name: "vm",
+            path: workspaceDirectory.path,
+            backendIdentifier: LumeWorkspaceProvider.identifier,
+            remoteId: "recorded-vm",
+            backendMetadataRaw: metadataRaw
+        )
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: vmStorageURL,
+            worktreeLister: StaticWorktreeLister(entries: []),
+            fileSystem: DefaultWorkspaceOrphanFileSystem()
+        )
+
+        let result = await reconciler.scan(
+            repositories: [
+                repoSnapshot(
+                    name: "sample-repo",
+                    localPath: testRoot.appendingPathComponent("repo", isDirectory: true).path,
+                    workspaces: [workspace]
+                )
+            ]
+        )
+
+        let item = try #require(result.items.first)
+        #expect(result.items.count == 1)
+        #expect(item.kind == .lumeVMWithoutWorkspace)
+        #expect(item.resourceName == "orphan-vm")
+    }
+
+    @Test("Does not mark legacy Lume metadata without storage path as orphaned")
+    func skipsLegacyLumeMetadataWithoutStoragePath() async throws {
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspacesRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        let vmStorageURL =
+            testRoot
+            .appendingPathComponent("LumeStorage", isDirectory: true)
+            .appendingPathComponent("workspace-vms", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: vmStorageURL.appendingPathComponent("legacy-vm", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let metadata = LumeWorkspaceMetadata(
+            vmName: "legacy-vm",
+            guestOS: .linux,
+            sharedHostPath: "/tmp/legacy-vm"
+        )
+        let metadataRaw = String(data: try JSONEncoder().encode(metadata), encoding: .utf8) ?? ""
+        let workspace = workspaceSnapshot(
+            name: "legacy-vm",
+            path: Workspace.remotePathSentinel,
+            backendIdentifier: LumeWorkspaceProvider.identifier,
+            remoteId: "legacy-vm",
+            backendMetadataRaw: metadataRaw,
+            usesHostWorkspaceFiles: false
+        )
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: vmStorageURL,
+            worktreeLister: StaticWorktreeLister(entries: []),
+            fileSystem: DefaultWorkspaceOrphanFileSystem()
+        )
+
+        let result = await reconciler.scan(
+            repositories: [
+                repoSnapshot(
+                    name: "sample-repo",
+                    localPath: testRoot.appendingPathComponent("repo", isDirectory: true).path,
+                    workspaces: [workspace]
+                )
+            ]
+        )
+
+        #expect(result.items.isEmpty)
+    }
+
+    @Test("Skips directory existence checks when live worktree and record paths match")
+    func skipsDirectoryChecksWhenCountsAndPathsMatch() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+        try repo.createFile("README.md", content: "hello\n")
+        try repo.commit(message: "initial")
+
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspacesRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        let worktreeURL =
+            workspacesRoot
+            .appendingPathComponent("sample-repo", isDirectory: true)
+            .appendingPathComponent("known-worktree", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktreeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try runGit(
+            ["worktree", "add", "-b", "workspace/known-worktree", worktreeURL.path, "HEAD"],
+            at: repo.url
+        )
+
+        let fileSystem = CountingFileSystem()
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: nil,
+            worktreeLister: GitPorcelainWorktreeLister(),
+            fileSystem: fileSystem
+        )
+        let result = await reconciler.scan(
+            repositories: [
+                repoSnapshot(
+                    name: "sample-repo",
+                    localPath: repo.url.path,
+                    workspaces: [
+                        workspaceSnapshot(
+                            name: "known-worktree",
+                            path: worktreeURL.path,
+                            gitBranch: "workspace/known-worktree"
+                        )
+                    ]
+                )
+            ]
+        )
+
+        #expect(result.items.isEmpty)
+        #expect(fileSystem.directoryExistsCallCount == 0)
+    }
+
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceOrphanReconcilerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func repoSnapshot(
+        id: UUID = UUID(),
+        name: String,
+        localPath: String,
+        workspaces: [WorkspaceOrphanWorkspaceSnapshot]
+    ) -> WorkspaceOrphanRepositorySnapshot {
+        WorkspaceOrphanRepositorySnapshot(
+            id: id,
+            name: name,
+            localPath: localPath,
+            workspaces: workspaces
+        )
+    }
+
+    private func workspaceSnapshot(
+        id: UUID = UUID(),
+        name: String,
+        path: String,
+        gitBranch: String? = nil,
+        backendIdentifier: String = "local",
+        remoteId: String? = nil,
+        backendMetadataRaw: String = "",
+        usesHostWorkspaceFiles: Bool = true
+    ) -> WorkspaceOrphanWorkspaceSnapshot {
+        WorkspaceOrphanWorkspaceSnapshot(
+            id: id,
+            name: name,
+            path: path,
+            gitBranch: gitBranch,
+            backendIdentifier: backendIdentifier,
+            remoteId: remoteId,
+            backendMetadataRaw: backendMetadataRaw,
+            usesHostWorkspaceFiles: usesHostWorkspaceFiles
+        )
+    }
+
+    private func runGit(_ args: [String], at directory: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = directory
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let output =
+            String(
+                data: stdout.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+        let errorOutput =
+            String(
+                data: stderr.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            throw OrphanReconcilerGitCommandError(args: args, stderr: errorOutput)
+        }
+
+        return output
+    }
+}


### PR DESCRIPTION
## Summary

- add startup orphan scanning for git worktrees without records, workspace records without directories, and Lume workspace VMs without workspace records
- run the scan after deferred startup status sync and surface results through a quiet dismissible cleanup banner
- require per-item destructive confirmation before cleaning git worktrees, stale records, or orphaned Lume VMs

## Mergeability

- Surface: desktop app / core workspace services
- User-facing behavior changed: Yes — the main window can show a quiet dismissible cleanup banner after deferred startup scan finds leftover workspace resources.
- Non-happy paths considered: Scan failures are logged per repo/storage path and do not block startup; cleanup is destructive-confirmed per item; legacy Lume metadata without storage paths is not misclassified.
- Release/ops preconditions: None; no release-sensitive files changed.
- Residual risk or follow-up: Low; cleanup still depends on provider/git deletion behavior at confirmation time, and failures surface through the existing workspace operation error alert.

## Validation

- [x] `swift-format lint --strict --recursive Sources/ Tests/`
- [x] `swift test` (893 tests in 141 suites passed)
- [x] UI fixture launch and capture verified the deferred scan banner (`workspace_orphan_scan ... item_count=11`) with `./scripts/capture-window.sh`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (validation commands above)
- [x] UI evidence attached (screenshot from the implementation under review)

Evidence links:

- [Workspace cleanup banner screenshot](https://evidence.cloudcompute.com/workspaces/pr-650/20260610-041848-issue-636-orphan-reconciliation.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

Closes #636
