### PR TITLE
Add production restore probes for TerminalRestorePlanner (durable sessions slice 3a)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptLocator.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptLocator.swift
@@ -1,0 +1,79 @@
+//
+//  ClaudeTranscriptLocator.swift
+//  WorkspaceManagerCore
+//
+//  Locates a Claude Code session transcript on disk so cold-start restore can
+//  decide whether `claude --resume <id>` will succeed. Claude stores transcripts
+//  at <claudeHome>/projects/<encoded-cwd>/<session-id>.jsonl, where the directory
+//  name encodes the launch cwd by replacing every non-ASCII-alphanumeric
+//  character with '-' (1:1, no run-collapsing — e.g. "/.claude" -> "--claude").
+//
+
+import Foundation
+
+/// Pure encoder + path composer for Claude transcript locations. No filesystem
+/// access, so the encoding is unit-testable in isolation.
+public struct ClaudeTranscriptLocator: Sendable {
+    public init() {}
+
+    /// Encode a cwd into Claude's `projects/` directory name: each character that
+    /// is not `[A-Za-z0-9]` becomes `-`, per Unicode scalar, preserving length.
+    public static func encodeProjectDirectory(_ path: String) -> String {
+        var encoded = String.UnicodeScalarView()
+        encoded.reserveCapacity(path.unicodeScalars.count)
+        for scalar in path.unicodeScalars {
+            switch scalar.value {
+            case 0x30...0x39, 0x41...0x5A, 0x61...0x7A:  // 0-9, A-Z, a-z
+                encoded.append(scalar)
+            default:
+                encoded.append("-")
+            }
+        }
+        return String(encoded)
+    }
+
+    /// The transcript path for a session launched from `cwd`. `cwd` is encoded
+    /// verbatim — not standardized or symlink-resolved — because Claude keyed the
+    /// directory off the exact cwd its hook reported, which is what the store
+    /// persisted in `agentCwd`.
+    public func transcriptURL(claudeHome: URL, cwd: String, sessionID: String) -> URL {
+        claudeHome
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(Self.encodeProjectDirectory(cwd), isDirectory: true)
+            .appendingPathComponent("\(sessionID).jsonl", isDirectory: false)
+    }
+}
+
+/// Synchronous transcript-existence check that conforms to the planner's
+/// `TranscriptResumabilityCheck`. Resolves `claudeHome` from `CLAUDE_CONFIG_DIR`
+/// when set, else `~/.claude`. Filesystem access is injected for testability.
+public struct ClaudeTranscriptResumability: Sendable {
+    private let claudeHome: URL
+    private let fileExists: @Sendable (String) -> Bool
+    private let locator = ClaudeTranscriptLocator()
+
+    public init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) {
+        if let configDir = environment["CLAUDE_CONFIG_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !configDir.isEmpty
+        {
+            claudeHome = URL(fileURLWithPath: (configDir as NSString).expandingTildeInPath, isDirectory: true)
+        } else {
+            claudeHome = homeDirectory.appendingPathComponent(".claude", isDirectory: true)
+        }
+        self.fileExists = fileExists
+    }
+
+    public func isResumable(agentSessionID: String, cwd: String) -> Bool {
+        let url = locator.transcriptURL(claudeHome: claudeHome, cwd: cwd, sessionID: agentSessionID)
+        return fileExists(url.path)
+    }
+
+    /// Adapt to the planner's injected `TranscriptResumabilityCheck` closure.
+    public func asCheck() -> TerminalRestorePlanner.TranscriptResumabilityCheck {
+        { agentSessionID, cwd in isResumable(agentSessionID: agentSessionID, cwd: cwd) }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/TerminalRestoreTargetResolver.swift
+++ b/Sources/WorkspaceManagerCore/Services/TerminalRestoreTargetResolver.swift
@@ -1,0 +1,91 @@
+//
+//  TerminalRestoreTargetResolver.swift
+//  WorkspaceManagerCore
+//
+//  Resolves a persisted continuity row to a live restore target, conservatively:
+//  a row restores only when its repo/workspace still exists in current data.
+//  Operates over a Sendable snapshot of paths (RestoreTargetIndex) rather than
+//  live SwiftData models, so resolution stays pure and container-free to test;
+//  the app target builds the snapshot from its ModelContext in a later slice.
+//
+
+import Foundation
+
+/// A Sendable snapshot of the paths a restore can resolve against. Workspaces are
+/// pre-filtered to non-archived by the builder.
+public struct RestoreTargetIndex: Sendable, Equatable {
+    public struct Entry: Sendable, Equatable {
+        public let normalizedPath: String
+        public let rootPath: String
+
+        public init(normalizedPath: String, rootPath: String) {
+            self.normalizedPath = normalizedPath
+            self.rootPath = rootPath
+        }
+    }
+
+    public let homeDirectoryPath: String
+    public let repos: [Entry]
+    public let workspaces: [Entry]
+
+    public init(homeDirectoryPath: String, repos: [Entry], workspaces: [Entry]) {
+        self.homeDirectoryPath = homeDirectoryPath
+        self.repos = repos
+        self.workspaces = workspaces
+    }
+}
+
+/// Maps a continuity row to a `ResolvedRestoreTarget`, or `nil` to drop it
+/// (missing repo/workspace, or a conservatively-excluded backend session).
+public struct TerminalRestoreTargetResolver: Sendable {
+    private let index: RestoreTargetIndex
+    private let normalizePath: @Sendable (String) -> String
+
+    public init(
+        index: RestoreTargetIndex,
+        normalizePath: @escaping @Sendable (String) -> String = TerminalRestoreTargetResolver.defaultNormalizePath
+    ) {
+        self.index = index
+        self.normalizePath = normalizePath
+    }
+
+    public func resolve(_ row: TerminalSessionContinuityRow) -> ResolvedRestoreTarget? {
+        switch row.targetKind {
+        case "default_home":
+            return ResolvedRestoreTarget(
+                key: .defaultHome,
+                rootDirectory: URL(fileURLWithPath: index.homeDirectoryPath)
+            )
+        case "repo":
+            guard let entry = match(row.targetPath, in: index.repos) else { return nil }
+            return ResolvedRestoreTarget(
+                key: .repoPath(entry.rootPath),
+                rootDirectory: URL(fileURLWithPath: entry.rootPath)
+            )
+        case "host_path":
+            guard let entry = match(row.targetPath, in: index.workspaces) else { return nil }
+            return ResolvedRestoreTarget(
+                key: .hostPath(entry.rootPath),
+                rootDirectory: URL(fileURLWithPath: entry.rootPath)
+            )
+        default:
+            // backend_session (remote) and any unknown kind are dropped.
+            return nil
+        }
+    }
+
+    /// Adapt to the planner's injected `TargetResolver` closure.
+    public func asResolver() -> TerminalRestorePlanner.TargetResolver {
+        { row in resolve(row) }
+    }
+
+    private func match(_ targetPath: String?, in entries: [RestoreTargetIndex.Entry]) -> RestoreTargetIndex.Entry? {
+        guard let targetPath, !targetPath.isEmpty else { return nil }
+        let normalized = normalizePath(targetPath)
+        return entries.first { $0.normalizedPath == normalized }
+    }
+
+    public static let defaultNormalizePath: @Sendable (String) -> String = { path in
+        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/TmuxSessionProbe.swift
+++ b/Sources/WorkspaceManagerCore/Services/TmuxSessionProbe.swift
@@ -1,0 +1,72 @@
+//
+//  TmuxSessionProbe.swift
+//  WorkspaceManagerCore
+//
+//  Probes whether a deterministic Workspaces tmux session is still alive on the
+//  dedicated `-L workspaces` socket, so cold-start restore can reattach to a
+//  surviving session instead of relaunching it. Command execution is injected so
+//  the probe is unit-testable without a real tmux server.
+//
+
+import Foundation
+
+public struct TmuxSessionProbe: Sendable {
+    /// Matches the `-L workspaces` socket the app launches sessions on.
+    public static let socketLabel = "workspaces"
+
+    /// Runs a command and yields its exit code, or `nil` on launch failure/timeout.
+    public typealias CommandRunner =
+        @Sendable (_ executable: String, _ arguments: [String], _ environment: [String: String]?) async -> Int32?
+
+    private let run: CommandRunner
+    private let environment: [String: String]
+
+    public init(
+        run: @escaping CommandRunner = TmuxSessionProbe.defaultRunner,
+        environment: [String: String] = TmuxSessionProbe.defaultEnvironment
+    ) {
+        self.run = run
+        self.environment = environment
+    }
+
+    /// True when `tmux -L workspaces has-session -t =<name>` exits 0. The `=`
+    /// prefix forces an exact match so a hash-suffixed name cannot prefix-match a
+    /// different live session.
+    public func isSessionAlive(_ tmuxSessionName: String) async -> Bool {
+        let exitCode = await run(
+            "/usr/bin/env",
+            ["tmux", "-L", Self.socketLabel, "has-session", "-t", "=\(tmuxSessionName)"],
+            environment
+        )
+        return exitCode == 0
+    }
+
+    /// Production runner: `ProcessRunner.run` with a short timeout so a wedged
+    /// tmux server cannot stall restore; any throw maps to `nil` (not alive).
+    public static let defaultRunner: CommandRunner = { executable, arguments, environment in
+        do {
+            let result = try await ProcessRunner.run(
+                executable: executable,
+                arguments: arguments,
+                environment: environment,
+                timeout: 5
+            )
+            return result.exitCode
+        } catch {
+            return nil
+        }
+    }
+
+    /// Process environment with the common Homebrew/system bin paths prepended so
+    /// `/usr/bin/env tmux` resolves regardless of the launch PATH.
+    public static let defaultEnvironment: [String: String] = {
+        var environment = ProcessInfo.processInfo.environment
+        let toolPaths = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        if let existing = environment["PATH"], !existing.isEmpty {
+            environment["PATH"] = "\(toolPaths):\(existing)"
+        } else {
+            environment["PATH"] = toolPaths
+        }
+        return environment
+    }()
+}

--- a/Tests/WorkspaceManagerTests/ClaudeTranscriptLocatorTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeTranscriptLocatorTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("ClaudeTranscriptLocator")
+struct ClaudeTranscriptLocatorTests {
+    // Real cwd → encoded-dir pairs pulled from live ~/.claude/projects transcripts.
+    // These regression-lock the two behaviors that are easy to get wrong: "/." → "--"
+    // (a double dash, not one) and no collapsing of dash runs.
+    @Test("Encoding matches real Claude project directory names")
+    func encodesRealPairs() {
+        #expect(
+            ClaudeTranscriptLocator.encodeProjectDirectory("/Users/fairchild/code/workspaces")
+                == "-Users-fairchild-code-workspaces"
+        )
+        #expect(
+            ClaudeTranscriptLocator.encodeProjectDirectory(
+                "/Users/fairchild/code/mfwiki/.claude/worktrees/chat-noise-routing"
+            ) == "-Users-fairchild-code-mfwiki--claude-worktrees-chat-noise-routing"
+        )
+    }
+
+    @Test("Every non-alphanumeric character becomes a single dash, length preserved")
+    func encodesSyntheticRule() {
+        #expect(ClaudeTranscriptLocator.encodeProjectDirectory("/tmp/a_b") == "-tmp-a-b")  // underscore
+        #expect(ClaudeTranscriptLocator.encodeProjectDirectory("/a/.b") == "-a--b")  // "/." -> "--"
+        #expect(ClaudeTranscriptLocator.encodeProjectDirectory("/x y") == "-x-y")  // space
+        #expect(ClaudeTranscriptLocator.encodeProjectDirectory("/Repo/CamelCase") == "-Repo-CamelCase")  // case kept
+        let path = "/Users/x/proj"
+        #expect(ClaudeTranscriptLocator.encodeProjectDirectory(path).count == path.count)  // 1:1 length
+    }
+
+    @Test("transcriptURL composes projects/<encoded>/<id>.jsonl")
+    func composesTranscriptURL() {
+        let url = ClaudeTranscriptLocator().transcriptURL(
+            claudeHome: URL(fileURLWithPath: "/home/.claude"),
+            cwd: "/repo/app",
+            sessionID: "sess-123"
+        )
+        #expect(url.path == "/home/.claude/projects/-repo-app/sess-123.jsonl")
+    }
+
+    @Test("Resumability reflects transcript presence under the default ~/.claude home")
+    func resumabilityUsesDefaultHome() {
+        let present = "/home/.claude/projects/-repo-app/sess-9.jsonl"
+        let checker = ClaudeTranscriptResumability(
+            environment: [:],
+            homeDirectory: URL(fileURLWithPath: "/home"),
+            fileExists: { $0 == present }
+        )
+        #expect(checker.isResumable(agentSessionID: "sess-9", cwd: "/repo/app"))
+        #expect(!checker.isResumable(agentSessionID: "missing", cwd: "/repo/app"))
+    }
+
+    @Test("CLAUDE_CONFIG_DIR re-roots the probed transcript path")
+    func resumabilityHonorsConfigDirOverride() {
+        let recorder = PathRecorder()
+        let checker = ClaudeTranscriptResumability(
+            environment: ["CLAUDE_CONFIG_DIR": "/custom/cfg"],
+            homeDirectory: URL(fileURLWithPath: "/home"),
+            fileExists: { path in
+                recorder.path = path
+                return true
+            }
+        )
+        #expect(checker.isResumable(agentSessionID: "sess-1", cwd: "/repo"))
+        #expect(recorder.path == "/custom/cfg/projects/-repo/sess-1.jsonl")
+    }
+}
+
+/// Reference recorder so a `@Sendable` `fileExists` stub can report the path it
+/// was handed (a mutable local can't be captured by a `@Sendable` closure).
+private final class PathRecorder: @unchecked Sendable {
+    var path: String?
+}

--- a/Tests/WorkspaceManagerTests/TerminalRestoreTargetResolverTests.swift
+++ b/Tests/WorkspaceManagerTests/TerminalRestoreTargetResolverTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("TerminalRestoreTargetResolver")
+struct TerminalRestoreTargetResolverTests {
+    private static let index = RestoreTargetIndex(
+        homeDirectoryPath: "/Users/me",
+        repos: [RestoreTargetIndex.Entry(normalizedPath: "/code/app", rootPath: "/code/app")],
+        // Workspaces are pre-filtered to non-archived by the builder, so an
+        // archived workspace simply isn't present here.
+        workspaces: [RestoreTargetIndex.Entry(normalizedPath: "/code/app/wt", rootPath: "/code/app/wt")]
+    )
+
+    // Identity normalizer keeps tests hermetic (no filesystem/symlink access).
+    private func makeResolver(
+        normalizePath: @escaping @Sendable (String) -> String = { $0 }
+    ) -> TerminalRestoreTargetResolver {
+        TerminalRestoreTargetResolver(index: Self.index, normalizePath: normalizePath)
+    }
+
+    private func row(targetKind: String, targetPath: String?) -> TerminalSessionContinuityRow {
+        TerminalSessionContinuityRow(
+            hostSessionID: UUID(),
+            sessionKey: "k",
+            targetKind: targetKind,
+            targetID: nil,
+            targetPath: targetPath,
+            backendIdentifier: nil,
+            backendInstanceID: nil,
+            directoryPath: targetPath ?? "/",
+            terminalMode: "ghostty_managed_splits",
+            tmuxSessionName: nil,
+            customCommandPresent: false,
+            isActive: true,
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            endedAt: nil,
+            agentSessionID: nil,
+            agentKind: nil,
+            agentRunState: nil,
+            agentCwd: nil,
+            agentModelDisplayName: nil,
+            agentEventAt: nil
+        )
+    }
+
+    @Test("A repo row matching a live repo resolves to a repo target")
+    func repoMatchResolves() throws {
+        let resolved = try #require(makeResolver().resolve(row(targetKind: "repo", targetPath: "/code/app")))
+        #expect(resolved.key == .repoPath("/code/app"))
+        #expect(resolved.rootDirectory == URL(fileURLWithPath: "/code/app"))
+    }
+
+    @Test("A repo row with no matching repo is dropped")
+    func repoNoMatchDropped() {
+        #expect(makeResolver().resolve(row(targetKind: "repo", targetPath: "/code/gone")) == nil)
+    }
+
+    @Test("A host_path row matching a non-archived workspace resolves")
+    func workspaceMatchResolves() throws {
+        let resolved = try #require(makeResolver().resolve(row(targetKind: "host_path", targetPath: "/code/app/wt")))
+        #expect(resolved.key == .hostPath("/code/app/wt"))
+        #expect(resolved.rootDirectory == URL(fileURLWithPath: "/code/app/wt"))
+    }
+
+    @Test("A host_path row whose workspace is archived (absent from the index) is dropped")
+    func archivedWorkspaceDropped() {
+        #expect(makeResolver().resolve(row(targetKind: "host_path", targetPath: "/code/archived")) == nil)
+    }
+
+    @Test("default_home always resolves, even against an empty index")
+    func defaultHomeAlwaysResolves() throws {
+        let emptyIndex = RestoreTargetIndex(homeDirectoryPath: "/Users/me", repos: [], workspaces: [])
+        let resolver = TerminalRestoreTargetResolver(index: emptyIndex, normalizePath: { $0 })
+        let resolved = try #require(resolver.resolve(row(targetKind: "default_home", targetPath: nil)))
+        #expect(resolved.key == .defaultHome)
+        #expect(resolved.rootDirectory == URL(fileURLWithPath: "/Users/me"))
+    }
+
+    @Test("Backend sessions and unknown kinds are dropped conservatively")
+    func backendAndUnknownDropped() {
+        #expect(makeResolver().resolve(row(targetKind: "backend_session", targetPath: nil)) == nil)
+        #expect(makeResolver().resolve(row(targetKind: "something_new", targetPath: "/code/app")) == nil)
+    }
+
+    @Test("A missing target path never matches")
+    func missingTargetPathDropped() {
+        #expect(makeResolver().resolve(row(targetKind: "repo", targetPath: nil)) == nil)
+    }
+
+    @Test("Normalization is applied before matching")
+    func normalizationApplied() throws {
+        // A trailing-slash variant matches once the injected normalizer strips it.
+        let resolver = makeResolver(normalizePath: { path in
+            path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
+        })
+        let resolved = try #require(resolver.resolve(row(targetKind: "repo", targetPath: "/code/app/")))
+        #expect(resolved.key == .repoPath("/code/app"))
+    }
+}

--- a/Tests/WorkspaceManagerTests/TmuxSessionProbeTests.swift
+++ b/Tests/WorkspaceManagerTests/TmuxSessionProbeTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("TmuxSessionProbe")
+struct TmuxSessionProbeTests {
+    @Test("Exit code 0 means the session is alive")
+    func exitZeroIsAlive() async {
+        let probe = TmuxSessionProbe(run: { _, _, _ in 0 }, environment: [:])
+        #expect(await probe.isSessionAlive("wm-repo-abcd1234"))
+    }
+
+    @Test("Non-zero exit means the session is not alive")
+    func nonZeroExitIsNotAlive() async {
+        let probe = TmuxSessionProbe(run: { _, _, _ in 1 }, environment: [:])
+        #expect(await probe.isSessionAlive("wm-repo-abcd1234") == false)
+    }
+
+    @Test("A launch failure (nil exit) is treated as not alive")
+    func launchFailureIsNotAlive() async {
+        let probe = TmuxSessionProbe(run: { _, _, _ in nil }, environment: [:])
+        #expect(await probe.isSessionAlive("wm-repo-abcd1234") == false)
+    }
+
+    @Test("Probe invokes has-session on the workspaces socket with an exact-match target")
+    func buildsExactMatchHasSessionCommand() async throws {
+        let recorder = ArgumentRecorder()
+        let probe = TmuxSessionProbe(
+            run: { executable, arguments, _ in
+                await recorder.record(executable: executable, arguments: arguments)
+                return 0
+            },
+            environment: [:]
+        )
+        _ = await probe.isSessionAlive("wm-repo-abcd1234")
+
+        let calls = await recorder.calls
+        let call = try #require(calls.first)
+        #expect(calls.count == 1)
+        #expect(call.executable == "/usr/bin/env")
+        #expect(call.arguments.contains("tmux"))
+        #expect(call.arguments.contains("has-session"))
+        // -L workspaces isolates from the user's default tmux server.
+        #expect(adjacent(call.arguments, "-L", "workspaces"))
+        // "=name" forces exact match so a hash suffix can't prefix-collide.
+        #expect(adjacent(call.arguments, "-t", "=wm-repo-abcd1234"))
+    }
+
+    private func adjacent(_ arguments: [String], _ first: String, _ second: String) -> Bool {
+        guard let index = arguments.firstIndex(of: first), index + 1 < arguments.count else { return false }
+        return arguments[index + 1] == second
+    }
+}
+
+private actor ArgumentRecorder {
+    private(set) var calls: [(executable: String, arguments: [String])] = []
+
+    func record(executable: String, arguments: [String]) {
+        calls.append((executable, arguments))
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 3a of the durable-sessions epic #728. Provides the three concrete dependencies that the merged `TerminalRestorePlanner` (#742) currently takes as injected closures. All additive, unit-tested, and **not yet wired into startup** — slice 3b wires them.
- **`TmuxSessionProbe`** — async liveness via `tmux -L workspaces has-session -t =<name>` (exact-match `=` prevents a hash-suffixed name from prefix-colliding; 5s timeout so a wedged tmux server can't stall restore). Command execution is injected, so it's tested without a real tmux server.
- **`ClaudeTranscriptLocator` + `ClaudeTranscriptResumability`** — locate `<claudeHome>/projects/<encoded-cwd>/<id>.jsonl` and check existence. The cwd→dir encoding (`[^A-Za-z0-9] → '-'`, per Unicode scalar, 1:1, no run-collapsing) was **derived empirically** from real `~/.claude/projects` names, not guessed — regression-locked in tests, including the easy-to-miss `"/." → "--"` (double dash). Honors `CLAUDE_CONFIG_DIR`; filesystem access injected.
- **`TerminalRestoreTargetResolver`** over a Sendable `RestoreTargetIndex` snapshot — `repo`/`host_path` resolve by normalized path against live repos / non-archived workspaces; `default_home` always resolves; `backend_session` and unknown kinds drop conservatively. Pure and container-free to test. The app-target snapshot builder that reads SwiftData is deferred to slice 3b (where it's exercised against real data).

## Mergeability

- Surface: desktop (Core)
- User-facing behavior changed: none — additive, no callers yet (mirrors slices 1 and 2).
- Non-happy paths considered: tmux launch failure / timeout → not alive; missing transcript → not resumable; `CLAUDE_CONFIG_DIR` override; repo/workspace absent or archived → dropped; missing target path, backend, unknown kind → dropped; path normalization applied before matching.
- Release/ops preconditions: none.
- Residual risk or follow-up: the encoding rule is proven locally for `/`, `.`, `-`, digits, lowercase; `_`/space/uppercase are covered by the same `[^A-Za-z0-9]` rule and pinned with synthetic tests but not observed on this machine. The async `TmuxSessionProbe` is bridged to the planner's sync `TmuxLivenessProbe` in slice 3b by pre-probing candidates into a `Set`. Wiring + the SwiftData `RestoreTargetIndex` builder + `claude --resume` launch + restore-prompt UI are slice 3b.

## Validation

- [x] `swift build`
- [x] `swift test` (`TmuxSessionProbe|ClaudeTranscriptLocator|TerminalRestoreTargetResolver` → 17/17; see evidence)
- [x] Other checks run: `swift-format lint --strict` on all six new files (exit 0)

## Performance

- [x] Not a performance-sensitive change

Pure/injected helpers invoked once per candidate session at startup in a later slice.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- `swift test` — 17/17 passed across the three new suites: ![slice3a-probe-tests](https://evidence.cloudcompute.com/workspaces/pr-743/20260703-063153-slice3a-probe-tests.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

Refs #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
