### PR TITLE
[codex] Add private feedback capture

### DIFF
--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -11,6 +11,10 @@ import SwiftData
 import SwiftUI
 import WorkspaceManagerCore
 
+extension Notification.Name {
+    static let showFeedbackSheet = Notification.Name("WorkspacesShowFeedbackSheet")
+}
+
 @main
 struct WorkspaceManagerApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -259,6 +263,11 @@ struct WorkspaceManagerApp: App {
             CommandGroup(after: .help) {
                 KeyboardShortcutsMenuItem()
 
+                Button("Send Feedback...") {
+                    appCommandState.perform(.sendFeedback)
+                }
+                .disabled(!appCommandState.mainWindowAvailability.canSendFeedback)
+
                 Button("Export Diagnostic Report...") {
                     Task {
                         await DiagnosticReportExporter.exportWithSavePanel()
@@ -447,6 +456,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Applying after activation-policy setup avoids Dock showing the generic executable icon.
         applyApplicationIconIfAvailable()
         applyVariantPresentationIfNeeded()
+        DispatchQueue.main.async { [weak self] in
+            self?.installHelpMenuItems()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.installHelpMenuItems()
+        }
 
         // Register existing windows with focus manager
         for window in NSApp.windows {
@@ -467,6 +482,41 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     self.applyVariantPresentation(to: window)
                 }
             }
+        }
+    }
+
+    private func installHelpMenuItems() {
+        guard let helpMenu = NSApp.mainMenu?.item(withTitle: "Help")?.submenu else { return }
+
+        if helpMenu.item(withTitle: "Send Feedback...") == nil {
+            helpMenu.addItem(.separator())
+            let item = NSMenuItem(
+                title: "Send Feedback...",
+                action: #selector(showFeedbackFromHelpMenu),
+                keyEquivalent: ""
+            )
+            item.target = self
+            helpMenu.addItem(item)
+        }
+
+        if helpMenu.item(withTitle: "Export Diagnostic Report...") == nil {
+            let item = NSMenuItem(
+                title: "Export Diagnostic Report...",
+                action: #selector(exportDiagnosticReportFromHelpMenu),
+                keyEquivalent: ""
+            )
+            item.target = self
+            helpMenu.addItem(item)
+        }
+    }
+
+    @objc private func showFeedbackFromHelpMenu() {
+        NotificationCenter.default.post(name: .showFeedbackSheet, object: nil)
+    }
+
+    @objc private func exportDiagnosticReportFromHelpMenu() {
+        Task {
+            await DiagnosticReportExporter.exportWithSavePanel()
         }
     }
 
@@ -555,6 +605,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidBecomeActive(_ notification: Notification) {
         NSLog("[AppDelegate] applicationDidBecomeActive")
+        installHelpMenuItems()
         applyApplicationIconIfAvailable()
         GhosttyAppManager.shared.setFocus(true)
         TerminalFocusManager.shared.appDidBecomeActive()
@@ -608,6 +659,10 @@ private struct ClaudeSettingsInstallerKey: EnvironmentKey {
     static let defaultValue: (any ClaudeSettingsInstalling)? = nil
 }
 
+private struct FeedbackServiceKey: EnvironmentKey {
+    static let defaultValue: any FeedbackServiceProtocol = FeedbackService.shared
+}
+
 extension EnvironmentValues {
     var gitService: any GitServiceProtocol {
         get { self[GitServiceKey.self] }
@@ -658,6 +713,11 @@ extension EnvironmentValues {
         get { self[ClaudeSettingsInstallerKey.self] }
         set { self[ClaudeSettingsInstallerKey.self] = newValue }
     }
+
+    var feedbackService: any FeedbackServiceProtocol {
+        get { self[FeedbackServiceKey.self] }
+        set { self[FeedbackServiceKey.self] = newValue }
+    }
 }
 
 struct MainWindowFocusedActions {
@@ -678,6 +738,7 @@ struct MainWindowFocusedActions {
     var copyPath: Action? = nil
     var openSessionSwitcher: Action? = nil
     var openCommandRunner: Action? = nil
+    var sendFeedback: Action? = nil
 
     @MainActor static let empty = MainWindowFocusedActions()
 }
@@ -698,6 +759,7 @@ struct MainWindowCommandAvailability: Equatable {
     let canCopyPath: Bool
     let canOpenSessionSwitcher: Bool
     let canOpenCommandRunner: Bool
+    let canSendFeedback: Bool
 
     static let empty = MainWindowCommandAvailability(
         canToggleSidebar: false,
@@ -714,7 +776,8 @@ struct MainWindowCommandAvailability: Equatable {
         canRevealInFinder: false,
         canCopyPath: false,
         canOpenSessionSwitcher: false,
-        canOpenCommandRunner: false
+        canOpenCommandRunner: false,
+        canSendFeedback: false
     )
 }
 
@@ -734,6 +797,7 @@ enum MainWindowCommand {
     case copyPath
     case openSessionSwitcher
     case openCommandRunner
+    case sendFeedback
 }
 
 @MainActor
@@ -800,6 +864,8 @@ final class AppCommandState: ObservableObject {
             mainWindowActions.openSessionSwitcher?()
         case .openCommandRunner:
             mainWindowActions.openCommandRunner?()
+        case .sendFeedback:
+            mainWindowActions.sendFeedback?()
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/FeedbackSheet.swift
+++ b/Sources/WorkspaceManager/Views/FeedbackSheet.swift
@@ -1,0 +1,203 @@
+import AppKit
+import SwiftUI
+import WorkspaceManagerCore
+
+struct FeedbackSheet: View {
+    private static let privacyCopy =
+        "Feedback is private to the WorkSpaces team unless we choose to publish an edited "
+        + "or aggregated issue."
+
+    @Environment(\.feedbackService) private var feedbackService
+    @ObservedObject var notificationCoordinator: NotificationCoordinator
+    let onDismiss: () -> Void
+
+    @State private var kind: FeedbackKind = .feedback
+    @State private var message = ""
+    @State private var contactEmail = ""
+    @State private var includesScreenshot = false
+    @State private var includesDiagnostics = false
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+    @State private var receipt: FeedbackSubmissionReceipt?
+
+    private var canSubmit: Bool {
+        !isSubmitting && !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            header
+
+            Picker("Type", selection: $kind) {
+                Text("Feedback").tag(FeedbackKind.feedback)
+                Text("Bug").tag(FeedbackKind.bug)
+                Text("Idea").tag(FeedbackKind.idea)
+            }
+            .pickerStyle(.segmented)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Message")
+                    .font(.headline)
+                TextEditor(text: $message)
+                    .font(.body)
+                    .frame(minHeight: 140)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(.separator, lineWidth: 1)
+                    }
+            }
+
+            TextField("Email (optional)", text: $contactEmail)
+                .textFieldStyle(.roundedBorder)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle("Attach a screenshot of the current WorkSpaces window", isOn: $includesScreenshot)
+                Toggle("Attach a diagnostic report zip", isOn: $includesDiagnostics)
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let receipt {
+                Text("Sent. Reference: \(receipt.id)")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Spacer()
+                Button(receipt == nil ? "Cancel" : "Done") {
+                    onDismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button {
+                    Task { await submit() }
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Text("Send")
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSubmit || receipt != nil)
+            }
+        }
+        .padding(24)
+        .frame(width: 520)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Send Feedback")
+                .font(.title2)
+                .bold()
+            Text(Self.privacyCopy)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @MainActor
+    private func submit() async {
+        isSubmitting = true
+        errorMessage = nil
+        defer { isSubmitting = false }
+
+        do {
+            let attachments = try await FeedbackAttachmentCollector.collect(
+                screenshot: includesScreenshot,
+                diagnostics: includesDiagnostics
+            )
+            let submission = FeedbackSubmission(
+                kind: kind,
+                message: message,
+                contactEmail: contactEmail.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                appVersion: Self.appVersion,
+                osVersion: Self.osVersion,
+                screenshot: attachments.screenshot,
+                diagnostics: attachments.diagnostics
+            )
+            let jwt = await notificationCoordinator.jwtForFeedbackSubmission()
+            receipt = try await feedbackService.submit(submission, jwt: jwt)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private static var appVersion: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        return "\(version) (\(build))"
+    }
+
+    private static var osVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+}
+
+private struct FeedbackCollectedAttachments {
+    let screenshot: FeedbackAttachment?
+    let diagnostics: FeedbackAttachment?
+}
+
+private enum FeedbackAttachmentCollector {
+    @MainActor
+    static func collect(screenshot: Bool, diagnostics: Bool) async throws -> FeedbackCollectedAttachments {
+        let screenshotAttachment = screenshot ? try captureMainWindowScreenshot() : nil
+        let diagnosticsAttachment = diagnostics ? try await assembleDiagnostics() : nil
+        return FeedbackCollectedAttachments(
+            screenshot: screenshotAttachment,
+            diagnostics: diagnosticsAttachment
+        )
+    }
+
+    @MainActor
+    private static func captureMainWindowScreenshot() throws -> FeedbackAttachment? {
+        guard
+            let window = NSApp.mainWindow ?? NSApp.keyWindow,
+            let contentView = window.contentView
+        else { return nil }
+
+        let bounds = contentView.bounds
+        guard
+            let representation = contentView.bitmapImageRepForCachingDisplay(in: bounds)
+        else { return nil }
+        contentView.cacheDisplay(in: bounds, to: representation)
+        guard let bitmap = representation.representation(using: .png, properties: [:]) else { return nil }
+
+        return FeedbackAttachment(
+            filename: "screenshot.png",
+            contentType: "image/png",
+            data: bitmap
+        )
+    }
+
+    private static func assembleDiagnostics() async throws -> FeedbackAttachment {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("workspaces-feedback-\(UUID().uuidString)")
+            .appendingPathExtension("zip")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        try await DiagnosticReportExporter.assembleReport(to: url)
+        return FeedbackAttachment(
+            filename: "diagnostics.zip",
+            contentType: "application/zip",
+            data: try Data(contentsOf: url)
+        )
+    }
+}
+
+extension String {
+    fileprivate var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -62,6 +62,7 @@ struct ContentView: View {
     @State private var dismissedWorkspaceOrphanItemIDs: Set<String> = []
     @State private var cleaningWorkspaceOrphanItemIDs: Set<String> = []
     @State private var pendingWorkspaceOrphanCleanup: WorkspaceOrphanItem?
+    @State private var isShowingFeedbackSheet = false
     @State private var accessRecorder = MainWindowAccessRecorder()
     @State private var presentedSessionSwitcherSnapshot: SessionSwitcherSnapshot?
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
@@ -446,7 +447,8 @@ struct ContentView: View {
             revealInFinder: revealInFinderFocusedAction,
             copyPath: copyPathFocusedAction,
             openSessionSwitcher: presentSessionSwitcher,
-            openCommandRunner: { viewState.isShowingThemeOverlay = true }
+            openCommandRunner: { viewState.isShowingThemeOverlay = true },
+            sendFeedback: { isShowingFeedbackSheet = true }
         )
     }
 
@@ -466,7 +468,8 @@ struct ContentView: View {
             canRevealInFinder: revealInFinderFocusedAction != nil,
             canCopyPath: copyPathFocusedAction != nil,
             canOpenSessionSwitcher: true,
-            canOpenCommandRunner: true
+            canOpenCommandRunner: true,
+            canSendFeedback: true
         )
     }
 
@@ -982,6 +985,9 @@ struct ContentView: View {
                 clearAppCommands()
                 accessRecorder.flushPendingSave(modelContext: modelContext)
             }
+            .onReceive(NotificationCenter.default.publisher(for: .showFeedbackSheet)) { _ in
+                isShowingFeedbackSheet = true
+            }
             .sheet(item: $repoForNewWorkspaceFromLanding) { repo in
                 NewWorkspaceSheet(
                     repo: repo,
@@ -1051,6 +1057,12 @@ struct ContentView: View {
                 TerminalThemeOverlay(
                     store: .shared,
                     onDismiss: { viewState.isShowingThemeOverlay = false }
+                )
+            }
+            .sheet(isPresented: $isShowingFeedbackSheet) {
+                FeedbackSheet(
+                    notificationCoordinator: notificationCoordinator,
+                    onDismiss: { isShowingFeedbackSheet = false }
                 )
             }
             .alert(

--- a/Sources/WorkspaceManager/Views/MainWindow/NotificationCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/NotificationCoordinator.swift
@@ -225,6 +225,15 @@ final class NotificationCoordinator: NotificationCoordinatorProtocol, Observable
         unseenEventCount = 0
     }
 
+    func jwtForFeedbackSubmission() async -> String? {
+        guard case .signedIn = authState else { return nil }
+        if jwtNeedsRefresh() {
+            let refreshed = await refreshJWT()
+            guard refreshed else { return nil }
+        }
+        return try? credentialStore.loadString(key: NotificationConstants.keychainJWTKey)
+    }
+
     // MARK: - Private
 
     private func handleEvent(_ event: WebhookEvent) {

--- a/Sources/WorkspaceManagerCore/Services/FeedbackService.swift
+++ b/Sources/WorkspaceManagerCore/Services/FeedbackService.swift
@@ -1,0 +1,244 @@
+import Foundation
+import os.log
+
+private let feedbackLog = Logger(subsystem: "com.cloudcompute.workspaces", category: "Feedback")
+
+public enum FeedbackKind: String, Codable, CaseIterable, Sendable {
+    case bug
+    case idea
+    case feedback
+}
+
+public struct FeedbackAttachment: Sendable, Equatable {
+    public let filename: String
+    public let contentType: String
+    public let data: Data
+
+    public init(filename: String, contentType: String, data: Data) {
+        self.filename = filename
+        self.contentType = contentType
+        self.data = data
+    }
+}
+
+public struct FeedbackSubmission: Sendable, Equatable {
+    public let kind: FeedbackKind
+    public let message: String
+    public let contactEmail: String?
+    public let appVersion: String
+    public let osVersion: String
+    public let client: String
+    public let honeypot: String?
+    public let screenshot: FeedbackAttachment?
+    public let diagnostics: FeedbackAttachment?
+
+    public init(
+        kind: FeedbackKind,
+        message: String,
+        contactEmail: String?,
+        appVersion: String,
+        osVersion: String,
+        client: String = "macos",
+        honeypot: String? = nil,
+        screenshot: FeedbackAttachment? = nil,
+        diagnostics: FeedbackAttachment? = nil
+    ) {
+        self.kind = kind
+        self.message = message
+        self.contactEmail = contactEmail
+        self.appVersion = appVersion
+        self.osVersion = osVersion
+        self.client = client
+        self.honeypot = honeypot
+        self.screenshot = screenshot
+        self.diagnostics = diagnostics
+    }
+}
+
+public struct FeedbackSubmissionReceipt: Codable, Sendable, Equatable {
+    public let id: String
+    public let status: String
+}
+
+public enum FeedbackServiceError: Error, LocalizedError, Equatable {
+    case emptyMessage
+    case messageTooLong(Int)
+    case requestFailed(Int)
+    case invalidResponse
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyMessage:
+            "Feedback message cannot be empty."
+        case .messageTooLong(let limit):
+            "Feedback message must be \(limit) characters or fewer."
+        case .requestFailed(let code):
+            "Feedback submission failed with status \(code)."
+        case .invalidResponse:
+            "The feedback service returned an invalid response."
+        }
+    }
+}
+
+public protocol FeedbackServiceProtocol: Sendable {
+    func submit(_ submission: FeedbackSubmission, jwt: String?) async throws -> FeedbackSubmissionReceipt
+}
+
+public actor FeedbackService: FeedbackServiceProtocol {
+    public static let shared = FeedbackService()
+    public static let maxMessageLength = 10_000
+
+    private let baseURL: URL
+    private let session: URLSession
+
+    public init(
+        baseURL: URL = NotificationConstants.feedbackBaseURL,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func submit(_ submission: FeedbackSubmission, jwt: String?) async throws -> FeedbackSubmissionReceipt {
+        let trimmedMessage = submission.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedMessage.isEmpty else { throw FeedbackServiceError.emptyMessage }
+        guard trimmedMessage.count <= Self.maxMessageLength else {
+            throw FeedbackServiceError.messageTooLong(Self.maxMessageLength)
+        }
+
+        do {
+            return try await submitValidated(submission, jwt: jwt)
+        } catch FeedbackServiceError.requestFailed(401) where jwt?.isEmpty == false {
+            feedbackLog.notice("Feedback JWT was rejected; retrying anonymously")
+            return try await submitValidated(submission, jwt: nil)
+        }
+    }
+
+    private func submitValidated(
+        _ submission: FeedbackSubmission,
+        jwt: String?
+    ) async throws -> FeedbackSubmissionReceipt {
+        var request = URLRequest(url: baseURL.appendingPathComponent("feedback"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let jwt, !jwt.isEmpty {
+            request.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
+        }
+
+        let boundary = "workspaces-feedback-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try Self.multipartBody(for: submission, boundary: boundary)
+
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw FeedbackServiceError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 201 || httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "(no body)"
+            feedbackLog.error("Feedback submission failed: \(httpResponse.statusCode) - \(body)")
+            throw FeedbackServiceError.requestFailed(httpResponse.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(FeedbackSubmissionReceipt.self, from: data)
+        } catch {
+            throw FeedbackServiceError.invalidResponse
+        }
+    }
+
+    static func multipartBody(for submission: FeedbackSubmission, boundary: String) throws -> Data {
+        var body = Data()
+        let payload = FeedbackPayload(submission: submission)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let payloadData = try encoder.encode(payload)
+
+        body.appendPart(
+            name: "payload",
+            filename: nil,
+            contentType: "application/json",
+            data: payloadData,
+            boundary: boundary
+        )
+
+        if let screenshot = submission.screenshot {
+            body.appendPart(
+                name: "screenshot",
+                filename: screenshot.filename,
+                contentType: screenshot.contentType,
+                data: screenshot.data,
+                boundary: boundary
+            )
+        }
+
+        if let diagnostics = submission.diagnostics {
+            body.appendPart(
+                name: "diagnostics",
+                filename: diagnostics.filename,
+                contentType: diagnostics.contentType,
+                data: diagnostics.data,
+                boundary: boundary
+            )
+        }
+
+        body.appendString("--\(boundary)--\r\n")
+        return body
+    }
+}
+
+private struct FeedbackPayload: Codable {
+    let kind: FeedbackKind
+    let message: String
+    let contactEmail: String?
+    let appVersion: String
+    let osVersion: String
+    let client: String
+    let honeypot: String?
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case message
+        case contactEmail = "contact_email"
+        case appVersion = "app_version"
+        case osVersion = "os_version"
+        case client
+        case honeypot
+    }
+
+    init(submission: FeedbackSubmission) {
+        kind = submission.kind
+        message = submission.message
+        contactEmail = submission.contactEmail
+        appVersion = submission.appVersion
+        osVersion = submission.osVersion
+        client = submission.client
+        honeypot = submission.honeypot
+    }
+}
+
+extension Data {
+    fileprivate mutating func appendString(_ string: String) {
+        append(Data(string.utf8))
+    }
+
+    fileprivate mutating func appendPart(
+        name: String,
+        filename: String?,
+        contentType: String,
+        data: Data,
+        boundary: String
+    ) {
+        appendString("--\(boundary)\r\n")
+        if let filename {
+            appendString(
+                "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n"
+            )
+        } else {
+            appendString("Content-Disposition: form-data; name=\"\(name)\"\r\n")
+        }
+        appendString("Content-Type: \(contentType)\r\n\r\n")
+        append(data)
+        appendString("\r\n")
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/NotificationConstants.swift
+++ b/Sources/WorkspaceManagerCore/Services/NotificationConstants.swift
@@ -11,6 +11,15 @@ public enum NotificationConstants {
         // Safe: constant URL string, always parses successfully
         return URL(string: "https://webhooks.cloudcompute.com")!
     }()
+    public static let feedbackBaseURL: URL = {
+        if let override = ProcessInfo.processInfo.environment[
+            "WORKSPACES_FEEDBACK_URL"],
+            let url = URL(string: override)
+        {
+            return url
+        }
+        return URL(string: "https://feedback.cloudcompute.com")!
+    }()
     public static let gitHubAppClientID = "Iv23liJBRgQoWIWjtRoO"
 
     public static let enabledKey = "notificationsEnabled"

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -194,6 +194,7 @@ public protocol NotificationCoordinatorProtocol: AnyObject {
     func connectStream(remoteURL: String) async
     func disconnectStream() async
     func markActivitySeen()
+    func jwtForFeedbackSubmission() async -> String?
 }
 
 public struct RuntimeCapabilities: Sendable, Equatable {

--- a/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
@@ -52,7 +52,8 @@ struct AppCommandStateTests {
             canRevealInFinder: false,
             canCopyPath: false,
             canOpenSessionSwitcher: true,
-            canOpenCommandRunner: true
+            canOpenCommandRunner: true,
+            canSendFeedback: true
         )
 
         state.setMainWindowActions(

--- a/Tests/WorkspaceManagerTests/FeedbackServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/FeedbackServiceTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("FeedbackService")
+struct FeedbackServiceTests {
+    @Test("submit sends multipart payload and optional JWT")
+    func submitMultipart() async throws {
+        final class RequestBox: @unchecked Sendable {
+            private let lock = NSLock()
+            private var stored: URLRequest?
+
+            var request: URLRequest? {
+                lock.lock()
+                defer { lock.unlock() }
+                return stored
+            }
+
+            func save(_ request: URLRequest) {
+                lock.lock()
+                stored = request
+                lock.unlock()
+            }
+        }
+
+        let requestBox = RequestBox()
+        let session = MockURLProtocol.session(requestHandlers: [
+            "/feedback": { request in
+                requestBox.save(request)
+                let data = Data(#"{"id":"fb_123","status":"new"}"#.utf8)
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 201,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (data, response)
+            }
+        ])
+        let service = FeedbackService(
+            baseURL: URL(string: "https://mock.test")!,
+            session: session
+        )
+
+        let receipt = try await service.submit(
+            FeedbackSubmission(
+                kind: .bug,
+                message: "The terminal vanished.",
+                contactEmail: "user@example.com",
+                appVersion: "1.2.3",
+                osVersion: "14.5",
+                screenshot: FeedbackAttachment(
+                    filename: "screenshot.png",
+                    contentType: "image/png",
+                    data: Data([1, 2, 3])
+                )
+            ),
+            jwt: "jwt-token"
+        )
+
+        #expect(receipt == FeedbackSubmissionReceipt(id: "fb_123", status: "new"))
+        let request = try #require(requestBox.request)
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer jwt-token")
+        #expect(request.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data") == true)
+        let bodyData = try #require(request.httpBody ?? Data(reading: request.httpBodyStream))
+        let body = String(data: bodyData, encoding: .utf8)
+        #expect(body?.contains("\"message\":\"The terminal vanished.\"") == true)
+        #expect(body?.contains("name=\"screenshot\"; filename=\"screenshot.png\"") == true)
+    }
+
+    @Test("submit retries anonymously when optional JWT is rejected")
+    func submitRetriesAnonymouslyAfterRejectedJWT() async throws {
+        final class RequestRecorder: @unchecked Sendable {
+            private let lock = NSLock()
+            private var authorizationHeaders: [String?] = []
+
+            func append(_ value: String?) {
+                lock.lock()
+                authorizationHeaders.append(value)
+                lock.unlock()
+            }
+
+            var values: [String?] {
+                lock.lock()
+                defer { lock.unlock() }
+                return authorizationHeaders
+            }
+        }
+
+        let recorder = RequestRecorder()
+        let session = MockURLProtocol.session(requestHandlers: [
+            "/feedback": { request in
+                let authorization = request.value(forHTTPHeaderField: "Authorization")
+                recorder.append(authorization)
+
+                if authorization != nil {
+                    let data = Data(#"{"error":"invalid jwt"}"#.utf8)
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 401,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "application/json"]
+                    )!
+                    return (data, response)
+                }
+
+                let data = Data(#"{"id":"fb_retry","status":"new"}"#.utf8)
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 201,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (data, response)
+            }
+        ])
+        let service = FeedbackService(
+            baseURL: URL(string: "https://mock.test")!,
+            session: session
+        )
+
+        let receipt = try await service.submit(
+            FeedbackSubmission(
+                kind: .feedback,
+                message: "Please keep accepting feedback.",
+                contactEmail: nil,
+                appVersion: "1.2.3",
+                osVersion: "14.5"
+            ),
+            jwt: "stale-jwt"
+        )
+
+        #expect(receipt == FeedbackSubmissionReceipt(id: "fb_retry", status: "new"))
+        #expect(recorder.values == ["Bearer stale-jwt", nil])
+    }
+
+    @Test("submit rejects empty message locally")
+    func submitRejectsEmptyMessage() async {
+        let service = FeedbackService(baseURL: URL(string: "https://mock.test")!)
+
+        do {
+            _ = try await service.submit(
+                FeedbackSubmission(
+                    kind: .feedback,
+                    message: " ",
+                    contactEmail: nil,
+                    appVersion: "dev",
+                    osVersion: "14.5"
+                ),
+                jwt: nil
+            )
+            Issue.record("Expected emptyMessage")
+        } catch let error as FeedbackServiceError {
+            #expect(error == .emptyMessage)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}
+
+extension Data {
+    fileprivate init?(reading stream: InputStream?) {
+        guard let stream else { return nil }
+        self.init()
+        stream.open()
+        defer { stream.close() }
+
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read > 0 {
+                append(buffer, count: read)
+            } else if read < 0 {
+                return nil
+            } else {
+                break
+            }
+        }
+    }
+}

--- a/Tests/WorkspaceManagerTests/Helpers/MockURLProtocol.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockURLProtocol.swift
@@ -10,28 +10,32 @@ final class MockURLProtocol: URLProtocol, @unchecked Sendable {
     static func session(
         handlers: [String: (json: [String: Any], statusCode: Int)]
     ) -> URLSession {
+        session(
+            requestHandlers: handlers.mapValues { spec in
+                { request in
+                    let data = try! JSONSerialization.data(withJSONObject: spec.json)
+                    let response = HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: spec.statusCode,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "application/json"]
+                    )!
+                    return (data, response)
+                }
+            }
+        )
+    }
+
+    static func session(
+        requestHandlers: [String: (URLRequest) -> (Data, HTTPURLResponse)]
+    ) -> URLSession {
         let sessionID = UUID().uuidString
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         config.httpAdditionalHeaders = ["X-Mock-Session-ID": sessionID]
 
-        var resolved: [String: (URLRequest) -> (Data, HTTPURLResponse)] = [:]
-        for (path, spec) in handlers {
-            let data = try! JSONSerialization.data(withJSONObject: spec.json)
-            let statusCode = spec.statusCode
-            resolved[path] = { request in
-                let response = HTTPURLResponse(
-                    url: request.url!,
-                    statusCode: statusCode,
-                    httpVersion: nil,
-                    headerFields: ["Content-Type": "application/json"]
-                )!
-                return (data, response)
-            }
-        }
-
         lock.lock()
-        handlersBySessionID[sessionID] = resolved
+        handlersBySessionID[sessionID] = requestHandlers
         lock.unlock()
 
         return URLSession(configuration: config)

--- a/docs/development/notifications.md
+++ b/docs/development/notifications.md
@@ -124,7 +124,12 @@ bun run --bun wrangler deploy --env preview # preview
 
 **Secrets** (set via `wrangler secret put`):
 - `GITHUB_WEBHOOK_SECRET` — shared secret for GitHub webhook signature verification
-- `JWT_SIGNING_SECRET` — HMAC-SHA256 key for JWT signing/verification
+- `JWT_SIGNING_SECRET` — HMAC-SHA256 key for notification-session JWT
+  signing/verification. This is a shared cross-worker secret: keep the same
+  value on `webhook-relay`, `webhook-relay-preview`, `feedback-store`, and
+  `feedback-store-preview`. Rotate all four together; mismatched values do not
+  break anonymous feedback submission, but they do break signed-in feedback
+  attribution and any other worker that verifies notification JWTs.
 - `WORKSPACES_WEBHOOK_CANARY_SECRET` — canary-only shared secret used to prove
   the signed Cloudflare-to-Vercel reviewer ingress path without starting an
   agent

--- a/infra/feedback-store/CONTRACT.md
+++ b/infra/feedback-store/CONTRACT.md
@@ -1,0 +1,98 @@
+# WorkSpaces Feedback Store Contract
+
+The feedback worker owns private in-app feedback for WorkSpaces at `https://feedback.cloudcompute.com`.
+
+## `POST /feedback`
+
+Clients submit `multipart/form-data`:
+
+- `payload`: JSON object
+- `screenshot`: optional PNG file
+- `diagnostics`: optional zip file
+
+`payload`:
+
+```json
+{
+  "kind": "bug|idea|feedback",
+  "message": "required, 1-10000 chars",
+  "contact_email": "optional",
+  "app_version": "required",
+  "os_version": "required",
+  "client": "macos",
+  "honeypot": "must be empty when present"
+}
+```
+
+`Authorization: Bearer <notification JWT>` is optional. When present, the worker verifies the HS256 JWT with `JWT_SIGNING_SECRET` and stores `sub` plus `login`; invalid JWTs are rejected with `401`. Anonymous submissions are accepted.
+
+`JWT_SIGNING_SECRET` is intentionally shared with the notification webhook relay.
+Keep the same value on Cloudflare Workers `webhook-relay`,
+`webhook-relay-preview`, `feedback-store`, and `feedback-store-preview`, and
+rotate all four together. If these drift, `/auth/session` can still issue
+notification JWTs, but the feedback worker cannot verify them for signed-in
+attribution.
+
+Response:
+
+```json
+{ "id": "<feedback uuid>", "status": "new" }
+```
+
+Abuse controls: message length cap, attachment size caps enforced by Worker request limits, honeypot discard, salted `ip_hash`, and a per-IP D1 rolling hourly limit backed by `POSTS_PER_HOUR`.
+
+## Storage
+
+D1 binding: `FEEDBACK_DB`.
+
+`feedback` table:
+
+- `id` TEXT PRIMARY KEY
+- `created_at` INTEGER milliseconds
+- `kind` TEXT (`bug|idea|feedback`)
+- `message` TEXT
+- `contact_email` TEXT nullable
+- `submitter_login` TEXT nullable
+- `submitter_id` TEXT nullable
+- `app_version` TEXT
+- `os_version` TEXT
+- `client` TEXT (`macos`)
+- `ip_hash` TEXT nullable
+- `status` TEXT default `new` (`new|triaged|planned|resolved|wont_fix`)
+- `admin_notes` TEXT nullable
+- `github_issue_url` TEXT nullable
+- `attachment_prefix` TEXT nullable
+- `has_screenshot` INTEGER
+- `has_diagnostics` INTEGER
+
+Indexes: `created_at`, `status`, `kind`.
+
+R2 binding: `FEEDBACK_BUCKET`, bucket `workspaces-feedback`.
+
+R2 keys:
+
+- `feedback/<id>/payload.json`
+- `feedback/<id>/screenshot.png`
+- `feedback/<id>/diagnostics.zip`
+
+## Admin
+
+Admin UI is served by the worker:
+
+- `GET /admin/login`
+- `GET /admin/callback`
+- `GET /admin`
+- `GET /admin/:id`
+- `POST /admin/:id`
+- `POST /admin/publish`
+- `POST /admin/logout`
+
+Admin auth uses GitHub OAuth with `GITHUB_CLIENT_ID` and
+`GITHUB_CLIENT_SECRET`. The Cloudflare secret binding is named
+`GITHUB_CLIENT_SECRET`, and it should be populated with the same GitHub OAuth
+client secret used by the web WorkSpaces app (`GITHUB_WEB_WORKSPACES_CLIENT_SECRET`
+in local operator env files). The callback fetches the GitHub user and requires
+their login to be present in comma-separated `ADMIN_ALLOWLIST`. Sessions are
+signed HS256 JWT cookies with `ADMIN_SESSION_SECRET`.
+
+Admin publish accepts selected feedback IDs plus editable `title` and `body`, creates an issue in `GITHUB_OWNER/GITHUB_REPO` using `GITHUB_ISSUE_TOKEN`, applies `enhancement` or `bug` and `needs-triage`, and writes the resulting `github_issue_url` back to every selected row.

--- a/infra/feedback-store/migrations/0001_feedback.sql
+++ b/infra/feedback-store/migrations/0001_feedback.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS feedback (
+  id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  message TEXT NOT NULL,
+  contact_email TEXT,
+  submitter_login TEXT,
+  submitter_id TEXT,
+  app_version TEXT NOT NULL,
+  os_version TEXT NOT NULL,
+  client TEXT NOT NULL,
+  ip_hash TEXT,
+  status TEXT NOT NULL DEFAULT 'new',
+  admin_notes TEXT,
+  github_issue_url TEXT,
+  attachment_prefix TEXT,
+  has_screenshot INTEGER NOT NULL DEFAULT 0,
+  has_diagnostics INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_created_at ON feedback(created_at);
+CREATE INDEX IF NOT EXISTS idx_feedback_status ON feedback(status);
+CREATE INDEX IF NOT EXISTS idx_feedback_kind ON feedback(kind);

--- a/infra/feedback-store/package-lock.json
+++ b/infra/feedback-store/package-lock.json
@@ -1,0 +1,1574 @@
+{
+  "name": "feedback-store",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "feedback-store",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4",
+        "typescript": "^5",
+        "wrangler": "^4"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260625.1.tgz",
+      "integrity": "sha512-naCfBv0WnnTQIQPTniqMoUlklOIFjrAcSn1X+IAOhY8aFLF/xGYtFjs1eEE8sFib3ZuChGGpU23FFORVczqr0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-jmH6zjp6Wrux46+qtFwDwrj+vd7s5bdwEqeGvdnwE0a4IEeAhKs0L42HQOyID+g5lkrHq9m55+AbhtmRAm63Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260625.1.tgz",
+      "integrity": "sha512-MiQkpA/dX8d83Zp64pzHUKfd6ca4cvwxnNobSP6CnXvfESvnNI9pfa+nfwnParla36sPmnYntNkjR7NjRuDeKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260625.1.tgz",
+      "integrity": "sha512-LxxW7Qv60Xvv37+w6gUSDpYZziyqMy+cZWd9IvSA5ehVgKAxmzEaYPMiSZlxk32nbIWL9u/tfjXYCOKJ4Lo+XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260625.1.tgz",
+      "integrity": "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260627.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260627.1.tgz",
+      "integrity": "sha512-QhVvier1eW9Ydw96N/Ez79i5CSGy7h39JucrUejQmAWQw9qBdlB1aOTjaD93EGYrV0t9U81YWetI3LcaxxILNw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260625.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260625.0.tgz",
+      "integrity": "sha512-3kKXwRUObJsnBYPBgR0NiNZYKF/yv8GFyha1cx2EeAEraxNODgRVcyeRo+F1ok1tg5Mg7iUpOWSkknQTHuFhwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260625.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260625.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260625.1.tgz",
+      "integrity": "sha512-GApQvFX52SDM6L4u0+RRnUDB1wJOnEwoXjinkmOPtIyofWBxrlZckdegJSYc1leg++lLZ3+DQ4zMVmBqYVtzfA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260625.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260625.1",
+        "@cloudflare/workerd-linux-64": "1.20260625.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260625.1",
+        "@cloudflare/workerd-windows-64": "1.20260625.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.105.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.105.0.tgz",
+      "integrity": "sha512-7dXFH6OLj1Fv0y6ZeRPUxFTkp+duWD7/xxVi/1c0vfOeEYwIFKWB7cdqnY05DvY1Ta3BnqAwRkXfLs8PDj538g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260625.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260625.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260625.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/infra/feedback-store/package.json
+++ b/infra/feedback-store/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "feedback-store",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test:e2e": "bun run test/e2e.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4",
+    "typescript": "^5",
+    "wrangler": "^4"
+  }
+}

--- a/infra/feedback-store/src/admin.ts
+++ b/infra/feedback-store/src/admin.ts
@@ -1,0 +1,289 @@
+import { ensureSchema } from "./db";
+import { signJWT, verifyJWT } from "./github-verify";
+import type { Env, FeedbackRow } from "./types";
+
+interface AdminSession {
+  login: string;
+  exp: number;
+}
+
+export async function handleAdmin(request: Request, env: Env): Promise<Response> {
+  await ensureSchema(env);
+
+  const url = new URL(request.url);
+  if (url.pathname === "/admin/login") {
+    return loginRedirect(url, env);
+  }
+  if (url.pathname === "/admin/callback") {
+    return callback(request, env);
+  }
+  if (url.pathname === "/admin/logout" && request.method === "POST") {
+    return redirect("/admin/login", [["Set-Cookie", "ws_feedback_admin=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax"]]);
+  }
+
+  const session = await requireSession(request, env);
+  if (!session) {
+    return redirect("/admin/login");
+  }
+
+  if (url.pathname === "/admin" && request.method === "GET") {
+    return list(request, env, session);
+  }
+
+  const attachmentMatch = url.pathname.match(/^\/admin\/attachment\/([^/]+)\/(screenshot\.png|diagnostics\.zip)$/);
+  if (attachmentMatch && request.method === "GET") {
+    return attachment(attachmentMatch[1], attachmentMatch[2], env);
+  }
+
+  const detailMatch = url.pathname.match(/^\/admin\/([^/]+)$/);
+  if (detailMatch && request.method === "GET") {
+    return detail(detailMatch[1], env, session);
+  }
+  if (detailMatch && request.method === "POST") {
+    return update(detailMatch[1], request, env);
+  }
+
+  return new Response("not found", { status: 404 });
+}
+
+async function attachment(id: string, filename: string, env: Env): Promise<Response> {
+  const row = await env.FEEDBACK_DB.prepare("SELECT attachment_prefix FROM feedback WHERE id = ?")
+    .bind(id)
+    .first<{ attachment_prefix: string | null }>();
+  if (!row?.attachment_prefix) return new Response("not found", { status: 404 });
+
+  const object = await env.FEEDBACK_BUCKET.get(`${row.attachment_prefix}/${filename}`);
+  if (!object) return new Response("not found", { status: 404 });
+
+  return new Response(object.body, {
+    headers: {
+      "Content-Type": object.httpMetadata?.contentType ?? contentTypeFor(filename),
+      "Cache-Control": "private, no-store",
+    },
+  });
+}
+
+export async function requireSession(request: Request, env: Env): Promise<AdminSession | null> {
+  const cookie = request.headers.get("Cookie") ?? "";
+  const token = cookie.match(/(?:^|;\s*)ws_feedback_admin=([^;]+)/)?.[1];
+  if (!token) return null;
+  const payload = await verifyJWT(token, env.ADMIN_SESSION_SECRET);
+  if (!payload || typeof payload.login !== "string") return null;
+  return { login: payload.login, exp: Number(payload.exp ?? 0) };
+}
+
+async function loginRedirect(url: URL, env: Env): Promise<Response> {
+  const state = crypto.randomUUID();
+  const callbackURL = `${url.origin}/admin/callback`;
+  const target = new URL("https://github.com/login/oauth/authorize");
+  target.searchParams.set("client_id", env.GITHUB_CLIENT_ID);
+  target.searchParams.set("redirect_uri", callbackURL);
+  target.searchParams.set("state", state);
+  target.searchParams.set("scope", "read:user");
+  return redirect(target.toString(), [
+    ["Set-Cookie", `ws_feedback_oauth_state=${state}; Path=/admin; Max-Age=600; HttpOnly; Secure; SameSite=Lax`],
+  ]);
+}
+
+async function callback(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const cookieState = request.headers.get("Cookie")?.match(/(?:^|;\s*)ws_feedback_oauth_state=([^;]+)/)?.[1];
+  if (!code || !state || state !== cookieState) {
+    return new Response("invalid oauth state", { status: 400 });
+  }
+
+  const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "workspaces-feedback-store",
+    },
+    body: JSON.stringify({
+      client_id: env.GITHUB_CLIENT_ID,
+      client_secret: env.GITHUB_CLIENT_SECRET,
+      code,
+      redirect_uri: `${url.origin}/admin/callback`,
+    }),
+  });
+  const tokenBody = (await tokenResponse.json()) as { access_token?: string };
+  if (!tokenBody.access_token) {
+    return new Response("oauth token exchange failed", { status: 401 });
+  }
+
+  const userResponse = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${tokenBody.access_token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "workspaces-feedback-store",
+    },
+  });
+  const user = (await userResponse.json()) as { login?: string };
+  if (!user.login || !allowedAdmins(env).has(user.login)) {
+    return new Response("not allowlisted", { status: 403 });
+  }
+
+  const exp = Math.floor(Date.now() / 1000) + 8 * 60 * 60;
+  const jwt = await signJWT({ login: user.login, exp }, env.ADMIN_SESSION_SECRET);
+  return redirect("/admin", [
+    ["Set-Cookie", `ws_feedback_admin=${jwt}; Path=/; Max-Age=${8 * 60 * 60}; HttpOnly; Secure; SameSite=Lax`],
+    ["Set-Cookie", "ws_feedback_oauth_state=; Path=/admin; Max-Age=0; HttpOnly; Secure; SameSite=Lax"],
+  ]);
+}
+
+async function list(request: Request, env: Env, session: AdminSession): Promise<Response> {
+  const url = new URL(request.url);
+  const status = url.searchParams.get("status") ?? "";
+  const kind = url.searchParams.get("kind") ?? "";
+  let query = "SELECT * FROM feedback";
+  const clauses: string[] = [];
+  const bindings: string[] = [];
+  if (status) {
+    clauses.push("status = ?");
+    bindings.push(status);
+  }
+  if (kind) {
+    clauses.push("kind = ?");
+    bindings.push(kind);
+  }
+  if (clauses.length) query += ` WHERE ${clauses.join(" AND ")}`;
+  query += " ORDER BY created_at DESC LIMIT 100";
+
+  const result = await env.FEEDBACK_DB.prepare(query).bind(...bindings).all<FeedbackRow>();
+  const rows = result.results ?? [];
+  return html(page("Feedback", session, table(rows, status, kind)));
+}
+
+async function detail(id: string, env: Env, session: AdminSession): Promise<Response> {
+  const row = await env.FEEDBACK_DB.prepare("SELECT * FROM feedback WHERE id = ?")
+    .bind(id)
+    .first<FeedbackRow>();
+  if (!row) return new Response("not found", { status: 404 });
+
+  const attachments = [
+    row.has_screenshot ? `<li><a href="/admin/attachment/${row.id}/screenshot.png">screenshot.png</a></li>` : "",
+    row.has_diagnostics ? `<li><a href="/admin/attachment/${row.id}/diagnostics.zip">diagnostics.zip</a></li>` : "",
+  ].join("");
+
+  return html(page("Feedback Detail", session, `
+    <p><a href="/admin">Back</a></p>
+    <article>
+      <h2>${escapeHTML(row.kind)} · ${escapeHTML(row.status)}</h2>
+      <p class="meta">${new Date(row.created_at).toLocaleString()} · ${escapeHTML(row.submitter_login ?? "anonymous")} · ${escapeHTML(row.app_version)}</p>
+      <pre>${escapeHTML(row.message)}</pre>
+      <p>Contact: ${escapeHTML(row.contact_email ?? "none")}</p>
+      <p>GitHub: ${row.github_issue_url ? `<a href="${escapeHTML(row.github_issue_url)}">${escapeHTML(row.github_issue_url)}</a>` : "none"}</p>
+      <ul>${attachments || "<li>No attachments</li>"}</ul>
+      <form method="post">
+        <label>Status <select name="status">${["new", "triaged", "planned", "resolved", "wont_fix"].map((value) => `<option ${value === row.status ? "selected" : ""}>${value}</option>`).join("")}</select></label>
+        <label>Notes <textarea name="admin_notes">${escapeHTML(row.admin_notes ?? "")}</textarea></label>
+        <button>Save</button>
+      </form>
+    </article>
+  `));
+}
+
+async function update(id: string, request: Request, env: Env): Promise<Response> {
+  const form = await request.formData();
+  const status = String(form.get("status") ?? "new");
+  const notes = String(form.get("admin_notes") ?? "");
+  await env.FEEDBACK_DB.prepare("UPDATE feedback SET status = ?, admin_notes = ? WHERE id = ?")
+    .bind(status, notes, id)
+    .run();
+  return redirect(`/admin/${id}`);
+}
+
+function table(rows: FeedbackRow[], status: string, kind: string): string {
+  return `
+    <form class="filters" method="get">
+      <input name="status" placeholder="status" value="${escapeHTML(status)}">
+      <input name="kind" placeholder="kind" value="${escapeHTML(kind)}">
+      <button>Filter</button>
+    </form>
+    <form method="post" action="/admin/publish">
+      <table>
+        <thead><tr><th></th><th>Created</th><th>Kind</th><th>Status</th><th>Submitter</th><th>Message</th></tr></thead>
+        <tbody>
+          ${rows.map((row) => `
+            <tr>
+              <td><input type="checkbox" name="ids" value="${escapeHTML(row.id)}"></td>
+              <td>${new Date(row.created_at).toLocaleString()}</td>
+              <td>${escapeHTML(row.kind)}</td>
+              <td>${escapeHTML(row.status)}</td>
+              <td>${escapeHTML(row.submitter_login ?? "anonymous")}</td>
+              <td><a href="/admin/${escapeHTML(row.id)}">${escapeHTML(row.message.slice(0, 120))}</a></td>
+            </tr>
+          `).join("")}
+        </tbody>
+      </table>
+      <label>Issue title <input name="title" required></label>
+      <label>Issue body <textarea name="body" required></textarea></label>
+      <button>Publish selected</button>
+    </form>
+  `;
+}
+
+function page(title: string, session: AdminSession, body: string): string {
+  return `<!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>${escapeHTML(title)}</title>
+        <style>
+          body { font: 14px system-ui, sans-serif; margin: 24px; color: #171717; }
+          header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+          table { border-collapse: collapse; width: 100%; margin: 16px 0; }
+          th, td { border-bottom: 1px solid #ddd; padding: 8px; text-align: left; vertical-align: top; }
+          textarea { display: block; width: 100%; min-height: 120px; margin: 6px 0 12px; }
+          input, select, button { font: inherit; }
+          label { display: block; margin: 12px 0; }
+          pre { white-space: pre-wrap; background: #f6f6f6; padding: 12px; border-radius: 6px; }
+          .meta { color: #666; }
+          .filters { display: flex; gap: 8px; align-items: center; }
+        </style>
+      </head>
+      <body>
+        <header>
+          <h1>${escapeHTML(title)}</h1>
+          <form method="post" action="/admin/logout"><span>${escapeHTML(session.login)}</span> <button>Logout</button></form>
+        </header>
+        ${body}
+      </body>
+    </html>`;
+}
+
+function allowedAdmins(env: Env): Set<string> {
+  return new Set(env.ADMIN_ALLOWLIST.split(",").map((entry) => entry.trim()).filter(Boolean));
+}
+
+function contentTypeFor(filename: string): string {
+  if (filename.endsWith(".png")) return "image/png";
+  if (filename.endsWith(".zip")) return "application/zip";
+  return "application/octet-stream";
+}
+
+export function redirect(location: string, headers: [string, string][] = []): Response {
+  return new Response(null, {
+    status: 302,
+    headers: [["Location", location], ...headers],
+  });
+}
+
+export function html(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+export function escapeHTML(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/infra/feedback-store/src/db.ts
+++ b/infra/feedback-store/src/db.ts
@@ -1,0 +1,16 @@
+import type { Env } from "./types";
+
+export async function ensureSchema(env: Env): Promise<void> {
+  await env.FEEDBACK_DB.exec(
+    "CREATE TABLE IF NOT EXISTS feedback (id TEXT PRIMARY KEY, created_at INTEGER NOT NULL, kind TEXT NOT NULL, message TEXT NOT NULL, contact_email TEXT, submitter_login TEXT, submitter_id TEXT, app_version TEXT NOT NULL, os_version TEXT NOT NULL, client TEXT NOT NULL, ip_hash TEXT, status TEXT NOT NULL DEFAULT 'new', admin_notes TEXT, github_issue_url TEXT, attachment_prefix TEXT, has_screenshot INTEGER NOT NULL DEFAULT 0, has_diagnostics INTEGER NOT NULL DEFAULT 0);"
+  );
+  await env.FEEDBACK_DB.exec(
+    "CREATE INDEX IF NOT EXISTS idx_feedback_created_at ON feedback(created_at);"
+  );
+  await env.FEEDBACK_DB.exec(
+    "CREATE INDEX IF NOT EXISTS idx_feedback_status ON feedback(status);"
+  );
+  await env.FEEDBACK_DB.exec(
+    "CREATE INDEX IF NOT EXISTS idx_feedback_kind ON feedback(kind);"
+  );
+}

--- a/infra/feedback-store/src/github-verify.ts
+++ b/infra/feedback-store/src/github-verify.ts
@@ -1,0 +1,77 @@
+const encoder = new TextEncoder();
+
+export async function signJWT(
+  payload: Record<string, unknown>,
+  secret: string
+): Promise<string> {
+  const header = { alg: "HS256", typ: "JWT" };
+  const segments = [
+    base64url(JSON.stringify(header)),
+    base64url(JSON.stringify(payload)),
+  ];
+  const signingInput = segments.join(".");
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(signingInput));
+  segments.push(base64url(sig));
+  return segments.join(".");
+}
+
+export async function verifyJWT(
+  token: string,
+  secret: string
+): Promise<Record<string, unknown> | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+
+  const signingInput = parts[0] + "." + parts[1];
+  const signature = base64urlDecode(parts[2]);
+
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    signature,
+    encoder.encode(signingInput)
+  );
+  if (!valid) return null;
+
+  const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+
+  if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+
+  return payload;
+}
+
+function base64url(input: string | ArrayBuffer): string {
+  const bytes =
+    typeof input === "string" ? encoder.encode(input) : new Uint8Array(input);
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecode(input: string): ArrayBuffer {
+  const padded = input + "=".repeat((4 - (input.length % 4)) % 4);
+  const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}

--- a/infra/feedback-store/src/index.ts
+++ b/infra/feedback-store/src/index.ts
@@ -1,0 +1,33 @@
+import { handleAdmin } from "./admin";
+import { handlePublish } from "./publish";
+import { handleSubmit } from "./submit";
+import type { Env } from "./types";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    try {
+      if (request.method === "GET" && url.pathname === "/health") {
+        return new Response("ok", { status: 200 });
+      }
+
+      if (request.method === "POST" && url.pathname === "/feedback") {
+        return handleSubmit(request, env);
+      }
+
+      if (url.pathname === "/admin/publish" && request.method === "POST") {
+        return handlePublish(request, env);
+      }
+
+      if (url.pathname.startsWith("/admin")) {
+        return handleAdmin(request, env);
+      }
+
+      return new Response("not found", { status: 404 });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return Response.json({ error: message }, { status: 500 });
+    }
+  },
+} satisfies ExportedHandler<Env>;

--- a/infra/feedback-store/src/publish.ts
+++ b/infra/feedback-store/src/publish.ts
@@ -1,0 +1,82 @@
+import { ensureSchema } from "./db";
+import { escapeHTML, html, redirect, requireSession } from "./admin";
+import type { Env, FeedbackRow } from "./types";
+
+export async function handlePublish(request: Request, env: Env): Promise<Response> {
+  await ensureSchema(env);
+  const session = await requireSession(request, env);
+  if (!session) return redirect("/admin/login");
+
+  const form = await request.formData();
+  const ids = form.getAll("ids").map(String).filter(Boolean);
+  const title = String(form.get("title") ?? "").trim();
+  const body = String(form.get("body") ?? "").trim();
+  if (ids.length === 0 || !title || !body) {
+    return html(`<p>Missing selected feedback, title, or body.</p><p><a href="/admin">Back</a></p>`, 400);
+  }
+  if (!env.GITHUB_ISSUE_TOKEN) {
+    return html(`<p>GITHUB_ISSUE_TOKEN is not configured.</p><p><a href="/admin">Back</a></p>`, 500);
+  }
+
+  const rows = await loadRows(env, ids);
+  const labels = labelsFor(rows);
+  const issueURL = await createIssue(env, title, buildIssueBody(body, rows), labels);
+
+  for (const id of ids) {
+    await env.FEEDBACK_DB.prepare("UPDATE feedback SET github_issue_url = ?, status = 'triaged' WHERE id = ?")
+      .bind(issueURL, id)
+      .run();
+  }
+
+  return html(`<p>Published <a href="${escapeHTML(issueURL)}">${escapeHTML(issueURL)}</a>.</p><p><a href="/admin">Back</a></p>`);
+}
+
+async function loadRows(env: Env, ids: string[]): Promise<FeedbackRow[]> {
+  const rows: FeedbackRow[] = [];
+  for (const id of ids) {
+    const row = await env.FEEDBACK_DB.prepare("SELECT * FROM feedback WHERE id = ?")
+      .bind(id)
+      .first<FeedbackRow>();
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+function labelsFor(rows: FeedbackRow[]): string[] {
+  const labels = new Set<string>(["needs-triage"]);
+  if (rows.some((row) => row.kind === "bug")) {
+    labels.add("bug");
+  } else {
+    labels.add("enhancement");
+  }
+  return [...labels];
+}
+
+function buildIssueBody(body: string, rows: FeedbackRow[]): string {
+  const refs = rows
+    .map((row) => `- feedback/${row.id} (${row.kind}, ${new Date(row.created_at).toISOString()})`)
+    .join("\n");
+  return `${body}\n\n---\nPrivate source feedback references:\n${refs}\n`;
+}
+
+async function createIssue(env: Env, title: string, body: string, labels: string[]): Promise<string> {
+  const owner = env.GITHUB_OWNER ?? "fairchild";
+  const repo = env.GITHUB_REPO ?? "workspaces";
+  const apiBase = env.GITHUB_API_BASE ?? "https://api.github.com";
+  const response = await fetch(`${apiBase}/repos/${owner}/${repo}/issues`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.GITHUB_ISSUE_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "User-Agent": "workspaces-feedback-store",
+    },
+    body: JSON.stringify({ title, body, labels }),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub issue create failed: ${response.status} ${await response.text()}`);
+  }
+  const data = (await response.json()) as { html_url?: string };
+  if (!data.html_url) throw new Error("GitHub issue response missing html_url");
+  return data.html_url;
+}

--- a/infra/feedback-store/src/submit.ts
+++ b/infra/feedback-store/src/submit.ts
@@ -1,0 +1,175 @@
+import { ensureSchema } from "./db";
+import { verifyJWT } from "./github-verify";
+import type { Env, FeedbackPayload } from "./types";
+
+const VALID_KINDS = new Set(["bug", "idea", "feedback"]);
+const MAX_MESSAGE_LENGTH = 10_000;
+
+interface Submitter {
+  login: string | null;
+  id: string | null;
+}
+
+export async function handleSubmit(request: Request, env: Env): Promise<Response> {
+  await ensureSchema(env);
+
+  const auth = request.headers.get("Authorization");
+  const submitter = await resolveSubmitter(auth, env);
+  if (auth && !submitter) {
+    return json({ error: "invalid jwt" }, 401);
+  }
+
+  let parsed: Awaited<ReturnType<typeof parseSubmission>>;
+  try {
+    parsed = await parseSubmission(request);
+  } catch {
+    return json({ error: "invalid payload" }, 400);
+  }
+  const { payload, screenshot, diagnostics } = parsed;
+  const validation = validatePayload(payload);
+  if (validation) {
+    return json({ error: validation }, 400);
+  }
+
+  if (payload.honeypot?.trim()) {
+    return json({ id: "discarded", status: "accepted" }, 202);
+  }
+
+  const ipHash = await hashedIP(request, env);
+  if (ipHash && (await isRateLimited(env, ipHash))) {
+    return json({ error: "rate limited" }, 429);
+  }
+
+  const id = crypto.randomUUID();
+  const createdAt = Date.now();
+  const prefix = `feedback/${id}`;
+  const hasScreenshot = screenshot != null ? 1 : 0;
+  const hasDiagnostics = diagnostics != null ? 1 : 0;
+
+  await env.FEEDBACK_BUCKET.put(`${prefix}/payload.json`, JSON.stringify(payload, null, 2), {
+    httpMetadata: { contentType: "application/json" },
+  });
+  if (screenshot) {
+    await env.FEEDBACK_BUCKET.put(`${prefix}/screenshot.png`, screenshot.stream(), {
+      httpMetadata: { contentType: screenshot.type || "image/png" },
+    });
+  }
+  if (diagnostics) {
+    await env.FEEDBACK_BUCKET.put(`${prefix}/diagnostics.zip`, diagnostics.stream(), {
+      httpMetadata: { contentType: diagnostics.type || "application/zip" },
+    });
+  }
+
+  await env.FEEDBACK_DB.prepare(
+    `INSERT INTO feedback (
+      id, created_at, kind, message, contact_email, submitter_login, submitter_id,
+      app_version, os_version, client, ip_hash, status, attachment_prefix,
+      has_screenshot, has_diagnostics
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'new', ?, ?, ?)`
+  )
+    .bind(
+      id,
+      createdAt,
+      payload.kind,
+      payload.message.trim(),
+      emptyToNull(payload.contact_email),
+      submitter?.login ?? null,
+      submitter?.id ?? null,
+      payload.app_version,
+      payload.os_version,
+      payload.client,
+      ipHash,
+      prefix,
+      hasScreenshot,
+      hasDiagnostics
+    )
+    .run();
+
+  return json({ id, status: "new" }, 201);
+}
+
+async function resolveSubmitter(auth: string | null, env: Env): Promise<Submitter | null | undefined> {
+  if (!auth) return undefined;
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+
+  const claims = await verifyJWT(match[1], env.JWT_SIGNING_SECRET);
+  if (!claims) return null;
+
+  return {
+    login: typeof claims.login === "string" ? claims.login : null,
+    id: typeof claims.sub === "string" ? claims.sub : null,
+  };
+}
+
+async function parseSubmission(request: Request): Promise<{
+  payload: FeedbackPayload;
+  screenshot: File | null;
+  diagnostics: File | null;
+}> {
+  const contentType = request.headers.get("Content-Type") ?? "";
+  if (contentType.includes("multipart/form-data")) {
+    const form = await request.formData();
+    const rawPayload = form.get("payload");
+    if (typeof rawPayload !== "string") {
+      throw new Error("missing payload");
+    }
+    return {
+      payload: JSON.parse(rawPayload) as FeedbackPayload,
+      screenshot: fileValue(form.get("screenshot")),
+      diagnostics: fileValue(form.get("diagnostics")),
+    };
+  }
+
+  return {
+    payload: (await request.json()) as FeedbackPayload,
+    screenshot: null,
+    diagnostics: null,
+  };
+}
+
+function validatePayload(payload: FeedbackPayload): string | null {
+  if (!VALID_KINDS.has(payload.kind)) return "invalid kind";
+  const message = payload.message?.trim() ?? "";
+  if (!message) return "message required";
+  if (message.length > MAX_MESSAGE_LENGTH) return "message too long";
+  if (!payload.app_version?.trim()) return "app_version required";
+  if (!payload.os_version?.trim()) return "os_version required";
+  if (payload.client !== "macos") return "invalid client";
+  return null;
+}
+
+function fileValue(value: FormDataEntryValue | null): File | null {
+  return value instanceof File && value.size > 0 ? value : null;
+}
+
+async function hashedIP(request: Request, env: Env): Promise<string | null> {
+  const ip = request.headers.get("CF-Connecting-IP");
+  if (!ip) return null;
+  const salt = env.FEEDBACK_IP_HASH_SALT ?? env.JWT_SIGNING_SECRET;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${salt}:${ip}`)
+  );
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function isRateLimited(env: Env, ipHash: string): Promise<boolean> {
+  const limit = Number(env.POSTS_PER_HOUR ?? "10");
+  const since = Date.now() - 60 * 60 * 1000;
+  const result = await env.FEEDBACK_DB.prepare(
+    "SELECT COUNT(*) AS count FROM feedback WHERE ip_hash = ? AND created_at >= ?"
+  )
+    .bind(ipHash, since)
+    .first<{ count: number }>();
+  return Number(result?.count ?? 0) >= limit;
+}
+
+function emptyToNull(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed : null;
+}
+
+function json(body: unknown, status: number): Response {
+  return Response.json(body, { status });
+}

--- a/infra/feedback-store/src/types.ts
+++ b/infra/feedback-store/src/types.ts
@@ -1,0 +1,45 @@
+export interface Env {
+  FEEDBACK_DB: D1Database;
+  FEEDBACK_BUCKET: R2Bucket;
+  JWT_SIGNING_SECRET: string;
+  ADMIN_SESSION_SECRET: string;
+  ADMIN_ALLOWLIST: string;
+  GITHUB_CLIENT_ID: string;
+  GITHUB_CLIENT_SECRET: string;
+  GITHUB_ISSUE_TOKEN?: string;
+  GITHUB_OWNER?: string;
+  GITHUB_REPO?: string;
+  GITHUB_API_BASE?: string;
+  FEEDBACK_IP_HASH_SALT?: string;
+  POSTS_PER_HOUR?: string;
+}
+
+export interface FeedbackPayload {
+  kind: "bug" | "idea" | "feedback";
+  message: string;
+  contact_email?: string;
+  app_version: string;
+  os_version: string;
+  client: string;
+  honeypot?: string;
+}
+
+export interface FeedbackRow {
+  id: string;
+  created_at: number;
+  kind: "bug" | "idea" | "feedback";
+  message: string;
+  contact_email: string | null;
+  submitter_login: string | null;
+  submitter_id: string | null;
+  app_version: string;
+  os_version: string;
+  client: string;
+  ip_hash: string | null;
+  status: string;
+  admin_notes: string | null;
+  github_issue_url: string | null;
+  attachment_prefix: string | null;
+  has_screenshot: number;
+  has_diagnostics: number;
+}

--- a/infra/feedback-store/tsconfig.json
+++ b/infra/feedback-store/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/infra/feedback-store/wrangler.toml
+++ b/infra/feedback-store/wrangler.toml
@@ -1,0 +1,50 @@
+name = "feedback-store"
+main = "src/index.ts"
+compatibility_date = "2025-12-01"
+
+[[routes]]
+pattern = "feedback.cloudcompute.com"
+custom_domain = true
+
+[[d1_databases]]
+binding = "FEEDBACK_DB"
+database_name = "workspaces-feedback"
+database_id = "9973e814-8556-429e-88c3-391a722b453d"
+migrations_dir = "migrations"
+
+[[r2_buckets]]
+binding = "FEEDBACK_BUCKET"
+bucket_name = "workspaces-feedback"
+
+[vars]
+GITHUB_CLIENT_ID = "Iv23liJBRgQoWIWjtRoO"
+GITHUB_OWNER = "fairchild"
+GITHUB_REPO = "workspaces"
+GITHUB_API_BASE = "https://api.github.com"
+POSTS_PER_HOUR = "10"
+ADMIN_ALLOWLIST = "fairchild"
+
+[env.preview]
+name = "feedback-store-preview"
+
+[env.preview.vars]
+GITHUB_CLIENT_ID = "Iv23liJBRgQoWIWjtRoO"
+GITHUB_OWNER = "fairchild"
+GITHUB_REPO = "workspaces"
+GITHUB_API_BASE = "https://api.github.com"
+POSTS_PER_HOUR = "10"
+ADMIN_ALLOWLIST = "fairchild"
+
+[[env.preview.routes]]
+pattern = "feedback-preview.cloudcompute.com"
+custom_domain = true
+
+[[env.preview.d1_databases]]
+binding = "FEEDBACK_DB"
+database_name = "workspaces-feedback-preview"
+database_id = "9ceb2bfb-8cb3-46aa-afe5-b0a5c5f228d6"
+migrations_dir = "migrations"
+
+[[env.preview.r2_buckets]]
+binding = "FEEDBACK_BUCKET"
+bucket_name = "workspaces-feedback-preview"


### PR DESCRIPTION
## Summary

Adds private in-app feedback capture for WorkSpaces and provisions the backing Cloudflare feedback store.

- Adds Help -> Send Feedback... with a native SwiftUI sheet for feedback/bug/idea reports.
- Captures optional screenshot and diagnostics attachments and submits them with the existing notification JWT when available.
- Adds a Cloudflare Worker feedback service with D1 metadata, R2 attachment storage, GitHub OAuth admin UI, and issue publishing.
- Documents the worker contract in `infra/feedback-store/CONTRACT.md`.

## Mergeability

- Surface: macOS app command/menu/sheet flow plus new `infra/feedback-store` Cloudflare Worker.
- User-facing behavior changed: Help -> Send Feedback... opens a private-by-default report sheet; successful submissions are stored in the feedback worker.
- Data handling: message/contact metadata are stored in D1, attachments in R2, submitter identity only when a valid app JWT is present.
- Non-happy paths considered: empty/overlong messages, invalid worker payloads, optional JWT rejection with anonymous app retry, honeypot discard, per-IP rate limit, missing attachments, admin allowlist.
- Residual risk or follow-up: Admin publish is intentionally minimal for this slice; future operator UX can add richer filtering, grouping, or bulk triage without changing the feedback capture contract.

## Verification

- `swift test` - passed, 1008 tests
- `mise run lint` - passed
- `cd infra/feedback-store && npm ci && npm run typecheck` - passed
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check HEAD~1..HEAD` - passed
- Production health: `https://feedback.cloudcompute.com/health` -> `ok`
- Production JSON smoke: D1/R2 verified feedback id `6aa54cf7-f110-470c-9e27-5a5698651a84`
- Production multipart smoke: D1 verified feedback id `168d0c1f-1a8c-44c1-8ea9-1fbcd14ddfb3`
- Production attachment smoke: D1/R2 verified feedback id `638989b2-5981-42c9-b5bd-23484f79c7ba`
- Preview health: `https://feedback-preview.cloudcompute.com/health` -> `ok`

## Evidence

- ![feedback-sheet](https://evidence.cloudcompute.com/workspaces/pr-699/20260627-222219-feedback-sheet.png)
- ![feedback-validation](https://evidence.cloudcompute.com/workspaces/pr-699/20260627-224450-feedback-validation.svg)

## Infra Provisioned

- D1 production: `workspaces-feedback` (`9973e814-8556-429e-88c3-391a722b453d`)
- D1 preview: `workspaces-feedback-preview` (`9ceb2bfb-8cb3-46aa-afe5-b0a5c5f228d6`)
- R2 production bucket: `workspaces-feedback`
- R2 preview bucket: `workspaces-feedback-preview`
- Worker production route: `feedback.cloudcompute.com`
- Worker preview route: `feedback-preview.cloudcompute.com`

## Infra Completed After Approval

- Rotated `JWT_SIGNING_SECRET` together on `webhook-relay`, `webhook-relay-preview`, `feedback-store`, and `feedback-store-preview`.
- Set `GITHUB_CLIENT_SECRET` on `feedback-store` and `feedback-store-preview` from the existing web WorkSpaces GitHub OAuth client secret (`GITHUB_WEB_WORKSPACES_CLIENT_SECRET` in local operator env).
- Signed-JWT production smoke verified D1 attribution: `95d9767b-826e-4817-b19f-0e2a88366674`.
- Signed-JWT preview smoke verified D1 attribution: `b2f4f20e-afa9-48e6-bb1e-31c20ab3ad42`.
