### PR TITLE
feat(web-next): auth-gated AI Gateway diagnostic probe

### DIFF
--- a/web-next/src/app/api/diag/gateway/route.ts
+++ b/web-next/src/app/api/diag/gateway/route.ts
@@ -1,0 +1,55 @@
+/*
+ * GET /api/diag/gateway — auth-gated diagnostic probe: makes one tiny real
+ * model call through the AI Gateway to prove the credential, billing, and
+ * model routing work in this deployment, before the real runtime (#750)
+ * depends on them. Returns the model's reply or the upstream error verbatim.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+
+export async function GET() {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const key = process.env.AI_GATEWAY_API_KEY;
+	if (!key) {
+		return Response.json(
+			{ ok: false, error: "AI_GATEWAY_API_KEY is not set in this deployment" },
+			{ status: 500 },
+		);
+	}
+
+	const startedAt = Date.now();
+	const response = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${key}`,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			model: "anthropic/claude-haiku-4.5",
+			messages: [{ role: "user", content: "Reply with exactly: gateway live" }],
+			max_tokens: 10,
+		}),
+	});
+
+	const body = await response.json().catch(() => null);
+	if (!response.ok) {
+		return Response.json(
+			{ ok: false, status: response.status, upstream: body },
+			{ status: 502 },
+		);
+	}
+
+	return Response.json({
+		ok: true,
+		model: body?.model,
+		reply: body?.choices?.[0]?.message?.content,
+		usage: body?.usage,
+		latencyMs: Date.now() - startedAt,
+	});
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/diag/gateway` — an allowlist-gated diagnostic probe that makes one tiny real model call (`anthropic/claude-haiku-4.5`, 10 max tokens) through the AI Gateway using the deployment's `AI_GATEWAY_API_KEY`, returning `{ok, model, reply, usage, latencyMs}` on success or the upstream error verbatim. It proves the credential, billing, and model routing work in whatever deployment it runs in — the exact layer #750's real runtime will sit on — per the repo lesson "ship a diagnostic probe instead of your third guess."

Deployed to production ahead of merge (CLI deploy) to verify the just-provisioned gateway key live; this PR makes the probe durable in the tree.

## Mergeability

- Surface: web (web-next — one new API route)
- User-facing behavior changed: No user-facing UI; adds one auth-gated diagnostics endpoint (401 unauthenticated / 403 non-allowlisted, same gate as every data route).
- Non-happy paths considered: missing `AI_GATEWAY_API_KEY` → explicit 500 with message; upstream non-OK → 502 carrying the upstream status/body; unauthenticated/forbidden callers get the standard auth refusals and no key material is ever echoed.
- Residual risk or follow-up: spends a few tokens per authorized call (bounded at 10 output tokens); consider folding into a broader `/api/diag` credential-status endpoint when #750 adds the sandbox + GitHub App credentials.

## Verification

- `pnpm typecheck` — clean (tests pass unaffected; the route has no unit-testable logic beyond the auth gate shared with existing routes).
- Live verification on the production deployment is the point of the probe — result lands in this PR once confirmed.

## Evidence

- Live probe response from production to follow in a comment (deployment in flight at PR-open time).


---
_Generated by [Claude Code](https://claude.ai/code/session_017T1abMphYcnbJBzjBKpGwQ)_