### PR TITLE
chore(backlog): archive completed web next-cycle plan to done/

### DIFF
--- a/.agents/skills/subagent-delegation/SKILL.md
+++ b/.agents/skills/subagent-delegation/SKILL.md
@@ -28,6 +28,9 @@ Source: the 2026-07-02 cycle (PRs #723–#732, six first-try gate passes).
 - Ship protocol: draft PR only (the gate flips it ready); `Closes #N` in the
   body; on `agent`+`task` issues do **not** touch claim labels —
   `sync-execution-state.py` owns that lane (`backlog/CLAUDE.md`).
+- PR-body Mergeability fields need real prose — the `readiness` check
+  (`scripts/pr-readiness.py`) fails on empty/default/`n/a` answers; when a
+  field doesn't apply, write *why* it doesn't.
 
 ## The gate, before a PR leaves draft
 

--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -326,6 +326,7 @@ Priority `idea` = parked in the `idea` label (speculative, may never be built); 
 
 Archived (in `backlog/done/`):
 
+- Web next-cycle plan (2026-07) — fully executed same-day 2026-07-02 (PRs #723–#735; milestone #7 closed); see `backlog/done/web-next-cycle_plan.md`
 - Pane-tree terminal tiling model — deferred 2026-04-23 (`docs/decisions/terminal-multiplexing.md`), then deliberately revived as the Tile Tree epic [#627](https://github.com/fairchild/workspaces/issues/627) (Phase 8 records the superseding ADR)
 - Terminal multiplexing decision session — resolved by `docs/decisions/terminal-multiplexing.md` (2026-04-23)
 - Isolation strategies (research) — superseded by Tahoe VZ execution brief

--- a/backlog/done/web-next-cycle_plan.md
+++ b/backlog/done/web-next-cycle_plan.md
@@ -1,9 +1,11 @@
 ---
-status: proposed
+status: done
 category: plan
 ---
 
 # Web Next Cycle Plan — 2026-07
+
+> **Completed 2026-07-02, same day.** All workstreams executed: W0 closures (#535/#543/#545/#522, residue → #724), W1 #541 (PR #727), W2 #536 (PR #731), W3 #540 retired (PR #725), W4 #539 (PR #732). Milestone #7 closed with 32 issues. Learnings recorded in `backlog/ROADMAP.md` § 2026-07-02; conventions encoded in `docs/development/remote-sessions.md` and `.agents/skills/subagent-delegation/SKILL.md`. W5 grooming items remain open for a future cycle (#521, #524, LEDGER gaps).
 
 Execution plan for the next round of `web/` work, grounded in a 2026-07-02 read of
 the roadmap, milestone #7, the open `web`-labeled issues, and the actual `web/` tree.


### PR DESCRIPTION
## Summary

- Moves `backlog/web-next-cycle_plan.md` → `backlog/done/` per the repo's completed-plan convention, with `status: done` frontmatter and a completion header (all workstreams executed 2026-07-02 via PRs #723–#735; milestone #7 closed with 32 issues; W5 grooming items noted as remaining for a future cycle).
- Adds the matching entry to ROADMAP's "Archived (in `backlog/done/`)" list.
- Rider (`96f39ae`): encodes one convention discovered on this very PR into `.agents/skills/subagent-delegation/SKILL.md` — the `readiness` gate (`scripts/pr-readiness.py`) rejects `n/a`/default Mergeability answers, so briefs must say *why* a field doesn't apply.

## Mergeability

- Surface: docs
- User-facing behavior changed: none (file move + status stamp + 3 skill lines)
- Non-happy paths considered: the only failure mode for a plan-file move is a dangling reference to the old path breaking future navigation — grep across the tree (excluding .git/node_modules) confirms zero references to `backlog/web-next-cycle_plan.md` remain; issue bodies that cite the old path (#733/#734) still resolve via git history and the archived-list pointer.
- Release/ops preconditions: none
- Residual risk or follow-up: none

## Validation

- [ ] `swift build` — n/a (docs-only)
- [ ] `swift test` — n/a
- [x] Other checks run: `grep -rn "web-next-cycle"` across the tree confirms no dangling references to the old path; `readiness` check green on this PR after the Mergeability fix (its failure is what produced the rider)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

Evidence links:

- n/a (git rename + a few lines of text; the grep result above is the verification)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8