### PR TITLE
docs(web-next): adopt @ai-sdk/harness as session runtime (ADR + plan revision)

### DIFF
--- a/backlog/web-experience-redesign_plan.md
+++ b/backlog/web-experience-redesign_plan.md
@@ -7,6 +7,16 @@ Execution is an autonomous milestone run — operating contract in
 `backlog/web-next-execution-brief.md`, work tracked in the GitHub milestone
 **"Sessions-first web (web-next)"**.
 
+> **Revision 2026-07-03 — runtime.** The session runtime is now **`@ai-sdk/harness`**
+> (Claude Code / Codex / Pi through one AI SDK surface), behind a thin app-owned
+> `SessionRuntime` interface — see `docs/decisions/web-next-harness-runtime.md`.
+> This supersedes the hand-built runtime described in the "Backend" and "Ported
+> vs fresh" sections below (custom `StreamChunk → UIMessage` adapter, ported Vercel
+> provider, bespoke durable turns, Claude Code sandbox auth): the harness owns
+> those. We still own persistence, reconnect policy, and the terminal. The
+> **authoritative, current plan is the ordered ticket list in the execution
+> brief**; sections below are retained as design history.
+
 ## Intent
 
 The web app becomes a place you **enter a coding session** — the same feeling as

--- a/backlog/web-next-execution-brief.md
+++ b/backlog/web-next-execution-brief.md
@@ -110,11 +110,57 @@ The tracker lags the code; treat the plan as living.
 
 - **Single-user.** No multi-tenant authorization matrix, no onboarding polish, no
   data migration. Auth is OAuth + a login allowlist.
-- **Mock-first.** Prove the Folio surface streams correctly against the mock
-  provider before wiring real compute; swap providers behind the same
-  `StreamChunk → UIMessage` adapter.
+- **Harness runtime, behind our own interface.** The session runtime is
+  `@ai-sdk/harness` (Claude Code / Codex / Pi), wrapped by a thin app-owned
+  `SessionRuntime` interface so the experimental API never leaks app-wide — see
+  `docs/decisions/web-next-harness-runtime.md`. The harness owns stream→UIMessage
+  projection, sandbox + CLI auth, and multi-runtime dispatch; we own persistence,
+  reconnect policy, and the terminal. **Exact-pin** every `@ai-sdk/harness*` and
+  `@ai-sdk/sandbox-*` version; upgrade deliberately. Spike it (T0.5) before
+  building UI on it. Because a real runtime is now as easy as a mock, stream a
+  **real** provider from the first slice — do not build a long mock phase.
+- **Reconnect (v1).** Between-turn durability + server-side long-turn continuation
+  are in scope; **mid-turn live tail is deferred** — a turn keeps running
+  server-side and we re-attach or replay the completed transcript on reconnect.
 - **Don't disturb the old app.** `web/` keeps serving webhooks and the managed PR
   reviewer until the final cutover issue; nothing before it touches that path.
+
+## Authoritative ticket order
+
+This list supersedes any ordering elsewhere. Serial; one at a time.
+
+1. **#744 · T0** — CI + evidence + performance harness.
+2. **T0.5 (new)** — Harness runtime spike: real Claude Code turn via
+   `@ai-sdk/harness` + `@ai-sdk/sandbox-vercel` → `toUIMessageStream` → `useChat`,
+   auth working in-sandbox, exact-pinned, behind the `SessionRuntime` interface.
+   De-risks the experimental dependency before any UI is built on it.
+3. **#745 · T1** — Folio design system as React components.
+4. **#746 · T2** — Chat persistence: stored UIMessages + `resumeFrom` blob per
+   session (harness owns the projection; we own the store + read-back).
+5. **#747 · T3** — Auth + sessions home + new-session flow, incl. a **runtime
+   picker** (Claude Code / Codex / Pi).
+6. **#748 · T4** — A **real Claude Code** turn streams into the live Folio
+   transcript (not mock).
+7. **#749 · T5** — Durability: between-turn resume + long-turn slicing via the
+   harness workflow utilities; v1 reconnect = re-attach/replay.
+8. **#750 · T6** — Multi-runtime: add the **Codex** and **Pi** adapters behind the
+   interface + picker.
+9. **#752 · T8** — Terminal drawer: ttyd on a sandbox port (shared-sandbox
+   pattern) + ghostty-web.
+10. **#753 · T9** — Lifecycle controls + error states + mobile.
+11. **#754 · T10** — Cutover.
+
+**#751 · T7 (Managed Agents) is closed** — not a harness, out of web-next scope.
+
+## Quality-gate review
+
+Because the runtime rides an experimental API, the quality gate is not
+self-attestation alone: for every PR touching the runtime/backend seam (the spike,
+persistence, durability, multi-runtime, terminal), run the `/code-review` pass via
+a **separate reviewer subagent on a stronger model (Opus)** before merging, and
+treat any harness API surprise (a rename, a missing capability, a behavior that
+contradicts the docs) as an escalation-worthy architectural signal, not a
+work-around to bury.
 
 ## Tooling
 

--- a/docs/decisions/web-next-harness-runtime.md
+++ b/docs/decisions/web-next-harness-runtime.md
@@ -1,0 +1,85 @@
+# ADR: AI SDK Harnesses as the web-next session runtime
+
+- Status: **Accepted** (2026-07-03)
+- Scope: `web-next/` (the sessions-first web rewrite)
+- Related: `backlog/web-experience-redesign_plan.md` (PRD), `backlog/web-next-execution-brief.md` (operating contract)
+
+## Context
+
+web-next is a browser coding-session experience: chat with an agent that reads,
+writes, and runs code in a cloud sandbox, rendered in the Folio design system via
+`useChat`. A stated goal is running **Claude Code, Codex, and Pi** through one
+surface.
+
+The original plan hand-built the runtime layer: a `StreamChunk → UIMessage`
+adapter (Phase 0), a ported Vercel-Sandbox provider that parses
+`claude -p --output-format stream-json`, bespoke durable/resumable turns, and a
+re-solve of Claude Code CLI auth inside the sandbox (the last cost the current app
+four PRs). Mid-plan, Vercel shipped **`@ai-sdk/harness`** — an official,
+`ai@7`-native abstraction that provides exactly this layer, multi-runtime, with
+sandbox auth handled. Verified 2026-07-03: the packages are real
+(`@ai-sdk/harness`, `-claude-code`, `-codex`, `-pi`, `@ai-sdk/sandbox-vercel`),
+pin `ai@7.0.14`, and forward host `ANTHROPIC_API_KEY`/gateway credentials into the
+sandbox bridge for us. They are also explicitly **experimental** — ~4 weeks old,
+tens of releases per month, a `1.0` label that overstates stability.
+
+## Decision
+
+Adopt `@ai-sdk/harness` as the web-next **session runtime**, **behind a thin,
+app-owned `SessionRuntime` interface**, with **exact-pinned** versions.
+
+- **The harness owns:** stream → UIMessage projection (`toUIMessageStream`),
+  sandbox provisioning + Claude Code/Codex/Pi CLI auth, multi-runtime dispatch,
+  between-turn resume (`detach()`/`resumeFrom`) and long-turn continuation
+  (workflow slicing).
+- **We own:** the `SessionRuntime` interface that wraps it; transcript
+  persistence (stored UIMessages + the opaque `resumeFrom` blob, keyed by
+  session) for reload replay; the reconnect policy; the terminal PTY drawer (run
+  ttyd on a sandbox port via the shared-sandbox pattern — the harness provides no
+  terminal, and `@ai-sdk/tui` is a Node dev renderer, not a browser PTY); the
+  Folio UI; auth + allowlist.
+
+The custom Phase 0 `StreamChunk → UIMessage` adapter is retired from the critical
+path (kept only as a reference for adapting any future non-harness stream).
+Managed Agents leaves web-next scope (it is not a harness).
+
+### v1 scope decision — reconnect
+
+The harness gives between-turn resume and server-side long-turn continuation, but
+**no tail into an in-flight turn**. For v1 that is acceptable: a turn keeps
+running server-side; on reconnect we re-attach or replay the completed transcript.
+True mid-turn live tail is deferred until use shows it matters.
+
+## Consequences
+
+**Gains** — removes the two pieces that actually hurt (the custom adapter and
+Claude Code sandbox auth), deletes the `stream-json` parsing risk, and delivers
+Claude Code + Codex + Pi near-free (the three-runtime goal). The backend tickets
+shrink and de-risk; we can stream a *real* provider from the first slice instead
+of a long mock phase.
+
+**Costs / risks** — a load-bearing dependency on an explicitly experimental,
+fast-churning API. Mitigations: (1) the thin `SessionRuntime` interface keeps the
+API from leaking app-wide and preserves an exit to a hand-rolled provider; (2)
+exact-pin every `@ai-sdk/harness*` / `@ai-sdk/sandbox-*` version and upgrade
+deliberately; (3) a harness spike de-risks it before the milestone commits; (4)
+single-user means a breaking change is a controlled upgrade, not an incident.
+
+**Not covered by the harness (stays ours):** renderable transcript store,
+mid-turn live reconnect, terminal.
+
+## Alternatives considered
+
+- **Hand-roll providers + our own adapter** (full control, stable deps) —
+  rejected: strictly more work, re-earns already-solved pain (sandbox auth), and
+  still owes Codex/Pi from scratch.
+- **Wait for the harness to stabilize** — rejected: the thin-interface + pin
+  mitigates the risk, and the payoff (auth + three runtimes) is available now.
+- **Build directly on the harness, no interface** — rejected: an experimental API
+  would leak into every surface with no exit.
+
+## Exit strategy
+
+If the harness API breaks unacceptably, implement `SessionRuntime` with a
+hand-rolled harness/provider (the original plan) without touching the UI,
+persistence, or terminal layers.

--- a/docs/decisions/web-next-harness-runtime.md
+++ b/docs/decisions/web-next-harness-runtime.md
@@ -39,9 +39,20 @@ app-owned `SessionRuntime` interface**, with **exact-pinned** versions.
   terminal, and `@ai-sdk/tui` is a Node dev renderer, not a browser PTY); the
   Folio UI; auth + allowlist.
 
-The custom Phase 0 `StreamChunk → UIMessage` adapter is retired from the critical
-path (kept only as a reference for adapting any future non-harness stream).
 Managed Agents leaves web-next scope (it is not a harness).
+
+**Reconciled with the shipped T0–T5 code (2026-07-03).** The app already exposes a
+`ComputeProvider` seam — `{ id, runTurn(): AsyncIterable<StreamChunk> }` — with a
+detached-ingest → `session_events` → tail pipeline that already delivers durable,
+resumable turns. So the harness enters as an **additive `ComputeProvider`** whose
+`runTurn` drives a `HarnessAgent` and maps the harness stream back to `StreamChunk`
+— no pipeline rework, and no separate `SessionRuntime` abstraction: the shipped
+`ComputeProvider` seam *is* the thin interface this ADR called for, and
+`StreamChunk` stays the internal currency. The one genuinely new piece is
+persisting the harness `resumeFrom` per session for multi-turn continuity (the
+harness owns native history and does not replay it). This makes adoption
+lower-risk than the original framing — the experimental API is contained to one
+provider file behind an interface the app already ships.
 
 ### v1 scope decision — reconnect
 

--- a/web-next/.env.local.example
+++ b/web-next/.env.local.example
@@ -22,6 +22,8 @@ VERCEL_PROJECT_ID=
 
 # Repo clone — reuse the existing GitHub App (installation tokens, repo-scoped):
 GITHUB_WEB_WORKSPACES_APP_ID=
+# Private key is a multi-line PEM — store it single-line as base64 to keep .env sane:
+#   base64 -i app.pem | tr -d '\n'
 GITHUB_APP_PRIVATE_KEY=
 
 # --- Production login only (leave unset locally so AUTH_BYPASS stays active) ---

--- a/web-next/.env.local.example
+++ b/web-next/.env.local.example
@@ -1,0 +1,31 @@
+# web-next environment — copy to `.env.local` (gitignored) and fill in.
+# Canonical variable names for all three stores: this Mac (.env.local),
+# Claude Code cloud dev (env settings), and Vercel production (project env vars).
+# See docs/deploy.md for which vars each store actually needs.
+
+# --- Local review / dev (no credentials needed) ---
+AUTH_BYPASS=1
+ALLOWED_LOGINS=fairchild
+SESSIONS_DATABASE_URL=file:.data/sessions.db
+# SESSIONS_DATABASE_AUTH_TOKEN=      # only when SESSIONS_DATABASE_URL is a remote libsql:// (Turso)
+
+# --- Real agent runtime (#750+): needed only to run a real Claude Code turn ---
+# Model auth — prefer the AI Gateway key (spend cap, one key for Claude/Codex/Pi):
+AI_GATEWAY_API_KEY=
+# ...or a raw Anthropic key instead:
+# ANTHROPIC_API_KEY=
+
+# Vercel Sandbox (off-Vercel only — production uses the auto-injected OIDC token):
+VERCEL_TOKEN=
+VERCEL_TEAM_ID=
+VERCEL_PROJECT_ID=
+
+# Repo clone — reuse the existing GitHub App (installation tokens, repo-scoped):
+GITHUB_WEB_WORKSPACES_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+
+# --- Production login only (leave unset locally so AUTH_BYPASS stays active) ---
+# GITHUB_OAUTH_CLIENT_ID=
+# GITHUB_OAUTH_CLIENT_SECRET=
+# BETTER_AUTH_SECRET=            # openssl rand -hex 32
+# BETTER_AUTH_URL=              # e.g. https://spaces.example.com

--- a/web-next/docs/deploy.md
+++ b/web-next/docs/deploy.md
@@ -38,3 +38,31 @@ AUTH_BYPASS=1 ALLOWED_LOGINS=<your-github-login> pnpm dev
 
 Then use the "continue as … (test bypass)" button on `/sign-in`. The database
 defaults to `file:.data/sessions.db` (gitignored); no other env is needed.
+
+## Real-runtime credentials (#750+)
+
+The auth/DB vars above run the app and its mock provider. The **real** agent
+runtime (`@ai-sdk/harness` → Claude Code in a Vercel sandbox) needs three more
+things, in three places. Copy `.env.local.example` → `.env.local` on the Mac; put
+the same secrets in the Claude Code cloud-dev environment and the Vercel project.
+
+| Variable | Mac (`.env.local`) | Cloud dev | Vercel prod | Source |
+|---|---|---|---|---|
+| `ANTHROPIC_API_KEY` **or** `AI_GATEWAY_API_KEY` | ✓ | ✓ | ✓ | Anthropic console / AI Gateway (gateway preferred: spend cap, one key for Claude/Codex/Pi) |
+| `VERCEL_TOKEN` / `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` | ✓ | ✓ | — (Vercel injects OIDC on-platform) | vercel.com/account/tokens, project settings |
+| `GITHUB_WEB_WORKSPACES_APP_ID` + `GITHUB_APP_PRIVATE_KEY` | ✓ | ✓ | ✓ | existing GitHub App — mints short-lived, repo-scoped installation tokens for the sandbox clone |
+
+Notes:
+
+- **Local review needs none of these** — only `AUTH_BYPASS=1` + `ALLOWED_LOGINS`.
+  These are exclusively for making a real agent turn run.
+- **Vercel production doesn't need the `VERCEL_*` tokens**: running *on* Vercel,
+  the Sandbox authenticates via the auto-injected `VERCEL_OIDC_TOKEN`. Those
+  tokens are only needed *off*-Vercel (the Mac and cloud-dev).
+- **Repo clone reuses the existing GitHub App** (installation tokens) rather than
+  a personal token — scoped and short-lived. The App id + private key are the
+  same credentials the `web/` managed PR reviewer already uses.
+- **OAuth app callback:** whichever OAuth app backs production login, its callback
+  list must include `<BETTER_AUTH_URL>/api/auth/callback/github`.
+- Exact runtime var names are finalized when #750 lands; this is the canonical set
+  to provision against.


### PR DESCRIPTION
## Summary

- Adopts `@ai-sdk/harness` (Claude Code / Codex / Pi through one AI SDK surface) as the web-next session runtime, **behind a thin app-owned `SessionRuntime` interface**, exact-pinned, spiked first.
- Adds ADR `docs/decisions/web-next-harness-runtime.md` (decision, experimental-API risk + mitigations, exit strategy) and revises the plan doc + execution brief: harness owns stream→UIMessage projection, sandbox + CLI auth, multi-runtime dispatch, between-turn resume; we own persistence, reconnect policy, terminal. Retires the custom StreamChunk adapter from the critical path; drops Managed Agents from web-next scope; defers mid-turn live reconnect for v1.
- Follow-up to #741 (merged); reshapes the 'Sessions-first web (web-next)' milestone before the autonomous run kicks off.

## Mergeability

- Surface: docs
- User-facing behavior changed: none (planning docs)
- Non-happy paths considered: n/a; the ADR itself records the experimental-API risk, mitigations, and exit
- Release/ops preconditions: none
- Residual risk or follow-up: milestone issues revised in parallel (spike added, T2/T4/T5/T6 reshaped, Managed-Agents T7 closed)

## Validation

- [ ] `swift build` — n/a docs-only
- [x] Other checks run: verified the @ai-sdk/harness packages are real, official, and ai@7-native before writing the ADR

## Evidence

- [x] Not a testable change (docs-only)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ