### PR TITLE
Fix diagnostic export main actor crash

### DIFF
--- a/Sources/WorkspaceManager/Diagnostics/DiagnosticReportExporter.swift
+++ b/Sources/WorkspaceManager/Diagnostics/DiagnosticReportExporter.swift
@@ -83,7 +83,11 @@ enum DiagnosticReportExporter {
         }
 
         // system-profile.txt
-        let profile = gatherSystemProfile(systemInfo)
+        let profile = gatherSystemProfile(
+            systemInfo,
+            modelStoreSnapshot: modelStoreSnapshot,
+            localStateSnapshot: localStateSnapshot
+        )
         try profile.write(to: tempDir.appendingPathComponent("system-profile.txt"), atomically: true, encoding: .utf8)
 
         // recent-logs.txt (unified log, last 5 minutes)
@@ -145,7 +149,11 @@ enum DiagnosticReportExporter {
         )
     }
 
-    private static func gatherSystemProfile(_ info: SystemInfo) -> String {
+    private static func gatherSystemProfile(
+        _ info: SystemInfo,
+        modelStoreSnapshot: ModelStoreStatusSnapshot,
+        localStateSnapshot: LocalStateStoreStatusSnapshot
+    ) -> String {
         var lines: [String] = []
         lines.append("WorkSpaces Diagnostic Report")
         lines.append("Generated: \(ISO8601DateFormatter().string(from: Date()))")
@@ -166,31 +174,25 @@ enum DiagnosticReportExporter {
         lines.append("  Path: \(AppBuildIdentity.current.fullPath)")
         lines.append("")
         lines.append("Model Store:")
-        let modelStore = MainActor.assumeIsolated {
-            ModelStoreStatusController.shared.snapshot
-        }
-        lines.append("  Mode: \(modelStore.mode.label)")
-        lines.append("  Path: \(modelStore.mode.path ?? "In-memory only")")
-        if modelStore.bootstrapErrors.isEmpty {
+        lines.append("  Mode: \(modelStoreSnapshot.mode.label)")
+        lines.append("  Path: \(modelStoreSnapshot.mode.path ?? "In-memory only")")
+        if modelStoreSnapshot.bootstrapErrors.isEmpty {
             lines.append("  Bootstrap Errors: none")
         } else {
             lines.append("  Bootstrap Errors:")
-            for error in modelStore.bootstrapErrors {
+            for error in modelStoreSnapshot.bootstrapErrors {
                 lines.append("    - \(error)")
             }
         }
         lines.append("")
         lines.append("Local State Store:")
-        let localStateStore = MainActor.assumeIsolated {
-            LocalStateStoreController.shared.snapshot
-        }
-        lines.append("  Mode: \(localStateStore.mode.label)")
-        lines.append("  Path: \(localStateStore.mode.path ?? "none")")
-        if localStateStore.bootstrapErrors.isEmpty {
+        lines.append("  Mode: \(localStateSnapshot.mode.label)")
+        lines.append("  Path: \(localStateSnapshot.mode.path ?? "none")")
+        if localStateSnapshot.bootstrapErrors.isEmpty {
             lines.append("  Bootstrap Errors: none")
         } else {
             lines.append("  Bootstrap Errors:")
-            for error in localStateStore.bootstrapErrors {
+            for error in localStateSnapshot.bootstrapErrors {
                 lines.append("    - \(error)")
             }
         }

--- a/Tests/WorkspaceManagerAppTests/DiagnosticReportExporterTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DiagnosticReportExporterTests.swift
@@ -60,4 +60,68 @@ struct DiagnosticReportExporterTests {
         #expect(report.localStateSummary == localStateSummary)
         #expect(report.schemaVersion == 3)
     }
+
+    @Test("report assembly completes after resuming away from the main actor")
+    func reportAssemblyCompletesOffMainActor() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+
+        let zipURL = fixture.url.appendingPathComponent("workspaces-report.zip")
+        try await Task.detached {
+            await Task.yield()
+            try await DiagnosticReportExporter.assembleReport(to: zipURL)
+        }.value
+
+        #expect(FileManager.default.fileExists(atPath: zipURL.path))
+
+        let extractedURL = fixture.url.appendingPathComponent("extracted", isDirectory: true)
+        try FileManager.default.createDirectory(at: extractedURL, withIntermediateDirectories: true)
+        try extractZip(zipURL, to: extractedURL)
+
+        let reportFiles = Set(try FileManager.default.contentsOfDirectory(atPath: extractedURL.path))
+        #expect(reportFiles.contains("report.json"))
+        #expect(reportFiles.contains("system-profile.txt"))
+        #expect(reportFiles.contains("recent-logs.txt"))
+
+        let profile = try String(
+            contentsOf: extractedURL.appendingPathComponent("system-profile.txt"),
+            encoding: .utf8
+        )
+        #expect(profile.contains("Model Store:"))
+        #expect(profile.contains("Local State Store:"))
+    }
+}
+
+private struct TemporaryDirectory {
+    let url: URL
+
+    init() throws {
+        url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiagnosticReportExporterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private func extractZip(_ zipURL: URL, to destinationURL: URL) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+    process.arguments = ["-x", "-k", zipURL.path, destinationURL.path]
+    let stderr = Pipe()
+    process.standardError = stderr
+    try process.run()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+        let message = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        throw NSError(
+            domain: "DiagnosticReportExporterTests",
+            code: Int(process.terminationStatus),
+            userInfo: [NSLocalizedDescriptionKey: message ?? "Failed to extract diagnostic report zip"]
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Remove `MainActor.assumeIsolated` from diagnostic report profile generation by passing already captured store snapshots into the formatter.
- Add a regression test that assembles a diagnostic report from a detached task after async suspension and verifies the zip includes `report.json`, `system-profile.txt`, and `recent-logs.txt`.

## Root Cause
The installed app died during diagnostic export after `report.json` and `local-state-summary.json` were written but before `system-profile.txt`. Unified logs showed `BUG IN CLIENT OF LIBDISPATCH: Assertion failed: Block was expected to execute on queue [com.apple.main-thread]` followed by `kLSNotifyApplicationAbnormalDeath`. The exporter resumed off-main after async work, then called `MainActor.assumeIsolated` inside `gatherSystemProfile`.

## Mergeability
- Surface: desktop diagnostics export
- User-facing behavior changed: diagnostics export should no longer terminate WorkSpaces when report assembly resumes off the main actor; report contents remain the same.
- Non-happy paths considered: detached-task regression covers the off-main resume crash shape and verifies the final zip contains the expected report artifacts.
- Residual risk or follow-up: low; the fix removes the unsafe executor assumption without changing terminal, sidebar, release, or persistence behavior.

## Validation
- `./scripts/build-ghosttykit.sh`
- `swift test --filter DiagnosticReportExporterTests`
- `swift-format lint --strict --recursive Sources/ Tests/`
- `swift test`
- `git -c core.whitespace=space-before-tab,trailing-space diff --check`

## Evidence
- [Validation artifact](https://evidence.cloudcompute.com/workspaces/pr-694/20260627-213123-diagnostic-export-mainactor-crash.svg)
