### PR TITLE
docs(web-next): CONTRIBUTING.md — local dev setup + real-runtime credentials

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing / local development — web-next
+
+How to run the sessions-first web app locally, from zero to a streaming mock
+turn, plus the extra credentials that light up the real agent runtime. The
+production environment matrix lives in [`docs/deploy.md`](docs/deploy.md);
+design system in [`docs/design.md`](docs/design.md).
+
+## Prerequisites
+
+- **Node 22** and **pnpm 10** (what CI pins — see `.github/workflows/web-next-ci.yml`).
+  pnpm 11 currently breaks `pnpm run` here (its verify-deps prompt writes an
+  invalid placeholder `pnpm-workspace.yaml` in no-TTY shells); if you see
+  `ERR_PNPM_IGNORED_BUILDS` or a stray `web-next/pnpm-workspace.yaml`, delete
+  that file and use pnpm 10 (`corepack prepare pnpm@10 --activate` or
+  `npx pnpm@10`).
+
+## Run it (no credentials needed)
+
+```bash
+cd web-next
+cp .env.local.example .env.local   # defaults are already correct for local dev
+pnpm install
+pnpm dev                            # http://localhost:3100
+```
+
+Sign in via the **“continue as fairchild (test bypass)”** button on `/sign-in`.
+That button is the `AUTH_BYPASS=1` test harness; it is hard-disabled the moment
+`GITHUB_OAUTH_CLIENT_ID` is set, so it can never leak into a real deployment.
+
+The database defaults to `file:.data/sessions.db` (gitignored, auto-migrated on
+first request). Everything runs against the **mock provider** — a scripted
+coding turn with reasoning, tool calls, a failing→passing test cycle, and a
+diff. Try `/sessions/demo?scenario=adversarial` or `?scenario=long` to stress
+the transcript.
+
+## Quality gates (what CI runs)
+
+```bash
+pnpm test        # vitest unit suite
+pnpm typecheck
+pnpm lint
+pnpm build       # production build — must stay clean (see #780 for the stale-.next trap)
+pnpm test:e2e    # Playwright; builds + serves on :3100 in auth-bypass mode
+pnpm evidence    # light+dark screenshot walk → output/evidence/
+pnpm perf        # perf harness vs perf/contract.json budgets
+```
+
+E2E notes:
+
+- The web server for e2e is a **production** build (`e2e:server` script); the
+  first `test:e2e` run builds it.
+- If port 3100 is stuck, look for an orphaned `next-server` process — killing
+  the `next start` wrapper does not always kill it.
+- In remote/sandboxed sessions where Playwright’s CDN is unreachable, point the
+  suite at a preinstalled browser:
+  `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/opt/pw-browsers/chromium-*/chrome-linux/chrome pnpm test:e2e`
+  (the config honors that variable; leave it unset on dev machines and CI).
+- A clean `pnpm build` failing with `<Html> should not be imported…` on
+  pages-router artifacts (`/404`, `/500`) means stale local state — this app
+  never builds those pages. `rm -rf .next` and rebuild (#780).
+
+## Extra keys — real agent runtime (#750+)
+
+Local UI/dev work needs **none** of these. They exist to run a *real* Claude
+Code turn in a Vercel sandbox instead of the mock. Copy each into `.env.local`
+(all names and inline notes are in [`.env.local.example`](.env.local.example)):
+
+| Key | Where to get it |
+|---|---|
+| `AI_GATEWAY_API_KEY` | `npx vercel ai-gateway api-keys create` (or Vercel dashboard → AI Gateway → API Keys). Preferred over a raw key: spend cap, one key for Claude/Codex/Pi. |
+| `ANTHROPIC_API_KEY` | console.anthropic.com → API Keys — only if not using the gateway. |
+| `VERCEL_TOKEN` | vercel.com/account/tokens (scope: the `cloudcompute` team). Off-Vercel only — production uses the auto-injected OIDC token. |
+| `VERCEL_TEAM_ID` | `team_oGt9u60VkiPutA2CiKDDGQKV` (also in `.vercel/project.json` after `vercel link`). |
+| `VERCEL_PROJECT_ID` | `prj_ucOY3JKR5BCrbtbfz8DTSFJe5U9m` (the `web-next` project). |
+| `GITHUB_WEB_WORKSPACES_APP_ID` | github.com/settings/apps → **`workspace-agents`** app → App ID. |
+| `GITHUB_APP_PRIVATE_KEY` | Same page → Generate a private key → store the `.pem` single-line: `base64 -i app.pem \| tr -d '\n'`. |
+
+Why the GitHub **App** (not an OAuth app): the sandbox clones with short-lived,
+repo-scoped *installation* tokens. An OAuth token would be user-scoped and
+long-lived — the wrong credential to hand an agent-controlled environment. The
+sign-in OAuth app and this App are separate identities doing separate jobs
+(see `docs/development/github-app-identities.md` at the repo root).
+
+The same credential set goes in the other two stores when relevant —
+Claude Code cloud-dev (environment settings) and Vercel production (project
+env vars) — per the matrix in [`docs/deploy.md`](docs/deploy.md).
+
+## Deploying
+
+The app is linked to Vercel project **`cloudcompute/web-next`**
+(https://web-next-ivory-six.vercel.app):
+
+```bash
+npx vercel login            # device flow
+npx vercel link --yes       # writes .vercel/ (gitignored)
+npx vercel deploy --prod    # env vars apply per-deployment — redeploy after changing them
+npx vercel env ls production
+npx vercel logs <deployment-url>
+```
+
+Production keeps Vercel’s deployment protection (SSO) on top of the app’s own
+GitHub OAuth + `ALLOWED_LOGINS` allowlist; only allowlisted GitHub logins get
+past the sign-in page, everyone else gets a refusal page and 403s from the API.


### PR DESCRIPTION
## Summary

Adds `web-next/CONTRIBUTING.md` — the zero-to-running local guide Michael asked for, written from today's live setup work:

- **Run it with no credentials**: pnpm 10 pin (and the pnpm 11 `pnpm-workspace.yaml` trap), `.env.local.example` copy, auth-bypass sign-in, mock provider + adversarial/long demo scenarios.
- **Quality gates** mirroring the CI lane, with the hard-won e2e caveats: production-build server, orphaned `next-server` on :3100, `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` for remote sandboxes, and the stale-`.next` build trap (#780).
- **Extra keys for the real runtime (#750+)**: a where-to-mint-each table — AI Gateway key via `vercel ai-gateway api-keys create`, Vercel token + the actual team/project IDs (non-secret), and the `workspace-agents` GitHub App — plus why the sandbox uses App installation tokens rather than the sign-in OAuth app.
- **Deploying**: the linked `cloudcompute/web-next` project, the deploy/env/logs loop, and the current production auth posture (Vercel SSO + OAuth allowlist).

## Mergeability

- Surface: docs (one new file, `web-next/CONTRIBUTING.md`)
- User-facing behavior changed: none — documentation only
- Non-happy paths considered: the doc itself documents the failure modes hit today (pnpm 11 breakage, stale `.next`, orphaned port, missing Playwright browser) with their fixes
- Residual risk or follow-up: exact runtime var names finalize when #750 lands; the doc points at `docs/deploy.md` as the canonical matrix

## Evidence

- [x] Not a testable change (docs only)

## Blockers

- [x] None


---
_Generated by [Claude Code](https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ)_