### PR TITLE
test: refresh LEDGER verified dates for authz suite run

### DIFF
--- a/web/tests/LEDGER.md
+++ b/web/tests/LEDGER.md
@@ -31,14 +31,14 @@ Add a `[gap]` row for behaviors you know matter but aren't yet tested. `qa-web-a
 
 | Behavior | Layer | Test | Verified | Owner |
 |---|---|---|---|---|
-| `GET /api/events?repo=...` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events?repo rejects another user's repo` | 2026-05-03 | qa-web-agent |
-| `GET /api/events/:id` rejects an event from another user's repo | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events/:id rejects an event from another user's repo` | 2026-05-03 | qa-web-agent |
-| `GET /api/events` rejects requests without a valid session | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events without a valid session returns unauthorized` | 2026-05-03 | qa-web-agent |
-| `GET /api/events/stats` rejects requests without a valid session | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events/stats without a valid session returns unauthorized` | 2026-05-03 | qa-web-agent |
-| `GET /api/chat/messages?repo=...` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/chat/messages rejects another user's repo` | 2026-05-03 | qa-web-agent |
-| `GET /api/repos/:owner/:repo/agents` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/repos/:owner/:repo/agents rejects another user's repo` | 2026-05-03 | qa-web-agent |
-| `GET /api/repos/:owner/:repo/webhook-status` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/repos/:owner/:repo/webhook-status rejects another user's repo` | 2026-05-03 | qa-web-agent |
-| `GET /api/managed-agents/transcript` rejects a managed-agent session for an unauthorized repo | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/managed-agents/transcript rejects a session for an unauthorized repo` | 2026-05-03 | qa-web-agent |
+| `GET /api/events?repo=...` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events?repo rejects another user's repo` | 2026-07-02 | qa-web-agent |
+| `GET /api/events/:id` rejects an event from another user's repo | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events/:id rejects an event from another user's repo` | 2026-07-02 | qa-web-agent |
+| `GET /api/events` rejects requests without a valid session | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events without a valid session returns unauthorized` | 2026-07-02 | qa-web-agent |
+| `GET /api/events/stats` rejects requests without a valid session | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/events/stats without a valid session returns unauthorized` | 2026-07-02 | qa-web-agent |
+| `GET /api/chat/messages?repo=...` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/chat/messages rejects another user's repo` | 2026-07-02 | qa-web-agent |
+| `GET /api/repos/:owner/:repo/agents` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/repos/:owner/:repo/agents rejects another user's repo` | 2026-07-02 | qa-web-agent |
+| `GET /api/repos/:owner/:repo/webhook-status` rejects a repo owned by another user | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/repos/:owner/:repo/webhook-status rejects another user's repo` | 2026-07-02 | qa-web-agent |
+| `GET /api/managed-agents/transcript` rejects a managed-agent session for an unauthorized repo | e2e-fast | `fast/api-authorization.spec.ts :: GET /api/managed-agents/transcript rejects a session for an unauthorized repo` | 2026-07-02 | qa-web-agent |
 
 ### Dashboard
 


### PR DESCRIPTION
## Summary

- Part of Workstream 0 (`backlog/web-next-cycle_plan.md`) ledger reconciliation: closed #535, #543, #545, #522 as already-shipped after re-verifying against current code/CI, and refresh the `Verified` dates for the 8 `api-authorization.spec.ts` LEDGER rows that were re-run green in this session.

## Mergeability

- Surface: docs (test ledger only)
- User-facing behavior changed: none — `web/tests/LEDGER.md` date-column edit only, no test or product code touched.
- Non-happy paths considered: n/a (no code change).
- Release/ops preconditions: none.
- Residual risk or follow-up: none. See closure comments on #535, #543, #545, #522 for the underlying verification evidence; #724 filed for the one genuine gap found while verifying #545 (missing `PR_REVIEWER_RERUNS_ENABLED` rollout flag).

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `cd web && pnpm exec playwright test api-authorization --project fast` → 6 passed, 2 skipped (both "no session" cases skip locally by design under `pnpm dev`'s `DEV_BYPASS_AUTH=1`; confirmed passing under real `CI=true` via the latest green `web-ci.yml` run on `main`: https://github.com/fairchild/workspaces/actions/runs/28534799478)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

Evidence links:

- Test run summary and CI cross-check are inlined in the closure comments on #535 (https://github.com/fairchild/workspaces/issues/535#issuecomment-4868368907) and #543 (https://github.com/fairchild/workspaces/issues/543#issuecomment-4868370838). The `EVIDENCE_UPLOAD_TOKEN` was not available in this container (no `.env`; `./scripts/setup --env-only` failed on an unrelated worktree trust-boundary check), so no hosted artifact was uploaded — pass/fail summaries are inlined instead per the task's fallback instruction.

## Blockers

- [x] None
- [ ] Blocked on evidence


---
_Generated by [Claude Code](https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8)_