### PR TITLE
Web experience redesign: sessions-first greenfield plan + Phase 0 spike

### DIFF
--- a/backlog/web-experience-redesign_plan.md
+++ b/backlog/web-experience-redesign_plan.md
@@ -1,0 +1,150 @@
+# Web Experience Redesign — Sessions-First
+
+Status: **proposed** — direction confirmed with Michael (2026-07-03); four secondary
+decisions below are recommendations awaiting sign-off before Phase 1 starts.
+
+## Intent
+
+The web app becomes a place you **enter a coding session** — the same feeling as
+working with Claude Code in the terminal, but in the browser: a first-class chat
+with a coding agent that can read, write, and run code in a live sandbox, with a
+real terminal into that same sandbox one keystroke away, and a transcript that
+survives closing the laptop. Monitoring (agent teams, pipeline, PR reviews)
+remains, but as the secondary surface; the session is the product.
+
+Test for done: from a phone or a fresh browser, sign in, open a recent session
+(or start one on any connected repo), ask the agent to make a change, watch it
+edit files and run tests as structured tool events — not a wall of text — and
+come back an hour later to a transcript that caught up without losing the thread.
+
+## Why (diagnosis of today's confusion)
+
+- The IA is repo-and-monitoring-first. The prime use case — a session — has no
+  first-class home; Chat and Terminal are two disconnected tabs that sometimes
+  point at the same sandbox.
+- Chat renders a coding agent as one growing text bubble: `tool_use` becomes a
+  transient status label, `tool_result` is discarded. Nothing rich is persisted
+  (`chat_messages` is flat text), so nothing can be replayed.
+- Web chat is hard-wired to read-only tools; the runner's `full` mode
+  (Write/Edit/Bash) has no UI entry point. You cannot actually code via web chat.
+- The turn model fights long sessions: one 300 s SSE request per turn, sandbox
+  snapshotted+killed after every turn.
+- Structural noise: orphaned review-runs page, unused DispatchDialog, silent
+  `catch {}` failures, 10 s polling, agent-identity slug hacks in the UI.
+
+## Decisions (confirmed)
+
+1. **Session-first IA.** Sessions are the primary object: a home screen of
+   active/recent sessions; "new session" picks a repo; entering one gives a
+   unified chat + terminal + context workspace.
+2. **Provider-pluggable runtime.** The session UI is written against the
+   existing `ComputeProvider` / `StreamChunk` seam, not one backend.
+   Vercel Sandbox and Anthropic Managed Agents are the two launch providers;
+   Lume/local later. Capability flags (PTY? snapshot? max duration?) drive
+   which affordances a session shows.
+3. **Vercel AI SDK + AI Elements** for the chat/transcript layer: `useChat`
+   transport, UIMessage message-parts model, AI Elements components for
+   messages/tool cards/code blocks, restyled to our design system.
+
+## Open questions (recommended defaults — confirm or veto)
+
+1. **Rewrite flavor** — recommended: **strangler-fig in-place**. Same Next.js
+   app, auth, DB, deployment, and `src/lib/` runtime; the new `/sessions`
+   surface is built fresh (Tailwind v4 + shadcn/AI Elements coexisting with
+   CSS Modules during transition) and the old Dashboard/Chat/Terminal tabs are
+   **deleted** in the final phase — replace, not co-exist forever. A true
+   greenfield skeleton re-learns paid-for lessons (Claude CLI auth in
+   sandboxes, Turso quota limits, ttyd ticket/HMAC model, cross-tenant authz)
+   for zero product gain and adds a dark period.
+2. **Visual identity** — recommended: **keep the Spaces aesthetic** (Instrument
+   Serif + JetBrains Mono, mint `#a6ffdf` on `#0e1117`), mapped onto
+   Tailwind/shadcn theme variables; consider softening noise/scanlines inside
+   the transcript for readability. Past prototypes that ignored the identity
+   "felt wrong immediately".
+3. **Session layout** — recommended: **chat primary, terminal on demand**. The
+   session is a transcript; a real PTY (ghostty-web) into the same sandbox
+   opens as a collapsible drawer/panel. Split-view can come later for desktop.
+4. **Monitoring** — recommended: **sessions first, port monitoring later**. The
+   old dashboard keeps running untouched while `/sessions` is built; a slim
+   mission-control view is rebuilt in the new stack afterwards (aligns with
+   roadmap item #680).
+
+## Target architecture
+
+### Information architecture
+
+- `/sessions` — home: active + recent sessions across repos (status, repo,
+  provider, last activity), "New session" (repo picker → provider/agent).
+- `/sessions/[id]` — the workspace: transcript (AI Elements), compose bar,
+  session header (repo, branch, provider, sandbox state, stop/resume),
+  terminal drawer (PTY providers only), context rail later (diff, PRs).
+- Old `/dashboard/*` untouched until Phase 4, then slimmed to mission control.
+
+### Backend: durable, resumable turns (the heart of the work)
+
+Today: turn = one ≤300 s SSE request; sandbox snapshot+stop per turn.
+Target:
+
+- **`session_events` table** — append-only structured event log per session
+  (seq, session_id, part type, payload). The single source of truth for the
+  transcript; replaces flat `chat_messages` for sessions. UIMessages are
+  projected from it.
+- **Detached execution**: the agent turn runs detached inside the sandbox (or
+  as a Managed Agents session) and its `StreamChunk`s are written to
+  `session_events` by a lightweight ingest path; the browser-facing route only
+  **tails** the log (SSE with `Last-Event-ID`/seq resume, AI SDK resumable
+  stream on the client). Closing the tab never kills a turn; reconnect catches
+  up. The 300 s route cap stops mattering.
+- **Adapter**: `StreamChunk → UIMessage stream parts` (text, tool-input,
+  tool-output, status). One adapter serves both providers; `TranscriptTerminal`
+  logic informs the tool-part rendering.
+- **Session lifecycle**: sandbox stays alive across turns within a session;
+  idle timeout → snapshot+pause (existing snapshot path); explicit
+  resume/stop controls. `full` tools enabled for sessions (per-session toggle,
+  default on; the sandbox is already network-allowlisted and repo-scoped).
+
+### What stays / what goes
+
+- **Stays untouched**: Better Auth + GitHub OAuth, Kysely/libSQL, provider
+  registry + both providers, terminal ticket/HMAC + ttyd/tmux, PR reviewer
+  subsystem, webhook relay, setup flow.
+- **Extended**: schema (`session_events`, session metadata), session-manager
+  (long-lived lifecycle), agent-stream route (replaced by tail route).
+- **Deleted (Phase 4)**: dashboard-shell tabs, chat-panel/streaming-bubble,
+  terminal-panel tab (canvas component is reused in the drawer), DispatchDialog,
+  old `chat_messages` write path for sessions.
+
+## Phased plan (each phase ships)
+
+- **Phase 0 — Foundation + spike.** Add `ai`, AI Elements, Tailwind v4
+  (scoped so CSS Modules keep working); map design tokens; throwaway
+  `/sessions/spike` page proving StreamChunk→UIMessage adapter end-to-end
+  against the mock provider. Exit: streamed tool cards render in our skin.
+- **Phase 1 — Durable transcript backend.** `session_events` schema +
+  projection to UIMessages; detached runner ingest for vercel-sandbox;
+  Managed Agents event ingest; tail route with resume. Exit: a turn survives
+  tab close/reopen; transcript replays from DB.
+- **Phase 2 — The session surface.** `/sessions` home + `/sessions/[id]`
+  chat with AI Elements (tool cards, code blocks, status), new-session flow,
+  full tools on, sandbox alive across turns with idle snapshot. Exit: real
+  coding session (edit + run tests) completed entirely via web chat.
+- **Phase 3 — Terminal + lifecycle polish.** Terminal drawer (PTY attach to
+  the session sandbox), pause/resume/stop controls, error surfaces (no more
+  silent `catch {}` in the new surface), mobile pass for the transcript.
+- **Phase 4 — Cutover.** Route `/dashboard` chat/terminal users to sessions;
+  delete old tabs/components; rebuild slim mission-control (agent grid,
+  pipeline, activity, review-runs links) in the new stack; reconcile
+  `web/tests/LEDGER.md` (old behaviors retired, new ones added).
+
+## Risks
+
+- **AI SDK protocol fit**: our two providers must both express cleanly as
+  UIMessage parts — de-risked in Phase 0 with the adapter spike before any UI
+  investment.
+- **Tailwind/CSS-Modules coexistence**: scope Tailwind preflight to the new
+  surface to avoid restyling the legacy dashboard accidentally.
+- **Long-lived sandboxes cost more** than snapshot-per-turn: idle timeout +
+  visible sandbox state + stop button keep it bounded.
+- **Full tools on a web surface**: sandbox is already repo-scoped,
+  network-allowlisted, token-scrubbed; keep the per-session toggle and audit
+  trail via `session_events`.

--- a/backlog/web-experience-redesign_plan.md
+++ b/backlog/web-experience-redesign_plan.md
@@ -1,7 +1,11 @@
 # Web Experience Redesign — Sessions-First Greenfield Rewrite
 
 Status: **active** — direction confirmed with Michael (2026-07-03): greenfield
-rewrite, sessions-first, single-user product. Phase 0 in progress on this branch.
+rewrite, sessions-first, single-user product. Phase 0 shipped. **Design locked:
+"Refined Folio"** (`prototypes/web-session-redesign/refine-folio.html`).
+Execution is an autonomous milestone run — operating contract in
+`backlog/web-next-execution-brief.md`, work tracked in the GitHub milestone
+**"Sessions-first web (web-next)"**.
 
 ## Intent
 

--- a/backlog/web-experience-redesign_plan.md
+++ b/backlog/web-experience-redesign_plan.md
@@ -1,7 +1,7 @@
-# Web Experience Redesign — Sessions-First
+# Web Experience Redesign — Sessions-First Greenfield Rewrite
 
-Status: **proposed** — direction confirmed with Michael (2026-07-03); four secondary
-decisions below are recommendations awaiting sign-off before Phase 1 starts.
+Status: **active** — direction confirmed with Michael (2026-07-03): greenfield
+rewrite, sessions-first, single-user product. Phase 0 in progress on this branch.
 
 ## Intent
 
@@ -17,7 +17,7 @@ Test for done: from a phone or a fresh browser, sign in, open a recent session
 edit files and run tests as structured tool events — not a wall of text — and
 come back an hour later to a transcript that caught up without losing the thread.
 
-## Why (diagnosis of today's confusion)
+## Why (diagnosis of the current `web/` app)
 
 - The IA is repo-and-monitoring-first. The prime use case — a session — has no
   first-class home; Chat and Terminal are two disconnected tabs that sometimes
@@ -32,7 +32,7 @@ come back an hour later to a transcript that caught up without losing the thread
 - Structural noise: orphaned review-runs page, unused DispatchDialog, silent
   `catch {}` failures, 10 s polling, agent-identity slug hacks in the UI.
 
-## Decisions (confirmed)
+## Decisions (confirmed 2026-07-03)
 
 1. **Session-first IA.** Sessions are the primary object: a home screen of
    active/recent sessions; "new session" picks a repo; entering one gives a
@@ -43,108 +43,112 @@ come back an hour later to a transcript that caught up without losing the thread
    Lume/local later. Capability flags (PTY? snapshot? max duration?) drive
    which affordances a session shows.
 3. **Vercel AI SDK + AI Elements** for the chat/transcript layer: `useChat`
-   transport, UIMessage message-parts model, AI Elements components for
+   transport, UIMessage message-parts model, AI Elements-style components for
    messages/tool cards/code blocks, restyled to our design system.
+4. **Greenfield rewrite.** A new app is built from scratch in `web-next/`
+   (renamed to `web/` at cutover) with its own Vercel project. The old app
+   keeps running untouched — including its webhook intake and the managed PR
+   reviewer — until the new app reaches cutover. Organs are **ported by copy**
+   from `web/src/lib/` where they encode paid-for lessons (agent-runtime
+   providers, Claude CLI sandbox auth via `env.sh`, base snapshots, ttyd
+   ticket/HMAC terminal security); everything UI, schema, and route-level is
+   designed fresh.
+5. **Single-user product.** Michael is the only user. Auth stays (the app is
+   internet-facing and holds GitHub tokens + sandbox access) but collapses to
+   GitHub OAuth + a login allowlist. No multi-tenant authz matrix, no
+   onboarding polish, no cross-tenant test suite, no data migration — the new
+   DB starts empty and the repo list is re-picked once.
 
-## Open questions (recommended defaults — confirm or veto)
+## Design defaults (standing unless vetoed)
 
-1. **Rewrite flavor** — recommended: **strangler-fig in-place**. Same Next.js
-   app, auth, DB, deployment, and `src/lib/` runtime; the new `/sessions`
-   surface is built fresh (Tailwind v4 + shadcn/AI Elements coexisting with
-   CSS Modules during transition) and the old Dashboard/Chat/Terminal tabs are
-   **deleted** in the final phase — replace, not co-exist forever. A true
-   greenfield skeleton re-learns paid-for lessons (Claude CLI auth in
-   sandboxes, Turso quota limits, ttyd ticket/HMAC model, cross-tenant authz)
-   for zero product gain and adds a dark period.
-2. **Visual identity** — recommended: **keep the Spaces aesthetic** (Instrument
-   Serif + JetBrains Mono, mint `#a6ffdf` on `#0e1117`), mapped onto
-   Tailwind/shadcn theme variables; consider softening noise/scanlines inside
-   the transcript for readability. Past prototypes that ignored the identity
-   "felt wrong immediately".
-3. **Session layout** — recommended: **chat primary, terminal on demand**. The
-   session is a transcript; a real PTY (ghostty-web) into the same sandbox
-   opens as a collapsible drawer/panel. Split-view can come later for desktop.
-4. **Monitoring** — recommended: **sessions first, port monitoring later**. The
-   old dashboard keeps running untouched while `/sessions` is built; a slim
-   mission-control view is rebuilt in the new stack afterwards (aligns with
-   roadmap item #680).
+- **Visual identity: keep the Spaces aesthetic** — Instrument Serif +
+  JetBrains Mono, mint `#a6ffdf` on `#0e1117` — mapped onto Tailwind theme
+  variables; soften noise/scanlines inside the transcript for readability.
+- **Session layout: chat primary, terminal on demand.** The session is a
+  transcript; a real PTY (ghostty-web) into the same sandbox opens as a
+  collapsible drawer. Desktop split-view can come later.
+- **Monitoring: sessions first.** The old dashboard keeps serving monitoring
+  until a slim mission-control view is rebuilt late in the new stack.
 
 ## Target architecture
 
 ### Information architecture
 
-- `/sessions` — home: active + recent sessions across repos (status, repo,
+- `/` — sessions home: active + recent sessions across repos (status, repo,
   provider, last activity), "New session" (repo picker → provider/agent).
-- `/sessions/[id]` — the workspace: transcript (AI Elements), compose bar,
-  session header (repo, branch, provider, sandbox state, stop/resume),
-  terminal drawer (PTY providers only), context rail later (diff, PRs).
-- Old `/dashboard/*` untouched until Phase 4, then slimmed to mission control.
+  Single-user: no marketing landing; unauthenticated → sign-in.
+- `/sessions/[id]` — the workspace: transcript (message parts + tool cards),
+  compose bar, session header (repo, branch, provider, sandbox state,
+  stop/resume), terminal drawer (PTY providers only), context rail later
+  (diff, PRs).
 
-### Backend: durable, resumable turns (the heart of the work)
-
-Today: turn = one ≤300 s SSE request; sandbox snapshot+stop per turn.
-Target:
+### Durable, resumable turns (the heart of the work)
 
 - **`session_events` table** — append-only structured event log per session
-  (seq, session_id, part type, payload). The single source of truth for the
-  transcript; replaces flat `chat_messages` for sessions. UIMessages are
-  projected from it.
+  (seq, session_id, part payload). The single source of truth for the
+  transcript; UIMessages are projected from it. Designed fresh — no legacy
+  `chat_messages` compatibility.
 - **Detached execution**: the agent turn runs detached inside the sandbox (or
-  as a Managed Agents session) and its `StreamChunk`s are written to
-  `session_events` by a lightweight ingest path; the browser-facing route only
-  **tails** the log (SSE with `Last-Event-ID`/seq resume, AI SDK resumable
-  stream on the client). Closing the tab never kills a turn; reconnect catches
-  up. The 300 s route cap stops mattering.
+  as a Managed Agents session) and its `StreamChunk`s are ingested into
+  `session_events`; the browser-facing route only **tails** the log (SSE with
+  seq-based resume, AI SDK resumable stream on the client). Closing the tab
+  never kills a turn; reconnect catches up. Route duration caps stop mattering.
 - **Adapter**: `StreamChunk → UIMessage stream parts` (text, tool-input,
-  tool-output, status). One adapter serves both providers; `TranscriptTerminal`
-  logic informs the tool-part rendering.
+  tool-output, status). One adapter serves both providers. De-risked first
+  (Phase 0) as a pure module with unit tests.
 - **Session lifecycle**: sandbox stays alive across turns within a session;
   idle timeout → snapshot+pause (existing snapshot path); explicit
-  resume/stop controls. `full` tools enabled for sessions (per-session toggle,
-  default on; the sandbox is already network-allowlisted and repo-scoped).
+  resume/stop controls. `full` tools (Write/Edit/Bash) on by default —
+  single-user, repo-scoped, network-allowlisted sandboxes.
 
-### What stays / what goes
+### Ported vs fresh vs left behind
 
-- **Stays untouched**: Better Auth + GitHub OAuth, Kysely/libSQL, provider
-  registry + both providers, terminal ticket/HMAC + ttyd/tmux, PR reviewer
-  subsystem, webhook relay, setup flow.
-- **Extended**: schema (`session_events`, session metadata), session-manager
-  (long-lived lifecycle), agent-stream route (replaced by tail route).
-- **Deleted (Phase 4)**: dashboard-shell tabs, chat-panel/streaming-bubble,
-  terminal-panel tab (canvas component is reused in the drawer), DispatchDialog,
-  old `chat_messages` write path for sessions.
+- **Ported by copy (with their tests where they exist)**: agent-runtime
+  (`types.ts`, provider registry, `vercel-sandbox.ts`, `managed-agents.ts` +
+  event mapping), terminal ticket/HMAC + ttyd/tmux logic, Better Auth + GitHub
+  OAuth config, Kysely/libSQL setup.
+- **Fresh**: all UI (Tailwind v4 + AI Elements-style components), schema
+  (`sessions`, `session_events`, minimal `repos`), API routes, session
+  orchestration (long-lived lifecycle replaces snapshot-per-turn
+  `session-manager.ts`).
+- **Left running in old `web/` until late**: webhook intake, managed PR
+  reviewer, activity feed, dashboard/monitoring. Ported or re-pointed at
+  cutover; the PR reviewer is the largest port and is explicitly its own
+  phase, not a blocker for sessions.
 
-## Phased plan (each phase ships)
+## Phased plan (each phase ships to the new app's preview URL)
 
-- **Phase 0 — Foundation + spike.** Add `ai`, AI Elements, Tailwind v4
-  (scoped so CSS Modules keep working); map design tokens; throwaway
-  `/sessions/spike` page proving StreamChunk→UIMessage adapter end-to-end
-  against the mock provider. Exit: streamed tool cards render in our skin.
+- **Phase 0 — Skeleton + adapter spike.** `web-next/` scaffold (Next 15, AI
+  SDK, Tailwind v4, design tokens ported), the `StreamChunk → UIMessage`
+  adapter as a pure unit-tested module, and a spike page streaming mock
+  provider chunks through the adapter into `useChat` with tool-part rendering.
+  Exit: streamed tool cards render in the Spaces skin.
 - **Phase 1 — Durable transcript backend.** `session_events` schema +
-  projection to UIMessages; detached runner ingest for vercel-sandbox;
-  Managed Agents event ingest; tail route with resume. Exit: a turn survives
-  tab close/reopen; transcript replays from DB.
-- **Phase 2 — The session surface.** `/sessions` home + `/sessions/[id]`
-  chat with AI Elements (tool cards, code blocks, status), new-session flow,
-  full tools on, sandbox alive across turns with idle snapshot. Exit: real
-  coding session (edit + run tests) completed entirely via web chat.
+  UIMessage projection; detached-runner ingest for vercel-sandbox; Managed
+  Agents event ingest; tail route with seq resume; auth (GitHub OAuth +
+  allowlist). Exit: a turn survives tab close/reopen; transcript replays
+  from DB.
+- **Phase 2 — The session surface.** Sessions home + `/sessions/[id]` with
+  full transcript UI, new-session flow, full tools on, sandbox alive across
+  turns with idle snapshot. Exit: a real coding session (edit + run tests)
+  completed entirely via the new app.
 - **Phase 3 — Terminal + lifecycle polish.** Terminal drawer (PTY attach to
-  the session sandbox), pause/resume/stop controls, error surfaces (no more
-  silent `catch {}` in the new surface), mobile pass for the transcript.
-- **Phase 4 — Cutover.** Route `/dashboard` chat/terminal users to sessions;
-  delete old tabs/components; rebuild slim mission-control (agent grid,
-  pipeline, activity, review-runs links) in the new stack; reconcile
-  `web/tests/LEDGER.md` (old behaviors retired, new ones added).
+  the session sandbox via ported ticket flow), pause/resume/stop controls,
+  first-class error surfaces, mobile pass for the transcript.
+- **Phase 4 — Cutover.** Point the production domain at the new app; port or
+  re-home webhook intake, PR reviewer, and a slim mission-control view;
+  retire the old `web/` (delete or archive) and rename `web-next/` → `web/`;
+  rebuild the test LEDGER around the new surface.
 
 ## Risks
 
-- **AI SDK protocol fit**: our two providers must both express cleanly as
-  UIMessage parts — de-risked in Phase 0 with the adapter spike before any UI
-  investment.
-- **Tailwind/CSS-Modules coexistence**: scope Tailwind preflight to the new
-  surface to avoid restyling the legacy dashboard accidentally.
+- **AI SDK protocol fit**: both providers must express cleanly as UIMessage
+  parts — de-risked in Phase 0 before any UI investment.
+- **PR reviewer port** is the long tail of cutover; mitigated by keeping the
+  old app deployed as the webhook/reviewer backend indefinitely until its
+  port is proven. Nothing in Phases 0–3 touches it.
+- **Two apps sharing sandbox/token secrets** during the transition: separate
+  Vercel projects, separate DBs; only provider credentials are shared.
 - **Long-lived sandboxes cost more** than snapshot-per-turn: idle timeout +
-  visible sandbox state + stop button keep it bounded.
-- **Full tools on a web surface**: sandbox is already repo-scoped,
-  network-allowlisted, token-scrubbed; keep the per-session toggle and audit
-  trail via `session_events`.
+  visible sandbox state + stop button keep it bounded; single user caps blast
+  radius.

--- a/backlog/web-next-execution-brief.md
+++ b/backlog/web-next-execution-brief.md
@@ -1,0 +1,132 @@
+# web-next Execution Brief — operating contract for the milestone orchestrator
+
+This is the standing contract for the autonomous run that builds the
+sessions-first web experience (`web-next/`). The **what** lives in the PRD
+(`backlog/web-experience-redesign_plan.md`) and the per-issue acceptance
+criteria; this file is the **how**: the quality bar, the loop, and the
+authority under which you operate. Read it fully before picking the first issue,
+and re-read the Definition of Done before every merge.
+
+## Mission
+
+Deliver the milestone **"Sessions-first web (web-next)"** to completion: a
+browser coding-session experience where the user signs in, opens or starts a
+session on a connected repo, chats with an agent that edits and runs code in a
+real cloud sandbox — rendered in the Folio design system — with a transcript
+that survives disconnect, a terminal into the same sandbox, deployed as the
+primary web session surface. The visual system is decided: the "Refined Folio"
+prototype (`prototypes/web-session-redesign/refine-folio.html`) is the spec.
+
+## Authority
+
+You have a **full autonomous mandate**. You make the quality decisions and the
+merge decisions. Michael is not in the per-PR loop.
+
+- **Self-merge** any PR that is scoped to `web-next/` (plus its own CI/docs) and
+  meets the Definition of Done below. Green + evidenced + within perf budget is
+  pre-approval.
+- **Escalate to Michael** (open the PR, do not merge, and leave a clear question)
+  only when a change reaches outside `web-next/` in a risky way, incurs
+  meaningful recurring cost, makes a one-way architectural decision the PRD
+  didn't anticipate, has a security dimension, or when CI fails the same way
+  three times and you cannot diagnose it. Taste calls are yours — do not stall a
+  slice on a subjective fork you can reason about; decide, note why, move on.
+- Uphold an **uncompromising bar**. "Tests pass" is the floor, not the target.
+  A PR that is green but unclear, unmeasured, or ugly does not meet the bar.
+
+## Operating mode: serial
+
+Work **one issue at a time, in issue order**. Concurrency is explicitly not
+wanted here — a clean, legible, well-verified relay beats a fast fan-out. You may
+still spawn subagents *within* an issue (a reviewer, a verifier, a perf runner),
+and route by strength: Fable for the Folio/UI component work, a stronger model
+(Opus) for the hairy backend (schema, durable/resumable turns, provider
+lifecycle, terminal port). But land one issue, merge it, reassess, then take the
+next.
+
+## Definition of Done — every PR must clear all of these
+
+1. **Acceptance criteria met** — each checkbox in the issue, verified against the
+   actual tree (not assumed). Close the issue with `Closes #N`.
+2. **Green CI** — the `web-next` lane (lint, typecheck, unit, build, Playwright,
+   perf) passes. No skips, no `[pending-ci]`.
+3. **Evidence, including screenshots** — most PRs change UI; those MUST include a
+   screenshot (or short video for motion) of the actual surface, captured from
+   the commit under review, in **both light and dark**. Backend-only PRs attach
+   test output and, where behavior is observable, a captured trace. Paste hosted
+   links (or a green-CI artifact link) into the PR body — never local-only paths.
+4. **Self-verification** — you drove the real flow, not just the tests. For a UI
+   slice that means loading the surface and exercising it (send a message, watch
+   it stream, toggle theme); for a backend slice, exercising the endpoint/turn
+   end to end. Use the `verify` skill's discipline: observe behavior, don't infer
+   it from a passing suite.
+5. **Performance measured** — for any perf-sensitive change (streaming,
+   transcript render, routing, providers, tail/resume) run the perf harness and
+   paste before/after/delta against the canonical scenarios. A metric regressing
+   past its budget blocks the merge until fixed or explicitly re-budgeted with a
+   reason.
+6. **Readability & maintainability — non-negotiable** — run `/code-review` and
+   `/simplify` and act on them. Names say what they mean; types carry the intent;
+   files that aren't self-evident open with a short purpose block; no dead code,
+   no commented-out code, no copy-paste that should be a function. A reviewer
+   opening this cold should understand it without you in the room.
+7. **Tests** — behavior over implementation. New behavior worth keeping gets a
+   test; the `web-next` test suite grows with the surface.
+
+## Performance discipline
+
+Stand up the perf harness in the first issue (T0) and keep a
+`web-next/perf/contract.json` of canonical scenarios + budgets (mirrors the
+Swift app's `config/performance/contract.json` culture). Track, at minimum:
+
+- **Time-to-first-token** — send → first token painted (separate budgets for the
+  mock provider and a real sandbox, since provisioning dominates the latter).
+- **Streaming cadence** — no long task >50ms while tokens arrive; the transcript
+  stays at 60fps. Token application is batched (rAF), not per-chunk React state.
+- **Transcript render at scale** — seed ~200 messages; initial render and scroll
+  stay within budget (reach for virtualization only if measurement demands it).
+- **Route performance** — `/` and `/sessions/[id]`: LCP, TBT, and first-load JS
+  budget.
+- **Resume latency** — reconnect → caught up for a ~100-event log.
+
+Establish the baseline early; from then on **no PR regresses a tracked metric
+past budget** without an explicit, reasoned re-budget. The point is a quantified,
+defended "fast" — not a vibe.
+
+## Reassessment loop — after every merged PR
+
+The tracker lags the code; treat the plan as living.
+
+1. Re-read the milestone and the remaining issues.
+2. `rg` each remaining issue's acceptance criteria against the current tree —
+   close anything already satisfied, in the same cycle.
+3. If reality diverged from the plan (a slice was bigger/smaller than thought, an
+   ordering is now wrong, a new prerequisite appeared), **edit the issues and the
+   PRD** to match before continuing. Split, merge, reorder, or add issues as the
+   work teaches you. Note what you changed and why in the issue.
+4. Then pick the next issue.
+
+## Scope guards
+
+- **Single-user.** No multi-tenant authorization matrix, no onboarding polish, no
+  data migration. Auth is OAuth + a login allowlist.
+- **Mock-first.** Prove the Folio surface streams correctly against the mock
+  provider before wiring real compute; swap providers behind the same
+  `StreamChunk → UIMessage` adapter.
+- **Don't disturb the old app.** `web/` keeps serving webhooks and the managed PR
+  reviewer until the final cutover issue; nothing before it touches that path.
+
+## Tooling
+
+Use the repo's machinery: the `drive` skill for milestone delivery, the
+`subagent-delegation` skill for within-issue fan-out, `verify` for
+self-validation, `/code-review` and `/simplify` for the quality gate, `qa-web`
+for the Playwright/evidence lane, and `evidence.sh` (or the sanctioned remote
+fallbacks in `docs/development/remote-sessions.md`) for hosted evidence.
+
+## Stop condition
+
+The milestone is done when every issue's acceptance criteria are met, `web-next`
+is the primary session surface at its URL, the old chat/terminal tabs are
+demoted, and the docs/LEDGER reconcile. At that point, report to Michael with the
+final state and the evidence trail.

--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -8,3 +8,4 @@ Open any file directly in a browser — no build step needed.
 | Project | Description | Status |
 |---------|-------------|--------|
 | [spaces-dashboard](spaces-dashboard/) | Agent discovery dashboard for spaces.cloudcompute.com | Chosen: Prototype D |
+| [web-session-redesign](web-session-redesign/) | Session-view concepts for the sessions-first web rewrite (calm, iA-Writer direction) | Chosen: Refined Folio (`refine-folio.html`) |

--- a/prototypes/web-session-redesign/.gitignore
+++ b/prototypes/web-session-redesign/.gitignore
@@ -1,0 +1,4 @@
+# Local-only design review artifacts — keep the lightweight HTML mockups in git,
+# but not the multi-MB rendered screenshots or the base64-embedded galleries.
+*.png
+gallery*.html

--- a/prototypes/web-session-redesign/alt-aperture.html
+++ b/prototypes/web-session-redesign/alt-aperture.html
@@ -1,0 +1,655 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Aperture — Spaces session view concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,300..700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  /* ————————————————————————————————————————————————
+     APERTURE — the session as a shallow depth of field.
+     The live work holds the focal plane: sharp, large, calm.
+     Completed turns fall back into a dimmed, blurred stack —
+     bokeh you can pull into focus. Progressive disclosure at
+     the layout level, not the paragraph level. Warm focus
+     light on a cool studio ground; warm charcoal at night.
+     ———————————————————————————————————————————————— */
+
+  :root {
+    --bg:        #F1F2F5;
+    --bg-hi:     #FBFBFD;
+    --focal:     #FFFFFF;
+    --recede:    #E9EAEE;
+    --ink:       #191B1F;
+    --muted:     #565A62;
+    --faint:     #9498A1;
+    --line:      #E3E5EA;
+    --line-soft: #ECEDF1;
+    --accent:    #B0722A;
+    --accent-hi: #C98B3E;
+    --accent-wash: rgba(176,114,42,.10);
+    --live:      #5E8F63;
+    --add-bg:    #EAF1E7;
+    --add-ink:   #3E6B43;
+    --del-bg:    #F4ECE6;
+    --del-ink:   #9A5B44;
+    --focal-shadow: 0 1px 2px rgba(20,22,26,.05), 0 30px 64px -34px rgba(20,22,26,.26);
+    --lift: 0 1px 2px rgba(20,22,26,.04), 0 14px 30px -20px rgba(20,22,26,.20);
+    --glow: transparent;
+    --grain: .015;
+    --sans: 'Bricolage Grotesque', 'Seravek', system-ui, sans-serif;
+    --mono: 'Geist Mono', ui-monospace, 'SF Mono', monospace;
+  }
+  html[data-theme="dark"] {
+    --bg:        #161410;
+    --bg-hi:     #1B1813;
+    --focal:     #221E17;
+    --recede:    #1A1712;
+    --ink:       #EAE4D6;
+    --muted:     #A79E8C;
+    --faint:     #756D5F;
+    --line:      rgba(234,222,196,.10);
+    --line-soft: rgba(234,222,196,.06);
+    --accent:    #E0A55C;
+    --accent-hi: #EDB671;
+    --accent-wash: rgba(224,165,92,.13);
+    --live:      #93BD82;
+    --add-bg:    rgba(147,189,130,.10);
+    --add-ink:   #AECF9C;
+    --del-bg:    rgba(207,133,112,.11);
+    --del-ink:   #D0977F;
+    --focal-shadow: 0 1px 0 rgba(234,222,196,.05) inset, 0 30px 70px -34px rgba(0,0,0,.9);
+    --lift: 0 22px 50px -30px rgba(0,0,0,.85);
+    --glow: radial-gradient(680px 300px at 50% 4%, rgba(224,165,92,.10), transparent 70%);
+    --grain: .03;
+  }
+
+  * { margin:0; padding:0; box-sizing:border-box; }
+  html { -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility; }
+  body {
+    min-height: 100vh;
+    background:
+      radial-gradient(1200px 720px at 50% -6%, var(--bg-hi), transparent 60%),
+      var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16px; line-height: 1.6;
+    transition: background .5s ease, color .5s ease;
+  }
+  /* faint film grain — atmosphere, not decoration */
+  body::before {
+    content:""; position: fixed; inset: 0; z-index: 0; pointer-events: none;
+    opacity: var(--grain);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+  ::selection { background: var(--accent-wash); }
+  button { font:inherit; color:inherit; background:none; border:none; cursor:pointer; }
+  code {
+    font-family: var(--mono); font-size: .84em;
+    background: color-mix(in srgb, var(--ink) 6%, transparent);
+    padding: 1px 5px 2px; border-radius: 4px;
+  }
+  html[data-theme="dark"] code { background: rgba(234,222,196,.08); }
+  .reticle { width: 15px; height: 15px; flex-shrink: 0; }
+
+  /* ——— identity: one quiet line, no wordmark ——— */
+  .ident {
+    position: relative; z-index: 5;
+    max-width: 1200px; margin: 0 auto;
+    display:flex; align-items:center; justify-content:space-between;
+    padding: 22px 40px 0;
+    font-family: var(--mono); font-size: 11.5px; color: var(--faint);
+    letter-spacing: .01em;
+  }
+  .ident .crumbs { display:flex; align-items:center; gap: 0; }
+  .ident b { color: var(--muted); font-weight: 500; }
+  .ident .sep { margin: 0 9px; opacity: .5; }
+  .live-dot {
+    width: 6px; height: 6px; border-radius: 50%; background: var(--live);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--live) 16%, transparent);
+    margin-right: 9px; display:inline-block; vertical-align: 1px;
+  }
+  .toggle {
+    display:flex; align-items:center; gap: 8px;
+    font-family: var(--mono); font-size: 11px; color: var(--faint);
+    border: 1px solid var(--line); border-radius: 99px;
+    padding: 5px 12px 5px 10px;
+    transition: border-color .2s, color .2s;
+  }
+  .toggle:hover { border-color: var(--faint); color: var(--muted); }
+  .toggle .g { color: var(--accent); }
+
+  /* ——— the lens: the optical field ——— */
+  .lens {
+    position: relative; z-index: 1;
+    max-width: 820px; margin: 0 auto;
+    padding: 30px 30px 44px;
+  }
+
+  /* ——— the depth: earlier turns, fallen out of focus ——— */
+  .depth-label {
+    display:flex; align-items:center; gap: 12px;
+    font-family: var(--mono); font-size: 10px; letter-spacing: .22em;
+    text-transform: uppercase; color: var(--faint);
+    padding: 4px 6px 2px;
+  }
+  .depth-label::after { content:""; height:1px; flex:1; background: var(--line-soft); }
+  .depth { display:flex; flex-direction: column; gap: 10px; padding: 10px 0 4px; }
+
+  .recede {
+    display:block; width: 90%; margin: 0 auto; text-align: left;
+    background: var(--recede); border: 1px solid var(--line-soft);
+    border-radius: 13px; padding: 13px 18px;
+    transform: scale(.965);
+    filter: blur(1.4px) saturate(.72);
+    opacity: .5;
+    transition: filter .45s cubic-bezier(.2,.7,.2,1), opacity .45s ease,
+                transform .45s cubic-bezier(.2,.7,.2,1), background .3s, box-shadow .4s;
+    cursor: pointer; position: relative;
+  }
+  .recede:nth-child(1) { transform: scale(.94); filter: blur(2px) saturate(.62); opacity: .4; width: 84%; }
+  .recede:hover { filter: blur(.3px) saturate(.9); opacity: .82; transform: scale(.985); }
+  .recede.pulled {
+    filter: none; opacity: 1; transform: none; width: 100%;
+    background: var(--focal); border-color: var(--line);
+    box-shadow: var(--lift); cursor: default;
+  }
+  .recede-line { display:flex; align-items: baseline; gap: 11px; }
+  .recede-who {
+    font-family: var(--mono); font-size: 11px; letter-spacing: .04em;
+    color: var(--accent); flex-shrink: 0;
+  }
+  .recede.agent .recede-who { color: var(--muted); }
+  .recede-gist {
+    color: var(--muted); font-size: 14px; white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis; min-width: 0;
+  }
+  .recede.pulled .recede-gist { display: none; }
+  .recede-pull {
+    margin-left: auto; flex-shrink: 0;
+    font-family: var(--mono); font-size: 10px; letter-spacing: .05em;
+    color: var(--faint); opacity: 0; transition: opacity .25s;
+    display:flex; align-items:center; gap: 6px;
+  }
+  .recede:hover .recede-pull { opacity: 1; }
+  .recede.pulled .recede-pull { display: none; }
+  .recede-full {
+    max-height: 0; overflow: hidden;
+    opacity: 0; transition: max-height .5s cubic-bezier(.2,.7,.2,1), opacity .4s ease .05s;
+  }
+  .recede.pulled .recede-full { max-height: 320px; opacity: 1; }
+  .recede-full .head {
+    display:flex; align-items:baseline; gap: 11px; margin-bottom: 8px;
+  }
+  .recede-full .head .who { font-family: var(--mono); font-size: 11px; color: var(--accent); }
+  .recede.agent .recede-full .head .who { color: var(--muted); }
+  .recede-full .head .t { font-family: var(--mono); font-size: 10.5px; color: var(--faint); margin-left: auto; }
+  .recede-full p { font-size: 15px; line-height: 1.62; color: var(--ink); padding-bottom: 4px; }
+  .recede.user .recede-full p { color: var(--muted); }
+
+  /* ——— the focal plane marker ——— */
+  .plane {
+    display:flex; align-items:center; gap: 14px; justify-content: center;
+    margin: 26px 0 16px; color: var(--accent);
+  }
+  .plane::before, .plane::after {
+    content:""; height: 1px; flex: 1;
+    background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--accent) 40%, transparent));
+  }
+  .plane::after { background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 40%, transparent), transparent); }
+  .plane .tag {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .22em;
+    text-transform: uppercase; display:flex; align-items:center; gap: 8px;
+  }
+
+  /* ——— the focal card: the live work, sharp ——— */
+  .focal {
+    position: relative;
+    background: var(--focal);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    padding: 30px 34px 28px;
+    box-shadow: var(--focal-shadow);
+  }
+  .focal::before {
+    content:""; position: absolute; inset: -40px -20px 40%; z-index: -1;
+    background: var(--glow); pointer-events: none;
+  }
+  .focal-head {
+    display:flex; align-items: baseline; gap: 12px; margin-bottom: 16px;
+  }
+  .focal-head .who { font-family: var(--mono); font-size: 12px; color: var(--muted); letter-spacing: .02em; }
+  .focal-head .who b { color: var(--ink); font-weight: 500; }
+  .focal-head .t { font-family: var(--mono); font-size: 10.5px; color: var(--faint); margin-left: auto; }
+  .focal p { font-size: 16.5px; line-height: 1.68; color: var(--ink); }
+  .focal p + p { margin-top: 14px; }
+  .focal p em { color: var(--muted); font-style: italic; }
+
+  /* ——— tool steps: quiet, collapsed, one open ——— */
+  .steps { margin: 20px 0 4px; border-top: 1px solid var(--line-soft); }
+  .step { border-bottom: 1px solid var(--line-soft); }
+  .step-head {
+    display:flex; align-items:center; gap: 12px; width:100%;
+    text-align:left; padding: 10px 4px;
+    font-family: var(--mono); font-size: 12.5px; color: var(--muted);
+    cursor: pointer;
+  }
+  .step-head:hover { color: var(--ink); }
+  .tw { width: 9px; color: var(--faint); font-size: 10px; transition: transform .2s ease; transform-origin: 46% 52%; flex-shrink:0; }
+  .step.open .tw { transform: rotate(90deg); }
+  .verb {
+    font-size: 9.5px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--faint); min-width: 3em; flex-shrink: 0;
+  }
+  .step.edit .verb, .step.run .verb { color: var(--accent); }
+  .obj { color: inherit; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; }
+  .step-meta { margin-left:auto; color: var(--faint); font-size: 11.5px; white-space:nowrap; padding-left: 14px; flex-shrink: 0; }
+  .step-meta .plus { color: var(--add-ink); } .step-meta .minus { color: var(--del-ink); }
+  .step-meta .pass { color: var(--add-ink); }
+  .step-body { display:none; padding: 0 4px 14px 30px; animation: reveal .32s ease both; }
+  .step.open .step-body { display:block; }
+  .term {
+    font-family: var(--mono); font-size: 12px; line-height: 1.85;
+    background: var(--bg); border: 1px solid var(--line-soft);
+    border-radius: 10px; padding: 12px 16px; overflow-x:auto; white-space: pre;
+    color: var(--muted);
+  }
+  html[data-theme="dark"] .term { background: #14110C; }
+  .term .ok { color: var(--add-ink); }
+  .term .num { color: var(--ink); font-weight: 500; }
+
+  /* ——— contextual moment: the diff, surfaced because the edit landed ——— */
+  .moment {
+    margin: 22px 0 6px;
+    border: 1px solid var(--line);
+    border-radius: 14px; overflow: hidden;
+    background: var(--bg-hi);
+    box-shadow: var(--lift);
+    animation: settle .7s cubic-bezier(.2,.7,.2,1) both .15s;
+  }
+  html[data-theme="dark"] .moment { background: #1D1913; }
+  .moment-cap {
+    display:flex; align-items:center; gap: 11px;
+    padding: 11px 16px; border-bottom: 1px solid var(--line-soft);
+    font-family: var(--mono); font-size: 11.5px; color: var(--muted);
+  }
+  .moment-cap .file { color: var(--ink); }
+  .moment-cap .delta .plus { color: var(--add-ink); } .moment-cap .delta .minus { color: var(--del-ink); margin-left: 6px; }
+  .moment-cap .why {
+    margin-left:auto; display:flex; align-items:center; gap: 7px;
+    font-size: 10.5px; color: var(--accent);
+  }
+  .moment-cap .close { color: var(--faint); font-size: 12px; line-height:1; padding: 2px 2px 2px 8px; opacity: 0; transition: opacity .2s; }
+  .moment:hover .close { opacity: 1; }
+  .moment-cap .close:hover { color: var(--ink); }
+  .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.78; padding: 12px 0; overflow-x:auto; }
+  .diff span { display:block; padding: 1px 18px; white-space: pre; color: var(--muted); }
+  .diff .add { background: var(--add-bg); color: var(--add-ink); }
+  .diff .del { background: var(--del-bg); color: var(--del-ink); }
+
+  /* ——— the forming edge: follow-up + the live turn taking shape ——— */
+  .forming { margin-top: 22px; }
+  .user-note {
+    display:flex; gap: 12px; align-items: baseline;
+    padding: 4px 6px 2px;
+  }
+  .user-note .who { font-family: var(--mono); font-size: 11px; color: var(--accent); flex-shrink: 0; }
+  .user-note p { font-size: 15.5px; color: var(--muted); line-height: 1.55; }
+  .user-note .t { font-family: var(--mono); font-size: 10.5px; color: var(--faint); margin-left:auto; flex-shrink: 0; }
+
+  .activity {
+    display:flex; align-items:center; gap: 13px;
+    margin-top: 14px; padding: 14px 18px;
+    border: 1px solid var(--line); border-radius: 14px;
+    background: color-mix(in srgb, var(--accent) 4%, var(--focal));
+    font-family: var(--mono); font-size: 13px; color: var(--muted);
+  }
+  html[data-theme="dark"] .activity { background: color-mix(in srgb, var(--accent) 7%, var(--recede)); }
+  .activity code { background:none; padding:0; color: var(--ink); }
+  .breath {
+    width: 9px; height: 9px; border-radius: 50%; background: var(--accent); flex-shrink: 0;
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 50%, transparent);
+    animation: breath 2.1s ease-in-out infinite;
+  }
+  .ellip::after { content:'…'; animation: ellip 1.8s steps(4) infinite; }
+  .watch {
+    margin-left:auto; font-size: 10.5px; letter-spacing: .05em; color: var(--faint);
+    display:flex; align-items:center; gap: 6px;
+    transition: color .2s;
+  }
+  .watch:hover { color: var(--accent); }
+  .watch .tw2 { font-size: 9px; transition: transform .2s; }
+  .activity.open .watch .tw2 { transform: rotate(90deg); }
+  .live-detail { display:none; margin: 6px 0 0 2px; animation: reveal .3s ease both; }
+  .activity.open + .live-detail { display:block; }
+  .live-detail .row {
+    display:flex; gap: 10px; padding: 4px 20px;
+    font-family: var(--mono); font-size: 11.5px; color: var(--faint);
+  }
+  .live-detail .row.now { color: var(--muted); }
+  .live-detail .row .cur { color: var(--accent); }
+
+  /* ——— compose: present, calm, well-considered ——— */
+  .compose-wrap { margin-top: 30px; }
+  .compose {
+    background: var(--focal);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 15px 16px 12px;
+    box-shadow: var(--lift);
+    transition: border-color .25s, box-shadow .25s;
+  }
+  .compose.is-focused {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+    box-shadow: var(--lift), 0 0 0 3px var(--accent-wash);
+  }
+  .compose-top { display:flex; align-items: flex-start; gap: 12px; }
+  .compose .caret { font-family: var(--mono); color: var(--accent); font-size: 15px; line-height: 1.5; padding-top: 1px; }
+  .compose .field {
+    flex:1; min-height: 24px;
+    font-family: var(--sans); font-size: 16px; color: var(--ink); line-height: 1.5;
+    outline: none;
+  }
+  .compose .field:empty::before { content: attr(data-ph); color: var(--faint); }
+  .compose.is-focused .caret::after { content:'▍'; margin-left: 1px; animation: blink 1.1s steps(2) infinite; }
+  .send {
+    width: 32px; height: 32px; border-radius: 9px; flex-shrink: 0;
+    background: var(--accent); color: var(--focal);
+    display:flex; align-items:center; justify-content:center;
+    font-size: 15px; transition: filter .15s, transform .15s;
+  }
+  html[data-theme="dark"] .send { color: #1C160C; }
+  .send:hover { filter: brightness(1.06); transform: translateY(-1px); }
+  .compose-foot {
+    display:flex; align-items:center; gap: 8px; margin-top: 12px;
+    padding-top: 11px; border-top: 1px solid var(--line-soft);
+  }
+  .chip {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .02em;
+    color: var(--muted); border: 1px solid var(--line);
+    border-radius: 8px; padding: 5px 10px;
+    display:flex; align-items:center; gap: 7px;
+    transition: border-color .2s, color .2s, background .2s;
+  }
+  .chip:hover { border-color: var(--faint); color: var(--ink); background: color-mix(in srgb, var(--ink) 3%, transparent); }
+  .chip .k { color: var(--accent); }
+  .compose-foot .hint {
+    margin-left:auto; font-family: var(--mono); font-size: 10.5px; color: var(--faint);
+    display:flex; gap: 14px;
+  }
+
+  /* ——— footer status line: current model, subordinate & dismissible ——— */
+  .status {
+    position: sticky; bottom: 0; z-index: 6;
+    background: color-mix(in srgb, var(--bg) 86%, transparent);
+    backdrop-filter: blur(10px) saturate(1.1);
+    border-top: 1px solid var(--line);
+  }
+  .status-inner {
+    max-width: 1200px; margin: 0 auto;
+    display:flex; align-items:center; gap: 0;
+    padding: 9px 40px;
+    font-family: var(--mono); font-size: 11px; color: var(--faint); letter-spacing: .02em;
+  }
+  .status .model { color: var(--muted); }
+  .status .model .dot { display:inline-block; width:5px; height:5px; border-radius:50%; background: var(--accent); margin-right: 8px; vertical-align: 1px; }
+  .status .sep { margin: 0 9px; opacity: .5; }
+  .status .close {
+    margin-left: auto; color: var(--faint); font-size: 12px; line-height:1;
+    padding: 3px 5px; border-radius: 6px; transition: color .2s, background .2s;
+  }
+  .status .close:hover { color: var(--ink); background: color-mix(in srgb, var(--ink) 5%, transparent); }
+  .status.gone { display: none; }
+
+  .status-handle {
+    position: fixed; right: 22px; bottom: 18px; z-index: 6;
+    display: none; align-items:center; gap: 7px;
+    font-family: var(--mono); font-size: 10.5px; color: var(--faint);
+    background: var(--focal); border: 1px solid var(--line);
+    border-radius: 99px; padding: 6px 12px; box-shadow: var(--lift);
+    transition: color .2s, border-color .2s;
+  }
+  .status-handle:hover { color: var(--muted); border-color: var(--faint); }
+  .status-handle.show { display: flex; }
+  .status-handle .dot { width:5px; height:5px; border-radius:50%; background: var(--accent); }
+
+  /* ——— motion ——— */
+  @keyframes reveal { from { opacity:0; transform: translateY(-3px);} to { opacity:1; transform:none;} }
+  @keyframes settle { from { opacity:0; transform: translateY(10px) scale(.99);} to { opacity:1; transform:none;} }
+  @keyframes breath {
+    0%,100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 45%, transparent); opacity: .8; }
+    50%     { box-shadow: 0 0 0 5px color-mix(in srgb, var(--accent) 0%, transparent); opacity: 1; }
+  }
+  @keyframes ellip { 0%{content:'';} 25%{content:'.';} 50%{content:'..';} 75%{content:'…';} }
+  @keyframes blink { 0%{opacity:1;} 50%{opacity:0;} }
+
+  .stagger > * { animation: rise .55s cubic-bezier(.2,.7,.2,1) both; }
+  .stagger > *:nth-child(1){animation-delay:.02s}
+  .stagger > *:nth-child(2){animation-delay:.08s}
+  .stagger > *:nth-child(3){animation-delay:.15s}
+  .stagger > *:nth-child(4){animation-delay:.22s}
+  .stagger > *:nth-child(5){animation-delay:.29s}
+  .stagger > *:nth-child(6){animation-delay:.36s}
+  @keyframes rise { from{opacity:0; transform: translateY(9px);} to{opacity:1; transform:none;} }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ——— identity: repo · branch · agent · sandbox — no wordmark ——— -->
+<header class="ident">
+  <span class="crumbs">
+    <span class="live-dot"></span><b>orbit/web</b>
+    <span class="sep">·</span>fix/session-resume
+    <span class="sep">·</span>Claude
+    <span class="sep">·</span>sandbox active
+  </span>
+  <button class="toggle" id="themeToggle" aria-label="Toggle theme">
+    <span class="g" id="themeGlyph">☾</span><span id="themeName">Dark</span>
+  </button>
+</header>
+
+<main class="lens stagger">
+
+  <!-- ═══ the depth: earlier turns, out of focus (pull one forward) ═══ -->
+  <div>
+    <div class="depth-label">Earlier · pull a turn into focus</div>
+    <div class="depth">
+
+      <button class="recede user" data-pull>
+        <div class="recede-line">
+          <span class="recede-who">You</span>
+          <span class="recede-gist">pnpm test is failing on the session suite — a missing id blows up instead of rejecting</span>
+          <span class="recede-pull"><svg class="reticle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>focus</span>
+        </div>
+        <div class="recede-full">
+          <div class="head"><span class="who">You</span><span class="t">9:38 am</span></div>
+          <p><code>pnpm test</code> is failing on the session suite — resuming a missing session id blows up instead of rejecting cleanly. Can you take a look and get it green?</p>
+        </div>
+      </button>
+
+      <button class="recede agent" data-pull>
+        <div class="recede-line">
+          <span class="recede-who">Claude</span>
+          <span class="recede-gist">reproduced it — a missing guard, not a flaky test. Reading the spec and resume path.</span>
+          <span class="recede-pull"><svg class="reticle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>focus</span>
+        </div>
+        <div class="recede-full">
+          <div class="head"><span class="who">Claude</span><span class="t">9:39 am</span></div>
+          <p>Reproduced on the first run — this isn't flake. <code>resumeSession</code> has no guard for an unknown id, so what the suite catches is a downstream <code>TypeError</code> rather than the rejection it asked for. Pulling up the failing spec and the resume path now.</p>
+        </div>
+      </button>
+
+    </div>
+  </div>
+
+  <!-- ═══ the focal plane ═══ -->
+  <div class="plane"><span class="tag"><svg class="reticle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>In focus · now</span></div>
+
+  <!-- the live work, sharp and large -->
+  <section class="focal">
+    <div class="focal-head">
+      <span class="who"><b>Claude</b> · resolved the failure</span>
+      <span class="t">9:41 am</span>
+    </div>
+
+    <p>The suite isn't flaky — it's a missing guard. <code>resumeSession</code> passes the
+    store's result straight into <code>hydrate</code>, so when the id doesn't exist the record
+    arrives as <code>undefined</code> and the failure surfaces one frame too late: a
+    <code>TypeError</code> inside <code>hydrate</code> instead of the <em>SessionNotFoundError</em>
+    the test is waiting for.</p>
+
+    <!-- tool steps: collapsed, the test run left open -->
+    <div class="steps">
+      <div class="step read">
+        <button class="step-head"><span class="tw">▸</span><span class="verb">Read</span><span class="obj">src/session/session.test.ts</span><span class="step-meta">41 lines</span></button>
+        <div class="step-body"><div class="term">it("rejects when the session id is unknown", async () =&gt; {
+  await expect(resumeSession("sess_missing")).rejects.toThrow(
+    SessionNotFoundError,
+  );
+});</div></div>
+      </div>
+      <div class="step read">
+        <button class="step-head"><span class="tw">▸</span><span class="verb">Read</span><span class="obj">src/session/resume.ts</span><span class="step-meta">18 lines</span></button>
+        <div class="step-body"><div class="term">export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {
+  const record = await store.get(id);
+  return hydrate(record);
+}</div></div>
+      </div>
+      <div class="step edit">
+        <button class="step-head"><span class="tw">▸</span><span class="verb">Edit</span><span class="obj">src/session/resume.ts</span><span class="step-meta"><span class="plus">+4</span> <span class="minus">−1</span></span></button>
+        <div class="step-body"><div class="term">Guard added before hydrate() — the change is on the stage below.</div></div>
+      </div>
+      <div class="step run open">
+        <button class="step-head"><span class="tw">▸</span><span class="verb">Ran</span><span class="obj">pnpm test</span><span class="step-meta"><span class="pass">28 passed</span> · 1.21s</span></button>
+        <div class="step-body"><div class="term"><span class="ok">✓</span> src/session/resume.test.ts   (6 tests)  128ms
+<span class="ok">✓</span> src/session/session.test.ts (14 tests)  412ms
+<span class="ok">✓</span> src/session/store.test.ts    (8 tests)   96ms
+
+Test Files  <span class="num">3 passed</span> (3)
+     Tests  <span class="num">28 passed</span> (28)
+  Duration  1.21s</div></div>
+      </div>
+    </div>
+
+    <!-- contextual moment: the diff, surfaced because the edit landed -->
+    <figure class="moment">
+      <figcaption class="moment-cap">
+        <span class="file">src/session/resume.ts</span>
+        <span class="delta"><span class="plus">+4</span><span class="minus">−1</span></span>
+        <span class="why"><svg class="reticle" style="width:12px;height:12px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none"/></svg>edit landed · just now</span>
+        <button class="close" title="Dismiss">✕</button>
+      </figcaption>
+      <pre class="diff"><span>  export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {</span><span>    const record = await store.get(id);</span><span class="del">-   return hydrate(record);</span><span class="add">+   if (!record) {</span><span class="add">+     throw new SessionNotFoundError(id);</span><span class="add">+   }</span><span class="add">+   return hydrate(record);</span><span>  }</span></pre>
+    </figure>
+
+    <p>The guard rejects at the boundary now, before hydration is ever attempted — 28 tests
+    green across the three session files, including the two that were red.</p>
+  </section>
+
+  <!-- ═══ the forming edge: the next turn taking shape ═══ -->
+  <div class="forming">
+    <div class="user-note">
+      <span class="who">You</span>
+      <p>Nice. While you're in there — add a regression test for the expired-session path; resuming past <code>expiresAt</code> should reject the same way.</p>
+      <span class="t">9:44 am</span>
+    </div>
+
+    <button class="activity" id="activity">
+      <span class="breath"></span>
+      <span>Writing <code>src/session/session.test.ts</code><span class="ellip"></span></span>
+      <span class="watch"><span class="tw2">▸</span>watch</span>
+    </button>
+    <div class="live-detail">
+      <div class="row"><span>✓</span><span>Read session.test.ts — located the expiry fixtures</span></div>
+      <div class="row now"><span class="cur">▍</span><span>Adding case “rejects resuming an expired session”</span></div>
+    </div>
+  </div>
+
+  <!-- ═══ compose ═══ -->
+  <div class="compose-wrap">
+    <div class="compose is-focused" id="compose">
+      <div class="compose-top">
+        <span class="caret">›</span>
+        <div class="field" id="field" contenteditable="true" role="textbox" aria-label="Reply to Claude" data-ph="Reply to Claude"></div>
+        <button class="send" title="Send">↑</button>
+      </div>
+      <div class="compose-foot">
+        <button class="chip"><span class="k">⌘K</span> commands</button>
+        <button class="chip">＋ context</button>
+        <button class="chip">▷ run tests</button>
+        <span class="hint"><span>⏎ send</span><span>⇧⏎ newline</span></span>
+      </div>
+    </div>
+  </div>
+
+</main>
+
+<!-- ——— footer status: current model, quiet & dismissible ——— -->
+<footer class="status" id="status">
+  <div class="status-inner">
+    <span class="model"><span class="dot"></span>opus-4.8</span>
+    <span class="sep">·</span><span>sandbox us-east</span>
+    <span class="sep">·</span><span>fix/session-resume</span>
+    <span class="sep">·</span><span>2.1k ctx</span>
+    <button class="close" id="statusClose" title="Hide status">✕</button>
+  </div>
+</footer>
+<button class="status-handle" id="statusHandle" title="Show status"><span class="dot"></span>opus-4.8</button>
+
+<script>
+  const root = document.documentElement;
+
+  // theme: url hash forces it (#dark / #light), default light
+  function applyTheme(t) {
+    root.setAttribute('data-theme', t);
+    document.getElementById('themeGlyph').textContent = t === 'dark' ? '☀' : '☾';
+    document.getElementById('themeName').textContent = t === 'dark' ? 'Light' : 'Dark';
+  }
+  applyTheme(location.hash === '#dark' ? 'dark' : 'light');
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+    history.replaceState(null, '', '#' + next);
+  });
+  window.addEventListener('hashchange', () => applyTheme(location.hash === '#dark' ? 'dark' : 'light'));
+
+  // pull focus: expand a receded turn into the focal plane
+  document.querySelectorAll('.recede[data-pull]').forEach((el) =>
+    el.addEventListener('click', () => el.classList.toggle('pulled')));
+
+  // tool steps: expand / collapse
+  document.querySelectorAll('.step-head').forEach((b) =>
+    b.addEventListener('click', () => b.closest('.step').classList.toggle('open')));
+
+  // live activity: reveal sub-steps
+  document.getElementById('activity').addEventListener('click', function () {
+    this.classList.toggle('open');
+  });
+
+  // contextual moment: dismiss the diff
+  document.querySelector('.moment .close')?.addEventListener('click', (e) =>
+    e.target.closest('.moment').remove());
+
+  // compose focus state
+  const compose = document.getElementById('compose'), field = document.getElementById('field');
+  field.addEventListener('focus', () => compose.classList.add('is-focused'));
+  field.addEventListener('blur', () => { if (!field.textContent.trim()) compose.classList.remove('is-focused'); });
+
+  // status line: dismiss to a small handle, restore on click
+  const status = document.getElementById('status'), handle = document.getElementById('statusHandle');
+  document.getElementById('statusClose').addEventListener('click', () => {
+    status.classList.add('gone'); handle.classList.add('show');
+  });
+  handle.addEventListener('click', () => {
+    status.classList.remove('gone'); handle.classList.remove('show');
+  });
+</script>
+
+</body>
+</html>

--- a/prototypes/web-session-redesign/fable-folio.html
+++ b/prototypes/web-session-redesign/fable-folio.html
@@ -1,0 +1,441 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Folio — Spaces session view concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..700;1,6..72,300..700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+<style>
+  /* ————————————————————————————————————————————————
+     FOLIO — the session as a manuscript.
+     One column of prose on warm paper. Tool work is a
+     quiet marginal apparatus; the machine speaks only
+     when it has something to show.
+     ———————————————————————————————————————————————— */
+  :root {
+    --paper:    #F7F4ED;
+    --raised:   #FDFBF6;
+    --ink:      #26221A;
+    --muted:    #7A7261;
+    --faint:    #ACA492;
+    --line:     #E7E1D2;
+    --accent:   #A15C31;
+    --live:     #6E9C72;
+    --add-bg:   #ECF2E6;
+    --add-ink:  #3E6B36;
+    --del-bg:   #F6EBE5;
+    --del-ink:  #9A4B33;
+    --serif: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+    --mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', monospace;
+  }
+  * { margin:0; padding:0; box-sizing:border-box; }
+  html { -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 17.5px;
+    line-height: 1.72;
+    font-optical-sizing: auto;
+  }
+  ::selection { background:#EBDFC8; }
+  button { font:inherit; color:inherit; background:none; border:none; cursor:pointer; }
+
+  code {
+    font-family: var(--mono);
+    font-size: .82em;
+    background: rgba(38,34,26,.05);
+    padding: 1px 5px 2px;
+    border-radius: 4px;
+  }
+
+  /* ——— masthead: session identity, kept to a whisper ——— */
+  .masthead {
+    position: sticky; top: 0; z-index: 20;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 32px; height: 52px;
+    background: rgba(247,244,237,.88);
+    backdrop-filter: blur(10px) saturate(1.1);
+    border-bottom: 1px solid var(--line);
+    font-family: var(--mono); font-size: 11.5px; letter-spacing: .02em;
+    color: var(--muted);
+  }
+  .masthead .title {
+    position:absolute; left:50%; transform:translateX(-50%);
+    font-family: var(--serif); font-style: italic; font-size: 13.5px;
+    color: var(--faint); letter-spacing: .01em;
+  }
+  .masthead .ident b { font-weight: 500; color: var(--ink); }
+  .masthead .ident .sep, .masthead .state .sep { color: var(--faint); margin: 0 7px; }
+  .dot {
+    display:inline-block; width:7px; height:7px; border-radius:50%;
+    background: var(--live); margin-right: 8px; vertical-align: 1px;
+    box-shadow: 0 0 0 3px rgba(110,156,114,.14);
+  }
+
+  /* ——— the page ——— */
+  .page {
+    max-width: 680px; margin: 0 auto;
+    padding: 76px 20px 48px;
+  }
+  .msg { position: relative; margin-bottom: 60px; animation: rise .55s ease both; }
+  .msg:nth-of-type(1){animation-delay:.03s} .msg:nth-of-type(2){animation-delay:.10s}
+  .msg:nth-of-type(3){animation-delay:.17s} .msg:nth-of-type(4){animation-delay:.24s}
+  @keyframes rise { from { opacity:0; transform: translateY(10px);} to { opacity:1; transform:none;} }
+
+  .label {
+    font-family: var(--mono); font-size: 10.5px; font-weight: 500;
+    letter-spacing: .16em; text-transform: uppercase;
+    color: var(--faint); margin-bottom: 14px;
+    display:flex; align-items:baseline; gap:12px;
+  }
+  .msg.user .label::before { content:""; width:14px; height:1px; background:var(--faint); align-self:center; }
+  .stamp { font-weight:400; letter-spacing:.04em; opacity:0; transition:opacity .25s ease; }
+  .msg:hover .stamp { opacity:.8; }
+  .msg p + p { margin-top: 16px; }
+  .msg.user p { color: #3B362B; }
+
+  /* ——— the workings: tool steps as a quiet apparatus ——— */
+  .workings {
+    margin: 26px 0 26px 2px;
+    border-left: 2px solid var(--line);
+    padding: 4px 0 4px 22px;
+  }
+  .step + .step { margin-top: 2px; }
+  .step-line {
+    display: flex; align-items: baseline; gap: 10px; width: 100%;
+    text-align: left; padding: 5px 8px 5px 0; border-radius: 6px;
+    font-family: var(--mono); font-size: 13px; color: var(--muted);
+  }
+  .step-line:hover { color: var(--ink); }
+  .step-line .tw {
+    display:inline-block; width: 10px; color: var(--faint);
+    transition: transform .18s ease; font-size: 11px; transform-origin: 45% 50%;
+  }
+  .step.open > .step-line .tw { transform: rotate(90deg); }
+  .step-line .verb { color: var(--faint); min-width: 3.6em; }
+  .step-line .obj  { color: inherit; }
+  .step-line .meta { margin-left: auto; color: var(--faint); font-size: 12px; padding-left: 16px; white-space: nowrap; }
+  .step-line .meta .plus { color: var(--add-ink); } .step-line .meta .minus { color: var(--del-ink); }
+
+  .step-body { display:none; margin: 8px 0 16px 20px; animation: rise .3s ease both; }
+  .step.open > .step-body { display:block; }
+  .step-body pre {
+    font-family: var(--mono); font-size: 12.5px; line-height: 1.75;
+    color: var(--muted); background: var(--raised);
+    border: 1px solid var(--line); border-radius: 8px;
+    padding: 12px 16px; overflow-x: auto; white-space: pre;
+  }
+  .step-body .ok { color: var(--add-ink); }
+  .step-body .num { color: var(--ink); font-weight: 500; }
+
+  /* ——— contextual moment: a diff surfaces because the edit landed ——— */
+  .landed {
+    margin: 30px 0;
+    background: var(--raised);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    box-shadow: 0 1px 2px rgba(60,50,30,.05), 0 12px 32px -24px rgba(60,50,30,.25);
+    overflow: hidden;
+    animation: settle .7s cubic-bezier(.2,.7,.2,1) both .35s;
+  }
+  @keyframes settle { from { opacity:0; transform: translateY(14px) scale(.99);} to { opacity:1; transform:none;} }
+  .landed figcaption {
+    display:flex; align-items:baseline; gap:12px;
+    padding: 11px 18px; border-bottom: 1px solid var(--line);
+    font-family: var(--mono); font-size: 12px; color: var(--muted);
+  }
+  .landed figcaption .file { color: var(--ink); font-weight: 500; }
+  .landed figcaption .delta .plus { color: var(--add-ink); }
+  .landed figcaption .delta .minus { color: var(--del-ink); margin-left: 6px; }
+  .landed figcaption .why {
+    margin-left:auto; font-family: var(--serif); font-style: italic;
+    font-size: 12.5px; color: var(--faint);
+  }
+  .landed .dismiss { color: var(--faint); font-size: 13px; line-height:1; padding: 0 0 0 10px; opacity:0; transition: opacity .2s; }
+  .landed:hover .dismiss { opacity: 1; }
+  .landed .dismiss:hover { color: var(--ink); }
+  .diff { font-family: var(--mono); font-size: 13px; line-height: 1.7; padding: 12px 0; overflow-x:auto; }
+  .diff span { display:block; padding: 1px 18px; white-space: pre; color: var(--muted); }
+  .diff .add { background: var(--add-bg); color: var(--add-ink); }
+  .diff .del { background: var(--del-bg); color: var(--del-ink); text-decoration: line-through; text-decoration-color: rgba(154,75,51,.35); }
+
+  /* ——— in-progress turn: one quiet line ——— */
+  .activity {
+    display:flex; align-items:center; gap: 12px;
+    font-family: var(--mono); font-size: 13.5px; color: var(--muted);
+  }
+  .activity code { background:none; padding:0; font-size: 13px; color: var(--ink); }
+  .pulse {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent); animation: breathe 2.2s ease-in-out infinite;
+  }
+  @keyframes breathe { 0%,100%{opacity:.35; transform:scale(.85);} 50%{opacity:1; transform:scale(1);} }
+  .ellip::after { content:'…'; animation: ellip 1.8s steps(4) infinite; }
+  @keyframes ellip { 0%{content:'';} 25%{content:'.';} 50%{content:'..';} 75%{content:'…';} }
+  .peek {
+    margin-left:auto; font-family: var(--mono); font-size: 11.5px;
+    color: var(--faint); letter-spacing: .06em;
+    border-bottom: 1px solid transparent; padding-bottom:1px;
+    opacity: 0; transition: opacity .25s;
+  }
+  .msg.working:hover .peek { opacity:1; }
+  .peek:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .live-detail { margin: 14px 0 0 20px; }
+  .live-detail .row {
+    font-family: var(--mono); font-size: 12.5px; color: var(--faint);
+    padding: 3px 0; display:flex; gap:10px;
+  }
+  .live-detail .row.now { color: var(--muted); }
+  .live-detail .row.now .cursor { color: var(--accent); animation: breathe 1.4s ease-in-out infinite; }
+  .hidden { display: none !important; }
+
+  /* ——— compose ——— */
+  .compose {
+    position: sticky; bottom: 0; z-index: 15;
+    padding: 40px 20px 30px;
+    background: linear-gradient(to top, var(--paper) 62%, rgba(247,244,237,0));
+  }
+  .compose-inner {
+    max-width: 680px; margin: 0 auto;
+    display:flex; align-items: baseline; gap: 14px;
+    border-top: 1px solid var(--line);
+    padding-top: 18px;
+  }
+  .compose-inner .caret { font-family: var(--mono); color: var(--accent); font-size: 15px; }
+  .compose-inner input {
+    flex:1; border:none; outline:none; background:transparent;
+    font-family: var(--serif); font-size: 17px; color: var(--ink);
+  }
+  .compose-inner input::placeholder { color: var(--faint); font-style: italic; }
+  .kbd-hint {
+    font-family: var(--mono); font-size: 11px; color: var(--faint);
+    border: 1px solid var(--line); border-radius: 5px; padding: 3px 7px;
+    background: var(--raised);
+  }
+
+  /* ——— reveal mechanic: the command palette (⌘K) ——— */
+  .palette-scrim {
+    position: fixed; inset: 0; z-index: 40;
+    display:flex; justify-content:center; align-items:flex-start;
+    padding-top: 13vh;
+    background: rgba(56,49,36,.14);
+    backdrop-filter: blur(2px);
+    animation: fadein .25s ease both;
+  }
+  @keyframes fadein { from{opacity:0;} to{opacity:1;} }
+  .palette {
+    width: 560px; max-width: calc(100vw - 48px);
+    background: var(--raised);
+    border: 1px solid var(--line); border-radius: 14px;
+    box-shadow: 0 40px 90px -24px rgba(48,40,24,.4), 0 2px 6px rgba(48,40,24,.08);
+    overflow: hidden;
+    animation: pop .3s cubic-bezier(.2,.8,.3,1.1) both;
+  }
+  @keyframes pop { from { opacity:0; transform: translateY(-8px) scale(.985);} to { opacity:1; transform:none;} }
+  .palette .search {
+    display:flex; align-items:baseline; gap: 12px;
+    padding: 16px 20px; border-bottom: 1px solid var(--line);
+  }
+  .palette .search .caret { font-family: var(--mono); color: var(--faint); }
+  .palette .search input {
+    flex:1; border:none; outline:none; background:transparent;
+    font-family: var(--serif); font-size: 17px; color: var(--ink);
+  }
+  .palette .search input::placeholder { color: var(--faint); font-style: italic; }
+  .palette .groups { padding: 8px 8px 10px; max-height: 52vh; overflow-y:auto; }
+  .palette .group-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing:.18em;
+    text-transform: uppercase; color: var(--faint);
+    padding: 12px 14px 5px;
+  }
+  .palette .item {
+    display:flex; align-items:baseline; gap: 12px; width:100%;
+    text-align:left; padding: 9px 14px; border-radius: 8px;
+    font-family: var(--serif); font-size: 15.5px; color: #4A4436;
+    position: relative;
+  }
+  .palette .item .sub { font-family: var(--mono); font-size: 11.5px; color: var(--faint); }
+  .palette .item kbd {
+    margin-left:auto; font-family: var(--mono); font-size: 11px;
+    color: var(--faint); letter-spacing: .05em;
+  }
+  .palette .item:hover { background: #F3EDDF; }
+  .palette .item.selected { background: #F1EADA; color: var(--ink); }
+  .palette .item.selected::before {
+    content:""; position:absolute; left:4px; top:9px; bottom:9px;
+    width:2px; border-radius:2px; background: var(--accent);
+  }
+  .palette .foot {
+    display:flex; gap: 18px; padding: 10px 20px;
+    border-top: 1px solid var(--line);
+    font-family: var(--mono); font-size: 10.5px; color: var(--faint); letter-spacing:.04em;
+  }
+  .palette .foot .spacer { margin-left:auto; font-style: italic; font-family: var(--serif); font-size: 11.5px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<header class="masthead">
+  <span class="ident"><b>orbit/web</b><span class="sep">·</span>fix/session-resume</span>
+  <span class="title">Fix the failing session-resume test</span>
+  <span class="state">Claude<span class="sep">·</span><span class="dot"></span>sandbox active</span>
+</header>
+
+<main class="page">
+
+  <!-- ——— user ——— -->
+  <article class="msg user">
+    <div class="label">Michael <span class="stamp">9:41 am</span></div>
+    <p>The session-resume path is broken — <code>resumeSession</code> comes back with
+    undefined when the id doesn’t exist, and there’s a failing repro in
+    <code>session.test.ts</code>. Can you track it down and fix it?</p>
+  </article>
+
+  <!-- ——— completed agent turn ——— -->
+  <article class="msg agent">
+    <div class="label">Claude <span class="stamp">9:42 am</span></div>
+    <p>Found it. The failing test — <em>rejects when the session id is unknown</em> —
+    expects a <code>SessionNotFoundError</code>, but <code>resumeSession</code> passes the
+    store’s result straight into <code>hydrate</code>. When the id is missing, the record
+    arrives as <code>undefined</code> and the failure surfaces one frame too late: a
+    <code>TypeError</code> inside <code>hydrate</code> instead of a meaningful rejection.</p>
+
+    <div class="workings">
+      <!-- collapsed steps -->
+      <div class="step">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Read</span><span class="obj">src/session/session.test.ts</span><span class="meta">41 lines</span></button>
+        <div class="step-body"><pre>it("rejects when the session id is unknown", async () =&gt; {
+  await expect(resumeSession("sess_missing")).rejects.toThrow(
+    SessionNotFoundError,
+  );
+});</pre></div>
+      </div>
+      <div class="step">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Read</span><span class="obj">src/session/resume.ts</span><span class="meta">18 lines</span></button>
+        <div class="step-body"><pre>export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {
+  const record = await store.get(id);
+  return hydrate(record);
+}</pre></div>
+      </div>
+      <div class="step">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Edit</span><span class="obj">src/session/resume.ts</span><span class="meta"><span class="plus">+4</span> <span class="minus">−1</span></span></button>
+        <div class="step-body"><pre>guard added before hydrate() — see the change below</pre></div>
+      </div>
+      <!-- expanded step -->
+      <div class="step open">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Ran</span><span class="obj">pnpm test</span><span class="meta">28 passed · 1.21s</span></button>
+        <div class="step-body"><pre><span class="ok">✓</span> src/session/resume.test.ts   (6 tests)  128ms
+<span class="ok">✓</span> src/session/session.test.ts (14 tests)  412ms
+<span class="ok">✓</span> src/session/store.test.ts    (8 tests)   96ms
+
+Test Files  <span class="num">3 passed</span> (3)
+     Tests  <span class="num">28 passed</span> (28)
+  Duration  1.21s</pre></div>
+      </div>
+    </div>
+
+    <!-- contextual moment: the diff surfaced because the edit landed -->
+    <figure class="landed">
+      <figcaption>
+        <span class="file">src/session/resume.ts</span>
+        <span class="delta"><span class="plus">+4</span><span class="minus">−1</span></span>
+        <span class="why">edit landed · just now</span>
+        <button class="dismiss" title="Dismiss">✕</button>
+      </figcaption>
+      <pre class="diff"><span>  export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {</span><span>    const record = await store.get(id);</span><span class="del">-   return hydrate(record);</span><span class="add">+   if (!record) {</span><span class="add">+     throw new SessionNotFoundError(id);</span><span class="add">+   }</span><span class="add">+   return hydrate(record);</span><span>  }</span></pre>
+    </figure>
+
+    <p>The guard now rejects at the boundary, before hydration is ever attempted.
+    Full suite is green — 28 tests across three files, including the two that
+    were red.</p>
+  </article>
+
+  <!-- ——— user follow-up ——— -->
+  <article class="msg user">
+    <div class="label">Michael <span class="stamp">9:44 am</span></div>
+    <p>Lovely. While you’re in there — add a regression test for the expired-session
+    path; resuming after <code>expiresAt</code> should reject the same way.</p>
+  </article>
+
+  <!-- ——— in-progress turn: one quiet line ——— -->
+  <article class="msg agent working">
+    <div class="label">Claude</div>
+    <div class="activity">
+      <span class="pulse"></span>
+      <span class="act-text">Editing <code>src/session/session.test.ts</code><span class="ellip"></span></span>
+      <button class="peek" data-reveal="live-detail">details</button>
+    </div>
+    <div id="live-detail" class="live-detail hidden">
+      <div class="row"><span>✓</span><span>Read src/session/session.test.ts — found the expiry fixtures</span></div>
+      <div class="row now"><span class="cursor">▍</span><span>Edit src/session/session.test.ts — adding “rejects resuming an expired session”</span></div>
+    </div>
+  </article>
+
+</main>
+
+<!-- ——— compose ——— -->
+<footer class="compose">
+  <div class="compose-inner">
+    <span class="caret">›</span>
+    <input type="text" placeholder="Reply to Claude" aria-label="Reply">
+    <span class="kbd-hint">⌘K</span>
+  </div>
+</footer>
+
+<!-- ——— reveal mechanic: ⌘K command palette, shown open ——— -->
+<div class="palette-scrim" id="palette">
+  <div class="palette" role="dialog" aria-label="Command palette">
+    <div class="search">
+      <span class="caret">›</span>
+      <input type="text" placeholder="Type a command" aria-label="Command">
+    </div>
+    <div class="groups">
+      <div class="group-label">Sandbox</div>
+      <button class="item selected">Run tests <span class="sub">pnpm test</span><kbd>↵</kbd></button>
+      <button class="item">Open terminal<kbd>⌘T</kbd></button>
+      <button class="item">Restart sandbox</button>
+      <div class="group-label">Code</div>
+      <button class="item">Open latest diff <span class="sub">resume.ts</span><kbd>⌘D</kbd></button>
+      <button class="item">Create pull request</button>
+      <div class="group-label">Session</div>
+      <button class="item">Focus mode<kbd>⌘.</kbd></button>
+      <button class="item">Pause Claude</button>
+    </div>
+    <div class="foot">
+      <span>↑↓ navigate</span><span>↵ run</span><span>esc close</span>
+      <span class="spacer">appears anywhere, holds everything</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  const palette = document.getElementById('palette');
+  // #quiet renders the resting state (used for the base screenshot); ⌘K brings the palette back.
+  if (location.hash === '#quiet') palette.classList.add('hidden');
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault(); palette.classList.toggle('hidden');
+    }
+    if (e.key === 'Escape') palette.classList.add('hidden');
+  });
+  palette.addEventListener('click', (e) => { if (e.target === palette) palette.classList.add('hidden'); });
+
+  document.querySelectorAll('.step-line').forEach((b) =>
+    b.addEventListener('click', () => b.closest('.step').classList.toggle('open')));
+
+  document.querySelectorAll('[data-reveal]').forEach((b) =>
+    b.addEventListener('click', () => document.getElementById(b.dataset.reveal).classList.toggle('hidden')));
+
+  document.querySelector('.landed .dismiss')?.addEventListener('click', (e) =>
+    e.target.closest('.landed').remove());
+</script>
+
+</body>
+</html>

--- a/prototypes/web-session-redesign/fable-nocturne.html
+++ b/prototypes/web-session-redesign/fable-nocturne.html
@@ -1,0 +1,434 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Nocturne — Spaces session view concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,300..700;1,300..700&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet">
+<style>
+  /* ————————————————————————————————————————————————
+     NOCTURNE — conversation and stage.
+     The thread stays prose; anything the work produces
+     (a test run, a diff) materializes on a stage at the
+     right, then condenses as newer moments arrive.
+     Warm lamplight dark, humanist sans, soft depth.
+     ———————————————————————————————————————————————— */
+  :root {
+    --bg:     #161410;
+    --card:   #211E18;
+    --card2:  #262218;
+    --line:   rgba(234,222,196,.09);
+    --line2:  rgba(234,222,196,.16);
+    --ink:    #EAE4D6;
+    --muted:  #A79E8C;
+    --faint:  #7B7263;
+    --amber:  #DFA45C;
+    --green:  #93BD82;
+    --red:    #CF8570;
+    --sans: 'Hanken Grotesk', 'Seravek', system-ui, sans-serif;
+    --mono: 'Fragment Mono', ui-monospace, 'SF Mono', monospace;
+  }
+  * { margin:0; padding:0; box-sizing:border-box; }
+  html { -webkit-font-smoothing:antialiased; }
+  body {
+    background:
+      radial-gradient(1100px 560px at 76% -6%, rgba(223,164,92,.065), transparent 62%),
+      radial-gradient(900px 500px at -10% 108%, rgba(147,189,130,.035), transparent 60%),
+      var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16.5px; line-height: 1.68;
+    min-height: 100vh;
+  }
+  ::selection { background: rgba(223,164,92,.28); }
+  button { font:inherit; color:inherit; background:none; border:none; cursor:pointer; }
+  code {
+    font-family: var(--mono); font-size: .84em;
+    background: rgba(234,222,196,.07);
+    padding: 1px 5px 2px; border-radius: 4px;
+  }
+
+  /* ——— identity: one quiet line across the top ——— */
+  .topbar {
+    max-width: 1352px; margin: 0 auto;
+    padding: 26px 44px 0;
+    display:flex; align-items:center; justify-content:space-between;
+    font-family: var(--mono); font-size: 11.5px; color: var(--faint);
+  }
+  .topbar .repo b { color: var(--muted); font-weight: 400; }
+  .topbar .sep { margin: 0 8px; opacity:.5; }
+  .dot { display:inline-block; width:7px; height:7px; border-radius:50%; margin-right:8px; vertical-align:1px; }
+  .dot.live { background: var(--green); box-shadow: 0 0 0 3px rgba(147,189,130,.12); }
+  .dot.work { background: var(--amber); box-shadow: 0 0 0 3px rgba(223,164,92,.12); animation: breathe 2.2s ease-in-out infinite; }
+  @keyframes breathe { 0%,100%{opacity:.4;} 50%{opacity:1;} }
+
+  /* ——— two regions: thread + stage ——— */
+  .layout {
+    max-width: 1352px; margin: 0 auto;
+    display: grid; grid-template-columns: minmax(0, 620px) minmax(380px, 1fr);
+    gap: 76px; padding: 44px 44px 80px;
+    align-items: start;
+  }
+
+  .thread > * { animation: rise .55s ease both; }
+  .thread > *:nth-child(1){animation-delay:.03s} .thread > *:nth-child(2){animation-delay:.09s}
+  .thread > *:nth-child(3){animation-delay:.15s} .thread > *:nth-child(4){animation-delay:.21s}
+  .thread > *:nth-child(5){animation-delay:.27s} .thread > *:nth-child(6){animation-delay:.33s}
+  @keyframes rise { from{opacity:0; transform:translateY(10px);} to{opacity:1; transform:none;} }
+
+  .session-title {
+    font-size: 21px; font-weight: 550; letter-spacing: -.012em;
+    margin-bottom: 34px; color: var(--ink);
+  }
+  .session-title .crumb { color: var(--faint); font-weight: 400; }
+
+  /* user messages: soft cards, Things-warm */
+  .msg-user {
+    margin: 30px 0 30px auto; max-width: 88%;
+    background: linear-gradient(180deg, #2A251C, #272219);
+    border: 1px solid rgba(223,164,92,.13);
+    border-radius: 16px 16px 5px 16px;
+    padding: 13px 19px; font-size: 15.5px; color: #DDD5C4;
+    box-shadow: 0 10px 26px -18px rgba(0,0,0,.7);
+  }
+
+  /* agent turns: open prose on the canvas */
+  .turn p { margin: 15px 0; color: var(--ink); }
+  .turn p em { color: var(--muted); }
+
+  /* ——— tool steps: quiet rows, actions on hover ——— */
+  .steps { margin: 20px 0; }
+  .step-row {
+    border-radius: 10px;
+    transition: background .18s ease;
+  }
+  .step-head {
+    display:flex; align-items:center; flex-wrap: nowrap; gap: 12px; width:100%;
+    text-align:left; padding: 7px 12px;
+    font-family: var(--mono); font-size: 12.5px; color: var(--muted);
+    cursor: pointer; user-select: none;
+  }
+  .step-row:hover, .step-row.is-hover { background: rgba(234,222,196,.045); }
+  .tw { width: 10px; color: var(--faint); font-size: 10px; transition: transform .18s ease; transform-origin: 45% 50%; flex-shrink:0; }
+  .step-row.open .tw { transform: rotate(90deg); }
+  .tag {
+    font-size: 9.5px; letter-spacing: .16em; font-weight: 400;
+    border: 1px solid var(--line2); border-radius: 99px;
+    padding: 2px 8px 1px; color: var(--faint); flex-shrink:0;
+  }
+  .tag.edit { color: var(--amber); border-color: rgba(223,164,92,.35); }
+  .obj { color: var(--muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; flex-shrink:1; }
+  .step-row:hover .obj, .step-row.is-hover .obj { color: var(--ink); }
+  .meta { margin-left:auto; color: var(--faint); font-size: 11.5px; white-space:nowrap; padding-left: 14px; }
+  .meta .plus { color: var(--green); } .meta .minus { color: var(--red); }
+  .meta .pass { color: var(--green); }
+
+  /* hover-revealed row actions — the reveal mechanic, shown on the run row */
+  .actions {
+    display:flex; gap: 4px; margin-left: 14px; flex-shrink: 0;
+    opacity: 0; transform: translateX(4px);
+    transition: opacity .18s ease, transform .18s ease;
+  }
+  .step-row:hover .actions, .step-row.is-hover .actions { opacity: 1; transform: none; }
+  .actions button {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .04em;
+    color: var(--faint); padding: 3px 8px; border-radius: 6px;
+  }
+  .actions button:hover { color: var(--amber); background: rgba(223,164,92,.09); }
+
+  /* expanded step body: inline diff */
+  .step-body { display:none; margin: 4px 10px 12px 34px; animation: rise .3s ease both; }
+  .step-row.open .step-body { display:block; }
+  .inline-diff {
+    font-family: var(--mono); font-size: 12.5px; line-height: 1.72;
+    background: #1B1813; border: 1px solid var(--line);
+    border-radius: 10px; padding: 10px 0; overflow-x: auto;
+  }
+  .inline-diff span { display:block; padding: 1px 16px; white-space: pre; color: var(--faint); }
+  .inline-diff .add { background: rgba(147,189,130,.09); color: #AECf9C; }
+  .inline-diff .del { background: rgba(207,133,112,.09); color: #CF9583; }
+
+  /* ——— in-progress: one quiet line with a slow shimmer ——— */
+  .activity {
+    display:flex; align-items:center; gap: 12px;
+    margin: 34px 0 8px; padding: 2px 12px;
+    font-family: var(--mono); font-size: 12.5px; color: var(--muted);
+  }
+  .activity code { background:none; padding:0; color: var(--ink); font-size: 12.5px; }
+  .activity .watch {
+    margin-left:auto; font-size: 10.5px; letter-spacing:.06em; color: var(--faint);
+    opacity:0; transition: opacity .2s;
+  }
+  .activity:hover .watch { opacity:1; }
+  .activity .watch:hover { color: var(--amber); }
+  .ellip::after { content:'…'; animation: ellip 1.8s steps(4) infinite; }
+  @keyframes ellip { 0%{content:'';} 25%{content:'.';} 50%{content:'..';} 75%{content:'…';} }
+  .strand {
+    height: 2px; width: 148px; margin: 0 12px 30px; border-radius: 2px;
+    background: linear-gradient(90deg, transparent, rgba(223,164,92,.55), transparent);
+    background-size: 200% 100%;
+    animation: sweep 2.6s ease-in-out infinite;
+  }
+  @keyframes sweep { 0%{background-position: 120% 0;} 100%{background-position: -120% 0;} }
+
+  /* ——— compose ——— */
+  .compose {
+    margin-top: 26px;
+    background: linear-gradient(180deg, var(--card), #1E1B15);
+    border: 1px solid var(--line2); border-radius: 16px;
+    padding: 7px 7px 7px 18px;
+    display:flex; align-items:center; gap: 14px;
+    box-shadow: 0 18px 40px -24px rgba(0,0,0,.8);
+  }
+  .compose input {
+    flex:1; border:none; outline:none; background:transparent;
+    font-family: var(--sans); font-size: 15.5px; color: var(--ink);
+  }
+  .compose input::placeholder { color: var(--faint); }
+  .send {
+    width: 34px; height: 34px; border-radius: 50%;
+    background: var(--amber); color: #1C160C;
+    font-size: 16px; font-weight: 600; line-height: 1;
+    display:flex; align-items:center; justify-content:center;
+    transition: transform .15s ease, filter .15s ease;
+  }
+  .send:hover { transform: translateY(-1px); filter: brightness(1.07); }
+  .compose-hints {
+    display:flex; gap: 16px; margin: 10px 14px 0;
+    font-family: var(--mono); font-size: 10.5px; color: var(--faint); letter-spacing:.04em;
+  }
+  .compose-hints .right { margin-left:auto; }
+
+  /* ——— the stage: contextual moments materialize here ——— */
+  .stage { position: sticky; top: 44px; display:flex; flex-direction:column; gap: 14px; }
+  .stage-mark {
+    display:flex; align-items:center; gap: 12px;
+    font-family: var(--mono); font-size: 10px; letter-spacing: .2em;
+    text-transform: uppercase; color: var(--faint);
+  }
+  .stage-mark::before, .stage-mark::after { content:""; height:1px; background: var(--line); flex:1; }
+
+  .moment {
+    background: linear-gradient(180deg, var(--card), #1F1C16);
+    border: 1px solid var(--line2);
+    border-radius: 16px;
+    box-shadow: 0 24px 60px -30px rgba(0,0,0,.85), 0 1px 0 rgba(234,222,196,.04) inset;
+    overflow: hidden;
+    animation: arrive .7s cubic-bezier(.2,.75,.25,1) both .4s;
+  }
+  @keyframes arrive { from { opacity:0; transform: translateX(18px);} to { opacity:1; transform:none;} }
+  .moment-head {
+    display:flex; align-items:center; gap: 12px;
+    padding: 13px 18px; border-bottom: 1px solid var(--line);
+  }
+  .moment-head .cmd { font-family: var(--mono); font-size: 13px; color: var(--ink); }
+  .pill {
+    font-family: var(--mono); font-size: 10px; letter-spacing:.1em; text-transform: uppercase;
+    color: var(--green); background: rgba(147,189,130,.12);
+    border-radius: 99px; padding: 3px 9px 2px;
+  }
+  .moment-head .time { margin-left:auto; font-family: var(--mono); font-size: 11px; color: var(--faint); }
+  .moment-head .close { color: var(--faint); font-size: 12px; padding: 2px 4px; opacity: 0; transition: opacity .2s; }
+  .moment:hover .close { opacity: 1; }
+  .moment-head .close:hover { color: var(--ink); }
+  .moment pre {
+    font-family: var(--mono); font-size: 12.5px; line-height: 1.78;
+    color: var(--muted); padding: 14px 18px 16px; overflow-x:auto; white-space: pre;
+  }
+  .moment pre .ok { color: var(--green); }
+  .moment pre .num { color: var(--ink); }
+  .moment-foot {
+    padding: 9px 18px 11px; border-top: 1px solid var(--line);
+    font-family: var(--mono); font-size: 10.5px; color: var(--faint);
+    display:flex; gap: 14px; font-style: italic;
+  }
+  .moment-foot button { font-style: normal; font-size: 10.5px; color: var(--faint); margin-left:auto; letter-spacing:.05em; }
+  .moment-foot button:hover { color: var(--amber); }
+
+  /* an earlier moment, condensed to a chip */
+  .moment-chip {
+    display:flex; align-items:center; gap: 12px;
+    background: rgba(33,30,24,.6);
+    border: 1px solid var(--line); border-radius: 12px;
+    padding: 10px 16px;
+    font-family: var(--mono); font-size: 12px; color: var(--muted);
+    animation: arrive .6s ease both .55s;
+    transition: border-color .2s ease;
+  }
+  .moment-chip:hover { border-color: var(--line2); }
+  .moment-chip .when { color: var(--faint); font-size: 10.5px; margin-left: 2px; }
+  .moment-chip .delta .plus { color: var(--green); } .moment-chip .delta .minus { color: var(--red); margin-left: 5px; }
+  .moment-chip .open-it { margin-left:auto; font-size: 10.5px; letter-spacing:.05em; color: var(--faint); opacity:0; transition: opacity .2s; }
+  .moment-chip:hover .open-it { opacity: 1; color: var(--amber); }
+
+  .stage-hint {
+    font-family: var(--mono); font-size: 10.5px; color: rgba(123,114,99,.6);
+    font-style: italic; text-align: center; padding-top: 4px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ——— identity, kept quiet ——— -->
+<header class="topbar">
+  <span class="repo"><span class="dot live"></span><b>orbit/web</b><span class="sep">·</span>fix/session-resume</span>
+  <span class="agent"><span class="dot work"></span>Claude · working</span>
+</header>
+
+<div class="layout">
+
+  <!-- ═══ the thread ═══ -->
+  <section class="thread">
+
+    <h1 class="session-title"><span class="crumb">Session — </span>Fix the failing session-resume test</h1>
+
+    <div class="msg-user">
+      <code>pnpm test</code> is failing on the session suite — looks like resuming a
+      missing session id blows up instead of rejecting cleanly. Take a look?
+    </div>
+
+    <!-- ——— completed agent turn ——— -->
+    <div class="turn">
+      <p>That failure is a missing guard, not a flaky test. <code>resumeSession</code>
+      hands the store’s result straight to <code>hydrate</code>, so an unknown id arrives
+      as <code>undefined</code> and dies there with a <code>TypeError</code> — the test
+      never gets the rejection it’s waiting for.</p>
+
+      <div class="steps">
+        <!-- collapsed -->
+        <div class="step-row">
+          <div class="step-head" role="button" tabindex="0">
+            <span class="tw">▶</span><span class="tag">read</span>
+            <span class="obj">src/session/session.test.ts</span>
+            <span class="actions"><button>open</button><button>copy path</button></span>
+            <span class="meta">41 lines</span>
+          </div>
+          <div class="step-body"><div class="inline-diff"><span>it("rejects when the session id is unknown", async () =&gt; {</span><span>  await expect(resumeSession("sess_missing")).rejects.toThrow(</span><span>    SessionNotFoundError,</span><span>  );</span><span>});</span></div></div>
+        </div>
+        <div class="step-row">
+          <div class="step-head" role="button" tabindex="0">
+            <span class="tw">▶</span><span class="tag">read</span>
+            <span class="obj">src/session/resume.ts</span>
+            <span class="actions"><button>open</button><button>copy path</button></span>
+            <span class="meta">18 lines</span>
+          </div>
+          <div class="step-body"><div class="inline-diff"><span>export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {</span><span>  const record = await store.get(id);</span><span>  return hydrate(record);</span><span>}</span></div></div>
+        </div>
+        <!-- expanded: the edit, diff inline -->
+        <div class="step-row open">
+          <div class="step-head" role="button" tabindex="0">
+            <span class="tw">▶</span><span class="tag edit">edit</span>
+            <span class="obj">src/session/resume.ts</span>
+            <span class="actions"><button>revert</button><button>copy</button></span>
+            <span class="meta"><span class="plus">+4</span> <span class="minus">−1</span></span>
+          </div>
+          <div class="step-body">
+            <div class="inline-diff"><span>  export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {</span><span>    const record = await store.get(id);</span><span class="del">-   return hydrate(record);</span><span class="add">+   if (!record) {</span><span class="add">+     throw new SessionNotFoundError(id);</span><span class="add">+   }</span><span class="add">+   return hydrate(record);</span><span>  }</span></div>
+          </div>
+        </div>
+        <!-- collapsed, shown mid-hover: row actions revealed -->
+        <div class="step-row is-hover">
+          <div class="step-head" role="button" tabindex="0">
+            <span class="tw">▶</span><span class="tag">run</span>
+            <span class="obj">pnpm test</span>
+            <span class="actions"><button>re-run</button><button>copy output</button><button>to stage →</button></span>
+            <span class="meta"><span class="pass">28 passed</span> · 1.21s</span>
+          </div>
+          <div class="step-body"><div class="inline-diff"><span>Test Files  3 passed (3)</span><span>     Tests  28 passed (28)</span><span>  Duration  1.21s</span></div></div>
+        </div>
+      </div>
+
+      <p>Fixed at the boundary: resume now rejects with <code>SessionNotFoundError</code>
+      before hydration is attempted. The whole suite is green — 28 tests across three
+      files, including the two that were failing.</p>
+    </div>
+
+    <div class="msg-user">
+      Good. Add a regression test for the expired-session path too — resuming past
+      <code>expiresAt</code> should reject the same way.
+    </div>
+
+    <!-- ——— in-progress: one quiet line ——— -->
+    <div class="working">
+      <div class="activity">
+        <span class="dot work"></span>
+        <span>Writing <code>src/session/session.test.ts</code><span class="ellip"></span></span>
+        <button class="watch">view work</button>
+      </div>
+      <div class="strand"></div>
+    </div>
+
+    <!-- ——— compose ——— -->
+    <div>
+      <div class="compose">
+        <input type="text" placeholder="Message Claude" aria-label="Message">
+        <button class="send" title="Send">↑</button>
+      </div>
+      <div class="compose-hints">
+        <span>⌘K commands</span><span>⇧⏎ newline</span>
+        <span class="right">sandbox us-east · 2 vCPU</span>
+      </div>
+    </div>
+
+  </section>
+
+  <!-- ═══ the stage: work materializes here when it matters ═══ -->
+  <aside class="stage">
+    <div class="stage-mark">just now</div>
+
+    <!-- contextual moment: the test run appeared because the command ran -->
+    <div class="moment">
+      <div class="moment-head">
+        <span class="dot live"></span>
+        <span class="cmd">pnpm test</span>
+        <span class="pill">passed</span>
+        <span class="time">1.21s</span>
+        <button class="close" title="Dismiss">✕</button>
+      </div>
+      <pre><span class="ok">✓</span> src/session/resume.test.ts   (6 tests)  128ms
+<span class="ok">✓</span> src/session/session.test.ts (14 tests)  412ms
+<span class="ok">✓</span> src/session/store.test.ts    (8 tests)   96ms
+
+Test Files  <span class="num">3 passed</span> (3)
+     Tests  <span class="num">28 passed</span> (28)
+  Duration  1.21s</pre>
+      <div class="moment-foot">
+        appeared when the suite finished
+        <button>pin</button>
+      </div>
+    </div>
+
+    <!-- an earlier moment, condensed -->
+    <div class="moment-chip">
+      <span>src/session/resume.ts</span>
+      <span class="delta"><span class="plus">+4</span><span class="minus">−1</span></span>
+      <span class="when">3m ago</span>
+      <button class="open-it">reopen ↗</button>
+    </div>
+
+    <p class="stage-hint">the stage stays empty until the work produces something worth seeing</p>
+  </aside>
+
+</div>
+
+<script>
+  document.querySelectorAll('.step-head').forEach((b) => {
+    const toggle = (e) => {
+      if (e.target.closest('.actions')) return;
+      b.closest('.step-row').classList.toggle('open');
+    };
+    b.addEventListener('click', toggle);
+    b.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(e); } });
+  });
+  document.querySelector('.moment .close')?.addEventListener('click', (e) =>
+    e.target.closest('.moment').remove());
+</script>
+
+</body>
+</html>

--- a/prototypes/web-session-redesign/opus-atelier.html
+++ b/prototypes/web-session-redesign/opus-atelier.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Spaces — Session (Atelier)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400;1,500&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#16171a;
+    --bg-2:#1b1d21;
+    --panel:#1f2126;
+    --panel-2:#24272c;
+    --elev:#282b31;
+    --border:#2c3037;
+    --border-soft:#24272c;
+    --hair:#33383f;
+    --text:#e8e4da;
+    --text-soft:#b6b1a6;
+    --muted:#87847b;
+    --faint:#615f58;
+    --honey:#e8b872;
+    --honey-2:#f0c98a;
+    --honey-dim:rgba(232,184,114,.12);
+    --honey-line:rgba(232,184,114,.28);
+    --slate:#9db6d4;
+    --add-bg:rgba(120,168,116,.13);
+    --add-ink:#a8cf9e;
+    --add-mark:#7ea872;
+    --del-bg:rgba(196,128,110,.13);
+    --del-ink:#dba996;
+    --del-mark:#c48870;
+    --ok:#8fc27c;
+    --shadow:0 1px 0 rgba(255,255,255,.02) inset, 0 18px 40px -22px rgba(0,0,0,.7);
+    --font:"Hanken Grotesk", system-ui, sans-serif;
+    --mono:"Geist Mono", ui-monospace, SFMono-Regular, monospace;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;height:100%;}
+  body{
+    background:var(--bg);color:var(--text);font-family:var(--font);
+    -webkit-font-smoothing:antialiased;letter-spacing:.005em;
+    height:100dvh;overflow:hidden;position:relative;
+  }
+  body::before{ /* warm ambient glow */
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+    background:
+      radial-gradient(90% 60% at 78% -8%, rgba(232,184,114,.06), transparent 55%),
+      radial-gradient(70% 50% at 12% 108%, rgba(157,182,212,.05), transparent 60%);
+  }
+  ::selection{background:rgba(232,184,114,.22);}
+
+  .app{position:relative;z-index:1;height:100dvh;display:flex;flex-direction:column;}
+
+  /* ---- Top identity bar ---- */
+  .top{
+    display:flex;align-items:center;gap:20px;
+    padding:0 26px;height:56px;flex-shrink:0;
+    border-bottom:1px solid var(--border-soft);
+    background:linear-gradient(180deg, rgba(255,255,255,.014), transparent);
+  }
+  .brand{display:flex;align-items:center;gap:9px;flex-shrink:0;}
+  .brand .glyph{width:20px;height:20px;border-radius:6px;background:linear-gradient(145deg,var(--honey),#c98f45);box-shadow:0 0 14px -2px rgba(232,184,114,.5);}
+  .brand .name{font-weight:600;font-size:15px;letter-spacing:.01em;}
+  .idbar{display:flex;align-items:center;gap:2px;font-family:var(--mono);font-size:12px;color:var(--muted);}
+  .idbar .seg{padding:0 13px;position:relative;white-space:nowrap;display:flex;align-items:center;gap:7px;}
+  .idbar .seg + .seg::before{content:"";position:absolute;left:0;top:50%;transform:translateY(-50%);width:1px;height:12px;background:var(--hair);}
+  .idbar .k{color:var(--faint);}
+  .idbar b{color:var(--text-soft);font-weight:500;}
+  .idbar .branch b{color:var(--honey-2);}
+  .live{display:inline-flex;align-items:center;gap:7px;color:var(--text-soft);font-weight:500;}
+  .live .d{width:6px;height:6px;border-radius:50%;background:var(--ok);box-shadow:0 0 0 3px rgba(143,194,124,.16);}
+  .top .spacer{flex:1;}
+  .cmdk{font-family:var(--mono);font-size:11px;color:var(--muted);border:1px solid var(--border);border-radius:8px;padding:6px 10px;background:var(--bg-2);cursor:pointer;}
+  .cmdk kbd{color:var(--text-soft);font-family:inherit;}
+  .av{width:26px;height:26px;border-radius:50%;background:conic-gradient(from 210deg,#3a3d44,#54585f);border:1px solid var(--hair);}
+
+  /* ---- Two-pane workbench ---- */
+  .work{flex:1;display:grid;grid-template-columns:minmax(0,1fr) 620px;min-height:0;}
+
+  /* Left: calm transcript */
+  .thread-col{display:flex;flex-direction:column;min-height:0;border-right:1px solid var(--border-soft);}
+  .thread{flex:1;overflow-y:auto;padding:34px 40px 20px;}
+  .thread{scrollbar-width:thin;scrollbar-color:var(--hair) transparent;}
+  .thread::-webkit-scrollbar{width:9px;}
+  .thread::-webkit-scrollbar-thumb{background:var(--hair);border-radius:6px;border:2px solid var(--bg);}
+
+  .turn{max-width:620px;margin:0 auto 30px;}
+  .who{font-size:11px;font-weight:600;letter-spacing:.13em;text-transform:uppercase;color:var(--faint);margin-bottom:11px;display:flex;align-items:center;gap:9px;}
+  .who .t{font-family:var(--mono);font-weight:400;letter-spacing:0;color:var(--faint);text-transform:none;font-size:11px;}
+  .who .agent-dot{width:6px;height:6px;border-radius:50%;background:var(--honey);}
+
+  .user-say{font-size:16px;line-height:1.55;color:var(--text-soft);background:var(--bg-2);border:1px solid var(--border-soft);border-radius:12px;padding:14px 16px;}
+  .user-say code{font-family:var(--mono);font-size:.82em;color:var(--honey-2);}
+
+  .msg{position:relative;border-radius:12px;padding:2px 12px;margin:0 -12px;transition:background .18s;}
+  .prose p{font-size:15.5px;line-height:1.62;color:var(--text);margin:0 0 14px;}
+  .prose p:last-child{margin-bottom:0;}
+  .prose code{font-family:var(--mono);font-size:.8em;color:var(--slate);background:rgba(157,182,212,.09);padding:1.5px 5px;border-radius:4px;}
+
+  /* hover-revealed row actions (reveal mechanic) */
+  .rowacts{position:absolute;top:8px;right:8px;display:flex;gap:4px;opacity:0;transform:translateY(-3px);transition:.18s;}
+  .msg:hover{background:linear-gradient(90deg, rgba(232,184,114,.04), transparent 70%);}
+  .msg:hover .rowacts, .msg.is-hovered .rowacts{opacity:1;transform:none;}
+  .msg.is-hovered{background:linear-gradient(90deg, rgba(232,184,114,.05), transparent 70%);}
+  .rowacts button{font-family:var(--font);font-size:11.5px;color:var(--text-soft);background:var(--elev);border:1px solid var(--border);border-radius:7px;padding:5px 9px;cursor:pointer;display:inline-flex;align-items:center;gap:5px;box-shadow:0 6px 16px -8px rgba(0,0,0,.6);}
+  .rowacts button:hover{color:var(--text);border-color:var(--honey-line);}
+  .rowacts .hint{position:absolute;top:-19px;right:2px;font-family:var(--mono);font-size:9.5px;letter-spacing:.06em;color:var(--faint);white-space:nowrap;}
+
+  /* quiet tool ledger */
+  .steps{margin:16px 0 4px;border-left:1px solid var(--border);}
+  details.step{border:0;}
+  details.step > summary{list-style:none;cursor:pointer;display:flex;align-items:center;gap:11px;padding:7px 10px 7px 16px;margin-left:-1px;border-left:1px solid transparent;font-family:var(--mono);font-size:12.5px;color:var(--muted);transition:.16s;}
+  details.step > summary::-webkit-details-marker{display:none;}
+  details.step > summary:hover{color:var(--text-soft);border-left-color:var(--honey-line);}
+  .step .v{color:var(--text-soft);font-weight:500;min-width:34px;}
+  .step .p{color:var(--muted);}
+  .step .m{color:var(--faint);}
+  .step .add{color:var(--add-mark);}
+  .step .del{color:var(--del-mark);}
+  .step .ok{color:var(--ok);}
+  .step .chev{margin-left:auto;color:var(--faint);opacity:0;transition:.16s;font-size:10px;}
+  details.step:hover .chev{opacity:.8;}
+  details.step[open] .chev{transform:rotate(90deg);}
+  .step .stage-link{margin-left:auto;font-size:10.5px;color:var(--honey);opacity:.75;}
+  .detail{padding:4px 0 12px 16px;font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--text-soft);border-left:1px solid var(--border-soft);margin-left:-1px;}
+  .detail .pass{color:var(--ok);}
+  .detail .dim{color:var(--faint);}
+
+  /* in-progress activity line */
+  .active{display:flex;align-items:center;gap:12px;font-family:var(--mono);font-size:13px;color:var(--text-soft);padding:6px 0;}
+  .active .breathe{width:8px;height:8px;border-radius:50%;background:var(--honey);animation:breathe 1.9s ease-in-out infinite;flex-shrink:0;}
+  @keyframes breathe{0%,100%{opacity:.35;transform:scale(.8)}50%{opacity:1;transform:scale(1.05)}}
+  .active .lbl{color:var(--text-soft);}
+  .active .p{color:var(--muted);}
+  .active .drill{margin-left:auto;font-size:11px;color:var(--faint);opacity:0;transition:.2s;}
+  .active:hover .drill{opacity:1;}
+
+  /* compose */
+  .compose{flex-shrink:0;padding:14px 40px 22px;background:linear-gradient(0deg, var(--bg) 55%, transparent);}
+  .compose-inner{max-width:620px;margin:0 auto;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:13px 15px 11px;box-shadow:var(--shadow);}
+  .compose-inner:focus-within{border-color:var(--honey-line);}
+  .field{font-size:15px;color:var(--text);line-height:1.5;min-height:24px;outline:none;}
+  .field:empty::before{content:"Reply to the agent…";color:var(--faint);}
+  .cbar{display:flex;align-items:center;gap:14px;margin-top:10px;font-family:var(--mono);font-size:11px;color:var(--muted);}
+  .cbar .tool{cursor:pointer;transition:.15s;}
+  .cbar .tool:hover{color:var(--text-soft);}
+  .cbar .send{margin-left:auto;background:var(--honey);color:#231a0c;font-family:var(--font);font-weight:600;font-size:12.5px;border-radius:9px;padding:7px 13px;cursor:pointer;display:inline-flex;gap:8px;align-items:center;}
+  .cbar .send kbd{font-family:var(--mono);opacity:.7;}
+
+  /* Right: contextual stage */
+  .stage{background:var(--bg-2);display:flex;flex-direction:column;min-height:0;}
+  .stage-head{flex-shrink:0;display:flex;align-items:center;gap:10px;padding:16px 22px;border-bottom:1px solid var(--border-soft);}
+  .stage-head .title{font-size:12px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);}
+  .stage-head .surfaced{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11px;color:var(--honey);background:var(--honey-dim);border:1px solid var(--honey-line);border-radius:20px;padding:4px 11px;}
+  .stage-head .x{margin-left:auto;color:var(--faint);cursor:pointer;font-size:15px;}
+  .stage-body{flex:1;overflow-y:auto;padding:22px;display:flex;flex-direction:column;gap:20px;}
+  .stage-body{scrollbar-width:thin;scrollbar-color:var(--hair) transparent;}
+  .stage-body::-webkit-scrollbar{width:9px;}
+  .stage-body::-webkit-scrollbar-thumb{background:var(--hair);border-radius:6px;border:2px solid var(--bg-2);}
+
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:13px;overflow:hidden;box-shadow:var(--shadow);animation:surface .5s cubic-bezier(.2,.8,.2,1) both;}
+  @keyframes surface{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:none}}
+  .card-head{display:flex;align-items:center;gap:10px;padding:13px 16px;border-bottom:1px solid var(--border-soft);font-family:var(--mono);font-size:12px;color:var(--muted);}
+  .card-head .fname{color:var(--text-soft);font-weight:500;}
+  .card-head .why{margin-left:auto;font-family:var(--font);font-size:11px;color:var(--faint);font-style:italic;}
+  .card-head .plus{color:var(--add-mark);}
+  .card-head .minus{color:var(--del-mark);}
+
+  .code{font-family:var(--mono);font-size:12.5px;line-height:1.85;padding:8px 0;}
+  .code .row{display:flex;padding:0 16px;white-space:pre;}
+  .code .ln{width:26px;text-align:right;color:var(--faint);padding-right:16px;user-select:none;flex-shrink:0;}
+  .code .gut{width:14px;color:var(--faint);user-select:none;flex-shrink:0;}
+  .code .txt{color:var(--text-soft);}
+  .code .row.add{background:var(--add-bg);}
+  .code .row.add .gut{color:var(--add-mark);}
+  .code .row.add .txt{color:var(--add-ink);}
+  .code .row.del{background:var(--del-bg);}
+  .code .row.del .gut{color:var(--del-mark);}
+  .code .row.del .txt{color:var(--del-ink);}
+  .code .tk{color:var(--honey-2);}
+  .code .fn{color:var(--slate);}
+
+  /* terminal / test panel */
+  .term{background:#121316;}
+  .term .card-head{border-bottom-color:rgba(255,255,255,.05);}
+  .term .out{font-family:var(--mono);font-size:12.5px;line-height:1.8;padding:14px 18px;color:#cbc6ba;}
+  .term .out .pass{color:var(--ok);}
+  .term .out .dim{color:#6f6c64;}
+  .term .out .f{color:#e4ddcd;}
+  .term .out .was{color:var(--honey);}
+  .term .out .sum{color:#a8a397;}
+
+  .stage-note{font-family:var(--mono);font-size:10.5px;color:var(--faint);text-align:center;letter-spacing:.03em;padding-top:2px;}
+
+  /* palette (kept available, closed by default) */
+  .scrim{position:fixed;inset:0;z-index:40;background:rgba(0,0,0,.5);backdrop-filter:blur(4px);display:none;align-items:flex-start;justify-content:center;padding-top:120px;}
+  .scrim.on{display:flex;}
+  .palette{width:540px;background:var(--panel);border:1px solid var(--border);border-radius:16px;box-shadow:0 40px 90px -20px rgba(0,0,0,.75);overflow:hidden;}
+  .palette .pin{display:flex;gap:12px;align-items:center;padding:16px 18px;border-bottom:1px solid var(--border-soft);}
+  .palette .pin input{flex:1;background:transparent;border:0;outline:none;color:var(--text);font-family:var(--font);font-size:16px;}
+  .palette .opt{display:flex;gap:12px;align-items:center;padding:10px 18px;color:var(--text-soft);font-size:14px;cursor:pointer;}
+  .palette .opt:hover{background:var(--honey-dim);color:var(--text);}
+  .palette .opt .sc{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);}
+</style>
+</head>
+<body>
+<div class="app">
+
+  <!-- ===== Top identity bar ===== -->
+  <div class="top">
+    <div class="brand"><span class="glyph"></span><span class="name">Spaces</span></div>
+    <div class="idbar">
+      <span class="seg"><span class="k">repo</span> <b>cloudcompute/api</b></span>
+      <span class="seg branch"><span class="k">branch</span> <b>fix/resume-null</b></span>
+      <span class="seg"><span class="k">agent</span> <b>Claude</b></span>
+      <span class="seg"><span class="live"><span class="d"></span> sandbox live · 14m</span></span>
+    </div>
+    <div class="spacer"></div>
+    <div class="cmdk" onclick="document.getElementById('scrim').classList.add('on')"><kbd>⌘K</kbd></div>
+    <div class="av"></div>
+  </div>
+
+  <!-- ===== Workbench ===== -->
+  <div class="work">
+
+    <!-- LEFT: calm transcript -->
+    <div class="thread-col">
+      <div class="thread">
+
+        <!-- user -->
+        <div class="turn">
+          <div class="who">You <span class="t">· 9:42</span></div>
+          <div class="user-say">The <code>resumeSession</code> test is red on CI — <code>returns null when the id is missing</code>. Can you find what's leaking through and fix it?</div>
+        </div>
+
+        <!-- agent completed (with hover row actions revealed) -->
+        <div class="turn">
+          <div class="who"><span class="agent-dot"></span> Claude <span class="t">· 9:42</span></div>
+          <div class="msg is-hovered">
+            <div class="rowacts">
+              <span class="hint">actions reveal on hover ↴</span>
+              <button>⧉ Copy</button>
+              <button>↻ Retry from here</button>
+              <button>◫ Open in stage</button>
+              <button>⌾</button>
+            </div>
+            <div class="prose">
+              <p>Found it. <code>resumeSession</code> looks the record up with <code>store.get(id)</code> and hands the result straight to <code>hydrate</code>. When the id isn't in the store, <code>store.get</code> returns <code>undefined</code>, <code>hydrate</code> does nothing with it, and that value falls through as the return — so the caller gets a bare <code>undefined</code> instead of a clean miss. That's what the test is objecting to.</p>
+              <p>I added a guard that returns <code>null</code> before we reach <code>hydrate</code>, and widened the signature to <code>Session | null</code> so the missing case shows up at the type level.</p>
+            </div>
+          </div>
+
+          <!-- quiet tool ledger -->
+          <div class="steps">
+            <details class="step">
+              <summary><span class="v">Read</span><span class="p">src/session/resume.ts</span><span class="m">· 1–24</span><span class="chev">▸</span></summary>
+              <div class="detail"><span class="dim"> 6</span>  export function resumeSession(id: string): Session {
+<span class="dim"> 7</span>    const record = store.get(id)
+<span class="dim"> 8</span>    return hydrate(record)
+<span class="dim"> 9</span>  }</div>
+            </details>
+
+            <details class="step">
+              <summary><span class="v">Edit</span><span class="p">src/session/resume.ts</span><span class="m"><span class="add">+4</span> <span class="del">−1</span></span><span class="stage-link">shown in stage →</span></summary>
+              <div class="detail"><span class="dim">the diff is open in the stage on the right →</span></div>
+            </details>
+
+            <!-- EXPANDED example -->
+            <details class="step" open>
+              <summary><span class="v">Run</span><span class="p">pnpm test</span><span class="m">· <span class="ok">4 passed</span></span><span class="chev">▸</span></summary>
+              <div class="detail"><span class="pass">✓</span> src/session/resume.test.ts <span class="dim">(4 tests) 21ms</span>
+<span class="dim">Test Files</span> <span class="pass">1 passed</span> · <span class="dim">Tests</span> <span class="pass">4 passed</span>
+<span class="dim">full output surfaced in the stage →</span></div>
+            </details>
+          </div>
+
+          <div class="prose" style="margin-top:12px">
+            <p>Green — four passed, including the case that was failing. Want me to also cover the empty-string id?</p>
+          </div>
+        </div>
+
+        <!-- user follow-up -->
+        <div class="turn">
+          <div class="who">You <span class="t">· 9:45</span></div>
+          <div class="user-say">Green, nice. Add the empty-string case too — same behaviour as a missing id.</div>
+        </div>
+
+        <!-- agent in-progress: one quiet activity line -->
+        <div class="turn">
+          <div class="who"><span class="agent-dot"></span> Claude <span class="t">· now</span></div>
+          <div class="active">
+            <span class="breathe"></span>
+            <span class="lbl">Editing</span>
+            <span class="p">src/session/resume.test.ts</span>
+            <span class="drill">show detail ▸</span>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- compose -->
+      <div class="compose">
+        <div class="compose-inner">
+          <div class="field" contenteditable="true" spellcheck="false"></div>
+          <div class="cbar">
+            <span class="tool">＠ file</span>
+            <span class="tool">⌗ branch</span>
+            <span class="tool">◫ terminal</span>
+            <span class="send">Send <kbd>⌘↵</kbd></span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT: contextual stage -->
+    <div class="stage">
+      <div class="stage-head">
+        <span class="title">Stage</span>
+        <span class="surfaced">◇ surfaced · an edit just landed</span>
+        <span class="x">✕</span>
+      </div>
+      <div class="stage-body">
+
+        <!-- contextual moment 1: the diff -->
+        <div class="card">
+          <div class="card-head">
+            <span class="fname">src/session/resume.ts</span>
+            <span class="plus">+4</span><span class="minus">−1</span>
+            <span class="why">guard added before hydrate</span>
+          </div>
+          <div class="code">
+            <div class="row"><span class="ln">4</span><span class="gut"> </span><span class="txt"><span class="tk">export function</span> <span class="fn">resumeSession</span>(id: string):</span></div>
+            <div class="row del"><span class="ln">5</span><span class="gut">−</span><span class="txt">  <span class="tk">Session</span> {</span></div>
+            <div class="row add"><span class="ln">5</span><span class="gut">+</span><span class="txt">  <span class="tk">Session</span> | <span class="tk">null</span> {</span></div>
+            <div class="row"><span class="ln">6</span><span class="gut"> </span><span class="txt">  const record = store.get(id)</span></div>
+            <div class="row add"><span class="ln">7</span><span class="gut">+</span><span class="txt">  if (!record) {</span></div>
+            <div class="row add"><span class="ln">8</span><span class="gut">+</span><span class="txt">    return <span class="tk">null</span></span></div>
+            <div class="row add"><span class="ln">9</span><span class="gut">+</span><span class="txt">  }</span></div>
+            <div class="row"><span class="ln">10</span><span class="gut"> </span><span class="txt">  return <span class="fn">hydrate</span>(record)</span></div>
+            <div class="row"><span class="ln">11</span><span class="gut"> </span><span class="txt">}</span></div>
+          </div>
+        </div>
+
+        <!-- contextual moment 2: the test run -->
+        <div class="card term">
+          <div class="card-head"><span class="dim" style="color:var(--faint)">$</span> <span class="fname">pnpm test resume</span><span class="why">ran after the edit</span></div>
+          <div class="out"><span class="pass">✓</span> <span class="f">src/session/resume.test.ts</span> <span class="dim">(4 tests) 21ms</span>
+   <span class="pass">✓</span> returns a hydrated session for a known id
+   <span class="pass">✓</span> returns null when the id is missing  <span class="was">← was failing</span>
+   <span class="pass">✓</span> keeps the store untouched on a miss
+   <span class="pass">✓</span> rehydrates nested workspace state
+
+ <span class="sum">Test Files</span>  <span class="pass">1 passed</span> <span class="dim">(1)</span>
+      <span class="sum">Tests</span>  <span class="pass">4 passed</span> <span class="dim">(4)</span>
+   <span class="sum">Duration</span>  <span class="dim">318ms</span></div>
+        </div>
+
+        <div class="stage-note">the stage clears itself when the turn settles · ⌘\ to pin</div>
+
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- command palette (closed by default; ⌘K opens) -->
+<div class="scrim" id="scrim" onclick="if(event.target===this)this.classList.remove('on')">
+  <div class="palette">
+    <div class="pin"><span style="color:var(--faint);font-family:var(--mono)">⌘K</span><input placeholder="Type a command or file…" autofocus></div>
+    <div class="opt">◎ Open src/session/resume.ts <span class="sc">↵</span></div>
+    <div class="opt">⟲ Re-run tests <span class="sc">⌘R</span></div>
+    <div class="opt">◈ Focus mode <span class="sc">⌘.</span></div>
+    <div class="opt">◧ Restart sandbox</div>
+  </div>
+</div>
+
+<script>
+  document.addEventListener('keydown', e=>{
+    if((e.metaKey||e.ctrlKey)&&e.key.toLowerCase()==='k'){e.preventDefault();document.getElementById('scrim').classList.toggle('on');}
+    if(e.key==='Escape'){document.getElementById('scrim').classList.remove('on');}
+  });
+</script>
+</body>
+</html>

--- a/prototypes/web-session-redesign/opus-manuscript.html
+++ b/prototypes/web-session-redesign/opus-manuscript.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Spaces — Session (Manuscript)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --paper:#f4f1e8;
+    --paper-2:#faf8f1;
+    --card:#fbf9f2;
+    --ink:#26231b;
+    --ink-soft:#524c3e;
+    --muted:#948b78;
+    --faint:#b7ae99;
+    --rule:#e5dfce;
+    --rule-2:#efe9da;
+    --rust:#a95a34;
+    --link:#8f4e2c;
+    --add-bg:#e9efe0;
+    --add-ink:#4a6438;
+    --add-mark:#7f9a5f;
+    --del-bg:#f4e3da;
+    --del-ink:#93503a;
+    --del-mark:#c08469;
+    --ok:#5f7d46;
+    --pulse:#b06a3f;
+    --shadow:0 1px 2px rgba(58,48,28,.05), 0 12px 34px -16px rgba(58,48,28,.28);
+    --font-serif:"Newsreader", Georgia, serif;
+    --font-mono:"IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;padding:0;}
+  body{
+    background:var(--paper);
+    color:var(--ink);
+    font-family:var(--font-serif);
+    -webkit-font-smoothing:antialiased;
+    text-rendering:optimizeLegibility;
+    min-height:100vh;
+    position:relative;
+  }
+  /* faint paper grain */
+  body::before{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+    opacity:.035;mix-blend-mode:multiply;
+  }
+  body::after{
+    content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+    background:radial-gradient(120% 80% at 50% -10%, rgba(255,252,243,.9), rgba(244,241,232,0) 55%);
+  }
+
+  /* ---- Masthead: quiet session identity ---- */
+  .masthead{
+    position:sticky;top:0;z-index:20;
+    background:linear-gradient(var(--paper) 78%, rgba(244,241,232,0));
+    backdrop-filter:saturate(1.05);
+  }
+  .masthead-inner{
+    max-width:1180px;margin:0 auto;
+    padding:20px 40px 14px;
+    display:flex;align-items:center;gap:22px;
+  }
+  .brand{
+    display:flex;align-items:baseline;gap:9px;flex-shrink:0;
+  }
+  .brand .mark{
+    font-family:var(--font-serif);font-weight:600;font-size:20px;letter-spacing:.01em;
+    color:var(--ink);
+  }
+  .brand .mark em{font-style:italic;font-weight:400;color:var(--rust);}
+  .idline{
+    display:flex;align-items:center;gap:0;flex-wrap:wrap;
+    font-family:var(--font-mono);font-size:12px;color:var(--muted);
+    letter-spacing:.01em;
+  }
+  .idline .seg{padding:0 12px;position:relative;white-space:nowrap;}
+  .idline .seg + .seg::before{
+    content:"";position:absolute;left:0;top:50%;transform:translateY(-50%);
+    width:1px;height:11px;background:var(--rule);
+  }
+  .idline b{color:var(--ink-soft);font-weight:500;}
+  .idline .k{color:var(--faint);}
+  .sandbox{
+    display:inline-flex;align-items:center;gap:7px;color:var(--ink-soft);font-weight:500;
+  }
+  .dot{width:6px;height:6px;border-radius:50%;background:var(--ok);box-shadow:0 0 0 3px rgba(95,125,70,.14);}
+  .spacer{flex:1;}
+  .kbd-hint{
+    font-family:var(--font-mono);font-size:11px;color:var(--muted);
+    border:1px solid var(--rule);border-radius:7px;padding:5px 9px;
+    background:var(--paper-2);cursor:pointer;transition:.16s;white-space:nowrap;
+  }
+  .kbd-hint:hover{color:var(--ink);border-color:var(--faint);}
+  .kbd-hint kbd{font-family:inherit;color:var(--ink-soft);}
+  .rule-full{max-width:1180px;margin:0 auto;height:1px;background:var(--rule);opacity:.7;}
+
+  /* ---- Document column ---- */
+  .doc{
+    position:relative;z-index:1;
+    max-width:720px;margin:0 auto;
+    padding:56px 24px 96px;
+  }
+  .turn{margin-bottom:46px;animation:rise .7s cubic-bezier(.2,.7,.2,1) both;}
+  .turn:nth-child(1){animation-delay:.02s}
+  .turn:nth-child(2){animation-delay:.10s}
+  .turn:nth-child(3){animation-delay:.18s}
+  .turn:nth-child(4){animation-delay:.26s}
+  @keyframes rise{from{opacity:0;transform:translateY(9px)}to{opacity:1;transform:none}}
+
+  .who{
+    font-family:var(--font-mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--faint);margin-bottom:14px;display:flex;align-items:center;gap:10px;
+  }
+  .who .tick{font-family:var(--font-mono);font-size:11px;color:var(--faint);letter-spacing:0;text-transform:none;}
+
+  .turn.user .say{
+    font-size:20px;line-height:1.55;color:var(--ink-soft);font-weight:400;
+    padding-left:18px;border-left:2px solid var(--rule);
+  }
+  .turn.user .say code{font-family:var(--font-mono);font-size:.82em;color:var(--rust);background:rgba(169,90,52,.07);padding:1px 5px;border-radius:4px;}
+
+  .prose p{
+    font-size:19px;line-height:1.66;color:var(--ink);margin:0 0 17px;
+    letter-spacing:.002em;
+  }
+  .prose p:last-child{margin-bottom:0;}
+  .prose code{
+    font-family:var(--font-mono);font-size:.79em;color:var(--ink-soft);
+    background:rgba(38,35,27,.05);padding:1.5px 5px;border-radius:4px;
+  }
+  .prose .kw{color:var(--rust);}
+
+  /* ---- Tool steps: quiet ledger ---- */
+  .steps{margin:22px 0;border-left:1.5px solid var(--rule);padding-left:0;}
+  details.step{border:0;margin:0;}
+  details.step > summary{
+    list-style:none;cursor:pointer;
+    display:flex;align-items:center;gap:12px;
+    padding:8px 12px 8px 18px;margin-left:-1.5px;
+    border-left:1.5px solid transparent;
+    font-family:var(--font-mono);font-size:13px;color:var(--muted);
+    transition:.18s;
+  }
+  details.step > summary::-webkit-details-marker{display:none;}
+  details.step > summary:hover{color:var(--ink-soft);border-left-color:var(--faint);background:linear-gradient(90deg, rgba(169,90,52,.03), transparent 60%);}
+  .step .verb{color:var(--ink-soft);font-weight:500;min-width:38px;}
+  .step .path{color:var(--muted);}
+  .step .meta{color:var(--faint);}
+  .step .add{color:var(--add-mark);}
+  .step .del{color:var(--del-mark);}
+  .step .chev{margin-left:auto;color:var(--faint);opacity:0;transition:.18s;font-size:11px;transform:rotate(0deg);}
+  details.step:hover .chev{opacity:1;}
+  details.step[open] .chev{transform:rotate(90deg);opacity:.7;}
+  .step .ok{color:var(--ok);}
+  .detail{padding:2px 0 16px 18px;margin-left:-1.5px;border-left:1.5px solid var(--rule-2);}
+
+  /* ---- Contextual diff card ---- */
+  .diff{
+    background:var(--card);border:1px solid var(--rule);border-radius:11px;
+    box-shadow:var(--shadow);overflow:hidden;margin-top:4px;
+  }
+  .diff-head{
+    display:flex;align-items:center;gap:10px;
+    padding:11px 15px;border-bottom:1px solid var(--rule-2);
+    font-family:var(--font-mono);font-size:12px;color:var(--muted);
+    background:linear-gradient(180deg, var(--paper-2), transparent);
+  }
+  .diff-head .file{color:var(--ink-soft);font-weight:500;}
+  .diff-head .when{margin-left:auto;color:var(--faint);font-style:normal;}
+  .diff-head .plus{color:var(--add-mark);}
+  .diff-head .minus{color:var(--del-mark);}
+  .code{font-family:var(--font-mono);font-size:12.5px;line-height:1.75;}
+  .code .row{display:flex;padding:0 14px;white-space:pre;}
+  .code .ln{width:30px;text-align:right;color:var(--faint);user-select:none;padding-right:16px;flex-shrink:0;}
+  .code .gut{width:14px;color:var(--faint);user-select:none;flex-shrink:0;}
+  .code .txt{color:var(--ink-soft);}
+  .code .row.add{background:var(--add-bg);}
+  .code .row.add .gut{color:var(--add-mark);}
+  .code .row.add .txt{color:var(--add-ink);}
+  .code .row.del{background:var(--del-bg);}
+  .code .row.del .gut{color:var(--del-mark);}
+  .code .row.del .txt{color:var(--del-ink);}
+  .code .cmt{color:var(--faint);}
+  .code .tk{color:var(--rust);}
+  .diff-foot{padding:9px 15px;border-top:1px solid var(--rule-2);font-family:var(--font-mono);font-size:11.5px;color:var(--faint);display:flex;gap:8px;align-items:center;}
+
+  /* test output detail (collapsed by default) */
+  .term{background:#231f18;border-radius:10px;overflow:hidden;box-shadow:var(--shadow);font-family:var(--font-mono);font-size:12.5px;line-height:1.7;}
+  .term .bar{padding:8px 14px;color:#b9ab8c;font-size:11px;border-bottom:1px solid rgba(255,255,255,.06);display:flex;gap:8px;align-items:center;}
+  .term .body{padding:12px 16px;color:#d8cdb2;}
+  .term .pass{color:#a7c58a;}
+  .term .dim{color:#7c7259;}
+  .term .file{color:#e4d9bd;}
+
+  /* ---- In-progress: one quiet activity line ---- */
+  .active{
+    display:flex;align-items:center;gap:13px;
+    font-family:var(--font-mono);font-size:13.5px;color:var(--ink-soft);
+    padding:9px 0;
+  }
+  .active .breathe{
+    width:8px;height:8px;border-radius:50%;background:var(--pulse);flex-shrink:0;
+    animation:breathe 1.9s ease-in-out infinite;
+  }
+  @keyframes breathe{0%,100%{opacity:.35;transform:scale(.82)}50%{opacity:1;transform:scale(1.05)}}
+  .active .lbl{color:var(--ink-soft);}
+  .active .path{color:var(--muted);}
+  .active .drill{margin-left:auto;font-size:11.5px;color:var(--faint);opacity:0;transition:.2s;}
+  .active:hover .drill{opacity:1;}
+
+  /* ---- Compose ---- */
+  .compose-wrap{margin-top:8px;}
+  .compose{max-width:720px;margin:0 auto;}
+  .compose .cue{font-family:var(--font-mono);font-size:11px;letter-spacing:.13em;text-transform:uppercase;color:var(--faint);margin-bottom:13px;display:block;}
+  .compose-inner{
+    background:var(--paper-2);border:1px solid var(--rule);border-radius:14px;
+    box-shadow:0 1px 2px rgba(58,48,28,.04), 0 20px 40px -24px rgba(58,48,28,.30);
+    padding:15px 17px 12px;display:flex;flex-direction:column;gap:10px;
+  }
+  .compose-inner:focus-within{border-color:var(--faint);}
+  .compose .field{
+    font-family:var(--font-serif);font-size:18px;color:var(--ink);line-height:1.5;
+    min-height:26px;outline:none;
+  }
+  .compose .field:empty::before{content:"Reply to the agent…";color:var(--faint);}
+  .compose .cbar{display:flex;align-items:center;gap:14px;color:var(--muted);font-family:var(--font-mono);font-size:11.5px;}
+  .compose .cbar .tool{display:inline-flex;align-items:center;gap:6px;color:var(--muted);cursor:pointer;transition:.15s;}
+  .compose .cbar .tool:hover{color:var(--ink-soft);}
+  .compose .cbar .send{margin-left:auto;display:inline-flex;align-items:center;gap:8px;color:var(--paper-2);background:var(--rust);border-radius:8px;padding:6px 12px;font-weight:500;cursor:pointer;}
+  .compose .cbar .send kbd{opacity:.75;font-family:inherit;}
+
+  /* ---- Cmd+K palette ---- */
+  .scrim{position:fixed;inset:0;z-index:40;background:rgba(40,33,20,.30);backdrop-filter:blur(3px) saturate(1.05);display:flex;align-items:flex-start;justify-content:center;padding-top:118px;animation:fade .2s ease both;}
+  @keyframes fade{from{opacity:0}to{opacity:1}}
+  .palette{
+    width:560px;background:var(--paper-2);border:1px solid var(--rule);border-radius:16px;
+    box-shadow:0 30px 80px -20px rgba(40,33,20,.55);overflow:hidden;
+    animation:pop .24s cubic-bezier(.2,.8,.2,1) both;
+  }
+  @keyframes pop{from{opacity:0;transform:translateY(-8px) scale(.985)}to{opacity:1;transform:none}}
+  .palette .pin{display:flex;align-items:center;gap:12px;padding:16px 20px;border-bottom:1px solid var(--rule-2);}
+  .palette .pin .q{font-family:var(--font-serif);font-size:19px;color:var(--ink);flex:1;outline:none;}
+  .palette .pin .q .cursor{display:inline-block;width:1.5px;height:19px;background:var(--rust);vertical-align:-3px;animation:blink 1.1s step-end infinite;}
+  @keyframes blink{50%{opacity:0}}
+  .palette .pin .esc{font-family:var(--font-mono);font-size:10.5px;color:var(--faint);border:1px solid var(--rule);border-radius:6px;padding:3px 7px;}
+  .palette .grp{padding:8px 0;}
+  .palette .grp .cap{font-family:var(--font-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--faint);padding:8px 20px 6px;}
+  .palette .opt{display:flex;align-items:center;gap:14px;padding:9px 20px;cursor:pointer;font-family:var(--font-serif);font-size:16px;color:var(--ink-soft);}
+  .palette .opt .ico{font-family:var(--font-mono);font-size:13px;color:var(--muted);width:18px;text-align:center;}
+  .palette .opt .sc{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--faint);}
+  .palette .opt.sel{background:linear-gradient(90deg, rgba(169,90,52,.10), rgba(169,90,52,.03));color:var(--ink);}
+  .palette .opt.sel .ico{color:var(--rust);}
+  .palette .opt:hover{background:rgba(169,90,52,.05);}
+
+  .hidden{display:none !important;}
+</style>
+</head>
+<body>
+
+  <!-- ===== Masthead: quiet session identity ===== -->
+  <header class="masthead">
+    <div class="masthead-inner">
+      <div class="brand"><span class="mark">Spaces<em>.</em></span></div>
+      <div class="idline">
+        <span class="seg"><span class="k">repo</span> <b>cloudcompute/api</b></span>
+        <span class="seg"><span class="k">branch</span> <b>fix/resume-null</b></span>
+        <span class="seg"><span class="k">agent</span> <b>Claude</b></span>
+        <span class="seg"><span class="sandbox"><span class="dot"></span> sandbox live · 14m</span></span>
+      </div>
+      <div class="spacer"></div>
+      <div class="kbd-hint" onclick="openPalette()"><kbd>⌘K</kbd>&nbsp; commands</div>
+    </div>
+    <div class="rule-full"></div>
+  </header>
+
+  <!-- ===== Document thread ===== -->
+  <main class="doc">
+
+    <!-- user turn -->
+    <section class="turn user">
+      <div class="who">You <span class="tick">· 9:42</span></div>
+      <p class="say">The <code>resumeSession</code> test is red on CI — <code>returns null when the id is missing</code>. Can you find what's leaking through and fix it?</p>
+    </section>
+
+    <!-- agent turn — completed -->
+    <section class="turn agent">
+      <div class="who">Claude <span class="tick">· 9:42</span></div>
+      <div class="prose">
+        <p>Found it. <code>resumeSession</code> looks the record up with <code>store.get(id)</code> and passes the result straight into <code>hydrate</code>. When the id isn't in the store, <code>store.get</code> hands back <code>undefined</code>, <code>hydrate</code> does nothing useful with it, and that value falls through as the return — so the caller gets a bare <code>undefined</code> instead of a clean miss. That's exactly what the test is objecting to.</p>
+        <p>I added an explicit guard: if there's no record for the id, return <code>null</code> before we ever touch <code>hydrate</code>. I widened the signature to <code>Session | null</code> in the same edit, so the missing case is visible at the type level and callers are made to handle it.</p>
+      </div>
+
+      <!-- quiet tool ledger -->
+      <div class="steps">
+
+        <!-- COLLAPSED example -->
+        <details class="step">
+          <summary>
+            <span class="verb">Read</span>
+            <span class="path">src/session/resume.ts</span>
+            <span class="meta">· lines 1–24</span>
+            <span class="chev">▸</span>
+          </summary>
+          <div class="detail">
+            <div class="term">
+              <div class="bar">src/session/resume.ts</div>
+              <div class="body"><span class="dim"> 6</span>  export function resumeSession(id: string): Session {
+<span class="dim"> 7</span>    const record = store.get(id)
+<span class="dim"> 8</span>    return hydrate(record)
+<span class="dim"> 9</span>  }</div>
+            </div>
+          </div>
+        </details>
+
+        <!-- EXPANDED example → contextual diff moment -->
+        <details class="step" open>
+          <summary>
+            <span class="verb">Edit</span>
+            <span class="path">src/session/resume.ts</span>
+            <span class="meta"><span class="add">+4</span> <span class="del">−1</span></span>
+            <span class="chev">▸</span>
+          </summary>
+          <div class="detail">
+            <div class="diff">
+              <div class="diff-head">
+                <span class="file">src/session/resume.ts</span>
+                <span class="plus">+4</span><span class="minus">−1</span>
+                <span class="when">edited just now</span>
+              </div>
+              <div class="code">
+                <div class="row"><span class="ln">4</span><span class="gut"> </span><span class="txt">export function resumeSession(id: string): Session {</span></div>
+                <div class="row del"><span class="ln">5</span><span class="gut">−</span><span class="txt">): <span class="tk">Session</span> {</span></div>
+                <div class="row add"><span class="ln">5</span><span class="gut">+</span><span class="txt">): <span class="tk">Session</span> | <span class="tk">null</span> {</span></div>
+                <div class="row"><span class="ln">6</span><span class="gut"> </span><span class="txt">  const record = store.get(id)</span></div>
+                <div class="row add"><span class="ln">7</span><span class="gut">+</span><span class="txt">  if (!record) {</span></div>
+                <div class="row add"><span class="ln">8</span><span class="gut">+</span><span class="txt">    return null</span></div>
+                <div class="row add"><span class="ln">9</span><span class="gut">+</span><span class="txt">  }</span></div>
+                <div class="row"><span class="ln">10</span><span class="gut"> </span><span class="txt">  return hydrate(record)</span></div>
+                <div class="row"><span class="ln">11</span><span class="gut"> </span><span class="txt">}</span></div>
+              </div>
+              <div class="diff-foot">◇ guard added before <span style="color:var(--muted)">hydrate(record)</span> · return type widened</div>
+            </div>
+          </div>
+        </details>
+
+        <!-- COLLAPSED bash summary -->
+        <details class="step">
+          <summary>
+            <span class="verb">Run</span>
+            <span class="path">pnpm test</span>
+            <span class="meta">· <span class="ok">4 passed</span> in 21ms</span>
+            <span class="chev">▸</span>
+          </summary>
+          <div class="detail">
+            <div class="term">
+              <div class="bar"><span class="dim">$</span> pnpm test resume</div>
+              <div class="body"><span class="pass">✓</span> <span class="file">src/session/resume.test.ts</span> <span class="dim">(4 tests) 21ms</span>
+   <span class="pass">✓</span> returns a hydrated session for a known id
+   <span class="pass">✓</span> returns null when the id is missing  <span class="dim">← was failing</span>
+   <span class="pass">✓</span> keeps the store untouched on a miss
+   <span class="pass">✓</span> rehydrates nested workspace state
+
+ <span class="dim">Test Files</span>  <span class="pass">1 passed</span> (1)
+      <span class="dim">Tests</span>  <span class="pass">4 passed</span> (4)</div>
+            </div>
+          </div>
+        </details>
+
+      </div>
+
+      <div class="prose">
+        <p>Suite's green — four passed, including the case that was failing. Want me to also cover the empty-string id, or is a <code>null</code> id out of scope here?</p>
+      </div>
+    </section>
+
+    <!-- user follow-up -->
+    <section class="turn user">
+      <div class="who">You <span class="tick">· 9:45</span></div>
+      <p class="say">Green, nice. Add the empty-string case too — it should behave the same as a missing id.</p>
+    </section>
+
+    <!-- agent turn — IN PROGRESS, one quiet activity line -->
+    <section class="turn agent">
+      <div class="who">Claude <span class="tick">· now</span></div>
+      <div class="active">
+        <span class="breathe"></span>
+        <span class="lbl">Editing</span>
+        <span class="path">src/session/resume.test.ts</span>
+        <span class="drill">show detail ▸</span>
+      </div>
+    </section>
+
+    <!-- ===== Compose — the next line you write ===== -->
+    <div class="compose-wrap">
+      <div class="compose">
+        <span class="cue">Your turn</span>
+        <div class="compose-inner">
+          <div class="field" contenteditable="true" spellcheck="false"></div>
+          <div class="cbar">
+            <span class="tool">＠ file</span>
+            <span class="tool">⌗ branch</span>
+            <span class="tool">◫ terminal</span>
+            <span class="send">Send <kbd>⌘↵</kbd></span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </main>
+
+  <!-- ===== Cmd+K palette (reveal mechanic) ===== -->
+  <div class="scrim" id="scrim" onclick="if(event.target===this)closePalette()">
+    <div class="palette" role="dialog" aria-label="Command palette">
+      <div class="pin">
+        <span style="color:var(--faint);font-family:var(--font-mono);font-size:14px">⌘K</span>
+        <div class="q">resu<span class="cursor"></span></div>
+        <span class="esc">esc</span>
+      </div>
+      <div class="grp">
+        <div class="cap">Jump to</div>
+        <div class="opt sel"><span class="ico">◎</span> Open <b>&nbsp;src/session/resume.ts</b><span class="sc">↵</span></div>
+        <div class="opt"><span class="ico">◎</span> Open&nbsp; src/session/resume.test.ts<span class="sc"></span></div>
+      </div>
+      <div class="grp" style="border-top:1px solid var(--rule-2)">
+        <div class="cap">Session</div>
+        <div class="opt"><span class="ico">⟲</span> Re-run tests <span style="color:var(--faint)">&nbsp;pnpm test</span><span class="sc">⌘R</span></div>
+        <div class="opt"><span class="ico">◈</span> Focus mode — hide everything but the thread<span class="sc">⌘.</span></div>
+        <div class="opt"><span class="ico">⌥</span> Switch branch…<span class="sc">⌘B</span></div>
+        <div class="opt"><span class="ico">◧</span> Restart sandbox<span class="sc"></span></div>
+      </div>
+    </div>
+  </div>
+
+<script>
+  const scrim = document.getElementById('scrim');
+  function openPalette(){ scrim.style.display='flex'; }
+  function closePalette(){ scrim.style.display='none'; }
+  document.addEventListener('keydown', e=>{
+    if((e.metaKey||e.ctrlKey) && e.key.toLowerCase()==='k'){ e.preventDefault(); openPalette(); }
+    if(e.key==='Escape'){ closePalette(); }
+  });
+  // Palette is shown on load to demonstrate the reveal; Esc dismisses to the calm thread.
+</script>
+</body>
+</html>

--- a/prototypes/web-session-redesign/refine-folio.html
+++ b/prototypes/web-session-redesign/refine-folio.html
@@ -1,0 +1,637 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Folio, refined — Spaces session view concept</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..700;1,6..72,300..700&family=IBM+Plex+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+<style>
+  /* ————————————————————————————————————————————————
+     FOLIO, REFINED — the session as a manuscript.
+     One column of prose; tool work as a quiet marginal
+     apparatus. This pass adds a first-class dark room
+     (warm charcoal, lamplight accent), a dismissible
+     status line for the model, and a compose field with
+     real presence. Theme: ◐ toggle, or force via
+     #light / #dark in the URL hash.
+     ———————————————————————————————————————————————— */
+  :root {
+    --paper:    #F7F4ED;
+    --raised:   #FDFBF6;
+    --ink:      #26221A;
+    --muted:    #7A7261;
+    --faint:    #ACA492;
+    --line:     #E7E1D2;
+    --line-strong: #DCD3BF;
+    --accent:   #A15C31;
+    --live:     #6E9C72;
+    --live-halo: rgba(110,156,114,.14);
+    --add-bg:   #ECF2E6;
+    --add-ink:  #3E6B36;
+    --del-bg:   #F6EBE5;
+    --del-ink:  #9A4B33;
+    --del-strike: rgba(154,75,51,.35);
+    --code-bg:  rgba(38,34,26,.05);
+    --sel:      #EBDFC8;
+    --user-ink: #3B362B;
+    --item-ink: #4A4436;
+    --mast-bg:  rgba(247,244,237,.88);
+    --paper-0:  rgba(247,244,237,0);
+    --hover-bg: #F3EDDF;
+    --selected-bg: #F1EADA;
+    --scrim:    rgba(56,49,36,.14);
+    --status-bg: #F1EDE0;
+    --card-shadow: 0 1px 2px rgba(60,50,30,.05), 0 12px 32px -24px rgba(60,50,30,.25);
+    --palette-shadow: 0 40px 90px -24px rgba(48,40,24,.4), 0 2px 6px rgba(48,40,24,.08);
+    --field-shadow: 0 1px 2px rgba(60,50,30,.05), 0 14px 34px -26px rgba(60,50,30,.35);
+    --focus-line: #C08B60;
+    --focus-ring: rgba(161,92,49,.09);
+    --send-ink: #F7F4ED;
+    --serif: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+    --mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', monospace;
+  }
+  /* ——— the dark room: warm charcoal, borrowed from Nocturne ——— */
+  :root[data-theme="dark"] {
+    --paper:    #161410;
+    --raised:   #211E18;
+    --ink:      #EAE4D6;
+    --muted:    #A79E8C;
+    --faint:    #837A69;
+    --line:     rgba(234,222,196,.10);
+    --line-strong: rgba(234,222,196,.20);
+    --accent:   #D89A62;
+    --live:     #93BD82;
+    --live-halo: rgba(147,189,130,.12);
+    --add-bg:   rgba(147,189,130,.11);
+    --add-ink:  #A9C896;
+    --del-bg:   rgba(207,133,112,.11);
+    --del-ink:  #CE9480;
+    --del-strike: rgba(206,148,128,.4);
+    --code-bg:  rgba(234,222,196,.08);
+    --sel:      rgba(216,154,98,.30);
+    --user-ink: #D8D0BE;
+    --item-ink: #CFC7B5;
+    --mast-bg:  rgba(22,20,16,.86);
+    --paper-0:  rgba(22,20,16,0);
+    --hover-bg: rgba(234,222,196,.05);
+    --selected-bg: rgba(234,222,196,.08);
+    --scrim:    rgba(0,0,0,.5);
+    --status-bg: #1B1913;
+    --card-shadow: 0 1px 2px rgba(0,0,0,.3), 0 16px 40px -26px rgba(0,0,0,.7);
+    --palette-shadow: 0 40px 90px -24px rgba(0,0,0,.75), 0 2px 6px rgba(0,0,0,.3);
+    --field-shadow: 0 1px 2px rgba(0,0,0,.25), 0 16px 38px -26px rgba(0,0,0,.7);
+    --focus-line: rgba(216,154,98,.55);
+    --focus-ring: rgba(216,154,98,.10);
+    --send-ink: #1C160C;
+  }
+
+  * { margin:0; padding:0; box-sizing:border-box; }
+  html { -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 17.5px;
+    line-height: 1.72;
+    font-optical-sizing: auto;
+    transition: background-color .25s ease, color .25s ease;
+  }
+  :root[data-theme="dark"] body {
+    background:
+      radial-gradient(1100px 560px at 76% -6%, rgba(216,154,98,.05), transparent 62%),
+      var(--paper);
+  }
+  ::selection { background: var(--sel); }
+  button { font:inherit; color:inherit; background:none; border:none; cursor:pointer; }
+
+  code {
+    font-family: var(--mono);
+    font-size: .82em;
+    background: var(--code-bg);
+    padding: 1px 5px 2px;
+    border-radius: 4px;
+  }
+
+  /* ——— masthead: session identity, kept to a whisper ——— */
+  .masthead {
+    position: sticky; top: 0; z-index: 20;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 32px; height: 52px;
+    background: var(--mast-bg);
+    backdrop-filter: blur(10px) saturate(1.1);
+    border-bottom: 1px solid var(--line);
+    font-family: var(--mono); font-size: 11.5px; letter-spacing: .02em;
+    color: var(--muted);
+  }
+  .masthead .title {
+    position:absolute; left:50%; transform:translateX(-50%);
+    font-family: var(--serif); font-style: italic; font-size: 13.5px;
+    color: var(--faint); letter-spacing: .01em;
+  }
+  .masthead .ident b { font-weight: 500; color: var(--ink); }
+  .masthead .ident .sep, .masthead .state .sep { color: var(--faint); margin: 0 7px; }
+  .masthead .state { display:flex; align-items:center; }
+  .dot {
+    display:inline-block; width:7px; height:7px; border-radius:50%;
+    background: var(--live); margin-right: 8px; vertical-align: 1px;
+    box-shadow: 0 0 0 3px var(--live-halo);
+  }
+  .theme-toggle {
+    margin-left: 16px; padding: 4px 6px;
+    font-size: 13px; line-height: 1; color: var(--faint);
+    border-radius: 6px;
+    transition: color .2s ease, transform .35s ease;
+  }
+  .theme-toggle:hover { color: var(--accent); }
+  :root[data-theme="dark"] .theme-toggle { transform: rotate(180deg); }
+
+  /* ——— the page ——— */
+  .page {
+    max-width: 680px; margin: 0 auto;
+    padding: 76px 20px 24px;
+  }
+  .msg { position: relative; margin-bottom: 60px; animation: rise .55s ease both; }
+  .msg:nth-of-type(1){animation-delay:.03s} .msg:nth-of-type(2){animation-delay:.10s}
+  .msg:nth-of-type(3){animation-delay:.17s} .msg:nth-of-type(4){animation-delay:.24s}
+  @keyframes rise { from { opacity:0; transform: translateY(10px);} to { opacity:1; transform:none;} }
+
+  .label {
+    font-family: var(--mono); font-size: 10.5px; font-weight: 500;
+    letter-spacing: .16em; text-transform: uppercase;
+    color: var(--faint); margin-bottom: 14px;
+    display:flex; align-items:baseline; gap:12px;
+  }
+  .msg.user .label::before { content:""; width:14px; height:1px; background:var(--faint); align-self:center; }
+  .stamp { font-weight:400; letter-spacing:.04em; opacity:0; transition:opacity .25s ease; }
+  .msg:hover .stamp { opacity:.8; }
+  .msg p + p { margin-top: 16px; }
+  .msg.user p { color: var(--user-ink); }
+
+  /* ——— focal hierarchy: just the cue. The live turn and the most-recent
+     completed work carry a quiet accent tick in the left gutter; the opening
+     request recedes a hair. Felt, not seen — no blur, scale, or motion. ——— */
+  .msg.focal::before {
+    content:""; position:absolute; left:-22px; top:3px; bottom:3px;
+    width:2px; border-radius:2px; background: var(--accent); opacity:.42;
+  }
+  .msg.recede { opacity:.76; }
+
+  /* ——— end-of-turn receipt: a faint one-line tally, completed turns only ——— */
+  .turn-stats {
+    margin-top: 20px;
+    font-family: var(--mono); font-size: 11px; letter-spacing: .04em;
+    color: var(--faint); opacity: .82;
+  }
+
+  /* ——— the workings: tool steps as a quiet apparatus ——— */
+  .workings {
+    margin: 26px 0 26px 2px;
+    border-left: 2px solid var(--line);
+    padding: 4px 0 4px 22px;
+  }
+  .step + .step { margin-top: 2px; }
+  .step-line {
+    display: flex; align-items: baseline; gap: 10px; width: 100%;
+    text-align: left; padding: 5px 8px 5px 0; border-radius: 6px;
+    font-family: var(--mono); font-size: 13px; color: var(--muted);
+  }
+  .step-line:hover { color: var(--ink); }
+  .step-line .tw {
+    display:inline-block; width: 10px; color: var(--faint);
+    transition: transform .18s ease; font-size: 11px; transform-origin: 45% 50%;
+  }
+  .step.open > .step-line .tw { transform: rotate(90deg); }
+  .step-line .verb { color: var(--faint); min-width: 3.6em; }
+  .step-line .obj  { color: inherit; }
+  .step-line .meta { margin-left: auto; color: var(--faint); font-size: 12px; padding-left: 16px; white-space: nowrap; }
+  .step-line .meta .plus { color: var(--add-ink); } .step-line .meta .minus { color: var(--del-ink); }
+
+  .step-body { display:none; margin: 8px 0 16px 20px; animation: rise .3s ease both; }
+  .step.open > .step-body { display:block; }
+  .step-body pre {
+    font-family: var(--mono); font-size: 12.5px; line-height: 1.75;
+    color: var(--muted); background: var(--raised);
+    border: 1px solid var(--line); border-radius: 8px;
+    padding: 12px 16px; overflow-x: auto; white-space: pre;
+  }
+  .step-body .ok { color: var(--add-ink); }
+  .step-body .num { color: var(--ink); font-weight: 500; }
+
+  /* ——— contextual moment: a diff surfaces because the edit landed ——— */
+  .landed {
+    margin: 30px 0;
+    background: var(--raised);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    box-shadow: var(--card-shadow);
+    overflow: hidden;
+    animation: settle .7s cubic-bezier(.2,.7,.2,1) both .35s;
+  }
+  @keyframes settle { from { opacity:0; transform: translateY(14px) scale(.99);} to { opacity:1; transform:none;} }
+  .landed figcaption {
+    display:flex; align-items:baseline; gap:12px;
+    padding: 11px 18px; border-bottom: 1px solid var(--line);
+    font-family: var(--mono); font-size: 12px; color: var(--muted);
+  }
+  .landed figcaption .file { color: var(--ink); font-weight: 500; }
+  .landed figcaption .delta .plus { color: var(--add-ink); }
+  .landed figcaption .delta .minus { color: var(--del-ink); margin-left: 6px; }
+  .landed figcaption .why {
+    margin-left:auto; font-family: var(--serif); font-style: italic;
+    font-size: 12.5px; color: var(--faint);
+  }
+  .landed .dismiss { color: var(--faint); font-size: 13px; line-height:1; padding: 0 0 0 10px; opacity:0; transition: opacity .2s; }
+  .landed:hover .dismiss { opacity: 1; }
+  .landed .dismiss:hover { color: var(--ink); }
+  .diff { font-family: var(--mono); font-size: 13px; line-height: 1.7; padding: 12px 0; overflow-x:auto; }
+  .diff span { display:block; padding: 1px 18px; white-space: pre; color: var(--muted); }
+  .diff .add { background: var(--add-bg); color: var(--add-ink); }
+  .diff .del { background: var(--del-bg); color: var(--del-ink); text-decoration: line-through; text-decoration-color: var(--del-strike); }
+
+  /* ——— in-progress turn: one quiet line ——— */
+  .activity {
+    display:flex; align-items:center; gap: 12px;
+    font-family: var(--mono); font-size: 13.5px; color: var(--muted);
+  }
+  .activity code { background:none; padding:0; font-size: 13px; color: var(--ink); }
+  .pulse {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--accent); animation: breathe 2.2s ease-in-out infinite;
+  }
+  @keyframes breathe { 0%,100%{opacity:.35; transform:scale(.85);} 50%{opacity:1; transform:scale(1);} }
+  .ellip::after { content:'…'; animation: ellip 1.8s steps(4) infinite; }
+  @keyframes ellip { 0%{content:'';} 25%{content:'.';} 50%{content:'..';} 75%{content:'…';} }
+  .peek {
+    margin-left:auto; font-family: var(--mono); font-size: 11.5px;
+    color: var(--faint); letter-spacing: .06em;
+    border-bottom: 1px solid transparent; padding-bottom:1px;
+    opacity: 0; transition: opacity .25s;
+  }
+  .msg.working:hover .peek { opacity:1; }
+  .peek:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .live-detail { margin: 14px 0 0 20px; }
+  .live-detail .row {
+    font-family: var(--mono); font-size: 12.5px; color: var(--faint);
+    padding: 3px 0; display:flex; gap:10px;
+  }
+  .live-detail .row.now { color: var(--muted); }
+  .live-detail .row.now .cursor { color: var(--accent); animation: breathe 1.4s ease-in-out infinite; }
+  .hidden { display: none !important; }
+
+  /* ——— the dock: compose + status line, pinned together ——— */
+  .dock { position: sticky; bottom: 0; z-index: 15; }
+
+  /* compose: a field with presence — clearly yours to write in */
+  .compose {
+    padding: 44px 20px 20px;
+    background: linear-gradient(to top, var(--paper) 66%, var(--paper-0));
+  }
+  .compose-field {
+    max-width: 680px; margin: 0 auto;
+    display: flex; align-items: center; gap: 13px;
+    background: var(--raised);
+    border: 1px solid var(--line-strong);
+    border-radius: 13px;
+    padding: 8px 8px 8px 19px;
+    min-height: 54px;
+    box-shadow: var(--field-shadow);
+    cursor: text;
+    transition: border-color .2s ease, box-shadow .2s ease;
+  }
+  .compose-field:hover { border-color: var(--focus-line); }
+  .compose-field:focus-within {
+    border-color: var(--focus-line);
+    box-shadow: 0 0 0 3px var(--focus-ring), var(--field-shadow);
+  }
+  .compose-field .caret { font-family: var(--mono); color: var(--accent); font-size: 15px; }
+  .compose-field input {
+    flex:1; border:none; outline:none; background:transparent; min-width: 0;
+    font-family: var(--serif); font-size: 17px; color: var(--ink);
+  }
+  .compose-field input::placeholder { color: var(--faint); font-style: italic; }
+  .field-hints {
+    display:flex; align-items:center; gap: 8px;
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .05em;
+    color: var(--faint); white-space: nowrap; padding-right: 2px;
+    transition: opacity .2s ease;
+  }
+  .compose-field:focus-within .field-hints { opacity: .6; }
+  .field-hints .mid { opacity: .6; }
+  .send {
+    width: 37px; height: 37px; flex-shrink: 0;
+    border: 1px solid var(--line-strong); border-radius: 10px;
+    color: var(--muted); font-size: 15px; line-height: 1;
+    display:flex; align-items:center; justify-content:center;
+    transition: background-color .2s ease, color .2s ease, border-color .2s ease;
+  }
+  .send:hover { color: var(--accent); border-color: var(--accent); }
+  .compose-field:focus-within .send {
+    background: var(--accent); border-color: var(--accent); color: var(--send-ink);
+  }
+
+  /* status line: model + quiet context, dismissible */
+  .statusline {
+    height: 30px;
+    background: var(--status-bg);
+    border-top: 1px solid var(--line);
+    font-family: var(--mono); font-size: 11px; letter-spacing: .03em;
+    color: var(--faint);
+  }
+  .statusline .sl-inner {
+    max-width: 680px; margin: 0 auto; height: 100%;
+    padding: 0 2px;
+    display:flex; align-items:center;
+  }
+  .statusline .model { color: var(--muted); font-weight: 500; }
+  .statusline .model::before {
+    content:""; display:inline-block; width:5px; height:5px; border-radius:50%;
+    background: var(--accent); margin-right: 8px; vertical-align: 2px; opacity:.75;
+  }
+  .statusline .sl-sep { margin: 0 9px; opacity:.55; }
+  .sl-close {
+    margin-left:auto; color: var(--faint); font-size: 11px; line-height: 1;
+    padding: 4px 6px; border-radius: 5px;
+    opacity: .7; transition: opacity .2s ease, color .2s ease;
+  }
+  .sl-close:hover { opacity: 1; color: var(--ink); }
+  .sl-handle {
+    position: absolute; right: 18px; bottom: 13px;
+    width: 9px; height: 9px; border-radius: 50%;
+    background: var(--faint); opacity: .4;
+    transition: opacity .2s ease, transform .2s ease, background-color .2s ease;
+  }
+  .sl-handle:hover { opacity: 1; transform: scale(1.35); background: var(--accent); }
+
+  /* ——— reveal mechanic: the command palette (⌘K) ——— */
+  .palette-scrim {
+    position: fixed; inset: 0; z-index: 40;
+    display:flex; justify-content:center; align-items:flex-start;
+    padding-top: 13vh;
+    background: var(--scrim);
+    backdrop-filter: blur(2px);
+    animation: fadein .25s ease both;
+  }
+  @keyframes fadein { from{opacity:0;} to{opacity:1;} }
+  .palette {
+    width: 560px; max-width: calc(100vw - 48px);
+    background: var(--raised);
+    border: 1px solid var(--line); border-radius: 14px;
+    box-shadow: var(--palette-shadow);
+    overflow: hidden;
+    animation: pop .3s cubic-bezier(.2,.8,.3,1.1) both;
+  }
+  @keyframes pop { from { opacity:0; transform: translateY(-8px) scale(.985);} to { opacity:1; transform:none;} }
+  .palette .search {
+    display:flex; align-items:baseline; gap: 12px;
+    padding: 16px 20px; border-bottom: 1px solid var(--line);
+  }
+  .palette .search .caret { font-family: var(--mono); color: var(--faint); }
+  .palette .search input {
+    flex:1; border:none; outline:none; background:transparent;
+    font-family: var(--serif); font-size: 17px; color: var(--ink);
+  }
+  .palette .search input::placeholder { color: var(--faint); font-style: italic; }
+  .palette .groups { padding: 8px 8px 10px; max-height: 52vh; overflow-y:auto; }
+  .palette .group-label {
+    font-family: var(--mono); font-size: 10px; letter-spacing:.18em;
+    text-transform: uppercase; color: var(--faint);
+    padding: 12px 14px 5px;
+  }
+  .palette .item {
+    display:flex; align-items:baseline; gap: 12px; width:100%;
+    text-align:left; padding: 9px 14px; border-radius: 8px;
+    font-family: var(--serif); font-size: 15.5px; color: var(--item-ink);
+    position: relative;
+  }
+  .palette .item .sub { font-family: var(--mono); font-size: 11.5px; color: var(--faint); }
+  .palette .item kbd {
+    margin-left:auto; font-family: var(--mono); font-size: 11px;
+    color: var(--faint); letter-spacing: .05em;
+  }
+  .palette .item:hover { background: var(--hover-bg); }
+  .palette .item.selected { background: var(--selected-bg); color: var(--ink); }
+  .palette .item.selected::before {
+    content:""; position:absolute; left:4px; top:9px; bottom:9px;
+    width:2px; border-radius:2px; background: var(--accent);
+  }
+  .palette .foot {
+    display:flex; gap: 18px; padding: 10px 20px;
+    border-top: 1px solid var(--line);
+    font-family: var(--mono); font-size: 10.5px; color: var(--faint); letter-spacing:.04em;
+  }
+  .palette .foot .spacer { margin-left:auto; font-style: italic; font-family: var(--serif); font-size: 11.5px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation: none !important; transition: none !important; }
+  }
+</style>
+</head>
+<body>
+
+<header class="masthead">
+  <span class="ident"><b>orbit/web</b><span class="sep">·</span>fix/session-resume</span>
+  <span class="title">Fix the failing session-resume test</span>
+  <span class="state">Claude<span class="sep">·</span><span class="dot"></span>sandbox active
+    <button class="theme-toggle" id="themeToggle" title="Toggle light / dark" aria-label="Toggle light / dark theme">◐</button>
+  </span>
+</header>
+
+<main class="page">
+
+  <!-- ——— user ——— -->
+  <article class="msg user recede">
+    <div class="label">Michael <span class="stamp">9:41 am</span></div>
+    <p>The session-resume path is broken — <code>resumeSession</code> comes back with
+    undefined when the id doesn’t exist, and there’s a failing repro in
+    <code>session.test.ts</code>. Can you track it down and fix it?</p>
+  </article>
+
+  <!-- ——— completed agent turn ——— -->
+  <article class="msg agent focal">
+    <div class="label">Claude <span class="stamp">9:42 am</span></div>
+    <p>Found it. The failing test — <em>rejects when the session id is unknown</em> —
+    expects a <code>SessionNotFoundError</code>, but <code>resumeSession</code> passes the
+    store’s result straight into <code>hydrate</code>. When the id is missing, the record
+    arrives as <code>undefined</code> and the failure surfaces one frame too late: a
+    <code>TypeError</code> inside <code>hydrate</code> instead of a meaningful rejection.</p>
+
+    <div class="workings">
+      <!-- collapsed steps -->
+      <div class="step">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Read</span><span class="obj">src/session/session.test.ts</span><span class="meta">41 lines</span></button>
+        <div class="step-body"><pre>it("rejects when the session id is unknown", async () =&gt; {
+  await expect(resumeSession("sess_missing")).rejects.toThrow(
+    SessionNotFoundError,
+  );
+});</pre></div>
+      </div>
+      <div class="step">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Read</span><span class="obj">src/session/resume.ts</span><span class="meta">18 lines</span></button>
+        <div class="step-body"><pre>export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {
+  const record = await store.get(id);
+  return hydrate(record);
+}</pre></div>
+      </div>
+      <div class="step">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Edit</span><span class="obj">src/session/resume.ts</span><span class="meta"><span class="plus">+4</span> <span class="minus">−1</span></span></button>
+        <div class="step-body"><pre>guard added before hydrate() — see the change below</pre></div>
+      </div>
+      <!-- expanded step -->
+      <div class="step open">
+        <button class="step-line"><span class="tw">▸</span><span class="verb">Ran</span><span class="obj">pnpm test</span><span class="meta">28 passed · 1.21s</span></button>
+        <div class="step-body"><pre><span class="ok">✓</span> src/session/resume.test.ts   (6 tests)  128ms
+<span class="ok">✓</span> src/session/session.test.ts (14 tests)  412ms
+<span class="ok">✓</span> src/session/store.test.ts    (8 tests)   96ms
+
+Test Files  <span class="num">3 passed</span> (3)
+     Tests  <span class="num">28 passed</span> (28)
+  Duration  1.21s</pre></div>
+      </div>
+    </div>
+
+    <!-- contextual moment: the diff surfaced because the edit landed -->
+    <figure class="landed">
+      <figcaption>
+        <span class="file">src/session/resume.ts</span>
+        <span class="delta"><span class="plus">+4</span><span class="minus">−1</span></span>
+        <span class="why">edit landed · just now</span>
+        <button class="dismiss" title="Dismiss">✕</button>
+      </figcaption>
+      <pre class="diff"><span>  export async function resumeSession(id: SessionId): Promise&lt;Session&gt; {</span><span>    const record = await store.get(id);</span><span class="del">-   return hydrate(record);</span><span class="add">+   if (!record) {</span><span class="add">+     throw new SessionNotFoundError(id);</span><span class="add">+   }</span><span class="add">+   return hydrate(record);</span><span>  }</span></pre>
+    </figure>
+
+    <p>The guard now rejects at the boundary, before hydration is ever attempted.
+    Full suite is green — 28 tests across three files, including the two that
+    were red.</p>
+
+    <div class="turn-stats">4 tools · 3.2k tokens · 18.6s</div>
+  </article>
+
+  <!-- ——— user follow-up ——— -->
+  <article class="msg user">
+    <div class="label">Michael <span class="stamp">9:44 am</span></div>
+    <p>Lovely. While you’re in there — add a regression test for the expired-session
+    path; resuming after <code>expiresAt</code> should reject the same way.</p>
+  </article>
+
+  <!-- ——— in-progress turn: one quiet line ——— -->
+  <article class="msg agent working focal">
+    <div class="label">Claude</div>
+    <div class="activity">
+      <span class="pulse"></span>
+      <span class="act-text">Editing <code>src/session/session.test.ts</code><span class="ellip"></span></span>
+      <button class="peek" data-reveal="live-detail">details</button>
+    </div>
+    <div id="live-detail" class="live-detail hidden">
+      <div class="row"><span>✓</span><span>Read src/session/session.test.ts — found the expiry fixtures</span></div>
+      <div class="row now"><span class="cursor">▍</span><span>Edit src/session/session.test.ts — adding “rejects resuming an expired session”</span></div>
+    </div>
+  </article>
+
+</main>
+
+<!-- ——— the dock: compose above, status line at the very bottom ——— -->
+<footer class="dock">
+  <div class="compose">
+    <div class="compose-field" id="composeField">
+      <span class="caret">›</span>
+      <input type="text" id="composeInput" autofocus aria-label="Reply to Claude">
+      <button class="send" title="Send" aria-label="Send">↑</button>
+    </div>
+  </div>
+  <div class="statusline" id="statusline">
+    <div class="sl-inner">
+      <span class="model">opus-4.8</span><span class="sl-sep">·</span>2.1k ctx
+      <button class="sl-close" id="slClose" title="Hide status line" aria-label="Hide status line">✕</button>
+    </div>
+  </div>
+  <button class="sl-handle hidden" id="slHandle" title="Show status line" aria-label="Show status line"></button>
+</footer>
+
+<!-- ——— reveal mechanic: ⌘K command palette (hidden until summoned) ——— -->
+<div class="palette-scrim hidden" id="palette">
+  <div class="palette" role="dialog" aria-label="Command palette">
+    <div class="search">
+      <span class="caret">›</span>
+      <input type="text" placeholder="Type a command" aria-label="Command">
+    </div>
+    <div class="groups">
+      <div class="group-label">Sandbox</div>
+      <button class="item selected">Run tests <span class="sub">pnpm test</span><kbd>↵</kbd></button>
+      <button class="item">Open terminal<kbd>⌘T</kbd></button>
+      <button class="item">Restart sandbox</button>
+      <div class="group-label">Code</div>
+      <button class="item">Open latest diff <span class="sub">resume.ts</span><kbd>⌘D</kbd></button>
+      <button class="item">Create pull request</button>
+      <div class="group-label">Session</div>
+      <button class="item" id="paletteTheme">Switch theme <span class="sub">light / dark</span></button>
+      <button class="item">Focus mode<kbd>⌘.</kbd></button>
+      <button class="item">Pause Claude</button>
+    </div>
+    <div class="foot">
+      <span>↑↓ navigate</span><span>↵ run</span><span>esc close</span>
+      <span class="spacer">appears anywhere, holds everything</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  // ——— theme: default light; #light / #dark force it (deterministic screenshots); ◐ toggles.
+  const root = document.documentElement;
+  const applyHashTheme = () => {
+    const h = location.hash.slice(1);
+    if (h === 'dark' || h === 'light') root.dataset.theme = h;
+  };
+  applyHashTheme();
+  window.addEventListener('hashchange', applyHashTheme);
+  const flipTheme = () => {
+    root.dataset.theme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+  };
+  document.getElementById('themeToggle').addEventListener('click', flipTheme);
+
+  // ——— command palette
+  const palette = document.getElementById('palette');
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault(); palette.classList.toggle('hidden');
+    }
+    if (e.key === 'Escape') palette.classList.add('hidden');
+  });
+  palette.addEventListener('click', (e) => { if (e.target === palette) palette.classList.add('hidden'); });
+  document.getElementById('paletteTheme').addEventListener('click', () => {
+    flipTheme(); palette.classList.add('hidden');
+  });
+
+  // ——— workings disclosure
+  document.querySelectorAll('.step-line').forEach((b) =>
+    b.addEventListener('click', () => b.closest('.step').classList.toggle('open')));
+
+  document.querySelectorAll('[data-reveal]').forEach((b) =>
+    b.addEventListener('click', () => document.getElementById(b.dataset.reveal).classList.toggle('hidden')));
+
+  document.querySelector('.landed .dismiss')?.addEventListener('click', (e) =>
+    e.target.closest('.landed').remove());
+
+  // ——— compose: the whole field is a click target; aim the cursor here on load
+  const field = document.getElementById('composeField');
+  const composeInput = document.getElementById('composeInput');
+  field.addEventListener('click', (e) => {
+    if (!e.target.closest('.send')) composeInput.focus();
+  });
+  composeInput.focus();
+
+  // ——— status line: ✕ collapses to a small handle; the handle brings it back
+  const statusline = document.getElementById('statusline');
+  const slHandle = document.getElementById('slHandle');
+  document.getElementById('slClose').addEventListener('click', () => {
+    statusline.classList.add('hidden'); slHandle.classList.remove('hidden');
+  });
+  slHandle.addEventListener('click', () => {
+    slHandle.classList.add('hidden'); statusline.classList.remove('hidden');
+  });
+</script>
+
+</body>
+</html>

--- a/web-next/.gitignore
+++ b/web-next/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.next/
+next-env.d.ts
+.env
+.env.local
+*.tsbuildinfo

--- a/web-next/next.config.ts
+++ b/web-next/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "spaces-next",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"dev": "next dev --port 3100",
+		"build": "next build",
+		"start": "next start --port 3100",
+		"test": "vitest run",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@ai-sdk/react": "^4.0.15",
+		"ai": "^7.0.14",
+		"next": "^15.5.19",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"zod": "^4.4.3"
+	},
+	"devDependencies": {
+		"@tailwindcss/postcss": "^4.3.2",
+		"@types/node": "^22",
+		"@types/react": "^19",
+		"@types/react-dom": "^19",
+		"tailwindcss": "^4.3.2",
+		"typescript": "^5.7.2",
+		"vitest": "^4.1.9"
+	}
+}

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -1,0 +1,1699 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@ai-sdk/react':
+        specifier: ^4.0.15
+        version: 4.0.15(react@19.2.7)(zod@4.4.3)
+      ai:
+        specifier: ^7.0.14
+        version: 7.0.14(zod@4.4.3)
+      next:
+        specifier: ^15.5.19
+        version: 15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.3.2
+        version: 4.3.2
+      '@types/node':
+        specifier: ^22
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.17)
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0))
+
+packages:
+
+  '@ai-sdk/gateway@4.0.11':
+    resolution: {integrity: sha512-ZdZzQnBxYfjJpWpSNkV+rRWycwTBhxyvwGvxcwx9g+WQoy3MK2xNahSySEgP9hD/X2xY9jkjd0xB67oDE3rLMA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@2.0.7':
+    resolution: {integrity: sha512-DX1v5M/R4RD2yi1KSH2ERLKcb6h2qJF0DKt0PGTTpNJNK+meXMmouwSRZS8Y+JocbyHk7U9p6PgqVmKU/e5XhQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.5':
+    resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.2':
+    resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.15':
+    resolution: {integrity: sha512-JN95NNG8m/OnAdOTtl3YbB0QnAp1IY8Yxrgh8ue+d95HsBKu079R+uq+b8pFt3MtGpjmY93OPgDZq1j33SOrhQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@next/env@15.5.20':
+    resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
+
+  '@next/swc-darwin-arm64@15.5.20':
+    resolution: {integrity: sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.20':
+    resolution: {integrity: sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    resolution: {integrity: sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.5.20':
+    resolution: {integrity: sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.5.20':
+    resolution: {integrity: sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.5.20':
+    resolution: {integrity: sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    resolution: {integrity: sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.20':
+    resolution: {integrity: sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
+
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.2':
+    resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  ai@7.0.14:
+    resolution: {integrity: sha512-qA82fZyD4xh9IDB+s3SvwbjwjR+GGRmJjTYMwON1uROj8vPDIQbPTZLLq6ZWTVESn9daeH1GMv0zKfVLwNU2sQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  caniuse-lite@1.0.30001800:
+    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@15.5.20:
+    resolution: {integrity: sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vite@8.1.3:
+    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@ai-sdk/gateway@4.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/mcp@2.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.2':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@4.0.15(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/mcp': 2.0.7(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      ai: 7.0.14(zod@4.4.3)
+      react: 19.2.7
+      swr: 2.4.2(react@19.2.7)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@next/env@15.5.20': {}
+
+  '@next/swc-darwin-arm64@15.5.20':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.20':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.20':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.20':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.20':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.20':
+    optional: true
+
+  '@oxc-project/types@0.138.0': {}
+
+  '@rolldown/binding-android-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.3.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
+  '@tailwindcss/postcss@4.3.2':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      postcss: 8.5.16
+      tailwindcss: 4.3.2
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@22.20.0)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@workflow/serde@4.1.0': {}
+
+  ai@7.0.14(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.11(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      zod: 4.4.3
+
+  assertion-error@2.0.1: {}
+
+  caniuse-lite@1.0.30001800: {}
+
+  chai@6.2.2: {}
+
+  client-only@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-module-lexer@2.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventsource-parser@3.1.0: {}
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.7.0: {}
+
+  json-schema@0.4.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.15: {}
+
+  next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 15.5.20
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001800
+      postcss: 8.4.31
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.20
+      '@next/swc-darwin-x64': 15.5.20
+      '@next/swc-linux-arm64-gnu': 15.5.20
+      '@next/swc-linux-arm64-musl': 15.5.20
+      '@next/swc-linux-x64-gnu': 15.5.20
+      '@next/swc-linux-x64-musl': 15.5.20
+      '@next/swc-win32-arm64-msvc': 15.5.20
+      '@next/swc-win32-x64-msvc': 15.5.20
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  obug@2.1.3: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react@19.2.7: {}
+
+  rolldown@1.1.4:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
+
+  scheduler@0.27.0: {}
+
+  semver@7.8.5:
+    optional: true
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  styled-jsx@5.1.6(react@19.2.7):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.7
+
+  swr@2.4.2(react@19.2.7):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  tailwindcss@4.3.2: {}
+
+  tapable@2.3.3: {}
+
+  throttleit@2.1.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
+  vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@22.20.0)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@4.4.3: {}

--- a/web-next/postcss.config.mjs
+++ b/web-next/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+	plugins: {
+		"@tailwindcss/postcss": {},
+	},
+};

--- a/web-next/src/app/api/spike/route.ts
+++ b/web-next/src/app/api/spike/route.ts
@@ -1,0 +1,21 @@
+/*
+ * Phase 0 spike endpoint: streams a mock provider turn through the
+ * StreamChunk → UIMessageChunk adapter as an AI SDK UIMessage SSE response.
+ */
+import { createUIMessageStreamResponse, type UIMessage } from "ai";
+import { toUIMessageChunkStream } from "@/lib/transcript/chunk-adapter";
+import { mockCodingTurn } from "@/lib/transcript/mock-turn";
+
+export async function POST(req: Request) {
+	const { messages }: { messages: UIMessage[] } = await req.json();
+	const lastUser = [...messages].reverse().find((m) => m.role === "user");
+	const userText =
+		lastUser?.parts
+			.filter((p) => p.type === "text")
+			.map((p) => p.text)
+			.join("") ?? "";
+
+	return createUIMessageStreamResponse({
+		stream: toUIMessageChunkStream(mockCodingTurn(userText)),
+	});
+}

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -1,0 +1,89 @@
+/*
+ * Spaces design tokens on Tailwind v4. Same palette/typography as the legacy
+ * web/ app (mint on deep navy, Instrument Serif + JetBrains Mono); CRT
+ * overlays kept but softened so long transcripts stay readable.
+ */
+@import "tailwindcss";
+
+@theme {
+	--color-canvas: #0e1117;
+	--color-surface: #141821;
+	--color-elevated: #1a1f2e;
+	--color-edge: #242a3a;
+	--color-edge-subtle: #1c2233;
+	--color-ink: #d4dae8;
+	--color-ink-muted: #5a6580;
+	--color-ink-faint: #3a4258;
+	--color-mint: #a6ffdf;
+	--color-mint-dim: rgba(166, 255, 223, 0.06);
+	--color-mint-glow: rgba(166, 255, 223, 0.12);
+	--color-mint-muted: rgba(166, 255, 223, 0.25);
+
+	--font-display: var(--font-instrument-serif), serif;
+	--font-mono: var(--font-jetbrains-mono), monospace;
+}
+
+html,
+body {
+	height: 100%;
+	background: var(--color-canvas);
+	color: var(--color-ink);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+body {
+	font-family: var(--font-mono);
+}
+
+/* Noise texture overlay (softer than legacy: 0.015 vs 0.025) */
+body::before {
+	content: "";
+	position: fixed;
+	inset: 0;
+	opacity: 0.015;
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='256' height='256' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
+	background-repeat: repeat;
+	background-size: 256px 256px;
+	pointer-events: none;
+	z-index: 1;
+}
+
+a {
+	transition: color 0.2s ease;
+}
+
+@keyframes blink {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0;
+	}
+}
+
+@keyframes pulse {
+	0%,
+	100% {
+		box-shadow:
+			0 0 0 0 rgba(166, 255, 223, 0.4),
+			0 0 4px 1px rgba(166, 255, 223, 0.15);
+	}
+	50% {
+		box-shadow:
+			0 0 0 4px rgba(166, 255, 223, 0),
+			0 0 8px 2px rgba(166, 255, 223, 0.08);
+	}
+}
+
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+		transform: translateY(8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}

--- a/web-next/src/app/layout.tsx
+++ b/web-next/src/app/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { Instrument_Serif, JetBrains_Mono } from "next/font/google";
+import "./globals.css";
+
+const instrumentSerif = Instrument_Serif({
+	weight: "400",
+	style: ["normal", "italic"],
+	subsets: ["latin"],
+	variable: "--font-instrument-serif",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+	subsets: ["latin"],
+	variable: "--font-jetbrains-mono",
+});
+
+export const metadata: Metadata = {
+	title: "Spaces",
+	description: "Coding sessions in the browser",
+};
+
+export default function RootLayout({
+	children,
+}: Readonly<{ children: React.ReactNode }>) {
+	return (
+		<html lang="en">
+			<body
+				className={`${instrumentSerif.variable} ${jetbrainsMono.variable}`}
+			>
+				{children}
+			</body>
+		</html>
+	);
+}

--- a/web-next/src/app/page.tsx
+++ b/web-next/src/app/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function Home() {
+	return (
+		<main className="flex h-screen flex-col items-center justify-center gap-6">
+			<h1 className="font-display text-5xl italic text-mint">Spaces</h1>
+			<p className="text-sm text-ink-muted">
+				Coding sessions in the browser — greenfield rewrite in progress.
+			</p>
+			<Link
+				href="/spike"
+				className="border border-edge px-4 py-2 text-sm text-ink-muted hover:border-mint-muted hover:text-mint"
+			>
+				&gt; Phase 0 transcript spike
+			</Link>
+		</main>
+	);
+}

--- a/web-next/src/app/spike/page.tsx
+++ b/web-next/src/app/spike/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/*
+ * Phase 0 spike: proves StreamChunk → UIMessageChunk → useChat end-to-end —
+ * streamed text parts, dynamic tool cards, and transient status — rendered
+ * in the Spaces skin. Throwaway page; the real session view replaces it.
+ */
+import { useChat } from "@ai-sdk/react";
+import {
+	DefaultChatTransport,
+	isDynamicToolUIPart,
+	type DynamicToolUIPart,
+	type UIMessage,
+} from "ai";
+import { useState } from "react";
+
+function ToolCard({ part }: { part: DynamicToolUIPart }) {
+	const running =
+		part.state === "input-streaming" || part.state === "input-available";
+	const failed = part.state === "output-error";
+	return (
+		<div className="my-2 border border-edge bg-surface text-xs">
+			<div className="flex items-center gap-2 border-b border-edge-subtle px-3 py-1.5">
+				<span
+					className={`inline-block h-1.5 w-1.5 rounded-full ${
+						failed ? "bg-red-400" : running ? "animate-pulse bg-mint" : "bg-mint-muted"
+					}`}
+				/>
+				<span className="text-mint">{part.toolName}</span>
+				{running && <span className="text-ink-faint">running…</span>}
+			</div>
+			{part.input !== undefined && (
+				<pre className="overflow-x-auto px-3 py-2 text-ink-muted">
+					{typeof part.input === "string"
+						? part.input
+						: JSON.stringify(part.input, null, 2)}
+				</pre>
+			)}
+			{part.state === "output-available" && (
+				<pre className="overflow-x-auto border-t border-edge-subtle px-3 py-2 text-ink">
+					{typeof part.output === "string"
+						? part.output
+						: JSON.stringify(part.output, null, 2)}
+				</pre>
+			)}
+			{failed && (
+				<pre className="overflow-x-auto border-t border-edge-subtle px-3 py-2 text-red-400">
+					{part.errorText}
+				</pre>
+			)}
+		</div>
+	);
+}
+
+function Message({ message }: { message: UIMessage }) {
+	const isUser = message.role === "user";
+	return (
+		<div className="animate-[fadeIn_0.3s_ease]">
+			<div className={`mb-1 text-xs ${isUser ? "text-ink-muted" : "text-mint"}`}>
+				{isUser ? "you" : "agent"}
+			</div>
+			<div className="text-sm leading-relaxed">
+				{message.parts.map((part, i) => {
+					if (part.type === "text")
+						return (
+							<p key={i} className="whitespace-pre-wrap text-ink">
+								{part.text}
+							</p>
+						);
+					if (isDynamicToolUIPart(part)) return <ToolCard key={i} part={part} />;
+					return null;
+				})}
+			</div>
+		</div>
+	);
+}
+
+export default function SpikePage() {
+	const [input, setInput] = useState("");
+	const [status, setStatus] = useState<string | null>(null);
+	const { messages, sendMessage, status: chatStatus } = useChat({
+		transport: new DefaultChatTransport({ api: "/api/spike" }),
+		onData: (part) => {
+			if (part.type === "data-status")
+				setStatus((part.data as { message?: string }).message ?? null);
+		},
+		onFinish: () => setStatus(null),
+	});
+
+	const busy = chatStatus === "streaming" || chatStatus === "submitted";
+	// Status lines describe provisioning; once the agent's reply starts
+	// rendering they are stale, so derive visibility from message state.
+	const lastMessage = messages.at(-1);
+	const replyStarted =
+		lastMessage?.role === "assistant" && lastMessage.parts.length > 0;
+	const visibleStatus = busy && !replyStarted ? status : null;
+
+	return (
+		<main className="mx-auto flex h-screen max-w-3xl flex-col px-6">
+			<header className="flex items-baseline gap-3 border-b border-edge-subtle py-4">
+				<h1 className="font-display text-2xl italic text-mint">Spaces</h1>
+				<span className="text-xs text-ink-faint">
+					phase 0 spike — mock provider through the chunk adapter
+				</span>
+			</header>
+			<div className="flex-1 space-y-6 overflow-y-auto py-6">
+				{messages.length === 0 && (
+					<p className="text-sm text-ink-faint">
+						Send a message to stream a simulated coding turn.
+					</p>
+				)}
+				{messages.map((m) => (
+					<Message key={m.id} message={m} />
+				))}
+				{visibleStatus && (
+					<div className="flex items-center gap-2 text-xs text-ink-muted">
+						<span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-mint" />
+						{visibleStatus}
+					</div>
+				)}
+			</div>
+			<form
+				className="flex gap-2 border-t border-edge-subtle py-4"
+				onSubmit={(e) => {
+					e.preventDefault();
+					if (!input.trim() || busy) return;
+					sendMessage({ text: input });
+					setInput("");
+				}}
+			>
+				<input
+					className="flex-1 border border-edge bg-surface px-3 py-2 text-sm text-ink outline-none placeholder:text-ink-faint focus:border-mint-muted"
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					placeholder="Ask the agent to fix something…"
+				/>
+				<button
+					type="submit"
+					disabled={busy}
+					className="border border-edge px-4 py-2 text-sm text-mint disabled:opacity-40"
+				>
+					{busy ? "streaming…" : "send"}
+				</button>
+			</form>
+		</main>
+	);
+}

--- a/web-next/src/lib/agent-runtime/stream-chunk.ts
+++ b/web-next/src/lib/agent-runtime/stream-chunk.ts
@@ -1,0 +1,10 @@
+/*
+ * The universal streaming unit shared with the legacy web/ agent runtime.
+ * Every compute provider (Vercel Sandbox, Anthropic Managed Agents, mock)
+ * emits these; the transcript adapter turns them into AI SDK UIMessage chunks.
+ */
+export interface StreamChunk {
+	type: "text" | "tool_use" | "tool_result" | "status" | "error" | "done";
+	content: string;
+	metadata?: Record<string, unknown>;
+}

--- a/web-next/src/lib/transcript/chunk-adapter.test.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+import type { StreamChunk } from "../agent-runtime/stream-chunk";
+import { toUIMessageChunks } from "./chunk-adapter";
+
+async function collect(chunks: StreamChunk[]) {
+	const ids = (function* () {
+		let n = 0;
+		while (true) yield `id-${n++}`;
+	})();
+	const out = [];
+	for await (const chunk of toUIMessageChunks(chunks, {
+		messageId: "msg-1",
+		generateId: () => ids.next().value as string,
+	})) {
+		out.push(chunk);
+	}
+	return out;
+}
+
+describe("toUIMessageChunks", () => {
+	test("brackets contiguous text chunks into one text part", async () => {
+		const out = await collect([
+			{ type: "text", content: "Hello " },
+			{ type: "text", content: "world" },
+			{ type: "done", content: "" },
+		]);
+		expect(out).toEqual([
+			{ type: "start", messageId: "msg-1" },
+			{ type: "text-start", id: "id-0" },
+			{ type: "text-delta", id: "id-0", delta: "Hello " },
+			{ type: "text-delta", id: "id-0", delta: "world" },
+			{ type: "text-end", id: "id-0" },
+			{ type: "finish" },
+		]);
+	});
+
+	test("tool_use closes text and emits a dynamic tool input", async () => {
+		const out = await collect([
+			{ type: "text", content: "Let me look." },
+			{
+				type: "tool_use",
+				content: "Read",
+				metadata: { toolUseId: "t-1", toolName: "Read", input: { file: "a.ts" } },
+			},
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({ type: "text-end", id: "id-0" });
+		expect(out).toContainEqual({
+			type: "tool-input-available",
+			toolCallId: "t-1",
+			toolName: "Read",
+			input: { file: "a.ts" },
+			dynamic: true,
+		});
+	});
+
+	test("tool_result pairs by explicit toolUseId", async () => {
+		const out = await collect([
+			{ type: "tool_use", content: "Read", metadata: { toolUseId: "t-1" } },
+			{ type: "tool_use", content: "Bash", metadata: { toolUseId: "t-2" } },
+			{ type: "tool_result", content: "ok", metadata: { toolUseId: "t-2" } },
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({
+			type: "tool-output-available",
+			toolCallId: "t-2",
+			output: "ok",
+			dynamic: true,
+		});
+	});
+
+	test("tool_result without id pairs FIFO against unresolved calls", async () => {
+		const out = await collect([
+			{ type: "tool_use", content: "Read", metadata: { toolUseId: "t-1" } },
+			{ type: "tool_use", content: "Bash", metadata: { toolUseId: "t-2" } },
+			{ type: "tool_result", content: "first" },
+			{ type: "tool_result", content: "second" },
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({
+			type: "tool-output-available",
+			toolCallId: "t-1",
+			output: "first",
+			dynamic: true,
+		});
+		expect(out).toContainEqual({
+			type: "tool-output-available",
+			toolCallId: "t-2",
+			output: "second",
+			dynamic: true,
+		});
+	});
+
+	test("error results become tool-output-error", async () => {
+		const out = await collect([
+			{ type: "tool_use", content: "Bash", metadata: { toolUseId: "t-1" } },
+			{
+				type: "tool_result",
+				content: "exit 1",
+				metadata: { toolUseId: "t-1", isError: true },
+			},
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({
+			type: "tool-output-error",
+			toolCallId: "t-1",
+			errorText: "exit 1",
+			dynamic: true,
+		});
+	});
+
+	test("status becomes a transient data-status chunk", async () => {
+		const out = await collect([
+			{ type: "status", content: "Starting sandbox" },
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({
+			type: "data-status",
+			data: { message: "Starting sandbox" },
+			transient: true,
+		});
+	});
+
+	test("status does not split an open text part", async () => {
+		const out = await collect([
+			{ type: "text", content: "a" },
+			{ type: "status", content: "still working" },
+			{ type: "text", content: "b" },
+			{ type: "done", content: "" },
+		]);
+		const starts = out.filter((c) => c.type === "text-start");
+		expect(starts).toHaveLength(1);
+	});
+
+	test("error chunk maps to stream error and stream still finishes", async () => {
+		const out = await collect([
+			{ type: "text", content: "partial" },
+			{ type: "error", content: "sandbox died" },
+		]);
+		expect(out).toContainEqual({ type: "error", errorText: "sandbox died" });
+		expect(out.at(-1)).toEqual({ type: "finish" });
+	});
+
+	test("source ending without done still closes text and finishes", async () => {
+		const out = await collect([{ type: "text", content: "abrupt" }]);
+		expect(out).toContainEqual({ type: "text-end", id: "id-0" });
+		expect(out.at(-1)).toEqual({ type: "finish" });
+	});
+
+	test("text after a tool call starts a new text part", async () => {
+		const out = await collect([
+			{ type: "text", content: "before" },
+			{ type: "tool_use", content: "Read", metadata: { toolUseId: "t-1" } },
+			{ type: "text", content: "after" },
+			{ type: "done", content: "" },
+		]);
+		const starts = out.filter((c) => c.type === "text-start");
+		expect(starts).toHaveLength(2);
+	});
+});

--- a/web-next/src/lib/transcript/chunk-adapter.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.ts
@@ -1,0 +1,142 @@
+/*
+ * Adapts the agent runtime's StreamChunk protocol to the AI SDK's
+ * UIMessageChunk stream, so any ComputeProvider renders as structured
+ * message parts (text blocks, dynamic tool cards, transient status).
+ */
+import type { UIMessageChunk } from "ai";
+import type { StreamChunk } from "../agent-runtime/stream-chunk";
+
+export interface AdapterOptions {
+	messageId?: string;
+	generateId?: () => string;
+}
+
+function defaultGenerateId(): string {
+	return crypto.randomUUID();
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Converts a provider StreamChunk sequence into UIMessageChunks.
+ *
+ * Contract:
+ * - Contiguous `text` chunks form one text part; any tool/error chunk closes it.
+ * - `tool_use`/`tool_result` become dynamic tool parts. Results pair by
+ *   `metadata.toolUseId` when present, otherwise FIFO against unresolved calls.
+ * - `status` becomes a transient `data-status` chunk (delivered via onData,
+ *   never persisted into the message).
+ * - `done` — or the source ending — closes open parts and emits `finish`.
+ */
+export async function* toUIMessageChunks(
+	source: AsyncIterable<StreamChunk> | Iterable<StreamChunk>,
+	options: AdapterOptions = {},
+): AsyncGenerator<UIMessageChunk> {
+	const generateId = options.generateId ?? defaultGenerateId;
+
+	let openTextId: string | null = null;
+	let finished = false;
+	const unresolvedToolIds: string[] = [];
+
+	function closeText(): UIMessageChunk[] {
+		if (openTextId === null) return [];
+		const end: UIMessageChunk = { type: "text-end", id: openTextId };
+		openTextId = null;
+		return [end];
+	}
+
+	yield { type: "start", messageId: options.messageId };
+
+	for await (const chunk of source) {
+		if (finished) break;
+
+		switch (chunk.type) {
+			case "text": {
+				if (chunk.content.length === 0) break;
+				if (openTextId === null) {
+					openTextId = generateId();
+					yield { type: "text-start", id: openTextId };
+				}
+				yield { type: "text-delta", id: openTextId, delta: chunk.content };
+				break;
+			}
+			case "tool_use": {
+				yield* closeText();
+				const toolCallId =
+					asString(chunk.metadata?.toolUseId) ?? generateId();
+				const toolName =
+					asString(chunk.metadata?.toolName) ??
+					asString(chunk.content) ??
+					"tool";
+				unresolvedToolIds.push(toolCallId);
+				yield {
+					type: "tool-input-available",
+					toolCallId,
+					toolName,
+					input: chunk.metadata?.input ?? chunk.content,
+					dynamic: true,
+				};
+				break;
+			}
+			case "tool_result": {
+				yield* closeText();
+				const explicitId = asString(chunk.metadata?.toolUseId);
+				const toolCallId = explicitId ?? unresolvedToolIds[0];
+				if (toolCallId === undefined) break; // result with no known call
+				const index = unresolvedToolIds.indexOf(toolCallId);
+				if (index !== -1) unresolvedToolIds.splice(index, 1);
+				yield {
+					type: chunk.metadata?.isError
+						? "tool-output-error"
+						: "tool-output-available",
+					toolCallId,
+					...(chunk.metadata?.isError
+						? { errorText: chunk.content }
+						: { output: chunk.metadata?.output ?? chunk.content }),
+					dynamic: true,
+				} as UIMessageChunk;
+				break;
+			}
+			case "status": {
+				yield {
+					type: "data-status",
+					data: { message: chunk.content },
+					transient: true,
+				};
+				break;
+			}
+			case "error": {
+				yield* closeText();
+				yield { type: "error", errorText: chunk.content };
+				break;
+			}
+			case "done": {
+				finished = true;
+				break;
+			}
+		}
+	}
+
+	yield* closeText();
+	yield { type: "finish" };
+}
+
+/** Wraps the adapted stream as a ReadableStream for createUIMessageStreamResponse. */
+export function toUIMessageChunkStream(
+	source: AsyncIterable<StreamChunk> | Iterable<StreamChunk>,
+	options: AdapterOptions = {},
+): ReadableStream<UIMessageChunk> {
+	const iterator = toUIMessageChunks(source, options);
+	return new ReadableStream<UIMessageChunk>({
+		async pull(controller) {
+			const { value, done } = await iterator.next();
+			if (done) controller.close();
+			else controller.enqueue(value);
+		},
+		async cancel() {
+			await iterator.return(undefined);
+		},
+	});
+}

--- a/web-next/src/lib/transcript/mock-turn.ts
+++ b/web-next/src/lib/transcript/mock-turn.ts
@@ -1,0 +1,94 @@
+/*
+ * Deterministic mock agent turn: emits the StreamChunk sequence a real
+ * coding session produces (status → text → tool calls → results → text),
+ * with small delays so streaming behavior is observable in the spike.
+ */
+import type { StreamChunk } from "../agent-runtime/stream-chunk";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function* mockCodingTurn(
+	userMessage: string,
+): AsyncGenerator<StreamChunk> {
+	yield { type: "status", content: "Starting sandbox" };
+	await sleep(300);
+	yield { type: "status", content: "Cloning repo" };
+	await sleep(300);
+
+	for (const word of `You asked: "${userMessage}". Let me look at the failing test first.`.split(
+		" ",
+	)) {
+		yield { type: "text", content: `${word} ` };
+		await sleep(30);
+	}
+
+	yield {
+		type: "tool_use",
+		content: "Read",
+		metadata: {
+			toolUseId: "tool-1",
+			toolName: "Read",
+			input: { file_path: "src/lib/session.ts" },
+		},
+	};
+	await sleep(400);
+	yield {
+		type: "tool_result",
+		content:
+			"export function resumeSession(id: string) {\n\treturn store.get(id); // BUG: no null check\n}",
+		metadata: { toolUseId: "tool-1" },
+	};
+
+	for (const word of "Found it — `resumeSession` never handles a missing id. I'll add the guard and re-run the tests.".split(
+		" ",
+	)) {
+		yield { type: "text", content: `${word} ` };
+		await sleep(30);
+	}
+
+	yield {
+		type: "tool_use",
+		content: "Edit",
+		metadata: {
+			toolUseId: "tool-2",
+			toolName: "Edit",
+			input: {
+				file_path: "src/lib/session.ts",
+				old_string: "return store.get(id);",
+				new_string:
+					'const session = store.get(id);\nif (!session) throw new SessionNotFoundError(id);\nreturn session;',
+			},
+		},
+	};
+	await sleep(400);
+	yield {
+		type: "tool_result",
+		content: "Edit applied.",
+		metadata: { toolUseId: "tool-2" },
+	};
+
+	yield {
+		type: "tool_use",
+		content: "Bash",
+		metadata: {
+			toolUseId: "tool-3",
+			toolName: "Bash",
+			input: { command: "pnpm test session" },
+		},
+	};
+	await sleep(700);
+	yield {
+		type: "tool_result",
+		content: "✓ session.test.ts (4 tests) 212ms\n\nTest Files  1 passed (1)\n     Tests  4 passed (4)",
+		metadata: { toolUseId: "tool-3" },
+	};
+
+	for (const word of "All four tests pass. The fix adds a `SessionNotFoundError` guard instead of returning undefined.".split(
+		" ",
+	)) {
+		yield { type: "text", content: `${word} ` };
+		await sleep(30);
+	}
+
+	yield { type: "done", content: "" };
+}

--- a/web-next/tsconfig.json
+++ b/web-next/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [{ "name": "next" }],
+		"paths": {
+			"@/*": ["./src/*"]
+		}
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/web-next/vitest.config.ts
+++ b/web-next/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		include: ["src/**/*.test.ts"],
+	},
+});


### PR DESCRIPTION
## Summary

- `backlog/web-experience-redesign_plan.md`: intent + phased plan for rethinking the web experience around a first-class **coding session**. v2 reflects Michael's confirmed direction: **greenfield rewrite** (new app in `web-next/`, organs ported by copy, old app keeps serving webhooks/PR reviewer until cutover) and **single-user scope**.
- **Phase 0 implementation** in `web-next/`: greenfield skeleton (Next 15, AI SDK 7, Tailwind v4, Spaces design tokens) plus the key de-risk — a unit-tested `StreamChunk → UIMessageChunk` adapter (`src/lib/transcript/chunk-adapter.ts`) converting the existing agent-runtime protocol into AI SDK message parts: text bracketing, dynamic tool cards (paired by `toolUseId` or FIFO), transient status, error mapping.
- `/spike` page proves it end-to-end: a mock coding turn (status → text → Read/Edit/Bash tool calls → results → text) streams through `/api/spike` into `useChat` and renders as structured tool cards in the Spaces skin (mint on `#0e1117`, Instrument Serif + JetBrains Mono).

## Mergeability

- Surface: web (new `web-next/` app) + docs
- User-facing behavior changed: none in the deployed app — `web-next/` is not yet wired to any deployment; legacy `web/` untouched
- Non-happy paths considered: adapter handles tool results without ids (FIFO), error results (`tool-output-error`), stream error chunks, and sources that end without a `done` chunk (still closes parts and finishes)
- Release/ops preconditions: none — no deployment changes
- Residual risk or follow-up: Phase 1 (durable `session_events` + tail route + real providers) per the plan doc; spike page is explicitly throwaway

## Validation

- [ ] `swift build` — n/a, no desktop changes
- [ ] `swift test` — n/a
- [x] Other checks run: `pnpm test` in `web-next/` (vitest, **10/10 adapter tests pass**), `pnpm typecheck` (clean), `pnpm build` (clean), Playwright E2E against the production build (send message → assert Read/Edit/Bash tool cards + ≥6 input/output blocks rendered)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Test output (from `web-next/`):

```
Test Files  1 passed (1)
     Tests  10 passed (10)
E2E OK: streamed transcript rendered with tool cards
  (Read/Edit/Bash cards, 6 pre blocks of tool input/output)
```

Evidence links:

- Remote (claude.ai) session — `EVIDENCE_UPLOAD_TOKEN` unavailable per `docs/development/remote-sessions.md`; screenshots of the streamed spike transcript (mid-stream + final) were captured via Playwright/Chromium and delivered in the session chat. Happy to re-upload via `evidence.sh` from a local checkout.

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ