### PR TITLE
fix(web): validate session freshness in middleware, not just cookie presence

### DIFF
--- a/web/e2e/fast/unauth-redirect.spec.ts
+++ b/web/e2e/fast/unauth-redirect.spec.ts
@@ -1,10 +1,42 @@
 import { expect, test } from "@playwright/test";
 
+// These specs assert middleware behavior and rely on production-mode auth
+// (no dev bypass): they pass in CI (`pnpm start`) and are red under `pnpm dev`
+// by design — see web/docs/local-dev.md.
 test.describe("Auth redirect", () => {
-	test("GET /dashboard without auth redirects to sign-in", async ({
-		page,
-	}) => {
+	test("GET /dashboard without auth redirects to sign-in", async ({ page }) => {
 		await page.goto("/dashboard");
 		await expect(page).toHaveURL(/\/sign-in/);
+	});
+
+	test("GET /dashboard with an invalid session cookie redirects from middleware (no shell flash)", async ({
+		browser,
+		baseURL,
+	}) => {
+		const context = await browser.newContext();
+		// Seed a session token plus a malformed cookie-cache cookie. Middleware
+		// must reject it at the document request itself — asserting on the
+		// redirect response (maxRedirects: 0), not the rendered page, proves the
+		// gate happens at the edge with no dashboard HTML served first.
+		const url = baseURL ?? "http://localhost:3000";
+		await context.addCookies([
+			{ name: "better-auth.session_token", value: "forged-invalid-token", url },
+			{
+				name: "better-auth.session_data",
+				// base64url("not-a-valid-session") — decodes but is not a valid
+				// signed session payload, so getCookieCache rejects it.
+				value: "bm90LWEtdmFsaWQtc2Vzc2lvbg",
+				url,
+			},
+		]);
+
+		const response = await context.request.get("/dashboard", {
+			maxRedirects: 0,
+		});
+
+		expect([302, 303, 307, 308]).toContain(response.status());
+		expect(response.headers().location).toMatch(/\/sign-in/);
+
+		await context.close();
 	});
 });

--- a/web/src/lib/__tests__/session-cookie.test.ts
+++ b/web/src/lib/__tests__/session-cookie.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { evaluateSessionFreshness } from "../session-cookie";
+
+const SECRET = "test-secret-for-session-cookie-1234567890";
+const TOKEN = "better-auth.session_token";
+const DATA = "better-auth.session_data";
+
+const encoder = new TextEncoder();
+
+function base64UrlNoPad(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
+function base64UrlEncodeString(value: string): string {
+	return base64UrlNoPad(encoder.encode(value));
+}
+
+async function hmacSha256(secret: string, data: string): Promise<string> {
+	const key = await crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(data));
+	return base64UrlNoPad(new Uint8Array(signature));
+}
+
+/**
+ * Build a compact-strategy `session_data` cookie value the same way Better
+ * Auth's `setCookieCache` does: `base64url(JSON({ session, expiresAt, signature }))`
+ * where `signature = HMAC-SHA256(secret, JSON({ ...session, expiresAt }))`.
+ */
+async function buildSessionDataCookie(opts: {
+	secret: string;
+	expiresAt: number;
+	tamper?: boolean;
+}): Promise<string> {
+	const session = {
+		session: {
+			id: "session-1",
+			userId: "user-1",
+			expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+		},
+		user: { id: "user-1", email: "user@example.com" },
+		updatedAt: Date.now(),
+		version: "1",
+	};
+	let signature = await hmacSha256(
+		opts.secret,
+		JSON.stringify({ ...session, expiresAt: opts.expiresAt }),
+	);
+	if (opts.tamper) {
+		signature = `${signature.slice(0, -1)}${signature.endsWith("A") ? "B" : "A"}`;
+	}
+	return base64UrlEncodeString(
+		JSON.stringify({ session, expiresAt: opts.expiresAt, signature }),
+	);
+}
+
+function requestWithCookies(cookies: Record<string, string>): Request {
+	const header = Object.entries(cookies)
+		.map(([name, value]) => `${name}=${value}`)
+		.join("; ");
+	return new Request("https://spaces.example/dashboard", {
+		headers: header ? { cookie: header } : {},
+	});
+}
+
+describe("evaluateSessionFreshness", () => {
+	it("returns 'fresh' for a valid, unexpired signed cookie cache", async () => {
+		const sessionData = await buildSessionDataCookie({
+			secret: SECRET,
+			expiresAt: Date.now() + 5 * 60_000,
+		});
+		const request = requestWithCookies({
+			[TOKEN]: "any-token-value",
+			[DATA]: sessionData,
+		});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"fresh",
+		);
+	});
+
+	it("returns 'stale' when the cookie cache has expired", async () => {
+		const sessionData = await buildSessionDataCookie({
+			secret: SECRET,
+			expiresAt: Date.now() - 1_000,
+		});
+		const request = requestWithCookies({
+			[TOKEN]: "any-token-value",
+			[DATA]: sessionData,
+		});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"stale",
+		);
+	});
+
+	it("returns 'stale' when the cookie-cache signature does not verify", async () => {
+		const sessionData = await buildSessionDataCookie({
+			secret: SECRET,
+			expiresAt: Date.now() + 5 * 60_000,
+			tamper: true,
+		});
+		const request = requestWithCookies({
+			[TOKEN]: "any-token-value",
+			[DATA]: sessionData,
+		});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"stale",
+		);
+	});
+
+	it("returns 'stale' when the cookie cache is present but malformed", async () => {
+		// A base64url payload that decodes to non-JSON — a corrupt/truncated
+		// cache cookie. getCookieCache returns null before touching the secret.
+		const request = requestWithCookies({
+			[TOKEN]: "any-token-value",
+			[DATA]: base64UrlEncodeString("not-a-valid-session-payload"),
+		});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"stale",
+		);
+	});
+
+	it("returns 'stale' when no session token cookie is present", async () => {
+		const request = requestWithCookies({});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"stale",
+		);
+	});
+
+	it("returns 'indeterminate' when the token is present but the cookie cache is absent", async () => {
+		// The short-TTL cache lapsed while the longer-lived token may still be
+		// valid — defer to layout getSession() rather than log the user out.
+		const request = requestWithCookies({ [TOKEN]: "any-token-value" });
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"indeterminate",
+		);
+	});
+
+	it("returns 'indeterminate' when cookie-cache verification throws (fail-open)", async () => {
+		// A value that cannot be base64-decoded makes getCookieCache throw; a
+		// verification error must never hard-fail middleware.
+		const request = requestWithCookies({
+			[TOKEN]: "any-token-value",
+			[DATA]: "!!!not-valid-base64!!!",
+		});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"indeterminate",
+		);
+	});
+
+	it("verifies the secure cookie-cache name when present", async () => {
+		const sessionData = await buildSessionDataCookie({
+			secret: SECRET,
+			expiresAt: Date.now() + 5 * 60_000,
+		});
+		const request = requestWithCookies({
+			"__Secure-better-auth.session_token": "any-token-value",
+			"__Secure-better-auth.session_data": sessionData,
+		});
+		expect(await evaluateSessionFreshness(request, { secret: SECRET })).toBe(
+			"fresh",
+		);
+	});
+});

--- a/web/src/lib/session-cookie.ts
+++ b/web/src/lib/session-cookie.ts
@@ -1,0 +1,85 @@
+/**
+ * Edge-safe session freshness check for middleware.
+ *
+ * Middleware historically redirected only when the Better Auth session-token
+ * cookie was absent, so expired or tampered sessions passed the edge and only
+ * bounced later at the layout `getSession()` DB read. This module verifies the
+ * short-TTL, HMAC-signed Better Auth cookie cache (`session_data`) via
+ * `getCookieCache` — a Web Crypto path with no Node-only imports — so stale
+ * sessions redirect straight from middleware instead of flashing the app shell.
+ */
+import { getCookieCache } from "better-auth/cookies";
+
+const SESSION_TOKEN_COOKIES = [
+	"better-auth.session_token",
+	"__Secure-better-auth.session_token",
+] as const;
+
+const SESSION_DATA_PLAIN = "better-auth.session_data";
+const SESSION_DATA_SECURE = "__Secure-better-auth.session_data";
+
+/**
+ * The middleware-relevant verdict for the request's session cookies.
+ *
+ * - `fresh` — the cookie cache verified and is unexpired; let the request through.
+ * - `stale` — no session token, or a present cookie cache is expired, tampered,
+ *   or malformed; redirect to sign-in.
+ * - `indeterminate` — freshness cannot be decided at the edge (cookie-cache TTL
+ *   lapsed while the longer-lived token may still be valid, or verification
+ *   errored); fall through and let layout `getSession()` make the call so
+ *   middleware never hard-fails the app.
+ */
+export type SessionFreshness = "fresh" | "stale" | "indeterminate";
+
+function cookieHeader(request: Request): string {
+	return request.headers.get("cookie") ?? "";
+}
+
+function hasCookie(header: string, name: string): boolean {
+	return header.split(";").some((pair) => pair.trim().startsWith(`${name}=`));
+}
+
+/**
+ * Evaluate the freshness of the Better Auth session cookies on `request`
+ * without a database round-trip. Pure and edge-runtime compatible: it only
+ * reads the request's `cookie` header and verifies the signed cookie cache with
+ * Web Crypto via `getCookieCache`.
+ */
+export async function evaluateSessionFreshness(
+	request: Request,
+	options: { secret: string },
+): Promise<SessionFreshness> {
+	const header = cookieHeader(request);
+
+	// Absent session token → redirect. Preserves the prior cookie-presence gate.
+	if (!SESSION_TOKEN_COOKIES.some((name) => hasCookie(header, name))) {
+		return "stale";
+	}
+
+	const hasSecureData = hasCookie(header, SESSION_DATA_SECURE);
+	const hasPlainData = hasCookie(header, SESSION_DATA_PLAIN);
+	if (!hasSecureData && !hasPlainData) {
+		// Token present but the short-TTL cookie cache has lapsed while the
+		// longer-lived token may still be valid. We cannot verify freshness at
+		// the edge, so defer to layout getSession() rather than log the user out.
+		return "indeterminate";
+	}
+
+	try {
+		const cached = await getCookieCache(request, {
+			secret: options.secret,
+			isSecure: hasSecureData,
+		});
+		// A verdict was reached: getCookieCache returns a payload only when the
+		// signature verifies and the embedded session is unexpired, and returns
+		// null when the cache cookie is expired, tampered, or unparseable. A
+		// present-but-unfresh cache cookie means the session is stale.
+		return cached ? "fresh" : "stale";
+	} catch {
+		// getCookieCache throws only when the cookie value cannot be decoded at
+		// all (e.g. corrupt base64). Treat verification errors as indeterminate
+		// so a crypto/parse fault never takes the app down — layout
+		// getSession() makes the final decision.
+		return "indeterminate";
+	}
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,3 +1,5 @@
+import { resolveBetterAuthSecret } from "@/lib/agent-runtime/config";
+import { evaluateSessionFreshness } from "@/lib/session-cookie";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
@@ -18,7 +20,16 @@ function isPublic(pathname: string): boolean {
 	return false;
 }
 
-export function middleware(request: NextRequest) {
+function redirectToSignIn(
+	request: NextRequest,
+	pathname: string,
+): NextResponse {
+	const signInUrl = new URL("/sign-in", request.url);
+	signInUrl.searchParams.set("callbackUrl", pathname);
+	return NextResponse.redirect(signInUrl);
+}
+
+export async function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
 	if (pathname.startsWith("/docs/") && !pathname.includes(".")) {
@@ -40,15 +51,26 @@ export function middleware(request: NextRequest) {
 		return NextResponse.next();
 	}
 
-	const sessionCookie =
-		request.cookies.get("better-auth.session_token") ??
-		request.cookies.get("__Secure-better-auth.session_token");
-	if (!sessionCookie?.value) {
-		const signInUrl = new URL("/sign-in", request.url);
-		signInUrl.searchParams.set("callbackUrl", pathname);
-		return NextResponse.redirect(signInUrl);
+	// Validate freshness, not just cookie presence: an absent token, or an
+	// expired/tampered/malformed Better Auth cookie cache, redirects straight
+	// from the edge instead of rendering the shell and bouncing at layout
+	// getSession(). If the secret can't be resolved (misconfig) we fall
+	// through so middleware never hard-fails the app; layout getSession()
+	// still gates the page.
+	let secret: string;
+	try {
+		secret = resolveBetterAuthSecret();
+	} catch {
+		return NextResponse.next();
 	}
 
+	const freshness = await evaluateSessionFreshness(request, { secret });
+	if (freshness === "stale") {
+		return redirectToSignIn(request, pathname);
+	}
+
+	// "fresh" proceeds; "indeterminate" also proceeds and defers to layout
+	// getSession() rather than logging out a possibly-valid idle session.
 	return NextResponse.next();
 }
 

--- a/web/tests/LEDGER.md
+++ b/web/tests/LEDGER.md
@@ -26,6 +26,8 @@ Add a `[gap]` row for behaviors you know matter but aren't yet tested. `qa-web-a
 | Deployed app serves landing, sign-in, docs, auth redirect, and unauth sync boundary | e2e-deployment-smoke | `deployment-smoke/app.spec.ts :: Deployment smoke` | 2026-06-27 | qa-web-agent |
 | `POST /api/workspaces/sync` rejects unauthenticated requests | e2e-fast | `fast/unauth-api.spec.ts :: POST /api/workspaces/sync without auth returns unauthorized` | 2026-04-17 | qa-web-agent |
 | `GET /dashboard` redirects unauthenticated users to sign-in | e2e-fast | `fast/unauth-redirect.spec.ts :: GET /dashboard without auth redirects to sign-in` | 2026-04-17 | qa-web-agent |
+| `GET /dashboard` with an expired/forged session cookie redirects from middleware at the document request (no shell flash) | e2e-fast | `fast/unauth-redirect.spec.ts :: GET /dashboard with an invalid session cookie redirects from middleware (no shell flash)` | 2026-07-02 | qa-web-agent |
+| Middleware session-cookie freshness: valid+fresh passes, expired/tampered/malformed cookie cache is stale, missing token is stale, absent cache or verify error is indeterminate | unit | `src/lib/__tests__/session-cookie.test.ts :: evaluateSessionFreshness` | 2026-07-02 | qa-web-agent |
 
 ### API authorization
 


### PR DESCRIPTION
## Summary

Closes #541.

Middleware previously redirected only when the Better Auth session-token cookie was **absent**, so expired/tampered/garbage tokens passed the edge, rendered the app shell, and only bounced later at layout `getSession()` — an extra load cycle and no real edge gate.

- New edge-safe helper `web/src/lib/session-cookie.ts` verifies the short-TTL, HMAC-signed Better Auth **cookie cache** (`session_data`) via `getCookieCache` — a Web Crypto path with no Node-only imports. Returns `fresh` / `stale` / `indeterminate`.
- `web/src/middleware.ts` now redirects `stale` sessions (absent token, or expired/tampered/malformed cookie cache) straight from the edge, and only falls through on `fresh`/`indeterminate`.
- Preserves exactly: `PUBLIC_PATHS`, the `/docs` rewrite, the `DEV_BYPASS_AUTH` dev gate, and the `callbackUrl` param on sign-in redirects.

**Chosen approach: #1 (Better Auth cookie cache).** `session.cookieCache` was already enabled in `auth.ts` (`{ enabled: true, maxAge: 5 * 60 }`), and better-auth 1.6.20 exports `getCookieCache(request, { secret, isSecure })` from `better-auth/cookies` — an edge-compatible verifier (compact strategy = base64url + HMAC-SHA256 via Web Crypto; the only transitive extra is `jose`, which is edge-safe). It verifies signature + embedded `expiresAt` with **no DB read**, so approaches #2 (hand-rolled HMAC) and #3 (`auth.api.getSession` in middleware) were unnecessary. Verified the built `ƒ Middleware` (52.4 kB) compiles for the Edge runtime with no Node-only import errors.

**Design / trade-offs (fail-open, never hard-fail):**
- Absent session token → `stale` → redirect (preserves prior behavior).
- Token present + cookie cache present-but-unfresh (expired / bad signature / non-JSON payload) → `stale` → redirect. **This is the new gate.**
- Token present + **no** cache cookie (idle past the ≤5 min TTL, token may still be valid) → `indeterminate` → fall through to layout `getSession()`, so valid idle users are not logged out.
- Cache value un-decodable (corrupt base64 → `getCookieCache` throws) or secret unresolvable → `indeterminate` → fall through. A verification error never takes the app down.
- **Sign-out revocation latency is bounded by the cookie-cache TTL (≤5 min)** — the accepted trade-off of the cookie-cache approach.

## Mergeability

- Surface: **web**
- User-facing behavior changed: expired/invalid sessions now redirect at the document request (no dashboard shell flash); valid and valid-but-idle sessions unchanged.
- Non-happy paths considered: absent token, expired cache, tampered signature, malformed/corrupt cache cookie, cache-miss on idle, secure vs non-secure cookie names, verification error, missing secret. All covered by unit tests or explicit fall-through.
- Release/ops preconditions: none. `session.cookieCache` was already enabled; no config or migration change. `BETTER_AUTH_SECRET` is already required in production.
- Residual risk or follow-up: a forged **session_token with no session_data** cookie still falls through to layout `getSession()` (edge can't verify a bare token without a DB read — out of scope per the issue's approach ordering). The cookie-cache TTL sets an upper bound on sign-out propagation. `getCookieCache` emits a benign "Error parsing JSON" log line when rejecting a malformed cache cookie (library-internal, not from our catch).

## Validation

- [ ] `swift build` — n/a (web-only)
- [ ] `swift test` — n/a (web-only)
- [x] Other checks run:
  - `pnpm run typecheck` → clean (`tsc --noEmit`, no errors) — author run + independent gate re-run + CI
  - `pnpm run lint` → `Checked 189 files … No fixes applied` (biome clean) — author run + independent gate re-run + CI
  - `pnpm test` → **Test Files 32 passed (32) / Tests 361 passed (361)**; new `src/lib/__tests__/session-cookie.test.ts` → **8 passed** (fresh / expired / bad-signature / malformed / absent-token / cache-miss-indeterminate / verify-error-indeterminate / secure-cookie-name) — author run + independent gate re-run + CI
  - `pnpm run build` → success; `ƒ Middleware 52.4 kB` compiled for Edge (no Node-only import errors)
  - Fast e2e in production mode (`CI=1 … pnpm start`, dev bypass off, `BETTER_AUTH_SECRET` set): `pnpm exec playwright test --project fast` → **31 passed, 0 failed**, including the new `fast/unauth-redirect.spec.ts` case asserting `GET /dashboard` with a forged token + malformed `session_data` returns **307 → Location /sign-in** at the document request (WebServer logs show the built edge `middleware.js` invoking `getCookieCache`). Re-confirmed by [Web CI passed on this branch](https://github.com/fairchild/workspaces/actions/runs/28608190370).

Note: the `fast/unauth-*` specs require `NODE_ENV=production` (they are red under `pnpm dev` by design — see `web/docs/local-dev.md`); the numbers above are from a production build.

## Performance

- [x] Not a performance-sensitive change (edge cookie verification, no DB round-trip added; `better-auth/cookies` + `jose` are both edge-safe).

## Evidence

- [x] Test evidence attached
- [ ] UI evidence attached — n/a (no visual change; redirect behavior covered by e2e)

Evidence links:

- [Web CI passed on this branch](https://github.com/fairchild/workspaces/actions/runs/28608190370) — docs-sync + lint + typecheck + build + unit (361/361) + Playwright `fast` project (31/31, including the new middleware-redirect spec) under real `CI=true` production mode, hosted run. (`EVIDENCE_UPLOAD_TOKEN` is not available in the authoring container, so no R2 upload; the green CI run is the hosted proof.)

## Blockers

- [x] None

Gate note: independently re-verified before ready-for-review — typecheck, biome (189 files), vitest 361/361 re-run from the gate session on commit `9bfd984`; full-diff security review covering bypass paths (none — every non-fresh verdict either redirects or falls back to the pre-existing layout gate), secret-parity between middleware and `auth.ts` (same `resolveBetterAuthSecret()`), and edge-bundle safety (`agent-runtime/config.ts` is a zero-import pure-env module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8)_