### PR TITLE
docs: add retro skill; wire it to arc-close moments

### DIFF
--- a/.agents/skills/drive/SKILL.md
+++ b/.agents/skills/drive/SKILL.md
@@ -82,7 +82,7 @@ Read these repo sources before acting:
 ### 6. Close out the milestone
 
 - Make sure each issue has a completion note and the relevant PR link.
-- Update the milestone with retro notes covering outcome, what went well, what was learned, and explicit follow-ups.
+- Run the `retro` skill (`.agents/skills/retro/SKILL.md`) — its output is shipped encodings and filed issues, not notes; summarize the outcome on the milestone.
 - If the milestone is truly complete, say so clearly in the final summary.
 
 ## PR Strategy Rules

--- a/.agents/skills/retro/SKILL.md
+++ b/.agents/skills/retro/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: retro
+description: >
+  Run an end-of-arc retrospective whose output is shipped encodings, not a
+  report. Use when a milestone closes, a plan moves to backlog/done/, or the
+  user asks to step back. Triggers: "retro", "retrospective", "what did we
+  learn", "reflect on this session/arc", arc or milestone completion.
+---
+
+# retro: close an arc by compounding it
+
+An arc is not finished when the last PR merges — it is finished when what the
+arc taught is cheaper for the next session than it was for this one. Process
+proven 2026-07-02 (milestone #7 cycle → PRs #735/#736/#739).
+
+## Two passes, in order
+
+1. **Work reflection** — fresh eyes on what shipped. Consistent patterns
+   (good and bad), issues created or left behind, simplification
+   opportunities. Judge from the code and CI history, not the tracker or
+   your own summaries. Name what the arc made stale.
+2. **Session retro** — how the work happened. What made it fast (keep), what
+   cost rounds/tokens/redos (change), including your own errors — a retro
+   that finds no self-inflicted cost wasn't looking. Quantify where cheap:
+   agent token spend, redo count, rounds-to-merge before vs after authority
+   was settled.
+
+## Rules
+
+- **Output is diffs and issues, not prose.** Every lesson either ships (doc
+  edit, skill edit, script, gate) or files (issue with the right lane label)
+  or is deliberately dropped — say which. A retro that only produces a
+  report has failed.
+- **Place each lesson by the encoding ladder** (see `AGENTS.md` § Startup
+  Instruction Budget): machinery > skill > linked doc > AGENTS.md, matched
+  to the moment the lesson must fire. Promote recurring prose upward and
+  delete what the promotion replaces.
+- **Workarounds name their own obsolescence condition** so the next retro
+  can trim them by lookup instead of judgment.
+- **File human-lane items immediately** (`ops`/`human` labels) — they are
+  the owner's queue, not the report's appendix.
+- Add the narrative to `backlog/ROADMAP.md` § Learnings (the archive layer),
+  dated, newest-first — after the encodings ship, referencing them.
+
+## Definition of done
+
+- [ ] Encoding PR(s) merged (or explicitly deferred with a reason)
+- [ ] Issues filed for non-encodable actions, each in its lane
+- [ ] ROADMAP Learnings entry references the shipped encodings
+- [ ] Anything the arc made stale (docs, tracker rows) is fixed or filed

--- a/backlog/AGENTS.md
+++ b/backlog/AGENTS.md
@@ -96,3 +96,5 @@ failed: dead-letter
 ## ROADMAP
 
 Strategic counterpart at `backlog/ROADMAP.md`. See the `backlog` skill's `references/roadmap.md`.
+
+Closing an arc — milestone done, or a plan moving to `backlog/done/` — includes running the `retro` skill (`.agents/skills/retro/SKILL.md`); the archive commit and the retro's encodings usually travel together.


### PR DESCRIPTION
## Summary

Makes the retrospective process self-sustaining by giving it the three properties that make a process repeat: **one word to invoke** (`.agents/skills/retro/SKILL.md`, capturing the two-pass process proven on 2026-07-02 — work reflection, then session retro), **wired to moments that already happen** (drive's milestone close-out step now runs it instead of writing "retro notes"; `backlog/AGENTS.md` ties it to the plan-archive convention), and **visible payoff enforced by its own definition of done** (output must be shipped encodings and filed issues placed by the encoding ladder — "a retro that only produces a report has failed").

## Mergeability

- Surface: docs (skill + two one-line wiring edits)
- User-facing behavior changed: none
- Non-happy paths considered: the skill's failure mode is becoming ceremony — its "diffs and issues, not prose" rule and definition-of-done checklist are the guard; arcs not managed by `drive` still hit the trigger via the plan-archive convention line or the skill's own trigger words.
- Release/ops preconditions: none
- Residual risk or follow-up: none — first live use will be the next arc's close.

## Validation

- [ ] `swift build` — n/a (docs-only)
- [ ] `swift test` — n/a
- [x] Other checks run: cross-references verified — skill path is identical in both wiring edits and the skill's ladder reference points at the AGENTS.md section that defines it.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config) — the process itself was live-tested today: this cycle's retro produced PRs #735/#736/#739 and issues #733/#734, which is the exact output shape the skill mandates.

Evidence links:

- n/a (docs-only; the cited PRs are the process's live run)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkURUFQpCN7ad4j4zqX8D8)_