### PR TITLE
feat(automation): experimental caller-scoped `input.write` capability

### DIFF
--- a/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
+++ b/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 enum ExperimentalFeature: String, CaseIterable, Identifiable {
     case automationAPI = "automationAPI"
+    case automationInputWrite = "automationInputWrite"
     case minimalToolbar = "minimalToolbar"
     case restoreSessionsOnLaunch = "restoreSessionsOnLaunch"
 
@@ -17,6 +18,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
         switch self {
         case .automationAPI:
             return "Automation API"
+        case .automationInputWrite:
+            return "Automation Input Write"
         case .minimalToolbar:
             return "Minimal Toolbar"
         case .restoreSessionsOnLaunch:
@@ -28,6 +31,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
         switch self {
         case .automationAPI:
             return "Expose a local same-user socket so terminal tiles can inspect and arrange their WorkSpaces shell."
+        case .automationInputWrite:
+            return "Let automation clients type into their own terminal tile. Requires the Automation API experiment."
         case .minimalToolbar:
             return "Hide secondary toolbar controls so terminal surfaces stay closer to the canvas."
         case .restoreSessionsOnLaunch:
@@ -47,6 +52,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
         switch self {
         case .automationAPI:
             return "WORKSPACES_AUTOMATION_API"
+        case .automationInputWrite:
+            return "WORKSPACES_AUTOMATION_INPUT_WRITE"
         case .minimalToolbar:
             return "WORKSPACES_PERF_MINIMAL_TOOLBAR"
         case .restoreSessionsOnLaunch:

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceTextInputBridge.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceTextInputBridge.swift
@@ -31,6 +31,17 @@ enum GhosttySurfaceTextInputBridge {
         }
     }
 
+    /// Automation write path: delivers text straight to the live libghostty surface, bypassing the
+    /// `keyTextAccumulator` IME diversion that keyboard-driven inserts honor. Returns false when the
+    /// view has no live surface to receive the bytes.
+    static func writeAutomationText(into view: GhosttySurfaceView, text: String) -> Bool {
+        guard let surface = view.surface else { return false }
+        text.withCString { pointer in
+            ghostty_surface_text(surface, pointer, UInt(text.utf8.count))
+        }
+        return true
+    }
+
     static func doCommand(in view: GhosttySurfaceView, selector: Selector) {
         if let lastPerformKeyEvent = view.lastPerformKeyEvent,
             let currentEvent = NSApp.currentEvent,

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceTextInputBridge.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceTextInputBridge.swift
@@ -42,6 +42,26 @@ enum GhosttySurfaceTextInputBridge {
         return true
     }
 
+    /// Automation submit path: presses and releases Return through the key-event pipeline.
+    /// `ghostty_surface_text` treats its payload as a paste, so a CR appended to the text arrives
+    /// inside the bracketed-paste envelope and shells insert it literally instead of executing.
+    /// A synthetic key event encodes CR outside any paste envelope, matching a physical Return.
+    static func sendAutomationReturn(into view: GhosttySurfaceView) -> Bool {
+        guard let surface = view.surface else { return false }
+        for action in [GHOSTTY_ACTION_PRESS, GHOSTTY_ACTION_RELEASE] {
+            var keyEvent = ghostty_input_key_s()
+            keyEvent.action = action
+            keyEvent.keycode = 0x24  // kVK_Return
+            keyEvent.text = nil
+            keyEvent.composing = false
+            keyEvent.mods = GHOSTTY_MODS_NONE
+            keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+            keyEvent.unshifted_codepoint = 0x0D
+            _ = ghostty_surface_key(surface, keyEvent)
+        }
+        return true
+    }
+
     static func doCommand(in view: GhosttySurfaceView, selector: Selector) {
         if let lastPerformKeyEvent = view.lastPerformKeyEvent,
             let currentEvent = NSApp.currentEvent,

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -7,17 +7,22 @@ final class AutomationController: AutomationControlling {
     private weak var hostTerminalState: HostTerminalStateStore?
     private var focusTerminal: @MainActor (UUID) -> Void
     private var requestCloseTerminal: @MainActor (UUID) -> Void
+    private let isInputWriteEnabled: @MainActor () -> Bool
 
     init(
         handleRegistry: AutomationHandleRegistry,
         hostTerminalState: HostTerminalStateStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
-        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
+        isInputWriteEnabled: @escaping @MainActor () -> Bool = {
+            ExperimentalFeatures.isEnabled(.automationInputWrite)
+        }
     ) {
         self.handleRegistry = handleRegistry
         self.hostTerminalState = hostTerminalState
         self.focusTerminal = focusTerminal
         self.requestCloseTerminal = requestCloseTerminal
+        self.isInputWriteEnabled = isInputWriteEnabled
     }
 
     func update(
@@ -110,6 +115,41 @@ final class AutomationController: AutomationControlling {
         return AutomationMutationResult(
             changed: true,
             closedSurfaceID: resolved.entry.hostSessionID.uuidString
+        )
+    }
+
+    func automationWriteInput(
+        for handle: String,
+        text: String,
+        submit: Bool
+    ) throws -> AutomationInputWriteResult {
+        let resolved = try resolve(handle, requiring: .inputWrite)
+        // Handles outlive settings changes, so the grant-time gate is re-checked per request.
+        guard isInputWriteEnabled() else {
+            throw AutomationServiceError(
+                .capabilityDenied,
+                "The Automation Input Write experiment is disabled."
+            )
+        }
+        guard
+            let terminal = resolved.hostTerminalState.surfaceStore.terminal(
+                for: resolved.entry.hostSessionID
+            )
+        else {
+            throw AutomationServiceError(
+                .staleHandle,
+                "The automation handle no longer maps to a live terminal surface."
+            )
+        }
+        let payload = submit ? text + "\r" : text
+        guard GhosttySurfaceTextInputBridge.writeAutomationText(into: terminal, text: payload) else {
+            throw AutomationServiceError(.staleHandle, "The terminal surface is not ready to receive input.")
+        }
+        return AutomationInputWriteResult(
+            accepted: true,
+            byteCount: payload.utf8.count,
+            surfaceID: resolved.entry.hostSessionID.uuidString,
+            system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -141,13 +141,17 @@ final class AutomationController: AutomationControlling {
                 "The automation handle no longer maps to a live terminal surface."
             )
         }
-        let payload = submit ? text + "\r" : text
-        guard GhosttySurfaceTextInputBridge.writeAutomationText(into: terminal, text: payload) else {
+        guard GhosttySurfaceTextInputBridge.writeAutomationText(into: terminal, text: text) else {
             throw AutomationServiceError(.staleHandle, "The terminal surface is not ready to receive input.")
+        }
+        // Submit goes through the key-event path, not an appended "\r": the text path is a paste,
+        // and bracketed paste turns an embedded CR into a literal newline instead of accept-line.
+        if submit, !GhosttySurfaceTextInputBridge.sendAutomationReturn(into: terminal) {
+            throw AutomationServiceError(.staleHandle, "The terminal surface dropped before the submit key.")
         }
         return AutomationInputWriteResult(
             accepted: true,
-            byteCount: payload.utf8.count,
+            byteCount: text.utf8.count,
             surfaceID: resolved.entry.hostSessionID.uuidString,
             system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
         )

--- a/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/HostTerminalStateStore.swift
@@ -827,9 +827,18 @@ final class HostTerminalStateStore: ObservableObject {
                 tileID: automationTileID(for: session.id),
                 surfaceKind: .terminal,
                 windowScopeID: automationWindowScopeID,
-                appScopeID: automationAppScopeID
+                appScopeID: automationAppScopeID,
+                capabilities: automationGrantedCapabilities
             )
         }
+    }
+
+    /// Grant list for automation handles. `input.write` joins only while its experiment is on;
+    /// `AutomationController` re-checks the flag per request because handles outlive settings changes.
+    private var automationGrantedCapabilities: [AutomationCapability] {
+        ExperimentalFeatures.isEnabled(.automationInputWrite)
+            ? AutomationAPI.inputWriteCapabilities
+            : AutomationAPI.v1Capabilities
     }
 
     /// Drops a single-pane primary's memoized tile binding when its session leaves. Split leaf bindings
@@ -959,7 +968,8 @@ final class HostTerminalStateStore: ObservableObject {
             tileID: automationTileID(for: session.id),
             surfaceKind: .terminal,
             windowScopeID: automationWindowScopeID,
-            appScopeID: automationAppScopeID
+            appScopeID: automationAppScopeID,
+            capabilities: automationGrantedCapabilities
         )
         return AutomationTerminalEnvironment(socketPath: automationSocketPath, handle: entry.handle)
     }

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -39,6 +39,7 @@ private final class CLIApp {
         "automation",
         "surface",
         "tile",
+        "input",
     ]
 
     private let stateStore = CLIStateStore()
@@ -83,6 +84,8 @@ private final class CLIApp {
             return try runSurface(arguments: tail)
         case "tile":
             return try runTile(arguments: tail)
+        case "input":
+            return try runInput(arguments: tail)
         default:
             throw CLIError("Unknown command '\(command)'. Run 'workspaces help'.")
         }
@@ -616,6 +619,43 @@ private final class CLIApp {
         }
     }
 
+    private func runInput(arguments: [String]) throws -> Int32 {
+        let usage = "workspaces input write <text> [--submit]"
+        guard arguments.first == "write" else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        var text: String?
+        var submit = false
+        for argument in arguments.dropFirst() {
+            switch argument {
+            case "--submit":
+                submit = true
+            default:
+                guard text == nil else {
+                    throw CLIError("Usage: \(usage)")
+                }
+                text = argument
+            }
+        }
+        guard let text, !text.isEmpty else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        let body = try JSONSerialization.data(
+            withJSONObject: ["text": text, "submit": submit] as [String: Any],
+            options: [.sortedKeys]
+        )
+        _ = try performAutomationRequest(
+            AutomationInputWriteResult.self,
+            method: "POST",
+            path: "/v1/input/write",
+            requiresHandle: true,
+            body: body
+        )
+        return 0
+    }
+
     private func performAutomationRequest<Result>(
         _ type: Result.Type = Result.self,
         method: String,
@@ -1133,6 +1173,7 @@ private func printHelp() {
           workspaces tile focus --left|--right|--up|--down|--next|--previous
           workspaces tile split --left|--right|--up|--down
           workspaces tile close
+          workspaces input write <text> [--submit]
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -13,6 +13,12 @@ public enum AutomationAPI {
         .tileSplit,
         .tileClose,
     ]
+
+    /// V1 capabilities plus the experimental caller-scoped `input.write` grant.
+    /// Kept separate from `v1Capabilities` so default handles never widen.
+    public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
+
+    public static let inputWriteMaxUTF8Bytes = 32_768
 }
 
 public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equatable {
@@ -21,6 +27,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case tileFocus = "tile.focus"
     case tileSplit = "tile.split"
     case tileClose = "tile.close"
+    case inputWrite = "input.write"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -172,6 +179,35 @@ public struct AutomationMutationResult: Codable, Sendable, Equatable {
     }
 }
 
+public struct AutomationInputWriteRequest: Codable, Sendable, Equatable {
+    public let text: String
+    public let submit: Bool?
+
+    public init(text: String, submit: Bool? = nil) {
+        self.text = text
+        self.submit = submit
+    }
+}
+
+public struct AutomationInputWriteResult: Codable, Sendable, Equatable {
+    public let accepted: Bool
+    public let byteCount: Int
+    public let surfaceID: String
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        accepted: Bool,
+        byteCount: Int,
+        surfaceID: String,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor()
+    ) {
+        self.accepted = accepted
+        self.byteCount = byteCount
+        self.surfaceID = surfaceID
+        self.system = system
+    }
+}
+
 public struct AutomationTerminalEnvironment: Sendable, Equatable {
     public let socketPath: String
     public let handle: String
@@ -272,4 +308,9 @@ public protocol AutomationControlling: AnyObject, Sendable {
         direction: AutomationTileSplitDirection
     ) throws -> AutomationMutationResult
     func automationCloseTile(for handle: String) throws -> AutomationMutationResult
+    func automationWriteInput(
+        for handle: String,
+        text: String,
+        submit: Bool
+    ) throws -> AutomationInputWriteResult
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -79,6 +79,14 @@ enum AutomationHTTPRouter {
             try rejectCallerSuppliedTargetIDs(in: request.body, allowEmptyBody: true)
             return try await controller.automationCloseTile(for: handle)
 
+        case ("POST", "/v1/input/write"):
+            let write = try decodeInputWrite(from: request.body)
+            return try await controller.automationWriteInput(
+                for: handle,
+                text: write.text,
+                submit: write.submit ?? false
+            )
+
         case (_, "/v1/context"):
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/context.")
         case (_, "/v1/surfaces"):
@@ -89,6 +97,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/split.")
         case (_, "/v1/tile/close"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/close.")
+        case (_, "/v1/input/write"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/input/write.")
         default:
             throw AutomationServiceError(.routeNotFound, "Unsupported automation route: \(method) \(request.path)")
         }
@@ -127,6 +137,29 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.invalidRequest, "Unsupported direction: \(rawDirection).")
         }
         return direction
+    }
+
+    private static func decodeInputWrite(from body: Data) throws -> AutomationInputWriteRequest {
+        try rejectCallerSuppliedTargetIDs(in: body, allowEmptyBody: false)
+        let request: AutomationInputWriteRequest
+        do {
+            request = try AutomationJSON.decoder.decode(AutomationInputWriteRequest.self, from: body)
+        } catch {
+            throw AutomationServiceError(
+                .invalidRequest,
+                "Request body must be JSON with a string 'text' and optional boolean 'submit'."
+            )
+        }
+        guard !request.text.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request 'text' must be a non-empty string.")
+        }
+        guard request.text.utf8.count <= AutomationAPI.inputWriteMaxUTF8Bytes else {
+            throw AutomationServiceError(
+                .invalidRequest,
+                "Request 'text' exceeds the \(AutomationAPI.inputWriteMaxUTF8Bytes)-byte limit."
+            )
+        }
+        return request
     }
 
     private static func rejectCallerSuppliedTargetIDs(in body: Data, allowEmptyBody: Bool) throws {
@@ -221,6 +254,7 @@ extension AutomationHealthResult: CodableSendableEquatable {}
 extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
 extension AutomationMutationResult: CodableSendableEquatable {}
+extension AutomationInputWriteResult: CodableSendableEquatable {}
 extension AutomationEmptyResult: CodableSendableEquatable {}
 
 enum AutomationJSON {

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -162,6 +162,46 @@ struct AutomationControllerTests {
         }
     }
 
+    @Test("Input write requires the input.write capability")
+    func inputWriteRequiresCapability() throws {
+        let fixture = makeFixture()
+
+        do {
+            _ = try fixture.controller.automationWriteInput(
+                for: fixture.primaryHandle,
+                text: "echo hi",
+                submit: false
+            )
+            Issue.record("Expected default v1 handle to lack input.write")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+    }
+
+    @Test("Input write fails closed when the experiment is disabled after grant")
+    func inputWriteFailsClosedWhenExperimentDisabled() throws {
+        let harness = makeInputWriteHarness(isInputWriteEnabled: false)
+
+        do {
+            _ = try harness.controller.automationWriteInput(for: "granted", text: "echo hi", submit: false)
+            Issue.record("Expected disabled experiment to deny granted handle")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+    }
+
+    @Test("Input write without a live surface view reports stale handle")
+    func inputWriteWithoutLiveSurfaceIsStale() throws {
+        let harness = makeInputWriteHarness(isInputWriteEnabled: true)
+
+        do {
+            _ = try harness.controller.automationWriteInput(for: "granted", text: "echo hi", submit: true)
+            Issue.record("Expected missing surface view to read as stale")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .staleHandle)
+        }
+    }
+
     @Test("Close routes through existing close request path")
     func closeRoutesThroughExistingClosePath() throws {
         let fixture = makeFixture()
@@ -215,5 +255,38 @@ struct AutomationControllerTests {
 
     private func makeFixture() -> Fixture {
         Fixture()
+    }
+
+    private struct InputWriteHarness {
+        let store: HostTerminalStateStore
+        let controller: AutomationController
+    }
+
+    /// Builds a controller whose "granted" handle carries `input.write`, with the experiment
+    /// gate injected so tests exercise both sides without touching global defaults.
+    private func makeInputWriteHarness(isInputWriteEnabled: Bool) -> InputWriteHarness {
+        let store = HostTerminalStateStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "granted" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.inputWriteCapabilities
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            hostTerminalState: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            isInputWriteEnabled: { isInputWriteEnabled }
+        )
+        return InputWriteHarness(store: store, controller: controller)
     }
 }

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -5,10 +5,17 @@ import Testing
 
 @MainActor
 private final class FakeAutomationController: AutomationControlling {
+    struct InputWrite: Equatable {
+        let handle: String
+        let text: String
+        let submit: Bool
+    }
+
     var contextCalls: [String] = []
     var focusDirections: [AutomationTileFocusDirection] = []
     var splitDirections: [AutomationTileSplitDirection] = []
     var closeHandles: [String] = []
+    var inputWrites: [InputWrite] = []
 
     func automationContext(for handle: String) throws -> AutomationContextResult {
         contextCalls.append(handle)
@@ -63,6 +70,19 @@ private final class FakeAutomationController: AutomationControlling {
         _ = try automationContext(for: handle)
         closeHandles.append(handle)
         return AutomationMutationResult(changed: true, closedSurfaceID: "surface-1")
+    }
+
+    func automationWriteInput(
+        for handle: String,
+        text: String,
+        submit: Bool
+    ) throws -> AutomationInputWriteResult {
+        guard handle != "nowrite" else {
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include input.write.")
+        }
+        _ = try automationContext(for: handle)
+        inputWrites.append(InputWrite(handle: handle, text: text, submit: submit))
+        return AutomationInputWriteResult(accepted: true, byteCount: text.utf8.count, surfaceID: "surface-1")
     }
 }
 
@@ -255,6 +275,110 @@ struct AutomationAPITests {
         #expect(controller.focusDirections == [.previous])
         #expect(controller.splitDirections == [.down])
         #expect(controller.closeHandles == ["live"])
+    }
+
+    @Test("Router maps input write and returns the result envelope")
+    @MainActor
+    func routerInputWriteHappyPath() async throws {
+        let controller = FakeAutomationController()
+        let response = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/input/write",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data(#"{"text":"echo hi","submit":true}"#.utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let envelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationInputWriteResult>.self,
+            from: response.body
+        )
+
+        #expect(response.status == 200)
+        #expect(envelope.result?.accepted == true)
+        #expect(envelope.result?.byteCount == "echo hi".utf8.count)
+        #expect(
+            controller.inputWrites == [
+                FakeAutomationController.InputWrite(handle: "live", text: "echo hi", submit: true)
+            ]
+        )
+    }
+
+    @Test("Router validates input write bodies before reaching the controller")
+    @MainActor
+    func routerInputWriteValidation() async throws {
+        let controller = FakeAutomationController()
+        let oversizeText = String(repeating: "a", count: AutomationAPI.inputWriteMaxUTF8Bytes + 1)
+        let invalidBodies: [Data] = [
+            Data(),
+            Data(#"{"submit":true}"#.utf8),
+            Data(#"{"text":""}"#.utf8),
+            Data(#"{"text":"\#(oversizeText)"}"#.utf8),
+            Data(#"{"text":"echo hi","surfaceID":"forged"}"#.utf8),
+        ]
+
+        for body in invalidBodies {
+            let response = await AutomationHTTPRouter.route(
+                HTTPRequest(
+                    method: "POST",
+                    path: "/v1/input/write",
+                    headers: [AutomationAPI.handleHeader: "live"],
+                    body: body
+                ),
+                controller: controller,
+                enabled: true
+            )
+            let envelope = try AutomationJSON.decoder.decode(
+                AutomationResponseEnvelope<AutomationEmptyResult>.self,
+                from: response.body
+            )
+            #expect(response.status == 400)
+            #expect(envelope.error?.code == .invalidRequest)
+        }
+        #expect(controller.inputWrites.isEmpty)
+
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/input/write",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("Router surfaces capability denial for under-capable input write handles")
+    @MainActor
+    func routerInputWriteCapabilityDenied() async throws {
+        let controller = FakeAutomationController()
+        let response = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/input/write",
+                headers: [AutomationAPI.handleHeader: "nowrite"],
+                body: Data(#"{"text":"echo hi"}"#.utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let envelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: response.body
+        )
+
+        #expect(response.status == 403)
+        #expect(envelope.error?.code == .capabilityDenied)
+        #expect(controller.inputWrites.isEmpty)
     }
 
     @Test("CLI formatter emits result JSON and surfaces envelope errors")

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -143,8 +143,10 @@ workspaces input write 'echo hello-from-automation'            # type without ex
 workspaces input write 'echo hello-from-automation' --submit   # type and press Enter
 ```
 
-`--submit` appends a single carriage return (what Enter sends to a PTY). Text
-is limited to 32 KiB UTF-8 per request. Requests from handles created while
+The text is delivered as a paste; `--submit` then presses Return as a
+synthetic key event (a `\r` inside the paste would be bracketed-paste-wrapped
+and inserted literally instead of executing). Text is limited to 32 KiB UTF-8
+per request. Requests from handles created while
 the experiment was off, or after it is turned off, fail with
 `capability_denied` — restart WorkSpaces and open a fresh tile after toggling
 it. The audit log records the route and outcome, never the written text.

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -125,6 +125,30 @@ workspaces tile close
 The request is scoped to the caller. There is no V1 command for closing an
 arbitrary tile by ID.
 
+## Write Into The Current Tile (Experimental)
+
+Input write is double-gated: enable both the Automation API experiment and the
+separate Automation Input Write experiment, then restart WorkSpaces and open a
+fresh terminal tile. For development launches:
+
+```bash
+WORKSPACES_AUTOMATION_API=1 WORKSPACES_AUTOMATION_INPUT_WRITE=1 ./scripts/launch-dev.sh --no-build
+```
+
+The command writes text into the caller's own PTY — the tile the script is
+running in. There is no way to write into another tile.
+
+```bash
+workspaces input write 'echo hello-from-automation'            # type without executing
+workspaces input write 'echo hello-from-automation' --submit   # type and press Enter
+```
+
+`--submit` appends a single carriage return (what Enter sends to a PTY). Text
+is limited to 32 KiB UTF-8 per request. Requests from handles created while
+the experiment was off, or after it is turned off, fail with
+`capability_denied` — restart WorkSpaces and open a fresh tile after toggling
+it. The audit log records the route and outcome, never the written text.
+
 ## Shell Alias Ideas
 
 These examples are intentionally small. They stay inside the V1 scope and do
@@ -172,8 +196,8 @@ from a live WorkSpaces terminal tile.
 `automation request failed: unsupported`
 
 The request is outside V1. Common examples are splitting from a secondary split
-tile or asking for capabilities such as browser mutation, input injection,
-resize/equalize, or global cross-workspace control.
+tile or asking for capabilities such as browser mutation, resize/equalize, or
+global cross-workspace control.
 
 ## V1 Boundaries
 
@@ -184,6 +208,9 @@ V1 is intentionally narrow:
 - focus a neighboring tile
 - split from a primary tile
 - close the caller tile through normal app behavior
+- write into the caller's own PTY (experimental, double-gated — see
+  [Automation Input Write Decision](./decisions/automation-input-write.md))
 
-V1 does not support browser mutation, opening URLs, tab metadata changes, input
-injection, resize/equalize, or global control across workspaces.
+V1 does not support browser mutation, opening URLs, tab metadata changes,
+writing into other tiles, resize/equalize, or global control across
+workspaces.

--- a/docs/decisions/automation-input-write.md
+++ b/docs/decisions/automation-input-write.md
@@ -1,0 +1,89 @@
+# Automation Input Write Decision
+
+## Status
+
+Accepted as an experimental V1.1 capability, double-gated and off by default.
+
+## Context
+
+[Automation API V1](./automation-api-v1.md) deliberately excluded terminal
+input injection: it has different safety and user-expectation questions than
+read/arrange verbs, and the decision record required any future capability to
+define its own authority model, user expectation, audit surface, tests, and
+documentation before landing. This record is that design.
+
+The product need is a keystone primitive for agent orchestration: a trusted
+process inside a WorkSpaces terminal tile writes text into its own tile's PTY
+(for example, a wrapper script that queues a prompt into the agent it is
+running next to). The PTY write path already exists — keyboard input and
+drag-and-drop both deliver bytes through `ghostty_surface_text` — so this adds
+a capability surface, not a new subsystem.
+
+## Decision
+
+Add `POST /v1/input/write` guarded by a new `input.write` capability.
+
+- **Caller-scoped only.** The opaque handle is the target, exactly as in V1.
+  Request bodies must not name a tile, surface, or host session; the existing
+  forbidden-target-ID rail applies. A caller can write only to the PTY of the
+  tile that owns its handle.
+- **Double experiment gate.** The capability is granted at handle upsert only
+  while the `Automation Input Write` experiment
+  (`WORKSPACES_AUTOMATION_INPUT_WRITE`) is enabled, and it is effective only
+  when the base Automation API experiment is also on. Because handles outlive
+  settings changes, the app-side controller re-checks the flag on every
+  request and fails closed with `capability_denied`.
+- **Not part of `v1Capabilities`.** Default handles never widen. The grant
+  list is a separate `inputWriteCapabilities` constant so the V1 envelope
+  contract (and its golden-string test) is unchanged when the experiment is
+  off.
+- **Bounded payloads.** `text` must be a non-empty string of at most 32 KiB
+  UTF-8. `submit: true` appends a single carriage return (`\r`, what Enter
+  sends to a PTY). No other transformation is applied.
+- **Content-free audit.** The listener's audit log records route-level
+  metadata and error codes for every allowed and denied request, and never
+  the written text — the same contract the audit stream already documents.
+- **IME bypass.** The write path calls the libghostty surface directly and
+  does not divert into the in-flight keyboard IME accumulator, so an
+  automation write cannot be swallowed by a half-composed keyboard event.
+
+## Consequences
+
+- Scripts and agents inside a tile can type into themselves; nothing can type
+  into another tile. Cross-tile orchestration still requires the target tile's
+  own cooperation (its own handle).
+- Users who never enable the experiment see no change: capability lists,
+  envelopes, and docs describe `input.write` as experimental and off by
+  default.
+- The submit semantics (`\r`) are verified against real shells; multi-line
+  payloads into bracketed-paste-aware TUIs may need paste-bracket wrapping in
+  a follow-up if smoke testing shows per-line autocomplete firing.
+
+## Rejected Alternatives
+
+### Targeted Write By Surface ID
+
+Rejected for this iteration. Writing into an arbitrary sibling tile would turn
+identity back into authority and needs a child-handle model (for example,
+handles minted by `tile.split` for surfaces the caller created). Deferred
+until that authority model is designed.
+
+### Gate Only At Grant Time
+
+Rejected. Handles live as long as their tile, so a user who turns the
+experiment off would leave already-granted handles writable. The per-request
+re-check makes the settings toggle authoritative.
+
+### Add `input.write` To `v1Capabilities`
+
+Rejected. It would silently widen every existing handle and change the stable
+V1 capability envelope. A separate grant list keeps default behavior
+byte-identical.
+
+## Documentation Contract
+
+- [Automation API Guide](../automation-api.md) documents the user-facing
+  command and its gating.
+- [Automation API Reference](../development/automation-api.md) documents the
+  route, capability, and limits.
+- This record explains why input injection is allowed now, in this shape.

--- a/docs/decisions/automation-input-write.md
+++ b/docs/decisions/automation-input-write.md
@@ -38,8 +38,15 @@ Add `POST /v1/input/write` guarded by a new `input.write` capability.
   contract (and its golden-string test) is unchanged when the experiment is
   off.
 - **Bounded payloads.** `text` must be a non-empty string of at most 32 KiB
-  UTF-8. `submit: true` appends a single carriage return (`\r`, what Enter
-  sends to a PTY). No other transformation is applied.
+  UTF-8. No transformation is applied to the text.
+- **Submit is a synthetic Return key, not an appended `\r`.** The text path
+  (`ghostty_surface_text`) treats its payload as a paste, so with bracketed
+  paste on (default in zsh) an embedded CR is inserted literally instead of
+  executing. `submit: true` therefore delivers the text first, then a
+  press/release of Return through the key-event path
+  (`ghostty_surface_key`), which encodes CR outside any paste envelope —
+  exactly what a physical Enter produces. Found by interactive smoke on the
+  first implementation, which appended `\r` to the paste payload.
 - **Content-free audit.** The listener's audit log records route-level
   metadata and error codes for every allowed and denied request, and never
   the written text — the same contract the audit stream already documents.
@@ -55,9 +62,10 @@ Add `POST /v1/input/write` guarded by a new `input.write` capability.
 - Users who never enable the experiment see no change: capability lists,
   envelopes, and docs describe `input.write` as experimental and off by
   default.
-- The submit semantics (`\r`) are verified against real shells; multi-line
-  payloads into bracketed-paste-aware TUIs may need paste-bracket wrapping in
-  a follow-up if smoke testing shows per-line autocomplete firing.
+- The submit semantics are smoke-verified against zsh with bracketed paste
+  on: text lands as a paste, the synthetic Return executes it. Multi-line
+  text benefits from the same split — the payload stays one paste, and only
+  the final submit is a key event.
 
 ## Rejected Alternatives
 

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -54,8 +54,10 @@ not terminal input or output.
   `hostSessionID`.
 - Capabilities are enforced before each scoped operation.
 - Mutation routes are stable product verbs, not raw `TileTreeAction` exposure.
-- Browser mutation, input injection, resize/equalize, and global control are
-  out of V1.
+- Browser mutation, resize/equalize, and global control are out of V1.
+- Input injection is caller-scoped only and double-gated behind the
+  `Automation Input Write` experiment; see
+  [Automation Input Write Decision](../decisions/automation-input-write.md).
 
 ## Envelope
 
@@ -87,6 +89,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
 | `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Each successful split creates a new terminal surface in the caller's tab. Secondary split-tile callers return `unsupported` in V1. |
 | `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
+| `POST /v1/input/write` | Experimental. Writes `text` into the caller's own PTY; `submit: true` appends a carriage return. Body is `{"text": "...", "submit": false}`, at most 32 KiB UTF-8 of text. Requires the `input.write` capability, granted only while the Automation Input Write experiment is on. |
 
 Mutation bodies must be projections over the supported operation, not raw tile
 state. For example:
@@ -111,6 +114,7 @@ handle.
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
+| `input.write` | `POST /v1/input/write` (experimental; granted per-handle only while the Automation Input Write experiment is enabled, and re-checked per request) |
 
 Under-capable handles fail with `capability_denied`.
 
@@ -150,6 +154,8 @@ workspaces tile split --right
 workspaces tile split --up
 workspaces tile split --down
 workspaces tile close
+workspaces input write 'echo hi'
+workspaces input write 'echo hi' --submit
 ```
 
 ## Implementation Map
@@ -184,6 +190,8 @@ If docs or public examples changed, also run the docs checks listed in
 ## V1 Non-Goals
 
 V1 does not support browser mutation, opening web URLs, tab title or metadata
-changes, input injection, resize/equalize, or global cross-workspace control.
-Those capabilities require separate product and safety review before they can
-be added.
+changes, writing into other tiles, resize/equalize, or global cross-workspace
+control. Those capabilities require separate product and safety review before
+they can be added. Caller-scoped input injection is the one reviewed
+exception: it ships as the experimental, double-gated `input.write` capability
+(see [Automation Input Write Decision](../decisions/automation-input-write.md)).

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -89,7 +89,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
 | `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Each successful split creates a new terminal surface in the caller's tab. Secondary split-tile callers return `unsupported` in V1. |
 | `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
-| `POST /v1/input/write` | Experimental. Writes `text` into the caller's own PTY; `submit: true` appends a carriage return. Body is `{"text": "...", "submit": false}`, at most 32 KiB UTF-8 of text. Requires the `input.write` capability, granted only while the Automation Input Write experiment is on. |
+| `POST /v1/input/write` | Experimental. Pastes `text` into the caller's own PTY; `submit: true` then presses Return as a synthetic key event (never an appended `\r`, which bracketed paste would insert literally). Body is `{"text": "...", "submit": false}`, at most 32 KiB UTF-8 of text. Requires the `input.write` capability, granted only while the Automation Input Write experiment is on. |
 
 Mutation bodies must be projections over the supported operation, not raw tile
 state. For example:


### PR DESCRIPTION
## Summary

- Adds `POST /v1/input/write` to the Automation API: a handle-scoped write into the **caller's own** terminal PTY, with `submit: true` pressing Return. This is the keystone primitive for agent orchestration (Phase 0 of the Orca-inspired investment map, #798).
- New `input.write` capability granted per-handle only while the new **Automation Input Write** experiment (`WORKSPACES_AUTOMATION_INPUT_WRITE`) is on — deliberately **not** added to `v1Capabilities`, so default handles and the stable V1 envelope never widen.
- Double gate: grant-time at handle upsert plus a per-request re-check in `AutomationController` (handles outlive settings changes). Caller-scoped only; the existing forbidden-target-ID rail still rejects any `tileID`/`surfaceID`/`hostSessionID` in bodies. Text capped at 32 KiB UTF-8. Audit stays content-free (route metadata only), inherited from the listener.
- New `GhosttySurfaceTextInputBridge.writeAutomationText` bypasses the keyboard IME accumulator so automation writes cannot be swallowed by a half-composed key event.
- **Submit is a synthetic Return key event, not an appended `\r`** (59eb9fc, found by interactive smoke): `ghostty_surface_text` treats its payload as a paste, so with bracketed paste on (zsh default) a CR in the text is inserted literally instead of executing. `sendAutomationReturn` presses/releases Return through `ghostty_surface_key`, encoding CR outside any paste envelope like a physical Enter.
- CLI: `workspaces input write <text> [--submit]`.
- Docs: guide + reference updates and a new decision record `docs/decisions/automation-input-write.md`, per the V1 decision's expansion contract ("future capabilities each define authority model, user expectation, audit surface, tests, and documentation").

Closes #798

## Mergeability

- Surface: desktop / docs
- User-facing behavior changed: none unless both experiments are enabled; default behavior (capability list, envelopes) is byte-identical — the `v1Capabilities` golden-string test is untouched and still passes.
- Non-happy paths considered: empty/missing/oversize text → `invalid_request`; forged target IDs → `invalid_request`; wrong method → `method_not_allowed`; handle without grant → `capability_denied`; experiment turned off after grant → `capability_denied` (request-time re-check); no live surface view → `stale_handle` (checked before the text write and again before the submit key).
- Release/ops preconditions: none; experimental, off by default.
- Residual risk or follow-up: targeted write by surfaceID is explicitly deferred pending a child-handle authority model. Submit-key delivery needs the smoke re-run below to confirm on a live desktop (the defective `\r` variant was caught exactly this way).

## Validation

- [x] `swift build` — [green in CI (macos-15)](https://github.com/fairchild/workspaces/actions/runs/28731576455/job/85198073162) at 89eb617; CI re-running for 59eb9fc
- [x] `swift test` — [green in CI (macos-15)](https://github.com/fairchild/workspaces/actions/runs/28731576455/job/85198073162) at 89eb617; also 1105 tests / 173 suites locally on macOS (smoke report below)
- [x] Other checks run: [Lint, Typecheck & Build passed](https://github.com/fairchild/workspaces/actions/runs/28731576451/job/85198073151); route/validation matrix covered in `AutomationAPITests`, grant/gate/stale paths in app-target `AutomationControllerTests` with an injected experiment gate.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Interactive smoke on a macOS desktop ([smoke report](https://github.com/fairchild/workspaces/pull/799#issuecomment-4899706312)) at 89eb617 — grant/deny lifecycle, caller scoping, request-time re-check, and audit hygiene all verified; it also caught the submit defect fixed in 59eb9fc:

- [CLI log](https://evidence.cloudcompute.com/workspaces/pr-799/20260707-030235-input-write-smoke-cli-log.png) · [text landed](https://evidence.cloudcompute.com/workspaces/pr-799/20260707-030234-input-write-smoke-text-landed.png) · [submit not executed (pre-fix)](https://evidence.cloudcompute.com/workspaces/pr-799/20260707-030235-input-write-smoke-submit-not-executed.png)
- [build-and-test passed (macos-15)](https://github.com/fairchild/workspaces/actions/runs/28731576455/job/85198073162) · [Lint, Typecheck & Build passed](https://github.com/fairchild/workspaces/actions/runs/28731576451/job/85198073151)

Re-verified at 59eb9fc (2026-07-06, macOS desktop): `swift build` clean, `swift test` 1105 tests / 173 suites passed, `mise run lint` clean, and the full smoke is green — `input write 'echo hello-from-automation' --submit` now executes (output + fresh prompt visible), confirmed twice over via a filesystem probe (`date > file` written by the tile shell), and the negative relaunch without the experiment still fails `capability_denied` with a content-free audit entry:

- [Submit executes — echo output + probe command ran, prompt returned](https://evidence.cloudcompute.com/workspaces/pr-799/20260707-032427-input-write-submit-executes.png)
- [Fix-smoke CLI log — submit leg, filesystem probe, negative leg, audit tail](https://evidence.cloudcompute.com/workspaces/pr-799/20260707-032428-input-write-fix-smoke-log.png)

## Blockers

- [x] None
- [ ] Blocked on evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRY9LS568zAVoeS2v6F2fc
