### PR TITLE
web-next: session_events + sessions schema + UIMessage projection

### DIFF
--- a/web-next/docs/schema.md
+++ b/web-next/docs/schema.md
@@ -1,0 +1,126 @@
+# web-next local schema
+
+The durable data foundation for sessions-first web. Fresh schema (no legacy
+`chat_messages` compatibility); only the Kysely/libSQL *setup* is ported by copy
+from the old `web/` app (idempotent append-only migrations, the libSQL dialect,
+the Turso row-read discipline).
+
+- **Engine:** libSQL / Turso (SQLite dialect) via Kysely.
+- **Migrations:** ordered, append-only in `src/lib/db/migrations.ts`; applied by
+  `ensureSchema()` (`src/lib/db/schema.ts`), which records each id in
+  `schema_migrations`. Never edit a shipped migration — append a new one.
+- **Row types:** the `Database` interface in `src/lib/db/client.ts`.
+- **Store API:** `src/lib/db/sessions.ts` (create/read sessions, append/read
+  events, project a transcript).
+
+Keep this doc in sync with the migrations whenever tables, indexes, or persisted
+meanings change.
+
+## Tables
+
+### `repos`
+
+A connected GitHub repo a session can run against. Minimal by design — the
+sessions home (#747) and lifecycle work extend it as needed.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | text PK | Stable repo id (GitHub node id or `owner/name`); referenced by `sessions.repo_id`. |
+| `full_name` | text | `owner/name`, the human-facing identifier. |
+| `default_branch` | text? | Branch a new session checks out; null until known. |
+| `created_at` | text | ISO-8601. |
+
+### `sessions`
+
+One coding session — the primary object of the app. A session owns an
+append-only `session_events` log; its UIMessage transcript is **projected** from
+that log, never stored here.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `id` | text PK | Session id. |
+| `repo_id` | text? | `repos.id` this session runs against; null until bound. |
+| `title` | text | Display title (defaults to `""`). |
+| `provider` | text | Compute provider id — `mock` \| `vercel` \| `anthropic` \| … |
+| `status` | text | Lifecycle — `active` \| `idle` \| `archived` (owned by #749/#750). |
+| `claude_session_id` | text? | Claude CLI session id for snapshot/resume; null until a turn runs. |
+| `created_at` | text | ISO-8601. |
+| `last_activity_at` | text | ISO-8601; bumped on every event append. |
+
+Index `idx_sessions_last_activity` on `last_activity_at desc` — the sessions
+home lists by recency.
+
+### `session_events`
+
+The append-only transcript log — **the single source of truth** for a session's
+transcript. Each row is one provider `StreamChunk` tagged with its turn role and
+a per-session monotonic `seq`.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `session_id` | text | Owning session. |
+| `seq` | integer | Per-session monotonic position, starting at 1. |
+| `role` | text | Whose turn — `user` \| `assistant`. |
+| `kind` | text | The StreamChunk `type` (`text` \| `tool_use` \| …), denormalized for cheap filtering/debugging. |
+| `payload` | text | JSON-serialized `StreamChunk`. |
+| `created_at` | text | ISO-8601. |
+
+Primary key `(session_id, seq)`. This composite PK does double duty: it enforces
+the monotonic cursor **and** lets the resume/tail query
+`WHERE session_id = ? AND seq > ? ORDER BY seq` seek the index instead of
+scanning the table — the Turso row-read lesson carried over from `web/`.
+`seq` is the resume cursor #749's tail route reads.
+
+## Payload shape decision: store StreamChunk-shaped, project at read time
+
+`session_events.payload` stores **provider-native `StreamChunk`s** (the universal
+streaming unit every compute provider emits), not pre-adapted `UIMessageChunk`s.
+The `StreamChunk → UIMessage` adapter runs at **read** time, inside the
+projection.
+
+Why store the raw provider events rather than the adapted form:
+
+- **The log stays the true source of truth.** The plan makes `session_events`
+  the single source of truth for the transcript; the raw provider stream is the
+  most faithful record. UIMessages are a *view*.
+- **Replay stays stable across adapter versions.** Tool-call pairing and text
+  bracketing are a moving target (they live in `chunk-adapter.ts` and will grow:
+  reasoning parts, richer tool metadata). Storing the adapted output would freeze
+  historical transcripts at the adapter version that wrote them; a bug fix or new
+  part type could never reach old sessions. Storing raw chunks means any log
+  re-projects correctly under the current adapter — projection is a pure function
+  re-runnable at any version.
+- **Ingest stays a dumb append.** #749 ingests provider `StreamChunk`s into this
+  table as they arrive (detached in the sandbox / Managed Agents session). Writing
+  them verbatim keeps ingest simple and fast — no adapter on the hot write path;
+  the adapter/pairing logic lives in exactly one place, on the read side.
+- **One adapter, both paths.** Live streaming and stored replay run through the
+  *same* `toUIMessageChunks` adapter, so a turn looks identical whether it's
+  streaming live or replayed after a reconnect.
+
+The cost — running the adapter on every read — is bounded and measured: the
+`projection_200` perf scenario projects a 200-event log in ~13ms (budget 40ms).
+If projection ever gets hot, a materialized-projection cache can sit *in front*
+of this log without changing the source of truth.
+
+## Projection
+
+`projectSessionEvents(sessionId, events)` (`src/lib/transcript/project-events.ts`)
+turns the log into the `UIMessage[]` a transcript renders. It **composes** the
+existing adapter with the AI SDK's `readUIMessageStream` reducer:
+
+```
+events → group by role/turn → StreamChunk[] → toUIMessageChunks (adapter)
+       → readUIMessageStream (reduce)        → UIMessage
+```
+
+- Consecutive `user` events → one user message (text concatenated).
+- Each `assistant` turn (a run up to and including a `done` chunk) replays
+  through the adapter and reduces to one assistant message. Transient `status`
+  chunks and stream `error`s never break projection (dropped / surfaced
+  out-of-band, per the adapter contract); an assistant turn with no renderable
+  parts is omitted.
+- **Deterministic:** same log in → same `UIMessage[]` out. Message ids are
+  `${sessionId}:${firstSeq}`; assistant part ids are seeded from the message id
+  (`…:p0`, `…:p1`), never randomized — which is what lets #749 resume a
+  transcript from the DB alone.

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -16,7 +16,9 @@
 	},
 	"dependencies": {
 		"@ai-sdk/react": "^4.0.15",
+		"@libsql/client": "^0.17.4",
 		"ai": "^7.0.14",
+		"kysely": "^0.28.17",
 		"next": "^15.5.19",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
@@ -32,6 +34,7 @@
 		"eslint": "^9.39.4",
 		"eslint-config-next": "^15.5.20",
 		"tailwindcss": "^4.3.2",
+		"tsx": "^4.22.5",
 		"typescript": "^5.7.2",
 		"vitest": "^4.1.9"
 	}

--- a/web-next/perf/BASELINE.md
+++ b/web-next/perf/BASELINE.md
@@ -18,6 +18,7 @@ tightening any budget.
 | ttft_mock | ttft_ms | median | 704 | 1500 | pass |
 | streaming_cadence | longest_task_ms | max | 0 | 50 | pass |
 | transcript_render_200 | initial_render_ms | median | 213.6 | 500 | pass |
+| projection_200 | projection_ms | median | 12.7 | 40 | pass |
 | route_home | lcp_ms | median | 60 | 1200 | pass |
 | route_home | tbt_ms | median | 0 | 200 | pass |
 | route_home | first_load_js_kb | exact | 103.7 | 200 | pass |
@@ -36,6 +37,7 @@ Raw samples from the baseline run:
 | ttft_mock | ttft_ms | 715, 704, 693 |
 | streaming_cadence | longest_task_ms | 0, 0, 0 |
 | transcript_render_200 | initial_render_ms | 223.4, 213.6, 207.2 |
+| projection_200 | projection_ms | 12.7, 14.2, 10.0 |
 | route_home | lcp_ms | 56, 60, 64 |
 | route_home | tbt_ms | 0, 0, 0 |
 | route_spike | lcp_ms | 140, 112, 76 |
@@ -53,6 +55,15 @@ Reading notes:
   same budgets as `route_spike`; the Folio view server-renders from fixtures,
   so its client JS (103.6 kB gz) is the shared baseline plus theme/disclosure
   interactivity — no chat runtime on this route yet (#748 will add it).
+- **2026-07-03 (#746):** `projection_200` added (measured) — the pure
+  events→UIMessage[] projection over a 200-event log (20 interleaved
+  user+assistant turns), run in-process under tsx via `perf/projection-bench.mjs`
+  (not the browser). First measurement 12.7ms median. Budget set to 40ms: ~3x
+  headroom over the dev-container median, chosen so ordinary noise and slower CI
+  pass while a real regression (e.g. an accidental O(n²) over events, or
+  per-event allocation blowup across the 20 `readUIMessageStream` reductions)
+  trips it. This is #749's tail/resume read cost, so it is budgeted tight rather
+  than generous. Re-baseline from CI if it proves noisy there.
 - `ttft_mock` includes ~600ms of scripted provisioning-status delay in the
   mock turn, so real client+server overhead is roughly 110ms of the median.
 - `longest_task_ms` uses the longtask API, which only reports tasks >= 50ms —

--- a/web-next/perf/contract.json
+++ b/web-next/perf/contract.json
@@ -5,7 +5,8 @@
 		"paint_timing": "waitForFunction polls on requestAnimationFrame, so 'painted' means the frame after the DOM change — within one frame of true paint.",
 		"long_tasks": "PerformanceObserver longtask entries, observed in-page. The longtask API only reports tasks >= 50ms, so longest_task_ms reads 0 in a clean run and any nonzero value is a budget violation.",
 		"tbt": "Sum of (longtask duration - 50ms) for buffered long tasks within the settle window after navigation.",
-		"first_load_js": "Gzipped size of the route's client JS chunks from the .next build manifests — same basis as the `next build` First Load JS column."
+		"first_load_js": "Gzipped size of the route's client JS chunks from the .next build manifests — same basis as the `next build` First Load JS column.",
+		"projection": "In-process (no browser): perf/projection-bench.mjs, run under tsx, builds a deterministic 200-event log and times projectSessionEvents over N runs after one warmup, printing JSON samples run.mjs aggregates. Measures the pure events→UIMessage[] projection (adapter + readUIMessageStream reduction) that #749's tail/resume path replays through."
 	},
 	"scenarios": [
 		{
@@ -34,6 +35,16 @@
 			"runs": 3,
 			"metrics": {
 				"initial_render_ms": { "stat": "median", "budget": 500 }
+			}
+		},
+		{
+			"id": "projection_200",
+			"status": "measured",
+			"harness": "node",
+			"description": "Project a 200-event session log (20 interleaved user+assistant turns with status/text/tool events) into UIMessage[] in-process; median wall-clock over the runs. This is the read path #749's tail/resume replays; it must stay cheap enough to project a full transcript on reconnect without blocking.",
+			"runs": 3,
+			"metrics": {
+				"projection_ms": { "stat": "median", "budget": 40 }
 			}
 		},
 		{

--- a/web-next/perf/projection-bench.mjs
+++ b/web-next/perf/projection-bench.mjs
@@ -1,0 +1,78 @@
+/*
+ * In-process benchmark for the session-events → UIMessage projection
+ * (perf/contract.json `projection_200`). Unlike the browser scenarios in
+ * run.mjs, this measures a pure Node function, so run.mjs invokes it under tsx
+ * (which resolves the TypeScript import) and reads the JSON samples it prints.
+ *
+ * Methodology: build a deterministic ~200-event log (20 interleaved
+ * user+assistant turns, each with status/text/tool events), warm up once to
+ * settle JIT, then time `projectSessionEvents` over N runs. Emits
+ * `{ "samples": [ms, …] }` on stdout.
+ */
+import { projectSessionEvents } from "../src/lib/transcript/project-events.ts";
+
+const RUNS = Number(process.argv[2] ?? 5);
+
+/** Ten events per turn → 20 turns = 200 events. */
+function buildTurn(turn) {
+	const s = turn * 10; // seq base for this turn
+	const a = (seq, type, content, metadata) => ({
+		seq,
+		role: "assistant",
+		chunk: { type, content, ...(metadata ? { metadata } : {}) },
+	});
+	return [
+		{ seq: s + 1, role: "user", chunk: { type: "text", content: `Request ${turn}` } },
+		a(s + 2, "status", "Working"),
+		a(s + 3, "text", "Let me investigate the issue. "),
+		a(s + 4, "tool_use", "Read", {
+			toolUseId: `t-${turn}-1`,
+			toolName: "Read",
+			input: { file_path: `src/mod-${turn}.ts` },
+		}),
+		a(s + 5, "tool_result", "const x = load();", { toolUseId: `t-${turn}-1` }),
+		a(s + 6, "text", "Found the cause. Applying the fix. "),
+		a(s + 7, "tool_use", "Bash", {
+			toolUseId: `t-${turn}-2`,
+			toolName: "Bash",
+			input: { command: "pnpm test" },
+		}),
+		a(s + 8, "tool_result", "Tests: 12 passed", { toolUseId: `t-${turn}-2` }),
+		a(s + 9, "text", "All tests pass."),
+		a(s + 10, "done", ""),
+	];
+}
+
+function buildLog(turns) {
+	const events = [];
+	for (let t = 0; t < turns; t++) events.push(...buildTurn(t));
+	return events;
+}
+
+async function main() {
+	const events = buildLog(20);
+	if (events.length !== 200) {
+		throw new Error(`expected 200 events, built ${events.length}`);
+	}
+
+	// Warm up (JIT + module init) so the first timed run isn't an outlier.
+	await projectSessionEvents("perf-warmup", events);
+
+	const samples = [];
+	for (let i = 0; i < RUNS; i++) {
+		const start = performance.now();
+		const messages = await projectSessionEvents("perf", events);
+		samples.push(performance.now() - start);
+		// Guard the workload actually produced the full transcript.
+		if (messages.length !== 40) {
+			throw new Error(`expected 40 messages, got ${messages.length}`);
+		}
+	}
+
+	process.stdout.write(`${JSON.stringify({ samples })}\n`);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/web-next/perf/run.mjs
+++ b/web-next/perf/run.mjs
@@ -5,7 +5,7 @@
  * scenarios (surfaces not built yet) are reported, never failed.
  */
 import { readFileSync, writeFileSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 import {
@@ -197,6 +197,20 @@ async function runTranscriptRender(browser, baseUrl, route, runs) {
 	return { initial_render_ms: samples };
 }
 
+// In-process (no browser): shells out to the tsx bench and reads its JSON
+// samples. Kept a subprocess so run.mjs itself stays plain Node/ESM while the
+// bench imports the TypeScript projection under tsx.
+function runProjectionBench(scenario) {
+	const stdout = execFileSync(
+		"pnpm",
+		["exec", "tsx", "perf/projection-bench.mjs", String(scenario.runs)],
+		{ cwd: WEB_NEXT_ROOT, encoding: "utf8" },
+	);
+	const lastLine = stdout.trim().split("\n").at(-1);
+	const { samples } = JSON.parse(lastLine);
+	return { projection_ms: samples };
+}
+
 const SCENARIO_RUNNERS = {
 	ttft_mock: (browser, baseUrl, scenario) =>
 		runTtftMock(browser, baseUrl, scenario.runs),
@@ -204,6 +218,7 @@ const SCENARIO_RUNNERS = {
 		runStreamingCadence(browser, baseUrl, scenario.runs),
 	transcript_render_200: (browser, baseUrl, scenario) =>
 		runTranscriptRender(browser, baseUrl, scenario.route, scenario.runs),
+	projection_200: (browser, baseUrl, scenario) => runProjectionBench(scenario),
 	route_home: (browser, baseUrl, scenario) =>
 		runRoute(browser, baseUrl, scenario.route, scenario.runs),
 	route_spike: (browser, baseUrl, scenario) =>

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@ai-sdk/react':
         specifier: ^4.0.15
         version: 4.0.15(react@19.2.7)(zod@4.4.3)
+      '@libsql/client':
+        specifier: ^0.17.4
+        version: 0.17.4
       ai:
         specifier: ^7.0.14
         version: 7.0.14(zod@4.4.3)
+      kysely:
+        specifier: ^0.28.17
+        version: 0.28.17
       next:
         specifier: ^15.5.19
         version: 15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -54,12 +60,15 @@ importers:
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
+      tsx:
+        specifier: ^4.22.5
+        version: 4.22.5
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0))
+        version: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))
 
 packages:
 
@@ -115,6 +124,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -343,11 +508,71 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.10.0':
+    resolution: {integrity: sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@next/env@15.5.20':
     resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
@@ -661,6 +886,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.62.1':
     resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
@@ -1077,6 +1305,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1134,6 +1366,11 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1548,6 +1785,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-base64@3.8.0:
+    resolution: {integrity: sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1578,6 +1818,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
+    engines: {node: '>=20.0.0'}
+
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
 
@@ -1588,6 +1832,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1851,6 +2100,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2088,6 +2340,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.5:
+    resolution: {integrity: sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2245,6 +2502,18 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2329,6 +2598,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -2509,6 +2856,64 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@libsql/client@0.17.4':
+    dependencies:
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
+      js-base64: 3.8.0
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/core@0.17.4':
+    dependencies:
+      js-base64: 3.8.0
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.10.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -2522,6 +2927,8 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@next/env@15.5.20': {}
 
@@ -2733,6 +3140,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2905,13 +3316,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@22.20.0)(jiti@2.7.0)
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -3157,6 +3568,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-libc@2.0.2: {}
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
@@ -3288,6 +3701,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-string-regexp@4.0.0: {}
 
@@ -3784,6 +4226,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-base64@3.8.0: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.0:
@@ -3813,6 +4257,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kysely@0.28.17: {}
+
   language-subtag-registry@0.3.23: {}
 
   language-tags@1.0.9:
@@ -3823,6 +4269,21 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4055,6 +4516,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  promise-limit@2.7.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -4369,6 +4832,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.5:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4452,7 +4921,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0):
+  vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -4461,13 +4930,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.22.5
 
-  vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0)):
+  vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.0)(jiti@2.7.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -4484,7 +4955,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@22.20.0)(jiti@2.7.0)
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.0
@@ -4542,6 +5013,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.21.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -1,0 +1,106 @@
+/*
+ * libSQL/Kysely wiring for web-next's durable session store. Defines the typed
+ * `Database` schema (the row shapes Kysely checks queries against) and opens a
+ * connection + query builder over @libsql/client. Tests open a throwaway
+ * `file:` handle; the app uses a lazily-created singleton from the
+ * env-configured URL.
+ *
+ * The schema itself is fresh (no legacy chat_messages compatibility); only the
+ * connection pattern is ported from web/src/lib/db.ts.
+ */
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { type Client, createClient } from "@libsql/client";
+import { Kysely } from "kysely";
+import { LibsqlDialect } from "./libsql-dialect";
+
+/**
+ * A connected repository (a GitHub repo a session can run against). Minimal by
+ * design — the sessions home (#747) and lifecycle work fill this out as needed.
+ */
+export interface ReposTable {
+	/** Stable repo id (GitHub node id or `owner/name`); referenced by sessions. */
+	id: string;
+	/** `owner/name`, the human-facing identifier. */
+	full_name: string;
+	/** Default branch a new session checks out; null until known. */
+	default_branch: string | null;
+	created_at: string;
+}
+
+/**
+ * One coding session — the primary object of the app. A session owns an
+ * append-only `session_events` log; its UIMessage transcript is projected from
+ * that log, never stored here.
+ */
+export interface SessionsTable {
+	id: string;
+	/** repos.id this session runs against; null for not-yet-bound sessions. */
+	repo_id: string | null;
+	title: string;
+	/** Compute provider id — "mock" | "vercel" | "anthropic" | … */
+	provider: string;
+	/** Lifecycle state — "active" | "idle" | "archived" (owned by #749/#750). */
+	status: string;
+	/** Claude CLI session id for snapshot/resume; null until a turn runs. */
+	claude_session_id: string | null;
+	created_at: string;
+	last_activity_at: string;
+}
+
+/**
+ * The append-only transcript log. Each row is one provider `StreamChunk`
+ * (see agent-runtime/stream-chunk.ts) tagged with the turn's role and a
+ * per-session monotonic `seq`. This is the single source of truth for a
+ * session's transcript; `seq` is the resume cursor #749's tail route reads.
+ */
+export interface SessionEventsTable {
+	session_id: string;
+	/** Monotonic per session, starting at 1. (session_id, seq) is the PK. */
+	seq: number;
+	/** Whose turn this chunk belongs to — "user" | "assistant". */
+	role: string;
+	/** The StreamChunk `type` ("text" | "tool_use" | …), denormalized for cheap filtering/debugging. */
+	kind: string;
+	/** JSON-serialized StreamChunk payload. */
+	payload: string;
+	created_at: string;
+}
+
+export interface Database {
+	repos: ReposTable;
+	sessions: SessionsTable;
+	session_events: SessionEventsTable;
+}
+
+/** A connected database: the raw client (for PRAGMA/DDL) and the typed builder. */
+export interface DatabaseHandle {
+	client: Client;
+	db: Kysely<Database>;
+}
+
+
+/** Opens a fresh handle over the given libSQL URL (`file:…` or a Turso URL). */
+export function openDatabase(url: string): DatabaseHandle {
+	if (url.startsWith("file:")) {
+		mkdirSync(dirname(url.slice("file:".length)), { recursive: true });
+	}
+	const client = createClient({
+		url,
+		authToken: process.env.SESSIONS_DATABASE_AUTH_TOKEN,
+	});
+	const db = new Kysely<Database>({ dialect: new LibsqlDialect({ client }) });
+	return { client, db };
+}
+
+let singleton: DatabaseHandle | undefined;
+
+/** The app-wide handle, created once from `SESSIONS_DATABASE_URL`. */
+export function getDatabase(): DatabaseHandle {
+	if (!singleton) {
+		singleton = openDatabase(
+			process.env.SESSIONS_DATABASE_URL ?? "file:.data/sessions.db",
+		);
+	}
+	return singleton;
+}

--- a/web-next/src/lib/db/libsql-dialect.ts
+++ b/web-next/src/lib/db/libsql-dialect.ts
@@ -1,0 +1,86 @@
+/*
+ * Kysely dialect for libSQL/Turso. Ported by copy from the legacy web/ app
+ * (web/src/lib/libsql-dialect.ts) — it encodes the working driver/connection
+ * wiring against @libsql/client that the query builder needs. Kept as its own
+ * file so the schema and store code depend on a stable seam.
+ */
+import type { Client, InValue } from "@libsql/client";
+import {
+	type DatabaseIntrospector,
+	type Dialect,
+	type DialectAdapter,
+	type Driver,
+	type Kysely,
+	type QueryCompiler,
+	SqliteAdapter,
+	SqliteIntrospector,
+	SqliteQueryCompiler,
+} from "kysely";
+
+class LibsqlDriver implements Driver {
+	constructor(private client: Client) {}
+	async init() {}
+	async acquireConnection() {
+		return new LibsqlConnection(this.client);
+	}
+	async beginTransaction(conn: LibsqlConnection) {
+		conn.transaction = await this.client.transaction("deferred");
+	}
+	async commitTransaction(conn: LibsqlConnection) {
+		await conn.transaction?.commit();
+		conn.transaction = undefined;
+	}
+	async rollbackTransaction(conn: LibsqlConnection) {
+		await conn.transaction?.rollback();
+		conn.transaction = undefined;
+	}
+	async releaseConnection() {}
+	async destroy() {
+		this.client.close();
+	}
+}
+
+class LibsqlConnection {
+	transaction?: Awaited<ReturnType<Client["transaction"]>>;
+	constructor(private client: Client) {}
+
+	async executeQuery<R>(query: {
+		sql: string;
+		parameters: readonly unknown[];
+	}) {
+		const target = this.transaction ?? this.client;
+		const result = await target.execute({
+			sql: query.sql,
+			args: query.parameters as InValue[],
+		});
+		return {
+			rows: (result.rows as unknown as R[]) ?? [],
+			numAffectedRows: BigInt(result.rowsAffected),
+			insertId:
+				result.lastInsertRowid != null
+					? BigInt(result.lastInsertRowid.toString())
+					: undefined,
+		};
+	}
+
+	async *streamQuery(): AsyncGenerator<never> {
+		throw new Error("Streaming not supported with libSQL");
+	}
+}
+
+export class LibsqlDialect implements Dialect {
+	constructor(private config: { client: Client }) {}
+	createAdapter(): DialectAdapter {
+		return new SqliteAdapter();
+	}
+	createDriver(): Driver {
+		return new LibsqlDriver(this.config.client);
+	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Kysely's Dialect interface requires Kysely<any>
+	createIntrospector(db: Kysely<any>): DatabaseIntrospector {
+		return new SqliteIntrospector(db);
+	}
+	createQueryCompiler(): QueryCompiler {
+		return new SqliteQueryCompiler();
+	}
+}

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -1,0 +1,77 @@
+/*
+ * Ordered, append-only schema migrations for the session store. Each has a
+ * stable `id` and an idempotent `up(db)` that brings a database to the state it
+ * describes; `ensureSchema()` (in ./schema) runs the pending ones in order and
+ * records each id in `schema_migrations`. Pattern ported from web/src/lib/schema
+ * (idempotent DDL, benign-race tolerance); the tables are fresh.
+ *
+ * Changing the schema: append a new migration with the next ordered id; never
+ * edit one that has shipped (it is already recorded and will not re-run). Keep
+ * `up` idempotent — `ifNotExists()` throughout — so a partial run re-applies
+ * cleanly and two cold starts can overlap.
+ */
+import type { Kysely } from "kysely";
+import type { Database } from "./client";
+
+/** One tracked migration: a stable `id` and an idempotent `up`. */
+export interface Migration {
+	id: string;
+	up(db: Kysely<Database>): Promise<void>;
+}
+
+/**
+ * Baseline: repos, sessions, and the append-only session_events log.
+ */
+const baseline: Migration = {
+	id: "0001_baseline",
+	async up(db) {
+		// --- repos ---
+		await db.schema
+			.createTable("repos")
+			.ifNotExists()
+			.addColumn("id", "text", (c) => c.primaryKey())
+			.addColumn("full_name", "text", (c) => c.notNull())
+			.addColumn("default_branch", "text")
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.execute();
+
+		// --- sessions ---
+		await db.schema
+			.createTable("sessions")
+			.ifNotExists()
+			.addColumn("id", "text", (c) => c.primaryKey())
+			.addColumn("repo_id", "text")
+			.addColumn("title", "text", (c) => c.notNull().defaultTo(""))
+			.addColumn("provider", "text", (c) => c.notNull())
+			.addColumn("status", "text", (c) => c.notNull().defaultTo("active"))
+			.addColumn("claude_session_id", "text")
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("last_activity_at", "text", (c) => c.notNull())
+			.execute();
+		// Sessions home (#747) lists by recency; index the sort key.
+		await db.schema
+			.createIndex("idx_sessions_last_activity")
+			.ifNotExists()
+			.on("sessions")
+			.column("last_activity_at desc")
+			.execute();
+
+		// --- session_events (append-only transcript log) ---
+		await db.schema
+			.createTable("session_events")
+			.ifNotExists()
+			.addColumn("session_id", "text", (c) => c.notNull())
+			.addColumn("seq", "integer", (c) => c.notNull())
+			.addColumn("role", "text", (c) => c.notNull())
+			.addColumn("kind", "text", (c) => c.notNull())
+			.addColumn("payload", "text", (c) => c.notNull())
+			.addColumn("created_at", "text", (c) => c.notNull())
+			// (session_id, seq) is the primary key: it both enforces the monotonic
+			// cursor and lets the tail query `WHERE session_id=? AND seq>?` seek the
+			// index instead of scanning — the Turso row-read lesson from web/.
+			.addPrimaryKeyConstraint("session_events_pk", ["session_id", "seq"])
+			.execute();
+	},
+};
+
+export const MIGRATIONS: Migration[] = [baseline];

--- a/web-next/src/lib/db/schema.ts
+++ b/web-next/src/lib/db/schema.ts
@@ -1,0 +1,40 @@
+/*
+ * The schema runner: applies ./migrations to a database handle and records
+ * which have run in `schema_migrations`. Every store method awaits
+ * `ensureSchema(handle)` before its first query. Idempotent and cheap after the
+ * first call per handle — a per-handle promise cache dedupes concurrent
+ * bootstraps and is cleared on failure so a later call retries.
+ */
+import type { DatabaseHandle } from "./client";
+import { MIGRATIONS } from "./migrations";
+
+/** One in-flight bootstrap per handle, so concurrent callers await one run. */
+const ready = new WeakMap<object, Promise<void>>();
+
+export function ensureSchema(handle: DatabaseHandle): Promise<void> {
+	const existing = ready.get(handle.client);
+	if (existing) return existing;
+	const run = runMigrations(handle).catch((err) => {
+		ready.delete(handle.client);
+		throw err;
+	});
+	ready.set(handle.client, run);
+	return run;
+}
+
+async function runMigrations({ client, db }: DatabaseHandle): Promise<void> {
+	await client.execute(
+		"CREATE TABLE IF NOT EXISTS schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL)",
+	);
+	const appliedRows = await client.execute("SELECT id FROM schema_migrations");
+	const applied = new Set(appliedRows.rows.map((r) => String(r.id)));
+
+	for (const migration of MIGRATIONS) {
+		if (applied.has(migration.id)) continue;
+		await migration.up(db);
+		await client.execute({
+			sql: "INSERT OR IGNORE INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+			args: [migration.id, new Date().toISOString()],
+		});
+	}
+}

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import type { StreamChunk } from "../agent-runtime/stream-chunk";
+import { type DatabaseHandle, openDatabase } from "./client";
+import {
+	type AppendEvent,
+	appendEvents,
+	createSession,
+	getSession,
+	readEvents,
+	readTranscript,
+} from "./sessions";
+
+// A throwaway on-disk libSQL DB per test — isolated, and (unlike a bare
+// `:memory:` client) it survives the reconnect the driver makes across a
+// transaction. Cleaned up in afterEach.
+let open: DatabaseHandle | undefined;
+let dir: string | undefined;
+
+function freshDb(): DatabaseHandle {
+	dir = mkdtempSync(join(tmpdir(), "web-next-db-"));
+	open = openDatabase(`file:${join(dir, "test.db")}`);
+	return open;
+}
+
+afterEach(async () => {
+	await open?.db.destroy();
+	open = undefined;
+	if (dir) rmSync(dir, { recursive: true, force: true });
+	dir = undefined;
+});
+
+function evt(role: AppendEvent["role"], chunk: StreamChunk): AppendEvent {
+	return { role, chunk };
+}
+
+describe("session store", () => {
+	test("migrations apply cleanly and are idempotent", async () => {
+		const handle = freshDb();
+		// Two sessions in a row exercises ensureSchema twice against one handle.
+		await createSession(handle, { id: "a", provider: "mock" });
+		await createSession(handle, { id: "b", provider: "mock" });
+		const recorded = await handle.client.execute(
+			"SELECT id FROM schema_migrations ORDER BY id",
+		);
+		expect(recorded.rows.map((r) => String(r.id))).toEqual(["0001_baseline"]);
+	});
+
+	test("creates and reads back a session", async () => {
+		const handle = freshDb();
+		const created = await createSession(handle, {
+			id: "s1",
+			repoId: "owner/name",
+			title: "Fix the bug",
+			provider: "mock",
+		});
+		expect(created).toMatchObject({
+			id: "s1",
+			repoId: "owner/name",
+			title: "Fix the bug",
+			provider: "mock",
+			status: "active",
+		});
+		expect(await getSession(handle, "s1")).toEqual(created);
+		expect(await getSession(handle, "missing")).toBeUndefined();
+	});
+
+	test("appends events with a monotonic per-session seq and round-trips them", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+
+		const last = await appendEvents(handle, "s1", [
+			evt("user", { type: "text", content: "hi" }),
+			evt("assistant", { type: "text", content: "hello" }),
+		]);
+		expect(last).toBe(2);
+
+		const nextLast = await appendEvents(handle, "s1", [
+			evt("assistant", { type: "done", content: "" }),
+		]);
+		expect(nextLast).toBe(3);
+
+		const events = await readEvents(handle, "s1");
+		expect(events.map((e) => e.seq)).toEqual([1, 2, 3]);
+		expect(events.map((e) => e.role)).toEqual(["user", "assistant", "assistant"]);
+		expect(events[0].chunk).toEqual({ type: "text", content: "hi" });
+
+		// Resume cursor: only events after seq 1.
+		const tail = await readEvents(handle, "s1", 1);
+		expect(tail.map((e) => e.seq)).toEqual([2, 3]);
+	});
+
+	test("keeps per-session seq independent across sessions", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+		await createSession(handle, { id: "s2", provider: "mock" });
+		await appendEvents(handle, "s1", [evt("user", { type: "text", content: "a" })]);
+		const s2Last = await appendEvents(handle, "s2", [
+			evt("user", { type: "text", content: "b" }),
+		]);
+		expect(s2Last).toBe(1); // s2 starts at 1 regardless of s1
+	});
+
+	test("persists a synthetic turn and projects it to the expected transcript", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "sess-1", provider: "mock" });
+		await appendEvents(handle, "sess-1", [
+			evt("user", { type: "text", content: "Fix the null check" }),
+			evt("assistant", { type: "status", content: "Starting sandbox" }),
+			evt("assistant", { type: "text", content: "Reading the file. " }),
+			evt("assistant", {
+				type: "tool_use",
+				content: "Read",
+				metadata: { toolUseId: "t-1", toolName: "Read", input: { file_path: "session.ts" } },
+			}),
+			evt("assistant", {
+				type: "tool_result",
+				content: "return store.get(id);",
+				metadata: { toolUseId: "t-1" },
+			}),
+			evt("assistant", { type: "text", content: "Found it." }),
+			evt("assistant", { type: "done", content: "" }),
+		]);
+
+		expect(await readTranscript(handle, "sess-1")).toEqual([
+			{
+				id: "sess-1:1",
+				role: "user",
+				parts: [{ type: "text", text: "Fix the null check", state: "done" }],
+			},
+			{
+				id: "sess-1:2",
+				role: "assistant",
+				parts: [
+					{ type: "text", text: "Reading the file. ", state: "done" },
+					{
+						type: "dynamic-tool",
+						toolName: "Read",
+						toolCallId: "t-1",
+						state: "output-available",
+						input: { file_path: "session.ts" },
+						output: "return store.get(id);",
+					},
+					{ type: "text", text: "Found it.", state: "done" },
+				],
+			},
+		]);
+	});
+});

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -1,0 +1,182 @@
+/*
+ * Persistence for sessions and their append-only event log. Writes provider
+ * StreamChunks into `session_events` (assigning the per-session monotonic seq),
+ * reads them back in order, and projects them to a UIMessage transcript via the
+ * pure projection in ../transcript/project-events.
+ *
+ * Payload shape: events are stored provider-native (StreamChunk-shaped), with
+ * the adapter run at read time. Rationale in web-next/docs/schema.md — keeping
+ * the raw log as the source of truth lets projection improve across adapter
+ * versions and keeps #749's ingest a dumb append.
+ */
+import type { StreamChunk } from "../agent-runtime/stream-chunk";
+import type {
+	ProjectedEvent,
+	SessionEventRole,
+} from "../transcript/project-events";
+import { projectSessionEvents } from "../transcript/project-events";
+import type { DatabaseHandle, SessionsTable } from "./client";
+import { ensureSchema } from "./schema";
+
+export interface NewSession {
+	id: string;
+	repoId?: string | null;
+	title?: string;
+	provider: string;
+	status?: string;
+	claudeSessionId?: string | null;
+}
+
+export interface Session {
+	id: string;
+	repoId: string | null;
+	title: string;
+	provider: string;
+	status: string;
+	claudeSessionId: string | null;
+	createdAt: string;
+	lastActivityAt: string;
+}
+
+/** An event to append: a StreamChunk plus whose turn it belongs to. */
+export interface AppendEvent {
+	role: SessionEventRole;
+	chunk: StreamChunk;
+}
+
+function rowToSession(row: SessionsTable): Session {
+	return {
+		id: row.id,
+		repoId: row.repo_id,
+		title: row.title,
+		provider: row.provider,
+		status: row.status,
+		claudeSessionId: row.claude_session_id,
+		createdAt: row.created_at,
+		lastActivityAt: row.last_activity_at,
+	};
+}
+
+export async function createSession(
+	handle: DatabaseHandle,
+	session: NewSession,
+): Promise<Session> {
+	await ensureSchema(handle);
+	const now = new Date().toISOString();
+	const row: SessionsTable = {
+		id: session.id,
+		repo_id: session.repoId ?? null,
+		title: session.title ?? "",
+		provider: session.provider,
+		status: session.status ?? "active",
+		claude_session_id: session.claudeSessionId ?? null,
+		created_at: now,
+		last_activity_at: now,
+	};
+	await handle.db.insertInto("sessions").values(row).execute();
+	return rowToSession(row);
+}
+
+export async function getSession(
+	handle: DatabaseHandle,
+	id: string,
+): Promise<Session | undefined> {
+	await ensureSchema(handle);
+	const row = await handle.db
+		.selectFrom("sessions")
+		.selectAll()
+		.where("id", "=", id)
+		.executeTakeFirst();
+	return row ? rowToSession(row) : undefined;
+}
+
+/**
+ * Appends events to a session's log, assigning each the next monotonic seq.
+ * Runs in a transaction so the read-max-then-insert is atomic (single-writer in
+ * production; the transaction keeps tests and any overlap correct). Returns the
+ * seq assigned to the last event — the cursor a tail reader would resume from.
+ */
+export async function appendEvents(
+	handle: DatabaseHandle,
+	sessionId: string,
+	events: readonly AppendEvent[],
+): Promise<number> {
+	await ensureSchema(handle);
+	if (events.length === 0) {
+		return currentMaxSeq(handle, sessionId);
+	}
+	const now = new Date().toISOString();
+	return handle.db.transaction().execute(async (trx) => {
+		const max = await trx
+			.selectFrom("session_events")
+			.select(({ fn }) => fn.max("seq").as("maxSeq"))
+			.where("session_id", "=", sessionId)
+			.executeTakeFirst();
+		let seq = Number(max?.maxSeq ?? 0);
+		for (const event of events) {
+			seq += 1;
+			await trx
+				.insertInto("session_events")
+				.values({
+					session_id: sessionId,
+					seq,
+					role: event.role,
+					kind: event.chunk.type,
+					payload: JSON.stringify(event.chunk),
+					created_at: now,
+				})
+				.execute();
+		}
+		await trx
+			.updateTable("sessions")
+			.set({ last_activity_at: now })
+			.where("id", "=", sessionId)
+			.execute();
+		return seq;
+	});
+}
+
+async function currentMaxSeq(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<number> {
+	const max = await handle.db
+		.selectFrom("session_events")
+		.select(({ fn }) => fn.max("seq").as("maxSeq"))
+		.where("session_id", "=", sessionId)
+		.executeTakeFirst();
+	return Number(max?.maxSeq ?? 0);
+}
+
+/**
+ * Reads a session's events in seq order, optionally only those after `sinceSeq`
+ * (the resume path — the composite PK makes this an index seek, not a scan).
+ */
+export async function readEvents(
+	handle: DatabaseHandle,
+	sessionId: string,
+	sinceSeq = 0,
+): Promise<ProjectedEvent[]> {
+	await ensureSchema(handle);
+	const rows = await handle.db
+		.selectFrom("session_events")
+		.select(["seq", "role", "payload"])
+		.where("session_id", "=", sessionId)
+		.where("seq", ">", sinceSeq)
+		.orderBy("seq", "asc")
+		.execute();
+	return rows.map((row) => ({
+		seq: row.seq,
+		role: row.role as SessionEventRole,
+		chunk: JSON.parse(row.payload) as StreamChunk,
+	}));
+}
+
+/** Convenience: read a session's full log and project it to a transcript. */
+export async function readTranscript(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<Awaited<ReturnType<typeof projectSessionEvents>>> {
+	const events = await readEvents(handle, sessionId);
+	return projectSessionEvents(sessionId, events);
+}

--- a/web-next/src/lib/transcript/project-events.test.ts
+++ b/web-next/src/lib/transcript/project-events.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "vitest";
+import {
+	type ProjectedEvent,
+	projectSessionEvents,
+} from "./project-events";
+
+/**
+ * Terse builders so the fixtures read as a transcript, not a wall of object
+ * literals. `u` = a user event, `a` = an assistant event; seq is auto-assigned
+ * in array order but each test can shuffle to prove ordering independence.
+ */
+function u(seq: number, content: string): ProjectedEvent {
+	return { seq, role: "user", chunk: { type: "text", content } };
+}
+function a(
+	seq: number,
+	type: ProjectedEvent["chunk"]["type"],
+	content: string,
+	metadata?: Record<string, unknown>,
+): ProjectedEvent {
+	return { seq, role: "assistant", chunk: { type, content, metadata } };
+}
+
+describe("projectSessionEvents", () => {
+	test("projects a full user+assistant turn (the canonical example)", async () => {
+		const events: ProjectedEvent[] = [
+			u(1, "Fix the null check in resumeSession"),
+			a(2, "status", "Starting sandbox"),
+			a(3, "text", "Let me read the file. "),
+			a(4, "tool_use", "Read", {
+				toolUseId: "t-1",
+				toolName: "Read",
+				input: { file_path: "session.ts" },
+			}),
+			a(5, "tool_result", "return store.get(id);", { toolUseId: "t-1" }),
+			a(6, "text", "Found the bug."),
+			a(7, "done", ""),
+		];
+
+		// This asserted value IS the projection example: same log in, same
+		// UIMessage[] out, every id derived from session id + seq.
+		expect(await projectSessionEvents("sess-1", events)).toEqual([
+			{
+				id: "sess-1:1",
+				role: "user",
+				parts: [
+					{ type: "text", text: "Fix the null check in resumeSession", state: "done" },
+				],
+			},
+			{
+				id: "sess-1:2",
+				role: "assistant",
+				parts: [
+					{ type: "text", text: "Let me read the file. ", state: "done" },
+					{
+						type: "dynamic-tool",
+						toolName: "Read",
+						toolCallId: "t-1",
+						state: "output-available",
+						input: { file_path: "session.ts" },
+						output: "return store.get(id);",
+					},
+					{ type: "text", text: "Found the bug.", state: "done" },
+				],
+			},
+		]);
+	});
+
+	test("is deterministic and order-independent (shuffled seq → same output)", async () => {
+		const ordered: ProjectedEvent[] = [
+			u(1, "hi"),
+			a(2, "text", "hello"),
+			a(3, "done", ""),
+		];
+		const shuffled = [ordered[2], ordered[0], ordered[1]];
+		const fromOrdered = await projectSessionEvents("s", ordered);
+		const fromShuffled = await projectSessionEvents("s", shuffled);
+		expect(fromShuffled).toEqual(fromOrdered);
+		expect(fromOrdered.map((m) => m.id)).toEqual(["s:1", "s:2"]);
+	});
+
+	test("pairs tool results by explicit toolUseId across two calls", async () => {
+		const messages = await projectSessionEvents("s", [
+			a(1, "tool_use", "Read", { toolUseId: "t-1", toolName: "Read" }),
+			a(2, "tool_use", "Bash", { toolUseId: "t-2", toolName: "Bash" }),
+			a(3, "tool_result", "second", { toolUseId: "t-2" }),
+			a(4, "tool_result", "first", { toolUseId: "t-1" }),
+			a(5, "done", ""),
+		]);
+		const parts = messages[0].parts.filter((p) => p.type === "dynamic-tool");
+		expect(parts).toMatchObject([
+			{ toolCallId: "t-1", state: "output-available", output: "first" },
+			{ toolCallId: "t-2", state: "output-available", output: "second" },
+		]);
+	});
+
+	test("pairs a tool result with no id FIFO against the open call", async () => {
+		const messages = await projectSessionEvents("s", [
+			a(1, "tool_use", "Bash", { toolUseId: "t-1", toolName: "Bash" }),
+			a(2, "tool_result", "done"),
+			a(3, "done", ""),
+		]);
+		expect(messages[0].parts).toMatchObject([
+			{ type: "dynamic-tool", toolCallId: "t-1", state: "output-available", output: "done" },
+		]);
+	});
+
+	test("maps an error tool result to an errored tool part", async () => {
+		const messages = await projectSessionEvents("s", [
+			a(1, "tool_use", "Bash", { toolUseId: "t-1", toolName: "Bash" }),
+			a(2, "tool_result", "exit 1", { toolUseId: "t-1", isError: true }),
+			a(3, "done", ""),
+		]);
+		expect(messages[0].parts).toMatchObject([
+			{ type: "dynamic-tool", state: "output-error", errorText: "exit 1" },
+		]);
+	});
+
+	test("a stream error preserves preceding text and never throws", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "go"),
+			a(2, "text", "partial answer"),
+			a(3, "error", "sandbox died"),
+		]);
+		expect(messages).toHaveLength(2);
+		expect(messages[1]).toMatchObject({
+			role: "assistant",
+			parts: [{ type: "text", text: "partial answer" }],
+		});
+	});
+
+	test("interleaves multiple user+assistant turns in one log", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "first question"),
+			a(2, "text", "first answer"),
+			a(3, "done", ""),
+			u(4, "second question"),
+			a(5, "text", "second answer"),
+			a(6, "done", ""),
+		]);
+		expect(
+			messages.map((m) => ({ id: m.id, role: m.role })),
+		).toEqual([
+			{ id: "s:1", role: "user" },
+			{ id: "s:2", role: "assistant" },
+			{ id: "s:4", role: "user" },
+			{ id: "s:5", role: "assistant" },
+		]);
+	});
+
+	test("splits back-to-back assistant turns at each done chunk", async () => {
+		const messages = await projectSessionEvents("s", [
+			a(1, "text", "turn one"),
+			a(2, "done", ""),
+			a(3, "text", "turn two"),
+			a(4, "done", ""),
+		]);
+		expect(messages.map((m) => m.id)).toEqual(["s:1", "s:3"]);
+		expect(messages.every((m) => m.role === "assistant")).toBe(true);
+	});
+
+	test("omits an assistant turn that yields no renderable parts", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "hi"),
+			a(2, "status", "provisioning"),
+			a(3, "done", ""),
+		]);
+		expect(messages.map((m) => m.role)).toEqual(["user"]);
+	});
+
+	test("concatenates consecutive user events into one message", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "part one "),
+			u(2, "part two"),
+			a(3, "text", "ok"),
+			a(4, "done", ""),
+		]);
+		expect(messages[0]).toEqual({
+			id: "s:1",
+			role: "user",
+			parts: [{ type: "text", text: "part one part two", state: "done" }],
+		});
+	});
+});

--- a/web-next/src/lib/transcript/project-events.ts
+++ b/web-next/src/lib/transcript/project-events.ts
@@ -1,0 +1,113 @@
+/*
+ * Pure projection: an append-only session_events log → the UIMessage[] a
+ * transcript renders. This is the read side of the durable-turns architecture
+ * (the log is the single source of truth; messages are never stored).
+ *
+ * It COMPOSES the existing StreamChunk→UIMessageChunk adapter (chunk-adapter.ts)
+ * with the AI SDK's `readUIMessageStream` reducer, so tool-call pairing and text
+ * bracketing live in exactly one place: stored events replay through the same
+ * adapter that live streams use, then reduce to messages identically. Same log
+ * in → same UIMessage[] out (ids are derived from session id + seq, never
+ * randomised), which is what lets #749 resume a transcript from the DB alone.
+ */
+import { type UIMessage, readUIMessageStream } from "ai";
+import type { StreamChunk } from "../agent-runtime/stream-chunk";
+import { toUIMessageChunkStream } from "./chunk-adapter";
+
+export type SessionEventRole = "user" | "assistant";
+
+/** One stored event: a provider StreamChunk tagged with its turn role and seq. */
+export interface ProjectedEvent {
+	/** Per-session monotonic position; also the id seed for the message it opens. */
+	seq: number;
+	role: SessionEventRole;
+	chunk: StreamChunk;
+}
+
+/**
+ * Projects a session's event log into its full transcript (user + assistant
+ * UIMessages). Deterministic: events are ordered by `seq`, grouped into
+ * messages, and given stable ids of the form `${sessionId}:${firstSeq}`.
+ *
+ * Grouping rules:
+ * - A run of consecutive `user` events becomes one user message (their text
+ *   concatenated) — a turn starts with the user's message.
+ * - A run of consecutive `assistant` events becomes one assistant message,
+ *   split whenever a `done` chunk closes a turn, so several assistant turns in
+ *   one log each project to their own message.
+ * - Assistant runs replay through the adapter + `readUIMessageStream`; transient
+ *   `status` chunks and stream `error`s never break projection (they are
+ *   dropped / surfaced out-of-band, matching the adapter contract).
+ * - An assistant run that yields no renderable parts (e.g. only status/error) is
+ *   omitted rather than emitting an empty bubble.
+ */
+export async function projectSessionEvents(
+	sessionId: string,
+	events: readonly ProjectedEvent[],
+): Promise<UIMessage[]> {
+	const ordered = [...events].sort((a, b) => a.seq - b.seq);
+	const messages: UIMessage[] = [];
+
+	let i = 0;
+	while (i < ordered.length) {
+		const { role, seq: firstSeq } = ordered[i];
+		if (role === "user") {
+			const chunks: StreamChunk[] = [];
+			while (i < ordered.length && ordered[i].role === "user") {
+				chunks.push(ordered[i].chunk);
+				i += 1;
+			}
+			messages.push(buildUserMessage(messageId(sessionId, firstSeq), chunks));
+		} else {
+			const chunks: StreamChunk[] = [];
+			while (i < ordered.length && ordered[i].role === "assistant") {
+				const chunk = ordered[i].chunk;
+				chunks.push(chunk);
+				i += 1;
+				if (chunk.type === "done") break; // this assistant turn ends here
+			}
+			const message = await buildAssistantMessage(
+				messageId(sessionId, firstSeq),
+				chunks,
+			);
+			if (message) messages.push(message);
+		}
+	}
+
+	return messages;
+}
+
+function messageId(sessionId: string, firstSeq: number): string {
+	return `${sessionId}:${firstSeq}`;
+}
+
+/** A user message is plain text — the concatenated content of its events. */
+function buildUserMessage(id: string, chunks: StreamChunk[]): UIMessage {
+	const text = chunks.map((chunk) => chunk.content).join("");
+	return { id, role: "user", parts: [{ type: "text", text, state: "done" }] };
+}
+
+/**
+ * Replays assistant events through the shared adapter and reduces the resulting
+ * UIMessageChunk stream to a single message. Part ids are seeded from the
+ * message id so the projection is byte-for-byte reproducible.
+ */
+async function buildAssistantMessage(
+	id: string,
+	chunks: StreamChunk[],
+): Promise<UIMessage | undefined> {
+	let part = 0;
+	const stream = toUIMessageChunkStream(chunks, {
+		messageId: id,
+		generateId: () => `${id}:p${part++}`,
+	});
+	let last: UIMessage | undefined;
+	// readUIMessageStream yields the growing message on each update; the final
+	// value is the complete one. onError swallows stream `error` chunks so a
+	// failed turn still projects whatever it produced before failing.
+	for await (const message of readUIMessageStream({ stream, onError: () => {} })) {
+		last = message;
+	}
+	if (!last || last.parts.length === 0) return undefined;
+	return last;
+}


### PR DESCRIPTION
Closes #746 — third issue of the **Sessions-first web (web-next)** milestone, executed under `backlog/web-next-execution-brief.md`. This is the durable transcript's data foundation: the append-only event log that #749's detached ingest + tail route will build on.

## Summary

- **Schema** (`web-next/src/lib/db/`, Kysely + libSQL, conventions ported from the legacy app's migration/dialect setup): minimal `repos`; `sessions` (id, repo, title, provider, status, `claude_session_id`, timestamps; indexed on `last_activity_at desc` for the #747 sessions home); append-only **`session_events`** (`session_id`, `seq`, `role`, `kind`, `payload`, `created_at`) with PK `(session_id, seq)` — the monotonic resume cursor, and an index seek (not a scan) for the tail query `WHERE session_id=? AND seq>?` (Turso row-read discipline).
- **Payload-shape decision, documented in `web-next/docs/schema.md`**: events store **StreamChunk-shaped (provider-native) payloads; the adapter runs at read time**. The raw log stays the source of truth; replay stays stable across adapter versions; #749's ingest is a dumb append; one adapter serves live streaming and stored replay.
- **Pure projection** (`src/lib/transcript/project-events.ts`): `projectSessionEvents(sessionId, events)` composes the existing `chunk-adapter` with the AI SDK's `readUIMessageStream` reducer — tool pairing/text bracketing live in exactly one place. Deterministic: message ids are `${sessionId}:${firstSeq}`, part ids seeded from the message id — same log always projects to the same `UIMessage[]`. User messages are events too, so the full transcript (user + assistant) projects from the log alone.
- **Perf**: new in-process `projection_200` scenario in the harness (200 events across 20 interleaved turns).

## Mergeability

- Surface: web (`web-next/`)
- User-facing behavior changed: none — no routes touched; library + schema layer only
- Non-happy paths considered: tool results without ids (FIFO pairing, tested), error events, interleaved turns, empty logs; migrations are idempotent append-only; tests use throwaway on-disk libSQL files because a bare `:memory:` client resets across the driver's transaction reconnect (documented)
- Release/ops preconditions: none — no production DB is wired yet; schema applies via `ensureSchema()` on first use
- Residual risk or follow-up: #749 adds ingest + tail route on this cursor; projection currently loads full logs (fine at session scale, measured at 12.7ms/200 events)

## Validation

- [ ] `swift build` — n/a
- [ ] `swift test` — n/a
- [x] Other checks run: in `web-next/` — `pnpm lint` clean · `pnpm typecheck` clean · `pnpm test` **47 passed** (11 projection + 6 store new) · `pnpm build` clean · `pnpm test:e2e` **10 passed** · `pnpm perf` exit 0

## Performance

- [ ] Not a performance-sensitive change
- [x] Used canonical scenario(s) from `web-next/perf/contract.json`
- [x] Before and after evidence — new scenario baseline below
- [x] Deltas called out — no existing scenario regressed

| Scenario | Metric | Result | Budget |
|---|---|---|---|
| projection_200 (new) | project_ms (median) | **12.7** | 40 |
| all prior scenarios | — | unchanged, within budget | — |

Budget reasoning: ~3× headroom over the measured median — tight enough to trip an accidental O(n²) in the projection or a per-reduction allocation blowup.

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached — vitest **47 passed** including the projection edge cases (tool result without id, error events, interleaved turns, determinism); a fixture-based projection example is asserted in `project-events.test.ts` (the example IS the test)
- [ ] UI evidence — n/a: no UI surface in this PR (backend/schema only); the CI lane still publishes the standard `web-next-evidence` artifact confirming routes are unaffected

Evidence links:

- `web-next-ci` run on this PR (Checks tab) → green lane + `web-next-perf-results` artifact with the `projection_200` baseline

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ)_