### PR TITLE
Add continuity read models to LocalStateStore (durable sessions slice 1)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -278,10 +278,11 @@ public actor LocalStateStore {
         activeHostSessionID: UUID?,
         selectedSurfaceKind: String?,
         selectedSurfaceID: String?,
-        splitPanes: [TerminalSplitSnapshotInput] = []
+        splitPanes: [TerminalSplitSnapshotInput] = [],
+        capturedAt: Date = Date()
     ) async throws {
         let snapshotID = UUID().uuidString
-        let now = Self.isoString(Date())
+        let now = Self.isoString(capturedAt)
         try await dbPool.write { db in
             try db.execute(
                 sql: """
@@ -462,6 +463,125 @@ public actor LocalStateStore {
                 arguments: [sessionIDString, cappedLimit]
             )
             return rows.compactMap(AgentStatusEventRow.init(row:))
+        }
+    }
+
+    /// Continuity read model (local-state-store plan, slice 3): the most recent
+    /// terminal sessions, each joined with the latest agent status event recorded
+    /// for that host session (or `nil` agent fields when none exists). Rows are
+    /// ordered newest `last_seen_at` first. Pass `activeOnly: true` to restrict to
+    /// sessions that have not been marked ended — after a crash or reboot the
+    /// previous run's sessions typically remain active, which is what a cold-start
+    /// restore wants to enumerate.
+    public func fetchContinuitySessions(
+        activeOnly: Bool = false,
+        limit: Int = 50,
+        offset: Int = 0
+    ) async throws -> [TerminalSessionContinuityRow] {
+        let cappedLimit = max(0, limit)
+        let cappedOffset = max(0, offset)
+        let activeOnlyValue = activeOnly ? 1 : 0
+        return try await dbPool.read { db -> [TerminalSessionContinuityRow] in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT
+                        ts.host_session_id,
+                        ts.session_key,
+                        ts.target_kind,
+                        ts.target_id,
+                        ts.target_path,
+                        ts.backend_identifier,
+                        ts.backend_instance_id,
+                        ts.directory_path,
+                        ts.terminal_mode,
+                        ts.tmux_session_name,
+                        ts.custom_command_present,
+                        ts.is_active,
+                        ts.created_at,
+                        ts.last_seen_at,
+                        ts.ended_at,
+                        ae.agent_session_id,
+                        ae.agent_kind,
+                        ae.run_state AS agent_run_state,
+                        ae.cwd AS agent_cwd,
+                        ae.model_display_name AS agent_model_display_name,
+                        ae.event_at AS agent_event_at
+                    FROM terminal_sessions ts
+                    LEFT JOIN (
+                        SELECT
+                            host_session_id,
+                            agent_session_id,
+                            agent_kind,
+                            run_state,
+                            cwd,
+                            model_display_name,
+                            event_at,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY host_session_id
+                                ORDER BY event_at DESC, id DESC
+                            ) AS event_rank
+                        FROM agent_status_events
+                    ) ae ON ae.host_session_id = ts.host_session_id AND ae.event_rank = 1
+                    WHERE (? = 0 OR (ts.is_active = 1 AND ts.ended_at IS NULL))
+                    ORDER BY ts.last_seen_at DESC
+                    LIMIT ? OFFSET ?
+                    """,
+                arguments: [activeOnlyValue, cappedLimit, cappedOffset]
+            )
+            return rows.compactMap(TerminalSessionContinuityRow.init(row:))
+        }
+    }
+
+    /// Continuity read model (local-state-store plan, slice 3): the most recently
+    /// captured terminal layout snapshot with its split pane rows, or `nil` when
+    /// no snapshot has been recorded.
+    public func fetchLatestLayoutSnapshot() async throws -> TerminalLayoutSnapshotRow? {
+        try await dbPool.read { db -> TerminalLayoutSnapshotRow? in
+            guard
+                let snapshotRow = try Row.fetchOne(
+                    db,
+                    sql: """
+                        SELECT id, captured_at, active_host_session_id, selected_surface_kind, selected_surface_id
+                        FROM terminal_layout_snapshots
+                        ORDER BY captured_at DESC, id DESC
+                        LIMIT 1
+                        """
+                )
+            else {
+                return nil
+            }
+
+            guard let snapshotID = snapshotRow["id"] as String? else { return nil }
+            let splitRows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT primary_host_session_id, split_host_session_id, axis, split_before_primary, split_fraction
+                    FROM terminal_split_snapshots
+                    WHERE snapshot_id = ?
+                    """,
+                arguments: [snapshotID]
+            )
+            let splitPanes = splitRows.compactMap { row -> TerminalSplitSnapshotInput? in
+                guard let primaryString = row["primary_host_session_id"] as String?,
+                    let primaryID = UUID(uuidString: primaryString),
+                    let splitString = row["split_host_session_id"] as String?,
+                    let splitID = UUID(uuidString: splitString),
+                    let axis = row["axis"] as String?,
+                    let splitBeforePrimary = row["split_before_primary"] as Int?,
+                    let splitFraction = row["split_fraction"] as Double?
+                else {
+                    return nil
+                }
+                return TerminalSplitSnapshotInput(
+                    primaryHostSessionID: primaryID,
+                    splitHostSessionID: splitID,
+                    axis: axis,
+                    splitBeforePrimary: splitBeforePrimary == 1,
+                    splitFraction: splitFraction
+                )
+            }
+            return TerminalLayoutSnapshotRow(row: snapshotRow, splitPanes: splitPanes)
         }
     }
 
@@ -985,12 +1105,177 @@ public struct AgentStatusEventRow: Sendable, Equatable, Identifiable {
     }
 
     private static func parseISODate(_ value: String) -> Date? {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = formatter.date(from: value) { return date }
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter.date(from: value)
+        parseLocalStateISODate(value)
     }
+}
+
+/// Read-side projection of one `terminal_sessions` row joined with the latest
+/// `agent_status_events` row for the same host session. Agent fields are `nil`
+/// when no agent event was ever recorded. Strings are kept verbatim from the
+/// tables; resolving targets against current SwiftData rows is a caller concern.
+public struct TerminalSessionContinuityRow: Sendable, Equatable, Identifiable {
+    public let hostSessionID: UUID
+    public let sessionKey: String
+    public let targetKind: String
+    public let targetID: String?
+    public let targetPath: String?
+    public let backendIdentifier: String?
+    public let backendInstanceID: String?
+    public let directoryPath: String
+    public let terminalMode: String
+    public let tmuxSessionName: String?
+    public let customCommandPresent: Bool
+    public let isActive: Bool
+    public let createdAt: Date
+    public let lastSeenAt: Date
+    public let endedAt: Date?
+    public let agentSessionID: String?
+    public let agentKind: String?
+    public let agentRunState: String?
+    public let agentCwd: String?
+    public let agentModelDisplayName: String?
+    public let agentEventAt: Date?
+
+    public var id: UUID { hostSessionID }
+
+    public init(
+        hostSessionID: UUID,
+        sessionKey: String,
+        targetKind: String,
+        targetID: String?,
+        targetPath: String?,
+        backendIdentifier: String?,
+        backendInstanceID: String?,
+        directoryPath: String,
+        terminalMode: String,
+        tmuxSessionName: String?,
+        customCommandPresent: Bool,
+        isActive: Bool,
+        createdAt: Date,
+        lastSeenAt: Date,
+        endedAt: Date?,
+        agentSessionID: String?,
+        agentKind: String?,
+        agentRunState: String?,
+        agentCwd: String?,
+        agentModelDisplayName: String?,
+        agentEventAt: Date?
+    ) {
+        self.hostSessionID = hostSessionID
+        self.sessionKey = sessionKey
+        self.targetKind = targetKind
+        self.targetID = targetID
+        self.targetPath = targetPath
+        self.backendIdentifier = backendIdentifier
+        self.backendInstanceID = backendInstanceID
+        self.directoryPath = directoryPath
+        self.terminalMode = terminalMode
+        self.tmuxSessionName = tmuxSessionName
+        self.customCommandPresent = customCommandPresent
+        self.isActive = isActive
+        self.createdAt = createdAt
+        self.lastSeenAt = lastSeenAt
+        self.endedAt = endedAt
+        self.agentSessionID = agentSessionID
+        self.agentKind = agentKind
+        self.agentRunState = agentRunState
+        self.agentCwd = agentCwd
+        self.agentModelDisplayName = agentModelDisplayName
+        self.agentEventAt = agentEventAt
+    }
+
+    init?(row: Row) {
+        guard let hostSessionIDString = row["host_session_id"] as String?,
+            let hostSessionID = UUID(uuidString: hostSessionIDString),
+            let sessionKey = row["session_key"] as String?,
+            let targetKind = row["target_kind"] as String?,
+            let directoryPath = row["directory_path"] as String?,
+            let terminalMode = row["terminal_mode"] as String?,
+            let createdAtRaw = row["created_at"] as String?,
+            let createdAt = parseLocalStateISODate(createdAtRaw),
+            let lastSeenAtRaw = row["last_seen_at"] as String?,
+            let lastSeenAt = parseLocalStateISODate(lastSeenAtRaw)
+        else {
+            return nil
+        }
+
+        self.init(
+            hostSessionID: hostSessionID,
+            sessionKey: sessionKey,
+            targetKind: targetKind,
+            targetID: row["target_id"] as String?,
+            targetPath: row["target_path"] as String?,
+            backendIdentifier: row["backend_identifier"] as String?,
+            backendInstanceID: row["backend_instance_id"] as String?,
+            directoryPath: directoryPath,
+            terminalMode: terminalMode,
+            tmuxSessionName: row["tmux_session_name"] as String?,
+            customCommandPresent: (row["custom_command_present"] as Int? ?? 0) == 1,
+            isActive: (row["is_active"] as Int? ?? 0) == 1,
+            createdAt: createdAt,
+            lastSeenAt: lastSeenAt,
+            endedAt: (row["ended_at"] as String?).flatMap(parseLocalStateISODate),
+            agentSessionID: row["agent_session_id"] as String?,
+            agentKind: row["agent_kind"] as String?,
+            agentRunState: row["agent_run_state"] as String?,
+            agentCwd: row["agent_cwd"] as String?,
+            agentModelDisplayName: row["agent_model_display_name"] as String?,
+            agentEventAt: (row["agent_event_at"] as String?).flatMap(parseLocalStateISODate)
+        )
+    }
+}
+
+/// Read-side projection of the latest `terminal_layout_snapshots` row plus its
+/// `terminal_split_snapshots` children.
+public struct TerminalLayoutSnapshotRow: Sendable, Equatable, Identifiable {
+    public let id: String
+    public let capturedAt: Date
+    public let activeHostSessionID: UUID?
+    public let selectedSurfaceKind: String?
+    public let selectedSurfaceID: String?
+    public let splitPanes: [TerminalSplitSnapshotInput]
+
+    public init(
+        id: String,
+        capturedAt: Date,
+        activeHostSessionID: UUID?,
+        selectedSurfaceKind: String?,
+        selectedSurfaceID: String?,
+        splitPanes: [TerminalSplitSnapshotInput]
+    ) {
+        self.id = id
+        self.capturedAt = capturedAt
+        self.activeHostSessionID = activeHostSessionID
+        self.selectedSurfaceKind = selectedSurfaceKind
+        self.selectedSurfaceID = selectedSurfaceID
+        self.splitPanes = splitPanes
+    }
+
+    init?(row: Row, splitPanes: [TerminalSplitSnapshotInput]) {
+        guard let id = row["id"] as String?,
+            let capturedAtRaw = row["captured_at"] as String?,
+            let capturedAt = parseLocalStateISODate(capturedAtRaw)
+        else {
+            return nil
+        }
+
+        self.init(
+            id: id,
+            capturedAt: capturedAt,
+            activeHostSessionID: (row["active_host_session_id"] as String?).flatMap(UUID.init(uuidString:)),
+            selectedSurfaceKind: row["selected_surface_kind"] as String?,
+            selectedSurfaceID: row["selected_surface_id"] as String?,
+            splitPanes: splitPanes
+        )
+    }
+}
+
+private func parseLocalStateISODate(_ value: String) -> Date? {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: value) { return date }
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: value)
 }
 
 public struct TerminalSplitSnapshotInput: Sendable, Equatable {

--- a/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
@@ -166,6 +166,162 @@ struct LocalStateStoreTests {
         #expect(toolDetail == "file_path_present")
     }
 
+    @Test("Continuity read model joins latest agent status per session")
+    func continuityReadModelJoinsLatestAgentStatus() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let databaseURL = fixture.url.appendingPathComponent("state.sqlite")
+        let store = try LocalStateStore(databaseURL: databaseURL)
+
+        let agentSessionID = UUID(uuidString: "1D14D5B0-38A5-4E6C-9C05-6E1C4E1B9A01")!
+        let agentSession = HostTerminalSession(
+            id: agentSessionID,
+            key: .repoPath("/tmp/workspaces/repo"),
+            directory: URL(fileURLWithPath: "/tmp/workspaces/repo")
+        )
+        try await store.recordTerminalSession(
+            agentSession,
+            terminalMode: "tmux_per_session",
+            isActive: true,
+            hooksSocketPath: nil
+        )
+
+        let endedSessionID = UUID(uuidString: "2D14D5B0-38A5-4E6C-9C05-6E1C4E1B9A02")!
+        let endedSession = HostTerminalSession(
+            id: endedSessionID,
+            key: .hostPath("/tmp/workspaces/other"),
+            directory: URL(fileURLWithPath: "/tmp/workspaces/other")
+        )
+        try await store.recordTerminalSession(
+            endedSession,
+            terminalMode: "ghostty_managed_splits",
+            isActive: true,
+            hooksSocketPath: nil
+        )
+        try await store.markTerminalSessionEnded(hostSessionID: endedSessionID)
+
+        let earlierStatus = AgentSessionStatus(
+            hostSessionID: agentSessionID,
+            agentSessionID: "claude-session-old",
+            kind: .claudeCode,
+            cwd: "/tmp/workspaces/repo",
+            run: .runningTool(name: "Read", detail: "README.md"),
+            modelDisplayName: "Claude",
+            lastEventAt: Date(timeIntervalSince1970: 1_700_000_000),
+            hookActive: true,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try await store.recordAgentEvents(
+            [.toolStart(name: "Read", detail: "README.md")],
+            hostSessionID: agentSessionID,
+            origin: .hook,
+            status: earlierStatus,
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let latestStatus = AgentSessionStatus(
+            hostSessionID: agentSessionID,
+            agentSessionID: "claude-session-new",
+            kind: .claudeCode,
+            cwd: "/tmp/workspaces/repo",
+            run: .runningTool(name: "Bash", detail: "swift test"),
+            modelDisplayName: "Claude",
+            lastEventAt: Date(timeIntervalSince1970: 1_700_000_100),
+            hookActive: true,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try await store.recordAgentEvents(
+            [.toolStart(name: "Bash", detail: "swift test")],
+            hostSessionID: agentSessionID,
+            origin: .hook,
+            status: latestStatus,
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+
+        let allRows = try await store.fetchContinuitySessions()
+        #expect(allRows.count == 2)
+
+        let endedRow = try #require(allRows.first { $0.hostSessionID == endedSessionID })
+        #expect(endedRow.isActive == false)
+        #expect(endedRow.endedAt != nil)
+        #expect(endedRow.agentSessionID == nil)
+        #expect(endedRow.agentRunState == nil)
+
+        let activeRows = try await store.fetchContinuitySessions(activeOnly: true)
+        #expect(activeRows.count == 1)
+        let activeRow = try #require(activeRows.first)
+        #expect(activeRow.hostSessionID == agentSessionID)
+        #expect(activeRow.directoryPath == "/tmp/workspaces/repo")
+        #expect(activeRow.terminalMode == "tmux_per_session")
+        #expect(activeRow.tmuxSessionName != nil)
+        #expect(activeRow.agentSessionID == "claude-session-new")
+        #expect(activeRow.agentRunState == "running_tool")
+        #expect(activeRow.agentCwd == "/tmp/workspaces/repo")
+        #expect(activeRow.agentEventAt == Date(timeIntervalSince1970: 1_700_000_100))
+    }
+
+    @Test("Latest layout snapshot returns newest capture with split panes")
+    func latestLayoutSnapshotReturnsNewestCapture() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let databaseURL = fixture.url.appendingPathComponent("state.sqlite")
+        let store = try LocalStateStore(databaseURL: databaseURL)
+
+        let emptyBefore = try await store.fetchLatestLayoutSnapshot()
+        #expect(emptyBefore == nil)
+
+        let primaryID = UUID(uuidString: "3D14D5B0-38A5-4E6C-9C05-6E1C4E1B9A03")!
+        let splitID = UUID(uuidString: "4D14D5B0-38A5-4E6C-9C05-6E1C4E1B9A04")!
+        for (sessionID, path) in [(primaryID, "/tmp/workspaces/repo"), (splitID, "/tmp/workspaces/other")] {
+            let session = HostTerminalSession(
+                id: sessionID,
+                key: .hostPath(path),
+                directory: URL(fileURLWithPath: path)
+            )
+            try await store.recordTerminalSession(
+                session,
+                terminalMode: "ghostty_managed_splits",
+                isActive: true,
+                hooksSocketPath: nil
+            )
+        }
+
+        try await store.recordTerminalLayoutSnapshot(
+            activeHostSessionID: primaryID,
+            selectedSurfaceKind: "repository_terminal",
+            selectedSurfaceID: primaryID.uuidString,
+            capturedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try await store.recordTerminalLayoutSnapshot(
+            activeHostSessionID: splitID,
+            selectedSurfaceKind: "workspace_terminal",
+            selectedSurfaceID: splitID.uuidString,
+            splitPanes: [
+                TerminalSplitSnapshotInput(
+                    primaryHostSessionID: primaryID,
+                    splitHostSessionID: splitID,
+                    axis: "leading_trailing",
+                    splitBeforePrimary: false,
+                    splitFraction: 0.5
+                )
+            ],
+            capturedAt: Date(timeIntervalSince1970: 1_700_000_100)
+        )
+
+        let latestSnapshot = try await store.fetchLatestLayoutSnapshot()
+        let snapshot = try #require(latestSnapshot)
+        #expect(snapshot.capturedAt == Date(timeIntervalSince1970: 1_700_000_100))
+        #expect(snapshot.activeHostSessionID == splitID)
+        #expect(snapshot.selectedSurfaceKind == "workspace_terminal")
+        #expect(snapshot.splitPanes.count == 1)
+        let pane = try #require(snapshot.splitPanes.first)
+        #expect(pane.primaryHostSessionID == primaryID)
+        #expect(pane.splitHostSessionID == splitID)
+        #expect(pane.axis == "leading_trailing")
+        #expect(pane.splitBeforePrimary == false)
+        #expect(pane.splitFraction == 0.5)
+    }
+
     @Test("docs/schema.sql loads as runnable SQLite")
     func schemaDocumentLoads() async throws {
         let fixture = try TemporaryDirectory()

--- a/backlog/AGENTS.md
+++ b/backlog/AGENTS.md
@@ -33,6 +33,10 @@ Every state transition and progress note is one comment on the issue, in this sh
 | `rescued`                | `claimer=<who>` `branch=<git-branch>`                   |
 | `retried`                | trail = `\| <reason>`                                      |
 
+### Claimer identity
+
+`claimer=` values follow `<harness>:<stable-id>` — e.g. `claude-code:session_01AB…`, `codex:silver-lake-refactor`, `gh-actions:run-28612644525`, `human:fairchild`. The branch, not the claimer, is what claim resolution keys on (below); `claimer` exists for audit trails, so prefer an identifier another agent or a human can trace back to a live session, thread, or run. If the harness exposes no stable identifier, use `<harness>:unknown` and note it in the trail.
+
 ## Claim resolution
 
 The **branch** is the claim identity (agents often share a GitHub account, so assignee isn't reliable). Walking comments chronologically:
@@ -46,6 +50,8 @@ The earliest `advanced to=claimed` since the most recent `retried`, optionally o
 ## Operating
 
 These conventions are operable directly via `gh issue` — open an issue, add the `claimed` label, post the right comment. The `backlog` skill (`add / take / advance / progress / cancel / fail / rescue / retry / maintain / status`) is a convenience layer that automates the patterns (auto-pick by priority, race-resolution at claim time, status counts) but isn't required for any of them. Mix both: skill for batch operations, raw `gh` for one-offs.
+
+The protocol is also transport-agnostic: state lives in the labels and worklog comments, not in the tool that wrote them, so the GitHub MCP tools or raw REST with `GH_TOKEN` are as valid as `gh`. See `docs/agents/issue-tracker.md` § "When `gh` Is Unavailable" for the operation mapping (remote containers commonly lack `gh`).
 
 Tasks are referenced by issue number — `take 42` or `take #42`. Titles are free text.
 

--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -243,7 +243,7 @@ Theme-to-milestone map:
 | Managed reviewer reliability and understandability | `area: platform` | Closed in `v0.17.0`: [#584](https://github.com/fairchild/workspaces/issues/584) / [milestone 8](https://github.com/fairchild/workspaces/milestone/8). Treat the ReviewRun-first model as baseline doctrine. |
 | Lume runtime hardening | `arc:lume-runtime` | Closed (#87/#88/#89). Label retained for future Lume work. |
 | Notification catch-up and reconnect correctness | `arc:notification-catchup` | Next standalone after core-reliability theme clears |
-| Terminal continuity (tmux + cross-session) | `arc:terminal-continuity` | 2026-04-23 decision partially superseded by #627 (pane-tree reversal; ADR in Phase 8). #548 cross-session restore stays valid; re-scope #549 after the ADR. |
+| Terminal continuity (tmux + cross-session) | `arc:terminal-continuity` | Owner-promoted 2026-07-02 to milestone [#10 — Durable sessions](https://github.com/fairchild/workspaces/milestone/10): epic [#728](https://github.com/fairchild/workspaces/issues/728) (cold-start resume + history browser), #548 (warm sibling), #729 (cloud handoff, deferred tail). Re-scope #549 after the ADR before pulling it in. Sequencing vs #9 per one-active-milestone rule. |
 | Strategic isolation backend direction | `arc:isolation-backend` | Backlog/research until promoted by a fresh approved discussion |
 
 ---

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,21 @@ Issues and PRDs for this repo live as GitHub issues in `fairchild/workspaces`. U
 
 Infer the repository from `git remote -v`; `gh` resolves `fairchild/workspaces` automatically when run inside this clone.
 
+## When `gh` Is Unavailable
+
+Remote/cloud sessions often lack the `gh` CLI. The same operations are available through the GitHub MCP server tools or raw REST with the session's `GH_TOKEN`/`GITHUB_TOKEN`. Issue state lives in labels and comments, not in the tool that wrote them, so any transport is equivalent.
+
+| Operation | `gh` | GitHub MCP tool | REST |
+|---|---|---|---|
+| Create issue | `gh issue create` | `issue_write` (method `create`) | `POST /repos/{o}/{r}/issues` |
+| Read issue | `gh issue view` | `issue_read` | `GET /repos/{o}/{r}/issues/{n}` |
+| Comment | `gh issue comment` | `add_issue_comment` | `POST /repos/{o}/{r}/issues/{n}/comments` |
+| Edit labels | `gh issue edit --add-label` | `issue_write` (method `update`, `labels`) | `PATCH /repos/{o}/{r}/issues/{n}` |
+| Close | `gh issue close` | `issue_write` (method `update`, `state`) | `PATCH /repos/{o}/{r}/issues/{n}` |
+| Milestones | `gh api repos/{o}/{r}/milestones` | not exposed — use REST | `POST /repos/{o}/{r}/milestones` |
+
+Caveat: MCP `issue_write` label updates **replace the full label set** — read the current labels first and send the complete list, or a label you didn't mention gets dropped.
+
 ## When a Skill Says "Publish to the Issue Tracker"
 
 Create a GitHub issue. Use the repo's normal issue labels from `docs/agents/triage-labels.md` and the agent-team conventions in `docs/development/agent-team.md` when the work is meant for the autonomous contributor pipeline.

--- a/docs/development/local-state-store-plan.md
+++ b/docs/development/local-state-store-plan.md
@@ -41,6 +41,7 @@ The foundation landed in PR #483 and shipped in WorkSpaces v0.15.0:
    - Add local-state queries for latest active Terminal Sessions, latest agent status per host session, and latest layout snapshot.
    - Keep restore conservative: resolve Repository/Workspace IDs through current SwiftData rows and fall back when a row is missing.
    - Tests: deleted or stale targets do not restore invalid Surfaces.
+   - Status: store-level read models landed (`fetchContinuitySessions`, `fetchLatestLayoutSnapshot`); the conservative SwiftData resolution and restore orchestration happen in the caller and are tracked in the durable-sessions epic (issue #728).
 
 4. Expose local state in diagnostics.
    - Initial Diagnostics tab section shows store mode, database path, schema version, table counts, and latest event times.


### PR DESCRIPTION
## Summary

- Slice 1 of the durable-sessions epic #728 (local-state-store plan slice 3, store level): the local SQLite sidecar has been recording terminal sessions and agent status events since v0.15.0, but nothing ever read them back. This PR adds the read models a cold-start restore and a session-history browser need.
- `fetchContinuitySessions(activeOnly:limit:offset:)` — terminal sessions newest-first, each joined with the latest `agent_status_events` row for that host session, exposing the last known `agent_session_id` (the key `claude --resume` needs), run state, cwd, and model. `activeOnly: true` returns sessions not marked ended — after a crash or reboot the previous run's sessions remain active, which is exactly the cold-start restore set.
- `fetchLatestLayoutSnapshot()` — newest `terminal_layout_snapshots` row with its split panes.
- No schema change: `agent_status_events.agent_session_id` is already populated on every event, so a join suffices; `docs/schema.sql` and `schemaVersion` stay at v1. `recordTerminalLayoutSnapshot` gains a defaulted `capturedAt:` parameter (mirroring `recordAgentEvents(occurredAt:)`) so snapshot ordering is deterministic in tests; it has no production call sites yet, so no callers change.
- Marks plan slice 3 store-level status in `docs/development/local-state-store-plan.md`; restore orchestration and UX are the next slices in #728.
- Two docs-only companion commits from the same working session (this session is pinned to one branch): the roadmap theme-to-milestone row now points terminal continuity at milestone #10, and the backlog protocol docs gain a `gh`-less transport-fallback table (`docs/agents/issue-tracker.md`) plus a claimer-identity grammar and transport-agnostic note (`backlog/AGENTS.md`) — gaps surfaced while operating the protocol from this container.

## Mergeability

- Surface: desktop / docs
- User-facing behavior changed: none — additive read-side APIs only, no callers wired yet; remainder is docs.
- Non-happy paths considered: sessions with no agent events project `nil` agent fields; malformed rows are dropped by failable projections rather than throwing; `activeOnly` excludes ended sessions; empty store returns `[]` / `nil`.
- Release/ops preconditions: none (no migration, no schema-version bump).
- Residual risk or follow-up: the latest-event join relies on `agent_status_events` retention — when plan slice 6 (retention) lands it must preserve the latest event per session or denormalize `agent_session_id` onto `terminal_sessions` first (noted in #728 slice 5). Follow-up slices: restore orchestration, cold-start restore UX, history browser (#728).

## Validation

- [x] `swift build`
- [x] `swift test`
- [x] Other checks run: both new queries executed verbatim against `docs/schema.sql` on SQLite 3.45 with fixtures mirroring the new Swift tests — latest-event-per-session join picks the newest `agent_session_id`, `activeOnly` filters ended sessions, sessions without agent events project NULL agent fields, and the snapshot query returns the newest capture with its split rows.

`swift build` and `swift test` passed on this head via CI ([build-and-test on macos-15, green](https://github.com/fairchild/workspaces/actions/runs/28618538606/job/84868262434)), including the two new Swift Testing cases (`continuityReadModelJoinsLatestAgentStatus`, `latestLayoutSnapshotReturnsNewestCapture`). The authoring session was a Linux container with no Swift toolchain, so CI is the canonical test run for this PR.

## Performance

- [x] Not a performance-sensitive change

Read-side queries on indexed columns (`idx_terminal_sessions_last_seen`, `idx_agent_status_events_host_time`), invoked at startup/history-browse frequency, not on hot paths.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Tests passed: [`build-and-test` CI run on this head](https://github.com/fairchild/workspaces/actions/runs/28618538606/job/84868262434) (`swift build` + `swift test`, macos-15)
- SQL-level verification of the query semantics against `docs/schema.sql` (SQLite 3.45) summarized in Validation above; not uploadable to the evidence store from this container (no `EVIDENCE_UPLOAD_TOKEN` — `mise` unavailable for `./scripts/setup --env-only`)

## Blockers

- [x] None
- [ ] Blocked on evidence

Previously marked blocked on evidence while CI was pending (authoring environment could not run `swift test`); backfilled with the green CI run above. Not UI-affecting, so no visual proof applies.

Refs #728, #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lkve1hP94VkEsj4x4ucQEr