### PR TITLE
release: v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.21.0] - 2026-06-27
+
+### Added
+- Insert dropped terminal paths into active sessions (#686).
+- Needs-you notification dropdown.
+
+### Fixed
+- Ghostty terminal scrolling.
+- Xcode Cloud Ghostty Zig selection.
+
+### Other
+- Add optional tester prerelease path (#676).
+- Enable Ghostty tab renaming.
+- Avoid no-op terminal tab title overrides.
+- Fix Lume orphan VM storage cleanup.
+- Rename Command Palette to Session Switcher.
+- Address session switcher review findings and follow-ups.
+- Close workspace terminals on archive.
+
 ## [0.21.0-beta.1] - 2026-06-25
 
 ### Added

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.21.0-beta.1</string>
+	<string>0.21.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>26</string>
+	<string>27</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

- Promote WorkSpaces from `0.21.0-beta.1` to stable `0.21.0`.
- Bump app build metadata from `26` to `27`.
- Add stable `0.21.0` release notes to `CHANGELOG.md`.

## Mergeability

- Surface: desktop / release
- User-facing behavior changed: yes, published app version and release notes become `0.21.0`.
- Non-happy paths considered: release workflow validates tag/version parity and release preflight on the target SHA; local `assert-tag-match v0.21.0` passed.
- Release/ops preconditions: protected `Release` workflow still requires release environment approval/signing lane after this PR merges and `v0.21.0` is tagged or dispatched.
- Residual risk or follow-up: GitHub-hosted release publication/notarization is not complete until the protected release workflow finishes.

## Validation

- [x] `swift build` via `swift test` build phase
- [x] `swift test`
- [x] Other checks run: `./scripts/build-ghosttykit.sh`; `./scripts/release-version.sh assert-tag-match v0.21.0`; `env UV_CACHE_DIR=/private/tmp/codex-uv-cache ./scripts/validate-release-changes.py --changed-files /private/tmp/workspaces-release-changed-files.json`; `swift-format lint --strict --recursive Sources/ Tests/`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![release-v0.21.0-validation](https://evidence.cloudcompute.com/workspaces/pr-688/20260627-073103-release-v0.21.0-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
