### PR TITLE
release: v0.21.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.21.0-beta.1] - 2026-06-25
+
+### Added
+- Needs-you notification dropdown.
+
+### Fixed
+- Ghostty terminal scrolling.
+
 ## [0.20.0] - 2026-06-17
 
 ### Added

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.20.0</string>
+	<string>0.21.0-beta.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>25</string>
+	<string>26</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

- Prepare tester prerelease `0.21.0-beta.1`.
- Bump `CFBundleVersion` from `25` to `26`.
- Add prerelease changelog notes for the mainline changes since `v0.20.0`.

## Mergeability

- Surface: desktop release metadata
- User-facing behavior changed: signed tester prerelease will identify as `0.21.0-beta.1`
- Non-happy paths considered: uses the new tester-prerelease path; manual `Release` dispatch from `main` publishes a non-latest prerelease
- Release/ops preconditions: after merge, dispatch `Release` from `main` and approve the protected `release` environment
- Residual risk or follow-up: testers must use the GitHub prerelease asset directly; Sparkle update checks intentionally continue to see the latest stable release

## Validation

- [ ] `swift build`
- [x] `swift test`
- [x] Other checks run: `./scripts/build-ghosttykit.sh`; `git diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Prerelease validation evidence](https://evidence.cloudcompute.com/workspaces/pr-678/20260626-041152-prerelease-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
