### PR TITLE
Fix managed review stuck-starting repair

### DIFF
--- a/.github/workflows/managed-reviewer-broker.yml
+++ b/.github/workflows/managed-reviewer-broker.yml
@@ -11,11 +11,13 @@ on:
     paths:
       - ".github/workflows/managed-reviewer-broker.yml"
       - "scripts/pr-reviewer-broker.py"
+      - "scripts/tests/test_pr_reviewer_broker.py"
       - "scripts/tests/test_security_hardening.py"
   pull_request:
     paths:
       - ".github/workflows/managed-reviewer-broker.yml"
       - "scripts/pr-reviewer-broker.py"
+      - "scripts/tests/test_pr_reviewer_broker.py"
       - "scripts/tests/test_security_hardening.py"
   workflow_dispatch:
     inputs:
@@ -51,6 +53,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
       - name: Check broker script help
         run: python3 scripts/pr-reviewer-broker.py --help
 
@@ -61,6 +65,9 @@ jobs:
             exit 1
           fi
           grep -q "WORKSPACES_WEBHOOK_CANARY_SECRET is required" broker.err
+
+      - name: Run broker script unit tests
+        run: uv run --script scripts/tests/test_pr_reviewer_broker.py
 
   broker:
     name: Reconcile completed managed reviews
@@ -73,7 +80,11 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: main
+          # Status-triggered broker runs are production projection repair and
+          # stay pinned to main. Manual dispatch may intentionally validate or
+          # recover with the selected ref, for example while repairing the
+          # broker workflow itself before merge.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || 'main' }}
           persist-credentials: false
 
       - name: Run managed reviewer broker
@@ -86,8 +97,21 @@ jobs:
         run: |
           for attempt in $(seq 1 "$BROKER_ATTEMPTS"); do
             echo "Managed reviewer broker attempt $attempt/$BROKER_ATTEMPTS"
-            output="$(python3 scripts/pr-reviewer-broker.py --json --limit "$BROKER_LIMIT" --repo "$BROKER_REPO")"
+            set +e
+            output="$(python3 scripts/pr-reviewer-broker.py --json --limit "$BROKER_LIMIT" --repo "$BROKER_REPO" 2>&1)"
+            script_status=$?
+            set -e
             echo "$output"
+
+            if [ "$script_status" -ne 0 ]; then
+              if [ "$script_status" -eq 75 ] && [ "$attempt" -lt "$BROKER_ATTEMPTS" ]; then
+                echo "::warning::Managed reviewer broker request failed transiently; retrying after $BROKER_POLL_SECONDS seconds."
+                sleep "$BROKER_POLL_SECONDS"
+                continue
+              fi
+              echo "::error::Managed reviewer broker command failed with exit code $script_status"
+              exit "$script_status"
+            fi
 
             metrics="$(python3 -c 'import json, sys; p=json.load(sys.stdin); print(p.get("checked", 0), p.get("applied", 0), p.get("failed", 0), p.get("retryable", 0), p.get("skippedRunning", 0), p.get("superseded", 0), p.get("requeued", 0))' <<<"$output")"
             set -- $metrics

--- a/scripts/pr-reviewer-broker.py
+++ b/scripts/pr-reviewer-broker.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -29,6 +30,7 @@ from typing import Any
 
 
 DEFAULT_BROKER_URL = "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-broker"
+EX_TEMPFAIL = 75
 SAFE_RESPONSE_KEYS = (
     "ok",
     "repo",
@@ -48,6 +50,10 @@ SAFE_RESPONSE_KEYS = (
 
 class BrokerError(RuntimeError):
     """Raised when the broker request fails or reports failed processing."""
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -108,12 +114,22 @@ def request_json(url: str, secret: str, timeout: float) -> dict[str, Any]:
             raw = response.read(64 * 1024)
     except urllib.error.HTTPError as error:
         raw = error.read(64 * 1024)
+        retryable = error.code == 408 or error.code == 429 or 500 <= error.code < 600
         raise BrokerError(
             f"managed reviewer broker returned HTTP {error.code}: "
-            f"{json.dumps(payload_for_error(raw), sort_keys=True)}"
+            f"{json.dumps(payload_for_error(raw), sort_keys=True)}",
+            retryable=retryable,
         ) from error
     except urllib.error.URLError as error:
-        raise BrokerError(f"managed reviewer broker request failed: {error.reason}") from error
+        raise BrokerError(
+            f"managed reviewer broker request failed: {error.reason}",
+            retryable=True,
+        ) from error
+    except (TimeoutError, socket.timeout) as error:
+        raise BrokerError(
+            f"managed reviewer broker request timed out: {error}",
+            retryable=True,
+        ) from error
 
     try:
         payload = json.loads(raw.decode("utf-8"))
@@ -138,7 +154,7 @@ def main(argv: list[str]) -> int:
             )
     except BrokerError as error:
         print(f"::error::{error}", file=sys.stderr)
-        return 1
+        return EX_TEMPFAIL if error.retryable else 1
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/tests/test_pr_reviewer_broker.py
+++ b/scripts/tests/test_pr_reviewer_broker.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Unit tests for the managed reviewer broker CLI wrapper."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pr-reviewer-broker.py"
+
+
+def load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("pr_reviewer_broker", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PrReviewerBrokerTests(unittest.TestCase):
+    def test_retryable_broker_error_returns_tempfail(self) -> None:
+        script = load_script()
+        with (
+            patch.dict(
+                os.environ,
+                {"WORKSPACES_WEBHOOK_CANARY_SECRET": "broker-secret"},
+            ),
+            patch.object(
+                script,
+                "request_json",
+                side_effect=script.BrokerError("read timed out", retryable=True),
+            ),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+        ):
+            self.assertEqual(script.main(["--json"]), script.EX_TEMPFAIL)
+        self.assertIn("read timed out", stderr.getvalue())
+
+    def test_nonretryable_broker_error_returns_failure(self) -> None:
+        script = load_script()
+        with (
+            patch.dict(
+                os.environ,
+                {"WORKSPACES_WEBHOOK_CANARY_SECRET": "broker-secret"},
+            ),
+            patch.object(
+                script,
+                "request_json",
+                side_effect=script.BrokerError("unauthorized", retryable=False),
+            ),
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+        ):
+            self.assertEqual(script.main(["--json"]), 1)
+        self.assertIn("unauthorized", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -495,7 +495,14 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("github.event.state == 'pending'", broker_workflow)
         self.assertIn("github.event.context || 'none'", broker_workflow)
         self.assertIn("github.event.state || 'none'", broker_workflow)
-        self.assertIn("ref: main", broker_workflow)
+        self.assertIn(
+            "github.event_name == 'workflow_dispatch' && github.ref || 'main'",
+            broker_workflow,
+        )
+        self.assertIn(
+            "Status-triggered broker runs are production projection repair",
+            broker_workflow,
+        )
         self.assertIn("persist-credentials: false", broker_workflow)
         self.assertIn("github.event_name == 'status' && '120'", broker_workflow)
         self.assertIn("github.event_name == 'status' && '15'", broker_workflow)

--- a/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review-runs.test.ts
@@ -552,6 +552,14 @@ describe("listPrReviewRunsForBroker", () => {
 			fingerprint: "fp_broker_projected",
 			prNumber: 13,
 		});
+		const stuckStarting = makeInput({
+			fingerprint: "fp_broker_stuck_starting",
+			prNumber: 14,
+		});
+		const freshStarting = makeInput({
+			fingerprint: "fp_broker_fresh_starting",
+			prNumber: 15,
+		});
 
 		await recordRunStart(started);
 		await recordRunResult(started.fingerprint, {
@@ -582,6 +590,15 @@ describe("listPrReviewRunsForBroker", () => {
 			sessionId: "sesn_projected",
 			status: "completed",
 		});
+		await recordRunStart(stuckStarting);
+		await recordRunStart(freshStarting);
+		const { getDb } = await import("../../db");
+		const oldStamp = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+		await getDb()
+			.updateTable("managed_pr_review_runs")
+			.set({ updated_at: oldStamp })
+			.where("fingerprint", "=", stuckStarting.fingerprint)
+			.execute();
 
 		const rows = await listPrReviewRunsForBroker();
 
@@ -589,7 +606,15 @@ describe("listPrReviewRunsForBroker", () => {
 			"fp_broker_missing_intent",
 			"fp_broker_repair",
 			"fp_broker_started",
+			"fp_broker_stuck_starting",
 		]);
+		expect(
+			rows.find((row) => row.fingerprint === stuckStarting.fingerprint),
+		).toMatchObject({
+			status: "started",
+			sessionId: null,
+			projectionStatus: "pending",
+		});
 		expect(
 			rows.find((row) => row.fingerprint === repair.fingerprint),
 		).toMatchObject({

--- a/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/pr-review.test.ts
@@ -1761,6 +1761,54 @@ describe("processPendingPrReviewRuns", () => {
 		expect(mocks.recordRunResult).not.toHaveBeenCalled();
 	});
 
+	it("fails stale started rows that never recorded an agent session", async () => {
+		vi.stubEnv("ANTHROPIC_API_KEY", "");
+		mocks.listPrReviewRunsForBroker.mockResolvedValue([
+			brokerRun({
+				fingerprint: "fp_stuck_starting",
+				repoFullName: "fairchild/workspaces",
+				prNumber: 486,
+				headSha: "head-sha",
+				triggerKind: "opened",
+				triggerSourceId: "head-sha",
+				sessionId: null,
+				createdAt: "2026-05-17T06:00:00Z",
+				updatedAt: "2026-05-17T06:00:00Z",
+			}),
+		]);
+		mocks.fetch.mockImplementation(async (url: string) => {
+			if (isManagedReviewStatusUrl(url)) {
+				return okResponse();
+			}
+			throw new Error(`Unexpected fetch URL: ${url}`);
+		});
+
+		const result = await processPendingPrReviewRuns({ limit: 1 });
+
+		expect(result).toMatchObject({
+			checked: 1,
+			completed: 0,
+			failed: 1,
+			skippedRunning: 0,
+		});
+		const statusPost = mocks.fetch.mock.calls.find(([url]) =>
+			String(url).includes("/statuses/head-sha"),
+		);
+		expect(statusPost?.[1]).toMatchObject({ method: "POST" });
+		expect(JSON.parse(String(statusPost?.[1]?.body))).toMatchObject({
+			state: "failure",
+			context: "WorkSpaces Managed Review",
+			description: "Managed review failed before posting.",
+			target_url:
+				"https://spaces.cloudcompute.com/dashboard/review-runs/fp_stuck_starting",
+		});
+		expect(mocks.recordRunResult).toHaveBeenCalledWith("fp_stuck_starting", {
+			sessionId: null,
+			status: "failed",
+			error: "started ReviewRun is missing an agent session",
+		});
+	});
+
 	it("waits through a short coalescing grace period before superseding a running session", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-05-17T06:25:30Z"));

--- a/web/src/lib/agent-runtime/pr-review-runs.ts
+++ b/web/src/lib/agent-runtime/pr-review-runs.ts
@@ -2043,11 +2043,22 @@ export async function listPrReviewRunsForBroker(
 ): Promise<BrokerPrReviewRun[]> {
 	await ensureSchema();
 	const limit = input.limit ?? 10;
+	const staleStartedBefore = new Date(
+		Date.now() - STALE_STARTED_MS,
+	).toISOString();
 	let startedQuery = getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select(BROKER_RUN_COLUMNS)
 		.where("status", "=", "started")
-		.where("session_id", "is not", null);
+		.where((eb) =>
+			eb.or([
+				eb("session_id", "is not", null),
+				eb.and([
+					eb("session_id", "is", null),
+					eb("updated_at", "<=", staleStartedBefore),
+				]),
+			]),
+		);
 	let completedQuery = getDb()
 		.selectFrom("managed_pr_review_runs")
 		.select(BROKER_RUN_COLUMNS)

--- a/web/src/lib/agent-runtime/pr-review.ts
+++ b/web/src/lib/agent-runtime/pr-review.ts
@@ -1895,7 +1895,9 @@ export async function processPendingPrReviewRuns(
 		limit: input.limit ?? 5,
 		repoFullName: input.repoFullName,
 	});
-	const needsAnthropic = pendingRuns.some((run) => run.status === "started");
+	const needsAnthropic = pendingRuns.some(
+		(run) => run.status === "started" && run.sessionId,
+	);
 	if (needsAnthropic && !apiKey) {
 		throw new Error("missing ANTHROPIC_API_KEY");
 	}


### PR DESCRIPTION
## Summary

- Repair stuck managed-review pickup rows that entered `started` but never recorded a managed-agent `session_id`.
- Make the broker workflow retry transient protected-route/read timeouts instead of aborting the 120-attempt status poll on attempt 1.
- Add focused coverage for stale no-session broker selection, failure projection, and retryable broker CLI exit handling.

## Mergeability

- Surface: agent-runtime / infra
- User-facing behavior changed: PRs should no longer remain indefinitely blocked by a required `WorkSpaces Managed Review` pending status when pickup never records a session id.
- Non-happy paths considered: fresh no-session pickup rows still stay out of the broker until the existing stale-start threshold; no-session repair does not require Anthropic credentials because there is no live session to poll; transient broker HTTP/transport failures retry, while nonretryable command failures still fail the workflow.
- Release/ops preconditions: deploy the web app after merge so the protected broker route uses the new stale-starting repair selector.
- Residual risk or follow-up: the ReviewRun operator report can still age old GitHub required pending statuses out of its default window; the GitHub projection audit catches active PRs, but the source-of-truth report should eventually include required pending statuses outside the ReviewRun window.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `uv run --script scripts/tests/test_pr_reviewer_broker.py`
  - `uv run --script scripts/tests/test_security_hardening.py`
  - `corepack pnpm typecheck`
  - `corepack pnpm lint`
  - `corepack pnpm exec vitest run src/lib/agent-runtime/__tests__/pr-review-runs.test.ts`
  - `corepack pnpm test`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![managed-review-stuck-starting-validation](https://evidence.cloudcompute.com/workspaces/pr-698/20260627-221930-managed-review-stuck-starting-validation.png)

## Blockers

- [x] None
- [ ] Blocked on evidence
