### PR TITLE
feat: render fallback status line when WorkSpaces host socket is absent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ New standalone Python utilities are single-file UV scripts: `#!/usr/bin/env -S u
 | Implement a component | docs/original_spec.md (find relevant section) | Read whole file |
 | libghostty internals + dev verification runbook | docs/development/libghostty-integration.md | - |
 | Notifications / webhooks | docs/development/notifications.md | - |
+| Claude Code hooks / status-line forwarders | docs/development/claude-code-integration.md | - |
 | Debug an issue | docs/development/troubleshooting.md | - |
 | Add Settings-gated experimental UI | docs/development/experimental-features.md | - |
 | Terminal keyboard focus | docs/development/solution-terminal-keyboard.md | - |

--- a/Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/event-forwarder.sh
@@ -15,6 +15,10 @@
 #
 # Agent update intake purpose: command hook forwarder.
 #
+# Ownership: ClaudeIntegrationLifecycle re-extracts this script to
+# ~/.local/share/workspaces/hook-forwarders/ on every app launch, overwriting
+# the installed copy. Edit this file, not the installed one.
+#
 # Hard requirements:
 #   * stdlib bash + curl only — no jq, no python.
 #   * Never block; if the socket is unreachable, drop the payload and exit 0.

--- a/Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh
+++ b/Sources/WorkspaceManager/Resources/HookForwarders/statusline.sh
@@ -3,22 +3,40 @@
 # statusline.sh — Claude Code status-line forwarder.
 #
 # Configured in ~/.claude/settings.json under `statusLine.command`. Claude Code
-# invokes this script ~every 5 s with the current status JSON on stdin. We POST
-# the body unchanged to the host's Unix socket on /statusline, then print a
-# single space so the terminal status row stays empty (the host owns
-# visualization).
+# invokes this script ~every 5 s with the current status JSON on stdin. When the
+# WorkSpaces host socket is reachable, we POST the body unchanged to /statusline
+# and print a single space so the terminal status row stays empty (the host owns
+# visualization). Without a socket — a plain terminal outside WorkSpaces — we
+# render a one-line status ourselves: model, cwd, git branch, context left.
 #
 # Agent update intake purpose: status-line forwarder.
 #
+# Ownership: ClaudeIntegrationLifecycle re-extracts this script to
+# ~/.local/share/workspaces/hook-forwarders/ on every app launch, overwriting
+# the installed copy. Edit this file, not the installed one. Docs:
+# docs/development/claude-code-integration.md § "Status-Line Forwarder".
+#
 # Hard requirements:
-#   * stdlib bash + curl only — no jq, no python.
+#   * stdlib bash + curl + sed + git only — no jq, no python.
 #   * Never block; if the socket is unreachable, drop the payload and exit 0.
-#   * Always print a single space and exit 0 so Claude doesn't render an error.
+#   * Always print something and exit 0 so Claude doesn't render an error.
 
 set -u
 
 socket="${WORKSPACES_HOOKS_SOCKET:-}"
 host_session_id="${WORKSPACES_HOST_SESSION_ID:-}"
+
+input="$(cat 2>/dev/null || true)"
+
+# Extracts a JSON string value and unescapes `\/` — some emitters escape
+# forward slashes, which would otherwise break path checks below.
+json_string() {
+    printf '%s' "$1" | sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed 's/\\\//\//g'
+}
+
+json_number() {
+    printf '%s' "$1" | sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*\(-\{0,1\}[0-9][0-9.]*\).*/\1/p'
+}
 
 if [[ -n "$socket" && -S "$socket" ]]; then
     headers=(-H 'Content-Type: application/json')
@@ -26,7 +44,7 @@ if [[ -n "$socket" && -S "$socket" ]]; then
         headers+=(-H "X-WorkSpaces-Host-Session-ID: $host_session_id")
     fi
 
-    /usr/bin/curl \
+    printf '%s' "$input" | /usr/bin/curl \
         --silent \
         --show-error \
         --max-time 1 \
@@ -36,11 +54,59 @@ if [[ -n "$socket" && -S "$socket" ]]; then
         --data-binary @- \
         'http://localhost/statusline' \
         >/dev/null 2>&1 || true
-else
-    # No socket means the host isn't running or the env var didn't propagate.
-    # Drain stdin so Claude doesn't block on the pipe.
-    cat >/dev/null 2>&1 || true
+
+    printf ' '
+    exit 0
 fi
 
-printf ' '
+# Fallback rendering for terminals not running under the WorkSpaces host.
+line="$(printf '%s' "$input" | tr -d '\n\r')"
+
+model="$(json_string "$line" 'display_name')"
+
+dir="$(json_string "$line" 'current_dir')"
+if [[ -z "$dir" ]]; then
+    dir="$(json_string "$line" 'cwd')"
+fi
+display_dir="$dir"
+if [[ -n "$dir" && "$dir" == "$HOME"* ]]; then
+    display_dir="~${dir#"$HOME"}"
+fi
+
+branch=""
+if [[ -n "$dir" && -d "$dir" ]]; then
+    branch="$(git --no-optional-locks -C "$dir" branch --show-current 2>/dev/null || true)"
+fi
+
+context=""
+remaining="$(json_number "$line" 'remaining_percentage')"
+used="$(json_number "$line" 'used_percentage')"
+if [[ -n "$remaining" ]]; then
+    context="Context: ${remaining}% remaining"
+elif [[ -n "$used" ]]; then
+    context="Context: ${used}% used"
+fi
+
+status=""
+add_part() {
+    if [[ -z "$1" ]]; then
+        return 0
+    fi
+    if [[ -n "$status" ]]; then
+        status="$status | $1"
+    else
+        status="$1"
+    fi
+}
+
+add_part "$model"
+add_part "$display_dir"
+add_part "$branch"
+add_part "$context"
+
+if [[ -n "$status" ]]; then
+    printf '%s' "$status"
+else
+    printf ' '
+fi
 exit 0

--- a/Tests/WorkspaceManagerTests/Helpers/TestGitRepository.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/TestGitRepository.swift
@@ -68,6 +68,11 @@ final class TestGitRepository {
         try Self.run(["git", "remote", "add", name, url], at: self.url)
     }
 
+    /// Create and switch to a new branch
+    func createBranch(_ name: String) throws {
+        try Self.run(["git", "checkout", "-b", name], at: url)
+    }
+
     /// Create a detached HEAD state
     func detachHead() throws {
         let head = try Self.runOutput(["git", "rev-parse", "HEAD"], at: url)

--- a/Tests/WorkspaceManagerTests/HookForwarderScriptTests.swift
+++ b/Tests/WorkspaceManagerTests/HookForwarderScriptTests.swift
@@ -57,6 +57,34 @@ struct HookForwarderScriptTests {
         return (process.terminationStatus, stdout, stderr)
     }
 
+    private static func runStatusLineFallback(
+        stdin: Data
+    ) throws -> (status: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [hookForwarder(named: "statusline.sh").path]
+        var environment = ProcessInfo.processInfo.environment
+        environment.removeValue(forKey: "WORKSPACES_HOOKS_SOCKET")
+        environment.removeValue(forKey: "WORKSPACES_HOST_SESSION_ID")
+        process.environment = environment
+
+        let input = Pipe()
+        let output = Pipe()
+        let error = Pipe()
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = error
+
+        try process.run()
+        try input.fileHandleForWriting.write(contentsOf: stdin)
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+
+        let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (process.terminationStatus, stdout, stderr)
+    }
+
     private static func runZshCommandStatusHook(
         socket: URL,
         hostSessionID: UUID
@@ -213,6 +241,40 @@ struct HookForwarderScriptTests {
         }
         #expect(reached)
         #expect(registry.statuses[hostSessionID]?.costUSD == 0.42)
+    }
+
+    @Test("statusline forwarder renders a fallback status line when the host socket is absent")
+    func statusLineForwarderRendersFallbackWithoutSocket() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+        try repo.createFile("README.md", content: "fallback")
+        try repo.commit(message: "init")
+        try repo.createBranch("statusline-fallback-test")
+
+        let payload: [String: Any] = [
+            "model": ["display_name": "Claude Sonnet 4.5"],
+            "workspace": ["current_dir": repo.url.path],
+            "context_window": ["remaining_percentage": 42],
+        ]
+        let result = try Self.runStatusLineFallback(
+            stdin: try JSONSerialization.data(withJSONObject: payload)
+        )
+
+        #expect(result.status == 0)
+        #expect(
+            result.stdout
+                == "Claude Sonnet 4.5 | \(repo.url.path) | statusline-fallback-test | Context: 42% remaining"
+        )
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test("statusline forwarder fallback prints a single space when the payload is empty")
+    func statusLineForwarderFallbackPrintsSpaceForEmptyPayload() async throws {
+        let result = try Self.runStatusLineFallback(stdin: Data("{}".utf8))
+
+        #expect(result.status == 0)
+        #expect(result.stdout == " ")
+        #expect(result.stderr.isEmpty)
     }
 
     @Test("command-status zsh hook posts command markers with host-session header")

--- a/docs/development/claude-code-integration.md
+++ b/docs/development/claude-code-integration.md
@@ -220,11 +220,27 @@ tilde-relative, unquoted shape. The installer overwrites any prior status-line
 command, so a stale bundle or `.build` path converges to the generic command on
 next launch.
 
-Claude Code runs it as `statusLine.command`. The script posts status JSON to
-`/statusline` and prints a single space so Claude's own status row stays visually
-empty. `StatusLinePayload` tolerates snake_case/camelCase keys and common ISO
-date variants. The listener maps the payload to `.statusFields(...)` and applies
-it through the same registry write surface.
+Claude Code runs it as `statusLine.command`. With a reachable host socket, the
+script posts status JSON to `/statusline` and prints a single space so Claude's
+own status row stays visually empty — the host owns visualization.
+`StatusLinePayload` tolerates snake_case/camelCase keys and common ISO date
+variants. The listener maps the payload to `.statusFields(...)` and applies it
+through the same registry write surface.
+
+Without a reachable socket — a terminal outside WorkSpaces, or the app not
+running — the script renders a one-line status itself from the same JSON: model
+display name, cwd (tilde-shortened; `workspace.current_dir` falling back to
+top-level `cwd`), git branch, and context remaining/used. Missing fields drop
+out of the line, and an empty payload degrades to the same single space.
+Parsing is plain `sed` per the script's no-jq requirement, and the branch
+lookup uses `git --no-optional-locks` so a status tick never contends with a
+running git operation.
+
+The extracted copies under `~/.local/share/workspaces/hook-forwarders/` are
+app-owned: `ClaudeIntegrationLifecycle` re-extracts the bundled scripts on
+every launch, overwriting whatever is there. Behavior changes belong in the
+bundled scripts under `Sources/WorkspaceManager/Resources/HookForwarders/`,
+covered by `HookForwarderScriptTests`.
 
 Status-line ticks never change `AgentRunState`; they only update display fields
 such as model, cost, context used, and five-hour limit state.

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -69,6 +69,15 @@ Clipboard callbacks are handled in `GhosttyAppManager`:
 For debugging, add temporary `NSLog` lines in those callbacks and verify
 `ghostty_surface_complete_clipboard_request(...)` is called.
 
+### 6. Edits to `~/.local/share/workspaces/hook-forwarders/*.sh` disappear
+
+The app re-extracts the bundled forwarder scripts on every launch
+(`ClaudeIntegrationLifecycle`), overwriting the installed copies. Edit the
+sources in `Sources/WorkspaceManager/Resources/HookForwarders/` instead;
+`HookForwarderScriptTests` covers them, and the installed copies converge on
+the next app launch. Details:
+`docs/development/claude-code-integration.md` § "Status-Line Forwarder".
+
 ## Useful Commands
 
 ```bash


### PR DESCRIPTION
## What

`statusline.sh` (the Claude Code `statusLine.command` forwarder) now renders a one-line status itself — `model | cwd | git branch | context remaining/used` — when the WorkSpaces host socket is unreachable, i.e. Claude Code running in a plain terminal outside the app. With a reachable socket, behavior is byte-identical to before: payload forwarded to `/statusline`, single space printed, host owns visualization.

Also documents forwarder **ownership** at every surface someone would hit when editing this: the installed copies under `~/.local/share/workspaces/hook-forwarders/` are re-extracted from the app bundle on every launch, so edits there silently disappear (this happened in practice — an edit to the installed copy was clobbered within minutes by a dev-build launch). Ownership notes added to both script headers, `claude-code-integration.md` § Status-Line Forwarder, a new troubleshooting entry ("edits to hook-forwarders disappear"), and a doc-nav row in AGENTS.md.

## Details

- Fallback parsing is plain `sed` (script's no-jq hard requirement), tolerates `\/`-escaped JSON strings, prefers `workspace.current_dir` over top-level `cwd`, tilde-shortens `$HOME`, and uses `git --no-optional-locks` for the branch so a status tick never contends with a running git operation. Missing fields drop out; an empty payload degrades to the original single space. Always exits 0.
- `TestGitRepository` gains a `createBranch` helper so the branch segment is covered deterministically.
- Two new `HookForwarderScriptTests` cases: fallback render (model/cwd/branch/context, exact match) and empty-payload blank degradation.

## Evidence

![statusline-fallback-rendering](https://evidence.cloudcompute.com/workspaces/pr-759/20260703-074601-statusline-fallback-rendering.png)

- Demo shows: full fallback render incl. branch, `used_percentage` variant, escaped-slash payload, empty-payload blank, and the 6/6 green forwarder suite.
- `swift test` full suite: passed locally (exit 0).
- `mise run lint` (swift-format strict): clean.

## Mergeability

- Scope: one behavior change (fallback render) + ownership docs; no socket-path or installer changes.
- Tests green (full suite), lint clean, evidence uploaded above.
- No schema, settings.json shape, or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)