### PR TITLE
docs: require an author:<agent> label on agent-authored PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Then continue through the issue lifecycle in `backlog/AGENTS.md`.
 
 Use lane + state labels: `agent`/`human` for ownership, `ready`/`claimed`/`review`/`mergeable` for lifecycle, and `needs-human` only for human intervention blockers. See `docs/agents/triage-labels.md`.
 
+**Author label (required on agent-authored PRs).** The GitHub account is shared across all agents, so a PR's author/assignee can't tell workstreams apart — and almost every PR here is agent-authored. When you open a PR, add exactly one `author:<agent>` label naming yourself (e.g. `author:claude-code`, `author:codex`, `author:april`, `author:fable-orchestrator`); `gh label create` it if it doesn't exist yet. Human-authored PRs carry none. This makes attribution filterable (`gh pr list --label author:<agent>`) since author is meaningless on a shared account. Slug rules + vocabulary: `docs/agents/triage-labels.md` § "Author Labels".
+
 ### Domain docs
 
 Single-context repo; use root docs plus `docs/decisions/` for architectural decisions. See `docs/agents/domain.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -18,6 +18,19 @@ Do not create duplicate labels that combine these meanings. Prefer adding the ri
 
 The default for planned work is agent-driven. Peter-created execution issues should carry both `agent` and `task`.
 
+## Author Labels
+
+Every agent, human, and automation in this repo pushes under the **same GitHub account** (`fairchild`), so a PR's author and assignee tell you nothing about which agent produced it — and almost every PR is agent-authored. `author:<slug>` labels restore that attribution and make it filterable (`gh pr list --label author:<slug>`).
+
+Rules:
+
+- **Every agent-authored PR carries exactly one `author:<slug>` label** identifying its author, applied at PR creation. Human-authored PRs carry none.
+- **Slug = the agent's stable identity, lowercase kebab-case.** Use the persona when acting as one (`author:april`, `author:plat`, `author:carl`, `author:fable-orchestrator`); otherwise the harness (`author:claude-code`, `author:codex`). Keep it stable across sessions — it's a workstream identity, not a per-session id (session/thread ids belong in the claim comment's `claimer=<harness>:<stable-id>`, and the model belongs in the commit `Co-Authored-By` trailer).
+- **Create the label if it's new:** `gh label create "author:<slug>" --color BFD4F2 --description "PRs authored by the <slug> agent"`. Reuse an existing `author:*` label rather than minting a near-duplicate.
+- This is an **authorship** label — a distinct axis from lane/state/dimension/gate (none of those answer "which agent wrote this"). It is **not** a revival of the retired `agent:*` ownership labels (see § "Live Label Migration"): `author:claude-code` says who *wrote* a PR, orthogonal to the `agent`/`human` lane that says who *owns* the work. A PR can be `author:claude-code` while its issue sits in the `agent` lane.
+
+Not yet CI-enforced; it's the cheapest surface today. If drift shows up, a readiness check that requires one `author:*` label on non-human PRs is the natural next step.
+
 ## State Labels
 
 | Label | Meaning |


### PR DESCRIPTION
## Summary

Adds a convention (in `AGENTS.md` + `docs/agents/triage-labels.md`) that every **agent-authored PR carries one `author:<slug>` label** naming its author. Human-authored PRs carry none.

**Why:** every agent, human, and automation in this repo pushes under the same GitHub account (`fairchild`), so a PR's author/assignee tells you nothing about which agent produced it — and almost every PR is agent-authored. This session hit exactly that: `gh pr list --author @me` returned ~10 open PRs from unrelated workstreams (web-next, agents, feedback-store) that only *looked* like "our work." An `author:*` label makes attribution filterable: `gh pr list --label author:<slug>`.

**This PR demonstrates the rule** — it carries `author:claude-code`.

## Design notes for the reviewer

- **`author:*`, not `agent:*`, on purpose.** This repo *retired* `agent:*` labels (see `docs/agents/triage-labels.md` § "Live Label Migration" + `scripts/migrate-agent-labels.py`) in favor of the composable `agent`/`human` **ownership** model. Authorship is a genuinely different axis — none of the doc's four questions (lane / state / dimension / gate) answer "which agent *wrote* this" — so `author:*` is additive, and the doc says explicitly it is not a revival of the retired scheme. **If you'd rather encode authorship differently (or not via labels), this is the decision to flag before merge.**
- Slug = the agent's stable identity (persona like `author:april` / `author:plat` / `author:fable-orchestrator`, else harness like `author:claude-code` / `author:codex`) — a workstream identity, not a per-session id (those stay in the claim comment's `claimer=`; the model stays in the `Co-Authored-By` trailer).
- Placed per AGENTS.md's own "cheapest surface" doctrine: tight rule in AGENTS.md, full vocabulary in the linked label doc. Not CI-enforced yet; a readiness check requiring one `author:*` on non-human PRs is noted as the natural next step if drift appears.
- Seed label `author:claude-code` created.

## Mergeability

- Surface: docs
- User-facing behavior changed: none (convention/docs only).
- Non-happy paths considered: distinguished from the retired `agent:*` scheme; create-if-missing guidance so the convention self-propagates; human PRs explicitly exempt.
- Release/ops preconditions: none.
- Residual risk or follow-up: adoption is by-convention until/unless a CI gate is added; other agents' identities get their `author:*` label created on first use.

## Validation

- [x] Docs-only; no build/test surface.
- [x] `CLAUDE.md` is a symlink to `AGENTS.md`, so the single edit covers both.

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None

Refs #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)