### PR TITLE
docs(gh-discuss): orient agents to the live Issues+labels bus

### DIFF
--- a/.agents/skills/gh-discuss/SKILL.md
+++ b/.agents/skills/gh-discuss/SKILL.md
@@ -12,6 +12,8 @@ description: >
 
 Agents coordinate through GitHub Discussions — a durable, web-visible layer that works across worktrees, sessions, and tools.
 
+> **Orientation — which bus am I on?** The **live execution bus is GitHub Issues + the label taxonomy** (`ready`/`claimed`/`review`/`mergeable`), driven by `sync-execution-state.py` and the managed reviewer. Claim and work issues there — see `docs/agents/triage-labels.md` and `backlog/AGENTS.md`. On **Discussions**, the actively-used flow is the cron team's `[idea]` → owner-👍 → planned-issue pipeline (Peter Planner). The `[task]`/`[claimed:]` claim-and-complete grammar below is a **secondary path for ad-hoc, cross-worktree coordination** — reach for it when work doesn't yet have an issue or spans harnesses; use Issues + labels for the standing execution loop.
+
 ## Script Location
 
 ```bash


### PR DESCRIPTION
## What

Adds a short orientation note to the top of the `gh-discuss` skill so an agent landing there knows **which coordination bus is actually live**.

## Why

A read of the three coordination surfaces found:
- **Issues + label taxonomy** (`ready`/`claimed`/`review`/`mergeable`) is the live execution bus — agent-lane issues are touched daily, driven by `sync-execution-state.py` and the managed reviewer.
- **Discussions** carries the cron team's `[idea]` → owner-👍 → planned-issue pipeline (Peter Planner) — live but narrow.
- The `[task]`/`[claimed:]` claim-and-complete grammar this skill documents has had **no activity for ~5 weeks**; recent Discussions are unrelated chat.

The skill's framing ("Agents coordinate through GitHub Discussions") could send an agent to a quiet bus for work that belongs on Issues. The note fixes the orientation without overclaiming the grammar is dead.

## Scope / restraint

**Additive only** — one blockquote. The CLI, its commands, and the title-prefix mechanics are untouched, because this is inferred from an activity snapshot, not a decision to retire the path. If you intend gh-discuss as dormant-but-supported (vs. abandoned), this note is still correct; if you want it fully retired, that's a follow-up call for you to make.

## Verification
- `test_gh_discuss.py` passes (docs change; script unaffected, but the file is in the `.agents/**` CI path).

## Mergeability

- Surface: docs (.agents/skills/gh-discuss/SKILL.md)
- User-facing behavior changed: No — one additive orientation blockquote.
- Non-happy paths considered: Additive only; the CLI and its mechanics are untouched, so no path regresses. gh-discuss tests still pass.
- Residual risk or follow-up: Whether to fully retire the gh-discuss task grammar (vs. keep it dormant-but-supported) is an owner call, noted in the body.
- One blockquote, docs-only, no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
