### PR TITLE
Centralize terminal launch context policy

### DIFF
--- a/Sources/WorkspaceManager/Surface/TerminalSurface.swift
+++ b/Sources/WorkspaceManager/Surface/TerminalSurface.swift
@@ -29,21 +29,15 @@ final class TerminalSurface: Surface {
         self.tileID = tileID
         self.session = session
 
-        if let customCommand = session.customCommand {
-            self.surfaceView = GhosttySurfaceView(
-                customCommand: customCommand,
-                onProcessExit: onProcessExit,
-                onCloseConfirmationRequired: onCloseConfirmationRequired
-            )
-        } else {
-            self.surfaceView = GhosttySurfaceView(
-                workingDirectory: session.directoryURL,
-                hostSessionID: session.id,
-                hooksSocketPath: hooksSocketPath,
-                onProcessExit: onProcessExit,
-                onCloseConfirmationRequired: onCloseConfirmationRequired
-            )
-        }
+        let launchContext = TerminalSessionLaunchContext.hostSession(
+            session,
+            hooksSocketPath: hooksSocketPath
+        )
+        self.surfaceView = GhosttySurfaceView(
+            launchContext: launchContext,
+            onProcessExit: onProcessExit,
+            onCloseConfirmationRequired: onCloseConfirmationRequired
+        )
         self.surfaceView.contextMenuProvider = contextMenuProvider
     }
 

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -34,21 +34,17 @@ final class GhosttySurfaceView: NSView {
     var contextMenuProvider: (() -> NSMenu?)?
 
     init(
-        workingDirectory: URL,
-        hostSessionID: UUID? = nil,
-        hooksSocketPath: String? = nil,
+        launchContext: TerminalSessionLaunchContext,
         onProcessExit: (() -> Void)? = nil,
         onCloseConfirmationRequired: (() -> Void)? = nil
     ) {
-        self.workingDirectory = workingDirectory
-        self.promptReadinessSignposts = TerminalPromptReadinessSignpostController(hostSessionID: hostSessionID)
+        self.workingDirectory = launchContext.workingDirectory
+        self.promptReadinessSignposts = TerminalPromptReadinessSignpostController(
+            hostSessionID: launchContext.promptReadinessHostSessionID
+        )
         self.onProcessExit = onProcessExit
         self.onCloseConfirmationRequired = onCloseConfirmationRequired
-        self.terminalConfig = GhosttyTerminalConfig(
-            workingDirectory: workingDirectory,
-            hostSessionID: hostSessionID,
-            hooksSocketPath: hooksSocketPath
-        )
+        self.terminalConfig = GhosttyTerminalConfig(launchContext: launchContext)
         self.readinessDiagnostics = TerminalReadinessDiagnostics(
             workingDirectoryName: workingDirectory.lastPathComponent,
             shellProfileMode: terminalConfig.shellProfileModeLabel
@@ -59,24 +55,34 @@ final class GhosttySurfaceView: NSView {
         createSurfaceIfNeeded()
     }
 
-    init(
+    convenience init(
+        workingDirectory: URL,
+        hostSessionID: UUID? = nil,
+        hooksSocketPath: String? = nil,
+        onProcessExit: (() -> Void)? = nil,
+        onCloseConfirmationRequired: (() -> Void)? = nil
+    ) {
+        self.init(
+            launchContext: .directoryBacked(
+                workingDirectory: workingDirectory,
+                hostSessionID: hostSessionID,
+                hooksSocketPath: hooksSocketPath
+            ),
+            onProcessExit: onProcessExit,
+            onCloseConfirmationRequired: onCloseConfirmationRequired
+        )
+    }
+
+    convenience init(
         customCommand: String,
         onProcessExit: (() -> Void)? = nil,
         onCloseConfirmationRequired: (() -> Void)? = nil
     ) {
-        self.workingDirectory = FileManager.default.temporaryDirectory
-        self.promptReadinessSignposts = TerminalPromptReadinessSignpostController(hostSessionID: nil)
-        self.onProcessExit = onProcessExit
-        self.onCloseConfirmationRequired = onCloseConfirmationRequired
-        self.terminalConfig = GhosttyTerminalConfig(customCommand: customCommand)
-        self.readinessDiagnostics = TerminalReadinessDiagnostics(
-            workingDirectoryName: workingDirectory.lastPathComponent,
-            shellProfileMode: terminalConfig.shellProfileModeLabel
+        self.init(
+            launchContext: .customCommand(customCommand),
+            onProcessExit: onProcessExit,
+            onCloseConfirmationRequired: onCloseConfirmationRequired
         )
-        super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
-        self.wantsLayer = true
-
-        createSurfaceIfNeeded()
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -32,6 +32,30 @@ struct GhosttyTerminalConfig {
     let shellProfileModeLabel: String
 
     init(
+        launchContext: TerminalSessionLaunchContext,
+        fontSize: Float32 = 13,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        terminalMultiplexingMode: TerminalMultiplexingMode? = nil,
+        isTmuxAvailableOverride: Bool? = nil
+    ) {
+        switch launchContext.commandMode {
+        case .customCommand(let customCommand):
+            self.init(customCommand: customCommand, fontSize: fontSize)
+
+        case .directoryShell:
+            self.init(
+                workingDirectory: launchContext.workingDirectory,
+                fontSize: fontSize,
+                environment: environment,
+                terminalMultiplexingMode: terminalMultiplexingMode,
+                isTmuxAvailableOverride: isTmuxAvailableOverride,
+                hostSessionID: launchContext.hostSessionID,
+                hooksSocketPath: launchContext.hooksSocketPath
+            )
+        }
+    }
+
+    init(
         workingDirectory: URL,
         fontSize: Float32 = 13,
         environment: [String: String] = ProcessInfo.processInfo.environment,

--- a/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
@@ -1,0 +1,134 @@
+//
+//  TerminalSessionLaunchContext.swift
+//  WorkspaceManager
+//
+//  Launch policy for one Terminal Session. It keeps command mode, working
+//  directory, host-session identity, and Agent hook reachability together so
+//  Ghostty surface creation has one place to ask what environment is safe.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+struct TerminalSessionLaunchContext: Equatable, Sendable {
+    enum CommandMode: Equatable, Sendable {
+        case directoryShell
+        case customCommand(String)
+
+        var label: String {
+            switch self {
+            case .directoryShell:
+                return "directory"
+            case .customCommand:
+                return "custom"
+            }
+        }
+    }
+
+    enum AgentCommunication: Equatable, Sendable {
+        case hookEnvironment
+        case terminalSignalsOnly(TerminalSignalOnlyReason)
+    }
+
+    enum TerminalSignalOnlyReason: String, Equatable, Sendable {
+        case customCommand
+        case incompleteHookContext
+    }
+
+    let workingDirectory: URL
+    let commandMode: CommandMode
+    let hostSessionID: UUID?
+    let hooksSocketPath: String?
+
+    static func hostSession(
+        _ session: HostTerminalSession,
+        hooksSocketPath: String?
+    ) -> TerminalSessionLaunchContext {
+        if let customCommand = session.customCommand {
+            return TerminalSessionLaunchContext(
+                workingDirectory: session.directoryURL,
+                commandMode: .customCommand(customCommand),
+                hostSessionID: session.id,
+                hooksSocketPath: hooksSocketPath
+            )
+        }
+
+        return directoryBacked(
+            workingDirectory: session.directoryURL,
+            hostSessionID: session.id,
+            hooksSocketPath: hooksSocketPath
+        )
+    }
+
+    static func directoryBacked(
+        workingDirectory: URL,
+        hostSessionID: UUID? = nil,
+        hooksSocketPath: String? = nil
+    ) -> TerminalSessionLaunchContext {
+        TerminalSessionLaunchContext(
+            workingDirectory: workingDirectory,
+            commandMode: .directoryShell,
+            hostSessionID: hostSessionID,
+            hooksSocketPath: hooksSocketPath
+        )
+    }
+
+    static func customCommand(
+        _ command: String,
+        workingDirectory: URL = FileManager.default.temporaryDirectory,
+        hostSessionID: UUID? = nil,
+        hooksSocketPath: String? = nil
+    ) -> TerminalSessionLaunchContext {
+        TerminalSessionLaunchContext(
+            workingDirectory: workingDirectory,
+            commandMode: .customCommand(command),
+            hostSessionID: hostSessionID,
+            hooksSocketPath: hooksSocketPath
+        )
+    }
+
+    var commandModeLabel: String {
+        commandMode.label
+    }
+
+    var promptReadinessHostSessionID: UUID? {
+        switch commandMode {
+        case .directoryShell:
+            return hostSessionID
+        case .customCommand:
+            return nil
+        }
+    }
+
+    var agentCommunication: AgentCommunication {
+        switch commandMode {
+        case .customCommand:
+            return .terminalSignalsOnly(.customCommand)
+        case .directoryShell:
+            guard hostSessionID != nil, hooksSocketPath != nil else {
+                return .terminalSignalsOnly(.incompleteHookContext)
+            }
+            return .hookEnvironment
+        }
+    }
+
+    func hookEnvironment(
+        commandStatusHookPath: String? = ClaudeIntegrationLifecycle.bundledCommandStatusHookPath()
+    ) -> [String: String] {
+        guard case .hookEnvironment = agentCommunication,
+            let hostSessionID,
+            let hooksSocketPath
+        else {
+            return [:]
+        }
+
+        var environment = [
+            "WORKSPACES_HOOKS_SOCKET": hooksSocketPath,
+            "WORKSPACES_HOST_SESSION_ID": hostSessionID.uuidString,
+        ]
+        if let commandStatusHookPath {
+            environment["WORKSPACES_COMMAND_STATUS_ZSH"] = commandStatusHookPath
+        }
+        return environment
+    }
+}

--- a/Sources/WorkspaceManager/Views/Components/TerminalView.swift
+++ b/Sources/WorkspaceManager/Views/Components/TerminalView.swift
@@ -55,22 +55,15 @@ final class HostTerminalSurfaceStore {
             return existing
         }
 
-        let created: GhosttySurfaceView
-        if let customCommand = session.customCommand {
-            created = GhosttySurfaceView(
-                customCommand: customCommand,
-                onProcessExit: wrappedOnProcessExit,
-                onCloseConfirmationRequired: onCloseConfirmationRequired
-            )
-        } else {
-            created = GhosttySurfaceView(
-                workingDirectory: session.directoryURL,
-                hostSessionID: session.id,
-                hooksSocketPath: hooksSocketPath,
-                onProcessExit: wrappedOnProcessExit,
-                onCloseConfirmationRequired: onCloseConfirmationRequired
-            )
-        }
+        let launchContext = TerminalSessionLaunchContext.hostSession(
+            session,
+            hooksSocketPath: hooksSocketPath
+        )
+        let created = GhosttySurfaceView(
+            launchContext: launchContext,
+            onProcessExit: wrappedOnProcessExit,
+            onCloseConfirmationRequired: onCloseConfirmationRequired
+        )
         surfaces[session.id] = created
         sessionIDsBySurfaceIdentity[ObjectIdentifier(created)] = session.id
         created.contextMenuProvider = contextMenuProvider
@@ -78,7 +71,7 @@ final class HostTerminalSurfaceStore {
             phase: "surface_store_created",
             fields: [
                 "session_id": session.id.uuidString,
-                "command_mode": session.customCommand == nil ? "directory" : "custom",
+                "command_mode": launchContext.commandModeLabel,
             ]
         )
         onSurfaceCreated?(session.id)

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -189,6 +189,17 @@ struct GhosttyTerminalConfigTests {
         #expect(missingHostID.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
     }
 
+    @Test("custom command config preserves explicit command without hook environment")
+    func customCommandConfigPreservesExplicitCommandWithoutHookEnvironment() {
+        let config = GhosttyTerminalConfig(customCommand: "/usr/local/bin/lume ssh vm-123")
+
+        #expect(config.command == "/usr/local/bin/lume ssh vm-123")
+        #expect(config.shellProfileModeLabel == "custom")
+        #expect(config.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
+    }
+
     @Test("tmux mode respects clean shell override")
     func tmuxModeRespectsCleanShellOverride() throws {
         let config = GhosttyTerminalConfig(

--- a/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
@@ -1,0 +1,77 @@
+//
+//  TerminalSessionLaunchContextTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@Suite("TerminalSessionLaunchContext")
+struct TerminalSessionLaunchContextTests {
+    @Test("Directory-backed host sessions expose hook environment")
+    func directoryBackedHostSessionsExposeHookEnvironment() {
+        let hostSessionID = UUID(uuidString: "7BD8C9BD-7F3B-456D-A9EC-16CDB2221339")!
+        let session = HostTerminalSession(
+            id: hostSessionID,
+            key: .repoPath("/Users/test/repo"),
+            directory: URL(fileURLWithPath: "/Users/test/repo")
+        )
+
+        let context = TerminalSessionLaunchContext.hostSession(
+            session,
+            hooksSocketPath: "/tmp/workspaces-hooks.sock"
+        )
+        let hookEnvironment = context.hookEnvironment(commandStatusHookPath: "/tmp/command-status.zsh")
+
+        #expect(context.commandModeLabel == "directory")
+        #expect(context.promptReadinessHostSessionID == hostSessionID)
+        #expect(context.agentCommunication == .hookEnvironment)
+        #expect(hookEnvironment["WORKSPACES_HOST_SESSION_ID"] == hostSessionID.uuidString)
+        #expect(hookEnvironment["WORKSPACES_HOOKS_SOCKET"] == "/tmp/workspaces-hooks.sock")
+        #expect(hookEnvironment["WORKSPACES_COMMAND_STATUS_ZSH"] == "/tmp/command-status.zsh")
+    }
+
+    @Test("Incomplete directory hook context falls back to terminal signals")
+    func incompleteDirectoryHookContextFallsBackToTerminalSignals() {
+        let hostSessionID = UUID(uuidString: "7BD8C9BD-7F3B-456D-A9EC-16CDB2221339")!
+        let context = TerminalSessionLaunchContext.directoryBacked(
+            workingDirectory: URL(fileURLWithPath: "/Users/test/repo"),
+            hostSessionID: hostSessionID
+        )
+
+        #expect(context.agentCommunication == .terminalSignalsOnly(.incompleteHookContext))
+        #expect(context.hookEnvironment(commandStatusHookPath: "/tmp/command-status.zsh").isEmpty)
+    }
+
+    @Test("Custom-command host sessions are terminal-signal only")
+    func customCommandHostSessionsAreTerminalSignalOnly() {
+        let hostSessionID = UUID(uuidString: "7BD8C9BD-7F3B-456D-A9EC-16CDB2221339")!
+        let session = HostTerminalSession(
+            id: hostSessionID,
+            key: .backendSession(providerID: "lume", instanceID: "vm-123"),
+            directory: URL(fileURLWithPath: "/tmp/workspaces/vm-123"),
+            customCommand: "/usr/local/bin/lume ssh vm-123"
+        )
+
+        let context = TerminalSessionLaunchContext.hostSession(
+            session,
+            hooksSocketPath: "/tmp/workspaces-hooks.sock"
+        )
+        let config = GhosttyTerminalConfig(launchContext: context)
+
+        #expect(context.commandModeLabel == "custom")
+        #expect(context.promptReadinessHostSessionID == nil)
+        #expect(context.agentCommunication == .terminalSignalsOnly(.customCommand))
+        #expect(context.hookEnvironment(commandStatusHookPath: "/tmp/command-status.zsh").isEmpty)
+        #expect(context.workingDirectory.path == "/tmp/workspaces/vm-123")
+        #expect(config.command == "/usr/local/bin/lume ssh vm-123")
+        #expect(config.shellProfileModeLabel == "custom")
+        #expect(config.workingDirectory == FileManager.default.temporaryDirectory.path)
+        #expect(config.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
+    }
+}

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -78,12 +78,27 @@ individual registry fields directly.
 
 ## Host Session Routing
 
-Routing is explicit. Every persistent host terminal created from a
-`HostTerminalSession` receives:
+Routing is explicit. `TerminalSessionLaunchContext` owns the launch-context
+policy for every `HostTerminalSession`: command mode, working directory,
+host-session identity, and whether hook environment is safe to expose.
+
+Directory-backed Terminal Sessions receive:
 
 - `WORKSPACES_HOOKS_SOCKET`
 - `WORKSPACES_HOST_SESSION_ID`
 - `WORKSPACES_COMMAND_STATUS_ZSH` when the bundled zsh producer is available
+
+This includes local repository/workspace sessions, Ghostty split sessions, and
+tmux-per-session launches because the Agent runs in the same host namespace as
+the app's Unix socket.
+
+Custom-command Terminal Sessions, such as provider SSH commands, intentionally
+do not receive the hook environment. WorkSpaces cannot assume the custom command's
+child shell can reach the local Unix socket, and leaking a local socket path into
+a remote session would be misleading. These sessions can still communicate with
+app chrome through terminal signals that libghostty observes, including OSC
+desktop notifications and BEL, because the surface resolver maps the
+`GhosttySurfaceView` back to its `HostTerminalSession`.
 
 The bundled shell forwarders include
 `X-WorkSpaces-Host-Session-ID: <uuid>` on every POST. The listener accepts the

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -126,6 +126,10 @@ Current migration uses surface/runtime config only:
 - `env_vars`
 - `font_size`
 
+`TerminalSessionLaunchContext` decides the command mode and hook environment
+before `GhosttyTerminalConfig` translates that policy into the libghostty surface
+fields above.
+
 Not configured yet (by design in this migration):
 - app-owned font-family override
 


### PR DESCRIPTION
## Summary

- Added `TerminalSessionLaunchContext` as the single launch-context policy for host Terminal Sessions: command mode, working directory, host session identity, prompt-readiness identity, and Agent hook reachability.
- Routed persistent terminal surfaces through that context in both the main host terminal surface store and `TerminalSurface`.
- Preserved existing runtime behavior: directory-backed sessions receive hook environment when complete; custom-command sessions intentionally remain terminal-signal-only and keep the existing custom-command Ghostty config shape.
- Updated terminal/Claude integration docs and added focused launch-context/config tests.

## Mergeability

- Surface: desktop terminal launch/session policy, Agent hook-context docs, focused Swift tests.
- User-facing behavior changed: No intentional visible behavior change. Local directory-backed Terminal Sessions still expose Agent hook environment; custom-command Terminal Sessions still do not receive local hook env, now as an explicit contract.
- Non-happy paths considered: Incomplete hook context falls back to terminal signals; custom-command sessions do not leak local socket paths into remote/provider commands; a candidate regression where `ghostty_surface_new` failed was diagnosed against `origin/main` and fixed before PR publication.
- Release/ops preconditions: None.
- Residual risk or follow-up: Low. The refactor keeps the pre-change Ghostty config builders for surface creation after the initial attempt proved that changing their shape could break `ghostty_surface_new`; any future attempt to further refactor `GhosttyTerminalConfig.withCValue` should keep the perf guardrail as a hard gate.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `./scripts/build-ghosttykit.sh`
  - `swift test --filter 'TerminalSessionLaunchContext|GhosttyTerminalConfig|HostTerminalStateStore|SurfaceStore'`
  - `swift-format lint --strict --recursive Sources/ Tests/`
  - `./scripts/desktop-ui-smoke.sh --no-build` passed after rerun outside the sandbox so `/bin/ps` could inspect the debug process. Result: `OK: 3 terminal attaches, 0 surface focuses, 3 focus timeouts` (expected no-activate focus caveat).

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `config/performance/contract.json`
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: `debug_no_activate`
- Before Summary: controller baseline `/tmp/workspaces-perf-baseline-20260613-092340/summary.txt`
  - `launch_to_first_prompt`: count=5 min=582.99 max=722.73 median=671.85 mean=664.63 p95=722.73
  - `repo_hydration`: count=5 min=1.30 max=21.76 median=1.46 mean=5.53 p95=21.76
  - `repo_click_to_focus`: missing
  - `workspace_click_to_focus`: missing
- After Summary: `/tmp/workspaces-perf-baseline-20260613-231254/summary.txt`
  - `launch_to_first_prompt`: count=5 min=505.43 max=680.13 median=626.20 mean=602.05 p95=680.13
  - `repo_hydration`: count=5 min=1.30 max=25.17 median=1.37 mean=6.12 p95=25.17
  - `repo_click_to_focus`: count=1 min=361.55 max=361.55 median=361.55 mean=361.55 p95=361.55
  - `workspace_click_to_focus`: missing
- Delta Summary:
  - `launch_to_first_prompt` median: -45.65 ms versus baseline; restored after diagnosing/fixing an interim `ghostty_surface_new_failed` regression.
  - `repo_hydration` median: -0.09 ms versus baseline; mean +0.59 ms and p95 +3.41 ms, still within budget.
  - `repo_click_to_focus`: after run captured one sample; controller baseline was missing, so no comparable delta.

Performance comparison notes:

- Exact commands used:
  - `./scripts/perf-baseline.sh 5 8 --assert-budget`
  - Diagnostic comparison against current `origin/main`: `/tmp/workspaces-origin-main-check` one-sample run emitted `launch_to_first_prompt=541.15 ms`, proving the interim failure was branch-local, not host/display drift.
- Workload / environment context: SwiftPM debug binary, no-activate launch mode, Ghostty resources from `/Users/fairchild/.cache/workspacemanager/ghostty/zig-out/share/ghostty`, same controller workload shape.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Validation and perf evidence](https://evidence.cloudcompute.com/workspaces/pr-672/20260614-061555-terminal-hook-context-validation-perf.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
