### PR TITLE
feat(cli): `ws race` — fan one prompt across N worktree workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ swift run workspaces .
 swift run workspaces repo add ~/code/my-repo
 swift run workspaces ws new my-repo feature-auth
 swift run workspaces open my-repo/feature-auth --cmd "claude"
+swift run workspaces ws race my-repo "add a health endpoint" --n 3 --cmd "claude"
 ```
+
+`ws race` fans one prompt across N fresh worktree workspaces (`race-<slug>-1..N`)
+and runs the agent headlessly in each (`<cmd> -p '<prompt>'`, output in the
+workspace's `.race-agent.log`). Use `workspaces open <repo>/<name>` to attach to
+any of them interactively.
 
 ## Configuration
 

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -196,7 +196,7 @@ private final class CLIApp {
 
     private func runWorkspace(arguments: [String], state: inout CLIState) async throws -> Int32 {
         guard let subcommand = arguments.first else {
-            throw CLIError("Missing ws subcommand. Expected: new, list, path")
+            throw CLIError("Missing ws subcommand. Expected: new, list, path, race")
         }
 
         switch subcommand {
@@ -264,9 +264,190 @@ private final class CLIApp {
             print(workspace.path)
             return 0
 
+        case "race":
+            return try await runWorkspaceRace(arguments: Array(arguments.dropFirst()), state: &state)
+
         default:
-            throw CLIError("Unknown ws subcommand '\(subcommand)'. Expected: new, list, path")
+            throw CLIError("Unknown ws subcommand '\(subcommand)'. Expected: new, list, path, race")
         }
+    }
+
+    /// Fans one prompt across N fresh worktree workspaces and launches a detached headless
+    /// agent (`<cmd> -p '<prompt>'`) in each. Fail-fast: a failure at workspace k keeps
+    /// workspaces 1..k-1 (recoverable via `ws list`) and reports what was created.
+    private func runWorkspaceRace(arguments: [String], state: inout CLIState) async throws -> Int32 {
+        let usage = "workspaces ws race <repo> <prompt...> [--n 3] [--cmd \"claude\"] [--name <slug>] [--no-launch]"
+
+        var repoToken: String?
+        var promptWords: [String] = []
+        var count = 3
+        var command = "claude"
+        var nameOverride: String?
+        var launch = true
+
+        var index = 0
+        while index < arguments.count {
+            let token = arguments[index]
+            switch token {
+            case "--n":
+                index += 1
+                guard index < arguments.count, let parsed = Int(arguments[index]) else {
+                    throw CLIError("Missing or invalid value for --n")
+                }
+                count = parsed
+            case "--cmd":
+                index += 1
+                guard index < arguments.count else {
+                    throw CLIError("Missing value for --cmd")
+                }
+                command = arguments[index]
+            case "--name":
+                index += 1
+                guard index < arguments.count else {
+                    throw CLIError("Missing value for --name")
+                }
+                nameOverride = arguments[index]
+            case "--no-launch":
+                launch = false
+            default:
+                if repoToken == nil {
+                    repoToken = token
+                } else {
+                    promptWords.append(token)
+                }
+            }
+            index += 1
+        }
+
+        guard let repoToken else {
+            throw CLIError("Usage: \(usage)")
+        }
+        let prompt = promptWords.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw CLIError("Usage: \(usage)")
+        }
+        guard RaceGroupPlanner.countRange.contains(count) else {
+            let range = RaceGroupPlanner.countRange
+            throw CLIError("--n must be between \(range.lowerBound) and \(range.upperBound).")
+        }
+        guard let repo = resolveRepo(token: repoToken, state: state) else {
+            throw CLIError("Repository not found: \(repoToken)")
+        }
+
+        let plan = RaceGroupPlanner.plan(
+            prompt: prompt,
+            count: count,
+            command: command,
+            nameOverride: nameOverride
+        )
+
+        var createdWorkspaces: [WorkspaceRecord] = []
+        var failure: (name: String, error: Error)?
+        for name in plan.workspaceNames {
+            do {
+                let info = try await workspaceService.createWorkspace(
+                    repoName: repo.name,
+                    repoLocalURL: URL(fileURLWithPath: repo.path),
+                    name: name
+                )
+                createdWorkspaces.append(
+                    WorkspaceRecord(
+                        id: UUID(),
+                        name: info.name,
+                        repoName: repo.name,
+                        repoPath: repo.path,
+                        path: info.path.path,
+                        gitBranch: info.gitBranch,
+                        createdAt: Date(),
+                        lastAccessedAt: Date(),
+                        defaultCommand: command
+                    )
+                )
+            } catch {
+                failure = (name, error)
+                break
+            }
+        }
+
+        for workspace in createdWorkspaces {
+            state.workspaces.removeAll { $0.path == workspace.path }
+            state.workspaces.append(workspace)
+        }
+
+        if !createdWorkspaces.isEmpty {
+            var record = RaceGroupRecord(
+                id: UUID(),
+                slug: plan.slug,
+                repoName: repo.name,
+                prompt: prompt,
+                command: command,
+                workspaceIDs: createdWorkspaces.map(\.id),
+                createdAt: Date(),
+                agentPIDs: []
+            )
+            if launch {
+                for workspace in createdWorkspaces {
+                    if let pid = spawnDetachedAgent(
+                        command: plan.agentCommand,
+                        workspaceURL: URL(fileURLWithPath: workspace.path)
+                    ) {
+                        record.agentPIDs.append(pid)
+                    }
+                }
+            }
+            var groups = state.raceGroups ?? []
+            groups.append(record)
+            state.raceGroups = groups
+        }
+        try stateStore.save(state)
+
+        for workspace in createdWorkspaces {
+            print("Created workspace: \(workspaceDisplayName(workspace))")
+            print("  Path: \(workspace.path)")
+            print("  Branch: \(workspace.gitBranch)")
+            if launch {
+                print("  Log: \(workspace.path)/\(Self.raceAgentLogName)")
+            }
+            print("  Attach: workspaces open \(workspace.repoName)/\(workspace.name)")
+        }
+
+        if let failure {
+            writeStderr("error: failed to create workspace '\(failure.name)': \(failure.error.localizedDescription)")
+            let progress = "\(createdWorkspaces.count) of \(plan.workspaceNames.count)"
+            writeStderr("Created \(progress) workspaces before failing; see 'workspaces ws list'.")
+            return 1
+        }
+        return 0
+    }
+
+    private static let raceAgentLogName = ".race-agent.log"
+
+    /// Launches the agent as a detached child (no waitUntilExit) with output captured to
+    /// the workspace's race log. Returns the PID, or nil when launch fails (recorded as a
+    /// warning; the workspace itself stays usable via `workspaces open`).
+    private func spawnDetachedAgent(command: String, workspaceURL: URL) -> Int32? {
+        let logURL = workspaceURL.appendingPathComponent(Self.raceAgentLogName)
+        FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        guard let logHandle = FileHandle(forWritingAtPath: logURL.path) else {
+            writeStderr("warning: could not open \(logURL.path) for agent output; skipping launch")
+            return nil
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", command]
+        process.currentDirectoryURL = workspaceURL
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+
+        do {
+            try process.run()
+        } catch {
+            writeStderr("warning: failed to launch agent in \(workspaceURL.path): \(error.localizedDescription)")
+            return nil
+        }
+        return process.processIdentifier
     }
 
     private func runOpen(arguments: [String], state: inout CLIState) async throws -> Int32 {
@@ -877,6 +1058,8 @@ private struct CLIState: Codable {
     var workspaces: [WorkspaceRecord] = []
     var recents: [RecentSession] = []
     var lastSession: LastSession?
+    // Optional so state.json files written before race groups existed keep decoding.
+    var raceGroups: [RaceGroupRecord]?
 }
 
 private struct RepoRecord: Codable {
@@ -896,6 +1079,17 @@ private struct WorkspaceRecord: Codable {
     var createdAt: Date
     var lastAccessedAt: Date
     var defaultCommand: String?
+}
+
+private struct RaceGroupRecord: Codable {
+    var id: UUID
+    var slug: String
+    var repoName: String
+    var prompt: String
+    var command: String
+    var workspaceIDs: [UUID]
+    var createdAt: Date
+    var agentPIDs: [Int32]
 }
 
 private struct RecentSession: Codable {
@@ -1120,6 +1314,7 @@ private func printHelp() {
           workspaces ws new <repo> <name>
           workspaces ws list
           workspaces ws path <workspace>
+          workspaces ws race <repo> <prompt...> [--n 3] [--cmd "claude"] [--name <slug>] [--no-launch]
           workspaces open <workspace> [--cmd "command"]
           workspaces run <workspace> -- <command...>
           workspaces run <workspace> --cmd "command"

--- a/Sources/WorkspaceManagerCore/Services/RaceGroupPlanner.swift
+++ b/Sources/WorkspaceManagerCore/Services/RaceGroupPlanner.swift
@@ -1,0 +1,83 @@
+//
+//  RaceGroupPlanner.swift
+//  WorkspaceManagerCore
+//
+//  Pure planning for `workspaces ws race`: derives the group slug, the race-N
+//  workspace names, and the shell-safe headless agent command. Kept free of
+//  side effects so the CLI's fan-out stays a thin loop over a tested plan.
+//
+
+import Foundation
+
+public struct RaceGroupPlan: Sendable, Equatable {
+    public let slug: String
+    public let workspaceNames: [String]
+    public let agentCommand: String
+
+    public init(slug: String, workspaceNames: [String], agentCommand: String) {
+        self.slug = slug
+        self.workspaceNames = workspaceNames
+        self.agentCommand = agentCommand
+    }
+}
+
+public enum RaceGroupPlanner {
+    public static let countRange = 1...8
+    public static let maxSlugLength = 40
+    public static let fallbackSlug = "group"
+
+    public static func plan(
+        prompt: String,
+        count: Int,
+        command: String,
+        nameOverride: String? = nil
+    ) -> RaceGroupPlan {
+        let clampedCount = min(max(count, countRange.lowerBound), countRange.upperBound)
+        let slug = deriveSlug(prompt: prompt, nameOverride: nameOverride)
+        let workspaceNames = (1...clampedCount).map { "race-\(slug)-\($0)" }
+        let agentCommand = "\(command) -p \(shellQuoted(prompt))"
+        return RaceGroupPlan(slug: slug, workspaceNames: workspaceNames, agentCommand: agentCommand)
+    }
+
+    /// Kebab-cases the override or the prompt's first four words. Stricter than
+    /// `WorkspaceService.sanitizeWorkspaceNameComponent` because the result also feeds
+    /// `git worktree add -b <name>`, so only letters, digits, and dashes survive.
+    static func deriveSlug(prompt: String, nameOverride: String?) -> String {
+        let trimmedOverride = nameOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source: String
+        if let trimmedOverride, !trimmedOverride.isEmpty {
+            source = trimmedOverride
+        } else {
+            source = prompt.split(whereSeparator: \.isWhitespace).prefix(4).joined(separator: " ")
+        }
+
+        var parts: [String] = []
+        var current = ""
+        for character in source.lowercased() {
+            if character.isLetter || character.isNumber {
+                current.append(character)
+            } else if !current.isEmpty {
+                parts.append(current)
+                current = ""
+            }
+        }
+        if !current.isEmpty {
+            parts.append(current)
+        }
+
+        var slug = parts.joined(separator: "-")
+        if slug.count > maxSlugLength {
+            slug = String(slug.prefix(maxSlugLength))
+            while slug.hasSuffix("-") {
+                slug = String(slug.dropLast())
+            }
+        }
+        return slug.isEmpty ? fallbackSlug : slug
+    }
+
+    /// Single-quote shell quoting: safe against `$`, backticks, double quotes, and
+    /// embedded single quotes (`'` becomes `'\''`).
+    public static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Tests/WorkspaceManagerTests/RaceGroupPlannerTests.swift
+++ b/Tests/WorkspaceManagerTests/RaceGroupPlannerTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("RaceGroupPlanner")
+struct RaceGroupPlannerTests {
+    @Test("Slug derives from the first four words of the prompt")
+    func slugFromPrompt() {
+        let plan = RaceGroupPlanner.plan(
+            prompt: "Add a health endpoint to the server",
+            count: 3,
+            command: "claude"
+        )
+
+        #expect(plan.slug == "add-a-health-endpoint")
+        #expect(
+            plan.workspaceNames == [
+                "race-add-a-health-endpoint-1",
+                "race-add-a-health-endpoint-2",
+                "race-add-a-health-endpoint-3",
+            ]
+        )
+    }
+
+    @Test("Name override wins over the prompt and is sanitized")
+    func nameOverrideWins() {
+        let plan = RaceGroupPlanner.plan(
+            prompt: "whatever the prompt says",
+            count: 1,
+            command: "claude",
+            nameOverride: "My Fix!"
+        )
+
+        #expect(plan.slug == "my-fix")
+        #expect(plan.workspaceNames == ["race-my-fix-1"])
+    }
+
+    @Test("Count clamps to the supported range")
+    func countClamping() {
+        #expect(RaceGroupPlanner.plan(prompt: "x", count: 0, command: "claude").workspaceNames.count == 1)
+        #expect(RaceGroupPlanner.plan(prompt: "x", count: 99, command: "claude").workspaceNames.count == 8)
+    }
+
+    @Test("Punctuation collapses to git-ref-safe dashes")
+    func slugSanitization() {
+        let plan = RaceGroupPlanner.plan(prompt: "fix: the / thing?!", count: 1, command: "claude")
+        #expect(plan.slug == "fix-the-thing")
+    }
+
+    @Test("Long derivations truncate to a bounded slug without a trailing dash")
+    func slugLengthBound() {
+        let plan = RaceGroupPlanner.plan(
+            prompt: "supercalifragilistic expialidocious antidisestablishmentarianism floccinaucinihilipilification",
+            count: 1,
+            command: "claude"
+        )
+
+        #expect(plan.slug.count <= RaceGroupPlanner.maxSlugLength)
+        #expect(!plan.slug.hasSuffix("-"))
+        #expect(!plan.slug.isEmpty)
+    }
+
+    @Test("Symbol-only prompts fall back to a stable slug")
+    func emptySlugFallback() {
+        let plan = RaceGroupPlanner.plan(prompt: "!!! ???", count: 1, command: "claude")
+        #expect(plan.slug == RaceGroupPlanner.fallbackSlug)
+    }
+
+    @Test("Prompt is single-quote shell escaped in the agent command")
+    func shellEscaping() {
+        let plan = RaceGroupPlanner.plan(
+            prompt: "don't `run` $HOME \"now\"",
+            count: 1,
+            command: "claude"
+        )
+
+        #expect(plan.agentCommand == "claude -p 'don'\\''t `run` $HOME \"now\"'")
+    }
+
+    @Test("Custom agent command passes through verbatim")
+    func commandPassthrough() {
+        let plan = RaceGroupPlanner.plan(
+            prompt: "do the thing",
+            count: 1,
+            command: "claude --permission-mode acceptEdits"
+        )
+
+        #expect(plan.agentCommand == "claude --permission-mode acceptEdits -p 'do the thing'")
+    }
+}

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -353,6 +353,44 @@ struct WorkspaceServiceTests {
         #expect(mockGit.createWorktreeCalls[0].source == repoDir)
     }
 
+    @Test("sequential race fan-out keeps earlier workspaces when a later one fails")
+    func sequentialRaceFanOutFailFast() async throws {
+        let materializer = RecordingWorkspaceMaterializer()
+        materializer.createsDestination = true
+        let service = WorkspaceService(materializer: materializer)
+        let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let plan = RaceGroupPlanner.plan(prompt: "demo race", count: 3, command: "claude")
+        var created: [URL] = []
+        var failedName: String?
+        for (index, name) in plan.workspaceNames.enumerated() {
+            if index == 2 {
+                materializer.materializeError = GitError.commandFailed(args: ["worktree", "add"], stderr: "boom")
+            }
+            do {
+                let info = try await service.createWorkspace(repoName: "test-repo", repoLocalURL: repoDir, name: name)
+                created.append(info.path)
+            } catch {
+                failedName = name
+                break
+            }
+        }
+
+        #expect(failedName == "race-demo-race-3")
+        #expect(created.count == 2)
+        for workspaceURL in created {
+            #expect(FileManager.default.fileExists(atPath: workspaceURL.path))
+        }
+        let failedDir =
+            wsRoot
+            .appendingPathComponent("test-repo", isDirectory: true)
+            .appendingPathComponent("race-demo-race-3", isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: failedDir.path))
+    }
+
     @Test("createWorkspace fails clearly when materialization fails")
     func createWorkspaceFailsWhenMaterializationFails() async throws {
         let materializer = RecordingWorkspaceMaterializer()


### PR DESCRIPTION
## Summary

- Adds `workspaces ws race <repo> <prompt...> [--n 3] [--cmd "claude"] [--name <slug>] [--no-launch]` — the CLI-first slice of the parallel-agent race primitive (Phase 1a of the Orca-inspired investment map, #800; independent of the Phase 0 `input.write` PR #799).
- Fan-out reuses the `ws new` path exactly: in-process `WorkspaceService.createWorkspace` per workspace (git worktree + `scripts/setup` hooks), names `race-<slug>-1..N` with the slug kebab-cased from the prompt's first words (or `--name`).
- Each agent launches as a **detached child process** (`<cmd> -p '<shell-escaped prompt>'`), cwd = its workspace, stdout/stderr to `<workspace>/.race-agent.log`; `defaultCommand` is set so `workspaces open <repo>/<name>` re-attaches interactively. `--no-launch` creates and records only.
- Race groups persist in CLI state (`~/.config/workspaces-cli/state.json`) as a new **optional** `raceGroups` field — optional so pre-existing `state.json` files keep decoding (synthesized Codable treats defaulted non-optionals as required keys).
- New pure `RaceGroupPlanner` in `WorkspaceManagerCore` (slug derivation, `race-N` naming, count clamp 1..8, single-quote shell escaping safe against `$`/backticks/quotes) — pure so it's unit-testable; the CLI target has no test target.

Closes #800

## Mergeability

- Surface: desktop (CLI) / docs
- User-facing behavior changed: new CLI verb only; `ws new`/`list`/`path`/`open` behavior unchanged. No app UI changes.
- Non-happy paths considered: missing repo/prompt/flag values → usage errors; `--n` out of 1..8 → clear error; creation failure at workspace k → fail-fast keeping 1..k-1, prints progress + error, exit 1 (no rollback; worktrees recoverable via `ws list`); agent launch failure → warning, workspace stays usable via `open`; prompt shell-metacharacters neutralized by single-quote escaping.
- Release/ops preconditions: none.
- Residual risk or follow-up: (1) race workspaces do **not** appear in the app sidebar — there is no CLI→app reconciliation today; acceptable for this slice, required for the fleet-view slice. (2) headless `<cmd> -p` may stall on permission prompts; `--cmd` passes through verbatim so users control flags (e.g. `--permission-mode`). (3) A command parameter on the `workspaces://focus` deep link was rejected — it would let any URL-opener execute shell commands.

## Validation

- [x] `swift build` — [green in CI (macos-15)](https://github.com/fairchild/workspaces/actions/runs/28731712096/job/85198473325)
- [x] `swift test` — [green in CI (macos-15)](https://github.com/fairchild/workspaces/actions/runs/28731712096/job/85198473325)
- [x] Other checks run: [Lint, Typecheck & Build passed](https://github.com/fairchild/workspaces/actions/runs/28731712081/job/85198473147). Unit coverage: `RaceGroupPlannerTests` (slug derivation/sanitization/truncation/fallback, count clamping, shell escaping incl. embedded quotes, command passthrough) and a `WorkspaceServiceTests` contract test proving sequential fan-out failure at k keeps workspaces 1..k-1 and cleans only the failed one.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [build-and-test passed (macos-15)](https://github.com/fairchild/workspaces/actions/runs/28731712096/job/85198473325)
- [Lint, Typecheck & Build passed](https://github.com/fairchild/workspaces/actions/runs/28731712081/job/85198473147)
- Local gates re-run on macOS at head (2026-07-06): `swift build` clean, `swift test` 1108 tests / 174 suites passed, `mise run lint` clean.
- End-to-end smoke on macOS (throwaway repo with a tiny Node http server, `ws race <repo> "add a health endpoint" --n 3 --cmd claude`):
  - [Fan-out + `ws list` + `raceGroups` state + 3 live `claude -p` PIDs](https://evidence.cloudcompute.com/workspaces/pr-801/20260707-030822-ws-race-fanout.png)
  - [All 3 `.race-agent.log` files with real agent output (each independently proposed the `/health` route)](https://evidence.cloudcompute.com/workspaces/pr-801/20260707-030845-ws-race-agent-logs.png)
  - [`defaultCommand=claude` persisted per workspace + `open` re-attach in workspace cwd](https://evidence.cloudcompute.com/workspaces/pr-801/20260707-030909-ws-race-open-attach.png)

Smoke notes: all legs of the Blockers runbook passed — 3 worktree workspaces on `workspace/race-add-a-health-endpoint-{1,2,3}` branches, `raceGroups` persisted with slug/prompt/command/workspaceIDs/agentPIDs, detached agents wrote real output to their logs, and `open` re-attached in the right cwd (exercised with a `--cmd` override to keep the run non-interactive; `defaultCommand=claude` shown persisted in state). One observed-as-anticipated behavior, not a defect: headless `claude -p` declined to edit files under default permissions and answered with a proposed diff instead — exactly residual risk (2) above; `--cmd` passthrough (e.g. `--permission-mode acceptEdits`) is the documented control.

## Blockers

- [x] None
- [ ] Blocked on evidence

Not UI-affecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRY9LS568zAVoeS2v6F2fc
