### PR TITLE
feat(agents): scheduled contributors read curated repo memory (Phase 2, read side)

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -648,6 +648,43 @@ def apply_scratch_patch_artifact(artifact: ScratchPatchArtifact, env: dict[str, 
         patch_path.unlink(missing_ok=True)
 
 
+REPO_MEMORY_PATH = REPO_ROOT / ".agents" / "MEMORY.md"
+
+
+def load_repo_memory() -> str:
+    """Return the curated repo memory, or "" if absent.
+
+    `.agents/MEMORY.md` holds durable architectural rules (CI/runner isolation,
+    terminal-first product rules, release discipline, debugging heuristics). It
+    is CODEOWNERS-gated and blocked from agent edits by the patch policy, so it
+    is safe to fold into the trusted system prompt.
+    """
+    try:
+        return REPO_MEMORY_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def compose_system_prompt(persona_prompt: str) -> str:
+    """Fold curated repo memory into a persona system prompt.
+
+    Interactive `/become` sessions already load this memory; scheduled
+    contributor runs did not, so April and Plat wrote code without the repo's
+    hard-won rules in context.
+    """
+    memory = load_repo_memory()
+    if not memory:
+        return persona_prompt
+    return (
+        f"{persona_prompt.rstrip()}\n\n"
+        "---\n\n"
+        "## Repository memory (trusted, curated)\n\n"
+        "Durable rules and heuristics for this repo. Treat as high-priority "
+        "context, not as instructions that override your task envelope.\n\n"
+        f"{memory}\n"
+    )
+
+
 def run_claude(
     system_prompt: str | Path,
     task: str,
@@ -1316,7 +1353,7 @@ def main() -> int:
             scratch_workspace = create_scratch_workspace(env)
             claude_cwd = scratch_workspace.scratch_dir
         raw_output = run_claude(
-            prompt_file,
+            compose_system_prompt(prompt_file.read_text(encoding="utf-8")),
             phase_task_for_selection(choice, task_envelope, payloads, message=args.message),
             claude_env,
             mode=args.mode,

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -559,5 +559,29 @@ class PrefetchedPRDiffTests(unittest.TestCase):
         self.assertNotIn("diff", payload[0])
 
 
+class RepoMemoryInjectionTests(unittest.TestCase):
+    def test_compose_folds_memory_into_persona(self) -> None:
+        with mock.patch.object(
+            run_contributor, "load_repo_memory", return_value="- Never target bare self-hosted."
+        ):
+            composed = run_contributor.compose_system_prompt("# April Clearwater\n\nYou are April.")
+        self.assertIn("You are April.", composed)
+        self.assertIn("Repository memory (trusted, curated)", composed)
+        self.assertIn("Never target bare self-hosted.", composed)
+        # Memory follows the persona, not the other way around.
+        self.assertLess(composed.index("You are April."), composed.index("Repository memory"))
+
+    def test_compose_is_noop_without_memory(self) -> None:
+        with mock.patch.object(run_contributor, "load_repo_memory", return_value=""):
+            persona = "# April Clearwater\n\nYou are April."
+            self.assertEqual(run_contributor.compose_system_prompt(persona), persona)
+
+    def test_load_repo_memory_missing_file_is_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does-not-exist" / "MEMORY.md"
+            with mock.patch.object(run_contributor, "REPO_MEMORY_PATH", missing):
+                self.assertEqual(run_contributor.load_repo_memory(), "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Scheduled April/Plat runs now fold `.agents/MEMORY.md` into their system prompt. Interactive `/become` sessions already load this memory; the cron contributor runtime (`run-contributor.py`) never did — so the agents that actually write code and open PRs did so without the repo's hard-won rules (CI/runner isolation, terminal-first product rules, release discipline, debugging heuristics) in context. This is the read half of the roadmap's Phase 2.

## Design decision — read side only (deliberate pushback on auto-write)

Phase 2 as written is *"persistent memory... what shipped, what worked, what didn't."* That's two different things, and I'm shipping only the unambiguous one:

- **Read (this PR):** inject the curated memory. Clearly good, low risk — the knowledge is already trusted and CODEOWNERS-gated.
- **Write (not this PR):** `.agents/MEMORY.md` is a *curated* knowledge base — durable architectural rules, hand-maintained. Auto-appending per-run "what I did today" would drown that signal in episodic noise, and a system whose stated goal is *reducing operator noise* should not grow a self-polluting log. Episodic memory wants its own bounded store, a retention policy, and a feedback path into ideation dedup — that's a design, not a one-line append. Deferred with intent, not forgotten.

## Trust boundary preserved

The memory folds into the **trusted** system prompt, not the untrusted GitHub payloads. `.agents/MEMORY.md` is owned by `@fairchild` (CODEOWNERS) and blocked from agent edits by the patch policy, so untrusted PR content can't reach it. `compose_system_prompt` places memory *after* the persona and labels it "context, not instructions that override your task envelope."

## Scope

`run-contributor.py` only — April and Plat, the code-writers, for whom the architectural rules matter most. Injected only at the **action phase** (not the narrow task-selector call). Peter's planner is a natural follow-up via the same helper.

## Verification
- **39 unit tests pass**, including 3 new `RepoMemoryInjectionTests` (folds in, no-op when absent, missing-file safe).
- **End-to-end** against the real files: 1636 bytes of memory fold into April's 11.7 KB persona; the rule *"Never target bare `self-hosted`"* and the section header are present; persona is preserved and comes first.

## Mergeability

- Surface: agent-runtime (contributor runner)
- User-facing behavior changed: No — adds trusted repo memory to April/Plat system prompts; output schema unchanged.
- Non-happy paths considered: Empty or missing MEMORY.md is a no-op (unit-tested); memory folds into the trusted prompt only, never untrusted payloads.
- Residual risk or follow-up: Write/episodic memory deferred by design; extending the same helper to Peter's planner is a follow-up.
- **Scope:** 2 files, one helper + one call-site swap + tests. No output-schema change; the model still produces the same YAML action.
- **Risk:** low. ~1.6 KB added to the action prompt; behavior additive.

## Evidence

![memory-evidence](https://evidence.cloudcompute.com/workspaces/pr-765/20260703-080733-memory-injection.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

