### PR TITLE
Polish managed review run detail

### DIFF
--- a/web/src/app/dashboard/review-runs/[fingerprint]/elapsed-duration.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/elapsed-duration.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { formatDuration } from "./review-run-detail-view-model";
+
+interface ElapsedDurationProps {
+	startValue: string;
+	endValue: string | null;
+	initialNow: number;
+}
+
+export function ElapsedDuration({
+	startValue,
+	endValue,
+	initialNow,
+}: ElapsedDurationProps) {
+	const [now, setNow] = useState(initialNow);
+
+	useEffect(() => {
+		if (endValue) return;
+		setNow(Date.now());
+		const interval = window.setInterval(() => setNow(Date.now()), 1000);
+		return () => window.clearInterval(interval);
+	}, [endValue]);
+
+	return <>{formatDuration(startValue, endValue, now)}</>;
+}

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.module.css
@@ -11,7 +11,6 @@
 	--run-blue: #83b7ff;
 	--run-amber: #f0c46b;
 	--run-red: #ff8b8b;
-	--run-purple: #c4a1ff;
 	position: relative;
 	z-index: 2;
 	display: flex;
@@ -600,6 +599,15 @@
 
 	.lifecycleStep:nth-child(4) {
 		border-left: 0;
+	}
+
+	.lifecycleStep:nth-child(3)::after,
+	.lifecycleStep:nth-child(4)::before {
+		display: none;
+	}
+
+	.lifecycleStep:nth-child(n + 4) {
+		border-top: 1px solid var(--run-border-soft);
 	}
 }
 

--- a/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/page.tsx
@@ -1,228 +1,27 @@
-import {
-	type PrReviewRunDetails,
-	type PrReviewRunStatus,
-	getPrReviewRunByFingerprint,
-} from "@/lib/agent-runtime/pr-review-runs";
+import { getPrReviewRunByFingerprint } from "@/lib/agent-runtime/pr-review-runs";
 import { authorizeRepoAccess } from "@/lib/api-auth";
 import { getSession } from "@/lib/auth-server";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { ElapsedDuration } from "./elapsed-duration";
 import styles from "./page.module.css";
+import {
+	lifecycleForRun,
+	phaseForRun,
+	titleCaseStatus,
+} from "./review-run-detail-view-model";
 import { ReviewRunRecoveryAction } from "./review-run-recovery-action";
 import { ReviewRunTranscript } from "./review-run-transcript";
 
 export const dynamic = "force-dynamic";
-
-type StepState = "done" | "current" | "pending" | "blocked" | "skipped";
-
-interface LifecycleStep {
-	key: string;
-	label: string;
-	description: string;
-	state: StepState;
-	time: string | null;
-}
 
 function formatDateTime(value: string | null): string {
 	if (!value) return "Not recorded";
 	return new Date(value).toLocaleString();
 }
 
-function formatDuration(startValue: string, endValue: string | null): string {
-	const start = new Date(startValue).getTime();
-	const end = endValue ? new Date(endValue).getTime() : Date.now();
-	if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) {
-		return "Unknown";
-	}
-	const totalSeconds = Math.max(0, Math.round((end - start) / 1000));
-	const hours = Math.floor(totalSeconds / 3600);
-	const minutes = Math.floor((totalSeconds % 3600) / 60);
-	const seconds = totalSeconds % 60;
-	if (hours > 0) return `${hours}h ${minutes}m`;
-	if (minutes > 0) return `${minutes}m ${seconds}s`;
-	return `${seconds}s`;
-}
-
 function shortSha(value: string | null): string {
 	return value ? value.slice(0, 12) : "unknown";
-}
-
-function titleCaseStatus(value: string): string {
-	return value
-		.split("_")
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(" ");
-}
-
-function phaseForRun(run: PrReviewRunDetails): {
-	label: string;
-	description: string;
-	tone: PrReviewRunStatus | "projection-failed";
-} {
-	if (run.status === "superseded") {
-		return {
-			label: "Superseded",
-			description:
-				"A newer managed-review trigger took over for this pull request.",
-			tone: "superseded",
-		};
-	}
-	if (run.status === "failed") {
-		return {
-			label: "Execution failed",
-			description:
-				run.failureMessage ??
-				"The reviewer run failed before it could produce a GitHub result.",
-			tone: "failed",
-		};
-	}
-	if (run.projectionStatus === "failed") {
-		return {
-			label: "GitHub output needs repair",
-			description:
-				run.projectionError ??
-				"The agent finished, but WorkSpaces could not publish the result to GitHub.",
-			tone: "projection-failed",
-		};
-	}
-	if (run.status === "completed" && run.projectionStatus === "projected") {
-		return {
-			label: "Published to GitHub",
-			description:
-				"The managed review completed and its status/review projection has been recorded.",
-			tone: "completed",
-		};
-	}
-	if (run.status === "completed") {
-		return {
-			label: "Awaiting GitHub output",
-			description:
-				"The agent produced review intent; the broker still needs to publish it to GitHub.",
-			tone: "completed",
-		};
-	}
-	if (run.sessionId) {
-		return {
-			label: "Agent running",
-			description:
-				"The run has been picked up and the managed PR reviewer session is active.",
-			tone: "started",
-		};
-	}
-	return {
-		label: "Waiting for pickup",
-		description:
-			"WorkSpaces created the ReviewRun and is waiting for a managed-agent session.",
-		tone: "started",
-	};
-}
-
-function lifecycleForRun(run: PrReviewRunDetails): LifecycleStep[] {
-	const failedBeforePickup = run.status === "failed" && !run.sessionId;
-	const projectionBlocked = run.projectionStatus === "failed";
-	const published = run.projectionStatus === "projected";
-	const superseded = run.status === "superseded";
-	const completed = run.status === "completed";
-	const failed = run.status === "failed";
-
-	return [
-		{
-			key: "trigger",
-			label: "Trigger",
-			description: `${titleCaseStatus(run.triggerKind)} created the ReviewRun.`,
-			state: "done",
-			time: run.createdAt,
-		},
-		{
-			key: "pickup",
-			label: "Pickup",
-			description: run.sessionId
-				? "Managed-agent session attached."
-				: "Waiting for a session id.",
-			state: run.sessionId
-				? "done"
-				: failedBeforePickup
-					? "blocked"
-					: superseded
-						? "skipped"
-						: "current",
-			time: run.sessionStartedAt,
-		},
-		{
-			key: "agent",
-			label: "Agent",
-			description:
-				failed && run.failureKind
-					? titleCaseStatus(run.failureKind)
-					: "Reviewer evaluates the PR and prepares review intent.",
-			state: failed
-				? "blocked"
-				: completed || published
-					? "done"
-					: superseded
-						? "skipped"
-						: run.sessionId
-							? "current"
-							: "pending",
-			time: run.failedAt ?? (completed || published ? run.updatedAt : null),
-		},
-		{
-			key: "intent",
-			label: "Review intent",
-			description: run.reviewIntent
-				? `${titleCaseStatus(run.reviewIntent.event)} intent recorded.`
-				: "No review intent recorded yet.",
-			state: run.reviewIntent
-				? "done"
-				: failed && run.failureKind === "review_intent_invalid"
-					? "blocked"
-					: superseded
-						? "skipped"
-						: completed
-							? "blocked"
-							: "pending",
-			time: run.reviewIntent ? run.updatedAt : null,
-		},
-		{
-			key: "github",
-			label: "GitHub output",
-			description:
-				run.projectionStatus === "projected"
-					? "Status and review projection published."
-					: run.projectionStatus === "failed"
-						? "Projection failed and can be repaired when available."
-						: "Broker publishes the ReviewRun result to GitHub.",
-			state: published
-				? "done"
-				: projectionBlocked
-					? "blocked"
-					: completed
-						? "current"
-						: superseded
-							? "skipped"
-							: "pending",
-			time: run.projectionUpdatedAt,
-		},
-		{
-			key: "outcome",
-			label:
-				run.status === "superseded"
-					? "Superseded"
-					: run.recovery.available
-						? "Recovery"
-						: "Done",
-			description: run.recovery.available
-				? run.recovery.reason
-				: run.nextAction,
-			state:
-				published || superseded
-					? "done"
-					: failed || projectionBlocked
-						? "current"
-						: "pending",
-			time: published || superseded ? run.updatedAt : null,
-		},
-	];
 }
 
 function projectionTypeLabel(value: string): string {
@@ -268,7 +67,7 @@ export default async function ReviewRunPage({
 		run.status === "started" || run.projectionStatus === "pending"
 			? null
 			: (run.projectionUpdatedAt ?? run.updatedAt);
-	const elapsed = formatDuration(run.createdAt, endTime);
+	const renderNow = Date.now();
 	const headChanged = run.latestKnownHeadSha !== run.headSha;
 	const lastProjectionAttempt = run.projections
 		.map((projection) => projection.lastAttemptedAt)
@@ -302,7 +101,13 @@ export default async function ReviewRunPage({
 				<div className={styles.heroStats} aria-label="Run summary">
 					<div>
 						<span>Elapsed</span>
-						<strong>{elapsed}</strong>
+						<strong>
+							<ElapsedDuration
+								startValue={run.createdAt}
+								endValue={endTime}
+								initialNow={renderNow}
+							/>
+						</strong>
 					</div>
 					<div>
 						<span>Execution</span>
@@ -348,11 +153,10 @@ export default async function ReviewRunPage({
 
 			<div className={styles.contentGrid}>
 				<section className={styles.currentPanel}>
-					<p className={styles.eyebrow}>Current phase</p>
+					<p className={styles.eyebrow}>Operator focus</p>
 					<h2>{phase.label}</h2>
-					<p>{phase.description}</p>
 					<div className={styles.nextAction}>
-						<span>Next</span>
+						<span>Next action</span>
 						<strong>{run.nextAction}</strong>
 						{run.failedAt && (
 							<small>Failure recorded {formatDateTime(run.failedAt)}</small>

--- a/web/src/app/dashboard/review-runs/[fingerprint]/review-run-detail-view-model.test.ts
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/review-run-detail-view-model.test.ts
@@ -1,0 +1,172 @@
+import type { PrReviewRunDetails } from "@/lib/agent-runtime/pr-review-runs";
+import { describe, expect, it } from "vitest";
+import {
+	formatDuration,
+	lifecycleForRun,
+	phaseForRun,
+} from "./review-run-detail-view-model";
+
+const START = "2026-06-30T20:00:00.000Z";
+const PICKUP = "2026-06-30T20:01:00.000Z";
+const UPDATE = "2026-06-30T20:03:00.000Z";
+
+function run(overrides: Partial<PrReviewRunDetails> = {}): PrReviewRunDetails {
+	return {
+		fingerprint: "fp_test",
+		repoFullName: "fairchild/workspaces",
+		prNumber: 714,
+		headSha: "9704ecbe24cc9f8ea716285f3ac2b9a1a95fd3f1",
+		triggerKind: "synchronize",
+		triggerSourceId: "9704ecbe24cc9f8ea716285f3ac2b9a1a95fd3f1",
+		status: "started",
+		sessionId: null,
+		sessionStartedAt: null,
+		createdAt: START,
+		updatedAt: START,
+		error: null,
+		executionState: "waiting_for_session",
+		latestKnownHeadSha: "9704ecbe24cc9f8ea716285f3ac2b9a1a95fd3f1",
+		failureKind: null,
+		failureMessage: null,
+		failureRetryable: null,
+		failedAt: null,
+		nextAction: "Wait for the managed-agent session to start.",
+		projectionStatus: "pending",
+		projectionUpdatedAt: START,
+		projectionError: null,
+		githubReviewId: null,
+		coalescedHeadSha: null,
+		coalescedTriggerKind: null,
+		coalescedTriggerSourceId: null,
+		coalescedAt: null,
+		reviewerConfigHash: "cfg",
+		reviewIntent: null,
+		projections: [],
+		recovery: {
+			available: false,
+			action: null,
+			label: null,
+			reason: "This ReviewRun is still active.",
+			reasonCode: "run_active",
+		},
+		...overrides,
+	};
+}
+
+describe("review run detail view model", () => {
+	it("formats active elapsed time from the supplied clock", () => {
+		expect(
+			formatDuration(START, null, new Date("2026-06-30T20:01:12Z").getTime()),
+		).toBe("1m 12s");
+	});
+
+	it("classifies a run waiting for session pickup", () => {
+		const phase = phaseForRun(run());
+
+		expect(phase).toMatchObject({
+			label: "Waiting for pickup",
+			tone: "started",
+		});
+		expect(
+			lifecycleForRun(run()).map((step) => [step.key, step.state]),
+		).toEqual([
+			["trigger", "done"],
+			["pickup", "current"],
+			["agent", "pending"],
+			["intent", "pending"],
+			["github", "pending"],
+			["outcome", "pending"],
+		]);
+	});
+
+	it("marks an attached session as the current agent step", () => {
+		const active = run({
+			sessionId: "sesn_test",
+			sessionStartedAt: PICKUP,
+			executionState: "running_session",
+			nextAction: "Wait for the managed-agent session to finish.",
+		});
+
+		expect(phaseForRun(active)).toMatchObject({
+			label: "Agent running",
+			tone: "started",
+		});
+		expect(
+			lifecycleForRun(active).map((step) => [step.key, step.state]),
+		).toEqual([
+			["trigger", "done"],
+			["pickup", "done"],
+			["agent", "current"],
+			["intent", "pending"],
+			["github", "pending"],
+			["outcome", "pending"],
+		]);
+	});
+
+	it("classifies a projected run as published", () => {
+		const published = run({
+			status: "completed",
+			sessionId: "sesn_test",
+			sessionStartedAt: PICKUP,
+			updatedAt: UPDATE,
+			executionState: "completed",
+			reviewIntent: { event: "approve", body: "Looks good.", labels: [] },
+			nextAction:
+				"No action needed; the ReviewRun has been published to GitHub.",
+			projectionStatus: "projected",
+			projectionUpdatedAt: UPDATE,
+			githubReviewId: "PRR_kw",
+		});
+
+		expect(phaseForRun(published)).toMatchObject({
+			label: "Published to GitHub",
+			tone: "completed",
+		});
+		expect(
+			lifecycleForRun(published).map((step) => [step.key, step.state]),
+		).toEqual([
+			["trigger", "done"],
+			["pickup", "done"],
+			["agent", "done"],
+			["intent", "done"],
+			["github", "done"],
+			["outcome", "done"],
+		]);
+	});
+
+	it("keeps projection failure distinct from execution failure", () => {
+		const projectionFailed = run({
+			status: "completed",
+			sessionId: "sesn_test",
+			sessionStartedAt: PICKUP,
+			updatedAt: UPDATE,
+			executionState: "completed",
+			reviewIntent: { event: "comment", body: "Needs work.", labels: [] },
+			nextAction:
+				"Broker or repair tooling should publish the completed ReviewRun projection to GitHub.",
+			projectionStatus: "failed",
+			projectionUpdatedAt: UPDATE,
+			projectionError: "GitHub status write failed.",
+			recovery: {
+				available: true,
+				action: "repair_projection",
+				label: "Repair projection",
+				reason: "Projection can be repaired.",
+				reasonCode: "projection_failed",
+			},
+		});
+
+		expect(phaseForRun(projectionFailed)).toMatchObject({
+			label: "GitHub output needs repair",
+			tone: "projection-failed",
+		});
+		expect(lifecycleForRun(projectionFailed).at(4)).toMatchObject({
+			key: "github",
+			state: "blocked",
+		});
+		expect(lifecycleForRun(projectionFailed).at(5)).toMatchObject({
+			key: "outcome",
+			state: "current",
+		});
+	});
+});

--- a/web/src/app/dashboard/review-runs/[fingerprint]/review-run-detail-view-model.ts
+++ b/web/src/app/dashboard/review-runs/[fingerprint]/review-run-detail-view-model.ts
@@ -1,0 +1,213 @@
+import type {
+	PrReviewRunDetails,
+	PrReviewRunStatus,
+} from "@/lib/agent-runtime/pr-review-runs";
+
+export type StepState = "done" | "current" | "pending" | "blocked" | "skipped";
+
+export interface LifecycleStep {
+	key: string;
+	label: string;
+	description: string;
+	state: StepState;
+	time: string | null;
+}
+
+export interface ReviewRunPhase {
+	label: string;
+	description: string;
+	tone: PrReviewRunStatus | "projection-failed";
+}
+
+export function formatDuration(
+	startValue: string,
+	endValue: string | null,
+	now = Date.now(),
+): string {
+	const start = new Date(startValue).getTime();
+	const end = endValue ? new Date(endValue).getTime() : now;
+	if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) {
+		return "Unknown";
+	}
+	const totalSeconds = Math.max(0, Math.round((end - start) / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
+}
+
+export function titleCaseStatus(value: string): string {
+	return value
+		.split("_")
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+export function phaseForRun(run: PrReviewRunDetails): ReviewRunPhase {
+	if (run.status === "superseded") {
+		return {
+			label: "Superseded",
+			description:
+				"A newer managed-review trigger took over for this pull request.",
+			tone: "superseded",
+		};
+	}
+	if (run.status === "failed") {
+		return {
+			label: "Execution failed",
+			description:
+				run.failureMessage ??
+				"The reviewer run failed before it could produce a GitHub result.",
+			tone: "failed",
+		};
+	}
+	if (run.projectionStatus === "failed") {
+		return {
+			label: "GitHub output needs repair",
+			description:
+				run.projectionError ??
+				"The agent finished, but WorkSpaces could not publish the result to GitHub.",
+			tone: "projection-failed",
+		};
+	}
+	if (run.status === "completed" && run.projectionStatus === "projected") {
+		return {
+			label: "Published to GitHub",
+			description:
+				"The managed review completed and its status/review projection has been recorded.",
+			tone: "completed",
+		};
+	}
+	if (run.status === "completed") {
+		return {
+			label: "Awaiting GitHub output",
+			description:
+				"The agent produced review intent; the broker still needs to publish it to GitHub.",
+			tone: "completed",
+		};
+	}
+	if (run.sessionId) {
+		return {
+			label: "Agent running",
+			description:
+				"The run has been picked up and the managed PR reviewer session is active.",
+			tone: "started",
+		};
+	}
+	return {
+		label: "Waiting for pickup",
+		description:
+			"WorkSpaces created the ReviewRun and is waiting for a managed-agent session.",
+		tone: "started",
+	};
+}
+
+export function lifecycleForRun(run: PrReviewRunDetails): LifecycleStep[] {
+	const failedBeforePickup = run.status === "failed" && !run.sessionId;
+	const projectionBlocked = run.projectionStatus === "failed";
+	const published = run.projectionStatus === "projected";
+	const superseded = run.status === "superseded";
+	const completed = run.status === "completed";
+	const failed = run.status === "failed";
+
+	return [
+		{
+			key: "trigger",
+			label: "Trigger",
+			description: `${titleCaseStatus(run.triggerKind)} created the ReviewRun.`,
+			state: "done",
+			time: run.createdAt,
+		},
+		{
+			key: "pickup",
+			label: "Pickup",
+			description: run.sessionId
+				? "Managed-agent session attached."
+				: "Waiting for a session id.",
+			state: run.sessionId
+				? "done"
+				: failedBeforePickup
+					? "blocked"
+					: superseded
+						? "skipped"
+						: "current",
+			time: run.sessionStartedAt,
+		},
+		{
+			key: "agent",
+			label: "Agent",
+			description:
+				failed && run.failureKind
+					? titleCaseStatus(run.failureKind)
+					: "Reviewer evaluates the PR and prepares review intent.",
+			state: failed
+				? "blocked"
+				: completed || published
+					? "done"
+					: superseded
+						? "skipped"
+						: run.sessionId
+							? "current"
+							: "pending",
+			time: run.failedAt ?? (completed || published ? run.updatedAt : null),
+		},
+		{
+			key: "intent",
+			label: "Review intent",
+			description: run.reviewIntent
+				? `${titleCaseStatus(run.reviewIntent.event)} intent recorded.`
+				: "No review intent recorded yet.",
+			state: run.reviewIntent
+				? "done"
+				: failed && run.failureKind === "review_intent_invalid"
+					? "blocked"
+					: superseded
+						? "skipped"
+						: completed
+							? "blocked"
+							: "pending",
+			time: run.reviewIntent ? run.updatedAt : null,
+		},
+		{
+			key: "github",
+			label: "GitHub output",
+			description:
+				run.projectionStatus === "projected"
+					? "Status and review projection published."
+					: run.projectionStatus === "failed"
+						? "Projection failed and can be repaired when available."
+						: "Broker publishes the ReviewRun result to GitHub.",
+			state: published
+				? "done"
+				: projectionBlocked
+					? "blocked"
+					: completed
+						? "current"
+						: superseded
+							? "skipped"
+							: "pending",
+			time: run.projectionUpdatedAt,
+		},
+		{
+			key: "outcome",
+			label:
+				run.status === "superseded"
+					? "Superseded"
+					: run.recovery.available
+						? "Recovery"
+						: "Done",
+			description: run.recovery.available
+				? run.recovery.reason
+				: run.nextAction,
+			state:
+				published || superseded
+					? "done"
+					: failed || projectionBlocked
+						? "current"
+						: "pending",
+			time: published || superseded ? run.updatedAt : null,
+		},
+	];
+}


### PR DESCRIPTION
## Summary
- add a live elapsed timer for active managed-review runs without hydration drift
- extract the run phase/lifecycle model into a unit-tested view-model module
- reduce repeated phase-description copy and clean up the medium-width lifecycle connector layout

## Verification
- [x] `mise -C web run web:check`
- [x] Playwright local visual smoke against `/dashboard/review-runs/local-review-run-polish` on desktop and mobile
- [x] Mobile horizontal overflow check returned `0`
- [x] Active elapsed timer advanced from `19m 59s` to `20m 0s`
- [x] Compatibility smoke kept the phase label as a section heading for the #714 E2E coverage path

## Evidence
![review-run-polish-desktop-v2](https://evidence.cloudcompute.com/workspaces/pr-715/20260630-213244-review-run-polish-desktop-v2.png)
![review-run-polish-mobile-v2](https://evidence.cloudcompute.com/workspaces/pr-715/20260630-213244-review-run-polish-mobile-v2.png)

## Mergeability

- Surface: web
- User-facing behavior changed: The managed-review run detail page now keeps active elapsed time live and makes the operator-focus panel about the next action without repeating the full hero phase description.
- Non-happy paths considered: The elapsed timer hydrates from a server-provided timestamp to avoid client/server text mismatch; mobile smoke checks horizontal overflow; the phase label remains a heading so PR #714 E2E coverage stays compatible when both PRs land.
- Release/ops preconditions: None.
- Residual risk or follow-up: Local transcript streaming returned a dev-only 503 for the synthetic session fixture, so the visual smoke ignored that resource while still checking page rendering and layout.
