### PR TITLE
fix: trust mise config first in setup so new workspaces don't show trust errors

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -50,6 +50,48 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+# Trust mise configs before any other setup work. Codex worktrees run setup
+# without an interactive terminal, but mise tasks can execute arbitrary shell,
+# so keep the trust surface small and fail closed if a new config appears.
+# Running this first means a freshly created workspace trusts its .mise.toml as
+# early as possible, so the interactive shell's mise hook does not print
+# "config not trusted" errors while the rest of setup runs.
+allowed_mise_config() {
+  case "$1" in
+    "$REPO_ROOT/.mise.toml"|"$REPO_ROOT/web/.mise.toml") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+validate_mise_config() {
+  local mise_config="$1"
+  local relative="${mise_config#$REPO_ROOT/}"
+  local forbidden_regex='(^[[:space:]]*\[(env|hooks)\][[:space:]]*$|trusted_config_paths|^[[:space:]]*(yes|ci)[[:space:]]*=[[:space:]]*true([[:space:]]*(#.*)?)?$|_[.](source|file)[[:space:]]*=)'
+
+  if ! allowed_mise_config "$mise_config"; then
+    echo "error: unallowlisted mise config: $relative" >&2
+    echo "Add it to scripts/setup only after reviewing its trust boundary." >&2
+    exit 1
+  fi
+
+  if grep -En "$forbidden_regex" "$mise_config" >&2; then
+    echo "error: forbidden trust/env directive in $relative" >&2
+    exit 1
+  fi
+}
+
+while IFS= read -r mise_config; do
+  validate_mise_config "$mise_config"
+  echo "=> Trusting mise config ${mise_config#$REPO_ROOT/}"
+  mise trust "$mise_config"
+done < <(
+  find "$REPO_ROOT" \
+    -path "*/.git" -prune -o \
+    -path "*/node_modules" -prune -o \
+    -path "*/.pnpm-store" -prune -o \
+    -name ".mise.toml" -print | sort
+)
+
 print_prek_install_instructions() {
   echo "error: prek not found in PATH but prek.toml is present." >&2
   echo "Install it with one of:" >&2
@@ -138,45 +180,6 @@ link_env_from_main
 if [[ "$ENV_ONLY" == "1" ]]; then
   exit 0
 fi
-
-# Trust and install mise-managed tools. Codex worktrees run setup without an
-# interactive terminal, but mise tasks can execute arbitrary shell. Keep the
-# trust surface small and fail closed if a new config appears.
-allowed_mise_config() {
-  case "$1" in
-    "$REPO_ROOT/.mise.toml"|"$REPO_ROOT/web/.mise.toml") return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-validate_mise_config() {
-  local mise_config="$1"
-  local relative="${mise_config#$REPO_ROOT/}"
-  local forbidden_regex='(^[[:space:]]*\[(env|hooks)\][[:space:]]*$|trusted_config_paths|^[[:space:]]*(yes|ci)[[:space:]]*=[[:space:]]*true([[:space:]]*(#.*)?)?$|_[.](source|file)[[:space:]]*=)'
-
-  if ! allowed_mise_config "$mise_config"; then
-    echo "error: unallowlisted mise config: $relative" >&2
-    echo "Add it to scripts/setup only after reviewing its trust boundary." >&2
-    exit 1
-  fi
-
-  if grep -En "$forbidden_regex" "$mise_config" >&2; then
-    echo "error: forbidden trust/env directive in $relative" >&2
-    exit 1
-  fi
-}
-
-while IFS= read -r mise_config; do
-  validate_mise_config "$mise_config"
-  echo "=> Trusting mise config ${mise_config#$REPO_ROOT/}"
-  mise trust "$mise_config"
-done < <(
-  find "$REPO_ROOT" \
-    -path "*/.git" -prune -o \
-    -path "*/node_modules" -prune -o \
-    -path "*/.pnpm-store" -prune -o \
-    -name ".mise.toml" -print | sort
-)
 
 if [[ "$FAST" == "1" ]]; then
   exit 0


### PR DESCRIPTION
## What

Hoist the `mise trust` step to be the **first** action in `scripts/setup`, before argument-gated paths and before `link_env_from_main`'s git work.

## Why

New Conductor workspaces briefly show repeated `mise ERROR ... Config files in .../<workspace>/.mise.toml are not trusted` blocks in the terminal on first open.

Cause: Conductor launches an interactive login shell *concurrently* with `scripts/setup`. With the global `paranoid = true` mise setting, trust is path-exact, so a brand-new worktree path is untrusted until setup runs `mise trust`. The interactive shell's `mise activate` precmd hook hits the untrusted config first and prints the error until setup catches up. Trust previously ran after arg parsing and after `link_env_from_main` (git `rev-parse` + `git worktree list` + symlinks), so that git latency sat inside the race window.

Making trust the first thing setup does shrinks the window to "spawn setup + two `mise trust` calls", landing trust as early as the repo can manage.

This is a **pure reorder** — the allowlist (`.mise.toml` / `web/.mise.toml`) and the forbidden-directive check (`[env]`/`[hooks]`/`trusted_config_paths`/`yes=true`/`ci=true`/`_.source`) run unchanged and still fail closed before any trust. Minor benign effect: `--hooks-only` / `--env-only` now also trust first (idempotent).

### Honest residual

Because the interactive shell starts concurrently with `setup`, the repo can't *guarantee* zero errors — only make trust the earliest action. A guaranteed-zero fix would need a hook before Conductor's env-capture shell (e.g. blanket `MISE_TRUSTED_CONFIG_PATHS`), which was declined to preserve the paranoid per-config review posture.

## Verification

- `bash -n scripts/setup` parses.
- Untrust → `./scripts/setup --fast` → `=> Trusting mise config` is the first output line.
- `test_mise_configs_keep_trust_surface_small` passes; all `scripts/setup` substring assertions in `test_mise_invocations_are_locked_and_pinned` preserved.

Evidence (shell change → verification log): [verification log](https://evidence.cloudcompute.com/workspaces/pr-657/20260610-053551-mise-trust-first.png)

## Note (out of scope)

`test_mise_invocations_are_locked_and_pinned` is currently red on `main` independent of this change: `15be467b` bumped `verify-mise-security.sh` to `v2026.6.1` but the test still asserts `v2026.6.0`. No CI workflow executes that test, so it doesn't gate, but it's worth a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Mergeability

- Surface: infra — repo lifecycle scripts (`scripts/setup`), no app/UI code
- User-facing behavior changed: No app behavior. Developer-facing: new Conductor workspaces stop showing transient `mise ... not trusted` errors on first terminal open (or show a much smaller window).
- Non-happy paths considered: Pure reorder — allowlist + forbidden-directive validation still run and fail closed before any `mise trust`; `--help` still exits early without side effects; `--hooks-only`/`--env-only` now trust first (idempotent); `bash -n` clean.
- Residual risk or follow-up: Cannot guarantee zero errors since Conductor's interactive shell starts concurrently with setup (documented in the PR). Separate pre-existing follow-up: `test_mise_invocations_are_locked_and_pinned` asserts `v2026.6.0` while the script is `v2026.6.1` (not CI-executed).
