### PR TITLE
Surface workspace journal in detail pane

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,10 @@ _Avoid_: Log line, message, activity item
 The per-**Workspace** read API over **Workspace Events**, ordered newest first. The Timeline tab of the **Detail Pane** consumes it.
 _Avoid_: Log, history, activity feed, audit trail
 
+**GitHub Activity**:
+Live webhook activity from GitHub for pull requests, checks, and repository updates. The Activity tab of the **Detail Pane** shows this stream when notifications are enabled.
+_Avoid_: Timeline, Workspace Journal, Workspace Event
+
 **Terminal Command Status**:
 The last shell command observed in a **Terminal Session** — its exit code, duration, and whether it is still running. Sourced from OSC 133 prompt marks or an equivalent shell hook.
 _Avoid_: Exit status, shell result, return code
@@ -88,6 +92,7 @@ _Avoid_: Notifications, alerts, warnings, tasks
 - A **Surface** is one selected **Repo Overview**, repository **Terminal Session**, workspace **Terminal Session**, or **Web Source**.
 - The **Detail Pane** follows the selected **Surface** when that surface has repository or workspace context.
 - An **Agent** runs inside a **Terminal Session** and emits **Workspace Events** that the **Workspace Journal** persists.
+- **GitHub Activity** is external webhook activity and does not write to the **Workspace Journal**.
 - A **Terminal Session** observes its own **Terminal Command Status** independently of any **Agent** running inside it.
 - **Attention** rolls up across all **Workspaces** and **Repositories**; the rollup at any moment determines the toolbar indicator.
 

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -20,6 +20,7 @@ struct WorkspaceManagerApp: App {
     @StateObject private var agentSessionRegistry: AgentSessionRegistry
     @StateObject private var lastCommandStatusRegistry: LastCommandStatusRegistry
     @StateObject private var workspaceStatusAggregator = WorkspaceStatusAggregator()
+    @StateObject private var workspaceJournal: WorkspaceJournal
     @StateObject private var claudeIntegrationLifecycle: ClaudeIntegrationLifecycle
     private let appRuntimeDependencies = AppRuntimeDependencies.resolved()
     private let localStateStore: LocalStateStore?
@@ -52,6 +53,7 @@ struct WorkspaceManagerApp: App {
         let commandStatusRegistry = LastCommandStatusRegistry()
         _agentSessionRegistry = StateObject(wrappedValue: registry)
         _lastCommandStatusRegistry = StateObject(wrappedValue: commandStatusRegistry)
+        _workspaceJournal = StateObject(wrappedValue: WorkspaceJournal(store: localStateBootstrap.store))
         self.sharedModelContainer = bootstrap.container
         self.localStateStore = localStateBootstrap.store
 
@@ -81,6 +83,7 @@ struct WorkspaceManagerApp: App {
             .environmentObject(agentSessionRegistry)
             .environmentObject(lastCommandStatusRegistry)
             .environmentObject(workspaceStatusAggregator)
+            .environmentObject(workspaceJournal)
             .environment(\.agentSessionRegistry, agentSessionRegistry)
             .environment(\.lastCommandStatusRegistry, lastCommandStatusRegistry)
             .environment(\.localStateStore, localStateStore)

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2796,6 +2796,7 @@ struct MainTerminalDetailView: View {
                         state: state,
                         diagnosticWorkspaceDirectories: diagnosticWorkspaceDirectories,
                         agentStatuses: agentStatuses,
+                        timelineHostSessionID: timelineHostSessionID(for: selectedWorkspace),
                         onFileSelected: onFileSelected
                     )
                     .rightPaneWidth(for: state)
@@ -2838,6 +2839,33 @@ struct MainTerminalDetailView: View {
         }
 
         return directories
+    }
+
+    private func timelineHostSessionID(for workspace: Workspace) -> UUID? {
+        guard let workspaceDirectory = workspace.localDirectoryURL else { return nil }
+        let workspacePath = normalizedPath(workspaceDirectory)
+
+        if let activeHostTerminalSessionID,
+            let activeVisibleSession = visibleHostTerminalSessions.first(where: {
+                $0.id == activeHostTerminalSessionID && normalizedPath($0.directoryURL) == workspacePath
+            })
+        {
+            return activeVisibleSession.id
+        }
+
+        if let visibleSession = visibleHostTerminalSessions.first(where: {
+            normalizedPath($0.directoryURL) == workspacePath
+        }) {
+            return visibleSession.id
+        }
+
+        return hostTerminalSessions.first {
+            normalizedPath($0.directoryURL) == workspacePath
+        }?.id
+    }
+
+    private func normalizedPath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     @ViewBuilder

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -2,7 +2,7 @@
 //  RightPaneView.swift
 //  WorkspaceManager
 //
-//  Collapsible Detail Pane with Files, Changes, Activity, and Diagnostics tabs.
+//  Collapsible Detail Pane with Files, Changes, Timeline, Activity, and Diagnostics tabs.
 //
 
 import AppKit
@@ -11,6 +11,7 @@ import WorkspaceManagerCore
 
 struct RightPaneTabPolicy {
     let supportsFilesystemInspection: Bool
+    let showTimeline: Bool
     let showActivity: Bool
     let notificationsEnabled: Bool
 
@@ -18,6 +19,10 @@ struct RightPaneTabPolicy {
         var tabs: [RightPaneView.Tab] = [.files]
         if supportsFilesystemInspection {
             tabs.append(.changes)
+        }
+
+        if showTimeline {
+            tabs.append(.timeline)
         }
 
         let canShowActivity = showActivity && notificationsEnabled
@@ -78,6 +83,7 @@ final class RightPaneSessionState: ObservableObject {
     @Published var changedFiles: [FileChange] = []
     @Published var isLoading = false
     @Published var lastRefresh = Date()
+    @Published var timelineLastRefresh: Date?
     @Published var expandedDirectoryPaths: Set<String> = []
     @Published var hasLoadedOnce = false
 }
@@ -115,18 +121,23 @@ struct RightPaneView: View {
     let onFileSelected: (CodePreviewSelection) -> Void
     let diagnosticWorkspaceDirectories: [URL]
     let agentStatuses: [AgentSessionStatus]
+    private let workspaceID: UUID?
+    private let timelineHostSessionID: UUID?
+    private let showTimeline: Bool
     private let showActivity: Bool
     private let supportsFilesystemInspection: Bool
 
     @AppStorage(NotificationConstants.enabledKey)
     private var notificationsEnabled = NotificationConstants.defaultEnabled
     @Environment(\.gitService) private var gitService
+    @EnvironmentObject private var workspaceJournal: WorkspaceJournal
     @ObservedObject private var state: RightPaneSessionState
     @ObservedObject private var notificationCoordinator = NotificationCoordinator.shared
 
     enum Tab: String, CaseIterable {
         case files = "Files"
         case changes = "Changes"
+        case timeline = "Timeline"
         case activity = "Activity"
         case diagnostics = "Diagnostics"
 
@@ -134,6 +145,7 @@ struct RightPaneView: View {
             switch self {
             case .files: return "folder"
             case .changes: return "arrow.triangle.2.circlepath"
+            case .timeline: return "clock"
             case .activity: return "bell"
             case .diagnostics: return "waveform.path.ecg"
             }
@@ -145,6 +157,7 @@ struct RightPaneView: View {
         state: RightPaneSessionState,
         diagnosticWorkspaceDirectories: [URL] = [],
         agentStatuses: [AgentSessionStatus] = [],
+        timelineHostSessionID: UUID? = nil,
         onFileSelected: @escaping (CodePreviewSelection) -> Void = { _ in }
     ) {
         self.targetID = "workspace-\(workspace.id.uuidString)"
@@ -153,6 +166,9 @@ struct RightPaneView: View {
         self.onFileSelected = onFileSelected
         self.diagnosticWorkspaceDirectories = diagnosticWorkspaceDirectories
         self.agentStatuses = agentStatuses
+        self.workspaceID = workspace.id
+        self.timelineHostSessionID = timelineHostSessionID
+        self.showTimeline = true
         self.showActivity = true
         self.supportsFilesystemInspection = workspace.localDirectoryURL != nil
     }
@@ -170,6 +186,9 @@ struct RightPaneView: View {
         self.onFileSelected = onFileSelected
         self.diagnosticWorkspaceDirectories = diagnosticWorkspaceDirectories
         self.agentStatuses = agentStatuses
+        self.workspaceID = nil
+        self.timelineHostSessionID = nil
+        self.showTimeline = false
         self.showActivity = false
         self.supportsFilesystemInspection = true
     }
@@ -228,6 +247,11 @@ struct RightPaneView: View {
                         isLoading: state.isLoading,
                         onFileSelected: selectFile
                     )
+                case .timeline:
+                    TimelineTabView(
+                        events: timelineEvents,
+                        hasHostSession: timelineHostSessionID != nil
+                    )
                 case .activity:
                     ActivityTabView(
                         events: notificationCoordinator.events,
@@ -266,6 +290,13 @@ struct RightPaneView: View {
                         .help(
                             "Diagnostics starts a 5-second in-memory process sampler only while this tab is visible. Trace counts come from existing telemetry; process samples are not persisted."
                         )
+                } else if displayedTab == .timeline {
+                    Circle()
+                        .fill(timelineHostSessionID == nil ? Color.secondary : Color.mint)
+                        .frame(width: 6, height: 6)
+                    Text(timelineFooterText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 } else if state.isLoading {
                     ProgressView()
                         .controlSize(.small)
@@ -280,14 +311,14 @@ struct RightPaneView: View {
 
                 Spacer()
 
-                if supportsFilesystemInspection, displayedTab == .files || displayedTab == .changes {
+                if supportsRefresh {
                     Button {
-                        Task { await refresh() }
+                        Task { await refreshDisplayedTab() }
                     } label: {
                         Image(systemName: "arrow.clockwise")
                     }
                     .buttonStyle(.borderless)
-                    .disabled(state.isLoading)
+                    .disabled(state.isLoading || (displayedTab == .timeline && timelineHostSessionID == nil))
                     .help("Refresh")
                 }
             }
@@ -300,6 +331,9 @@ struct RightPaneView: View {
                 await refresh()
             }
         }
+        .task(id: timelineRefreshKey) {
+            await refreshTimelineIfNeeded()
+        }
         .onChange(of: notificationsEnabled) { _, _ in
             normalizeSelectedTab()
         }
@@ -308,6 +342,7 @@ struct RightPaneView: View {
     private var tabPolicy: RightPaneTabPolicy {
         RightPaneTabPolicy(
             supportsFilesystemInspection: supportsFilesystemInspection,
+            showTimeline: showTimeline,
             showActivity: showActivity,
             notificationsEnabled: notificationsEnabled
         )
@@ -338,6 +373,9 @@ struct RightPaneView: View {
         case .files: return nil
         case .changes:
             let count = state.changedFiles.count
+            return count > 0 ? count : nil
+        case .timeline:
+            let count = timelineEvents.count
             return count > 0 ? count : nil
         case .activity:
             let count = notificationCoordinator.unseenEventCount
@@ -437,17 +475,103 @@ struct RightPaneView: View {
                 return "Working tree clean"
             }
             return "\(changeCount) changed file\(changeCount == 1 ? "" : "s")"
+        case .timeline:
+            guard timelineHostSessionID != nil else {
+                return "Open a workspace terminal to collect agent events"
+            }
+            let eventCount = timelineEvents.count
+            if eventCount == 0 {
+                return "No agent events yet"
+            }
+            return "\(eventCount) workspace event\(eventCount == 1 ? "" : "s")"
         case .activity:
             if notificationCoordinator.unseenEventCount > 0 {
                 return "\(notificationCoordinator.unseenEventCount) unseen updates"
             }
             return notificationCoordinator.isStreamConnected
-                ? "Live workspace activity"
-                : "Activity stream disconnected"
+                ? "Live GitHub activity"
+                : "GitHub activity stream disconnected"
         case .diagnostics:
             return "Runtime health and process history"
         }
     }
+
+    private var supportsRefresh: Bool {
+        switch displayedTab {
+        case .files, .changes:
+            return supportsFilesystemInspection
+        case .timeline:
+            return true
+        case .activity, .diagnostics:
+            return false
+        }
+    }
+
+    private var timelineEvents: [WorkspaceEvent] {
+        guard let workspaceID else { return [] }
+        return workspaceJournal.events(for: workspaceID)
+    }
+
+    private var timelineFooterText: String {
+        guard timelineHostSessionID != nil else {
+            return "No workspace terminal session"
+        }
+        if let refreshed = state.timelineLastRefresh {
+            return "Updated \(refreshed.formatted(.relative(presentation: .named)))"
+        }
+        return "Timeline ready"
+    }
+
+    private var latestTimelineAgentEventAt: Date? {
+        guard let timelineHostSessionID else { return nil }
+        return
+            agentStatuses
+            .filter { $0.hostSessionID == timelineHostSessionID }
+            .map(\.lastEventAt)
+            .max()
+    }
+
+    private var timelineRefreshKey: TimelineRefreshKey {
+        TimelineRefreshKey(
+            targetID: targetID,
+            selectedTab: displayedTab,
+            hostSessionID: timelineHostSessionID,
+            latestAgentEventAt: latestTimelineAgentEventAt
+        )
+    }
+
+    @MainActor
+    private func refreshDisplayedTab() async {
+        switch displayedTab {
+        case .files, .changes:
+            await refresh()
+        case .timeline:
+            await refreshTimelineIfNeeded(force: true)
+        case .activity, .diagnostics:
+            break
+        }
+    }
+
+    @MainActor
+    private func refreshTimelineIfNeeded(force: Bool = false) async {
+        guard displayedTab == .timeline || force,
+            let workspaceID,
+            let timelineHostSessionID
+        else { return }
+
+        await workspaceJournal.refresh(
+            workspaceID: workspaceID,
+            hostSessionID: timelineHostSessionID
+        )
+        state.timelineLastRefresh = Date()
+    }
+}
+
+private struct TimelineRefreshKey: Equatable {
+    let targetID: String
+    let selectedTab: RightPaneView.Tab
+    let hostSessionID: UUID?
+    let latestAgentEventAt: Date?
 }
 
 // MARK: - Files Tab
@@ -564,6 +688,202 @@ struct ChangedFilesTabView: View {
             }
             .listStyle(.plain)
         }
+    }
+}
+
+// MARK: - Timeline Tab
+
+struct WorkspaceTimelinePresentation: Equatable {
+    enum Tone: Equatable {
+        case neutral
+        case running
+        case attention
+        case critical
+        case success
+
+        var color: Color {
+            switch self {
+            case .neutral:
+                return .secondary
+            case .running:
+                return .blue
+            case .attention:
+                return .yellow
+            case .critical:
+                return .red
+            case .success:
+                return .mint
+            }
+        }
+    }
+
+    let title: String
+    let detail: String
+    let systemImage: String
+    let tone: Tone
+
+    static func event(_ event: WorkspaceEvent) -> WorkspaceTimelinePresentation {
+        switch event.kind {
+        case .started:
+            return WorkspaceTimelinePresentation(
+                title: "Agent started",
+                detail: "Workspace session began",
+                systemImage: "play.circle",
+                tone: .running
+            )
+        case .stateTransition(_, let runState):
+            return runStatePresentation(runState)
+        case .toolRun(let name):
+            return WorkspaceTimelinePresentation(
+                title: "Ran \(name)",
+                detail: "Tool execution",
+                systemImage: "hammer",
+                tone: .running
+            )
+        case .error(let category, let message):
+            return WorkspaceTimelinePresentation(
+                title: errorTitle(for: category),
+                detail: errorDetail(message),
+                systemImage: "exclamationmark.triangle",
+                tone: .critical
+            )
+        case .completed:
+            return WorkspaceTimelinePresentation(
+                title: "Agent completed",
+                detail: "Workspace session finished",
+                systemImage: "checkmark.circle",
+                tone: .success
+            )
+        }
+    }
+
+    private static func runStatePresentation(_ state: AgentRunState) -> WorkspaceTimelinePresentation {
+        let projection = AgentChromeProjection.runState(state)
+        switch state {
+        case .idle:
+            return WorkspaceTimelinePresentation(
+                title: "Agent idle",
+                detail: projection.summaryText,
+                systemImage: "pause.circle",
+                tone: .neutral
+            )
+        case .thinking:
+            return WorkspaceTimelinePresentation(
+                title: "Agent thinking",
+                detail: projection.summaryText,
+                systemImage: "brain.head.profile",
+                tone: .running
+            )
+        case .runningTool:
+            return WorkspaceTimelinePresentation(
+                title: projection.summaryText,
+                detail: "Tool execution",
+                systemImage: "hammer",
+                tone: .running
+            )
+        case .awaitingInput:
+            return WorkspaceTimelinePresentation(
+                title: "Agent needs input",
+                detail: projection.summaryText,
+                systemImage: "hand.raised",
+                tone: .attention
+            )
+        case .complete:
+            return WorkspaceTimelinePresentation(
+                title: "Agent completed",
+                detail: projection.summaryText,
+                systemImage: "checkmark.circle",
+                tone: .success
+            )
+        case .errored:
+            return WorkspaceTimelinePresentation(
+                title: projection.summaryText,
+                detail: "Agent reported an error",
+                systemImage: "exclamationmark.triangle",
+                tone: .critical
+            )
+        }
+    }
+
+    private static func errorTitle(for category: AgentErrorCategory) -> String {
+        switch category {
+        case .rateLimit:
+            return "Rate limited"
+        case .authentication:
+            return "Authentication error"
+        case .server:
+            return "Server error"
+        case .toolFailure:
+            return "Tool failed"
+        case .unknown:
+            return "Agent error"
+        }
+    }
+
+    private static func errorDetail(_ message: String?) -> String {
+        guard let message = message?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !message.isEmpty
+        else {
+            return "Agent reported an error"
+        }
+        return message
+    }
+}
+
+struct TimelineTabView: View {
+    let events: [WorkspaceEvent]
+    let hasHostSession: Bool
+
+    var body: some View {
+        if !hasHostSession {
+            ContentUnavailableView(
+                "No Timeline",
+                systemImage: "clock",
+                description: Text("Open this workspace's terminal to connect agent events to the Timeline.")
+            )
+        } else if events.isEmpty {
+            ContentUnavailableView(
+                "No Timeline Events",
+                systemImage: "clock",
+                description: Text("Agent run state changes will appear here.")
+            )
+        } else {
+            List(events) { event in
+                WorkspaceTimelineEventRow(event: event)
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+struct WorkspaceTimelineEventRow: View {
+    let event: WorkspaceEvent
+
+    var body: some View {
+        let presentation = WorkspaceTimelinePresentation.event(event)
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: presentation.systemImage)
+                .foregroundStyle(presentation.tone.color)
+                .frame(width: 16)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(presentation.title)
+                    .font(.callout)
+                    .lineLimit(2)
+
+                Text(presentation.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                Text(event.timestamp.formatted(.relative(presentation: .named)))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Models/WorkspaceEvent.swift
+++ b/Sources/WorkspaceManagerCore/Models/WorkspaceEvent.swift
@@ -3,7 +3,7 @@
 //  WorkspaceManagerCore
 //
 //  Value-type domain model over rows in the SQLite `agent_status_events`
-//  table. The Timeline inspector consumes these via `WorkspaceJournal`; the
+//  table. The Detail Pane Timeline consumes these via `WorkspaceJournal`; the
 //  shape collapses the storage event_name / run_state pair into a small set
 //  of cases keyed for display.
 //

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceJournal.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceJournal.swift
@@ -3,8 +3,8 @@
 //  WorkspaceManagerCore
 //
 //  Read-side repository over `agent_status_events`, exposing a per-workspace
-//  list of `WorkspaceEvent` values ordered newest first. The Timeline inspector
-//  observes this; refresh is explicit so views can scope SQL load to the
+//  list of `WorkspaceEvent` values ordered newest first. The Detail Pane
+//  Timeline observes this; refresh is explicit so views can scope SQL load to the
 //  active workspace.
 //
 

--- a/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RightPaneTabPolicyTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import Testing
+import WorkspaceManagerCore
 
 @testable import WorkspaceManager
 
@@ -8,28 +10,50 @@ struct RightPaneTabPolicyTests {
     func workspaceTabsIncludeActivityWhenNotificationsEnabled() {
         let policy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: true
         )
 
-        #expect(policy.visibleTabs == [.files, .changes, .activity, .diagnostics])
+        #expect(policy.visibleTabs == [.files, .changes, .timeline, .activity, .diagnostics])
     }
 
     @Test("Workspace tabs exclude activity when notifications are disabled")
     func workspaceTabsExcludeActivityWhenNotificationsDisabled() {
         let policy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: false
         )
 
-        #expect(policy.visibleTabs == [.files, .changes, .diagnostics])
+        #expect(policy.visibleTabs == [.files, .changes, .timeline, .diagnostics])
+    }
+
+    @Test("Workspace timeline is independent of notification settings")
+    func workspaceTimelineIsIndependentOfNotificationSettings() {
+        let disabledPolicy = RightPaneTabPolicy(
+            supportsFilesystemInspection: true,
+            showTimeline: true,
+            showActivity: true,
+            notificationsEnabled: false
+        )
+        let enabledPolicy = RightPaneTabPolicy(
+            supportsFilesystemInspection: true,
+            showTimeline: true,
+            showActivity: true,
+            notificationsEnabled: true
+        )
+
+        #expect(disabledPolicy.visibleTabs.contains(.timeline))
+        #expect(enabledPolicy.visibleTabs.contains(.timeline))
     }
 
     @Test("Disabling notifications normalizes activity selection to files")
     func disablingNotificationsNormalizesActivitySelectionToFiles() {
         let policy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: false
         )
@@ -41,11 +65,13 @@ struct RightPaneTabPolicyTests {
     func repoTabsExcludeActivityRegardlessOfNotificationSetting() {
         let disabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: false,
             showActivity: false,
             notificationsEnabled: false
         )
         let enabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: false,
             showActivity: false,
             notificationsEnabled: true
         )
@@ -58,12 +84,14 @@ struct RightPaneTabPolicyTests {
     func disabledNotificationsPreserveNonActivitySelections() {
         let disabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: false
         )
 
         #expect(disabledPolicy.normalizedSelection(for: .files) == .files)
         #expect(disabledPolicy.normalizedSelection(for: .changes) == .changes)
+        #expect(disabledPolicy.normalizedSelection(for: .timeline) == .timeline)
         #expect(disabledPolicy.normalizedSelection(for: .diagnostics) == .diagnostics)
     }
 
@@ -71,12 +99,14 @@ struct RightPaneTabPolicyTests {
     func reenablingNotificationsKeepsNormalizedFilesSelection() {
         let disabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: false
         )
         let normalizedSelection = disabledPolicy.normalizedSelection(for: .activity)
         let reenabledPolicy = RightPaneTabPolicy(
             supportsFilesystemInspection: true,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: true
         )
@@ -89,11 +119,12 @@ struct RightPaneTabPolicyTests {
     func diagnosticsStaysVisibleWithoutFilesystemInspection() {
         let policy = RightPaneTabPolicy(
             supportsFilesystemInspection: false,
+            showTimeline: true,
             showActivity: true,
             notificationsEnabled: false
         )
 
-        #expect(policy.visibleTabs == [.files, .diagnostics])
+        #expect(policy.visibleTabs == [.files, .timeline, .diagnostics])
         #expect(policy.normalizedSelection(for: .diagnostics) == .diagnostics)
     }
 
@@ -102,6 +133,40 @@ struct RightPaneTabPolicyTests {
         let policy = RightPaneWidthPolicy()
 
         #expect(policy.width(for: .files) == RightPaneWidth(minimum: 220, ideal: 280, maximum: 400))
+        #expect(policy.width(for: .timeline) == RightPaneWidth(minimum: 220, ideal: 280, maximum: 400))
         #expect(policy.width(for: .diagnostics) == RightPaneWidth(minimum: 360, ideal: 640, maximum: 760))
+    }
+
+    @Test("Timeline projection names agent events")
+    func timelineProjectionNamesAgentEvents() {
+        let workspaceID = UUID()
+        let hostSessionID = UUID()
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let tool = WorkspaceTimelinePresentation.event(
+            WorkspaceEvent(
+                workspaceID: workspaceID,
+                hostSessionID: hostSessionID,
+                timestamp: timestamp,
+                kind: .toolRun(name: "Bash"),
+                rowID: "tool"
+            )
+        )
+        #expect(tool.title == "Ran Bash")
+        #expect(tool.detail == "Tool execution")
+        #expect(tool.tone == WorkspaceTimelinePresentation.Tone.running)
+
+        let awaiting = WorkspaceTimelinePresentation.event(
+            WorkspaceEvent(
+                workspaceID: workspaceID,
+                hostSessionID: hostSessionID,
+                timestamp: timestamp,
+                kind: .stateTransition(from: .thinking, to: .awaitingInput(reason: .permissionPrompt)),
+                rowID: "awaiting"
+            )
+        )
+        #expect(awaiting.title == "Agent needs input")
+        #expect(awaiting.detail == "Awaiting input")
+        #expect(awaiting.tone == WorkspaceTimelinePresentation.Tone.attention)
     }
 }


### PR DESCRIPTION
## Summary

- Adds a Detail Pane Timeline tab for workspace surfaces, backed by `WorkspaceJournal`.
- Keeps the existing Activity tab scoped to GitHub webhook activity and updates the domain language to make that distinction explicit.
- Adds focused tab-policy and timeline presentation tests so Timeline visibility and agent-event labels have one contract.

## Mergeability

- Surface: desktop Detail Pane, Workspace Journal read-side projection, and domain language in `CONTEXT.md`.
- User-facing behavior changed: Workspace detail panes now show a Timeline tab for agent workspace events. The existing Activity tab remains webhook-only and is labeled/described as GitHub activity when present.
- Non-happy paths considered: Timeline shows an empty state when no workspace terminal session is available, another empty state when no agent events exist, disables manual refresh without a host session, and preserves Diagnostics visibility when filesystem inspection is unavailable. `WorkspaceJournal` read failures remain non-fatal and publish an empty event list.
- Release/ops preconditions: none.
- Residual risk or follow-up: The Timeline currently refreshes from the host terminal session selected for the workspace and does not add filtering or grouping. If multiple agent sessions are active for one workspace, richer session selection can be added later without changing the journal contract.

## Validation

- [x] `swift build` passed.
- [x] `swift test` passed: 926 tests.
- [x] Other checks run:
  - `swift test --filter 'RightPaneTabPolicyTests|WorkspaceJournalTests|WorkspaceEventTests'` passed: 29 tests.
  - `swift-format lint --strict --recursive Sources/ Tests/` passed.
  - `./scripts/desktop-ui-smoke.sh --no-build` passed in shared-desktop-safe mode: 3 terminal attaches, 0 surface focuses, 3 focus timeouts. Focus is best-effort in no-activate mode; terminal attach is the hard gate.

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `config/performance/contract.json`
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: `debug_no_activate`
- Before Summary: `/tmp/workspaces-perf-baseline-20260613-092340/summary.txt`
- After Summary: `/tmp/workspaces-perf-baseline-20260613-222820/summary.txt` and `/tmp/workspaces-perf-baseline-20260613-222915/summary.txt`
- Delta Summary:
  - Sample 1: `launch_to_first_prompt` median 734.22 ms (+62.37 ms), p95 741.69 ms (+18.96 ms); `repo_hydration` median 1.45 ms (-0.01 ms), p95 15.80 ms (-5.96 ms). Budget assertion passed.
  - Sample 2: `launch_to_first_prompt` median 578.69 ms (-93.16 ms), p95 654.26 ms (-68.47 ms); `repo_hydration` median 1.43 ms (-0.03 ms), p95 18.52 ms (-3.24 ms). Budget assertion passed.

Performance comparison notes:

- Exact commands used: `./scripts/perf-baseline.sh 5 8 --assert-budget`
- Workload / environment context: debug build, no-activate launch mode, same run count and sleep interval as the controller baseline. The first launch sample was noisy but within budget; the repeat sample was faster than the controller baseline on launch and comparable on hydration. This change adds an idle Journal environment object and a right-pane projection, with no measurable regression in the canonical startup guardrail.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![validation-summary](https://evidence.cloudcompute.com/workspaces/pr-669/20260614-053248-validation-summary.png)
- ![desktop-ui-smoke-summary](https://evidence.cloudcompute.com/workspaces/pr-669/20260614-053248-desktop-ui-smoke-summary.png)
- ![perf-sample-1](https://evidence.cloudcompute.com/workspaces/pr-669/20260614-053248-perf-sample-1.png)
- ![perf-sample-2](https://evidence.cloudcompute.com/workspaces/pr-669/20260614-053248-perf-sample-2.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

<!-- readiness-refresh: 2026-06-14T05:43Z -->
