### PR TITLE
Close workspace terminals on archive

### DIFF
--- a/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalContinuityManifest.swift
@@ -208,9 +208,14 @@ struct TerminalContinuityManifest: Codable, Equatable {
         )
     }
 
-    func hostSessionSnapshot(fileManager: FileManager = .default) -> HostSessionSnapshot? {
+    func hostSessionSnapshot(
+        excludingScopeKeys excludedScopeKeys: Set<HostTerminalSessionKey> = [],
+        fileManager: FileManager = .default
+    ) -> HostSessionSnapshot? {
         let restoredSessions = sessionRecords.compactMap {
             $0.restoredSession(fileManager: fileManager)
+        }.filter {
+            !excludedScopeKeys.contains($0.key)
         }
         guard !restoredSessions.isEmpty else { return nil }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -106,6 +106,36 @@ struct ContentView: View {
         )
     }
 
+    private var archivedWorkspaceTerminalScopeKeys: Set<HostTerminalSessionKey> {
+        Set(
+            repos
+                .flatMap(\.workspaces)
+                .filter { $0.status == .archived }
+                .compactMap(terminalSessionKey(for:))
+        )
+    }
+
+    private var terminalContinuityInputs:
+        (
+            sessions: [HostTerminalSession],
+            activeSessionID: UUID?,
+            activeSessionIDByScopeKey: [HostTerminalSessionKey: UUID]
+        )
+    {
+        let excludedScopeKeys = archivedWorkspaceTerminalScopeKeys
+        let sessions = hostTerminalState.sessions.filter { !excludedScopeKeys.contains($0.key) }
+        let validSessionIDs = Set(sessions.map(\.id))
+        let activeSessionID =
+            hostTerminalState.activeSessionID.flatMap {
+                validSessionIDs.contains($0) ? $0 : sessions.last?.id
+            } ?? sessions.last?.id
+        let activeSessionIDByScopeKey = hostTerminalState.activeSessionIDByScopeKey.filter {
+            !excludedScopeKeys.contains($0.key) && validSessionIDs.contains($0.value)
+        }
+
+        return (sessions, activeSessionID, activeSessionIDByScopeKey)
+    }
+
     private var currentSelectedWorkspace: Workspace? {
         mainSelectionCoordinator.cachedWorkspace(with: viewState.selectedWorkspace?.workspaceID)
     }
@@ -1444,6 +1474,16 @@ struct ContentView: View {
         terminalFocusCoordinator.cancelPendingRepoClickMeasurement(reason: "workspace_selected")
         terminalFocusCoordinator.cancelPendingFocusRequest(reason: "workspace_selected")
 
+        guard workspace.status != .archived else {
+            abandonPendingRemoteConnection(reason: "archived_workspace_selected")
+            if let repo = workspace.sourceRepo {
+                applyNavigationDestination(.repoOverview(repo))
+            } else {
+                setSelectedWorkspace(nil)
+            }
+            return
+        }
+
         if workspace.backend != .local {
             handleProviderBackedWorkspaceSelection(workspace)
         } else {
@@ -2289,7 +2329,7 @@ struct ContentView: View {
     private func ensureInitialHostSession() {
         if !hostTerminalState.hasSessions,
             let snapshot = TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue)?
-                .hostSessionSnapshot()
+                .hostSessionSnapshot(excludingScopeKeys: archivedWorkspaceTerminalScopeKeys)
         {
             hostTerminalState.restoreSessions(
                 snapshot.sessions,
@@ -2512,15 +2552,16 @@ struct ContentView: View {
         rootURL: URL,
         launchURL: URL
     ) {
+        let continuityInputs = terminalContinuityInputs
         let manifest = TerminalContinuityManifest(
             targetKind: targetKind,
             targetID: targetID,
             rootURL: rootURL,
             launchURL: launchURL,
             terminalMode: terminalMultiplexingMode,
-            sessions: hostTerminalState.sessions,
-            activeSessionID: hostTerminalState.activeSessionID,
-            activeSessionIDByScopeKey: hostTerminalState.activeSessionIDByScopeKey
+            sessions: continuityInputs.sessions,
+            activeSessionID: continuityInputs.activeSessionID,
+            activeSessionIDByScopeKey: continuityInputs.activeSessionIDByScopeKey
         )
         terminalContinuityManifestRawValue = manifest.rawValue
         NSLog(
@@ -2535,13 +2576,14 @@ struct ContentView: View {
     }
 
     private func persistTerminalContinuitySnapshot() {
+        let continuityInputs = terminalContinuityInputs
         let manifest = TerminalContinuityManifest.snapshot(
             previous: TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue),
             defaultHomeURL: resolvedDefaultHostDirectory,
             terminalMode: terminalMultiplexingMode,
-            sessions: hostTerminalState.sessions,
-            activeSessionID: hostTerminalState.activeSessionID,
-            activeSessionIDByScopeKey: hostTerminalState.activeSessionIDByScopeKey
+            sessions: continuityInputs.sessions,
+            activeSessionID: continuityInputs.activeSessionID,
+            activeSessionIDByScopeKey: continuityInputs.activeSessionIDByScopeKey
         )
         terminalContinuityManifestRawValue = manifest.rawValue
     }
@@ -2565,6 +2607,18 @@ struct ContentView: View {
                 targetID: workspace.id,
                 rootURL: workspaceDirectory
             )
+    }
+
+    private func terminalSessionKey(for workspace: Workspace) -> HostTerminalSessionKey? {
+        if workspace.backend == .local {
+            return .hostPath(normalizePath(workspace.workspaceURL.path))
+        }
+
+        guard let provider = workspaceProviderRegistry.provider(for: workspace) else {
+            return nil
+        }
+
+        return provider.sessionKey(for: WorkspaceProviderTarget(workspace)).normalized()
     }
 
     private func terminalContextMenu(for session: HostTerminalSession) -> NSMenu? {

--- a/Sources/WorkspaceManager/Views/MainWindow/MainSelectionCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainSelectionCoordinator.swift
@@ -76,7 +76,7 @@ struct MainSelectionCoordinator {
         pathIsInside: (String, String) -> Bool
     ) -> Workspace? {
         let normalizedCWD = normalizePath(cwd)
-        let allWorkspaces = repos.flatMap(\.workspaces)
+        let allWorkspaces = repos.flatMap(\.workspaces).filter { $0.status != .archived }
 
         let matches = allWorkspaces.compactMap { workspace -> (workspace: Workspace, matchLength: Int)? in
             let workspacePath = normalizePath(workspace.path)

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowBootstrapController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowBootstrapController.swift
@@ -205,7 +205,9 @@ struct MainWindowBootstrapController {
             return .select(.repoTerminal(repo))
 
         case .workspaceTerminal:
-            guard let workspace = selectionCoordinator.workspace(with: savedSurface.id, in: repos) else {
+            guard let workspace = selectionCoordinator.workspace(with: savedSurface.id, in: repos),
+                workspace.status != .archived
+            else {
                 return .clearInvalid
             }
             return .select(.workspace(workspace))
@@ -235,12 +237,13 @@ struct MainWindowBootstrapController {
         repos: [Repo],
         webSources: [WebSource]
     ) -> MainWindowLaunchSurface? {
-        if let workspace =
+        let workspace =
             repos
             .flatMap(\.workspaces)
+            .filter { $0.status != .archived }
             .sorted(by: { $0.lastAccessedAt > $1.lastAccessedAt })
             .first
-        {
+        if let workspace {
             return .workspace(workspace)
         }
 
@@ -273,7 +276,9 @@ struct MainWindowBootstrapController {
         ownerRepoID: UUID?,
         repos: [Repo]
     ) -> MainWindowLaunchSurface? {
-        if let workspace = selectionCoordinator.workspace(with: ownerWorkspaceID, in: repos) {
+        if let workspace = selectionCoordinator.workspace(with: ownerWorkspaceID, in: repos),
+            workspace.status != .archived
+        {
             return .workspace(workspace)
         }
 
@@ -285,12 +290,13 @@ struct MainWindowBootstrapController {
     }
 
     func nonWebFallbackSurface(repos: [Repo]) -> MainWindowLaunchSurface? {
-        if let workspace =
+        let workspace =
             repos
             .flatMap(\.workspaces)
+            .filter { $0.status != .archived }
             .sorted(by: { $0.lastAccessedAt > $1.lastAccessedAt })
             .first
-        {
+        if let workspace {
             return .workspace(workspace)
         }
 

--- a/Tests/WorkspaceManagerAppTests/MainWindowBootstrapControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowBootstrapControllerTests.swift
@@ -53,6 +53,34 @@ struct MainWindowBootstrapControllerTests {
         }
     }
 
+    @Test("Deep link skips archived workspaces")
+    func deepLinkSkipsArchivedWorkspaces() {
+        let repo = Repo(name: "app", localPath: URL(fileURLWithPath: "/tmp/app"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/app/workspaces/feature-a"),
+            sourceRepo: repo,
+            status: .archived
+        )
+        repo.workspaces = [workspace]
+
+        let request = makeDeepLink(cwd: "/tmp/app/workspaces/feature-a/Sources/App/main.swift")
+        let decision = controller.deepLinkDecision(
+            pendingRequest: request,
+            repos: [repo],
+            normalizePath: normalizePath,
+            pathIsInside: path(_:isInside:)
+        )
+
+        switch decision {
+        case .selectRepo(let pendingRequest, let matchedRepo):
+            #expect(pendingRequest == request)
+            #expect(matchedRepo.id == repo.id)
+        default:
+            Issue.record("Expected deep link decision to fall back to the repo")
+        }
+    }
+
     @Test("Deep link selects matching repo when cwd is inside repo root")
     func deepLinkSelectsMatchingRepo() {
         let repo = Repo(name: "app", localPath: URL(fileURLWithPath: "/tmp/app"))
@@ -347,6 +375,32 @@ struct MainWindowBootstrapControllerTests {
         }
     }
 
+    @Test("Restored surface clears archived workspace terminals")
+    func restoredSurfaceClearsArchivedWorkspaceTerminals() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo,
+            status: .archived
+        )
+        repo.workspaces = [workspace]
+        let saved = MainWindowLastSurface(kind: .workspaceTerminal, id: workspace.id)
+
+        let decision = controller.restoredSurfaceDecision(
+            rawValue: saved.rawValue,
+            repos: [repo],
+            webSources: []
+        )
+
+        switch decision {
+        case .clearInvalid:
+            _ = Bool(true)
+        default:
+            Issue.record("Expected archived workspace terminal restore to clear")
+        }
+    }
+
     @Test("Restored surface clears invalid targets")
     func restoredSurfaceClearsInvalidTargets() {
         let saved = MainWindowLastSurface(kind: .repoOverview, id: UUID())
@@ -415,6 +469,38 @@ struct MainWindowBootstrapControllerTests {
         }
     }
 
+    @Test("Fallback skips archived workspaces")
+    func fallbackSkipsArchivedWorkspaces() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let archivedWorkspace = Workspace(
+            name: "archived",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/archived"),
+            sourceRepo: repo,
+            lastAccessedAt: Date(timeIntervalSince1970: 30),
+            status: .archived
+        )
+        let activeWorkspace = Workspace(
+            name: "active",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/active"),
+            sourceRepo: repo,
+            lastAccessedAt: Date(timeIntervalSince1970: 20),
+            status: .active
+        )
+        repo.workspaces = [archivedWorkspace, activeWorkspace]
+
+        let fallback = controller.fallbackSurface(
+            repos: [repo],
+            webSources: []
+        )
+
+        switch fallback {
+        case .workspace(let workspace):
+            #expect(workspace.id == activeWorkspace.id)
+        default:
+            Issue.record("Expected fallback to skip archived workspaces")
+        }
+    }
+
     @Test("Fallback prefers most recent web view before first repo when no workspace exists")
     func fallbackPrefersWebViewBeforeRepo() {
         let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
@@ -456,6 +542,28 @@ struct MainWindowBootstrapControllerTests {
             #expect(selectedWorkspace.id == workspace.id)
         default:
             Issue.record("Expected non-web fallback to prefer the most recent workspace")
+        }
+    }
+
+    @Test("Non-web fallback skips archived workspaces")
+    func nonWebFallbackSkipsArchivedWorkspaces() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "archived",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/archived"),
+            sourceRepo: repo,
+            lastAccessedAt: Date(timeIntervalSince1970: 20),
+            status: .archived
+        )
+        repo.workspaces = [workspace]
+
+        let fallback = controller.nonWebFallbackSurface(repos: [repo])
+
+        switch fallback {
+        case .repoOverview(let selectedRepo):
+            #expect(selectedRepo.id == repo.id)
+        default:
+            Issue.record("Expected non-web fallback to skip archived workspaces")
         }
     }
 
@@ -514,6 +622,31 @@ struct MainWindowBootstrapControllerTests {
             #expect(selectedWorkspace.id == workspace.id)
         default:
             Issue.record("Expected workspace-owned web view removal to return to the workspace")
+        }
+    }
+
+    @Test("Removing workspace-owned web view skips archived workspace")
+    func removingWorkspaceOwnedWebViewSkipsArchivedWorkspace() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/alpha/workspaces/feature-a"),
+            sourceRepo: repo,
+            status: .archived
+        )
+        repo.workspaces = [workspace]
+
+        let fallback = controller.fallbackSurfaceAfterRemovingWebSource(
+            ownerWorkspaceID: workspace.id,
+            ownerRepoID: repo.id,
+            repos: [repo]
+        )
+
+        switch fallback {
+        case .repoOverview(let selectedRepo):
+            #expect(selectedRepo.id == repo.id)
+        default:
+            Issue.record("Expected archived workspace-owned web fallback to use repo overview")
         }
     }
 

--- a/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalContinuityManifestTests.swift
@@ -184,6 +184,39 @@ struct TerminalContinuityManifestTests {
         #expect(snapshot.activeSessionIDByScopeKey[.backendSession(providerID: "lume", instanceID: "vm-123")] == nil)
     }
 
+    @Test("Host session snapshot excludes archived workspace scopes")
+    func hostSessionSnapshotExcludesArchivedWorkspaceScopes() throws {
+        let home = try temporaryDirectory()
+        let workspace = try temporaryDirectory()
+        let homeSession = HostTerminalSession(key: .defaultHome, directory: home)
+        let workspaceSession = HostTerminalSession(key: .hostPath(workspace.path), directory: workspace)
+        let secondWorkspaceSession = HostTerminalSession(key: .hostPath(workspace.path), directory: workspace)
+
+        let manifest = TerminalContinuityManifest(
+            targetKind: .workspace,
+            targetID: UUID(),
+            rootURL: workspace,
+            launchURL: workspace,
+            terminalMode: .ghosttyManagedSplits,
+            sessions: [homeSession, workspaceSession, secondWorkspaceSession],
+            activeSessionID: secondWorkspaceSession.id,
+            activeSessionIDByScopeKey: [
+                .defaultHome: homeSession.id,
+                .hostPath(workspace.path): secondWorkspaceSession.id,
+            ],
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let snapshot = try #require(
+            manifest.hostSessionSnapshot(excludingScopeKeys: [.hostPath(workspace.path)])
+        )
+
+        #expect(snapshot.sessions.map(\.id) == [homeSession.id])
+        #expect(snapshot.activeSessionID == homeSession.id)
+        #expect(snapshot.activeSessionIDByScopeKey[.defaultHome] == homeSession.id)
+        #expect(snapshot.activeSessionIDByScopeKey[.hostPath(workspace.path)] == nil)
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("TerminalContinuityManifestTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- retire archived workspace terminal scopes from continuity persistence and restore
- block archived workspaces from terminal activation through selection, restore, deep links, and fallback
- add regression coverage for archived workspace terminal restore/fallback and session snapshot filtering

## Mergeability
- Surface: desktop
- User-facing behavior changed: Archiving a workspace no longer leaves that workspace eligible for active or restored terminal sessions.
- Non-happy paths considered: Restored continuity manifests, persisted host session snapshots, direct workspace selection, deep links, web-source fallback, non-web fallback, and archived remote/local workspace terminal keys are filtered away.
- Residual risk or follow-up: Low; the change is intentionally scoped to archived workspace terminal continuity and activation paths. CI and managed review are still running.

## Validation
- ./scripts/build-ghosttykit.sh
- swift test --filter MainWindowBootstrapControllerTests
- swift test --filter TerminalContinuityManifestTests
- swift test --filter SidebarWorkspaceControllerBehaviorTests
- swift test --filter HostTerminalStateStoreTests
- swift test
- swift-format lint --strict --recursive Sources/ Tests/

## Evidence
- ![archive-terminal-session-validation](https://evidence.cloudcompute.com/workspaces/pr-682/20260626-212951-archive-terminal-session-validation.png)