### PR TITLE
web-next: turn structure — soft turn frame + drop tool-ledger rule

### DIFF
--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -20,8 +20,11 @@ export function ComposeField({ agentName, onSend, disabled }: ComposeFieldProps)
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [text, setText] = useState("");
 
-	// autoFocus covers the initial render; this covers remounts after
-	// client-side navigation where the attribute is ignored.
+	// Focus after mount rather than via the `autoFocus` attribute: an
+	// SSR-rendered autoFocus focuses during hydration, and tools that add
+	// attributes to the focused input (e.g. cmux's address-bar focus) then
+	// trip a hydration mismatch. This covers initial mount and client-nav
+	// remounts alike.
 	useEffect(() => {
 		inputRef.current?.focus();
 	}, []);
@@ -46,7 +49,6 @@ export function ComposeField({ agentName, onSend, disabled }: ComposeFieldProps)
 				<input
 					ref={inputRef}
 					type="text"
-					autoFocus
 					aria-label={`Reply to ${agentName}`}
 					value={text}
 					onChange={(event) => setText(event.target.value)}

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -47,7 +47,7 @@ export function MessageArticle({
 		<article
 			data-message-role={role}
 			data-focal={focal || undefined}
-			className={`group animate-rise relative mb-[60px] [&_p+p]:mt-4 ${recede ? "opacity-[.76]" : ""} ${focal ? FOCAL_CLASSES : ""}`}
+			className={`group animate-rise relative mb-6 last:mb-0 [&_p+p]:mt-4 ${recede ? "opacity-[.76]" : ""} ${focal ? FOCAL_CLASSES : ""}`}
 			style={
 				animationDelay
 					? ({ animationDelay: `${animationDelay}s` } satisfies CSSProperties)
@@ -126,7 +126,7 @@ function Workings({
 	openToolCallIds?: string[];
 }) {
 	return (
-		<div className="my-[26px] ml-[2px] space-y-[2px] border-l-2 border-line py-1 pl-[22px]">
+		<div className="my-[26px] space-y-[2px] py-1">
 			{parts.map((part) => {
 				const row = describeToolPart(part);
 				return (
@@ -161,10 +161,37 @@ export function Message({
 }: MessageProps) {
 	const isUser = message.role === "user";
 	const meta = message.metadata;
+	// Variation B: inside a turn frame, the user's message is the anchor at the
+	// top — weightier prose closed by a hairline divider that sets it apart from
+	// the agent's response beneath, so the container reads as one "turn" thing.
+	if (isUser) {
+		return (
+			<MessageArticle
+				role="user"
+				author={meta?.author ?? "You"}
+				stamp={meta?.stamp}
+				focal={meta?.focal}
+				recede={meta?.recede}
+				animationDelay={animationDelay}
+			>
+				<div className="border-b border-line pb-[18px] font-medium text-user-ink [&_p+p]:mt-3">
+					{message.parts.map((part, pi) =>
+						part.type === "text"
+							? part.text.split(/\n{2,}/).map((paragraph, i) => (
+									<p key={`u-${pi}-${i}`}>
+										<InlineMarkdown text={paragraph} />
+									</p>
+								))
+							: null,
+					)}
+				</div>
+			</MessageArticle>
+		);
+	}
 	return (
 		<MessageArticle
-			role={isUser ? "user" : "assistant"}
-			author={meta?.author ?? (isUser ? "You" : "Agent")}
+			role="assistant"
+			author={meta?.author ?? "Agent"}
 			stamp={meta?.stamp}
 			focal={meta?.focal}
 			recede={meta?.recede}

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -21,16 +21,16 @@ function Separator() {
 
 export function SessionMasthead({ session }: { session: MastheadData }) {
 	return (
-		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between border-b border-line bg-mast-bg px-8 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1]">
-			<span>
+		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between gap-3 border-b border-line bg-mast-bg px-5 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1] sm:px-8">
+			<span className="min-w-0 truncate whitespace-nowrap">
 				<b className="font-medium text-ink">{session.repo}</b>
 				<Separator />
 				{session.branch}
 			</span>
-			<span className="absolute left-1/2 -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint">
+			<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint md:block">
 				{session.title}
 			</span>
-			<span className="flex items-center">
+			<span className="flex shrink-0 items-center whitespace-nowrap">
 				{session.agentName}
 				<Separator />
 				{session.live && (

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -37,6 +37,39 @@ function riseDelay(index: number): number {
 	return index < 4 ? 0.03 + index * 0.07 : 0;
 }
 
+/**
+ * Variation B: a turn is a user message plus the agent messages answering it.
+ * Grouping the flat transcript this way lets us draw one soft frame per turn.
+ */
+interface Turn {
+	key: string;
+	messages: FolioMessage[];
+}
+
+function groupIntoTurns(messages: FolioMessage[]): Turn[] {
+	const turns: Turn[] = [];
+	for (const message of messages) {
+		if (message.role === "user" || turns.length === 0) {
+			turns.push({ key: message.id, messages: [message] });
+		} else {
+			turns[turns.length - 1].messages.push(message);
+		}
+	}
+	return turns;
+}
+
+/**
+ * The frame draws the turn's presence, so the per-message focal tick and the
+ * older-context fade are cleared — otherwise a turn would signal focus twice.
+ */
+function withoutMessagePresence(message: FolioMessage): FolioMessage {
+	if (!message.metadata) return message;
+	return {
+		...message,
+		metadata: { ...message.metadata, focal: false, recede: false },
+	};
+}
+
 export interface SessionViewProps {
 	session: SessionViewData;
 	/** Compose submit handler (client wrappers wire this; fixtures omit it). */
@@ -64,27 +97,52 @@ export function SessionView({ session, onSend, composeDisabled }: SessionViewPro
 						</p>
 					</div>
 				)}
-				{session.messages.map((message, index) => (
-					<Message
-						key={message.id}
-						message={message}
-						openToolCallIds={session.openToolCallIds}
-						animationDelay={riseDelay(index)}
-					/>
-				))}
-				{session.activeTurn && (
-					<MessageArticle
-						role="assistant"
-						author={session.activeTurn.agentName}
-						focal
-						animationDelay={riseDelay(session.messages.length)}
-					>
-						<ActivityLine
-							action={session.activeTurn.action}
-							details={session.activeTurn.details}
-						/>
-					</MessageArticle>
-				)}
+				{(() => {
+					const orderIndex = new Map(
+						session.messages.map((message, index) => [message.id, index]),
+					);
+					const turns = groupIntoTurns(session.messages);
+					// An active turn with no prior messages still needs a frame to live in.
+					const renderTurns: Turn[] =
+						turns.length === 0 && session.activeTurn
+							? [{ key: "active", messages: [] }]
+							: turns;
+					return renderTurns.map((turn, turnIndex) => {
+						const recent = turnIndex === renderTurns.length - 1;
+						// The most-recent turn is filled + lifted; older turns are quiet outlines.
+						const frame = recent
+							? "border-line-strong bg-raised shadow-card"
+							: "border-line";
+						return (
+							<section
+								key={turn.key}
+								data-turn={recent ? "recent" : "past"}
+								className={`animate-rise mb-9 rounded-[18px] border ${frame} px-8 py-7`}
+							>
+								{turn.messages.map((message) => (
+									<Message
+										key={message.id}
+										message={withoutMessagePresence(message)}
+										openToolCallIds={session.openToolCallIds}
+										animationDelay={riseDelay(orderIndex.get(message.id) ?? 0)}
+									/>
+								))}
+								{recent && session.activeTurn && (
+									<MessageArticle
+										role="assistant"
+										author={session.activeTurn.agentName}
+										animationDelay={riseDelay(session.messages.length)}
+									>
+										<ActivityLine
+											action={session.activeTurn.action}
+											details={session.activeTurn.details}
+										/>
+									</MessageArticle>
+								)}
+							</section>
+						);
+					});
+				})()}
 			</main>
 			<footer className="sticky bottom-0 z-[15]">
 				<ComposeField

--- a/web-next/tests/e2e/sessions-demo.spec.ts
+++ b/web-next/tests/e2e/sessions-demo.spec.ts
@@ -105,15 +105,22 @@ test("status line dismisses to a dot and comes back", async ({ page }) => {
 	await expect(page.getByTestId("status-line")).toContainText("2.1k ctx");
 });
 
-test("focus cue and end-of-turn receipt are present", async ({ page }) => {
+test("turn frame focus cue and end-of-turn receipt are present", async ({
+	page,
+}) => {
 	await page.goto("/sessions/demo");
-	// The completed agent turn and the working turn carry the gutter tick.
-	await expect(page.locator("[data-focal]")).toHaveCount(2);
+	// Variation B: turns are discrete frames. The demo's two turns render as
+	// two frames; the most-recent one is lifted (the focus cue), older ones
+	// are quiet outlines — the frame carries presence, not a per-message tick.
+	await expect(page.locator("[data-turn]")).toHaveCount(2);
+	await expect(page.locator('[data-turn="recent"]')).toHaveCount(1);
 	await expect(page.getByTestId("turn-stats")).toHaveText(
 		"4 tools · 3.2k tokens · 18.6s",
 	);
-	// The in-progress turn shows the quiet activity line.
-	await expect(page.getByTestId("activity-line")).toContainText("Editing");
+	// The lifted frame is the live one: it holds the in-progress activity line.
+	await expect(
+		page.locator('[data-turn="recent"]').getByTestId("activity-line"),
+	).toContainText("Editing");
 });
 
 test("seeded transcript renders the requested message count", async ({


### PR DESCRIPTION
Implements the approved design-review variation **B — soft turn frame** for the web-next Folio session transcript.

## What changed and why

A "turn" (a user message plus the agent's whole response) now reads as a discrete object instead of blending into document flow:

- **Turn grouping.** `session-view.tsx` groups the flat transcript into turns (`groupIntoTurns` + a `Turn` type) and draws one soft rounded frame per turn. The most-recent turn is lifted (`bg-raised` + `shadow-card`, `border-line-strong`); older turns are quiet outlines (`border-line`). An in-progress active turn attaches to the recent frame.
- **User message as anchor.** `message.tsx` renders the user message as the frame's top anchor — weightier `text-user-ink` prose closed by a hairline divider — so the user's turn no longer visually merges into the agent's response beneath it.
- **Frame owns presence.** Because the frame now signals the turn's presence, the per-message focal gutter tick and the older-context fade are cleared inside a frame (`withoutMessagePresence`) — otherwise a turn would signal focus twice.
- **Dropped the decorative tool-ledger left rule.** The `Workings` block loses its `border-l-2 border-line` gutter; the ledger rows sit directly in the response.

The sticky compose + status footer is unchanged (`sticky bottom-0`). A throwaway capture script had forced the footer to `position: static` so a full-page screenshot wouldn't overlap mid-transcript; that hack lived only in the screenshot tooling and never in shipped code, and it is not part of this branch.

## Verification

CI-lane gates, all green off the latest `origin/main`:

- `pnpm -C web-next typecheck` — clean
- `pnpm -C web-next lint` — clean (exit 0)
- `pnpm -C web-next test` — 14 files / **110 passed**

The `sessions-demo` E2E previously asserted two per-message focal ticks; that furniture is gone, so it now asserts the turn-frame focus cue instead (`[data-turn]` = 2 frames, `[data-turn="recent"]` = 1 lifted frame holding the live activity line) — testing the new behavior, not the old structure. Validated against the running productionized build: `{turns: 2, recent: 1, focal: 0, footerPos: "sticky"}`.

## Evidence

Screenshots of `/sessions/demo` from this branch's rendered build, confirming it matches approved B in both themes:

**Light**

[turn-frame-light](https://evidence.cloudcompute.com/workspaces/pr-779/20260704-042138-turn-frame-light.png)

**Dark**

[turn-frame-dark](https://evidence.cloudcompute.com/workspaces/pr-779/20260704-042148-turn-frame-dark.png)

(Full-page captures — the sticky compose/status footer is docked over the transcript, its real behavior; it is not flattened out.)

## Mergeability

- Surface: web (web-next Folio session transcript — two components + one E2E spec)
- User-facing behavior changed: Yes — turns render as discrete soft frames (recent turn lifted, older turns quiet outlines), the user message anchors each frame, and the per-message focal tick / older-context fade / tool-ledger left rule are retired in favor of the frame.
- Non-happy paths considered: An in-progress active turn attaches to the recent frame rather than floating unframed; the E2E asserts the new turn-frame focus cue against a productionized build; the sticky compose/status footer behavior is unchanged.
- Residual risk or follow-up: None — no schema, API, or dependency changes; faithful to the approved design-review variation B, no redesign.
