### PR TITLE
Add session-history read/view-model layer (durable sessions slice 4a)

### DIFF
--- a/Sources/WorkspaceManager/Views/History/SessionHistoryItem.swift
+++ b/Sources/WorkspaceManager/Views/History/SessionHistoryItem.swift
@@ -1,0 +1,85 @@
+//
+//  SessionHistoryItem.swift
+//  WorkspaceManager
+//
+//  Display model for the session history browser: a durable-session continuity
+//  row projected into what the list needs (title, path, time, model, whether the
+//  Claude transcript still exists), plus a pure day-grouping fold. The mapping is
+//  a static function so it is unit-testable without a store.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+struct SessionHistoryItem: Identifiable, Equatable {
+    let id: UUID  // hostSessionID
+    let title: String
+    let path: String
+    let timestamp: Date
+    let endedAt: Date?
+    let modelDisplayName: String?
+    let agentKind: String?
+    let agentSessionID: String?
+    let agentCwd: String?
+    /// Non-nil when the Claude transcript still exists on disk — the same
+    /// predicate as "resumable", carrying the URL for the detail view.
+    let transcriptURL: URL?
+
+    var isResumable: Bool { transcriptURL != nil }
+
+    static func make(
+        from row: TerminalSessionContinuityRow,
+        resumability: ClaudeTranscriptResumability
+    ) -> SessionHistoryItem {
+        let path = row.targetPath ?? row.directoryPath
+        let transcriptURL: URL? = {
+            guard let agentSessionID = row.agentSessionID, let agentCwd = row.agentCwd else { return nil }
+            return resumability.existingTranscriptURL(agentSessionID: agentSessionID, cwd: agentCwd)
+        }()
+        return SessionHistoryItem(
+            id: row.hostSessionID,
+            title: displayTitle(for: path),
+            path: path,
+            timestamp: row.lastSeenAt,
+            endedAt: row.endedAt,
+            modelDisplayName: row.agentModelDisplayName,
+            agentKind: row.agentKind,
+            agentSessionID: row.agentSessionID,
+            agentCwd: row.agentCwd,
+            transcriptURL: transcriptURL
+        )
+    }
+
+    private static func displayTitle(for path: String) -> String {
+        let trimmed = path.hasSuffix("/") && path.count > 1 ? String(path.dropLast()) : path
+        let last = (trimmed as NSString).lastPathComponent
+        return last.isEmpty ? trimmed : last
+    }
+}
+
+/// A day bucket of history items, newest day first, items within kept in input
+/// order (the store already returns newest `last_seen_at` first).
+struct SessionHistoryDaySection: Identifiable, Equatable {
+    let id: Date  // start-of-day
+    let items: [SessionHistoryItem]
+}
+
+enum SessionHistoryGrouping {
+    /// Fold a newest-first item list into day sections. `calendar`/`now` are
+    /// injectable so the fold is deterministic under test.
+    static func byDay(
+        _ items: [SessionHistoryItem],
+        calendar: Calendar = .current
+    ) -> [SessionHistoryDaySection] {
+        var order: [Date] = []
+        var buckets: [Date: [SessionHistoryItem]] = [:]
+        for item in items {
+            let day = calendar.startOfDay(for: item.timestamp)
+            if buckets[day] == nil {
+                order.append(day)
+            }
+            buckets[day, default: []].append(item)
+        }
+        return order.map { SessionHistoryDaySection(id: $0, items: buckets[$0] ?? []) }
+    }
+}

--- a/Sources/WorkspaceManager/Views/History/SessionHistoryViewModel.swift
+++ b/Sources/WorkspaceManager/Views/History/SessionHistoryViewModel.swift
@@ -1,0 +1,69 @@
+//
+//  SessionHistoryViewModel.swift
+//  WorkspaceManager
+//
+//  Loads the session history index from the local state store (newest-first,
+//  paginated), maps rows to display items, and lazily fetches a session's
+//  privacy-bounded event timeline on selection. Reads only the SQLite sidecar —
+//  it renders titles from the stored path strings, not live SwiftData.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+final class SessionHistoryViewModel: ObservableObject {
+    @Published private(set) var items: [SessionHistoryItem] = []
+    @Published private(set) var isLoading = false
+    @Published private(set) var loadError: String?
+    @Published private(set) var canLoadMore = true
+
+    private let store: LocalStateStore?
+    private let resumability: ClaudeTranscriptResumability
+    private let pageSize: Int
+    private var offset = 0
+
+    init(
+        store: LocalStateStore?,
+        resumability: ClaudeTranscriptResumability = ClaudeTranscriptResumability(),
+        pageSize: Int = 50
+    ) {
+        self.store = store
+        self.resumability = resumability
+        self.pageSize = max(1, pageSize)
+    }
+
+    var sections: [SessionHistoryDaySection] { SessionHistoryGrouping.byDay(items) }
+
+    func loadFirstPage() async {
+        items = []
+        offset = 0
+        canLoadMore = true
+        await loadMore()
+    }
+
+    func loadMore() async {
+        guard !isLoading, canLoadMore, let store else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let rows = try await store.fetchContinuitySessions(activeOnly: false, limit: pageSize, offset: offset)
+            let page = rows.map { SessionHistoryItem.make(from: $0, resumability: resumability) }
+            items.append(contentsOf: page)
+            offset += rows.count
+            canLoadMore = rows.count == pageSize
+            loadError = nil
+        } catch {
+            loadError = String(describing: error)
+            canLoadMore = false
+        }
+    }
+
+    /// The session's event timeline in chronological order (the store returns
+    /// newest-first). Empty when there are no events or no store.
+    func events(for item: SessionHistoryItem) async -> [AgentStatusEventRow] {
+        guard let store else { return [] }
+        let rows = (try? await store.fetchAgentStatusEvents(hostSessionID: item.id)) ?? []
+        return rows.reversed()
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptLocator.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptLocator.swift
@@ -68,8 +68,16 @@ public struct ClaudeTranscriptResumability: Sendable {
     }
 
     public func isResumable(agentSessionID: String, cwd: String) -> Bool {
+        existingTranscriptURL(agentSessionID: agentSessionID, cwd: cwd) != nil
+    }
+
+    /// The transcript URL for this session when the file still exists on disk,
+    /// else `nil`. Same predicate as `isResumable`, but returns the resolved URL
+    /// so a history view can both badge resumability and render the transcript
+    /// from one `claudeHome` resolution.
+    public func existingTranscriptURL(agentSessionID: String, cwd: String) -> URL? {
         let url = locator.transcriptURL(claudeHome: claudeHome, cwd: cwd, sessionID: agentSessionID)
-        return fileExists(url.path)
+        return fileExists(url.path) ? url : nil
     }
 
     /// Adapt to the planner's injected `TranscriptResumabilityCheck` closure.

--- a/Tests/WorkspaceManagerAppTests/SessionHistoryViewModelTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SessionHistoryViewModelTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@Suite("SessionHistory")
+struct SessionHistoryViewModelTests {
+    // MARK: Pure mapping
+
+    @Test("Maps a continuity row to a display item, title from the target path")
+    func mapsRowToItem() {
+        let row = makeRow(
+            targetPath: "/Users/me/code/app/",
+            agentSessionID: "sess-1",
+            agentCwd: "/Users/me/code/app",
+            model: "Claude"
+        )
+        // Transcript "exists" → item carries the URL and reads as resumable.
+        let resumability = ClaudeTranscriptResumability(
+            environment: [:],
+            homeDirectory: URL(fileURLWithPath: "/home"),
+            fileExists: { _ in true }
+        )
+        let item = SessionHistoryItem.make(from: row, resumability: resumability)
+        #expect(item.title == "app")  // basename, trailing slash trimmed
+        #expect(item.path == "/Users/me/code/app/")
+        #expect(item.modelDisplayName == "Claude")
+        #expect(item.isResumable)
+        #expect(item.transcriptURL?.lastPathComponent == "sess-1.jsonl")
+    }
+
+    @Test("A missing transcript yields a non-resumable item with no URL")
+    func mapsNonResumableItem() {
+        let row = makeRow(targetPath: "/x/repo", agentSessionID: "sess-2", agentCwd: "/x/repo")
+        let resumability = ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false })
+        let item = SessionHistoryItem.make(from: row, resumability: resumability)
+        #expect(!item.isResumable)
+        #expect(item.transcriptURL == nil)
+    }
+
+    @Test("Rows without an agent session are never resumable")
+    func mapsRowWithoutAgent() {
+        let row = makeRow(targetPath: "/x/repo", agentSessionID: nil, agentCwd: nil)
+        let resumability = ClaudeTranscriptResumability(environment: [:], fileExists: { _ in true })
+        let item = SessionHistoryItem.make(from: row, resumability: resumability)
+        #expect(!item.isResumable)
+    }
+
+    // MARK: Day grouping
+
+    @Test("Items fold into day sections, newest day first, order preserved within a day")
+    func groupsByDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let day2 = Date(timeIntervalSince1970: 1_700_000_000)  // later day
+        let day1 = day2.addingTimeInterval(-48 * 3600)  // two days earlier
+        let items = [
+            item(id: 1, at: day2.addingTimeInterval(100)),
+            item(id: 2, at: day2),
+            item(id: 3, at: day1),
+        ]
+        let sections = SessionHistoryGrouping.byDay(items, calendar: calendar)
+        #expect(sections.count == 2)
+        #expect(sections[0].items.map(\.id) == items[0...1].map(\.id))  // newest day, input order kept
+        #expect(sections[1].items.map(\.id) == [items[2].id])
+    }
+
+    // MARK: View model over a temp store
+
+    @Test("Loads history newest-first and paginates")
+    func loadsAndPaginates() async throws {
+        let store = try makeStore()
+        // Record three sessions sequentially; last_seen_at is monotonic → newest first.
+        for path in ["/a", "/b", "/c"] {
+            try await store.recordTerminalSession(
+                HostTerminalSession(id: UUID(), key: .repoPath(path), directory: URL(fileURLWithPath: path)),
+                terminalMode: "ghostty_managed_splits",
+                isActive: true,
+                hooksSocketPath: nil
+            )
+        }
+        let vm = await SessionHistoryViewModel(
+            store: store,
+            resumability: ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false }),
+            pageSize: 2
+        )
+        await vm.loadFirstPage()
+        var items = await vm.items
+        #expect(items.count == 2)  // first page fills to pageSize
+        #expect(await vm.canLoadMore)
+
+        await vm.loadMore()
+        items = await vm.items
+        #expect(items.count == 3)
+        #expect(Set(items.map(\.title)) == ["a", "b", "c"])  // every session surfaced across pages
+        #expect(await vm.canLoadMore == false)  // last page was short → end reached
+    }
+
+    @Test("Event timeline is returned in chronological order")
+    func eventsAreChronological() async throws {
+        let store = try makeStore()
+        let sessionID = UUID()
+        try await store.recordTerminalSession(
+            HostTerminalSession(id: sessionID, key: .repoPath("/a"), directory: URL(fileURLWithPath: "/a")),
+            terminalMode: "ghostty_managed_splits",
+            isActive: true,
+            hooksSocketPath: nil
+        )
+        for (index, tool) in ["Read", "Bash"].enumerated() {
+            try await store.recordAgentEvents(
+                [.toolStart(name: tool, detail: nil)],
+                hostSessionID: sessionID,
+                origin: .hook,
+                status: AgentSessionStatus(
+                    hostSessionID: sessionID,
+                    agentSessionID: "s",
+                    kind: .claudeCode,
+                    cwd: "/a",
+                    run: .runningTool(name: tool, detail: nil),
+                    modelDisplayName: "Claude",
+                    lastEventAt: Date(timeIntervalSince1970: 1_700_000_000 + Double(index)),
+                    hookActive: true,
+                    createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+                ),
+                occurredAt: Date(timeIntervalSince1970: 1_700_000_000 + Double(index))
+            )
+        }
+        let vm = await SessionHistoryViewModel(store: store)
+        let item = SessionHistoryItem(
+            id: sessionID, title: "a", path: "/a", timestamp: Date(), endedAt: nil,
+            modelDisplayName: nil, agentKind: nil, agentSessionID: nil, agentCwd: nil, transcriptURL: nil
+        )
+        let events = await vm.events(for: item)
+        #expect(events.map(\.toolName) == ["Read", "Bash"])  // chronological, not newest-first
+    }
+
+    // MARK: Helpers
+
+    private func item(id: Int, at date: Date) -> SessionHistoryItem {
+        SessionHistoryItem(
+            id: UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", id))")!,
+            title: "\(id)", path: "/\(id)", timestamp: date, endedAt: nil,
+            modelDisplayName: nil, agentKind: nil, agentSessionID: nil, agentCwd: nil, transcriptURL: nil
+        )
+    }
+
+    private func makeRow(
+        targetPath: String?,
+        agentSessionID: String?,
+        agentCwd: String?,
+        model: String? = nil
+    ) -> TerminalSessionContinuityRow {
+        TerminalSessionContinuityRow(
+            hostSessionID: UUID(),
+            sessionKey: "k",
+            targetKind: "repo",
+            targetID: nil,
+            targetPath: targetPath,
+            backendIdentifier: nil,
+            backendInstanceID: nil,
+            directoryPath: targetPath ?? "/",
+            terminalMode: "ghostty_managed_splits",
+            tmuxSessionName: nil,
+            customCommandPresent: false,
+            isActive: false,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastSeenAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_700_000_100),
+            agentSessionID: agentSessionID,
+            agentKind: agentSessionID == nil ? nil : "claudeCode",
+            agentRunState: nil,
+            agentCwd: agentCwd,
+            agentModelDisplayName: model,
+            agentEventAt: nil
+        )
+    }
+
+    private func makeStore() throws -> LocalStateStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionHistoryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return try LocalStateStore(databaseURL: directory.appendingPathComponent("state.sqlite"))
+    }
+}


### PR DESCRIPTION
## Summary

- Slice 4a of the durable-sessions epic #728: the pure, unit-tested data layer for a **session history browser**. No UI — the browser window is slice 4b.
- **`ClaudeTranscriptResumability.existingTranscriptURL(agentSessionID:cwd:)`** — additive accessor returning the transcript URL only when the file exists, so a history row derives both its "resumable" badge and its render URL from one `claudeHome` resolution. `isResumable` now delegates to it.
- **`SessionHistoryItem` + `make(from:resumability:)`** — maps a `TerminalSessionContinuityRow` to a display item (title from target/dir path, timestamp, model, transcript URL). Pure; tested without a store.
- **`SessionHistoryGrouping.byDay`** — deterministic newest-day-first fold (injectable calendar).
- **`SessionHistoryViewModel`** (`@MainActor`) — loads history via the existing `fetchContinuitySessions(activeOnly: false)` (**no new store query**), paginates, and lazily returns a session's event timeline in chronological order.

## Mergeability

- Surface: desktop (app target + one additive Core accessor)
- User-facing behavior changed: none — no callers/UI yet (mirrors the additive-first slices 1/3a/4a pattern).
- Non-happy paths considered: missing transcript → non-resumable, no URL; row without an agent session → never resumable; store read error → `loadError` set + pagination stops; short last page → `canLoadMore` false.
- Release/ops preconditions: none.
- Residual risk or follow-up: history order is `last_seen_at DESC` with no tiebreaker (the slice-1 query), so sessions sharing a timestamp order arbitrarily among themselves — acceptable for contemporaneous sessions; a deterministic tiebreaker (e.g. rowid) is a possible follow-up. Slice 4b adds the browser window (list-detail reusing `ConversationLogView` + the transcript URL, event-timeline fallback, "transcript no longer available" state) and needs launch-dev verification.

## Validation

- [x] `swift build`
- [x] `swift test` (`SessionHistory` → 6/6)
- [x] Other checks run: `swift-format lint --strict` (exit 0)

## Performance

- [x] Not a performance-sensitive change

Paginated, indexed reads (`idx_terminal_sessions_last_seen`) on demand.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- `swift test --filter SessionHistory` — 6/6: ![slice4a-tests](https://evidence.cloudcompute.com/workspaces/pr-763/20260703-075936-slice4a-tests.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

Refs #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
