### PR TITLE
release: v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.22.0] - 2026-06-28
+
+### Added
+- WorkSpaces automation API v1 for local scripting and host integration (#684).
+- Tile-tree Phase 4 recursive renderer with N-way tiling support (#658).
+- Help -> Keyboard Shortcuts cheat sheet (#691).
+- In-app feedback capture backed by feedback-store infrastructure (#699).
+- Preview deployment QA flow.
+
+### Changed
+- Redesign managed review run details.
+- Update web security dependencies.
+
+### Fixed
+- Ensure terminal sessions exit before workspace retirement (#689).
+- Fix Codex worker mise bootstrap.
+- Fix diagnostic export main actor crash (#694).
+- Fix managed review stuck-starting repair.
+
+### Other
+- Harden tile-tree focus, teardown, and Lume terminal launch storage coverage (#692, #695).
+- Record the tile-tree reversal and terminal-multiplexing ADR update (#693).
+
 ## [0.21.0] - 2026-06-27
 
 ### Added

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.21.0</string>
+	<string>0.22.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>27</string>
+	<string>28</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

- Bump WorkSpaces to `0.22.0` / build `28`.
- Add the `0.22.0` changelog entry for the merged work since `v0.21.0`.

## Mergeability

- Surface: infra / docs
- User-facing behavior changed: no runtime behavior in this PR; release metadata and release notes only
- Non-happy paths considered: version metadata is asserted against `v0.22.0`
- Release/ops preconditions: after merge, tag the merged main commit as `v0.22.0`, push the tag, approve the protected `release` environment, and verify published assets
- Residual risk or follow-up: none known

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run:
  - `./scripts/release-version.sh assert-tag-match v0.22.0`
  - `./scripts/build-ghosttykit.sh`
  - `mise run lint`
  - `git diff --check`
  - `./scripts/validate-release-changes.py --changed-files /private/tmp/workspaces-v0.22.0-changed-files.json`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- ![release-v0.22.0-validation](https://evidence.cloudcompute.com/workspaces/pr-707/20260628-154602-release-v0.22.0-validation.svg)

## Blockers

- [x] None
- [ ] Blocked on evidence
