### PR TITLE
feat: archive workspaces to .archived/ with purge and hidden UI (#651)

### DIFF
--- a/Sources/WorkspaceManager/App/ArchivedWorkspaceSettings.swift
+++ b/Sources/WorkspaceManager/App/ArchivedWorkspaceSettings.swift
@@ -1,0 +1,23 @@
+//
+//  ArchivedWorkspaceSettings.swift
+//  WorkspaceManager
+//
+//  Shared keys/defaults for the archived-workspace purge sweep, used by both the
+//  Settings UI (`SettingsView`) and the startup purge pass (`ContentView`).
+//
+
+import Foundation
+
+enum ArchivedWorkspaceSettings {
+    /// `UserDefaults`/`@AppStorage` key for the purge delay, in days.
+    static let purgeDaysKey = "archivedWorkspacePurgeDays"
+
+    /// Days an archived workspace is retained before the purge sweep deletes it.
+    static let defaultPurgeDays = 30
+
+    /// Resolves the configured delay, falling back to the default when unset (`0`).
+    static func purgeDays(from defaults: UserDefaults = .standard) -> Int {
+        let stored = defaults.integer(forKey: purgeDaysKey)
+        return stored > 0 ? stored : defaultPurgeDays
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1802,6 +1802,72 @@ struct ContentView: View {
 
         await syncWorkspaceStatuses(trigger: "launch_deferred")
         await refreshWorkspaceOrphans(trigger: "launch_deferred")
+        await purgeExpiredArchivedWorkspaces(trigger: "launch_deferred")
+    }
+
+    /// Local archived workspaces whose `.archived/` directory has aged past the
+    /// configured retention. Pure so the selection rule is unit-testable; workspaces
+    /// without an `archivedAt` (archived before this was tracked) are never auto-purged.
+    static func expiredArchivedWorkspaces(
+        _ workspaces: [Workspace],
+        now: Date,
+        delayDays: Int
+    ) -> [Workspace] {
+        guard delayDays > 0 else { return [] }
+        let cutoff = now.addingTimeInterval(-Double(delayDays) * 86_400)
+        return workspaces.filter { workspace in
+            workspace.backend == .local
+                && workspace.status == .archived
+                && (workspace.archivedAt.map { $0 <= cutoff } ?? false)
+        }
+    }
+
+    @MainActor
+    private func purgeExpiredArchivedWorkspaces(trigger: String) async {
+        let delayDays = ArchivedWorkspaceSettings.purgeDays()
+        let candidates = Self.expiredArchivedWorkspaces(
+            repos.flatMap(\.workspaces),
+            now: Date(),
+            delayDays: delayDays
+        )
+        guard !candidates.isEmpty else { return }
+
+        let startedAt = Date()
+        let controller = SidebarWorkspaceController(
+            modelContext: modelContext,
+            workspaceService: workspaceService,
+            workspaceProviderRegistry: workspaceProviderRegistry,
+            retireTerminalSessions: { key in
+                await retireTerminalSessions(inScope: key)
+            }
+        )
+
+        var purgedCount = 0
+        for workspace in candidates {
+            let wasSelected = currentSelectedWorkspace?.id == workspace.id
+            do {
+                try await controller.deleteWorkspace(workspace, deleteFiles: true)
+                if wasSelected {
+                    setSelectedWorkspace(nil)
+                }
+                purgedCount += 1
+            } catch {
+                NSLog(
+                    "[ArchivedWorkspacePurge] Failed to purge '%@': %@",
+                    workspace.name,
+                    error.localizedDescription
+                )
+            }
+        }
+
+        NSLog(
+            "[Perf] metric=archived_workspace_purge duration_ms=%.2f trigger=%@ delay_days=%ld candidate_count=%ld purged_count=%ld",
+            Date().timeIntervalSince(startedAt) * 1000,
+            trigger,
+            delayDays,
+            candidates.count,
+            purgedCount
+        )
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -80,6 +80,7 @@ struct SidebarView: View {
     @State private var expansionController = SidebarExpansionStateController()
     @FocusState private var sidebarHasKeyFocus: Bool
     @State private var workspaceAction: WorkspaceActionState?
+    @State private var expandedArchivedRepoIDs: Set<UUID> = []
     @State private var workspaceCreationStatusByRepoID: [UUID: WorkspaceCreationStatus] = [:]
     @State private var repoLastAccessedSnapshotByID: [UUID: Date] = [:]
     @State private var isPreparingNewWorkspaceSheet = false
@@ -511,56 +512,19 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func repoWorkspaceList(_ repo: Repo) -> some View {
-        let repoWorkspaces = sortedWorkspaces(for: repo)
+        let activeWorkspaces = activeWorkspaces(for: repo)
+        let archivedWorkspaces = archivedWorkspaces(for: repo)
 
-        if !repoWorkspaces.isEmpty {
-            ForEach(repoWorkspaces) { workspace in
-                WorkspaceRow(
-                    workspace: workspace,
-                    isSelected: selectedWorkspace?.id == workspace.id,
-                    statusMessage: workspaceStatusMessage(workspace),
-                    sessionActivity: sessionActivity(for: sessionKey(for: workspace)),
-                    paneCount: paneCount(for: sessionKey(for: workspace)),
-                    isNested: true,
-                    isExpanded: isWorkspaceExpanded(workspace),
-                    showsDisclosure: !workspace.webSources.isEmpty,
-                    onToggleExpansion: {
-                        toggleWorkspaceExpansion(workspace)
-                    },
-                    onSelect: {
-                        selectWorkspace(workspace)
-                    }
-                )
-                .contextMenu {
-                    Button("Open in New Window") {
-                        openInNewWindow(workspace)
-                    }
-                    .disabled(true)
+        ForEach(activeWorkspaces) { workspace in
+            workspaceRow(workspace)
+        }
 
-                    if usesHostWorkspaceFiles(for: workspace) {
-                        Button("Reveal in Finder") {
-                            NSWorkspace.shared.selectFile(
-                                nil, inFileViewerRootedAtPath: workspace.path)
-                        }
-                    }
+        if !archivedWorkspaces.isEmpty {
+            archivedSectionHeader(for: repo, count: archivedWorkspaces.count)
 
-                    Divider()
-
-                    if workspace.backend == .local {
-                        localWorkspaceActions(workspace)
-                    } else {
-                        providerWorkspaceActions(workspace)
-                    }
-
-                    Divider()
-
-                    Button("Delete Workspace", role: .destructive) {
-                        deleteWorkspace(workspace)
-                    }
-                }
-
-                if isWorkspaceExpanded(workspace) {
-                    workspaceWebSourceList(workspace)
+            if isArchivedSectionExpanded(repo) {
+                ForEach(archivedWorkspaces) { workspace in
+                    workspaceRow(workspace)
                 }
             }
         }
@@ -576,6 +540,80 @@ struct SidebarView: View {
             }
             .padding(.leading, 28)
         }
+    }
+
+    @ViewBuilder
+    private func workspaceRow(_ workspace: Workspace) -> some View {
+        WorkspaceRow(
+            workspace: workspace,
+            isSelected: selectedWorkspace?.id == workspace.id,
+            statusMessage: workspaceStatusMessage(workspace),
+            sessionActivity: sessionActivity(for: sessionKey(for: workspace)),
+            paneCount: paneCount(for: sessionKey(for: workspace)),
+            isNested: true,
+            isExpanded: isWorkspaceExpanded(workspace),
+            showsDisclosure: !workspace.webSources.isEmpty,
+            onToggleExpansion: {
+                toggleWorkspaceExpansion(workspace)
+            },
+            onSelect: {
+                selectWorkspace(workspace)
+            }
+        )
+        .contextMenu {
+            Button("Open in New Window") {
+                openInNewWindow(workspace)
+            }
+            .disabled(true)
+
+            if usesHostWorkspaceFiles(for: workspace) {
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.selectFile(
+                        nil, inFileViewerRootedAtPath: workspace.path)
+                }
+            }
+
+            Divider()
+
+            if workspace.backend == .local {
+                localWorkspaceActions(workspace)
+            } else {
+                providerWorkspaceActions(workspace)
+            }
+
+            Divider()
+
+            Button("Delete Workspace", role: .destructive) {
+                deleteWorkspace(workspace)
+            }
+        }
+
+        if isWorkspaceExpanded(workspace) {
+            workspaceWebSourceList(workspace)
+        }
+    }
+
+    @ViewBuilder
+    private func archivedSectionHeader(for repo: Repo, count: Int) -> some View {
+        let expanded = isArchivedSectionExpanded(repo)
+        Button {
+            toggleArchivedSection(for: repo)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.semibold))
+                    .rotationEffect(.degrees(expanded ? 90 : 0))
+                    .foregroundStyle(.secondary)
+                Text("Archived (\(count))")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+            .padding(.leading, 28)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Archived workspaces, \(count)")
     }
 
     @ViewBuilder
@@ -878,7 +916,7 @@ struct SidebarView: View {
             }
         } else {
             Button("Unarchive") {
-                toggleLocalWorkspaceArchive(workspace, archived: false)
+                performUnarchive(workspace)
             }
         }
     }
@@ -918,10 +956,18 @@ struct SidebarView: View {
         }
     }
 
-    private func toggleLocalWorkspaceArchive(_ workspace: Workspace, archived: Bool) {
-        workspace.status = archived ? .archived : .active
-        if !saveModelContext(action: archived ? "archive workspace" : "unarchive workspace") {
-            modelContext.rollback()
+    private func performUnarchive(_ workspace: Workspace) {
+        workspaceAction = WorkspaceActionState(workspaceID: workspace.id, message: "Unarchiving...")
+
+        Task { @MainActor in
+            do {
+                try await workspaceController.unarchive(workspace)
+                workspaceAction = nil
+            } catch {
+                workspaceAction = nil
+                errorMessage = "Failed to unarchive workspace: \(error.localizedDescription)"
+                showingError = true
+            }
         }
     }
 
@@ -1509,6 +1555,37 @@ struct SidebarView: View {
     private func sortedWorkspaces(for repo: Repo) -> [Workspace] {
         repo.workspaces.sorted { lhs, rhs in
             lhs.lastAccessedAt > rhs.lastAccessedAt
+        }
+    }
+
+    private func activeWorkspaces(for repo: Repo) -> [Workspace] {
+        sortedWorkspaces(for: repo).filter { $0.status != .archived }
+    }
+
+    private func archivedWorkspaces(for repo: Repo) -> [Workspace] {
+        sortedWorkspaces(for: repo).filter { $0.status == .archived }
+    }
+
+    /// Collapsed by default; auto-expands when the selected workspace is archived so a
+    /// restored selection isn't hidden inside a collapsed section.
+    private func isArchivedSectionExpanded(_ repo: Repo) -> Bool {
+        if expandedArchivedRepoIDs.contains(repo.id) {
+            return true
+        }
+        if let selected = selectedWorkspace,
+            selected.status == .archived,
+            selected.sourceRepo?.id == repo.id
+        {
+            return true
+        }
+        return false
+    }
+
+    private func toggleArchivedSection(for repo: Repo) {
+        if expandedArchivedRepoIDs.contains(repo.id) {
+            expandedArchivedRepoIDs.remove(repo.id)
+        } else {
+            expandedArchivedRepoIDs.insert(repo.id)
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -201,13 +201,27 @@ struct SidebarWorkspaceController {
         await retireTerminalSessions(sessionKey)
 
         if workspace.backend == .local {
-            try await workspaceService.archiveWorkspace(at: workspace.workspaceURL)
+            let archivedURL = try await workspaceService.archiveWorkspace(at: workspace.workspaceURL)
+            workspace.path = archivedURL.path
         } else {
             let provider = try provider(for: workspace)
             try await provider.archiveWorkspace(WorkspaceProviderTarget(workspace))
         }
+        workspace.archivedAt = Date()
         workspace.status = .archived
         try saveModelContext(action: "archive workspace")
+    }
+
+    /// Restores a local workspace: moves its directory back out of `.archived/` and
+    /// clears the archived state. Non-local workspaces just flip status back.
+    func unarchive(_ workspace: Workspace) async throws {
+        if workspace.backend == .local {
+            let restoredURL = try await workspaceService.unarchiveWorkspace(at: workspace.workspaceURL)
+            workspace.path = restoredURL.path
+        }
+        workspace.archivedAt = nil
+        workspace.status = .active
+        try saveModelContext(action: "unarchive workspace")
     }
 
     private func upsertWorkspace(

--- a/Sources/WorkspaceManager/Views/SettingsView.swift
+++ b/Sources/WorkspaceManager/Views/SettingsView.swift
@@ -20,6 +20,8 @@ struct SettingsView: View {
     private var terminalMultiplexingModeRawValue: String = TerminalMultiplexingMode.defaultValue.rawValue
     @AppStorage(NotificationConstants.enabledKey)
     private var notificationsEnabled: Bool = NotificationConstants.defaultEnabled
+    @AppStorage(ArchivedWorkspaceSettings.purgeDaysKey)
+    private var archivedWorkspacePurgeDays: Int = ArchivedWorkspaceSettings.defaultPurgeDays
 
     @State private var showFolderPicker = false
     @State private var commandLineToolStatus: CommandLineToolStatus?
@@ -96,6 +98,23 @@ struct SettingsView: View {
                             .font(.caption)
                         }
                     }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Stepper(
+                        "Delete archived workspaces after \(archivedWorkspacePurgeDays) days",
+                        value: $archivedWorkspacePurgeDays,
+                        in: 1...365
+                    )
+                    .font(.headline)
+
+                    Text(
+                        "Archiving moves a workspace into a hidden .archived folder. It is permanently deleted after this delay."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
             } header: {
                 Text("General")

--- a/Sources/WorkspaceManagerCore/Models/Models.swift
+++ b/Sources/WorkspaceManagerCore/Models/Models.swift
@@ -289,6 +289,10 @@ public final class Workspace {
     public var statusRaw: String
     public var gitBranch: String?
 
+    /// When the workspace was archived (its directory moved to `.archived/`).
+    /// `nil` while active; drives the purge-after-delay sweep.
+    public var archivedAt: Date?
+
     /// Workspace-level default agent command (e.g. `claude --resume`). Most
     /// specific tier — overrides both the repo and global defaults.
     public var defaultAgentCommand: String?
@@ -420,6 +424,7 @@ public final class Workspace {
         lastAccessedAt: Date = Date(),
         status: WorkspaceStatus = .active,
         gitBranch: String? = nil,
+        archivedAt: Date? = nil,
         defaultAgentCommand: String? = nil,
         backendIdentifier: String = "local",
         remoteId: String? = nil,
@@ -435,6 +440,7 @@ public final class Workspace {
         self.lastAccessedAt = lastAccessedAt
         self.statusRaw = status.rawValue
         self.gitBranch = gitBranch
+        self.archivedAt = archivedAt
         self.defaultAgentCommand = defaultAgentCommand
         self.backendIdentifier = backendIdentifier
         self.remoteId = remoteId

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -111,7 +111,10 @@ public protocol WorkspaceServiceProtocol: Sendable {
         name: String,
         progress: WorkspaceCreationProgressHandler?
     ) async throws -> NewWorkspaceInfo
-    func archiveWorkspace(at workspaceURL: URL) async throws
+    @discardableResult
+    func archiveWorkspace(at workspaceURL: URL) async throws -> URL
+    @discardableResult
+    func unarchiveWorkspace(at workspaceURL: URL) async throws -> URL
     func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws
     func runLifecycleScript(_ scriptName: String, in directory: URL) async throws -> WorkspaceService.ScriptResult
     func getWorkspaceSize(at workspaceURL: URL) async throws -> Int64

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryArchiver.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryArchiver.swift
@@ -1,0 +1,106 @@
+//
+//  WorkspaceDirectoryArchiver.swift
+//  WorkspaceManager
+//
+//  Moves a workspace directory into (and back out of) the `.archived/` area of
+//  the workspaces root, preserving git worktree metadata via `git worktree move`.
+//
+
+import Foundation
+import os.log
+
+private let log = Logger(subsystem: "com.cloudcompute.workspaces", category: "WorkspaceDirectoryArchiver")
+
+public enum WorkspaceDirectoryArchiver {
+    /// Archived layout mirrors the live layout one level down a `.archived/` dir:
+    /// a workspace at `<root>/<repo>/<name>` archives to `<root>/.archived/<repo>/<name>`.
+    public static let archivedDirectoryComponent = ".archived"
+
+    /// Destination for archiving `<root>/<repo>/<name>` → `<root>/.archived/<repo>/<name>`.
+    public static func archivedDestination(for source: URL) -> URL {
+        let name = source.lastPathComponent
+        let repoDir = source.deletingLastPathComponent()
+        let repo = repoDir.lastPathComponent
+        let root = repoDir.deletingLastPathComponent()
+        return
+            root
+            .appendingPathComponent(archivedDirectoryComponent, isDirectory: true)
+            .appendingPathComponent(repo, isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+    }
+
+    /// Destination for restoring `<root>/.archived/<repo>/<name>` → `<root>/<repo>/<name>`.
+    public static func restoredDestination(for archivedSource: URL) -> URL {
+        let name = archivedSource.lastPathComponent
+        let repoDir = archivedSource.deletingLastPathComponent()
+        let repo = repoDir.lastPathComponent
+        let archivedRoot = repoDir.deletingLastPathComponent()
+        let root = archivedRoot.deletingLastPathComponent()
+        return
+            root
+            .appendingPathComponent(repo, isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+    }
+
+    /// Moves a workspace directory, keeping git worktree bookkeeping consistent.
+    ///
+    /// A linked worktree's `.git` file and `.git/worktrees/<id>/gitdir` both encode
+    /// absolute paths, so a plain `FileManager.moveItem` would orphan the worktree —
+    /// `git worktree move` updates both sides atomically.
+    public static func move(from sourceURL: URL, to destinationURL: URL) async throws {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: sourceURL.path) else {
+            throw WorkspaceError.deletionFailed(reason: "No workspace directory at \(sourceURL.path)")
+        }
+        guard !fileManager.fileExists(atPath: destinationURL.path) else {
+            throw WorkspaceError.alreadyExists(name: destinationURL.lastPathComponent)
+        }
+
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        if WorkspaceDirectoryRemover.isLinkedGitWorktree(at: sourceURL, fileManager: fileManager) {
+            try await moveGitWorktree(from: sourceURL, to: destinationURL)
+        } else {
+            try fileManager.moveItem(at: sourceURL, to: destinationURL)
+        }
+
+        WorkspaceDirectoryRemover.cleanupEmptyParent(of: sourceURL, fileManager: fileManager)
+    }
+
+    private static func moveGitWorktree(from sourceURL: URL, to destinationURL: URL) async throws {
+        let commonGitDirectoryURL: URL?
+        do {
+            commonGitDirectoryURL = try await WorkspaceDirectoryRemover.commonGitDirectory(at: sourceURL)
+        } catch {
+            commonGitDirectoryURL = nil
+            log.warning(
+                "Failed to read common git directory for workspace move at \(sourceURL.path): \(error.localizedDescription)"
+            )
+        }
+
+        let arguments: [String]
+        if let commonGitDirectory = commonGitDirectoryURL {
+            arguments = [
+                "--git-dir", commonGitDirectory.path,
+                "worktree", "move", sourceURL.path, destinationURL.path,
+            ]
+        } else {
+            arguments = ["worktree", "move", sourceURL.path, destinationURL.path]
+        }
+
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/git",
+            arguments: arguments,
+            currentDirectory: sourceURL.deletingLastPathComponent(),
+            timeout: 30
+        )
+
+        guard result.success else {
+            let reason = result.stderr.isEmpty ? "Unknown error" : result.stderr
+            throw WorkspaceError.deletionFailed(reason: reason)
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceDirectoryRemover.swift
@@ -94,7 +94,7 @@ enum WorkspaceDirectoryRemover {
         cleanupEmptyParent(of: workspaceURL, fileManager: fileManager)
     }
 
-    private static func isLinkedGitWorktree(at workspaceURL: URL, fileManager: FileManager) -> Bool {
+    static func isLinkedGitWorktree(at workspaceURL: URL, fileManager: FileManager) -> Bool {
         let gitFileURL = workspaceURL.appendingPathComponent(".git")
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: gitFileURL.path, isDirectory: &isDirectory) else {
@@ -119,7 +119,7 @@ enum WorkspaceDirectoryRemover {
         return branchName.isEmpty ? nil : branchName
     }
 
-    private static func commonGitDirectory(at workspaceURL: URL) async throws -> URL? {
+    static func commonGitDirectory(at workspaceURL: URL) async throws -> URL? {
         let result = try await ProcessRunner.run(
             executable: "/usr/bin/git",
             arguments: ["rev-parse", "--path-format=absolute", "--git-common-dir"],
@@ -137,7 +137,7 @@ enum WorkspaceDirectoryRemover {
         return path.isEmpty ? nil : URL(fileURLWithPath: path)
     }
 
-    private static func cleanupEmptyParent(of workspaceURL: URL, fileManager: FileManager) {
+    static func cleanupEmptyParent(of workspaceURL: URL, fileManager: FileManager) {
         let parentDir = workspaceURL.deletingLastPathComponent()
         guard fileManager.fileExists(atPath: parentDir.path) else { return }
 

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -179,8 +179,22 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
 
     // MARK: - Archive Workspace
 
-    public func archiveWorkspace(at workspaceURL: URL) async throws {
+    /// Runs teardown lifecycle scripts, then moves the workspace directory into the
+    /// `.archived/` area of the workspaces root. Returns the new archived location.
+    @discardableResult
+    public func archiveWorkspace(at workspaceURL: URL) async throws -> URL {
         try await runTeardownLifecycle(in: workspaceURL)
+        let destination = WorkspaceDirectoryArchiver.archivedDestination(for: workspaceURL)
+        try await WorkspaceDirectoryArchiver.move(from: workspaceURL, to: destination)
+        return destination
+    }
+
+    /// Moves an archived workspace directory back to its live location and returns it.
+    @discardableResult
+    public func unarchiveWorkspace(at workspaceURL: URL) async throws -> URL {
+        let destination = WorkspaceDirectoryArchiver.restoredDestination(for: workspaceURL)
+        try await WorkspaceDirectoryArchiver.move(from: workspaceURL, to: destination)
+        return destination
     }
 
     // MARK: - Delete Workspace

--- a/Tests/WorkspaceManagerAppTests/ArchivedWorkspacePurgeTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ArchivedWorkspacePurgeTests.swift
@@ -1,0 +1,111 @@
+//
+//  ArchivedWorkspacePurgeTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Coverage for the pure selection rule that drives the archived-workspace purge sweep.
+//
+
+import Foundation
+import SwiftData
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("ArchivedWorkspacePurge")
+struct ArchivedWorkspacePurgeTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let day = 86_400.0
+
+    private func makeContext() throws -> ModelContext {
+        let schema = Schema([Repo.self, Workspace.self, WebSource.self])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [configuration])
+        return ModelContext(container)
+    }
+
+    @discardableResult
+    private func makeWorkspace(
+        in context: ModelContext,
+        repo: Repo,
+        name: String,
+        status: WorkspaceStatus,
+        backendIdentifier: String,
+        archivedAt: Date?
+    ) -> Workspace {
+        let workspace = Workspace(
+            name: name,
+            path: URL(fileURLWithPath: "/tmp/workspaces/\(name)"),
+            sourceRepo: repo,
+            status: status,
+            archivedAt: archivedAt,
+            backendIdentifier: backendIdentifier
+        )
+        context.insert(workspace)
+        return workspace
+    }
+
+    @Test("Selects only local archived workspaces past the delay (boundary inclusive)")
+    func selectsExpiredLocalArchived() throws {
+        let context = try makeContext()
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        context.insert(repo)
+
+        let expired = makeWorkspace(
+            in: context, repo: repo, name: "expired",
+            status: .archived, backendIdentifier: "local",
+            archivedAt: now.addingTimeInterval(-40 * day)
+        )
+        let boundary = makeWorkspace(
+            in: context, repo: repo, name: "boundary",
+            status: .archived, backendIdentifier: "local",
+            archivedAt: now.addingTimeInterval(-30 * day)
+        )
+        makeWorkspace(
+            in: context, repo: repo, name: "fresh",
+            status: .archived, backendIdentifier: "local",
+            archivedAt: now.addingTimeInterval(-10 * day)
+        )
+        makeWorkspace(
+            in: context, repo: repo, name: "no-timestamp",
+            status: .archived, backendIdentifier: "local", archivedAt: nil
+        )
+        makeWorkspace(
+            in: context, repo: repo, name: "active",
+            status: .active, backendIdentifier: "local", archivedAt: nil
+        )
+        makeWorkspace(
+            in: context, repo: repo, name: "remote-archived",
+            status: .archived, backendIdentifier: "daytona",
+            archivedAt: now.addingTimeInterval(-40 * day)
+        )
+
+        let result = ContentView.expiredArchivedWorkspaces(
+            [expired, boundary],
+            now: now,
+            delayDays: 30
+        )
+
+        // Re-run over the full set to confirm filtering excludes the others.
+        let all = repo.workspaces
+        let resultAll = ContentView.expiredArchivedWorkspaces(all, now: now, delayDays: 30)
+        #expect(Set(resultAll.map(\.name)) == ["expired", "boundary"])
+        #expect(Set(result.map(\.name)) == ["expired", "boundary"])
+    }
+
+    @Test("Zero or negative delay disables purge")
+    func zeroDelayDisablesPurge() throws {
+        let context = try makeContext()
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        context.insert(repo)
+        let expired = makeWorkspace(
+            in: context, repo: repo, name: "expired",
+            status: .archived, backendIdentifier: "local",
+            archivedAt: now.addingTimeInterval(-400 * day)
+        )
+
+        #expect(ContentView.expiredArchivedWorkspaces([expired], now: now, delayDays: 0).isEmpty)
+        #expect(ContentView.expiredArchivedWorkspaces([expired], now: now, delayDays: -5).isEmpty)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -555,6 +555,46 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(workspace.status == .archived)
     }
 
+    @Test("Local archive records archivedAt and moves path under .archived; unarchive reverses")
+    @MainActor
+    func localArchiveAndUnarchiveUpdateArchivedState() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: workspaceURL,
+            sourceRepo: repo,
+            status: .active,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let workspaceService = MockWorkspaceService()
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()]
+        )
+
+        try await controller.archive(workspace)
+
+        let archivedPath = "/tmp/workspaces/.archived/api/feature-a"
+        #expect(workspace.status == .archived)
+        #expect(workspace.archivedAt != nil)
+        #expect(workspace.path == archivedPath)
+
+        try await controller.unarchive(workspace)
+
+        #expect(workspaceService.unarchiveWorkspaceCalls == [URL(fileURLWithPath: archivedPath)])
+        #expect(workspace.status == .active)
+        #expect(workspace.archivedAt == nil)
+        #expect(workspace.path == workspaceURL.path)
+    }
+
     @Test("Archiving local workspace retires terminal sessions before service lifecycle")
     @MainActor
     func archivingLocalWorkspaceRetiresTerminalSessionsBeforeServiceLifecycle() async throws {
@@ -701,6 +741,7 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
     var createWorkspaceResult: NewWorkspaceInfo?
     var createWorkspaceCalls: [CreateWorkspaceCall] = []
     var archiveWorkspaceCalls: [URL] = []
+    var unarchiveWorkspaceCalls: [URL] = []
     var deleteWorkspaceCalls: [(workspaceURL: URL, deleteFiles: Bool)] = []
     var createWorkspaceDelay: @Sendable () async -> Void = {}
     var archiveWorkspaceWillRun: @Sendable () async -> Void = {}
@@ -731,9 +772,15 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         )
     }
 
-    func archiveWorkspace(at workspaceURL: URL) async throws {
+    func archiveWorkspace(at workspaceURL: URL) async throws -> URL {
         await archiveWorkspaceWillRun()
         archiveWorkspaceCalls.append(workspaceURL)
+        return WorkspaceDirectoryArchiver.archivedDestination(for: workspaceURL)
+    }
+
+    func unarchiveWorkspace(at workspaceURL: URL) async throws -> URL {
+        unarchiveWorkspaceCalls.append(workspaceURL)
+        return WorkspaceDirectoryArchiver.restoredDestination(for: workspaceURL)
     }
 
     func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws {

--- a/Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift
@@ -183,7 +183,13 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         )
     }
 
-    func archiveWorkspace(at workspaceURL: URL) async throws {}
+    func archiveWorkspace(at workspaceURL: URL) async throws -> URL {
+        WorkspaceDirectoryArchiver.archivedDestination(for: workspaceURL)
+    }
+
+    func unarchiveWorkspace(at workspaceURL: URL) async throws -> URL {
+        WorkspaceDirectoryArchiver.restoredDestination(for: workspaceURL)
+    }
 
     func deleteWorkspace(at workspaceURL: URL, deleteFiles: Bool) async throws {}
 

--- a/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceOrphanReconcilerTests.swift
@@ -328,6 +328,55 @@ struct WorkspaceOrphanReconcilerTests {
         #expect(fileSystem.directoryExistsCallCount == 0)
     }
 
+    @Test("Archived workspace under .archived produces no orphan items")
+    func archivedWorkspaceProducesNoOrphans() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+        try repo.createFile("README.md", content: "hello\n")
+        try repo.commit(message: "initial")
+
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let workspacesRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        let worktreeURL =
+            workspacesRoot
+            .appendingPathComponent("sample-repo", isDirectory: true)
+            .appendingPathComponent("to-archive", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktreeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        _ = try runGit(
+            ["worktree", "add", "-b", "workspace/to-archive", worktreeURL.path, "HEAD"],
+            at: repo.url
+        )
+
+        // Archive moves the worktree into <workspacesRoot>/.archived/sample-repo/to-archive.
+        let archivedURL = WorkspaceDirectoryArchiver.archivedDestination(for: worktreeURL)
+        try await WorkspaceDirectoryArchiver.move(from: worktreeURL, to: archivedURL)
+
+        let workspace = workspaceSnapshot(
+            name: "to-archive",
+            path: archivedURL.path,
+            gitBranch: "workspace/to-archive"
+        )
+        let reconciler = WorkspaceOrphanReconciler(
+            workspacesRoot: workspacesRoot,
+            lumeWorkspaceStorageURL: nil
+        )
+        let result = await reconciler.scan(
+            repositories: [
+                repoSnapshot(
+                    name: "sample-repo",
+                    localPath: repo.url.path,
+                    workspaces: [workspace]
+                )
+            ]
+        )
+
+        #expect(result.items.isEmpty)
+    }
+
     private func makeTempDir() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("WorkspaceOrphanReconcilerTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -786,31 +786,44 @@ struct WorkspaceServiceTests {
 
     // MARK: - archiveWorkspace Tests
 
-    @Test("archiveWorkspace succeeds when no archive script exists")
+    @Test("archiveWorkspace moves the directory into .archived when no script exists")
     func archiveWorkspaceSucceedsWithoutScript() async throws {
         let mockGit = MockGitService()
         let service = WorkspaceService(gitService: mockGit)
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        try await service.archiveWorkspace(at: tempDir)
+        let wsDir = tempDir.appendingPathComponent("repo/ws", isDirectory: true)
+        try FileManager.default.createDirectory(at: wsDir, withIntermediateDirectories: true)
+
+        let destination = try await service.archiveWorkspace(at: wsDir)
+
+        #expect(destination.path == tempDir.appendingPathComponent(".archived/repo/ws").path)
+        #expect(!FileManager.default.fileExists(atPath: wsDir.path))
+        #expect(FileManager.default.fileExists(atPath: destination.path))
     }
 
-    @Test("archiveWorkspace runs archive.sh")
+    @Test("archiveWorkspace runs archive.sh before moving the directory")
     func archiveWorkspaceRunsScript() async throws {
         let mockGit = MockGitService()
         let service = WorkspaceService(gitService: mockGit)
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
+        let wsDir = tempDir.appendingPathComponent("repo/ws", isDirectory: true)
+        try FileManager.default.createDirectory(at: wsDir, withIntermediateDirectories: true)
+
+        // Marker is written outside the workspace dir so it survives the archive move.
         try """
         #!/bin/bash
         touch "\(tempDir.path)/archived.marker"
-        """.write(to: tempDir.appendingPathComponent("archive.sh"), atomically: true, encoding: .utf8)
+        """.write(to: wsDir.appendingPathComponent("archive.sh"), atomically: true, encoding: .utf8)
 
-        try await service.archiveWorkspace(at: tempDir)
+        let destination = try await service.archiveWorkspace(at: wsDir)
 
         #expect(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("archived.marker").path))
+        #expect(FileManager.default.fileExists(atPath: destination.path))
+        #expect(!FileManager.default.fileExists(atPath: wsDir.path))
     }
 
     @Test("archiveWorkspace runs project-scripts stop then archive")
@@ -820,7 +833,8 @@ struct WorkspaceServiceTests {
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        let scriptsDir = tempDir.appendingPathComponent("scripts", isDirectory: true)
+        let wsDir = tempDir.appendingPathComponent("repo/ws", isDirectory: true)
+        let scriptsDir = wsDir.appendingPathComponent("scripts", isDirectory: true)
         try FileManager.default.createDirectory(at: scriptsDir, withIntermediateDirectories: true)
         let orderFile = tempDir.appendingPathComponent("teardown-order.log")
         try """
@@ -834,10 +848,73 @@ struct WorkspaceServiceTests {
         printf "archive\\n" >> "\(orderFile.path)"
         """.write(to: scriptsDir.appendingPathComponent("archive"), atomically: true, encoding: .utf8)
 
-        try await service.archiveWorkspace(at: tempDir)
+        try await service.archiveWorkspace(at: wsDir)
 
         let order = try String(contentsOf: orderFile, encoding: .utf8)
         #expect(order == "stop\narchive\n")
+    }
+
+    @Test("archived and restored destinations round-trip")
+    func archivedRestoredDestinationsRoundTrip() {
+        let source = URL(fileURLWithPath: "/tmp/roots/myrepo/feature-x", isDirectory: true)
+        let archived = WorkspaceDirectoryArchiver.archivedDestination(for: source)
+        #expect(archived.path == "/tmp/roots/.archived/myrepo/feature-x")
+        let restored = WorkspaceDirectoryArchiver.restoredDestination(for: archived)
+        #expect(restored.path == source.path)
+    }
+
+    @Test("archiveWorkspace moves a linked worktree and updates git metadata")
+    func archiveWorkspaceMovesLinkedWorktree() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "archive-me"
+        )
+
+        let archivedURL = try await service.archiveWorkspace(at: info.path)
+
+        #expect(archivedURL.path == wsRoot.appendingPathComponent(".archived/test-repo/archive-me").path)
+        #expect(!FileManager.default.fileExists(atPath: info.path.path))
+        #expect(FileManager.default.fileExists(atPath: archivedURL.path))
+
+        let list = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
+        #expect(self.worktreeList(list, contains: archivedURL))
+        #expect(!self.worktreeList(list, contains: info.path))
+
+        // The moved worktree is still a valid git worktree (status succeeds, doesn't throw).
+        _ = try runGit(["status", "--porcelain"], at: archivedURL)
+    }
+
+    @Test("unarchiveWorkspace restores a linked worktree to its original path")
+    func unarchiveWorkspaceRestoresLinkedWorktree() async throws {
+        let service = WorkspaceService()
+        let (testRoot, repoDir, wsRoot) = try makeGitWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "round-trip"
+        )
+        let archivedURL = try await service.archiveWorkspace(at: info.path)
+
+        let restoredURL = try await service.unarchiveWorkspace(at: archivedURL)
+
+        #expect(restoredURL.path == info.path.path)
+        #expect(FileManager.default.fileExists(atPath: restoredURL.path))
+        #expect(!FileManager.default.fileExists(atPath: archivedURL.path))
+
+        let list = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
+        #expect(self.worktreeList(list, contains: restoredURL))
+        #expect(!self.worktreeList(list, contains: archivedURL))
     }
 
     @Test("deleteWorkspace runs project-scripts teardown before removing workspace")


### PR DESCRIPTION
Closes #651.

## What

Archiving a local workspace now *archives* it instead of only flipping a status flag:

- **Moves the directory** into a hidden `.archived/<repo>/<name>` area of the workspaces root, via `git worktree move` so the worktree's `.git` pointer and `.git/worktrees/<id>/gitdir` bookkeeping stay consistent (a plain move would orphan the worktree). `archivedAt` is recorded on the model.
- **Hides archived workspaces** behind a collapsible, per-repo **"Archived (n)"** section in the sidebar — collapsed by default, auto-expands when the selected workspace is archived so a restored selection isn't stranded.
- **Purges** archived workspaces whose `archivedAt` has aged past a **Settings-configurable delay (default 30 days)** in a startup sweep, reusing the existing delete path.
- **Unarchive** moves the directory back out of `.archived/` and clears the archived state.

**Scope:** local git-worktree workspaces. Remote/Lume keep their existing provider-archive behavior.

## Key files
- `WorkspaceDirectoryArchiver` (new) — `git worktree move` / `FileManager` move + pure `archivedDestination`/`restoredDestination` path helpers.
- `WorkspaceService.archiveWorkspace` (now moves + returns the new URL) / `unarchiveWorkspace` (new).
- `SidebarWorkspaceController.archive`/`unarchive`, `SidebarView` collapsible section, `SettingsView` purge-days, `ContentView.purgeExpiredArchivedWorkspaces`.
- `Workspace.archivedAt` (additive SwiftData field; lightweight migration).

## Evidence
- **Tests:** full suite green — `swift test` → 904 tests / 143 suites pass; `mise run lint` clean. New coverage: `git worktree move` archive + unarchive round-trip against a real repo (worktree list reflects the moved path), controller archive/unarchive state, purge-selection boundary cases, and an orphan-reconciler regression asserting an archived workspace yields no false orphans.
- **Boot + UI:** dev-smoke (`--no-activate`) confirms the SwiftData migration applies and the sidebar renders the collapsed "Archived (1)" section. Screenshot below.

![Sidebar: archived workspace hidden in a collapsed "Archived (1)" section](https://evidence.cloudcompute.com/workspaces/pr-661/20260610-081342-sidebar-archived-collapsed.png)

## Out of scope
- Recording archive/purge events in `LocalStateStore` (diagnostics nicety).
- Directory move for remote/Lume backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Mergeability

- Surface: desktop
- User-facing behavior changed: Yes — archiving a local workspace moves its directory into a hidden `.archived/` area and removes it from the active sidebar list (now under a collapsible "Archived (n)" section); a Settings control sets the auto-purge delay (default 30 days); unarchive restores it.
- Non-happy paths considered: Yes — `git worktree move` failures surface as `WorkspaceError`; destination-exists/source-missing guarded; unarchive fails clearly if the original path is occupied; archived workspaces with no `archivedAt` (pre-feature) are never auto-purged; orphan reconciler verified to not flag `.archived/` worktrees.
- Residual risk or follow-up: Low. Move is local-worktree-only (remote/Lume unchanged). Follow-ups (out of scope): recording archive/purge events in `LocalStateStore`; surfacing archived workspaces in the command palette.

## Validation

- `swift test` → 904 tests / 143 suites pass; `mise run lint` clean.
- dev-smoke (`--no-activate`) boots the debug build (SwiftData `archivedAt` migration applies) and renders the collapsed "Archived (1)" sidebar section (screenshot above).
