### PR TITLE
feat: insert dropped terminal paths

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttyDroppedContentFormatter.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyDroppedContentFormatter.swift
@@ -1,0 +1,56 @@
+//
+//  GhosttyDroppedContentFormatter.swift
+//  WorkspaceManager
+//
+
+import AppKit
+import Foundation
+
+/// Formats drag-and-drop pasteboard payloads for insertion into a live terminal.
+/// File paths and URLs are escaped for shell editing; plain strings are passed
+/// through so dragging selected command text keeps its original contents.
+enum GhosttyDroppedContentFormatter {
+    static let pasteboardTypes: [NSPasteboard.PasteboardType] = [
+        .string,
+        .fileURL,
+        .URL,
+    ]
+
+    static func accepts(types: [NSPasteboard.PasteboardType]?) -> Bool {
+        guard let types else { return false }
+        return !Set(types).isDisjoint(with: pasteboardTypes)
+    }
+
+    static func content(from pasteboard: NSPasteboard) -> String? {
+        if let url = pasteboard.string(forType: .URL) {
+            return shellEscape(url)
+        }
+
+        if let urls = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL],
+            let content = content(forURLs: urls)
+        {
+            return content
+        }
+
+        return pasteboard.string(forType: .string)
+    }
+
+    static func content(forURLs urls: [URL]) -> String? {
+        guard !urls.isEmpty else { return nil }
+        return
+            urls
+            .map { shellEscape($0.isFileURL ? $0.path : $0.absoluteString) }
+            .joined(separator: " ")
+    }
+
+    static func shellEscape(_ value: String) -> String {
+        var result = value
+        for character in "\\ ()[]{}<>\"'`!#$&;|*?\t" {
+            result = result.replacingOccurrences(
+                of: String(character),
+                with: "\\\(character)"
+            )
+        }
+        return result
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -54,6 +54,7 @@ final class GhosttySurfaceView: NSView {
         )
         super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
         self.wantsLayer = true
+        registerForDraggedTypes(GhosttyDroppedContentFormatter.pasteboardTypes)
 
         createSurfaceIfNeeded()
     }
@@ -421,6 +422,29 @@ final class GhosttySurfaceView: NSView {
     func scrollToRow(_ row: Int) {
         guard let surface else { return }
         _ = performBindingAction("scroll_to_row:\(row)", surface: surface)
+    }
+
+    // MARK: - Drag and drop
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard GhosttyDroppedContentFormatter.accepts(types: sender.draggingPasteboard.types) else {
+            return []
+        }
+        return .copy
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        draggingEntered(sender)
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let content = GhosttyDroppedContentFormatter.content(from: sender.draggingPasteboard) else {
+            return false
+        }
+
+        TerminalFocusManager.shared.requestFocus(for: self)
+        insertText(content, replacementRange: NSRange(location: 0, length: 0))
+        return true
     }
 
     // MARK: - Keyboard input

--- a/Tests/WorkspaceManagerAppTests/GhosttyDroppedContentFormatterTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyDroppedContentFormatterTests.swift
@@ -1,0 +1,72 @@
+//
+//  GhosttyDroppedContentFormatterTests.swift
+//  WorkspaceManagerAppTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("GhosttyDroppedContentFormatter")
+struct GhosttyDroppedContentFormatterTests {
+    @Test("Accepts string, file URL, and URL pasteboard types")
+    func acceptsRegisteredPasteboardTypes() {
+        #expect(GhosttyDroppedContentFormatter.accepts(types: [.string]))
+        #expect(GhosttyDroppedContentFormatter.accepts(types: [.fileURL]))
+        #expect(GhosttyDroppedContentFormatter.accepts(types: [.URL]))
+        #expect(!GhosttyDroppedContentFormatter.accepts(types: [.png]))
+        #expect(!GhosttyDroppedContentFormatter.accepts(types: nil))
+    }
+
+    @Test("Escapes shell-sensitive characters in dropped file paths")
+    func escapesShellSensitiveCharacters() {
+        let path = #"/Users/fairchild/My Files/[draft] "quote" and 'apostrophe'?.md"#
+
+        #expect(
+            GhosttyDroppedContentFormatter.shellEscape(path)
+                == #"/Users/fairchild/My\ Files/\[draft\]\ \"quote\"\ and\ \'apostrophe\'\?.md"#
+        )
+    }
+
+    @Test("Joins multiple file URLs with escaped paths")
+    func joinsMultipleFileURLs() {
+        let content = GhosttyDroppedContentFormatter.content(forURLs: [
+            URL(fileURLWithPath: "/tmp/My File.txt"),
+            URL(fileURLWithPath: "/tmp/query?.swift"),
+        ])
+
+        #expect(content == #"/tmp/My\ File.txt /tmp/query\?.swift"#)
+    }
+
+    @Test("Returns nil for an empty file URL list")
+    func emptyFileURLListReturnsNil() {
+        #expect(GhosttyDroppedContentFormatter.content(forURLs: []) == nil)
+    }
+
+    @Test("Keeps non-file URL objects intact")
+    func keepsNonFileURLObjectsIntact() throws {
+        let url = try #require(URL(string: "https://example.com/a b?q=1&x=2"))
+
+        #expect(GhosttyDroppedContentFormatter.content(forURLs: [url]) == #"https://example.com/a%20b\?q=1\&x=2"#)
+    }
+
+    @Test("Keeps plain strings unescaped")
+    func keepsPlainStringsUnescaped() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("workspaces-drop-string-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString("echo 'already quoted' && ls ~/Desktop", forType: .string)
+
+        #expect(GhosttyDroppedContentFormatter.content(from: pasteboard) == "echo 'already quoted' && ls ~/Desktop")
+    }
+
+    @Test("Escapes URL pasteboard strings before insertion")
+    func escapesURLPasteboardStrings() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("workspaces-drop-url-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString("https://example.com/a b?q=1&x=2", forType: .URL)
+
+        #expect(GhosttyDroppedContentFormatter.content(from: pasteboard) == #"https://example.com/a\ b\?q=1\&x=2"#)
+    }
+}


### PR DESCRIPTION
## Summary
- accept string, file URL, and URL drops on embedded Ghostty terminal surfaces
- insert escaped file/URL payloads into the focused terminal while preserving plain text drops
- cover pasteboard type acceptance and shell escaping behavior with focused Swift tests

## Mergeability
- Surface: desktop terminal / Ghostty surface drag-and-drop
- User-facing behavior changed: files, URLs, and text dragged onto a terminal are inserted at the prompt instead of ignored
- Non-happy paths considered: unsupported pasteboard types are rejected, empty URL lists return nil, plain strings stay unescaped, file and URL payloads are shell-escaped
- Residual risk or follow-up: no manual GUI capture yet; this PR is currently validated through formatter unit tests, lint, and build

## Validation
- swift-format lint --strict --recursive Sources/ Tests/
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check
- ./scripts/build-ghosttykit.sh
- swift build
- swift test --filter GhosttyDroppedContentFormatter

## Evidence
- [terminal-drag-drop-validation](https://evidence.cloudcompute.com/workspaces/pr-686/20260627-065344-terminal-drag-drop-validation.svg)