### PR TITLE
Add Cmd-S save for native editor

### DIFF
--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -229,6 +229,14 @@ struct WorkspaceManagerApp: App {
                 .disabled(!appCommandState.mainWindowAvailability.canOpenCommandRunner)
             }
 
+            CommandGroup(replacing: .saveItem) {
+                Button("Save") {
+                    appCommandState.performSaveDocument()
+                }
+                .keyboardShortcut("s", modifiers: .command)
+                .disabled(!appCommandState.canSaveDocument)
+            }
+
             SidebarCommands()
 
             CommandMenu("Selection") {
@@ -803,9 +811,11 @@ enum MainWindowCommand {
 @MainActor
 final class AppCommandState: ObservableObject {
     @Published private(set) var canCreateWorkspace = false
+    @Published private(set) var canSaveDocument = false
     @Published private(set) var mainWindowAvailability = MainWindowCommandAvailability.empty
 
     private var newWorkspaceAction: (@MainActor () -> Void)?
+    private var saveDocumentAction: (@MainActor () -> Void)?
     private var mainWindowActions = MainWindowFocusedActions.empty
 
     func setNewWorkspaceAction(_ action: (@MainActor () -> Void)?) {
@@ -813,6 +823,17 @@ final class AppCommandState: ObservableObject {
         let nextAvailability = action != nil
         guard canCreateWorkspace != nextAvailability else { return }
         canCreateWorkspace = nextAvailability
+    }
+
+    func setSaveDocumentAction(_ action: (@MainActor () -> Void)?, isEnabled: Bool) {
+        saveDocumentAction = action
+        let nextAvailability = action != nil && isEnabled
+        guard canSaveDocument != nextAvailability else { return }
+        canSaveDocument = nextAvailability
+    }
+
+    func clearSaveDocumentAction() {
+        setSaveDocumentAction(nil, isEnabled: false)
     }
 
     func setMainWindowActions(
@@ -830,6 +851,11 @@ final class AppCommandState: ObservableObject {
 
     func performNewWorkspace() {
         newWorkspaceAction?()
+    }
+
+    func performSaveDocument() {
+        guard canSaveDocument else { return }
+        saveDocumentAction?()
     }
 
     func perform(_ command: MainWindowCommand) {

--- a/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
@@ -26,6 +26,8 @@ struct CodePreviewSelection: Identifiable, Hashable {
 }
 
 struct CodeFilePreviewView: View {
+    @ObservedObject var appCommandState: AppCommandState
+
     let selection: CodePreviewSelection
     let editorOptions: [ExternalEditorDescriptor]
     let defaultEditor: ExternalEditorDescriptor?
@@ -34,6 +36,8 @@ struct CodeFilePreviewView: View {
     let onClose: () -> Void
 
     @State private var state: LoadState = .loading
+    @State private var isSaving = false
+    @State private var saveErrorMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -94,15 +98,13 @@ struct CodeFilePreviewView: View {
                     .accessibilityLabel("Discard Edits")
 
                     Button {
-                        // Phase 2 wires the safe disk-write pipeline. Keep the
-                        // control visible but inert so this slice cannot write
-                        // files before the save-safety contract is implemented.
+                        triggerSave()
                     } label: {
                         Image(systemName: "square.and.arrow.down")
                     }
                     .buttonStyle(.borderless)
-                    .disabled(true)
-                    .help("Save is disabled until the safe write pipeline is implemented")
+                    .disabled(!canSaveDocument)
+                    .help(canSaveDocument ? "Save File (Cmd+S)" : "No changes to save")
                     .accessibilityLabel("Save File")
                 }
 
@@ -130,6 +132,23 @@ struct CodeFilePreviewView: View {
             .background(Color(nsColor: .windowBackgroundColor))
 
             Divider()
+
+            if let saveErrorMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                    Text(saveErrorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.red.opacity(0.08))
+
+                Divider()
+            }
 
             Group {
                 switch state {
@@ -179,11 +198,29 @@ struct CodeFilePreviewView: View {
         .task(id: selection.id) {
             await loadPreview()
         }
+        .onAppear {
+            syncSaveCommand()
+        }
+        .onDisappear {
+            appCommandState.clearSaveDocumentAction()
+        }
+        .onChange(of: selection.id) { _, _ in
+            saveErrorMessage = nil
+            appCommandState.clearSaveDocumentAction()
+        }
+        .onChange(of: isDirty) { _, _ in
+            syncSaveCommand()
+        }
+        .onChange(of: isSaving) { _, _ in
+            syncSaveCommand()
+        }
     }
 
     @MainActor
     private func loadPreview() async {
         state = .loading
+        saveErrorMessage = nil
+        syncSaveCommand()
         CodePreviewDiagnostics.log("selected file=\(selection.fileURL.path)")
 
         do {
@@ -198,17 +235,20 @@ struct CodeFilePreviewView: View {
             )
 
             state = .loaded(CodeEditorDocument(payload: payload))
+            syncSaveCommand()
             CodePreviewDiagnostics.log("state=loaded file=\(selection.fileURL.path)")
         } catch is CancellationError {
             CodePreviewDiagnostics.log("state=cancelled file=\(selection.fileURL.path)")
             return
         } catch let error as CodePreviewError {
             state = .failed(error.errorDescription ?? "Could not load this file.")
+            syncSaveCommand()
             CodePreviewDiagnostics.log(
                 "state=failed file=\(selection.fileURL.path) error=\(error.errorDescription ?? "unknown")"
             )
         } catch {
             state = .failed(error.localizedDescription)
+            syncSaveCommand()
             CodePreviewDiagnostics.log(
                 "state=failed file=\(selection.fileURL.path) error=\(error.localizedDescription)"
             )
@@ -228,6 +268,10 @@ struct CodeFilePreviewView: View {
         loadedDocument?.isDirty ?? false
     }
 
+    private var canSaveDocument: Bool {
+        isDirty && !isSaving && loadedDocument?.canEdit == true
+    }
+
     private var currentTextBinding: Binding<String> {
         Binding(
             get: {
@@ -237,6 +281,7 @@ struct CodeFilePreviewView: View {
                 guard case .loaded(var document) = state else { return }
                 document.currentText = newValue
                 state = .loaded(document)
+                saveErrorMessage = nil
             }
         )
     }
@@ -245,16 +290,53 @@ struct CodeFilePreviewView: View {
         guard case .loaded(var document) = state else { return }
         document.currentText = document.originalText
         state = .loaded(document)
+        saveErrorMessage = nil
+    }
+
+    private func triggerSave() {
+        Task { @MainActor in
+            saveCurrentDocument()
+        }
+    }
+
+    @MainActor
+    private func saveCurrentDocument() {
+        guard canSaveDocument, case .loaded(var document) = state else { return }
+
+        isSaving = true
+        saveErrorMessage = nil
+        defer {
+            isSaving = false
+            syncSaveCommand()
+        }
+
+        do {
+            try document.save(to: selection.fileURL)
+            state = .loaded(document)
+        } catch let error as CodeEditorSaveError {
+            saveErrorMessage = error.errorDescription
+        } catch {
+            saveErrorMessage = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func syncSaveCommand() {
+        if canSaveDocument {
+            appCommandState.setSaveDocumentAction({ triggerSave() }, isEnabled: true)
+        } else {
+            appCommandState.setSaveDocumentAction(nil, isEnabled: false)
+        }
     }
 }
 
-enum CodeEditorEditability: Equatable {
+enum CodeEditorEditability: Equatable, Sendable {
     case editable
     case readOnly(String)
 }
 
-struct CodeEditorDocument: Equatable {
-    let originalText: String
+struct CodeEditorDocument: Equatable, Sendable {
+    private(set) var originalText: String
     var currentText: String
     let language: CodeSyntaxLanguage
     let spans: [HighlightSpan]
@@ -303,6 +385,31 @@ struct CodeEditorDocument: Equatable {
         )
     }
 
+    mutating func save(to fileURL: URL) throws {
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch {
+            throw CodeEditorSaveError.readFailed(error.localizedDescription)
+        }
+
+        guard let diskText = String(data: data, encoding: .utf8) else {
+            throw CodeEditorSaveError.unsupportedEncoding
+        }
+
+        guard diskText == originalText else {
+            throw CodeEditorSaveError.changedOnDisk
+        }
+
+        do {
+            try Data(currentText.utf8).write(to: fileURL, options: .atomic)
+        } catch {
+            throw CodeEditorSaveError.writeFailed(error.localizedDescription)
+        }
+
+        originalText = currentText
+    }
+
     private static func editability(for payload: CodePreviewPayload) -> CodeEditorEditability {
         if payload.isTruncated {
             return .readOnly(
@@ -310,6 +417,26 @@ struct CodeEditorDocument: Equatable {
             )
         }
         return .editable
+    }
+}
+
+enum CodeEditorSaveError: LocalizedError, Equatable {
+    case unsupportedEncoding
+    case changedOnDisk
+    case readFailed(String)
+    case writeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedEncoding:
+            return "This file is no longer UTF-8 text. Reload it before saving."
+        case .changedOnDisk:
+            return "This file changed on disk. Reload it before saving so you do not overwrite newer changes."
+        case .readFailed(let message):
+            return "Could not read the latest file contents before saving: \(message)"
+        case .writeFailed(let message):
+            return "Could not save this file: \(message)"
+        }
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -500,6 +500,7 @@ struct ContentView: View {
     @ViewBuilder
     private var terminalDetailContent: some View {
         MainTerminalDetailView(
+            appCommandState: appCommandState,
             selectedWorkspace: selectedWorkspaceForToolbar,
             selectedRepo: selectedRepoForToolbar ?? selectedRepoForInspector,
             activeHostSession: activeHostSession,
@@ -2947,6 +2948,7 @@ private final class ContextMenuActionItem: NSObject {
 // MARK: - Main Terminal (Host-pinned)
 
 struct MainTerminalDetailView: View {
+    @ObservedObject var appCommandState: AppCommandState
     let selectedWorkspace: Workspace?
     let selectedRepo: Repo?
     let activeHostSession: HostTerminalSession?
@@ -3073,6 +3075,7 @@ struct MainTerminalDetailView: View {
             if isTerminalPanelVisible {
                 VSplitView {
                     CodeFilePreviewView(
+                        appCommandState: appCommandState,
                         selection: selectedCodePreview,
                         editorOptions: availableEditors,
                         defaultEditor: defaultEditor,
@@ -3089,6 +3092,7 @@ struct MainTerminalDetailView: View {
                 }
             } else {
                 CodeFilePreviewView(
+                    appCommandState: appCommandState,
                     selection: selectedCodePreview,
                     editorOptions: availableEditors,
                     defaultEditor: defaultEditor,

--- a/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
@@ -28,6 +28,35 @@ struct AppCommandStateTests {
         #expect(emissions == 2)
     }
 
+    @Test("save document action only runs when enabled")
+    func saveDocumentActionOnlyRunsWhenEnabled() {
+        let state = AppCommandState()
+        var saveCount = 0
+        var emissions = 0
+        let cancellable = state.objectWillChange.sink { _ in
+            emissions += 1
+        }
+        defer { cancellable.cancel() }
+
+        state.setSaveDocumentAction({ saveCount += 1 }, isEnabled: false)
+        #expect(!state.canSaveDocument)
+        #expect(emissions == 0)
+
+        state.performSaveDocument()
+        #expect(saveCount == 0)
+
+        state.setSaveDocumentAction({ saveCount += 1 }, isEnabled: true)
+        #expect(state.canSaveDocument)
+        #expect(emissions == 1)
+
+        state.performSaveDocument()
+        #expect(saveCount == 1)
+
+        state.clearSaveDocumentAction()
+        #expect(!state.canSaveDocument)
+        #expect(emissions == 2)
+    }
+
     @Test("main window actions only publish when availability changes")
     func mainWindowActionsOnlyPublishWhenAvailabilityChanges() {
         let state = AppCommandState()

--- a/Tests/WorkspaceManagerAppTests/CodeEditorDocumentTests.swift
+++ b/Tests/WorkspaceManagerAppTests/CodeEditorDocumentTests.swift
@@ -54,6 +54,61 @@ struct CodeEditorDocumentTests {
         #expect(document.currentText == "after\n")
     }
 
+    @Test("Saving writes UTF-8 text and clears dirty state")
+    func savingWritesTextAndClearsDirtyState() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("notes.md")
+        try Data("before\n".utf8).write(to: fileURL)
+
+        var document = CodeEditorDocument(
+            payload: CodePreviewPayload(
+                text: "before\n",
+                language: .markdown,
+                spans: [],
+                isTruncated: false
+            )
+        )
+        document.currentText = "after\n"
+
+        try document.save(to: fileURL)
+
+        #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "after\n")
+        #expect(!document.isDirty)
+        #expect(document.originalText == "after\n")
+    }
+
+    @Test("Saving refuses to overwrite files changed on disk")
+    func savingRefusesStaleDiskContents() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("notes.md")
+        try Data("before\n".utf8).write(to: fileURL)
+
+        var document = CodeEditorDocument(
+            payload: CodePreviewPayload(
+                text: "before\n",
+                language: .markdown,
+                spans: [],
+                isTruncated: false
+            )
+        )
+        document.currentText = "after\n"
+        try Data("external\n".utf8).write(to: fileURL)
+
+        do {
+            try document.save(to: fileURL)
+            Issue.record("Expected changed-on-disk save error")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .changedOnDisk)
+        }
+
+        #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "external\n")
+        #expect(document.isDirty)
+    }
+
     @Test("Truncated files are read-only")
     func truncatedFilesAreReadOnly() {
         let payload = CodePreviewPayload(


### PR DESCRIPTION
## Summary
- add a real app-level Save command and Cmd-S routing for the native file editor
- enable the in-pane save control when a file has unsaved edits
- write UTF-8 files atomically and refuse to overwrite if the file changed on disk since load

## Mergeability

- Surface: desktop
- User-facing behavior changed: Native file previews now save like a regular Mac app via File > Save, Cmd-S, or the in-pane save button when edits are dirty.
- Non-happy paths considered: Save refuses stale overwrites when the file changed on disk, keeps the buffer dirty on failure, and shows a visible inline error. Unsupported encodings and truncated files remain read-only.
- Release/ops preconditions: none
- Residual risk or follow-up: Autosave remains intentionally out of scope; if we add it later it should reuse the same conflict-safe write path.

## Validation
- swift build
- swift test --filter CodeEditorDocumentTests
- swift test --filter AppCommandStateTests
- swift test
- mise run lint
- ./scripts/dev-smoke.sh --no-build

## Evidence
![editor-save-dev-smoke](https://evidence.cloudcompute.com/workspaces/pr-717/20260701-062956-editor-save-dev-smoke.png)

## Notes
- Autosave is intentionally not included in this slice; explicit Cmd-S/save-button behavior matches the expected Mac editing flow and keeps overwrite safety clear.