### PR TITLE
Add preview deployment QA flow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -173,14 +173,15 @@ jobs:
       - name: Install Playwright system deps
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
-      - name: Run Playwright fast against preview
+      - name: Run Playwright deployment smoke against preview
         env:
           PLAYWRIGHT_BASE_URL: ${{ needs.preview-web.outputs.preview_url }}
           PLAYWRIGHT_SKIP_WEB_SERVER: "1"
+          PLAYWRIGHT_SKIP_DB_FIXTURES: "1"
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
           set +e
-          pnpm exec playwright test --project fast --reporter=json > playwright-report.json
+          pnpm exec playwright test --project deployment-smoke --reporter=json > playwright-report.json
           PW_EXIT=$?
           node scripts/playwright-findings.js playwright-report.json > findings.md || echo "_findings script failed_" > findings.md
           exit $PW_EXIT
@@ -283,7 +284,7 @@ jobs:
         env:
           VALIDATOR: playwright
           PREVIEW_URL: ${{ needs.preview-web.outputs.preview_url }}
-          REPRO_HINT: cd web && PLAYWRIGHT_BASE_URL=${{ needs.preview-web.outputs.preview_url }} PLAYWRIGHT_SKIP_WEB_SERVER=1 pnpm exec playwright test --project fast
+          REPRO_HINT: cd web && PLAYWRIGHT_BASE_URL=${{ needs.preview-web.outputs.preview_url }} PLAYWRIGHT_SKIP_WEB_SERVER=1 PLAYWRIGHT_SKIP_DB_FIXTURES=1 pnpm exec playwright test --project deployment-smoke
         with:
           script: |
             // github-script runs from its own dist dir; relative imports look
@@ -382,13 +383,14 @@ jobs:
             } > findings.md
           fi
           exit "$CANARY_EXIT"
-      - name: Playwright fast against prod
+      - name: Playwright deployment smoke against prod
         env:
           PLAYWRIGHT_BASE_URL: https://spaces.cloudcompute.com
           PLAYWRIGHT_SKIP_WEB_SERVER: "1"
+          PLAYWRIGHT_SKIP_DB_FIXTURES: "1"
         run: |
           set +e
-          pnpm exec playwright test --project fast --reporter=json > prod-report.json
+          pnpm exec playwright test --project deployment-smoke --reporter=json > prod-report.json
           PW_EXIT=$?
           node scripts/playwright-findings.js prod-report.json > findings.md || echo "_findings script failed_" > findings.md
           exit $PW_EXIT

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -22,6 +22,11 @@ jobs:
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.preview_url }}
+      qa_url: ${{ steps.alias.outputs.qa_url }}
+      smoke_url: ${{ steps.alias.outputs.qa_url || steps.deploy.outputs.preview_url }}
+      qa_alias_ok: ${{ steps.alias.outputs.alias_ok }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -73,26 +78,72 @@ jobs:
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
           echo "::notice::Preview deployed to $URL"
 
+      - name: Alias preview for OAuth QA
+        id: alias
+        continue-on-error: true
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          QA_HOST="pr-${PR_NUMBER}.spaces-preview.cloudcompute.com"
+          set +e
+          OUTPUT=$(npx vercel@51 alias set "$PREVIEW_URL" "$QA_HOST" --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" 2>&1)
+          STATUS=$?
+          set -e
+          printf '%s\n' "$OUTPUT"
+          if [[ "$STATUS" -eq 0 ]]; then
+            echo "qa_url=https://$QA_HOST" >> "$GITHUB_OUTPUT"
+            echo "alias_ok=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Preview QA alias https://$QA_HOST"
+          else
+            echo "qa_url=" >> "$GITHUB_OUTPUT"
+            echo "alias_ok=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "alias_error<<EOF"
+              printf '%s\n' "$OUTPUT" | tail -20
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "::error::Failed to assign Preview QA alias https://$QA_HOST"
+          fi
+
       - name: Comment preview URL
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+          QA_URL: ${{ steps.alias.outputs.qa_url }}
+          QA_ALIAS_OK: ${{ steps.alias.outputs.alias_ok }}
+          QA_ALIAS_ERROR: ${{ steps.alias.outputs.alias_error }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
             const marker = '<!-- spaces-web-preview -->';
             const previewUrl = process.env.PREVIEW_URL;
+            const qaUrl = process.env.QA_URL;
+            const aliasOk = process.env.QA_ALIAS_OK === 'true';
+            const aliasError = process.env.QA_ALIAS_ERROR || '';
             const headSha = process.env.HEAD_SHA;
             const shortSha = headSha.slice(0, 7);
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const issue_number = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
+            const aliasErrorLine = aliasError.split('\n').filter(Boolean).at(-1);
+            const aliasLines = aliasOk
+              ? [
+                  `- Preview QA: ${qaUrl}`,
+                  'Preview QA uses the stable alias so GitHub OAuth callbacks match the production app host rules.',
+                ]
+              : [
+                  '- Preview QA: blocked until `*.spaces-preview.cloudcompute.com` is configured on Vercel/DNS',
+                  `- Deployment smoke: using raw deployment ${previewUrl}`,
+                  aliasErrorLine ? `- Alias error: \`${aliasErrorLine.replaceAll('`', "'")}\`` : '',
+                ].filter(Boolean);
 
             const body = [
               marker,
               '### Vercel Preview: `spaces-web`',
               '',
-              `- Preview: ${previewUrl}`,
+              ...aliasLines,
+              `- Raw deployment: ${previewUrl}`,
               `- Commit: \`${shortSha}\``,
               `- Workflow: [run ${process.env.GITHUB_RUN_NUMBER}](${workflowUrl})`,
               '',
@@ -122,3 +173,73 @@ jobs:
                 body,
               });
             }
+
+  preview-smoke:
+    name: Playwright deployment smoke
+    needs: preview
+    if: ${{ needs.preview.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          package_json_file: web/package.json
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm exec playwright --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 15
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run deployment smoke against preview
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ needs.preview.outputs.smoke_url }}
+          PLAYWRIGHT_SKIP_WEB_SERVER: "1"
+          PLAYWRIGHT_SKIP_DB_FIXTURES: "1"
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set +e
+          pnpm exec playwright test --project deployment-smoke --reporter=json > playwright-report.json
+          PW_EXIT=$?
+          node scripts/playwright-findings.js playwright-report.json > findings.md || echo "_findings script failed_" > findings.md
+          exit "$PW_EXIT"
+
+      - if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: preview-smoke-findings
+          path: |
+            web/findings.md
+            web/playwright-report.json
+            web/test-results/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ docs/papers/*.pdf
 .pi/skills/sandbox/
 
 # Playwright
+web/.auth/
+web/output/preview-qa/
 web/playwright-report/
 web/test-results/
 

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -79,7 +79,7 @@ After: every push to `main` produces a preview deployment, gets validated agains
 | `scripts/cd/config.toml` | Declarative manifest. Workers, preview health URLs, secret names, GitHub Actions secrets. **Add a worker = one TOML block.** |
 | `scripts/cd/.env.bootstrap.example` | Template for the gitignored `.env.bootstrap` where the operator's tokens live locally. |
 | `web/vercel.json` | Generated. Contains `git.deploymentEnabled = false` — disables Vercel's automatic Git deployments so Actions owns PR previews and production promotion. |
-| `web/playwright.config.ts` | Honors `PLAYWRIGHT_BASE_URL` to target the preview URL; skips the local `webServer` block when set. |
+| `web/playwright.config.ts` | Honors `PLAYWRIGHT_BASE_URL` to target deployed URLs; `deployment-smoke` is the remote-safe preview/prod project. |
 | `web/lighthouserc.json` | Perf budgets: LCP ≤2500ms, CLS ≤0.1, TBT ≤200ms, perf score ≥0.9. Desktop preset, 3 runs, median assertions. URL passed at invocation via `--collect.url`. |
 | `web/scripts/{playwright,lhci}-findings.mjs` | Render validator JSON output into markdown tables for the failure-issue body. |
 | `infra/<worker>/wrangler.toml` | Each in-tree worker has an `[env.preview]` block with separate routes/bindings (e.g. `evidence-screenshots-preview` R2 bucket). |
@@ -149,7 +149,7 @@ scheduled Managed Reviewer Broker/Health workflows and
 ## Design decisions worth understanding
 
 - **Why monolithic `cd.yml` not split workflows.** Promote needs `needs:` semantics across web + workers. Splitting loses the "all validators must pass before any promote" atomicity.
-- **Why `fast` Playwright project only.** `full` needs a seeded DB; preview targets Vercel's serverless DB which we can't seed from CI. Future: staging env with seeded Turso.
+- **Why `deployment-smoke` Playwright project only.** `full` and parts of `fast` need seeded DB state; deployed preview/prod validation must use only tests that are meaningful against the real serverless app.
 - **Why separate R2 bucket for evidence-store preview.** Preview test writes would otherwise pollute the prod keyspace and share the prod auth token's blast radius. 7-day lifecycle on `evidence-screenshots-preview` keeps storage cost ~$0.
 - **Why `vercel.json` over dashboard branch flip.** Code-controlled, survives project recreation, visible in diffs. Vercel's deprecated `github.enabled` is the legacy form; `git.deploymentEnabled` is current.
 - **Why Actions-owned PR previews.** Vercel's ignored-build path still creates canceled deployments; the path-filtered workflow avoids deployments entirely for non-web PRs.

--- a/web/.mise.toml
+++ b/web/.mise.toml
@@ -87,6 +87,104 @@ echo "Removed and formatted."
 description = "Run the qa-explore Playwright project (video + trace + axe-core)."
 run = "pnpm exec playwright test --project=qa-explore --reporter=list"
 
+[tasks."web:e2e:deployment-smoke"]
+description = "Run deployment-safe Playwright smoke locally."
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+PORT="${PORT:-3212}"
+PORT="$PORT" \
+PLAYWRIGHT_BASE_URL="http://127.0.0.1:$PORT" \
+PLAYWRIGHT_SKIP_DB_FIXTURES=1 \
+pnpm exec playwright test --project=deployment-smoke --workers=1 --reporter=list
+"""
+
+[tasks."web:preview:auth"]
+description = "Create or refresh a real-OAuth Playwright storage state for a Vercel preview."
+run = "node scripts/preview-auth.mjs"
+
+[tasks."web:preview:smoke"]
+description = "Run deployment-safe Playwright smoke against a Vercel preview."
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      shift
+      URL="https://pr-${1:?missing PR number}.spaces-preview.cloudcompute.com"
+      ;;
+    --url)
+      shift
+      URL="${1:?missing preview URL}"
+      ;;
+    *)
+      echo "usage: mise run web:preview:smoke -- --pr <number> | --url <url>" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$URL" ]]; then
+  echo "usage: mise run web:preview:smoke -- --pr <number> | --url <url>" >&2
+  exit 2
+fi
+
+PLAYWRIGHT_BASE_URL="$URL" \
+PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+PLAYWRIGHT_SKIP_DB_FIXTURES=1 \
+pnpm exec playwright test --project=deployment-smoke --reporter=list
+"""
+
+[tasks."web:preview:explore"]
+description = "Run exploratory Playwright QA against an authenticated Vercel preview."
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      shift
+      URL="https://pr-${1:?missing PR number}.spaces-preview.cloudcompute.com"
+      ;;
+    --url)
+      shift
+      URL="${1:?missing preview URL}"
+      ;;
+    *)
+      echo "usage: mise run web:preview:explore -- --pr <number> | --url <url>" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$URL" ]]; then
+  echo "usage: mise run web:preview:explore -- --pr <number> | --url <url>" >&2
+  exit 2
+fi
+
+HOST="$(node -e 'console.log(new URL(process.argv[1]).host.replace(/[^A-Za-z0-9_.-]/g, "_"))' "$URL")"
+STATE=".auth/preview-${HOST}.json"
+if [[ ! -f "$STATE" ]]; then
+  echo "missing $STATE; run: mise run web:preview:auth -- --url $URL" >&2
+  exit 2
+fi
+
+mkdir -p "output/preview-qa/$HOST"
+PLAYWRIGHT_BASE_URL="$URL" \
+PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+PLAYWRIGHT_SKIP_DB_FIXTURES=1 \
+PLAYWRIGHT_STORAGE_STATE="$STATE" \
+PLAYWRIGHT_OUTPUT_DIR="output/preview-qa/$HOST/test-results" \
+pnpm exec playwright test --project=qa-explore --reporter=list
+"""
+
 [tasks."web:qa:init-agents"]
 description = "One-shot: scaffold Playwright's agent-loop instructions (for Claude Code) into the repo. Run once; commit the output."
 run = "pnpm exec playwright init-agents --loop=claude"

--- a/web/docs/local-dev.md
+++ b/web/docs/local-dev.md
@@ -15,8 +15,12 @@ changes.
 mise run web:check                          # typecheck + lint + unit tests
 mise run web:dev                            # seed DB + auth bypass + start dev server
 mise run web:e2e                            # Playwright E2E (fast + full)
+mise run web:e2e:deployment-smoke           # remote-safe smoke against local dev server (default port 3212)
 mise run web:e2e:demo                       # Playwright demo with video recording
 mise run web:e2e:explore                    # qa-explore project (video + trace + axe-core)
+mise run web:preview:smoke -- --pr <N>      # remote-safe smoke against PR preview alias
+mise run web:preview:auth -- --pr <N>       # headed real-OAuth preview login + storage state
+mise run web:preview:explore -- --pr <N>    # authenticated exploratory QA against preview
 mise run web:qa:init-agents                 # one-shot: scaffold Playwright's agent-loop files
 mise run web:qa:codegen                     # interactive Playwright codegen recorder
 mise run web:evidence -- --pr <N> --name <slug>  # screenshot capture + evidence upload
@@ -57,3 +61,22 @@ the bypass entirely and forces the real OAuth flow.
 
 Screenshots without auth: start the dev server with `DEV_BYPASS_AUTH=1 pnpm dev`
 (or just `mise run web:dev`).
+
+## Preview QA
+
+PR previews publish an OAuth-compatible alias:
+
+```text
+https://pr-<N>.spaces-preview.cloudcompute.com
+```
+
+Run the cheap deployed-app smoke first, then create or refresh the real-OAuth
+storage state, then run exploratory QA:
+
+```bash
+mise run web:preview:smoke -- --pr <N>
+mise run web:preview:auth -- --pr <N>
+mise run web:preview:explore -- --pr <N>
+```
+
+See `preview-qa.md` for the adversarial checklist and evidence flow.

--- a/web/docs/preview-qa.md
+++ b/web/docs/preview-qa.md
@@ -1,0 +1,48 @@
+# Preview QA Runbook
+
+Use this when a PR has a Vercel preview and the change needs more confidence
+than CI smoke can provide. The CI lane stays cheap; local agents do the
+authenticated and adversarial pass against the deployed artifact.
+
+## Prerequisites
+
+- The PR preview workflow must publish a `Preview QA` URL shaped like
+  `https://pr-<number>.spaces-preview.cloudcompute.com`.
+- `VERCEL_AUTOMATION_BYPASS_SECRET` must be available locally for Playwright to
+  bypass Vercel Deployment Protection. Without it, use Chrome with an existing
+  Vercel session as the fallback browser.
+- The wildcard domain `*.spaces-preview.cloudcompute.com` must be configured on
+  the Vercel project and in DNS.
+- The GitHub OAuth app callback remains
+  `https://spaces.cloudcompute.com/api/auth/callback/github`; GitHub accepts
+  OAuth redirect subdomains when the registrable host and path match.
+
+## Standard Flow
+
+```bash
+mise -C web run web:preview:smoke -- --pr <N>
+mise -C web run web:preview:auth -- --pr <N>
+mise -C web run web:preview:explore -- --pr <N>
+```
+
+`web:preview:auth` opens a headed Playwright browser, completes real GitHub
+OAuth, and saves storage state under `web/.auth/`. It also captures a dashboard
+screenshot under `web/output/preview-qa/`.
+
+`web:preview:explore` reuses that storage state and runs the exploratory
+Playwright project with video and trace enabled.
+
+## Adversarial Agent Checklist
+
+- Dashboard and repo detail pages load after refresh and direct navigation.
+- Docs remain public and navigable.
+- Sign-out and sign-in return to the expected dashboard route.
+- Mobile viewport does not overflow or hide primary controls.
+- Browser back/forward does not strand the app on loading or stale state.
+- Chat and terminal tabs render their empty, paused, and unavailable states.
+- Failed network requests are expected and understandable; unexpected 401, 403,
+  or 500 responses are findings.
+- Console errors, stuck spinners, layout overlap, and confusing reauth prompts
+  are findings.
+
+Upload notable screenshots or traces with `./scripts/evidence.sh --pr <N>`.

--- a/web/e2e/deployment-smoke/app.spec.ts
+++ b/web/e2e/deployment-smoke/app.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Deployment smoke", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("serves the landing page and sign-in affordance", async ({ page }) => {
+		await page.goto("/");
+
+		await expect(page.getByText("Spaces", { exact: true }).first()).toBeVisible();
+		await expect(page.getByRole("link", { name: /login/i })).toHaveAttribute(
+			"href",
+			"/sign-in",
+		);
+	});
+
+	test("serves the sign-in page", async ({ page }) => {
+		await page.goto("/sign-in");
+
+		await expect(page.getByRole("heading", { name: "Spaces" })).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: "Continue with GitHub" }),
+		).toBeVisible();
+	});
+
+	test("redirects unauthenticated dashboard requests to sign-in", async ({
+		page,
+	}) => {
+		test.skip(
+			process.env.PLAYWRIGHT_SKIP_WEB_SERVER !== "1",
+			"local Playwright webServer runs with DEV_BYPASS_AUTH=1",
+		);
+
+		await page.goto("/dashboard");
+
+		await expect(page).toHaveURL(/\/sign-in/);
+		await expect(page).toHaveURL(/callbackUrl=%2Fdashboard/);
+	});
+
+	test("serves public docs without authentication", async ({ request }) => {
+		const redirect = await request.get("/docs", { maxRedirects: 0 });
+		expect([307, 308]).toContain(redirect.status());
+		expect(redirect.headers().location).toBe("/docs/index.html");
+
+		const landing = await request.get("/docs/index.html");
+		expect(landing.ok()).toBe(true);
+		await expect(landing.text()).resolves.toContain(
+			"Terminal-first control for your code portfolio.",
+		);
+	});
+
+	test("rejects unauthenticated workspace sync writes", async ({ request }) => {
+		const response = await request.post("/api/workspaces/sync", {
+			data: { workspaces: [] },
+			maxRedirects: 0,
+		});
+
+		expect(response.status()).toBe(401);
+	});
+});

--- a/web/e2e/seed.ts
+++ b/web/e2e/seed.ts
@@ -49,6 +49,8 @@ function minutesAgo(day: number, minutes: number): string {
 }
 
 export default async function globalSetup() {
+	if (process.env.PLAYWRIGHT_SKIP_DB_FIXTURES === "1") return;
+
 	mkdirSync("data", { recursive: true });
 	const db = createClient({ url: DB_URL });
 

--- a/web/e2e/teardown.ts
+++ b/web/e2e/teardown.ts
@@ -28,6 +28,8 @@ const CHAT_IDS = [
 ];
 
 export default async function globalTeardown() {
+	if (process.env.PLAYWRIGHT_SKIP_DB_FIXTURES === "1") return;
+
 	const db = createClient({ url: DB_URL });
 
 	await db.execute({

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
 		"test": "vitest run",
 		"test:unit": "vitest run",
 		"test:e2e": "playwright test",
+		"test:e2e:deployment-smoke": "PLAYWRIGHT_SKIP_DB_FIXTURES=1 PLAYWRIGHT_SKIP_WEB_SERVER=1 playwright test --project deployment-smoke",
 		"test:e2e:fast": "playwright test --project fast",
 		"test:e2e:docs": "PORT=3211 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3211 playwright test e2e/fast/docs.spec.ts --project=fast",
 		"test:e2e:docs-local": "PLAYWRIGHT_SKIP_WEB_SERVER=1 playwright test e2e/fast/docs-local-server.spec.ts --project=fast",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from "@playwright/test";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 const SKIP_WEB_SERVER = process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1";
+const STORAGE_STATE = process.env.PLAYWRIGHT_STORAGE_STATE;
+const OUTPUT_DIR = process.env.PLAYWRIGHT_OUTPUT_DIR;
 const E2E_DATABASE_URL =
 	process.env.PLAYWRIGHT_DATABASE_URL ??
 	(process.env.CI ? "file:data/e2e-auth.db" : process.env.TURSO_DATABASE_URL);
@@ -24,12 +26,19 @@ export default defineConfig({
 	retries: process.env.CI ? 2 : 0,
 	workers: process.env.CI ? 1 : undefined,
 	reporter: "html",
+	...(OUTPUT_DIR ? { outputDir: OUTPUT_DIR } : {}),
 	use: {
 		baseURL: BASE_URL,
 		trace: "on-first-retry",
 		extraHTTPHeaders,
+		...(STORAGE_STATE ? { storageState: STORAGE_STATE } : {}),
 	},
 	projects: [
+		{
+			name: "deployment-smoke",
+			testMatch: "deployment-smoke/**",
+			use: { ...devices["Desktop Chrome"] },
+		},
 		{
 			name: "fast",
 			testMatch: "fast/**",

--- a/web/scripts/preview-auth.mjs
+++ b/web/scripts/preview-auth.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const DEFAULT_PREVIEW_DOMAIN = "spaces-preview.cloudcompute.com";
+
+function usage() {
+	return [
+		"usage: node scripts/preview-auth.mjs (--pr <number> | --url <url>)",
+		"",
+		"Creates a local authenticated Playwright storage state for a Vercel preview.",
+	].join("\n");
+}
+
+function parseArgs(argv) {
+	let pr = "";
+	let url = "";
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--pr") {
+			pr = argv[++i] ?? "";
+		} else if (arg === "--url") {
+			url = argv[++i] ?? "";
+		} else if (arg === "--help" || arg === "-h") {
+			console.log(usage());
+			process.exit(0);
+		} else {
+			throw new Error(`unknown argument: ${arg}`);
+		}
+	}
+
+	if (url && pr) throw new Error("pass either --pr or --url, not both");
+	if (pr) {
+		if (!/^\d+$/.test(pr)) throw new Error("--pr must be a PR number");
+		return new URL(`https://pr-${pr}.${DEFAULT_PREVIEW_DOMAIN}`);
+	}
+	if (url) return new URL(url);
+	throw new Error("missing --pr or --url");
+}
+
+function safeHost(host) {
+	return host.replace(/[^A-Za-z0-9_.-]/g, "_");
+}
+
+function isDashboardUrl(url, origin) {
+	try {
+		const current = new URL(url);
+		return (
+			current.origin === origin && current.pathname.startsWith("/dashboard")
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function clickGitHubSignIn(page) {
+	const button = page.getByRole("button", { name: /Continue with GitHub/i });
+	if ((await button.count()) === 0) return false;
+	await button.click();
+	return true;
+}
+
+const target = parseArgs(process.argv.slice(2));
+const origin = target.origin;
+const host = safeHost(target.host);
+const authDir = path.join(process.cwd(), ".auth");
+const outputDir = path.join(process.cwd(), "output", "preview-qa");
+const userDataDir = path.join(authDir, "preview-profile");
+const storageStatePath = path.join(authDir, `preview-${host}.json`);
+const screenshotPath = path.join(
+	outputDir,
+	`${host}-authenticated-dashboard.png`,
+);
+
+await mkdir(authDir, { recursive: true });
+await mkdir(outputDir, { recursive: true });
+
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+if (!bypassSecret) {
+	console.warn(
+		"VERCEL_AUTOMATION_BYPASS_SECRET is not set; this only works if your browser profile already passes Vercel Deployment Protection.",
+	);
+}
+
+const context = await chromium.launchPersistentContext(userDataDir, {
+	headless: false,
+	viewport: { width: 1440, height: 900 },
+});
+
+try {
+	const page = context.pages()[0] ?? (await context.newPage());
+	const dashboardUrl = new URL("/dashboard", origin).toString();
+
+	if (bypassSecret) {
+		await context.request
+			.get(dashboardUrl, {
+				failOnStatusCode: false,
+				headers: {
+					"x-vercel-protection-bypass": bypassSecret,
+					"x-vercel-set-bypass-cookie": "true",
+				},
+				timeout: 15_000,
+			})
+			.catch(() => {});
+	}
+
+	console.log(`Opening preview dashboard at ${origin}`);
+	await page.goto(dashboardUrl, { waitUntil: "domcontentloaded" });
+
+	if (!isDashboardUrl(page.url(), origin)) {
+		const clicked = await clickGitHubSignIn(page);
+		if (clicked) {
+			console.log(
+				"Complete the GitHub OAuth flow in the opened browser window. Waiting up to 5 minutes...",
+			);
+		} else {
+			console.log(
+				"Waiting for the preview browser to reach /dashboard. Sign in manually if prompted.",
+			);
+		}
+		await page.waitForURL((url) => isDashboardUrl(url.toString(), origin), {
+			timeout: 300_000,
+			waitUntil: "domcontentloaded",
+		});
+	}
+
+	await page
+		.waitForLoadState("networkidle", { timeout: 15_000 })
+		.catch(() => {});
+
+	if (!isDashboardUrl(page.url(), origin)) {
+		throw new Error("preview auth did not finish on the dashboard route");
+	}
+
+	await context.storageState({ path: storageStatePath });
+	await page
+		.screenshot({ path: screenshotPath, fullPage: true })
+		.catch(() => {});
+
+	console.log(`Saved storage state: ${storageStatePath}`);
+	console.log(`Saved dashboard screenshot: ${screenshotPath}`);
+} finally {
+	await context.close();
+}

--- a/web/src/lib/__tests__/auth-base-url.test.ts
+++ b/web/src/lib/__tests__/auth-base-url.test.ts
@@ -22,6 +22,7 @@ describe("getAuthBaseURL", () => {
 		).toEqual({
 			allowedHosts: [
 				"spaces.cloudcompute.com",
+				"*.spaces-preview.cloudcompute.com",
 				"*.cloudcompute.vercel.app",
 				"*.vercel.app",
 				"localhost:*",

--- a/web/src/lib/auth-base-url.ts
+++ b/web/src/lib/auth-base-url.ts
@@ -9,6 +9,7 @@ export type AuthBaseURL = string | DynamicAuthBaseURL;
 const LOCAL_ALLOWED_HOSTS = ["localhost:*", "127.0.0.1:*"];
 const VERCEL_ALLOWED_HOSTS = [
 	"spaces.cloudcompute.com",
+	"*.spaces-preview.cloudcompute.com",
 	"*.cloudcompute.vercel.app",
 	"*.vercel.app",
 ];

--- a/web/tests/LEDGER.md
+++ b/web/tests/LEDGER.md
@@ -9,7 +9,7 @@ A behavior → test mapping. The `qa-web-agent` reads this at the start of every
 Each row is a *user-visible behavior*. Columns:
 
 - **Behavior** — the oracle, stated in plain English (what a user can do or observe).
-- **Layer** — `unit` (Vitest, `web/src/**/__tests__/*.test.ts`), `e2e-fast`, `e2e-full`, `e2e-demo`, `e2e-explore`, or `manual`.
+- **Layer** — `unit` (Vitest, `web/src/**/__tests__/*.test.ts`), `e2e-deployment-smoke`, `e2e-fast`, `e2e-full`, `e2e-demo`, `e2e-explore`, or `manual`.
 - **Test** — file path + test name, or `—` if not yet automated.
 - **Verified** — ISO date the test last ran green in CI. `—` if not automated.
 - **Owner** — who cares if this breaks. `qa-web-agent` is allowed as an owner, meaning the agent is responsible for keeping it green.
@@ -23,6 +23,7 @@ Add a `[gap]` row for behaviors you know matter but aren't yet tested. `qa-web-a
 | Behavior | Layer | Test | Verified | Owner |
 |---|---|---|---|---|
 | Landing page loads with Spaces branding | e2e-fast | `fast/landing.spec.ts :: loads with Spaces branding` | 2026-04-17 | qa-web-agent |
+| Deployed app serves landing, sign-in, docs, auth redirect, and unauth sync boundary | e2e-deployment-smoke | `deployment-smoke/app.spec.ts :: Deployment smoke` | 2026-06-27 | qa-web-agent |
 | `POST /api/workspaces/sync` rejects unauthenticated requests | e2e-fast | `fast/unauth-api.spec.ts :: POST /api/workspaces/sync without auth returns unauthorized` | 2026-04-17 | qa-web-agent |
 | `GET /dashboard` redirects unauthenticated users to sign-in | e2e-fast | `fast/unauth-redirect.spec.ts :: GET /dashboard without auth redirects to sign-in` | 2026-04-17 | qa-web-agent |
 


### PR DESCRIPTION
## Summary
- add a remote-safe `deployment-smoke` Playwright project for deployed previews with DB fixtures disabled
- alias each web PR preview to `pr-<number>.spaces-preview.cloudcompute.com` for real OAuth-compatible QA and show that alias as the primary PR comment URL when available
- add local authenticated preview QA tooling and runbook for agent-driven Playwright plus adversarial browser testing

## Mergeability
- Surface: web preview CI, Playwright config, preview QA tooling/docs
- User-facing behavior changed: no production UI behavior change intended
- Non-happy paths considered: deployment smoke avoids seeded DB state; local OAuth tooling keeps Vercel bypass scoped to preview cookie seeding and never logs auth material; CI falls back to the raw Vercel preview URL for unauthenticated deployment smoke when the OAuth alias prerequisite is not configured yet
- Residual risk or follow-up: Vercel currently rejects the alias with `You don't have access to the domain pr-697.spaces-preview.cloudcompute.com under cloudcompute.` The one-time `*.spaces-preview.cloudcompute.com` Vercel domain/DNS prerequisite must be completed before real OAuth preview QA can use the stable alias.

## Validation
- `mise -C web run web:check`: typecheck, Biome, and 30 Vitest files / 347 tests passed after rebase
- `mise -C web run web:e2e:deployment-smoke`: 4 passed / 1 skipped locally; the skipped dashboard redirect runs in remote mode where `PLAYWRIGHT_SKIP_WEB_SERVER=1`
- `mise -C web run web:preview:auth -- --help`: verified the local auth task entrypoint
- `node --check web/scripts/preview-auth.mjs`
- YAML parsed for `.github/workflows/web-preview.yml` and `.github/workflows/cd.yml`

## Evidence
- ![preview-qa-web-check-rebased](https://evidence.cloudcompute.com/workspaces/pr-697/20260627-215428-preview-qa-web-check-rebased.svg)
- ![preview-qa-deployment-smoke-rebased](https://evidence.cloudcompute.com/workspaces/pr-697/20260627-215428-preview-qa-deployment-smoke-rebased.svg)
