### PR TITLE
release: v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.19.0] - 2026-06-10
+
+### Added
+- tile-tree core model + reducer (Phase 0–1)
+- tile-tree Phase 2 — protocol Surface seam + SurfaceStore (#633)
+- desktop UI smoke for daily-driver flows (create workspace, terminal follows selection)
+- tile-tree Phase 3 — TileTreeState is the split-layout source of truth (#645)
+- reconcile orphaned workspace resources (#650)
+- adopt ProcessRunner.run timeout: at all non-Lume call sites (#648)
+- archive workspaces to .archived/ with purge and hidden UI (#661)
+
+### Fixed
+- harden tile tree ratio clamping
+- harden ProcessRunner against subprocess hang classes (#634) (#640)
+- exempt docs-only PRs from the readiness evidence gate
+- trust mise config first in setup so new workspaces don't show trust errors (#657)
+
+### Other
+- lock close-focus reassignment + single-tile close no-op
+- satisfy swift-format strict lint in tile-tree tests
+- Fix debug performance benchmark contract
+- refresh roadmap — tile-tree reversal, v0.18.0, core-reliability cluster
+- tighten AGENTS.md to its startup budget (#626)
+- Coordinate workspace deletion cleanup
+- Document GitHub issue claim workflow in AGENTS
+- bump pinned mise to v2026.6.1 to satisfy verify-mise-security
+- Improve managed review timing observability
+- Stabilize docs operator search
+- Dedup and close prod CD failure issues
+- add main window hotspot baselines (#655)
+- Speed up managed review turnaround (#656)
+- Simplify repo terminal toolbar title (#659)
+
 ## [0.18.0] - 2026-06-07
 
 ### Added

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.18.0</string>
+	<string>0.19.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

Prepare WorkSpaces v0.19.0 from origin/main.

- Bumps CFBundleShortVersionString to 0.19.0 and CFBundleVersion to 24.
- Prepends the v0.19.0 changelog section.
- Direct main push was rejected by branch protection, so this PR is the protected release path.

## Mergeability

- Surface: desktop release metadata / changelog
- User-facing behavior changed: Installed app and Sparkle-visible version become 0.19.0; release notes include the v0.19.0 changelog.
- Non-happy paths considered: Direct main push is blocked by repository rules; tag v0.19.0 was not pushed, so the public release workflow has not started prematurely.
- Release/ops preconditions: Merge this PR through protected main, then push tag v0.19.0 from the merged main commit or rerun the release tag step from protected main.
- Residual risk or follow-up: Normal PR checks and managed review must pass before merge; after the tag-driven release passes, finish with the documented DMG download and Sparkle Check for Updates verification.

## Validation

- [x] ./scripts/build-ghosttykit.sh
- [x] swift test: passed outside workspace sandbox, 907 tests in 143 suites
- [x] Other checks run: ./scripts/release-preflight.sh --dry-run bc6db1b2 fairchild/workspaces passed; ./scripts/build-release.sh --no-sign passed; ./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-v0.19.0-installed-perf-verify passed outside sandbox

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from config/performance/contract.json
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: installed_clean_shell
- Before Summary: /tmp/workspaces-v0.19.0-installed-perf-verify/installed-clean-summary.json
- After Summary: /tmp/workspaces-v0.19.0-installed-perf-verify/installed-clean-summary.json
- Delta Summary: Release signoff is budget-based rather than branch-delta based; the same installed summary was reused only to render the hosted evidence SVG. launch_to_first_prompt 132.51ms <= 800ms; terminal_first_output 118.27ms <= 675ms; first_prompt_ready 118.27ms <= 675ms.

Performance comparison notes:

- Exact commands used: ./scripts/build-release.sh --no-sign; ./scripts/verify-installed-perf.sh build/WorkSpaces.app /tmp/workspaces-v0.19.0-installed-perf-verify
- Workload / environment context: installed_clean_shell on Mac16,13 / macOS 26.4.1; no-activate clean-shell packaged app capture; verifier confirmed terminal_first_output and first_prompt_ready were present.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![release-v0.19.0-installed-perf](https://evidence.cloudcompute.com/workspaces/pr-662/20260610-094252-release-v0.19.0-installed-perf.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
