### PR TITLE
Wire cold-start restore planning behind an experimental flag (durable sessions slice 3b)

### DIFF
--- a/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
+++ b/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum ExperimentalFeature: String, CaseIterable, Identifiable {
     case automationAPI = "automationAPI"
     case minimalToolbar = "minimalToolbar"
+    case restoreSessionsOnLaunch = "restoreSessionsOnLaunch"
 
     var id: String { rawValue }
 
@@ -18,6 +19,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
             return "Automation API"
         case .minimalToolbar:
             return "Minimal Toolbar"
+        case .restoreSessionsOnLaunch:
+            return "Restore Sessions on Launch"
         }
     }
 
@@ -27,6 +30,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
             return "Expose a local same-user socket so terminal tiles can inspect and arrange their WorkSpaces shell."
         case .minimalToolbar:
             return "Hide secondary toolbar controls so terminal surfaces stay closer to the canvas."
+        case .restoreSessionsOnLaunch:
+            return "Offer to reopen the terminal sessions from your previous run when the app starts."
         }
     }
 
@@ -44,6 +49,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
             return "WORKSPACES_AUTOMATION_API"
         case .minimalToolbar:
             return "WORKSPACES_PERF_MINIMAL_TOOLBAR"
+        case .restoreSessionsOnLaunch:
+            return "WORKSPACES_RESTORE_SESSIONS_ON_LAUNCH"
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -24,6 +24,8 @@ private struct ModelSnapshot: Equatable {
 
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.localStateStore) private var localStateStore
+    @ExperimentalFeatureFlag(.restoreSessionsOnLaunch) private var restoreSessionsOnLaunchEnabled: Bool
     @Binding var deepLinkState: WorkspaceDeepLinkState
     @Binding var lastSurfaceRawValue: String
     @ObservedObject var appCommandState: AppCommandState
@@ -717,6 +719,7 @@ struct ContentView: View {
                 Task { @MainActor in
                     await configureAutomationIntegration()
                     ensureInitialHostSession()
+                    await computeRestorePlanIfEnabled()
                     prewarmPerfTerminalSurfacesIfNeeded()
                     resolveSurfaceLifecycle()
                     applyDiagnosticsFixtureIfNeeded()
@@ -2825,6 +2828,28 @@ struct ContentView: View {
     private func normalizePath(_ rawPath: String) -> String {
         let expanded = NSString(string: rawPath).expandingTildeInPath
         return URL(fileURLWithPath: expanded).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    /// Cold-start restore (experimental, opt-in): compute what could be restored
+    /// from the previous run and log the result. Wiring only — nothing is launched
+    /// and no UI is shown here; the restore banner and execution land in a
+    /// follow-up. A no-op unless the `restoreSessionsOnLaunch` flag is enabled.
+    @MainActor
+    private func computeRestorePlanIfEnabled() async {
+        guard restoreSessionsOnLaunchEnabled, let localStateStore else { return }
+        let index = RestoreTargetIndexBuilder(
+            homeDirectoryPath: resolvedDefaultHostDirectory.path,
+            normalizePath: RestorePathNormalization.normalize
+        ).build(repos: repos)
+        let plan = await TerminalRestoreCoordinator(
+            localStateStore: localStateStore,
+            normalizePath: RestorePathNormalization.normalize
+        ).makePlan(index: index)
+        if plan.surfaces.isEmpty {
+            NSLog("[Restore] no restorable surfaces from previous run")
+        } else {
+            NSLog("[Restore] planned %ld restorable surface(s)", plan.surfaces.count)
+        }
     }
 
     private func refreshWorkspaceStatusAggregator() {

--- a/Sources/WorkspaceManager/Views/MainWindow/RestoreTargetIndexBuilder.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RestoreTargetIndexBuilder.swift
@@ -1,0 +1,40 @@
+//
+//  RestoreTargetIndexBuilder.swift
+//  WorkspaceManager
+//
+//  Snapshots the current repos and non-archived workspaces into a Sendable
+//  RestoreTargetIndex, so cold-start restore resolves persisted targets against
+//  live data without carrying SwiftData models off the main actor. Uses the same
+//  root-path derivation as the app's host-session key building.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+struct RestoreTargetIndexBuilder {
+    let homeDirectoryPath: String
+    let normalizePath: @Sendable (String) -> String
+
+    func build(repos: [Repo]) -> RestoreTargetIndex {
+        RestoreTargetIndex(
+            homeDirectoryPath: homeDirectoryPath,
+            repos: repos.map { repo in
+                RestoreTargetIndex.Entry(
+                    normalizedPath: normalizePath(repo.localPath),
+                    rootPath: repo.localURL.path
+                )
+            },
+            workspaces:
+                repos
+                .flatMap(\.workspaces)
+                .filter { $0.status != .archived }
+                .map { workspace in
+                    RestoreTargetIndex.Entry(
+                        normalizedPath: normalizePath(workspace.path),
+                        rootPath: workspace.workspaceURL.path
+                    )
+                }
+        )
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalRestoreCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalRestoreCoordinator.swift
@@ -1,0 +1,77 @@
+//
+//  TerminalRestoreCoordinator.swift
+//  WorkspaceManager
+//
+//  Drives cold-start restore planning: reads the durable continuity read model,
+//  pre-probes tmux liveness concurrently (bridging the async probe to the
+//  planner's synchronous liveness closure), and returns a decided RestorePlan.
+//  The SwiftData-derived RestoreTargetIndex is built on the main actor and passed
+//  in as a Sendable snapshot, so this coordinator stays off the main actor.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+/// Shared path normalization for restore resolution — expands `~`, standardizes,
+/// and resolves symlinks, matching `ContentView.normalizePath` so the index the
+/// builder produces and the paths the resolver compares are normalized alike.
+enum RestorePathNormalization {
+    static let normalize: @Sendable (String) -> String = { rawPath in
+        let expanded = NSString(string: rawPath).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}
+
+struct TerminalRestoreCoordinator: Sendable {
+    let localStateStore: LocalStateStore
+    let tmuxProbe: TmuxSessionProbe
+    let transcriptResumability: ClaudeTranscriptResumability
+    let normalizePath: @Sendable (String) -> String
+
+    init(
+        localStateStore: LocalStateStore,
+        tmuxProbe: TmuxSessionProbe = TmuxSessionProbe(),
+        transcriptResumability: ClaudeTranscriptResumability = ClaudeTranscriptResumability(),
+        normalizePath: @escaping @Sendable (String) -> String = RestorePathNormalization.normalize
+    ) {
+        self.localStateStore = localStateStore
+        self.tmuxProbe = tmuxProbe
+        self.transcriptResumability = transcriptResumability
+        self.normalizePath = normalizePath
+    }
+
+    /// Read the previous run's active sessions + latest layout, pre-probe tmux
+    /// liveness, and produce a fully-decided plan. Store read failures degrade to
+    /// an empty plan rather than throwing.
+    func makePlan(index: RestoreTargetIndex) async -> RestorePlan {
+        let rows = (try? await localStateStore.fetchContinuitySessions(activeOnly: true, limit: 100)) ?? []
+        let layout = (try? await localStateStore.fetchLatestLayoutSnapshot()) ?? nil
+
+        let liveNames = await probeLiveTmuxSessions(Set(rows.compactMap(\.tmuxSessionName)))
+
+        let resolver = TerminalRestoreTargetResolver(index: index, normalizePath: normalizePath)
+        let planner = TerminalRestorePlanner(
+            resolveTarget: resolver.asResolver(),
+            isTmuxSessionAlive: { liveNames.contains($0) },
+            isTranscriptResumable: transcriptResumability.asCheck()
+        )
+        return planner.plan(rows: rows, layout: layout)
+    }
+
+    /// Fan out `has-session` probes concurrently and collect the live names, so
+    /// the planner receives a pure synchronous membership test.
+    private func probeLiveTmuxSessions(_ names: Set<String>) async -> Set<String> {
+        guard !names.isEmpty else { return [] }
+        let probe = tmuxProbe
+        return await withTaskGroup(of: (String, Bool).self) { group in
+            for name in names {
+                group.addTask { (name, await probe.isSessionAlive(name)) }
+            }
+            var live: Set<String> = []
+            for await (name, alive) in group where alive {
+                live.insert(name)
+            }
+            return live
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/ExperimentalFeaturesTests.swift
+++ b/Tests/WorkspaceManagerAppTests/ExperimentalFeaturesTests.swift
@@ -86,6 +86,22 @@ struct ExperimentalFeaturesTests {
         )
     }
 
+    @Test("Restore-sessions-on-launch defaults off and honors its force-on override")
+    func restoreSessionsOnLaunchFlag() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(!ExperimentalFeature.restoreSessionsOnLaunch.defaultEnabled)
+        #expect(!ExperimentalFeatures.isEnabled(.restoreSessionsOnLaunch, userDefaults: defaults, environment: [:]))
+        #expect(
+            ExperimentalFeatures.isEnabled(
+                .restoreSessionsOnLaunch,
+                userDefaults: defaults,
+                environment: ["WORKSPACES_RESTORE_SESSIONS_ON_LAUNCH": "1"]
+            )
+        )
+    }
+
     @Test("Feature metadata has stable unique non-empty values")
     func featureMetadataIsUniqueAndNonEmpty() {
         let features = ExperimentalFeature.allCases

--- a/Tests/WorkspaceManagerAppTests/RestoreTargetIndexBuilderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RestoreTargetIndexBuilderTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("RestoreTargetIndexBuilder")
+struct RestoreTargetIndexBuilderTests {
+    private func makeBuilder() -> RestoreTargetIndexBuilder {
+        RestoreTargetIndexBuilder(homeDirectoryPath: "/Users/me", normalizePath: { $0 })
+    }
+
+    @Test("Repos map to normalized-path/root entries")
+    func mapsRepos() {
+        let repo = Repo(name: "app", localPath: URL(fileURLWithPath: "/code/app"))
+        let index = makeBuilder().build(repos: [repo])
+        #expect(index.homeDirectoryPath == "/Users/me")
+        #expect(index.repos == [RestoreTargetIndex.Entry(normalizedPath: "/code/app", rootPath: "/code/app")])
+    }
+
+    @Test("Only non-archived workspaces are indexed")
+    func filtersArchivedWorkspaces() {
+        let repo = Repo(name: "app", localPath: URL(fileURLWithPath: "/code/app"))
+        let active = Workspace(
+            name: "wt", path: URL(fileURLWithPath: "/code/app/wt"), sourceRepo: repo, status: .active)
+        let archived = Workspace(
+            name: "old",
+            path: URL(fileURLWithPath: "/code/app/old"),
+            sourceRepo: repo,
+            status: .archived
+        )
+        repo.workspaces = [active, archived]
+
+        let index = makeBuilder().build(repos: [repo])
+        #expect(
+            index.workspaces == [RestoreTargetIndex.Entry(normalizedPath: "/code/app/wt", rootPath: "/code/app/wt")])
+    }
+
+    @Test("Normalization is applied to indexed paths")
+    func appliesNormalization() {
+        let builder = RestoreTargetIndexBuilder(
+            homeDirectoryPath: "/Users/me",
+            normalizePath: { $0.uppercased() }
+        )
+        let repo = Repo(name: "app", localPath: URL(fileURLWithPath: "/code/app"))
+        let index = builder.build(repos: [repo])
+        #expect(index.repos.first?.normalizedPath == "/CODE/APP")
+        #expect(index.repos.first?.rootPath == "/code/app")  // root stays the real path
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/TerminalRestoreCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalRestoreCoordinatorTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@Suite("TerminalRestoreCoordinator")
+struct TerminalRestoreCoordinatorTests {
+    /// End-to-end over a real (temporary) LocalStateStore: seed an active
+    /// tmux-backed session, then assert the coordinator reads it, bridges the
+    /// async tmux probe to the planner, resolves the target, and plans a reattach.
+    @Test("Plans a tmux reattach for a live, resolvable session")
+    func plansReattachForLiveSession() async throws {
+        let directory = URL(fileURLWithPath: "/code/app")
+        let store = try makeStore()
+        try await store.recordTerminalSession(
+            HostTerminalSession(id: UUID(), key: .repoPath(directory.path), directory: directory),
+            terminalMode: "tmux_per_session",
+            isActive: true,
+            hooksSocketPath: nil
+        )
+
+        let coordinator = TerminalRestoreCoordinator(
+            localStateStore: store,
+            tmuxProbe: TmuxSessionProbe(run: { _, _, _ in 0 }, environment: [:]),  // every session "alive"
+            transcriptResumability: ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false }),
+            normalizePath: { $0 }
+        )
+        let index = RestoreTargetIndex(
+            homeDirectoryPath: "/Users/me",
+            repos: [RestoreTargetIndex.Entry(normalizedPath: directory.path, rootPath: directory.path)],
+            workspaces: []
+        )
+
+        let plan = await coordinator.makePlan(index: index)
+        let surface = try #require(plan.surfaces.first)
+        #expect(plan.surfaces.count == 1)
+        if case .reattachTmux = surface.action {
+        } else {
+            Issue.record("expected reattachTmux, got \(surface.action)")
+        }
+    }
+
+    @Test("Plans nothing when the session's target no longer resolves")
+    func dropsUnresolvableSession() async throws {
+        let directory = URL(fileURLWithPath: "/code/gone")
+        let store = try makeStore()
+        try await store.recordTerminalSession(
+            HostTerminalSession(id: UUID(), key: .repoPath(directory.path), directory: directory),
+            terminalMode: "tmux_per_session",
+            isActive: true,
+            hooksSocketPath: nil
+        )
+
+        let coordinator = TerminalRestoreCoordinator(
+            localStateStore: store,
+            tmuxProbe: TmuxSessionProbe(run: { _, _, _ in 0 }, environment: [:]),
+            transcriptResumability: ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false }),
+            normalizePath: { $0 }
+        )
+        // Empty index → the repo target does not resolve.
+        let index = RestoreTargetIndex(homeDirectoryPath: "/Users/me", repos: [], workspaces: [])
+
+        let plan = await coordinator.makePlan(index: index)
+        #expect(plan.surfaces.isEmpty)
+    }
+
+    private func makeStore() throws -> LocalStateStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TerminalRestoreCoordinatorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return try LocalStateStore(databaseURL: directory.appendingPathComponent("state.sqlite"))
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 3b of the durable-sessions epic #728. Assembles the merged planner (#742) and probes (#743) into the app's startup path, **gated behind a new experimental flag (default OFF)**, so default launch behavior is byte-identical. This slice **computes and logs** the restore plan only — nothing is launched and no UI is shown. Execution + the restore banner are slice 3c.
- **`ExperimentalFeature.restoreSessionsOnLaunch`** — default off; force-on env `WORKSPACES_RESTORE_SESSIONS_ON_LAUNCH`. The Settings row appears automatically (the list iterates `allCases`).
- **`RestoreTargetIndexBuilder`** (`@MainActor`) — snapshots repos + non-archived workspaces into a Sendable `RestoreTargetIndex`, so target resolution runs off the main actor without carrying SwiftData models.
- **`TerminalRestoreCoordinator`** — reads `fetchContinuitySessions`/`fetchLatestLayoutSnapshot`, pre-probes tmux liveness concurrently (`withTaskGroup`) to bridge the async `TmuxSessionProbe` to the planner's synchronous `TmuxLivenessProbe`, resolves targets, and returns a decided `RestorePlan`.
- **`ContentView`** — on launch, when the flag is enabled, builds the index, makes a plan, logs the count; a guarded no-op when off.

## Mergeability

- Surface: desktop (app target + Core-consuming)
- User-facing behavior changed: **none** — flag defaults off; when off, the new startup step is a guarded early return. Even when on, this slice only logs (no launch, no UI).
- Non-happy paths considered: store read failure → empty plan (degrades, doesn't throw); no `localStateStore` → skip; unresolvable/archived targets → dropped; empty candidate set → no tmux probing.
- Release/ops preconditions: none. New experimental flag ships off.
- Residual risk or follow-up: slice 3c adds `RestoreLaunchCommand.claudeResume`, `executeRestore(_:)`, and the in-window restore banner (the agreed UX), and enables the launch-dev verification below.

## Validation

- [x] `swift build`
- [x] `swift test` (`ExperimentalFeatures|RestoreTargetIndexBuilder|TerminalRestoreCoordinator` → 13/13; see evidence). The two `TerminalRestoreCoordinator` cases run over a **real temporary `LocalStateStore`**, exercising the exact store→probe→plan pipeline the startup path invokes (seeded live session → reattach plan; unresolvable target → empty plan).
- [x] Other checks run: `swift-format lint --strict` on all changed files (exit 0)

## Performance

- [x] Not a performance-sensitive change

One bounded read + concurrent probes at startup, only when the flag is on.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- `swift test` — 13/13 passed: ![slice3b-wiring-tests](https://evidence.cloudcompute.com/workspaces/pr-755/20260703-071005-slice3b-wiring-tests.png)

**Deferred: launch-dev startup-log verification.** The intended real-app check (flag on → `[Restore] planned N surfaces` / `no restorable surfaces` log at launch; flag off → silent) was **not run**: the installed WorkSpaces app is currently running an active session on this shared desktop, and `launch-dev.sh` kills `/Applications/WorkSpaces.app`. Rather than tear down a live session unattended, this check is deferred to slice 3c, which needs `launch-dev` for the banner UI regardless. The coordinator integration tests above cover the same pipeline headlessly.

## Blockers

- [x] None
- [ ] Blocked on evidence

Refs #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
