### PR TITLE
Prepare v0.23.0-beta.1 tester prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.23.0-beta.1] - 2026-06-30
+
+### Added
+- Guarded native text editing phase 1: small UTF-8 files can now open in an in-memory editable buffer, with read-only safety gates for unsupported files (#713).
+
+### Changed
+- Refactor preview QA to use a reusable alias (#702).
+
+### Other
+- Refresh roadmap to v0.22 and groom backlog labels for milestone #9 (#711).
+
 ## [0.22.0] - 2026-06-28
 
 ### Added

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.22.0</string>
+	<string>0.23.0-beta.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary
- Prepare tester prerelease metadata for `0.23.0-beta.1` / build `29`.
- Add changelog notes for native editor phase 1 and supporting preview/backlog updates since `v0.22.0`.
- Limit release prep changes to `CHANGELOG.md` and `Info.plist`; publication follows by dispatching `Release` from `main` after merge.

## Mergeability
- Surface: release metadata / tester prerelease prep.
- User-facing behavior changed: published prerelease will identify as `0.23.0-beta.1` build `29`.
- Non-happy paths considered: no signing, workflow, or release-script changes in this PR.
- Residual risk or follow-up: after merge, dispatch the protected `Release` workflow from `main`, approve the `release` environment if it waits, then verify the published DMG.

## Validation
- `./scripts/build-ghosttykit.sh`
- `swift test` — 1021 tests in 163 suites passed
- `mise run lint`
- `UV_CACHE_DIR=/tmp/workspaces-uv-cache uv run --script scripts/validate-release-changes.py --changed-files /tmp/workspaces-prerelease-changed-files.json` — no release-sensitive files changed

## Evidence
- [v0.23.0-beta.1-validation](https://evidence.cloudcompute.com/workspaces/pr-716/20260630-224552-v0.23.0-beta.1-validation.svg)