### PR TITLE
[codex] native editor save safety

### DIFF
--- a/Sources/WorkspaceManager/Services/CodeEditorSaveService.swift
+++ b/Sources/WorkspaceManager/Services/CodeEditorSaveService.swift
@@ -1,0 +1,231 @@
+//
+//  CodeEditorSaveService.swift
+//  WorkspaceManager
+//
+//  Safe disk-write pipeline for the native small-edit surface.
+//
+
+import Darwin
+import Foundation
+
+enum CodeEditorLineEndingStyle: Equatable, Sendable {
+    case lf
+    case crlf
+    case cr
+    case mixed
+
+    init(text: String) {
+        let bytes = Array(text.utf8)
+        var index = 0
+        var sawLF = false
+        var sawCRLF = false
+        var sawCR = false
+
+        while index < bytes.count {
+            let byte = bytes[index]
+            if byte == 0x0D {
+                let nextIndex = index + 1
+                if nextIndex < bytes.count, bytes[nextIndex] == 0x0A {
+                    sawCRLF = true
+                    index += 2
+                } else {
+                    sawCR = true
+                    index += 1
+                }
+            } else if byte == 0x0A {
+                sawLF = true
+                index += 1
+            } else {
+                index += 1
+            }
+        }
+
+        switch (sawLF, sawCRLF, sawCR) {
+        case (false, true, false):
+            self = .crlf
+        case (false, false, true):
+            self = .cr
+        case (false, false, false), (true, false, false):
+            self = .lf
+        default:
+            self = .mixed
+        }
+    }
+}
+
+struct CodeEditorFileSnapshot: Equatable, Sendable {
+    let byteCount: Int
+    let contentHash: UInt64
+    let posixMode: Int
+    let lineEndingStyle: CodeEditorLineEndingStyle
+
+    static func make(fileURL: URL, data: Data) throws -> CodeEditorFileSnapshot {
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o644
+        let text = String(decoding: data, as: UTF8.self)
+        return CodeEditorFileSnapshot(
+            byteCount: data.count,
+            contentHash: stableContentHash(data),
+            posixMode: mode,
+            lineEndingStyle: CodeEditorLineEndingStyle(text: text)
+        )
+    }
+
+    func matches(fileURL: URL, data: Data) throws -> Bool {
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o644
+        return byteCount == data.count
+            && contentHash == Self.stableContentHash(data)
+            && posixMode == mode
+    }
+
+    private static func stableContentHash(_ data: Data) -> UInt64 {
+        data.reduce(0xcbf2_9ce4_8422_2325) { hash, byte in
+            (hash ^ UInt64(byte)) &* 0x0100_0000_01b3
+        }
+    }
+}
+
+struct CodeEditorSaveRequest: Sendable {
+    let rootURL: URL
+    let relativePath: String
+    let editedText: String
+    let snapshot: CodeEditorFileSnapshot?
+}
+
+enum CodeEditorSaveError: LocalizedError, Equatable {
+    case missingSnapshot
+    case invalidRelativePath
+    case pathEscapesRoot
+    case symlinkRefused
+    case changedOnDisk
+    case utf8EncodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSnapshot:
+            return "Save is unavailable because this file was not loaded with a safety snapshot."
+        case .invalidRelativePath:
+            return "Save refused because the selected path is not a relative file path."
+        case .pathEscapesRoot:
+            return "Save refused because the selected path resolves outside the workspace root."
+        case .symlinkRefused:
+            return "Save refused because the selected file is a symbolic link."
+        case .changedOnDisk:
+            return "Save refused because the file changed on disk. Reload before saving."
+        case .utf8EncodingFailed:
+            return "Save refused because the edited text could not be encoded as UTF-8."
+        }
+    }
+}
+
+enum CodeEditorSaveService {
+    static func save(_ request: CodeEditorSaveRequest) async throws -> CodeEditorFileSnapshot {
+        try await Task.detached(priority: .userInitiated) {
+            try saveSynchronously(request)
+        }
+        .value
+    }
+
+    static func saveSynchronously(_ request: CodeEditorSaveRequest) throws -> CodeEditorFileSnapshot {
+        guard let snapshot = request.snapshot else {
+            throw CodeEditorSaveError.missingSnapshot
+        }
+
+        let lexicalTargetURL = try lexicalFileURL(rootURL: request.rootURL, relativePath: request.relativePath)
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: lexicalTargetURL.path)) == nil else {
+            throw CodeEditorSaveError.symlinkRefused
+        }
+
+        let targetURL = try containedFileURL(rootURL: request.rootURL, relativePath: request.relativePath)
+
+        let currentData = try Data(contentsOf: targetURL)
+        guard try snapshot.matches(fileURL: targetURL, data: currentData) else {
+            throw CodeEditorSaveError.changedOnDisk
+        }
+
+        guard
+            let replacementData = normalizedData(
+                from: request.editedText,
+                lineEndingStyle: snapshot.lineEndingStyle
+            )
+        else {
+            throw CodeEditorSaveError.utf8EncodingFailed
+        }
+
+        let temporaryURL =
+            targetURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(targetURL.lastPathComponent).workspaces-save-\(UUID().uuidString).tmp")
+
+        do {
+            try replacementData.write(to: temporaryURL)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: snapshot.posixMode)],
+                ofItemAtPath: temporaryURL.path
+            )
+
+            guard Darwin.rename(temporaryURL.path, targetURL.path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+
+            let savedData = try Data(contentsOf: targetURL)
+            return try CodeEditorFileSnapshot.make(fileURL: targetURL, data: savedData)
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw error
+        }
+    }
+
+    static func containedFileURL(rootURL: URL, relativePath: String) throws -> URL {
+        let lexicalTarget = try lexicalFileURL(rootURL: rootURL, relativePath: relativePath)
+
+        let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+        let target = lexicalTarget.resolvingSymlinksInPath()
+
+        guard target.path == root.path || target.path.hasPrefix(root.path + "/") else {
+            throw CodeEditorSaveError.pathEscapesRoot
+        }
+
+        return target
+    }
+
+    private static func lexicalFileURL(rootURL: URL, relativePath: String) throws -> URL {
+        guard !relativePath.isEmpty,
+            !relativePath.hasPrefix("/"),
+            relativePath.split(separator: "/").allSatisfy({ $0 != ".." && $0 != "." })
+        else {
+            throw CodeEditorSaveError.invalidRelativePath
+        }
+
+        return
+            rootURL
+            .appendingPathComponent(relativePath)
+            .standardizedFileURL
+    }
+
+    private static func normalizedData(
+        from text: String,
+        lineEndingStyle: CodeEditorLineEndingStyle
+    ) -> Data? {
+        let outputText: String
+        switch lineEndingStyle {
+        case .lf, .mixed:
+            outputText = text
+        case .crlf:
+            let normalized =
+                text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            outputText = normalized.replacingOccurrences(of: "\n", with: "\r\n")
+        case .cr:
+            let normalized =
+                text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            outputText = normalized.replacingOccurrences(of: "\n", with: "\r")
+        }
+
+        return outputText.data(using: .utf8)
+    }
+}

--- a/Sources/WorkspaceManager/Services/FilePreviewService.swift
+++ b/Sources/WorkspaceManager/Services/FilePreviewService.swift
@@ -22,6 +22,24 @@ struct CodePreviewPayload: Sendable {
     let language: CodeSyntaxLanguage
     let spans: [HighlightSpan]
     let isTruncated: Bool
+    let fileSnapshot: CodeEditorFileSnapshot?
+    let readOnlyReason: String?
+
+    init(
+        text: String,
+        language: CodeSyntaxLanguage,
+        spans: [HighlightSpan],
+        isTruncated: Bool,
+        fileSnapshot: CodeEditorFileSnapshot? = nil,
+        readOnlyReason: String? = nil
+    ) {
+        self.text = text
+        self.language = language
+        self.spans = spans
+        self.isTruncated = isTruncated
+        self.fileSnapshot = fileSnapshot
+        self.readOnlyReason = readOnlyReason
+    }
 }
 
 enum CodePreviewLoader {
@@ -56,6 +74,14 @@ enum CodePreviewLoader {
                 language: language,
                 maxCharacters: maxHighlightCharacters
             )
+            let snapshot = isTruncated ? nil : try CodeEditorFileSnapshot.make(fileURL: fileURL, data: data)
+            let readOnlyReason: String?
+            if (try? FileManager.default.destinationOfSymbolicLink(atPath: fileURL.path)) != nil {
+                readOnlyReason =
+                    "Symbolic links are read-only in the native editor. Open externally to edit deliberately."
+            } else {
+                readOnlyReason = nil
+            }
             CodePreviewDiagnostics.log(
                 "load complete file=\(fileURL.path) chars=\(text.count) spans=\(spans.count) truncated=\(isTruncated)"
             )
@@ -64,7 +90,9 @@ enum CodePreviewLoader {
                 text: text,
                 language: language,
                 spans: spans,
-                isTruncated: isTruncated
+                isTruncated: isTruncated,
+                fileSnapshot: snapshot,
+                readOnlyReason: readOnlyReason
             )
         }
         .value

--- a/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
@@ -31,9 +31,13 @@ struct CodeFilePreviewView: View {
     let defaultEditor: ExternalEditorDescriptor?
     let onOpenInDefaultEditor: () -> Void
     let onOpenInEditor: (ExternalEditorID) -> Void
+    let onSaved: () -> Void
     let onClose: () -> Void
 
     @State private var state: LoadState = .loading
+    @State private var isSaving = false
+    @State private var saveStatusMessage: String?
+    @State private var saveErrorMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -80,6 +84,13 @@ struct CodeFilePreviewView: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
+
+                    if let saveStatusMessage {
+                        Text(saveStatusMessage)
+                            .font(.caption2)
+                            .foregroundStyle(.green)
+                            .lineLimit(1)
+                    }
                 }
 
                 if isEditorLoaded {
@@ -94,15 +105,18 @@ struct CodeFilePreviewView: View {
                     .accessibilityLabel("Discard Edits")
 
                     Button {
-                        // Phase 2 wires the safe disk-write pipeline. Keep the
-                        // control visible but inert so this slice cannot write
-                        // files before the save-safety contract is implemented.
+                        saveDocument()
                     } label: {
-                        Image(systemName: "square.and.arrow.down")
+                        if isSaving {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Image(systemName: "square.and.arrow.down")
+                        }
                     }
                     .buttonStyle(.borderless)
-                    .disabled(true)
-                    .help("Save is disabled until the safe write pipeline is implemented")
+                    .disabled(!canSave)
+                    .help(canSave ? "Save file" : "Save is available for dirty, safely loaded text files")
                     .accessibilityLabel("Save File")
                 }
 
@@ -145,30 +159,29 @@ struct CodeFilePreviewView: View {
                     )
 
                 case .loaded(let document):
-                    if document.canEdit {
-                        EditableCodeTextView(text: currentTextBinding)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else {
-                        VStack(spacing: 0) {
-                            if let reason = document.readOnlyReason {
-                                HStack(spacing: 8) {
-                                    Image(systemName: "lock")
-                                        .foregroundStyle(.secondary)
-                                    Text(reason)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(2)
-                                    Spacer()
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(Color(nsColor: .controlBackgroundColor))
-
-                                Divider()
+                    VStack(spacing: 0) {
+                        if let saveErrorMessage {
+                            HStack(spacing: 8) {
+                                Image(systemName: "exclamationmark.triangle")
+                                    .foregroundStyle(.orange)
+                                Text(saveErrorMessage)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                                Spacer()
                             }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color(nsColor: .controlBackgroundColor))
 
-                            ReadOnlyCodeTextView(attributedText: document.attributedText)
+                            Divider()
+                        }
+
+                        if document.canEdit {
+                            EditableCodeTextView(text: currentTextBinding)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else {
+                            readOnlyDocumentView(document)
                         }
                     }
                 }
@@ -181,9 +194,36 @@ struct CodeFilePreviewView: View {
         }
     }
 
+    @ViewBuilder
+    private func readOnlyDocumentView(_ document: CodeEditorDocument) -> some View {
+        VStack(spacing: 0) {
+            if let reason = document.readOnlyReason {
+                HStack(spacing: 8) {
+                    Image(systemName: "lock")
+                        .foregroundStyle(.secondary)
+                    Text(reason)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color(nsColor: .controlBackgroundColor))
+
+                Divider()
+            }
+
+            ReadOnlyCodeTextView(attributedText: document.attributedText)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
     @MainActor
     private func loadPreview() async {
         state = .loading
+        saveStatusMessage = nil
+        saveErrorMessage = nil
         CodePreviewDiagnostics.log("selected file=\(selection.fileURL.path)")
 
         do {
@@ -228,6 +268,11 @@ struct CodeFilePreviewView: View {
         loadedDocument?.isDirty ?? false
     }
 
+    private var canSave: Bool {
+        guard let document = loadedDocument else { return false }
+        return document.canSave && !isSaving
+    }
+
     private var currentTextBinding: Binding<String> {
         Binding(
             get: {
@@ -245,6 +290,42 @@ struct CodeFilePreviewView: View {
         guard case .loaded(var document) = state else { return }
         document.currentText = document.originalText
         state = .loaded(document)
+        saveErrorMessage = nil
+        saveStatusMessage = nil
+    }
+
+    private func saveDocument() {
+        guard case .loaded(let document) = state, document.canSave else { return }
+
+        isSaving = true
+        saveErrorMessage = nil
+        saveStatusMessage = nil
+
+        Task {
+            do {
+                let snapshot = try await CodeEditorSaveService.save(
+                    CodeEditorSaveRequest(
+                        rootURL: selection.rootURL,
+                        relativePath: selection.relativePath,
+                        editedText: document.currentText,
+                        snapshot: document.fileSnapshot
+                    )
+                )
+                await MainActor.run {
+                    guard case .loaded(var latestDocument) = state else { return }
+                    latestDocument.markSaved(snapshot: snapshot)
+                    state = .loaded(latestDocument)
+                    isSaving = false
+                    saveStatusMessage = "Saved"
+                    onSaved()
+                }
+            } catch {
+                await MainActor.run {
+                    isSaving = false
+                    saveErrorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                }
+            }
+        }
     }
 }
 
@@ -254,11 +335,12 @@ enum CodeEditorEditability: Equatable {
 }
 
 struct CodeEditorDocument: Equatable {
-    let originalText: String
+    var originalText: String
     var currentText: String
     let language: CodeSyntaxLanguage
     let spans: [HighlightSpan]
     let editability: CodeEditorEditability
+    var fileSnapshot: CodeEditorFileSnapshot?
 
     init(payload: CodePreviewPayload) {
         originalText = payload.text
@@ -266,6 +348,7 @@ struct CodeEditorDocument: Equatable {
         language = payload.language
         spans = payload.spans
         editability = Self.editability(for: payload)
+        fileSnapshot = payload.fileSnapshot
     }
 
     var canEdit: Bool {
@@ -278,6 +361,10 @@ struct CodeEditorDocument: Equatable {
 
     var isDirty: Bool {
         currentText != originalText
+    }
+
+    var canSave: Bool {
+        canEdit && isDirty && fileSnapshot != nil
     }
 
     var readOnlyReason: String? {
@@ -303,7 +390,15 @@ struct CodeEditorDocument: Equatable {
         )
     }
 
+    mutating func markSaved(snapshot: CodeEditorFileSnapshot) {
+        originalText = currentText
+        fileSnapshot = snapshot
+    }
+
     private static func editability(for payload: CodePreviewPayload) -> CodeEditorEditability {
+        if let readOnlyReason = payload.readOnlyReason {
+            return .readOnly(readOnlyReason)
+        }
         if payload.isTruncated {
             return .readOnly(
                 "This file is too large for in-app editing. The preview is truncated; open externally to edit safely."

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -532,6 +532,7 @@ struct ContentView: View {
             defaultEditor: defaultEditorDescriptor,
             onOpenInDefaultEditor: openInDefaultEditor,
             onOpenInEditor: openInSelectedEditor,
+            onCodePreviewSaved: requestRightPaneRefreshAfterCodeSave,
             rightPaneStateStore: rightPaneStateStore,
             isRightPaneVisible: $viewState.isRightPaneVisible
         )
@@ -2553,6 +2554,15 @@ struct ContentView: View {
     }
 
     @MainActor
+    private func requestRightPaneRefreshAfterCodeSave() {
+        if let workspace = currentSelectedWorkspace {
+            rightPaneStateStore.state(for: workspace).requestRefresh()
+        } else if let repo = currentSelectedRepoForLanding ?? selectedRepoForInspector {
+            rightPaneStateStore.state(for: repo).requestRefresh()
+        }
+    }
+
+    @MainActor
     private func refreshSessionSwitcherSnapshotIfPresented() {
         guard viewState.isShowingSessionSwitcher else { return }
         presentedSessionSwitcherSnapshot = makeSessionSwitcherSnapshot()
@@ -2972,6 +2982,7 @@ struct MainTerminalDetailView: View {
     let defaultEditor: ExternalEditorDescriptor?
     let onOpenInDefaultEditor: () -> Void
     let onOpenInEditor: (ExternalEditorID) -> Void
+    let onCodePreviewSaved: () -> Void
     let rightPaneStateStore: RightPaneStateStore
     @Binding var isRightPaneVisible: Bool
 
@@ -3077,7 +3088,8 @@ struct MainTerminalDetailView: View {
                         editorOptions: availableEditors,
                         defaultEditor: defaultEditor,
                         onOpenInDefaultEditor: onOpenInDefaultEditor,
-                        onOpenInEditor: onOpenInEditor
+                        onOpenInEditor: onOpenInEditor,
+                        onSaved: onCodePreviewSaved
                     ) {
                         self.selectedCodePreview = nil
                         self.isTerminalPanelVisible = true
@@ -3093,7 +3105,8 @@ struct MainTerminalDetailView: View {
                     editorOptions: availableEditors,
                     defaultEditor: defaultEditor,
                     onOpenInDefaultEditor: onOpenInDefaultEditor,
-                    onOpenInEditor: onOpenInEditor
+                    onOpenInEditor: onOpenInEditor,
+                    onSaved: onCodePreviewSaved
                 ) {
                     self.selectedCodePreview = nil
                     self.isTerminalPanelVisible = true

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -86,6 +86,11 @@ final class RightPaneSessionState: ObservableObject {
     @Published var timelineLastRefresh: Date?
     @Published var expandedDirectoryPaths: Set<String> = []
     @Published var hasLoadedOnce = false
+    @Published var refreshRequestID = UUID()
+
+    func requestRefresh() {
+        refreshRequestID = UUID()
+    }
 }
 
 @MainActor
@@ -330,6 +335,10 @@ struct RightPaneView: View {
             if supportsFilesystemInspection, !state.hasLoadedOnce || state.fileTree == nil {
                 await refresh()
             }
+        }
+        .task(id: state.refreshRequestID) {
+            guard state.hasLoadedOnce else { return }
+            await refresh()
         }
         .task(id: timelineRefreshKey) {
             await refreshTimelineIfNeeded()

--- a/Tests/WorkspaceManagerAppTests/CodeEditorDocumentTests.swift
+++ b/Tests/WorkspaceManagerAppTests/CodeEditorDocumentTests.swift
@@ -54,6 +54,34 @@ struct CodeEditorDocumentTests {
         #expect(document.currentText == "after\n")
     }
 
+    @Test("Loaded UTF-8 files can save once dirty")
+    func loadedUTF8FilesCanSaveOnceDirty() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("note.txt")
+        try Data("before\n".utf8).write(to: fileURL)
+
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        var document = CodeEditorDocument(payload: payload)
+        document.currentText = "after\n"
+
+        #expect(document.canSave)
+
+        let savedSnapshot = try CodeEditorSaveService.saveSynchronously(
+            CodeEditorSaveRequest(
+                rootURL: directory,
+                relativePath: "note.txt",
+                editedText: document.currentText,
+                snapshot: document.fileSnapshot
+            )
+        )
+        document.markSaved(snapshot: savedSnapshot)
+
+        #expect(!document.isDirty)
+        #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "after\n")
+    }
+
     @Test("Truncated files are read-only")
     func truncatedFilesAreReadOnly() {
         let payload = CodePreviewPayload(
@@ -83,6 +111,7 @@ struct CodeEditorDocumentTests {
 
         #expect(payload.isTruncated)
         #expect(!document.canEdit)
+        #expect(!document.canSave)
     }
 
     @Test("Loader rejects unsupported text encoding")
@@ -99,6 +128,148 @@ struct CodeEditorDocumentTests {
         } catch let error as CodePreviewError {
             #expect(error == .unsupportedEncoding)
         }
+    }
+
+    @Test("Save preserves CRLF line endings, trailing newline state, and mode bits")
+    func savePreservesCRLFLineEndingsTrailingNewlineStateAndModeBits() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("script.txt")
+        try Data("one\r\ntwo".utf8).write(to: fileURL)
+        try FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: fileURL.path)
+
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        let snapshot = try CodeEditorSaveService.saveSynchronously(
+            CodeEditorSaveRequest(
+                rootURL: directory,
+                relativePath: "script.txt",
+                editedText: "one\ntwo\nthree",
+                snapshot: payload.fileSnapshot
+            )
+        )
+
+        #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "one\r\ntwo\r\nthree")
+        #expect(snapshot.posixMode & 0o777 == 0o755)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        #expect(mode & 0o777 == 0o755)
+    }
+
+    @Test("Save refuses changed-on-disk files")
+    func saveRefusesChangedOnDiskFiles() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("conflict.txt")
+        try Data("original\n".utf8).write(to: fileURL)
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        try Data("external\n".utf8).write(to: fileURL)
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "conflict.txt",
+                    editedText: "editor\n",
+                    snapshot: payload.fileSnapshot
+                )
+            )
+            Issue.record("Expected changed-on-disk refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .changedOnDisk)
+        }
+
+        #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "external\n")
+    }
+
+    @Test("Save refuses relative path escapes")
+    func saveRefusesRelativePathEscapes() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("inside.txt")
+        try Data("inside\n".utf8).write(to: fileURL)
+        let snapshot = try CodeEditorFileSnapshot.make(fileURL: fileURL, data: Data("inside\n".utf8))
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "../outside.txt",
+                    editedText: "escape\n",
+                    snapshot: snapshot
+                )
+            )
+            Issue.record("Expected path escape refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .invalidRelativePath)
+        }
+    }
+
+    @Test("Save refuses symlink targets")
+    func saveRefusesSymlinkTargets() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let targetURL = directory.appendingPathComponent("target.txt")
+        let linkURL = directory.appendingPathComponent("link.txt")
+        try Data("target\n".utf8).write(to: targetURL)
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let payload = try await CodePreviewLoader.load(fileURL: linkURL)
+        let document = CodeEditorDocument(payload: payload)
+        #expect(!document.canEdit)
+        #expect(document.readOnlyReason?.contains("Symbolic links") == true)
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "link.txt",
+                    editedText: "editor\n",
+                    snapshot: payload.fileSnapshot
+                )
+            )
+            Issue.record("Expected symlink refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .symlinkRefused)
+        }
+
+        #expect(String(data: try Data(contentsOf: targetURL), encoding: .utf8) == "target\n")
+    }
+
+    @Test("Save refuses symlink parent escapes")
+    func saveRefusesSymlinkParentEscapes() throws {
+        let directory = try temporaryDirectory()
+        let outsideDirectory = try temporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        let linkDirectory = directory.appendingPathComponent("linked")
+        let outsideFileURL = outsideDirectory.appendingPathComponent("outside.txt")
+        try Data("outside\n".utf8).write(to: outsideFileURL)
+        try FileManager.default.createSymbolicLink(at: linkDirectory, withDestinationURL: outsideDirectory)
+        let snapshot = try CodeEditorFileSnapshot.make(fileURL: outsideFileURL, data: Data("outside\n".utf8))
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "linked/outside.txt",
+                    editedText: "escape\n",
+                    snapshot: snapshot
+                )
+            )
+            Issue.record("Expected resolved path escape refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .pathEscapesRoot)
+        }
+
+        #expect(String(data: try Data(contentsOf: outsideFileURL), encoding: .utf8) == "outside\n")
     }
 
     private func temporaryDirectory() throws -> URL {


### PR DESCRIPTION
## Summary

- Add a native editor save-safety service for guarded local text writes.
- Capture load-time file snapshots and refuse unsafe saves for path escapes, symlink targets, changed-on-disk files, and missing safety metadata.
- Enable the editor Save button for dirty, safely loaded files and refresh the Files/Changes pane after successful saves.
- Extend focused editor tests for UTF-8 save, CRLF/trailing-newline and mode preservation, changed-on-disk refusal, path escape refusal, symlink refusal, and truncated/unsupported file behavior.

## Mergeability

- Surface: desktop
- User-facing behavior changed: supported local text files can now be saved from the native editor with inline success/error status; symlink files are read-only in the native editor.
- Non-happy paths considered: root escape, symlink target, symlink parent escape, changed-on-disk drift, unsupported encoding, truncated files, mode preservation, and CRLF/trailing-newline preservation.
- Release/ops preconditions: none.
- Residual risk or follow-up: Cmd-S focus-aware command ownership, dirty navigation prompts, and native diff review remain follow-up #704 slices. Pierre/#706 remains deferred.

## Validation

- [x] `swift build` (covered by `swift test` build step)
- [x] `swift test`
- [x] Other checks run: `./scripts/build-ghosttykit.sh`; `swift test --filter CodeEditorDocumentTests`; `mise run lint`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Validation summary: https://evidence.cloudcompute.com/workspaces/pr-719/20260701-065122-native-editor-save-safety-validation.svg
- UI capture blocker: https://evidence.cloudcompute.com/workspaces/pr-719/20260701-065122-native-editor-save-safety-ui-capture-blocked.svg

## Blockers

- [ ] None
- [x] Blocked on evidence

UI fixture launch succeeded and found a visible debug window, but `capture-window.sh` repeatedly failed with
`could not create image from window`; the fullscreen fallback was black. The script reported likely macOS Screen
Recording permission for Terminal/Codex. The debug app process was no longer running after the failed capture attempt.
