### PR TITLE
web-next: Folio design system as React components

### DIFF
--- a/web-next/perf/BASELINE.md
+++ b/web-next/perf/BASELINE.md
@@ -6,7 +6,8 @@ records the measured baseline the budgets were set against. Refresh it (rerun
 tightening any budget.
 
 - **Date:** 2026-07-03
-- **Commit:** `bd30142` (harness PR branch; app surface = Phase 0 spike)
+- **Commit:** `55e3b98` + the Folio design-system change (#745 branch; app
+  surface = Phase 0 spike + `/sessions/demo` Folio session view)
 - **Environment:** Linux dev container, headless Chromium (Playwright),
   production build via `next start` on localhost, 3 runs per scenario
 - **Command:** `pnpm perf` (with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` set,
@@ -14,36 +15,51 @@ tightening any budget.
 
 | Scenario | Metric | Stat | Baseline | Budget | Status |
 |---|---|---|---|---|---|
-| ttft_mock | ttft_ms | median | 713 | 1500 | pass |
+| ttft_mock | ttft_ms | median | 704 | 1500 | pass |
 | streaming_cadence | longest_task_ms | max | 0 | 50 | pass |
-| transcript_render_200 | — | — | — | — | pending (#745/#748) |
-| route_home | lcp_ms | median | 100 | 1200 | pass |
+| transcript_render_200 | initial_render_ms | median | 213.6 | 500 | pass |
+| route_home | lcp_ms | median | 60 | 1200 | pass |
 | route_home | tbt_ms | median | 0 | 200 | pass |
 | route_home | first_load_js_kb | exact | 103.7 | 200 | pass |
-| route_spike | lcp_ms | median | 120 | 1200 | pass |
-| route_spike | tbt_ms | median | 2 | 200 | pass |
+| route_spike | lcp_ms | median | 112 | 1200 | pass |
+| route_spike | tbt_ms | median | 0 | 200 | pass |
 | route_spike | first_load_js_kb | exact | 158.1 | 200 | pass |
+| route_sessions_demo | lcp_ms | median | 112 | 1200 | pass |
+| route_sessions_demo | tbt_ms | median | 0 | 200 | pass |
+| route_sessions_demo | first_load_js_kb | exact | 103.6 | 200 | pass |
 | resume_latency_100 | — | — | — | — | pending (#749) |
 
 Raw samples from the baseline run:
 
 | Scenario | Metric | Samples |
 |---|---|---|
-| ttft_mock | ttft_ms | 745, 713, 708 |
+| ttft_mock | ttft_ms | 715, 704, 693 |
 | streaming_cadence | longest_task_ms | 0, 0, 0 |
-| route_home | lcp_ms | 100, 100, 100 |
-| route_home | tbt_ms | 0, 1, 0 |
-| route_spike | lcp_ms | 120, 112, 128 |
-| route_spike | tbt_ms | 0, 2, 10 |
+| transcript_render_200 | initial_render_ms | 223.4, 213.6, 207.2 |
+| route_home | lcp_ms | 56, 60, 64 |
+| route_home | tbt_ms | 0, 0, 0 |
+| route_spike | lcp_ms | 140, 112, 76 |
+| route_spike | tbt_ms | 1, 0, 0 |
+| route_sessions_demo | lcp_ms | 112, 112, 152 |
+| route_sessions_demo | tbt_ms | 0, 0, 0 |
 
 Reading notes:
 
+- **2026-07-03 (#745):** `transcript_render_200` converted from pending to
+  measured — it loads `/sessions/demo?seed=200` (200 server-rendered fixture
+  messages) and times navigation start → all 200 messages present in a
+  painted frame. First measurement 213.6ms median against the provisional
+  500ms budget, which is now confirmed. `route_sessions_demo` added with the
+  same budgets as `route_spike`; the Folio view server-renders from fixtures,
+  so its client JS (103.6 kB gz) is the shared baseline plus theme/disclosure
+  interactivity — no chat runtime on this route yet (#748 will add it).
 - `ttft_mock` includes ~600ms of scripted provisioning-status delay in the
   mock turn, so real client+server overhead is roughly 110ms of the median.
 - `longest_task_ms` uses the longtask API, which only reports tasks >= 50ms —
   0 means "no long task observed", and any nonzero value exceeds budget.
 - `first_load_js_kb` is gzipped KiB from the build manifests; `next build`
-  reported 106 kB (/) and 161 kB (/spike) for the same build (kB vs KiB).
+  reported 106 kB (/), 161 kB (/spike), and 105 kB (/sessions/demo) for the
+  same build (kB vs KiB).
 - CI (ubuntu-latest) is slower than this container; budgets carry enough
   headroom that route metrics should hold there. If CI runs prove noisy,
   re-baseline from CI numbers rather than widening budgets ad hoc.

--- a/web-next/perf/contract.json
+++ b/web-next/perf/contract.json
@@ -28,9 +28,9 @@
 		},
 		{
 			"id": "transcript_render_200",
-			"status": "pending",
-			"reason": "transcript-at-scale surface lands with the Folio session view (#745/#748); budget is provisional until first measurement",
-			"description": "Seed a session with ~200 messages; initial transcript render stays within budget.",
+			"status": "measured",
+			"description": "Cold production load of /sessions/demo?seed=200 (200 fixture messages, server-rendered); time from navigation start to all 200 messages present in a painted frame.",
+			"route": "/sessions/demo?seed=200",
 			"runs": 3,
 			"metrics": {
 				"initial_render_ms": { "stat": "median", "budget": 500 }
@@ -53,6 +53,18 @@
 			"status": "measured",
 			"description": "Cold production load of /spike (stand-in for /sessions/[id] until it exists): LCP, total blocking time, and first-load JS.",
 			"route": "/spike",
+			"runs": 3,
+			"metrics": {
+				"lcp_ms": { "stat": "median", "budget": 1200 },
+				"tbt_ms": { "stat": "median", "budget": 200 },
+				"first_load_js_kb": { "stat": "exact", "budget": 200 }
+			}
+		},
+		{
+			"id": "route_sessions_demo",
+			"status": "measured",
+			"description": "Cold production load of /sessions/demo (Folio session view on fixture data): LCP, total blocking time, and first-load JS.",
+			"route": "/sessions/demo",
 			"runs": 3,
 			"metrics": {
 				"lcp_ms": { "stat": "median", "budget": 1200 },

--- a/web-next/perf/run.mjs
+++ b/web-next/perf/run.mjs
@@ -175,14 +175,40 @@ async function runRoute(browser, baseUrl, route, runs) {
 	};
 }
 
+// Time from navigation start until every seeded message is present in a
+// painted frame (waitForFunction polls on rAF; performance.now() is relative
+// to navigationStart), on a cold context per run.
+async function runTranscriptRender(browser, baseUrl, route, runs) {
+	const messageCount = Number(new URL(route, baseUrl).searchParams.get("seed"));
+	const samples = [];
+	for (let i = 0; i < runs; i++) {
+		const context = await browser.newContext({ baseURL: baseUrl });
+		const page = await context.newPage();
+		await page.goto(route, { waitUntil: "commit" });
+		await page.waitForFunction(
+			(count) =>
+				document.querySelectorAll("[data-message-role]").length >= count,
+			messageCount,
+			{ timeout: TURN_TIMEOUT_MS },
+		);
+		samples.push(await page.evaluate(() => performance.now()));
+		await context.close();
+	}
+	return { initial_render_ms: samples };
+}
+
 const SCENARIO_RUNNERS = {
 	ttft_mock: (browser, baseUrl, scenario) =>
 		runTtftMock(browser, baseUrl, scenario.runs),
 	streaming_cadence: (browser, baseUrl, scenario) =>
 		runStreamingCadence(browser, baseUrl, scenario.runs),
+	transcript_render_200: (browser, baseUrl, scenario) =>
+		runTranscriptRender(browser, baseUrl, scenario.route, scenario.runs),
 	route_home: (browser, baseUrl, scenario) =>
 		runRoute(browser, baseUrl, scenario.route, scenario.runs),
 	route_spike: (browser, baseUrl, scenario) =>
+		runRoute(browser, baseUrl, scenario.route, scenario.runs),
+	route_sessions_demo: (browser, baseUrl, scenario) =>
 		runRoute(browser, baseUrl, scenario.route, scenario.runs),
 };
 

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -1,10 +1,12 @@
 /*
- * Evidence capture: screenshots of / and /spike in both color schemes
- * (light + dark), with /spike captured after a full streamed mock turn.
- * Output goes to output/evidence/ (gitignored); CI uploads it as an
- * artifact — the sanctioned publish path per docs/development/remote-sessions.md.
- * The app is dark-only today, so the light captures record current reality.
+ * Evidence capture: screenshots of /, /spike (after a full streamed mock
+ * turn), and the Folio session demo (/sessions/demo) in both themes —
+ * plus the refine-folio prototype itself, captured beside the demo for
+ * pixel comparison. Output goes to output/evidence/ (gitignored); CI
+ * uploads it as an artifact — the sanctioned publish path per
+ * docs/development/remote-sessions.md.
  */
+import { execFileSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
 import {
@@ -16,6 +18,12 @@ import {
 const OUTPUT_DIR = path.join(WEB_NEXT_ROOT, "output", "evidence");
 const PORT = Number(process.env.EVIDENCE_PORT ?? 3100);
 const TURN_TIMEOUT_MS = 20_000;
+// Entry animations (rise/settle) finish ~1.1s after load; let them land.
+const ANIMATION_SETTLE_MS = 1500;
+const PROTOTYPE_PATH = path.resolve(
+	WEB_NEXT_ROOT,
+	"../prototypes/web-session-redesign/refine-folio.html",
+);
 
 async function captureHome(page, file) {
 	await page.goto("/", { waitUntil: "networkidle" });
@@ -48,24 +56,92 @@ async function captureSpikeAfterTurn(page, file) {
 	await page.screenshot({ path: file });
 }
 
+async function captureSessionsDemo(page, file) {
+	await page.goto("/sessions/demo", { waitUntil: "networkidle" });
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: file });
+}
+
+// --- prototype capture -------------------------------------------------------
+// The prototype loads Newsreader/IBM Plex Mono from Google Fonts; headless
+// Chromium in sandboxes has no direct egress, so font requests are fulfilled
+// through curl (which honors the agent proxy + CA bundle).
+
+const fontCache = new Map();
+
+function fetchFontResource(url, userAgent) {
+	if (!fontCache.has(url)) {
+		fontCache.set(
+			url,
+			execFileSync(
+				"curl",
+				["-sS", "--fail", "--max-time", "30", "-A", userAgent, url],
+				{ maxBuffer: 64 * 1024 * 1024 },
+			),
+		);
+	}
+	return fontCache.get(url);
+}
+
+export async function routeFontsThroughCurl(context) {
+	await context.route(
+		(url) =>
+			url.hostname === "fonts.googleapis.com" ||
+			url.hostname === "fonts.gstatic.com",
+		async (route) => {
+			const request = route.request();
+			try {
+				const body = fetchFontResource(
+					request.url(),
+					request.headers()["user-agent"] ?? "Mozilla/5.0",
+				);
+				await route.fulfill({
+					body,
+					contentType: request.url().includes("googleapis")
+						? "text/css"
+						: "font/woff2",
+				});
+			} catch {
+				await route.abort();
+			}
+		},
+	);
+}
+
+async function capturePrototype(page, theme, file) {
+	await page.goto(`file://${PROTOTYPE_PATH}#${theme}`, {
+		waitUntil: "networkidle",
+	});
+	await page.evaluate(() => document.fonts.ready);
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: file });
+}
+
 async function main() {
 	mkdirSync(OUTPUT_DIR, { recursive: true });
 	const server = await startProductionServer(PORT);
 	const browser = await launchChromium();
 	try {
 		for (const colorScheme of ["light", "dark"]) {
+			// colorScheme emulation drives the app theme (system preference is
+			// the default resolution); the prototype is forced via its hash.
 			const context = await browser.newContext({
 				baseURL: server.baseUrl,
 				colorScheme,
 				viewport: { width: 1280, height: 800 },
 				deviceScaleFactor: 2,
 			});
+			await routeFontsThroughCurl(context);
 			const page = await context.newPage();
 			const shot = (name) => path.join(OUTPUT_DIR, `${name}-${colorScheme}.png`);
 			await captureHome(page, shot("home"));
 			await captureSpikeAfterTurn(page, shot("spike"));
+			await captureSessionsDemo(page, shot("sessions-demo"));
+			await capturePrototype(page, colorScheme, shot("prototype-folio"));
 			await context.close();
-			console.log(`captured home + spike (${colorScheme})`);
+			console.log(
+				`captured home + spike + sessions-demo + prototype (${colorScheme})`,
+			);
 		}
 	} finally {
 		await browser.close();

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -1,89 +1,258 @@
 /*
- * Spaces design tokens on Tailwind v4. Same palette/typography as the legacy
- * web/ app (mint on deep navy, Instrument Serif + JetBrains Mono); CRT
- * overlays kept but softened so long transcripts stay readable.
+ * Folio design tokens on Tailwind v4 — the "Refined Folio" system from
+ * prototypes/web-session-redesign/refine-folio.html: paper light theme +
+ * warm-charcoal dark, Newsreader serif prose, IBM Plex Mono apparatus.
+ * Palettes live on :root[data-theme=...]; `@theme inline` maps them to
+ * Tailwind tokens so utilities follow the active theme attribute.
  */
 @import "tailwindcss";
 
+/* Theme is a data attribute (set pre-paint by themeInitScript), not the
+   OS scheme — system preference only feeds the initial resolution. */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+:root {
+	--paper: #f7f4ed;
+	--raised: #fdfbf6;
+	--ink: #26221a;
+	--muted: #7a7261;
+	--faint: #aca492;
+	--line: #e7e1d2;
+	--line-strong: #dcd3bf;
+	--accent: #a15c31;
+	--live: #6e9c72;
+	--live-halo: rgba(110, 156, 114, 0.14);
+	--add-bg: #ecf2e6;
+	--add-ink: #3e6b36;
+	--del-bg: #f6ebe5;
+	--del-ink: #9a4b33;
+	--del-strike: rgba(154, 75, 51, 0.35);
+	--code-bg: rgba(38, 34, 26, 0.05);
+	--sel: #ebdfc8;
+	--user-ink: #3b362b;
+	--item-ink: #4a4436;
+	--mast-bg: rgba(247, 244, 237, 0.88);
+	--paper-0: rgba(247, 244, 237, 0);
+	--hover-bg: #f3eddf;
+	--selected-bg: #f1eada;
+	--scrim: rgba(56, 49, 36, 0.14);
+	--status-bg: #f1ede0;
+	--card-shadow:
+		0 1px 2px rgba(60, 50, 30, 0.05), 0 12px 32px -24px rgba(60, 50, 30, 0.25);
+	--palette-shadow:
+		0 40px 90px -24px rgba(48, 40, 24, 0.4), 0 2px 6px rgba(48, 40, 24, 0.08);
+	--field-shadow:
+		0 1px 2px rgba(60, 50, 30, 0.05), 0 14px 34px -26px rgba(60, 50, 30, 0.35);
+	--focus-line: #c08b60;
+	--focus-ring: rgba(161, 92, 49, 0.09);
+	--send-ink: #f7f4ed;
+}
+
+/* The dark room: warm charcoal, lamplight accent. */
+:root[data-theme="dark"] {
+	--paper: #161410;
+	--raised: #211e18;
+	--ink: #eae4d6;
+	--muted: #a79e8c;
+	--faint: #837a69;
+	--line: rgba(234, 222, 196, 0.1);
+	--line-strong: rgba(234, 222, 196, 0.2);
+	--accent: #d89a62;
+	--live: #93bd82;
+	--live-halo: rgba(147, 189, 130, 0.12);
+	--add-bg: rgba(147, 189, 130, 0.11);
+	--add-ink: #a9c896;
+	--del-bg: rgba(207, 133, 112, 0.11);
+	--del-ink: #ce9480;
+	--del-strike: rgba(206, 148, 128, 0.4);
+	--code-bg: rgba(234, 222, 196, 0.08);
+	--sel: rgba(216, 154, 98, 0.3);
+	--user-ink: #d8d0be;
+	--item-ink: #cfc7b5;
+	--mast-bg: rgba(22, 20, 16, 0.86);
+	--paper-0: rgba(22, 20, 16, 0);
+	--hover-bg: rgba(234, 222, 196, 0.05);
+	--selected-bg: rgba(234, 222, 196, 0.08);
+	--scrim: rgba(0, 0, 0, 0.5);
+	--status-bg: #1b1913;
+	--card-shadow:
+		0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 40px -26px rgba(0, 0, 0, 0.7);
+	--palette-shadow:
+		0 40px 90px -24px rgba(0, 0, 0, 0.75), 0 2px 6px rgba(0, 0, 0, 0.3);
+	--field-shadow:
+		0 1px 2px rgba(0, 0, 0, 0.25), 0 16px 38px -26px rgba(0, 0, 0, 0.7);
+	--focus-line: rgba(216, 154, 98, 0.55);
+	--focus-ring: rgba(216, 154, 98, 0.1);
+	--send-ink: #1c160c;
+}
+
+@theme inline {
+	--color-paper: var(--paper);
+	--color-raised: var(--raised);
+	--color-ink: var(--ink);
+	--color-muted: var(--muted);
+	--color-faint: var(--faint);
+	--color-line: var(--line);
+	--color-line-strong: var(--line-strong);
+	--color-accent: var(--accent);
+	--color-live: var(--live);
+	--color-live-halo: var(--live-halo);
+	--color-add-bg: var(--add-bg);
+	--color-add-ink: var(--add-ink);
+	--color-del-bg: var(--del-bg);
+	--color-del-ink: var(--del-ink);
+	--color-del-strike: var(--del-strike);
+	--color-code-bg: var(--code-bg);
+	--color-sel: var(--sel);
+	--color-user-ink: var(--user-ink);
+	--color-item-ink: var(--item-ink);
+	--color-mast-bg: var(--mast-bg);
+	--color-paper-0: var(--paper-0);
+	--color-hover-bg: var(--hover-bg);
+	--color-selected-bg: var(--selected-bg);
+	--color-scrim: var(--scrim);
+	--color-status-bg: var(--status-bg);
+	--color-focus-line: var(--focus-line);
+	--color-focus-ring: var(--focus-ring);
+	--color-send-ink: var(--send-ink);
+
+	--shadow-card: var(--card-shadow);
+	--shadow-palette: var(--palette-shadow);
+	--shadow-field: var(--field-shadow);
+}
+
 @theme {
-	--color-canvas: #0e1117;
-	--color-surface: #141821;
-	--color-elevated: #1a1f2e;
-	--color-edge: #242a3a;
-	--color-edge-subtle: #1c2233;
-	--color-ink: #d4dae8;
-	--color-ink-muted: #5a6580;
-	--color-ink-faint: #3a4258;
-	--color-mint: #a6ffdf;
-	--color-mint-dim: rgba(166, 255, 223, 0.06);
-	--color-mint-glow: rgba(166, 255, 223, 0.12);
-	--color-mint-muted: rgba(166, 255, 223, 0.25);
+	/* The next/font variables must be defined on <html> (see layout.tsx):
+	   these tokens are substituted at :root, where a <body>-scoped variable
+	   would be invisible and the whole token would go invalid. */
+	--font-serif: var(--font-newsreader), "Iowan Old Style", Georgia, serif;
+	--font-mono: var(--font-plex-mono), ui-monospace, "SF Mono", monospace;
 
-	--font-display: var(--font-instrument-serif), serif;
-	--font-mono: var(--font-jetbrains-mono), monospace;
-}
+	/* Type scale (from the prototype, largest to smallest). */
+	--text-body: 17.5px;
+	--text-body--line-height: 1.72;
+	--text-compose: 17px;
+	--text-title: 13.5px; /* masthead center title, serif italic */
+	--text-tool: 13px; /* ledger rows, diff body */
+	--text-code: 12.5px; /* expanded step bodies */
+	--text-code--line-height: 1.75;
+	--text-caption: 12px; /* diff-card caption, ledger meta */
+	--text-masthead: 11.5px;
+	--text-stat: 11px; /* turn stats, status line */
+	--text-label: 10.5px; /* message author labels */
 
-html,
-body {
-	height: 100%;
-	background: var(--color-canvas);
-	color: var(--color-ink);
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
+	--animate-rise: rise 0.55s ease both;
+	--animate-rise-fast: rise 0.3s ease both;
+	--animate-settle: settle 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) both 0.35s;
+	--animate-breathe: breathe 2.2s ease-in-out infinite;
+	--animate-breathe-fast: breathe 1.4s ease-in-out infinite;
 
-body {
-	font-family: var(--font-mono);
-}
-
-/* Noise texture overlay (softer than legacy: 0.015 vs 0.025) */
-body::before {
-	content: "";
-	position: fixed;
-	inset: 0;
-	opacity: 0.015;
-	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='256' height='256' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
-	background-repeat: repeat;
-	background-size: 256px 256px;
-	pointer-events: none;
-	z-index: 1;
-}
-
-a {
-	transition: color 0.2s ease;
-}
-
-@keyframes blink {
-	0%,
-	100% {
-		opacity: 1;
+	@keyframes rise {
+		from {
+			opacity: 0;
+			transform: translateY(10px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
 	}
-	50% {
-		opacity: 0;
+	@keyframes settle {
+		from {
+			opacity: 0;
+			transform: translateY(14px) scale(0.99);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+		}
 	}
-}
-
-@keyframes pulse {
-	0%,
-	100% {
-		box-shadow:
-			0 0 0 0 rgba(166, 255, 223, 0.4),
-			0 0 4px 1px rgba(166, 255, 223, 0.15);
-	}
-	50% {
-		box-shadow:
-			0 0 0 4px rgba(166, 255, 223, 0),
-			0 0 8px 2px rgba(166, 255, 223, 0.08);
+	@keyframes breathe {
+		0%,
+		100% {
+			opacity: 0.35;
+			transform: scale(0.85);
+		}
+		50% {
+			opacity: 1;
+			transform: scale(1);
+		}
 	}
 }
 
-@keyframes fadeIn {
-	from {
-		opacity: 0;
-		transform: translateY(8px);
+@layer base {
+	html {
+		-webkit-font-smoothing: antialiased;
+		text-rendering: optimizeLegibility;
 	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
+
+	body {
+		background: var(--paper);
+		color: var(--ink);
+		font-family: var(--font-serif);
+		font-size: 17.5px;
+		line-height: 1.72;
+		font-optical-sizing: auto;
+		transition:
+			background-color 0.25s ease,
+			color 0.25s ease;
+	}
+
+	:root[data-theme="dark"] body {
+		background:
+			radial-gradient(
+				1100px 560px at 76% -6%,
+				rgba(216, 154, 98, 0.05),
+				transparent 62%
+			),
+			var(--paper);
+	}
+
+	::selection {
+		background: var(--sel);
+	}
+
+	button {
+		cursor: pointer;
+	}
+
+	code {
+		font-family: var(--font-mono);
+		font-size: 0.82em;
+		background: var(--code-bg);
+		padding: 1px 5px 2px;
+		border-radius: 4px;
+	}
+}
+
+@layer components {
+	/* Animated trailing dots ('' → . → .. → …); content keyframes can't be
+	   expressed as a Tailwind utility. */
+	.ellipsis-dots::after {
+		content: "…";
+		animation: ellip 1.8s steps(4) infinite;
+	}
+	@keyframes ellip {
+		0% {
+			content: "";
+		}
+		25% {
+			content: ".";
+		}
+		50% {
+			content: "..";
+		}
+		75% {
+			content: "…";
+		}
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation: none !important;
+		transition: none !important;
 	}
 }

--- a/web-next/src/app/layout.tsx
+++ b/web-next/src/app/layout.tsx
@@ -1,17 +1,20 @@
 import type { Metadata } from "next";
-import { Instrument_Serif, JetBrains_Mono } from "next/font/google";
+import { IBM_Plex_Mono, Newsreader } from "next/font/google";
+import { themeInitScript } from "@/lib/theme";
 import "./globals.css";
 
-const instrumentSerif = Instrument_Serif({
-	weight: "400",
-	style: ["normal", "italic"],
+const newsreader = Newsreader({
 	subsets: ["latin"],
-	variable: "--font-instrument-serif",
+	style: ["normal", "italic"],
+	axes: ["opsz"],
+	variable: "--font-newsreader",
 });
 
-const jetbrainsMono = JetBrains_Mono({
+const plexMono = IBM_Plex_Mono({
 	subsets: ["latin"],
-	variable: "--font-jetbrains-mono",
+	weight: ["400", "500"],
+	style: ["normal", "italic"],
+	variable: "--font-plex-mono",
 });
 
 export const metadata: Metadata = {
@@ -22,11 +25,20 @@ export const metadata: Metadata = {
 export default function RootLayout({
 	children,
 }: Readonly<{ children: React.ReactNode }>) {
+	// data-theme is rewritten pre-paint by themeInitScript (hash > stored
+	// choice > system preference), so the server-rendered value is only a
+	// no-JS fallback — hence suppressHydrationWarning.
+	// Font variables live on <html>: the @theme font tokens reference them
+	// from :root, where a <body>-scoped variable would be invisible.
 	return (
-		<html lang="en">
-			<body
-				className={`${instrumentSerif.variable} ${jetbrainsMono.variable}`}
-			>
+		<html
+			lang="en"
+			data-theme="light"
+			suppressHydrationWarning
+			className={`${newsreader.variable} ${plexMono.variable}`}
+		>
+			<body>
+				<script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
 				{children}
 			</body>
 		</html>

--- a/web-next/src/app/page.tsx
+++ b/web-next/src/app/page.tsx
@@ -3,16 +3,24 @@ import Link from "next/link";
 export default function Home() {
 	return (
 		<main className="flex h-screen flex-col items-center justify-center gap-6">
-			<h1 className="font-display text-5xl italic text-mint">Spaces</h1>
-			<p className="text-sm text-ink-muted">
+			<h1 className="font-serif text-5xl italic">Spaces</h1>
+			<p className="font-mono text-[13px] text-muted">
 				Coding sessions in the browser — greenfield rewrite in progress.
 			</p>
-			<Link
-				href="/spike"
-				className="border border-edge px-4 py-2 text-sm text-ink-muted hover:border-mint-muted hover:text-mint"
-			>
-				&gt; Phase 0 transcript spike
-			</Link>
+			<nav className="flex gap-3 font-mono text-[13px]">
+				<Link
+					href="/sessions/demo"
+					className="rounded-md border border-line-strong px-4 py-2 text-muted transition-colors hover:border-accent hover:text-accent"
+				>
+					Folio session demo
+				</Link>
+				<Link
+					href="/spike"
+					className="rounded-md border border-line-strong px-4 py-2 text-muted transition-colors hover:border-accent hover:text-accent"
+				>
+					&gt; Phase 0 transcript spike
+				</Link>
+			</nav>
 		</main>
 	);
 }

--- a/web-next/src/app/sessions/demo/page.tsx
+++ b/web-next/src/app/sessions/demo/page.tsx
@@ -1,0 +1,21 @@
+/*
+ * /sessions/demo — the Folio design system rendered from fixture data, no
+ * backend. `?seed=<n>` swaps in a generated n-message transcript for the
+ * transcript_render_200 perf scenario.
+ */
+import { SessionView } from "@/components/folio/session-view";
+import { demoSession, seededDemoSession } from "@/lib/fixtures/demo-session";
+
+export default async function DemoSessionPage({
+	searchParams,
+}: {
+	searchParams: Promise<{ seed?: string }>;
+}) {
+	const { seed } = await searchParams;
+	const seedCount = Number(seed);
+	const session =
+		Number.isInteger(seedCount) && seedCount > 0
+			? seededDemoSession(seedCount)
+			: demoSession();
+	return <SessionView session={session} />;
+}

--- a/web-next/src/app/spike/page.tsx
+++ b/web-next/src/app/spike/page.tsx
@@ -2,8 +2,8 @@
 
 /*
  * Phase 0 spike: proves StreamChunk → UIMessageChunk → useChat end-to-end —
- * streamed text parts, dynamic tool cards, and transient status — rendered
- * in the Spaces skin. Throwaway page; the real session view replaces it.
+ * streamed text parts, dynamic tool cards, and transient status — on the
+ * Folio tokens. Throwaway page; the real session view replaces it.
  */
 import { useChat } from "@ai-sdk/react";
 import {
@@ -22,33 +22,33 @@ function ToolCard({ part }: { part: DynamicToolUIPart }) {
 		<div
 			data-testid="tool-card"
 			data-tool={part.toolName}
-			className="my-2 border border-edge bg-surface text-xs"
+			className="my-2 border border-line-strong bg-raised text-xs"
 		>
-			<div className="flex items-center gap-2 border-b border-edge-subtle px-3 py-1.5">
+			<div className="flex items-center gap-2 border-b border-line px-3 py-1.5">
 				<span
 					className={`inline-block h-1.5 w-1.5 rounded-full ${
-						failed ? "bg-red-400" : running ? "animate-pulse bg-mint" : "bg-mint-muted"
+						failed ? "bg-red-400" : running ? "animate-pulse bg-accent" : "bg-faint"
 					}`}
 				/>
-				<span className="text-mint">{part.toolName}</span>
-				{running && <span className="text-ink-faint">running…</span>}
+				<span className="text-accent">{part.toolName}</span>
+				{running && <span className="text-faint">running…</span>}
 			</div>
 			{part.input !== undefined && (
-				<pre className="overflow-x-auto px-3 py-2 text-ink-muted">
+				<pre className="overflow-x-auto px-3 py-2 text-muted">
 					{typeof part.input === "string"
 						? part.input
 						: JSON.stringify(part.input, null, 2)}
 				</pre>
 			)}
 			{part.state === "output-available" && (
-				<pre className="overflow-x-auto border-t border-edge-subtle px-3 py-2 text-ink">
+				<pre className="overflow-x-auto border-t border-line px-3 py-2 text-ink">
 					{typeof part.output === "string"
 						? part.output
 						: JSON.stringify(part.output, null, 2)}
 				</pre>
 			)}
 			{failed && (
-				<pre className="overflow-x-auto border-t border-edge-subtle px-3 py-2 text-red-400">
+				<pre className="overflow-x-auto border-t border-line px-3 py-2 text-red-400">
 					{part.errorText}
 				</pre>
 			)}
@@ -61,9 +61,9 @@ function Message({ message }: { message: UIMessage }) {
 	return (
 		<div
 			data-message-role={isUser ? "user" : "assistant"}
-			className="animate-[fadeIn_0.3s_ease]"
+			className="animate-rise-fast"
 		>
-			<div className={`mb-1 text-xs ${isUser ? "text-ink-muted" : "text-mint"}`}>
+			<div className={`mb-1 text-xs ${isUser ? "text-muted" : "text-accent"}`}>
 				{isUser ? "you" : "agent"}
 			</div>
 			<div className="text-sm leading-relaxed">
@@ -104,15 +104,15 @@ export default function SpikePage() {
 
 	return (
 		<main className="mx-auto flex h-screen max-w-3xl flex-col px-6">
-			<header className="flex items-baseline gap-3 border-b border-edge-subtle py-4">
-				<h1 className="font-display text-2xl italic text-mint">Spaces</h1>
-				<span className="text-xs text-ink-faint">
+			<header className="flex items-baseline gap-3 border-b border-line py-4">
+				<h1 className="font-serif text-2xl italic text-accent">Spaces</h1>
+				<span className="text-xs text-faint">
 					phase 0 spike — mock provider through the chunk adapter
 				</span>
 			</header>
 			<div className="flex-1 space-y-6 overflow-y-auto py-6">
 				{messages.length === 0 && (
-					<p className="text-sm text-ink-faint">
+					<p className="text-sm text-faint">
 						Send a message to stream a simulated coding turn.
 					</p>
 				)}
@@ -120,14 +120,14 @@ export default function SpikePage() {
 					<Message key={m.id} message={m} />
 				))}
 				{visibleStatus && (
-					<div className="flex items-center gap-2 text-xs text-ink-muted">
-						<span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-mint" />
+					<div className="flex items-center gap-2 text-xs text-muted">
+						<span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
 						{visibleStatus}
 					</div>
 				)}
 			</div>
 			<form
-				className="flex gap-2 border-t border-edge-subtle py-4"
+				className="flex gap-2 border-t border-line py-4"
 				onSubmit={(e) => {
 					e.preventDefault();
 					if (!input.trim() || busy) return;
@@ -136,7 +136,7 @@ export default function SpikePage() {
 				}}
 			>
 				<input
-					className="flex-1 border border-edge bg-surface px-3 py-2 text-sm text-ink outline-none placeholder:text-ink-faint focus:border-mint-muted"
+					className="flex-1 border border-line-strong bg-raised px-3 py-2 text-sm text-ink outline-none placeholder:text-faint focus:border-focus-line"
 					value={input}
 					onChange={(e) => setInput(e.target.value)}
 					placeholder="Ask the agent to fix something…"
@@ -144,7 +144,7 @@ export default function SpikePage() {
 				<button
 					type="submit"
 					disabled={busy}
-					className="border border-edge px-4 py-2 text-sm text-mint disabled:opacity-40"
+					className="border border-line-strong px-4 py-2 text-sm text-accent disabled:opacity-40"
 				>
 					{busy ? "streaming…" : "send"}
 				</button>

--- a/web-next/src/components/folio/activity-line.tsx
+++ b/web-next/src/components/folio/activity-line.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/*
+ * In-progress turn: one quiet breathing line naming the current action,
+ * with a hover-revealed "details" peek that discloses the live step list.
+ * Expects to sit inside a `group` message shell (peek shows on hover).
+ */
+import { useState } from "react";
+import { InlineMarkdown } from "./inline-markdown";
+
+export interface ActivityDetailRow {
+	state: "done" | "current";
+	text: string;
+}
+
+export interface ActivityLineProps {
+	/** Current action, inline-markdown (e.g. "Editing `src/session.ts`"). */
+	action: string;
+	details?: ActivityDetailRow[];
+}
+
+export function ActivityLine({ action, details }: ActivityLineProps) {
+	const [showDetails, setShowDetails] = useState(false);
+	return (
+		<div data-testid="activity-line">
+			<div className="flex items-center gap-3 font-mono text-[13.5px] text-muted">
+				<span className="animate-breathe h-2 w-2 rounded-full bg-accent" />
+				<span className="[&_code]:bg-transparent [&_code]:p-0 [&_code]:text-[13px] [&_code]:text-ink">
+					<InlineMarkdown text={action} />
+					<span className="ellipsis-dots" />
+				</span>
+				{details !== undefined && details.length > 0 && (
+					<button
+						type="button"
+						onClick={() => setShowDetails((current) => !current)}
+						className="ml-auto border-b border-transparent pb-px font-mono text-masthead tracking-[.06em] text-faint opacity-0 transition-opacity duration-[.25s] group-hover:opacity-100 hover:border-accent hover:text-accent"
+					>
+						details
+					</button>
+				)}
+			</div>
+			{showDetails && details !== undefined && (
+				<div className="mt-3.5 ml-5" data-testid="activity-detail">
+					{details.map((row, i) => (
+						<div
+							key={i}
+							className={`flex gap-2.5 py-[3px] font-mono text-code ${row.state === "current" ? "text-muted" : "text-faint"}`}
+						>
+							{row.state === "current" ? (
+								<span className="animate-breathe-fast text-accent">▍</span>
+							) : (
+								<span>✓</span>
+							)}
+							<span>{row.text}</span>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/*
+ * Compose: a field with presence — autofocused on load, no placeholder or
+ * hint chips, the whole field a click target, the send affordance warming
+ * up only while focused. Sits over a paper gradient so the transcript
+ * fades out beneath it.
+ */
+import { useEffect, useRef, useState } from "react";
+
+export interface ComposeFieldProps {
+	/** Names the reply target for assistive tech ("Reply to Claude"). */
+	agentName: string;
+	onSend?: (text: string) => void;
+}
+
+export function ComposeField({ agentName, onSend }: ComposeFieldProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [text, setText] = useState("");
+
+	// autoFocus covers the initial render; this covers remounts after
+	// client-side navigation where the attribute is ignored.
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, []);
+
+	const submit = () => {
+		const trimmed = text.trim();
+		if (trimmed.length === 0) return;
+		onSend?.(trimmed);
+		setText("");
+	};
+
+	return (
+		<div className="bg-[linear-gradient(to_top,var(--paper)_66%,var(--paper-0))] px-5 pt-11 pb-5">
+			<div
+				className="group mx-auto flex min-h-[54px] max-w-[680px] cursor-text items-center gap-[13px] rounded-[13px] border border-line-strong bg-raised py-2 pr-2 pl-[19px] shadow-field transition-[border-color,box-shadow] duration-200 hover:border-focus-line focus-within:border-focus-line focus-within:shadow-[0_0_0_3px_var(--focus-ring),var(--field-shadow)]"
+				onClick={(event) => {
+					if (!(event.target as HTMLElement).closest("button"))
+						inputRef.current?.focus();
+				}}
+			>
+				<span className="font-mono text-[15px] text-accent">›</span>
+				<input
+					ref={inputRef}
+					type="text"
+					autoFocus
+					aria-label={`Reply to ${agentName}`}
+					value={text}
+					onChange={(event) => setText(event.target.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") submit();
+					}}
+					className="min-w-0 flex-1 border-none bg-transparent font-serif text-compose text-ink outline-none"
+				/>
+				<button
+					type="button"
+					title="Send"
+					aria-label="Send"
+					onClick={submit}
+					className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent"
+				>
+					↑
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/web-next/src/components/folio/diff-card.tsx
+++ b/web-next/src/components/folio/diff-card.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/*
+ * Contextual diff card: a landed edit surfaces as a raised, dismissible
+ * figure — file + delta caption, then the hunk with add/del washes.
+ * Takes structured DiffCardData; #748 maps real Edit results onto it.
+ */
+import { useState } from "react";
+import type { DiffCardData, DiffLine } from "./types";
+
+const LINE_CLASS: Record<DiffLine["kind"], string> = {
+	context: "",
+	add: "bg-add-bg text-add-ink",
+	del: "bg-del-bg text-del-ink line-through [text-decoration-color:var(--del-strike)]",
+};
+
+export function DiffCard({ diff }: { diff: DiffCardData }) {
+	const [dismissed, setDismissed] = useState(false);
+	if (dismissed) return null;
+	return (
+		<figure
+			data-testid="diff-card"
+			className="group/landed animate-settle my-[30px] overflow-hidden rounded-xl border border-line bg-raised shadow-card"
+		>
+			<figcaption className="flex items-baseline gap-3 border-b border-line px-[18px] py-[11px] font-mono text-caption text-muted">
+				<span className="font-medium text-ink">{diff.file}</span>
+				<span>
+					<span className="text-add-ink">+{diff.additions}</span>
+					<span className="ml-1.5 text-del-ink">−{diff.deletions}</span>
+				</span>
+				{diff.note !== undefined && (
+					<span className="ml-auto font-serif text-[12.5px] italic text-faint">
+						{diff.note}
+					</span>
+				)}
+				<button
+					type="button"
+					title="Dismiss"
+					aria-label="Dismiss diff card"
+					onClick={() => setDismissed(true)}
+					className={`pl-2.5 text-[13px] leading-none text-faint opacity-0 transition-opacity duration-200 group-hover/landed:opacity-100 hover:text-ink ${diff.note === undefined ? "ml-auto" : ""}`}
+				>
+					✕
+				</button>
+			</figcaption>
+			<pre className="overflow-x-auto py-3 font-mono text-tool leading-[1.7]">
+				{diff.lines.map((line, i) => (
+					<span
+						key={i}
+						className={`block px-[18px] py-px whitespace-pre text-muted ${LINE_CLASS[line.kind]}`}
+					>
+						{line.text}
+					</span>
+				))}
+			</pre>
+		</figure>
+	);
+}

--- a/web-next/src/components/folio/inline-markdown.tsx
+++ b/web-next/src/components/folio/inline-markdown.tsx
@@ -1,0 +1,14 @@
+/*
+ * Renders Folio inline markdown (`code` spans, *emphasis*) as elements.
+ * Parsing lives in parse-inline.ts.
+ */
+import type { ReactNode } from "react";
+import { parseInline } from "./parse-inline";
+
+export function InlineMarkdown({ text }: { text: string }): ReactNode {
+	return parseInline(text).map((token, i) => {
+		if (token.kind === "code") return <code key={i}>{token.text}</code>;
+		if (token.kind === "em") return <em key={i}>{token.text}</em>;
+		return token.text;
+	});
+}

--- a/web-next/src/components/folio/ledger.test.ts
+++ b/web-next/src/components/folio/ledger.test.ts
@@ -1,0 +1,148 @@
+import type { DynamicToolUIPart } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+	describeToolPart,
+	formatTurnStats,
+	highlightTestOutput,
+	parseTestSummary,
+} from "./ledger";
+
+function toolPart(overrides: Partial<DynamicToolUIPart>): DynamicToolUIPart {
+	return {
+		type: "dynamic-tool",
+		toolCallId: "tool-1",
+		toolName: "Read",
+		state: "output-available",
+		input: {},
+		output: "",
+		...overrides,
+	} as DynamicToolUIPart;
+}
+
+describe("describeToolPart", () => {
+	it("renders Read with a file subject and an explicit summary", () => {
+		const row = describeToolPart(
+			toolPart({
+				input: { file_path: "src/session/session.test.ts" },
+				output: { content: "it(...)", summary: "41 lines" },
+			}),
+		);
+		expect(row).toMatchObject({
+			verb: "Read",
+			subject: "src/session/session.test.ts",
+			meta: { kind: "text", text: "41 lines" },
+			body: { kind: "code", content: "it(...)" },
+		});
+	});
+
+	it("falls back to a line count for Read without a summary", () => {
+		const row = describeToolPart(
+			toolPart({ input: { file_path: "a.ts" }, output: "one\ntwo\nthree" }),
+		);
+		expect(row.meta).toEqual({ kind: "text", text: "3 lines" });
+	});
+
+	it("derives an Edit delta from old/new strings", () => {
+		const row = describeToolPart(
+			toolPart({
+				toolName: "Edit",
+				input: {
+					file_path: "src/session/resume.ts",
+					old_string: "return hydrate(record);",
+					new_string: "if (!record) {\n\tthrow e;\n}\nreturn hydrate(record);",
+				},
+				output: "guard added",
+			}),
+		);
+		expect(row.verb).toBe("Edit");
+		expect(row.meta).toEqual({ kind: "delta", additions: 4, deletions: 1 });
+	});
+
+	it("recognizes a passing test run and summarizes it", () => {
+		const output = [
+			"✓ src/a.test.ts (6 tests) 128ms",
+			"",
+			"Test Files  3 passed (3)",
+			"     Tests  28 passed (28)",
+			"  Duration  1.21s",
+		].join("\n");
+		const row = describeToolPart(
+			toolPart({ toolName: "Bash", input: { command: "pnpm test" }, output }),
+		);
+		expect(row.verb).toBe("Ran");
+		expect(row.subject).toBe("pnpm test");
+		expect(row.meta).toEqual({ kind: "text", text: "28 passed · 1.21s" });
+		expect(row.body).toMatchObject({ kind: "test-output", passed: true });
+	});
+
+	it("marks failed tool calls", () => {
+		const row = describeToolPart(
+			toolPart({
+				state: "output-error",
+				errorText: "boom",
+				output: undefined,
+			} as Partial<DynamicToolUIPart>),
+		);
+		expect(row.meta).toEqual({ kind: "text", text: "failed" });
+		expect(row.body).toEqual({ kind: "code", content: "boom" });
+	});
+
+	it("omits body and meta while a call is still running", () => {
+		const row = describeToolPart(
+			toolPart({
+				state: "input-available",
+				input: { command: "pnpm test" },
+				toolName: "Bash",
+				output: undefined,
+			} as Partial<DynamicToolUIPart>),
+		);
+		expect(row).toEqual({ verb: "Ran", subject: "pnpm test" });
+	});
+});
+
+describe("parseTestSummary", () => {
+	it("takes the final passed count and the Duration line", () => {
+		expect(
+			parseTestSummary("Test Files 3 passed (3)\nTests 28 passed (28)\nDuration 1.21s"),
+		).toBe("28 passed · 1.21s");
+	});
+
+	it("returns undefined for non-test output", () => {
+		expect(parseTestSummary("compiled successfully")).toBeUndefined();
+	});
+});
+
+describe("highlightTestOutput", () => {
+	it("tones check marks and passed counts", () => {
+		const [checkLine, , totalLine] = highlightTestOutput(
+			"✓ src/a.test.ts (6 tests)\n\n Tests  28 passed (28)",
+		);
+		expect(checkLine[0]).toEqual({ text: "✓", tone: "ok" });
+		expect(totalLine).toContainEqual({ text: "28 passed", tone: "strong" });
+	});
+
+	it("marks failures", () => {
+		const [line] = highlightTestOutput("✗ src/a.test.ts");
+		expect(line[0]).toEqual({ text: "✗", tone: "fail" });
+	});
+});
+
+describe("formatTurnStats", () => {
+	it("formats the prototype receipt", () => {
+		expect(
+			formatTurnStats({ toolCount: 4, tokenCount: 3200, durationMs: 18600 }),
+		).toBe("4 tools · 3.2k tokens · 18.6s");
+	});
+
+	it("handles singulars, small counts, and minutes", () => {
+		expect(
+			formatTurnStats({ toolCount: 1, tokenCount: 950, durationMs: 75000 }),
+		).toBe("1 tool · 950 tokens · 1m 15s");
+	});
+
+	it("trims trailing .0 from token counts", () => {
+		expect(
+			formatTurnStats({ toolCount: 2, tokenCount: 12000, durationMs: 900 }),
+		).toBe("2 tools · 12k tokens · 0.9s");
+	});
+});

--- a/web-next/src/components/folio/ledger.ts
+++ b/web-next/src/components/folio/ledger.ts
@@ -1,0 +1,179 @@
+/*
+ * Maps AI SDK dynamic-tool parts onto tool-ledger row content: a verb, a
+ * subject, a right-aligned meta summary, and an expandable body. Pure logic
+ * so #748 can point real tool outputs at the same rows without UI changes.
+ */
+import type { DynamicToolUIPart } from "ai";
+import type { TurnStatsData } from "./types";
+
+export type LedgerMeta =
+	| { kind: "text"; text: string }
+	| { kind: "delta"; additions: number; deletions: number };
+
+export type LedgerBody =
+	| { kind: "code"; content: string }
+	| { kind: "test-output"; content: string; passed: boolean };
+
+export interface LedgerRowModel {
+	verb: string;
+	subject: string;
+	meta?: LedgerMeta;
+	body?: LedgerBody;
+}
+
+/** Ledger verbs for well-known tools; unknown tools show their own name. */
+const TOOL_VERBS: Record<string, string> = {
+	Read: "Read",
+	Edit: "Edit",
+	Write: "Wrote",
+	Bash: "Ran",
+};
+
+/** Tool outputs may carry a display summary next to their content. */
+interface StructuredToolOutput {
+	content: string;
+	summary?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function asOptionalString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function normalizeOutput(output: unknown): StructuredToolOutput | undefined {
+	if (typeof output === "string") return { content: output };
+	const record = asRecord(output);
+	const content = asOptionalString(record.content);
+	if (content === undefined) return undefined;
+	return { content, summary: asOptionalString(record.summary) };
+}
+
+function countLines(text: string): number {
+	return text.split("\n").length;
+}
+
+/** "28 passed · 1.21s" from vitest-style output, or undefined. */
+export function parseTestSummary(output: string): string | undefined {
+	const passedMatches = [...output.matchAll(/(\d+)\s+passed/g)];
+	const passed = passedMatches.at(-1)?.[1];
+	if (passed === undefined) return undefined;
+	const duration = output.match(/Duration\s+([\d.]+\s?m?s)/i)?.[1];
+	return duration ? `${passed} passed · ${duration}` : `${passed} passed`;
+}
+
+function looksLikeTestOutput(content: string): boolean {
+	return /^\s*[✓✗×]/m.test(content) || /\d+\s+passed/.test(content);
+}
+
+export function describeToolPart(part: DynamicToolUIPart): LedgerRowModel {
+	const input = asRecord(part.input);
+	const verb = TOOL_VERBS[part.toolName] ?? part.toolName;
+	const subject =
+		asOptionalString(input.file_path) ??
+		asOptionalString(input.command) ??
+		part.toolName;
+
+	if (part.state === "output-error") {
+		return {
+			verb,
+			subject,
+			meta: { kind: "text", text: "failed" },
+			body: { kind: "code", content: part.errorText },
+		};
+	}
+	const output =
+		part.state === "output-available" ? normalizeOutput(part.output) : undefined;
+	if (output === undefined) return { verb, subject };
+
+	const body: LedgerBody = looksLikeTestOutput(output.content)
+		? {
+				kind: "test-output",
+				content: output.content,
+				passed: !/\d+\s+failed|[✗×]/.test(output.content),
+			}
+		: { kind: "code", content: output.content };
+
+	return { verb, subject, meta: deriveMeta(part, input, output), body };
+}
+
+function deriveMeta(
+	part: DynamicToolUIPart,
+	input: Record<string, unknown>,
+	output: StructuredToolOutput,
+): LedgerMeta | undefined {
+	if (output.summary !== undefined)
+		return { kind: "text", text: output.summary };
+	const oldString = asOptionalString(input.old_string);
+	const newString = asOptionalString(input.new_string);
+	if (part.toolName === "Edit" && oldString !== undefined && newString !== undefined) {
+		return {
+			kind: "delta",
+			additions: countLines(newString),
+			deletions: countLines(oldString),
+		};
+	}
+	const testSummary = parseTestSummary(output.content);
+	if (testSummary !== undefined) return { kind: "text", text: testSummary };
+	if (part.toolName === "Read")
+		return { kind: "text", text: `${countLines(output.content)} lines` };
+	return undefined;
+}
+
+// --- test-output highlighting -----------------------------------------------
+
+export interface OutputSegment {
+	text: string;
+	tone: "plain" | "ok" | "fail" | "strong";
+}
+
+/**
+ * Splits test output into per-line segments: leading check marks read as
+ * pass/fail, "N passed" counts read as strong — the prototype's quiet
+ * highlighting of a green run.
+ */
+export function highlightTestOutput(content: string): OutputSegment[][] {
+	return content.split("\n").map((line) => {
+		const segments: OutputSegment[] = [];
+		const mark = line.match(/^(\s*)([✓✗×])/);
+		let rest = line;
+		if (mark) {
+			if (mark[1]) segments.push({ text: mark[1], tone: "plain" });
+			segments.push({ text: mark[2], tone: mark[2] === "✓" ? "ok" : "fail" });
+			rest = line.slice(mark[0].length);
+		}
+		let cursor = 0;
+		for (const match of rest.matchAll(/\d+ passed/g)) {
+			if (match.index > cursor)
+				segments.push({ text: rest.slice(cursor, match.index), tone: "plain" });
+			segments.push({ text: match[0], tone: "strong" });
+			cursor = match.index + match[0].length;
+		}
+		if (cursor < rest.length)
+			segments.push({ text: rest.slice(cursor), tone: "plain" });
+		return segments;
+	});
+}
+
+// --- end-of-turn receipt ----------------------------------------------------
+
+function formatTokenCount(count: number): string {
+	if (count < 1000) return String(count);
+	return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+}
+
+function formatDuration(ms: number): string {
+	const seconds = ms / 1000;
+	if (seconds < 60) return `${seconds.toFixed(1)}s`;
+	return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+}
+
+/** "4 tools · 3.2k tokens · 18.6s" */
+export function formatTurnStats(stats: TurnStatsData): string {
+	const tools = `${stats.toolCount} tool${stats.toolCount === 1 ? "" : "s"}`;
+	return `${tools} · ${formatTokenCount(stats.tokenCount)} tokens · ${formatDuration(stats.durationMs)}`;
+}

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -1,0 +1,193 @@
+/*
+ * The manuscript message: serif prose paragraphs with contiguous tool
+ * parts grouped into a quiet "workings" apparatus, landed edits surfacing
+ * as diff cards, and an end-of-turn receipt. Consumes AI SDK UIMessages
+ * (text / dynamic-tool / data-diff parts) so live streaming (#748) renders
+ * through the same component.
+ */
+import { isDynamicToolUIPart, type DynamicToolUIPart } from "ai";
+import type { CSSProperties, ReactNode } from "react";
+import { DiffCard } from "./diff-card";
+import { InlineMarkdown } from "./inline-markdown";
+import { describeToolPart, type LedgerBody, type LedgerMeta } from "./ledger";
+import { TestOutputPanel } from "./test-output-panel";
+import { ToolLedgerRow } from "./tool-ledger-row";
+import { TurnStatsReceipt } from "./turn-stats";
+import type { DiffCardData, FolioMessage } from "./types";
+
+// --- shell -------------------------------------------------------------------
+
+export interface MessageArticleProps {
+	role: "user" | "assistant";
+	author: string;
+	stamp?: string;
+	focal?: boolean;
+	recede?: boolean;
+	animationDelay?: number;
+	children: ReactNode;
+}
+
+const FOCAL_CLASSES =
+	"before:absolute before:-left-[22px] before:top-[3px] before:bottom-[3px] before:w-[2px] before:rounded-[2px] before:bg-accent before:opacity-[.42] before:content-['']";
+
+/**
+ * Article + author label shared by regular messages and the in-progress
+ * turn. `focal` draws the gutter tick; `recede` fades older context.
+ */
+export function MessageArticle({
+	role,
+	author,
+	stamp,
+	focal,
+	recede,
+	animationDelay,
+	children,
+}: MessageArticleProps) {
+	return (
+		<article
+			data-message-role={role}
+			data-focal={focal || undefined}
+			className={`group animate-rise relative mb-[60px] [&_p+p]:mt-4 ${recede ? "opacity-[.76]" : ""} ${focal ? FOCAL_CLASSES : ""}`}
+			style={
+				animationDelay
+					? ({ animationDelay: `${animationDelay}s` } satisfies CSSProperties)
+					: undefined
+			}
+		>
+			<div className="mb-3.5 flex items-baseline gap-3 font-mono text-label font-medium tracking-[.16em] uppercase text-faint">
+				{role === "user" && (
+					<span aria-hidden className="h-px w-3.5 self-center bg-faint" />
+				)}
+				{author}
+				{stamp !== undefined && (
+					<span className="font-normal tracking-[.04em] opacity-0 transition-opacity duration-[.25s] group-hover:opacity-80">
+						{stamp}
+					</span>
+				)}
+			</div>
+			{children}
+		</article>
+	);
+}
+
+// --- part grouping -----------------------------------------------------------
+
+type Segment =
+	| { kind: "text"; key: string; text: string }
+	| { kind: "tools"; key: string; parts: DynamicToolUIPart[] }
+	| { kind: "diff"; key: string; data: DiffCardData };
+
+/** Contiguous tool parts collapse into one workings block. */
+function groupParts(parts: FolioMessage["parts"]): Segment[] {
+	const segments: Segment[] = [];
+	parts.forEach((part, index) => {
+		if (part.type === "text") {
+			segments.push({ kind: "text", key: `part-${index}`, text: part.text });
+		} else if (isDynamicToolUIPart(part)) {
+			const last = segments.at(-1);
+			if (last?.kind === "tools") last.parts.push(part);
+			else segments.push({ kind: "tools", key: `part-${index}`, parts: [part] });
+		} else if (part.type === "data-diff") {
+			segments.push({ kind: "diff", key: `part-${index}`, data: part.data });
+		}
+	});
+	return segments;
+}
+
+// --- ledger row rendering ------------------------------------------------------
+
+function LedgerMetaView({ meta }: { meta: LedgerMeta }) {
+	if (meta.kind === "delta") {
+		return (
+			<>
+				<span className="text-add-ink">+{meta.additions}</span>{" "}
+				<span className="text-del-ink">−{meta.deletions}</span>
+			</>
+		);
+	}
+	return meta.text;
+}
+
+function LedgerBodyView({ body }: { body: LedgerBody }) {
+	if (body.kind === "test-output")
+		return <TestOutputPanel output={body.content} passed={body.passed} />;
+	return (
+		<pre className="overflow-x-auto rounded-lg border border-line bg-raised px-4 py-3 font-mono text-code whitespace-pre text-muted">
+			{body.content}
+		</pre>
+	);
+}
+
+function Workings({
+	parts,
+	openToolCallIds,
+}: {
+	parts: DynamicToolUIPart[];
+	openToolCallIds?: string[];
+}) {
+	return (
+		<div className="my-[26px] ml-[2px] space-y-[2px] border-l-2 border-line py-1 pl-[22px]">
+			{parts.map((part) => {
+				const row = describeToolPart(part);
+				return (
+					<ToolLedgerRow
+						key={part.toolCallId}
+						verb={row.verb}
+						subject={row.subject}
+						meta={row.meta && <LedgerMetaView meta={row.meta} />}
+						defaultOpen={openToolCallIds?.includes(part.toolCallId)}
+					>
+						{row.body && <LedgerBodyView body={row.body} />}
+					</ToolLedgerRow>
+				);
+			})}
+		</div>
+	);
+}
+
+// --- the message ----------------------------------------------------------------
+
+export interface MessageProps {
+	message: FolioMessage;
+	/** Tool calls whose ledger rows start expanded (e.g. the landed test run). */
+	openToolCallIds?: string[];
+	animationDelay?: number;
+}
+
+export function Message({
+	message,
+	openToolCallIds,
+	animationDelay,
+}: MessageProps) {
+	const isUser = message.role === "user";
+	const meta = message.metadata;
+	return (
+		<MessageArticle
+			role={isUser ? "user" : "assistant"}
+			author={meta?.author ?? (isUser ? "You" : "Agent")}
+			stamp={meta?.stamp}
+			focal={meta?.focal}
+			recede={meta?.recede}
+			animationDelay={animationDelay}
+		>
+			{groupParts(message.parts).map((segment) => {
+				if (segment.kind === "tools")
+					return (
+						<Workings
+							key={segment.key}
+							parts={segment.parts}
+							openToolCallIds={openToolCallIds}
+						/>
+					);
+				if (segment.kind === "diff")
+					return <DiffCard key={segment.key} diff={segment.data} />;
+				return segment.text.split(/\n{2,}/).map((paragraph, i) => (
+					<p key={`${segment.key}-${i}`} className={isUser ? "text-user-ink" : ""}>
+						<InlineMarkdown text={paragraph} />
+					</p>
+				));
+			})}
+			{meta?.turnStats && <TurnStatsReceipt stats={meta.turnStats} />}
+		</MessageArticle>
+	);
+}

--- a/web-next/src/components/folio/parse-inline.test.ts
+++ b/web-next/src/components/folio/parse-inline.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseInline } from "./parse-inline";
+
+describe("parseInline", () => {
+	it("passes plain text through", () => {
+		expect(parseInline("just prose")).toEqual([
+			{ kind: "text", text: "just prose" },
+		]);
+	});
+
+	it("extracts code spans and emphasis", () => {
+		expect(parseInline("the *failing test* calls `resumeSession` twice")).toEqual([
+			{ kind: "text", text: "the " },
+			{ kind: "em", text: "failing test" },
+			{ kind: "text", text: " calls " },
+			{ kind: "code", text: "resumeSession" },
+			{ kind: "text", text: " twice" },
+		]);
+	});
+
+	it("handles adjacent and trailing tokens", () => {
+		expect(parseInline("`a``b`")).toEqual([
+			{ kind: "code", text: "a" },
+			{ kind: "code", text: "b" },
+		]);
+		expect(parseInline("ends with `code`")).toEqual([
+			{ kind: "text", text: "ends with " },
+			{ kind: "code", text: "code" },
+		]);
+	});
+
+	it("leaves unbalanced markers alone", () => {
+		expect(parseInline("a * b and a ` c")).toEqual([
+			{ kind: "text", text: "a * b and a ` c" },
+		]);
+	});
+});

--- a/web-next/src/components/folio/parse-inline.ts
+++ b/web-next/src/components/folio/parse-inline.ts
@@ -1,0 +1,24 @@
+/*
+ * Minimal inline markdown parser for Folio prose: `code` spans and
+ * *emphasis*. Deliberately tiny — block markdown is out of scope until a
+ * real streaming transcript (#748) demands more.
+ */
+export type InlineToken =
+	| { kind: "text"; text: string }
+	| { kind: "code"; text: string }
+	| { kind: "em"; text: string };
+
+export function parseInline(text: string): InlineToken[] {
+	const tokens: InlineToken[] = [];
+	const pattern = /`([^`]+)`|\*([^*]+)\*/g;
+	let cursor = 0;
+	for (const match of text.matchAll(pattern)) {
+		if (match.index > cursor)
+			tokens.push({ kind: "text", text: text.slice(cursor, match.index) });
+		if (match[1] !== undefined) tokens.push({ kind: "code", text: match[1] });
+		else tokens.push({ kind: "em", text: match[2] });
+		cursor = match.index + match[0].length;
+	}
+	if (cursor < text.length) tokens.push({ kind: "text", text: text.slice(cursor) });
+	return tokens;
+}

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/*
+ * Session masthead: identity kept to a whisper — repo/branch on the left,
+ * the session title centered in serif italic, agent + sandbox state and
+ * the theme toggle on the right. Sticky, translucent, blurred.
+ */
+import { useThemeToggle } from "./use-theme";
+
+export interface MastheadData {
+	repo: string;
+	branch: string;
+	title: string;
+	agentName: string;
+	/** e.g. "sandbox active"; `live` adds the green halo dot. */
+	stateLabel: string;
+	live?: boolean;
+}
+
+function Separator() {
+	return <span className="mx-[7px] text-faint">·</span>;
+}
+
+export function SessionMasthead({ session }: { session: MastheadData }) {
+	const toggleTheme = useThemeToggle();
+	return (
+		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between border-b border-line bg-mast-bg px-8 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1]">
+			<span>
+				<b className="font-medium text-ink">{session.repo}</b>
+				<Separator />
+				{session.branch}
+			</span>
+			<span className="absolute left-1/2 -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint">
+				{session.title}
+			</span>
+			<span className="flex items-center">
+				{session.agentName}
+				<Separator />
+				{session.live && (
+					<span className="mr-2 inline-block h-[7px] w-[7px] rounded-full bg-live align-[1px] shadow-[0_0_0_3px_var(--live-halo)]" />
+				)}
+				{session.stateLabel}
+				<button
+					type="button"
+					onClick={toggleTheme}
+					title="Toggle light / dark"
+					aria-label="Toggle light / dark theme"
+					className="ml-4 rounded-md px-1.5 py-1 text-[13px] leading-none text-faint [transition:color_.2s_ease,transform_.35s_ease] hover:text-accent dark:rotate-180"
+				>
+					◐
+				</button>
+			</span>
+		</header>
+	);
+}

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -1,0 +1,65 @@
+/*
+ * The full Folio session surface: masthead, manuscript transcript (with an
+ * optional in-progress turn), and the dock — compose over the dismissible
+ * status line. Pure composition over data; no fixture knowledge.
+ */
+import { ActivityLine, type ActivityLineProps } from "./activity-line";
+import { ComposeField } from "./compose-field";
+import { Message, MessageArticle } from "./message";
+import { SessionMasthead, type MastheadData } from "./session-masthead";
+import { StatusLine, type StatusLineData } from "./status-line";
+import type { FolioMessage } from "./types";
+
+/** The live turn: always focal, labeled but unstamped while it works. */
+export interface ActiveTurnData extends ActivityLineProps {
+	agentName: string;
+}
+
+export interface SessionViewData {
+	masthead: MastheadData;
+	messages: FolioMessage[];
+	/** Ledger rows that start expanded (by toolCallId). */
+	openToolCallIds?: string[];
+	activeTurn?: ActiveTurnData;
+	statusLine: StatusLineData;
+}
+
+/** Entry stagger for the first few messages, matching the prototype. */
+function riseDelay(index: number): number {
+	return index < 4 ? 0.03 + index * 0.07 : 0;
+}
+
+export function SessionView({ session }: { session: SessionViewData }) {
+	return (
+		<>
+			<SessionMasthead session={session.masthead} />
+			<main className="mx-auto max-w-[680px] px-5 pt-[76px] pb-6">
+				{session.messages.map((message, index) => (
+					<Message
+						key={message.id}
+						message={message}
+						openToolCallIds={session.openToolCallIds}
+						animationDelay={riseDelay(index)}
+					/>
+				))}
+				{session.activeTurn && (
+					<MessageArticle
+						role="assistant"
+						author={session.activeTurn.agentName}
+						focal
+						animationDelay={riseDelay(session.messages.length)}
+					>
+						<ActivityLine
+							action={session.activeTurn.action}
+							details={session.activeTurn.details}
+						/>
+					</MessageArticle>
+				)}
+			</main>
+			<footer className="sticky bottom-0 z-[15]">
+				<ComposeField agentName={session.masthead.agentName} />
+				<StatusLine status={session.statusLine} />
+			</footer>
+		</>
+	);
+}

--- a/web-next/src/components/folio/status-line.tsx
+++ b/web-next/src/components/folio/status-line.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/*
+ * Model status line: model + quiet context figures pinned under the
+ * compose. ✕ collapses it to a small corner dot (the handle); the dot
+ * brings it back. Expects a positioned ancestor for the handle.
+ */
+import { useState } from "react";
+
+export interface StatusLineData {
+	model: string;
+	/** Preformatted context figure (e.g. "2.1k ctx"). */
+	contextLabel: string;
+}
+
+export function StatusLine({ status }: { status: StatusLineData }) {
+	const [dismissed, setDismissed] = useState(false);
+
+	if (dismissed) {
+		return (
+			<button
+				type="button"
+				data-testid="status-line-handle"
+				title="Show status line"
+				aria-label="Show status line"
+				onClick={() => setDismissed(false)}
+				className="absolute right-[18px] bottom-[13px] h-[9px] w-[9px] rounded-full bg-faint opacity-40 transition-[opacity,transform,background-color] duration-200 hover:scale-[1.35] hover:bg-accent hover:opacity-100"
+			/>
+		);
+	}
+
+	return (
+		<div
+			data-testid="status-line"
+			className="h-[30px] border-t border-line bg-status-bg font-mono text-stat tracking-[.03em] text-faint"
+		>
+			<div className="mx-auto flex h-full max-w-[680px] items-center px-0.5">
+				<span className="font-medium text-muted before:mr-2 before:inline-block before:h-[5px] before:w-[5px] before:rounded-full before:bg-accent before:align-[2px] before:opacity-75 before:content-['']">
+					{status.model}
+				</span>
+				<span className="mx-[9px] opacity-55">·</span>
+				{status.contextLabel}
+				<button
+					type="button"
+					title="Hide status line"
+					aria-label="Hide status line"
+					onClick={() => setDismissed(true)}
+					className="ml-auto rounded-[5px] px-1.5 py-1 text-stat leading-none text-faint opacity-70 transition-[opacity,color] duration-200 hover:text-ink hover:opacity-100"
+				>
+					✕
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/web-next/src/components/folio/test-output-panel.tsx
+++ b/web-next/src/components/folio/test-output-panel.tsx
@@ -1,0 +1,43 @@
+/*
+ * Test-output panel: command output rendered as the workings' quiet code
+ * block, with pass marks and "N passed" counts gently highlighted.
+ * Structured props so #748 can pipe real runner output straight in.
+ */
+import { highlightTestOutput } from "./ledger";
+
+const TONE_CLASS = {
+	plain: undefined,
+	ok: "text-add-ink",
+	fail: "text-del-ink",
+	strong: "font-medium text-ink",
+} as const;
+
+export interface TestOutputPanelProps {
+	output: string;
+	passed: boolean;
+}
+
+export function TestOutputPanel({ output, passed }: TestOutputPanelProps) {
+	return (
+		<pre
+			data-testid="test-output"
+			data-passed={passed}
+			className="overflow-x-auto rounded-lg border border-line bg-raised px-4 py-3 font-mono text-code whitespace-pre text-muted"
+		>
+			{highlightTestOutput(output).map((segments, lineIndex) => (
+				<span key={lineIndex}>
+					{lineIndex > 0 && "\n"}
+					{segments.map((segment, i) =>
+						TONE_CLASS[segment.tone] === undefined ? (
+							segment.text
+						) : (
+							<span key={i} className={TONE_CLASS[segment.tone]}>
+								{segment.text}
+							</span>
+						),
+					)}
+				</span>
+			))}
+		</pre>
+	);
+}

--- a/web-next/src/components/folio/tool-ledger-row.tsx
+++ b/web-next/src/components/folio/tool-ledger-row.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+/*
+ * One step of the workings apparatus: a quiet mono row (twist · verb ·
+ * subject · meta) that discloses its body on click. State is per-row;
+ * nothing here knows about tools — Message maps parts onto these props.
+ */
+import { useState, type ReactNode } from "react";
+
+export interface ToolLedgerRowProps {
+	verb: string;
+	subject: string;
+	/** Right-aligned summary (e.g. "41 lines", "+4 −1", "28 passed · 1.21s"). */
+	meta?: ReactNode;
+	defaultOpen?: boolean;
+	/** Expanded body; rows without one still render (running calls). */
+	children?: ReactNode;
+}
+
+export function ToolLedgerRow({
+	verb,
+	subject,
+	meta,
+	defaultOpen = false,
+	children,
+}: ToolLedgerRowProps) {
+	const [open, setOpen] = useState(defaultOpen);
+	return (
+		<div data-testid="tool-row" data-open={open || undefined}>
+			<button
+				type="button"
+				aria-expanded={open}
+				onClick={() => setOpen((current) => !current)}
+				className="flex w-full items-baseline gap-2.5 rounded-md py-[5px] pr-2 text-left font-mono text-tool text-muted hover:text-ink"
+			>
+				<span
+					aria-hidden
+					className={`inline-block w-2.5 origin-[45%_50%] text-[11px] text-faint transition-transform duration-[.18s] ${open ? "rotate-90" : ""}`}
+				>
+					▸
+				</span>
+				<span className="min-w-[3.6em] text-faint">{verb}</span>
+				<span>{subject}</span>
+				{meta !== undefined && (
+					<span className="ml-auto pl-4 text-caption whitespace-nowrap text-faint">
+						{meta}
+					</span>
+				)}
+			</button>
+			{open && children !== undefined && (
+				<div
+					data-testid="tool-row-body"
+					className="animate-rise-fast mt-2 mb-4 ml-5"
+				>
+					{children}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/web-next/src/components/folio/turn-stats.tsx
+++ b/web-next/src/components/folio/turn-stats.tsx
@@ -1,0 +1,16 @@
+/*
+ * End-of-turn receipt: a faint one-line tally under completed agent turns.
+ */
+import { formatTurnStats } from "./ledger";
+import type { TurnStatsData } from "./types";
+
+export function TurnStatsReceipt({ stats }: { stats: TurnStatsData }) {
+	return (
+		<div
+			data-testid="turn-stats"
+			className="mt-5 font-mono text-stat tracking-[.04em] text-faint opacity-[.82]"
+		>
+			{formatTurnStats(stats)}
+		</div>
+	);
+}

--- a/web-next/src/components/folio/types.ts
+++ b/web-next/src/components/folio/types.ts
@@ -1,0 +1,47 @@
+/*
+ * Shared Folio data shapes: the message metadata + custom data parts the
+ * components consume. Messages are AI SDK UIMessages so #748 can stream
+ * into the same components; everything visual rides in metadata/data parts.
+ */
+import type { UIMessage } from "ai";
+
+/** End-of-turn receipt numbers ("4 tools · 3.2k tokens · 18.6s"). */
+export interface TurnStatsData {
+	toolCount: number;
+	tokenCount: number;
+	durationMs: number;
+}
+
+export interface FolioMetadata {
+	/** Display name in the message label (e.g. "Michael", "Claude"). */
+	author: string;
+	/** Hover-revealed timestamp, preformatted (e.g. "9:41 am"). */
+	stamp?: string;
+	/** Current-turn focus cue: accent tick in the left gutter. */
+	focal?: boolean;
+	/** Older context recedes a hair (opacity). */
+	recede?: boolean;
+	/** Present on completed agent turns only. */
+	turnStats?: TurnStatsData;
+}
+
+export interface DiffLine {
+	kind: "context" | "add" | "del";
+	text: string;
+}
+
+/** A landed edit surfaced as a contextual card. */
+export interface DiffCardData {
+	file: string;
+	additions: number;
+	deletions: number;
+	/** Italic caption on the right (e.g. "edit landed · just now"). */
+	note?: string;
+	lines: DiffLine[];
+}
+
+export type FolioDataParts = {
+	diff: DiffCardData;
+};
+
+export type FolioMessage = UIMessage<FolioMetadata, FolioDataParts>;

--- a/web-next/src/components/folio/use-theme.ts
+++ b/web-next/src/components/folio/use-theme.ts
@@ -1,0 +1,48 @@
+"use client";
+
+/*
+ * Client side of the Folio theme: a toggle that flips and persists the
+ * data-theme attribute, plus listeners keeping hash (#light/#dark) and
+ * system-preference changes live after the pre-paint init script ran.
+ */
+import { useCallback, useEffect } from "react";
+import { resolveTheme, THEME_STORAGE_KEY, type Theme } from "@/lib/theme";
+
+function applyTheme(theme: Theme) {
+	document.documentElement.dataset.theme = theme;
+}
+
+function readStoredTheme(): string | null {
+	try {
+		return localStorage.getItem(THEME_STORAGE_KEY);
+	} catch {
+		return null;
+	}
+}
+
+export function useThemeToggle(): () => void {
+	useEffect(() => {
+		const media = window.matchMedia("(prefers-color-scheme: dark)");
+		const reapply = () =>
+			applyTheme(
+				resolveTheme(location.hash.slice(1), readStoredTheme(), media.matches),
+			);
+		window.addEventListener("hashchange", reapply);
+		media.addEventListener("change", reapply);
+		return () => {
+			window.removeEventListener("hashchange", reapply);
+			media.removeEventListener("change", reapply);
+		};
+	}, []);
+
+	return useCallback(() => {
+		const next: Theme =
+			document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+		applyTheme(next);
+		try {
+			localStorage.setItem(THEME_STORAGE_KEY, next);
+		} catch {
+			// Private mode etc. — the toggle still works for this page view.
+		}
+	}, []);
+}

--- a/web-next/src/lib/fixtures/demo-session.ts
+++ b/web-next/src/lib/fixtures/demo-session.ts
@@ -1,0 +1,233 @@
+/*
+ * Fixture data for /sessions/demo: the refine-folio prototype's session —
+ * one completed coding turn (workings, landed diff, receipt), a follow-up,
+ * and an in-progress turn — expressed as AI SDK UIMessages. Also seeds
+ * arbitrary-length transcripts for the transcript_render_200 perf scenario.
+ */
+import type { DynamicToolUIPart } from "ai";
+import type { SessionViewData } from "@/components/folio/session-view";
+import type { FolioMessage } from "@/components/folio/types";
+
+function completedTool(
+	toolCallId: string,
+	toolName: string,
+	input: Record<string, unknown>,
+	output: string | { content: string; summary?: string },
+): DynamicToolUIPart {
+	return {
+		type: "dynamic-tool",
+		toolCallId,
+		toolName,
+		state: "output-available",
+		input,
+		output,
+	};
+}
+
+const TEST_RUN_OUTPUT = [
+	"✓ src/session/resume.test.ts   (6 tests)  128ms",
+	"✓ src/session/session.test.ts (14 tests)  412ms",
+	"✓ src/session/store.test.ts    (8 tests)   96ms",
+	"",
+	"Test Files  3 passed (3)",
+	"     Tests  28 passed (28)",
+	"  Duration  1.21s",
+].join("\n");
+
+export function demoSession(): SessionViewData {
+	const messages: FolioMessage[] = [
+		{
+			id: "msg-1",
+			role: "user",
+			metadata: { author: "Michael", stamp: "9:41 am", recede: true },
+			parts: [
+				{
+					type: "text",
+					text: "The session-resume path is broken — `resumeSession` comes back with undefined when the id doesn’t exist, and there’s a failing repro in `session.test.ts`. Can you track it down and fix it?",
+				},
+			],
+		},
+		{
+			id: "msg-2",
+			role: "assistant",
+			metadata: {
+				author: "Claude",
+				stamp: "9:42 am",
+				focal: true,
+				turnStats: { toolCount: 4, tokenCount: 3200, durationMs: 18600 },
+			},
+			parts: [
+				{
+					type: "text",
+					text: "Found it. The failing test — *rejects when the session id is unknown* — expects a `SessionNotFoundError`, but `resumeSession` passes the store’s result straight into `hydrate`. When the id is missing, the record arrives as `undefined` and the failure surfaces one frame too late: a `TypeError` inside `hydrate` instead of a meaningful rejection.",
+				},
+				completedTool(
+					"tool-1",
+					"Read",
+					{ file_path: "src/session/session.test.ts" },
+					{
+						content:
+							'it("rejects when the session id is unknown", async () => {\n  await expect(resumeSession("sess_missing")).rejects.toThrow(\n    SessionNotFoundError,\n  );\n});',
+						summary: "41 lines",
+					},
+				),
+				completedTool(
+					"tool-2",
+					"Read",
+					{ file_path: "src/session/resume.ts" },
+					{
+						content:
+							"export async function resumeSession(id: SessionId): Promise<Session> {\n  const record = await store.get(id);\n  return hydrate(record);\n}",
+						summary: "18 lines",
+					},
+				),
+				completedTool(
+					"tool-3",
+					"Edit",
+					{
+						file_path: "src/session/resume.ts",
+						old_string: "  return hydrate(record);",
+						new_string:
+							"  if (!record) {\n    throw new SessionNotFoundError(id);\n  }\n  return hydrate(record);",
+					},
+					"guard added before hydrate() — see the change below",
+				),
+				completedTool(
+					"tool-4",
+					"Bash",
+					{ command: "pnpm test" },
+					TEST_RUN_OUTPUT,
+				),
+				{
+					type: "data-diff",
+					data: {
+						file: "src/session/resume.ts",
+						additions: 4,
+						deletions: 1,
+						note: "edit landed · just now",
+						lines: [
+							{
+								kind: "context",
+								text: "  export async function resumeSession(id: SessionId): Promise<Session> {",
+							},
+							{ kind: "context", text: "    const record = await store.get(id);" },
+							{ kind: "del", text: "-   return hydrate(record);" },
+							{ kind: "add", text: "+   if (!record) {" },
+							{ kind: "add", text: "+     throw new SessionNotFoundError(id);" },
+							{ kind: "add", text: "+   }" },
+							{ kind: "add", text: "+   return hydrate(record);" },
+							{ kind: "context", text: "  }" },
+						],
+					},
+				},
+				{
+					type: "text",
+					text: "The guard now rejects at the boundary, before hydration is ever attempted. Full suite is green — 28 tests across three files, including the two that were red.",
+				},
+			],
+		},
+		{
+			id: "msg-3",
+			role: "user",
+			metadata: { author: "Michael", stamp: "9:44 am" },
+			parts: [
+				{
+					type: "text",
+					text: "Lovely. While you’re in there — add a regression test for the expired-session path; resuming after `expiresAt` should reject the same way.",
+				},
+			],
+		},
+	];
+
+	return {
+		masthead: {
+			repo: "orbit/web",
+			branch: "fix/session-resume",
+			title: "Fix the failing session-resume test",
+			agentName: "Claude",
+			stateLabel: "sandbox active",
+			live: true,
+		},
+		messages,
+		openToolCallIds: ["tool-4"],
+		activeTurn: {
+			agentName: "Claude",
+			action: "Editing `src/session/session.test.ts`",
+			details: [
+				{
+					state: "done",
+					text: "Read src/session/session.test.ts — found the expiry fixtures",
+				},
+				{
+					state: "current",
+					text: "Edit src/session/session.test.ts — adding “rejects resuming an expired session”",
+				},
+			],
+		},
+		statusLine: { model: "opus-4.8", contextLabel: "2.1k ctx" },
+	};
+}
+
+/**
+ * Deterministic transcript of `messageCount` alternating user/agent
+ * messages (agent turns carry a tool part + receipt), representative of a
+ * long session for the transcript_render_200 scenario.
+ */
+export function seededDemoSession(messageCount: number): SessionViewData {
+	const base = demoSession();
+	const messages: FolioMessage[] = [];
+	for (let i = 0; i < messageCount; i++) {
+		if (i % 2 === 0) {
+			messages.push({
+				id: `seed-${i}`,
+				role: "user",
+				metadata: { author: "Michael", stamp: "9:41 am" },
+				parts: [
+					{
+						type: "text",
+						text: `Tighten the retry logic in \`worker-${i}.ts\` — it re-queues failures without any backoff.`,
+					},
+				],
+			});
+		} else {
+			messages.push({
+				id: `seed-${i}`,
+				role: "assistant",
+				metadata: {
+					author: "Claude",
+					stamp: "9:42 am",
+					turnStats: { toolCount: 1, tokenCount: 800 + i, durationMs: 4200 },
+				},
+				parts: [
+					{
+						type: "text",
+						text: `Done — \`worker-${i}.ts\` now backs off exponentially before re-queuing, capped at five attempts.`,
+					},
+					completedTool(
+						`seed-tool-${i}`,
+						"Read",
+						{ file_path: `src/workers/worker-${i}.ts` },
+						{
+							content: `export const retry = backoff(${i});`,
+							summary: "12 lines",
+						},
+					),
+					{
+						type: "text",
+						text: "The queue drains cleanly in the smoke run.",
+					},
+				],
+			});
+		}
+	}
+	return {
+		...base,
+		masthead: {
+			...base.masthead,
+			title: `Seeded transcript — ${messageCount} messages`,
+		},
+		messages,
+		openToolCallIds: undefined,
+		activeTurn: undefined,
+	};
+}

--- a/web-next/src/lib/theme.test.ts
+++ b/web-next/src/lib/theme.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveTheme, themeInitScript } from "./theme";
+
+describe("resolveTheme", () => {
+	it("follows system preference when nothing is forced or stored", () => {
+		expect(resolveTheme("", null, false)).toBe("light");
+		expect(resolveTheme("", null, true)).toBe("dark");
+	});
+
+	it("prefers a stored toggle choice over system preference", () => {
+		expect(resolveTheme("", "light", true)).toBe("light");
+		expect(resolveTheme("", "dark", false)).toBe("dark");
+	});
+
+	it("lets a #light/#dark hash override everything", () => {
+		expect(resolveTheme("dark", "light", false)).toBe("dark");
+		expect(resolveTheme("light", "dark", true)).toBe("light");
+	});
+
+	it("ignores unrecognized hash and storage values", () => {
+		expect(resolveTheme("sepia", "solarized", true)).toBe("dark");
+		expect(resolveTheme("sepia", "solarized", false)).toBe("light");
+	});
+
+	it("serializes the resolver into the init script", () => {
+		// The blocking script embeds resolveTheme via toString; if the function
+		// stops being self-contained, the reference breaks at runtime.
+		expect(themeInitScript).toContain("document.documentElement.dataset.theme");
+		expect(() => new Function(themeInitScript)).not.toThrow();
+	});
+});

--- a/web-next/src/lib/theme.ts
+++ b/web-next/src/lib/theme.ts
@@ -1,0 +1,36 @@
+/*
+ * Folio theme resolution: system preference by default, an explicit toggle
+ * choice (localStorage) overrides it, and a #light/#dark URL hash overrides
+ * both — hash parity with the refine-folio prototype for deterministic
+ * screenshots. themeInitScript runs blocking before first paint.
+ */
+
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "folio-theme";
+
+/**
+ * Resolution order: hash > stored toggle choice > system preference.
+ * Self-contained on purpose — it is serialized into themeInitScript.
+ */
+export function resolveTheme(
+	hash: string,
+	stored: string | null,
+	systemPrefersDark: boolean,
+): Theme {
+	if (hash === "light" || hash === "dark") return hash;
+	if (stored === "light" || stored === "dark") return stored;
+	return systemPrefersDark ? "dark" : "light";
+}
+
+/** Inline <script> body: applies the resolved theme before first paint. */
+export const themeInitScript = `(function () {
+	var resolve = ${resolveTheme.toString()};
+	var stored = null;
+	try { stored = localStorage.getItem("${THEME_STORAGE_KEY}"); } catch (e) {}
+	document.documentElement.dataset.theme = resolve(
+		location.hash.slice(1),
+		stored,
+		window.matchMedia("(prefers-color-scheme: dark)").matches
+	);
+})();`;

--- a/web-next/tests/e2e/sessions-demo.spec.ts
+++ b/web-next/tests/e2e/sessions-demo.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * E2E for the Folio session demo (/sessions/demo): theme resolution
+ * (toggle, persistence, #light/#dark hash parity), autofocused bare
+ * compose, ledger row disclosure, diff card dismissal, status line
+ * dismiss-to-dot, and the focus cue / receipt furniture.
+ */
+import { expect, test } from "@playwright/test";
+
+const theme = (page: import("@playwright/test").Page) =>
+	page.locator("html").getAttribute("data-theme");
+
+test("theme: system preference by default, toggle overrides and persists", async ({
+	page,
+}) => {
+	await page.emulateMedia({ colorScheme: "dark" });
+	await page.goto("/sessions/demo");
+	expect(await theme(page)).toBe("dark");
+
+	const toggle = page.getByRole("button", { name: /toggle light \/ dark/i });
+	await toggle.click();
+	expect(await theme(page)).toBe("light");
+
+	// The explicit choice survives a reload even though the system says dark.
+	await page.reload();
+	expect(await theme(page)).toBe("light");
+});
+
+test("theme: #light/#dark hash forces the theme like the prototype", async ({
+	page,
+}) => {
+	await page.emulateMedia({ colorScheme: "light" });
+	await page.goto("/sessions/demo#dark");
+	expect(await theme(page)).toBe("dark");
+
+	await page.goto("/sessions/demo#light");
+	expect(await theme(page)).toBe("light");
+
+	// Hash wins over a stored toggle choice on the next load. (A same-hash
+	// goto is a same-document navigation — no reload, no hashchange — so
+	// reload instead, like a shared #light link being opened.)
+	await page.getByRole("button", { name: /toggle light \/ dark/i }).click();
+	expect(await theme(page)).toBe("dark");
+	await page.reload();
+	expect(await theme(page)).toBe("light");
+});
+
+test("compose autofocuses with no placeholder or hint chips", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+	const input = page.getByRole("textbox", { name: "Reply to Claude" });
+	await expect(input).toBeFocused();
+	await expect(input).not.toHaveAttribute("placeholder", /./);
+	// No hint chips ride inside the field: caret, input, send button only.
+	expect(
+		await page.locator("footer input ~ *, footer button").count(),
+	).toBeLessThanOrEqual(2);
+});
+
+test("tool ledger rows disclose and collapse their bodies", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+
+	// The landed test run starts open, per the fixture.
+	const openBody = page.getByTestId("test-output");
+	await expect(openBody).toBeVisible();
+	await expect(openBody).toContainText("28 passed");
+
+	const readRow = page
+		.getByRole("button", { name: /Read src\/session\/session\.test\.ts/ })
+		.first();
+	await readRow.click();
+	const readBody = page
+		.getByTestId("tool-row")
+		.filter({ has: readRow })
+		.getByTestId("tool-row-body");
+	await expect(readBody).toBeVisible();
+	await expect(readBody).toContainText("rejects when the session id is unknown");
+	await readRow.click();
+	await expect(readBody).toBeHidden();
+});
+
+test("diff card renders the landed edit and dismisses", async ({ page }) => {
+	await page.goto("/sessions/demo");
+	const card = page.getByTestId("diff-card");
+	await expect(card).toContainText("src/session/resume.ts");
+	await expect(card).toContainText("throw new SessionNotFoundError(id);");
+	await card.hover();
+	await card.getByRole("button", { name: /dismiss/i }).click();
+	await expect(card).toHaveCount(0);
+});
+
+test("status line dismisses to a dot and comes back", async ({ page }) => {
+	await page.goto("/sessions/demo");
+	const statusLine = page.getByTestId("status-line");
+	await expect(statusLine).toContainText("opus-4.8");
+
+	await statusLine.getByRole("button", { name: /hide status line/i }).click();
+	await expect(statusLine).toHaveCount(0);
+
+	const handle = page.getByTestId("status-line-handle");
+	await expect(handle).toBeVisible();
+	await handle.click();
+	await expect(page.getByTestId("status-line")).toContainText("2.1k ctx");
+});
+
+test("focus cue and end-of-turn receipt are present", async ({ page }) => {
+	await page.goto("/sessions/demo");
+	// The completed agent turn and the working turn carry the gutter tick.
+	await expect(page.locator("[data-focal]")).toHaveCount(2);
+	await expect(page.getByTestId("turn-stats")).toHaveText(
+		"4 tools · 3.2k tokens · 18.6s",
+	);
+	// The in-progress turn shows the quiet activity line.
+	await expect(page.getByTestId("activity-line")).toContainText("Editing");
+});
+
+test("seeded transcript renders the requested message count", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo?seed=20");
+	await expect(page.locator("[data-message-role]")).toHaveCount(20);
+});


### PR DESCRIPTION
Closes #745 — second issue of the **Sessions-first web (web-next)** milestone, executed under `backlog/web-next-execution-brief.md`. Visual spec: `prototypes/web-session-redesign/refine-folio.html` ("Refined Folio", locked 2026-07-03).

## Summary

- **Folio theme system** — replaces the mint-on-navy Spaces tokens with the Folio palettes: paper light + warm-charcoal dark on `:root[data-theme]`, mapped through `@theme inline` so Tailwind utilities track the active theme; prototype type scale (17.5px serif body → 10.5px mono labels); Newsreader + IBM Plex Mono via next/font. Theme resolution (hash `#light`/`#dark` > stored toggle > system preference) is a unit-tested pure function serialized into a pre-paint inline script; hashchange and system changes stay live.
- **Data-driven components** (`src/components/folio/`, consuming AI SDK `UIMessage` parts so #748 can stream into them unchanged): session masthead (+ theme toggle), message (user/agent; contiguous tool parts group into the "workings" apparatus; focal/recede turn cues), tool-ledger row (collapsed/expanded), diff card (structured + dismissible), test-output panel, end-of-turn stats receipt, activity line, autofocused minimal compose (no placeholder, no hint chips), dismissible model status-line footer (dismiss-to-dot).
- **`/sessions/demo`** — the prototype's exact session rendered from fixture data; `?seed=n` generates an n-message transcript for perf.
- **Perf**: new `route_sessions_demo` scenario; `transcript_render_200` converted from pending → **measured** (213.6ms median vs 500ms budget). Baselines updated.

## Mergeability

- Surface: web (`web-next/`)
- User-facing behavior changed: none deployed (`web-next/` has no production URL yet); within the app, global theme changes from Spaces-dark-only to Folio light+dark — `/spike` migrated to the new tokens and keeps working
- Non-happy paths considered: no-JS fallback theme (SSR `data-theme="light"` + `suppressHydrationWarning` documented); `prefers-reduced-motion` disables all animation; tool parts without ids still group correctly; theme persists across reloads and respects hash overrides
- Release/ops preconditions: none
- Residual risk or follow-up: `next/font` variables must live on `<html>` (documented in `globals.css` — `@theme` tokens substitute at `:root` where body-scoped vars are invisible); command palette deliberately not built (not in issue scope)

## Validation

- [ ] `swift build` — n/a
- [ ] `swift test` — n/a
- [x] Other checks run: in `web-next/` — `pnpm lint` clean · `pnpm typecheck` clean · `pnpm test` **32 passed** · `pnpm build` clean · `pnpm test:e2e` **10 passed** (new sessions-demo spec: theme toggle/persistence/hash parity, compose autofocus, ledger expand, diff dismiss, dismiss-to-dot, focus cue, seeded transcript count) · `pnpm evidence` · `pnpm perf` exit 0

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `web-next/perf/contract.json`
- [x] Before and after evidence — first measurement of the new route; `transcript_render_200` converted pending → measured
- [x] Deltas called out below

| Scenario | Metric | Result | Budget |
|---|---|---|---|
| route_sessions_demo | lcp / tbt / first-load JS | 112ms / 0ms / 103.6KB | 1200 / 200 / 200KB |
| transcript_render_200 | render_ms (median) | **213.6** (was pending) | 500 |
| route_home / route_spike | unchanged within budget | — | — |

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached — vitest **32 passed**, Playwright e2e **10 passed**, perf exit 0
- [x] UI evidence attached — light+dark screenshots of `/sessions/demo` captured **beside the prototype** (`prototype-folio-{light,dark}.png`) plus home/spike, published as the `web-next-evidence` artifact on this PR's `web-next-ci` run (sanctioned remote-session publish path per `docs/development/remote-sessions.md`)

Evidence links:

- `web-next-evidence` + `web-next-perf-results` artifacts on this PR's `web-next-ci` run (Checks tab); screenshots also delivered in the session chat for direct review

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ)_