### PR TITLE
fix(carl): update model to Sonnet 5, fail fast on missing API key

### DIFF
--- a/scripts/carl-community.py
+++ b/scripts/carl-community.py
@@ -683,7 +683,7 @@ def parse_args() -> argparse.Namespace:
                         help="Generate commentary without posting")
     parser.add_argument("--fixtures-dir", type=Path,
                         help="Load data from fixture pack instead of live GitHub")
-    parser.add_argument("--model", default="claude-sonnet-4-20250514",
+    parser.add_argument("--model", default="claude-sonnet-5",
                         help="Claude model for commentary generation")
     parser.add_argument("--threshold", type=int, default=5,
                         help="Minimum activity score to post (default: 5)")
@@ -706,6 +706,16 @@ def output_result(
 
 def main() -> None:
     args = parse_args()
+
+    # Fail fast before spending minutes on GitHub calls: a live post needs the
+    # API key, and the daily cron has repeatedly wasted its whole run reaching
+    # the call site only to abort for a missing key.
+    live_post = not (args.fixtures_dir or args.dry_run)
+    if live_post and not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        raise CarlError(
+            "ANTHROPIC_API_KEY is required to post commentary. "
+            "Set it as a repo Actions secret, or run with --dry-run."
+        )
 
     if args.fixtures_dir:
         fixture_path = args.fixtures_dir
@@ -768,9 +778,7 @@ def main() -> None:
         output_result(result, json_output=args.json_output)
         return
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-    if not api_key:
-        raise CarlError("ANTHROPIC_API_KEY environment variable is required")
+    api_key = os.environ["ANTHROPIC_API_KEY"]  # guaranteed by the fail-fast check above
     log(f"Calling Claude ({args.model})...")
     commentary = call_claude(system_msg, user_msg, model=args.model, api_key=api_key)
 


### PR DESCRIPTION
## What

Carl Community's daily cron has failed every day for the last 3+ days. Two independent problems:

1. **Stale model pin.** `scripts/carl-community.py` defaulted to `claude-sonnet-4-20250514` — a year-old model — while every other LLM persona floats to the current default. Carl's narrative is what Michael reads daily, so quality here matters. Now `claude-sonnet-5`.
2. **Wasteful failure mode.** The `ANTHROPIC_API_KEY` check happened *after* ~5 minutes of GitHub gathering (discussions, issues, PRs, runs, git log), so a missing key burned the whole run before aborting with a cryptic message. The check now runs before any network call, with an actionable message.

## Why Carl is still red until you act

This PR makes Carl fail *fast and clearly*; it does not by itself make him post, because **the `ANTHROPIC_API_KEY` secret does not exist** at repo or environment level (verified via `gh secret list`). That's the root cause of the daily failures. Two ways forward — **your call:**

- **(A, recommended) Add the `ANTHROPIC_API_KEY` repo secret.** Keeps Carl's dead-simple single-call design; costs pennies/day. Zero code change beyond this PR.
- **(B) Route Carl through the existing `CLAUDE_CODE_OAUTH_TOKEN`** (already provisioned, already used by April/Plat). No new secret, but it means a follow-up PR: Carl's raw Messages-API call would switch to the OAuth `Authorization: Bearer` + beta path, which I want to verify against the live API before shipping (can't do that here without the token). Say the word and I'll do it as a fast follow-up.

I did **not** guess and implement (B) blind — shipping unverified auth code would violate verify-after-each-change.

## Verification

Both paths exercised locally (see evidence):
- **Fixture dry-run** (`--fixtures-dir fixtures/carl-community/active-day`): gathers → scores 31 → builds the prompt with the new model, no key needed. ✅
- **Live path, no key**: aborts *immediately* (no "Fetching live data" log = no wasted `gh` calls), exit 1, actionable message. ✅

## Mergeability

- Surface: agent-runtime (scripts/carl-community.py + workflow)
- User-facing behavior changed: No — internal agent; Carl still posts to Discussions once the API key is set.
- Non-happy paths considered: Missing key now fails fast before any GitHub call; fixture and dry-run paths preserved (verified).
- Residual risk or follow-up: Carl stays red until the ANTHROPIC_API_KEY secret is added (owner action) or he is routed to the existing CLAUDE_CODE_OAUTH_TOKEN.

- **Scope:** one file, +12/−4. No behavior change to the happy path beyond the model id.
- **Risk:** low. `claude-sonnet-5` is the current Sonnet alias; the Messages API requires an explicit model, so the floating alias matches the "use latest" intent of the rest of the fleet.
- **CI:** `ci-agents.yml` is path-filtered to `.agents/**` and does not cover `scripts/carl-community.py`; the script runs clean under `uv`.
- **Not addressed here (surfaced above):** the missing secret is an owner action, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

![carl-runtime-fix](https://evidence.cloudcompute.com/workspaces/pr-760/20260703-075208-carl-runtime-fix.png)

