### PR TITLE
[codex] fix Ghostty terminal scrolling

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift
@@ -158,20 +158,19 @@ final class GhosttyAppManager: NSObject {
         config = newConfig
     }
 
-    /// Build a finalized `ghostty_config_t` for the given theme pair. When a
-    /// theme is selected, the app-owned config file is (re)written and loaded;
-    /// when nothing is selected, a bare config preserves Ghostty's default.
+    /// Build a finalized `ghostty_config_t` from the app-owned config file.
+    /// Theme selection is optional, but WorkSpaces-owned terminal behavior
+    /// defaults such as scrollbar and scroll-speed tuning are always loaded.
     private func makeConfig(for pair: GhosttyThemePersistence.Pair) -> ghostty_config_t? {
         guard let config = ghostty_config_new() else {
             NSLog("[GhosttyAppManager] ghostty_config_new failed")
             return nil
         }
 
-        let writeResult = try? GhosttyThemeConfig.writeConfigFile(
+        if let url = try? GhosttyThemeConfig.writeConfigFile(
             lightTheme: pair.lightTheme,
             darkTheme: pair.darkTheme
-        )
-        if let url = writeResult.flatMap({ $0 }) {
+        ) {
             ghostty_config_load_file(config, url.path)
         }
 

--- a/Sources/WorkspaceManager/Terminal/GhosttyRuntimeActionBridge.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyRuntimeActionBridge.swift
@@ -298,6 +298,14 @@ enum GhosttyRuntimeActionBridge {
             }
             return true
 
+        case GHOSTTY_ACTION_SCROLLBAR:
+            let scrollbarState = GhosttyScrollbarState(action.action.scrollbar)
+            runOnMainAsync {
+                guard let surfaceView = resolveSurfaceView(sourceSurfaceAddress) else { return }
+                surfaceView.updateScrollbarState(scrollbarState)
+            }
+            return true
+
         default:
             return false
         }

--- a/Sources/WorkspaceManager/Terminal/GhosttyScrollState.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyScrollState.swift
@@ -1,0 +1,104 @@
+//
+//  GhosttyScrollState.swift
+//  WorkspaceManager
+//
+
+import AppKit
+import Foundation
+import GhosttyKit
+
+struct GhosttyScrollbarState: Equatable, Sendable {
+    let total: UInt64
+    let offset: UInt64
+    let length: UInt64
+
+    init(total: UInt64, offset: UInt64, length: UInt64) {
+        self.total = total
+        self.offset = offset
+        self.length = length
+    }
+
+    init(_ action: ghostty_action_scrollbar_s) {
+        self.init(total: action.total, offset: action.offset, length: action.len)
+    }
+
+    var maxOffset: UInt64 {
+        total > length ? total - length : 0
+    }
+}
+
+enum GhosttyScrollPositionMapper {
+    static func rowHeight(contentHeight: CGFloat, visibleRows: UInt64) -> CGFloat? {
+        guard contentHeight > 0, visibleRows > 0 else { return nil }
+        return contentHeight / CGFloat(visibleRows)
+    }
+
+    static func documentHeight(contentHeight: CGFloat, state: GhosttyScrollbarState?) -> CGFloat {
+        guard
+            let state,
+            let rowHeight = rowHeight(contentHeight: contentHeight, visibleRows: state.length)
+        else {
+            return max(contentHeight, 0)
+        }
+
+        return max(contentHeight, CGFloat(state.total) * rowHeight)
+    }
+
+    static func contentOffsetY(contentHeight: CGFloat, state: GhosttyScrollbarState) -> CGFloat {
+        guard let rowHeight = rowHeight(contentHeight: contentHeight, visibleRows: state.length) else {
+            return 0
+        }
+
+        let offsetFromBottom = state.maxOffset - min(state.offset, state.maxOffset)
+        return CGFloat(offsetFromBottom) * rowHeight
+    }
+
+    static func row(
+        visibleRect: CGRect,
+        documentHeight: CGFloat,
+        contentHeight: CGFloat,
+        state: GhosttyScrollbarState?
+    ) -> Int? {
+        guard
+            let state,
+            let rowHeight = rowHeight(contentHeight: contentHeight, visibleRows: state.length),
+            rowHeight > 0
+        else {
+            return nil
+        }
+
+        let offsetFromTop = max(0, documentHeight - visibleRect.origin.y - visibleRect.height)
+        let rawRow = UInt64(max(0, round(offsetFromTop / rowHeight)))
+        return Int(min(rawRow, state.maxOffset))
+    }
+}
+
+enum GhosttyScrollInput {
+    static func mods(from event: NSEvent) -> ghostty_input_scroll_mods_t {
+        var value: Int32 = 0
+        if event.hasPreciseScrollingDeltas {
+            value |= 0b0000_0001
+        }
+        value |= Int32(momentumRawValue(from: event.momentumPhase)) << 1
+        return ghostty_input_scroll_mods_t(value)
+    }
+
+    private static func momentumRawValue(from phase: NSEvent.Phase) -> UInt8 {
+        switch phase {
+        case .began:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_BEGAN.rawValue)
+        case .stationary:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_STATIONARY.rawValue)
+        case .changed:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_CHANGED.rawValue)
+        case .ended:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_ENDED.rawValue)
+        case .cancelled:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_CANCELLED.rawValue)
+        case .mayBegin:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_MAY_BEGIN.rawValue)
+        default:
+            return UInt8(GHOSTTY_MOUSE_MOMENTUM_NONE.rawValue)
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -26,12 +26,14 @@ final class GhosttySurfaceView: NSView {
     private(set) var surface: ghostty_surface_t?
     private(set) var terminalTitle: String = ""
     private(set) var currentWorkingDirectory: String?
+    private(set) var latestScrollbarState: GhosttyScrollbarState?
     private var didProcessExit = false
     private var promptReadinessSignposts: TerminalPromptReadinessSignpostController
     private var lastScaleAndSize: GhosttySurfaceScaleCalculator.ScaleAndSize?
     private var trackingAreaInstalled = false
     var workingDirectoryPath: String { workingDirectory.path }
     var contextMenuProvider: (() -> NSMenu?)?
+    var onScrollbarStateChange: ((GhosttyScrollbarState) -> Void)?
 
     init(
         launchContext: TerminalSessionLaunchContext,
@@ -229,6 +231,11 @@ final class GhosttySurfaceView: NSView {
         )
     }
 
+    func updateScrollbarState(_ state: GhosttyScrollbarState) {
+        latestScrollbarState = state
+        onScrollbarStateChange?(state)
+    }
+
     func runtimeDidRequestClose(processAlive: Bool) {
         if processAlive {
             onCloseConfirmationRequired?()
@@ -398,7 +405,17 @@ final class GhosttySurfaceView: NSView {
 
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
-        ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, 0)
+        ghostty_surface_mouse_scroll(
+            surface,
+            event.scrollingDeltaX,
+            event.scrollingDeltaY,
+            GhosttyScrollInput.mods(from: event)
+        )
+    }
+
+    func scrollToRow(_ row: Int) {
+        guard let surface else { return }
+        _ = performBindingAction("scroll_to_row:\(row)", surface: surface)
     }
 
     // MARK: - Keyboard input

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalScrollContainerView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalScrollContainerView.swift
@@ -1,0 +1,179 @@
+//
+//  GhosttyTerminalScrollContainerView.swift
+//  WorkspaceManager
+//
+
+import AppKit
+
+/// Wraps the raw Ghostty surface in an AppKit scroll view so embedded terminals
+/// expose native scrollbar position without replacing Ghostty's scrollback model.
+@MainActor
+final class GhosttyTerminalScrollContainerView: NSView {
+    let surfaceView: GhosttySurfaceView
+
+    private let scrollView = NSScrollView()
+    private let documentView = NSView()
+    private var observers: [NSObjectProtocol] = []
+    private var isLiveScrolling = false
+    private var lastSentRow: Int?
+    private var scrollbarState: GhosttyScrollbarState?
+
+    init(surfaceView: GhosttySurfaceView) {
+        self.surfaceView = surfaceView
+
+        super.init(frame: .zero)
+
+        configureScrollView()
+        surfaceView.onScrollbarStateChange = { [weak self] state in
+            self?.applyScrollbarState(state)
+        }
+
+        if let state = surfaceView.latestScrollbarState {
+            scrollbarState = state
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    deinit {
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        window?.makeFirstResponder(surfaceView)
+        return true
+    }
+
+    override func layout() {
+        super.layout()
+        scrollView.frame = bounds
+        documentView.frame.size.width = scrollView.contentSize.width
+        surfaceView.frame.size = scrollView.contentSize
+        synchronizeScrollViewPosition()
+        synchronizeSurfacePosition()
+    }
+
+    func updateContextMenuProvider(_ provider: (() -> NSMenu?)?) {
+        surfaceView.contextMenuProvider = provider
+    }
+
+    // MARK: - Setup
+
+    private func configureScrollView() {
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = false
+        scrollView.usesPredominantAxisScrolling = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.drawsBackground = false
+        scrollView.contentView.clipsToBounds = false
+
+        documentView.frame = bounds
+        documentView.addSubview(surfaceView)
+        scrollView.documentView = documentView
+        addSubview(scrollView)
+
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        observers.append(
+            NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: scrollView.contentView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.synchronizeSurfacePosition()
+                }
+            })
+
+        observers.append(
+            NotificationCenter.default.addObserver(
+                forName: NSScrollView.willStartLiveScrollNotification,
+                object: scrollView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.isLiveScrolling = true
+                }
+            })
+
+        observers.append(
+            NotificationCenter.default.addObserver(
+                forName: NSScrollView.didEndLiveScrollNotification,
+                object: scrollView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.isLiveScrolling = false
+                }
+            })
+
+        observers.append(
+            NotificationCenter.default.addObserver(
+                forName: NSScrollView.didLiveScrollNotification,
+                object: scrollView,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor in
+                    self?.sendDraggedScrollbarPosition()
+                }
+            })
+    }
+
+    // MARK: - Synchronization
+
+    private func applyScrollbarState(_ state: GhosttyScrollbarState) {
+        guard scrollbarState != state else { return }
+        scrollbarState = state
+        synchronizeScrollViewPosition()
+        scrollView.flashScrollers()
+    }
+
+    private func synchronizeScrollViewPosition() {
+        let contentHeight = scrollView.contentSize.height
+        documentView.frame.size.height = GhosttyScrollPositionMapper.documentHeight(
+            contentHeight: contentHeight,
+            state: scrollbarState
+        )
+
+        if !isLiveScrolling, let state = scrollbarState {
+            let offsetY = GhosttyScrollPositionMapper.contentOffsetY(
+                contentHeight: contentHeight,
+                state: state
+            )
+            scrollView.contentView.scroll(to: CGPoint(x: 0, y: offsetY))
+            lastSentRow = Int(min(state.offset, state.maxOffset))
+        }
+
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        synchronizeSurfacePosition()
+    }
+
+    private func synchronizeSurfacePosition() {
+        surfaceView.frame.origin = scrollView.contentView.documentVisibleRect.origin
+    }
+
+    private func sendDraggedScrollbarPosition() {
+        let contentHeight = scrollView.contentSize.height
+        let documentHeight = documentView.frame.height
+        guard
+            let row = GhosttyScrollPositionMapper.row(
+                visibleRect: scrollView.contentView.documentVisibleRect,
+                documentHeight: documentHeight,
+                contentHeight: contentHeight,
+                state: scrollbarState
+            ),
+            row != lastSentRow
+        else {
+            return
+        }
+
+        lastSentRow = row
+        surfaceView.scrollToRow(row)
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttyThemeConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyThemeConfig.swift
@@ -5,14 +5,15 @@
 
 import Foundation
 
-/// Generates and writes the app-owned Ghostty config file that carries the
-/// Terminal Theme. The file is isolated from the user's `~/.config/ghostty`
-/// (we never load that) and contains only a `theme = light:…,dark:…` line.
+/// Generates and writes the app-owned Ghostty config file for embedded terminal
+/// behavior. The file is isolated from the user's `~/.config/ghostty` and holds
+/// only WorkSpaces-managed defaults such as terminal theme and scroll behavior.
 ///
 /// String generation is pure so it can be unit-tested; file placement follows
 /// the `WORKSPACES_DATA_DIR` convention, falling back to the app support dir.
 enum GhosttyThemeConfig {
     static let configFileName = "workspaces.config"
+    static let mouseScrollMultiplier = "precision:0.7,discrete:1"
 
     /// The value for Ghostty's `theme` key, or nil when neither slot is set.
     ///
@@ -28,11 +29,16 @@ enum GhosttyThemeConfig {
         return "light:\(resolvedLight),dark:\(resolvedDark)"
     }
 
-    /// The full contents of the app-owned config file, or nil when nothing is
-    /// selected (so the caller can preserve Ghostty's bare default behavior).
-    static func configContents(lightTheme: String, darkTheme: String) -> String? {
-        guard let value = themeValue(lightTheme: lightTheme, darkTheme: darkTheme) else { return nil }
-        return "theme = \(value)\n"
+    /// The full contents of the app-owned config file.
+    static func configContents(lightTheme: String, darkTheme: String) -> String {
+        var lines = [
+            "scrollbar = system",
+            "mouse-scroll-multiplier = \(mouseScrollMultiplier)",
+        ]
+        if let value = themeValue(lightTheme: lightTheme, darkTheme: darkTheme) {
+            lines.append("theme = \(value)")
+        }
+        return lines.joined(separator: "\n") + "\n"
     }
 
     /// `<dataDir>/ghostty/<configFileName>` — app-owned and isolated.
@@ -45,28 +51,20 @@ enum GhosttyThemeConfig {
             .appendingPathComponent(configFileName, isDirectory: false)
     }
 
-    /// Write (or clear) the app-owned config file for the given pair.
-    ///
-    /// Returns the file URL when a theme line was written, or nil when nothing
-    /// is selected — in which case any stale file is removed so a later bare
-    /// config rebuild reflects the cleared selection. The parent directory is
-    /// created on demand.
+    /// Write the app-owned config file for the given pair.
     @discardableResult
     static func writeConfigFile(
         lightTheme: String,
         darkTheme: String,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
-    ) throws -> URL? {
+    ) throws -> URL {
         let url = try configFileURL(environment: environment, fileManager: fileManager)
-        guard let contents = configContents(lightTheme: lightTheme, darkTheme: darkTheme) else {
-            try? fileManager.removeItem(at: url)
-            return nil
-        }
         try fileManager.createDirectory(
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
+        let contents = configContents(lightTheme: lightTheme, darkTheme: darkTheme)
         try contents.write(to: url, atomically: true, encoding: .utf8)
         return url
     }

--- a/Sources/WorkspaceManager/Views/Components/TerminalView.swift
+++ b/Sources/WorkspaceManager/Views/Components/TerminalView.swift
@@ -172,14 +172,15 @@ struct GhosttyTerminalRepresentable: NSViewRepresentable {
     let workingDirectory: URL
     var onProcessExit: (() -> Void)?
 
-    func makeNSView(context: Context) -> GhosttySurfaceView {
-        GhosttySurfaceView(
+    func makeNSView(context: Context) -> GhosttyTerminalScrollContainerView {
+        let surfaceView = GhosttySurfaceView(
             workingDirectory: workingDirectory,
             onProcessExit: onProcessExit
         )
+        return GhosttyTerminalScrollContainerView(surfaceView: surfaceView)
     }
 
-    func updateNSView(_ nsView: GhosttySurfaceView, context: Context) {
+    func updateNSView(_ nsView: GhosttyTerminalScrollContainerView, context: Context) {
         _ = context
         _ = nsView
     }
@@ -227,18 +228,19 @@ private struct PersistentHostGhosttyRepresentable: NSViewRepresentable {
     var onCloseConfirmationRequired: (() -> Void)?
     var onProcessExit: (() -> Void)?
 
-    func makeNSView(context: Context) -> GhosttySurfaceView {
-        surfaceStore.view(
+    func makeNSView(context: Context) -> GhosttyTerminalScrollContainerView {
+        let surfaceView = surfaceStore.view(
             for: session,
             onProcessExit: onProcessExit,
             onCloseConfirmationRequired: onCloseConfirmationRequired,
             contextMenuProvider: contextMenuProvider
         )
+        return GhosttyTerminalScrollContainerView(surfaceView: surfaceView)
     }
 
-    func updateNSView(_ nsView: GhosttySurfaceView, context: Context) {
+    func updateNSView(_ nsView: GhosttyTerminalScrollContainerView, context: Context) {
         _ = context
-        nsView.onCloseConfirmationRequired = onCloseConfirmationRequired
-        nsView.contextMenuProvider = contextMenuProvider
+        nsView.surfaceView.onCloseConfirmationRequired = onCloseConfirmationRequired
+        nsView.updateContextMenuProvider(contextMenuProvider)
     }
 }

--- a/Tests/WorkspaceManagerAppTests/GhosttyRuntimeActionBridgeTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyRuntimeActionBridgeTests.swift
@@ -59,20 +59,25 @@ struct GhosttyRuntimeActionBridgeTests {
         #expect(scheduledCount.value == 1)
     }
 
-    @Test("Unrecognized action tag still returns false (default fall-through)")
-    func unknownActionStillFallsThrough() async {
+    @Test("SCROLLBAR returns true and schedules main-thread work")
+    func scrollbarDispatches() async {
         var action = ghostty_action_s()
-        // SCROLLBAR is not handled by the bridge; verify the default branch.
         action.tag = GHOSTTY_ACTION_SCROLLBAR
+        action.action.scrollbar = ghostty_action_scrollbar_s(total: 120, offset: 80, len: 24)
         let target = ghostty_target_s()
+        let scheduledCount = LockedCounter()
         let handled = GhosttyRuntimeActionBridge.handle(
             target: target,
             action: action,
             resolveSurfaceAddress: { _ in 0x1 },
             resolveSurfaceView: { _ in nil },
-            runOnMainAsync: { _ in }
+            runOnMainAsync: { closure in
+                scheduledCount.increment()
+                _ = closure
+            }
         )
-        #expect(handled == false)
+        #expect(handled == true)
+        #expect(scheduledCount.value == 1)
     }
 
     @Test("Bridge skips entirely when surface address resolution fails")

--- a/Tests/WorkspaceManagerAppTests/GhosttyScrollStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyScrollStateTests.swift
@@ -1,0 +1,46 @@
+//
+//  GhosttyScrollStateTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyScrollPositionMapper")
+struct GhosttyScrollPositionMapperTests {
+    @Test("document height scales terminal rows into scroll view pixels")
+    func documentHeightScalesRows() {
+        let state = GhosttyScrollbarState(total: 120, offset: 96, length: 24)
+
+        #expect(
+            GhosttyScrollPositionMapper.documentHeight(contentHeight: 480, state: state)
+                == 2400
+        )
+    }
+
+    @Test("terminal offset maps to AppKit bottom-origin content offset")
+    func terminalOffsetMapsToAppKitOffset() {
+        let state = GhosttyScrollbarState(total: 120, offset: 80, length: 24)
+
+        #expect(
+            GhosttyScrollPositionMapper.contentOffsetY(contentHeight: 480, state: state)
+                == 320
+        )
+    }
+
+    @Test("scroll view visible rect maps back to a terminal row")
+    func visibleRectMapsBackToTerminalRow() throws {
+        let state = GhosttyScrollbarState(total: 120, offset: 80, length: 24)
+        let row = try #require(
+            GhosttyScrollPositionMapper.row(
+                visibleRect: CGRect(x: 0, y: 320, width: 800, height: 480),
+                documentHeight: 2400,
+                contentHeight: 480,
+                state: state
+            ))
+
+        #expect(row == 80)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/GhosttyThemeConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyThemeConfigTests.swift
@@ -13,7 +13,10 @@ struct GhosttyThemeConfigTests {
     @Test("No selection produces no theme value")
     func emptyPairHasNoValue() {
         #expect(GhosttyThemeConfig.themeValue(lightTheme: "", darkTheme: "") == nil)
-        #expect(GhosttyThemeConfig.configContents(lightTheme: "", darkTheme: "") == nil)
+        #expect(
+            GhosttyThemeConfig.configContents(lightTheme: "", darkTheme: "")
+                == "scrollbar = system\nmouse-scroll-multiplier = precision:0.7,discrete:1\n"
+        )
     }
 
     @Test("Both slots set produce the dual light/dark value")
@@ -24,7 +27,8 @@ struct GhosttyThemeConfigTests {
         )
         #expect(
             GhosttyThemeConfig.configContents(lightTheme: "Nord", darkTheme: "Dracula")
-                == "theme = light:Nord,dark:Dracula\n"
+                == "scrollbar = system\nmouse-scroll-multiplier = precision:0.7,discrete:1\n"
+                + "theme = light:Nord,dark:Dracula\n"
         )
     }
 
@@ -60,28 +64,31 @@ struct GhosttyThemeConfigTests {
         #expect(url.path.hasPrefix(dataDir.path))
     }
 
-    @Test("Writing a selected pair persists the config file; clearing removes it")
-    func writeAndClearConfigFile() throws {
+    @Test("Writing always persists the WorkSpaces-managed Ghostty config file")
+    func writeConfigFile() throws {
         let dataDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: dataDir) }
         let environment = ["WORKSPACES_DATA_DIR": dataDir.path]
 
-        let writtenURL = try GhosttyThemeConfig.writeConfigFile(
+        let url = try GhosttyThemeConfig.writeConfigFile(
             lightTheme: "Nord",
             darkTheme: "Dracula",
             environment: environment
         )
-        let url = try #require(writtenURL)
         let contents = try String(contentsOf: url, encoding: .utf8)
-        #expect(contents == "theme = light:Nord,dark:Dracula\n")
+        #expect(
+            contents
+                == "scrollbar = system\nmouse-scroll-multiplier = precision:0.7,discrete:1\n"
+                + "theme = light:Nord,dark:Dracula\n"
+        )
 
-        let cleared = try GhosttyThemeConfig.writeConfigFile(
+        let unthemed = try GhosttyThemeConfig.writeConfigFile(
             lightTheme: "",
             darkTheme: "",
             environment: environment
         )
-        #expect(cleared == nil)
-        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(unthemed == url)
+        #expect(FileManager.default.fileExists(atPath: url.path))
     }
 }

--- a/docs/decisions/ghostty-theme-config.md
+++ b/docs/decisions/ghostty-theme-config.md
@@ -7,14 +7,15 @@ related:
   - docs/development/shortcut-routing.md
 ---
 
-# App-owned Ghostty config carries the Terminal Theme, applied live
+# App-owned Ghostty config carries WorkSpaces terminal defaults, applied live
 
 ## Decision
 
-**WorkSpaces manages the Terminal Theme through a small, app-owned Ghostty
-config file that it generates and loads itself, and applies live via
+**WorkSpaces manages embedded-terminal defaults through a small, app-owned
+Ghostty config file that it generates and loads itself, and applies live via
 `ghostty_app_update_config` / `ghostty_surface_update_config`.** The file holds
-only a `theme = light:<L>,dark:<D>` line and lives under the
+only WorkSpaces-owned keys such as scrollbar visibility, mouse scroll speed, and
+an optional `theme = light:<L>,dark:<D>` line. It lives under the
 `WORKSPACES_DATA_DIR` convention (`<dataDir>/ghostty/workspaces.config`),
 separate from the bundled resources directory that supplies terminfo and the
 theme catalog.
@@ -34,8 +35,8 @@ Ghostty.app uses), not libghostty-vt. The pinned header (ghostty
   push a new config — including `theme = …` — to **live** surfaces with no
   recreation and no lost scrollback.
 
-So a theme change is: rewrite the file, rebuild a fresh `ghostty_config_t`,
-broadcast it to the app and every registered surface, then free the previous
+So a behavior or theme change is: rewrite the file, rebuild a fresh
+`ghostty_config_t`, broadcast it to the app and every registered surface, then free the previous
 config. This mirrors how reload-config works in the real app and gives us all
 ~460 bundled iTerm2 themes by name plus native dual light/dark, where the active
 half follows the macOS appearance via the existing `set_color_scheme` path.
@@ -55,8 +56,8 @@ half follows the macOS appearance via the existing `set_color_scheme` path.
   previous one is freed after each `update_config` broadcast to avoid leaks.
 - **Single-sided pairs are invalid.** Ghostty rejects `theme = light:foo`
   without a `dark:` peer, so an unset slot is filled with `Builtin Light` /
-  `Builtin Dark`. When neither slot is set, no theme line is written and the
-  bare default behavior is preserved.
+  `Builtin Dark`. When neither slot is set, no theme line is written, but the
+  WorkSpaces-managed non-theme defaults are still loaded.
 
 ## Surface registry
 

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -133,20 +133,27 @@ fields above.
 Not configured yet (by design in this migration):
 - app-owned font-family override
 
-Reason: keep integration on stable C fields. The Terminal Theme (below) is the
-one app-owned config-file key we manage.
+App-owned config-file keys:
+- `theme = light:<L>,dark:<D>` when Terminal Theme is selected
+- `scrollbar = system`
+- `mouse-scroll-multiplier = precision:0.7,discrete:1`
+
+Reason: keep integration on stable C fields and a small isolated config file
+instead of loading the user's `~/.config/ghostty`.
 
 ## Terminal Theme (app-owned config + live update)
 
-WorkSpaces sets the terminal color theme through a small, app-owned config file
-applied live — never via OSC escapes or surface recreation. See the ADR
+WorkSpaces sets terminal behavior defaults and the optional terminal color theme
+through a small, app-owned config file applied live — never via OSC escapes or
+surface recreation. See the ADR
 `docs/decisions/ghostty-theme-config.md` for the rationale.
 
 Contract:
 
 - **Config file**: `<dataDir>/ghostty/workspaces.config` (the `WORKSPACES_DATA_DIR`
   convention, else the app support dir), isolated from `~/.config/ghostty`, which
-  we never load. It contains only `theme = light:<L>,dark:<D>`.
+  we never load. It contains WorkSpaces-managed keys only: scrollbar visibility,
+  scroll speed, and an optional `theme = light:<L>,dark:<D>`.
 - **Catalog**: themes are enumerated at runtime from `<resources>/ghostty/themes/`
   via `GhosttyResourcesLocator.resolvedResourcesDirectory()` — each filename *is*
   the `theme =` value. `GhosttyThemeCatalog` exposes `all`, `featured`, and fuzzy
@@ -157,10 +164,10 @@ Contract:
   `./scripts/launch-dev.sh` shows themes; a direct-binary launch still needs the
   env var set by hand.
 - **Startup**: `initializeIfNeeded()` builds the initial `ghostty_config_t` from
-  the persisted pair (`GhosttyThemePersistence`, `UserDefaults`). With no
-  selection it stays a bare default; with a selection it writes the file and
-  `ghostty_config_load_file`s it before `ghostty_app_new`, so the first surfaces
-  inherit the theme.
+  the persisted pair (`GhosttyThemePersistence`, `UserDefaults`). The config file
+  is always written for WorkSpaces scroll defaults; with a selected theme it also
+  includes `theme = …`. The file is loaded before `ghostty_app_new`, so the first
+  surfaces inherit the behavior.
 - **Live change**: `applyTheme(lightTheme:darkTheme:)` rewrites the file, rebuilds
   a fresh config, broadcasts via `ghostty_app_update_config(app, cfg)` and
   `ghostty_surface_update_config(surface, cfg)` over the weak surface registry,
@@ -168,7 +175,7 @@ Contract:
   inherit the theme from the updated app config.
 - **Dual form is required**: Ghostty rejects a single-sided `theme = light:foo`,
   so an unset slot is filled with `Builtin Light` / `Builtin Dark`; both unset
-  writes no theme line (bare default).
+  writes no theme line while preserving the WorkSpaces-managed non-theme defaults.
 - **Preview/commit**: `GhosttyThemeStore` (the observable both the Settings
   pickers and the Cmd+Shift+P overlay bind to) drives debounced previews
   (`preview`/`endPreview`, no persistence) and commits (`setLightTheme` /


### PR DESCRIPTION
## Summary

- Enables native AppKit vertical scrollbar plumbing around Ghostty surfaces while keeping Ghostty as the scrollback source of truth.
- Lowers Ghostty's precision wheel multiplier via the app-owned config so trackpad scrolling is less aggressive while preserving discrete wheel behavior.
- Adds scrollbar action handling, row mapping tests, config tests, and docs for the app-owned Ghostty scroll defaults.

## Mergeability

- Surface: desktop
- User-facing behavior changed: Embedded Ghostty terminals now use a visible native vertical scrollbar and a calmer precision scroll multiplier; discrete mouse-wheel behavior remains at default speed.
- Non-happy paths considered: Missing/zero scrollbar state falls back to normal content height; drag synchronization suppresses duplicate row sends; no-activation launch and terminal config generation were verified.
- Release/ops preconditions: none; no release, signing, workflow, or deployment files changed.
- Residual risk or follow-up: Low; the native scrollbar mirrors Ghostty scrollback state, so future upstream Ghostty scrollbar action shape changes would need matching bridge updates.

## Validation

- `swift-format lint --strict --recursive Sources/ Tests/`
- `./scripts/build-ghosttykit.sh`
- `swift build`
- `swift test --filter 'GhosttyThemeConfig|GhosttyRuntimeActionBridge|GhosttyScrollPositionMapper'`
- `swift test` (937 tests / 150 suites on rebased branch)
- Debug no-activation launch from this branch and `./scripts/capture-window.sh`
- Generated config verified:
  - `scrollbar = system`
  - `mouse-scroll-multiplier = precision:0.7,discrete:1`

## Performance

Compared against updated `origin/main` (`389eb08e`) after rebasing this branch.

- `debug_no_activate`: `launch_to_first_prompt` median 774.38 ms -> 726.24 ms (-48.14 ms, -6.2%); PR branch passed 740 ms gate.
- `debug_no_activate`: `repo_hydration` median 1.47 ms -> 1.60 ms (+0.13 ms, +8.8%); one PR-run outlier produced a warning, median remains well below the 25 ms gate.
- `main_window_idle_cpu_diagnostics_closed`: median 1.65% -> 0.25% (-1.40 percentage points); PR branch passed 3% gate, p95 0.79%.
- Discarded one idle CPU PR run where the app became active mid-sample and failed the idle scenario; rerun stayed no-activation idle and passed.

## Evidence

- ![ghostty-scroll-window](https://evidence.cloudcompute.com/workspaces/pr-677/20260626-025848-ghostty-scroll-window.png)
- ![ghostty-scroll-validation](https://evidence.cloudcompute.com/workspaces/pr-677/20260626-030051-ghostty-scroll-validation.png)
