### PR TITLE
Fix Codex worker mise bootstrap

### DIFF
--- a/.codex/environments/workspaces.toml
+++ b/.codex/environments/workspaces.toml
@@ -1,4 +1,4 @@
 name = "WorkSpaces"
 
 [setup]
-script = "./scripts/setup"
+script = "./scripts/setup --fast"

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -26,6 +26,8 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+CODEX_ENVIRONMENT = (REPO_ROOT / ".codex/environments/workspaces.toml").read_text()
+assert 'script = "./scripts/setup --fast"' in CODEX_ENVIRONMENT
 
 
 class SecurityHardeningTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Run Codex worker environment setup through `./scripts/setup --fast` so new worker checkouts trust reviewed mise configs before the first interactive terminal starts.
- Add a security regression assertion that the Codex environment keeps using the fast setup bootstrap.

## Mergeability

- Surface: agent tooling / Codex environment bootstrap
- User-facing behavior changed: new Codex worker terminals should no longer print mise untrusted-config errors on first shell startup after the environment setup hook runs.
- Non-happy paths considered: the fast setup still fails closed through `scripts/setup` if unallowlisted mise configs or forbidden trust/env directives appear.
- Release/ops preconditions: none; this changes worker bootstrap config only.
- Residual risk or follow-up: existing already-created worker worktrees need `./scripts/setup --fast` once, because environment setup hooks only run for newly prepared sessions.

## Evidence

![codex-mise-bootstrap](https://evidence.cloudcompute.com/workspaces/pr-685/20260627-064619-codex-mise-bootstrap.svg)

## Validation

- `./scripts/setup --fast` passed after allowing mise to update the user trust store.
- `mise trust --show` reports this worktree's `.mise.toml` trusted.
- Outside-sandbox login shell repro: `zsh -lic 'echo MISE_REPRO_OK'` prints no mise trust error.
- `git diff --check` passed.
- `uv run --script ./scripts/tests/test_security_hardening.py SecurityHardeningTests.test_mise_invocations_are_locked_and_pinned` passed.
- `uv run --script ./scripts/tests/test_security_hardening.py` passed.

## Known Caveat

- `./scripts/verify-mise-security.sh` is currently blocked on host mise currency: installed `mise 2026.5.7` does not match current latest `v2026.6.14`. The checks before that version gate passed.