### PR TITLE
[codex] harden native editor save path

### DIFF
--- a/Sources/WorkspaceManager/Services/CodeEditorSaveService.swift
+++ b/Sources/WorkspaceManager/Services/CodeEditorSaveService.swift
@@ -1,0 +1,234 @@
+//
+//  CodeEditorSaveService.swift
+//  WorkspaceManager
+//
+//  Safe disk-write pipeline for the native small-file editor.
+//
+
+import Darwin
+import Foundation
+
+enum CodeEditorLineEndingStyle: Equatable, Sendable {
+    case lf
+    case crlf
+    case cr
+    case mixed
+
+    init(text: String) {
+        let bytes = Array(text.utf8)
+        var index = 0
+        var sawLF = false
+        var sawCRLF = false
+        var sawCR = false
+
+        while index < bytes.count {
+            let byte = bytes[index]
+            if byte == 0x0D {
+                let nextIndex = index + 1
+                if nextIndex < bytes.count, bytes[nextIndex] == 0x0A {
+                    sawCRLF = true
+                    index += 2
+                } else {
+                    sawCR = true
+                    index += 1
+                }
+            } else if byte == 0x0A {
+                sawLF = true
+                index += 1
+            } else {
+                index += 1
+            }
+        }
+
+        switch (sawLF, sawCRLF, sawCR) {
+        case (false, true, false):
+            self = .crlf
+        case (false, false, true):
+            self = .cr
+        case (false, false, false), (true, false, false):
+            self = .lf
+        default:
+            self = .mixed
+        }
+    }
+}
+
+struct CodeEditorFileSnapshot: Equatable, Sendable {
+    let byteCount: Int
+    let contentHash: UInt64
+    let posixMode: Int
+    let lineEndingStyle: CodeEditorLineEndingStyle
+
+    static func make(fileURL: URL, data: Data) throws -> CodeEditorFileSnapshot {
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o644
+        let text = String(decoding: data, as: UTF8.self)
+        return CodeEditorFileSnapshot(
+            byteCount: data.count,
+            contentHash: stableContentHash(data),
+            posixMode: mode,
+            lineEndingStyle: CodeEditorLineEndingStyle(text: text)
+        )
+    }
+
+    func matches(fileURL: URL, data: Data) throws -> Bool {
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o644
+        return byteCount == data.count
+            && contentHash == Self.stableContentHash(data)
+            && posixMode == mode
+    }
+
+    private static func stableContentHash(_ data: Data) -> UInt64 {
+        data.reduce(0xcbf2_9ce4_8422_2325) { hash, byte in
+            (hash ^ UInt64(byte)) &* 0x0100_0000_01b3
+        }
+    }
+}
+
+struct CodeEditorSaveRequest: Sendable {
+    let rootURL: URL
+    let relativePath: String
+    let editedText: String
+    let snapshot: CodeEditorFileSnapshot?
+}
+
+enum CodeEditorSaveError: LocalizedError, Equatable {
+    case missingSnapshot
+    case invalidRelativePath
+    case pathEscapesRoot
+    case symlinkRefused
+    case changedOnDisk
+    case readFailed(String)
+    case writeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSnapshot:
+            return "Save is unavailable because this file was not loaded with a safety snapshot."
+        case .invalidRelativePath:
+            return "Save refused because the selected path is not a relative file path."
+        case .pathEscapesRoot:
+            return "Save refused because the selected path resolves outside the workspace root."
+        case .symlinkRefused:
+            return "Save refused because the selected file is a symbolic link."
+        case .changedOnDisk:
+            return "This file changed on disk. Reload it before saving so you do not overwrite newer changes."
+        case .readFailed(let message):
+            return "Could not read the latest file contents before saving: \(message)"
+        case .writeFailed(let message):
+            return "Could not save this file: \(message)"
+        }
+    }
+}
+
+enum CodeEditorSaveService {
+    static func save(_ request: CodeEditorSaveRequest) async throws -> CodeEditorFileSnapshot {
+        try await Task.detached(priority: .userInitiated) {
+            try saveSynchronously(request)
+        }
+        .value
+    }
+
+    static func saveSynchronously(_ request: CodeEditorSaveRequest) throws -> CodeEditorFileSnapshot {
+        guard let snapshot = request.snapshot else {
+            throw CodeEditorSaveError.missingSnapshot
+        }
+
+        let lexicalTargetURL = try lexicalFileURL(rootURL: request.rootURL, relativePath: request.relativePath)
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: lexicalTargetURL.path)) == nil else {
+            throw CodeEditorSaveError.symlinkRefused
+        }
+
+        let targetURL = try containedFileURL(rootURL: request.rootURL, relativePath: request.relativePath)
+
+        let currentData: Data
+        do {
+            currentData = try Data(contentsOf: targetURL)
+        } catch {
+            throw CodeEditorSaveError.readFailed(error.localizedDescription)
+        }
+
+        guard try snapshot.matches(fileURL: targetURL, data: currentData) else {
+            throw CodeEditorSaveError.changedOnDisk
+        }
+
+        let replacementData = normalizedData(
+            from: request.editedText,
+            lineEndingStyle: snapshot.lineEndingStyle
+        )
+
+        let temporaryURL =
+            targetURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(targetURL.lastPathComponent).workspaces-save-\(UUID().uuidString).tmp")
+
+        do {
+            try replacementData.write(to: temporaryURL)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: snapshot.posixMode)],
+                ofItemAtPath: temporaryURL.path
+            )
+
+            guard Darwin.rename(temporaryURL.path, targetURL.path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+
+            let savedData = try Data(contentsOf: targetURL)
+            return try CodeEditorFileSnapshot.make(fileURL: targetURL, data: savedData)
+        } catch let error as CodeEditorSaveError {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw error
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            throw CodeEditorSaveError.writeFailed(error.localizedDescription)
+        }
+    }
+
+    static func containedFileURL(rootURL: URL, relativePath: String) throws -> URL {
+        let lexicalTarget = try lexicalFileURL(rootURL: rootURL, relativePath: relativePath)
+
+        let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+        let target = lexicalTarget.resolvingSymlinksInPath()
+
+        guard target.path == root.path || target.path.hasPrefix(root.path + "/") else {
+            throw CodeEditorSaveError.pathEscapesRoot
+        }
+
+        return target
+    }
+
+    private static func lexicalFileURL(rootURL: URL, relativePath: String) throws -> URL {
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        guard !relativePath.isEmpty,
+            !relativePath.hasPrefix("/"),
+            components.allSatisfy({ !$0.isEmpty && $0 != ".." && $0 != "." })
+        else {
+            throw CodeEditorSaveError.invalidRelativePath
+        }
+
+        return rootURL.appendingPathComponent(relativePath).standardizedFileURL
+    }
+
+    private static func normalizedData(from text: String, lineEndingStyle: CodeEditorLineEndingStyle) -> Data {
+        let outputText: String
+        switch lineEndingStyle {
+        case .lf, .mixed:
+            outputText = text
+        case .crlf:
+            let normalized =
+                text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            outputText = normalized.replacingOccurrences(of: "\n", with: "\r\n")
+        case .cr:
+            let normalized =
+                text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            outputText = normalized.replacingOccurrences(of: "\n", with: "\r")
+        }
+
+        return Data(outputText.utf8)
+    }
+}

--- a/Sources/WorkspaceManager/Services/FilePreviewService.swift
+++ b/Sources/WorkspaceManager/Services/FilePreviewService.swift
@@ -22,6 +22,24 @@ struct CodePreviewPayload: Sendable {
     let language: CodeSyntaxLanguage
     let spans: [HighlightSpan]
     let isTruncated: Bool
+    let fileSnapshot: CodeEditorFileSnapshot?
+    let readOnlyReason: String?
+
+    init(
+        text: String,
+        language: CodeSyntaxLanguage,
+        spans: [HighlightSpan],
+        isTruncated: Bool,
+        fileSnapshot: CodeEditorFileSnapshot? = nil,
+        readOnlyReason: String? = nil
+    ) {
+        self.text = text
+        self.language = language
+        self.spans = spans
+        self.isTruncated = isTruncated
+        self.fileSnapshot = fileSnapshot
+        self.readOnlyReason = readOnlyReason
+    }
 }
 
 enum CodePreviewLoader {
@@ -56,6 +74,14 @@ enum CodePreviewLoader {
                 language: language,
                 maxCharacters: maxHighlightCharacters
             )
+            let snapshot = isTruncated ? nil : try CodeEditorFileSnapshot.make(fileURL: fileURL, data: data)
+            let readOnlyReason: String?
+            if (try? FileManager.default.destinationOfSymbolicLink(atPath: fileURL.path)) != nil {
+                readOnlyReason =
+                    "Symbolic links are read-only in the native editor. Open externally to edit deliberately."
+            } else {
+                readOnlyReason = nil
+            }
             CodePreviewDiagnostics.log(
                 "load complete file=\(fileURL.path) chars=\(text.count) spans=\(spans.count) truncated=\(isTruncated)"
             )
@@ -64,7 +90,9 @@ enum CodePreviewLoader {
                 text: text,
                 language: language,
                 spans: spans,
-                isTruncated: isTruncated
+                isTruncated: isTruncated,
+                fileSnapshot: snapshot,
+                readOnlyReason: readOnlyReason
             )
         }
         .value

--- a/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
@@ -33,6 +33,7 @@ struct CodeFilePreviewView: View {
     let defaultEditor: ExternalEditorDescriptor?
     let onOpenInDefaultEditor: () -> Void
     let onOpenInEditor: (ExternalEditorID) -> Void
+    var onSaved: () -> Void = {}
     let onClose: () -> Void
 
     @State private var state: LoadState = .loading
@@ -269,7 +270,7 @@ struct CodeFilePreviewView: View {
     }
 
     private var canSaveDocument: Bool {
-        isDirty && !isSaving && loadedDocument?.canEdit == true
+        !isSaving && loadedDocument?.canSave == true
     }
 
     private var currentTextBinding: Binding<String> {
@@ -294,29 +295,45 @@ struct CodeFilePreviewView: View {
     }
 
     private func triggerSave() {
-        Task { @MainActor in
-            saveCurrentDocument()
+        Task {
+            await saveCurrentDocument()
         }
     }
 
     @MainActor
-    private func saveCurrentDocument() {
-        guard canSaveDocument, case .loaded(var document) = state else { return }
+    private func saveCurrentDocument() async {
+        guard canSaveDocument, case .loaded(let document) = state else { return }
+        let savedText = document.currentText
 
         isSaving = true
         saveErrorMessage = nil
-        defer {
-            isSaving = false
-            syncSaveCommand()
-        }
+        var didSave = false
 
         do {
-            try document.save(to: selection.fileURL)
-            state = .loaded(document)
+            let snapshot = try await CodeEditorSaveService.save(
+                CodeEditorSaveRequest(
+                    rootURL: selection.rootURL,
+                    relativePath: selection.relativePath,
+                    editedText: savedText,
+                    snapshot: document.fileSnapshot
+                )
+            )
+            if case .loaded(var latestDocument) = state {
+                latestDocument.markSaved(text: savedText, snapshot: snapshot)
+                state = .loaded(latestDocument)
+                didSave = true
+            }
         } catch let error as CodeEditorSaveError {
             saveErrorMessage = error.errorDescription
         } catch {
             saveErrorMessage = error.localizedDescription
+        }
+
+        isSaving = false
+        syncSaveCommand()
+
+        if didSave {
+            onSaved()
         }
     }
 
@@ -341,6 +358,7 @@ struct CodeEditorDocument: Equatable, Sendable {
     let language: CodeSyntaxLanguage
     let spans: [HighlightSpan]
     let editability: CodeEditorEditability
+    private(set) var fileSnapshot: CodeEditorFileSnapshot?
 
     init(payload: CodePreviewPayload) {
         originalText = payload.text
@@ -348,6 +366,7 @@ struct CodeEditorDocument: Equatable, Sendable {
         language = payload.language
         spans = payload.spans
         editability = Self.editability(for: payload)
+        fileSnapshot = payload.fileSnapshot
     }
 
     var canEdit: Bool {
@@ -360,6 +379,10 @@ struct CodeEditorDocument: Equatable, Sendable {
 
     var isDirty: Bool {
         currentText != originalText
+    }
+
+    var canSave: Bool {
+        canEdit && isDirty && fileSnapshot != nil
     }
 
     var readOnlyReason: String? {
@@ -385,58 +408,33 @@ struct CodeEditorDocument: Equatable, Sendable {
         )
     }
 
-    mutating func save(to fileURL: URL) throws {
-        let data: Data
-        do {
-            data = try Data(contentsOf: fileURL)
-        } catch {
-            throw CodeEditorSaveError.readFailed(error.localizedDescription)
-        }
+    mutating func markSaved(text savedText: String? = nil, snapshot: CodeEditorFileSnapshot) {
+        originalText = savedText ?? currentText
+        fileSnapshot = snapshot
+    }
 
-        guard let diskText = String(data: data, encoding: .utf8) else {
-            throw CodeEditorSaveError.unsupportedEncoding
-        }
-
-        guard diskText == originalText else {
-            throw CodeEditorSaveError.changedOnDisk
-        }
-
-        do {
-            try Data(currentText.utf8).write(to: fileURL, options: .atomic)
-        } catch {
-            throw CodeEditorSaveError.writeFailed(error.localizedDescription)
-        }
-
-        originalText = currentText
+    mutating func save(rootURL: URL, relativePath: String) throws {
+        let snapshot = try CodeEditorSaveService.saveSynchronously(
+            CodeEditorSaveRequest(
+                rootURL: rootURL,
+                relativePath: relativePath,
+                editedText: currentText,
+                snapshot: fileSnapshot
+            )
+        )
+        markSaved(snapshot: snapshot)
     }
 
     private static func editability(for payload: CodePreviewPayload) -> CodeEditorEditability {
+        if let readOnlyReason = payload.readOnlyReason {
+            return .readOnly(readOnlyReason)
+        }
         if payload.isTruncated {
             return .readOnly(
                 "This file is too large for in-app editing. The preview is truncated; open externally to edit safely."
             )
         }
         return .editable
-    }
-}
-
-enum CodeEditorSaveError: LocalizedError, Equatable {
-    case unsupportedEncoding
-    case changedOnDisk
-    case readFailed(String)
-    case writeFailed(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .unsupportedEncoding:
-            return "This file is no longer UTF-8 text. Reload it before saving."
-        case .changedOnDisk:
-            return "This file changed on disk. Reload it before saving so you do not overwrite newer changes."
-        case .readFailed(let message):
-            return "Could not read the latest file contents before saving: \(message)"
-        case .writeFailed(let message):
-            return "Could not save this file: \(message)"
-        }
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -534,6 +534,7 @@ struct ContentView: View {
             defaultEditor: defaultEditorDescriptor,
             onOpenInDefaultEditor: openInDefaultEditor,
             onOpenInEditor: openInSelectedEditor,
+            onCodePreviewSaved: requestRightPaneRefreshAfterCodeSave,
             rightPaneStateStore: rightPaneStateStore,
             isRightPaneVisible: $viewState.isRightPaneVisible
         )
@@ -2580,6 +2581,15 @@ struct ContentView: View {
     }
 
     @MainActor
+    private func requestRightPaneRefreshAfterCodeSave() {
+        if let workspace = currentSelectedWorkspace {
+            rightPaneStateStore.state(for: workspace).requestRefresh()
+        } else if let repo = currentSelectedRepoForLanding ?? selectedRepoForInspector {
+            rightPaneStateStore.state(for: repo).requestRefresh()
+        }
+    }
+
+    @MainActor
     private func refreshSessionSwitcherSnapshotIfPresented() {
         guard viewState.isShowingSessionSwitcher else { return }
         presentedSessionSwitcherSnapshot = makeSessionSwitcherSnapshot()
@@ -3001,6 +3011,7 @@ struct MainTerminalDetailView: View {
     let defaultEditor: ExternalEditorDescriptor?
     let onOpenInDefaultEditor: () -> Void
     let onOpenInEditor: (ExternalEditorID) -> Void
+    let onCodePreviewSaved: () -> Void
     let rightPaneStateStore: RightPaneStateStore
     @Binding var isRightPaneVisible: Bool
 
@@ -3107,7 +3118,8 @@ struct MainTerminalDetailView: View {
                         editorOptions: availableEditors,
                         defaultEditor: defaultEditor,
                         onOpenInDefaultEditor: onOpenInDefaultEditor,
-                        onOpenInEditor: onOpenInEditor
+                        onOpenInEditor: onOpenInEditor,
+                        onSaved: onCodePreviewSaved
                     ) {
                         self.selectedCodePreview = nil
                         self.isTerminalPanelVisible = true
@@ -3124,7 +3136,8 @@ struct MainTerminalDetailView: View {
                     editorOptions: availableEditors,
                     defaultEditor: defaultEditor,
                     onOpenInDefaultEditor: onOpenInDefaultEditor,
-                    onOpenInEditor: onOpenInEditor
+                    onOpenInEditor: onOpenInEditor,
+                    onSaved: onCodePreviewSaved
                 ) {
                     self.selectedCodePreview = nil
                     self.isTerminalPanelVisible = true

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -86,6 +86,11 @@ final class RightPaneSessionState: ObservableObject {
     @Published var timelineLastRefresh: Date?
     @Published var expandedDirectoryPaths: Set<String> = []
     @Published var hasLoadedOnce = false
+    @Published var refreshRequestID = UUID()
+
+    func requestRefresh() {
+        refreshRequestID = UUID()
+    }
 }
 
 @MainActor
@@ -330,6 +335,10 @@ struct RightPaneView: View {
             if supportsFilesystemInspection, !state.hasLoadedOnce || state.fileTree == nil {
                 await refresh()
             }
+        }
+        .task(id: state.refreshRequestID) {
+            guard state.hasLoadedOnce else { return }
+            await refresh()
         }
         .task(id: timelineRefreshKey) {
             await refreshTimelineIfNeeded()

--- a/Tests/WorkspaceManagerAppTests/CodeEditorDocumentTests.swift
+++ b/Tests/WorkspaceManagerAppTests/CodeEditorDocumentTests.swift
@@ -55,24 +55,20 @@ struct CodeEditorDocumentTests {
     }
 
     @Test("Saving writes UTF-8 text and clears dirty state")
-    func savingWritesTextAndClearsDirtyState() throws {
+    func savingWritesTextAndClearsDirtyState() async throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let fileURL = directory.appendingPathComponent("notes.md")
         try Data("before\n".utf8).write(to: fileURL)
 
-        var document = CodeEditorDocument(
-            payload: CodePreviewPayload(
-                text: "before\n",
-                language: .markdown,
-                spans: [],
-                isTruncated: false
-            )
-        )
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        var document = CodeEditorDocument(payload: payload)
         document.currentText = "after\n"
 
-        try document.save(to: fileURL)
+        #expect(document.canSave)
+
+        try document.save(rootURL: directory, relativePath: "notes.md")
 
         #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "after\n")
         #expect(!document.isDirty)
@@ -80,26 +76,20 @@ struct CodeEditorDocumentTests {
     }
 
     @Test("Saving refuses to overwrite files changed on disk")
-    func savingRefusesStaleDiskContents() throws {
+    func savingRefusesStaleDiskContents() async throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let fileURL = directory.appendingPathComponent("notes.md")
         try Data("before\n".utf8).write(to: fileURL)
 
-        var document = CodeEditorDocument(
-            payload: CodePreviewPayload(
-                text: "before\n",
-                language: .markdown,
-                spans: [],
-                isTruncated: false
-            )
-        )
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        var document = CodeEditorDocument(payload: payload)
         document.currentText = "after\n"
         try Data("external\n".utf8).write(to: fileURL)
 
         do {
-            try document.save(to: fileURL)
+            try document.save(rootURL: directory, relativePath: "notes.md")
             Issue.record("Expected changed-on-disk save error")
         } catch let error as CodeEditorSaveError {
             #expect(error == .changedOnDisk)
@@ -138,6 +128,7 @@ struct CodeEditorDocumentTests {
 
         #expect(payload.isTruncated)
         #expect(!document.canEdit)
+        #expect(!document.canSave)
     }
 
     @Test("Loader rejects unsupported text encoding")
@@ -154,6 +145,152 @@ struct CodeEditorDocumentTests {
         } catch let error as CodePreviewError {
             #expect(error == .unsupportedEncoding)
         }
+    }
+
+    @Test("Save preserves CRLF line endings, trailing newline state, and mode bits")
+    func savePreservesCRLFLineEndingsTrailingNewlineStateAndModeBits() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("script.txt")
+        try Data("one\r\ntwo".utf8).write(to: fileURL)
+        try FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: fileURL.path)
+
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        let snapshot = try CodeEditorSaveService.saveSynchronously(
+            CodeEditorSaveRequest(
+                rootURL: directory,
+                relativePath: "script.txt",
+                editedText: "one\ntwo\nthree",
+                snapshot: payload.fileSnapshot
+            )
+        )
+
+        #expect(String(data: try Data(contentsOf: fileURL), encoding: .utf8) == "one\r\ntwo\r\nthree")
+        #expect(snapshot.posixMode & 0o777 == 0o755)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mode = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        #expect(mode & 0o777 == 0o755)
+    }
+
+    @Test("Saved baseline updates without discarding newer in-memory edits")
+    func savedBaselineUpdatesWithoutDiscardingNewerInMemoryEdits() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("notes.md")
+        try Data("before\n".utf8).write(to: fileURL)
+
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+        var document = CodeEditorDocument(payload: payload)
+        let savedText = "saved\n"
+        document.currentText = savedText
+
+        let snapshot = try CodeEditorSaveService.saveSynchronously(
+            CodeEditorSaveRequest(
+                rootURL: directory,
+                relativePath: "notes.md",
+                editedText: savedText,
+                snapshot: document.fileSnapshot
+            )
+        )
+
+        document.currentText = "newer\n"
+        document.markSaved(text: savedText, snapshot: snapshot)
+
+        #expect(document.originalText == savedText)
+        #expect(document.currentText == "newer\n")
+        #expect(document.isDirty)
+    }
+
+    @Test("Save refuses relative path escapes")
+    func saveRefusesRelativePathEscapes() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("inside.txt")
+        try Data("inside\n".utf8).write(to: fileURL)
+        let payload = try await CodePreviewLoader.load(fileURL: fileURL)
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "../outside.txt",
+                    editedText: "escape\n",
+                    snapshot: payload.fileSnapshot
+                )
+            )
+            Issue.record("Expected path escape refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .invalidRelativePath)
+        }
+    }
+
+    @Test("Save refuses symlink targets")
+    func saveRefusesSymlinkTargets() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let targetURL = directory.appendingPathComponent("target.txt")
+        let linkURL = directory.appendingPathComponent("link.txt")
+        try Data("target\n".utf8).write(to: targetURL)
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: targetURL)
+
+        let payload = try await CodePreviewLoader.load(fileURL: linkURL)
+        let document = CodeEditorDocument(payload: payload)
+        #expect(!document.canEdit)
+        #expect(!document.canSave)
+        #expect(document.readOnlyReason?.contains("Symbolic links") == true)
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "link.txt",
+                    editedText: "editor\n",
+                    snapshot: payload.fileSnapshot
+                )
+            )
+            Issue.record("Expected symlink refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .symlinkRefused)
+        }
+
+        #expect(String(data: try Data(contentsOf: targetURL), encoding: .utf8) == "target\n")
+    }
+
+    @Test("Save refuses symlink parent escapes")
+    func saveRefusesSymlinkParentEscapes() async throws {
+        let directory = try temporaryDirectory()
+        let outsideDirectory = try temporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+            try? FileManager.default.removeItem(at: outsideDirectory)
+        }
+
+        let linkDirectory = directory.appendingPathComponent("linked")
+        let outsideFileURL = outsideDirectory.appendingPathComponent("outside.txt")
+        try Data("outside\n".utf8).write(to: outsideFileURL)
+        try FileManager.default.createSymbolicLink(at: linkDirectory, withDestinationURL: outsideDirectory)
+        let snapshot = try CodeEditorFileSnapshot.make(fileURL: outsideFileURL, data: Data("outside\n".utf8))
+
+        do {
+            _ = try CodeEditorSaveService.saveSynchronously(
+                CodeEditorSaveRequest(
+                    rootURL: directory,
+                    relativePath: "linked/outside.txt",
+                    editedText: "escape\n",
+                    snapshot: snapshot
+                )
+            )
+            Issue.record("Expected resolved path escape refusal")
+        } catch let error as CodeEditorSaveError {
+            #expect(error == .pathEscapesRoot)
+        }
+
+        #expect(String(data: try Data(contentsOf: outsideFileURL), encoding: .utf8) == "outside\n")
     }
 
     private func temporaryDirectory() throws -> URL {


### PR DESCRIPTION
## Summary

Supersedes the still-open draft #719 with a current-main follow-up after #713 and #717.

- Adds a narrow `CodeEditorSaveService` for the existing native editor save path.
- Refuses unsafe save targets: missing load snapshot, invalid relative path traversal, paths resolving outside the workspace root, direct symlink targets, and changed-on-disk files.
- Preserves original line-ending style and POSIX mode bits while keeping the existing atomic write behavior.
- Refreshes the right pane Files/Changes data after a successful in-pane/Cmd-S/File > Save.
- Adds focused save-safety coverage for stale disk state, symlinks, path traversal, CRLF/trailing newline behavior, mode preservation, and async save baseline handling.

## Mergeability

- Surface: desktop
- User-facing behavior changed: Native editor saves now refuse stale or unsafe destinations and refresh the right-pane Files/Changes data after a successful save; normal in-pane and Cmd-S save behavior remains intact.
- Non-happy paths considered: Missing load snapshots, changed-on-disk files, relative path traversal, direct symlink targets, symlink parent escapes, files outside the workspace root, CRLF/trailing newline preservation, and POSIX mode preservation are covered by focused tests.
- Release/ops preconditions: None.
- Residual risk or follow-up: This intentionally does not add new status UI beyond the existing #717 save error surface. Close #719 as superseded after this replacement lands; keep #706 as the deferred enhanced diff-review surface.

## Not Ported From #719

- Did not replace #717's save UI or command plumbing with #719's older broader wiring.
- Did not add extra status messaging beyond the current #717 error surface.
- Did not close #719; close it separately once this replacement lands.

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab diff --check origin/main...HEAD`; `swift-format lint --strict --recursive Sources/ Tests/`; `swift test --filter CodeEditorDocument` (13 tests); post-rebase `swift test` passed with 1039 tests in 163 suites.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: N/A
- Before Summary: N/A
- After Summary: N/A
- Delta Summary: N/A

Performance comparison notes:

- Exact commands used: N/A
- Workload / environment context: N/A

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Initial validation: https://evidence.cloudcompute.com/workspaces/pr-720/20260701-143328-native-editor-save-safety.svg
- Post-rebase validation: https://evidence.cloudcompute.com/workspaces/pr-720/20260701-172804-native-editor-save-safety-post-rebase.svg

## Blockers

- [x] None
- [ ] Blocked on evidence
