### PR TITLE
Add Needs You notification dropdown

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/AttentionSummaryResolver.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AttentionSummaryResolver.swift
@@ -1,0 +1,102 @@
+//
+//  AttentionSummaryResolver.swift
+//  WorkspaceManager
+//
+//  Turns agent attention targets into compact toolbar dropdown rows. Keeping
+//  this outside the SwiftUI view makes the summary text testable and lets the
+//  performance benchmark measure the same resolution path the toolbar uses.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+struct AttentionSummaryItem: Identifiable, Equatable {
+    let id: String
+    let target: WorkspaceStatusAggregator.AttentionTarget
+    let title: String
+    let context: String
+    let detail: String
+    let badge: String
+    let systemImage: String
+    let isError: Bool
+}
+
+struct AttentionSummaryResolver {
+    static func resolve(
+        attentionItems: [WorkspaceStatusAggregator.AttentionItem],
+        repos: [Repo]
+    ) -> [AttentionSummaryItem] {
+        guard !attentionItems.isEmpty, !repos.isEmpty else { return [] }
+
+        var reposByID: [UUID: Repo] = [:]
+        reposByID.reserveCapacity(repos.count)
+        var workspacesByID: [UUID: (workspace: Workspace, repo: Repo)] = [:]
+
+        for repo in repos {
+            reposByID[repo.id] = repo
+            for workspace in repo.workspaces {
+                workspacesByID[workspace.id] = (workspace, repo)
+            }
+        }
+
+        return attentionItems.compactMap { item in
+            let presentation = presentation(for: item.run)
+            switch item.target {
+            case .workspace(let id):
+                guard let resolved = workspacesByID[id] else { return nil }
+                return AttentionSummaryItem(
+                    id: item.id,
+                    target: item.target,
+                    title: resolved.workspace.name,
+                    context: "\(resolved.repo.name) tab",
+                    detail: presentation.detail,
+                    badge: presentation.badge,
+                    systemImage: presentation.systemImage,
+                    isError: presentation.isError
+                )
+            case .repo(let id):
+                guard let repo = reposByID[id] else { return nil }
+                return AttentionSummaryItem(
+                    id: item.id,
+                    target: item.target,
+                    title: repo.name,
+                    context: "Repo tab",
+                    detail: presentation.detail,
+                    badge: presentation.badge,
+                    systemImage: presentation.systemImage,
+                    isError: presentation.isError
+                )
+            }
+        }
+    }
+
+    private static func presentation(
+        for run: AgentRunState
+    ) -> (badge: String, detail: String, systemImage: String, isError: Bool) {
+        switch run {
+        case .awaitingInput(let reason):
+            switch reason {
+            case .permissionPrompt:
+                return ("Permission", "Awaiting permission", "hand.raised.fill", false)
+            case .idlePrompt:
+                return ("Prompt", "Waiting for your reply", "text.bubble.fill", false)
+            case .custom:
+                return ("Input", "Waiting for input", "questionmark.bubble.fill", false)
+            }
+        case .errored(_, let message):
+            let detail = trimmed(message) ?? "Agent errored"
+            return ("Error", detail, "exclamationmark.triangle.fill", true)
+        case .idle, .thinking, .runningTool, .complete:
+            return ("Needs you", "Needs attention", "bell.badge.fill", false)
+        }
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else { return nil }
+        if trimmedValue.count <= 72 { return trimmedValue }
+        let endIndex = trimmedValue.index(trimmedValue.startIndex, offsetBy: 69)
+        return "\(trimmedValue[..<endIndex])..."
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/NeedsYouToolbarPill.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NeedsYouToolbarPill.swift
@@ -12,20 +12,23 @@ import WorkspaceManagerCore
 
 struct NeedsYouToolbarPill: View {
     @EnvironmentObject private var aggregator: WorkspaceStatusAggregator
+    @State private var isDropdownPresented = false
     let repos: [Repo]
     let onActivateWorkspace: (Workspace) -> Void
     let onActivateRepo: (Repo) -> Void
 
     var body: some View {
-        if aggregator.attentionCount > 0, let firstAttentionTarget {
+        let items = resolvedAttentionItems
+        let attentionCount = items.count
+        if !items.isEmpty {
             Button {
-                activate(firstAttentionTarget)
+                isDropdownPresented.toggle()
             } label: {
                 HStack(spacing: 6) {
-                    Circle()
-                        .fill(AgentChromeProjection.attentionTone.color)
-                        .frame(width: 7, height: 7)
-                    Text("\(aggregator.attentionCount) need you")
+                    Image(systemName: "bell.badge.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(AgentChromeProjection.attentionTone.color)
+                    Text("\(attentionCount) need you")
                         .font(.callout.weight(.medium))
                         .monospacedDigit()
                 }
@@ -41,9 +44,22 @@ struct NeedsYouToolbarPill: View {
                 )
             }
             .buttonStyle(.plain)
-            .help(tooltipText)
-            .accessibilityLabel("\(aggregator.attentionCount) sessions need attention")
+            .help(tooltipText(for: items))
+            .accessibilityLabel("\(attentionCount) sessions need attention")
+            .popover(isPresented: $isDropdownPresented, arrowEdge: .top) {
+                NeedsYouDropdown(
+                    items: items,
+                    onSelect: { item in
+                        isDropdownPresented = false
+                        activate(item.target)
+                    }
+                )
+            }
         }
+    }
+
+    private var resolvedAttentionItems: [AttentionSummaryItem] {
+        AttentionSummaryResolver.resolve(attentionItems: aggregator.attentionItems, repos: repos)
     }
 
     private var reposByID: [UUID: Repo] {
@@ -52,18 +68,6 @@ struct NeedsYouToolbarPill: View {
 
     private var workspacesByID: [UUID: Workspace] {
         Dictionary(uniqueKeysWithValues: repos.flatMap(\.workspaces).map { ($0.id, $0) })
-    }
-
-    private var firstAttentionTarget: WorkspaceStatusAggregator.AttentionTarget? {
-        for target in aggregator.attentionTargets {
-            switch target {
-            case .workspace(let id):
-                if workspacesByID[id] != nil { return target }
-            case .repo(let id):
-                if reposByID[id] != nil { return target }
-            }
-        }
-        return nil
     }
 
     private func activate(_ target: WorkspaceStatusAggregator.AttentionTarget) {
@@ -77,28 +81,102 @@ struct NeedsYouToolbarPill: View {
         }
     }
 
-    private var tooltipText: String {
-        let names = aggregator.attentionTargets
-            .compactMap(displayName(for:))
-            .prefix(5)
+    private func tooltipText(for items: [AttentionSummaryItem]) -> String {
+        let names = items.map(\.title).prefix(5)
         if names.isEmpty {
-            return AgentChromeProjection.attentionTooltipFallback(count: aggregator.attentionCount)
+            return AgentChromeProjection.attentionTooltipFallback(count: items.count)
         }
-        let remaining = aggregator.attentionCount - names.count
+        let remaining = items.count - names.count
         let listed = names.joined(separator: ", ")
         if remaining > 0 {
             return "\(listed), and \(remaining) more"
         }
         return listed
     }
+}
 
-    private func displayName(for target: WorkspaceStatusAggregator.AttentionTarget) -> String? {
-        switch target {
-        case .workspace(let id):
-            return workspacesByID[id]?.name
-        case .repo(let id):
-            guard let repo = reposByID[id] else { return nil }
-            return "\(repo.name) repo"
+private struct NeedsYouDropdown: View {
+    let items: [AttentionSummaryItem]
+    let onSelect: (AttentionSummaryItem) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Needs You")
+                    .font(.headline)
+                Spacer()
+                Text("\(items.count)")
+                    .font(.caption.weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(items) { item in
+                        Button {
+                            onSelect(item)
+                        } label: {
+                            NeedsYouDropdownRow(item: item)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(6)
+            }
+            .frame(maxHeight: 280)
         }
+        .frame(width: 320)
+    }
+}
+
+private struct NeedsYouDropdownRow: View {
+    let item: AttentionSummaryItem
+
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: item.systemImage)
+                .foregroundStyle(item.isError ? .red : .yellow)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(item.title)
+                        .font(.callout.weight(.medium))
+                        .lineLimit(1)
+                    Text(item.badge)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(item.isError ? .red : .yellow)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(
+                            Capsule()
+                                .fill((item.isError ? Color.red : Color.yellow).opacity(0.14))
+                        )
+                }
+
+                Text("\(item.detail) - \(item.context)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+            Image(systemName: "arrow.right")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.primary.opacity(0.001))
+        )
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
@@ -73,13 +73,43 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         }
     }
 
+    public struct AttentionItem: Identifiable, Equatable, Sendable {
+        public let target: AttentionTarget
+        public let run: AgentRunState
+        public let lastEventAt: Date
+        public let lastAccessedAt: Date
+
+        public var id: String {
+            switch target {
+            case .workspace(let id): return "workspace-\(id.uuidString)"
+            case .repo(let id): return "repo-\(id.uuidString)"
+            }
+        }
+
+        public init(
+            target: AttentionTarget,
+            run: AgentRunState,
+            lastEventAt: Date,
+            lastAccessedAt: Date
+        ) {
+            self.target = target
+            self.run = run
+            self.lastEventAt = lastEventAt
+            self.lastAccessedAt = lastAccessedAt
+        }
+    }
+
     private struct AttentionEntry: Equatable {
         let target: AttentionTarget
+        let status: AgentSessionStatus
         let lastAccessedAt: Date
     }
 
     @Published public private(set) var workspaceStatuses: [UUID: AgentSessionStatus] = [:]
     @Published public private(set) var repoStatuses: [UUID: AgentSessionStatus] = [:]
+    /// Resolved repo or workspace targets currently demanding attention,
+    /// ordered by `lastAccessedAt` descending with their exact agent state.
+    @Published public private(set) var attentionItems: [AttentionItem] = []
     /// Repo or workspace targets currently demanding attention, ordered by
     /// `lastAccessedAt` descending.
     @Published public private(set) var attentionTargets: [AttentionTarget] = []
@@ -90,7 +120,7 @@ public final class WorkspaceStatusAggregator: ObservableObject {
     /// `lastAccessedAt` descending.
     @Published public private(set) var attentionRepos: [UUID] = []
 
-    public var attentionCount: Int { attentionTargets.count }
+    public var attentionCount: Int { attentionItems.count }
 
     public init() {}
 
@@ -120,6 +150,7 @@ public final class WorkspaceStatusAggregator: ObservableObject {
             guard let status = input.status, Self.demandsAttention(status.run) else { return nil }
             return AttentionEntry(
                 target: .workspace(input.workspaceID),
+                status: status,
                 lastAccessedAt: input.lastAccessedAt
             )
         }
@@ -127,10 +158,11 @@ public final class WorkspaceStatusAggregator: ObservableObject {
             guard let status = input.status, Self.demandsAttention(status.run) else { return nil }
             return AttentionEntry(
                 target: .repo(input.repoID),
+                status: status,
                 lastAccessedAt: input.lastAccessedAt
             )
         }
-        let attentionTargets =
+        let attentionEntries =
             (workspaceAttention + repoAttention)
             .sorted { lhs, rhs in
                 if lhs.lastAccessedAt != rhs.lastAccessedAt {
@@ -138,7 +170,15 @@ public final class WorkspaceStatusAggregator: ObservableObject {
                 }
                 return lhs.target.stableSortKey < rhs.target.stableSortKey
             }
-            .map(\.target)
+        let attentionItems = attentionEntries.map { entry in
+            AttentionItem(
+                target: entry.target,
+                run: entry.status.run,
+                lastEventAt: entry.status.lastEventAt,
+                lastAccessedAt: entry.lastAccessedAt
+            )
+        }
+        let attentionTargets = attentionItems.map(\.target)
         let attentionWorkspaces = attentionTargets.compactMap(\.workspaceID)
         let attentionRepos = attentionTargets.compactMap(\.repoID)
 
@@ -147,6 +187,9 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         }
         if self.repoStatuses != repoStatuses {
             self.repoStatuses = repoStatuses
+        }
+        if self.attentionItems != attentionItems {
+            self.attentionItems = attentionItems
         }
         if self.attentionTargets != attentionTargets {
             self.attentionTargets = attentionTargets

--- a/Tests/WorkspaceManagerAppTests/AttentionSummaryResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AttentionSummaryResolverTests.swift
@@ -1,0 +1,119 @@
+//
+//  AttentionSummaryResolverTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("AttentionSummaryResolver")
+struct AttentionSummaryResolverTests {
+    @Test("Resolves workspace and repo attention rows")
+    func resolvesWorkspaceAndRepoRows() {
+        let repo = Repo(
+            name: "workspaces",
+            localPath: URL(fileURLWithPath: "/tmp/workspaces"),
+            lastAccessedAt: Date()
+        )
+        let workspace = Workspace(
+            name: "notification-menu",
+            path: URL(fileURLWithPath: "/tmp/workspaces/notification-menu"),
+            sourceRepo: repo,
+            lastAccessedAt: Date()
+        )
+        repo.workspaces = [workspace]
+
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                .init(
+                    target: .workspace(workspace.id),
+                    run: .awaitingInput(reason: .permissionPrompt),
+                    lastEventAt: Date(),
+                    lastAccessedAt: Date()
+                ),
+                .init(
+                    target: .repo(repo.id),
+                    run: .errored(category: .toolFailure, message: "merge failed"),
+                    lastEventAt: Date(),
+                    lastAccessedAt: Date().addingTimeInterval(-30)
+                ),
+            ],
+            repos: [repo]
+        )
+
+        #expect(rows.count == 2)
+        #expect(rows[0].title == "notification-menu")
+        #expect(rows[0].context == "workspaces tab")
+        #expect(rows[0].badge == "Permission")
+        #expect(rows[0].isError == false)
+        #expect(rows[1].title == "workspaces")
+        #expect(rows[1].context == "Repo tab")
+        #expect(rows[1].badge == "Error")
+        #expect(rows[1].detail == "merge failed")
+        #expect(rows[1].isError)
+    }
+
+    @Test("Skips stale attention targets")
+    func skipsStaleAttentionTargets() {
+        let repo = Repo(
+            name: "workspaces",
+            localPath: URL(fileURLWithPath: "/tmp/workspaces"),
+            lastAccessedAt: Date()
+        )
+
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                .init(
+                    target: .workspace(UUID()),
+                    run: .awaitingInput(reason: .custom),
+                    lastEventAt: Date(),
+                    lastAccessedAt: Date()
+                )
+            ],
+            repos: [repo]
+        )
+
+        #expect(rows.isEmpty)
+    }
+
+    @Test("Resolved rows are the actionable count when stale targets are mixed in")
+    func resolvedRowsAreActionableCount() {
+        let repo = Repo(
+            name: "workspaces",
+            localPath: URL(fileURLWithPath: "/tmp/workspaces"),
+            lastAccessedAt: Date()
+        )
+        let workspace = Workspace(
+            name: "notification-menu",
+            path: URL(fileURLWithPath: "/tmp/workspaces/notification-menu"),
+            sourceRepo: repo,
+            lastAccessedAt: Date()
+        )
+        repo.workspaces = [workspace]
+
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                .init(
+                    target: .workspace(workspace.id),
+                    run: .awaitingInput(reason: .permissionPrompt),
+                    lastEventAt: Date(),
+                    lastAccessedAt: Date()
+                ),
+                .init(
+                    target: .workspace(UUID()),
+                    run: .errored(category: .toolFailure, message: "stale session"),
+                    lastEventAt: Date(),
+                    lastAccessedAt: Date().addingTimeInterval(-30)
+                ),
+            ],
+            repos: [repo]
+        )
+
+        #expect(rows.count == 1)
+        #expect(rows.first?.target == .workspace(workspace.id))
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowHotSpotPerfTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowHotSpotPerfTests.swift
@@ -33,8 +33,10 @@ struct MainWindowHotSpotPerfTests {
         var statuses = fixture.statuses
         let statusSessionIDs = Array(statuses.keys)
         let refreshes = 1_000
-        var samples: [Double] = []
-        samples.reserveCapacity(refreshes)
+        var sidebarSamples: [Double] = []
+        sidebarSamples.reserveCapacity(refreshes)
+        var dropdownSamples: [Double] = []
+        dropdownSamples.reserveCapacity(refreshes)
 
         for iteration in 0..<refreshes {
             if let sessionID = statusSessionIDs[safe: iteration % statusSessionIDs.count],
@@ -90,10 +92,19 @@ struct MainWindowHotSpotPerfTests {
 
             aggregator.update(workspaces: workspaceInputs, repos: repoInputs)
             let elapsed = DispatchTime.now().uptimeNanoseconds - started
-            samples.append(Double(elapsed) / 1_000_000.0)
+            sidebarSamples.append(Double(elapsed) / 1_000_000.0)
+
+            let dropdownStarted = DispatchTime.now().uptimeNanoseconds
+            _ = AttentionSummaryResolver.resolve(
+                attentionItems: aggregator.attentionItems,
+                repos: fixture.repos
+            )
+            let dropdownElapsed = DispatchTime.now().uptimeNanoseconds - dropdownStarted
+            dropdownSamples.append(Double(dropdownElapsed) / 1_000_000.0)
         }
 
-        let stats = summarize(samples, unit: "ms")
+        let sidebarStats = summarize(sidebarSamples, unit: "ms")
+        let dropdownStats = summarize(dropdownSamples, unit: "ms")
         try writeResult(
             [
                 "scenario": "main_window_agent_activity_burst",
@@ -102,13 +113,15 @@ struct MainWindowHotSpotPerfTests {
                 "workspace_count": fixture.repos.flatMap(\.workspaces).count,
                 "session_count": fixture.sessions.count,
                 "metrics": [
-                    "main_window_agent_activity_burst_sidebar_latency_ms": stats
+                    "main_window_agent_activity_burst_sidebar_latency_ms": sidebarStats,
+                    "main_window_attention_dropdown_resolution_ms": dropdownStats,
                 ],
             ],
             scenario: "main_window_agent_activity_burst"
         )
 
-        #expect(stats["median"] as? Double ?? .infinity < 1_000)
+        #expect(sidebarStats["median"] as? Double ?? .infinity < 1_000)
+        #expect(dropdownStats["median"] as? Double ?? .infinity < 1_000)
     }
 
     private struct SidebarFixture {

--- a/Tests/WorkspaceManagerTests/WorkspaceStatusAggregatorTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceStatusAggregatorTests.swift
@@ -31,6 +31,7 @@ struct WorkspaceStatusAggregatorTests {
         aggregator.update(workspaces: [], repos: [])
         #expect(aggregator.workspaceStatuses.isEmpty)
         #expect(aggregator.repoStatuses.isEmpty)
+        #expect(aggregator.attentionItems.isEmpty)
         #expect(aggregator.attentionWorkspaces.isEmpty)
         #expect(aggregator.attentionCount == 0)
     }
@@ -71,6 +72,7 @@ struct WorkspaceStatusAggregatorTests {
         )
 
         #expect(aggregator.attentionCount == 2)
+        #expect(aggregator.attentionItems.map(\.target) == [.workspace(recentAwaiting), .workspace(olderErrored)])
         #expect(aggregator.attentionWorkspaces == [recentAwaiting, olderErrored])
     }
 
@@ -101,6 +103,7 @@ struct WorkspaceStatusAggregatorTests {
         )
 
         #expect(aggregator.attentionCount == 2)
+        #expect(aggregator.attentionItems.map(\.target) == [.repo(repoID), .workspace(wsID)])
         #expect(aggregator.attentionTargets == [.repo(repoID), .workspace(wsID)])
         #expect(aggregator.attentionRepos == [repoID])
         #expect(aggregator.attentionWorkspaces == [wsID])
@@ -251,5 +254,43 @@ struct WorkspaceStatusAggregatorTests {
         let firstSnapshot = aggregator.repoStatuses
         aggregator.update(workspaces: [workspace], repos: [.init(repoID: repoID, status: nil)])
         #expect(aggregator.repoStatuses == firstSnapshot)
+    }
+
+    @Test("Attention items preserve exact target state separate from bubbled repo status")
+    func attentionItemsPreserveExactTargetState() {
+        let aggregator = WorkspaceStatusAggregator()
+        let repoID = UUID()
+        let wsID = UUID()
+
+        aggregator.update(
+            workspaces: [
+                .init(
+                    workspaceID: wsID,
+                    repoID: repoID,
+                    lastAccessedAt: Date().addingTimeInterval(-30),
+                    status: status(run: .errored(category: .toolFailure, message: "tool failed"))
+                )
+            ],
+            repos: [
+                .init(
+                    repoID: repoID,
+                    lastAccessedAt: Date(),
+                    status: status(run: .awaitingInput(reason: .permissionPrompt))
+                )
+            ]
+        )
+
+        if case .errored = aggregator.repoStatuses[repoID]?.run {
+            // pass
+        } else {
+            Issue.record("expected workspace error to remain the bubbled repo status")
+        }
+
+        let repoAttention = aggregator.attentionItems.first { $0.target == .repo(repoID) }
+        if case .awaitingInput(reason: .permissionPrompt) = repoAttention?.run {
+            // pass
+        } else {
+            Issue.record("expected repo attention item to keep the repo terminal status")
+        }
     }
 }

--- a/config/performance/contract.json
+++ b/config/performance/contract.json
@@ -392,6 +392,19 @@
       }
     },
     {
+      "name": "main_window_attention_dropdown_resolution_ms",
+      "unit": "ms",
+      "supported_scenarios": [
+        "main_window_agent_activity_burst"
+      ],
+      "reference_baselines": {
+        "main_window_agent_activity_burst": {
+          "median_ms": 2,
+          "p95_ms": 4
+        }
+      }
+    },
+    {
       "name": "new_workspace_sheet_ready",
       "unit": "ms",
       "supported_scenarios": [

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -110,6 +110,74 @@ This replaces cwd/agent-session inference. `SessionStart` still records
 tabs and split panes on the same repository remain distinct because their host
 session IDs are distinct from terminal spawn time.
 
+## Sending Agent Status to the Needs You Dropdown
+
+The top-right "Needs You" bubble and dropdown are driven by
+`AgentSessionRegistry` via `WorkspaceStatusAggregator.attentionItems`. A terminal
+tab appears in the dropdown when its registered host session reaches
+`AgentRunState.awaitingInput` or `AgentRunState.errored`.
+
+For Claude Code, use the installed hook and status-line forwarders. For another
+agent running inside a WorkSpaces terminal, post Claude-compatible hook JSON to
+the exported Unix socket and include the exported host-session header. Do not
+invent a host session ID; unregistered IDs are dropped.
+
+```bash
+cat <<JSON | /usr/bin/curl \
+  --silent \
+  --show-error \
+  --max-time 1 \
+  --unix-socket "$WORKSPACES_HOOKS_SOCKET" \
+  -H 'Content-Type: application/json' \
+  -H "X-WorkSpaces-Host-Session-ID: $WORKSPACES_HOST_SESSION_ID" \
+  --data-binary @- \
+  'http://localhost/event'
+{
+  "hook_event_name": "Notification",
+  "session_id": "custom-agent-$WORKSPACES_HOST_SESSION_ID",
+  "cwd": "$PWD",
+  "notification_type": "permission_prompt",
+  "title": "Permission requested",
+  "message": "Approve the command to continue"
+}
+JSON
+```
+
+Useful `hook_event_name` values:
+
+| Desired UI state | Event payload |
+|---|---|
+| Permission row in the dropdown | `Notification` with `notification_type: "permission_prompt"` or `PermissionRequest` |
+| Prompt/input row in the dropdown | `Notification` with `notification_type: "idle_prompt"` |
+| Generic attention row | `Notification` with any other non-empty `notification_type` |
+| Error row | `StopFailure` or `PostToolUseFailure` with an `error` string |
+| Clear attention after success | `Stop` |
+| Active/running status dot | `UserPromptSubmit`, then `PreToolUse` / `PostToolUse` events |
+
+Status-line posts enrich the selected tab with model, context, rate-limit, and
+cost fields, but they do not create or clear a Needs You row because they never
+change `AgentRunState`:
+
+```bash
+cat <<JSON | /usr/bin/curl \
+  --silent \
+  --show-error \
+  --max-time 1 \
+  --unix-socket "$WORKSPACES_HOOKS_SOCKET" \
+  -H 'Content-Type: application/json' \
+  -H "X-WorkSpaces-Host-Session-ID: $WORKSPACES_HOST_SESSION_ID" \
+  --data-binary @- \
+  'http://localhost/statusline'
+{
+  "session_id": "custom-agent-$WORKSPACES_HOST_SESSION_ID",
+  "cwd": "$PWD",
+  "model": { "display_name": "Custom Agent" },
+  "context_window": { "used_percentage": 42 },
+  "cost": { "total_cost_usd": 0.13 }
+}
+JSON
+```
+
 ## Command Hook Forwarder
 
 Script: `Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh`.

--- a/docs/performance/metrics-reference.md
+++ b/docs/performance/metrics-reference.md
@@ -229,6 +229,17 @@ Scenario:
 Why it matters:
 - It guards the path that refires when agent session status changes, where repeated sidebar refresh work can become visible during active agent sessions.
 
+### `main_window_attention_dropdown_resolution_ms`
+
+What it measures:
+- Time spent resolving `WorkspaceStatusAggregator.attentionItems` into the concise rows used by the top-right "Needs You" dropdown.
+
+Scenario:
+- `main_window_agent_activity_burst`
+
+Why it matters:
+- It guards the click-prep path for the notification bubble so the dropdown stays cheap even when agent status changes rapidly across many tabs.
+
 ### `workspace_provider_availability_refresh`
 
 What it measures:


### PR DESCRIPTION
## Summary

- Add a top-right "Needs You" dropdown that summarizes tabs needing action and routes directly to the selected repo/workspace tab.
- Preserve exact attention state in `WorkspaceStatusAggregator.attentionItems` so repo-level errors and bubbled child states do not get conflated.
- Document the hook/status-line contract for agents that want to surface status in the dropdown, and add a canonical perf metric for dropdown row resolution.

## Mergeability

- Surface: desktop / agent-runtime / docs
- User-facing behavior changed: the notification bubble now opens a concise dropdown; selecting a row activates that tab.
- Non-happy paths considered: stale targets are skipped, repo and workspace attention states stay separate, empty attention hides the pill, and error/permission/prompt/custom input states get distinct row summaries.
- Release/ops preconditions: none.
- Residual risk or follow-up: none known. The UI was verified in fixture mode with the debug app, and the new dropdown resolver is covered by unit tests plus the canonical perf scenario.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `swift-format lint --strict --recursive Sources/ Tests/`
  - `swift test --filter AttentionSummaryResolverTests`
  - `env UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/tests/test_perf_tools.py`
  - UI fixture launch with `WORKSPACES_UI_FIXTURE=1 WORKSPACES_UI_FIXTURE_AGENT_STATES=bugfix-422:awaitingInput,refactor-runtime:errored`
  - AX routing check: selected `refactor-runtime`; window title changed to `bread-builder / refactor-runtime`

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `config/performance/contract.json`
- [x] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: `main_window_agent_activity_burst`
- Before Summary: `origin/main` `183dfe624`, sidebar latency median `1.23 ms`, p95 `1.64 ms`, gate `<= 10 ms` pass.
- After Summary: `8203d381`, sidebar latency median `1.08 ms`, p95 `1.42 ms`, gate `<= 10 ms` pass; dropdown resolution median `0.03 ms`, p95 `0.03 ms`, gate `<= 3 ms` pass.
- Delta Summary: sidebar latency `1.23 -> 1.08 ms`, `-0.15 ms` (`-12.2%`); dropdown resolution `n/a -> 0.03 ms`, gate pass.

Performance comparison notes:

- Exact commands used:
  - `git worktree add /tmp/workspaces-attention-dropdown-before-main origin/main`
  - `./scripts/build-ghosttykit.sh`
  - `./scripts/perf-runner.sh --scenario main_window_agent_activity_burst --assert-budget --output-dir /tmp/workspaces-attention-dropdown-perf-before-main`
  - `./scripts/perf-runner.sh --scenario main_window_agent_activity_burst --assert-budget --output-dir /tmp/workspaces-attention-dropdown-perf-after-finding-fix`
- Workload / environment context: same host, SwiftPM debug test runner, 1000 synthetic agent status refreshes. The dropdown metric is missing before by design because this PR adds it.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- UI screenshot: ![needs-you-dropdown-ui-review-fix](https://evidence.cloudcompute.com/workspaces/pr-675/20260626-021252-needs-you-dropdown-ui-review-fix.png)
- Validation and performance summary: ![needs-you-dropdown-validation-review-fix](https://evidence.cloudcompute.com/workspaces/pr-675/20260626-021141-needs-you-dropdown-validation-review-fix.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
