### PR TITLE
feat: hover info card for sidebar workspace rows

### DIFF
--- a/Sources/WorkspaceManager/Views/Components/AgentKindPresentation.swift
+++ b/Sources/WorkspaceManager/Views/Components/AgentKindPresentation.swift
@@ -1,0 +1,69 @@
+//
+//  AgentKindPresentation.swift
+//  WorkspaceManager
+//
+//  UI presentation for agent identity and run state: maps each AgentKind to an
+//  SF Symbol + tint (the "favicon" shown in the workspace hover card) and turns a
+//  run state into a short human summary line.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+extension AgentKind {
+    /// Human-facing name, matching the agent notification copy.
+    var displayName: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .opencode: return "OpenCode"
+        case .aider: return "Aider"
+        case .unknown: return "Agent"
+        }
+    }
+
+    /// SF Symbol standing in for the agent's icon.
+    var symbolName: String {
+        switch self {
+        case .claudeCode: return "sparkles"
+        case .opencode: return "chevron.left.forwardslash.chevron.right"
+        case .aider: return "wand.and.rays"
+        case .unknown: return "cpu"
+        }
+    }
+
+    /// Tint applied to the agent symbol so kinds read apart at a glance.
+    var tintColor: Color {
+        switch self {
+        case .claudeCode: return .orange
+        case .opencode: return .blue
+        case .aider: return .purple
+        case .unknown: return .secondary
+        }
+    }
+}
+
+extension AgentRunState {
+    /// One-line summary of what the agent is doing right now.
+    var summaryText: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .thinking:
+            return "Thinking…"
+        case .runningTool(let name, _):
+            return "Running: \(name)"
+        case .awaitingInput:
+            return "Awaiting input"
+        case .complete:
+            return "Done"
+        case .errored(let category, _):
+            switch category {
+            case .rateLimit: return "Rate limited"
+            case .authentication: return "Auth error"
+            case .server: return "Server error"
+            case .toolFailure: return "Tool failed"
+            case .unknown: return "Error"
+            }
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
+++ b/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
@@ -15,6 +15,12 @@ struct SidebarInfoCard: View {
     var branch: String? = nil
     var agentStatus: AgentSessionStatus? = nil
 
+    /// Whether the card would show anything beyond the name. When false the
+    /// caller should skip the popover entirely — a name-only card is just noise.
+    static func hasContent(branch: String?, agentStatus: AgentSessionStatus?) -> Bool {
+        (branch?.isEmpty == false) || agentStatus != nil
+    }
+
     private var trimmedBranch: String? {
         guard let branch, !branch.isEmpty else { return nil }
         return branch

--- a/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
+++ b/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
@@ -1,32 +1,33 @@
 //
-//  WorkspaceInfoCard.swift
+//  SidebarInfoCard.swift
 //  WorkspaceManager
 //
-//  Hover card for a sidebar workspace row: branch, the active agent's icon and
-//  run-state summary, and agent telemetry (model, context, cost, last active).
-//  Styled to match WorkspaceCardView so the popover feels native.
+//  Hover card for a sidebar item (repo root or workspace): the git branch, the
+//  active agent's icon and run-state summary, and agent telemetry (model,
+//  context, cost, last active). Styled to match WorkspaceCardView.
 //
 
 import SwiftUI
 import WorkspaceManagerCore
 
-struct WorkspaceInfoCard: View {
-    let workspace: Workspace
+struct SidebarInfoCard: View {
+    let name: String
+    var branch: String? = nil
     var agentStatus: AgentSessionStatus? = nil
 
-    private var branch: String? {
-        guard let branch = workspace.gitBranch, !branch.isEmpty else { return nil }
+    private var trimmedBranch: String? {
+        guard let branch, !branch.isEmpty else { return nil }
         return branch
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(workspace.name)
+            Text(name)
                 .font(.callout.weight(.semibold))
                 .lineLimit(1)
 
-            if let branch {
-                Label(branch, systemImage: "arrow.triangle.branch")
+            if let trimmedBranch {
+                Label(trimmedBranch, systemImage: "arrow.triangle.branch")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -69,35 +70,29 @@ struct WorkspaceInfoCard: View {
             }
 
             if let model = status.modelDisplayName, !model.isEmpty {
-                detailRow("Model", model)
+                detailRow("Model") { Text(model) }
             }
             if let context = status.contextUsedPercent {
-                detailRow("Context", "\(Int(context.rounded()))%")
+                detailRow("Context") { Text("\(Int(context.rounded()))%") }
             }
             if let cost = status.costUSD {
-                detailRow("Cost", String(format: "$%.2f", cost))
+                detailRow("Cost") { Text(String(format: "$%.2f", cost)) }
             }
-            detailRow("Last active", relativeLastActive(status.lastEventAt))
+            detailRow("Last active") { Text(status.lastEventAt, style: .relative) }
         }
     }
 
     @ViewBuilder
-    private func detailRow(_ label: String, _ value: String) -> some View {
+    private func detailRow(_ label: String, @ViewBuilder _ value: () -> some View) -> some View {
         HStack {
             Text(label)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
             Spacer(minLength: 12)
-            Text(value)
+            value()
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
         }
-    }
-
-    private func relativeLastActive(_ date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: date, relativeTo: Date())
     }
 }

--- a/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
+++ b/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
@@ -2,28 +2,51 @@
 //  SidebarInfoCard.swift
 //  WorkspaceManager
 //
-//  Hover card for a sidebar item (repo root or workspace): the git branch, the
-//  active agent's icon and run-state summary, and agent telemetry (model,
-//  context, cost, last active). Styled to match WorkspaceCardView.
+//  Hover card for a sidebar item (repo root or workspace): the git branch and a
+//  one-line summary of each open terminal tab — agent tabs show the agent icon
+//  and run state, plain tabs show their terminal title. When a single agent is
+//  running, its telemetry (model, context, cost, last active) is shown too.
+//  Styled to match WorkspaceCardView.
 //
 
 import SwiftUI
 import WorkspaceManagerCore
 
+/// One terminal tab/pane of a sidebar row. `title` is the tab's display title
+/// (the running program's terminal title, a user override, or the directory);
+/// `agentStatus` is set when that tab is running a known agent.
+struct SidebarTabSummary: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    var agentStatus: AgentSessionStatus? = nil
+}
+
 struct SidebarInfoCard: View {
     let name: String
     var branch: String? = nil
-    var agentStatus: AgentSessionStatus? = nil
+    var tabs: [SidebarTabSummary] = []
 
     /// Whether the card would show anything beyond the name. When false the
     /// caller should skip the popover entirely — a name-only card is just noise.
-    static func hasContent(branch: String?, agentStatus: AgentSessionStatus?) -> Bool {
-        (branch?.isEmpty == false) || agentStatus != nil
+    /// A lone plain tab whose title equals the row name adds nothing.
+    static func hasContent(name: String, branch: String?, tabs: [SidebarTabSummary]) -> Bool {
+        if branch?.isEmpty == false { return true }
+        if tabs.contains(where: { $0.agentStatus != nil }) { return true }
+        if tabs.count > 1 { return true }
+        if let only = tabs.first { return only.title != name }
+        return false
     }
 
     private var trimmedBranch: String? {
         guard let branch, !branch.isEmpty else { return nil }
         return branch
+    }
+
+    /// The single running agent, if exactly one tab has one — used to surface its
+    /// telemetry without crowding the card when several agents are running.
+    private var soleAgent: AgentSessionStatus? {
+        let agents = tabs.compactMap(\.agentStatus)
+        return agents.count == 1 ? agents.first : nil
     }
 
     var body: some View {
@@ -39,9 +62,16 @@ struct SidebarInfoCard: View {
                     .lineLimit(1)
             }
 
-            if let agentStatus {
+            if !tabs.isEmpty {
                 Divider()
-                agentSection(agentStatus)
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(tabs) { tabRow($0) }
+                }
+            }
+
+            if let soleAgent {
+                Divider()
+                agentDetails(soleAgent)
             }
         }
         .padding(14)
@@ -57,24 +87,32 @@ struct SidebarInfoCard: View {
     }
 
     @ViewBuilder
-    private func agentSection(_ status: AgentSessionStatus) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Image(systemName: status.kind.symbolName)
-                    .foregroundStyle(status.kind.tintColor)
-                    .frame(width: 16)
-                Text(status.kind.displayName)
-                    .font(.caption.weight(.semibold))
+    private func tabRow(_ tab: SidebarTabSummary) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: tab.agentStatus?.kind.symbolName ?? "terminal")
+                .foregroundStyle(tab.agentStatus?.kind.tintColor ?? Color.secondary)
+                .frame(width: 16)
+            Text(tab.title)
+                .font(.caption)
+                .lineLimit(1)
+            if let agent = tab.agentStatus {
                 Spacer(minLength: 8)
                 Circle()
-                    .fill(SidebarSessionActivity.from(status).indicatorColor)
+                    .fill(SidebarSessionActivity.from(agent).indicatorColor)
                     .frame(width: 6, height: 6)
-                Text(status.run.summaryText)
-                    .font(.caption)
+                Text(agent.run.summaryText)
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+            } else {
+                Spacer(minLength: 8)
             }
+        }
+    }
 
+    @ViewBuilder
+    private func agentDetails(_ status: AgentSessionStatus) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
             if let model = status.modelDisplayName, !model.isEmpty {
                 detailRow("Model") { Text(model) }
             }

--- a/Sources/WorkspaceManager/Views/Components/WorkspaceInfoCard.swift
+++ b/Sources/WorkspaceManager/Views/Components/WorkspaceInfoCard.swift
@@ -1,0 +1,103 @@
+//
+//  WorkspaceInfoCard.swift
+//  WorkspaceManager
+//
+//  Hover card for a sidebar workspace row: branch, the active agent's icon and
+//  run-state summary, and agent telemetry (model, context, cost, last active).
+//  Styled to match WorkspaceCardView so the popover feels native.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+struct WorkspaceInfoCard: View {
+    let workspace: Workspace
+    var agentStatus: AgentSessionStatus? = nil
+
+    private var branch: String? {
+        guard let branch = workspace.gitBranch, !branch.isEmpty else { return nil }
+        return branch
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(workspace.name)
+                .font(.callout.weight(.semibold))
+                .lineLimit(1)
+
+            if let branch {
+                Label(branch, systemImage: "arrow.triangle.branch")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if let agentStatus {
+                Divider()
+                agentSection(agentStatus)
+            }
+        }
+        .padding(14)
+        .frame(width: 260, alignment: .leading)
+        .background {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(nsColor: .windowBackgroundColor))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(Color(nsColor: .separatorColor).opacity(0.55), lineWidth: 0.5)
+        }
+    }
+
+    @ViewBuilder
+    private func agentSection(_ status: AgentSessionStatus) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: status.kind.symbolName)
+                    .foregroundStyle(status.kind.tintColor)
+                    .frame(width: 16)
+                Text(status.kind.displayName)
+                    .font(.caption.weight(.semibold))
+                Spacer(minLength: 8)
+                Circle()
+                    .fill(SidebarSessionActivity.from(status).indicatorColor)
+                    .frame(width: 6, height: 6)
+                Text(status.run.summaryText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            if let model = status.modelDisplayName, !model.isEmpty {
+                detailRow("Model", model)
+            }
+            if let context = status.contextUsedPercent {
+                detailRow("Context", "\(Int(context.rounded()))%")
+            }
+            if let cost = status.costUSD {
+                detailRow("Cost", String(format: "$%.2f", cost))
+            }
+            detailRow("Last active", relativeLastActive(status.lastEventAt))
+        }
+    }
+
+    @ViewBuilder
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Spacer(minLength: 12)
+            Text(value)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func relativeLastActive(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -524,6 +524,10 @@ struct ContentView: View {
                 activeSessionKey: activeSessionKeyForSidebar,
                 hostSessions: hostTerminalState.sessions,
                 agentStatusBySessionID: agentSessionRegistry.statuses,
+                titleForSession: { session in
+                    hostTerminalState.tabTitleOverride(for: session.id)
+                        ?? hostTerminalState.surfaceStore.displayTitle(for: session)
+                },
                 connectingWorkspaceID: viewState.connectingWorkspaceID,
                 onRepoSelected: handleRepoSelection,
                 onRepoTerminalSelected: handleRepoTerminalSelection,

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -212,8 +212,8 @@ struct RepoRow: View {
     let onSelectRepo: () -> Void
     let onNewWorkspace: (() -> Void)?
     let onNewWebView: (() -> Void)?
-    /// Resolved lazily only when the hover card opens (the repo root session).
-    var agentStatusProvider: (() -> AgentSessionStatus?)? = nil
+    /// Resolved lazily only when the hover card opens (the repo root's tabs).
+    var tabsProvider: (() -> [SidebarTabSummary])? = nil
 
     @State private var isHovering = false
 
@@ -259,10 +259,11 @@ struct RepoRow: View {
         .sidebarHoverCard(
             onHoverChange: { isHovering = $0 },
             shouldShow: {
-                SidebarInfoCard.hasContent(branch: nil, agentStatus: agentStatusProvider?())
+                SidebarInfoCard.hasContent(
+                    name: repo.name, branch: nil, tabs: tabsProvider?() ?? [])
             },
             card: {
-                SidebarInfoCard(name: repo.name, agentStatus: agentStatusProvider?())
+                SidebarInfoCard(name: repo.name, tabs: tabsProvider?() ?? [])
             }
         )
         .accessibilityElement(children: .contain)
@@ -358,7 +359,7 @@ struct WorkspaceRow: View {
     var showsDisclosure: Bool = false
     /// Resolved lazily only when the hover card opens, so frequent agent-status
     /// updates never re-render idle rows.
-    var agentStatusProvider: (() -> AgentSessionStatus?)? = nil
+    var tabsProvider: (() -> [SidebarTabSummary])? = nil
     var onToggleExpansion: (() -> Void)? = nil
     var onSelect: (() -> Void)? = nil
 
@@ -441,13 +442,14 @@ struct WorkspaceRow: View {
         .sidebarHoverCard(
             shouldShow: {
                 SidebarInfoCard.hasContent(
-                    branch: workspace.gitBranch, agentStatus: agentStatusProvider?())
+                    name: workspace.name, branch: workspace.gitBranch,
+                    tabs: tabsProvider?() ?? [])
             },
             card: {
                 SidebarInfoCard(
                     name: workspace.name,
                     branch: workspace.gitBranch,
-                    agentStatus: agentStatusProvider?()
+                    tabs: tabsProvider?() ?? []
                 )
             }
         )

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -256,9 +256,15 @@ struct RepoRow: View {
             RoundedRectangle(cornerRadius: 5)
                 .fill(isSelected ? Color.accentColor.opacity(0.1) : .clear)
         )
-        .sidebarHoverCard(onHoverChange: { isHovering = $0 }) {
-            SidebarInfoCard(name: repo.name, agentStatus: agentStatusProvider?())
-        }
+        .sidebarHoverCard(
+            onHoverChange: { isHovering = $0 },
+            shouldShow: {
+                SidebarInfoCard.hasContent(branch: nil, agentStatus: agentStatusProvider?())
+            },
+            card: {
+                SidebarInfoCard(name: repo.name, agentStatus: agentStatusProvider?())
+            }
+        )
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityDescription)
     }
@@ -432,13 +438,19 @@ struct WorkspaceRow: View {
                 + (workspace.status == .archived ? ", archived" : "")
                 + (statusMessage.map { ", \($0)" } ?? "")
         )
-        .sidebarHoverCard {
-            SidebarInfoCard(
-                name: workspace.name,
-                branch: workspace.gitBranch,
-                agentStatus: agentStatusProvider?()
-            )
-        }
+        .sidebarHoverCard(
+            shouldShow: {
+                SidebarInfoCard.hasContent(
+                    branch: workspace.gitBranch, agentStatus: agentStatusProvider?())
+            },
+            card: {
+                SidebarInfoCard(
+                    name: workspace.name,
+                    branch: workspace.gitBranch,
+                    agentStatus: agentStatusProvider?()
+                )
+            }
+        )
     }
 
     private var rowContent: some View {
@@ -501,6 +513,9 @@ private struct SidebarHoverCardModifier<Card: View>: ViewModifier {
     private static var dismissDelay: UInt64 { 250_000_000 }
 
     var onHoverChange: ((Bool) -> Void)? = nil
+    /// Evaluated lazily when the show delay fires; when it returns false the
+    /// popover is suppressed (e.g. a row whose card would only repeat the name).
+    var shouldShow: () -> Bool = { true }
     @ViewBuilder var card: () -> Card
 
     @State private var showCard = false
@@ -527,7 +542,7 @@ private struct SidebarHoverCardModifier<Card: View>: ViewModifier {
         showTask?.cancel()
         showTask = Task {
             try? await Task.sleep(nanoseconds: Self.showDelay)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, shouldShow() else { return }
             showCard = true
         }
     }
@@ -546,8 +561,11 @@ private struct SidebarHoverCardModifier<Card: View>: ViewModifier {
 extension View {
     func sidebarHoverCard(
         onHoverChange: ((Bool) -> Void)? = nil,
+        shouldShow: @escaping () -> Bool = { true },
         @ViewBuilder card: @escaping () -> some View
     ) -> some View {
-        modifier(SidebarHoverCardModifier(onHoverChange: onHoverChange, card: card))
+        modifier(
+            SidebarHoverCardModifier(
+                onHoverChange: onHoverChange, shouldShow: shouldShow, card: card))
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -348,8 +348,13 @@ struct WorkspaceRow: View {
     var isNested: Bool = false
     var isExpanded: Bool = false
     var showsDisclosure: Bool = false
+    var agentStatus: AgentSessionStatus? = nil
     var onToggleExpansion: (() -> Void)? = nil
     var onSelect: (() -> Void)? = nil
+
+    @State private var isHovering = false
+    @State private var showCard = false
+    @State private var hoverTask: Task<Void, Never>?
 
     private var isBusy: Bool {
         statusMessage != nil || workspace.status == .provisioning
@@ -427,6 +432,22 @@ struct WorkspaceRow: View {
                 + (workspace.status == .archived ? ", archived" : "")
                 + (statusMessage.map { ", \($0)" } ?? "")
         )
+        .onHover { hovering in
+            isHovering = hovering
+            hoverTask?.cancel()
+            guard hovering else {
+                showCard = false
+                return
+            }
+            hoverTask = Task {
+                try? await Task.sleep(nanoseconds: 400_000_000)
+                guard !Task.isCancelled, isHovering else { return }
+                showCard = true
+            }
+        }
+        .popover(isPresented: $showCard, arrowEdge: .trailing) {
+            WorkspaceInfoCard(workspace: workspace, agentStatus: agentStatus)
+        }
     }
 
     private var rowContent: some View {

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -212,6 +212,8 @@ struct RepoRow: View {
     let onSelectRepo: () -> Void
     let onNewWorkspace: (() -> Void)?
     let onNewWebView: (() -> Void)?
+    /// Resolved lazily only when the hover card opens (the repo root session).
+    var agentStatusProvider: (() -> AgentSessionStatus?)? = nil
 
     @State private var isHovering = false
 
@@ -254,8 +256,8 @@ struct RepoRow: View {
             RoundedRectangle(cornerRadius: 5)
                 .fill(isSelected ? Color.accentColor.opacity(0.1) : .clear)
         )
-        .onHover { hovering in
-            isHovering = hovering
+        .sidebarHoverCard(onHoverChange: { isHovering = $0 }) {
+            SidebarInfoCard(name: repo.name, agentStatus: agentStatusProvider?())
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityDescription)
@@ -348,13 +350,11 @@ struct WorkspaceRow: View {
     var isNested: Bool = false
     var isExpanded: Bool = false
     var showsDisclosure: Bool = false
-    var agentStatus: AgentSessionStatus? = nil
+    /// Resolved lazily only when the hover card opens, so frequent agent-status
+    /// updates never re-render idle rows.
+    var agentStatusProvider: (() -> AgentSessionStatus?)? = nil
     var onToggleExpansion: (() -> Void)? = nil
     var onSelect: (() -> Void)? = nil
-
-    @State private var isHovering = false
-    @State private var showCard = false
-    @State private var hoverTask: Task<Void, Never>?
 
     private var isBusy: Bool {
         statusMessage != nil || workspace.status == .provisioning
@@ -432,21 +432,12 @@ struct WorkspaceRow: View {
                 + (workspace.status == .archived ? ", archived" : "")
                 + (statusMessage.map { ", \($0)" } ?? "")
         )
-        .onHover { hovering in
-            isHovering = hovering
-            hoverTask?.cancel()
-            guard hovering else {
-                showCard = false
-                return
-            }
-            hoverTask = Task {
-                try? await Task.sleep(nanoseconds: 400_000_000)
-                guard !Task.isCancelled, isHovering else { return }
-                showCard = true
-            }
-        }
-        .popover(isPresented: $showCard, arrowEdge: .trailing) {
-            WorkspaceInfoCard(workspace: workspace, agentStatus: agentStatus)
+        .sidebarHoverCard {
+            SidebarInfoCard(
+                name: workspace.name,
+                branch: workspace.gitBranch,
+                agentStatus: agentStatusProvider?()
+            )
         }
     }
 
@@ -497,5 +488,47 @@ struct WorkspaceRow: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
+    }
+}
+
+/// Shows an info card popover after a short hover delay, dismissing on hover-out.
+/// The delay avoids flashing cards while the pointer crosses the list; the card
+/// closure is evaluated only while presented, so its agent lookup stays lazy.
+private struct SidebarHoverCardModifier<Card: View>: ViewModifier {
+    var onHoverChange: ((Bool) -> Void)? = nil
+    @ViewBuilder var card: () -> Card
+
+    @State private var isHovering = false
+    @State private var showCard = false
+    @State private var hoverTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                isHovering = hovering
+                onHoverChange?(hovering)
+                hoverTask?.cancel()
+                guard hovering else {
+                    showCard = false
+                    return
+                }
+                hoverTask = Task {
+                    try? await Task.sleep(nanoseconds: 400_000_000)
+                    guard !Task.isCancelled, isHovering else { return }
+                    showCard = true
+                }
+            }
+            .popover(isPresented: $showCard, arrowEdge: .trailing) {
+                card()
+            }
+    }
+}
+
+extension View {
+    func sidebarHoverCard(
+        onHoverChange: ((Bool) -> Void)? = nil,
+        @ViewBuilder card: @escaping () -> some View
+    ) -> some View {
+        modifier(SidebarHoverCardModifier(onHoverChange: onHoverChange, card: card))
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -491,36 +491,55 @@ struct WorkspaceRow: View {
     }
 }
 
-/// Shows an info card popover after a short hover delay, dismissing on hover-out.
-/// The delay avoids flashing cards while the pointer crosses the list; the card
-/// closure is evaluated only while presented, so its agent lookup stays lazy.
+/// Shows an info card popover after a short hover delay. The show delay avoids
+/// flashing cards while the pointer crosses the list; a dismiss grace period lets
+/// the pointer travel onto the card to read it (the card's own hover cancels the
+/// dismiss). The card closure is evaluated only while presented, so its agent
+/// lookup stays lazy.
 private struct SidebarHoverCardModifier<Card: View>: ViewModifier {
+    private static var showDelay: UInt64 { 400_000_000 }
+    private static var dismissDelay: UInt64 { 250_000_000 }
+
     var onHoverChange: ((Bool) -> Void)? = nil
     @ViewBuilder var card: () -> Card
 
-    @State private var isHovering = false
     @State private var showCard = false
-    @State private var hoverTask: Task<Void, Never>?
+    @State private var showTask: Task<Void, Never>?
+    @State private var dismissTask: Task<Void, Never>?
 
     func body(content: Content) -> some View {
         content
             .onHover { hovering in
-                isHovering = hovering
                 onHoverChange?(hovering)
-                hoverTask?.cancel()
-                guard hovering else {
-                    showCard = false
-                    return
-                }
-                hoverTask = Task {
-                    try? await Task.sleep(nanoseconds: 400_000_000)
-                    guard !Task.isCancelled, isHovering else { return }
-                    showCard = true
-                }
+                if hovering { scheduleShow() } else { scheduleDismiss() }
             }
             .popover(isPresented: $showCard, arrowEdge: .trailing) {
                 card()
+                    .onHover { hovering in
+                        if hovering { dismissTask?.cancel() } else { scheduleDismiss() }
+                    }
             }
+    }
+
+    private func scheduleShow() {
+        dismissTask?.cancel()
+        guard !showCard else { return }
+        showTask?.cancel()
+        showTask = Task {
+            try? await Task.sleep(nanoseconds: Self.showDelay)
+            guard !Task.isCancelled else { return }
+            showCard = true
+        }
+    }
+
+    private func scheduleDismiss() {
+        showTask?.cancel()
+        dismissTask?.cancel()
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: Self.dismissDelay)
+            guard !Task.isCancelled else { return }
+            showCard = false
+        }
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -463,7 +463,8 @@ struct SidebarView: View {
             },
             onNewWebView: {
                 onRequestWebSourceCreation(.repo(repo))
-            }
+            },
+            agentStatusProvider: { agentStatus(for: repoSessionKey) }
         )
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
@@ -524,7 +525,7 @@ struct SidebarView: View {
                     isNested: true,
                     isExpanded: isWorkspaceExpanded(workspace),
                     showsDisclosure: !workspace.webSources.isEmpty,
-                    agentStatus: agentStatus(for: workspace),
+                    agentStatusProvider: { agentStatus(for: workspace) },
                     onToggleExpansion: {
                         toggleWorkspaceExpansion(workspace)
                     },
@@ -1384,12 +1385,16 @@ struct SidebarView: View {
         )
     }
 
-    private func agentStatus(for workspace: Workspace) -> AgentSessionStatus? {
+    private func agentStatus(for key: HostTerminalSessionKey) -> AgentSessionStatus? {
         workspacePresentationController.freshestAgentStatus(
-            for: sessionKey(for: workspace),
+            for: key,
             sessions: hostSessions,
             agentStatusBySessionID: agentStatusBySessionID
         )
+    }
+
+    private func agentStatus(for workspace: Workspace) -> AgentSessionStatus? {
+        agentStatus(for: sessionKey(for: workspace))
     }
 
     /// Merge the repo's own-session baseline with the aggregator-bubbled state derived

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -48,6 +48,9 @@ struct SidebarView: View {
     let activeSessionKey: HostTerminalSessionKey?
     let hostSessions: [HostTerminalSession]
     let agentStatusBySessionID: [UUID: AgentSessionStatus]
+    /// Display title for a terminal tab (user override → live terminal title →
+    /// directory). Resolved lazily by the hover card; mirrors the tab bar's title.
+    let titleForSession: @MainActor (HostTerminalSession) -> String
     let connectingWorkspaceID: UUID?
     let onRepoSelected: (Repo) -> Void
     let onRepoTerminalSelected: (Repo) -> Void
@@ -465,7 +468,7 @@ struct SidebarView: View {
             onNewWebView: {
                 onRequestWebSourceCreation(.repo(repo))
             },
-            agentStatusProvider: { agentStatus(for: repoSessionKey) }
+            tabsProvider: { tabSummaries(for: repoSessionKey) }
         )
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
@@ -554,7 +557,7 @@ struct SidebarView: View {
             isNested: true,
             isExpanded: isWorkspaceExpanded(workspace),
             showsDisclosure: !workspace.webSources.isEmpty,
-            agentStatusProvider: { agentStatus(for: workspace) },
+            tabsProvider: { tabSummaries(for: workspace) },
             onToggleExpansion: {
                 toggleWorkspaceExpansion(workspace)
             },
@@ -1431,16 +1434,24 @@ struct SidebarView: View {
         )
     }
 
-    private func agentStatus(for key: HostTerminalSessionKey) -> AgentSessionStatus? {
-        workspacePresentationController.freshestAgentStatus(
-            for: key,
-            sessions: hostSessions,
-            agentStatusBySessionID: agentStatusBySessionID
-        )
+    /// One summary per terminal tab sharing `key`, in session order. Each carries
+    /// its display title and agent status (when that tab runs a known agent).
+    private func tabSummaries(for key: HostTerminalSessionKey) -> [SidebarTabSummary] {
+        let normalizedKey = key.normalized()
+        return
+            hostSessions
+            .filter { $0.key == normalizedKey }
+            .map { session in
+                SidebarTabSummary(
+                    id: session.id,
+                    title: titleForSession(session),
+                    agentStatus: agentStatusBySessionID[session.id]
+                )
+            }
     }
 
-    private func agentStatus(for workspace: Workspace) -> AgentSessionStatus? {
-        agentStatus(for: sessionKey(for: workspace))
+    private func tabSummaries(for workspace: Workspace) -> [SidebarTabSummary] {
+        tabSummaries(for: sessionKey(for: workspace))
     }
 
     /// Merge the repo's own-session baseline with the aggregator-bubbled state derived

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -524,6 +524,7 @@ struct SidebarView: View {
                     isNested: true,
                     isExpanded: isWorkspaceExpanded(workspace),
                     showsDisclosure: !workspace.webSources.isEmpty,
+                    agentStatus: agentStatus(for: workspace),
                     onToggleExpansion: {
                         toggleWorkspaceExpansion(workspace)
                     },
@@ -1378,6 +1379,14 @@ struct SidebarView: View {
             for: key,
             paneCountBySessionKey: paneCountBySessionKey,
             activeSessionKey: activeSessionKey,
+            sessions: hostSessions,
+            agentStatusBySessionID: agentStatusBySessionID
+        )
+    }
+
+    private func agentStatus(for workspace: Workspace) -> AgentSessionStatus? {
+        workspacePresentationController.freshestAgentStatus(
+            for: sessionKey(for: workspace),
             sessions: hostSessions,
             agentStatusBySessionID: agentStatusBySessionID
         )

--- a/Tests/WorkspaceManagerAppTests/AgentKindPresentationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AgentKindPresentationTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@Suite("AgentKindPresentation")
+struct AgentKindPresentationTests {
+    @Test("Every agent kind has a non-empty display name and symbol")
+    func everyKindHasDisplayNameAndSymbol() {
+        for kind in [AgentKind.claudeCode, .opencode, .aider, .unknown] {
+            #expect(!kind.displayName.isEmpty)
+            #expect(!kind.symbolName.isEmpty)
+        }
+    }
+
+    @Test("Display names match the known agents")
+    func displayNamesAreStable() {
+        #expect(AgentKind.claudeCode.displayName == "Claude Code")
+        #expect(AgentKind.opencode.displayName == "OpenCode")
+        #expect(AgentKind.aider.displayName == "Aider")
+        #expect(AgentKind.unknown.displayName == "Agent")
+    }
+
+    @Test("Known agent kinds use distinct symbols")
+    func knownKindsHaveDistinctSymbols() {
+        let symbols = [AgentKind.claudeCode, .opencode, .aider].map(\.symbolName)
+        #expect(Set(symbols).count == symbols.count)
+    }
+
+    @Test("Run states summarize to readable text")
+    func runStateSummaries() {
+        #expect(AgentRunState.idle.summaryText == "Idle")
+        #expect(AgentRunState.thinking.summaryText == "Thinking…")
+        #expect(AgentRunState.runningTool(name: "Bash", detail: nil).summaryText == "Running: Bash")
+        #expect(AgentRunState.awaitingInput(reason: .permissionPrompt).summaryText == "Awaiting input")
+        #expect(AgentRunState.complete.summaryText == "Done")
+        #expect(AgentRunState.errored(category: .rateLimit, message: nil).summaryText == "Rate limited")
+        #expect(AgentRunState.errored(category: .unknown, message: nil).summaryText == "Error")
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SidebarInfoCardTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarInfoCardTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@Suite("SidebarInfoCard")
+struct SidebarInfoCardTests {
+    private func status() -> AgentSessionStatus {
+        AgentSessionStatus(hostSessionID: UUID(), kind: .claudeCode, cwd: "/tmp")
+    }
+
+    @Test("Name-only card has no content")
+    func nameOnlyHasNoContent() {
+        #expect(!SidebarInfoCard.hasContent(branch: nil, agentStatus: nil))
+        #expect(!SidebarInfoCard.hasContent(branch: "", agentStatus: nil))
+    }
+
+    @Test("A branch is content")
+    func branchIsContent() {
+        #expect(SidebarInfoCard.hasContent(branch: "main", agentStatus: nil))
+    }
+
+    @Test("An agent status is content")
+    func agentStatusIsContent() {
+        #expect(SidebarInfoCard.hasContent(branch: nil, agentStatus: status()))
+        #expect(SidebarInfoCard.hasContent(branch: "", agentStatus: status()))
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SidebarInfoCardTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarInfoCardTests.swift
@@ -6,24 +6,48 @@ import Testing
 
 @Suite("SidebarInfoCard")
 struct SidebarInfoCardTests {
-    private func status() -> AgentSessionStatus {
-        AgentSessionStatus(hostSessionID: UUID(), kind: .claudeCode, cwd: "/tmp")
+    private func agentTab(title: String = "Claude Code") -> SidebarTabSummary {
+        SidebarTabSummary(
+            id: UUID(),
+            title: title,
+            agentStatus: AgentSessionStatus(hostSessionID: UUID(), kind: .claudeCode, cwd: "/tmp")
+        )
     }
 
-    @Test("Name-only card has no content")
+    private func plainTab(title: String) -> SidebarTabSummary {
+        SidebarTabSummary(id: UUID(), title: title)
+    }
+
+    @Test("Name-only — no branch, no tabs — has no content")
     func nameOnlyHasNoContent() {
-        #expect(!SidebarInfoCard.hasContent(branch: nil, agentStatus: nil))
-        #expect(!SidebarInfoCard.hasContent(branch: "", agentStatus: nil))
+        #expect(!SidebarInfoCard.hasContent(name: "repo", branch: nil, tabs: []))
+        #expect(!SidebarInfoCard.hasContent(name: "repo", branch: "", tabs: []))
     }
 
     @Test("A branch is content")
     func branchIsContent() {
-        #expect(SidebarInfoCard.hasContent(branch: "main", agentStatus: nil))
+        #expect(SidebarInfoCard.hasContent(name: "ws", branch: "main", tabs: []))
     }
 
-    @Test("An agent status is content")
-    func agentStatusIsContent() {
-        #expect(SidebarInfoCard.hasContent(branch: nil, agentStatus: status()))
-        #expect(SidebarInfoCard.hasContent(branch: "", agentStatus: status()))
+    @Test("An agent tab is content")
+    func agentTabIsContent() {
+        #expect(SidebarInfoCard.hasContent(name: "repo", branch: nil, tabs: [agentTab()]))
+    }
+
+    @Test("A lone plain tab whose title equals the name adds nothing")
+    func loneRedundantTabHasNoContent() {
+        #expect(!SidebarInfoCard.hasContent(name: "repo", branch: nil, tabs: [plainTab(title: "repo")]))
+    }
+
+    @Test("A lone plain tab with a distinct title is content")
+    func loneDistinctTabIsContent() {
+        #expect(
+            SidebarInfoCard.hasContent(name: "repo", branch: nil, tabs: [plainTab(title: "server.ts")]))
+    }
+
+    @Test("Multiple tabs are content even when plain")
+    func multiplePlainTabsAreContent() {
+        let tabs = [plainTab(title: "repo"), plainTab(title: "repo")]
+        #expect(SidebarInfoCard.hasContent(name: "repo", branch: nil, tabs: tabs))
     }
 }


### PR DESCRIPTION
Closes #652

## What

Hovering a **repo row or workspace row** in the left sidebar now surfaces an **info card** (after a ~0.4s delay, dismissed on hover-out) showing:

- the git **branch**
- the **active agent's icon** (SF Symbol + tint per `AgentKind`) and **run-state summary** (Thinking / Running: <tool> / Awaiting input / …)
- agent telemetry when available: **model**, **context %**, **cost**, and **last active**
- when a row has **multiple terminal tabs**, one summary line per tab: agent tabs show the agent icon + run-state badge, plain tabs show their terminal title; single-agent telemetry still shown below

Workspaces without a live agent show just the name + branch; every detail row hides gracefully when its field is absent.

## How

- `AgentKindPresentation.swift` — `AgentKind` → display name / SF Symbol / tint, and `AgentRunState.summaryText`.
- `WorkspaceInfoCard.swift` — the card, styled after `WorkspaceCardView` (continuous rounded rect, window-background fill, separator stroke).
- `WorkspaceRow` (`SidebarRows.swift`) — `.onHover` with a cancellable delay → `.popover(arrowEdge: .trailing)`.
- `SidebarView.swift` — resolves the freshest `AgentSessionStatus` per workspace via the existing `SidebarWorkspacePresentationController.freshestAgentStatus`, mirroring `sessionActivity(for:)`.

- **Performance:** the card's agent status is resolved through a **lazy provider closure** invoked only while the popover is presented — so frequent `AgentSessionStatus` updates (which tick on every agent event) no longer re-render idle sidebar rows. A shared `SidebarHoverCardModifier` centralizes the hover-delay + popover. The repo card omits the branch (not cached on `Repo`; a git subprocess on hover would be wasteful).

All data already existed in the app; this surfaces it on hover. No new services or model changes.

## Mergeability
- Surface: desktop main window left sidebar (repo + workspace rows)
- User-facing behavior changed: hovering a repo row or workspace row in the sidebar shows an info card after ~0.4s, with one summary line per open terminal tab (agent run-state for agent tabs, terminal title for plain tabs), with the git branch, the active agent's icon + run-state summary, and model/context/cost/last-active when an agent is running; dismisses on hover-out.
- Non-happy paths considered: workspaces with no live agent show only name + branch; each telemetry row hides when its field is nil; an empty/absent branch is omitted; the hover-delay Task is cancelled on hover-out so fast pointer passes over the list never flash a card.
- Residual risk or follow-up: agent "favicon" is an SF Symbol per AgentKind (no per-agent image assets); the popover dismisses when the pointer leaves the row, so the card is read-only by design; repo cards omit branch (not cached). Perf: tab/agent lookup is lazy (popover-only), so idle rows do not re-render on agent-status ticks. Real foreground-process names for plain shells are a follow-up (#666); terminal title is the signal until then.

## Verification

- `swift build` clean; `swift test` — **901 tests pass**; `mise run lint` (swift-format strict) clean.
- New unit tests cover the pure mapping (`AgentKindPresentationTests`).
- Evidence below: deterministic render of the actual `WorkspaceInfoCard` view (via `ImageRenderer`) — left = workspace with a live Claude Code agent, right = workspace with no agent.

![hover-info-card](https://evidence.cloudcompute.com/workspaces/pr-660/20260610-080119-hover-info-card.png)

Repo root card + workspace cards (active and idle):

![repo-and-workspace-cards](https://evidence.cloudcompute.com/workspaces/pr-660/20260610-092124-repo-and-workspace-cards.png)

Per-tab summaries (multi-tab workspace, single-agent telemetry, repo root with two terminals):

![per-tab-summary](https://evidence.cloudcompute.com/workspaces/pr-660/20260612-065106-per-tab-summary.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


