### PR TITLE
Refactor preview QA to reusable alias

### DIFF
--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -24,9 +24,6 @@ jobs:
     timeout-minutes: 30
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
-      qa_url: ${{ steps.alias.outputs.qa_url }}
-      smoke_url: ${{ steps.alias.outputs.qa_url || steps.deploy.outputs.preview_url }}
-      qa_alias_ok: ${{ steps.alias.outputs.alias_ok }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -78,72 +75,28 @@ jobs:
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
           echo "::notice::Preview deployed to $URL"
 
-      - name: Alias preview for OAuth QA
-        id: alias
-        continue-on-error: true
-        env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          QA_HOST="pr-${PR_NUMBER}.spaces-preview.cloudcompute.com"
-          set +e
-          OUTPUT=$(npx vercel@51 alias set "$PREVIEW_URL" "$QA_HOST" --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID" 2>&1)
-          STATUS=$?
-          set -e
-          printf '%s\n' "$OUTPUT"
-          if [[ "$STATUS" -eq 0 ]]; then
-            echo "qa_url=https://$QA_HOST" >> "$GITHUB_OUTPUT"
-            echo "alias_ok=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Preview QA alias https://$QA_HOST"
-          else
-            echo "qa_url=" >> "$GITHUB_OUTPUT"
-            echo "alias_ok=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "alias_error<<EOF"
-              printf '%s\n' "$OUTPUT" | tail -20
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-            echo "::error::Failed to assign Preview QA alias https://$QA_HOST"
-          fi
-
       - name: Comment preview URL
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
-          QA_URL: ${{ steps.alias.outputs.qa_url }}
-          QA_ALIAS_OK: ${{ steps.alias.outputs.alias_ok }}
-          QA_ALIAS_ERROR: ${{ steps.alias.outputs.alias_error }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
             const marker = '<!-- spaces-web-preview -->';
             const previewUrl = process.env.PREVIEW_URL;
-            const qaUrl = process.env.QA_URL;
-            const aliasOk = process.env.QA_ALIAS_OK === 'true';
-            const aliasError = process.env.QA_ALIAS_ERROR || '';
             const headSha = process.env.HEAD_SHA;
             const shortSha = headSha.slice(0, 7);
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const issue_number = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
-            const aliasErrorLine = aliasError.split('\n').filter(Boolean).at(-1);
-            const aliasLines = aliasOk
-              ? [
-                  `- Preview QA: ${qaUrl}`,
-                  'Preview QA uses the stable alias so GitHub OAuth callbacks match the production app host rules.',
-                ]
-              : [
-                  '- Preview QA: blocked until `*.spaces-preview.cloudcompute.com` is configured on Vercel/DNS',
-                  `- Deployment smoke: using raw deployment ${previewUrl}`,
-                  aliasErrorLine ? `- Alias error: \`${aliasErrorLine.replaceAll('`', "'")}\`` : '',
-                ].filter(Boolean);
 
             const body = [
               marker,
               '### Vercel Preview: `spaces-web`',
               '',
-              ...aliasLines,
               `- Raw deployment: ${previewUrl}`,
+              '- Deployment smoke: runs against the raw deployment URL.',
+              '- Authenticated QA: assign `qa.spaces-preview.cloudcompute.com` on demand with `mise -C web run web:preview:alias -- --pr <N>`.',
               `- Commit: \`${shortSha}\``,
               `- Workflow: [run ${process.env.GITHUB_RUN_NUMBER}](${workflowUrl})`,
               '',
@@ -223,7 +176,7 @@ jobs:
 
       - name: Run deployment smoke against preview
         env:
-          PLAYWRIGHT_BASE_URL: ${{ needs.preview.outputs.smoke_url }}
+          PLAYWRIGHT_BASE_URL: ${{ needs.preview.outputs.preview_url }}
           PLAYWRIGHT_SKIP_WEB_SERVER: "1"
           PLAYWRIGHT_SKIP_DB_FIXTURES: "1"
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/web/.mise.toml
+++ b/web/.mise.toml
@@ -103,6 +103,10 @@ pnpm exec playwright test --project=deployment-smoke --workers=1 --reporter=list
 description = "Create or refresh a real-OAuth Playwright storage state for a Vercel preview."
 run = "node scripts/preview-auth.mjs"
 
+[tasks."web:preview:alias"]
+description = "Assign the reusable OAuth QA hostname to a Vercel preview deployment."
+run = "node scripts/preview-alias.mjs"
+
 [tasks."web:preview:smoke"]
 description = "Run deployment-safe Playwright smoke against a Vercel preview."
 run = """
@@ -110,11 +114,13 @@ run = """
 set -euo pipefail
 
 URL=""
+QA_HOST="${PREVIEW_QA_ALIAS_HOST:-qa.spaces-preview.cloudcompute.com}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pr)
       shift
-      URL="https://pr-${1:?missing PR number}.spaces-preview.cloudcompute.com"
+      : "${1:?missing PR number}"
+      URL="https://$QA_HOST"
       ;;
     --url)
       shift
@@ -146,11 +152,13 @@ run = """
 set -euo pipefail
 
 URL=""
+QA_HOST="${PREVIEW_QA_ALIAS_HOST:-qa.spaces-preview.cloudcompute.com}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pr)
       shift
-      URL="https://pr-${1:?missing PR number}.spaces-preview.cloudcompute.com"
+      : "${1:?missing PR number}"
+      URL="https://$QA_HOST"
       ;;
     --url)
       shift

--- a/web/docs/local-dev.md
+++ b/web/docs/local-dev.md
@@ -18,9 +18,10 @@ mise run web:e2e                            # Playwright E2E (fast + full)
 mise run web:e2e:deployment-smoke           # remote-safe smoke against local dev server (default port 3212)
 mise run web:e2e:demo                       # Playwright demo with video recording
 mise run web:e2e:explore                    # qa-explore project (video + trace + axe-core)
-mise run web:preview:smoke -- --pr <N>      # remote-safe smoke against PR preview alias
+mise run web:preview:alias -- --pr <N>      # assign qa.spaces-preview.cloudcompute.com to this PR preview
+mise run web:preview:smoke -- --pr <N>      # remote-safe smoke against the reusable QA alias
 mise run web:preview:auth -- --pr <N>       # headed real-OAuth preview login + storage state
-mise run web:preview:explore -- --pr <N>    # authenticated exploratory QA against preview
+mise run web:preview:explore -- --pr <N>    # authenticated exploratory QA against the reusable QA alias
 mise run web:qa:init-agents                 # one-shot: scaffold Playwright's agent-loop files
 mise run web:qa:codegen                     # interactive Playwright codegen recorder
 mise run web:evidence -- --pr <N> --name <slug>  # screenshot capture + evidence upload
@@ -64,16 +65,18 @@ Screenshots without auth: start the dev server with `DEV_BYPASS_AUTH=1 pnpm dev`
 
 ## Preview QA
 
-PR previews publish an OAuth-compatible alias:
+PR previews publish a raw Vercel deployment URL. When a PR needs authenticated
+QA, assign the reusable OAuth-compatible alias to that raw preview:
 
 ```text
-https://pr-<N>.spaces-preview.cloudcompute.com
+https://qa.spaces-preview.cloudcompute.com
 ```
 
 Run the cheap deployed-app smoke first, then create or refresh the real-OAuth
 storage state, then run exploratory QA:
 
 ```bash
+mise run web:preview:alias -- --pr <N>
 mise run web:preview:smoke -- --pr <N>
 mise run web:preview:auth -- --pr <N>
 mise run web:preview:explore -- --pr <N>

--- a/web/docs/preview-qa.md
+++ b/web/docs/preview-qa.md
@@ -6,13 +6,14 @@ authenticated and adversarial pass against the deployed artifact.
 
 ## Prerequisites
 
-- The PR preview workflow must publish a `Preview QA` URL shaped like
-  `https://pr-<number>.spaces-preview.cloudcompute.com`.
+- The PR preview workflow must publish a raw Vercel deployment URL in its PR
+  comment.
+- The reusable QA host `qa.spaces-preview.cloudcompute.com` must be configured
+  on the Vercel project and in DNS. Assign it to a PR preview only when
+  authenticated QA is needed.
 - `VERCEL_AUTOMATION_BYPASS_SECRET` must be available locally for Playwright to
   bypass Vercel Deployment Protection. Without it, use Chrome with an existing
   Vercel session as the fallback browser.
-- The wildcard domain `*.spaces-preview.cloudcompute.com` must be configured on
-  the Vercel project and in DNS.
 - The GitHub OAuth app callback remains
   `https://spaces.cloudcompute.com/api/auth/callback/github`; GitHub accepts
   OAuth redirect subdomains when the registrable host and path match.
@@ -20,10 +21,16 @@ authenticated and adversarial pass against the deployed artifact.
 ## Standard Flow
 
 ```bash
+mise -C web run web:preview:alias -- --pr <N>
 mise -C web run web:preview:smoke -- --pr <N>
 mise -C web run web:preview:auth -- --pr <N>
 mise -C web run web:preview:explore -- --pr <N>
 ```
+
+`web:preview:alias` reads the PR preview comment, finds the raw deployment URL,
+and assigns `qa.spaces-preview.cloudcompute.com` to that deployment. This single
+reusable alias is intentionally manual: most PRs only need CI smoke, and the QA
+alias should point at one preview under active investigation.
 
 `web:preview:auth` opens a headed Playwright browser, completes real GitHub
 OAuth, and saves storage state under `web/.auth/`. It also captures a dashboard

--- a/web/scripts/preview-alias.mjs
+++ b/web/scripts/preview-alias.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_QA_HOST = "qa.spaces-preview.cloudcompute.com";
+const PREVIEW_COMMENT_MARKER = "<!-- spaces-web-preview -->";
+
+function usage() {
+	return [
+		"usage: node scripts/preview-alias.mjs (--pr <number> | --url <raw-preview-url>) [--host <host>] [--scope <scope>]",
+		"",
+		"Assigns the reusable OAuth QA hostname to a deployed Vercel preview.",
+	].join("\n");
+}
+
+function parseArgs(argv) {
+	const args = {
+		host: process.env.PREVIEW_QA_ALIAS_HOST ?? DEFAULT_QA_HOST,
+		pr: "",
+		scope: process.env.VERCEL_SCOPE ?? "",
+		url: "",
+	};
+
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--pr") {
+			args.pr = argv[++i] ?? "";
+		} else if (arg === "--url") {
+			args.url = argv[++i] ?? "";
+		} else if (arg === "--host") {
+			args.host = argv[++i] ?? "";
+		} else if (arg === "--scope") {
+			args.scope = argv[++i] ?? "";
+		} else if (arg === "--help" || arg === "-h") {
+			console.log(usage());
+			process.exit(0);
+		} else {
+			throw new Error(`unknown argument: ${arg}`);
+		}
+	}
+
+	if (args.pr && args.url)
+		throw new Error("pass either --pr or --url, not both");
+	if (!args.pr && !args.url) throw new Error("missing --pr or --url");
+	if (args.pr && !/^\d+$/.test(args.pr))
+		throw new Error("--pr must be a PR number");
+	if (!args.host) throw new Error("missing --host");
+	return args;
+}
+
+async function rawPreviewUrlForPr(pr) {
+	const { stdout } = await execFileAsync("gh", [
+		"pr",
+		"view",
+		pr,
+		"--json",
+		"comments",
+	]);
+	const data = JSON.parse(stdout);
+	const previewComment = [...data.comments]
+		.reverse()
+		.find((comment) => comment.body?.includes(PREVIEW_COMMENT_MARKER));
+	if (!previewComment) {
+		throw new Error(`PR #${pr} does not have a spaces web preview comment`);
+	}
+
+	const match = previewComment.body.match(
+		/- Raw deployment:\s+(https:\/\/\S+)/,
+	);
+	if (!match) {
+		throw new Error(
+			`PR #${pr} preview comment does not include a raw deployment URL`,
+		);
+	}
+	return match[1];
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const rawUrl = args.url || (await rawPreviewUrlForPr(args.pr));
+	new URL(rawUrl);
+
+	console.log(`Assigning https://${args.host} to ${rawUrl}`);
+	const aliasArgs = ["--yes", "vercel@51", "alias", "set", rawUrl, args.host];
+	if (args.scope) aliasArgs.push("--scope", args.scope);
+
+	await execFileAsync("npx", aliasArgs, {
+		stdio: "inherit",
+	});
+	console.log(`Preview QA URL: https://${args.host}`);
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+});

--- a/web/scripts/preview-auth.mjs
+++ b/web/scripts/preview-auth.mjs
@@ -3,17 +3,18 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "@playwright/test";
 
-const DEFAULT_PREVIEW_DOMAIN = "spaces-preview.cloudcompute.com";
+const DEFAULT_QA_HOST = "qa.spaces-preview.cloudcompute.com";
 
 function usage() {
 	return [
-		"usage: node scripts/preview-auth.mjs (--pr <number> | --url <url>)",
+		"usage: node scripts/preview-auth.mjs (--pr <number> | --url <url>) [--host <host>]",
 		"",
 		"Creates a local authenticated Playwright storage state for a Vercel preview.",
 	].join("\n");
 }
 
 function parseArgs(argv) {
+	let host = process.env.PREVIEW_QA_ALIAS_HOST ?? DEFAULT_QA_HOST;
 	let pr = "";
 	let url = "";
 	for (let i = 0; i < argv.length; i += 1) {
@@ -22,6 +23,8 @@ function parseArgs(argv) {
 			pr = argv[++i] ?? "";
 		} else if (arg === "--url") {
 			url = argv[++i] ?? "";
+		} else if (arg === "--host") {
+			host = argv[++i] ?? "";
 		} else if (arg === "--help" || arg === "-h") {
 			console.log(usage());
 			process.exit(0);
@@ -33,7 +36,8 @@ function parseArgs(argv) {
 	if (url && pr) throw new Error("pass either --pr or --url, not both");
 	if (pr) {
 		if (!/^\d+$/.test(pr)) throw new Error("--pr must be a PR number");
-		return new URL(`https://pr-${pr}.${DEFAULT_PREVIEW_DOMAIN}`);
+		if (!host) throw new Error("missing --host");
+		return new URL(`https://${host}`);
 	}
 	if (url) return new URL(url);
 	throw new Error("missing --pr or --url");

--- a/web/src/lib/__tests__/auth-base-url.test.ts
+++ b/web/src/lib/__tests__/auth-base-url.test.ts
@@ -22,7 +22,7 @@ describe("getAuthBaseURL", () => {
 		).toEqual({
 			allowedHosts: [
 				"spaces.cloudcompute.com",
-				"*.spaces-preview.cloudcompute.com",
+				"qa.spaces-preview.cloudcompute.com",
 				"*.cloudcompute.vercel.app",
 				"*.vercel.app",
 				"localhost:*",

--- a/web/src/lib/auth-base-url.ts
+++ b/web/src/lib/auth-base-url.ts
@@ -9,7 +9,7 @@ export type AuthBaseURL = string | DynamicAuthBaseURL;
 const LOCAL_ALLOWED_HOSTS = ["localhost:*", "127.0.0.1:*"];
 const VERCEL_ALLOWED_HOSTS = [
 	"spaces.cloudcompute.com",
-	"*.spaces-preview.cloudcompute.com",
+	"qa.spaces-preview.cloudcompute.com",
 	"*.cloudcompute.vercel.app",
 	"*.vercel.app",
 ];


### PR DESCRIPTION
## Summary
- stop auto-assigning a per-PR wildcard OAuth alias from preview CI
- keep CI deployment smoke on the raw Vercel deployment URL
- add `web:preview:alias` to deliberately point the reusable `qa.spaces-preview.cloudcompute.com` host at a PR preview when authenticated QA is needed
- tighten Better Auth preview allow-list to the reusable QA host instead of a wildcard preview domain

## Mergeability
- Surface: web preview CI, local preview QA tooling, docs, Better Auth allowed hosts
- User-facing behavior changed: no production UI behavior change intended
- Non-happy paths considered: most PRs only need raw preview smoke; authenticated QA is now an explicit local action so the reusable OAuth host cannot accidentally follow every PR or a single branch wildcard
- Residual risk or follow-up: `qa.spaces-preview.cloudcompute.com` must remain configured in Vercel/DNS as the reusable host. The helper intentionally relies on the linked Vercel project context by default; pass `--scope` only if a caller needs to override it.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/web-preview.yml")'`
- `node --check web/scripts/preview-auth.mjs && node --check web/scripts/preview-alias.mjs`
- `mise -C web run web:check`: typecheck, Biome, and 30 Vitest files / 348 tests passed
- `mise -C web run web:preview:alias -- --pr 702`: assigned `https://qa.spaces-preview.cloudcompute.com` to PR #702's raw preview
- `curl -I https://qa.spaces-preview.cloudcompute.com`: returned HTTP 200
- `mise -C web run web:preview:smoke -- --pr 702`: 5 deployment-smoke tests passed against the reusable QA host

## Evidence
- ![preview-qa-static-alias-web-check-final](https://evidence.cloudcompute.com/workspaces/pr-702/20260627-233538-preview-qa-static-alias-web-check-final.svg)
- ![preview-qa-static-alias-preview-smoke](https://evidence.cloudcompute.com/workspaces/pr-702/20260627-233538-preview-qa-static-alias-preview-smoke.svg)
