### PR TITLE
Enable Ghostty tab renaming

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -34,6 +34,7 @@ final class GhosttySurfaceView: NSView {
     var workingDirectoryPath: String { workingDirectory.path }
     var contextMenuProvider: (() -> NSMenu?)?
     var onScrollbarStateChange: ((GhosttyScrollbarState) -> Void)?
+    var onTerminalTitleChanged: ((String) -> Void)?
 
     init(
         launchContext: TerminalSessionLaunchContext,
@@ -185,7 +186,11 @@ final class GhosttySurfaceView: NSView {
     // MARK: - Runtime updates
 
     func updateTerminalTitle(_ title: String) {
+        let previousTitle = terminalTitle
         terminalTitle = title
+        if previousTitle != title {
+            onTerminalTitleChanged?(title)
+        }
         guard !title.isEmpty else { return }
         observePromptReadinessSignal(.setTitle)
     }

--- a/Sources/WorkspaceManager/Views/Components/TerminalView.swift
+++ b/Sources/WorkspaceManager/Views/Components/TerminalView.swift
@@ -28,6 +28,7 @@ final class HostTerminalSurfaceStore {
     var hooksSocketPath: String?
     var onSurfaceCreated: (@MainActor (UUID) -> Void)?
     var onSurfaceInvalidated: (@MainActor (UUID) -> Void)?
+    var onTerminalTitleChanged: (@MainActor (UUID) -> Void)?
 
     func view(
         for session: HostTerminalSession,
@@ -52,6 +53,9 @@ final class HostTerminalSurfaceStore {
             existing.onProcessExit = wrappedOnProcessExit
             existing.onCloseConfirmationRequired = onCloseConfirmationRequired
             existing.contextMenuProvider = contextMenuProvider
+            existing.onTerminalTitleChanged = { [weak self] _ in
+                self?.onTerminalTitleChanged?(sessionID)
+            }
             return existing
         }
 
@@ -67,6 +71,9 @@ final class HostTerminalSurfaceStore {
         surfaces[session.id] = created
         sessionIDsBySurfaceIdentity[ObjectIdentifier(created)] = session.id
         created.contextMenuProvider = contextMenuProvider
+        created.onTerminalTitleChanged = { [weak self] _ in
+            self?.onTerminalTitleChanged?(sessionID)
+        }
         InvestigationDiagnostics.emitFocus(
             phase: "surface_store_created",
             fields: [
@@ -106,6 +113,7 @@ final class HostTerminalSurfaceStore {
     func invalidate(sessionID: UUID) {
         if let removed = surfaces.removeValue(forKey: sessionID) {
             sessionIDsBySurfaceIdentity.removeValue(forKey: ObjectIdentifier(removed))
+            removed.onTerminalTitleChanged = nil
         }
         onSurfaceInvalidated?(sessionID)
     }
@@ -118,6 +126,7 @@ final class HostTerminalSurfaceStore {
         }
 
         sessionIDsBySurfaceIdentity.removeValue(forKey: ObjectIdentifier(removed))
+        removed.onTerminalTitleChanged = nil
         removed.forceCloseForSessionRetirement()
         onSurfaceInvalidated?(sessionID)
         return true

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -455,6 +455,7 @@ struct ContentView: View {
             },
             onSelectTerminalTab: selectTerminalTab(sessionID:),
             onCloseTerminalTab: closeTerminalTab(sessionID:),
+            onRenameTerminalTab: renameTerminalTab(sessionID:title:),
             onTerminalCloseConfirmationRequired: requestCloseConfirmationForTerminalTab(sessionID:),
             onTerminalProcessExit: handleTerminalProcessExit(sessionID:),
             selectedCodePreview: $viewState.selectedCodePreview,
@@ -1810,6 +1811,11 @@ struct ContentView: View {
     }
 
     @MainActor
+    private func renameTerminalTab(sessionID: UUID, title: String?) {
+        _ = hostTerminalState.setTabTitle(title, for: sessionID)
+    }
+
+    @MainActor
     private func requestCloseTerminalTabs(_ sessionIDs: [UUID]) {
         let results = terminalSessionController.closeTabs(
             sessionIDs,
@@ -2770,6 +2776,7 @@ struct MainTerminalDetailView: View {
     let onSplitFractionChanged: (CGFloat) -> Void
     var onSelectTerminalTab: ((UUID) -> Void)?
     var onCloseTerminalTab: ((UUID) -> Void)?
+    var onRenameTerminalTab: ((UUID, String?) -> Void)?
     var onTerminalCloseConfirmationRequired: ((UUID) -> Void)?
     var onTerminalProcessExit: ((UUID) -> Void)?
     @Binding var selectedCodePreview: CodePreviewSelection?
@@ -2924,6 +2931,7 @@ struct MainTerminalDetailView: View {
             onSplitFractionChanged: onSplitFractionChanged,
             onSelectTab: onSelectTerminalTab,
             onCloseTab: onCloseTerminalTab,
+            onRenameTab: onRenameTerminalTab,
             onCloseConfirmationRequired: onTerminalCloseConfirmationRequired,
             onTerminalProcessExit: onTerminalProcessExit,
             contextMenuProvider: terminalContextMenuProvider

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalSessionStack.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalSessionStack.swift
@@ -15,6 +15,7 @@ struct HostTerminalSessionStack: View {
     let onSplitFractionChanged: ((CGFloat) -> Void)?
     var onSelectTab: ((UUID) -> Void)?
     var onCloseTab: ((UUID) -> Void)?
+    var onRenameTab: ((UUID, String?) -> Void)?
     var onCloseConfirmationRequired: ((UUID) -> Void)?
     var onTerminalProcessExit: ((UUID) -> Void)?
     var contextMenuProvider: ((HostTerminalSession) -> NSMenu?)?
@@ -68,7 +69,8 @@ struct HostTerminalSessionStack: View {
                         activeSessionID: activeSession.id,
                         titleForSession: tabTitle(for:),
                         onSelectTab: onSelectTab,
-                        onCloseTab: onCloseTab
+                        onCloseTab: onCloseTab,
+                        onRenameTab: onRenameTab
                     )
                 }
 
@@ -103,11 +105,18 @@ struct HostTerminalSessionStack: View {
 }
 
 private struct TerminalTabStrip: View {
+    private static let titleWidth: CGFloat = 160
+
     let sessions: [HostTerminalSession]
     let activeSessionID: UUID
     let titleForSession: (HostTerminalSession) -> String
     var onSelectTab: ((UUID) -> Void)?
     var onCloseTab: ((UUID) -> Void)?
+    var onRenameTab: ((UUID, String?) -> Void)?
+
+    @State private var editingSessionID: UUID?
+    @State private var editingTitle = ""
+    @FocusState private var isEditingTitleFocused: Bool
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -124,22 +133,55 @@ private struct TerminalTabStrip: View {
         .overlay(alignment: .bottom) {
             Divider()
         }
+        .onChange(of: sessions.map(\.id)) { _, sessionIDs in
+            guard let editingSessionID, !sessionIDs.contains(editingSessionID) else { return }
+            cancelRename()
+        }
     }
 
     private func tabButton(for session: HostTerminalSession) -> some View {
         let isActive = session.id == activeSessionID
+        let title = titleForSession(session)
+        let isEditing = editingSessionID == session.id
         return HStack(spacing: 6) {
-            Button {
-                onSelectTab?(session.id)
-            } label: {
-                Text(titleForSession(session))
-                    .font(.system(size: 12, weight: isActive ? .semibold : .regular))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .frame(maxWidth: 180, alignment: .leading)
+            Group {
+                if isEditing {
+                    TextField("", text: $editingTitle)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 12, weight: .semibold))
+                        .lineLimit(1)
+                        .frame(width: Self.titleWidth, alignment: .leading)
+                        .focused($isEditingTitleFocused)
+                        .onSubmit {
+                            commitRename(for: session)
+                        }
+                        .onExitCommand {
+                            cancelRename()
+                        }
+                        .onAppear {
+                            isEditingTitleFocused = true
+                        }
+                        .onChange(of: isEditingTitleFocused) { _, isFocused in
+                            guard !isFocused else { return }
+                            commitRename(for: session)
+                        }
+                } else {
+                    Button {
+                        handleTabTap(session, isActive: isActive, title: title)
+                    } label: {
+                        Text(title)
+                            .font(.system(size: 12, weight: isActive ? .semibold : .regular))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .frame(width: Self.titleWidth, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
-            .buttonStyle(.plain)
-            .help(titleForSession(session))
+            .help(isActive ? "Rename Tab" : title)
+            .accessibilityLabel(
+                isEditing ? "Tab Title" : (isActive ? "Rename \(title)" : title)
+            )
 
             Button {
                 onCloseTab?(session.id)
@@ -162,6 +204,37 @@ private struct TerminalTabStrip: View {
             RoundedRectangle(cornerRadius: 5)
                 .stroke(isActive ? Color(nsColor: .separatorColor) : Color.clear, lineWidth: 1)
         }
+    }
+
+    private func handleTabTap(_ session: HostTerminalSession, isActive: Bool, title: String) {
+        guard isActive else {
+            onSelectTab?(session.id)
+            return
+        }
+
+        beginRename(sessionID: session.id, title: title)
+    }
+
+    private func beginRename(sessionID: UUID, title: String) {
+        editingSessionID = sessionID
+        editingTitle = title
+        isEditingTitleFocused = true
+    }
+
+    private func commitRename(for session: HostTerminalSession) {
+        guard editingSessionID == session.id else { return }
+
+        let title = editingTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        editingSessionID = nil
+        editingTitle = ""
+        isEditingTitleFocused = false
+        onRenameTab?(session.id, title.isEmpty ? nil : title)
+    }
+
+    private func cancelRename() {
+        editingSessionID = nil
+        editingTitle = ""
+        isEditingTitleFocused = false
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalSessionStack.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalSessionStack.swift
@@ -116,6 +116,7 @@ private struct TerminalTabStrip: View {
 
     @State private var editingSessionID: UUID?
     @State private var editingTitle = ""
+    @State private var editingOriginalTitle = ""
     @FocusState private var isEditingTitleFocused: Bool
 
     var body: some View {
@@ -218,23 +219,56 @@ private struct TerminalTabStrip: View {
     private func beginRename(sessionID: UUID, title: String) {
         editingSessionID = sessionID
         editingTitle = title
+        editingOriginalTitle = title
         isEditingTitleFocused = true
     }
 
     private func commitRename(for session: HostTerminalSession) {
         guard editingSessionID == session.id else { return }
 
-        let title = editingTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let renameAction = TerminalTabRenameAction.resolve(
+            originalTitle: editingOriginalTitle,
+            editedTitle: editingTitle
+        )
         editingSessionID = nil
         editingTitle = ""
+        editingOriginalTitle = ""
         isEditingTitleFocused = false
-        onRenameTab?(session.id, title.isEmpty ? nil : title)
+
+        switch renameAction {
+        case .unchanged:
+            break
+        case .clearOverride:
+            onRenameTab?(session.id, nil)
+        case .setOverride(let title):
+            onRenameTab?(session.id, title)
+        }
     }
 
     private func cancelRename() {
         editingSessionID = nil
         editingTitle = ""
+        editingOriginalTitle = ""
         isEditingTitleFocused = false
+    }
+}
+
+enum TerminalTabRenameAction: Equatable {
+    case unchanged
+    case clearOverride
+    case setOverride(String)
+
+    static func resolve(originalTitle: String, editedTitle: String) -> Self {
+        let original = normalized(originalTitle)
+        let edited = normalized(editedTitle)
+
+        guard original != edited else { return .unchanged }
+        guard !edited.isEmpty else { return .clearOverride }
+        return .setOverride(edited)
+    }
+
+    private static func normalized(_ title: String) -> String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -67,6 +67,12 @@ final class HostTerminalStateStore: ObservableObject {
     /// so we only register/deregister on real edge transitions.
     private var registeredAgentSessionIDs: Set<UUID> = []
 
+    init() {
+        surfaceStore.onTerminalTitleChanged = { [weak self] _ in
+            self?.objectWillChange.send()
+        }
+    }
+
     func attach(agentSessionRegistry: AgentSessionRegistry) {
         attach(
             agentSessionRegistry: agentSessionRegistry,
@@ -239,10 +245,14 @@ final class HostTerminalStateStore: ObservableObject {
     func setTabTitle(_ title: String?, for sourceSessionID: UUID?) -> Bool {
         guard let primarySessionID = resolvedPrimarySessionID(sourceSessionID) else { return false }
         let normalizedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        var updatedOverrides = tabTitleOverridesBySessionID
         if let normalizedTitle, !normalizedTitle.isEmpty {
-            tabTitleOverridesBySessionID[primarySessionID] = normalizedTitle
+            updatedOverrides[primarySessionID] = normalizedTitle
         } else {
-            tabTitleOverridesBySessionID.removeValue(forKey: primarySessionID)
+            updatedOverrides.removeValue(forKey: primarySessionID)
+        }
+        if updatedOverrides != tabTitleOverridesBySessionID {
+            tabTitleOverridesBySessionID = updatedOverrides
         }
         return true
     }

--- a/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/HostTerminalStateStoreTests.swift
@@ -5,6 +5,7 @@
 //  Verifies split layout and directional focus behavior for host terminal splits.
 //
 
+import Combine
 import Foundation
 import Testing
 
@@ -72,6 +73,45 @@ struct HostTerminalStateStoreTests {
 
         #expect(store.setTabTitle("Build", for: split.id))
         #expect(store.tabTitleOverride(for: primary.id) == "Build")
+    }
+
+    @Test("Tab title overrides trim and clear empty titles")
+    func tabTitleOverridesTrimAndClearEmptyTitles() {
+        let store = HostTerminalStateStore()
+        let session = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+
+        #expect(store.setTabTitle("  Build  ", for: session.id))
+        #expect(store.tabTitleOverride(for: session.id) == "Build")
+
+        #expect(store.setTabTitle("   ", for: session.id))
+        #expect(store.tabTitleOverride(for: session.id) == nil)
+    }
+
+    @Test("Surface title changes publish host terminal state updates")
+    func surfaceTitleChangesPublishHostTerminalStateUpdates() {
+        let store = HostTerminalStateStore()
+        let session = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        let terminal = store.surfaceStore.view(for: session)
+
+        var emissions = 0
+        let cancellable = store.objectWillChange.sink { _ in
+            emissions += 1
+        }
+        defer { cancellable.cancel() }
+
+        terminal.updateTerminalTitle("Build")
+
+        #expect(store.surfaceStore.displayTitle(for: session) == "Build")
+        #expect(emissions == 1)
+
+        terminal.updateTerminalTitle("Build")
+        #expect(emissions == 1)
     }
 
     @Test("Close tab candidates support this other and right")

--- a/Tests/WorkspaceManagerAppTests/TabRoutingControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TabRoutingControllerTests.swift
@@ -46,6 +46,22 @@ struct TabRoutingControllerTests {
         #expect(closeRequests == [[third.id]])
     }
 
+    @Test("set_tab_title notification updates the source tab title")
+    func setTabTitleNotificationUpdatesSourceTabTitle() throws {
+        let store = makeStore()
+        let first = try #require(store.sessions.first)
+        let source = store.surfaceStore.view(for: first)
+
+        TabRoutingController().handle(
+            notification: tabActionNotification(kind: .setTabTitle, title: "Build", source: source),
+            hostTerminalState: store,
+            focusTerminal: { _ in },
+            requestCloseTabs: { _ in }
+        )
+
+        #expect(store.tabTitleOverride(for: first.id) == "Build")
+    }
+
     @Test("Invalid tab action payload leaves terminal state unchanged")
     func invalidTabActionPayloadLeavesTerminalStateUnchanged() throws {
         let store = makeStore()

--- a/Tests/WorkspaceManagerAppTests/TerminalTabRenameActionTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalTabRenameActionTests.swift
@@ -1,0 +1,44 @@
+//
+//  TerminalTabRenameActionTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Verifies the terminal tab rename commit rules before SwiftUI dispatches
+//  title changes into HostTerminalStateStore.
+//
+
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("TerminalTabRenameAction")
+struct TerminalTabRenameActionTests {
+    @Test("Unchanged titles do not create a manual override")
+    func unchangedTitlesDoNotCreateManualOverride() {
+        #expect(
+            TerminalTabRenameAction.resolve(
+                originalTitle: "Build",
+                editedTitle: "Build"
+            ) == .unchanged
+        )
+    }
+
+    @Test("Whitespace-only edits clear the current override")
+    func whitespaceOnlyEditsClearOverride() {
+        #expect(
+            TerminalTabRenameAction.resolve(
+                originalTitle: "Build",
+                editedTitle: "   "
+            ) == .clearOverride
+        )
+    }
+
+    @Test("Changed titles are trimmed and stored")
+    func changedTitlesAreTrimmedAndStored() {
+        #expect(
+            TerminalTabRenameAction.resolve(
+                originalTitle: "Build",
+                editedTitle: "  Deploy  "
+            ) == .setOverride("Deploy")
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add inline rename editing when tapping the active Ghostty terminal tab
- let terminal title updates publish through the host terminal state so shell-driven tab title commands repaint the tab strip
- avoid creating a manual tab-title override when the rename editor is submitted without changes
- cover manual tab title overrides, shell-routed set_tab_title behavior, and no-op rename resolution with Swift tests

## Mergeability
- Surface: desktop terminal tab strip / Ghostty host terminal state
- User-facing behavior changed: active Ghostty terminal tabs can be tapped to rename, and a terminal can rename its own tab through the existing set_tab_title command path
- Non-happy paths considered: inactive tab taps still select, Escape cancels editing, unchanged submissions do not freeze live shell titles, empty submitted titles clear the manual override, and duplicate terminal title callbacks do not republish state
- Residual risk or follow-up: manual screenshot capture via ./scripts/capture-window.sh was blocked because the no-activate debug app exited before capture attached; launch-dev still verified a visible debug window and terminal set_title readiness in .dev-data/logs/launch-dev-20260617-221145.log

## Review Findings Addressed
- Removed the unrelated local drag/drop work from the PR path; the current PR diff has no GhosttyDroppedContentFormatter references
- Fixed no-op rename submission so live terminal titles keep following future shell/OSC title changes
- Confirmed swift-format lint passes on the current PR diff

## Validation
- swift-format lint --strict --recursive Sources/ Tests/
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --cached --check
- swift build
- swift test --filter TerminalTabRenameAction
- swift test --filter TabRoutingController
- swift test --filter HostTerminalStateStore
- swift test: 936 tests in 149 suites passed
- ./scripts/build-ghosttykit.sh
- ./scripts/launch-dev.sh --no-build --no-activate --trust-mise

## Evidence
- [Review fix validation summary](https://evidence.cloudcompute.com/workspaces/pr-674/20260618-202041-ghostty-tab-rename-review-fix-validation.svg)
- [Original validation summary](https://evidence.cloudcompute.com/workspaces/pr-674/20260618-053055-ghostty-tab-rename-validation.svg)