### PR TITLE
Fix reboot-resume: login-shell resume launch + previous-run scoping (#783)

### DIFF
--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -52,7 +52,8 @@ struct GhosttyTerminalConfig {
                 isTmuxAvailableOverride: isTmuxAvailableOverride,
                 hostSessionID: launchContext.hostSessionID,
                 hooksSocketPath: launchContext.hooksSocketPath,
-                automationEnvironment: launchContext.automationEnvironment
+                automationEnvironment: launchContext.automationEnvironment,
+                initialCommand: launchContext.initialCommand
             )
         }
     }
@@ -65,7 +66,8 @@ struct GhosttyTerminalConfig {
         isTmuxAvailableOverride: Bool? = nil,
         hostSessionID: UUID? = nil,
         hooksSocketPath: String? = nil,
-        automationEnvironment: AutomationTerminalEnvironment? = nil
+        automationEnvironment: AutomationTerminalEnvironment? = nil,
+        initialCommand: String? = nil
     ) {
         self.fontSize = fontSize
         self.workingDirectory = workingDirectory.path
@@ -118,8 +120,20 @@ struct GhosttyTerminalConfig {
             let tmuxSessionName = Self.tmuxSessionName(for: workingDirectory)
             let quotedSession = Self.singleQuoted(tmuxSessionName)
             let quotedWorkingDirectory = Self.singleQuoted(workingDirectory.path)
-            let tmuxScript = "exec tmux -L workspaces new-session -A -s \(quotedSession) -c \(quotedWorkingDirectory)"
+            var tmuxScript =
+                "exec tmux -L workspaces new-session -A -s \(quotedSession) -c \(quotedWorkingDirectory)"
+            if let initialCommand {
+                // Trailing shell-command → the tmux session's initial process. The whole
+                // tmux invocation runs under the login shell, so the session inherits the
+                // login PATH and `claude` resolves; `-A` ignores it on a later reattach.
+                tmuxScript += " \(Self.singleQuoted(initialCommand))"
+            }
             self.command = Self.shellInvocation(shell: shell, profileMode: shellProfileMode, command: tmuxScript)
+        } else if let initialCommand {
+            // No tmux: run the agent in the login shell, cd'd into the directory, so PATH
+            // and profile match a normal terminal and the surface exits when the agent does.
+            let cdExec = "cd \(Self.singleQuoted(workingDirectory.path)) && exec \(initialCommand)"
+            self.command = Self.shellInvocation(shell: shell, profileMode: shellProfileMode, command: cdExec)
         } else {
             self.command = Self.shellInvocation(shell: shell, profileMode: shellProfileMode)
         }

--- a/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
+++ b/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
@@ -2,32 +2,19 @@
 //  RestoreLaunchCommand.swift
 //  WorkspaceManager
 //
-//  Builds the launch command that resumes a Claude Code conversation during
-//  cold-start restore. It wraps `claude --resume <id>` in a `-L workspaces`
-//  tmux session named deterministically from the cwd — matching how the app
-//  launches every other terminal — so the resumed session reattaches like the
-//  rest and survives a later app restart.
+//  The agent command a restored surface runs as its initial process during
+//  cold-start restore. It is intentionally bare: the directory-backed launch
+//  path (GhosttyTerminalConfig) wraps it in the user's login shell — and, in
+//  tmux mode, in a deterministic `-L workspaces` `new-session -A` — so `claude`
+//  resolves on the login PATH and the session reattaches like any other surface
+//  on a later restore.
 //
 
 import Foundation
-import WorkspaceManagerCore
 
 enum RestoreLaunchCommand {
-    /// `tmux -L <socket> new-session -A -s <name> -c <cwd> 'claude --resume <id>'`,
-    /// with the same deterministic session name a normal launch would use for
-    /// this directory, so `new-session -A` reattaches on a subsequent restore.
-    static func claudeResume(
-        cwd: URL,
-        sessionID: String,
-        socketLabel: String = TmuxSessionProbe.socketLabel
-    ) -> String {
-        let name = GhosttyTerminalConfig.tmuxSessionName(for: cwd)
-        let inner = "claude --resume \(sessionID)"
-        return "tmux -L \(quoted(socketLabel)) new-session -A -s \(quoted(name)) "
-            + "-c \(quoted(cwd.path)) \(quoted(inner))"
-    }
-
-    private static func quoted(_ value: String) -> String {
-        "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    /// `claude --resume <id>` — run as the restored surface's initial command.
+    static func claudeResume(sessionID: String) -> String {
+        "claude --resume \(sessionID)"
     }
 }

--- a/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
@@ -40,6 +40,12 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
     let hostSessionID: UUID?
     let hooksSocketPath: String?
     let automationEnvironment: AutomationTerminalEnvironment?
+    /// Agent command to run as this directory-backed surface's initial process
+    /// (e.g. `claude --resume <id>` for cold-start restore). It is wrapped by the
+    /// login-shell/tmux launch path, so it resolves on the user's PATH and reattaches
+    /// like any other surface. `nil` for a plain shell and for remote `customCommand`
+    /// sessions.
+    let initialCommand: String?
 
     static func hostSession(
         _ session: HostTerminalSession,
@@ -52,7 +58,8 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
                 commandMode: .customCommand(customCommand),
                 hostSessionID: session.id,
                 hooksSocketPath: hooksSocketPath,
-                automationEnvironment: nil
+                automationEnvironment: nil,
+                initialCommand: nil
             )
         }
 
@@ -60,7 +67,8 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
             workingDirectory: session.directoryURL,
             hostSessionID: session.id,
             hooksSocketPath: hooksSocketPath,
-            automationEnvironment: automationEnvironment
+            automationEnvironment: automationEnvironment,
+            initialCommand: session.initialCommand
         )
     }
 
@@ -68,14 +76,16 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
         workingDirectory: URL,
         hostSessionID: UUID? = nil,
         hooksSocketPath: String? = nil,
-        automationEnvironment: AutomationTerminalEnvironment? = nil
+        automationEnvironment: AutomationTerminalEnvironment? = nil,
+        initialCommand: String? = nil
     ) -> TerminalSessionLaunchContext {
         TerminalSessionLaunchContext(
             workingDirectory: workingDirectory,
             commandMode: .directoryShell,
             hostSessionID: hostSessionID,
             hooksSocketPath: hooksSocketPath,
-            automationEnvironment: automationEnvironment
+            automationEnvironment: automationEnvironment,
+            initialCommand: initialCommand
         )
     }
 
@@ -92,7 +102,8 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
             commandMode: .customCommand(command),
             hostSessionID: hostSessionID,
             hooksSocketPath: hooksSocketPath,
-            automationEnvironment: nil
+            automationEnvironment: nil,
+            initialCommand: nil
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2400,7 +2400,13 @@ struct ContentView: View {
 
     @MainActor
     private func ensureInitialHostSession() {
-        if !hostTerminalState.hasSessions,
+        // When durable restore is enabled, let the RestorePlan own repo/workspace
+        // (re)creation so a resume surface is never shadowed by a manifest-seeded
+        // session on the same key (issue #783 #3). The default-home fallback below
+        // still seeds one shell so the window isn't empty pre-restore, and
+        // executeRestore retires that shell if the plan claims its key.
+        if !restoreSessionsOnLaunchEnabled,
+            !hostTerminalState.hasSessions,
             let snapshot = TerminalContinuityManifest.decode(from: terminalContinuityManifestRawValue)?
                 .hostSessionSnapshot(excludingScopeKeys: archivedWorkspaceTerminalScopeKeys)
         {
@@ -2779,12 +2785,13 @@ struct ContentView: View {
     @discardableResult
     @MainActor
     private func activateHostSession(
-        key: HostTerminalSessionKey, directory: URL, customCommand: String? = nil
+        key: HostTerminalSessionKey, directory: URL, customCommand: String? = nil, initialCommand: String? = nil
     ) -> HostTerminalSession {
         let result = hostTerminalState.activateSession(
             key: key,
             directory: directory,
-            customCommand: customCommand
+            customCommand: customCommand,
+            initialCommand: initialCommand
         )
         if result.created {
             NSLog(
@@ -2868,20 +2875,33 @@ struct ContentView: View {
 
     /// Launch each surface in a restore plan. Reattach/fresh surfaces are a plain
     /// directory-backed launch (the deterministic tmux name reattaches a surviving
-    /// session automatically); resume surfaces carry a `claude --resume` command.
+    /// session automatically); resume surfaces run `claude --resume` as their
+    /// initial command through the login-shell path (correct PATH + hook env).
     /// Then honor the plan's advisory focus by re-activating the selected surface.
     @MainActor
     private func executeRestore(_ plan: RestorePlan) {
+        // #3: the restore plan owns every key it restores. Retire any session a
+        // pre-restore seed (the default-home fallback) left on those keys, so a
+        // resume/reattach surface is created fresh and the coordinator's key-reuse
+        // path can't drop its initial command.
+        for key in Set(plan.surfaces.map(\.key)) {
+            _ = hostTerminalState.retireSessions(inScope: key)
+        }
+
         var activatedByHostSessionID: [UUID: HostTerminalSession] = [:]
         for surface in plan.surfaces {
-            let command: String?
+            let initialCommand: String?
             switch surface.action {
             case .reattachTmux, .freshShell:
-                command = nil
+                initialCommand = nil
             case .resumeClaude(let agentSessionID):
-                command = RestoreLaunchCommand.claudeResume(cwd: surface.directory, sessionID: agentSessionID)
+                initialCommand = RestoreLaunchCommand.claudeResume(sessionID: agentSessionID)
             }
-            let session = activateHostSession(key: surface.key, directory: surface.directory, customCommand: command)
+            let session = activateHostSession(
+                key: surface.key,
+                directory: surface.directory,
+                initialCommand: initialCommand
+            )
             activatedByHostSessionID[surface.hostSessionID] = session
         }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -226,9 +226,15 @@ final class HostTerminalStateStore: ObservableObject {
     func activateSession(
         key: HostTerminalSessionKey,
         directory: URL,
-        customCommand: String? = nil
+        customCommand: String? = nil,
+        initialCommand: String? = nil
     ) -> HostTerminalSessionActivationResult {
-        let result = coordinator.activate(key: key, directory: directory, customCommand: customCommand)
+        let result = coordinator.activate(
+            key: key,
+            directory: directory,
+            customCommand: customCommand,
+            initialCommand: initialCommand
+        )
         publishSnapshot()
         return result
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalRestoreCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalRestoreCoordinator.swift
@@ -44,7 +44,7 @@ struct TerminalRestoreCoordinator: Sendable {
     /// liveness, and produce a fully-decided plan. Store read failures degrade to
     /// an empty plan rather than throwing.
     func makePlan(index: RestoreTargetIndex) async -> RestorePlan {
-        let rows = (try? await localStateStore.fetchContinuitySessions(activeOnly: true, limit: 100)) ?? []
+        let rows = (try? await localStateStore.fetchPreviousRunSessions(limit: 100)) ?? []
         let layout = (try? await localStateStore.fetchLatestLayoutSnapshot()) ?? nil
 
         let liveNames = await probeLiveTmuxSessions(Set(rows.compactMap(\.tmuxSessionName)))

--- a/Sources/WorkspaceManagerCore/Services/HostTerminalSessionCoordinator.swift
+++ b/Sources/WorkspaceManagerCore/Services/HostTerminalSessionCoordinator.swift
@@ -106,8 +106,13 @@ public struct HostTerminalSession: Identifiable, Hashable, Sendable {
     public let key: HostTerminalSessionKey
     public let directoryPath: String
     /// Custom shell command override (e.g. SSH to remote sandbox). When set, the terminal
-    /// launches this command instead of the user's default shell.
+    /// launches this command instead of the user's default shell, on a fixed PATH.
     public let customCommand: String?
+    /// Agent command to run as this directory-backed surface's initial process (e.g.
+    /// `claude --resume <id>` for cold-start restore). Unlike `customCommand`, it runs
+    /// through the login-shell/tmux path (correct PATH, hook env) and does not mark the
+    /// session remote. `nil` for a plain shell.
+    public let initialCommand: String?
 
     public var directoryURL: URL {
         URL(fileURLWithPath: directoryPath)
@@ -117,11 +122,18 @@ public struct HostTerminalSession: Identifiable, Hashable, Sendable {
         customCommand != nil
     }
 
-    public init(id: UUID = UUID(), key: HostTerminalSessionKey, directory: URL, customCommand: String? = nil) {
+    public init(
+        id: UUID = UUID(),
+        key: HostTerminalSessionKey,
+        directory: URL,
+        customCommand: String? = nil,
+        initialCommand: String? = nil
+    ) {
         self.id = id
         self.key = key.normalized()
         self.directoryPath = Self.normalize(directory).path
         self.customCommand = customCommand
+        self.initialCommand = initialCommand
     }
 
     static func normalize(_ url: URL) -> URL {
@@ -203,7 +215,8 @@ public struct HostTerminalSessionCoordinator: Sendable {
     public mutating func activate(
         key: HostTerminalSessionKey,
         directory: URL,
-        customCommand: String? = nil
+        customCommand: String? = nil,
+        initialCommand: String? = nil
     ) -> HostTerminalSessionActivationResult {
         let normalizedDirectory = HostTerminalSession.normalize(directory)
         let normalizedPath = normalizedDirectory.path
@@ -231,7 +244,8 @@ public struct HostTerminalSessionCoordinator: Sendable {
         let session = HostTerminalSession(
             key: normalizedKey,
             directory: normalizedDirectory,
-            customCommand: customCommand
+            customCommand: customCommand,
+            initialCommand: initialCommand
         )
         sessions.append(session)
         setActiveSessionID(session.id)

--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -169,13 +169,26 @@ public struct LocalStateStoreSummary: Codable, Equatable, Sendable {
 }
 
 public actor LocalStateStore {
-    public static let schemaVersion = 1
+    public static let schemaVersion = 2
     public let databaseURL: URL
+
+    /// Identity of this app run. One store instance == one process == one run, so
+    /// every terminal session recorded through it is stamped with this run, and
+    /// cold-start restore can offer only the single most recent *prior* run
+    /// (issue #783 #2) instead of every never-cleanly-closed session ever.
+    private let runID: String
+    private let runStartedAt: String
 
     private let dbPool: DatabasePool
 
-    public init(databaseURL: URL) throws {
+    public init(
+        databaseURL: URL,
+        runID: UUID = UUID(),
+        runStartedAt: Date = Date()
+    ) throws {
         self.databaseURL = databaseURL
+        self.runID = runID.uuidString
+        self.runStartedAt = Self.isoString(runStartedAt)
 
         var configuration = Configuration()
         configuration.label = "WorkSpaces local state"
@@ -202,6 +215,8 @@ public actor LocalStateStore {
         let customCommandPresent = session.customCommand == nil ? 0 : 1
         let activeValue = isActive ? 1 : 0
         let tmuxSessionName = Self.tmuxSessionName(for: session.directoryURL, terminalMode: terminalMode)
+        let runID = self.runID
+        let runStartedAt = self.runStartedAt
 
         try await dbPool.write { db in
             try db.execute(
@@ -222,9 +237,11 @@ public actor LocalStateStore {
                         is_active,
                         created_at,
                         last_seen_at,
+                        run_id,
+                        run_started_at,
                         ended_at
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
                     ON CONFLICT(host_session_id) DO UPDATE SET
                         session_key = excluded.session_key,
                         target_kind = excluded.target_kind,
@@ -239,6 +256,8 @@ public actor LocalStateStore {
                         hooks_socket_path = excluded.hooks_socket_path,
                         is_active = excluded.is_active,
                         last_seen_at = excluded.last_seen_at,
+                        run_id = excluded.run_id,
+                        run_started_at = excluded.run_started_at,
                         ended_at = NULL
                     """,
                 arguments: [
@@ -257,6 +276,8 @@ public actor LocalStateStore {
                     activeValue,
                     now,
                     now,
+                    runID,
+                    runStartedAt,
                 ])
         }
     }
@@ -336,12 +357,16 @@ public actor LocalStateStore {
         let originFields = Self.originFields(origin)
         let runState = Self.runStateName(status.run)
 
+        let runID = self.runID
+        let runStartedAt = self.runStartedAt
         try await dbPool.write { db in
             try Self.ensureTerminalSessionRow(
                 db,
                 hostSessionID: hostSessionID,
                 cwd: status.cwd,
-                now: now
+                now: now,
+                runID: runID,
+                runStartedAt: runStartedAt
             )
 
             for event in events {
@@ -404,7 +429,9 @@ public actor LocalStateStore {
         _ db: Database,
         hostSessionID: UUID,
         cwd: String,
-        now: String
+        now: String,
+        runID: String,
+        runStartedAt: String
     ) throws {
         try db.execute(
             sql: """
@@ -424,9 +451,11 @@ public actor LocalStateStore {
                     is_active,
                     created_at,
                     last_seen_at,
+                    run_id,
+                    run_started_at,
                     ended_at
                 )
-                VALUES (?, ?, 'host_path', NULL, ?, NULL, NULL, ?, 'unknown', NULL, 0, NULL, 0, ?, ?, NULL)
+                VALUES (?, ?, 'host_path', NULL, ?, NULL, NULL, ?, 'unknown', NULL, 0, NULL, 0, ?, ?, ?, ?, NULL)
                 ON CONFLICT(host_session_id) DO NOTHING
                 """,
             arguments: [
@@ -436,6 +465,8 @@ public actor LocalStateStore {
                 cwd,
                 now,
                 now,
+                runID,
+                runStartedAt,
             ])
     }
 
@@ -528,6 +559,76 @@ public actor LocalStateStore {
                     LIMIT ? OFFSET ?
                     """,
                 arguments: [activeOnlyValue, cappedLimit, cappedOffset]
+            )
+            return rows.compactMap(TerminalSessionContinuityRow.init(row:))
+        }
+    }
+
+    /// Cold-start restore read model (issue #783 #2): the active continuity rows
+    /// belonging to the single most-recent *prior* app run — the run whose
+    /// `run_started_at` is the greatest value strictly less than this store
+    /// instance's run. Rows from older never-cleanly-closed runs and from the
+    /// current run are excluded, so restore offers only the user's previous
+    /// session set instead of an all-time backlog of stale "active" rows. Returns
+    /// `[]` on first launch and for pre-v2 rows (NULL `run_id`).
+    public func fetchPreviousRunSessions(limit: Int = 100) async throws -> [TerminalSessionContinuityRow] {
+        let cappedLimit = max(0, limit)
+        let currentRunStartedAt = runStartedAt
+        return try await dbPool.read { db -> [TerminalSessionContinuityRow] in
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT
+                        ts.host_session_id,
+                        ts.session_key,
+                        ts.target_kind,
+                        ts.target_id,
+                        ts.target_path,
+                        ts.backend_identifier,
+                        ts.backend_instance_id,
+                        ts.directory_path,
+                        ts.terminal_mode,
+                        ts.tmux_session_name,
+                        ts.custom_command_present,
+                        ts.is_active,
+                        ts.created_at,
+                        ts.last_seen_at,
+                        ts.ended_at,
+                        ae.agent_session_id,
+                        ae.agent_kind,
+                        ae.run_state AS agent_run_state,
+                        ae.cwd AS agent_cwd,
+                        ae.model_display_name AS agent_model_display_name,
+                        ae.event_at AS agent_event_at
+                    FROM terminal_sessions ts
+                    LEFT JOIN (
+                        SELECT
+                            host_session_id,
+                            agent_session_id,
+                            agent_kind,
+                            run_state,
+                            cwd,
+                            model_display_name,
+                            event_at,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY host_session_id
+                                ORDER BY event_at DESC, id DESC
+                            ) AS event_rank
+                        FROM agent_status_events
+                    ) ae ON ae.host_session_id = ts.host_session_id AND ae.event_rank = 1
+                    WHERE ts.run_id = (
+                        SELECT run_id
+                        FROM terminal_sessions
+                        WHERE run_started_at IS NOT NULL AND run_started_at < ?
+                        ORDER BY run_started_at DESC
+                        LIMIT 1
+                    )
+                    AND ts.is_active = 1
+                    AND ts.ended_at IS NULL
+                    ORDER BY ts.last_seen_at DESC
+                    LIMIT ?
+                    """,
+                arguments: [currentRunStartedAt, cappedLimit]
             )
             return rows.compactMap(TerminalSessionContinuityRow.init(row:))
         }
@@ -830,6 +931,20 @@ public actor LocalStateStore {
 
                     CREATE INDEX IF NOT EXISTS idx_diagnostic_exports_created
                         ON diagnostic_exports(created_at DESC);
+                    """)
+        }
+        migrator.registerMigration("v2") { db in
+            // App-run epoch (issue #783 #2): stamp each session with the run that
+            // recorded it so cold-start restore can offer only the previous run,
+            // not every never-cleanly-closed session. Additive; pre-v2 rows keep
+            // NULL and are excluded from previous-run restore.
+            try db.execute(
+                sql: """
+                    ALTER TABLE terminal_sessions ADD COLUMN run_id TEXT;
+                    ALTER TABLE terminal_sessions ADD COLUMN run_started_at TEXT;
+
+                    CREATE INDEX IF NOT EXISTS idx_terminal_sessions_run
+                        ON terminal_sessions(run_started_at DESC);
                     """)
         }
         return migrator

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -45,6 +45,77 @@ struct GhosttyTerminalConfigTests {
         #expect(command.contains("'wm-repo-a-"))
     }
 
+    @Test("tmux mode runs an initial command as the session's process under the login shell")
+    func tmuxModeRunsInitialCommand() throws {
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
+            terminalMultiplexingMode: .tmuxPerSession,
+            isTmuxAvailableOverride: true,
+            initialCommand: "claude --resume sess-123"
+        )
+
+        let command = try #require(config.command)
+        // Login shell wraps the tmux invocation → the tmux session inherits the login PATH,
+        // so `claude` resolves (the whole point of the #783 fix vs the fixed-PATH path).
+        #expect(command.contains("/bin/zsh --login -c "))
+        #expect(command.contains("tmux -L workspaces new-session -A -s"))
+        #expect(command.contains("claude --resume sess-123"))
+    }
+
+    @Test("ghostty-splits mode runs an initial command via cd + exec in the login shell")
+    func ghosttyModeRunsInitialCommand() throws {
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true,
+            initialCommand: "claude --resume sess-123"
+        )
+
+        let command = try #require(config.command)
+        #expect(command.contains("/bin/zsh --login -c "))
+        #expect(command.contains("exec claude --resume sess-123"))
+        #expect(command.contains("/tmp/repo-a"))
+        #expect(!command.contains("tmux"))
+    }
+
+    @Test("A nil initial command leaves each mode's command unchanged")
+    func nilInitialCommandIsNoOp() throws {
+        let splits = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true,
+            initialCommand: nil
+        )
+        #expect(splits.command == "/bin/zsh --login")  // identical to the reattach/fresh path
+
+        let tmux = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
+            terminalMultiplexingMode: .tmuxPerSession,
+            isTmuxAvailableOverride: true,
+            initialCommand: nil
+        )
+        let tmuxCommand = try #require(tmux.command)
+        #expect(!tmuxCommand.contains(" exec claude"))  // no trailing initial command
+    }
+
+    @Test("Single quotes in an initial command are escaped")
+    func initialCommandQuotesEscaped() throws {
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true,
+            initialCommand: "echo x'y"
+        )
+        // The whole cd+exec is single-quoted, so an inner ' becomes '"'"'.
+        let command = try #require(config.command)
+        #expect(command.contains("x'\"'\"'y"))
+    }
+
     @Test("tmux mode falls back to login shell when tmux unavailable")
     func tmuxModeFallsBackWhenTmuxMissing() {
         let config = GhosttyTerminalConfig(

--- a/Tests/WorkspaceManagerAppTests/RestoreLaunchCommandTests.swift
+++ b/Tests/WorkspaceManagerAppTests/RestoreLaunchCommandTests.swift
@@ -5,25 +5,10 @@ import Testing
 
 @Suite("RestoreLaunchCommand")
 struct RestoreLaunchCommandTests {
-    @Test("Wraps claude --resume in a deterministic -L workspaces tmux session")
-    func buildsResumeCommand() {
-        let cwd = URL(fileURLWithPath: "/code/app")
-        let name = GhosttyTerminalConfig.tmuxSessionName(for: cwd)
-        let command = RestoreLaunchCommand.claudeResume(cwd: cwd, sessionID: "sess-123")
-
-        #expect(command == "tmux -L 'workspaces' new-session -A -s '\(name)' -c '/code/app' 'claude --resume sess-123'")
-    }
-
-    @Test("Uses the same session name a normal launch would, so restore reattaches")
-    func nameMatchesNormalLaunch() {
-        let cwd = URL(fileURLWithPath: "/Users/me/proj")
-        let command = RestoreLaunchCommand.claudeResume(cwd: cwd, sessionID: "s1")
-        #expect(command.contains("-s '\(GhosttyTerminalConfig.tmuxSessionName(for: cwd))'"))
-    }
-
-    @Test("Single quotes in the session id are escaped safely")
-    func escapesQuotes() {
-        let command = RestoreLaunchCommand.claudeResume(cwd: URL(fileURLWithPath: "/x"), sessionID: "a'b")
-        #expect(command.hasSuffix("'claude --resume a'\"'\"'b'"))
+    // The command is intentionally bare — the login-shell/tmux wrapping (and its
+    // quoting) now lives in GhosttyTerminalConfig, verified in its own tests.
+    @Test("Produces a bare claude --resume command for the restored surface")
+    func buildsBareResumeCommand() {
+        #expect(RestoreLaunchCommand.claudeResume(sessionID: "sess-123") == "claude --resume sess-123")
     }
 }

--- a/Tests/WorkspaceManagerAppTests/TerminalRestoreCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalRestoreCoordinatorTests.swift
@@ -6,14 +6,20 @@ import WorkspaceManagerCore
 
 @Suite("TerminalRestoreCoordinator")
 struct TerminalRestoreCoordinatorTests {
-    /// End-to-end over a real (temporary) LocalStateStore: seed an active
-    /// tmux-backed session, then assert the coordinator reads it, bridges the
-    /// async tmux probe to the planner, resolves the target, and plans a reattach.
-    @Test("Plans a tmux reattach for a live, resolvable session")
+    private static let priorRun = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let currentRun = Date(timeIntervalSince1970: 1_700_100_000)
+
+    /// End-to-end over a real (temporary) LocalStateStore: a PRIOR run records an
+    /// active tmux-backed session; the coordinator (constructed with a CURRENT-run
+    /// store on the same DB) reads only the previous run, bridges the async tmux
+    /// probe to the planner, resolves the target, and plans a reattach.
+    @Test("Plans a tmux reattach for a live, resolvable previous-run session")
     func plansReattachForLiveSession() async throws {
         let directory = URL(fileURLWithPath: "/code/app")
-        let store = try makeStore()
-        try await store.recordTerminalSession(
+        let db = try makeDatabaseURL()
+
+        let priorRun = try makeStore(at: db, runStartedAt: Self.priorRun)
+        try await priorRun.recordTerminalSession(
             HostTerminalSession(id: UUID(), key: .repoPath(directory.path), directory: directory),
             terminalMode: "tmux_per_session",
             isActive: true,
@@ -21,7 +27,7 @@ struct TerminalRestoreCoordinatorTests {
         )
 
         let coordinator = TerminalRestoreCoordinator(
-            localStateStore: store,
+            localStateStore: try makeStore(at: db, runStartedAt: Self.currentRun),
             tmuxProbe: TmuxSessionProbe(run: { _, _, _ in 0 }, environment: [:]),  // every session "alive"
             transcriptResumability: ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false }),
             normalizePath: { $0 }
@@ -41,11 +47,13 @@ struct TerminalRestoreCoordinatorTests {
         }
     }
 
-    @Test("Plans nothing when the session's target no longer resolves")
+    @Test("Plans nothing when the previous-run session's target no longer resolves")
     func dropsUnresolvableSession() async throws {
         let directory = URL(fileURLWithPath: "/code/gone")
-        let store = try makeStore()
-        try await store.recordTerminalSession(
+        let db = try makeDatabaseURL()
+
+        let priorRun = try makeStore(at: db, runStartedAt: Self.priorRun)
+        try await priorRun.recordTerminalSession(
             HostTerminalSession(id: UUID(), key: .repoPath(directory.path), directory: directory),
             terminalMode: "tmux_per_session",
             isActive: true,
@@ -53,7 +61,7 @@ struct TerminalRestoreCoordinatorTests {
         )
 
         let coordinator = TerminalRestoreCoordinator(
-            localStateStore: store,
+            localStateStore: try makeStore(at: db, runStartedAt: Self.currentRun),
             tmuxProbe: TmuxSessionProbe(run: { _, _, _ in 0 }, environment: [:]),
             transcriptResumability: ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false }),
             normalizePath: { $0 }
@@ -65,10 +73,44 @@ struct TerminalRestoreCoordinatorTests {
         #expect(plan.surfaces.isEmpty)
     }
 
-    private func makeStore() throws -> LocalStateStore {
+    @Test("Plans nothing when only the current run has sessions (no previous run)")
+    func plansNothingWithoutPriorRun() async throws {
+        let directory = URL(fileURLWithPath: "/code/app")
+        let db = try makeDatabaseURL()
+
+        // Only the current run records a session — there is no prior run to restore.
+        let current = try makeStore(at: db, runStartedAt: Self.currentRun)
+        try await current.recordTerminalSession(
+            HostTerminalSession(id: UUID(), key: .repoPath(directory.path), directory: directory),
+            terminalMode: "tmux_per_session",
+            isActive: true,
+            hooksSocketPath: nil
+        )
+
+        let coordinator = TerminalRestoreCoordinator(
+            localStateStore: current,
+            tmuxProbe: TmuxSessionProbe(run: { _, _, _ in 0 }, environment: [:]),
+            transcriptResumability: ClaudeTranscriptResumability(environment: [:], fileExists: { _ in false }),
+            normalizePath: { $0 }
+        )
+        let index = RestoreTargetIndex(
+            homeDirectoryPath: "/Users/me",
+            repos: [RestoreTargetIndex.Entry(normalizedPath: directory.path, rootPath: directory.path)],
+            workspaces: []
+        )
+
+        let plan = await coordinator.makePlan(index: index)
+        #expect(plan.surfaces.isEmpty)
+    }
+
+    private func makeDatabaseURL() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("TerminalRestoreCoordinatorTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return try LocalStateStore(databaseURL: directory.appendingPathComponent("state.sqlite"))
+        return directory.appendingPathComponent("state.sqlite")
+    }
+
+    private func makeStore(at databaseURL: URL, runStartedAt: Date) throws -> LocalStateStore {
+        try LocalStateStore(databaseURL: databaseURL, runID: UUID(), runStartedAt: runStartedAt)
     }
 }

--- a/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
@@ -34,6 +34,38 @@ struct TerminalSessionLaunchContextTests {
         #expect(hookEnvironment["WORKSPACES_COMMAND_STATUS_ZSH"] == "/tmp/command-status.zsh")
     }
 
+    @Test("A resume session stays directory-backed with hook env and carries its initial command")
+    func resumeSessionIsDirectoryBackedWithInitialCommand() {
+        let hostSessionID = UUID(uuidString: "7BD8C9BD-7F3B-456D-A9EC-16CDB2221339")!
+        let session = HostTerminalSession(
+            id: hostSessionID,
+            key: .repoPath("/Users/test/repo"),
+            directory: URL(fileURLWithPath: "/Users/test/repo"),
+            initialCommand: "claude --resume sess-9"
+        )
+
+        let context = TerminalSessionLaunchContext.hostSession(session, hooksSocketPath: "/tmp/hooks.sock")
+
+        #expect(context.commandModeLabel == "directory")
+        #expect(context.initialCommand == "claude --resume sess-9")
+        // The resumed claude runs through the directory path, so it still gets hooks —
+        // unlike the old fixed-PATH customCommand path.
+        #expect(context.agentCommunication == .hookEnvironment)
+    }
+
+    @Test("A customCommand session ignores any initial command and maps to custom mode")
+    func customCommandSessionMapsToCustomMode() {
+        let session = HostTerminalSession(
+            id: UUID(),
+            key: .repoPath("/Users/test/repo"),
+            directory: URL(fileURLWithPath: "/Users/test/repo"),
+            customCommand: "ssh sandbox"
+        )
+        let context = TerminalSessionLaunchContext.hostSession(session, hooksSocketPath: "/tmp/hooks.sock")
+        #expect(context.commandModeLabel == "custom")
+        #expect(context.initialCommand == nil)
+    }
+
     @Test("Incomplete directory hook context falls back to terminal signals")
     func incompleteDirectoryHookContextFallsBackToTerminalSignals() {
         let hostSessionID = UUID(uuidString: "7BD8C9BD-7F3B-456D-A9EC-16CDB2221339")!

--- a/Tests/WorkspaceManagerTests/HostTerminalSessionCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerTests/HostTerminalSessionCoordinatorTests.swift
@@ -330,4 +330,30 @@ struct HostTerminalSessionCoordinatorTests {
         #expect(first.session.id == third.session.id)
         #expect(coordinator.sessions.count == 1)
     }
+
+    @Test("Activating a fresh key sets initialCommand; reuse does not adopt a new one")
+    func initialCommandOnCreateNotOnReuse() {
+        var coordinator = HostTerminalSessionCoordinator()
+        let directory = URL(fileURLWithPath: "/code/repo")
+
+        let created = coordinator.activate(
+            key: .repoPath(directory.path),
+            directory: directory,
+            initialCommand: "claude --resume sess-1"
+        )
+        #expect(created.created)
+        #expect(created.session.initialCommand == "claude --resume sess-1")
+
+        // Reusing the same key returns the existing session and does NOT adopt a new
+        // initialCommand — which is exactly why executeRestore retires a pre-seeded
+        // session on a plan's key before restoring (issue #783 #3).
+        let reused = coordinator.activate(
+            key: .repoPath(directory.path),
+            directory: directory,
+            initialCommand: "claude --resume sess-2"
+        )
+        #expect(!reused.created)
+        #expect(reused.session.id == created.session.id)
+        #expect(reused.session.initialCommand == "claude --resume sess-1")
+    }
 }

--- a/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
@@ -52,7 +52,7 @@ struct LocalStateStoreTests {
         )
 
         let summary = try await store.summary()
-        #expect(summary.schemaVersion == 1)
+        #expect(summary.schemaVersion == 2)
         #expect(summary.tableCounts["terminal_sessions"] == 1)
         #expect(summary.tableCounts["agent_status_events"] == 1)
         #expect(summary.tableCounts["diagnostic_events"] == 1)
@@ -362,6 +362,104 @@ struct LocalStateStoreTests {
             )
         }
         #expect(tableCount == 7)
+
+        // Schema doc must carry the v2 run-epoch columns (issue #783 #2) so a DB
+        // built from docs/schema.sql matches a migrated store.
+        let runColumns = try await dbQueue.read {
+            try Int.fetchOne(
+                $0,
+                sql: """
+                    SELECT COUNT(*) FROM pragma_table_info('terminal_sessions')
+                    WHERE name IN ('run_id', 'run_started_at')
+                    """
+            )
+        }
+        #expect(runColumns == 2)
+    }
+
+    @Test("fetchPreviousRunSessions returns only the immediately-prior run's active sessions")
+    func previousRunSessionsBoundToPriorRun() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let db = fixture.url.appendingPathComponent("state.sqlite")
+
+        let run1 = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let staleID = UUID()
+        try await run1.recordTerminalSession(
+            HostTerminalSession(id: staleID, key: .repoPath("/code/old"), directory: URL(fileURLWithPath: "/code/old")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        let run2 = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_100_000))
+        let prevID = UUID()
+        try await run2.recordTerminalSession(
+            HostTerminalSession(
+                id: prevID, key: .repoPath("/code/prev"), directory: URL(fileURLWithPath: "/code/prev")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        let current = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_200_000))
+
+        let rows = try await current.fetchPreviousRunSessions(limit: 100)
+        #expect(rows.map(\.hostSessionID) == [prevID])
+
+        // The old broad query still sees BOTH stale runs — the bug being fixed.
+        let broad = try await current.fetchContinuitySessions(activeOnly: true, limit: 100)
+        #expect(Set(broad.map(\.hostSessionID)) == [staleID, prevID])
+    }
+
+    @Test("fetchPreviousRunSessions excludes ended prior-run rows and current-run rows")
+    func previousRunExcludesEndedAndCurrent() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let db = fixture.url.appendingPathComponent("state.sqlite")
+
+        let prev = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let keptID = UUID()
+        let endedID = UUID()
+        for (id, path) in [(keptID, "/code/kept"), (endedID, "/code/ended")] {
+            try await prev.recordTerminalSession(
+                HostTerminalSession(id: id, key: .repoPath(path), directory: URL(fileURLWithPath: path)),
+                terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+        }
+        try await prev.markTerminalSessionEnded(hostSessionID: endedID)
+
+        let current = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_100_000))
+        try await current.recordTerminalSession(
+            HostTerminalSession(id: UUID(), key: .repoPath("/code/now"), directory: URL(fileURLWithPath: "/code/now")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        let rows = try await current.fetchPreviousRunSessions()
+        #expect(rows.map(\.hostSessionID) == [keptID])
+    }
+
+    @Test("fetchPreviousRunSessions is empty with no prior run and ignores pre-v2 rows")
+    func previousRunEmptyWhenNoPriorRun() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let db = fixture.url.appendingPathComponent("state.sqlite")
+
+        let current = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_100_000))
+        #expect(try await current.fetchPreviousRunSessions().isEmpty)  // first launch
+
+        // Simulate a row written by schema v1 (run_id / run_started_at NULL).
+        let dbQueue = try DatabaseQueue(path: db.path)
+        try await dbQueue.write {
+            try $0.execute(
+                sql: """
+                    INSERT INTO terminal_sessions
+                      (host_session_id, session_key, target_kind, target_path, directory_path,
+                       terminal_mode, is_active, created_at, last_seen_at)
+                    VALUES (?, 'legacy', 'host_path', '/code/legacy', '/code/legacy',
+                       'tmux_per_session', 1, '2020-01-01T00:00:00.000Z', '2020-01-01T00:00:00.000Z')
+                    """,
+                arguments: [UUID().uuidString])
+        }
+        #expect(try await current.fetchPreviousRunSessions().isEmpty)  // NULL run excluded
     }
 
     private func repoRoot() -> URL {

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -21,7 +21,7 @@
 PRAGMA foreign_keys = ON;
 PRAGMA journal_mode = WAL;
 PRAGMA synchronous = NORMAL;
-PRAGMA user_version = 1;
+PRAGMA user_version = 2;
 
 BEGIN;
 
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS local_state_metadata (
 ) STRICT;
 
 INSERT INTO local_state_metadata (key, value, updated_at)
-VALUES ('schema_version', '1', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+VALUES ('schema_version', '2', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 ON CONFLICT(key) DO UPDATE SET
     value = excluded.value,
     updated_at = excluded.updated_at;
@@ -71,13 +71,21 @@ CREATE TABLE IF NOT EXISTS terminal_sessions (
         CHECK (is_active IN (0, 1)),
     created_at TEXT NOT NULL,
     last_seen_at TEXT NOT NULL,
-    ended_at TEXT
+    ended_at TEXT,
+    -- App-run epoch (issue #783 #2): the process run that recorded this row, and
+    -- when that run started. Cold-start restore offers only the single most
+    -- recent prior run, so crash/reboot rows do not accumulate as "active"
+    -- forever. NULL for rows written before schema v2 (added by ALTER TABLE).
+    run_id TEXT,
+    run_started_at TEXT
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_terminal_sessions_target
     ON terminal_sessions(target_kind, target_id, target_path);
 CREATE INDEX IF NOT EXISTS idx_terminal_sessions_last_seen
     ON terminal_sessions(last_seen_at DESC);
+CREATE INDEX IF NOT EXISTS idx_terminal_sessions_run
+    ON terminal_sessions(run_started_at DESC);
 
 -- Point-in-time layout snapshots for the terminal surface. This table is ready
 -- for UI restore and diagnostics even before every layout-producing call site


### PR DESCRIPTION
## Summary

Fixes the two confirmed bugs from the reflection on the durable-sessions restore feature ([#783](https://github.com/fairchild/workspaces/issues/783)). All of restore is behind the default-off `restoreSessionsOnLaunch` flag, so there is **no user impact** — but these are the gates before that flag should ever default on.

**#1 / #3 — the resume launch was broken and could silently downgrade.**
`.resumeClaude` dispatched `claude --resume <id>` through the fixed-PATH `customCommand` path (`PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`, no login shell), so `claude` — installed at `~/.local/bin/claude` on this machine, and generally under a version manager / `~/.local/bin` — was **not found**. And a manifest-seeded surface on the same key made `executeRestore` reuse it, dropping the command entirely.

Fix: introduce a first-class **`initialCommand`** (distinct from the remote-SSH `customCommand`) and route resume through the proven directory-backed launch. `GhosttyTerminalConfig` wraps it in the user's **login shell** (correct PATH) and, in tmux mode, appends it to `new-session -A` under the deterministic name so it reattaches like any other surface. `RestoreLaunchCommand` reduces to the bare `claude --resume <id>` — the config owns all wrapping/quoting. Because the surface stays `.directoryShell`, the resumed claude now also gets the **hook environment** (which the old fixed-PATH path lost). `executeRestore` retires any pre-seeded session on a plan's key first, and `ensureInitialHostSession` yields the manifest path to durable restore — closing the downgrade.

**#2 — the restore set was unbounded.**
`fetchContinuitySessions(activeOnly: true)` returned every never-cleanly-closed session across all runs (a hard reboot never marks sessions ended), so the banner could say "Resume 100 sessions" including stale rows from days ago. Adds an **app-run epoch** (`run_id` / `run_started_at`) stamped per row from the `LocalStateStore` instance (one store == one process == one run; schema **v2**, additive migration + `docs/schema.sql` in sync). New `fetchPreviousRunSessions` offers only the single most-recent prior run; the coordinator uses it. Crash/reboot rows keep their epoch; pre-v2 (NULL) rows are excluded.

## Mergeability

- Surface: desktop (app + Core)
- User-facing behavior changed: none while the flag is off. With the flag on, resume now actually runs `claude --resume` (was broken), and the banner offers only the previous run's sessions (was all-time).
- Non-happy paths considered: claude not on the fixed PATH (the bug); manifest/default-home seed on a restored key (retired first); reuse ignoring `initialCommand` (why we retire — unit-locked); crash/reboot rows (keep epoch); schema upgrade from v1 (NULL-run rows excluded, restore resumes normally next launch); both multiplexing modes.
- Release/ops preconditions: schema v2 is an additive `ALTER TABLE ADD COLUMN` migration; `docs/schema.sql` bumped to match.
- Residual risk or follow-up: banner-nags-every-launch (#783 #4) and split-layout fidelity (#783 #5) remain, tracked in #783. This PR closes #1/#2/#3.

## Validation

- [x] `swift build`
- [x] `swift test` — **1097 tests in 173 suites pass** (no regressions from the cross-cutting `initialCommand` thread), including: login-shell resume command for **both** multiplexing modes + quoting + nil-regression (`GhosttyTerminalConfig`); reuse-does-not-adopt-`initialCommand` (the #3 rationale); resume session stays directory-backed with hook env; and previous-run scoping (prior-run only; excludes ended/current/pre-v2).
- [x] Other checks run: `swift-format lint --strict` (exit 0)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (test output / equivalent)
- [ ] UI evidence attached

**Verified the actual failing path** (this is the thing the reflection said was skipped before) — deterministically, at the command level, rather than a one-off screenshot:

![resume-fix-verification](https://evidence.cloudcompute.com/workspaces/pr-786/20260704-054345-resume-fix-verification.png)

1. `claude` is at `~/.local/bin/claude`.
2. **Bug reproduced:** under the old fixed PATH (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`), `command -v claude` → **NOT FOUND** — the old resume launch died here.
3. **Fix proven:** both command *forms* the fix now generates actually run claude — `zsh --login -c 'exec claude --version'` → `2.1.201`, and the tmux form (`zsh --login → tmux new-session -c <repo> 'claude …'`) → `2.1.201`.
4. Unit tests prove the app emits exactly those login-shell command forms with `claude --resume <id>` for each mode.

So the full causal chain is established: the app generates command X (unit-tested) → command X resolves and runs claude on the login PATH (shown above) → the resume works. The one link not captured is a literal screenshot of claude's TUI inside the app's GPU-rendered pane; it's confirmatory, since `config.command` is the same launch mechanism every working terminal already uses, and every other link is proven.

## Blockers

- [x] None
- [ ] Blocked on evidence

Refs #728, #783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
