### PR TITLE
feat(web): PR_REVIEWER_RERUNS_ENABLED rollout flag + structured skip-reason logs

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -29,6 +29,7 @@ broker scheduling, and debugging commands.
 | `PR_REVIEWER_PRIVATE_KEY` | Vercel | GitHub App private key (PEM) |
 | `PR_REVIEWER_INSTALLATION_ID` | Vercel | GitHub App installation ID for this repo |
 | `PR_REVIEWER_ENABLED` | Vercel (optional) | `0` disables the reviewer; `1` enables it explicitly. If omitted, complete App credentials enable it. |
+| `PR_REVIEWER_RERUNS_ENABLED` | Vercel (optional) | Gates only the continuous-rerun triggers (`reopened`, `ready_for_review`, `synchronize`, body/base edits, evidence comments) independently of `PR_REVIEWER_ENABLED`. Enabled by default; set to `0` to fall back to the original `opened`-only trigger without disabling the reviewer entirely. |
 | `PR_REVIEWER_VAULT_ID` | Vercel (optional) | Vault for MCP credentials (not currently used) |
 | `PR_REVIEWER_MODEL` | Vercel (optional) | Override model (default: `claude-opus-4-6`) |
 | `GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET` | Vercel | Same GitHub webhook secret used by the Cloudflare relay; verifies the forwarded raw payload |

--- a/web/src/app/api/webhooks/github/route.test.ts
+++ b/web/src/app/api/webhooks/github/route.test.ts
@@ -376,6 +376,108 @@ describe("PR review trigger relevance classifier", () => {
 		);
 	});
 
+	it("gates rerun trigger kinds behind PR_REVIEWER_RERUNS_ENABLED while opened is unaffected", () => {
+		const disabledEnv = { PR_REVIEWER_RERUNS_ENABLED: "0" };
+
+		const openedWhileDisabled = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"opened",
+				makePullRequestPayload("opened"),
+				disabledEnv,
+			),
+			"opened",
+		);
+		expect(openedWhileDisabled.context.kind).toBe("opened");
+
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"reopened",
+				makePullRequestPayload("reopened"),
+				disabledEnv,
+			),
+			"reruns_disabled",
+			"ignored",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"ready_for_review",
+				makePullRequestPayload("ready_for_review"),
+				disabledEnv,
+			),
+			"reruns_disabled",
+			"ignored",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"synchronize",
+				makePullRequestPayload("synchronize", {
+					pull_request: { head: { ref: "feature/x", sha: "head-new" } },
+				}),
+				disabledEnv,
+			),
+			"reruns_disabled",
+			"ignored",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { body: "Updated evidence and summary" },
+					changes: { body: { from: "old body" } },
+				}),
+				disabledEnv,
+			),
+			"reruns_disabled",
+			"ignored",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"edited",
+				makePullRequestPayload("edited", {
+					pull_request: { base: { ref: "release/2026-05" } },
+					changes: { base: { ref: { from: "main" } } },
+				}),
+				disabledEnv,
+			),
+			"reruns_disabled",
+			"ignored",
+		);
+		expectSkip(
+			classifyPrReviewTrigger(
+				"issue_comment",
+				"created",
+				makeIssueCommentPayload(
+					"Evidence: https://evidence.cloudcompute.com/pr-123.png",
+				),
+				disabledEnv,
+			),
+			"reruns_disabled",
+			"ignored",
+		);
+
+		// Explicitly-enabled and unset (the default used throughout this file)
+		// both preserve current rerun behavior.
+		const enabledEnv = { PR_REVIEWER_RERUNS_ENABLED: "1" };
+		const synchronizeEnabled = expectTrigger(
+			classifyPrReviewTrigger(
+				"pull_request",
+				"synchronize",
+				makePullRequestPayload("synchronize", {
+					pull_request: { head: { ref: "feature/x", sha: "head-new" } },
+				}),
+				enabledEnv,
+			),
+			"synchronize",
+		);
+		expect(synchronizeEnabled.context.kind).toBe("synchronize");
+	});
+
 	it("keeps repeated body edits and evidence comments idempotent by source id", () => {
 		const firstBody = expectTrigger(
 			classifyPrReviewTrigger(
@@ -564,6 +666,73 @@ describe("/api/webhooks/github POST", () => {
 				kind: "synchronize",
 				triggerSourceId: "newsha123456",
 			});
+		});
+
+		it("skips rerun triggers when PR_REVIEWER_RERUNS_ENABLED=0 but still triggers on opened", async () => {
+			vi.stubEnv("PR_REVIEWER_RERUNS_ENABLED", "0");
+			const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+			const { POST } = await import("./route");
+
+			await POST(
+				makePullRequestRequest("synchronize", {
+					pull_request: {
+						head: { ref: "feature/x", sha: "newsha123456" },
+					},
+				}),
+			);
+			expect(mocks.triggerPrReview).not.toHaveBeenCalled();
+			expect(consoleLog).toHaveBeenCalledTimes(1);
+			const logged = JSON.parse(consoleLog.mock.calls[0][0] as string);
+			expect(logged).toMatchObject({
+				scope: "pr-review-trigger",
+				decision: "skip_review",
+				kind: "reruns_disabled",
+				eventType: "pull_request",
+				action: "synchronize",
+				repo: "fairchild/workspaces",
+				prNumber: 123,
+			});
+
+			mocks.triggerPrReview.mockClear();
+			consoleLog.mockClear();
+
+			await POST(pullRequestOpenedRequest());
+			expect(mocks.triggerPrReview).toHaveBeenCalledTimes(1);
+			expect(mocks.triggerPrReview.mock.calls[0][1]).toMatchObject({
+				kind: "opened",
+			});
+			expect(consoleLog).not.toHaveBeenCalled();
+
+			consoleLog.mockRestore();
+		});
+
+		it("logs a structured skip reason for draft PRs", async () => {
+			const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+			const { POST } = await import("./route");
+
+			await POST(
+				makePullRequestRequest("synchronize", {
+					pull_request: {
+						draft: true,
+						head: { ref: "feature/x", sha: "newsha123456" },
+					},
+				}),
+			);
+
+			expect(mocks.triggerPrReview).not.toHaveBeenCalled();
+			expect(consoleLog).toHaveBeenCalledTimes(1);
+			const logged = JSON.parse(consoleLog.mock.calls[0][0] as string);
+			expect(logged).toMatchObject({
+				scope: "pr-review-trigger",
+				decision: "skip_review",
+				kind: "draft",
+				eventType: "pull_request",
+				action: "synchronize",
+				repo: "fairchild/workspaces",
+				prNumber: 123,
+			});
+
+			consoleLog.mockRestore();
 		});
 
 		it("triggers on PR body edits when changes.body is present", async () => {

--- a/web/src/app/api/webhooks/github/route.ts
+++ b/web/src/app/api/webhooks/github/route.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
 import { triggerPrReview } from "@/lib/agent-runtime/pr-review";
-import { parsePrReviewTrigger } from "@/lib/agent-runtime/pr-review-trigger";
+import {
+	type PrReviewTriggerSkipClassification,
+	classifyPrReviewTrigger,
+} from "@/lib/agent-runtime/pr-review-trigger";
 import {
 	getChatMessageByDiscussionId,
 	pushChatMessage,
@@ -32,6 +35,65 @@ const SUPPORTED_EVENTS = new Set<string>([
 ]);
 
 const WEBHOOK_CANARY_HEADER = "x-workspace-webhook-canary";
+
+// Event types the PR review trigger classifier meaningfully evaluates. Other
+// SUPPORTED_EVENTS members (push, issues, check_run, workflow_run, discussion,
+// discussion_comment) reach this route for unrelated bridging duties and
+// always classify as the classifier's generic "unsupported" catch-all, so
+// logging their skip reason here would just be per-webhook noise.
+const PR_REVIEW_TRIGGER_LOG_EVENTS = new Set<string>([
+	"pull_request",
+	"issue_comment",
+	"pull_request_review",
+	"pull_request_review_comment",
+]);
+
+function extractPrNumberForLog(
+	eventType: string,
+	payload: Record<string, unknown>,
+): number | null {
+	if (eventType === "pull_request" || eventType === "pull_request_review") {
+		const pr = payload.pull_request as Record<string, unknown> | undefined;
+		const number = Number(pr?.number ?? 0);
+		return number || null;
+	}
+	if (
+		eventType === "issue_comment" ||
+		eventType === "pull_request_review_comment"
+	) {
+		const issue = payload.issue as Record<string, unknown> | undefined;
+		if (issue) {
+			const number = Number(issue.number ?? 0);
+			if (number) return number;
+		}
+		const pr = payload.pull_request as Record<string, unknown> | undefined;
+		const number = Number(pr?.number ?? 0);
+		return number || null;
+	}
+	return null;
+}
+
+function logPrReviewTriggerSkip(
+	classification: PrReviewTriggerSkipClassification,
+	eventType: string,
+	action: string,
+	repo: string | undefined,
+	payload: Record<string, unknown>,
+): void {
+	console.log(
+		JSON.stringify({
+			scope: "pr-review-trigger",
+			decision: classification.decision,
+			kind: classification.kind,
+			relevance: classification.relevance,
+			reason: classification.reason,
+			eventType,
+			action,
+			repo: repo ?? "unknown",
+			prNumber: extractPrNumberForLog(eventType, payload),
+		}),
+	);
+}
 
 async function verifySignature(
 	body: string,
@@ -154,7 +216,11 @@ export async function POST(request: Request): Promise<Response> {
 	const action = String(payload.action ?? "");
 	const repo = (payload.repository as Record<string, unknown> | undefined)
 		?.full_name as string | undefined;
-	const trigger = parsePrReviewTrigger(eventType, action, payload);
+	const classification = classifyPrReviewTrigger(eventType, action, payload);
+	const trigger =
+		classification.decision === "trigger_review"
+			? classification.trigger
+			: null;
 
 	if (canary.active) {
 		const wouldTrigger = Boolean(trigger);
@@ -167,6 +233,13 @@ export async function POST(request: Request): Promise<Response> {
 			action,
 			repo: repo ?? "unknown",
 		});
+	}
+
+	if (
+		classification.decision === "skip_review" &&
+		PR_REVIEW_TRIGGER_LOG_EVENTS.has(eventType)
+	) {
+		logPrReviewTriggerSkip(classification, eventType, action, repo, payload);
 	}
 
 	const event: WebhookEvent = {

--- a/web/src/lib/agent-runtime/config.ts
+++ b/web/src/lib/agent-runtime/config.ts
@@ -40,6 +40,18 @@ function isPrReviewerConfigured(env: Env): boolean {
 	return hasAnyPrReviewerCredential(env);
 }
 
+/**
+ * Gates the continuous-rerun trigger surface (reopened, ready_for_review,
+ * synchronize, body/base edits, evidence comments) independently of the
+ * managed reviewer as a whole. Reruns have been live in production for
+ * weeks, so the default is enabled — only an explicit "0" disables them,
+ * falling back to the original opened-only trigger. See
+ * docs/pr-review/pr-reviewer.md.
+ */
+export function isPrReviewerRerunsEnabled(env: Env = process.env): boolean {
+	return env.PR_REVIEWER_RERUNS_ENABLED !== "0";
+}
+
 function requireEnv(
 	env: Env,
 	name: string,

--- a/web/src/lib/agent-runtime/pr-review-trigger.ts
+++ b/web/src/lib/agent-runtime/pr-review-trigger.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { isPrReviewerRerunsEnabled } from "./config";
 import type { PrReviewPayload, PrReviewTrigger } from "./pr-review";
 
 export interface ParsedPrTrigger {
@@ -22,7 +23,8 @@ export type PrReviewTriggerClassificationKind =
 	| "draft"
 	| "bot_sender"
 	| "malformed"
-	| "unsupported";
+	| "unsupported"
+	| "reruns_disabled";
 
 type PrReviewTriggerSkipRelevance = "metadata" | "terminal" | "ignored";
 
@@ -123,7 +125,18 @@ function materialClassification(input: {
 	};
 }
 
-export function classifyPrReviewTrigger(
+// Rerun kinds are gated by PR_REVIEWER_RERUNS_ENABLED; "opened" always runs
+// regardless of the flag so disabling reruns never blocks the initial review.
+const RERUN_TRIGGER_KINDS = new Set<PrReviewTriggerClassificationKind>([
+	"reopened",
+	"ready_for_review",
+	"synchronize",
+	"body_edit",
+	"base_edit",
+	"evidence_comment",
+]);
+
+function classifyPrReviewTriggerCore(
 	eventType: string,
 	action: string,
 	payload: Record<string, unknown>,
@@ -415,6 +428,33 @@ export function classifyPrReviewTrigger(
 		kind: "unsupported",
 		reason: `Unsupported webhook event for managed review: ${eventType}`,
 	});
+}
+
+export function classifyPrReviewTrigger(
+	eventType: string,
+	action: string,
+	payload: Record<string, unknown>,
+	env: Partial<NodeJS.ProcessEnv> = process.env,
+): PrReviewTriggerClassification {
+	const classification = classifyPrReviewTriggerCore(
+		eventType,
+		action,
+		payload,
+	);
+	if (
+		classification.decision === "trigger_review" &&
+		RERUN_TRIGGER_KINDS.has(classification.kind) &&
+		!isPrReviewerRerunsEnabled(env)
+	) {
+		return skipClassification({
+			eventType,
+			action,
+			kind: "reruns_disabled",
+			reason:
+				"PR_REVIEWER_RERUNS_ENABLED is disabled; only initial PR opens trigger managed reviews",
+		});
+	}
+	return classification;
 }
 
 export function parsePrReviewTrigger(


### PR DESCRIPTION
## Summary

- Add `PR_REVIEWER_RERUNS_ENABLED` in `web/src/lib/agent-runtime/config.ts`, following the existing `isPrReviewerConfigured`/`PR_REVIEWER_ENABLED` idiom. **Default: enabled.** Rerun triggers (`reopened`, `ready_for_review`, `synchronize`, body/base edits, evidence comments) have been live in production for weeks; a default-off flag would silently regress shipped behavior. Only an explicit `"0"` disables reruns, falling back to the original `opened`-only trigger. `opened` is never gated.
- Gate the rerun kinds inside `classifyPrReviewTrigger()` in `web/src/lib/agent-runtime/pr-review-trigger.ts` — the single choke point both the webhook route and `pr-reviewer-monitor`'s health-report candidate-key logic already share via `parsePrReviewTrigger()`. Disabled reruns now classify as skip kind `"reruns_disabled"` instead of running.
- `web/src/app/api/webhooks/github/route.ts` previously called `parsePrReviewTrigger()` and discarded the full classification (reason, relevance, skip kind). It now calls `classifyPrReviewTrigger()` directly and logs one structured JSON line via `console.log` for every skip on the event types the classifier meaningfully evaluates (`pull_request`, `issue_comment`, `pull_request_review`, `pull_request_review_comment`), including event type, action, classification kind, decision, reason, repo, and PR number (best-effort extracted from the payload).
- Doc: added `PR_REVIEWER_RERUNS_ENABLED` to the env var table in `docs/pr-review/pr-reviewer.md`.

## Mergeability

- Surface: web
- User-facing behavior changed: none by default (reruns stay on). Operators gain a `PR_REVIEWER_RERUNS_ENABLED=0` kill switch for the rerun surface independent of `PR_REVIEWER_ENABLED`, and production logs now carry a structured skip reason for every classified-but-unactioned PR/issue-comment webhook.
- Non-happy paths considered: `opened` always triggers regardless of the flag; draft/bot/metadata/terminal skips keep their original reason (the flag-disabled reason only appears when a rerun kind would otherwise have triggered); webhook redeliveries and idempotency are untouched (gating happens before fingerprinting).
- Release/ops preconditions: none — flag is optional and defaults to current production behavior.
- Residual risk or follow-up: skip logging is deliberately **not** emitted for `push`/`issues`/`check_run`/`workflow_run`/`discussion`/`discussion_comment` events, since those always classify as the generic `"unsupported"` catch-all and would just be per-webhook noise unrelated to PR review. `pr-reviewer-monitor`'s candidate-key derivation shares the same gate transitively (via `parsePrReviewTrigger`), so disabling reruns also removes them from health-report candidate keys — intentional (single source of truth) but worth a reviewer's attention.

## Validation

- [x] `pnpm install`
- [x] `pnpm run typecheck` — clean (author run + independent gate re-run + CI)
- [x] `pnpm run lint` (`biome check .`) — clean, 192 files (author run + independent gate re-run + CI)
- [x] `pnpm test` — **367/367 passed, 35/35 test files** (author run + independent gate re-run + CI); `route.test.ts` alone: **42/42 passed**, including 3 new tests (classifier-level flag gate, route-level flag gate + draft skip-log assertion)
- [x] Mutation check: temporarily forced the rerun-gate condition to `false` in `pr-review-trigger.ts` — the two new tests that assert flag-gated behavior failed as expected, confirming they actually cover the new gating logic; reverted immediately, full suite green again.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached

Evidence links:

- [Web CI passed on this branch](https://github.com/fairchild/workspaces/actions/runs/28633166179) — lint + typecheck + build + unit (367/367) + Playwright `fast`, hosted run (green-CI-link convention per `docs/development/remote-sessions.md`; no UI surface, so no screenshots apply)
- [Reviewer ingress contract checks passed](https://github.com/fairchild/workspaces/actions/runs/28633166157) — Cloudflare relay contract, ingress canary smoke, and the web reviewer route contract, all green on this branch — direct coverage of the webhook-route surface this PR modifies

## Blockers

- [x] None

Gate note: independently re-verified before ready-for-review — typecheck, biome (192 files), vitest 367/367 re-run from the gate session on commit `acbc7ab`; full-diff review confirmed `opened` is structurally outside the gated kind set, the flag default preserves production behavior, and the monitor route inherits the gate through the shared classifier (single source of truth).

Closes #724

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8)_