### PR TITLE
Add WorkSpaces automation API v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ For introducing Settings-gated UI experiments, see:
 
 - [docs/development/experimental-features.md](./docs/development/experimental-features.md)
 
+For local app-shell automation from WorkSpaces terminal tiles, see:
+
+- [docs/automation-api.md](./docs/automation-api.md)
+- [docs/development/automation-api.md](./docs/development/automation-api.md)
+
 For VM and provider-backed workspace architecture, see:
 
 - [docs/vm-provider-architecture.md](./docs/vm-provider-architecture.md)

--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -1,0 +1,116 @@
+//
+//  AutomationIntegrationLifecycle.swift
+//  WorkspaceManager
+//
+//  Starts the local app-shell automation listener when the experimental feature
+//  is enabled and exposes its socket/handle registry to terminal surfaces.
+//
+
+import AppKit
+import Combine
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+final class AutomationIntegrationLifecycle: ObservableObject {
+    static let shared = AutomationIntegrationLifecycle()
+
+    let handleRegistry = AutomationHandleRegistry()
+
+    private(set) var listener: AutomationListener?
+    private(set) var controller: AutomationController?
+    @Published private(set) var socketPath: String?
+    private var teardownObserver: Any?
+    private var didStart = false
+
+    private init() {}
+
+    var isEnabled: Bool {
+        ExperimentalFeatures.isEnabled(.automationAPI)
+    }
+
+    func configure(
+        hostTerminalState: HostTerminalStateStore,
+        focusTerminal: @escaping @MainActor (UUID) -> Void,
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+    ) {
+        guard isEnabled else {
+            hostTerminalState.configureAutomation(handleRegistry: nil, socketPath: nil)
+            return
+        }
+
+        startIfNeeded(
+            hostTerminalState: hostTerminalState,
+            focusTerminal: focusTerminal,
+            requestCloseTerminal: requestCloseTerminal
+        )
+        hostTerminalState.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
+    }
+
+    func startIfNeeded(
+        hostTerminalState: HostTerminalStateStore,
+        focusTerminal: @escaping @MainActor (UUID) -> Void,
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+    ) {
+        guard !didStart else {
+            controller?.update(
+                hostTerminalState: hostTerminalState,
+                focusTerminal: focusTerminal,
+                requestCloseTerminal: requestCloseTerminal
+            )
+            return
+        }
+        didStart = true
+
+        let controller = AutomationController(
+            handleRegistry: handleRegistry,
+            hostTerminalState: hostTerminalState,
+            focusTerminal: focusTerminal,
+            requestCloseTerminal: requestCloseTerminal
+        )
+        self.controller = controller
+
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
+        let auditLogger = AutomationAuditLogger(
+            auditURL: AutomationAuditLogger.defaultAuditURL(bundleIdentifier: bundleID)
+        )
+        let listener = AutomationListener(
+            bundleIdentifier: bundleID,
+            controller: controller,
+            auditLogger: auditLogger,
+            isEnabled: { ExperimentalFeatures.isEnabled(.automationAPI) }
+        )
+        self.listener = listener
+        self.socketPath = listener.socketPath
+
+        Task { @MainActor in
+            do {
+                try await listener.start()
+                NSLog("[AutomationIntegration] listener started at %@", listener.socketPath)
+            } catch {
+                NSLog("[AutomationIntegration] listener failed to start: %@", "\(error)")
+            }
+        }
+
+        teardownObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in await self?.stop() }
+        }
+    }
+
+    func stop() async {
+        await listener?.stop()
+        listener = nil
+        controller = nil
+        socketPath = nil
+        didStart = false
+        handleRegistry.removeAll()
+        if let teardownObserver {
+            NotificationCenter.default.removeObserver(teardownObserver)
+            self.teardownObserver = nil
+        }
+    }
+}

--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -22,6 +22,7 @@ final class AutomationIntegrationLifecycle: ObservableObject {
     @Published private(set) var socketPath: String?
     private var teardownObserver: Any?
     private var didStart = false
+    private var startTask: Task<String, Error>?
 
     private init() {}
 
@@ -33,34 +34,52 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         hostTerminalState: HostTerminalStateStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void
-    ) {
+    ) async {
         guard isEnabled else {
             hostTerminalState.configureAutomation(handleRegistry: nil, socketPath: nil)
             return
         }
 
-        startIfNeeded(
-            hostTerminalState: hostTerminalState,
-            focusTerminal: focusTerminal,
-            requestCloseTerminal: requestCloseTerminal
-        )
-        hostTerminalState.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
+        do {
+            let socketPath = try await startIfNeeded(
+                hostTerminalState: hostTerminalState,
+                focusTerminal: focusTerminal,
+                requestCloseTerminal: requestCloseTerminal
+            )
+            hostTerminalState.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
+        } catch {
+            hostTerminalState.configureAutomation(handleRegistry: nil, socketPath: nil)
+            handleRegistry.removeAll()
+            NSLog("[AutomationIntegration] listener unavailable: %@", "\(error)")
+        }
     }
 
     func startIfNeeded(
         hostTerminalState: HostTerminalStateStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void
-    ) {
+    ) async throws -> String {
+        if let startTask {
+            let socketPath = try await startTask.value
+            controller?.update(
+                hostTerminalState: hostTerminalState,
+                focusTerminal: focusTerminal,
+                requestCloseTerminal: requestCloseTerminal
+            )
+            return socketPath
+        }
+
         guard !didStart else {
             controller?.update(
                 hostTerminalState: hostTerminalState,
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal
             )
-            return
+            guard let socketPath else {
+                throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
+            }
+            return socketPath
         }
-        didStart = true
 
         let controller = AutomationController(
             handleRegistry: handleRegistry,
@@ -68,7 +87,6 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             focusTerminal: focusTerminal,
             requestCloseTerminal: requestCloseTerminal
         )
-        self.controller = controller
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
         let auditLogger = AutomationAuditLogger(
@@ -80,17 +98,27 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             auditLogger: auditLogger,
             isEnabled: { ExperimentalFeatures.isEnabled(.automationAPI) }
         )
-        self.listener = listener
-        self.socketPath = listener.socketPath
 
-        Task { @MainActor in
-            do {
-                try await listener.start()
-                NSLog("[AutomationIntegration] listener started at %@", listener.socketPath)
-            } catch {
-                NSLog("[AutomationIntegration] listener failed to start: %@", "\(error)")
-            }
+        let startTask = Task<String, Error> {
+            try await listener.start()
+            return listener.socketPath
         }
+        self.startTask = startTask
+
+        let startedSocketPath: String
+        do {
+            startedSocketPath = try await startTask.value
+        } catch {
+            self.startTask = nil
+            throw error
+        }
+
+        self.controller = controller
+        self.listener = listener
+        self.socketPath = startedSocketPath
+        didStart = true
+        self.startTask = nil
+        NSLog("[AutomationIntegration] listener started at %@", listener.socketPath)
 
         teardownObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification,
@@ -99,9 +127,12 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in await self?.stop() }
         }
+        return listener.socketPath
     }
 
     func stop() async {
+        startTask?.cancel()
+        startTask = nil
         await listener?.stop()
         listener = nil
         controller = nil

--- a/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
+++ b/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
@@ -7,12 +7,15 @@ import Foundation
 import SwiftUI
 
 enum ExperimentalFeature: String, CaseIterable, Identifiable {
+    case automationAPI = "automationAPI"
     case minimalToolbar = "minimalToolbar"
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
+        case .automationAPI:
+            return "Automation API"
         case .minimalToolbar:
             return "Minimal Toolbar"
         }
@@ -20,6 +23,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
 
     var description: String {
         switch self {
+        case .automationAPI:
+            return "Expose a local same-user socket so terminal tiles can inspect and arrange their WorkSpaces shell."
         case .minimalToolbar:
             return "Hide secondary toolbar controls so terminal surfaces stay closer to the canvas."
         }
@@ -35,6 +40,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
 
     var forceOnEnvironmentKey: String? {
         switch self {
+        case .automationAPI:
+            return "WORKSPACES_AUTOMATION_API"
         case .minimalToolbar:
             return "WORKSPACES_PERF_MINIMAL_TOOLBAR"
         }

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -15,6 +15,9 @@ final class SurfaceStore {
 
     /// Forwarded to terminal surfaces at creation so libghostty can reach the agent hook socket.
     var hooksSocketPath: String?
+    /// Forwarded to terminal surfaces at creation so tile-local processes can reach the Automation
+    /// API with an opaque capability handle.
+    var automationEnvironmentProvider: ((HostTerminalSession) -> AutomationTerminalEnvironment?)?
 
     /// Fired when a surface is first created for a tile (drives focus-coordinator readiness).
     var onSurfaceCreated: (@MainActor (TileID) -> Void)?
@@ -69,6 +72,7 @@ final class SurfaceStore {
             tileID: tileID,
             session: session,
             hooksSocketPath: hooksSocketPath,
+            automationEnvironment: automationEnvironmentProvider?(session),
             onProcessExit: wrappedOnProcessExit,
             onCloseConfirmationRequired: onCloseConfirmationRequired,
             contextMenuProvider: contextMenuProvider

--- a/Sources/WorkspaceManager/Surface/TerminalSurface.swift
+++ b/Sources/WorkspaceManager/Surface/TerminalSurface.swift
@@ -22,6 +22,7 @@ final class TerminalSurface: Surface {
         tileID: TileID,
         session: HostTerminalSession,
         hooksSocketPath: String?,
+        automationEnvironment: AutomationTerminalEnvironment? = nil,
         onProcessExit: (() -> Void)? = nil,
         onCloseConfirmationRequired: (() -> Void)? = nil,
         contextMenuProvider: (() -> NSMenu?)? = nil
@@ -31,7 +32,8 @@ final class TerminalSurface: Surface {
 
         let launchContext = TerminalSessionLaunchContext.hostSession(
             session,
-            hooksSocketPath: hooksSocketPath
+            hooksSocketPath: hooksSocketPath,
+            automationEnvironment: automationEnvironment
         )
         self.surfaceView = GhosttySurfaceView(
             launchContext: launchContext,

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -6,6 +6,7 @@
 import AppKit
 import Foundation
 import GhosttyKit
+import WorkspaceManagerCore
 
 struct GhosttyTerminalConfig {
     private enum ShellProfileMode: String {
@@ -50,7 +51,8 @@ struct GhosttyTerminalConfig {
                 terminalMultiplexingMode: terminalMultiplexingMode,
                 isTmuxAvailableOverride: isTmuxAvailableOverride,
                 hostSessionID: launchContext.hostSessionID,
-                hooksSocketPath: launchContext.hooksSocketPath
+                hooksSocketPath: launchContext.hooksSocketPath,
+                automationEnvironment: launchContext.automationEnvironment
             )
         }
     }
@@ -62,7 +64,8 @@ struct GhosttyTerminalConfig {
         terminalMultiplexingMode: TerminalMultiplexingMode? = nil,
         isTmuxAvailableOverride: Bool? = nil,
         hostSessionID: UUID? = nil,
-        hooksSocketPath: String? = nil
+        hooksSocketPath: String? = nil,
+        automationEnvironment: AutomationTerminalEnvironment? = nil
     ) {
         self.fontSize = fontSize
         self.workingDirectory = workingDirectory.path
@@ -81,6 +84,10 @@ struct GhosttyTerminalConfig {
             if let commandStatusHookPath = ClaudeIntegrationLifecycle.bundledCommandStatusHookPath() {
                 environment["WORKSPACES_COMMAND_STATUS_ZSH"] = commandStatusHookPath
             }
+        }
+        if let automationEnvironment {
+            environment[AutomationAPI.socketEnvironmentKey] = automationEnvironment.socketPath
+            environment[AutomationAPI.handleEnvironmentKey] = automationEnvironment.handle
         }
 
         if let path = environment["PATH"] {

--- a/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
@@ -39,37 +39,43 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
     let commandMode: CommandMode
     let hostSessionID: UUID?
     let hooksSocketPath: String?
+    let automationEnvironment: AutomationTerminalEnvironment?
 
     static func hostSession(
         _ session: HostTerminalSession,
-        hooksSocketPath: String?
+        hooksSocketPath: String?,
+        automationEnvironment: AutomationTerminalEnvironment? = nil
     ) -> TerminalSessionLaunchContext {
         if let customCommand = session.customCommand {
             return TerminalSessionLaunchContext(
                 workingDirectory: session.directoryURL,
                 commandMode: .customCommand(customCommand),
                 hostSessionID: session.id,
-                hooksSocketPath: hooksSocketPath
+                hooksSocketPath: hooksSocketPath,
+                automationEnvironment: nil
             )
         }
 
         return directoryBacked(
             workingDirectory: session.directoryURL,
             hostSessionID: session.id,
-            hooksSocketPath: hooksSocketPath
+            hooksSocketPath: hooksSocketPath,
+            automationEnvironment: automationEnvironment
         )
     }
 
     static func directoryBacked(
         workingDirectory: URL,
         hostSessionID: UUID? = nil,
-        hooksSocketPath: String? = nil
+        hooksSocketPath: String? = nil,
+        automationEnvironment: AutomationTerminalEnvironment? = nil
     ) -> TerminalSessionLaunchContext {
         TerminalSessionLaunchContext(
             workingDirectory: workingDirectory,
             commandMode: .directoryShell,
             hostSessionID: hostSessionID,
-            hooksSocketPath: hooksSocketPath
+            hooksSocketPath: hooksSocketPath,
+            automationEnvironment: automationEnvironment
         )
     }
 
@@ -77,13 +83,16 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
         _ command: String,
         workingDirectory: URL = FileManager.default.temporaryDirectory,
         hostSessionID: UUID? = nil,
-        hooksSocketPath: String? = nil
+        hooksSocketPath: String? = nil,
+        automationEnvironment: AutomationTerminalEnvironment? = nil
     ) -> TerminalSessionLaunchContext {
-        TerminalSessionLaunchContext(
+        _ = automationEnvironment
+        return TerminalSessionLaunchContext(
             workingDirectory: workingDirectory,
             commandMode: .customCommand(command),
             hostSessionID: hostSessionID,
-            hooksSocketPath: hooksSocketPath
+            hooksSocketPath: hooksSocketPath,
+            automationEnvironment: nil
         )
     }
 

--- a/Sources/WorkspaceManager/Views/Components/TerminalView.swift
+++ b/Sources/WorkspaceManager/Views/Components/TerminalView.swift
@@ -26,6 +26,7 @@ final class HostTerminalSurfaceStore {
     private var surfaces: [UUID: GhosttySurfaceView] = [:]
     private var sessionIDsBySurfaceIdentity: [ObjectIdentifier: UUID] = [:]
     var hooksSocketPath: String?
+    var automationEnvironmentProvider: ((HostTerminalSession) -> AutomationTerminalEnvironment?)?
     var onSurfaceCreated: (@MainActor (UUID) -> Void)?
     var onSurfaceInvalidated: (@MainActor (UUID) -> Void)?
     var onTerminalTitleChanged: (@MainActor (UUID) -> Void)?
@@ -61,7 +62,8 @@ final class HostTerminalSurfaceStore {
 
         let launchContext = TerminalSessionLaunchContext.hostSession(
             session,
-            hooksSocketPath: hooksSocketPath
+            hooksSocketPath: hooksSocketPath,
+            automationEnvironment: automationEnvironmentProvider?(session)
         )
         let created = GhosttySurfaceView(
             launchContext: launchContext,

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -31,20 +31,23 @@ final class AutomationController: AutomationControlling {
     }
 
     func automationContext(for handle: String) throws -> AutomationContextResult {
-        let resolved = try resolve(handle)
-        return try context(for: resolved, handle: handle)
+        let resolved = try resolve(handle, requiring: .contextRead)
+        return try context(for: resolved)
     }
 
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult {
-        let resolved = try resolve(handle)
-        return AutomationSurfacesResult(surfaces: surfaceDescriptors(for: resolved))
+        let resolved = try resolve(handle, requiring: .surfacesRead)
+        return AutomationSurfacesResult(
+            surfaces: surfaceDescriptors(for: resolved),
+            system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
+        )
     }
 
     func automationFocusTile(
         for handle: String,
         direction: AutomationTileFocusDirection
     ) throws -> AutomationMutationResult {
-        let resolved = try resolve(handle)
+        let resolved = try resolve(handle, requiring: .tileFocus)
         let focusDirection = GhosttyAppManager.SplitFocusDirection(automationDirection: direction)
         guard
             let targetSessionID = resolved.hostTerminalState.splitFocusTarget(
@@ -66,7 +69,7 @@ final class AutomationController: AutomationControlling {
         for handle: String,
         direction: AutomationTileSplitDirection
     ) throws -> AutomationMutationResult {
-        let resolved = try resolve(handle)
+        let resolved = try resolve(handle, requiring: .tileSplit)
         guard
             let primarySessionID = resolved.hostTerminalState.activatePrimarySession(
                 containing: resolved.entry.hostSessionID
@@ -74,8 +77,16 @@ final class AutomationController: AutomationControlling {
         else {
             throw AutomationServiceError(.staleHandle, "The automation handle no longer maps to a live terminal tile.")
         }
+        guard primarySessionID == resolved.entry.hostSessionID else {
+            throw AutomationServiceError(
+                .unsupported,
+                "Splitting from a secondary split tile is not supported by Automation API V1."
+            )
+        }
 
         let layout = HostTerminalStateStore.SplitPaneLayout(automationDirection: direction)
+        let existingSplit = resolved.hostTerminalState.splitSession(for: primarySessionID)
+        let existingLayout = resolved.hostTerminalState.splitLayout(for: primarySessionID)
         guard
             let splitSession = resolved.hostTerminalState.ensureSplit(
                 forPrimarySessionID: primarySessionID,
@@ -88,15 +99,25 @@ final class AutomationController: AutomationControlling {
         DispatchQueue.main.asyncAfter(deadline: .now() + GhosttyTerminalIntentRouter.splitFocusDelay) {
             self.focusTerminal(splitSession.id)
         }
+        let createdSurfaceID = existingSplit == nil ? splitSession.id.uuidString : nil
+        let reason: String?
+        if existingSplit == nil {
+            reason = nil
+        } else if existingLayout != layout {
+            reason = "relayout"
+        } else {
+            reason = "already_split"
+        }
         return AutomationMutationResult(
             changed: true,
             focusedSurfaceID: splitSession.id.uuidString,
-            createdSurfaceID: splitSession.id.uuidString
+            createdSurfaceID: createdSurfaceID,
+            reason: reason
         )
     }
 
     func automationCloseTile(for handle: String) throws -> AutomationMutationResult {
-        let resolved = try resolve(handle)
+        let resolved = try resolve(handle, requiring: .tileClose)
         requestCloseTerminal(resolved.entry.hostSessionID)
         return AutomationMutationResult(
             changed: true,
@@ -109,13 +130,22 @@ final class AutomationController: AutomationControlling {
         let hostTerminalState: HostTerminalStateStore
     }
 
-    private func resolve(_ handle: String) throws -> ResolvedHandle {
+    private func resolve(
+        _ handle: String,
+        requiring capability: AutomationCapability
+    ) throws -> ResolvedHandle {
         guard let hostTerminalState else {
             throw AutomationServiceError(
                 .unsupported, "No WorkSpaces window is currently attached to the Automation API.")
         }
         guard let entry = handleRegistry.resolve(handle) else {
             throw AutomationServiceError(.staleHandle, "The automation handle is missing or stale.")
+        }
+        guard entry.capabilities.contains(capability) else {
+            throw AutomationServiceError(
+                .capabilityDenied,
+                "The automation handle does not include \(capability.rawValue)."
+            )
         }
         guard hostTerminalState.primarySessionID(containing: entry.hostSessionID) != nil else {
             handleRegistry.remove(hostSessionID: entry.hostSessionID)
@@ -125,13 +155,13 @@ final class AutomationController: AutomationControlling {
     }
 
     private func context(
-        for resolved: ResolvedHandle,
-        handle: String
+        for resolved: ResolvedHandle
     ) throws -> AutomationContextResult {
         let surface = try surfaceDescriptor(
             hostSessionID: resolved.entry.hostSessionID,
             callerHostSessionID: resolved.entry.hostSessionID,
-            hostTerminalState: resolved.hostTerminalState
+            hostTerminalState: resolved.hostTerminalState,
+            capabilities: resolved.entry.capabilities
         )
         let primaryID = resolved.hostTerminalState.primarySessionID(containing: resolved.entry.hostSessionID)
         let primarySession = primaryID.flatMap { id in
@@ -144,9 +174,9 @@ final class AutomationController: AutomationControlling {
             primaryHostSessionID: primaryID
         )
         return AutomationContextResult(
-            handle: handle,
             surface: surface,
-            scope: scope
+            scope: scope,
+            system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
         )
     }
 
@@ -167,7 +197,8 @@ final class AutomationController: AutomationControlling {
             try? surfaceDescriptor(
                 hostSessionID: session.id,
                 callerHostSessionID: resolved.entry.hostSessionID,
-                hostTerminalState: resolved.hostTerminalState
+                hostTerminalState: resolved.hostTerminalState,
+                capabilities: resolved.entry.capabilities
             )
         }
     }
@@ -175,7 +206,8 @@ final class AutomationController: AutomationControlling {
     private func surfaceDescriptor(
         hostSessionID: UUID,
         callerHostSessionID: UUID,
-        hostTerminalState: HostTerminalStateStore
+        hostTerminalState: HostTerminalStateStore,
+        capabilities: [AutomationCapability]
     ) throws -> AutomationSurfaceDescriptor {
         let session: HostTerminalSession?
         if let primaryID = hostTerminalState.primarySessionID(containing: hostSessionID),
@@ -208,7 +240,8 @@ final class AutomationController: AutomationControlling {
             cwd: session.directoryPath,
             isCaller: session.id == callerHostSessionID,
             isActive: session.id == hostTerminalState.activeSessionID,
-            isVisible: isVisible
+            isVisible: isVisible,
+            capabilities: capabilities
         )
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -85,11 +85,9 @@ final class AutomationController: AutomationControlling {
         }
 
         let layout = HostTerminalStateStore.SplitPaneLayout(automationDirection: direction)
-        let existingSplit = resolved.hostTerminalState.splitSession(for: primarySessionID)
-        let existingLayout = resolved.hostTerminalState.splitLayout(for: primarySessionID)
         guard
-            let splitSession = resolved.hostTerminalState.ensureSplit(
-                forPrimarySessionID: primarySessionID,
+            let splitSession = resolved.hostTerminalState.splitFocusedTile(
+                inTabContaining: primarySessionID,
                 preferredLayout: layout
             )
         else {
@@ -99,20 +97,10 @@ final class AutomationController: AutomationControlling {
         DispatchQueue.main.asyncAfter(deadline: .now() + GhosttyTerminalIntentRouter.splitFocusDelay) {
             self.focusTerminal(splitSession.id)
         }
-        let createdSurfaceID = existingSplit == nil ? splitSession.id.uuidString : nil
-        let reason: String?
-        if existingSplit == nil {
-            reason = nil
-        } else if existingLayout != layout {
-            reason = "relayout"
-        } else {
-            reason = "already_split"
-        }
         return AutomationMutationResult(
             changed: true,
             focusedSurfaceID: splitSession.id.uuidString,
-            createdSurfaceID: createdSurfaceID,
-            reason: reason
+            createdSurfaceID: splitSession.id.uuidString
         )
     }
 
@@ -189,9 +177,7 @@ final class AutomationController: AutomationControlling {
         }
 
         var sessions = resolved.hostTerminalState.sessions(inScope: primarySession.key)
-        if let split = resolved.hostTerminalState.splitSession(for: primaryID) {
-            sessions.append(split)
-        }
+        sessions.append(contentsOf: resolved.hostTerminalState.splitSessions(forPrimarySessionID: primaryID))
 
         return sessions.compactMap { session in
             try? surfaceDescriptor(
@@ -215,8 +201,9 @@ final class AutomationController: AutomationControlling {
         {
             session = hostTerminalState.sessions.first { $0.id == hostSessionID }
         } else if let primaryID = hostTerminalState.primarySessionID(containing: hostSessionID),
-            let split = hostTerminalState.splitSession(for: primaryID),
-            split.id == hostSessionID
+            let split = hostTerminalState.splitSessions(forPrimarySessionID: primaryID).first(where: {
+                $0.id == hostSessionID
+            })
         {
             session = split
         } else {

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -1,0 +1,248 @@
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+final class AutomationController: AutomationControlling {
+    private let handleRegistry: AutomationHandleRegistry
+    private weak var hostTerminalState: HostTerminalStateStore?
+    private var focusTerminal: @MainActor (UUID) -> Void
+    private var requestCloseTerminal: @MainActor (UUID) -> Void
+
+    init(
+        handleRegistry: AutomationHandleRegistry,
+        hostTerminalState: HostTerminalStateStore,
+        focusTerminal: @escaping @MainActor (UUID) -> Void,
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+    ) {
+        self.handleRegistry = handleRegistry
+        self.hostTerminalState = hostTerminalState
+        self.focusTerminal = focusTerminal
+        self.requestCloseTerminal = requestCloseTerminal
+    }
+
+    func update(
+        hostTerminalState: HostTerminalStateStore,
+        focusTerminal: @escaping @MainActor (UUID) -> Void,
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+    ) {
+        self.hostTerminalState = hostTerminalState
+        self.focusTerminal = focusTerminal
+        self.requestCloseTerminal = requestCloseTerminal
+    }
+
+    func automationContext(for handle: String) throws -> AutomationContextResult {
+        let resolved = try resolve(handle)
+        return try context(for: resolved, handle: handle)
+    }
+
+    func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult {
+        let resolved = try resolve(handle)
+        return AutomationSurfacesResult(surfaces: surfaceDescriptors(for: resolved))
+    }
+
+    func automationFocusTile(
+        for handle: String,
+        direction: AutomationTileFocusDirection
+    ) throws -> AutomationMutationResult {
+        let resolved = try resolve(handle)
+        let focusDirection = GhosttyAppManager.SplitFocusDirection(automationDirection: direction)
+        guard
+            let targetSessionID = resolved.hostTerminalState.splitFocusTarget(
+                from: resolved.entry.hostSessionID,
+                direction: focusDirection
+            )
+        else {
+            return AutomationMutationResult(changed: false, reason: "no_neighbor")
+        }
+
+        focusTerminal(targetSessionID)
+        return AutomationMutationResult(
+            changed: true,
+            focusedSurfaceID: targetSessionID.uuidString
+        )
+    }
+
+    func automationSplitTile(
+        for handle: String,
+        direction: AutomationTileSplitDirection
+    ) throws -> AutomationMutationResult {
+        let resolved = try resolve(handle)
+        guard
+            let primarySessionID = resolved.hostTerminalState.activatePrimarySession(
+                containing: resolved.entry.hostSessionID
+            )
+        else {
+            throw AutomationServiceError(.staleHandle, "The automation handle no longer maps to a live terminal tile.")
+        }
+
+        let layout = HostTerminalStateStore.SplitPaneLayout(automationDirection: direction)
+        guard
+            let splitSession = resolved.hostTerminalState.ensureSplit(
+                forPrimarySessionID: primarySessionID,
+                preferredLayout: layout
+            )
+        else {
+            throw AutomationServiceError(.unsupported, "No active terminal tile is available to split.")
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + GhosttyTerminalIntentRouter.splitFocusDelay) {
+            self.focusTerminal(splitSession.id)
+        }
+        return AutomationMutationResult(
+            changed: true,
+            focusedSurfaceID: splitSession.id.uuidString,
+            createdSurfaceID: splitSession.id.uuidString
+        )
+    }
+
+    func automationCloseTile(for handle: String) throws -> AutomationMutationResult {
+        let resolved = try resolve(handle)
+        requestCloseTerminal(resolved.entry.hostSessionID)
+        return AutomationMutationResult(
+            changed: true,
+            closedSurfaceID: resolved.entry.hostSessionID.uuidString
+        )
+    }
+
+    private struct ResolvedHandle {
+        let entry: AutomationHandleRegistry.Entry
+        let hostTerminalState: HostTerminalStateStore
+    }
+
+    private func resolve(_ handle: String) throws -> ResolvedHandle {
+        guard let hostTerminalState else {
+            throw AutomationServiceError(
+                .unsupported, "No WorkSpaces window is currently attached to the Automation API.")
+        }
+        guard let entry = handleRegistry.resolve(handle) else {
+            throw AutomationServiceError(.staleHandle, "The automation handle is missing or stale.")
+        }
+        guard hostTerminalState.primarySessionID(containing: entry.hostSessionID) != nil else {
+            handleRegistry.remove(hostSessionID: entry.hostSessionID)
+            throw AutomationServiceError(.staleHandle, "The automation handle no longer maps to a live terminal tile.")
+        }
+        return ResolvedHandle(entry: entry, hostTerminalState: hostTerminalState)
+    }
+
+    private func context(
+        for resolved: ResolvedHandle,
+        handle: String
+    ) throws -> AutomationContextResult {
+        let surface = try surfaceDescriptor(
+            hostSessionID: resolved.entry.hostSessionID,
+            callerHostSessionID: resolved.entry.hostSessionID,
+            hostTerminalState: resolved.hostTerminalState
+        )
+        let primaryID = resolved.hostTerminalState.primarySessionID(containing: resolved.entry.hostSessionID)
+        let primarySession = primaryID.flatMap { id in
+            resolved.hostTerminalState.sessions.first { $0.id == id }
+        }
+        let scope = AutomationScopeDescriptor(
+            app: resolved.entry.appScopeID,
+            window: resolved.entry.windowScopeID,
+            scopeKey: primarySession?.key.debugDescription,
+            primaryHostSessionID: primaryID
+        )
+        return AutomationContextResult(
+            handle: handle,
+            surface: surface,
+            scope: scope
+        )
+    }
+
+    private func surfaceDescriptors(for resolved: ResolvedHandle) -> [AutomationSurfaceDescriptor] {
+        guard
+            let primaryID = resolved.hostTerminalState.primarySessionID(containing: resolved.entry.hostSessionID),
+            let primarySession = resolved.hostTerminalState.sessions.first(where: { $0.id == primaryID })
+        else {
+            return []
+        }
+
+        var sessions = resolved.hostTerminalState.sessions(inScope: primarySession.key)
+        if let split = resolved.hostTerminalState.splitSession(for: primaryID) {
+            sessions.append(split)
+        }
+
+        return sessions.compactMap { session in
+            try? surfaceDescriptor(
+                hostSessionID: session.id,
+                callerHostSessionID: resolved.entry.hostSessionID,
+                hostTerminalState: resolved.hostTerminalState
+            )
+        }
+    }
+
+    private func surfaceDescriptor(
+        hostSessionID: UUID,
+        callerHostSessionID: UUID,
+        hostTerminalState: HostTerminalStateStore
+    ) throws -> AutomationSurfaceDescriptor {
+        let session: HostTerminalSession?
+        if let primaryID = hostTerminalState.primarySessionID(containing: hostSessionID),
+            primaryID == hostSessionID
+        {
+            session = hostTerminalState.sessions.first { $0.id == hostSessionID }
+        } else if let primaryID = hostTerminalState.primarySessionID(containing: hostSessionID),
+            let split = hostTerminalState.splitSession(for: primaryID),
+            split.id == hostSessionID
+        {
+            session = split
+        } else {
+            session = nil
+        }
+
+        guard let session else {
+            throw AutomationServiceError(.staleHandle, "The terminal surface no longer exists.")
+        }
+
+        let tileID = hostTerminalState.automationTileIDString(for: session.id)
+        let primaryID = hostTerminalState.primarySessionID(containing: session.id)
+        let isVisible = primaryID == hostTerminalState.activeSessionID
+        return AutomationSurfaceDescriptor(
+            surfaceID: session.id.uuidString,
+            tileID: tileID,
+            kind: .terminal,
+            hostSessionID: session.id,
+            title: hostTerminalState.tabTitleOverride(for: session.id)
+                ?? hostTerminalState.surfaceStore.displayTitle(for: session),
+            cwd: session.directoryPath,
+            isCaller: session.id == callerHostSessionID,
+            isActive: session.id == hostTerminalState.activeSessionID,
+            isVisible: isVisible
+        )
+    }
+}
+
+extension GhosttyAppManager.SplitFocusDirection {
+    fileprivate init(automationDirection: AutomationTileFocusDirection) {
+        switch automationDirection {
+        case .left:
+            self = .left
+        case .right:
+            self = .right
+        case .up:
+            self = .up
+        case .down:
+            self = .down
+        case .next:
+            self = .next
+        case .previous:
+            self = .previous
+        }
+    }
+}
+
+extension HostTerminalStateStore.SplitPaneLayout {
+    fileprivate init(automationDirection: AutomationTileSplitDirection) {
+        switch automationDirection {
+        case .left:
+            self.init(axis: .leadingTrailing, splitBeforePrimary: true)
+        case .right:
+            self = .defaultTrailing
+        case .up:
+            self.init(axis: .topBottom, splitBeforePrimary: true)
+        case .down:
+            self.init(axis: .topBottom, splitBeforePrimary: false)
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -708,6 +708,7 @@ struct ContentView: View {
                 mainSelectionCoordinator.rebuildCachesIfNeeded(
                     repos: repos, webSources: webSources, normalizePath: normalizePath
                 )
+                configureAutomationIntegration()
                 ensureInitialHostSession()
                 prewarmPerfTerminalSurfacesIfNeeded()
                 resolveSurfaceLifecycle()
@@ -1964,6 +1965,19 @@ struct ContentView: View {
         }
         terminal.requestClose()
         return true
+    }
+
+    @MainActor
+    private func configureAutomationIntegration() {
+        AutomationIntegrationLifecycle.shared.configure(
+            hostTerminalState: hostTerminalState,
+            focusTerminal: { sessionID in
+                focusTerminalTab(sessionID)
+            },
+            requestCloseTerminal: { sessionID in
+                requestCloseTerminalTabs([sessionID])
+            }
+        )
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -708,19 +708,17 @@ struct ContentView: View {
                 mainSelectionCoordinator.rebuildCachesIfNeeded(
                     repos: repos, webSources: webSources, normalizePath: normalizePath
                 )
-                configureAutomationIntegration()
-                ensureInitialHostSession()
-                prewarmPerfTerminalSurfacesIfNeeded()
-                resolveSurfaceLifecycle()
-                applyDiagnosticsFixtureIfNeeded()
-                applySessionSwitcherFixtureIfNeeded()
-                pruneRightPaneState()
-                syncOpenInEditorShortcutRouting()
-                refreshWorkspaceStatusAggregator()
                 Task { @MainActor in
+                    await configureAutomationIntegration()
+                    ensureInitialHostSession()
+                    prewarmPerfTerminalSurfacesIfNeeded()
+                    resolveSurfaceLifecycle()
+                    applyDiagnosticsFixtureIfNeeded()
+                    applySessionSwitcherFixtureIfNeeded()
+                    pruneRightPaneState()
+                    syncOpenInEditorShortcutRouting()
+                    refreshWorkspaceStatusAggregator()
                     await hostLumeSmokeAutomation.noteLaunchReady()
-                }
-                Task { @MainActor in
                     await desktopUISmokeAutomation.noteLaunchReady()
                 }
                 notificationCoordinator.loadStoredAuth()
@@ -1968,8 +1966,8 @@ struct ContentView: View {
     }
 
     @MainActor
-    private func configureAutomationIntegration() {
-        AutomationIntegrationLifecycle.shared.configure(
+    private func configureAutomationIntegration() async {
+        await AutomationIntegrationLifecycle.shared.configure(
             hostTerminalState: hostTerminalState,
             focusTerminal: { sessionID in
                 focusTerminalTab(sessionID)

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -462,10 +462,22 @@ final class HostTerminalStateStore: ObservableObject {
     /// is registered with the agent subsystems and holds at any depth (each extra pane is a leaf here).
     private var derivedSplitSessions: [HostTerminalSession] {
         treesByPrimaryID.flatMap { primarySessionID, tree -> [HostTerminalSession] in
-            guard let primaryTile = tileIDBySessionID[primarySessionID] else { return [] }
-            return tree.leafIDs.compactMap { tileID in
-                tileID == primaryTile ? nil : sessionByTileID[tileID]
-            }
+            splitSessions(in: tree, primarySessionID: primarySessionID)
+        }
+    }
+
+    /// Live split sessions for a tab, including depth ≥ 2 panes. This is the public read path for
+    /// app controllers that need every non-primary surface; the legacy `splitSession` projection above
+    /// intentionally remains depth-1 only.
+    func splitSessions(forPrimarySessionID primarySessionID: UUID?) -> [HostTerminalSession] {
+        guard let primarySessionID, let tree = treesByPrimaryID[primarySessionID] else { return [] }
+        return splitSessions(in: tree, primarySessionID: primarySessionID)
+    }
+
+    private func splitSessions(in tree: TileTreeState, primarySessionID: UUID) -> [HostTerminalSession] {
+        guard let primaryTile = tileIDBySessionID[primarySessionID] else { return [] }
+        return tree.leafIDs.compactMap { tileID in
+            tileID == primaryTile ? nil : sessionByTileID[tileID]
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -49,6 +49,11 @@ final class HostTerminalStateStore: ObservableObject {
     private var sessionByTileID: [TileID: HostTerminalSession] = [:]
     private var tileIDBySessionID: [UUID: TileID] = [:]
     private var primaryIDBySplitSessionID: [UUID: UUID] = [:]
+    private var automationTileIDBySessionID: [UUID: TileID] = [:]
+    private var automationHandleRegistry: AutomationHandleRegistry?
+    private var automationSocketPath: String?
+    private let automationWindowScopeID = UUID().uuidString
+    private let automationAppScopeID = "workspaces.local"
     private let tileTreeReducer = TileTreeReducer()
 
     let surfaceStore = HostTerminalSurfaceStore()
@@ -90,6 +95,9 @@ final class HostTerminalStateStore: ObservableObject {
         self.localStateStore = localStateStore
         self.lastCommandStatusRegistry = lastCommandStatusRegistry
         self.surfaceStore.hooksSocketPath = hooksSocketPath
+        self.surfaceStore.automationEnvironmentProvider = { [weak self] session in
+            self?.automationEnvironment(for: session)
+        }
         guard self.agentSessionRegistry !== agentSessionRegistry else {
             syncRegistry()
             return
@@ -105,6 +113,15 @@ final class HostTerminalStateStore: ObservableObject {
         AgentOSCRouter.shared.attach(registry: agentSessionRegistry) { surfaceView in
             store.sessionID(for: surfaceView)
         }
+    }
+
+    func configureAutomation(handleRegistry: AutomationHandleRegistry?, socketPath: String?) {
+        automationHandleRegistry = handleRegistry
+        automationSocketPath = socketPath
+        surfaceStore.automationEnvironmentProvider = { [weak self] session in
+            self?.automationEnvironment(for: session)
+        }
+        syncAutomationRegistry()
     }
 
     var hasSessions: Bool {
@@ -486,7 +503,7 @@ final class HostTerminalStateStore: ObservableObject {
         }
 
         let existingTree = treesByPrimaryID[primarySessionID]
-        let primaryTile = tileIDBySessionID[primarySessionID] ?? TileID()
+        let primaryTile = tileIDBySessionID[primarySessionID] ?? automationTileID(for: primarySessionID)
         let seedTree = existingTree ?? TileTreeState(singleTile: primaryTile)
         // Split the source pane's tile when it is bound; a freshly seeded tab has only the primary,
         // whose tile is `seedTree.focusedTileID`.
@@ -520,6 +537,7 @@ final class HostTerminalStateStore: ObservableObject {
         treesByPrimaryID[primarySessionID] = grownTree
 
         syncRegistry()
+        syncAutomationRegistry()
         objectWillChange.send()
         return splitSession
     }
@@ -675,6 +693,7 @@ final class HostTerminalStateStore: ObservableObject {
         }
 
         syncRegistry()
+        syncAutomationRegistry()
 
         for session in sessions {
             recordTerminalSession(
@@ -719,8 +738,31 @@ final class HostTerminalStateStore: ObservableObject {
             registry.deregister(hostSessionID: sessionID)
             lastCommandStatusRegistry?.clear(terminalSessionID: sessionID)
             recordTerminalSessionEnded(sessionID)
+            automationHandleRegistry?.remove(hostSessionID: sessionID)
+            automationTileIDBySessionID.removeValue(forKey: sessionID)
         }
         registeredAgentSessionIDs.subtract(removed)
+    }
+
+    private func syncAutomationRegistry() {
+        guard let automationHandleRegistry, automationSocketPath != nil else { return }
+        let allSessions = coordinator.sessions + derivedSplitSessions
+        let liveIDs = Set(allSessions.map(\.id))
+
+        for session in allSessions {
+            _ = automationHandleRegistry.upsert(
+                hostSessionID: session.id,
+                tileID: automationTileID(for: session.id),
+                surfaceKind: .terminal,
+                windowScopeID: automationWindowScopeID,
+                appScopeID: automationAppScopeID
+            )
+        }
+
+        for staleID in Array(automationTileIDBySessionID.keys) where !liveIDs.contains(staleID) {
+            automationHandleRegistry.remove(hostSessionID: staleID)
+            automationTileIDBySessionID.removeValue(forKey: staleID)
+        }
     }
 
     /// Collapses the split for `primarySessionID` (process-exit / reconcile path): drops its tree and
@@ -799,6 +841,10 @@ final class HostTerminalStateStore: ObservableObject {
     /// Deregisters a session from the agent subsystems if it was registered. Shared by the
     /// collapse and retire teardown paths, which differ only in their surface-store call.
     private func deregisterTerminalSession(_ sessionID: UUID) {
+        defer {
+            automationHandleRegistry?.remove(hostSessionID: sessionID)
+            automationTileIDBySessionID.removeValue(forKey: sessionID)
+        }
         guard registeredAgentSessionIDs.contains(sessionID) else { return }
         agentSessionRegistry?.deregister(hostSessionID: sessionID)
         lastCommandStatusRegistry?.clear(terminalSessionID: sessionID)
@@ -830,6 +876,35 @@ final class HostTerminalStateStore: ObservableObject {
         Task {
             try? await localStateStore.markTerminalSessionEnded(hostSessionID: sessionID)
         }
+    }
+
+    func automationEnvironment(for session: HostTerminalSession) -> AutomationTerminalEnvironment? {
+        guard let automationHandleRegistry, let automationSocketPath else { return nil }
+        let entry = automationHandleRegistry.upsert(
+            hostSessionID: session.id,
+            tileID: automationTileID(for: session.id),
+            surfaceKind: .terminal,
+            windowScopeID: automationWindowScopeID,
+            appScopeID: automationAppScopeID
+        )
+        return AutomationTerminalEnvironment(socketPath: automationSocketPath, handle: entry.handle)
+    }
+
+    func automationTileIDString(for sessionID: UUID) -> String? {
+        automationTileID(for: sessionID).rawValue.uuidString
+    }
+
+    private func automationTileID(for sessionID: UUID) -> TileID {
+        if let tileID = tileIDBySessionID[sessionID] {
+            automationTileIDBySessionID[sessionID] = tileID
+            return tileID
+        }
+        if let tileID = automationTileIDBySessionID[sessionID] {
+            return tileID
+        }
+        let tileID = TileID()
+        automationTileIDBySessionID[sessionID] = tileID
+        return tileID
     }
 
     private func resolvedPrimarySessionID(_ sourceSessionID: UUID?) -> UUID? {

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -36,6 +36,9 @@ private final class CLIApp {
         "status",
         "recent",
         "doctor",
+        "automation",
+        "surface",
+        "tile",
     ]
 
     private let stateStore = CLIStateStore()
@@ -74,6 +77,12 @@ private final class CLIApp {
             return runRecent(state: state)
         case "doctor":
             return try await runDoctor(state: state)
+        case "automation":
+            return try runAutomation(arguments: tail)
+        case "surface":
+            return try runSurface(arguments: tail)
+        case "tile":
+            return try runTile(arguments: tail)
         default:
             throw CLIError("Unknown command '\(command)'. Run 'workspaces help'.")
         }
@@ -496,6 +505,186 @@ private final class CLIApp {
         print("[INFO] tracked repos: \(state.repos.count)")
         print("[INFO] tracked workspaces: \(state.workspaces.count)")
         return failures == 0 ? 0 : 1
+    }
+
+    private func runAutomation(arguments: [String]) throws -> Int32 {
+        guard let subcommand = arguments.first else {
+            throw CLIError("Missing automation subcommand. Expected: health, context")
+        }
+
+        switch subcommand {
+        case "health":
+            let result: AutomationHealthResult = try performAutomationRequest(
+                method: "GET",
+                path: "/v1/health",
+                requiresHandle: false
+            )
+            if arguments.dropFirst().contains("--json") {
+                print(try AutomationCLIResultPrinter.resultJSON(result))
+            } else {
+                print(result.status.uppercased())
+            }
+            return 0
+
+        case "context":
+            let json = try requireJSONFlag(
+                arguments: Array(arguments.dropFirst()), usage: "workspaces automation context --json")
+            let result: AutomationContextResult = try performAutomationRequest(
+                method: "GET",
+                path: "/v1/context",
+                requiresHandle: true
+            )
+            if json {
+                print(try AutomationCLIResultPrinter.resultJSON(result))
+            }
+            return 0
+
+        default:
+            throw CLIError("Unknown automation subcommand '\(subcommand)'. Expected: health, context")
+        }
+    }
+
+    private func runSurface(arguments: [String]) throws -> Int32 {
+        guard arguments.first == "list" else {
+            throw CLIError("Usage: workspaces surface list --json")
+        }
+        let json = try requireJSONFlag(arguments: Array(arguments.dropFirst()), usage: "workspaces surface list --json")
+        let result: AutomationSurfacesResult = try performAutomationRequest(
+            method: "GET",
+            path: "/v1/surfaces",
+            requiresHandle: true
+        )
+        if json {
+            print(try AutomationCLIResultPrinter.resultJSON(result))
+        }
+        return 0
+    }
+
+    private func runTile(arguments: [String]) throws -> Int32 {
+        guard let subcommand = arguments.first else {
+            throw CLIError("Missing tile subcommand. Expected: focus, split, close")
+        }
+        let tail = Array(arguments.dropFirst())
+
+        switch subcommand {
+        case "focus":
+            let direction = try singleDirectionFlag(
+                AutomationTileFocusDirection.self,
+                arguments: tail,
+                usage: "workspaces tile focus --left|--right|--up|--down|--next|--previous"
+            )
+            let body = try directionBody(direction.rawValue)
+            _ = try performAutomationRequest(
+                AutomationMutationResult.self,
+                method: "POST",
+                path: "/v1/tile/focus",
+                requiresHandle: true,
+                body: body
+            )
+            return 0
+
+        case "split":
+            let direction = try singleDirectionFlag(
+                AutomationTileSplitDirection.self,
+                arguments: tail,
+                usage: "workspaces tile split --left|--right|--up|--down"
+            )
+            let body = try directionBody(direction.rawValue)
+            _ = try performAutomationRequest(
+                AutomationMutationResult.self,
+                method: "POST",
+                path: "/v1/tile/split",
+                requiresHandle: true,
+                body: body
+            )
+            return 0
+
+        case "close":
+            guard tail.isEmpty else {
+                throw CLIError("Usage: workspaces tile close")
+            }
+            _ = try performAutomationRequest(
+                AutomationMutationResult.self,
+                method: "POST",
+                path: "/v1/tile/close",
+                requiresHandle: true
+            )
+            return 0
+
+        default:
+            throw CLIError("Unknown tile subcommand '\(subcommand)'. Expected: focus, split, close")
+        }
+    }
+
+    private func performAutomationRequest<Result>(
+        _ type: Result.Type = Result.self,
+        method: String,
+        path: String,
+        requiresHandle: Bool,
+        body: Data = Data()
+    ) throws -> Result where Result: Codable & Sendable & Equatable {
+        let client = try automationClient()
+        let handle = try automationHandle(required: requiresHandle)
+        let response = try client.request(
+            method: method,
+            path: path,
+            handle: handle,
+            body: body
+        )
+        do {
+            return try AutomationCLIResultPrinter.decodeEnvelope(type, from: response)
+        } catch let error as AutomationServiceError {
+            throw CLIError(
+                "automation request failed: \(error.response.code.rawValue): \(error.response.message)"
+            )
+        }
+    }
+
+    private func automationClient() throws -> AutomationSocketClient {
+        let environment = ProcessInfo.processInfo.environment
+        let socketPath =
+            environment[AutomationAPI.socketEnvironmentKey]
+            ?? AutomationListener.defaultSocketURL(bundleIdentifier: Self.appBundleIdentifier).path
+        return AutomationSocketClient(socketPath: socketPath)
+    }
+
+    private func automationHandle(required: Bool) throws -> String? {
+        guard required else { return nil }
+        guard
+            let handle = ProcessInfo.processInfo.environment[AutomationAPI.handleEnvironmentKey],
+            !handle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw CLIError(
+                "\(AutomationAPI.handleEnvironmentKey) is missing. Run this command from a WorkSpaces terminal tile."
+            )
+        }
+        return handle
+    }
+
+    private func requireJSONFlag(arguments: [String], usage: String) throws -> Bool {
+        guard arguments == ["--json"] else {
+            throw CLIError("Usage: \(usage)")
+        }
+        return true
+    }
+
+    private func singleDirectionFlag<Direction>(
+        _ type: Direction.Type,
+        arguments: [String],
+        usage: String
+    ) throws -> Direction where Direction: CaseIterable & RawRepresentable, Direction.RawValue == String {
+        guard arguments.count == 1, let rawFlag = arguments.first, rawFlag.hasPrefix("--") else {
+            throw CLIError("Usage: \(usage)")
+        }
+        let rawValue = String(rawFlag.dropFirst(2))
+        guard let direction = Direction(rawValue: rawValue) else {
+            throw CLIError("Usage: \(usage)")
+        }
+        return direction
+    }
+
+    private func directionBody(_ direction: String) throws -> Data {
+        try JSONSerialization.data(withJSONObject: ["direction": direction], options: [.sortedKeys])
     }
 
     private func printGitStatus(for workspace: WorkspaceRecord, workspaceURL: URL) async throws {
@@ -938,6 +1127,12 @@ private func printHelp() {
           workspaces status <workspace> [--watch] [--interval <seconds>]
           workspaces recent
           workspaces doctor
+          workspaces automation health
+          workspaces automation context --json
+          workspaces surface list --json
+          workspaces tile focus --left|--right|--up|--down|--next|--previous
+          workspaces tile split --left|--right|--up|--down
+          workspaces tile close
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -1,0 +1,277 @@
+import Foundation
+
+public enum AutomationAPI {
+    public static let version = 1
+    public static let handleHeader = "x-workspaces-automation-handle"
+    public static let socketEnvironmentKey = "WORKSPACES_AUTOMATION_SOCKET"
+    public static let handleEnvironmentKey = "WORKSPACES_AUTOMATION_HANDLE"
+
+    public static let v1Capabilities = [
+        AutomationCapability.contextRead,
+        .surfacesRead,
+        .tileFocus,
+        .tileSplit,
+        .tileClose,
+    ]
+}
+
+public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equatable {
+    case contextRead = "context.read"
+    case surfacesRead = "surfaces.read"
+    case tileFocus = "tile.focus"
+    case tileSplit = "tile.split"
+    case tileClose = "tile.close"
+}
+
+public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
+    case terminal
+    case web
+}
+
+public enum AutomationTileFocusDirection: String, Codable, Sendable, CaseIterable, Equatable {
+    case left
+    case right
+    case up
+    case down
+    case next
+    case previous
+}
+
+public enum AutomationTileSplitDirection: String, Codable, Sendable, CaseIterable, Equatable {
+    case left
+    case right
+    case up
+    case down
+}
+
+public struct AutomationSystemDescriptor: Codable, Sendable, Equatable {
+    public let capabilities: [AutomationCapability]
+
+    public init(capabilities: [AutomationCapability] = AutomationAPI.v1Capabilities) {
+        self.capabilities = capabilities
+    }
+}
+
+public struct AutomationHealthResult: Codable, Sendable, Equatable {
+    public let status: String
+    public let system: AutomationSystemDescriptor
+
+    public init(status: String = "ok", system: AutomationSystemDescriptor = AutomationSystemDescriptor()) {
+        self.status = status
+        self.system = system
+    }
+}
+
+public struct AutomationScopeDescriptor: Codable, Sendable, Equatable {
+    public let app: String
+    public let window: String
+    public let scopeKey: String?
+    public let primaryHostSessionID: UUID?
+
+    public init(
+        app: String,
+        window: String,
+        scopeKey: String?,
+        primaryHostSessionID: UUID?
+    ) {
+        self.app = app
+        self.window = window
+        self.scopeKey = scopeKey
+        self.primaryHostSessionID = primaryHostSessionID
+    }
+}
+
+public struct AutomationSurfaceDescriptor: Codable, Sendable, Equatable {
+    public let surfaceID: String
+    public let tileID: String?
+    public let kind: AutomationSurfaceKind
+    public let hostSessionID: UUID?
+    public let title: String
+    public let cwd: String?
+    public let isCaller: Bool
+    public let isActive: Bool
+    public let isVisible: Bool
+    public let capabilities: [AutomationCapability]
+
+    public init(
+        surfaceID: String,
+        tileID: String?,
+        kind: AutomationSurfaceKind,
+        hostSessionID: UUID?,
+        title: String,
+        cwd: String?,
+        isCaller: Bool,
+        isActive: Bool,
+        isVisible: Bool,
+        capabilities: [AutomationCapability] = AutomationAPI.v1Capabilities
+    ) {
+        self.surfaceID = surfaceID
+        self.tileID = tileID
+        self.kind = kind
+        self.hostSessionID = hostSessionID
+        self.title = title
+        self.cwd = cwd
+        self.isCaller = isCaller
+        self.isActive = isActive
+        self.isVisible = isVisible
+        self.capabilities = capabilities
+    }
+}
+
+public struct AutomationContextResult: Codable, Sendable, Equatable {
+    public let handle: String
+    public let surface: AutomationSurfaceDescriptor
+    public let scope: AutomationScopeDescriptor
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        handle: String,
+        surface: AutomationSurfaceDescriptor,
+        scope: AutomationScopeDescriptor,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor()
+    ) {
+        self.handle = handle
+        self.surface = surface
+        self.scope = scope
+        self.system = system
+    }
+}
+
+public struct AutomationSurfacesResult: Codable, Sendable, Equatable {
+    public let surfaces: [AutomationSurfaceDescriptor]
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        surfaces: [AutomationSurfaceDescriptor],
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor()
+    ) {
+        self.surfaces = surfaces
+        self.system = system
+    }
+}
+
+public struct AutomationMutationResult: Codable, Sendable, Equatable {
+    public let changed: Bool
+    public let focusedSurfaceID: String?
+    public let createdSurfaceID: String?
+    public let closedSurfaceID: String?
+    public let reason: String?
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        changed: Bool,
+        focusedSurfaceID: String? = nil,
+        createdSurfaceID: String? = nil,
+        closedSurfaceID: String? = nil,
+        reason: String? = nil,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor()
+    ) {
+        self.changed = changed
+        self.focusedSurfaceID = focusedSurfaceID
+        self.createdSurfaceID = createdSurfaceID
+        self.closedSurfaceID = closedSurfaceID
+        self.reason = reason
+        self.system = system
+    }
+}
+
+public struct AutomationTerminalEnvironment: Sendable, Equatable {
+    public let socketPath: String
+    public let handle: String
+
+    public init(socketPath: String, handle: String) {
+        self.socketPath = socketPath
+        self.handle = handle
+    }
+}
+
+public struct AutomationResponseEnvelope<Result: Codable & Sendable>: Codable, Sendable, Equatable
+where Result: Equatable {
+    public let v: Int
+    public let ok: Bool
+    public let result: Result?
+    public let error: AutomationErrorResponse?
+
+    public init(result: Result) {
+        self.v = AutomationAPI.version
+        self.ok = true
+        self.result = result
+        self.error = nil
+    }
+
+    public init(error: AutomationErrorResponse) {
+        self.v = AutomationAPI.version
+        self.ok = false
+        self.result = nil
+        self.error = error
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(v, forKey: .v)
+        try container.encode(ok, forKey: .ok)
+        if let result {
+            try container.encode(result, forKey: .result)
+        }
+        if let error {
+            try container.encode(error, forKey: .error)
+        }
+    }
+}
+
+public struct AutomationEmptyResult: Codable, Sendable, Equatable {
+    public init() {}
+}
+
+public enum AutomationErrorCode: String, Codable, Sendable, Equatable {
+    case disabled
+    case missingHandle = "missing_handle"
+    case staleHandle = "stale_handle"
+    case invalidRequest = "invalid_request"
+    case malformedJSON = "malformed_json"
+    case routeNotFound = "route_not_found"
+    case methodNotAllowed = "method_not_allowed"
+    case unsupported
+    case internalError = "internal_error"
+}
+
+public struct AutomationErrorResponse: Codable, Sendable, Equatable, LocalizedError {
+    public let code: AutomationErrorCode
+    public let message: String
+
+    public init(code: AutomationErrorCode, message: String) {
+        self.code = code
+        self.message = message
+    }
+
+    public var errorDescription: String? {
+        "\(code.rawValue): \(message)"
+    }
+}
+
+public struct AutomationServiceError: Error, Sendable, Equatable {
+    public let response: AutomationErrorResponse
+
+    public init(_ code: AutomationErrorCode, _ message: String) {
+        self.response = AutomationErrorResponse(code: code, message: message)
+    }
+
+    public init(response: AutomationErrorResponse) {
+        self.response = response
+    }
+}
+
+@MainActor
+public protocol AutomationControlling: AnyObject, Sendable {
+    func automationContext(for handle: String) throws -> AutomationContextResult
+    func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
+    func automationFocusTile(
+        for handle: String,
+        direction: AutomationTileFocusDirection
+    ) throws -> AutomationMutationResult
+    func automationSplitTile(
+        for handle: String,
+        direction: AutomationTileSplitDirection
+    ) throws -> AutomationMutationResult
+    func automationCloseTile(for handle: String) throws -> AutomationMutationResult
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -119,18 +119,15 @@ public struct AutomationSurfaceDescriptor: Codable, Sendable, Equatable {
 }
 
 public struct AutomationContextResult: Codable, Sendable, Equatable {
-    public let handle: String
     public let surface: AutomationSurfaceDescriptor
     public let scope: AutomationScopeDescriptor
     public let system: AutomationSystemDescriptor
 
     public init(
-        handle: String,
         surface: AutomationSurfaceDescriptor,
         scope: AutomationScopeDescriptor,
         system: AutomationSystemDescriptor = AutomationSystemDescriptor()
     ) {
-        self.handle = handle
         self.surface = surface
         self.scope = scope
         self.system = system
@@ -225,6 +222,7 @@ public struct AutomationEmptyResult: Codable, Sendable, Equatable {
 
 public enum AutomationErrorCode: String, Codable, Sendable, Equatable {
     case disabled
+    case capabilityDenied = "capability_denied"
     case missingHandle = "missing_handle"
     case staleHandle = "stale_handle"
     case invalidRequest = "invalid_request"

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+public actor AutomationAuditLogger {
+    public struct Event: Codable, Sendable, Equatable {
+        public let timestamp: String
+        public let method: String
+        public let path: String
+        public let handlePresent: Bool
+        public let allowed: Bool
+        public let errorCode: AutomationErrorCode?
+
+        public init(
+            timestamp: String,
+            method: String,
+            path: String,
+            handlePresent: Bool,
+            allowed: Bool,
+            errorCode: AutomationErrorCode?
+        ) {
+            self.timestamp = timestamp
+            self.method = method
+            self.path = path
+            self.handlePresent = handlePresent
+            self.allowed = allowed
+            self.errorCode = errorCode
+        }
+    }
+
+    private let auditURL: URL
+    private let encoder = JSONEncoder()
+    private let timestampFormatter = ISO8601DateFormatter()
+
+    public init(auditURL: URL) {
+        self.auditURL = auditURL
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    public nonisolated static func defaultAuditURL(bundleIdentifier: String) -> URL {
+        let appSupport =
+            FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first ?? FileManager.default.temporaryDirectory
+        let dir = appSupport.appendingPathComponent(bundleIdentifier, isDirectory: true)
+        return dir.appendingPathComponent("automation-audit.jsonl", isDirectory: false)
+    }
+
+    public func record(method: String, path: String, headers: [String: String], responseBody: Data) {
+        let summary = (try? AutomationJSON.decoder.decode(AuditEnvelopeSummary.self, from: responseBody))
+        let event = Event(
+            timestamp: timestampFormatter.string(from: Date()),
+            method: method,
+            path: path,
+            handlePresent: headers[AutomationAPI.handleHeader]?.isEmpty == false,
+            allowed: summary?.ok == true,
+            errorCode: summary?.error?.code
+        )
+        guard let data = try? encoder.encode(event) else { return }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: auditURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if !FileManager.default.fileExists(atPath: auditURL.path) {
+                try Data().write(to: auditURL)
+            }
+            let handle = try FileHandle(forWritingTo: auditURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            try handle.write(contentsOf: Data("\n".utf8))
+        } catch {
+            NSLog("[AutomationAudit] append failed: %@", "\(error)")
+        }
+    }
+}
+
+private struct AuditEnvelopeSummary: Decodable {
+    let ok: Bool
+    let error: AutomationErrorResponse?
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum AutomationCLIResultPrinter {
+    public static func resultJSON<Result: Encodable>(_ result: Result) throws -> String {
+        let data = try AutomationJSON.prettyEncoder.encode(result)
+        return String(data: data, encoding: .utf8) ?? "{}"
+    }
+
+    public static func decodeEnvelope<Result: Codable & Sendable & Equatable>(
+        _ type: Result.Type,
+        from response: AutomationSocketClient.Response
+    ) throws -> Result {
+        let envelope = try AutomationJSON.decoder.decode(AutomationResponseEnvelope<Result>.self, from: response.body)
+        if envelope.ok, let result = envelope.result {
+            return result
+        }
+        let error =
+            envelope.error
+            ?? AutomationErrorResponse(code: .internalError, message: "Automation response did not include an error.")
+        throw AutomationServiceError(response: error)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -189,7 +189,7 @@ enum AutomationHTTPRouter {
 
     private static func httpStatus(for code: AutomationErrorCode) -> Int {
         switch code {
-        case .disabled:
+        case .disabled, .capabilityDenied:
             return 403
         case .missingHandle, .staleHandle:
             return 401

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -1,0 +1,240 @@
+import Foundation
+
+struct AutomationHTTPResult: Sendable {
+    let status: Int
+    let body: Data
+}
+
+enum AutomationHTTPRouter {
+    static func route(
+        _ request: HTTPRequest,
+        controller: any AutomationControlling,
+        enabled: Bool,
+        encoder: JSONEncoder = AutomationJSON.encoder
+    ) async -> AutomationHTTPResult {
+        do {
+            let result = try await routeResult(request, controller: controller, enabled: enabled)
+            return try success(result, encoder: encoder)
+        } catch let error as AutomationServiceError {
+            return failure(error.response, status: httpStatus(for: error.response.code), encoder: encoder)
+        } catch {
+            return failure(
+                AutomationErrorResponse(code: .internalError, message: "\(error)"),
+                status: 500,
+                encoder: encoder
+            )
+        }
+    }
+
+    private static func routeResult(
+        _ request: HTTPRequest,
+        controller: any AutomationControlling,
+        enabled: Bool
+    ) async throws -> any CodableSendableEquatable {
+        let method = request.method.uppercased()
+        switch (method, request.path) {
+        case ("GET", "/v1/health"):
+            return AutomationHealthResult()
+
+        case (_, "/v1/health"):
+            throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/health.")
+
+        default:
+            break
+        }
+
+        guard enabled else {
+            throw AutomationServiceError(
+                .disabled,
+                "The WorkSpaces Automation API is disabled. Enable the Automation API experiment and restart WorkSpaces."
+            )
+        }
+
+        let handle = try scopedHandle(from: request)
+
+        switch (method, request.path) {
+        case ("GET", "/v1/context"):
+            return try await controller.automationContext(for: handle)
+
+        case ("GET", "/v1/surfaces"):
+            return try await controller.automationSurfaces(for: handle)
+
+        case ("POST", "/v1/tile/focus"):
+            let direction = try decodeDirection(
+                AutomationTileFocusDirection.self,
+                from: request.body,
+                allowEmptyBody: false
+            )
+            return try await controller.automationFocusTile(for: handle, direction: direction)
+
+        case ("POST", "/v1/tile/split"):
+            let direction = try decodeDirection(
+                AutomationTileSplitDirection.self,
+                from: request.body,
+                allowEmptyBody: false
+            )
+            return try await controller.automationSplitTile(for: handle, direction: direction)
+
+        case ("POST", "/v1/tile/close"):
+            try rejectCallerSuppliedTargetIDs(in: request.body, allowEmptyBody: true)
+            return try await controller.automationCloseTile(for: handle)
+
+        case (_, "/v1/context"):
+            throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/context.")
+        case (_, "/v1/surfaces"):
+            throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/surfaces.")
+        case (_, "/v1/tile/focus"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
+        case (_, "/v1/tile/split"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/split.")
+        case (_, "/v1/tile/close"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/close.")
+        default:
+            throw AutomationServiceError(.routeNotFound, "Unsupported automation route: \(method) \(request.path)")
+        }
+    }
+
+    private static func scopedHandle(from request: HTTPRequest) throws -> String {
+        guard
+            let handle = request.headers[AutomationAPI.handleHeader]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !handle.isEmpty
+        else {
+            throw AutomationServiceError(
+                .missingHandle,
+                "Missing \(AutomationAPI.handleHeader) header. Run this command from a WorkSpaces terminal tile."
+            )
+        }
+        return handle
+    }
+
+    private static func decodeDirection<Direction>(
+        _ type: Direction.Type,
+        from body: Data,
+        allowEmptyBody: Bool
+    ) throws -> Direction where Direction: RawRepresentable, Direction.RawValue == String {
+        try rejectCallerSuppliedTargetIDs(in: body, allowEmptyBody: allowEmptyBody)
+        guard !body.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request body must include a direction.")
+        }
+        guard
+            let object = try JSONSerialization.jsonObject(with: body) as? [String: Any],
+            let rawDirection = object["direction"] as? String
+        else {
+            throw AutomationServiceError(.invalidRequest, "Request body must be JSON with a string direction.")
+        }
+        guard let direction = Direction(rawValue: rawDirection) else {
+            throw AutomationServiceError(.invalidRequest, "Unsupported direction: \(rawDirection).")
+        }
+        return direction
+    }
+
+    private static func rejectCallerSuppliedTargetIDs(in body: Data, allowEmptyBody: Bool) throws {
+        guard !body.isEmpty else {
+            if allowEmptyBody { return }
+            throw AutomationServiceError(.invalidRequest, "Request body is required.")
+        }
+
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: body)
+        } catch {
+            throw AutomationServiceError(.malformedJSON, "Request body is not valid JSON.")
+        }
+
+        guard let dictionary = object as? [String: Any] else {
+            throw AutomationServiceError(.invalidRequest, "Request body must be a JSON object.")
+        }
+
+        let forbiddenKeys = [
+            "tileID",
+            "tileId",
+            "surfaceID",
+            "surfaceId",
+            "targetTileID",
+            "targetTileId",
+            "targetSurfaceID",
+            "targetSurfaceId",
+            "hostSessionID",
+            "hostSessionId",
+        ]
+        if let forbidden = dictionary.keys.first(where: { forbiddenKeys.contains($0) }) {
+            throw AutomationServiceError(
+                .invalidRequest,
+                "Scoped operations resolve the caller from \(AutomationAPI.handleEnvironmentKey); caller-supplied '\(forbidden)' is not accepted."
+            )
+        }
+    }
+
+    private static func success(
+        _ result: any CodableSendableEquatable,
+        encoder: JSONEncoder
+    ) throws -> AutomationHTTPResult {
+        let data = try result.encodeSuccessEnvelope(encoder: encoder)
+        return AutomationHTTPResult(status: 200, body: data)
+    }
+
+    private static func failure(
+        _ error: AutomationErrorResponse,
+        status: Int,
+        encoder: JSONEncoder
+    ) -> AutomationHTTPResult {
+        let envelope = AutomationResponseEnvelope<AutomationEmptyResult>(error: error)
+        let data =
+            (try? encoder.encode(envelope))
+            ?? Data(
+                "{\"v\":1,\"ok\":false,\"error\":{\"code\":\"internal_error\",\"message\":\"Encoding failed.\"}}".utf8)
+        return AutomationHTTPResult(status: status, body: data)
+    }
+
+    private static func httpStatus(for code: AutomationErrorCode) -> Int {
+        switch code {
+        case .disabled:
+            return 403
+        case .missingHandle, .staleHandle:
+            return 401
+        case .invalidRequest, .malformedJSON:
+            return 400
+        case .methodNotAllowed:
+            return 405
+        case .routeNotFound:
+            return 404
+        case .unsupported:
+            return 409
+        case .internalError:
+            return 500
+        }
+    }
+}
+
+protocol CodableSendableEquatable: Codable, Sendable, Equatable {
+    func encodeSuccessEnvelope(encoder: JSONEncoder) throws -> Data
+}
+
+extension CodableSendableEquatable {
+    func encodeSuccessEnvelope(encoder: JSONEncoder) throws -> Data {
+        try encoder.encode(AutomationResponseEnvelope(result: self))
+    }
+}
+
+extension AutomationHealthResult: CodableSendableEquatable {}
+extension AutomationContextResult: CodableSendableEquatable {}
+extension AutomationSurfacesResult: CodableSendableEquatable {}
+extension AutomationMutationResult: CodableSendableEquatable {}
+extension AutomationEmptyResult: CodableSendableEquatable {}
+
+enum AutomationJSON {
+    static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    static var prettyEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+
+    static let decoder = JSONDecoder()
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+@MainActor
+public final class AutomationHandleRegistry {
+    public struct Entry: Sendable, Equatable {
+        public let handle: String
+        public let hostSessionID: UUID
+        public let tileID: TileID?
+        public let surfaceKind: AutomationSurfaceKind
+        public let windowScopeID: String
+        public let appScopeID: String
+        public let capabilities: [AutomationCapability]
+
+        public init(
+            handle: String,
+            hostSessionID: UUID,
+            tileID: TileID?,
+            surfaceKind: AutomationSurfaceKind,
+            windowScopeID: String,
+            appScopeID: String,
+            capabilities: [AutomationCapability] = AutomationAPI.v1Capabilities
+        ) {
+            self.handle = handle
+            self.hostSessionID = hostSessionID
+            self.tileID = tileID
+            self.surfaceKind = surfaceKind
+            self.windowScopeID = windowScopeID
+            self.appScopeID = appScopeID
+            self.capabilities = capabilities
+        }
+    }
+
+    private var handleByHostSessionID: [UUID: String] = [:]
+    private var entriesByHandle: [String: Entry] = [:]
+    private let makeHandle: () -> String
+
+    public init(makeHandle: @escaping () -> String = { UUID().uuidString.lowercased() }) {
+        self.makeHandle = makeHandle
+    }
+
+    @discardableResult
+    public func upsert(
+        hostSessionID: UUID,
+        tileID: TileID?,
+        surfaceKind: AutomationSurfaceKind,
+        windowScopeID: String,
+        appScopeID: String,
+        capabilities: [AutomationCapability] = AutomationAPI.v1Capabilities
+    ) -> Entry {
+        let handle = handleByHostSessionID[hostSessionID] ?? makeUniqueHandle()
+        handleByHostSessionID[hostSessionID] = handle
+
+        let entry = Entry(
+            handle: handle,
+            hostSessionID: hostSessionID,
+            tileID: tileID,
+            surfaceKind: surfaceKind,
+            windowScopeID: windowScopeID,
+            appScopeID: appScopeID,
+            capabilities: capabilities
+        )
+        entriesByHandle[handle] = entry
+        return entry
+    }
+
+    public func resolve(_ handle: String) -> Entry? {
+        entriesByHandle[handle]
+    }
+
+    public func handle(for hostSessionID: UUID) -> String? {
+        handleByHostSessionID[hostSessionID]
+    }
+
+    public func remove(hostSessionID: UUID) {
+        guard let handle = handleByHostSessionID.removeValue(forKey: hostSessionID) else { return }
+        entriesByHandle.removeValue(forKey: handle)
+    }
+
+    public func removeAll() {
+        handleByHostSessionID.removeAll()
+        entriesByHandle.removeAll()
+    }
+
+    private func makeUniqueHandle() -> String {
+        var handle = makeHandle()
+        while entriesByHandle[handle] != nil {
+            handle = makeHandle()
+        }
+        return handle
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
@@ -1,0 +1,248 @@
+import Darwin
+import Foundation
+import Network
+
+public actor AutomationListener {
+    public enum ListenerError: Error, Sendable {
+        case alreadyStarted
+        case socketBindFailed(String)
+    }
+
+    public struct Statistics: Sendable, Equatable {
+        public var requestCount: Int = 0
+        public var unsupportedRoutes: Int = 0
+        public var deniedRequests: Int = 0
+    }
+
+    private let socketURL: URL
+    private let lockURL: URL
+    private let controller: any AutomationControlling
+    private let isEnabled: @Sendable () -> Bool
+    private let auditLogger: AutomationAuditLogger?
+    private let logger: @Sendable (String) -> Void
+    private var listener: NWListener?
+    private var lockFileDescriptor: Int32?
+    private var statistics = Statistics()
+
+    public init(
+        bundleIdentifier: String,
+        controller: any AutomationControlling,
+        socketURLOverride: URL? = nil,
+        auditLogger: AutomationAuditLogger? = nil,
+        isEnabled: @escaping @Sendable () -> Bool = { true },
+        logger: @escaping @Sendable (String) -> Void = { NSLog("[AutomationListener] %@", $0) }
+    ) {
+        self.controller = controller
+        self.auditLogger = auditLogger
+        self.isEnabled = isEnabled
+        self.logger = logger
+        if let socketURLOverride {
+            self.socketURL = socketURLOverride
+        } else {
+            self.socketURL = Self.defaultSocketURL(bundleIdentifier: bundleIdentifier)
+        }
+        self.lockURL = socketURL.deletingPathExtension().appendingPathExtension("lock")
+    }
+
+    public nonisolated var socketPath: String { socketURL.path }
+
+    public nonisolated static func defaultSocketURL(bundleIdentifier: String) -> URL {
+        let appSupport =
+            FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first ?? FileManager.default.temporaryDirectory
+        let dir = appSupport.appendingPathComponent(bundleIdentifier, isDirectory: true)
+        return dir.appendingPathComponent("automation.sock", isDirectory: false)
+    }
+
+    public func currentStatistics() -> Statistics { statistics }
+
+    public func start() async throws {
+        guard listener == nil else { throw ListenerError.alreadyStarted }
+
+        try ensureParentDirectoryExists()
+        guard try acquireSocketLock() else {
+            logger("listener dormant; another process owns \(socketURL.path)")
+            return
+        }
+        try? FileManager.default.removeItem(at: socketURL)
+
+        let endpoint = NWEndpoint.unix(path: socketURL.path)
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = endpoint
+        parameters.allowLocalEndpointReuse = true
+
+        let listener: NWListener
+        do {
+            listener = try NWListener(using: parameters)
+        } catch {
+            releaseSocketLock()
+            throw ListenerError.socketBindFailed("\(error)")
+        }
+
+        listener.newConnectionHandler = { [weak self] connection in
+            guard let self else { return }
+            Task { await self.accept(connection: connection) }
+        }
+        listener.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            Task { await self.handleListenerState(state) }
+        }
+        listener.start(queue: .global(qos: .userInitiated))
+        self.listener = listener
+        hardenSocketFileIfPresent()
+        logger("listener started at \(socketURL.path)")
+    }
+
+    public func stop() async {
+        let hadListener = listener != nil
+        listener?.cancel()
+        listener = nil
+        if hadListener {
+            try? FileManager.default.removeItem(at: socketURL)
+            logger("listener stopped; socket file removed at \(socketURL.path)")
+        }
+        releaseSocketLock()
+    }
+
+    private func handleListenerState(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            hardenSocketFileIfPresent()
+            logger("listener ready")
+        case .failed(let error):
+            logger("listener failed: \(error)")
+        case .cancelled:
+            logger("listener cancelled")
+        default:
+            break
+        }
+    }
+
+    private func accept(connection: NWConnection) {
+        connection.start(queue: .global(qos: .userInitiated))
+        readRequest(connection: connection, accumulated: Data())
+    }
+
+    private nonisolated func readRequest(connection: NWConnection, accumulated: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { data, _, isComplete, error in
+            if let error {
+                NSLog("[AutomationListener] read error: %@", "\(error)")
+                connection.cancel()
+                return
+            }
+
+            var buffer = accumulated
+            if let data { buffer.append(data) }
+
+            if let request = HTTPRequest.parse(buffer) {
+                Task { [weak connection] in
+                    guard let connection else { return }
+                    await self.respond(request: request, connection: connection)
+                }
+                return
+            }
+
+            if isComplete {
+                connection.cancel()
+                return
+            }
+
+            if buffer.count > 1_048_576 {
+                NSLog("[AutomationListener] oversized request, dropping")
+                connection.cancel()
+                return
+            }
+
+            self.readRequest(connection: connection, accumulated: buffer)
+        }
+    }
+
+    private func respond(request: HTTPRequest, connection: NWConnection) async {
+        let result = await AutomationHTTPRouter.route(
+            request,
+            controller: controller,
+            enabled: isEnabled()
+        )
+        statistics.requestCount += 1
+        if result.status == 404 {
+            statistics.unsupportedRoutes += 1
+        }
+        if result.status >= 400 {
+            statistics.deniedRequests += 1
+        }
+
+        let response = Self.httpResponse(status: result.status, body: result.body)
+        await auditLogger?.record(
+            method: request.method,
+            path: request.path,
+            headers: request.headers,
+            responseBody: result.body
+        )
+        connection.send(
+            content: response,
+            completion: .contentProcessed { _ in
+                connection.cancel()
+            })
+    }
+
+    private func ensureParentDirectoryExists() throws {
+        let dir = socketURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        chmod(dir.path, S_IRWXU)
+    }
+
+    private func acquireSocketLock() throws -> Bool {
+        let fd = open(lockURL.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            throw ListenerError.socketBindFailed("could not open lock \(lockURL.path): errno=\(errno)")
+        }
+
+        if flock(fd, LOCK_EX | LOCK_NB) != 0 {
+            close(fd)
+            return false
+        }
+
+        lockFileDescriptor = fd
+        return true
+    }
+
+    private func releaseSocketLock() {
+        guard let fd = lockFileDescriptor else { return }
+        flock(fd, LOCK_UN)
+        close(fd)
+        lockFileDescriptor = nil
+    }
+
+    private nonisolated func hardenSocketFileIfPresent() {
+        guard FileManager.default.fileExists(atPath: socketURL.path) else { return }
+        chmod(socketURL.path, S_IRUSR | S_IWUSR)
+    }
+
+    private static func httpResponse(status: Int, body: Data) -> Data {
+        let reason: String
+        switch status {
+        case 200: reason = "OK"
+        case 400: reason = "Bad Request"
+        case 401: reason = "Unauthorized"
+        case 403: reason = "Forbidden"
+        case 404: reason = "Not Found"
+        case 405: reason = "Method Not Allowed"
+        case 409: reason = "Conflict"
+        default: reason = "Error"
+        }
+
+        var head = "HTTP/1.1 \(status) \(reason)\r\n"
+        head += "Content-Type: application/json; charset=utf-8\r\n"
+        head += "Content-Length: \(body.count)\r\n"
+        head += "Connection: close\r\n\r\n"
+        var out = Data(head.utf8)
+        out.append(body)
+        return out
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
@@ -5,6 +5,7 @@ import Network
 public actor AutomationListener {
     public enum ListenerError: Error, Sendable {
         case alreadyStarted
+        case socketAlreadyOwned(String)
         case socketBindFailed(String)
     }
 
@@ -64,7 +65,7 @@ public actor AutomationListener {
         try ensureParentDirectoryExists()
         guard try acquireSocketLock() else {
             logger("listener dormant; another process owns \(socketURL.path)")
-            return
+            throw ListenerError.socketAlreadyOwned(socketURL.path)
         }
         try? FileManager.default.removeItem(at: socketURL)
 

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift
@@ -1,0 +1,165 @@
+import Darwin
+import Foundation
+
+public struct AutomationSocketClient: Sendable {
+    public struct Response: Sendable, Equatable {
+        public let statusCode: Int
+        public let body: Data
+
+        public init(statusCode: Int, body: Data) {
+            self.statusCode = statusCode
+            self.body = body
+        }
+    }
+
+    public enum ClientError: LocalizedError, Sendable, Equatable {
+        case socketPathTooLong
+        case socketOpenFailed(Int32)
+        case connectFailed(String, Int32)
+        case writeFailed(Int32)
+        case readFailed(Int32)
+        case invalidHTTPResponse
+
+        public var errorDescription: String? {
+            switch self {
+            case .socketPathTooLong:
+                return "Automation socket path is too long."
+            case .socketOpenFailed(let code):
+                return "Could not open Unix socket: errno=\(code)."
+            case .connectFailed(let path, let code):
+                return "Could not connect to WorkSpaces Automation API at \(path): errno=\(code)."
+            case .writeFailed(let code):
+                return "Could not write automation request: errno=\(code)."
+            case .readFailed(let code):
+                return "Could not read automation response: errno=\(code)."
+            case .invalidHTTPResponse:
+                return "WorkSpaces Automation API returned an invalid HTTP response."
+            }
+        }
+    }
+
+    public let socketPath: String
+
+    public init(socketPath: String) {
+        self.socketPath = socketPath
+    }
+
+    public func request(
+        method: String,
+        path: String,
+        handle: String? = nil,
+        body: Data = Data()
+    ) throws -> Response {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw ClientError.socketOpenFailed(errno) }
+        defer { close(fd) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(socketPath.utf8)
+        let capacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard pathBytes.count < capacity else {
+            throw ClientError.socketPathTooLong
+        }
+
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: capacity) { buffer in
+                for index in 0..<capacity {
+                    buffer[index] = 0
+                }
+                for (index, byte) in pathBytes.enumerated() {
+                    buffer[index] = CChar(bitPattern: byte)
+                }
+            }
+        }
+
+        let connectResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                Darwin.connect(
+                    fd,
+                    sockaddrPointer,
+                    socklen_t(MemoryLayout<sa_family_t>.size + pathBytes.count + 1)
+                )
+            }
+        }
+        guard connectResult == 0 else {
+            throw ClientError.connectFailed(socketPath, errno)
+        }
+
+        var request = "\(method) \(path) HTTP/1.1\r\n"
+        request += "Host: localhost\r\n"
+        request += "Accept: application/json\r\n"
+        request += "Connection: close\r\n"
+        if let handle, !handle.isEmpty {
+            request += "X-WorkSpaces-Automation-Handle: \(handle)\r\n"
+        }
+        if !body.isEmpty {
+            request += "Content-Type: application/json\r\n"
+            request += "Content-Length: \(body.count)\r\n"
+        } else {
+            request += "Content-Length: 0\r\n"
+        }
+        request += "\r\n"
+
+        var outbound = Data(request.utf8)
+        outbound.append(body)
+        try writeAll(outbound, fd: fd)
+
+        var responseData = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            if count > 0 {
+                responseData.append(buffer, count: count)
+            } else if count == 0 {
+                break
+            } else if errno == EINTR {
+                continue
+            } else {
+                throw ClientError.readFailed(errno)
+            }
+        }
+
+        return try parseHTTPResponse(responseData)
+    }
+
+    private func writeAll(_ data: Data, fd: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var written = 0
+            while written < data.count {
+                let result = Darwin.write(
+                    fd,
+                    baseAddress.advanced(by: written),
+                    data.count - written
+                )
+                if result > 0 {
+                    written += result
+                } else if result < 0 && errno == EINTR {
+                    continue
+                } else {
+                    throw ClientError.writeFailed(errno)
+                }
+            }
+        }
+    }
+
+    private func parseHTTPResponse(_ data: Data) throws -> Response {
+        guard let headerEnd = data.range(of: Data("\r\n\r\n".utf8)) else {
+            throw ClientError.invalidHTTPResponse
+        }
+        let headerData = data.subdata(in: 0..<headerEnd.lowerBound)
+        guard let header = String(data: headerData, encoding: .utf8) else {
+            throw ClientError.invalidHTTPResponse
+        }
+        guard let statusLine = header.split(separator: "\r\n").first else {
+            throw ClientError.invalidHTTPResponse
+        }
+        let parts = statusLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
+        guard parts.count >= 2, let statusCode = Int(parts[1]) else {
+            throw ClientError.invalidHTTPResponse
+        }
+        let body = data.subdata(in: headerEnd.upperBound..<data.endIndex)
+        return Response(statusCode: statusCode, body: body)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("AutomationController")
+struct AutomationControllerTests {
+    @Test("Context resolves caller from opaque handle")
+    func contextResolvesCaller() throws {
+        let fixture = makeFixture()
+        let context = try fixture.controller.automationContext(for: fixture.primaryHandle)
+
+        #expect(context.handle == fixture.primaryHandle)
+        #expect(context.surface.hostSessionID == fixture.primary.id)
+        #expect(context.surface.kind == .terminal)
+        #expect(context.surface.isCaller)
+        #expect(context.surface.tileID != nil)
+        #expect(context.scope.primaryHostSessionID == fixture.primary.id)
+    }
+
+    @Test("Missing or stale handles fail closed")
+    func staleHandlesFailClosed() throws {
+        let fixture = makeFixture()
+        #expect(throws: AutomationServiceError.self) {
+            _ = try fixture.controller.automationContext(for: "not-live")
+        }
+
+        _ = fixture.store.handleProcessExit(for: fixture.primary.id)
+        do {
+            _ = try fixture.controller.automationContext(for: fixture.primaryHandle)
+            Issue.record("Expected stale handle after process exit")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .staleHandle)
+        }
+    }
+
+    @Test("Surfaces list stays inside caller scope")
+    func surfacesStayInsideCallerScope() throws {
+        let fixture = makeFixture()
+        let sibling = try #require(fixture.store.createTab())
+        _ = fixture.store.activateSession(
+            key: .repoPath("/Users/test/other"),
+            directory: URL(fileURLWithPath: "/Users/test/other")
+        )
+        _ = fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id)
+
+        let surfaces = try fixture.controller.automationSurfaces(for: fixture.primaryHandle).surfaces
+        let hostIDs = Set(surfaces.compactMap(\.hostSessionID))
+
+        #expect(hostIDs.contains(fixture.primary.id))
+        #expect(hostIDs.contains(sibling.id))
+        #expect(hostIDs.count == 3)
+        #expect(!hostIDs.contains(fixture.store.activeSessionID ?? UUID()))
+    }
+
+    @Test("Directional focus reports no neighbor without mutation")
+    func directionalFocusNoNeighbor() throws {
+        let fixture = makeFixture()
+
+        let result = try fixture.controller.automationFocusTile(for: fixture.primaryHandle, direction: .right)
+
+        #expect(result.changed == false)
+        #expect(result.reason == "no_neighbor")
+        #expect(fixture.focusedSessionIDs.isEmpty)
+    }
+
+    @Test("Directional and relative focus target the paired split tile")
+    func focusTargetsSplitTile() throws {
+        let fixture = makeFixture()
+        let split = try #require(fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id))
+        let splitHandle = try #require(fixture.store.automationEnvironment(for: split)?.handle)
+
+        let right = try fixture.controller.automationFocusTile(for: fixture.primaryHandle, direction: .right)
+        let previous = try fixture.controller.automationFocusTile(for: splitHandle, direction: .previous)
+
+        #expect(right.changed)
+        #expect(right.focusedSurfaceID == split.id.uuidString)
+        #expect(previous.changed)
+        #expect(previous.focusedSurfaceID == fixture.primary.id.uuidString)
+        #expect(fixture.focusedSessionIDs == [split.id, fixture.primary.id])
+    }
+
+    @Test("Split creates or relayouts through host terminal state")
+    func splitUsesHostTerminalState() async throws {
+        let fixture = makeFixture()
+
+        let result = try fixture.controller.automationSplitTile(for: fixture.primaryHandle, direction: .down)
+        let split = try #require(fixture.store.splitSession(for: fixture.primary.id))
+
+        #expect(result.changed)
+        #expect(result.createdSurfaceID == split.id.uuidString)
+        #expect(fixture.store.splitLayout(for: fixture.primary.id)?.axis == .topBottom)
+
+        try await Task.sleep(for: .milliseconds(180))
+        #expect(fixture.focusedSessionIDs == [split.id])
+    }
+
+    @Test("Close routes through existing close request path")
+    func closeRoutesThroughExistingClosePath() throws {
+        let fixture = makeFixture()
+
+        let result = try fixture.controller.automationCloseTile(for: fixture.primaryHandle)
+
+        #expect(result.changed)
+        #expect(result.closedSurfaceID == fixture.primary.id.uuidString)
+        #expect(fixture.closedSessionIDs == [fixture.primary.id])
+    }
+
+    @MainActor
+    private final class Fixture {
+        let store: HostTerminalStateStore
+        let controller: AutomationController
+        let primary: HostTerminalSession
+        let primaryHandle: String
+        var focusedSessionIDs: [UUID] = []
+        var closedSessionIDs: [UUID] = []
+
+        init() {
+            store = HostTerminalStateStore()
+            let handleRegistry = AutomationHandleRegistry()
+            store.configureAutomation(
+                handleRegistry: handleRegistry,
+                socketPath: "/tmp/workspaces-automation.sock"
+            )
+            primary =
+                store.activateSession(
+                    key: .repoPath("/Users/test/repo"),
+                    directory: URL(fileURLWithPath: "/Users/test/repo")
+                ).session
+            primaryHandle = store.automationEnvironment(for: primary)?.handle ?? ""
+            controller = AutomationController(
+                handleRegistry: handleRegistry,
+                hostTerminalState: store,
+                focusTerminal: { _ in },
+                requestCloseTerminal: { _ in }
+            )
+            controller.update(
+                hostTerminalState: store,
+                focusTerminal: { [weak self] sessionID in
+                    self?.focusedSessionIDs.append(sessionID)
+                },
+                requestCloseTerminal: { [weak self] sessionID in
+                    self?.closedSessionIDs.append(sessionID)
+                }
+            )
+        }
+    }
+
+    private func makeFixture() -> Fixture {
+        Fixture()
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -44,7 +44,7 @@ struct AutomationControllerTests {
             key: .repoPath("/Users/test/other"),
             directory: URL(fileURLWithPath: "/Users/test/other")
         )
-        _ = fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id)
+        _ = fixture.store.splitFocusedTile(inTabContaining: fixture.primary.id)
 
         let surfaces = try fixture.controller.automationSurfaces(for: fixture.primaryHandle).surfaces
         let hostIDs = Set(surfaces.compactMap(\.hostSessionID))
@@ -69,7 +69,7 @@ struct AutomationControllerTests {
     @Test("Directional and relative focus target the paired split tile")
     func focusTargetsSplitTile() throws {
         let fixture = makeFixture()
-        let split = try #require(fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id))
+        let split = try #require(fixture.store.splitFocusedTile(inTabContaining: fixture.primary.id))
         let splitHandle = try #require(fixture.store.automationEnvironment(for: split)?.handle)
 
         let right = try fixture.controller.automationFocusTile(for: fixture.primaryHandle, direction: .right)
@@ -82,7 +82,7 @@ struct AutomationControllerTests {
         #expect(fixture.focusedSessionIDs == [split.id, fixture.primary.id])
     }
 
-    @Test("Split creates or relayouts through host terminal state")
+    @Test("Split creates a new pane through host terminal state")
     func splitUsesHostTerminalState() async throws {
         let fixture = makeFixture()
 
@@ -97,28 +97,28 @@ struct AutomationControllerTests {
         #expect(fixture.focusedSessionIDs == [split.id])
     }
 
-    @Test("Split reports existing and relaid-out split surfaces without claiming creation")
-    func splitExistingSurfaceDoesNotClaimCreation() throws {
+    @Test("Split grows an existing split tree from the primary tile")
+    func splitExistingTreeCreatesNewSurface() throws {
         let fixture = makeFixture()
-        let split = try #require(fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id))
+        let firstSplit = try #require(fixture.store.splitFocusedTile(inTabContaining: fixture.primary.id))
 
-        let alreadySplit = try fixture.controller.automationSplitTile(for: fixture.primaryHandle, direction: .right)
-        let relayout = try fixture.controller.automationSplitTile(for: fixture.primaryHandle, direction: .down)
+        let secondSplit = try fixture.controller.automationSplitTile(for: fixture.primaryHandle, direction: .down)
+        let secondSurfaceIDString = try #require(secondSplit.createdSurfaceID)
+        let secondSurfaceID = try #require(UUID(uuidString: secondSurfaceIDString))
+        let surfaces = try fixture.controller.automationSurfaces(for: fixture.primaryHandle).surfaces
+        let hostIDs = Set(surfaces.compactMap(\.hostSessionID))
 
-        #expect(alreadySplit.changed)
-        #expect(alreadySplit.focusedSurfaceID == split.id.uuidString)
-        #expect(alreadySplit.createdSurfaceID == nil)
-        #expect(alreadySplit.reason == "already_split")
-        #expect(relayout.changed)
-        #expect(relayout.focusedSurfaceID == split.id.uuidString)
-        #expect(relayout.createdSurfaceID == nil)
-        #expect(relayout.reason == "relayout")
+        #expect(secondSplit.changed)
+        #expect(secondSplit.createdSurfaceID != firstSplit.id.uuidString)
+        #expect(fixture.store.paneCount(forPrimarySessionID: fixture.primary.id) == 3)
+        #expect(hostIDs.contains(firstSplit.id))
+        #expect(hostIDs.contains(secondSurfaceID))
     }
 
     @Test("Split from secondary tile is rejected until arbitrary tile splitting lands")
     func splitFromSecondaryTileIsUnsupported() throws {
         let fixture = makeFixture()
-        let split = try #require(fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id))
+        let split = try #require(fixture.store.splitFocusedTile(inTabContaining: fixture.primary.id))
         let splitHandle = try #require(fixture.store.automationEnvironment(for: split)?.handle)
 
         do {

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -12,12 +12,12 @@ struct AutomationControllerTests {
         let fixture = makeFixture()
         let context = try fixture.controller.automationContext(for: fixture.primaryHandle)
 
-        #expect(context.handle == fixture.primaryHandle)
         #expect(context.surface.hostSessionID == fixture.primary.id)
         #expect(context.surface.kind == .terminal)
         #expect(context.surface.isCaller)
         #expect(context.surface.tileID != nil)
         #expect(context.scope.primaryHostSessionID == fixture.primary.id)
+        #expect(context.system.capabilities.contains(.contextRead))
     }
 
     @Test("Missing or stale handles fail closed")
@@ -95,6 +95,71 @@ struct AutomationControllerTests {
 
         try await Task.sleep(for: .milliseconds(180))
         #expect(fixture.focusedSessionIDs == [split.id])
+    }
+
+    @Test("Split reports existing and relaid-out split surfaces without claiming creation")
+    func splitExistingSurfaceDoesNotClaimCreation() throws {
+        let fixture = makeFixture()
+        let split = try #require(fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id))
+
+        let alreadySplit = try fixture.controller.automationSplitTile(for: fixture.primaryHandle, direction: .right)
+        let relayout = try fixture.controller.automationSplitTile(for: fixture.primaryHandle, direction: .down)
+
+        #expect(alreadySplit.changed)
+        #expect(alreadySplit.focusedSurfaceID == split.id.uuidString)
+        #expect(alreadySplit.createdSurfaceID == nil)
+        #expect(alreadySplit.reason == "already_split")
+        #expect(relayout.changed)
+        #expect(relayout.focusedSurfaceID == split.id.uuidString)
+        #expect(relayout.createdSurfaceID == nil)
+        #expect(relayout.reason == "relayout")
+    }
+
+    @Test("Split from secondary tile is rejected until arbitrary tile splitting lands")
+    func splitFromSecondaryTileIsUnsupported() throws {
+        let fixture = makeFixture()
+        let split = try #require(fixture.store.ensureSplit(forPrimarySessionID: fixture.primary.id))
+        let splitHandle = try #require(fixture.store.automationEnvironment(for: split)?.handle)
+
+        do {
+            _ = try fixture.controller.automationSplitTile(for: splitHandle, direction: .right)
+            Issue.record("Expected secondary split tile request to be unsupported")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .unsupported)
+        }
+    }
+
+    @Test("Limited handles cannot use capabilities they were not granted")
+    func limitedHandleCapabilitiesAreEnforced() throws {
+        let store = HostTerminalStateStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "limited" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: [.contextRead]
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            hostTerminalState: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in }
+        )
+
+        _ = try controller.automationContext(for: "limited")
+        do {
+            _ = try controller.automationSplitTile(for: "limited", direction: .right)
+            Issue.record("Expected tile.split to require tile.split capability")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
     }
 
     @Test("Close routes through existing close request path")

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -7,6 +7,7 @@ import Foundation
 import Testing
 
 @testable import WorkspaceManager
+@testable import WorkspaceManagerCore
 
 @Suite("GhosttyTerminalConfig")
 struct GhosttyTerminalConfigTests {
@@ -187,6 +188,32 @@ struct GhosttyTerminalConfigTests {
         #expect(missingHostID.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == nil)
         #expect(missingHostID.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == nil)
         #expect(missingHostID.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
+    }
+
+    @Test("Automation context exports only socket and opaque handle")
+    func exportsAutomationContextOnly() {
+        let hostSessionID = UUID(uuidString: "2D4D6044-1E11-49C9-9CB0-A1D7B9F44E31")!
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: [
+                "SHELL": "/bin/zsh",
+                "PATH": "/usr/bin:/bin",
+            ],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true,
+            hostSessionID: hostSessionID,
+            hooksSocketPath: "/tmp/workspaces-hooks.sock",
+            automationEnvironment: AutomationTerminalEnvironment(
+                socketPath: "/tmp/workspaces-automation.sock",
+                handle: "opaque-handle"
+            )
+        )
+
+        #expect(config.environmentVariables["WORKSPACES_AUTOMATION_SOCKET"] == "/tmp/workspaces-automation.sock")
+        #expect(config.environmentVariables["WORKSPACES_AUTOMATION_HANDLE"] == "opaque-handle")
+        #expect(config.environmentVariables["WORKSPACES_TILE_ID"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_SURFACE_ID"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == hostSessionID.uuidString)
     }
 
     @Test("custom command config preserves explicit command without hook environment")

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -839,9 +839,11 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         name: String,
         progress: WorkspaceCreationProgressHandler?
     ) async throws -> NewWorkspaceInfo {
-        createWorkspaceCalls.append(
-            CreateWorkspaceCall(repoName: repoName, repoLocalURL: repoLocalURL, name: name)
-        )
+        await MainActor.run {
+            createWorkspaceCalls.append(
+                CreateWorkspaceCall(repoName: repoName, repoLocalURL: repoLocalURL, name: name)
+            )
+        }
         await createWorkspaceDelay()
         if let createWorkspaceResult {
             return createWorkspaceResult

--- a/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
@@ -72,6 +72,8 @@ struct TerminalSessionLaunchContextTests {
         #expect(config.workingDirectory == FileManager.default.temporaryDirectory.path)
         #expect(config.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == nil)
         #expect(config.environmentVariables["WORKSPACES_HOOKS_SOCKET"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_AUTOMATION_SOCKET"] == nil)
+        #expect(config.environmentVariables["WORKSPACES_AUTOMATION_HANDLE"] == nil)
         #expect(config.environmentVariables["WORKSPACES_COMMAND_STATUS_ZSH"] == nil)
     }
 }

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -1,0 +1,326 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@MainActor
+private final class FakeAutomationController: AutomationControlling {
+    var contextCalls: [String] = []
+    var focusDirections: [AutomationTileFocusDirection] = []
+    var splitDirections: [AutomationTileSplitDirection] = []
+    var closeHandles: [String] = []
+
+    func automationContext(for handle: String) throws -> AutomationContextResult {
+        contextCalls.append(handle)
+        guard handle == "live" else {
+            throw AutomationServiceError(.staleHandle, "stale")
+        }
+        return AutomationContextResult(
+            handle: handle,
+            surface: AutomationSurfaceDescriptor(
+                surfaceID: "surface-1",
+                tileID: "tile-1",
+                kind: .terminal,
+                hostSessionID: UUID(uuidString: "11111111-1111-1111-1111-111111111111"),
+                title: "Terminal",
+                cwd: "/tmp/repo",
+                isCaller: true,
+                isActive: true,
+                isVisible: true
+            ),
+            scope: AutomationScopeDescriptor(
+                app: "workspaces.local",
+                window: "window-1",
+                scopeKey: "repoPath(/tmp/repo)",
+                primaryHostSessionID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")
+            )
+        )
+    }
+
+    func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult {
+        _ = try automationContext(for: handle)
+        return AutomationSurfacesResult(surfaces: [])
+    }
+
+    func automationFocusTile(
+        for handle: String,
+        direction: AutomationTileFocusDirection
+    ) throws -> AutomationMutationResult {
+        _ = try automationContext(for: handle)
+        focusDirections.append(direction)
+        return AutomationMutationResult(changed: true, focusedSurfaceID: "surface-2")
+    }
+
+    func automationSplitTile(
+        for handle: String,
+        direction: AutomationTileSplitDirection
+    ) throws -> AutomationMutationResult {
+        _ = try automationContext(for: handle)
+        splitDirections.append(direction)
+        return AutomationMutationResult(changed: true, createdSurfaceID: "surface-2")
+    }
+
+    func automationCloseTile(for handle: String) throws -> AutomationMutationResult {
+        _ = try automationContext(for: handle)
+        closeHandles.append(handle)
+        return AutomationMutationResult(changed: true, closedSurfaceID: "surface-1")
+    }
+}
+
+@Suite("Automation API")
+struct AutomationAPITests {
+    @Test("Response envelopes encode stable v1 success and failure shapes")
+    func responseEnvelopeShapes() throws {
+        let success = AutomationResponseEnvelope(result: AutomationHealthResult())
+        let successData = try AutomationJSON.encoder.encode(success)
+        let successText = String(data: successData, encoding: .utf8)
+        #expect(
+            successText
+                == #"{"ok":true,"result":{"status":"ok","system":{"capabilities":["context.read","surfaces.read","tile.focus","tile.split","tile.close"]}},"v":1}"#
+        )
+
+        let failure = AutomationResponseEnvelope<AutomationEmptyResult>(
+            error: AutomationErrorResponse(code: .missingHandle, message: "Missing handle.")
+        )
+        let failureData = try AutomationJSON.encoder.encode(failure)
+        let failureText = String(data: failureData, encoding: .utf8)
+        #expect(failureText == #"{"error":{"code":"missing_handle","message":"Missing handle."},"ok":false,"v":1}"#)
+    }
+
+    @Test("Handle registry resolves live handles and drops stale mappings")
+    @MainActor
+    func handleRegistryLookup() {
+        let firstID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let registry = AutomationHandleRegistry(makeHandle: { "handle-1" })
+        let entry = registry.upsert(
+            hostSessionID: firstID,
+            tileID: TileID(UUID(uuidString: "22222222-2222-2222-2222-222222222222")!),
+            surfaceKind: .terminal,
+            windowScopeID: "window-1",
+            appScopeID: "app"
+        )
+
+        #expect(entry.handle == "handle-1")
+        #expect(registry.resolve("handle-1")?.hostSessionID == firstID)
+        #expect(registry.handle(for: firstID) == "handle-1")
+
+        registry.remove(hostSessionID: firstID)
+        #expect(registry.resolve("handle-1") == nil)
+        #expect(registry.handle(for: firstID) == nil)
+    }
+
+    @Test("Router allows unauthenticated health and blocks scoped requests when disabled")
+    @MainActor
+    func routerHealthAndDisabled() async throws {
+        let controller = FakeAutomationController()
+        let health = await AutomationHTTPRouter.route(
+            HTTPRequest(method: "GET", path: "/v1/health", headers: [:], body: Data()),
+            controller: controller,
+            enabled: false
+        )
+        let healthEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationHealthResult>.self,
+            from: health.body
+        )
+        #expect(health.status == 200)
+        #expect(healthEnvelope.ok)
+
+        let context = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/context",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: false
+        )
+        let contextEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: context.body
+        )
+        #expect(context.status == 403)
+        #expect(contextEnvelope.error?.code == .disabled)
+    }
+
+    @Test("Router rejects missing and stale handles")
+    @MainActor
+    func routerHandleFailures() async throws {
+        let controller = FakeAutomationController()
+        let missing = await AutomationHTTPRouter.route(
+            HTTPRequest(method: "GET", path: "/v1/context", headers: [:], body: Data()),
+            controller: controller,
+            enabled: true
+        )
+        let missingEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: missing.body
+        )
+        #expect(missing.status == 401)
+        #expect(missingEnvelope.error?.code == .missingHandle)
+
+        let stale = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/context",
+                headers: [AutomationAPI.handleHeader: "stale"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let staleEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: stale.body
+        )
+        #expect(stale.status == 401)
+        #expect(staleEnvelope.error?.code == .staleHandle)
+    }
+
+    @Test("Router rejects malformed body and caller-supplied target identifiers")
+    @MainActor
+    func routerRejectsMalformedAndTargetIDs() async throws {
+        let controller = FakeAutomationController()
+        let malformed = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/tile/focus",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data("{".utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let malformedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: malformed.body
+        )
+        #expect(malformed.status == 400)
+        #expect(malformedEnvelope.error?.code == .malformedJSON)
+
+        let targetID = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/tile/focus",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data(#"{"direction":"right","tileID":"forged"}"#.utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let targetEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: targetID.body
+        )
+        #expect(targetID.status == 400)
+        #expect(targetEnvelope.error?.code == .invalidRequest)
+        #expect(controller.focusDirections.isEmpty)
+    }
+
+    @Test("Router maps focus split and close verbs")
+    @MainActor
+    func routerMapsMutationVerbs() async throws {
+        let controller = FakeAutomationController()
+
+        _ = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/tile/focus",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data(#"{"direction":"previous"}"#.utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        _ = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/tile/split",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data(#"{"direction":"down"}"#.utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        _ = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/tile/close",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+
+        #expect(controller.focusDirections == [.previous])
+        #expect(controller.splitDirections == [.down])
+        #expect(controller.closeHandles == ["live"])
+    }
+
+    @Test("CLI formatter emits result JSON and surfaces envelope errors")
+    func cliFormatter() throws {
+        let result = AutomationContextResult(
+            handle: "handle",
+            surface: AutomationSurfaceDescriptor(
+                surfaceID: "surface",
+                tileID: "tile",
+                kind: .terminal,
+                hostSessionID: nil,
+                title: "Terminal",
+                cwd: nil,
+                isCaller: true,
+                isActive: true,
+                isVisible: true
+            ),
+            scope: AutomationScopeDescriptor(app: "app", window: "window", scopeKey: nil, primaryHostSessionID: nil)
+        )
+        let json = try AutomationCLIResultPrinter.resultJSON(result)
+        #expect(json.contains(#""handle" : "handle""#))
+
+        let failure = AutomationResponseEnvelope<AutomationContextResult>(
+            error: AutomationErrorResponse(code: .staleHandle, message: "stale")
+        )
+        let response = AutomationSocketClient.Response(
+            statusCode: 401,
+            body: try AutomationJSON.encoder.encode(failure)
+        )
+        do {
+            _ = try AutomationCLIResultPrinter.decodeEnvelope(AutomationContextResult.self, from: response)
+            Issue.record("Expected stale handle error")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .staleHandle)
+        }
+    }
+}
+
+@Suite("AutomationListener", .serialized)
+struct AutomationListenerTests {
+    @Test("Socket smoke returns health envelope")
+    @MainActor
+    func socketSmoke() async throws {
+        let socket = URL(fileURLWithPath: "/tmp/wm-auto-\(UUID().uuidString.prefix(8)).sock")
+        let controller = FakeAutomationController()
+        let listener = AutomationListener(
+            bundleIdentifier: "com.test.workspaces",
+            controller: controller,
+            socketURLOverride: socket,
+            auditLogger: nil
+        )
+        try await listener.start()
+        defer { Task { await listener.stop() } }
+        try await Task.sleep(for: .milliseconds(250))
+
+        let client = AutomationSocketClient(socketPath: socket.path)
+        let response = try client.request(method: "GET", path: "/v1/health")
+        let envelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationHealthResult>.self,
+            from: response.body
+        )
+
+        #expect(response.statusCode == 200)
+        #expect(envelope.ok)
+        #expect(envelope.result?.status == "ok")
+        await listener.stop()
+    }
+}

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -16,7 +16,6 @@ private final class FakeAutomationController: AutomationControlling {
             throw AutomationServiceError(.staleHandle, "stale")
         }
         return AutomationContextResult(
-            handle: handle,
             surface: AutomationSurfaceDescriptor(
                 surfaceID: "surface-1",
                 tileID: "tile-1",
@@ -261,7 +260,6 @@ struct AutomationAPITests {
     @Test("CLI formatter emits result JSON and surfaces envelope errors")
     func cliFormatter() throws {
         let result = AutomationContextResult(
-            handle: "handle",
             surface: AutomationSurfaceDescriptor(
                 surfaceID: "surface",
                 tileID: "tile",
@@ -276,7 +274,8 @@ struct AutomationAPITests {
             scope: AutomationScopeDescriptor(app: "app", window: "window", scopeKey: nil, primaryHostSessionID: nil)
         )
         let json = try AutomationCLIResultPrinter.resultJSON(result)
-        #expect(json.contains(#""handle" : "handle""#))
+        #expect(!json.contains(#""handle""#))
+        #expect(json.contains(#""surfaceID" : "surface""#))
 
         let failure = AutomationResponseEnvelope<AutomationContextResult>(
             error: AutomationErrorResponse(code: .staleHandle, message: "stale")
@@ -291,6 +290,36 @@ struct AutomationAPITests {
         } catch let error as AutomationServiceError {
             #expect(error.response.code == .staleHandle)
         }
+    }
+
+    @Test("A second listener fails instead of becoming a dormant handle issuer")
+    @MainActor
+    func listenerLockContentionThrows() async throws {
+        let socket = URL(fileURLWithPath: "/tmp/wm-auto-lock-\(UUID().uuidString.prefix(8)).sock")
+        let first = AutomationListener(
+            bundleIdentifier: "com.test.workspaces",
+            controller: FakeAutomationController(),
+            socketURLOverride: socket,
+            auditLogger: nil
+        )
+        let second = AutomationListener(
+            bundleIdentifier: "com.test.workspaces",
+            controller: FakeAutomationController(),
+            socketURLOverride: socket,
+            auditLogger: nil
+        )
+        try await first.start()
+
+        do {
+            try await second.start()
+            Issue.record("Expected second listener to fail lock acquisition")
+        } catch AutomationListener.ListenerError.socketAlreadyOwned(let path) {
+            #expect(path == socket.path)
+        } catch {
+            await first.stop()
+            throw error
+        }
+        await first.stop()
     }
 }
 

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -1,0 +1,189 @@
+# WorkSpaces Automation API Guide
+
+The WorkSpaces Automation API lets a trusted process running inside a
+WorkSpaces terminal tile ask the app shell about its current context and make a
+small set of tile changes. It is local-only, same-user, and experimental.
+
+Use this guide when you are writing a script, shell alias, or coding-agent tool
+that runs from a WorkSpaces terminal. For the wire contract, see
+[Automation API Reference](./development/automation-api.md). For the design
+rationale and V1 boundaries, see
+[Automation API V1 Decision](./decisions/automation-api-v1.md).
+
+## Enable It
+
+The API is disabled by default.
+
+1. Open WorkSpaces Settings.
+2. Enable Experimental Features.
+3. Enable Automation API.
+4. Restart WorkSpaces.
+5. Open a new terminal tile.
+
+For development launches, you can force the feature on for that process:
+
+```bash
+WORKSPACES_AUTOMATION_API=1 ./scripts/launch-dev.sh --no-build
+```
+
+Terminal processes receive automation environment only when their surface is
+created. If you turn the experiment on or off, restart WorkSpaces and create a
+fresh terminal tile before testing.
+
+## Check Your Terminal
+
+Inside a WorkSpaces terminal tile:
+
+```bash
+echo "$WORKSPACES_AUTOMATION_SOCKET"
+echo "$WORKSPACES_AUTOMATION_HANDLE"
+```
+
+Both values should be present. The handle is an opaque capability. Do not copy
+it into another terminal, save it in dotfiles, or treat it as a tile ID.
+
+`workspaces automation health` checks only that a local listener is reachable:
+
+```bash
+workspaces automation health
+workspaces automation health --json
+```
+
+Scoped commands also require `WORKSPACES_AUTOMATION_HANDLE`. They are expected
+to fail outside a WorkSpaces terminal tile.
+
+## See The Current Context
+
+Use context when a script needs to know which terminal tile it is running in:
+
+```bash
+workspaces automation context --json
+```
+
+The result includes the current surface, window/app scope, primary host session,
+and granted capabilities. It does not echo the opaque handle.
+
+Example uses:
+
+```bash
+surface_id=$(workspaces automation context --json | jq -r '.surface.surfaceID')
+cwd=$(workspaces automation context --json | jq -r '.surface.cwd')
+```
+
+## List Visible Surfaces
+
+Use the surface list to inspect terminal surfaces in the caller's app/window
+scope:
+
+```bash
+workspaces surface list --json
+```
+
+Each entry reports a stable surface ID, surface kind, title, working directory,
+visibility, active state, and whether it is the caller.
+
+## Focus A Neighboring Tile
+
+Focus commands are relative to the caller tile:
+
+```bash
+workspaces tile focus --left
+workspaces tile focus --right
+workspaces tile focus --up
+workspaces tile focus --down
+workspaces tile focus --next
+workspaces tile focus --previous
+```
+
+If there is no neighbor in that direction, the request succeeds without changing
+focus and reports `reason: "no_neighbor"` at the API level.
+
+## Split The Current Tile
+
+Split commands are also relative to the caller tile:
+
+```bash
+workspaces tile split --right
+workspaces tile split --down
+workspaces tile split --left
+workspaces tile split --up
+```
+
+V1 supports splitting from a primary terminal tile. If a split already exists,
+the command focuses or relayouts that existing split instead of claiming a new
+surface was created. Calling split from the secondary split tile returns
+`unsupported` in V1.
+
+## Close The Current Tile
+
+Close routes through the same close-confirmation path as the app:
+
+```bash
+workspaces tile close
+```
+
+The request is scoped to the caller. There is no V1 command for closing an
+arbitrary tile by ID.
+
+## Shell Alias Ideas
+
+These examples are intentionally small. They stay inside the V1 scope and do
+not inject input into terminals.
+
+```bash
+alias ws-right='workspaces tile focus --right'
+alias ws-left='workspaces tile focus --left'
+alias ws-split='workspaces tile split --right'
+alias ws-context='workspaces automation context --json'
+```
+
+A script can use the current directory from WorkSpaces context:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+context=$(workspaces automation context --json)
+title=$(jq -r '.surface.title' <<<"$context")
+cwd=$(jq -r '.surface.cwd // ""' <<<"$context")
+
+printf 'WorkSpaces surface: %s\n' "$title"
+printf 'Working directory: %s\n' "$cwd"
+```
+
+## Troubleshooting
+
+`WORKSPACES_AUTOMATION_HANDLE is missing`
+
+Run the command from a WorkSpaces terminal tile created after the experiment was
+enabled. Repo overviews, web sources, ordinary Terminal.app windows, and remote
+custom-command sessions do not provide the scoped handle.
+
+`Could not connect to WorkSpaces Automation API`
+
+The app is not running, the experiment is disabled, or the terminal inherited an
+old socket path. Restart WorkSpaces and create a new terminal tile.
+
+`automation request failed: stale_handle`
+
+The terminal tile that owned the handle was closed or replaced. Run the command
+from a live WorkSpaces terminal tile.
+
+`automation request failed: unsupported`
+
+The request is outside V1. Common examples are splitting from a secondary split
+tile or asking for capabilities such as browser mutation, input injection,
+resize/equalize, or global cross-workspace control.
+
+## V1 Boundaries
+
+V1 is intentionally narrow:
+
+- read current context
+- list in-scope terminal surfaces
+- focus a neighboring tile
+- split from a primary tile
+- close the caller tile through normal app behavior
+
+V1 does not support browser mutation, opening URLs, tab metadata changes, input
+injection, resize/equalize, or global control across workspaces.

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -109,9 +109,9 @@ workspaces tile split --left
 workspaces tile split --up
 ```
 
-V1 supports splitting from a primary terminal tile. If a split already exists,
-the command focuses or relayouts that existing split instead of claiming a new
-surface was created. Calling split from the secondary split tile returns
+V1 supports splitting from a primary terminal tile. Each successful split creates
+a new terminal surface in the caller's tab and focuses it after the app's normal
+split-focus delay. Calling split from a secondary split tile returns
 `unsupported` in V1.
 
 ## Close The Current Tile

--- a/docs/decisions/automation-api-v1.md
+++ b/docs/decisions/automation-api-v1.md
@@ -1,0 +1,96 @@
+# Automation API V1 Decision
+
+## Status
+
+Accepted for the V1 experimental Automation API.
+
+## Context
+
+WorkSpaces has strong internal primitives for a local app-shell control plane:
+terminal surfaces have host-session identity, `SurfaceStore` owns surface
+registration, and the tile model can focus, split, and close terminal surfaces.
+Trusted coding agents and scripts running inside a WorkSpaces terminal need a
+small way to ask the app shell about their context and request nearby tile
+changes.
+
+The risk is that a broad API could accidentally become cmux-style remote
+control before the product has reviewed safety, user expectations, browser
+mutation, input injection, and cross-workspace authority.
+
+## Decision
+
+V1 ships as a local-only, same-user, experimental API exposed through a Unix
+domain socket named `automation.sock`. It is separate from the Claude hook
+listener and has its own lock file.
+
+Only terminal surfaces receive discovery environment:
+
+```bash
+WORKSPACES_AUTOMATION_SOCKET=/path/to/automation.sock
+WORKSPACES_AUTOMATION_HANDLE=<opaque capability handle>
+```
+
+The opaque handle is the authority for scoped requests. Requests do not get to
+name their target tile, surface, or host session. The app resolves the handle
+against the live terminal-surface mapping and derives:
+
+- live host session
+- tile identity
+- surface kind
+- window scope
+- app scope
+- capabilities
+
+V1 exposes only:
+
+- unauthenticated liveness
+- caller context
+- in-scope surface listing
+- tile focus relative to the caller
+- tile split from a primary terminal tile
+- caller tile close through the normal close path
+
+## Consequences
+
+This keeps the first API useful for shell ergonomics and coding-agent
+coordination while preserving strong boundaries:
+
+- no caller-supplied target identifiers for scoped mutations
+- no raw reducer action exposure
+- no terminal input injection
+- no browser mutation
+- no global cross-workspace control
+- no authority based on raw environment tile IDs
+
+The API can grow only by adding stable product verbs over reviewed operations.
+Future V2 capabilities should each define their own authority model, user
+expectation, audit surface, tests, and documentation before landing.
+
+## Rejected Alternatives
+
+### Reuse The Claude Hook Listener
+
+Rejected. The hook listener ingests events and status from agents. Automation
+mutations need a separate transport, lock, audit stream, and failure behavior.
+
+### Trust Raw Tile IDs In Environment
+
+Rejected. A raw tile or surface ID in environment would be easy to copy and
+would turn identity into authority. V1 uses an opaque live handle instead.
+
+### Expose Internal TileTree Actions
+
+Rejected. Reducer actions are implementation detail. The public API should be a
+stable projection over safe product operations.
+
+### Ship Browser Or Input Mutation In V1
+
+Rejected. Those capabilities have different safety and user-expectation
+questions. They remain out of scope until separately designed.
+
+## Documentation Contract
+
+- [Automation API Guide](../automation-api.md) is the example-first user path.
+- [Automation API Reference](../development/automation-api.md) is the wire and
+  maintainer contract.
+- This decision record explains why V1 is intentionally narrow.

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -29,8 +29,11 @@ The handle is the authority. Requests for scoped routes send it as
 `x-workspaces-automation-handle`; requests do not get to name their tile,
 surface, or host session. The app resolves the handle against its live mapping
 to recover the caller tile, host session, surface kind, window scope, app
-scope, and capabilities. Missing, stale, disabled, or out-of-scope handles fail
-closed.
+scope, and capabilities. Missing, stale, disabled, out-of-scope, or
+under-capable handles fail closed. Context responses do not echo the handle.
+
+Restart WorkSpaces after changing the Automation API experiment. Terminal
+processes only receive automation environment when their surface is created.
 
 Allowed and denied requests are appended to `automation-audit.jsonl` next to
 the socket state. The audit log stores route-level metadata and error codes,
@@ -64,7 +67,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/context` | Returns the caller's resolved context and capabilities. |
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
-| `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` relative to the caller tile. |
+| `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Existing splits are focused or relaid out without claiming a new surface. Secondary split-tile callers return `unsupported` in V1. |
 | `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
 
 Mutation bodies must be projections over the supported operation, not raw tile

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -5,6 +5,10 @@ running inside WorkSpaces terminal tiles. V1 is intentionally narrow: a caller
 can discover its live shell context, list in-scope surfaces, and request core
 tile mutations relative to its own tile.
 
+This is the wire and maintainer reference. For example-first usage, see
+[Automation API Guide](../automation-api.md). For rationale and future-expansion
+boundaries, see [Automation API V1 Decision](../decisions/automation-api-v1.md).
+
 The API is experimental and disabled by default. Enable it from the
 Experimental Features settings, or force it on for development with:
 
@@ -38,6 +42,20 @@ processes only receive automation environment when their surface is created.
 Allowed and denied requests are appended to `automation-audit.jsonl` next to
 the socket state. The audit log stores route-level metadata and error codes,
 not terminal input or output.
+
+## Invariants
+
+- The socket listener is distinct from `AgentHookListener`.
+- Only same-user local processes that can reach the user-private socket can
+  connect.
+- Scoped routes require `x-workspaces-automation-handle`.
+- The server resolves caller identity from its live handle registry.
+- Scoped requests must not accept caller-supplied `tileID`, `surfaceID`, or
+  `hostSessionID`.
+- Capabilities are enforced before each scoped operation.
+- Mutation routes are stable product verbs, not raw `TileTreeAction` exposure.
+- Browser mutation, input injection, resize/equalize, and global control are
+  out of V1.
 
 ## Envelope
 
@@ -80,6 +98,37 @@ state. For example:
 Bodies that try to supply target identifiers such as `tileID`, `surfaceID`, or
 `hostSessionID` are rejected.
 
+## Capabilities
+
+Capabilities are attached to the live handle entry and returned in descriptors
+for discovery. They do not broaden scope; the caller is still resolved from the
+handle.
+
+| Capability | Allows |
+| --- | --- |
+| `context.read` | `GET /v1/context` |
+| `surfaces.read` | `GET /v1/surfaces` |
+| `tile.focus` | `POST /v1/tile/focus` |
+| `tile.split` | `POST /v1/tile/split` |
+| `tile.close` | `POST /v1/tile/close` |
+
+Under-capable handles fail with `capability_denied`.
+
+## Error Codes
+
+| Code | Meaning |
+| --- | --- |
+| `disabled` | The experiment is off for this launch. |
+| `capability_denied` | The handle does not include the required capability. |
+| `missing_handle` | The scoped request omitted `x-workspaces-automation-handle`. |
+| `stale_handle` | The handle is missing or no longer maps to a live terminal tile. |
+| `invalid_request` | The request shape is not allowed, including caller-supplied target IDs. |
+| `malformed_json` | A JSON body could not be decoded. |
+| `route_not_found` | The route is not part of the API. |
+| `method_not_allowed` | The path exists but the HTTP method is wrong. |
+| `unsupported` | The requested V1 operation is not supported in the current context. |
+| `internal_error` | Unexpected server-side failure. |
+
 ## CLI
 
 The `workspaces` CLI wraps the socket API. Scoped commands read the same
@@ -102,6 +151,35 @@ workspaces tile split --up
 workspaces tile split --down
 workspaces tile close
 ```
+
+## Implementation Map
+
+| Concern | File |
+| --- | --- |
+| Wire models and envelopes | `Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift` |
+| Socket listener and lock | `Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift` |
+| HTTP route projection | `Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift` |
+| CLI socket client | `Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift` |
+| CLI formatting | `Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift` |
+| App-side controller | `Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift` |
+| Feature lifecycle and injection | `Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift` |
+| Terminal environment provider | `Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift` |
+| Terminal config injection | `Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift` |
+| CLI command router | `Sources/WorkspaceManagerCLI/main.swift` |
+
+## Verification
+
+After changing this API, run:
+
+```bash
+swift test --filter Automation
+swift test
+swift-format lint --strict --recursive Sources/ Tests/
+./scripts/dev-smoke.sh --no-build
+```
+
+If docs or public examples changed, also run the docs checks listed in
+[Docs Site Runbook](../README.md).
 
 ## V1 Non-Goals
 

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -85,7 +85,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/context` | Returns the caller's resolved context and capabilities. |
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
-| `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Existing splits are focused or relaid out without claiming a new surface. Secondary split-tile callers return `unsupported` in V1. |
+| `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Each successful split creates a new terminal surface in the caller's tab. Secondary split-tile callers return `unsupported` in V1. |
 | `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
 
 Mutation bodies must be projections over the supported operation, not raw tile

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -1,0 +1,108 @@
+# WorkSpaces Automation API V1
+
+The Automation API is a local app-shell control plane for trusted processes
+running inside WorkSpaces terminal tiles. V1 is intentionally narrow: a caller
+can discover its live shell context, list in-scope surfaces, and request core
+tile mutations relative to its own tile.
+
+The API is experimental and disabled by default. Enable it from the
+Experimental Features settings, or force it on for development with:
+
+```bash
+WORKSPACES_AUTOMATION_API=1
+```
+
+## Trust Boundary
+
+The listener is separate from the Claude hook listener. It binds a local Unix
+domain socket named `automation.sock`, protected by its own `automation.lock`,
+under the user-private WorkSpaces application support directory.
+
+Terminal surfaces receive only the minimum discovery environment:
+
+```bash
+WORKSPACES_AUTOMATION_SOCKET=/path/to/automation.sock
+WORKSPACES_AUTOMATION_HANDLE=<opaque capability handle>
+```
+
+The handle is the authority. Requests for scoped routes send it as
+`x-workspaces-automation-handle`; requests do not get to name their tile,
+surface, or host session. The app resolves the handle against its live mapping
+to recover the caller tile, host session, surface kind, window scope, app
+scope, and capabilities. Missing, stale, disabled, or out-of-scope handles fail
+closed.
+
+Allowed and denied requests are appended to `automation-audit.jsonl` next to
+the socket state. The audit log stores route-level metadata and error codes,
+not terminal input or output.
+
+## Envelope
+
+Every route returns a versioned JSON envelope:
+
+```json
+{ "v": 1, "ok": true, "result": {} }
+```
+
+```json
+{
+  "v": 1,
+  "ok": false,
+  "error": { "code": "missing_handle", "message": "Missing automation handle." }
+}
+```
+
+## Routes
+
+`GET /v1/health` is the only unauthenticated route. It reports listener
+liveness only and does not prove that a terminal handle is valid.
+
+Scoped routes require `x-workspaces-automation-handle`:
+
+| Route | Behavior |
+| --- | --- |
+| `GET /v1/context` | Returns the caller's resolved context and capabilities. |
+| `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
+| `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
+| `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` relative to the caller tile. |
+| `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
+
+Mutation bodies must be projections over the supported operation, not raw tile
+state. For example:
+
+```json
+{ "direction": "right" }
+```
+
+Bodies that try to supply target identifiers such as `tileID`, `surfaceID`, or
+`hostSessionID` are rejected.
+
+## CLI
+
+The `workspaces` CLI wraps the socket API. Scoped commands read the same
+environment that WorkSpaces injects into terminal surfaces.
+
+```bash
+workspaces automation health
+workspaces automation health --json
+workspaces automation context --json
+workspaces surface list --json
+workspaces tile focus --left
+workspaces tile focus --right
+workspaces tile focus --up
+workspaces tile focus --down
+workspaces tile focus --next
+workspaces tile focus --previous
+workspaces tile split --left
+workspaces tile split --right
+workspaces tile split --up
+workspaces tile split --down
+workspaces tile close
+```
+
+## V1 Non-Goals
+
+V1 does not support browser mutation, opening web URLs, tab title or metadata
+changes, input injection, resize/equalize, or global cross-workspace control.
+Those capabilities require separate product and safety review before they can
+be added.

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -83,6 +83,11 @@ The Settings UI enumerates `ExperimentalFeature.allCases`, so a registered
 feature appears automatically under Settings -> Experimental Features when the
 master toggle is on.
 
+The Automation API is an example of a Settings-gated experiment with both user
+and maintainer docs. Keep [Automation API Guide](../automation-api.md) and
+[Automation API Reference](./automation-api.md) aligned when its feature flag,
+environment override, or terminal environment behavior changes.
+
 ## Environment Overrides
 
 Use a force-on environment key only for developer-launch and evidence workflows.

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -9,6 +9,11 @@ integration with GhosttyKit (`libghostty`).
 xcframework behavior can change between commits. This guide captures the exact
 integration contract in this repo so future sessions can upgrade safely.
 
+The local [Automation API Reference](./automation-api.md) builds on the same
+terminal session and surface identity model. When changing split or focus
+behavior here, keep the automation API's context, surface list, focus, and split
+semantics aligned.
+
 ## Current Integration Shape
 
 ### Build + pinning

--- a/docs/development/shortcut-routing.md
+++ b/docs/development/shortcut-routing.md
@@ -61,6 +61,10 @@ Current split UI model is a two-pane stack:
 - `up` / `down`: directional focus when target exists for vertical stacks.
 - Orthogonal directions remain no-ops when they do not match the active split axis.
 
+The [Automation API Reference](./automation-api.md) exposes the same directional
+focus and split vocabulary for trusted processes running inside terminal tiles.
+Do not broaden those commands here without updating the API docs and tests.
+
 ## Verification Checklist
 
 1. Launch debug app via `./scripts/launch-dev.sh --no-build`

--- a/docs/index.html
+++ b/docs/index.html
@@ -840,6 +840,7 @@
           <div class="doc-strip" aria-label="High-level documentation entry points">
             <a class="doc-link" href="/docs/product_overview"><strong>Product Overview</strong>High-level purpose, principles, and non-goals.</a>
             <a class="doc-link" href="user-guide/"><strong>User Guide</strong>Day-to-day workflows and shortcuts.</a>
+            <a class="doc-link" href="/docs/automation-api"><strong>Automation API</strong>Local terminal-to-app shell commands and safety model.</a>
             <a class="doc-link" href="/docs/branding"><strong>Branding</strong>Icon metaphor, palette, and asset rules.</a>
             <a class="doc-link" href="/docs/development/mergeability-standard"><strong>Mergeability</strong>Review and evidence expectations.</a>
           </div>
@@ -1031,6 +1032,7 @@
         <div class="artifact-grid">
           <a class="artifact" href="/docs/product_overview"><span class="type">Product</span><strong>Product Overview</strong><p>Problem, solution, native app principles, and non-goals.</p></a>
           <a class="artifact" href="user-guide/"><span class="type">User</span><strong>User Guide</strong><p>Repository, workspace, terminal, and shortcut workflows.</p></a>
+          <a class="artifact" href="/docs/automation-api"><span class="type">Automation</span><strong>Automation API</strong><p>Local app-shell context, surface, focus, split, and close commands.</p></a>
           <a class="artifact" href="/docs/branding"><span class="type">Brand</span><strong>Branding</strong><p>Icon metaphor and visual rules grounded in the repository portfolio model.</p></a>
           <a class="artifact" href="/docs/development/libghostty-integration"><span class="type">Terminal</span><strong>Ghostty Integration</strong><p>Shortcut, split, and terminal surface contract.</p></a>
           <a class="artifact" href="/docs/development/lume-integration"><span class="type">Runtime</span><strong>Lume Integration</strong><p>VM-backed workspace runtime setup and storage contracts.</p></a>

--- a/web/e2e/fast/docs-local-server.spec.ts
+++ b/web/e2e/fast/docs-local-server.spec.ts
@@ -128,6 +128,17 @@ test.describe("Local docs server", () => {
 		const searchPayload = await search.json();
 		expect(searchPayload.results.length).toBeGreaterThan(0);
 
+		const automationSearch = await context.request.get(
+			`${baseURL}/docs/api/search?q=tile%20split&limit=5`,
+		);
+		expect(automationSearch.ok()).toBe(true);
+		const automationPayload = await automationSearch.json();
+		expect(
+			automationPayload.results.some(
+				(result: { title?: string }) => result.title === "Automation API Guide",
+			),
+		).toBe(true);
+
 		await routeInput.press("Enter");
 		await expect(page.locator("#autocomplete")).toBeVisible();
 		await expect(page.locator("#route-form + #search-hint + #autocomplete")).toHaveCount(

--- a/web/e2e/fast/docs.spec.ts
+++ b/web/e2e/fast/docs.spec.ts
@@ -27,6 +27,26 @@ test.describe("Public docs", () => {
 		await expect(page.getByText("Repository").first()).toBeVisible();
 	});
 
+	test("renders the Automation API guide and reference", async ({ page }) => {
+		await page.goto("/docs/index.html");
+		await page
+			.getByRole("link", { name: /Automation API/ })
+			.first()
+			.click();
+
+		await expect(page).toHaveURL(/\/docs\/automation-api$/);
+		await expect(
+			page.getByRole("heading", { name: "WorkSpaces Automation API Guide" }),
+		).toBeVisible();
+		await expect(page.getByText("workspaces tile split --right").first()).toBeVisible();
+
+		await page.goto("/docs/development/automation-api");
+		await expect(
+			page.getByRole("heading", { name: "WorkSpaces Automation API V1" }),
+		).toBeVisible();
+		await expect(page.getByText("capability_denied").first()).toBeVisible();
+	});
+
 	test("renders README reference-style images", async ({ page }) => {
 		await page.goto("/docs/README");
 

--- a/web/scripts/docs-sync-manifest.json
+++ b/web/scripts/docs-sync-manifest.json
@@ -41,6 +41,23 @@
 			"aliases": ["surface", "surfaces", "last surface"]
 		},
 		{
+			"id": "automation",
+			"label": "Automation",
+			"definition": "The local app-shell API and CLI surface for trusted terminal processes to read context and request scoped tile actions.",
+			"chip": true,
+			"priority": 45,
+			"aliases": [
+				"automation",
+				"automation api",
+				"app-shell automation",
+				"workspaces automation",
+				"tile focus",
+				"tile split",
+				"surface list",
+				"automation socket"
+			]
+		},
+		{
 			"id": "provider",
 			"label": "Provider",
 			"definition": "A backing runtime that can create isolated workspace environments.",
@@ -217,6 +234,22 @@
 			"summary": "Daytona-backed workspace runtime notes."
 		},
 		{
+			"source": "docs/automation-api.md",
+			"dest": "automation-api.md",
+			"title": "Automation API Guide",
+			"group": "Development",
+			"topics": ["automation", "terminal-session", "surface", "workspaces"],
+			"summary": "Example-first guide for using workspaces automation health, context, surface list, tile focus, tile split, and tile close from a terminal tile."
+		},
+		{
+			"source": "docs/decisions/automation-api-v1.md",
+			"dest": "decisions/automation-api-v1.md",
+			"title": "Automation API V1 Decision",
+			"group": "Architecture",
+			"topics": ["automation", "terminal-session", "surface", "mergeability"],
+			"summary": "Decision record for the local socket, opaque handle authority model, narrow V1 scope, and excluded browser/input/global control."
+		},
+		{
 			"source": "docs/performance-testing.md",
 			"dest": "performance-testing.md",
 			"title": "Performance Testing",
@@ -239,6 +272,14 @@
 			"group": "Development",
 			"topics": ["terminal-session", "ghostty", "surface", "workspace"],
 			"summary": "Ghostty integration contract for terminal focus, shortcuts, tabs, and splits."
+		},
+		{
+			"source": "docs/development/automation-api.md",
+			"dest": "development/automation-api.md",
+			"title": "Automation API Reference",
+			"group": "Development",
+			"topics": ["automation", "terminal-session", "surface", "ghostty"],
+			"summary": "Wire reference for automation.sock, WORKSPACES_AUTOMATION_HANDLE, capabilities, envelopes, error codes, routes, and CLI behavior."
 		},
 		{
 			"source": "docs/development/lume-integration.md",


### PR DESCRIPTION
## Summary
- Add an experimental local Automation API listener on automation.sock with a separate lock, opaque handle registry, stable V1 envelopes, and append-only audit logging.
- Inject only WORKSPACES_AUTOMATION_SOCKET and WORKSPACES_AUTOMATION_HANDLE into terminal surfaces, then resolve scoped requests through the live app-side handle mapping.
- Add CLI wrappers for automation health/context, surface list, and tile focus/split/close plus V1 development docs and regression coverage.
- Follow-up hardening: listener lock contention now disables injection instead of issuing unusable handles, scoped responses no longer echo the opaque handle, handle capabilities are enforced, and split now grows the live tile tree from primary terminal tiles while secondary split-tile callers remain unsupported in V1.
- Document V1 with a published quickstart guide, expanded reference, decision record, docs-site manifest topic, landing/README cross-links, and docs E2E coverage.
- Rebased onto current origin/main and stabilized the concurrent workspace-create test double that failed the first post-rebase CI run.

## Scope
V1 is limited to read context/surfaces and core tile focus/split/close mutations. It does not implement browser mutation, open-web, tab title/metadata changes, input injection, resize/equalize, or global cross-workspace control.

Closes #628

## Mergeability
- Surface: desktop app / CLI / local automation API / docs site
- User-facing behavior changed: Adds disabled-by-default experimental automation commands for trusted processes running inside WorkSpaces terminal tiles, with user-facing quickstart and reference docs.
- Non-happy paths considered: Disabled feature, missing/stale/under-capable handle, malformed JSON, caller-supplied target IDs, no focus neighbor, socket lock contention, socket smoke, repeated primary-tile splits, secondary split rejection, close routing through the existing confirmation path, and docs-site public/local discovery are covered by tests.
- Residual risk or follow-up: V1 does not expose browser mutation, input injection, resizing, metadata, or global control; peer credential validation beyond private socket permissions remains a future hardening option if Network.framework exposes a reliable path here.

## Validation
- swift-format lint --strict --recursive Sources/ Tests/
- swift build
- swift test --filter Automation (33 tests in 6 suites passed)
- swift test --filter SidebarWorkspaceControllerBehavior (18 tests in 1 suite passed)
- swift test (1002 tests in 160 suites passed)
- .build/debug/workspaces help
- ./scripts/dev-smoke.sh --no-build
- corepack pnpm@10.18.3 --dir web docs:sync
- corepack pnpm@10.18.3 --dir web docs:check
- uv run --script scripts/docs-server-smoke.py
- PYTHONPYCACHEPREFIX=/tmp/workspaces-docs-pycache python3 -m py_compile docs/server.py scripts/docs_catalog.py scripts/docs-server-smoke.py
- node --check docs/assets/operator-index.js
- corepack pnpm@10.18.3 --dir web test:e2e:docs-local (3 passed)
- corepack pnpm@10.18.3 --dir web test:e2e:docs (13 passed, 2 skipped)
- GitHub Actions on 8007968c: build-and-test, Web CI, Web Preview, readiness, perf evidence, release-change-validation, and WorkSpaces Managed Review passed.

## Evidence
- ![automation-api-v1](https://evidence.cloudcompute.com/workspaces/pr-684/20260627-061753-automation-api-v1.png)
- ![automation-api-v1-followup-smoke](https://evidence.cloudcompute.com/workspaces/pr-684/20260627-082425-automation-api-v1-followup-smoke.png)
- ![automation-api-docs](https://evidence.cloudcompute.com/workspaces/pr-684/20260627-161723-automation-api-docs.png)