### PR TITLE
Ensure terminal sessions exit before workspace retirement

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -8,6 +8,21 @@ import Foundation
 import GhosttyKit
 import QuartzCore
 
+enum GhosttySurfaceRetirementCloseError: LocalizedError {
+    case processStillRunning(title: String)
+    case timedOut(title: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .processStillRunning(let title):
+            return
+                "Terminal '\(title)' still has a running process. Close it before archiving or deleting the workspace."
+        case .timedOut(let title):
+            return "Terminal '\(title)' did not exit before the workspace lifecycle timeout."
+        }
+    }
+}
+
 @MainActor
 final class GhosttySurfaceView: NSView {
     private let workingDirectory: URL
@@ -262,15 +277,49 @@ final class GhosttySurfaceView: NSView {
         ghostty_surface_request_close(surface)
     }
 
-    func forceCloseForSessionRetirement() {
-        onCloseConfirmationRequired = nil
-        onProcessExit = nil
-        didProcessExit = true
-
+    func requestCloseForSessionRetirement(
+        timeout: Duration = .seconds(5),
+        pollInterval: Duration = .milliseconds(50)
+    ) async throws {
         guard let surface else { return }
-        GhosttyAppManager.shared.unregisterSurface(self)
-        ghostty_surface_free(surface)
-        self.surface = nil
+        guard !ghostty_surface_process_exited(surface) else { return }
+
+        var processStillRunning = false
+        let previousCloseConfirmation = onCloseConfirmationRequired
+        onCloseConfirmationRequired = {
+            processStillRunning = true
+        }
+        defer {
+            onCloseConfirmationRequired = previousCloseConfirmation
+        }
+
+        ghostty_surface_request_close(surface)
+
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if self.surface == nil || ghostty_surface_process_exited(surface) {
+                return
+            }
+            if processStillRunning {
+                throw GhosttySurfaceRetirementCloseError.processStillRunning(title: displayTitleForLifecycleError)
+            }
+            try await Task.sleep(for: pollInterval)
+        }
+
+        if self.surface == nil || ghostty_surface_process_exited(surface) {
+            return
+        }
+        throw GhosttySurfaceRetirementCloseError.timedOut(title: displayTitleForLifecycleError)
+    }
+
+    private var displayTitleForLifecycleError: String {
+        let title = terminalTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !title.isEmpty {
+            return title
+        }
+
+        let fallback = workingDirectory.lastPathComponent
+        return fallback.isEmpty ? "Terminal" : fallback
     }
 
     // MARK: - Local event monitor

--- a/Sources/WorkspaceManager/Views/Components/TerminalView.swift
+++ b/Sources/WorkspaceManager/Views/Components/TerminalView.swift
@@ -119,16 +119,12 @@ final class HostTerminalSurfaceStore {
     }
 
     @discardableResult
-    func retire(sessionID: UUID) -> Bool {
-        guard let removed = surfaces.removeValue(forKey: sessionID) else {
-            onSurfaceInvalidated?(sessionID)
+    func closeForSessionRetirement(sessionID: UUID) async throws -> Bool {
+        guard let terminal = surfaces[sessionID] else {
             return false
         }
 
-        sessionIDsBySurfaceIdentity.removeValue(forKey: ObjectIdentifier(removed))
-        removed.onTerminalTitleChanged = nil
-        removed.forceCloseForSessionRetirement()
-        onSurfaceInvalidated?(sessionID)
+        try await terminal.requestCloseForSessionRetirement()
         return true
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -602,7 +602,7 @@ struct ContentView: View {
                 },
                 onWorkspaceCreated: handleWorkspaceCreated,
                 retireTerminalSessions: { key in
-                    await retireTerminalSessions(inScope: key)
+                    try await retireTerminalSessions(inScope: key)
                 },
                 workspaceProviderSetupCoordinator: workspaceProviderSetupCoordinator,
                 hostLumeSmokeAutomation: hostLumeSmokeAutomation,
@@ -1695,7 +1695,7 @@ struct ContentView: View {
             workspaceService: workspaceService,
             workspaceProviderRegistry: workspaceProviderRegistry,
             retireTerminalSessions: { key in
-                await retireTerminalSessions(inScope: key)
+                try await retireTerminalSessions(inScope: key)
             }
         )
         let workspace = try await controller.createWorkspace(
@@ -1722,7 +1722,7 @@ struct ContentView: View {
             workspaceService: workspaceService,
             workspaceProviderRegistry: workspaceProviderRegistry,
             retireTerminalSessions: { key in
-                await retireTerminalSessions(inScope: key)
+                try await retireTerminalSessions(inScope: key)
             }
         )
         do {
@@ -1824,7 +1824,12 @@ struct ContentView: View {
     }
 
     @MainActor
-    private func retireTerminalSessions(inScope scopeKey: HostTerminalSessionKey) async {
+    private func retireTerminalSessions(inScope scopeKey: HostTerminalSessionKey) async throws {
+        let sessionIDs = hostTerminalState.terminalSessionIDs(inScope: scopeKey)
+        for sessionID in sessionIDs {
+            try await hostTerminalState.surfaceStore.closeForSessionRetirement(sessionID: sessionID)
+        }
+
         let retiredSessionIDs = hostTerminalState.retireSessions(inScope: scopeKey)
         guard !retiredSessionIDs.isEmpty else { return }
 
@@ -2018,7 +2023,7 @@ struct ContentView: View {
             workspaceService: workspaceService,
             workspaceProviderRegistry: workspaceProviderRegistry,
             retireTerminalSessions: { key in
-                await retireTerminalSessions(inScope: key)
+                try await retireTerminalSessions(inScope: key)
             }
         )
 

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -123,6 +123,25 @@ final class HostTerminalStateStore: ObservableObject {
         coordinator.sessions(inScope: scopeKey)
     }
 
+    func terminalSessionIDs(inScope scopeKey: HostTerminalSessionKey) -> [UUID] {
+        coordinator.sessions(inScope: scopeKey).flatMap { primarySession in
+            var sessionIDs: [UUID] = []
+
+            if let tree = treesByPrimaryID[primarySession.id],
+                let primaryTile = tileIDBySessionID[primarySession.id]
+            {
+                for tileID in tree.leafIDs where tileID != primaryTile {
+                    if let splitSession = sessionByTileID[tileID] {
+                        sessionIDs.append(splitSession.id)
+                    }
+                }
+            }
+
+            sessionIDs.append(primarySession.id)
+            return sessionIDs
+        }
+    }
+
     func activeSession(inScope scopeKey: HostTerminalSessionKey) -> HostTerminalSession? {
         let scopedSessions = coordinator.sessions(inScope: scopeKey)
         guard !scopedSessions.isEmpty else { return nil }
@@ -715,8 +734,8 @@ final class HostTerminalStateStore: ObservableObject {
 
     /// Drops the split tree for `primarySessionID` and every binding it owned, returning the split
     /// session(s) it held (the non-primary leaves) so the caller can tear them down its own way —
-    /// `invalidate` on collapse vs `retire` on workspace deletion. The primary tile binding falls
-    /// away with the tree; the primary session itself stays in the coordinator and is untouched here.
+    /// collapse invalidation vs post-close workspace cleanup. The primary tile binding falls away
+    /// with the tree; the primary session itself stays in the coordinator and is untouched here.
     @discardableResult
     private func dropSplitTree(forPrimarySessionID primarySessionID: UUID) -> [HostTerminalSession] {
         guard let tree = treesByPrimaryID.removeValue(forKey: primarySessionID) else { return [] }
@@ -751,7 +770,7 @@ final class HostTerminalStateStore: ObservableObject {
     }
 
     private func retireTerminalSession(_ sessionID: UUID) {
-        surfaceStore.retire(sessionID: sessionID)
+        surfaceStore.invalidate(sessionID: sessionID)
         deregisterTerminalSession(sessionID)
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -57,7 +57,7 @@ struct SidebarView: View {
     let onWebSourceSelected: (WebSource) -> Void
     let onRequestWebSourceCreation: (WebSourceCreationTarget) -> Void
     let onWorkspaceCreated: () -> Void
-    let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async -> Void
+    let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async throws -> Void
     let workspaceProviderSetupCoordinator: WorkspaceProviderSetupCoordinator
     let hostLumeSmokeAutomation: HostLumeSmokeAutomationController
     let desktopUISmokeAutomation: DesktopUISmokeAutomationController

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -31,13 +31,13 @@ struct SidebarWorkspaceController {
     let modelContext: ModelContext
     let workspaceService: any WorkspaceServiceProtocol
     let workspaceProviderRegistry: WorkspaceProviderRegistry
-    let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async -> Void
+    let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async throws -> Void
 
     init(
         modelContext: ModelContext,
         workspaceService: any WorkspaceServiceProtocol,
         workspaceProviderRegistry: WorkspaceProviderRegistry,
-        retireTerminalSessions: @escaping @MainActor (HostTerminalSessionKey) async -> Void = { _ in }
+        retireTerminalSessions: @escaping @MainActor (HostTerminalSessionKey) async throws -> Void = { _ in }
     ) {
         self.modelContext = modelContext
         self.workspaceService = workspaceService
@@ -166,7 +166,7 @@ struct SidebarWorkspaceController {
     func deleteWorkspace(_ workspace: Workspace, deleteFiles: Bool) async throws {
         let workspaceURL = workspace.workspaceURL
         let sessionKey = try terminalSessionKey(for: workspace)
-        await retireTerminalSessions(sessionKey)
+        try await retireTerminalSessions(sessionKey)
 
         if workspace.backend == .local {
             try await workspaceService.deleteWorkspace(at: workspaceURL, deleteFiles: deleteFiles)
@@ -198,7 +198,7 @@ struct SidebarWorkspaceController {
 
     func archive(_ workspace: Workspace) async throws {
         let sessionKey = try terminalSessionKey(for: workspace)
-        await retireTerminalSessions(sessionKey)
+        try await retireTerminalSessions(sessionKey)
 
         if workspace.backend == .local {
             let archivedURL = try await workspaceService.archiveWorkspace(at: workspace.workspaceURL)

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -19,6 +19,10 @@ struct SidebarWorkspaceControllerBehaviorTests {
         }
     }
 
+    struct TerminalRetirementError: LocalizedError {
+        let errorDescription: String? = "terminal still running"
+    }
+
     @Test("Local request routes through WorkspaceService")
     @MainActor
     func localRequestRoutesThroughWorkspaceService() async throws {
@@ -375,6 +379,46 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(await recorder.snapshot() == ["retire:hostPath(\(workspaceURL.path))", "delete"])
     }
 
+    @Test("Deleting local workspace fails before service cleanup when terminal retirement fails")
+    @MainActor
+    func deletingLocalWorkspaceFailsWhenTerminalRetirementFails() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: workspaceURL,
+            sourceRepo: repo,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let recorder = OperationRecorder()
+        let workspaceService = MockWorkspaceService()
+        workspaceService.deleteWorkspaceWillRun = {
+            await recorder.record("delete")
+        }
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()],
+            retireTerminalSessions: { key in
+                await recorder.record("retire:\(key.debugDescription)")
+                throw TerminalRetirementError()
+            }
+        )
+
+        await #expect(throws: TerminalRetirementError.self) {
+            try await controller.deleteWorkspace(workspace, deleteFiles: true)
+        }
+
+        #expect(await recorder.snapshot() == ["retire:hostPath(\(workspaceURL.path))"])
+        #expect(workspaceService.deleteWorkspaceCalls.isEmpty)
+    }
+
     @Test("Deleting remote workspace preserves the record when provider deletion fails")
     @MainActor
     func deletingRemoteWorkspacePreservesRecordWhenProviderDeletionFails() async throws {
@@ -633,6 +677,48 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(workspace.status == .archived)
     }
 
+    @Test("Archiving local workspace fails before service lifecycle when terminal retirement fails")
+    @MainActor
+    func archivingLocalWorkspaceFailsWhenTerminalRetirementFails() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: workspaceURL,
+            sourceRepo: repo,
+            status: .active,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let recorder = OperationRecorder()
+        let workspaceService = MockWorkspaceService()
+        workspaceService.archiveWorkspaceWillRun = {
+            await recorder.record("archive")
+        }
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()],
+            retireTerminalSessions: { key in
+                await recorder.record("retire:\(key.debugDescription)")
+                throw TerminalRetirementError()
+            }
+        )
+
+        await #expect(throws: TerminalRetirementError.self) {
+            try await controller.archive(workspace)
+        }
+
+        #expect(await recorder.snapshot() == ["retire:hostPath(\(workspaceURL.path))"])
+        #expect(workspaceService.archiveWorkspaceCalls.isEmpty)
+        #expect(workspace.status == .active)
+    }
+
     @Test("Managed lifecycle operations fail closed when remote identifier is missing")
     @MainActor
     func managedLifecycleOperationsFailClosedWhenRemoteIdentifierIsMissing() async throws {
@@ -702,7 +788,7 @@ struct SidebarWorkspaceControllerBehaviorTests {
         context: ModelContext,
         workspaceService: MockWorkspaceService,
         providers: [any WorkspaceProviderProtocol],
-        retireTerminalSessions: @escaping @MainActor (HostTerminalSessionKey) async -> Void = { _ in }
+        retireTerminalSessions: @escaping @MainActor (HostTerminalSessionKey) async throws -> Void = { _ in }
     ) -> SidebarWorkspaceController {
         SidebarWorkspaceController(
             modelContext: context,


### PR DESCRIPTION
## Summary
- Close terminal surfaces via Ghostty close request before workspace archive/delete retirement.
- Fail archive/delete if a terminal still has a running process or does not exit before timeout.
- Add controller regressions so service cleanup is skipped when terminal retirement fails.

## Validation
- `mise run lint`
- `swift test` (971 tests, 154 suites)
- `./scripts/build-ghosttykit.sh`
- `swift build`
- `./scripts/dev-smoke.sh --no-build`

## Evidence
- ![archive-terminal-retirement-smoke-v2](https://evidence.cloudcompute.com/workspaces/pr-689/20260627-083400-archive-terminal-retirement-smoke-v2.png)

## Mergeability
- Surface: desktop
- User-facing behavior changed: workspace archive/delete now requests terminal close first and blocks the lifecycle if a terminal still has a running process.
- Non-happy paths considered: close confirmation and timeout paths fail before workspace service cleanup; split sessions are included in the retirement scope.
- Residual risk or follow-up: Ghostty exposes close-request plus process-exit observation here, not a separate force-terminate-and-wait primitive, so unresolved terminals surface an error instead of being silently detached.