### PR TITLE
feat(web-next): reasoning traces + adversarial mock (#784, #785)

### DIFF
--- a/web-next/package.json
+++ b/web-next/package.json
@@ -17,6 +17,8 @@
 	"dependencies": {
 		"@ai-sdk/react": "^4.0.15",
 		"@libsql/client": "^0.17.4",
+		"@radix-ui/react-collapsible": "^1.1.15",
+		"@radix-ui/react-use-controllable-state": "^1.2.3",
 		"ai": "^7.0.14",
 		"better-auth": "1.6.20",
 		"kysely": "^0.28.17",

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@libsql/client':
         specifier: ^0.17.4
         version: 0.17.4
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@19.2.17)(react@19.2.7)
       ai:
         specifier: ^7.0.14
         version: 7.0.14(zod@4.4.3)
@@ -451,105 +457,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -679,28 +669,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.20':
     resolution: {integrity: sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.20':
     resolution: {integrity: sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.20':
     resolution: {integrity: sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.20':
     resolution: {integrity: sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==}
@@ -750,6 +736,111 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
+  '@radix-ui/react-collapsible@1.1.15':
+    resolution: {integrity: sha512-8A1zibu5skAQ+UVbaeNH5hVMibiFCRJzgMuM14LTWGttnTZKQL9jwYnhAbHRuxrtCqPXa4JvvnVUq1pTNgyZYw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -785,42 +876,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.4':
     resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.4':
     resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.4':
     resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.4':
     resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.4':
     resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
@@ -898,28 +983,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
@@ -1082,61 +1163,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2043,28 +2114,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3216,6 +3283,89 @@ snapshots:
   '@playwright/test@1.61.1':
     dependencies:
       playwright: 1.61.1
+
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-collapsible@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true

--- a/web-next/src/app/(app)/sessions/demo/page.tsx
+++ b/web-next/src/app/(app)/sessions/demo/page.tsx
@@ -1,21 +1,33 @@
 /*
  * /sessions/demo — the Folio design system rendered from fixture data, no
  * backend. `?seed=<n>` swaps in a generated n-message transcript for the
- * transcript_render_200 perf scenario.
+ * transcript_render_200 perf scenario; `?scenario=adversarial` renders one
+ * worst-case turn (long reasoning, 16 tools, a 100+ line diff, a failure) and
+ * `?scenario=long` a 15+ turn session for reviewing the frame at scale.
  */
 import { SessionView } from "@/components/folio/session-view";
-import { demoSession, seededDemoSession } from "@/lib/fixtures/demo-session";
+import {
+	adversarialSession,
+	demoSession,
+	longTranscriptSession,
+	seededDemoSession,
+} from "@/lib/fixtures/demo-session";
+
+function pickSession(scenario: string | undefined, seed: string | undefined) {
+	if (scenario === "adversarial") return adversarialSession();
+	if (scenario === "long") return longTranscriptSession();
+	const seedCount = Number(seed);
+	if (Number.isInteger(seedCount) && seedCount > 0) {
+		return seededDemoSession(seedCount);
+	}
+	return demoSession();
+}
 
 export default async function DemoSessionPage({
 	searchParams,
 }: {
-	searchParams: Promise<{ seed?: string }>;
+	searchParams: Promise<{ seed?: string; scenario?: string }>;
 }) {
-	const { seed } = await searchParams;
-	const seedCount = Number(seed);
-	const session =
-		Number.isInteger(seedCount) && seedCount > 0
-			? seededDemoSession(seedCount)
-			: demoSession();
-	return <SessionView session={session} />;
+	const { seed, scenario } = await searchParams;
+	return <SessionView session={pickSession(scenario, seed)} />;
 }

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -20,8 +20,11 @@ export function ComposeField({ agentName, onSend, disabled }: ComposeFieldProps)
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [text, setText] = useState("");
 
-	// autoFocus covers the initial render; this covers remounts after
-	// client-side navigation where the attribute is ignored.
+	// Focus after mount rather than via the `autoFocus` attribute: an
+	// SSR-rendered autoFocus focuses during hydration, and tools that add
+	// attributes to the focused input (e.g. cmux's address-bar focus) then
+	// trip a hydration mismatch. This covers initial mount and client-nav
+	// remounts alike.
 	useEffect(() => {
 		inputRef.current?.focus();
 	}, []);
@@ -46,7 +49,6 @@ export function ComposeField({ agentName, onSend, disabled }: ComposeFieldProps)
 				<input
 					ref={inputRef}
 					type="text"
-					autoFocus
 					aria-label={`Reply to ${agentName}`}
 					value={text}
 					onChange={(event) => setText(event.target.value)}

--- a/web-next/src/components/folio/diff-card.tsx
+++ b/web-next/src/components/folio/diff-card.tsx
@@ -4,9 +4,14 @@
  * Contextual diff card: a landed edit surfaces as a raised, dismissible
  * figure — file + delta caption, then the hunk with add/del washes.
  * Takes structured DiffCardData; #748 maps real Edit results onto it.
+ * A long refactor stays a bounded figure: past ~28 lines the hunk scrolls
+ * inside the card instead of stretching the turn into a wall.
  */
 import { useState } from "react";
 import type { DiffCardData, DiffLine } from "./types";
+
+/** Beyond this many lines the hunk gets its own scroll rather than growing the turn. */
+const TALL_DIFF_LINES = 28;
 
 const LINE_CLASS: Record<DiffLine["kind"], string> = {
 	context: "",
@@ -43,7 +48,9 @@ export function DiffCard({ diff }: { diff: DiffCardData }) {
 					✕
 				</button>
 			</figcaption>
-			<pre className="overflow-x-auto py-3 font-mono text-tool leading-[1.7]">
+			<pre
+				className={`overflow-x-auto py-3 font-mono text-tool leading-[1.7] ${diff.lines.length > TALL_DIFF_LINES ? "max-h-[460px] overflow-y-auto" : ""}`}
+			>
 				{diff.lines.map((line, i) => (
 					<span
 						key={i}

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -10,6 +10,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { DiffCard } from "./diff-card";
 import { InlineMarkdown } from "./inline-markdown";
 import { describeToolPart, type LedgerBody, type LedgerMeta } from "./ledger";
+import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
 import { TestOutputPanel } from "./test-output-panel";
 import { ToolLedgerRow } from "./tool-ledger-row";
 import { TurnStatsReceipt } from "./turn-stats";
@@ -74,6 +75,7 @@ export function MessageArticle({
 
 type Segment =
 	| { kind: "text"; key: string; text: string }
+	| { kind: "reasoning"; key: string; text: string; streaming: boolean }
 	| { kind: "tools"; key: string; parts: DynamicToolUIPart[] }
 	| { kind: "diff"; key: string; data: DiffCardData };
 
@@ -83,6 +85,13 @@ function groupParts(parts: FolioMessage["parts"]): Segment[] {
 	parts.forEach((part, index) => {
 		if (part.type === "text") {
 			segments.push({ kind: "text", key: `part-${index}`, text: part.text });
+		} else if (part.type === "reasoning") {
+			segments.push({
+				kind: "reasoning",
+				key: `part-${index}`,
+				text: part.text,
+				streaming: part.state === "streaming",
+			});
 		} else if (isDynamicToolUIPart(part)) {
 			const last = segments.at(-1);
 			if (last?.kind === "tools") last.parts.push(part);
@@ -198,6 +207,13 @@ export function Message({
 			animationDelay={animationDelay}
 		>
 			{groupParts(message.parts).map((segment) => {
+				if (segment.kind === "reasoning")
+					return (
+						<Reasoning key={segment.key} isStreaming={segment.streaming}>
+							<ReasoningTrigger />
+							<ReasoningContent>{segment.text}</ReasoningContent>
+						</Reasoning>
+					);
 				if (segment.kind === "tools")
 					return (
 						<Workings

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -47,7 +47,7 @@ export function MessageArticle({
 		<article
 			data-message-role={role}
 			data-focal={focal || undefined}
-			className={`group animate-rise relative mb-[60px] [&_p+p]:mt-4 ${recede ? "opacity-[.76]" : ""} ${focal ? FOCAL_CLASSES : ""}`}
+			className={`group animate-rise relative mb-6 last:mb-0 [&_p+p]:mt-4 ${recede ? "opacity-[.76]" : ""} ${focal ? FOCAL_CLASSES : ""}`}
 			style={
 				animationDelay
 					? ({ animationDelay: `${animationDelay}s` } satisfies CSSProperties)
@@ -126,7 +126,7 @@ function Workings({
 	openToolCallIds?: string[];
 }) {
 	return (
-		<div className="my-[26px] ml-[2px] space-y-[2px] border-l-2 border-line py-1 pl-[22px]">
+		<div className="my-[26px] space-y-[2px] py-1">
 			{parts.map((part) => {
 				const row = describeToolPart(part);
 				return (
@@ -161,10 +161,37 @@ export function Message({
 }: MessageProps) {
 	const isUser = message.role === "user";
 	const meta = message.metadata;
+	// Variation B: inside a turn frame, the user's message is the anchor at the
+	// top — weightier prose closed by a hairline divider that sets it apart from
+	// the agent's response beneath, so the container reads as one "turn" thing.
+	if (isUser) {
+		return (
+			<MessageArticle
+				role="user"
+				author={meta?.author ?? "You"}
+				stamp={meta?.stamp}
+				focal={meta?.focal}
+				recede={meta?.recede}
+				animationDelay={animationDelay}
+			>
+				<div className="border-b border-line pb-[18px] font-medium text-user-ink [&_p+p]:mt-3">
+					{message.parts.map((part, pi) =>
+						part.type === "text"
+							? part.text.split(/\n{2,}/).map((paragraph, i) => (
+									<p key={`u-${pi}-${i}`}>
+										<InlineMarkdown text={paragraph} />
+									</p>
+								))
+							: null,
+					)}
+				</div>
+			</MessageArticle>
+		);
+	}
 	return (
 		<MessageArticle
-			role={isUser ? "user" : "assistant"}
-			author={meta?.author ?? (isUser ? "You" : "Agent")}
+			role="assistant"
+			author={meta?.author ?? "Agent"}
 			stamp={meta?.stamp}
 			focal={meta?.focal}
 			recede={meta?.recede}

--- a/web-next/src/components/folio/reasoning.tsx
+++ b/web-next/src/components/folio/reasoning.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/*
+ * The thinking aside: a quiet, collapsible reasoning block that recedes — the
+ * model's inner voice set apart from its answer by a hairline rule. Adopted
+ * from Vercel AI Elements' Reasoning component (its auto-open-while-streaming,
+ * collapse-shortly-after-done, and duration tracking), rebuilt on Radix
+ * Collapsible + useControllableState and restyled to Folio tokens: mono trigger,
+ * serif muted prose (Folio's InlineMarkdown, not Streamdown), a breathing accent
+ * dot instead of a shadcn shimmer. A reasoning part that mounts already done
+ * (a replayed or fixture turn) starts collapsed; one that mounts mid-stream
+ * opens while it thinks, then folds itself away.
+ */
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import {
+	createContext,
+	memo,
+	useContext,
+	useEffect,
+	useRef,
+	useState,
+	type ComponentProps,
+	type ReactNode,
+} from "react";
+import { InlineMarkdown } from "./inline-markdown";
+
+type ReasoningContextValue = {
+	isStreaming: boolean;
+	isOpen: boolean;
+	setIsOpen: (open: boolean) => void;
+	duration: number | undefined;
+};
+
+const ReasoningContext = createContext<ReasoningContextValue | null>(null);
+
+export function useReasoning(): ReasoningContextValue {
+	const context = useContext(ReasoningContext);
+	if (!context) {
+		throw new Error("Reasoning components must be used within <Reasoning>");
+	}
+	return context;
+}
+
+export type ReasoningProps = ComponentProps<typeof Collapsible.Root> & {
+	isStreaming?: boolean;
+	open?: boolean;
+	defaultOpen?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	duration?: number;
+};
+
+/** Grace period after thinking ends before the block folds away, so the last
+ * lines are readable for a beat. */
+const AUTO_CLOSE_DELAY = 1000;
+const MS_IN_S = 1000;
+
+export const Reasoning = memo(function Reasoning({
+	className,
+	isStreaming = false,
+	open,
+	defaultOpen,
+	onOpenChange,
+	duration: durationProp,
+	children,
+	...props
+}: ReasoningProps) {
+	const [isOpen, setIsOpen] = useControllableState({
+		prop: open,
+		// Open only if it mounted mid-thought; a completed reasoning starts folded.
+		defaultProp: defaultOpen ?? isStreaming,
+		onChange: onOpenChange,
+		caller: "Reasoning",
+	});
+	const [duration, setDuration] = useControllableState<number | undefined>({
+		prop: durationProp,
+		defaultProp: undefined,
+		caller: "Reasoning",
+	});
+
+	const [startTime, setStartTime] = useState<number | null>(
+		isStreaming ? Date.now() : null,
+	);
+	const wasStreaming = useRef(isStreaming);
+
+	// Track how long the thinking took (from AI Elements): start on the first
+	// streaming frame, resolve to whole seconds when it stops.
+	useEffect(() => {
+		if (isStreaming) {
+			if (startTime === null) setStartTime(Date.now());
+		} else if (startTime !== null) {
+			setDuration(Math.ceil((Date.now() - startTime) / MS_IN_S));
+			setStartTime(null);
+		}
+	}, [isStreaming, startTime, setDuration]);
+
+	// Hold open while thinking; fold away a beat after it ends (once). A block
+	// that never streamed is left at its initial (folded) state, and a manual
+	// toggle is never overridden.
+	useEffect(() => {
+		const justStopped = wasStreaming.current && !isStreaming;
+		wasStreaming.current = isStreaming;
+		if (isStreaming) {
+			setIsOpen(true);
+			return;
+		}
+		if (justStopped) {
+			const timer = setTimeout(() => setIsOpen(false), AUTO_CLOSE_DELAY);
+			return () => clearTimeout(timer);
+		}
+	}, [isStreaming, setIsOpen]);
+
+	return (
+		<ReasoningContext.Provider value={{ isStreaming, isOpen, setIsOpen, duration }}>
+			<Collapsible.Root
+				data-testid="reasoning"
+				data-streaming={isStreaming || undefined}
+				className={`my-[26px] ${className ?? ""}`}
+				open={isOpen}
+				onOpenChange={setIsOpen}
+				{...props}
+			>
+				{children}
+			</Collapsible.Root>
+		</ReasoningContext.Provider>
+	);
+});
+
+function thinkingLabel(isStreaming: boolean, duration: number | undefined): ReactNode {
+	if (isStreaming) {
+		return (
+			<span className="flex items-center gap-2 text-muted">
+				<span className="animate-breathe h-1.5 w-1.5 rounded-full bg-accent" />
+				<span>
+					Thinking
+					<span className="ellipsis-dots" />
+				</span>
+			</span>
+		);
+	}
+	if (duration === undefined || duration === 0) {
+		return <span>Thought for a few seconds</span>;
+	}
+	return <span>Thought for {duration}s</span>;
+}
+
+export type ReasoningTriggerProps = ComponentProps<typeof Collapsible.Trigger>;
+
+export const ReasoningTrigger = memo(function ReasoningTrigger({
+	className,
+	children,
+	...props
+}: ReasoningTriggerProps) {
+	const { isStreaming, isOpen, duration } = useReasoning();
+	return (
+		<Collapsible.Trigger
+			className={`group/reasoning flex w-full items-center gap-2.5 rounded-md py-[5px] pr-2 text-left font-mono text-tool text-faint transition-colors hover:text-muted ${className ?? ""}`}
+			{...props}
+		>
+			{children ?? (
+				<>
+					<span
+						aria-hidden
+						className={`inline-block w-2.5 origin-[45%_50%] text-[11px] transition-transform duration-[.18s] ${isOpen ? "rotate-90" : ""}`}
+					>
+						▸
+					</span>
+					{thinkingLabel(isStreaming, duration)}
+				</>
+			)}
+		</Collapsible.Trigger>
+	);
+});
+
+export type ReasoningContentProps = Omit<
+	ComponentProps<typeof Collapsible.Content>,
+	"children"
+> & {
+	children: string;
+};
+
+export const ReasoningContent = memo(function ReasoningContent({
+	className,
+	children,
+	...props
+}: ReasoningContentProps) {
+	return (
+		<Collapsible.Content
+			data-testid="reasoning-content"
+			className={`overflow-hidden ${className ?? ""}`}
+			{...props}
+		>
+			<div className="animate-rise-fast mt-2.5 mb-1 border-l border-line pl-4 text-[16px] leading-[1.65] text-muted [&_code]:text-[.8em] [&_p+p]:mt-3">
+				{children.split(/\n{2,}/).map((paragraph, i) => (
+					<p key={i}>
+						<InlineMarkdown text={paragraph} />
+					</p>
+				))}
+			</div>
+		</Collapsible.Content>
+	);
+});

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -21,16 +21,16 @@ function Separator() {
 
 export function SessionMasthead({ session }: { session: MastheadData }) {
 	return (
-		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between border-b border-line bg-mast-bg px-8 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1]">
-			<span>
+		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between gap-3 border-b border-line bg-mast-bg px-5 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1] sm:px-8">
+			<span className="min-w-0 truncate whitespace-nowrap">
 				<b className="font-medium text-ink">{session.repo}</b>
 				<Separator />
 				{session.branch}
 			</span>
-			<span className="absolute left-1/2 -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint">
+			<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint md:block">
 				{session.title}
 			</span>
-			<span className="flex items-center">
+			<span className="flex shrink-0 items-center whitespace-nowrap">
 				{session.agentName}
 				<Separator />
 				{session.live && (

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -37,6 +37,39 @@ function riseDelay(index: number): number {
 	return index < 4 ? 0.03 + index * 0.07 : 0;
 }
 
+/**
+ * Variation B: a turn is a user message plus the agent messages answering it.
+ * Grouping the flat transcript this way lets us draw one soft frame per turn.
+ */
+interface Turn {
+	key: string;
+	messages: FolioMessage[];
+}
+
+function groupIntoTurns(messages: FolioMessage[]): Turn[] {
+	const turns: Turn[] = [];
+	for (const message of messages) {
+		if (message.role === "user" || turns.length === 0) {
+			turns.push({ key: message.id, messages: [message] });
+		} else {
+			turns[turns.length - 1].messages.push(message);
+		}
+	}
+	return turns;
+}
+
+/**
+ * The frame draws the turn's presence, so the per-message focal tick and the
+ * older-context fade are cleared — otherwise a turn would signal focus twice.
+ */
+function withoutMessagePresence(message: FolioMessage): FolioMessage {
+	if (!message.metadata) return message;
+	return {
+		...message,
+		metadata: { ...message.metadata, focal: false, recede: false },
+	};
+}
+
 export interface SessionViewProps {
 	session: SessionViewData;
 	/** Compose submit handler (client wrappers wire this; fixtures omit it). */
@@ -64,27 +97,52 @@ export function SessionView({ session, onSend, composeDisabled }: SessionViewPro
 						</p>
 					</div>
 				)}
-				{session.messages.map((message, index) => (
-					<Message
-						key={message.id}
-						message={message}
-						openToolCallIds={session.openToolCallIds}
-						animationDelay={riseDelay(index)}
-					/>
-				))}
-				{session.activeTurn && (
-					<MessageArticle
-						role="assistant"
-						author={session.activeTurn.agentName}
-						focal
-						animationDelay={riseDelay(session.messages.length)}
-					>
-						<ActivityLine
-							action={session.activeTurn.action}
-							details={session.activeTurn.details}
-						/>
-					</MessageArticle>
-				)}
+				{(() => {
+					const orderIndex = new Map(
+						session.messages.map((message, index) => [message.id, index]),
+					);
+					const turns = groupIntoTurns(session.messages);
+					// An active turn with no prior messages still needs a frame to live in.
+					const renderTurns: Turn[] =
+						turns.length === 0 && session.activeTurn
+							? [{ key: "active", messages: [] }]
+							: turns;
+					return renderTurns.map((turn, turnIndex) => {
+						const recent = turnIndex === renderTurns.length - 1;
+						// The most-recent turn is filled + lifted; older turns are quiet outlines.
+						const frame = recent
+							? "border-line-strong bg-raised shadow-card"
+							: "border-line";
+						return (
+							<section
+								key={turn.key}
+								data-turn={recent ? "recent" : "past"}
+								className={`animate-rise mb-9 rounded-[18px] border ${frame} px-8 py-7`}
+							>
+								{turn.messages.map((message) => (
+									<Message
+										key={message.id}
+										message={withoutMessagePresence(message)}
+										openToolCallIds={session.openToolCallIds}
+										animationDelay={riseDelay(orderIndex.get(message.id) ?? 0)}
+									/>
+								))}
+								{recent && session.activeTurn && (
+									<MessageArticle
+										role="assistant"
+										author={session.activeTurn.agentName}
+										animationDelay={riseDelay(session.messages.length)}
+									>
+										<ActivityLine
+											action={session.activeTurn.action}
+											details={session.activeTurn.details}
+										/>
+									</MessageArticle>
+								)}
+							</section>
+						);
+					});
+				})()}
 			</main>
 			<footer className="sticky bottom-0 z-[15]">
 				<ComposeField

--- a/web-next/src/lib/agent-runtime/mock-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.test.ts
@@ -22,16 +22,36 @@ describe("mockCodingTurn", () => {
 		expect(prose).toContain('You asked: "Fix the flaky retry"');
 	});
 
-	test("runs the Read → Edit → Bash script with paired results", async () => {
+	test("thinks first: a reasoning trace leads, before any prose or tool", async () => {
+		const chunks = await fullTurn("go");
+		const reasoning = chunks
+			.filter((chunk) => chunk.type === "reasoning")
+			.map((chunk) => chunk.content)
+			.join("");
+		expect(reasoning).toContain("SessionNotFoundError");
+		// The thinking block precedes the visible answer and the first tool call.
+		const firstReasoning = chunks.findIndex((c) => c.type === "reasoning");
+		const firstText = chunks.findIndex((c) => c.type === "text");
+		const firstTool = chunks.findIndex((c) => c.type === "tool_use");
+		expect(firstReasoning).toBeGreaterThanOrEqual(0);
+		expect(firstReasoning).toBeLessThan(firstText);
+		expect(firstReasoning).toBeLessThan(firstTool);
+	});
+
+	test("reproduces (failing), fixes, then re-runs (passing)", async () => {
 		const chunks = await fullTurn("go");
 		const calls = chunks.filter((chunk) => chunk.type === "tool_use");
 		expect(calls.map((chunk) => chunk.metadata?.toolName)).toEqual([
+			"Bash",
 			"Read",
 			"Edit",
 			"Bash",
 		]);
 		const results = chunks.filter((chunk) => chunk.type === "tool_result");
-		expect(results).toHaveLength(3);
+		expect(results).toHaveLength(4);
+		// The first test run fails; the run after the edit passes.
+		const failed = results.filter((chunk) => chunk.metadata?.isError === true);
+		expect(failed).toHaveLength(1);
 		// Each tool announces itself as a status first (the activity line).
 		const statuses = chunks
 			.filter((chunk) => chunk.type === "status")
@@ -44,7 +64,7 @@ describe("mockCodingTurn", () => {
 		const chunks = await fullTurn("go");
 		const editResult = chunks.find(
 			(chunk) =>
-				chunk.type === "tool_result" && chunk.metadata?.toolUseId === "tool-2",
+				chunk.type === "tool_result" && chunk.metadata?.toolUseId === "tool-3",
 		);
 		expect(editResult?.metadata?.diff).toMatchObject({
 			file: "src/lib/session.ts",
@@ -57,7 +77,7 @@ describe("mockCodingTurn", () => {
 		const chunks = await fullTurn("go");
 		const stats = deriveTurnStats(chunks);
 		expect(stats).toMatchObject({
-			toolCount: 3,
+			toolCount: 4,
 			filesChanged: 1,
 			additions: 3,
 			deletions: 1,

--- a/web-next/src/lib/agent-runtime/mock-provider.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.ts
@@ -1,7 +1,8 @@
 /*
  * The mock compute provider: a deterministic scripted coding turn (status →
- * prose → Read/Edit/Bash with results, a landed diff, a test run → done with
- * usage figures) that exercises the whole Folio apparatus without a sandbox.
+ * reasoning → prose → a failing test → Read/Edit → a passing test, a landed
+ * diff → done with usage figures) that exercises the whole Folio apparatus —
+ * including the thinking block and the error tool path — without a sandbox.
  * Paced with small delays so streaming behavior is observable and measurable.
  */
 import type { ComputeProvider, TurnRequest } from "./provider";
@@ -12,6 +13,21 @@ type Sleep = (ms: number) => Promise<void>;
 const defaultSleep: Sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const EDITED_FILE = "src/lib/session.ts";
+
+const REASONING_TRACE = [
+	"The repro says `resumeSession` comes back with undefined for an unknown id, and the test expects a thrown `SessionNotFoundError`.",
+	"So the failure is a missing guard: `store.get` returns undefined, and nothing between it and the caller turns that into the error the test wants.",
+	"Plan: reproduce the failure first to be sure I'm looking at the right path, read the function, add the null check, then re-run to confirm the suite goes green.",
+].join("\n\n");
+
+const FAILING_TEST_OUTPUT = [
+	"❯ src/lib/session.test.ts (4 tests | 1 failed) 208ms",
+	"  × resumeSession › rejects when the id is unknown",
+	"    → expected [Function] to throw SessionNotFoundError",
+	"",
+	"Test Files  1 failed (1)",
+	"     Tests  1 failed | 3 passed (4)",
+].join("\n");
 
 const EDIT_DIFF = {
 	file: EDITED_FILE,
@@ -54,13 +70,43 @@ export async function* mockCodingTurn(
 		}
 	}
 
+	async function* reasoning(text: string): AsyncGenerator<StreamChunk> {
+		for (const word of text.split(" ")) {
+			yield { type: "reasoning", content: `${word} ` };
+			await sleep(22);
+		}
+	}
+
 	yield { type: "status", content: "Starting sandbox" };
 	await sleep(300);
 	yield { type: "status", content: "Cloning repo" };
 	await sleep(300);
 
+	yield* reasoning(REASONING_TRACE);
+
 	yield* prose(
-		`You asked: "${userMessage}". Let me look at the failing test first.`,
+		`You asked: "${userMessage}". Let me reproduce the failure first.`,
+	);
+
+	yield { type: "status", content: "Running `pnpm test session`" };
+	yield {
+		type: "tool_use",
+		content: "Bash",
+		metadata: {
+			toolUseId: "tool-1",
+			toolName: "Bash",
+			input: { command: "pnpm test session" },
+		},
+	};
+	await sleep(600);
+	yield {
+		type: "tool_result",
+		content: FAILING_TEST_OUTPUT,
+		metadata: { toolUseId: "tool-1", isError: true },
+	};
+
+	yield* prose(
+		"Confirmed — it throws a `TypeError` inside `hydrate` instead of rejecting. Reading the source.",
 	);
 
 	yield { type: "status", content: `Reading \`${EDITED_FILE}\`` };
@@ -68,7 +114,7 @@ export async function* mockCodingTurn(
 		type: "tool_use",
 		content: "Read",
 		metadata: {
-			toolUseId: "tool-1",
+			toolUseId: "tool-2",
 			toolName: "Read",
 			input: { file_path: EDITED_FILE },
 		},
@@ -78,7 +124,7 @@ export async function* mockCodingTurn(
 		type: "tool_result",
 		content:
 			"export function resumeSession(id: string) {\n\treturn store.get(id); // BUG: no null check\n}",
-		metadata: { toolUseId: "tool-1" },
+		metadata: { toolUseId: "tool-2" },
 	};
 
 	yield* prose(
@@ -90,7 +136,7 @@ export async function* mockCodingTurn(
 		type: "tool_use",
 		content: "Edit",
 		metadata: {
-			toolUseId: "tool-2",
+			toolUseId: "tool-3",
 			toolName: "Edit",
 			input: {
 				file_path: EDITED_FILE,
@@ -104,7 +150,7 @@ export async function* mockCodingTurn(
 	yield {
 		type: "tool_result",
 		content: "Edit applied.",
-		metadata: { toolUseId: "tool-2", diff: EDIT_DIFF },
+		metadata: { toolUseId: "tool-3", diff: EDIT_DIFF },
 	};
 
 	yield { type: "status", content: "Running `pnpm test session`" };
@@ -112,7 +158,7 @@ export async function* mockCodingTurn(
 		type: "tool_use",
 		content: "Bash",
 		metadata: {
-			toolUseId: "tool-3",
+			toolUseId: "tool-4",
 			toolName: "Bash",
 			input: { command: "pnpm test session" },
 		},
@@ -121,7 +167,7 @@ export async function* mockCodingTurn(
 	yield {
 		type: "tool_result",
 		content: TEST_RUN_OUTPUT,
-		metadata: { toolUseId: "tool-3" },
+		metadata: { toolUseId: "tool-4" },
 	};
 
 	yield { type: "status", content: "Writing up the fix" };

--- a/web-next/src/lib/agent-runtime/stream-chunk.ts
+++ b/web-next/src/lib/agent-runtime/stream-chunk.ts
@@ -4,7 +4,14 @@
  * emits these; the transcript adapter turns them into AI SDK UIMessage chunks.
  */
 export interface StreamChunk {
-	type: "text" | "tool_use" | "tool_result" | "status" | "error" | "done";
+	type:
+		| "text"
+		| "reasoning"
+		| "tool_use"
+		| "tool_result"
+		| "status"
+		| "error"
+		| "done";
 	content: string;
 	metadata?: Record<string, unknown>;
 }

--- a/web-next/src/lib/fixtures/demo-session.ts
+++ b/web-next/src/lib/fixtures/demo-session.ts
@@ -1,12 +1,21 @@
 /*
  * Fixture data for /sessions/demo: the refine-folio prototype's session —
- * one completed coding turn (workings, landed diff, receipt), a follow-up,
- * and an in-progress turn — expressed as AI SDK UIMessages. Also seeds
- * arbitrary-length transcripts for the transcript_render_200 perf scenario.
+ * one completed coding turn (a thinking block, workings, landed diff, receipt),
+ * a follow-up, and an in-progress turn — expressed as AI SDK UIMessages. Also:
+ *   - seededDemoSession: arbitrary-length transcripts for transcript_render_200.
+ *   - adversarialSession (?scenario=adversarial): one worst-case turn — a long
+ *     reasoning trace, 16 tool calls (one failed), a 100+ line diff, long prose —
+ *     the stress test the turn frame, workings, diff card, and receipt must hold.
+ *   - longTranscriptSession (?scenario=long): 15+ stacked turns to check the
+ *     card-in-card framing (recent turn lifted, older ones quiet) at scale.
  */
 import type { DynamicToolUIPart } from "ai";
 import type { SessionViewData } from "@/components/folio/session-view";
-import type { FolioMessage } from "@/components/folio/types";
+import type {
+	DiffCardData,
+	DiffLine,
+	FolioMessage,
+} from "@/components/folio/types";
 
 function completedTool(
 	toolCallId: string,
@@ -21,6 +30,22 @@ function completedTool(
 		state: "output-available",
 		input,
 		output,
+	};
+}
+
+function erroredTool(
+	toolCallId: string,
+	toolName: string,
+	input: Record<string, unknown>,
+	errorText: string,
+): DynamicToolUIPart {
+	return {
+		type: "dynamic-tool",
+		toolCallId,
+		toolName,
+		state: "output-error",
+		input,
+		errorText,
 	};
 }
 
@@ -57,6 +82,11 @@ export function demoSession(): SessionViewData {
 				turnStats: { toolCount: 4, tokenCount: 3200, durationMs: 18600 },
 			},
 			parts: [
+				{
+					type: "reasoning",
+					state: "done",
+					text: "The failing test expects `resumeSession` to reject with a `SessionNotFoundError` for an unknown id. Right now it forwards whatever `store.get` returns straight into `hydrate`, so a missing record shows up as `undefined` and blows up one frame later as a `TypeError`.\n\nThe fix is a guard at the boundary: check the record before hydrating and throw the typed error there. I'll read the test and the resume path to be sure of the exact shape, then add the guard and run the suite.",
+				},
 				{
 					type: "text",
 					text: "Found it. The failing test — *rejects when the session id is unknown* — expects a `SessionNotFoundError`, but `resumeSession` passes the store’s result straight into `hydrate`. When the id is missing, the record arrives as `undefined` and the failure surfaces one frame too late: a `TypeError` inside `hydrate` instead of a meaningful rejection.",
@@ -225,6 +255,368 @@ export function seededDemoSession(messageCount: number): SessionViewData {
 		masthead: {
 			...base.masthead,
 			title: `Seeded transcript — ${messageCount} messages`,
+		},
+		messages,
+		openToolCallIds: undefined,
+		activeTurn: undefined,
+	};
+}
+
+// --- adversarial scale fixture ----------------------------------------------
+
+/** Backend modules the registry refactor touches — drives the big diff + reads. */
+const ADVERSARIAL_MODULES = [
+	"sessions",
+	"workspaces",
+	"terminals",
+	"diffs",
+	"reviews",
+	"webhooks",
+	"evidence",
+	"runners",
+	"sandboxes",
+	"notifications",
+	"auth",
+	"billing",
+];
+
+const ADVERSARIAL_TEST_OUTPUT = [
+	"✓ src/lib/agent-runtime/provider-registry.test.ts (12 tests)  84ms",
+	"✓ src/lib/agent-runtime/run-turn.test.ts               (9 tests) 141ms",
+	"✓ src/lib/agent-runtime/turn-tail.test.ts             (11 tests) 260ms",
+	"✓ src/lib/agent-runtime/backends/*.test.ts            (10 tests) 512ms",
+	"",
+	"Test Files  4 passed (4)",
+	"     Tests  42 passed (42)",
+	"  Duration  1.63s",
+].join("\n");
+
+/**
+ * A 100+ line refactor: a hand-wired provider `switch` replaced by a
+ * self-registering map, rippling across a dozen backend modules. Deliberately
+ * tall — the stress the diff card (and the frame around it) has to survive.
+ */
+function bigRefactorDiff(): DiffCardData {
+	const lines: DiffLine[] = [
+		{ kind: "context", text: "  // src/lib/agent-runtime/provider-registry.ts" },
+		{ kind: "context", text: '  import type { ComputeProvider } from "./provider";' },
+		{ kind: "context", text: "" },
+		{ kind: "del", text: "- // Every backend hand-wired into one growing switch." },
+		{ kind: "del", text: "- export function getProvider(id: string): ComputeProvider {" },
+		{ kind: "del", text: "-   switch (id) {" },
+	];
+	for (const name of ADVERSARIAL_MODULES) {
+		lines.push({ kind: "del", text: `-     case "${name}":` });
+		lines.push({ kind: "del", text: `-       return ${name}Provider;` });
+	}
+	lines.push({ kind: "del", text: "-     default:" });
+	lines.push({ kind: "del", text: "-       throw new Error(`Unknown provider: ${id}`);" });
+	lines.push({ kind: "del", text: "-   }" });
+	lines.push({ kind: "del", text: "- }" });
+	lines.push({ kind: "context", text: "" });
+	const additionsHead = [
+		"+ // Providers self-register at import; the registry never edits per backend.",
+		"+ const registry = new Map<string, ComputeProvider>();",
+		"+",
+		"+ export function registerProvider(provider: ComputeProvider): void {",
+		"+   if (registry.has(provider.id)) {",
+		"+     throw new Error(`Duplicate provider: ${provider.id}`);",
+		"+   }",
+		"+   registry.set(provider.id, provider);",
+		"+ }",
+		"+",
+		"+ export function getProvider(id: string): ComputeProvider {",
+		"+   const provider = registry.get(id);",
+		"+   if (!provider) throw new Error(`Unknown provider: ${id}`);",
+		"+   return provider;",
+		"+ }",
+	];
+	for (const text of additionsHead) lines.push({ kind: "add", text });
+	lines.push({ kind: "context", text: "" });
+	for (const name of ADVERSARIAL_MODULES) {
+		lines.push({
+			kind: "context",
+			text: `  // src/lib/agent-runtime/backends/${name}.ts`,
+		});
+		lines.push({ kind: "del", text: '- import { registerLegacy } from "../legacy";' });
+		lines.push({ kind: "del", text: `- registerLegacy("${name}", ${name}Provider);` });
+		lines.push({
+			kind: "add",
+			text: '+ import { registerProvider } from "../provider-registry";',
+		});
+		lines.push({ kind: "add", text: `+ registerProvider(${name}Provider);` });
+	}
+	const additions = lines.filter((line) => line.kind === "add").length;
+	const deletions = lines.filter((line) => line.kind === "del").length;
+	return {
+		file: "provider-registry.ts + 12 backends",
+		additions,
+		deletions,
+		note: "refactor landed · just now",
+		lines,
+	};
+}
+
+/** 16 tool calls — a grep, a spread of reads, four edits, a failed typecheck,
+ * its green re-run, and the suite. One `output-error` row exercises failure. */
+function adversarialWorkings(): DynamicToolUIPart[] {
+	const tools: DynamicToolUIPart[] = [
+		completedTool(
+			"adv-1",
+			"Bash",
+			{ command: "rg -l 'getProvider|registerLegacy' src" },
+			{
+				content: ADVERSARIAL_MODULES.map(
+					(m) => `src/lib/agent-runtime/backends/${m}.ts`,
+				).join("\n"),
+				summary: "14 matches",
+			},
+		),
+		completedTool(
+			"adv-2",
+			"Read",
+			{ file_path: "src/lib/agent-runtime/provider.ts" },
+			{ content: "export function getProvider(id: string) { … }", summary: "63 lines" },
+		),
+		completedTool(
+			"adv-3",
+			"Read",
+			{ file_path: "src/lib/agent-runtime/run-turn.ts" },
+			{ content: "const provider = getProvider(session.provider);", summary: "48 lines" },
+		),
+	];
+	ADVERSARIAL_MODULES.slice(0, 6).forEach((name, i) => {
+		tools.push(
+			completedTool(
+				`adv-r${i}`,
+				"Read",
+				{ file_path: `src/lib/agent-runtime/backends/${name}.ts` },
+				{ content: `registerLegacy("${name}", ${name}Provider);`, summary: `${20 + i} lines` },
+			),
+		);
+	});
+	tools.push(
+		completedTool(
+			"adv-e-registry",
+			"Edit",
+			{
+				file_path: "src/lib/agent-runtime/provider-registry.ts",
+				old_string: "switch (id) {\n    case …",
+				new_string: "const provider = registry.get(id);\nif (!provider) …",
+			},
+			"switch replaced by a registry lookup",
+		),
+	);
+	ADVERSARIAL_MODULES.slice(0, 3).forEach((name, i) => {
+		tools.push(
+			completedTool(
+				`adv-e${i}`,
+				"Edit",
+				{
+					file_path: `src/lib/agent-runtime/backends/${name}.ts`,
+					old_string: `registerLegacy("${name}", ${name}Provider);`,
+					new_string: `registerProvider(${name}Provider);`,
+				},
+				"self-registration",
+			),
+		);
+	});
+	tools.push(
+		erroredTool(
+			"adv-typecheck",
+			"Bash",
+			{ command: "pnpm typecheck" },
+			'src/lib/agent-runtime/backends/auth.ts(3,10): error TS2305: Module "../provider-registry" has no exported member "registerProvider".\nsrc/lib/agent-runtime/index.ts(7,1): error TS2308: Module ./provider-registry has already exported a member named getProvider.\n\nFound 2 errors in 2 files.',
+		),
+	);
+	tools.push(
+		completedTool(
+			"adv-typecheck-2",
+			"Bash",
+			{ command: "pnpm typecheck" },
+			{ content: "tsc --noEmit — no errors", summary: "0 errors" },
+		),
+	);
+	tools.push(
+		completedTool(
+			"adv-test",
+			"Bash",
+			{ command: "pnpm test agent-runtime" },
+			ADVERSARIAL_TEST_OUTPUT,
+		),
+	);
+	return tools;
+}
+
+const ADVERSARIAL_ASK =
+	"The provider lookup has turned into a 12-case switch that every new backend has to edit — it’s a merge magnet and it keeps drifting out of sync with the backends themselves. Can you flip it to a self-registering registry: each backend registers itself at import, `getProvider` just does a map lookup, and update every call site + the barrel. Keep the error on an unknown id, and don’t regress the run-turn path.";
+
+const ADVERSARIAL_REASONING =
+	"The switch is the coupling point: twelve `case` arms that each new backend has to touch, which is exactly why it drifts. Inverting it means the registry owns a `Map` and exposes `registerProvider`, and each backend calls that at module load — so adding a backend is one import, never an edit here.\n\nThe risk is import-order: a backend only registers when its module is imported, so if `getProvider` runs before the backend is pulled in, the map is empty. The barrel (`index.ts`) already imports every backend for its side effects, so as long as the barrel is the entry the registry is warm by first use. I'll verify that ordering rather than assume it.\n\nPlan: read the current switch and the run-turn call site, write the registry with a duplicate-id guard, convert each backend to self-register, then typecheck (I expect a barrel conflict on the first pass) and run the suite. Keep the unknown-id error identical so nothing downstream changes.";
+
+const ADVERSARIAL_INTRO =
+	"This is a coupling problem more than a lookup problem — the switch forces every backend to know about a central file. I’ll invert it so backends register themselves and the registry stays closed for modification. Reading the current shape and the one hot call site first, then making the change across all twelve modules.";
+
+const ADVERSARIAL_CONCLUSION =
+	"Done. The switch is gone: `getProvider` is a map lookup with the same unknown-id error, and all twelve backends self-register at import. The first typecheck caught the barrel double-exporting `getProvider` and a missing re-export — both fixed in the same pass — and the full `agent-runtime` suite is green at 42 tests, including the run-turn path you flagged. Adding the thirteenth backend is now a single `registerProvider` call in its own module, with nothing to edit here.";
+
+/**
+ * One worst-case turn: a long thinking block, 16 tool calls (one failed), a
+ * 100+ line diff, and long prose on both sides — the stress test the turn
+ * frame, workings apparatus, diff card, reasoning block, and receipt must hold.
+ */
+export function adversarialSession(): SessionViewData {
+	const diff = bigRefactorDiff();
+	const messages: FolioMessage[] = [
+		{
+			id: "adv-user",
+			role: "user",
+			metadata: { author: "Michael", stamp: "2:14 pm" },
+			parts: [{ type: "text", text: ADVERSARIAL_ASK }],
+		},
+		{
+			id: "adv-agent",
+			role: "assistant",
+			metadata: {
+				author: "Claude",
+				stamp: "2:31 pm",
+				turnStats: {
+					toolCount: 16,
+					tokenCount: 48200,
+					durationMs: 1042000,
+					filesChanged: 13,
+					additions: diff.additions,
+					deletions: diff.deletions,
+					testsPassed: 42,
+				},
+			},
+			parts: [
+				{ type: "reasoning", state: "done", text: ADVERSARIAL_REASONING },
+				{ type: "text", text: ADVERSARIAL_INTRO },
+				...adversarialWorkings(),
+				{ type: "data-diff", data: diff },
+				{ type: "text", text: ADVERSARIAL_CONCLUSION },
+			],
+		},
+	];
+	return {
+		masthead: {
+			repo: "orbit/web",
+			branch: "refactor/provider-registry",
+			title: "Replace the provider switch with a registry",
+			agentName: "Claude",
+			stateLabel: "sandbox active",
+			live: true,
+		},
+		messages,
+		openToolCallIds: ["adv-test"],
+		statusLine: { model: "opus-4.8", contextLabel: "48.2k ctx" },
+	};
+}
+
+// --- long transcript (card-in-card at scale) --------------------------------
+
+const LONG_ASKS = [
+	"The retry logic in the queue worker never backs off — can you add exponential backoff capped at five attempts?",
+	"Sessions aren’t expiring; `expiresAt` is set but nothing sweeps them. Add a reaper.",
+	"The diff parser chokes on CRLF files. Normalize line endings before parsing.",
+	"Add a `--json` flag to the status CLI so we can pipe it.",
+	"Webhook signatures aren’t verified. Add HMAC verification with a constant-time compare.",
+	"The masthead title overflows on narrow windows — truncate it.",
+	"Cache the repo tree between requests; we refetch it on every keystroke.",
+	"Add a health endpoint that checks the DB and the sandbox pool.",
+	"The evidence uploader retries forever on a 413. Give up after the first and surface it.",
+	"Token counts in the receipt are off by the system prompt — subtract it.",
+	"Add keyboard nav (j/k) to the transcript.",
+	"The dark theme flashes light on first paint. Set the theme before hydration.",
+	"Rate-limit the chat route per session.",
+	"Collapse consecutive identical statuses in the activity line.",
+];
+
+function longAssistantParts(index: number): FolioMessage["parts"] {
+	const mod = index % 3;
+	if (mod === 0) {
+		return [
+			{
+				type: "reasoning",
+				state: "done",
+				text: `The failure is narrow — the guard is in the wrong place, so the edge case (${index}) slips past. I'll fix it at the boundary and add a case that pins the behavior.`,
+			},
+			{
+				type: "text",
+				text: `Fixed. The edge case now short-circuits before the hot path, and there's a regression test pinning it.`,
+			},
+			completedTool(
+				`lt-tool-${index}`,
+				"Bash",
+				{ command: "pnpm test" },
+				TEST_RUN_OUTPUT,
+			),
+		];
+	}
+	if (mod === 1) {
+		return [
+			{
+				type: "text",
+				text: `Done — the change is small and contained. Reading the call site first confirmed nothing else depended on the old shape.`,
+			},
+			completedTool(
+				`lt-read-${index}`,
+				"Read",
+				{ file_path: `src/lib/module-${index}.ts` },
+				{ content: `export const value = ${index};`, summary: "24 lines" },
+			),
+		];
+	}
+	return [
+		{
+			type: "text",
+			text: `Shipped. One-line fix plus a comment explaining why the order matters here — the trap is subtle enough to earn it.`,
+		},
+	];
+}
+
+/**
+ * 15+ stacked turns with the adversarial turn spliced into the middle — the
+ * fixture for reviewing the card-in-card framing at scale (recent turn lifted
+ * and filled, older turns quiet outlines) and how the thinking block reads when
+ * it repeats down a long session.
+ */
+export function longTranscriptSession(): SessionViewData {
+	const base = demoSession();
+	const messages: FolioMessage[] = [];
+	LONG_ASKS.forEach((ask, i) => {
+		messages.push({
+			id: `lt-u-${i}`,
+			role: "user",
+			metadata: { author: "Michael", stamp: "9:4?".replace("?", String(i % 10)) },
+			parts: [{ type: "text", text: ask }],
+		});
+		messages.push({
+			id: `lt-a-${i}`,
+			role: "assistant",
+			metadata: {
+				author: "Claude",
+				stamp: "9:4?".replace("?", String(i % 10)),
+				turnStats: {
+					toolCount: i % 3 === 0 ? 1 : i % 3 === 1 ? 1 : 0,
+					tokenCount: 900 + i * 130,
+					durationMs: 3200 + i * 400,
+					testsPassed: i % 3 === 0 ? 28 : undefined,
+				},
+			},
+			parts: longAssistantParts(i),
+		});
+	});
+	// Drop the worst-case turn into the middle so the frame is reviewed with a
+	// heavy turn stacked among light ones.
+	const adversarial = adversarialSession();
+	messages.splice(10, 0, ...adversarial.messages);
+	return {
+		...base,
+		masthead: {
+			...base.masthead,
+			title: `Long session — ${LONG_ASKS.length + 1} turns`,
 		},
 		messages,
 		openToolCallIds: undefined,

--- a/web-next/src/lib/transcript/chunk-adapter.test.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.test.ts
@@ -191,6 +191,55 @@ describe("toUIMessageChunks", () => {
 		expect(seen).toEqual([0, 2]);
 	});
 
+	test("brackets contiguous reasoning chunks into one reasoning part", async () => {
+		const out = await collect([
+			{ type: "reasoning", content: "Think " },
+			{ type: "reasoning", content: "more" },
+			{ type: "done", content: "" },
+		]);
+		expect(out).toEqual([
+			{ type: "start", messageId: "msg-1" },
+			{ type: "reasoning-start", id: "id-0" },
+			{ type: "reasoning-delta", id: "id-0", delta: "Think " },
+			{ type: "reasoning-delta", id: "id-0", delta: "more" },
+			{ type: "reasoning-end", id: "id-0" },
+			{ type: "finish" },
+		]);
+	});
+
+	test("reasoning and text close each other; they never overlap", async () => {
+		const out = await collect([
+			{ type: "reasoning", content: "let me think" },
+			{ type: "text", content: "here's the answer" },
+			{ type: "done", content: "" },
+		]);
+		// reasoning is closed before the text part opens
+		const reasoningEnd = out.findIndex((c) => c.type === "reasoning-end");
+		const textStart = out.findIndex((c) => c.type === "text-start");
+		expect(reasoningEnd).toBeGreaterThanOrEqual(0);
+		expect(textStart).toBeGreaterThan(reasoningEnd);
+	});
+
+	test("a tool call closes an open reasoning part", async () => {
+		const out = await collect([
+			{ type: "reasoning", content: "I should read the file" },
+			{ type: "tool_use", content: "Read", metadata: { toolUseId: "t-1" } },
+			{ type: "done", content: "" },
+		]);
+		const reasoningEnd = out.findIndex((c) => c.type === "reasoning-end");
+		const toolInput = out.findIndex((c) => c.type === "tool-input-available");
+		expect(reasoningEnd).toBeGreaterThanOrEqual(0);
+		expect(toolInput).toBeGreaterThan(reasoningEnd);
+	});
+
+	test("empty reasoning content opens no part", async () => {
+		const out = await collect([
+			{ type: "reasoning", content: "" },
+			{ type: "done", content: "" },
+		]);
+		expect(out.some((c) => c.type === "reasoning-start")).toBe(false);
+	});
+
 	test("text after a tool call starts a new text part", async () => {
 		const out = await collect([
 			{ type: "text", content: "before" },

--- a/web-next/src/lib/transcript/chunk-adapter.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.ts
@@ -30,6 +30,8 @@ function asString(value: unknown): string | undefined {
  *
  * Contract:
  * - Contiguous `text` chunks form one text part; any tool/error chunk closes it.
+ * - Contiguous `reasoning` chunks form one reasoning part (the model's thinking);
+ *   it and an open text part close each other, so the two never overlap.
  * - `tool_use`/`tool_result` become dynamic tool parts. Results pair by
  *   `metadata.toolUseId` when present, otherwise FIFO against unresolved calls.
  * - A `tool_result` carrying `metadata.diff` additionally surfaces it as a
@@ -45,6 +47,7 @@ export async function* toUIMessageChunks(
 	const generateId = options.generateId ?? defaultGenerateId;
 
 	let openTextId: string | null = null;
+	let openReasoningId: string | null = null;
 	let finished = false;
 	const unresolvedToolIds: string[] = [];
 	const consumed: StreamChunk[] = [];
@@ -53,6 +56,13 @@ export async function* toUIMessageChunks(
 		if (openTextId === null) return [];
 		const end: UIMessageChunk = { type: "text-end", id: openTextId };
 		openTextId = null;
+		return [end];
+	}
+
+	function closeReasoning(): UIMessageChunk[] {
+		if (openReasoningId === null) return [];
+		const end: UIMessageChunk = { type: "reasoning-end", id: openReasoningId };
+		openReasoningId = null;
 		return [end];
 	}
 
@@ -69,6 +79,7 @@ export async function* toUIMessageChunks(
 		switch (chunk.type) {
 			case "text": {
 				if (chunk.content.length === 0) break;
+				yield* closeReasoning();
 				if (openTextId === null) {
 					openTextId = generateId();
 					yield { type: "text-start", id: openTextId };
@@ -76,8 +87,23 @@ export async function* toUIMessageChunks(
 				yield { type: "text-delta", id: openTextId, delta: chunk.content };
 				break;
 			}
+			case "reasoning": {
+				if (chunk.content.length === 0) break;
+				yield* closeText();
+				if (openReasoningId === null) {
+					openReasoningId = generateId();
+					yield { type: "reasoning-start", id: openReasoningId };
+				}
+				yield {
+					type: "reasoning-delta",
+					id: openReasoningId,
+					delta: chunk.content,
+				};
+				break;
+			}
 			case "tool_use": {
 				yield* closeText();
+				yield* closeReasoning();
 				const toolCallId =
 					asString(chunk.metadata?.toolUseId) ?? generateId();
 				const toolName =
@@ -96,6 +122,7 @@ export async function* toUIMessageChunks(
 			}
 			case "tool_result": {
 				yield* closeText();
+				yield* closeReasoning();
 				const explicitId = asString(chunk.metadata?.toolUseId);
 				const toolCallId = explicitId ?? unresolvedToolIds[0];
 				if (toolCallId === undefined) break; // result with no known call
@@ -130,6 +157,7 @@ export async function* toUIMessageChunks(
 			}
 			case "error": {
 				yield* closeText();
+				yield* closeReasoning();
 				yield { type: "error", errorText: chunk.content };
 				break;
 			}
@@ -141,6 +169,7 @@ export async function* toUIMessageChunks(
 	}
 
 	yield* closeText();
+	yield* closeReasoning();
 	yield {
 		type: "finish",
 		messageMetadata: options.messageMetadata?.(consumed),

--- a/web-next/src/lib/transcript/project-events.test.ts
+++ b/web-next/src/lib/transcript/project-events.test.ts
@@ -164,6 +164,37 @@ describe("projectSessionEvents", () => {
 		});
 	});
 
+	test("projects a reasoning event into a reasoning part before the answer", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "why is it failing?"),
+			a(2, "reasoning", "The guard is missing, so undefined slips through."),
+			a(3, "text", "Found it."),
+			a(4, "done", ""),
+		]);
+		expect(messages[1]).toMatchObject({
+			role: "assistant",
+			parts: [
+				{
+					type: "reasoning",
+					text: "The guard is missing, so undefined slips through.",
+					state: "done",
+				},
+				{ type: "text", text: "Found it." },
+			],
+		});
+	});
+
+	test("a reasoning-only turn still renders (it is a real part)", async () => {
+		const messages = await projectSessionEvents("s", [
+			a(1, "reasoning", "thinking out loud"),
+			a(2, "done", ""),
+		]);
+		expect(messages).toHaveLength(1);
+		expect(messages[0].parts).toMatchObject([
+			{ type: "reasoning", text: "thinking out loud" },
+		]);
+	});
+
 	test("interleaves multiple user+assistant turns in one log", async () => {
 		const messages = await projectSessionEvents("s", [
 			u(1, "first question"),

--- a/web-next/tests/e2e/sessions-demo.spec.ts
+++ b/web-next/tests/e2e/sessions-demo.spec.ts
@@ -105,15 +105,22 @@ test("status line dismisses to a dot and comes back", async ({ page }) => {
 	await expect(page.getByTestId("status-line")).toContainText("2.1k ctx");
 });
 
-test("focus cue and end-of-turn receipt are present", async ({ page }) => {
+test("turn frame focus cue and end-of-turn receipt are present", async ({
+	page,
+}) => {
 	await page.goto("/sessions/demo");
-	// The completed agent turn and the working turn carry the gutter tick.
-	await expect(page.locator("[data-focal]")).toHaveCount(2);
+	// Variation B: turns are discrete frames. The demo's two turns render as
+	// two frames; the most-recent one is lifted (the focus cue), older ones
+	// are quiet outlines — the frame carries presence, not a per-message tick.
+	await expect(page.locator("[data-turn]")).toHaveCount(2);
+	await expect(page.locator('[data-turn="recent"]')).toHaveCount(1);
 	await expect(page.getByTestId("turn-stats")).toHaveText(
 		"4 tools · 3.2k tokens · 18.6s",
 	);
-	// The in-progress turn shows the quiet activity line.
-	await expect(page.getByTestId("activity-line")).toContainText("Editing");
+	// The lifted frame is the live one: it holds the in-progress activity line.
+	await expect(
+		page.locator('[data-turn="recent"]').getByTestId("activity-line"),
+	).toContainText("Editing");
 });
 
 test("seeded transcript renders the requested message count", async ({


### PR DESCRIPTION
Adds reasoning traces to the transcript and an adversarial mock to stress the Folio design at scale. Two tickets, one branch: **Closes #784** (reasoning treatment) and **Closes #785** (adversarial mock).

> **Stacking:** branched off `web-next-turn-frame`, so reasoning renders inside the turn frame. Base is `main` for review, but this should **merge after #779** (turn structure) — until then the diff carries the three turn-frame commits.

## Feature A — reasoning traces (#784)

`StreamChunk` gains a `reasoning` variant, threaded through the pipeline so a model's thinking persists and replays like any other part:

- **`stream-chunk.ts`** — `reasoning` added to the type union (the only chunk-side type edit).
- **`chunk-adapter.ts`** (the load-bearing edit) — contiguous `reasoning` chunks bracket into one AI SDK reasoning part (`reasoning-start` / `reasoning-delta` / `reasoning-end`), mirroring the text handling. An open text part and an open reasoning part close each other, so the two never overlap; a tool/error also closes an open reasoning part.
- **`project-events.ts`** — no change. `readUIMessageStream` natively reduces the reasoning chunks into a `{ type: "reasoning", text, state }` UIMessage part, so stored turns replay identically. (Persistence is also free: `session_events.kind` denormalizes from `chunk.type`.)
- **`message.tsx`** — a `reasoning` segment renders the new block, before the answer prose.

The block is styled as **a quiet, collapsible thinking block that recedes**, per the design intent: a mono trigger (`▸ Thought for 4s` / breathing dot + `Thinking…` while streaming) over a serif, muted aside set off by a hairline left rule. Completed reasoning (a replay or fixture) mounts **collapsed**; a turn that streams reasoning **opens while it thinks, then folds itself away** a beat after.

## Feature B — adversarial mock (#785)

- **`mock-provider.ts`** now streams a reasoning trace and a **failing-then-passing** test cycle — so the live path exercises both the new reasoning part *and* the error tool path end to end, not just the happy path.
- **`?scenario=adversarial`** — one worst-case turn: long reasoning, **16 tool calls** (including a failed `typecheck`), a **111-line diff**, a failed→green cycle, and long prose on both sides.
- **`?scenario=long`** — **16 stacked turns** (the adversarial one spliced into the middle) for reviewing the card-in-card framing at scale.

### Scale review findings

Ran the turn frame, masthead, compose, receipt, and the reasoning block against the adversarial + long fixtures:

- **Fixed:** the diff card was unbounded — a 111-line diff turned a contextual "figure" into a wall and pushed the conclusion + receipt far below the fold (the turn was ~9,400px tall). Diffs past ~28 lines now **scroll inside the card** (turn back to ~5,050px). Short diffs are unchanged.
- **Held up:** the card-in-card framing (recent turn lifted + filled, older ones quiet outlines), the masthead title (centers + truncates), compose, and the receipt (`16 tools · 13 files · +39 −55 · 42 tests · 48.2k tokens · 17m 22s`). The 16-row workings block stays compact and scannable. The reasoning block starting collapsed matters here — it adds no height to an already-heavy turn.

## AI Elements adoption — the judgment call

Reviewed AI Elements (Reasoning, Tool, Message, Response, Conversation, PromptInput) and its install model (the `npx ai-elements` shadcn-style CLI that *vendors* component source in, pulling shadcn/Radix/Tailwind + lucide + streamdown).

**Adopted:** AI Elements' **Reasoning** component — its API shape (`Reasoning` / `ReasoningTrigger` / `ReasoningContent` + `useReasoning`), its behavior (auto-open-while-streaming, collapse-shortly-after-done, duration tracking), and the two Radix primitives it's actually built on (`@radix-ui/react-collapsible`, `@radix-ui/react-use-controllable-state`). That behavior is exactly what #784 called for.

**Restyled / did not import:** Folio is a bespoke Tailwind-v4 system with zero UI libraries, and the design brief was explicit that reasoning read *calm, not like raw shadcn*. So I did **not** pull the shadcn token system (`components.json`, the `ui/` dir, `--muted-foreground` etc.), `lucide` (used a Folio chevron), `streamdown` (used Folio's own `InlineMarkdown`, so reasoning matches the rest of the transcript), or the shimmer (used Folio's breathing dot). Net new deps: two headless Radix packages.

**Deliberately did NOT migrate:** the working custom Folio components (Message, the tool-ledger Workings, DiffCard) stay as-is — no wholesale rip-out.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — **117 passed** (added: reasoning bracketing + mutual-close in the adapter; reasoning projection incl. a reasoning-only turn; the mock's reasoning-leads + failing-then-passing cycle)
- `pnpm build` — compiles + type-validates clean. The build then fails prerendering the auto-generated `/500` / `/_error` pages (`<Html> should not be imported outside of pages/_document`) — **this is pre-existing on `web-next-turn-frame`** (the untouched base fails identically) and unrelated to these changes. Tracked as #780.

## Evidence

**Reasoning block (#784)** — the thinking block collapsed (recedes to one quiet mono line) and expanded (serif muted aside with a hairline rule), light + dark:

| | Collapsed (default) | Expanded |
|---|---|---|
| Light | [screenshot](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155516-reasoning-collapsed-light.png) | [screenshot](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155504-reasoning-expanded-light.png) |
| Dark | [screenshot](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155517-reasoning-collapsed-dark.png) | [screenshot](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155517-reasoning-expanded-dark.png) |

[reasoning expanded, light](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155504-reasoning-expanded-light.png)

**At scale (#785)** — the adversarial turn (bounded diff, 16-tool workings, receipt) and the long transcript (card-in-card framing), light + dark:

- Adversarial turn — [light](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155518-adversarial-turn-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155519-adversarial-turn-dark.png)
- Long transcript — [light](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155519-long-transcript-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-787/20260704-155520-long-transcript-dark.png)

## Mergeability

- Surface: web (web-next — StreamChunk protocol, chunk adapter, mock provider, Folio message/reasoning components)
- User-facing behavior changed: Yes — a model's reasoning renders as a quiet collapsible thinking block (auto-opens while streaming, folds away after); long diffs scroll inside the diff card instead of dominating the turn; the demo gains `?scenario=adversarial` and `?scenario=long` fixtures.
- Non-happy paths considered: The mock now exercises the failed-tool path end to end (failing→passing test cycle); reasoning-only turns replay correctly from storage; an open reasoning part is closed by text, tool, or error chunks so parts never overlap; completed reasoning mounts collapsed so heavy turns gain no height.
- Residual risk or follow-up: Merge after #779 (shares the turn-frame commits until then); the `/500`/`/_error` prerender failure pre-exists on the base and is tracked as #780; two new headless Radix deps (`react-collapsible`, `react-use-controllable-state`).
