### PR TITLE
Centralize agent chrome projection

### DIFF
--- a/Sources/WorkspaceManager/Services/AgentNotificationPoster.swift
+++ b/Sources/WorkspaceManager/Services/AgentNotificationPoster.swift
@@ -41,13 +41,12 @@ public final class AgentNotificationPoster {
             let previous = observedRuns[hostID]
             observedRuns[hostID] = status.run
 
-            // Only fire on *transition* into permissionPrompt awaiting state.
             guard
-                case .awaitingInput(let reason) = status.run,
-                reason == .permissionPrompt
+                AgentChromeProjection.shouldPostPermissionPromptNotification(
+                    previous: previous,
+                    current: status.run
+                )
             else { continue }
-
-            if let previous, previous == status.run { continue }
 
             // Coalesce.
             let now = Date()
@@ -86,7 +85,7 @@ public final class AgentNotificationPoster {
     private func deliverNotification(for status: AgentSessionStatus) async {
         guard Self.isUserNotificationsAvailable else { return }
         let content = UNMutableNotificationContent()
-        content.title = agentDisplayName(for: status.kind) + " is awaiting input"
+        content.title = status.kind.displayName + " is awaiting input"
         content.body = "Permission requested in \(status.cwd)"
         content.sound = .default
         let request = UNNotificationRequest(
@@ -107,13 +106,4 @@ public final class AgentNotificationPoster {
         // `swift run` it points at the executable's parent directory.
         return Bundle.main.bundleURL.pathExtension == "app"
     }()
-
-    private func agentDisplayName(for kind: AgentKind) -> String {
-        switch kind {
-        case .claudeCode: return "Claude Code"
-        case .opencode: return "OpenCode"
-        case .aider: return "Aider"
-        case .unknown: return "Agent"
-        }
-    }
 }

--- a/Sources/WorkspaceManager/Views/CommandPalette/CommandPaletteView.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/CommandPaletteView.swift
@@ -283,13 +283,8 @@ struct CommandPaletteView: View {
     }
 
     private func waitingDescriptor(for state: AgentRunState?) -> String? {
-        switch state {
-        case .awaitingInput: return "awaiting input"
-        case .errored: return "errored"
-        case .thinking: return "thinking"
-        case .runningTool: return "running tool"
-        case .idle, .complete, .none: return nil
-        }
+        guard let state else { return nil }
+        return AgentChromeProjection.runState(state).commandPaletteDescriptor
     }
 
     private func moveHighlight(by delta: Int) {

--- a/Sources/WorkspaceManager/Views/Components/AgentChromeProjectionStyle.swift
+++ b/Sources/WorkspaceManager/Views/Components/AgentChromeProjectionStyle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import WorkspaceManagerCore
+
+extension AgentChromeProjection.Tone {
+    var color: Color {
+        switch self {
+        case .hidden:
+            return .clear
+        case .live:
+            return Color.accentColor.opacity(0.75)
+        case .active:
+            return .accentColor
+        case .neutral:
+            return .secondary
+        case .running:
+            return .blue
+        case .attention:
+            return .yellow
+        case .critical:
+            return .red
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/Components/AgentKindPresentation.swift
+++ b/Sources/WorkspaceManager/Views/Components/AgentKindPresentation.swift
@@ -45,25 +45,6 @@ extension AgentKind {
 extension AgentRunState {
     /// One-line summary of what the agent is doing right now.
     var summaryText: String {
-        switch self {
-        case .idle:
-            return "Idle"
-        case .thinking:
-            return "Thinking…"
-        case .runningTool(let name, _):
-            return "Running: \(name)"
-        case .awaitingInput:
-            return "Awaiting input"
-        case .complete:
-            return "Done"
-        case .errored(let category, _):
-            switch category {
-            case .rateLimit: return "Rate limited"
-            case .authentication: return "Auth error"
-            case .server: return "Server error"
-            case .toolFailure: return "Tool failed"
-            case .unknown: return "Error"
-            }
-        }
+        AgentChromeProjection.runState(self).summaryText
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -660,7 +660,7 @@ private struct AgentSessionStatusList: View {
                 ForEach(sortedStatuses, id: \.hostSessionID) { status in
                     HStack(alignment: .firstTextBaseline, spacing: 10) {
                         Circle()
-                            .fill(color(for: status.run))
+                            .fill(AgentChromeProjection.runState(status.run).tone.color)
                             .frame(width: 7, height: 7)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(sessionTitle(status))
@@ -688,31 +688,7 @@ private struct AgentSessionStatusList: View {
 
     private func sessionTitle(_ status: AgentSessionStatus) -> String {
         let model = status.modelDisplayName ?? status.kind.rawValue
-        return "\(model) - \(runStateLabel(status.run))"
-    }
-
-    private func runStateLabel(_ state: AgentRunState) -> String {
-        switch state {
-        case .idle: return "Idle"
-        case .thinking: return "Thinking"
-        case .runningTool(let name, _): return "Running \(name)"
-        case .awaitingInput(let reason): return "Awaiting \(reason.rawValue)"
-        case .complete: return "Complete"
-        case .errored(let category, _): return "Errored: \(category.rawValue)"
-        }
-    }
-
-    private func color(for state: AgentRunState) -> Color {
-        switch state {
-        case .idle, .complete:
-            return .secondary
-        case .thinking, .runningTool:
-            return .blue
-        case .awaitingInput:
-            return .yellow
-        case .errored:
-            return .red
-        }
+        return "\(model) - \(AgentChromeProjection.runState(status.run).diagnosticsLabel)"
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/NeedsYouToolbarPill.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NeedsYouToolbarPill.swift
@@ -23,7 +23,7 @@ struct NeedsYouToolbarPill: View {
             } label: {
                 HStack(spacing: 6) {
                     Circle()
-                        .fill(Color.yellow)
+                        .fill(AgentChromeProjection.attentionTone.color)
                         .frame(width: 7, height: 7)
                     Text("\(aggregator.attentionCount) need you")
                         .font(.callout.weight(.medium))
@@ -33,11 +33,11 @@ struct NeedsYouToolbarPill: View {
                 .padding(.vertical, 4)
                 .background(
                     Capsule()
-                        .fill(Color.yellow.opacity(0.18))
+                        .fill(AgentChromeProjection.attentionTone.color.opacity(0.18))
                 )
                 .overlay(
                     Capsule()
-                        .stroke(Color.yellow.opacity(0.35), lineWidth: 0.5)
+                        .stroke(AgentChromeProjection.attentionTone.color.opacity(0.35), lineWidth: 0.5)
                 )
             }
             .buttonStyle(.plain)
@@ -82,7 +82,7 @@ struct NeedsYouToolbarPill: View {
             .compactMap(displayName(for:))
             .prefix(5)
         if names.isEmpty {
-            return "\(aggregator.attentionCount) sessions awaiting input or errored"
+            return AgentChromeProjection.attentionTooltipFallback(count: aggregator.attentionCount)
         }
         let remaining = aggregator.attentionCount - names.count
         let listed = names.joined(separator: ", ")

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -66,19 +66,23 @@ enum SidebarSessionActivity: Equatable {
     }
 
     var indicatorColor: Color {
+        indicatorTone.color
+    }
+
+    var indicatorTone: AgentChromeProjection.Tone {
         switch self {
         case .inactive:
-            return .clear
+            return .hidden
         case .live:
-            return Color.accentColor.opacity(0.75)
+            return .live
         case .active:
-            return .accentColor
+            return .active
         case .thinking, .runningTool:
-            return .blue
+            return .running
         case .awaitingInput:
-            return .yellow
+            return .attention
         case .errored:
-            return .red
+            return .critical
         }
     }
 
@@ -105,13 +109,13 @@ enum SidebarSessionActivity: Equatable {
         case .active:
             return "active session"
         case .thinking:
-            return "agent thinking"
+            return AgentChromeProjection.runState(.thinking).accessibilityDescription
         case .runningTool:
-            return "agent running tool"
+            return AgentChromeProjection.runState(.runningTool(name: "", detail: nil)).accessibilityDescription
         case .awaitingInput:
-            return "agent awaiting input"
+            return AgentChromeProjection.runState(.awaitingInput(reason: .custom)).accessibilityDescription
         case .errored(let category):
-            return "agent errored (\(category.rawValue))"
+            return AgentChromeProjection.runState(.errored(category: category, message: nil)).accessibilityDescription
         }
     }
 
@@ -123,9 +127,14 @@ enum SidebarSessionActivity: Equatable {
     /// bubbled activity derived from child workspaces. Higher wins.
     var severity: Int {
         switch self {
-        case .errored: return 5
-        case .awaitingInput: return 4
-        case .runningTool, .thinking: return 3
+        case .errored(let category):
+            return AgentChromeProjection.runState(.errored(category: category, message: nil)).sidebarPriority
+        case .awaitingInput:
+            return AgentChromeProjection.runState(.awaitingInput(reason: .custom)).sidebarPriority
+        case .runningTool:
+            return AgentChromeProjection.runState(.runningTool(name: "", detail: nil)).sidebarPriority
+        case .thinking:
+            return AgentChromeProjection.runState(.thinking).sidebarPriority
         case .active: return 2
         case .live: return 1
         case .inactive: return 0

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -1477,10 +1477,7 @@ struct SidebarView: View {
         guard bubbled != baseline else { return nil }
         let attentionCount = repo.workspaces.reduce(into: 0) { count, workspace in
             guard let status = workspaceStatusAggregator.workspaceStatuses[workspace.id] else { return }
-            switch status.run {
-            case .awaitingInput, .errored: count += 1
-            default: break
-            }
+            if AgentChromeProjection.demandsAttention(status.run) { count += 1 }
         }
         guard attentionCount > 0 else { return nil }
         switch bubbled {

--- a/Sources/WorkspaceManagerCore/Services/AgentChromeProjection.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentChromeProjection.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Presentation policy for projecting Agent Run State into WorkSpaces chrome.
+/// Callers get labels, semantic tone, severity, Attention, and notification
+/// policy from one Module instead of re-encoding Run State in each surface.
+public struct AgentChromeProjection: Sendable, Equatable {
+    public enum Tone: Sendable, Equatable {
+        case hidden
+        case live
+        case active
+        case neutral
+        case running
+        case attention
+        case critical
+    }
+
+    public let diagnosticsLabel: String
+    public let summaryText: String
+    public let accessibilityDescription: String
+    public let commandPaletteDescriptor: String?
+    public let tone: Tone
+    public let severity: Int
+    public let sidebarPriority: Int
+    public let demandsAttention: Bool
+
+    public static let attentionTone: Tone = .attention
+
+    public static func runState(_ state: AgentRunState) -> AgentChromeProjection {
+        switch state {
+        case .idle:
+            return AgentChromeProjection(
+                diagnosticsLabel: "Idle",
+                summaryText: "Idle",
+                accessibilityDescription: "agent idle",
+                commandPaletteDescriptor: nil,
+                tone: .neutral,
+                severity: 1,
+                sidebarPriority: 1,
+                demandsAttention: false
+            )
+        case .thinking:
+            return AgentChromeProjection(
+                diagnosticsLabel: "Thinking",
+                summaryText: "Thinking…",
+                accessibilityDescription: "agent thinking",
+                commandPaletteDescriptor: "thinking",
+                tone: .running,
+                severity: 2,
+                sidebarPriority: 3,
+                demandsAttention: false
+            )
+        case .runningTool(let name, _):
+            return AgentChromeProjection(
+                diagnosticsLabel: "Running \(name)",
+                summaryText: "Running: \(name)",
+                accessibilityDescription: "agent running tool",
+                commandPaletteDescriptor: "running tool",
+                tone: .running,
+                severity: 3,
+                sidebarPriority: 3,
+                demandsAttention: false
+            )
+        case .awaitingInput(let reason):
+            return AgentChromeProjection(
+                diagnosticsLabel: "Awaiting \(reason.rawValue)",
+                summaryText: "Awaiting input",
+                accessibilityDescription: "agent awaiting input",
+                commandPaletteDescriptor: "awaiting input",
+                tone: .attention,
+                severity: 4,
+                sidebarPriority: 4,
+                demandsAttention: true
+            )
+        case .complete:
+            return AgentChromeProjection(
+                diagnosticsLabel: "Complete",
+                summaryText: "Done",
+                accessibilityDescription: "agent complete",
+                commandPaletteDescriptor: nil,
+                tone: .neutral,
+                severity: 1,
+                sidebarPriority: 1,
+                demandsAttention: false
+            )
+        case .errored(let category, _):
+            return AgentChromeProjection(
+                diagnosticsLabel: "Errored: \(category.rawValue)",
+                summaryText: errorSummary(for: category),
+                accessibilityDescription: "agent errored (\(category.rawValue))",
+                commandPaletteDescriptor: "errored",
+                tone: .critical,
+                severity: 5,
+                sidebarPriority: 5,
+                demandsAttention: true
+            )
+        }
+    }
+
+    public static func severity(of state: AgentRunState) -> Int {
+        runState(state).severity
+    }
+
+    public static func demandsAttention(_ state: AgentRunState) -> Bool {
+        runState(state).demandsAttention
+    }
+
+    public static func shouldPostPermissionPromptNotification(
+        previous: AgentRunState?,
+        current: AgentRunState
+    ) -> Bool {
+        guard case .awaitingInput(.permissionPrompt) = current else { return false }
+        return previous != current
+    }
+
+    public static func attentionTooltipFallback(count: Int) -> String {
+        "\(count) sessions awaiting input or errored"
+    }
+
+    private static func errorSummary(for category: AgentErrorCategory) -> String {
+        switch category {
+        case .rateLimit: return "Rate limited"
+        case .authentication: return "Auth error"
+        case .server: return "Server error"
+        case .toolFailure: return "Tool failed"
+        case .unknown: return "Error"
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
@@ -163,20 +163,11 @@ public final class WorkspaceStatusAggregator: ObservableObject {
     /// Both active agent states render blue in the sidebar, but a running tool
     /// outranks a merely thinking agent when choosing one bubbled status.
     public static func severity(of state: AgentRunState) -> Int {
-        switch state {
-        case .errored: return 5
-        case .awaitingInput: return 4
-        case .runningTool: return 3
-        case .thinking: return 2
-        case .idle, .complete: return 1
-        }
+        AgentChromeProjection.severity(of: state)
     }
 
     public static func demandsAttention(_ state: AgentRunState) -> Bool {
-        switch state {
-        case .awaitingInput, .errored: return true
-        case .idle, .thinking, .runningTool, .complete: return false
-        }
+        AgentChromeProjection.demandsAttention(state)
     }
 
     private static func mostSevere(among statuses: [AgentSessionStatus]) -> AgentSessionStatus? {

--- a/Tests/WorkspaceManagerAppTests/SidebarSessionPresentationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarSessionPresentationTests.swift
@@ -33,6 +33,25 @@ struct SidebarSessionPresentationTests {
         #expect(SidebarSessionActivity.active.hasLiveSession)
     }
 
+    @Test("Activity uses shared chrome projection tones and priorities")
+    func activityChromeProjectionPolicy() {
+        #expect(SidebarSessionActivity.inactive.indicatorTone == .hidden)
+        #expect(SidebarSessionActivity.live.indicatorTone == .live)
+        #expect(SidebarSessionActivity.active.indicatorTone == .active)
+        #expect(SidebarSessionActivity.thinking.indicatorTone == .running)
+        #expect(SidebarSessionActivity.runningTool.indicatorTone == .running)
+        #expect(SidebarSessionActivity.awaitingInput.indicatorTone == .attention)
+        #expect(SidebarSessionActivity.errored(category: .server).indicatorTone == .critical)
+
+        #expect(SidebarSessionActivity.errored(category: .server).severity == 5)
+        #expect(SidebarSessionActivity.awaitingInput.severity == 4)
+        #expect(SidebarSessionActivity.runningTool.severity == 3)
+        #expect(SidebarSessionActivity.thinking.severity == 3)
+        #expect(SidebarSessionActivity.active.severity == 2)
+        #expect(SidebarSessionActivity.live.severity == 1)
+        #expect(SidebarSessionActivity.inactive.severity == 0)
+    }
+
     @Test("Pane count badge appears only when more than one pane exists")
     func paneCountBadgeThreshold() {
         #expect(!SidebarSessionActivity.showsPaneCountBadge(for: 0))

--- a/Tests/WorkspaceManagerTests/AgentChromeProjectionTests.swift
+++ b/Tests/WorkspaceManagerTests/AgentChromeProjectionTests.swift
@@ -1,0 +1,99 @@
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("AgentChromeProjection")
+struct AgentChromeProjectionTests {
+    @Test("Run states project labels tones severity and attention")
+    func runStateProjectionMatrix() {
+        let idle = AgentChromeProjection.runState(.idle)
+        #expect(idle.diagnosticsLabel == "Idle")
+        #expect(idle.summaryText == "Idle")
+        #expect(idle.commandPaletteDescriptor == nil)
+        #expect(idle.tone == .neutral)
+        #expect(idle.severity == 1)
+        #expect(idle.sidebarPriority == 1)
+        #expect(!idle.demandsAttention)
+
+        let thinking = AgentChromeProjection.runState(.thinking)
+        #expect(thinking.diagnosticsLabel == "Thinking")
+        #expect(thinking.summaryText == "Thinking…")
+        #expect(thinking.commandPaletteDescriptor == "thinking")
+        #expect(thinking.tone == .running)
+        #expect(thinking.severity == 2)
+        #expect(thinking.sidebarPriority == 3)
+        #expect(!thinking.demandsAttention)
+
+        let running = AgentChromeProjection.runState(.runningTool(name: "Bash", detail: nil))
+        #expect(running.diagnosticsLabel == "Running Bash")
+        #expect(running.summaryText == "Running: Bash")
+        #expect(running.commandPaletteDescriptor == "running tool")
+        #expect(running.tone == .running)
+        #expect(running.severity == 3)
+        #expect(running.sidebarPriority == 3)
+        #expect(!running.demandsAttention)
+
+        let awaiting = AgentChromeProjection.runState(.awaitingInput(reason: .permissionPrompt))
+        #expect(awaiting.diagnosticsLabel == "Awaiting permissionPrompt")
+        #expect(awaiting.summaryText == "Awaiting input")
+        #expect(awaiting.commandPaletteDescriptor == "awaiting input")
+        #expect(awaiting.tone == .attention)
+        #expect(awaiting.severity == 4)
+        #expect(awaiting.sidebarPriority == 4)
+        #expect(awaiting.demandsAttention)
+
+        let complete = AgentChromeProjection.runState(.complete)
+        #expect(complete.diagnosticsLabel == "Complete")
+        #expect(complete.summaryText == "Done")
+        #expect(complete.commandPaletteDescriptor == nil)
+        #expect(complete.tone == .neutral)
+        #expect(complete.severity == 1)
+        #expect(complete.sidebarPriority == 1)
+        #expect(!complete.demandsAttention)
+
+        let errored = AgentChromeProjection.runState(.errored(category: .rateLimit, message: nil))
+        #expect(errored.diagnosticsLabel == "Errored: rateLimit")
+        #expect(errored.summaryText == "Rate limited")
+        #expect(errored.commandPaletteDescriptor == "errored")
+        #expect(errored.tone == .critical)
+        #expect(errored.severity == 5)
+        #expect(errored.sidebarPriority == 5)
+        #expect(errored.demandsAttention)
+    }
+
+    @Test("Permission prompt notification fires only on transition into permission prompt")
+    func permissionPromptNotificationPolicy() {
+        #expect(
+            AgentChromeProjection.shouldPostPermissionPromptNotification(
+                previous: nil,
+                current: .awaitingInput(reason: .permissionPrompt)
+            )
+        )
+        #expect(
+            !AgentChromeProjection.shouldPostPermissionPromptNotification(
+                previous: .awaitingInput(reason: .permissionPrompt),
+                current: .awaitingInput(reason: .permissionPrompt)
+            )
+        )
+        #expect(
+            !AgentChromeProjection.shouldPostPermissionPromptNotification(
+                previous: .thinking,
+                current: .awaitingInput(reason: .idlePrompt)
+            )
+        )
+        #expect(
+            !AgentChromeProjection.shouldPostPermissionPromptNotification(
+                previous: .thinking,
+                current: .errored(category: .server, message: nil)
+            )
+        )
+    }
+
+    @Test("Attention tooltip fallback names attention states")
+    func attentionTooltipFallback() {
+        #expect(
+            AgentChromeProjection.attentionTooltipFallback(count: 3)
+                == "3 sessions awaiting input or errored"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add AgentChromeProjection in core to own run-state labels, severity, attention, command-palette descriptors, and notification transition policy.
- Add a SwiftUI tone adapter and route sidebar, toolbar, diagnostics, command palette, aggregator, and notification posting through the shared projection.
- Add focused projection tests plus sidebar presentation coverage for shared tones and priorities.

## Mergeability
- Surface: macOS app Agent chrome projection across sidebar rows, toolbar Needs You pill, Diagnostics agent list, command palette descriptors, WorkspaceStatusAggregator severity/attention, and AgentNotificationPoster permission-prompt transition policy.
- User-facing behavior changed: No intentional behavior change. Labels, tones, severity ordering, attention semantics, command-palette descriptors, permission-prompt notification conditions, and SidebarInfoCard idle/complete dot behavior are preserved while moving the duplicated policy behind AgentChromeProjection.
- Non-happy paths considered: Awaiting-input and errored states remain attention-demanding; repeated permission-prompt state updates still do not repost notifications; unknown/error categories continue to use the existing fallback labels; app-only Color mapping remains outside the core module.
- Residual risk or follow-up: Launch perf p95 was noisy on this host despite budget passing twice; the narrow touched-path sidebar aggregation perf check is clean. No follow-up required unless CI or managed review finds drift.
- Rebased on latest origin/main before push.

## Validation
- ./scripts/build-ghosttykit.sh
- swift build
- swift test (924 tests passed; opt-in perf suites skipped as expected)
- swift-format lint --strict --recursive Sources/ Tests/
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check
- ./scripts/desktop-ui-smoke.sh --no-build (passed; 3 terminal attaches, 0 surface focuses, 3 focus timeouts in background/no-activate mode)
- WORKSPACES_PERF_RUN=1 WORKSPACES_PERF_OUT=/tmp/workspaces-agent-chrome-hotspot.json swift test --filter MainWindowHotSpotPerf (1 perf test passed)
- After managed-review visual-delta note: swift test --filter 'SidebarInfoCardTests|SidebarSessionPresentationTests|AgentChromeProjectionTests' (15 tests passed)
- After managed-review visual-delta note: swift-format lint --strict --recursive Sources/ Tests/

## Performance
Controller baseline (/tmp/workspaces-perf-baseline-20260613-092340/summary.txt):
- launch_to_first_prompt median 671.85 ms, p95 722.73 ms
- repo_hydration median 1.46 ms, p95 21.76 ms

Candidate guardrail 1 (/tmp/workspaces-perf-baseline-20260613-213601/summary.txt):
- launch_to_first_prompt median 693.24 ms (+21.39 ms, +3.2%), p95 1038.71 ms (+315.98 ms, noisy single-run max)
- repo_hydration median 1.39 ms (-0.07 ms, -4.8%), p95 116.07 ms (+94.31 ms, noisy single-run max)
- Budget assertion passed.

Candidate guardrail 2 (/tmp/workspaces-perf-baseline-20260613-213659/summary.txt):
- launch_to_first_prompt median 701.94 ms (+30.09 ms, +4.5%), p95 1083.85 ms (+361.12 ms, noisy single-run max)
- repo_hydration median 1.41 ms (-0.05 ms, -3.4%), p95 130.80 ms (+109.04 ms, noisy single-run max)
- Budget assertion passed.

Narrow touched-path check (/tmp/workspaces-agent-chrome-hotspot.json): main_window_agent_activity_burst_sidebar_latency_ms median 1.09 ms, p95 2.32 ms across 1,000 refreshes.

Perf note: both launch guardrails pass budget, but p95 is host-noisy. The narrow sidebar aggregation hot-spot is clean. I will not merge without CI/managed review green and acceptance of the residual p95 noise.

## Evidence
- [Desktop UI smoke final screenshot](https://evidence.cloudcompute.com/workspaces/pr-668/20260614-043959-desktop-ui-smoke-final.png)
- [Desktop UI smoke summary](https://evidence.cloudcompute.com/workspaces/pr-668/20260614-044205-desktop-ui-smoke-summary.png)
- [Perf guardrail 1 summary](https://evidence.cloudcompute.com/workspaces/pr-668/20260614-044127-perf-guardrail-1.png)
- [Perf guardrail 2 summary](https://evidence.cloudcompute.com/workspaces/pr-668/20260614-044138-perf-guardrail-2.png)
- [Main-window hot-spot perf JSON](https://evidence.cloudcompute.com/workspaces/pr-668/20260614-044152-main-window-hotspot-perf.png)

## Blockers
- None currently; waiting for CI/managed review after the behavior-preserving amend.
