### PR TITLE
Add TerminalRestorePlanner for cold-start restore (durable sessions slice 2)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift
+++ b/Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift
@@ -1,0 +1,165 @@
+//
+//  TerminalRestorePlanner.swift
+//  WorkspaceManagerCore
+//
+//  Turns the durable-session read model (LocalStateStore continuity rows plus the
+//  latest layout snapshot) into an ordered RestorePlan for cold-start restore.
+//  Pure and dependency-injected: SwiftData target resolution, tmux liveness, and
+//  Claude transcript resumability are supplied by the caller so the ladder logic
+//  stays unit-testable. Producing a plan performs no launches — wiring into
+//  startup is a later slice.
+//
+
+import Foundation
+
+/// A per-surface restore instruction. The chosen rung determines how the surface
+/// comes back; `directory` is the effective working directory for that rung.
+public enum RestoreSurfaceAction: Sendable, Equatable {
+    /// Reattach to a live tmux session that survived (same-login-session continuity).
+    case reattachTmux(sessionName: String)
+    /// Relaunch a Claude Code conversation from its still-present transcript.
+    case resumeClaude(agentSessionID: String)
+    /// Start a plain shell — no live process and no resumable conversation.
+    case freshShell
+}
+
+/// One surface to restore, carrying the persisted host-session identity, the
+/// canonical session key resolved against current data, the effective launch
+/// directory, and the action to take.
+public struct RestoreSurfacePlan: Sendable, Equatable, Identifiable {
+    public let hostSessionID: UUID
+    public let key: HostTerminalSessionKey
+    public let directory: URL
+    public let action: RestoreSurfaceAction
+
+    public var id: UUID { hostSessionID }
+
+    public init(
+        hostSessionID: UUID,
+        key: HostTerminalSessionKey,
+        directory: URL,
+        action: RestoreSurfaceAction
+    ) {
+        self.hostSessionID = hostSessionID
+        self.key = key
+        self.directory = directory
+        self.action = action
+    }
+}
+
+/// The full ordered restore plan. `surfaces` preserves read-model order (newest
+/// `last_seen_at` first). `selectedHostSessionID` is advisory — which surface to
+/// focus after restore — and is honored by the wiring slice, not here.
+public struct RestorePlan: Sendable, Equatable {
+    public let surfaces: [RestoreSurfacePlan]
+    public let selectedHostSessionID: UUID?
+
+    public init(surfaces: [RestoreSurfacePlan], selectedHostSessionID: UUID?) {
+        self.surfaces = surfaces
+        self.selectedHostSessionID = selectedHostSessionID
+    }
+}
+
+/// A continuity row that resolved against current SwiftData state. The resolver
+/// owns key reconstruction (it has the model context) and guarantees
+/// `rootDirectory` exists, so the planner can treat it as a validated fallback.
+public struct ResolvedRestoreTarget: Sendable, Equatable {
+    public let key: HostTerminalSessionKey
+    public let rootDirectory: URL
+
+    public init(key: HostTerminalSessionKey, rootDirectory: URL) {
+        self.key = key
+        self.rootDirectory = rootDirectory
+    }
+}
+
+/// Builds a `RestorePlan` from continuity rows. All environment access is
+/// injected; the planner itself is pure and `Sendable`.
+public struct TerminalRestorePlanner: Sendable {
+    /// Resolve a row to a live target, or `nil` to drop it (missing/archived
+    /// SwiftData row, or a conservatively-excluded remote/backend session).
+    public typealias TargetResolver = @Sendable (TerminalSessionContinuityRow) -> ResolvedRestoreTarget?
+    /// Whether a tmux session with the given deterministic name is alive.
+    public typealias TmuxLivenessProbe = @Sendable (_ tmuxSessionName: String) -> Bool
+    /// Whether a Claude transcript for this session id and cwd is still present.
+    public typealias TranscriptResumabilityCheck = @Sendable (_ agentSessionID: String, _ cwd: String) -> Bool
+    /// Whether a directory currently exists (defaults to a `FileManager` probe).
+    public typealias DirectoryExistenceCheck = @Sendable (_ path: String) -> Bool
+
+    private let resolveTarget: TargetResolver
+    private let isTmuxSessionAlive: TmuxLivenessProbe
+    private let isTranscriptResumable: TranscriptResumabilityCheck
+    private let directoryExists: DirectoryExistenceCheck
+
+    public init(
+        resolveTarget: @escaping TargetResolver,
+        isTmuxSessionAlive: @escaping TmuxLivenessProbe,
+        isTranscriptResumable: @escaping TranscriptResumabilityCheck,
+        directoryExists: @escaping DirectoryExistenceCheck = Self.defaultDirectoryExists
+    ) {
+        self.resolveTarget = resolveTarget
+        self.isTmuxSessionAlive = isTmuxSessionAlive
+        self.isTranscriptResumable = isTranscriptResumable
+        self.directoryExists = directoryExists
+    }
+
+    public func plan(
+        rows: [TerminalSessionContinuityRow],
+        layout: TerminalLayoutSnapshotRow?
+    ) -> RestorePlan {
+        var surfaces: [RestoreSurfacePlan] = []
+        for row in rows {
+            guard row.endedAt == nil, row.isActive else { continue }
+            guard let resolved = resolveTarget(row) else { continue }
+            let (action, directory) = decideAction(row: row, resolved: resolved)
+            surfaces.append(
+                RestoreSurfacePlan(
+                    hostSessionID: row.hostSessionID,
+                    key: resolved.key,
+                    directory: directory,
+                    action: action
+                )
+            )
+        }
+        return RestorePlan(surfaces: surfaces, selectedHostSessionID: layout?.activeHostSessionID)
+    }
+
+    /// The restore ladder: live tmux → resumable Claude transcript → fresh shell.
+    private func decideAction(
+        row: TerminalSessionContinuityRow,
+        resolved: ResolvedRestoreTarget
+    ) -> (RestoreSurfaceAction, URL) {
+        if let tmuxSessionName = row.tmuxSessionName, isTmuxSessionAlive(tmuxSessionName) {
+            return (.reattachTmux(sessionName: tmuxSessionName), nearestValidDirectory(row: row, resolved: resolved))
+        }
+
+        if row.agentKind == AgentKind.claudeCode.rawValue,
+            let agentSessionID = row.agentSessionID,
+            let agentCwd = row.agentCwd,
+            directoryExists(agentCwd),
+            isTranscriptResumable(agentSessionID, agentCwd)
+        {
+            return (.resumeClaude(agentSessionID: agentSessionID), URL(fileURLWithPath: agentCwd))
+        }
+
+        return (.freshShell, nearestValidDirectory(row: row, resolved: resolved))
+    }
+
+    /// Prefer the recorded launch directory when it still exists; otherwise fall
+    /// back to the resolved (validated) target root.
+    private func nearestValidDirectory(
+        row: TerminalSessionContinuityRow,
+        resolved: ResolvedRestoreTarget
+    ) -> URL {
+        if directoryExists(row.directoryPath) {
+            return URL(fileURLWithPath: row.directoryPath)
+        }
+        return resolved.rootDirectory
+    }
+
+    /// Default directory-existence probe: true only for an existing directory.
+    public static let defaultDirectoryExists: DirectoryExistenceCheck = { path in
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+}

--- a/Tests/WorkspaceManagerTests/TerminalRestorePlannerTests.swift
+++ b/Tests/WorkspaceManagerTests/TerminalRestorePlannerTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("TerminalRestorePlanner")
+struct TerminalRestorePlannerTests {
+    private static let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: Fixtures
+
+    private func makeRow(
+        hostSessionID: UUID = UUID(),
+        targetKind: String = "repo",
+        directoryPath: String = "/repo",
+        terminalMode: String = "ghostty_managed_splits",
+        tmuxSessionName: String? = nil,
+        isActive: Bool = true,
+        endedAt: Date? = nil,
+        agentSessionID: String? = nil,
+        agentKind: String? = nil,
+        agentCwd: String? = nil
+    ) -> TerminalSessionContinuityRow {
+        TerminalSessionContinuityRow(
+            hostSessionID: hostSessionID,
+            sessionKey: "repoPath(\(directoryPath))",
+            targetKind: targetKind,
+            targetID: nil,
+            targetPath: directoryPath,
+            backendIdentifier: nil,
+            backendInstanceID: nil,
+            directoryPath: directoryPath,
+            terminalMode: terminalMode,
+            tmuxSessionName: tmuxSessionName,
+            customCommandPresent: false,
+            isActive: isActive,
+            createdAt: Self.baseDate,
+            lastSeenAt: Self.baseDate,
+            endedAt: endedAt,
+            agentSessionID: agentSessionID,
+            agentKind: agentKind,
+            agentRunState: agentSessionID == nil ? nil : "running_tool",
+            agentCwd: agentCwd,
+            agentModelDisplayName: agentSessionID == nil ? nil : "Claude",
+            agentEventAt: agentSessionID == nil ? nil : Self.baseDate
+        )
+    }
+
+    private func makePlanner(
+        resolve: @escaping TerminalRestorePlanner.TargetResolver = { row in
+            ResolvedRestoreTarget(
+                key: .repoPath(row.directoryPath),
+                rootDirectory: URL(fileURLWithPath: row.directoryPath)
+            )
+        },
+        tmuxAlive: @escaping TerminalRestorePlanner.TmuxLivenessProbe = { _ in false },
+        transcriptResumable: @escaping TerminalRestorePlanner.TranscriptResumabilityCheck = { _, _ in false },
+        directoryExists: @escaping TerminalRestorePlanner.DirectoryExistenceCheck = { _ in true }
+    ) -> TerminalRestorePlanner {
+        TerminalRestorePlanner(
+            resolveTarget: resolve,
+            isTmuxSessionAlive: tmuxAlive,
+            isTranscriptResumable: transcriptResumable,
+            directoryExists: directoryExists
+        )
+    }
+
+    // MARK: Tests
+
+    @Test("Ended or inactive rows are excluded")
+    func endedOrInactiveExcluded() {
+        let planner = makePlanner()
+        let plan = planner.plan(
+            rows: [
+                makeRow(endedAt: Self.baseDate),
+                makeRow(isActive: false),
+            ],
+            layout: nil
+        )
+        #expect(plan.surfaces.isEmpty)
+    }
+
+    @Test("Rows whose target no longer resolves are dropped")
+    func unresolvedTargetExcluded() {
+        let planner = makePlanner(resolve: { _ in nil })
+        let plan = planner.plan(rows: [makeRow()], layout: nil)
+        #expect(plan.surfaces.isEmpty)
+    }
+
+    @Test("Live tmux session reattaches and takes precedence over the resume rung")
+    func liveTmuxReattaches() throws {
+        let planner = makePlanner(
+            tmuxAlive: { $0 == "wm-repo-abcd1234" },
+            // Would pick resume if the ladder fell through — proves tmux short-circuits.
+            transcriptResumable: { _, _ in true }
+        )
+        let row = makeRow(
+            tmuxSessionName: "wm-repo-abcd1234",
+            agentSessionID: "claude-session-1",
+            agentKind: "claudeCode",
+            agentCwd: "/repo"
+        )
+        let plan = planner.plan(rows: [row], layout: nil)
+        let surface = try #require(plan.surfaces.first)
+        #expect(surface.action == .reattachTmux(sessionName: "wm-repo-abcd1234"))
+    }
+
+    @Test("A present Claude transcript resumes in the recorded cwd")
+    func transcriptPresentResumes() throws {
+        let planner = makePlanner(transcriptResumable: { id, cwd in id == "claude-session-2" && cwd == "/repo" })
+        let row = makeRow(agentSessionID: "claude-session-2", agentKind: "claudeCode", agentCwd: "/repo")
+        let plan = planner.plan(rows: [row], layout: nil)
+        let surface = try #require(plan.surfaces.first)
+        #expect(surface.action == .resumeClaude(agentSessionID: "claude-session-2"))
+        #expect(surface.directory == URL(fileURLWithPath: "/repo"))
+    }
+
+    @Test("An absent transcript falls through to a fresh shell")
+    func transcriptAbsentFreshShell() throws {
+        let planner = makePlanner(transcriptResumable: { _, _ in false })
+        let row = makeRow(agentSessionID: "claude-session-3", agentKind: "claudeCode", agentCwd: "/repo")
+        let plan = planner.plan(rows: [row], layout: nil)
+        let surface = try #require(plan.surfaces.first)
+        #expect(surface.action == .freshShell)
+    }
+
+    @Test("A moved recorded directory falls back to the resolved root")
+    func directoryMovedFallsBackToRoot() throws {
+        let planner = makePlanner(
+            resolve: { _ in
+                ResolvedRestoreTarget(
+                    key: .repoPath("/repo"),
+                    rootDirectory: URL(fileURLWithPath: "/resolved-root")
+                )
+            },
+            directoryExists: { $0 == "/resolved-root" }
+        )
+        let row = makeRow(directoryPath: "/moved-away")
+        let plan = planner.plan(rows: [row], layout: nil)
+        let surface = try #require(plan.surfaces.first)
+        #expect(surface.action == .freshShell)
+        #expect(surface.directory == URL(fileURLWithPath: "/resolved-root"))
+    }
+
+    @Test("A non-Claude agent never picks the resume rung")
+    func nonClaudeAgentNeverResumes() throws {
+        let planner = makePlanner(transcriptResumable: { _, _ in true })
+        let row = makeRow(agentSessionID: "opencode-session", agentKind: "opencode", agentCwd: "/repo")
+        let plan = planner.plan(rows: [row], layout: nil)
+        let surface = try #require(plan.surfaces.first)
+        #expect(surface.action == .freshShell)
+    }
+
+    @Test("Surface order is preserved and the selected session comes from the layout snapshot")
+    func orderAndSelectionPreserved() throws {
+        let first = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000001")!
+        let second = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000002")!
+        let planner = makePlanner()
+        let layout = TerminalLayoutSnapshotRow(
+            id: "snap-1",
+            capturedAt: Self.baseDate,
+            activeHostSessionID: second,
+            selectedSurfaceKind: "repository_terminal",
+            selectedSurfaceID: second.uuidString,
+            splitPanes: []
+        )
+        let plan = planner.plan(
+            rows: [
+                makeRow(hostSessionID: first, directoryPath: "/repo-a"),
+                makeRow(hostSessionID: second, directoryPath: "/repo-b"),
+            ],
+            layout: layout
+        )
+        #expect(plan.surfaces.map(\.hostSessionID) == [first, second])
+        #expect(plan.selectedHostSessionID == second)
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 2 of the durable-sessions epic #728. Adds `TerminalRestorePlanner` (`Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift`) — a pure planner that turns the slice-1 read model (`TerminalSessionContinuityRow` rows + the latest `TerminalLayoutSnapshotRow`) into an ordered `RestorePlan` for cold-start restore.
- **Restore ladder, per surface:** live tmux session → `reattachTmux`; else a Claude Code session whose transcript is still present → `resumeClaude` in the recorded cwd; else `freshShell` in the nearest valid directory (recorded dir if it still exists, else the resolved target root).
- **Conservative:** ended/inactive rows are dropped, and rows whose target no longer resolves against current SwiftData are dropped (the injected resolver returns `nil`, which also excludes remote/backend sessions).
- **Testable by construction:** SwiftData target resolution, tmux liveness, transcript resumability, and directory existence are injected (closures with protocol-shaped typealiases), so the ladder is unit-tested with no DB, SwiftData, or process access. Reuses `HostTerminalSessionKey` and `AgentKind.claudeCode` rather than reintroducing identity strings.

## Mergeability

- Surface: desktop (Core)
- User-facing behavior changed: none — additive and **unwired**, mirroring slice 1. No callers yet.
- Non-happy paths considered: ended/inactive rows excluded; unresolved target dropped; moved recorded directory falls back to resolved root; non-Claude agent never picks the resume rung; tmux precedence over resume verified.
- Release/ops preconditions: none.
- Residual risk or follow-up: the three production dependencies (SwiftData resolver, `tmux -L workspaces has-session` probe, `~/.claude/projects/<encoded-cwd>/<id>.jsonl` locator) and the wiring into `ContentView.ensureInitialHostSession()` plus the launch-prompt UI are **slice 3**. Documented in the file and in #728.

## Validation

- [x] `swift build`
- [x] `swift test` (`--filter TerminalRestorePlanner` → 8/8; see evidence)
- [x] Other checks run: `swift-format lint --strict` on both new files (exit 0)

## Performance

- [x] Not a performance-sensitive change

Pure in-memory transform over a bounded read model, invoked once at startup in a later slice.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- `swift test --filter TerminalRestorePlanner` — 8/8 passed: ![slice2-planner-tests](https://evidence.cloudcompute.com/workspaces/pr-742/20260703-054139-slice2-planner-tests.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

Refs #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
