### PR TITLE
Deepen agent update intake routing

### DIFF
--- a/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/ClaudeIntegrationLifecycle.swift
@@ -37,14 +37,14 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         let eventForwarderPath = ClaudeIntegrationLifecycle.extractEventForwarderScript()
         if eventForwarderPath == nil {
             NSLog(
-                "[ClaudeIntegration] event-forwarder.sh extraction failed; Channel 1 will be skipped this session"
+                "[ClaudeIntegration] event-forwarder.sh extraction failed; command hook forwarder will be skipped this session"
             )
         }
 
         let statusLinePath = ClaudeIntegrationLifecycle.extractStatusLineForwarderScript()
         if statusLinePath == nil {
             NSLog(
-                "[ClaudeIntegration] statusline.sh extraction failed; skipping Channel 2 contribution"
+                "[ClaudeIntegration] statusline.sh extraction failed; skipping status-line forwarder"
             )
         }
 
@@ -138,17 +138,16 @@ final class ClaudeIntegrationLifecycle: ObservableObject {
         }
     }
 
-    /// Copy the bundled `event-forwarder.sh` (Channel 1 hook event forwarder) to a
-    /// stable location and chmod it executable. Returns the destination path, or
-    /// nil if extraction failed — the contribution then declines to register, and
-    /// Channel 1 stays dormant for this session.
+    /// Copy the bundled command hook forwarder to a stable location and chmod it
+    /// executable. Returns the destination path, or nil if extraction failed —
+    /// the contribution then declines to register.
     nonisolated static func extractEventForwarderScript() -> String? {
         extractHookForwarderScript(named: "event-forwarder")
     }
 
-    /// Copy the bundled `statusline.sh` (Channel 2 status-line forwarder) to the
-    /// same stable extraction dir as Channel 1, symmetric with the event
-    /// forwarder. Returns the destination path, or nil if extraction failed.
+    /// Copy the bundled status-line forwarder to the same stable extraction dir
+    /// as the command hook forwarder. Returns the destination path, or nil if
+    /// extraction failed.
     nonisolated static func extractStatusLineForwarderScript() -> String? {
         extractHookForwarderScript(named: "statusline")
     }

--- a/Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh
@@ -13,7 +13,7 @@
 # pipeline errors. curl, however, supports `--unix-socket`, so we pipe through
 # it from a small command-hook script. Same pattern as `statusline.sh`.
 #
-# Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 1.
+# Agent update intake purpose: command hook forwarder.
 #
 # Hard requirements:
 #   * stdlib bash + curl only — no jq, no python.

--- a/Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh
@@ -8,7 +8,7 @@
 # single space so the terminal status row stays empty (the host owns
 # visualization).
 #
-# Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 2.
+# Agent update intake purpose: status-line forwarder.
 #
 # Hard requirements:
 #   * stdlib bash + curl only — no jq, no python.

--- a/Sources/WorkspaceManager/Services/AgentNotificationPoster.swift
+++ b/Sources/WorkspaceManager/Services/AgentNotificationPoster.swift
@@ -3,8 +3,8 @@
 //  WorkspaceManager
 //
 //  Observes the AgentSessionRegistry and posts a macOS user notification when a
-//  session transitions into `.awaitingInput(.permissionPrompt)`. Per spec § Channel 1
-//  ("Notification → permission_prompt"), this is the canonical attention signal.
+//  session transitions into `.awaitingInput(.permissionPrompt)`. Command hook
+//  notification events are the canonical attention signal.
 //
 //  Coalescing: at most one notification per host session per 30s.
 //

--- a/Sources/WorkspaceManager/Terminal/AgentOSCRouter.swift
+++ b/Sources/WorkspaceManager/Terminal/AgentOSCRouter.swift
@@ -2,12 +2,9 @@
 //  AgentOSCRouter.swift
 //  WorkspaceManager
 //
-//  Channel 3 entry point: routes libghostty OSC notifications and BEL into the
-//  AgentSessionRegistry. Sits between GhosttyRuntimeActionBridge (raw C action
-//  tags) and the registry (typed AgentEvents) so the bridge never imports
-//  WorkspaceManagerCore directly.
-//
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 3.
+//  Terminal attention fallback entry point: routes libghostty OSC notifications
+//  and BEL into the AgentSessionRegistry. Sits between GhosttyRuntimeActionBridge
+//  (raw C action tags) and the registry (typed AgentEvents).
 //
 
 import AppKit
@@ -53,7 +50,7 @@ final class AgentOSCRouter {
         guard let hostID = resolveHostSession?(surfaceView) else { return }
         guard let registry else { return }
         let kind = registry.statuses[hostID]?.kind ?? .unknown
-        let event = AgentOSCEventMapper.mapNotification(kind: kind, title: title, body: body)
+        let event = AgentUpdateIntake.terminalNotificationEvent(kind: kind, title: title, body: body)
         registry.apply(
             events: [event],
             for: hostID,
@@ -71,7 +68,7 @@ final class AgentOSCRouter {
         guard let hostID = resolveHostSession?(surfaceView) else { return }
         guard let registry else { return }
         let kind = registry.statuses[hostID]?.kind ?? .unknown
-        let event = AgentOSCEventMapper.mapBell(kind: kind)
+        let event = AgentUpdateIntake.terminalBellEvent(kind: kind)
         registry.apply(
             events: [event],
             for: hostID,

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -197,9 +197,9 @@ final class GhosttySurfaceView: NSView {
         promptReadinessSignposts.completeIfNeeded(signal: signal)
     }
 
-    /// Channel 3: an OSC 9 / OSC 777 notification from the agent. Forward to the
-    /// registry via the OSC router so the sidebar dot, macOS notifications, and
-    /// the dedup window all see the same event.
+    /// Terminal attention fallback: an OSC 9 / OSC 777 notification from the
+    /// agent. Forward to the registry via the OSC router so the sidebar dot,
+    /// macOS notifications, and the dedup window all see the same event.
     func handleDesktopNotification(
         title: String?,
         body: String,
@@ -213,8 +213,9 @@ final class GhosttySurfaceView: NSView {
         )
     }
 
-    /// Channel 3: terminal BEL. Routed through the OSC router so the registry's
-    /// adapter has a single ingestion path for non-hook attention signals.
+    /// Terminal attention fallback: terminal BEL. Routed through the OSC router
+    /// so the registry has a single ingestion path for non-hook attention
+    /// signals.
     func handleRingBell(surfaceAddress: UInt) {
         AgentOSCRouter.shared.handleRingBell(
             surfaceView: self,

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -48,9 +48,9 @@ struct GhosttyTerminalConfig {
         environment["COLORTERM"] = "truecolor"
         environment["LANG"] = "en_US.UTF-8"
 
-        // Channel 1 plumbing: when both pieces of context are available, expose them to
-        // the embedded shell so Claude Code (and any forwarder script) can address the
-        // host's hook listener over its Unix socket without per-process discovery.
+        // Command hook plumbing: when both pieces of context are available,
+        // expose them to the embedded shell so Agent hooks can address the host's
+        // hook listener over its Unix socket without per-process discovery.
         if let hooksSocketPath, let hostSessionID {
             environment["WORKSPACES_HOOKS_SOCKET"] = hooksSocketPath
             environment["WORKSPACES_HOST_SESSION_ID"] = hostSessionID.uuidString

--- a/Sources/WorkspaceManager/Terminal/PTYForegroundProbe.swift
+++ b/Sources/WorkspaceManager/Terminal/PTYForegroundProbe.swift
@@ -5,7 +5,7 @@
 //  Detect the foreground agent type for a libghostty surface by looking at the
 //  PTY's foreground process group leader (`tcgetpgrp` + `proc_pidpath`). PR #1
 //  ships a fail-safe default that always returns `.claudeCode`, since the only
-//  rich-hooks adapter is Claude — OSC fallback covers everything else and an
+//  rich hook speaker is Claude — OSC fallback covers everything else and an
 //  upstream libghostty change is required to expose the PTY fd cleanly.
 //
 //  See coordination.md (PR #1 deviations) and spec § "Anti-patterns" → process-name
@@ -33,8 +33,8 @@ public struct PTYForegroundProbe: Sendable {
     // decodes hook payloads, and the OSC fallback covers every other agent
     // regardless of detected kind.
     //
-    // Real foreground-process detection becomes a Channel 3 concern when opencode
-    // or aider parity matters. At that point, replace the body with
+    // Real foreground-process detection becomes necessary when opencode or aider
+    // parity matters. At that point, replace the body with
     // `tcgetpgrp` + a `proc_pidpath` lookup against the slave-side PTY fd (requires
     // either an upstream libghostty addition that exposes the fd, or platform
     // traversal of the surface's child-process tree via `proc_listpids`). The

--- a/Sources/WorkspaceManager/Views/AgentsSettingsView.swift
+++ b/Sources/WorkspaceManager/Views/AgentsSettingsView.swift
@@ -7,7 +7,7 @@
 //  actual on-disk install state so the toggle is self-healing if the user reverts
 //  the install externally.
 //
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 1 ("Configuration").
+//  Installs the command hook and status-line forwarders.
 //
 
 import AppKit
@@ -409,8 +409,8 @@ private struct ClaudeHookRevertSheet: View {
     }
 }
 
-/// Compact status row that surfaces the live status fields populated by Channel 2
-/// (status-line forwarder). Reads `AgentSessionRegistry.statuses` directly — no
+/// Compact status row that surfaces the live status fields populated by the
+/// status-line forwarder. Reads `AgentSessionRegistry.statuses` directly — no
 /// new `@Published` publisher; we observe via the registry's own `objectWillChange`.
 ///
 /// "Focused session" is the most-recently-updated session in the registry. PR #2
@@ -422,7 +422,7 @@ private struct AgentStatusFieldsIndicator: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("Live Status (Channel 2)")
+            Text("Live Status")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
 

--- a/Sources/WorkspaceManager/Views/Conversation/ConversationLogView.swift
+++ b/Sources/WorkspaceManager/Views/Conversation/ConversationLogView.swift
@@ -6,8 +6,7 @@
 //  conversation log") opens this view. Renders the transcript as a scrollable
 //  list. Unknown record types render as collapsed JSON.
 //
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 4 ("Show me the
-//  conversation log UI per copy").
+//  Conversation log view for the transcript JSONL reader.
 //
 
 import AppKit

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -60,7 +60,8 @@ final class HostTerminalStateStore: ObservableObject {
     private weak var lastCommandStatusRegistry: LastCommandStatusRegistry?
     private var localStateStore: LocalStateStore?
     /// Stub probe used to seed `kind` on register; PR #1 ships a fail-safe
-    /// `.claudeCode` default. Replace with the real probe in a Channel 3 follow-up.
+    /// `.claudeCode` default. Replace with the real probe in a foreground Agent
+    /// detection follow-up.
     private let foregroundProbe = PTYForegroundProbe()
     /// Set of session IDs the store has already registered with the agent registry,
     /// so we only register/deregister on real edge transitions.
@@ -91,8 +92,9 @@ final class HostTerminalStateStore: ObservableObject {
         // Backfill: any sessions already in the coordinator should be registered.
         syncRegistry()
 
-        // Channel 3: hook the surface→host-session resolver into the OSC router so
-        // libghostty desktop notifications and BEL events can find their session.
+        // Terminal attention fallback: hook the surface→host-session resolver
+        // into the OSC router so libghostty desktop notifications and BEL events
+        // can find their session.
         let store = self.surfaceStore
         AgentOSCRouter.shared.attach(registry: agentSessionRegistry) { surfaceView in
             store.sessionID(for: surfaceView)
@@ -665,7 +667,8 @@ final class HostTerminalStateStore: ObservableObject {
         // Register newly-seen sessions.
         for session in allSessions where !registeredAgentSessionIDs.contains(session.id) {
             // PR #1: probe is a stub returning `.claudeCode` for every surface.
-            // Replace surfaceID with a real value when the Channel 3 probe lands.
+            // Replace surfaceID with a real value when foreground Agent
+            // detection lands.
             let kind = foregroundProbe.detect(surfaceID: 0)
             registry.register(
                 hostSessionID: session.id,

--- a/Sources/WorkspaceManagerCore/Models/AgentEvent.swift
+++ b/Sources/WorkspaceManagerCore/Models/AgentEvent.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// Agent event normalized from an input channel (HTTP hook, status line, OSC notification,
-/// or transcript reader). The registry consumes only this type.
+/// Agent event normalized from an Agent update intake path (HTTP hook, status
+/// line, terminal attention fallback, or transcript reader). The registry
+/// consumes only this type.
 ///
 /// New cases must be additive — never rename or repurpose without a migration.
 public enum AgentEvent: Sendable {

--- a/Sources/WorkspaceManagerCore/Models/StatusLinePayload.swift
+++ b/Sources/WorkspaceManagerCore/Models/StatusLinePayload.swift
@@ -7,7 +7,7 @@
 //  feeds it on stdin to the host's `/statusline` route. We decode tolerantly:
 //  missing fields are nil, unknown keys are ignored.
 //
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 2 ("Fields the host reads").
+//  Wire payload for the status-line forwarder.
 //
 
 import Foundation

--- a/Sources/WorkspaceManagerCore/Models/TranscriptRecord.swift
+++ b/Sources/WorkspaceManagerCore/Models/TranscriptRecord.swift
@@ -4,7 +4,7 @@
 //
 //  Tolerant decoder for Claude Code transcript JSONL records.
 //
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 4. Transcripts live at
+//  Transcript JSONL reader. Transcripts live at
 //  ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl. Hook payloads carry
 //  `transcript_path`; we never derive the path. Schema is technically internal
 //  and slow-moving — unknown record types decode to `.opaque(raw:)` and pass

--- a/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentHookListener.swift
@@ -2,15 +2,13 @@
 //  AgentHookListener.swift
 //  WorkspaceManagerCore
 //
-//  Unix domain socket listener for Claude Code's HTTP hook channel.
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 1 ("Listener", "Async by default").
+//  Unix domain socket listener for Agent update forwarders.
 //
 //  Routes:
-//    POST /event       — hook event, decoded via ClaudeHookTranslator
-//    POST /statusline  — Channel 2 status-line forwarder; decodes StatusLinePayload
-//                        and applies status fields for the header-routed session
+//    POST /event       — command hook forwarder, decoded via AgentUpdateIntake
+//    POST /statusline  — status-line forwarder, decoded via AgentUpdateIntake
 //    POST /command-markers
-//                      — raw OSC 133 command markers for LastCommandStatusRegistry
+//                      — command-status producer for LastCommandStatusRegistry
 //    GET  /healthz     — 200 OK "OK"
 //
 //  Framing: minimal HTTP/1.1 — request line, headers, body. We respond 200 OK
@@ -211,25 +209,15 @@ public actor AgentHookListener {
     }
 
     private func route(_ request: HTTPRequest) -> (Int, Data) {
-        switch (request.method.uppercased(), request.path) {
-        case ("GET", "/healthz"):
-            return (200, Data("OK".utf8))
-        case ("POST", "/event"):
-            return (200, Data())
-        case ("POST", "/statusline"):
-            return (200, Data())
-        case ("POST", "/command-markers"):
-            return (200, Data())
-        default:
-            return (200, Data())
-        }
+        let route = AgentUpdateIntake.httpRoute(method: request.method, path: request.path)
+        return (200, route?.responseBody ?? Data())
     }
 
     private func process(request: HTTPRequest) async {
-        switch (request.method.uppercased(), request.path) {
-        case ("POST", "/event"):
+        switch AgentUpdateIntake.httpRoute(method: request.method, path: request.path)?.purpose {
+        case .commandHookForwarder:
             await processEvent(request: request)
-        case ("POST", "/statusline"):
+        case .statusLineForwarder:
             await processStatusLine(request: request)
         default:
             break
@@ -237,7 +225,8 @@ public actor AgentHookListener {
     }
 
     private static func isCommandMarkerRequest(_ request: HTTPRequest) -> Bool {
-        request.method.uppercased() == "POST" && request.path == "/command-markers"
+        AgentUpdateIntake.httpRoute(method: request.method, path: request.path)?.purpose
+            == .commandStatusProducer
     }
 
     private func enqueueCommandMarkerRequest(_ request: HTTPRequest) {
@@ -270,7 +259,7 @@ public actor AgentHookListener {
 
         let event: AgentEvent?
         do {
-            event = try ClaudeHookTranslator.decodeAgentEvent(from: request.body)
+            event = try AgentUpdateIntake.decodeHookEvent(from: request.body)
         } catch {
             statistics.decodeFailures += 1
             logger("decode error: \(error)")
@@ -292,13 +281,12 @@ public actor AgentHookListener {
             return
         }
 
-        guard let payload = StatusLinePayload.decode(from: request.body) else {
+        guard let fields = AgentUpdateIntake.decodeStatusFields(from: request.body) else {
             statistics.decodeFailures += 1
             logger("statusline decode failed")
             return
         }
 
-        let fields = payload.toStatusFields()
         await MainActor.run { [registry] in
             registry.apply(events: [.statusFields(fields)], for: hostSessionID, origin: .statusLine)
         }
@@ -316,7 +304,7 @@ public actor AgentHookListener {
             return
         }
 
-        let markers = CommandMarkerParser.parse(request.body)
+        let markers = AgentUpdateIntake.decodeCommandMarkers(from: request.body)
         guard !markers.isEmpty else {
             statistics.decodeFailures += 1
             logger("command marker decode failed: no OSC 133 markers")

--- a/Sources/WorkspaceManagerCore/Services/AgentSessionRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentSessionRegistry.swift
@@ -3,10 +3,8 @@
 //  WorkspaceManagerCore
 //
 //  Live registry of agent session statuses keyed by host session ID. Consumes
-//  AgentEvent values from hook, status-line, and OSC inputs, then produces a
-//  normalized AgentRunState for the UI.
-//
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 1, Channel 3 ("Dedup with hooks").
+//  AgentEvent values from hook, status-line, and terminal attention inputs,
+//  then produces a normalized AgentRunState for the UI.
 //
 
 import Combine

--- a/Sources/WorkspaceManagerCore/Services/AgentUpdateIntake.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentUpdateIntake.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Owns the host-side language and transport routing for Agent updates. The
+/// concrete decoders remain below this Module; callers choose an intake purpose
+/// instead of carrying legacy channel numbers or transport details.
+public enum AgentUpdateIntake {
+    public enum RegistryTarget: Sendable, Equatable {
+        case agentSessionRegistry
+        case lastCommandStatusRegistry
+        case none
+    }
+
+    public enum Purpose: String, CaseIterable, Sendable, Equatable {
+        case commandHookForwarder
+        case statusLineForwarder
+        case commandStatusProducer
+        case terminalAttentionFallback
+        case transcriptReader
+
+        public var displayName: String {
+            switch self {
+            case .commandHookForwarder:
+                "Command hook forwarder"
+            case .statusLineForwarder:
+                "Status-line forwarder"
+            case .commandStatusProducer:
+                "Command-status producer"
+            case .terminalAttentionFallback:
+                "libghostty OSC/BEL fallback"
+            case .transcriptReader:
+                "Transcript JSONL reader"
+            }
+        }
+
+        public var registryTarget: RegistryTarget {
+            switch self {
+            case .commandHookForwarder, .statusLineForwarder, .terminalAttentionFallback:
+                .agentSessionRegistry
+            case .commandStatusProducer:
+                .lastCommandStatusRegistry
+            case .transcriptReader:
+                .none
+            }
+        }
+    }
+
+    public enum HTTPRoute: Sendable, Equatable {
+        case healthCheck
+        case accepted(Purpose)
+
+        public var purpose: Purpose? {
+            switch self {
+            case .healthCheck:
+                nil
+            case .accepted(let purpose):
+                purpose
+            }
+        }
+
+        public var responseBody: Data {
+            switch self {
+            case .healthCheck:
+                Data("OK".utf8)
+            case .accepted:
+                Data()
+            }
+        }
+    }
+
+    public static func httpRoute(method: String, path: String) -> HTTPRoute? {
+        switch (method.uppercased(), path) {
+        case ("GET", "/healthz"):
+            .healthCheck
+        case ("POST", "/event"):
+            .accepted(.commandHookForwarder)
+        case ("POST", "/statusline"):
+            .accepted(.statusLineForwarder)
+        case ("POST", "/command-markers"):
+            .accepted(.commandStatusProducer)
+        default:
+            nil
+        }
+    }
+
+    public static func decodeHookEvent(from raw: Data) throws -> AgentEvent? {
+        try ClaudeHookTranslator.decodeAgentEvent(from: raw)
+    }
+
+    public static func decodeStatusFields(from raw: Data) -> AgentEvent.StatusFields? {
+        StatusLinePayload.decode(from: raw)?.toStatusFields()
+    }
+
+    public static func decodeCommandMarkers(from raw: Data) -> [CommandMarker] {
+        CommandMarkerParser.parse(raw)
+    }
+
+    public static func terminalNotificationEvent(
+        kind: AgentKind,
+        title: String?,
+        body: String
+    ) -> AgentEvent {
+        AgentOSCEventMapper.mapNotification(kind: kind, title: title, body: body)
+    }
+
+    public static func terminalBellEvent(kind: AgentKind) -> AgentEvent {
+        AgentOSCEventMapper.mapBell(kind: kind)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/TranscriptReader.swift
+++ b/Sources/WorkspaceManagerCore/Services/TranscriptReader.swift
@@ -4,7 +4,7 @@
 //
 //  Streaming reader for Claude Code transcript JSONL files.
 //
-//  Spec: pasted_text_2026-05-03_22-18-10.txt § Channel 4. Two consumption shapes:
+//  Transcript JSONL reader. Two consumption shapes:
 //
 //    - `tail()`: opens the file, yields every record from the start, then ends.
 //      Conversation replay uses this. The reader deliberately does not rebuild

--- a/Tests/WorkspaceManagerAppTests/GhosttyRuntimeActionBridgeTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyRuntimeActionBridgeTests.swift
@@ -2,10 +2,10 @@
 //  GhosttyRuntimeActionBridgeTests.swift
 //  WorkspaceManagerAppTests
 //
-//  Channel 3: confirms the runtime bridge recognizes the desktop-notification
-//  and bell action tags and routes them through `runOnMainAsync` to a resolved
-//  surface view. The full end-to-end registry integration is covered by
-//  OSCDedupIntegrationTests in WorkspaceManagerTests.
+//  Terminal attention fallback: confirms the runtime bridge recognizes the
+//  desktop-notification and bell action tags and routes them through
+//  `runOnMainAsync` to a resolved surface view. The full end-to-end registry
+//  integration is covered by OSCDedupIntegrationTests in WorkspaceManagerTests.
 //
 
 import Foundation
@@ -14,7 +14,7 @@ import Testing
 
 @testable import WorkspaceManager
 
-@Suite("GhosttyRuntimeActionBridge — Channel 3 dispatch")
+@Suite("GhosttyRuntimeActionBridge — terminal attention dispatch")
 struct GhosttyRuntimeActionBridgeTests {
 
     @Test("DESKTOP_NOTIFICATION returns true and schedules main-thread work")

--- a/Tests/WorkspaceManagerTests/AgentUpdateIntakeTests.swift
+++ b/Tests/WorkspaceManagerTests/AgentUpdateIntakeTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("AgentUpdateIntake")
+struct AgentUpdateIntakeTests {
+    @Test("HTTP routes map to named intake purposes")
+    func httpRoutesMapToPurposes() {
+        #expect(AgentUpdateIntake.httpRoute(method: "GET", path: "/healthz") == .healthCheck)
+        #expect(
+            AgentUpdateIntake.httpRoute(method: "POST", path: "/event")?.purpose
+                == .commandHookForwarder
+        )
+        #expect(
+            AgentUpdateIntake.httpRoute(method: "POST", path: "/statusline")?.purpose
+                == .statusLineForwarder
+        )
+        #expect(
+            AgentUpdateIntake.httpRoute(method: "POST", path: "/command-markers")?.purpose
+                == .commandStatusProducer
+        )
+        #expect(AgentUpdateIntake.httpRoute(method: "POST", path: "/unknown") == nil)
+    }
+
+    @Test("Intake purposes declare registry targets")
+    func purposesDeclareRegistryTargets() {
+        #expect(
+            AgentUpdateIntake.Purpose.commandHookForwarder.registryTarget
+                == .agentSessionRegistry
+        )
+        #expect(
+            AgentUpdateIntake.Purpose.statusLineForwarder.registryTarget
+                == .agentSessionRegistry
+        )
+        #expect(
+            AgentUpdateIntake.Purpose.terminalAttentionFallback.registryTarget
+                == .agentSessionRegistry
+        )
+        #expect(
+            AgentUpdateIntake.Purpose.commandStatusProducer.registryTarget
+                == .lastCommandStatusRegistry
+        )
+        #expect(AgentUpdateIntake.Purpose.transcriptReader.registryTarget == .none)
+    }
+
+    @Test("Terminal attention notification maps through intake module")
+    func terminalAttentionNotificationMapsThroughIntakeModule() {
+        let event = AgentUpdateIntake.terminalNotificationEvent(
+            kind: .claudeCode,
+            title: "Permission",
+            body: "Tool needs permission"
+        )
+
+        if case .awaitingInput(.permissionPrompt, "Permission"?, "Tool needs permission"?) = event {
+            // ok
+        } else {
+            Issue.record("expected permission prompt event, got \(event)")
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerBackupRotationTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeSettingsInstallerBackupRotationTests.swift
@@ -2,8 +2,8 @@
 //  ClaudeSettingsInstallerBackupRotationTests.swift
 //  WorkspaceManagerTests
 //
-//  Channel 3 mitigation: backups should not accumulate without bound. The
-//  installer caps `*.workspaces-backup-*` files per settings file at
+//  Settings installer mitigation: backups should not accumulate without bound.
+//  The installer caps `*.workspaces-backup-*` files per settings file at
 //  `maxBackupsPerFile`, deleting older entries by mtime on each install.
 //
 

--- a/Tests/WorkspaceManagerTests/OSCDedupIntegrationTests.swift
+++ b/Tests/WorkspaceManagerTests/OSCDedupIntegrationTests.swift
@@ -2,9 +2,9 @@
 //  OSCDedupIntegrationTests.swift
 //  WorkspaceManagerTests
 //
-//  Channel 3 dedup: when a hook event has been applied recently, an OSC event
-//  with the same effective state is suppressed; once the 750ms window elapses
-//  the OSC event applies.
+//  Terminal attention dedup: when a hook event has been applied recently, an OSC
+//  event with the same effective state is suppressed; once the 750ms window
+//  elapses the OSC event applies.
 //
 
 import Foundation
@@ -13,7 +13,7 @@ import Testing
 @testable import WorkspaceManagerCore
 
 @MainActor
-@Suite("Channel 3 OSC dedup integration")
+@Suite("Terminal attention OSC dedup integration")
 struct OSCDedupIntegrationTests {
     private func apply(
         _ event: AgentEvent,
@@ -45,7 +45,7 @@ struct OSCDedupIntegrationTests {
         )
         let runAfterHook = registry.statuses[id]?.run
 
-        let oscEvent = AgentOSCEventMapper.mapNotification(
+        let oscEvent = AgentUpdateIntake.terminalNotificationEvent(
             kind: .claudeCode,
             title: "perm",
             body: "permission requested"
@@ -71,7 +71,7 @@ struct OSCDedupIntegrationTests {
         apply(.toolStart(name: "Read", detail: nil), to: registry, hostSessionID: id, origin: .hook)
 
         clock.advance(by: 1.0)
-        let oscEvent = AgentOSCEventMapper.mapNotification(
+        let oscEvent = AgentUpdateIntake.terminalNotificationEvent(
             kind: .claudeCode,
             title: "permission",
             body: "Tool needs permission"
@@ -92,7 +92,7 @@ struct OSCDedupIntegrationTests {
         let registry = AgentSessionRegistry()
         let id = UUID()
         registry.register(hostSessionID: id, cwd: "/tmp/opencode", kind: .opencode)
-        let event = AgentOSCEventMapper.mapNotification(
+        let event = AgentUpdateIntake.terminalNotificationEvent(
             kind: .opencode,
             title: "ready",
             body: "agent finished"

--- a/Tests/WorkspaceManagerTests/Perf/PerfChannel1Tests.swift
+++ b/Tests/WorkspaceManagerTests/Perf/PerfChannel1Tests.swift
@@ -2,7 +2,7 @@
 //  PerfChannel1Tests.swift
 //  WorkspaceManagerTests
 //
-//  In-process perf scenarios for the Channel 1 hook stack. Opt-in via
+//  In-process perf scenarios for the command hook forwarder stack. Opt-in via
 //  WORKSPACES_PERF_RUN=1 so they don't run on every `swift test`. Each scenario
 //  writes a result.json file to WORKSPACES_PERF_OUT (or a temp path) in the
 //  shape:
@@ -521,9 +521,9 @@ struct PerfChannel1Tests {
         try Self.writeResult(
             payload, to: Self.resultPath(scenario: "channel1_risk_backup_accumulation"))
 
-        // Channel 3 mitigation: backup rotation is now active. After 10 installs
-        // we expect exactly `maxBackupsPerFile` backups on disk (the newest 5),
-        // not 10. Asserts both the cap and the rotation-on guarantee.
+        // Backup rotation is active. After 10 installs we expect exactly
+        // `maxBackupsPerFile` backups on disk (the newest 5), not 10. Asserts
+        // both the cap and the rotation-on guarantee.
         #expect(backups.count == ClaudeSettingsInstaller.maxBackupsPerFile)
         #expect(backups.count == 5)
     }

--- a/Tests/WorkspaceManagerTests/Perf/PerfChannel2Tests.swift
+++ b/Tests/WorkspaceManagerTests/Perf/PerfChannel2Tests.swift
@@ -2,7 +2,7 @@
 //  PerfChannel2Tests.swift
 //  WorkspaceManagerTests
 //
-//  In-process perf scenario for the Channel 2 status-line route. Mirrors the
+//  In-process perf scenario for the status-line forwarder route. Mirrors the
 //  Scenario A pattern from PerfChannel1Tests; differences are: the URL path
 //  is `/statusline`, the body is a status-line payload, and we measure the
 //  same two metrics (HTTP 200 latency, registry update latency).

--- a/Tests/WorkspaceManagerTests/StatusLinePayloadTests.swift
+++ b/Tests/WorkspaceManagerTests/StatusLinePayloadTests.swift
@@ -2,9 +2,10 @@
 //  StatusLinePayloadTests.swift
 //  WorkspaceManagerTests
 //
-//  Decoder behaviour for the Channel 2 wire format. The decoder must be tolerant
-//  — unknown keys and missing fields are silent; only a non-object body returns
-//  nil. This keeps the host robust to schema additions in Claude Code.
+//  Decoder behaviour for the status-line forwarder wire format. The decoder must
+//  be tolerant — unknown keys and missing fields are silent; only a non-object
+//  body returns nil. This keeps the host robust to schema additions in Claude
+//  Code.
 //
 
 import Foundation

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -8,19 +8,24 @@ from terminal state, and transcript viewing.
 This document describes the shipped architecture. Deferred programmatic/headless
 Claude work is tracked separately in `backlog/headless-claude-programmatic-runner.md`.
 
-## Shipped Channels
+## Agent Update Intake
 
-The first, second, and fourth channels feed `AgentSessionRegistry`. Channel 3
-feeds `LastCommandStatusRegistry`. Channel 5 is a transcript reader for the
-conversation log UI; it is not a state recovery path.
+`AgentUpdateIntake` owns the host-side vocabulary for Agent update intake and
+maps transports to named purposes. Legacy channel numbers are retained here only
+to line up older specs and PRs; app code should prefer purpose names.
 
-| Channel | Role | Registry input |
+The command hook forwarder, status-line forwarder, and terminal attention
+fallback feed `AgentSessionRegistry`. The command-status producer feeds
+`LastCommandStatusRegistry`. The transcript reader is for the conversation log UI;
+it is not a state recovery path.
+
+| Legacy | Purpose | Registry input |
 |---|---|---|
-| 1. Command hook forwarder | Primary event stream: tool start/end, awaiting input, complete, errored | Yes |
-| 2. Status-line forwarder | Model, cost, context fill, rate-limit headroom | Yes |
-| 3. Command-status producer | Last shell command start/end and exit status | LastCommandStatusRegistry |
-| 4. libghostty OSC/BEL | Fallback attention signal for unhooked or degraded sessions | Yes |
-| 5. Transcript JSONL | Conversation replay/audit view | No |
+| 1 | Command hook forwarder | AgentSessionRegistry |
+| 2 | Status-line forwarder | AgentSessionRegistry |
+| 3 | Command-status producer | LastCommandStatusRegistry |
+| 4 | libghostty OSC/BEL fallback | AgentSessionRegistry |
+| 5 | Transcript JSONL reader | No |
 
 ```text
                  +------------------------------------+
@@ -53,11 +58,14 @@ conversation log UI; it is not a state recovery path.
   hook JSON. Unknown hook events decode to `.unknown`.
 - `Sources/WorkspaceManagerCore/Models/AgentEvent.swift` is the normalized event
   shape consumed by the registry.
-- `Sources/WorkspaceManagerCore/Services/AgentEventTranslators.swift` contains
-  the concrete Claude hook translator and OSC mapper. There is no adapter
-  protocol until a second rich hook-speaking agent exists.
-- `AgentHookListener` exposes `/event`, `/statusline`, `/command-markers`,
-  and `/healthz`.
+- `Sources/WorkspaceManagerCore/Services/AgentUpdateIntake.swift` owns purpose
+  names, HTTP route mapping, and the intake helpers used by callers.
+- `Sources/WorkspaceManagerCore/Services/AgentEventTranslators.swift` remains
+  the concrete Claude hook translator and OSC mapper. There is no adapter protocol
+  until a second rich hook-speaking agent exists.
+- `AgentHookListener` exposes `/event` for the command hook forwarder,
+  `/statusline` for the status-line forwarder, `/command-markers` for the
+  command-status producer, and `/healthz`.
 
 The registry write surface is deliberately small:
 
@@ -87,7 +95,7 @@ This replaces cwd/agent-session inference. `SessionStart` still records
 tabs and split panes on the same repository remain distinct because their host
 session IDs are distinct from terminal spawn time.
 
-## Channel 1: Command Hook Forwarder
+## Command Hook Forwarder
 
 Script: `Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh`.
 
@@ -100,8 +108,9 @@ Content-Type: application/json
 X-WorkSpaces-Host-Session-ID: <uuid>
 ```
 
-The listener decodes with `ClaudeHookTranslator.decodeAgentEvent(from:)` and
-applies the resulting `AgentEvent` to the registry with origin `.hook`.
+The listener routes `/event` through `AgentUpdateIntake`, which decodes with the
+concrete Claude hook translator and applies the resulting `AgentEvent` to the
+registry with origin `.hook`.
 
 The app extracts `event-forwarder.sh` to a stable, space-free directory —
 `~/.local/share/workspaces/hook-forwarders/` (honoring `XDG_DATA_HOME`) — and
@@ -119,13 +128,14 @@ any prior machine-specific event-forwarder command (an `Application Support` pat
 or a `.build` bundle path, quoted or unquoted, ending in
 `HookForwarders/event-forwarder.sh`) with the generic tilde command.
 
-## Channel 2: Status-Line Forwarder
+## Status-Line Forwarder
 
 Script: `Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh`,
 extracted to the same `~/.local/share/workspaces/hook-forwarders/` directory as
-Channel 1 and written to `statusLine.command` as the same tilde-relative,
-unquoted shape. The installer overwrites any prior status-line command, so a
-stale bundle or `.build` path converges to the generic command on next launch.
+the command hook forwarder and written to `statusLine.command` as the same
+tilde-relative, unquoted shape. The installer overwrites any prior status-line
+command, so a stale bundle or `.build` path converges to the generic command on
+next launch.
 
 Claude Code runs it as `statusLine.command`. The script posts status JSON to
 `/statusline` and prints a single space so Claude's own status row stays visually
@@ -136,7 +146,7 @@ it through the same registry write surface.
 Status-line ticks never change `AgentRunState`; they only update display fields
 such as model, cost, context used, and five-hour limit state.
 
-## Channel 3: Command-Status Producer
+## Command-Status Producer
 
 Script: `Sources/WorkspaceManager/Resources/HookForwarders/command-status.zsh`.
 
@@ -158,7 +168,7 @@ The app does not mutate shell profiles automatically. Missing socket/session
 environment, missing `curl`, stopped host listeners, and malformed payloads
 drop quietly with diagnostics.
 
-## Channel 4: libghostty OSC/BEL
+## Terminal Attention Fallback
 
 `GhosttyRuntimeActionBridge` recognizes:
 
@@ -166,7 +176,7 @@ drop quietly with diagnostics.
 - `GHOSTTY_ACTION_RING_BELL`
 
 `AgentOSCRouter` resolves the `GhosttySurfaceView` back to its host session and
-uses `AgentOSCEventMapper` to create an `AgentEvent`. Claude Code OSC bodies get
+uses `AgentUpdateIntake` to create an `AgentEvent`. Claude Code OSC bodies get
 small permission/idle heuristics; other agent kinds map to a generic custom
 awaiting-input event.
 
@@ -178,7 +188,7 @@ Notification channel selection is concrete installer behavior: `~/.claude.json`
 is patched to `preferredNotifChannel: "iterm2"` because OSC 9 is the reliable
 path libghostty surfaces today.
 
-## Channel 5: Transcript JSONL
+## Transcript JSONL Reader
 
 `Sources/WorkspaceManagerCore/Services/TranscriptReader.swift` reads Claude Code
 transcripts for `ConversationLogView`.


### PR DESCRIPTION
## Summary

- Add AgentUpdateIntake as the named Module for Agent update purpose language, HTTP route mapping, and terminal attention event mapping.
- Route AgentHookListener and AgentOSCRouter through AgentUpdateIntake while keeping concrete Claude hook/OSC translators behind it.
- Update integration docs and nearby comments/tests to prefer purpose names over legacy channel numbers.

## Mergeability

- Surface: desktop / docs
- User-facing behavior changed: Settings Agents live-status label drops the legacy channel number; runtime routing behavior is intended to be unchanged.
- Non-happy paths considered: unknown routes still return 200/no-op as before; malformed hook/status/command-marker payloads keep existing decode-failure paths; unregistered host sessions still drop.
- Release/ops preconditions: none.
- Residual risk or follow-up: low; the behavior change is concentrated at routing helpers, and existing concrete translators plus registry apply semantics are unchanged.

## Validation

- [x] ./scripts/build-ghosttykit.sh
- [x] swift build
- [x] swift test
- [x] swift-format lint --strict --recursive Sources/ Tests/
- [x] Other checks run: swift test --filter AgentUpdateIntakeTests; swift test --filter 'AgentHookListenerTests|OSCDedupIntegrationTests|GhosttyRuntimeActionBridgeTests|StatusLinePayloadTests'; ./scripts/claude-integration-smoke.sh --non-interactive --no-build --trust-mise --output-dir output/claude-integration-smoke/20260613-agent-update-intake; ./scripts/perf-baseline.sh 5 8 --assert-budget; git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from config/performance/contract.json
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: debug_no_activate
- Before Summary: /tmp/workspaces-perf-baseline-20260613-092340/summary.txt
- After Summary: /tmp/workspaces-perf-baseline-20260613-093358/summary.txt
- Delta Summary: launch_to_first_prompt median +3.87 ms (+0.6%) and p95 -25.11 ms; repo_hydration median -0.10 ms and p95 +41.55 ms. Budget assertion passed.

Performance comparison notes:

- Exact commands used: before from controller: ./scripts/perf-baseline.sh 5 8 --assert-budget; after from this PR: ./scripts/perf-baseline.sh 5 8 --assert-budget.
- Workload / environment context: both debug_no_activate, 5 runs, 8s sleep per run. repo_hydration p95 is a single-sample outlier in a 5-run baseline, still only 63.31 ms absolute and within budget. repo_click_to_focus and workspace_click_to_focus were missing in both runs.

| Metric | Controller baseline median / p95 | This PR median / p95 | Delta |
|---|---:|---:|---:|
| launch_to_first_prompt | 671.85 / 722.73 ms | 675.72 / 697.62 ms | median +3.87 ms (+0.6%), p95 -25.11 ms |
| repo_hydration | 1.46 / 21.76 ms | 1.36 / 63.31 ms | median -0.10 ms, p95 +41.55 ms |

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Claude integration smoke screenshot](https://evidence.cloudcompute.com/workspaces/pr-667/20260613-163730-agent-update-intake-smoke.png)

## Blockers

- [x] None
- [ ] Blocked on evidence