### PR TITLE
test: harden depth-≥2 directional focus + close PR #658 review follow-ups

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/GhosttyTerminalIntentRouter.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/GhosttyTerminalIntentRouter.swift
@@ -161,7 +161,8 @@ struct GhosttyTerminalIntentRouter {
             NSLog("[SplitRouting] new_split ignored: no active/primary session")
             return []
         }
-        // Activate the containing tab (side effect); the split itself grows from `sourcePaneID`'s tile.
+        // Called for its tab-activation side effect only; the returned primary id is used for the log
+        // line below, not threaded into the split — `splitFocusedTile` resolves its own primary.
         let primarySessionID = hostTerminalState.activatePrimarySession(containing: sourcePaneID)
         NSLog(
             "[SplitRouting] new_split source=%@ primary=%@",

--- a/Sources/WorkspaceManager/Views/MainWindow/TileTreeView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TileTreeView.swift
@@ -61,7 +61,9 @@ struct TileTreeView: View {
             .id(session.id)
         } else {
             // A leaf with no session binding is a transient inconsistency; fill the slot rather than
-            // collapse the geometry so neighboring panes keep their sizes until the next snapshot.
+            // collapse the geometry so neighboring panes keep their sizes until the next snapshot. This
+            // must stay transient — Phase 5's `SurfaceStore.sync` eviction should ensure an unbound tile
+            // never survives a snapshot restore, so this placeholder is never persistently visible.
             Color(nsColor: .windowBackgroundColor)
         }
     }

--- a/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
@@ -263,6 +263,90 @@ struct TileTreeReducerTests {
         #expect(blocked.focusedTileID == added)
     }
 
+    // MARK: - Directional focus (depth ≥ 2, cross-axis)
+    //
+    // Depth-1 directional focus is depth-1 parity above; the geometric ancestor-walk at depth ≥ 2 is
+    // new behavior with no legacy baseline (PR #658 review follow-up). These pin the cross-axis cases —
+    // moving across a split whose axis differs from the one being navigated — which exercise the
+    // "rise to the nearest matching-axis ancestor, then descend into the entering edge" traversal.
+
+    /// Focus `from`, then navigate `direction`; returns the resulting focused tile (== `from` when the
+    /// move is blocked, since the reducer leaves focus put when there is no neighbor).
+    private func directional(
+        _ state: TileTreeState,
+        reducer: TileTreeReducer,
+        from: TileID,
+        _ direction: TileFocusDirection
+    ) -> TileID {
+        let focused = reducer.reduce(state, .setFocus(from))
+        return reducer.reduce(focused, .focusDirectional(from: from, direction: direction)).focusedTileID
+    }
+
+    @Test("Directional focus crosses a leading/trailing root into a nested top/bottom column")
+    func directionalNestedColumn() {
+        // a | (b over c):  left column = a, right column = b (top) / c (bottom).
+        let reducer = TileTreeReducer()
+        let a = TileID()
+        let b = TileID()
+        let c = TileID()
+        let state = TileTreeState(
+            root: .split(
+                id: SplitID(),
+                axis: .leadingTrailing,
+                ratio: 0.5,
+                first: .tile(a),
+                second: .split(id: SplitID(), axis: .topBottom, ratio: 0.5, first: .tile(b), second: .tile(c))
+            ),
+            focusedTileID: a
+        )
+
+        // Left from either nested pane lands on the single left column.
+        #expect(directional(state, reducer: reducer, from: b, .left) == a)
+        #expect(directional(state, reducer: reducer, from: c, .left) == a)
+        // Right from the left column enters the nested column at its leading (top) edge.
+        #expect(directional(state, reducer: reducer, from: a, .right) == b)
+        // Vertical moves stay inside the nested top/bottom split.
+        #expect(directional(state, reducer: reducer, from: b, .down) == c)
+        #expect(directional(state, reducer: reducer, from: c, .up) == b)
+        // Blocked edges: no pane above b, none below c, nothing right of the nested column, none above a.
+        #expect(directional(state, reducer: reducer, from: b, .up) == b)
+        #expect(directional(state, reducer: reducer, from: c, .down) == c)
+        #expect(directional(state, reducer: reducer, from: b, .right) == b)
+        #expect(directional(state, reducer: reducer, from: a, .up) == a)
+    }
+
+    @Test("Directional focus crosses a top/bottom root into a nested leading/trailing row")
+    func directionalNestedRow() {
+        // a over (b | c):  top row = a, bottom row = b (left) / c (right).
+        let reducer = TileTreeReducer()
+        let a = TileID()
+        let b = TileID()
+        let c = TileID()
+        let state = TileTreeState(
+            root: .split(
+                id: SplitID(),
+                axis: .topBottom,
+                ratio: 0.5,
+                first: .tile(a),
+                second: .split(id: SplitID(), axis: .leadingTrailing, ratio: 0.5, first: .tile(b), second: .tile(c))
+            ),
+            focusedTileID: a
+        )
+
+        // Up from either nested pane lands on the single top row.
+        #expect(directional(state, reducer: reducer, from: b, .up) == a)
+        #expect(directional(state, reducer: reducer, from: c, .up) == a)
+        // Down from the top row enters the nested row at its leading (left) edge.
+        #expect(directional(state, reducer: reducer, from: a, .down) == b)
+        // Horizontal moves stay inside the nested leading/trailing split.
+        #expect(directional(state, reducer: reducer, from: b, .right) == c)
+        #expect(directional(state, reducer: reducer, from: c, .left) == b)
+        // Blocked edges: nothing left of b, nothing below the nested row, no horizontal neighbor for a.
+        #expect(directional(state, reducer: reducer, from: b, .left) == b)
+        #expect(directional(state, reducer: reducer, from: c, .down) == c)
+        #expect(directional(state, reducer: reducer, from: a, .left) == a)
+    }
+
     // MARK: - Relative focus
 
     @Test("Relative focus toggles between two leaves and wraps")


### PR DESCRIPTION
## Summary

Closes the three non-blocking follow-ups from the Phase 4 (#658, merged) review — no production logic changes.

1. **Depth-≥2 cross-axis directional focus** was flagged as new, not-hardened behavior with no combinatorial coverage. Added reducer tests over two nested trees — a leading/trailing root with a nested top/bottom column, and its mirror — pinning every cross-axis case: entering a nested split lands on the leading edge, moves stay inside the matching-axis subtree, and outer edges block. The reducer's geometric ancestor-walk matches the hand-derived geometry exactly (so this both *covers* and *confirms-correct* the behavior).
2. **Router side-effect clarity** (`GhosttyTerminalIntentRouter`): the captured `primarySessionID` from `activatePrimarySession` is log-only — `splitFocusedTile` resolves its own primary. Comment now says so.
3. **Unbound-tile placeholder** (`TileTreeView`): noted that Phase 5's `SurfaceStore.sync` eviction must keep the `Color(nsColor:)` fallback transient (never survives a snapshot restore).

## Mergeability

- Surface: **desktop** (tests + comments only)
- User-facing behavior changed: **no** — test coverage + two clarifying comments; zero production logic change.
- Non-happy paths considered: the new tests *are* the non-happy-path coverage (blocked edges at every boundary of a depth-2 tree).
- Release/ops preconditions: none.
- Residual risk or follow-up: none. Follow-up #3 (unbound-tile eviction) is a Phase-5 design constraint, now documented at the call site; nothing to implement until `SurfaceStore` goes live.

## Validation

- [x] `swift build`
- [x] `swift test` — **980 tests in 155 suites passed**
- [x] Other checks: `mise run lint` (swift-format --strict) exit 0

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (full suite + directional-focus coverage)
- [x] Not a UI-behavior change (no screenshots needed)

Evidence links:

- [Test summary](https://evidence.cloudcompute.com/workspaces/pr-692/20260627-203236-p4followup-tests.png) — 980 tests / 155 suites + directional-focus coverage

  ![p4followup-tests](https://evidence.cloudcompute.com/workspaces/pr-692/20260627-203236-p4followup-tests.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
