### PR TITLE
fix(agents): stop persisting App token on disk (R1), pin Claude Code CLI (R4)

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -274,6 +274,14 @@ EXECUTION_TOOLS = "Read,Grep,Glob,Edit,Write,MultiEdit"
 PRIVILEGED_PATCH_LABEL = "privileged-agent-patch"
 PRIVILEGED_PATCH_ENV = "AGENT_ALLOW_PRIVILEGED_PATCHES"
 
+# Pin the Claude Code CLI to an exact version so a compromised `@latest` release
+# can't run in the contributor job (where GH_TOKEN is still in the environment).
+# Bump via the CONTRIBUTOR_CLAUDE_CODE_VERSION env/repo-var — no code change needed.
+CLAUDE_CODE_VERSION = os.environ.get(
+    "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.200"
+).strip() or "2.1.200"
+CLAUDE_CODE_PACKAGE = f"@anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}"
+
 SENSITIVE_PATH_PREFIXES = (
     ".github/",
     ".agents/",
@@ -705,7 +713,7 @@ def run_claude(
     cmd = [
         "npx",
         "--yes",
-        "@anthropic-ai/claude-code",
+        CLAUDE_CODE_PACKAGE,
         "--print",
         "--system-prompt",
         prompt_text,

--- a/.github/workflows/agent-executor.yml
+++ b/.github/workflows/agent-executor.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           fetch-depth: 50
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
       - name: Resolve target workspace
         id: target-workspace
         if: needs.claim.outputs.target_type == 'pull_request'
@@ -180,6 +181,7 @@ jobs:
         with:
           fetch-depth: 50
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
       - name: Resolve target workspace
         id: target-workspace
         if: needs.claim.outputs.target_type == 'pull_request'

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -583,5 +583,15 @@ class RepoMemoryInjectionTests(unittest.TestCase):
                 self.assertEqual(run_contributor.load_repo_memory(), "")
 
 
+class ClaudeCodePinTests(unittest.TestCase):
+    def test_cli_package_is_version_pinned(self) -> None:
+        # The contributor fetches the CLI with GH_TOKEN in the environment, so it
+        # must never resolve `@latest`. Guard against a regression to an unpinned spec.
+        package = run_contributor.CLAUDE_CODE_PACKAGE
+        self.assertTrue(package.startswith("@anthropic-ai/claude-code@"))
+        version = package.rsplit("@", 1)[1]
+        self.assertRegex(version, r"^\d+\.\d+\.\d+")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Two hardening fixes from a security audit of the Actions contributor agents. The audit's overall finding: the design is genuinely sound (structured-payload isolation, token stripped from the model subprocess, read-only review of untrusted PRs, sensitive-path patch gating, human-merge gate). These are the two concrete code gaps it found.

### R1 (most severe) — App token was persisted on disk beside a prompt-injectable model

The executor's April and Plat jobs checked out the base repo **with the GitHub App token but without `persist-credentials: false`**, so the token landed in `.git/config` on the same runner where the read-only review model runs against an attacker-controlled `refs/pull/<n>/head`. The model's env is stripped of `GH_TOKEN`, but its `Read` tool takes absolute paths — a maintainer mislabels a malicious PR, the PR's files carry a prompt injection, the model is steered to read `$GITHUB_WORKSPACE/.git/config` and embed the `contents`/`pull_requests`-write token in its review body, which posts publicly → repo push access.

**Fix:** add `persist-credentials: false` to both base checkouts. This makes the executor consistent with the scheduled `agent-april.yml`, which already sets it. **No functional change** — the contributor pushes via `gh auth setup-git` + `GH_TOKEN` (`execution.py:501-508`), never the persisted checkout credential, and the scheduled path already runs this exact code with credentials un-persisted.

Scoped deliberately to the two App-token base checkouts. The `peter` job has no checkout; the `claude` job checks out the *base* repo with the default scoped `GITHUB_TOKEN` (contents:read), and touching its checkout risks breaking claude-code-action's own git ops.

### R4 — unpinned Claude Code CLI fetched with GH_TOKEN in scope

`run-contributor.py` ran `npx --yes @anthropic-ai/claude-code` unpinned, so a compromised `@latest` release would execute with `GH_TOKEN` present (the fetch happens before the model-env stripping). Pinned to an exact version (`2.1.200`), overridable via `CONTRIBUTOR_CLAUDE_CODE_VERSION` so bumps need no code change. A new guard test (`ClaudeCodePinTests`) fails if the spec ever regresses to unpinned.

## Verification
- Security guard tests: **37 pass** (was 36 + the new pin guard).
- `agent-executor.yml` parses; all four App-token executor checkouts now carry `persist-credentials: false`.
- Version override verified (`get(...).strip() or default`); empty value falls back to the pinned default.

## Owner actions (not code — from the same audit, tracked separately)
- **R2 — verify GitHub App scopes.** The App *installation* permissions, not the workflow `permissions:` block, are the true blast radius of any token leak. `docs/development/github-app-identities.md` lists `contents:write`, `pull_requests:write`, `metadata:read` for both apps and **no** `workflows`/`administration` — please confirm live in App settings. If either app can edit workflows or administer the repo, a leak becomes takeover.
- **R3 — self-hosted runner ephemerality.** Docs (`lume-runner-setup.md` § Runner persistence) describe persistent launchd runners on standing VMs, and `ci-fallback.yml:15-16` says not to run failed PR heads on persistent self-hosted runners. Currently latent (only `blue-workspaces`/signing-host is online; no `lume-macos`/`tart-ui`). Keep the evidence lane on agent-authored branches, or make runners ephemeral before that changes.

## Note on current state
`AGENT_AUTOMATIONS_ENABLED` is **true** and the fleet is live (April/Plat ran on schedule 07-01 and 07-02). So this is "safe as currently running," not "safe to re-enable."

## Mergeability

- Surface: infra + agent-runtime (.github/workflows + contributor runner)
- User-facing behavior changed: No — credential hygiene and a pinned dependency; no product surface.
- Non-happy paths considered: Base checkout without persisted creds still pushes via 'gh auth setup-git' + GH_TOKEN (proven by the scheduled workflow); empty CLI-version override falls back to the pin.
- Residual risk or follow-up: R2 (confirm App scopes exclude workflows/administration) and R3 (make self-hosted runners ephemeral) are owner actions, tracked in the body.
- **Scope:** 3 files, +21/−1. R1 is 2 lines; R4 is a constant + interpolation + guard test.
- **Risk:** low. R1 proven no-op by the scheduled workflow's identical pattern; R4 pins to a confirmed-published version with an escape hatch.

## Evidence

![hardening-evidence](https://evidence.cloudcompute.com/workspaces/pr-762/20260703-075859-hardening.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

