### PR TITLE
Add restore banner + execution (durable sessions slice 3c)

### DIFF
--- a/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
+++ b/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
@@ -1,0 +1,33 @@
+//
+//  RestoreLaunchCommand.swift
+//  WorkspaceManager
+//
+//  Builds the launch command that resumes a Claude Code conversation during
+//  cold-start restore. It wraps `claude --resume <id>` in a `-L workspaces`
+//  tmux session named deterministically from the cwd — matching how the app
+//  launches every other terminal — so the resumed session reattaches like the
+//  rest and survives a later app restart.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+enum RestoreLaunchCommand {
+    /// `tmux -L <socket> new-session -A -s <name> -c <cwd> 'claude --resume <id>'`,
+    /// with the same deterministic session name a normal launch would use for
+    /// this directory, so `new-session -A` reattaches on a subsequent restore.
+    static func claudeResume(
+        cwd: URL,
+        sessionID: String,
+        socketLabel: String = TmuxSessionProbe.socketLabel
+    ) -> String {
+        let name = GhosttyTerminalConfig.tmuxSessionName(for: cwd)
+        let inner = "claude --resume \(sessionID)"
+        return "tmux -L \(quoted(socketLabel)) new-session -A -s \(quoted(name)) "
+            + "-c \(quoted(cwd.path)) \(quoted(inner))"
+    }
+
+    private static func quoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -64,6 +64,8 @@ struct ContentView: View {
     @State private var dismissedWorkspaceOrphanItemIDs: Set<String> = []
     @State private var cleaningWorkspaceOrphanItemIDs: Set<String> = []
     @State private var pendingWorkspaceOrphanCleanup: WorkspaceOrphanItem?
+    @State private var pendingRestorePlan: RestorePlan?
+    @State private var restoreBannerDismissed = false
     @State private var isShowingFeedbackSheet = false
     @State private var accessRecorder = MainWindowAccessRecorder()
     @State private var presentedSessionSwitcherSnapshot: SessionSwitcherSnapshot?
@@ -698,6 +700,18 @@ struct ContentView: View {
                         dismissedWorkspaceOrphanItemIDs.formUnion(
                             visibleWorkspaceOrphanItems.map(\.id)
                         )
+                    }
+                )
+            }
+            if let plan = pendingRestorePlan, !plan.surfaces.isEmpty, !restoreBannerDismissed {
+                RestoreSessionsBanner(
+                    sessionCount: plan.surfaces.count,
+                    onRestore: {
+                        executeRestore(plan)
+                        restoreBannerDismissed = true
+                    },
+                    onDismiss: {
+                        restoreBannerDismissed = true
                     }
                 )
             }
@@ -2831,9 +2845,8 @@ struct ContentView: View {
     }
 
     /// Cold-start restore (experimental, opt-in): compute what could be restored
-    /// from the previous run and log the result. Wiring only — nothing is launched
-    /// and no UI is shown here; the restore banner and execution land in a
-    /// follow-up. A no-op unless the `restoreSessionsOnLaunch` flag is enabled.
+    /// from the previous run and, when non-empty, surface the restore banner.
+    /// A no-op unless the `restoreSessionsOnLaunch` flag is enabled.
     @MainActor
     private func computeRestorePlanIfEnabled() async {
         guard restoreSessionsOnLaunchEnabled, let localStateStore else { return }
@@ -2849,7 +2862,33 @@ struct ContentView: View {
             NSLog("[Restore] no restorable surfaces from previous run")
         } else {
             NSLog("[Restore] planned %ld restorable surface(s)", plan.surfaces.count)
+            pendingRestorePlan = plan
         }
+    }
+
+    /// Launch each surface in a restore plan. Reattach/fresh surfaces are a plain
+    /// directory-backed launch (the deterministic tmux name reattaches a surviving
+    /// session automatically); resume surfaces carry a `claude --resume` command.
+    /// Then honor the plan's advisory focus by re-activating the selected surface.
+    @MainActor
+    private func executeRestore(_ plan: RestorePlan) {
+        var activatedByHostSessionID: [UUID: HostTerminalSession] = [:]
+        for surface in plan.surfaces {
+            let command: String?
+            switch surface.action {
+            case .reattachTmux, .freshShell:
+                command = nil
+            case .resumeClaude(let agentSessionID):
+                command = RestoreLaunchCommand.claudeResume(cwd: surface.directory, sessionID: agentSessionID)
+            }
+            let session = activateHostSession(key: surface.key, directory: surface.directory, customCommand: command)
+            activatedByHostSessionID[surface.hostSessionID] = session
+        }
+
+        if let selected = plan.selectedHostSessionID, let target = activatedByHostSessionID[selected] {
+            _ = activateHostSession(key: target.key, directory: target.directoryURL)
+        }
+        NSLog("[Restore] executed %ld surface(s)", plan.surfaces.count)
     }
 
     private func refreshWorkspaceStatusAggregator() {

--- a/Sources/WorkspaceManager/Views/MainWindow/RestoreSessionsBanner.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RestoreSessionsBanner.swift
@@ -1,0 +1,60 @@
+//
+//  RestoreSessionsBanner.swift
+//  WorkspaceManager
+//
+//  Quiet, non-blocking main-window affordance offering to reopen the terminal
+//  sessions from the previous run. Opt-in: ignoring it leaves the app fully
+//  usable. Matches the existing top-of-window banner idiom.
+//
+
+import SwiftUI
+
+struct RestoreSessionsBanner: View {
+    let sessionCount: Int
+    let onRestore: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Resume your previous session\(sessionCount == 1 ? "" : "s")?")
+                        .font(.callout.weight(.semibold))
+                    Text(summaryText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button(action: onRestore) {
+                    Label("Restore", systemImage: "arrow.uturn.backward")
+                }
+                .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier("restore-sessions.restore")
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .help("Dismiss")
+                .accessibilityIdentifier("restore-sessions.dismiss")
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+        }
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.72))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityIdentifier("restore-sessions.banner")
+    }
+
+    private var summaryText: String {
+        "\(sessionCount) terminal \(sessionCount == 1 ? "session" : "sessions") from your last run."
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/RestoreLaunchCommandTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RestoreLaunchCommandTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("RestoreLaunchCommand")
+struct RestoreLaunchCommandTests {
+    @Test("Wraps claude --resume in a deterministic -L workspaces tmux session")
+    func buildsResumeCommand() {
+        let cwd = URL(fileURLWithPath: "/code/app")
+        let name = GhosttyTerminalConfig.tmuxSessionName(for: cwd)
+        let command = RestoreLaunchCommand.claudeResume(cwd: cwd, sessionID: "sess-123")
+
+        #expect(command == "tmux -L 'workspaces' new-session -A -s '\(name)' -c '/code/app' 'claude --resume sess-123'")
+    }
+
+    @Test("Uses the same session name a normal launch would, so restore reattaches")
+    func nameMatchesNormalLaunch() {
+        let cwd = URL(fileURLWithPath: "/Users/me/proj")
+        let command = RestoreLaunchCommand.claudeResume(cwd: cwd, sessionID: "s1")
+        #expect(command.contains("-s '\(GhosttyTerminalConfig.tmuxSessionName(for: cwd))'"))
+    }
+
+    @Test("Single quotes in the session id are escaped safely")
+    func escapesQuotes() {
+        let command = RestoreLaunchCommand.claudeResume(cwd: URL(fileURLWithPath: "/x"), sessionID: "a'b")
+        #expect(command.hasSuffix("'claude --resume a'\"'\"'b'"))
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 3c of the durable-sessions epic #728, **stacked on #755** (slice 3b). Turns the computed `RestorePlan` into a user action — still behind the `restoreSessionsOnLaunch` experimental flag (default off).
- **`RestoreSessionsBanner`** — a quiet, non-blocking top-of-window affordance ("Resume your previous session? / N terminal sessions from your last run" with **Restore** + dismiss), modeled on `WorkspaceOrphanReconciliationBanner`. Chosen over a modal/menu because it fits the repo's quiet-discoverability and chrome-free-terminal lessons.
- **`executeRestore(_:)`** (ContentView) — launches each surface: reattach/fresh via the existing directory-backed `activateHostSession` (the deterministic tmux name reattaches a surviving session automatically); resume via a `claude --resume` launch command. Then honors the plan's advisory focus.
- **`RestoreLaunchCommand.claudeResume`** — wraps `claude --resume <id>` in `tmux -L workspaces new-session -A` under the same deterministic name a normal launch uses, so a resumed session reattaches like any other on a later restore.
- `computeRestorePlanIfEnabled` (from 3b) now surfaces the banner when the plan is non-empty.

## Mergeability

- Surface: desktop
- User-facing behavior changed: a restore banner appears at launch **only** when the experimental flag is enabled and a resolvable session exists from the previous run; default (flag off) launch is unchanged.
- Non-happy paths considered: empty/no plan → no banner; dismiss hides it without launching; resume targets a `claude --resume` command; reattach falls back to fresh when the recorded dir is gone (planner) or the tmux session died.
- Release/ops preconditions: none. Flag ships off.
- Residual risk or follow-up: split from the base into a distinct branch — merge #755 first (this PR is based on it). Broader multi-session / split-layout restoration and the `claude --resume` path against a real Claude transcript (vs the default-home reattach demonstrated here) are natural follow-ups within #728.

## Validation

- [x] `swift build`
- [x] `swift test` (`RestoreLaunchCommand|ExperimentalFeatures|RestoreTargetIndexBuilder|TerminalRestoreCoordinator` → 16/16)
- [x] Other checks run: `swift-format lint --strict` (exit 0); **end-to-end in the debug app** against an isolated temp data dir

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Real end-to-end run in the debug app (flag on, isolated temp data dir; SwiftData + local-state both redirected, real data untouched):

1. Startup logged `[Restore] planned 1 restorable surface(s)` — the default-home session resolved; unresolvable perf-fixture rows were correctly dropped.
2. **Banner rendered:** ![banner](https://evidence.cloudcompute.com/workspaces/pr-756/20260703-073651-slice3c-banner.png)
3. Clicking **Restore** logged `[Restore] executed 1 surface(s)` + `[HostSession] Reusing session … key=defaultHome path=/Users/fairchild/code`.
4. **After Restore:** banner gone, default-home terminal restored: ![after](https://evidence.cloudcompute.com/workspaces/pr-756/20260703-073651-slice3c-after.png)
5. Unit suites: ![tests](https://evidence.cloudcompute.com/workspaces/pr-756/20260703-073652-slice3c-tests.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

Refs #728. Stacked on #755 (rebase onto main once #755 merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
