### PR TITLE
feat: keyboard-shortcut cheat-sheet (Help → Keyboard Shortcuts)

### DIFF
--- a/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
+++ b/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
@@ -113,7 +113,7 @@ enum AppChromeShortcut: CaseIterable {
         case .openInEditor: return "Open in Editor"
         case .settings: return "Settings"
         case .workspaceSwitcher: return "Switch Session"
-        case .commandRunner: return "Terminal Theme / Commands"
+        case .commandRunner: return "Run Command"
         }
     }
 
@@ -135,6 +135,9 @@ enum AppChromeShortcut: CaseIterable {
     }
 
     private static func keyGlyph(for keyString: String) -> String {
+        // Covers the keys app shortcuts bind today (letters, digits, `,` `[` `]`, tab, space). Add
+        // arrow/escape glyph cases here before binding any app-level shortcut that uses them, else they
+        // render as the raw key string.
         switch keyString {
         case "\t": return "⇥"
         case " ": return "Space"

--- a/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
+++ b/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
@@ -96,6 +96,51 @@ enum AppChromeShortcut: CaseIterable {
             modifiers: appKitModifiers
         )
     }
+
+    /// Human-readable label for the shortcut cheat-sheet (Help → Keyboard Shortcuts).
+    var displayName: String {
+        switch self {
+        case .toggleSidebar: return "Toggle Sidebar"
+        case .toggleInspector: return "Toggle Inspector"
+        case .toggleTerminalPanel: return "Toggle Terminal Panel"
+        case .newWorkspace: return "New Workspace"
+        case .newTerminalTab: return "New Terminal Tab"
+        case .closeTerminalTab: return "Close Terminal Tab"
+        case .nextTerminalTab: return "Next Terminal Tab"
+        case .previousTerminalTab: return "Previous Terminal Tab"
+        case .alternateNextTerminalTab: return "Next Terminal Tab (alternate)"
+        case .alternatePreviousTerminalTab: return "Previous Terminal Tab (alternate)"
+        case .openInEditor: return "Open in Editor"
+        case .settings: return "Settings"
+        case .workspaceSwitcher: return "Switch Session"
+        case .commandRunner: return "Terminal Theme / Commands"
+        }
+    }
+
+    /// The chord rendered as macOS modifier glyphs (⌃⌥⇧⌘) plus the key, for display.
+    var keyboardGlyphs: String {
+        Self.keyboardGlyphs(modifiers: appKitModifiers, keyString: keyString)
+    }
+
+    /// Render `(modifiers, key)` as the canonical macOS glyph string, e.g. `⌘⇧B`.
+    /// Modifiers are emitted in the platform order Control → Option → Shift → Command.
+    static func keyboardGlyphs(modifiers: NSEvent.ModifierFlags, keyString: String) -> String {
+        var result = ""
+        if modifiers.contains(.control) { result += "⌃" }
+        if modifiers.contains(.option) { result += "⌥" }
+        if modifiers.contains(.shift) { result += "⇧" }
+        if modifiers.contains(.command) { result += "⌘" }
+        result += keyGlyph(for: keyString)
+        return result
+    }
+
+    private static func keyGlyph(for keyString: String) -> String {
+        switch keyString {
+        case "\t": return "⇥"
+        case " ": return "Space"
+        default: return keyString.uppercased()
+        }
+    }
 }
 
 enum AppChromeShortcutCatalog {

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -257,6 +257,8 @@ struct WorkspaceManagerApp: App {
             }
 
             CommandGroup(after: .help) {
+                KeyboardShortcutsMenuItem()
+
                 Button("Export Diagnostic Report...") {
                     Task {
                         await DiagnosticReportExporter.exportWithSavePanel()
@@ -264,6 +266,11 @@ struct WorkspaceManagerApp: App {
                 }
             }
         }
+
+        Window("Keyboard Shortcuts", id: KeyboardShortcutsView.windowID) {
+            KeyboardShortcutsView()
+        }
+        .windowResizability(.contentSize)
 
         Settings {
             SettingsView(softwareUpdateController: softwareUpdateController)
@@ -275,6 +282,18 @@ struct WorkspaceManagerApp: App {
                 .environmentObject(lastCommandStatusRegistry)
                 .environment(\.agentSessionRegistry, agentSessionRegistry)
                 .environment(\.lastCommandStatusRegistry, lastCommandStatusRegistry)
+        }
+    }
+}
+
+/// Help-menu entry that opens the keyboard-shortcut cheat-sheet window. A small view so it can hold
+/// the `openWindow` environment action the surrounding `App` body cannot.
+private struct KeyboardShortcutsMenuItem: View {
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Keyboard Shortcuts") {
+            openWindow(id: KeyboardShortcutsView.windowID)
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/KeyboardShortcutsView.swift
+++ b/Sources/WorkspaceManager/Views/KeyboardShortcutsView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// A read-only keyboard-shortcut cheat-sheet (Help → Keyboard Shortcuts), so the app's navigation
+/// keys are discoverable rather than hidden. App-owned shortcuts are derived from `AppChromeShortcut`
+/// so they can never drift from the real bindings; terminal/tile shortcuts are libghostty defaults and
+/// are documented here as a static, clearly-labeled section (the app routes them but does not own them).
+
+struct KeyboardShortcutRow: Identifiable, Equatable {
+    let label: String
+    let glyphs: String
+    var id: String { label }
+}
+
+struct KeyboardShortcutSection: Identifiable {
+    let title: String
+    let footnote: String?
+    let rows: [KeyboardShortcutRow]
+    var id: String { title }
+}
+
+enum KeyboardShortcutsCatalog {
+    /// App-owned shortcuts, sourced directly from `AppChromeShortcut` so the sheet stays in sync.
+    static var appRows: [KeyboardShortcutRow] {
+        AppChromeShortcut.allCases.map {
+            KeyboardShortcutRow(label: $0.displayName, glyphs: $0.keyboardGlyphs)
+        }
+    }
+
+    /// Terminal & tile shortcuts. These are libghostty's macOS defaults (the app owns none of them);
+    /// the values mirror the pinned Ghostty config and the actions the app's split router handles.
+    static let tilingRows: [KeyboardShortcutRow] = [
+        KeyboardShortcutRow(label: "Split right", glyphs: "⌘D"),
+        KeyboardShortcutRow(label: "Split down", glyphs: "⇧⌘D"),
+        KeyboardShortcutRow(label: "Focus previous tile", glyphs: "⌘["),
+        KeyboardShortcutRow(label: "Focus next tile", glyphs: "⌘]"),
+        KeyboardShortcutRow(label: "Focus tile by direction", glyphs: "⌥⌘ ← ↑ ↓ →"),
+        KeyboardShortcutRow(label: "Resize split", glyphs: "⌃⌘ ← ↑ ↓ →"),
+        KeyboardShortcutRow(label: "Equalize splits", glyphs: "⌃⌘="),
+    ]
+
+    static var sections: [KeyboardShortcutSection] {
+        [
+            KeyboardShortcutSection(title: "App", footnote: nil, rows: appRows),
+            KeyboardShortcutSection(
+                title: "Terminal & Tiles",
+                footnote: "Terminal defaults from the embedded terminal — active when a terminal tile has focus.",
+                rows: tilingRows
+            ),
+        ]
+    }
+}
+
+struct KeyboardShortcutsView: View {
+    static let windowID = "keyboard-shortcuts"
+
+    var body: some View {
+        ScrollView {
+            KeyboardShortcutsContent()
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(minWidth: 440, minHeight: 540)
+    }
+}
+
+/// The cheat-sheet body, split out of the `ScrollView` so it can be rendered at natural size (the
+/// live window scrolls it; PR-evidence rendering and previews lay it out whole).
+struct KeyboardShortcutsContent: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            ForEach(KeyboardShortcutsCatalog.sections) { section in
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(section.title)
+                        .font(.headline)
+                        .padding(.bottom, 2)
+
+                    ForEach(section.rows) { row in
+                        HStack(alignment: .firstTextBaseline) {
+                            Text(row.label)
+                            Spacer(minLength: 24)
+                            Text(row.glyphs)
+                                .font(.system(.body, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 1)
+                    }
+
+                    if let footnote = section.footnote {
+                        Text(footnote)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 4)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/KeyboardShortcutsView.swift
+++ b/Sources/WorkspaceManager/Views/KeyboardShortcutsView.swift
@@ -5,9 +5,11 @@ import SwiftUI
 /// so they can never drift from the real bindings; terminal/tile shortcuts are libghostty defaults and
 /// are documented here as a static, clearly-labeled section (the app routes them but does not own them).
 
-struct KeyboardShortcutRow: Identifiable, Equatable {
+struct KeyboardShortcutRow: Identifiable {
     let label: String
     let glyphs: String
+    /// Labels are unique within the catalog — the App rows come from distinct `AppChromeShortcut`
+    /// cases and the tiling rows are hand-curated — so the label is a stable `ForEach` identity.
     var id: String { label }
 }
 

--- a/Tests/WorkspaceManagerAppTests/KeyboardShortcutsCatalogTests.swift
+++ b/Tests/WorkspaceManagerAppTests/KeyboardShortcutsCatalogTests.swift
@@ -1,0 +1,46 @@
+import AppKit
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("KeyboardShortcutsCatalog")
+struct KeyboardShortcutsCatalogTests {
+    @Test("Every app-owned shortcut surfaces a label and glyphs derived from its real binding")
+    func appRowsCoverAllShortcuts() {
+        let rows = KeyboardShortcutsCatalog.appRows
+
+        #expect(rows.count == AppChromeShortcut.allCases.count)
+        for row in rows {
+            #expect(!row.label.isEmpty)
+            #expect(!row.glyphs.isEmpty)
+        }
+
+        // Derived from the binding, so it can't drift: ⌘B = toggle sidebar.
+        let sidebar = rows.first { $0.label == AppChromeShortcut.toggleSidebar.displayName }
+        #expect(sidebar?.glyphs == "⌘B")
+    }
+
+    @Test("Glyphs render modifiers in canonical macOS order with key substitutions")
+    func glyphFormatting() {
+        // Platform order is Control → Option → Shift → Command (Command rightmost), as macOS menus
+        // render it (e.g. ⇧⌘Z), regardless of the order the flags are supplied in.
+        #expect(AppChromeShortcut.keyboardGlyphs(modifiers: [.command, .shift], keyString: "b") == "⇧⌘B")
+        #expect(
+            AppChromeShortcut.keyboardGlyphs(modifiers: [.command, .control, .option, .shift], keyString: "d")
+                == "⌃⌥⇧⌘D"
+        )
+        #expect(AppChromeShortcut.keyboardGlyphs(modifiers: [.control], keyString: "\t") == "⌃⇥")
+        #expect(AppChromeShortcut.alternateNextTerminalTab.keyboardGlyphs == "⇧⌘]")
+    }
+
+    @Test("Catalog exposes the documented terminal/tile section")
+    func tilingSectionPresent() {
+        let titles = KeyboardShortcutsCatalog.sections.map(\.title)
+        #expect(titles.contains("App"))
+        #expect(titles.contains("Terminal & Tiles"))
+
+        let tiling = KeyboardShortcutsCatalog.tilingRows
+        #expect(tiling.contains { $0.glyphs == "⌘D" })
+        #expect(tiling.contains { $0.label == "Focus tile by direction" })
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/KeyboardShortcutsRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/KeyboardShortcutsRenderTests.swift
@@ -1,0 +1,36 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("KeyboardShortcutsView render")
+struct KeyboardShortcutsRenderTests {
+    /// Renders the cheat-sheet to a non-empty image (a crash/layout smoke), and — when
+    /// `WORKSPACES_EVIDENCE_DIR` is set — writes a PNG there for PR evidence without launching the app.
+    @Test("Cheat-sheet renders to a non-empty image")
+    func rendersNonEmpty() throws {
+        let content =
+            KeyboardShortcutsContent()
+            .padding(24)
+            .frame(width: 440, alignment: .leading)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .environment(\.colorScheme, .light)
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("keyboard-shortcuts.png")
+        try png.write(to: url)
+    }
+}


### PR DESCRIPTION
## Summary

Makes the app's navigation keys **discoverable** instead of hidden. Adds **Help → "Keyboard Shortcuts"**, opening a dedicated window with two sections:

- **App** — every shortcut derived from `AppChromeShortcut` (new `displayName` + `keyboardGlyphs`), so the sheet can't drift from the real bindings. Glyphs render in canonical macOS order (`⌃⌥⇧⌘`, Command rightmost, e.g. `⇧⌘B`).
- **Terminal & Tiles** — the split/focus/resize keys (`⌘D`, `⇧⌘D`, `⌘[`/`⌘]`, `⌥⌘`-arrows, `⌃⌘`-arrows, `⌃⌘=`). These are libghostty's macOS defaults — the app's split router handles them but does not own them — so they're a clearly-labeled documented section, staying true to Ghostty-First shortcut routing.

Came out of a keyboard-navigation review of the tile-tree work: the keys all already route, but nothing surfaced them. (The separate depth-≥2 directional-focus *hardening* is tracked as #690.)

## Mergeability

- Surface: **desktop**
- User-facing behavior changed: **yes** — new Help menu item + a "Keyboard Shortcuts" window. No existing behavior altered.
- Non-happy paths considered: window is a standalone `Window` scene (reopen is idempotent via `openWindow(id:)`); content is static/read-only; app-owned rows fail safe (every `AppChromeShortcut` case has a `displayName`, asserted by test).
- Release/ops preconditions: none.
- Residual risk or follow-up: the documented terminal/tile glyphs are hand-mirrored from the pinned Ghostty config — if the Ghostty pin changes its split keybinds, this section needs a manual update (the app-owned section is auto-derived and immune).

## Validation

- [x] `swift build`
- [x] `swift test` — 975 tests / 156 suites, all passing (incl. new `KeyboardShortcutsCatalog` + render-smoke)
- [x] `swift-format lint --strict` — clean

## Evidence

- [x] UI evidence attached (rendered from the real SwiftUI view via `ImageRenderer`, no app launch)

Evidence links:

- [Keyboard Shortcuts window — rendered from the SwiftUI view](https://evidence.cloudcompute.com/workspaces/pr-691/20260627-162428-keyboard-shortcuts-cheatsheet.png)

![keyboard-shortcuts](https://evidence.cloudcompute.com/workspaces/pr-691/20260627-162428-keyboard-shortcuts-cheatsheet.png)

## Blockers

- [x] None
