### PR TITLE
Extract attention summary resolver to core

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,10 @@ _Avoid_: Ref, head, version
 The project-wide rollup of **Workspaces** or **Repositories** that currently demand the user — agents that are awaiting input or have errored. Drives the "N need you" toolbar indicator.
 _Avoid_: Notifications, alerts, warnings, tasks
 
+**Attention Summary**:
+The value-level presentation of **Attention** for a **Surface**: resolved **Repository** and **Workspace** names, reason text, badge, icon name, and error flag. Derived from **Attention** plus lightweight **Repository**/**Workspace** snapshots; platform views render it but do not decide which targets demand the user.
+_Avoid_: Notification row, alert item, task card
+
 ## Relationships
 
 - A **Repository** owns zero or more **Workspaces**.
@@ -95,6 +99,7 @@ _Avoid_: Notifications, alerts, warnings, tasks
 - **GitHub Activity** is external webhook activity and does not write to the **Workspace Journal**.
 - A **Terminal Session** observes its own **Terminal Command Status** independently of any **Agent** running inside it.
 - **Attention** rolls up across all **Workspaces** and **Repositories**; the rollup at any moment determines the toolbar indicator.
+- An **Attention Summary** is derived from **Attention** plus **Repository**/**Workspace** snapshots; it is portable across Mac and companion surfaces.
 
 ## Example Dialogue
 
@@ -108,3 +113,4 @@ _Avoid_: Notifications, alerts, warnings, tasks
 - "Event" without a scope was ambiguous between **Workspace Events** (agent state changes inside a workspace) and webhook events from external systems. Resolved: use **Workspace Event** for the in-app domain type; reserve "webhook event" (lowercased, qualified) for the external GitHub stream.
 - "Journal" vs "log" vs "history" — domain reads use **Workspace Journal**; "log" stays a runtime/diagnostic term; "history" is informal narration and shouldn't appear in types.
 - "Status" is overloaded — there is workspace **Agent** status, **Terminal Command Status**, and git status (file changes). Resolved: qualify every use; never ship a public `status:` property without a scope-revealing prefix.
+- "Attention" vs "Attention Summary" — **Attention** is the domain rollup of targets demanding the user; **Attention Summary** is the display-ready value projection of those targets for Mac or companion surfaces.

--- a/Sources/WorkspaceManager/Views/MainWindow/AttentionSummaryResolver.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AttentionSummaryResolver.swift
@@ -2,101 +2,37 @@
 //  AttentionSummaryResolver.swift
 //  WorkspaceManager
 //
-//  Turns agent attention targets into compact toolbar dropdown rows. Keeping
-//  this outside the SwiftUI view makes the summary text testable and lets the
-//  performance benchmark measure the same resolution path the toolbar uses.
+//  Adapts SwiftData repositories into the core Attention summary values used
+//  by the toolbar. The portable resolver lives in WorkspaceManagerCore so
+//  companion surfaces can reuse the same Attention language.
 //
 
-import Foundation
 import WorkspaceManagerCore
 
-struct AttentionSummaryItem: Identifiable, Equatable {
-    let id: String
-    let target: WorkspaceStatusAggregator.AttentionTarget
-    let title: String
-    let context: String
-    let detail: String
-    let badge: String
-    let systemImage: String
-    let isError: Bool
+extension AttentionWorkspaceSnapshot {
+    fileprivate init(workspace: Workspace) {
+        self.init(id: workspace.id, name: workspace.name)
+    }
 }
 
-struct AttentionSummaryResolver {
+extension AttentionRepositorySnapshot {
+    fileprivate init(repo: Repo) {
+        self.init(
+            id: repo.id,
+            name: repo.name,
+            workspaces: repo.workspaces.map(AttentionWorkspaceSnapshot.init(workspace:))
+        )
+    }
+}
+
+extension AttentionSummaryResolver {
     static func resolve(
         attentionItems: [WorkspaceStatusAggregator.AttentionItem],
         repos: [Repo]
     ) -> [AttentionSummaryItem] {
-        guard !attentionItems.isEmpty, !repos.isEmpty else { return [] }
-
-        var reposByID: [UUID: Repo] = [:]
-        reposByID.reserveCapacity(repos.count)
-        var workspacesByID: [UUID: (workspace: Workspace, repo: Repo)] = [:]
-
-        for repo in repos {
-            reposByID[repo.id] = repo
-            for workspace in repo.workspaces {
-                workspacesByID[workspace.id] = (workspace, repo)
-            }
-        }
-
-        return attentionItems.compactMap { item in
-            let presentation = presentation(for: item.run)
-            switch item.target {
-            case .workspace(let id):
-                guard let resolved = workspacesByID[id] else { return nil }
-                return AttentionSummaryItem(
-                    id: item.id,
-                    target: item.target,
-                    title: resolved.workspace.name,
-                    context: "\(resolved.repo.name) tab",
-                    detail: presentation.detail,
-                    badge: presentation.badge,
-                    systemImage: presentation.systemImage,
-                    isError: presentation.isError
-                )
-            case .repo(let id):
-                guard let repo = reposByID[id] else { return nil }
-                return AttentionSummaryItem(
-                    id: item.id,
-                    target: item.target,
-                    title: repo.name,
-                    context: "Repo tab",
-                    detail: presentation.detail,
-                    badge: presentation.badge,
-                    systemImage: presentation.systemImage,
-                    isError: presentation.isError
-                )
-            }
-        }
-    }
-
-    private static func presentation(
-        for run: AgentRunState
-    ) -> (badge: String, detail: String, systemImage: String, isError: Bool) {
-        switch run {
-        case .awaitingInput(let reason):
-            switch reason {
-            case .permissionPrompt:
-                return ("Permission", "Awaiting permission", "hand.raised.fill", false)
-            case .idlePrompt:
-                return ("Prompt", "Waiting for your reply", "text.bubble.fill", false)
-            case .custom:
-                return ("Input", "Waiting for input", "questionmark.bubble.fill", false)
-            }
-        case .errored(_, let message):
-            let detail = trimmed(message) ?? "Agent errored"
-            return ("Error", detail, "exclamationmark.triangle.fill", true)
-        case .idle, .thinking, .runningTool, .complete:
-            return ("Needs you", "Needs attention", "bell.badge.fill", false)
-        }
-    }
-
-    private static func trimmed(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedValue.isEmpty else { return nil }
-        if trimmedValue.count <= 72 { return trimmedValue }
-        let endIndex = trimmedValue.index(trimmedValue.startIndex, offsetBy: 69)
-        return "\(trimmedValue[..<endIndex])..."
+        resolve(
+            attentionItems: attentionItems,
+            repositories: repos.map(AttentionRepositorySnapshot.init(repo:))
+        )
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/AttentionSummaryResolver.swift
+++ b/Sources/WorkspaceManagerCore/Services/AttentionSummaryResolver.swift
@@ -1,0 +1,144 @@
+//
+//  AttentionSummaryResolver.swift
+//  WorkspaceManagerCore
+//
+//  Turns Attention items plus lightweight repository snapshots into portable
+//  summary rows. Platform views render these rows, but do not decide which
+//  Attention targets exist or how their agent states should read.
+//
+
+import Foundation
+
+public struct AttentionWorkspaceSnapshot: Equatable, Sendable {
+    public let id: UUID
+    public let name: String
+
+    public init(id: UUID, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+public struct AttentionRepositorySnapshot: Equatable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let workspaces: [AttentionWorkspaceSnapshot]
+
+    public init(id: UUID, name: String, workspaces: [AttentionWorkspaceSnapshot]) {
+        self.id = id
+        self.name = name
+        self.workspaces = workspaces
+    }
+}
+
+public struct AttentionSummaryItem: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let target: WorkspaceStatusAggregator.AttentionTarget
+    public let title: String
+    public let context: String
+    public let detail: String
+    public let badge: String
+    public let systemImage: String
+    public let isError: Bool
+
+    public init(
+        id: String,
+        target: WorkspaceStatusAggregator.AttentionTarget,
+        title: String,
+        context: String,
+        detail: String,
+        badge: String,
+        systemImage: String,
+        isError: Bool
+    ) {
+        self.id = id
+        self.target = target
+        self.title = title
+        self.context = context
+        self.detail = detail
+        self.badge = badge
+        self.systemImage = systemImage
+        self.isError = isError
+    }
+}
+
+public enum AttentionSummaryResolver {
+    public static func resolve(
+        attentionItems: [WorkspaceStatusAggregator.AttentionItem],
+        repositories: [AttentionRepositorySnapshot]
+    ) -> [AttentionSummaryItem] {
+        guard !attentionItems.isEmpty, !repositories.isEmpty else { return [] }
+
+        var repositoriesByID: [UUID: AttentionRepositorySnapshot] = [:]
+        repositoriesByID.reserveCapacity(repositories.count)
+        var workspacesByID: [UUID: (workspace: AttentionWorkspaceSnapshot, repository: AttentionRepositorySnapshot)] =
+            [:]
+
+        for repository in repositories {
+            repositoriesByID[repository.id] = repository
+            for workspace in repository.workspaces {
+                workspacesByID[workspace.id] = (workspace, repository)
+            }
+        }
+
+        return attentionItems.compactMap { item in
+            let presentation = presentation(for: item.run)
+            switch item.target {
+            case .workspace(let id):
+                guard let resolved = workspacesByID[id] else { return nil }
+                return AttentionSummaryItem(
+                    id: item.id,
+                    target: item.target,
+                    title: resolved.workspace.name,
+                    context: "\(resolved.repository.name) tab",
+                    detail: presentation.detail,
+                    badge: presentation.badge,
+                    systemImage: presentation.systemImage,
+                    isError: presentation.isError
+                )
+            case .repo(let id):
+                guard let repository = repositoriesByID[id] else { return nil }
+                return AttentionSummaryItem(
+                    id: item.id,
+                    target: item.target,
+                    title: repository.name,
+                    context: "Repo tab",
+                    detail: presentation.detail,
+                    badge: presentation.badge,
+                    systemImage: presentation.systemImage,
+                    isError: presentation.isError
+                )
+            }
+        }
+    }
+
+    private static func presentation(
+        for run: AgentRunState
+    ) -> (badge: String, detail: String, systemImage: String, isError: Bool) {
+        switch run {
+        case .awaitingInput(let reason):
+            switch reason {
+            case .permissionPrompt:
+                return ("Permission", "Awaiting permission", "hand.raised.fill", false)
+            case .idlePrompt:
+                return ("Prompt", "Waiting for your reply", "text.bubble.fill", false)
+            case .custom:
+                return ("Input", "Waiting for input", "questionmark.bubble.fill", false)
+            }
+        case .errored(_, let message):
+            let detail = trimmed(message) ?? "Agent errored"
+            return ("Error", detail, "exclamationmark.triangle.fill", true)
+        case .idle, .thinking, .runningTool, .complete:
+            return ("Needs you", "Needs attention", "bell.badge.fill", false)
+        }
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else { return nil }
+        if trimmedValue.count <= 72 { return trimmedValue }
+        let endIndex = trimmedValue.index(trimmedValue.startIndex, offsetBy: 69)
+        return "\(trimmedValue[..<endIndex])..."
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AttentionSummaryResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AttentionSummaryResolverTests.swift
@@ -10,10 +10,10 @@ import Testing
 @testable import WorkspaceManagerCore
 
 @MainActor
-@Suite("AttentionSummaryResolver")
-struct AttentionSummaryResolverTests {
-    @Test("Resolves workspace and repo attention rows")
-    func resolvesWorkspaceAndRepoRows() {
+@Suite("AttentionSummaryResolver Mac adapter")
+struct AttentionSummaryResolverAdapterTests {
+    @Test("Converts SwiftData repos into core attention snapshots")
+    func convertsSwiftDataReposIntoCoreSnapshots() {
         let repo = Repo(
             name: "workspaces",
             localPath: URL(fileURLWithPath: "/tmp/workspaces"),
@@ -51,74 +51,9 @@ struct AttentionSummaryResolverTests {
         #expect(rows[0].title == "notification-menu")
         #expect(rows[0].context == "workspaces tab")
         #expect(rows[0].badge == "Permission")
-        #expect(rows[0].isError == false)
         #expect(rows[1].title == "workspaces")
         #expect(rows[1].context == "Repo tab")
         #expect(rows[1].badge == "Error")
-        #expect(rows[1].detail == "merge failed")
-        #expect(rows[1].isError)
-    }
-
-    @Test("Skips stale attention targets")
-    func skipsStaleAttentionTargets() {
-        let repo = Repo(
-            name: "workspaces",
-            localPath: URL(fileURLWithPath: "/tmp/workspaces"),
-            lastAccessedAt: Date()
-        )
-
-        let rows = AttentionSummaryResolver.resolve(
-            attentionItems: [
-                .init(
-                    target: .workspace(UUID()),
-                    hostSessionID: UUID(),
-                    run: .awaitingInput(reason: .custom),
-                    lastEventAt: Date(),
-                    lastAccessedAt: Date()
-                )
-            ],
-            repos: [repo]
-        )
-
-        #expect(rows.isEmpty)
-    }
-
-    @Test("Resolved rows are the actionable count when stale targets are mixed in")
-    func resolvedRowsAreActionableCount() {
-        let repo = Repo(
-            name: "workspaces",
-            localPath: URL(fileURLWithPath: "/tmp/workspaces"),
-            lastAccessedAt: Date()
-        )
-        let workspace = Workspace(
-            name: "notification-menu",
-            path: URL(fileURLWithPath: "/tmp/workspaces/notification-menu"),
-            sourceRepo: repo,
-            lastAccessedAt: Date()
-        )
-        repo.workspaces = [workspace]
-
-        let rows = AttentionSummaryResolver.resolve(
-            attentionItems: [
-                .init(
-                    target: .workspace(workspace.id),
-                    hostSessionID: UUID(),
-                    run: .awaitingInput(reason: .permissionPrompt),
-                    lastEventAt: Date(),
-                    lastAccessedAt: Date()
-                ),
-                .init(
-                    target: .workspace(UUID()),
-                    hostSessionID: UUID(),
-                    run: .errored(category: .toolFailure, message: "stale session"),
-                    lastEventAt: Date(),
-                    lastAccessedAt: Date().addingTimeInterval(-30)
-                ),
-            ],
-            repos: [repo]
-        )
-
-        #expect(rows.count == 1)
         #expect(rows.first?.target == .workspace(workspace.id))
     }
 }

--- a/Tests/WorkspaceManagerTests/AttentionSummaryResolverTests.swift
+++ b/Tests/WorkspaceManagerTests/AttentionSummaryResolverTests.swift
@@ -1,0 +1,126 @@
+//
+//  AttentionSummaryResolverTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("AttentionSummaryResolver")
+struct AttentionSummaryResolverTests {
+    @Test("Resolves workspace and repo attention rows")
+    func resolvesWorkspaceAndRepoRows() {
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                item(
+                    target: .workspace(workspaceID),
+                    run: .awaitingInput(reason: .permissionPrompt)
+                ),
+                item(
+                    target: .repo(repoID),
+                    run: .errored(category: .toolFailure, message: "merge failed"),
+                    at: Date().addingTimeInterval(-30)
+                ),
+            ],
+            repositories: [
+                .init(
+                    id: repoID,
+                    name: "workspaces",
+                    workspaces: [.init(id: workspaceID, name: "notification-menu")]
+                )
+            ]
+        )
+
+        #expect(rows.count == 2)
+        #expect(rows[0].title == "notification-menu")
+        #expect(rows[0].context == "workspaces tab")
+        #expect(rows[0].badge == "Permission")
+        #expect(rows[0].isError == false)
+        #expect(rows[1].title == "workspaces")
+        #expect(rows[1].context == "Repo tab")
+        #expect(rows[1].badge == "Error")
+        #expect(rows[1].detail == "merge failed")
+        #expect(rows[1].isError)
+    }
+
+    @Test("Skips stale attention targets")
+    func skipsStaleAttentionTargets() {
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                item(
+                    target: .workspace(UUID()),
+                    run: .awaitingInput(reason: .custom)
+                )
+            ],
+            repositories: [.init(id: UUID(), name: "workspaces", workspaces: [])]
+        )
+
+        #expect(rows.isEmpty)
+    }
+
+    @Test("Resolved rows are the actionable count when stale targets are mixed in")
+    func resolvedRowsAreActionableCount() {
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                item(
+                    target: .workspace(workspaceID),
+                    run: .awaitingInput(reason: .permissionPrompt)
+                ),
+                item(
+                    target: .workspace(UUID()),
+                    run: .errored(category: .toolFailure, message: "stale session"),
+                    at: Date().addingTimeInterval(-30)
+                ),
+            ],
+            repositories: [
+                .init(
+                    id: repoID,
+                    name: "workspaces",
+                    workspaces: [.init(id: workspaceID, name: "notification-menu")]
+                )
+            ]
+        )
+
+        #expect(rows.count == 1)
+        #expect(rows.first?.target == .workspace(workspaceID))
+    }
+
+    @Test("Trims long error detail")
+    func trimsLongErrorDetail() {
+        let repoID = UUID()
+        let message = String(repeating: "x", count: 90)
+
+        let rows = AttentionSummaryResolver.resolve(
+            attentionItems: [
+                item(
+                    target: .repo(repoID),
+                    run: .errored(category: .toolFailure, message: message)
+                )
+            ],
+            repositories: [.init(id: repoID, name: "workspaces", workspaces: [])]
+        )
+
+        #expect(rows.first?.detail.count == 72)
+        #expect(rows.first?.detail.hasSuffix("...") == true)
+    }
+
+    private func item(
+        target: WorkspaceStatusAggregator.AttentionTarget,
+        run: AgentRunState,
+        at date: Date = Date()
+    ) -> WorkspaceStatusAggregator.AttentionItem {
+        WorkspaceStatusAggregator.AttentionItem(
+            target: target,
+            hostSessionID: UUID(),
+            run: run,
+            lastEventAt: date,
+            lastAccessedAt: date
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the Attention summary row model and resolver into `WorkspaceManagerCore`.
- Keep the Mac app surface as a thin SwiftData-to-snapshot adapter so the toolbar and benchmark keep their existing call shape.
- Move resolver behavior coverage to core tests and keep one Mac adapter smoke test.
- Update `CONTEXT.md` with the new `Attention Summary` domain term and relationship.

Refs #721.

## Mergeability

- Surface: desktop core and docs
- User-facing behavior changed: No intended visible behavior change; the Needs You toolbar rows keep the existing labels, badges, and activation targets.
- Non-happy paths considered: Empty inputs, stale Attention targets, mixed stale/actionable targets, long error messages, and SwiftData-to-snapshot conversion are covered by focused tests.
- Residual risk or follow-up: Low; this is the first shared Attention seam, and a later slice can split a broader portable target if the iOS app needs more domain modules.

## Validation

- `./scripts/build-ghosttykit.sh`
- `swift-format lint --strict --recursive Sources/ Tests/`
- `swift test --filter AttentionSummaryResolver` - 5 tests in 2 suites passed
- `swift test` - 1036 tests in 164 suites passed
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`

## Evidence

- [Validation evidence](https://evidence.cloudcompute.com/workspaces/pr-722/20260701-190425-attention-summary-validation.svg)
