### PR TITLE
Clear acknowledged Needs You notifications

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -813,6 +813,9 @@ struct ContentView: View {
                         }
                     )
                     syncSidebarSelectionToActiveSessionFromActiveHostSession()
+                    if let activeSessionID = hostTerminalState.activeSessionID {
+                        acknowledgeVisitedAgentSession(activeSessionID)
+                    }
                 }
             }
     }
@@ -1430,6 +1433,7 @@ struct ContentView: View {
             scopePath: repoDirectory.path
         )
         markAccessed(repo: repo)
+        acknowledgeVisitedAttentionTarget(.repo(repo.id))
         applyNavigationDestination(.repoTerminal(repo))
         persistTerminalContinuity(
             targetKind: .repo,
@@ -1518,6 +1522,7 @@ struct ContentView: View {
                 scopePath: workspaceDirectory.path
             )
             markAccessed(workspace: workspace)
+            acknowledgeVisitedAttentionTarget(.workspace(workspace.id))
             applyNavigationDestination(.workspaceTerminal(workspace))
             persistTerminalContinuity(
                 targetKind: .workspace,
@@ -1556,8 +1561,10 @@ struct ContentView: View {
         {
             abandonPendingRemoteConnection(reason: "remote_workspace_reused_existing_session")
             markAccessed(workspace: workspace)
+            acknowledgeVisitedAttentionTarget(.workspace(workspace.id))
             applyNavigationDestination(.workspaceTerminal(workspace))
             hostTerminalState.activateExistingSession(sessionID: existing.id)
+            acknowledgeVisitedAgentSession(existing.id)
             terminalFocusCoordinator.requestMainTerminalFocus(
                 targetSessionID: existing.id,
                 surfaceStore: hostTerminalState.surfaceStore,
@@ -1600,6 +1607,7 @@ struct ContentView: View {
                 customCommand: launchSpec.customCommand
             )
             viewState.columnVisibility = .all
+            acknowledgeVisitedAttentionTarget(.workspace(workspace.id))
             terminalFocusCoordinator.requestMainTerminalFocus(
                 targetSessionID: session.id,
                 surfaceStore: hostTerminalState.surfaceStore,
@@ -1852,7 +1860,23 @@ struct ContentView: View {
         _ result: MainWindowTerminalSessionController.SessionFocusResult
     ) {
         setSelectedWorkspace(result.syncedWorkspace)
+        acknowledgeVisitedAgentSession(result.focusSessionID)
         focusTerminalTab(result.focusSessionID)
+    }
+
+    @MainActor
+    private func acknowledgeVisitedAttentionTarget(
+        _ target: WorkspaceStatusAggregator.AttentionTarget
+    ) {
+        workspaceStatusAggregator.acknowledgeAttention(for: target)
+        refreshWorkspaceStatusAggregator()
+    }
+
+    @MainActor
+    private func acknowledgeVisitedAgentSession(_ sessionID: UUID) {
+        guard let status = agentSessionRegistry.statuses[sessionID] else { return }
+        workspaceStatusAggregator.acknowledgeAttention(for: status)
+        refreshWorkspaceStatusAggregator()
     }
 
     @MainActor
@@ -2517,6 +2541,7 @@ struct ContentView: View {
     @MainActor
     private func activateSessionSwitcherHostSession(_ sessionID: UUID) {
         guard hostTerminalState.activateExistingSession(sessionID: sessionID) else { return }
+        acknowledgeVisitedAgentSession(sessionID)
         if let activeHostSession,
             let destination = terminalSessionController.terminalNavigationDestination(
                 for: activeHostSession,

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
@@ -75,6 +75,7 @@ public final class WorkspaceStatusAggregator: ObservableObject {
 
     public struct AttentionItem: Identifiable, Equatable, Sendable {
         public let target: AttentionTarget
+        public let hostSessionID: UUID
         public let run: AgentRunState
         public let lastEventAt: Date
         public let lastAccessedAt: Date
@@ -88,11 +89,13 @@ public final class WorkspaceStatusAggregator: ObservableObject {
 
         public init(
             target: AttentionTarget,
+            hostSessionID: UUID,
             run: AgentRunState,
             lastEventAt: Date,
             lastAccessedAt: Date
         ) {
             self.target = target
+            self.hostSessionID = hostSessionID
             self.run = run
             self.lastEventAt = lastEventAt
             self.lastAccessedAt = lastAccessedAt
@@ -120,9 +123,22 @@ public final class WorkspaceStatusAggregator: ObservableObject {
     /// `lastAccessedAt` descending.
     @Published public private(set) var attentionRepos: [UUID] = []
 
+    private var acknowledgedAttentionEventAtBySessionID: [UUID: Date] = [:]
+
     public var attentionCount: Int { attentionItems.count }
 
     public init() {}
+
+    public func acknowledgeAttention(for status: AgentSessionStatus) {
+        guard Self.demandsAttention(status.run) else { return }
+        acknowledgedAttentionEventAtBySessionID[status.hostSessionID] = status.lastEventAt
+    }
+
+    public func acknowledgeAttention(for target: AttentionTarget) {
+        for item in attentionItems where item.target == target {
+            acknowledgedAttentionEventAtBySessionID[item.hostSessionID] = item.lastEventAt
+        }
+    }
 
     public func update(workspaces: [WorkspaceInput], repos: [RepoInput]) {
         var workspaceStatuses: [UUID: AgentSessionStatus] = [:]
@@ -147,7 +163,7 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         }
 
         let workspaceAttention = workspaces.compactMap { input -> AttentionEntry? in
-            guard let status = input.status, Self.demandsAttention(status.run) else { return nil }
+            guard let status = input.status, shouldShowAttention(for: status) else { return nil }
             return AttentionEntry(
                 target: .workspace(input.workspaceID),
                 status: status,
@@ -155,7 +171,7 @@ public final class WorkspaceStatusAggregator: ObservableObject {
             )
         }
         let repoAttention = repos.compactMap { input -> AttentionEntry? in
-            guard let status = input.status, Self.demandsAttention(status.run) else { return nil }
+            guard let status = input.status, shouldShowAttention(for: status) else { return nil }
             return AttentionEntry(
                 target: .repo(input.repoID),
                 status: status,
@@ -173,6 +189,7 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         let attentionItems = attentionEntries.map { entry in
             AttentionItem(
                 target: entry.target,
+                hostSessionID: entry.status.hostSessionID,
                 run: entry.status.run,
                 lastEventAt: entry.status.lastEventAt,
                 lastAccessedAt: entry.lastAccessedAt
@@ -200,6 +217,8 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         if self.attentionRepos != attentionRepos {
             self.attentionRepos = attentionRepos
         }
+
+        pruneAcknowledgements(for: Array(workspaceStatuses.values) + Array(repoStatuses.values))
     }
 
     /// Severity ordering — higher number wins when choosing the bubbled state.
@@ -221,5 +240,22 @@ public final class WorkspaceStatusAggregator: ObservableObject {
                 if ls != rs { return ls < rs }
                 return lhs.lastEventAt < rhs.lastEventAt
             }
+    }
+
+    private func shouldShowAttention(for status: AgentSessionStatus) -> Bool {
+        guard Self.demandsAttention(status.run) else { return false }
+        guard let acknowledgedAt = acknowledgedAttentionEventAtBySessionID[status.hostSessionID] else {
+            return true
+        }
+        return status.lastEventAt > acknowledgedAt
+    }
+
+    private func pruneAcknowledgements(for activeStatuses: some Sequence<AgentSessionStatus>) {
+        guard !acknowledgedAttentionEventAtBySessionID.isEmpty else { return }
+
+        for status in activeStatuses {
+            guard !Self.demandsAttention(status.run) else { continue }
+            acknowledgedAttentionEventAtBySessionID.removeValue(forKey: status.hostSessionID)
+        }
     }
 }

--- a/Tests/WorkspaceManagerAppTests/AttentionSummaryResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AttentionSummaryResolverTests.swift
@@ -31,12 +31,14 @@ struct AttentionSummaryResolverTests {
             attentionItems: [
                 .init(
                     target: .workspace(workspace.id),
+                    hostSessionID: UUID(),
                     run: .awaitingInput(reason: .permissionPrompt),
                     lastEventAt: Date(),
                     lastAccessedAt: Date()
                 ),
                 .init(
                     target: .repo(repo.id),
+                    hostSessionID: UUID(),
                     run: .errored(category: .toolFailure, message: "merge failed"),
                     lastEventAt: Date(),
                     lastAccessedAt: Date().addingTimeInterval(-30)
@@ -69,6 +71,7 @@ struct AttentionSummaryResolverTests {
             attentionItems: [
                 .init(
                     target: .workspace(UUID()),
+                    hostSessionID: UUID(),
                     run: .awaitingInput(reason: .custom),
                     lastEventAt: Date(),
                     lastAccessedAt: Date()
@@ -99,12 +102,14 @@ struct AttentionSummaryResolverTests {
             attentionItems: [
                 .init(
                     target: .workspace(workspace.id),
+                    hostSessionID: UUID(),
                     run: .awaitingInput(reason: .permissionPrompt),
                     lastEventAt: Date(),
                     lastAccessedAt: Date()
                 ),
                 .init(
                     target: .workspace(UUID()),
+                    hostSessionID: UUID(),
                     run: .errored(category: .toolFailure, message: "stale session"),
                     lastEventAt: Date(),
                     lastAccessedAt: Date().addingTimeInterval(-30)

--- a/Tests/WorkspaceManagerTests/WorkspaceStatusAggregatorTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceStatusAggregatorTests.swift
@@ -109,6 +109,142 @@ struct WorkspaceStatusAggregatorTests {
         #expect(aggregator.attentionWorkspaces == [wsID])
     }
 
+    @Test("Acknowledged attention target is removed from the global attention list")
+    func acknowledgedTargetDropsFromAttentionList() {
+        let aggregator = WorkspaceStatusAggregator()
+        let repoID = UUID()
+        let wsID = UUID()
+        let hostID = UUID()
+        let eventAt = Date()
+        let workspace = WorkspaceStatusAggregator.WorkspaceInput(
+            workspaceID: wsID,
+            repoID: repoID,
+            lastAccessedAt: eventAt,
+            status: status(
+                host: hostID,
+                run: .awaitingInput(reason: .permissionPrompt),
+                at: eventAt
+            )
+        )
+
+        aggregator.update(workspaces: [workspace], repos: [.init(repoID: repoID, status: nil)])
+        #expect(aggregator.attentionItems.map(\.target) == [.workspace(wsID)])
+
+        aggregator.acknowledgeAttention(for: .workspace(wsID))
+        aggregator.update(workspaces: [workspace], repos: [.init(repoID: repoID, status: nil)])
+
+        #expect(aggregator.attentionItems.isEmpty)
+        #expect(aggregator.attentionWorkspaces.isEmpty)
+        #expect(aggregator.workspaceStatuses[wsID]?.run == .awaitingInput(reason: .permissionPrompt))
+    }
+
+    @Test("Newer attention event reappears after acknowledgement")
+    func newerEventReappearsAfterAcknowledgement() {
+        let aggregator = WorkspaceStatusAggregator()
+        let repoID = UUID()
+        let wsID = UUID()
+        let hostID = UUID()
+        let eventAt = Date()
+        let acknowledgedWorkspace = WorkspaceStatusAggregator.WorkspaceInput(
+            workspaceID: wsID,
+            repoID: repoID,
+            lastAccessedAt: eventAt,
+            status: status(
+                host: hostID,
+                run: .awaitingInput(reason: .permissionPrompt),
+                at: eventAt
+            )
+        )
+
+        aggregator.update(
+            workspaces: [acknowledgedWorkspace],
+            repos: [.init(repoID: repoID, status: nil)]
+        )
+        aggregator.acknowledgeAttention(for: .workspace(wsID))
+        aggregator.update(
+            workspaces: [acknowledgedWorkspace],
+            repos: [.init(repoID: repoID, status: nil)]
+        )
+        #expect(aggregator.attentionItems.isEmpty)
+
+        let newerWorkspace = WorkspaceStatusAggregator.WorkspaceInput(
+            workspaceID: wsID,
+            repoID: repoID,
+            lastAccessedAt: eventAt,
+            status: status(
+                host: hostID,
+                run: .awaitingInput(reason: .permissionPrompt),
+                at: eventAt.addingTimeInterval(1)
+            )
+        )
+        aggregator.update(workspaces: [newerWorkspace], repos: [.init(repoID: repoID, status: nil)])
+
+        #expect(aggregator.attentionItems.map(\.target) == [.workspace(wsID)])
+    }
+
+    @Test("Masked acknowledged session stays hidden until it produces a newer event")
+    func maskedAcknowledgementSurvivesFreshestStatusChanges() {
+        let aggregator = WorkspaceStatusAggregator()
+        let repoID = UUID()
+        let wsID = UUID()
+        let acknowledgedHostID = UUID()
+        let maskingHostID = UUID()
+        let eventAt = Date()
+        let acknowledgedStatus = status(
+            host: acknowledgedHostID,
+            run: .awaitingInput(reason: .permissionPrompt),
+            at: eventAt
+        )
+
+        aggregator.acknowledgeAttention(for: acknowledgedStatus)
+        aggregator.update(
+            workspaces: [
+                .init(
+                    workspaceID: wsID,
+                    repoID: repoID,
+                    lastAccessedAt: eventAt,
+                    status: status(
+                        host: maskingHostID,
+                        run: .thinking,
+                        at: eventAt.addingTimeInterval(1)
+                    )
+                )
+            ],
+            repos: [.init(repoID: repoID, status: nil)]
+        )
+        aggregator.update(
+            workspaces: [
+                .init(
+                    workspaceID: wsID,
+                    repoID: repoID,
+                    lastAccessedAt: eventAt,
+                    status: acknowledgedStatus
+                )
+            ],
+            repos: [.init(repoID: repoID, status: nil)]
+        )
+
+        #expect(aggregator.attentionItems.isEmpty)
+
+        aggregator.update(
+            workspaces: [
+                .init(
+                    workspaceID: wsID,
+                    repoID: repoID,
+                    lastAccessedAt: eventAt,
+                    status: status(
+                        host: acknowledgedHostID,
+                        run: .awaitingInput(reason: .permissionPrompt),
+                        at: eventAt.addingTimeInterval(2)
+                    )
+                )
+            ],
+            repos: [.init(repoID: repoID, status: nil)]
+        )
+
+        #expect(aggregator.attentionItems.map(\.target) == [.workspace(wsID)])
+    }
+
     @Test("demandsAttention only fires for awaiting/errored")
     func demandsAttentionMatrix() {
         #expect(WorkspaceStatusAggregator.demandsAttention(.awaitingInput(reason: .permissionPrompt)))


### PR DESCRIPTION
## Summary
- add per-agent-session acknowledgement for Needs You attention events
- clear acknowledged workspace/repo/session entries when users activate the target terminal or switch to the tab
- keep acknowledged events hidden until the agent produces a newer attention event

## Review finding addressed
- Fixed an edge case where an acknowledged Needs You session could be masked by a newer non-attention tab, have its acknowledgement pruned, and later reappear without any new agent event.

## Validation
- ./scripts/build-ghosttykit.sh
- swift-format lint --strict --recursive Sources/ Tests/
- swift test --filter WorkspaceStatusAggregatorTests
- swift test --filter AttentionSummaryResolverTests
- swift test

## Evidence
- ![needs-you-ack-validation](https://evidence.cloudcompute.com/workspaces/pr-718/20260701-064054-needs-you-ack-validation.svg)

## Mergeability
- Surface: desktop notification bar, terminal selection routing, and Needs You attention aggregation.
- User-facing behavior changed: acknowledged Needs You items clear when the user visits the relevant terminal/session, then reappear only after a newer attention event.
- Non-happy paths considered: multiple sessions for one workspace, masked older attention, repo and workspace targets, tab switching, and stale/non-attention status transitions.
- Residual risk or follow-up: full local Swift suite and focused aggregator/resolver tests pass; awaiting GitHub CI and managed review for remote confirmation.
