### PR TITLE
web-next: fix 1-in-16 flake in session-cookie tamper test

### DIFF
--- a/web-next/src/lib/auth/session-cookie.test.ts
+++ b/web-next/src/lib/auth/session-cookie.test.ts
@@ -61,7 +61,13 @@ async function buildSessionDataCookie(opts: {
 		JSON.stringify({ ...session, expiresAt: opts.expiresAt }),
 	);
 	if (opts.tamper) {
-		signature = `${signature.slice(0, -1)}${signature.endsWith("A") ? "B" : "A"}`;
+		// Flip the FIRST character, which carries 6 fully-significant bits, so
+		// the tampered string always decodes to different signature bytes. Do
+		// not tamper the 43rd (final) char: it encodes only 4 significant bits
+		// (the low 2 are padding that decoders discard), so e.g. 'A'->'B' there
+		// decodes to identical bytes and HMAC verification still passes —
+		// a 1-in-16 flake, since the signed payload embeds Date.now().
+		signature = `${signature.startsWith("A") ? "B" : "A"}${signature.slice(1)}`;
 	}
 	return base64UrlEncodeString(
 		JSON.stringify({ session, expiresAt: opts.expiresAt, signature }),


### PR DESCRIPTION
Closes #774 — CI-reliability fix for the milestone relay, executed under `backlog/web-next-execution-brief.md`.

## Summary

- The intermittent `session-cookie.test.ts` failure was **not** test ordering or Better Auth shared state (the issue's suspicion was wrong). The tamper helper flipped the **last** base64url character of the HMAC-SHA256 signature — but a 32-byte signature is 43 base64url chars whose 43rd character carries only 4 significant bits. Better Auth decodes the signature to bytes before `crypto.subtle.verify`, so whenever the genuine final char was `A` (1/16 per run — the payload embeds `Date.now()`), the "tampered" `B` decoded to identical bytes and verification passed: `fresh` instead of `stale`.
- Fix: tamper the **first** character (fully significant 6 bits), with a comment explaining why the final char must not be used. Test-only, +7/−1; the assertion is unchanged and now deterministic.

## Mergeability

- Surface: web (`web-next/` test only)
- User-facing behavior changed: none
- Non-happy paths considered: the pre-fix flake reproduced 4/40 isolated runs; a standalone Web Crypto script deterministically demonstrates last-char `A→B` verifying true while a first-char flip verifies false
- Release/ops preconditions: none
- Residual risk or follow-up: none

## Validation

- [ ] `swift build` — n/a
- [ ] `swift test` — n/a
- [x] Other checks run: in `web-next/` — **12/12 consecutive full-suite runs passed**, 5/5 shuffled-seed runs passed (seeds 1, 7, 42, 1337, 99991), 40/40 isolated runs of the fixed file passed (vs 4/40 failures pre-fix); `pnpm lint` / `pnpm typecheck` / `pnpm build` clean

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached — run counts above; 12 consecutive green full-suite runs is the issue's acceptance criterion, met
- [ ] UI evidence — n/a, test-only change

Evidence links:

- This PR's `web-next-ci` run (Checks tab) — the lane exercises the fixed suite

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ)_