### PR TITLE
docs: encode 2026-07-02 session retrospective at the right surfaces

### DIFF
--- a/.agents/skills/subagent-delegation/SKILL.md
+++ b/.agents/skills/subagent-delegation/SKILL.md
@@ -30,14 +30,21 @@ Source: the 2026-07-02 cycle (PRs #723–#732, six first-try gate passes).
   `sync-execution-state.py` owns that lane (`backlog/CLAUDE.md`).
 - PR-body Mergeability fields need real prose — the `readiness` check
   (`scripts/pr-readiness.py`) fails on empty/default/`n/a` answers; when a
-  field doesn't apply, write *why* it doesn't.
+  field doesn't apply, write *why* it doesn't. Read that script before the
+  session's first PR body — it is the body contract.
+- Author the Evidence section with a placeholder slot for the hosted CI link
+  so the gate edits the PR body exactly once, at ready-flip (every body
+  update resends the full text).
 
 ## The gate, before a PR leaves draft
 
-Calibrate depth to risk (#733 tracks formalizing the tiers).
+Calibrate depth to risk — default tiers until #733 lands: docs/test-only →
+diff read + CI + managed reviewer suffice; behavior → add an independent
+suite re-run (don't trust reported counts); security/UI → add the
+adversarial/visual passes below.
 
-- Always: re-run the verification suites yourself — don't trust reported
-  counts; cite the green CI run in the Evidence section; check `Closes #N`.
+- Always: read the full diff; cite the green CI run in the Evidence section;
+  check `Closes #N`.
 - Security-touching: adversarial pass — bypass paths, every failure path no
   worse than pre-change behavior, signer/verifier secret parity.
 - UI-touching: view the screenshots yourself; run the Playwright `full`
@@ -54,4 +61,4 @@ Calibrate depth to risk (#733 tracks formalizing the tiers).
 Serialize PRs touching `package.json`/lockfile; everything else parallelizes in
 worktrees. `web/tests/LEDGER.md` conflicts are expected and additive — keep
 both blocks. One watch owns merge-event follow-through (merge and CI-success
-events don't push to sessions).
+events don't push to sessions) — `scripts/pr-wait.sh <sha>` is that watch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,13 @@ Mac-native app for managing AI coding sessions with embedded terminal.
 
 Craft matters. Plan work so it can land mergeably: correct, coherent with the product, reviewable, verified, and leaving the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist.
 
-When the user asks to implement a change, default to carrying it through to a PR: branch if needed, make the edit, verify it, commit, rebase on the latest `origin/main`, push, open the PR, and report its status. Treat this as a strong default, not a mandate; pause short of PR creation when the user asks for exploration only, says not to publish, or evidence/permissions are blocked.
+When the user asks to implement a change, default to carrying it through to a PR: branch if needed, make the edit, verify it, commit, rebase on the latest `origin/main`, push, open the PR, and report its status. Treat this as a strong default, not a mandate; pause short of PR creation when the user asks for exploration only, says not to publish, or evidence/permissions are blocked. At the start of a multi-PR working session, propose the authority contract explicitly (who reviews, who flips ready, who merges) instead of discovering it one approval at a time — it was the single biggest cycle-time lever in the 2026-07-02 cycle.
 
 ## Startup Instruction Budget
 
 `AGENTS.md` is startup context for every repo session. Keep it under about **4,500 tokens** (roughly **3,300 words**) unless the added guidance is more important than the recurring context cost. Prefer tightening, deduplicating, or moving detailed policy into linked docs over expanding this file.
 
-Continuous improvement of `AGENTS.md` is important to the health and longevity of the codebase: it is how this repo teaches future agents to meet product, quality, evidence, and operational objectives. Improve it when the guidance becomes clearer, shorter, or more actionable.
+Continuous improvement of `AGENTS.md` is important to the health and longevity of the codebase: it is how this repo teaches future agents to meet product, quality, evidence, and operational objectives. Improve it when the guidance becomes clearer, shorter, or more actionable. When encoding a lesson, place it at the cheapest surface that fires at the right moment — machinery (CI gates, scripts) over skills, skills over linked docs, this file last — and when a lesson graduates upward (e.g. prose becomes a script), delete the prose it replaces.
 
 ## Agent skills
 

--- a/docs/development/remote-sessions.md
+++ b/docs/development/remote-sessions.md
@@ -64,6 +64,16 @@ and CI. The `fast/unauth-*` specs still need production mode
 
 ## Session practices that earn their keep
 
+- **File human-lane blockers as issues the moment you hit them** (labels
+  `ops`/`human`), not at reflection time. On 2026-07-02 the evidence-token gap
+  was confirmed in the first hour but filed six hours later — every agent in
+  between paid the same workaround. An early issue gives the owner a chance to
+  fix the environment mid-session.
+- **Wait on PR checks with `scripts/pr-wait.sh <sha>`** (blocks until check
+  runs + the managed-review status are terminal; exits 0 only if all latest
+  runs are green/skipped). Webhook subscription + a per-SHA wait beats a
+  recurring cron for PR babysitting — and beats hand-rolled poll loops, one of
+  which shipped with an early-exit bug before this script existed.
 - **Capture full command output to a file first, filter second.** A flaky test's
   identity was lost in this repo once because grep pipelines ate the failure
   name before anyone saved raw output. `cmd > log 2>&1` then grep the log.

--- a/scripts/pr-wait.sh
+++ b/scripts/pr-wait.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Wait for a commit's CI check-runs and the WorkSpaces Managed Review status
+# to reach terminal states, then exit 0 (all green/skipped) or 1. Replaces the
+# ad-hoc curl/jq poll loops sessions kept reimplementing (one shipped with an
+# early-exit bug on 2026-07-02 — this is the tested single copy).
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") <sha> [--repo owner/name] [--interval seconds] [--no-review]" >&2
+  echo "  Waits for all check-runs (and, unless --no-review, the 'WorkSpaces Managed" >&2
+  echo "  Review' commit status) on <sha> to complete. Requires GH_TOKEN." >&2
+}
+
+SHA="${1:-}"
+[[ -z "$SHA" || "$SHA" == "-h" || "$SHA" == "--help" ]] && { usage; exit 2; }
+shift
+
+REPO="fairchild/workspaces"
+INTERVAL=45
+WAIT_REVIEW=1
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --no-review) WAIT_REVIEW=0; shift ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+API="https://api.github.com/repos/${REPO}/commits/${SHA}"
+AUTH=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+
+checks_settled() {
+  curl -sf "${AUTH[@]}" "${API}/check-runs" |
+    jq -e '(.total_count > 0) and ([[.check_runs | group_by(.name)[] | max_by(.started_at)][] | select(.status != "completed")] | length == 0)' >/dev/null
+}
+
+review_settled() {
+  [[ "$WAIT_REVIEW" == "0" ]] && return 0
+  curl -sf "${AUTH[@]}" "${API}/status" |
+    jq -e '[.statuses[] | select(.context == "WorkSpaces Managed Review"
+            and (.state == "success" or .state == "failure" or .state == "error"))] | length > 0' >/dev/null
+}
+
+until checks_settled && review_settled; do
+  sleep "$INTERVAL"
+done
+
+# Superseded runs (e.g. cancelled re-triggers) linger on the SHA; judge and
+# report only the latest run per check name.
+LATEST='[.check_runs | group_by(.name)[] | max_by(.started_at)]'
+
+echo "== check runs (latest per name) =="
+curl -sf "${AUTH[@]}" "${API}/check-runs" |
+  jq -r "${LATEST} | .[] | \"\(.name): \(.conclusion)\"" | sort -u
+if [[ "$WAIT_REVIEW" == "1" ]]; then
+  echo "== statuses =="
+  curl -sf "${AUTH[@]}" "${API}/status" |
+    jq -r '.statuses[] | "\(.context): \(.state)"' | sort -u
+fi
+
+BAD_CHECKS=$(curl -sf "${AUTH[@]}" "${API}/check-runs" |
+  jq "${LATEST} | [.[] | select(.conclusion != null and .conclusion != \"success\" and .conclusion != \"skipped\" and .conclusion != \"neutral\")] | length")
+BAD_STATUS=0
+if [[ "$WAIT_REVIEW" == "1" ]]; then
+  BAD_STATUS=$(curl -sf "${AUTH[@]}" "${API}/status" |
+    jq '[.statuses[] | select(.context == "WorkSpaces Managed Review" and .state != "success")] | length')
+fi
+[[ "$BAD_CHECKS" == "0" && "$BAD_STATUS" == "0" ]]


### PR DESCRIPTION
## Summary

Encodes the 2026-07-02 *session* retrospective (how we worked, distinct from the already-merged code-state learnings in #735) using the encoding ladder — each lesson placed at the cheapest surface that fires at the right moment, machinery first:

- **Rung 1 — machinery**: `scripts/pr-wait.sh` (new) — the PR check + managed-review wait that this session hand-rolled eight times (once with an early-exit bug). Blocks until all check runs and the `WorkSpaces Managed Review` status are terminal; exits 0 only when the **latest run per check name** is green/skipped (superseded cancelled runs on the same SHA are ignored — a real case found during live testing). `--no-review` for push commits, which never receive the managed-review status.
- **Rung 2 — skill** (`subagent-delegation`): default gate tiers by change class (docs/test-only → diff read + CI + reviewer; behavior → add independent suite re-run; security/UI → add adversarial/visual passes); read `scripts/pr-readiness.py` before the session's first PR body; author PR bodies with an evidence-link placeholder so the gate edits the body exactly once.
- **Rung 3 — linked doc** (`remote-sessions.md`): file human-lane blockers as issues the moment they're hit (the evidence-token gap was known in hour one, filed in hour six — every intervening agent paid the same workaround); per-SHA `pr-wait.sh` over recurring cron for PR babysitting.
- **Rung 4 — AGENTS.md** (two sentences): propose the authority contract (who reviews / flips ready / merges) at the start of a multi-PR session — it was the day's biggest cycle-time lever; and the encoding-ladder principle itself, including the rule that prose graduating into machinery must be deleted.

## Mergeability

- Surface: docs + one new standalone script (no product code touched)
- User-facing behavior changed: none
- Non-happy paths considered: `pr-wait.sh` on a push commit would wait forever for a managed-review status that never arrives — `--no-review` exists and the failure mode was hit and understood during live testing; non-green latest runs → exit 1 (verified); missing `GH_TOKEN` → immediate error via `${GH_TOKEN:?}`; superseded cancelled check runs no longer poison the verdict (latest-run-per-name grouping).
- Release/ops preconditions: none
- Residual risk or follow-up: AGENTS.md grows by ~85 words (now 2,775 of the ~3,300 budget) — both added sentences are universal-behavior lessons, the ladder's bar for that file.

## Validation

- [ ] `swift build` — n/a (no Swift changes)
- [ ] `swift test` — n/a
- [x] Other checks run: `bash -n scripts/pr-wait.sh` clean; live-tested against real SHAs — PR head `acbc7ab` → prints latest-run table, exit 0 (green path); push commit with `--no-review` → exit 1 (non-green path); the initial version's cancelled-run false-negative was caught by this live test and fixed before commit

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config) — the script's live-test transcript is summarized in Validation; no product surface is affected

Evidence links:

- Live test output inline above (docs + standalone tooling script; no CI-runnable surface)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8)_