### PR TITLE
test(web-next): repair the e2e lane after #787 — sessions spec + a latent auth flake

### DIFF
--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -112,9 +112,10 @@ async function captureSessionTurn(page, shot) {
 	);
 	await page.screenshot({ path: shot("session-turn-midstream") });
 
-	// Final: receipt rendered; disclose the test run's output panel.
+	// Final: receipt rendered; disclose the passing re-run's output panel
+	// (the mock turn is: failed run, Read, Edit, passing run).
 	await page.getByTestId("turn-stats").waitFor({ timeout: TURN_TIMEOUT_MS });
-	await page.getByTestId("tool-row").nth(2).locator("button").first().click();
+	await page.getByTestId("tool-row").nth(3).locator("button").first().click();
 	await page.getByTestId("test-output").waitFor();
 	// Scroll to the end of the turn so diff card + receipt are in frame.
 	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
@@ -151,7 +152,7 @@ async function captureDisconnectResume(context, shot) {
 	await starter.keyboard.press("Enter");
 	// Mid-turn: first prose streamed — the moment before the tab is closed.
 	await starter
-		.getByText("Let me look at the failing test")
+		.getByText("Let me reproduce the failure first")
 		.waitFor({ timeout: TURN_TIMEOUT_MS });
 	await starter.waitForTimeout(300);
 	await starter.screenshot({ path: shot("resume-midturn") });

--- a/web-next/tests/e2e/auth.spec.ts
+++ b/web-next/tests/e2e/auth.spec.ts
@@ -43,7 +43,10 @@ test.describe("signed out", () => {
 			.getByRole("button", { name: `continue as ${E2E_LOGIN} (test bypass)` })
 			.click();
 		await expect(page).toHaveURL("/");
-		await expect(page.getByText("Spaces")).toBeVisible();
+		// Scoped to the masthead: bare getByText("Spaces") is a case-insensitive
+		// substring match, so once sessions exist, rows for ".../workspaces"
+		// match it too (order-dependent flake).
+		await expect(page.getByRole("banner").getByText("Spaces")).toBeVisible();
 	});
 });
 

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -15,7 +15,7 @@ test.describe.configure({ mode: "serial" });
 
 const SESSION_URL = /\/sessions\/[0-9a-f-]{36}$/;
 
-// The mock turn takes ~7s of scripted delays end to end.
+// The mock turn takes ~9s of scripted delays end to end.
 const TURN_TIMEOUT = 20_000;
 
 test.beforeAll(async () => {
@@ -121,18 +121,25 @@ test("sending a message streams a mock coding turn into the Folio transcript", a
 	// The activity line breathes while the provider provisions.
 	await expect(page.getByTestId("activity-line")).toBeVisible();
 
-	// The turn streams the whole apparatus: prose…
+	// The turn streams the whole apparatus: the thinking block…
+	await expect(page.getByTestId("reasoning")).toBeVisible({
+		timeout: TURN_TIMEOUT,
+	});
+	// …prose…
 	await expect(page.locator('[data-message-role="assistant"]')).toContainText(
-		"Let me look at the failing test",
+		"Let me reproduce the failure first",
 		{ timeout: TURN_TIMEOUT },
 	);
-	// …the tool ledger (Read, Edit with its line delta, Ran)…
+	// …the tool ledger (a failing run, Read, Edit with its line delta, the
+	// passing re-run)…
 	const rows = page.getByTestId("tool-row");
-	await expect(rows).toHaveCount(3, { timeout: TURN_TIMEOUT });
-	await expect(rows.nth(0)).toContainText("Read");
-	await expect(rows.nth(1)).toContainText("+3 −1");
-	await expect(rows.nth(2)).toContainText("Ran");
-	await expect(rows.nth(2)).toContainText("pnpm test session");
+	await expect(rows).toHaveCount(4, { timeout: TURN_TIMEOUT });
+	await expect(rows.nth(0)).toContainText("Ran");
+	await expect(rows.nth(0)).toContainText("failed");
+	await expect(rows.nth(1)).toContainText("Read");
+	await expect(rows.nth(2)).toContainText("+3 −1");
+	await expect(rows.nth(3)).toContainText("Ran");
+	await expect(rows.nth(3)).toContainText("pnpm test session");
 	// …the landed diff card…
 	await expect(page.getByTestId("diff-card")).toContainText(
 		"SessionNotFoundError",
@@ -140,12 +147,15 @@ test("sending a message streams a mock coding turn into the Folio transcript", a
 	);
 	// …and the end-of-turn receipt derived from the stream.
 	await expect(page.getByTestId("turn-stats")).toContainText(
-		"3 tools · 1 file · +3 −1 · 4 tests",
+		"4 tools · 1 file · +3 −1 · 4 tests",
 		{ timeout: TURN_TIMEOUT },
 	);
 
-	// The test run discloses the highlighted output panel.
-	await rows.nth(2).locator("button").first().click();
+	// The completed thinking block has receded to its collapsed trigger.
+	await expect(page.getByTestId("reasoning")).toContainText("Thought for");
+
+	// The passing re-run discloses the highlighted output panel.
+	await rows.nth(3).locator("button").first().click();
 	await expect(page.getByTestId("test-output")).toContainText("4 passed");
 	await expect(page.getByTestId("test-output")).toHaveAttribute(
 		"data-passed",
@@ -164,10 +174,10 @@ test("a reload renders the same turn from the persisted event log", async ({
 	await expect(page.locator('[data-message-role="user"]')).toContainText(
 		"Fix the failing session test",
 	);
-	await expect(page.getByTestId("tool-row")).toHaveCount(3);
+	await expect(page.getByTestId("tool-row")).toHaveCount(4);
 	await expect(page.getByTestId("diff-card")).toContainText("src/lib/session.ts");
 	await expect(page.getByTestId("turn-stats")).toContainText(
-		"3 tools · 1 file · +3 −1 · 4 tests",
+		"4 tools · 1 file · +3 −1 · 4 tests",
 	);
 	// Nothing is in flight after a reload — the receipt is served, not replayed.
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
@@ -182,7 +192,7 @@ test("a turn survives a mid-stream reload and resumes to completion", async ({
 	await page.keyboard.press("Enter");
 
 	// Wait until the second turn's first tool call landed in the log…
-	await expect(page.getByTestId("tool-row")).toHaveCount(4, {
+	await expect(page.getByTestId("tool-row")).toHaveCount(5, {
 		timeout: TURN_TIMEOUT,
 	});
 	// …then abandon the stream mid-turn. The turn runs detached server-side, so
@@ -191,12 +201,12 @@ test("a turn survives a mid-stream reload and resumes to completion", async ({
 
 	// Both turns' user messages survive; the reopened tab resumes the in-flight
 	// turn from the event log and it finishes — a second receipt lands and the
-	// full ledger (both turns, 3 tools each) is present.
+	// full ledger (both turns, 4 tools each) is present.
 	await expect(page.locator('[data-message-role="user"]')).toHaveCount(2);
 	await expect(page.getByTestId("turn-stats")).toHaveCount(2, {
 		timeout: TURN_TIMEOUT,
 	});
-	await expect(page.getByTestId("tool-row")).toHaveCount(6);
+	await expect(page.getByTestId("tool-row")).toHaveCount(8);
 	// Nothing is in flight once the resumed turn completes.
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
 });
@@ -220,7 +230,7 @@ test("closing the tab mid-turn does not kill it — a fresh tab catches up", asy
 	await page.keyboard.press("Enter");
 	// The turn is genuinely under way (first prose streamed) before we leave.
 	await expect(page.locator('[data-message-role="assistant"]')).toContainText(
-		"Let me look at the failing test",
+		"Let me reproduce the failure first",
 		{ timeout: TURN_TIMEOUT },
 	);
 
@@ -232,7 +242,7 @@ test("closing the tab mid-turn does not kill it — a fresh tab catches up", asy
 	// The detached turn kept running; the reopened tab resumes it from the log
 	// and it completes — the receipt is the proof it caught up live.
 	await expect(reopened.getByTestId("turn-stats")).toContainText(
-		"3 tools · 1 file · +3 −1 · 4 tests",
+		"4 tools · 1 file · +3 −1 · 4 tests",
 		{ timeout: TURN_TIMEOUT },
 	);
 	await expect(reopened.getByTestId("activity-line")).toHaveCount(0);


### PR DESCRIPTION
#787 merged with its CI lane red: the mock coding turn changed shape (leading reasoning trace, a failing-then-passing test cycle, 4 tools, new prose) but `tests/e2e/sessions.spec.ts` still asserted the old 3-tool script, so the `web-next-ci` E2E step fails on `main` right now (see the lane's failure on #787's head, run [28714915882](https://github.com/fairchild/workspaces/actions/runs/28714915882)). This PR repairs the lane.

## What changed

- **`sessions.spec.ts`** — assertions follow the new turn shape: 4 ledger rows (failing `Ran` marked `failed`, `Read`, `Edit +3 −1`, passing `Ran`), the new prose anchor, the `4 tools · 1 file · +3 −1 · 4 tests` receipt, and the downstream counts in the reload / mid-stream-resume / closed-tab specs (4 → 5 → 8 rows, receipt text). It also now covers the thinking block: visible while the turn streams, receded to its collapsed `Thought for …` trigger once complete.
- **`auth.spec.ts`** — fixed a latent order-dependent flake found while verifying: `getByText("Spaces")` is a case-insensitive substring match, so once the home lists sessions on a `…/workspaces` repo it resolves to 4 elements and fails strict mode. It only passed in CI because `auth.spec` runs before `sessions.spec` populates the DB. Now scoped to the masthead (`getByRole("banner")`).

## Verification

Against a production build of the merged code (`next start`, auth-bypass e2e server):

- Full Playwright suite: sessions spec **7 passed**; auth spec **7 passed** run *after* the DB was populated — the exact condition that previously broke it.
- Unit tests: **117 passed** (14 files) · typecheck clean · lint clean.

## Mergeability

- Surface: web (web-next e2e specs only — no runtime code)
- User-facing behavior changed: No — test-only; restores a red `web-next-ci` lane on `main` to green.
- Non-happy paths considered: The updated spec still exercises the failed-tool path (the failing run's `failed` meta and the passing re-run's output panel), mid-stream reload resume, and the closed-tab catch-up; the auth fix was verified under the populated-DB ordering that exposed the flake.
- Residual risk or follow-up: None — assertions are derived from the mock script and the ledger/receipt formatters on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ)_