### PR TITLE
test: cover Lume terminal launch storage command

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
@@ -290,14 +290,17 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
         )
 
         let executablePath = try await runtimeService.executablePath()
-        let storageArgument =
-            (await lumeStorageSelector(for: metadata.storagePath))
-            .map { " --storage '\($0)'" } ?? ""
+        let workspaceVMStoragePath = await validatedBaseService.workspaceVMStorageDirectoryURL.path
 
         return TerminalLaunchSpec(
             sessionKey: sessionKey(for: workspace),
             workingDirectory: URL(fileURLWithPath: metadata.sharedHostPath),
-            customCommand: "\(executablePath) ssh \(metadata.vmName)\(storageArgument)",
+            customCommand: Self.terminalLaunchCommand(
+                executablePath: executablePath,
+                vmName: metadata.vmName,
+                storagePath: metadata.storagePath,
+                workspaceVMStoragePath: workspaceVMStoragePath
+            ),
             statusAfterLaunch: .active
         )
     }
@@ -1064,6 +1067,19 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
             return workspaceVMStorageName
         }
         return storagePath
+    }
+
+    nonisolated static func terminalLaunchCommand(
+        executablePath: String,
+        vmName: String,
+        storagePath: String?,
+        workspaceVMStoragePath: String
+    ) -> String {
+        let storageArgument =
+            lumeStorageSelector(for: storagePath, workspaceVMStoragePath: workspaceVMStoragePath)
+            .map { " --storage '\($0)'" } ?? ""
+
+        return "\(executablePath) ssh \(vmName)\(storageArgument)"
     }
 
     private nonisolated static func normalizedStoragePath(_ path: String) -> String {

--- a/Tests/WorkspaceManagerTests/WorkspaceProviderTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceProviderTests.swift
@@ -215,6 +215,44 @@ struct WorkspaceProviderTests {
         )
     }
 
+    @Test("Lume terminal launch command maps Workspaces VM storage path")
+    func lumeTerminalLaunchCommandMapsWorkspaceVMStoragePath() {
+        let workspaceVMStoragePath =
+            "/Users/test/Library/Application Support/WorkspaceManager/LumeStorage/workspace-vms"
+
+        let command = LumeWorkspaceProvider.terminalLaunchCommand(
+            executablePath: "/opt/homebrew/bin/lume",
+            vmName: "repo-feature-1234",
+            storagePath: workspaceVMStoragePath,
+            workspaceVMStoragePath: workspaceVMStoragePath
+        )
+
+        #expect(command == "/opt/homebrew/bin/lume ssh repo-feature-1234 --storage 'workspaces'")
+    }
+
+    @Test("Lume terminal launch command passes through optional storage selectors")
+    func lumeTerminalLaunchCommandPassesThroughOptionalStorageSelectors() {
+        let workspaceVMStoragePath =
+            "/Users/test/Library/Application Support/WorkspaceManager/LumeStorage/workspace-vms"
+
+        #expect(
+            LumeWorkspaceProvider.terminalLaunchCommand(
+                executablePath: "/opt/homebrew/bin/lume",
+                vmName: "repo-feature-1234",
+                storagePath: nil,
+                workspaceVMStoragePath: workspaceVMStoragePath
+            ) == "/opt/homebrew/bin/lume ssh repo-feature-1234"
+        )
+        #expect(
+            LumeWorkspaceProvider.terminalLaunchCommand(
+                executablePath: "/opt/homebrew/bin/lume",
+                vmName: "repo-feature-1234",
+                storagePath: "validated-bases",
+                workspaceVMStoragePath: workspaceVMStoragePath
+            ) == "/opt/homebrew/bin/lume ssh repo-feature-1234 --storage 'validated-bases'"
+        )
+    }
+
     @Test("Lume CLI progress messaging surfaces macOS download, install, and setup phases")
     func lumeCLIProgressMessaging() {
         #expect(


### PR DESCRIPTION
## Summary
- Extract Lume terminal launch command construction into a focused internal helper.
- Add WorkspaceProviderTests coverage for Workspaces-managed absolute VM storage mapping to --storage 'workspaces'.
- Add pass-through coverage for nil storage and an already named selector.

Closes #671

## Mergeability
- Surface: desktop
- User-facing behavior changed: No runtime behavior change intended; this only preserves existing Lume terminal command construction behind focused tests.
- Non-happy paths considered: Covered nil storage plus already named selector pass-through so commands do not gain an unintended storage argument or remap named selectors.
- Residual risk or follow-up: Low; helper extraction keeps the existing command shape and focused WorkspaceProviderTests cover the issue scope.

## Validation
- ./scripts/build-ghosttykit.sh
- swift-format lint --strict Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift Tests/WorkspaceManagerTests/WorkspaceProviderTests.swift
- swift test --filter WorkspaceProviderTests passed: 16 tests in 1 suite

## Evidence
- ![terminal-launch-spec-tests](https://evidence.cloudcompute.com/workspaces/pr-695/20260627-214836-terminal-launch-spec-tests.svg)