### PR TITLE
feat(web-next): real harness-backed agent runtime + sandbox template prewarm (#750)

### DIFF
--- a/docs/decisions/web-next-harness-runtime.md
+++ b/docs/decisions/web-next-harness-runtime.md
@@ -19,9 +19,13 @@ four PRs). Mid-plan, Vercel shipped **`@ai-sdk/harness`** — an official,
 `ai@7`-native abstraction that provides exactly this layer, multi-runtime, with
 sandbox auth handled. Verified 2026-07-03: the packages are real
 (`@ai-sdk/harness`, `-claude-code`, `-codex`, `-pi`, `@ai-sdk/sandbox-vercel`),
-pin `ai@7.0.14`, and forward host `ANTHROPIC_API_KEY`/gateway credentials into the
-sandbox bridge for us. They are also explicitly **experimental** — ~4 weeks old,
-tens of releases per month, a `1.0` label that overstates stability.
+carry a pinned `ai` dependency, and forward host `ANTHROPIC_API_KEY`/gateway
+credentials into the sandbox bridge for us. The pinned `ai` version tracks the
+harness release train and moves with it — as of `@ai-sdk/harness@1.0.18` it is
+`ai@7.0.15` (a direct dependency, so installing the harness bumps the app's `ai`
+to match; reconcile the repo's pin rather than fight the transitive dep). They are
+also explicitly **experimental** — ~4 weeks old, tens of releases per month, a
+`1.0` label that overstates stability.
 
 ## Decision
 

--- a/docs/decisions/web-next-harness-runtime.md
+++ b/docs/decisions/web-next-harness-runtime.md
@@ -22,8 +22,10 @@ sandbox auth handled. Verified 2026-07-03: the packages are real
 carry a pinned `ai` dependency, and forward host `ANTHROPIC_API_KEY`/gateway
 credentials into the sandbox bridge for us. The pinned `ai` version tracks the
 harness release train and moves with it — as of `@ai-sdk/harness@1.0.18` it is
-`ai@7.0.15` (a direct dependency, so installing the harness bumps the app's `ai`
-to match; reconcile the repo's pin rather than fight the transitive dep). They are
+`ai@7.0.15`, so the app exact-pins `ai@7.0.15` to match the harness rather than
+fight the transitive dep (`@ai-sdk/react@4.0.15` still carries its own
+transitive `ai@7.0.14`; that is the react adapter's constraint, not the app
+pin). They are
 also explicitly **experimental** — ~4 weeks old, tens of releases per month, a
 `1.0` label that overstates stability.
 

--- a/handoff.md
+++ b/handoff.md
@@ -1,47 +1,245 @@
-# Session Handoff
+# Handoff — Issue #750: web-next real runtime (harness-backed `ComputeProvider`)
 
-## Current Task
-Web frontend performance: fixed 7,225ms INP on compose bar and reduced re-renders across the dashboard.
+**For:** a Fable orchestrator driving #750 to completion in the next session.
+**Prepared:** 2026-07-05 (Opus).
+**Branch:** `fairchild/web-next-real-runtime-harness-backed-computeprov`.
+**Issue:** [#750](https://github.com/fairchild/workspaces/issues/750) — **OPEN** (body refreshed 2026-07-05 to match this handoff).
+**Milestone:** [#11 "Sessions-first web (web-next)"](https://github.com/fairchild/workspaces/milestone/11) — 11 closed / 5 open. #750 is the last **runtime** piece; siblings still open: #752 (terminal drawer), #753 (lifecycle/mobile), #754 (cutover), #790 (edit→diff view). Follow-on refinement lives in milestones #12 (a11y/resilience) and #13 (self-validation across envs).
 
-## Progress
-- Fixed INP root cause: streaming state no longer recreates `handleSend` callback (streaming ref pattern)
-- Extracted StreamingBubble as isolated sibling so SSE updates don't touch MessageList tree
-- Batched SSE chunks via requestAnimationFrame (max 60 renders/sec, was 100+)
-- Wrapped ComposeBar, ChatMessageRow, EventGroupRow in React.memo
-- Stabilized polling with compare-before-replace (length + first/last ID)
-- Stabilized handleNewChatMessage via activeTabRef (created once)
-- Cached formatTime (30s TTL) and dayKey (permanent) to reduce Date allocations
-- Fixed double tryParseDispatchMetadata call in message-list render
-- Rebased on main's persistent sandbox PR (#277), resolved 5 conflicts integrating streaming status states + optimistic rendering with perf architecture
-- Reverted mention debounce during /reflect — added latency for negligible gain
+### Already built this session (on the branch, not yet committed)
 
-## Key Decisions
-- **Streaming ref over state for handleSend guard**: The core INP fix. `streamingRef.current` breaks the dependency chain so `handleSend` is stable during streaming. ComposeBar's `onSend` prop stops changing.
-- **StreamingBubble as sibling, not inside MessageList**: Trades scroll-with-messages for render isolation. The bubble pins above compose bar — acceptable UX, significant perf win.
-- **Compare-before-replace for polling**: `setEntries(prev => same ? prev : data)` avoids reference changes on identical polls. Uses length + first/last ID — sufficient for append-only timelines.
-- **RAF batching, not debounce**: Accumulate SSE chunks in ref, flush once per animation frame. Preserves streaming responsiveness while capping renders.
-- **No mention debounce**: Reverted during reflect. The regex is trivial; 150ms delay made autocomplete feel sluggish for no real gain.
+A **preflight health-check** was added to de-risk phase 2 — it proves every capability a real turn needs, in the environment it's deployed to:
 
-## Next Steps
-1. Fill in bot command routing TODO stubs (5 tests for @spaces status/pipeline)
-2. Seed test data for remaining E2E placeholders (repo detail, activity feed, day separators)
-3. Visual QA collapsed events with live webhook data on Vercel preview
-4. Consider list virtualization (Phase 5 from plan) if timelines exceed ~200 entries
+- **`GET /api/diag/preflight`** (`web-next/src/app/api/diag/preflight/route.ts`) — auth-gated. Default run checks: **env** presence, **llm** (gateway or anthropic-direct), **github** (App JWT → discover installation → installation token → repo-read), **vercel** (token/team/project reachability, or OIDC note on-platform). Add **`?sandbox=1`** to also create a live Vercel sandbox and run **bash + `git clone --depth 1`** the repo inside it. Returns 200 all-pass / 503 otherwise; **never returns secret values**, redacts the clone token from captured output.
+- Supporting: `web-next/src/lib/diag/preflight.ts` (checks) + `web-next/src/lib/diag/github-app.ts` (hand-rolled App JWT via `node:crypto`, no dep; accepts base64-or-PEM key; **reusable by the #750 provider for repo clone**) + `github-app.test.ts` (5 tests, green).
+- Added dep: **`@vercel/sandbox@2.4.0`** (exact-pinned; aligns with the harness's `@vercel/sandbox ^2.0.1`).
+- Gates: **typecheck ✓, lint ✓, unit tests ✓**. Should land as its own small PR with a green `preflight` run as evidence.
+- ⚠️ **Clean `pnpm build` fails** — see "Open gate" in §7. Not caused by these additions (they're an API route + libs; `/500`/`/_error` are Next built-ins).
 
-## Relevant Files
-- `web/src/app/dashboard/components/chat-panel.tsx` — streaming ref, RAF batching, optimistic sends
-- `web/src/app/dashboard/components/streaming-bubble.tsx` — NEW: isolated streaming display with status labels
-- `web/src/app/dashboard/components/compose-bar.tsx` — React.memo wrapped
-- `web/src/app/dashboard/components/message-list.tsx` — removed streaming, memo ChatMessageRow, ChatOrDispatchRow
-- `web/src/app/dashboard/components/event-group-row.tsx` — React.memo wrapped
-- `web/src/app/dashboard/components/activity-feed.tsx` — stable setEvents comparison
-- `web/src/app/dashboard/components/dashboard-shell.tsx` — stable handleNewChatMessage via activeTabRef
-- `web/src/lib/timeline-utils.ts` — cached `dayKey`, `formatCompactTime`, `formatRelativeTime` (the old `components/timeline-utils.ts` split was folded in here later, in PR #342)
-
-## Open Questions
-- Pre-existing race: rapid stream switching can null newer stream via old finally block (narrow window, not introduced by this PR)
-- `agents ?? []` in chat-panel creates new empty array each render when no agents — breaks memo in loading state, low impact
+_(This overwrites a stale 2026-04-02 handoff for PR #280, an unrelated `web/` INP perf fix — this file is the repo's rolling session-handoff scratch doc.)_
 
 ---
-*Session completed on 2026-04-02*
-*PR: #280 — perf(web): fix INP on compose bar and reduce re-renders*
+
+## 1. TL;DR — where this stands
+
+The goal: **a real Claude Code turn runs in a Vercel sandbox and streams into the Folio transcript**, behind the already-shipped `ComputeProvider` seam. Everything shipped so far (T0–T5) runs on a **mock** provider; no real agent has ever run.
+
+**All preconditions from the issue body are already done** — the issue's "start here" orientation is stale (written 2026-07-04, several PRs have landed since):
+
+- #777 (harness ADR), #779 (Folio turn frame), #781 (design doc) — **all MERGED**.
+- #784 (reasoning treatment), #785 (adversarial mock) — **both CLOSED**, landed via **#787** (`eb7f7994`). Reasoning is fully wired end-to-end already (see §4).
+- #780 (`next build` /404 failure) — **CLOSED**.
+- Newer prep since the issue was written: **#796** (CONTRIBUTING — local dev + creds), **#797** (`/api/diag/gateway` credential smoke probe), **#803** (`architecture.html`).
+
+So the runway is clear. **The real-runtime work itself has not been started.** This branch is the place to do it.
+
+### Two corrections to the issue's mental model (important)
+
+1. **Interface naming.** The ADR originally proposed a new `SessionRuntime` interface, then reconciled with shipped code: **the existing `ComputeProvider` seam _is_ that interface.** Do **not** build a `SessionRuntime` abstraction. Add an additive `ComputeProvider`; `StreamChunk` stays the internal currency; the ingest→log→tail pipeline is untouched. Where the brief still says "`SessionRuntime`," read "`ComputeProvider`."
+
+2. **Issue scope vs. the brief's T-numbering.** The execution brief's internal numbering maps #750→"T6 Codex+Pi." **Ignore that — trust the GitHub issue.** Issue #750 is the **Claude Code real runtime**. Codex + Pi adapters + a runtime picker are explicitly **follow-on**, out of scope here.
+
+---
+
+## 2. The harness API — corrected against the shipped `.d.ts` (net-new intel)
+
+The issue text says "drives `HarnessAgent(claudeCode)`." **That signature is wrong.** Verified against the published typings (`@ai-sdk/harness@1.0.18`, all three packages on a lockstep train, all marked *experimental*):
+
+### Versions to exact-pin
+```
+@ai-sdk/harness              1.0.18
+@ai-sdk/harness-claude-code  1.0.18
+@ai-sdk/sandbox-vercel       1.0.18
+```
+⚠️ **`ai` version conflict to resolve first.** `@ai-sdk/harness@1.0.18` declares `ai@7.0.15` as a **direct dependency**. The repo currently pins `ai@^7.0.14` (lock resolves `7.0.14`). Installing the harness will pull `ai@7.0.15`. **Reconcile deliberately** — bump the repo to `ai@7.0.15` to match. Don't fight the transitive dep. (The ADR now records this correctly — it previously claimed the harness pins `ai@7.0.14`, corrected 2026-07-05.) (Also pulls `@vercel/sandbox@^2.0.1`, `@anthropic-ai/claude-agent-sdk`, `ws@^8.21.0`.)
+
+### Construction (stateless agent, construct once at module scope)
+```ts
+import { HarnessAgent } from '@ai-sdk/harness';
+import { claudeCode, createClaudeCode } from '@ai-sdk/harness-claude-code';
+import { createVercelSandbox } from '@ai-sdk/sandbox-vercel';
+
+const agent = new HarnessAgent({
+  harness: claudeCode,                          // or createClaudeCode({ ... })
+  sandbox: createVercelSandbox({ /* settings */ }), // a HarnessV1SandboxProvider, NOT a raw Sandbox
+  permissionMode: 'allow-all',                  // default
+  instructions,                                 // prepended once to first user msg of a fresh session
+});
+```
+
+**Auth goes on the adapter, not the agent/sandbox:**
+```ts
+createClaudeCode({
+  auth: { gateway: { apiKey: process.env.AI_GATEWAY_API_KEY } },   // preferred (spend cap)
+  //  or: { anthropic: { apiKey: process.env.ANTHROPIC_API_KEY } },
+  thinking: 'on',   // <-- turn on extended thinking so reasoning parts flow
+  model,            // optional Anthropic model id; unset = CLI default
+});
+```
+
+**Sandbox settings** (`createVercelSandbox`) — either wrap a caller-owned `@vercel/sandbox` (`{ sandbox, bridgePorts }`) or let the provider create/manage one (forwards `Sandbox.create` params + optional `name`). In managed mode it uses `Sandbox.getOrCreate` to keep a **persistent named template snapshot** keyed by the Claude Code bootstrap recipe and forks an ephemeral sandbox per session — this is the across-turn reuse the acceptance criteria want. `prepareHarnessSandboxTemplate(...)` (from `@ai-sdk/harness`) pre-bakes that snapshot from a CI/deploy step.
+
+### Sessions are explicit and threaded through every call
+```ts
+const session = await agent.createSession({
+  sessionId?,      // omit → generated; supply the original id to REATTACH
+  resumeFrom?,     // HarnessAgentResumeSessionState from a prior detach()/stop()
+});
+session.sessionId  // <-- stable id you persist
+
+const result = await agent.stream({ prompt, session });  // prompt: string | UserModelMessage
+// consume result.fullStream (standard ai@7 StreamTextResult), switch on part.type
+```
+
+### The stream shape → map to `StreamChunk`
+`result.fullStream` is a standard ai@7 stream. Part kinds that flow (from `HarnessV1StreamPart`):
+- `text-start`/`text-delta`/`text-end` → **`text`**
+- `reasoning-start`/`reasoning-delta`/`reasoning-end` → **`reasoning`** (gated by `thinking:'on'`)
+- `tool-call` → **`tool_use`** (carry id + name + input into `metadata.toolUseId`/`toolName`/`input`); `tool-result` → **`tool_result`** (`metadata.isError`, `metadata.diff` where relevant)
+- `finish`/`finish-step` (`finishReason`, `usage`) → **`done`** (`metadata.durationMs`, `tokenCount`)
+- Harness extras: `file-change`, `compaction`, `error`, `raw`
+
+⚠️ **Verify empirically once installed:** (a) whether reasoning deltas expose `.delta` vs `.text` on the consumer `fullStream` (harness internal type uses `delta`; ai@7 consumer type may differ); (b) whether `file-change`/`compaction` surface on the consumer stream or are adapter-internal. Don't guess — log the raw parts on the first real turn.
+
+### Resume — the part to get exactly right
+`resumeFrom` is **not** a stream token. It's returned by session lifecycle methods:
+```ts
+const resumeFrom = await session.detach();  // parks sandbox+runtime alive
+//  or: await session.stop();               // persists state, stops runtime+sandbox
+```
+`resumeFrom: HarnessAgentResumeSessionState` = `{ harnessId, specificationVersion:'harness-v1', type:'resume-session', data: JSONValue, continueFrom? }`.
+
+**Persist BOTH `session.sessionId` AND the `resumeFrom` object per app session.** The `sessionId` is the key the Vercel provider uses to reattach the same sandbox; `resumeFrom` carries the conversation-history pointer. One without the other won't reattach. Next turn: `agent.createSession({ sessionId, resumeFrom })` → `agent.stream(...)`.
+
+(There's a finer-grained `suspendTurn()`→`continueFrom`→`continueStream()` path for freezing a mid-turn at a process boundary — that's the "workflow slice" for long turns, **not** needed for basic multi-turn continuity. Defer unless a turn genuinely outruns the serverless budget.)
+
+Extracted `.d.ts` for re-inspection: `scratchpad/harness-inspect/{harness,harness-claude-code,sandbox-vercel}/package/dist/*.d.ts`.
+
+---
+
+## 3. The seam to fill — exact files & line refs
+
+All paths under `web-next/`. The additive path is small and well-contained.
+
+### Provider seam (`src/lib/agent-runtime/`)
+- **`provider.ts:11-21`** — `ComputeProvider = { readonly id; runTurn(req: TurnRequest): AsyncIterable<StreamChunk> }`; `TurnRequest = { sessionId; userMessage }`.
+- **`provider.ts:23-31`** — the registry is a plain in-module `Record` (`providers = { [mockProvider.id]: mockProvider }`) + `getProvider(id)` (throws on unknown). **Register the new provider here.**
+- **`stream-chunk.ts:6-17`** — `StreamChunk = { type: "text"|"reasoning"|"tool_use"|"tool_result"|"status"|"error"|"done"; content: string; metadata?: Record<string,unknown> }`. Single interface, `type` discriminant, untyped `metadata` bag. `reasoning` already present.
+- **`mock-provider.ts:58-192`** — reference implementation of a full scripted turn (`mockCodingTurn` → status/reasoning/text/tool_use/tool_result/done). Copy its shape.
+- **`run-turn.ts:34-42`** — `runSessionTurn(handle, session, userText, provider=getProvider(session.provider))` → `{ fromSeq, ingest, stream: tailStream(...) }`. Provider resolved from `session.provider`. No per-request override.
+- **`turn-ingest.ts:106-136`** — `ingestTurn` consumes `provider.runTurn(...)`, appends each chunk to `session_events`, guarantees exactly one terminal `done`, never rejects. **This is the #750 seam** (comment at `:16-19`). The contract you must honor: yield `StreamChunk`s, end with (or let it synthesize) a `done`.
+
+### Persistence (`src/lib/db/`)
+- **`client.ts:36-49`** — `SessionsTable`. Has `provider`, `claude_session_id` (`:45`, *"Claude CLI session id for snapshot/resume"* — **currently always written `null`; this is the placeholder the ADR names for the resume blob**). **No `resume_from` column exists.**
+- **`client.ts:57-68`** — `SessionEventsTable` = `{ session_id, seq, role, kind, payload(JSON StreamChunk), created_at }`, PK `(session_id, seq)`.
+- **`migrations.ts:147`** — ordered `MIGRATIONS[]`; `Migration = { id; up(db) }`. Append `0003_*` (never edit shipped ones; keep `up` idempotent — SQLite ADD COLUMN has no `IF NOT EXISTS`, guard it). Runner: `schema.ts` `ensureSchema`/`runMigrations`.
+- **`sessions.ts`** — `NewSession`/`Session`/`rowToSession`/`createSession` (`:27,36,54,72`) thread `claude_session_id`↔`claudeSessionId`. **Mirror this to thread whatever you persist.** The harness needs **two** values (`sessionId` + `resumeFrom` blob), so a `resume_from` TEXT column (JSON) plus reusing `claude_session_id` for the id — or two new columns — is cleaner than overloading one.
+- **`appendEvents` (`sessions.ts:127-165`)** — assigns monotonic seq in a txn, bumps `last_activity_at`, returns last seq. Natural place to also record the resume cursor.
+
+### Streaming / tail (durable resume — leave untouched)
+- **`turn-tail.ts:52-76`** — `resolveTurn` classifies the last turn from the log + liveness. **Known inefficiency:** reads the *entire* event log (`readEvents` with no `sinceSeq`, `:56`) to find `lastUserSeq` via linear scan. A `resume_from`/last-user-seq cursor on `sessions` makes this O(1). Carry-over from #773 review — address while here (non-blocking).
+- **`turn-tail.ts:122-199`** — `tailChunks`/`tailStream` (seq-cursored, `toUIMessageChunkStream`, deterministic ids). `STALE_TURN_MS=30_000`, `DEFAULT_POLL_MS=250`.
+- **Routes:** kickoff `POST /api/sessions/[id]/chat` (`chat/route.ts:43-54`, `runSessionTurn` + `after(()=>turn.ingest)` to keep the serverless invocation alive); reconnect `GET /api/sessions/[id]/stream` (`stream/route.ts`, returns 204 when nothing to resume).
+
+### Provider selection today
+`startSession` (`start-session.ts:34-38`) **hardcodes `provider: "mock"`**. To activate the real runtime: register the provider in `provider.ts`, then either flip that default or add provider selection to the new-session flow (gate on credentials being present — fall back to mock when unset, so local no-cred dev still works).
+
+---
+
+## 4. What's already built downstream (no work needed)
+
+The whole render path already handles the full `StreamChunk` union **including reasoning** — verified. So mapping the harness stream to `StreamChunk` correctly is *all* the UI needs.
+
+- **`src/lib/transcript/chunk-adapter.ts:43-177`** — `StreamChunk → UIMessageChunk`. Contiguous `reasoning` chunks coalesce into one reasoning part (`reasoning-start/delta/end`, `:90-103`); open text/reasoning parts mutually close; `tool_result` with `metadata.diff` → `data-diff` part.
+- **`src/components/folio/reasoning.tsx`** — the collapsible "thinking" aside (Radix Collapsible): auto-opens while streaming, auto-collapses 1s after, replayed reasoning mounts collapsed. `data-testid="reasoning"`.
+- **`src/components/folio/message.tsx:83-216`** — groups parts; reasoning→`<Reasoning>`, tools→`Workings`, diff→`DiffCard`.
+- **`src/app/(app)/sessions/[id]/live-session-view.tsx`** — `useChat` (`@ai-sdk/react`), throttled paint (`TOKEN_THROTTLE_MS=50`).
+- **Adversarial mock** (#785/#787) is a **UI fixture**, not a provider: `src/lib/fixtures/demo-session.ts:265+` (`adversarialSession()`), reachable at `/sessions/demo?scenario=adversarial` and `?scenario=long`. Useful to eyeball the design at scale; it never touches `ComputeProvider`.
+
+---
+
+## 5. Credentials — three things, three places (all gated)
+
+Full matrix: `web-next/docs/deploy.md:42-67`; template `web-next/.env.local.example`; sourcing values `web-next/CONTRIBUTING.md`.
+
+| Variable | Mac `.env.local` | Cloud dev | Vercel prod | Source |
+|---|---|---|---|---|
+| `AI_GATEWAY_API_KEY` (preferred) **or** `ANTHROPIC_API_KEY` | ✓ | ✓ | ✓ | `npx vercel ai-gateway api-keys create` / console.anthropic.com |
+| `VERCEL_TOKEN` / `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` | ✓ | ✓ | **✗** (prod uses auto-injected `VERCEL_OIDC_TOKEN`) | vercel.com/account/tokens (team **`cloudcompute`**) |
+| `GITHUB_WEB_WORKSPACES_APP_ID` + `GITHUB_APP_PRIVATE_KEY` | ✓ | ✓ | ✓ | `workspace-agents` GitHub App; PEM as single-line base64 |
+
+Concrete values from CONTRIBUTING: `VERCEL_TEAM_ID=team_oGt9u60VkiPutA2CiKDDGQKV`, `VERCEL_PROJECT_ID=prj_ucOY3JKR5BCrbtbfz8DTSFJe5U9m`, Vercel project `cloudcompute/web-next` (https://web-next-ivory-six.vercel.app). Repo clone uses **short-lived, repo-scoped GitHub App installation tokens** (1h) — not a personal/OAuth token.
+
+**Local review needs NONE of these** — only `AUTH_BYPASS=1` + `ALLOWED_LOGINS=fairchild`. Keep the provider falling back to mock when creds are absent so no-cred dev keeps working.
+
+**Credential smoke test (do this first): `GET /api/diag/gateway`** (`src/app/api/diag/gateway/route.ts`, #797). Auth-gated; makes one tiny real call through the AI Gateway (`anthropic/claude-haiku-4.5`, "Reply with exactly: gateway live"). Healthy: `{ ok:true, reply:"gateway live", model, usage, latencyMs }`. Prove creds + billing + routing work here *before* wiring the runtime. Note this probe reads `AI_GATEWAY_API_KEY` specifically — a bare `ANTHROPIC_API_KEY` won't satisfy it, though it *will* satisfy the harness adapter's `auth.anthropic` path.
+
+### Provisioning status (verified 2026-07-05 — partial, NOT fully unblocked)
+
+Michael began provisioning. Current state, checking key names only (values redacted):
+
+| Credential | Status | Note |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | ✓ set (root `./.env`) | model auth covered; gateway key optional |
+| `AI_GATEWAY_API_KEY` | ✗ | not set — so `/api/diag/gateway` will 500 until added; harness can use `ANTHROPIC_API_KEY` instead |
+| `VERCEL_TOKEN` | ✓ set (root `./.env` + Vercel prod) | see two corrections below |
+| `VERCEL_TEAM_ID` / `VERCEL_PROJECT_ID` | ✗ | **required off-platform** alongside the token; values known (`team_oGt9u60VkiPutA2CiKDDGQKV` / `prj_ucOY3JKR5BCrbtbfz8DTSFJe5U9m`) or `npx vercel link` in `web-next/` |
+| `GITHUB_WEB_WORKSPACES_APP_ID` | ✓ set (root `./.env`) | |
+| `GITHUB_APP_PRIVATE_KEY` | ✗ | **the repo-clone credential** — App ID present but PEM missing; sandbox can stream but can't clone without it |
+
+**Two corrections the orchestrator must make before phase 2 passes:**
+
+1. **Env-file location.** The runtime vars are in the **repo-root `./.env`**, but Next.js loads env from the `web-next/` cwd. `web-next/.env.local` is **absent**, so the dev server sees none of these. Move/copy the runtime vars into `web-next/.env.local` (`cp .env.local.example .env.local`, fill in). This is why nothing is wired yet despite the secrets existing.
+2. **Production `VERCEL_TOKEN` is contrary to the design.** It was added to the Vercel prod deployment, but `deploy.md:52,59` says prod authenticates the Sandbox via the **auto-injected `VERCEL_OIDC_TOKEN`** — a static token there is redundant and a larger blast radius. Verify OIDC works in prod with a sandbox smoke, then remove the static prod token. (Off-platform — Mac/cloud-dev — the static token is correct and needed.)
+
+**Remaining to run a real turn:** move vars to `web-next/.env.local` · add `VERCEL_TEAM_ID`+`VERCEL_PROJECT_ID` · add `GITHUB_APP_PRIVATE_KEY` · (optionally `AI_GATEWAY_API_KEY` if you want the gateway spend-cap path + a green diag probe). Model auth is already covered. This is the escalation trigger (recurring cost + secrets): the acceptance criteria are explicitly **live**, so confirm the full set with Michael or have him run the live gate before declaring the criteria met.
+
+---
+
+## 6. Proposed plan (phased, each phase independently reviewable)
+
+Serial, one concern at a time. The seam is additive; nothing below rewrites the pipeline.
+
+1. **Deps + version reconcile.** Add the three harness packages **exact-pinned** (`1.0.18`), bump `ai` to `7.0.15`. `pnpm install`, then `pnpm -C web-next typecheck && build` clean (watch the #780 `/404` stale-`.next` trap → `rm -rf .next`).
+2. **Credential preflight.** Vars are already in `web-next/.env.local`. Start the dev server and hit **`GET /api/diag/preflight?sandbox=1`** (built this session) — it proves model + GitHub clone + Vercel + live sandbox bash/clone in one call. (`/api/diag/gateway` is the narrow model-only probe.) Land the preflight as its own small PR first, with a green run as evidence. If a check fails → fix creds / escalate to Michael before wiring the provider.
+3. **Persistence: resume columns.** Migration `0003_*` adding `resume_from` (TEXT/JSON) + reusing/adding a harness session-id column; thread through `client.ts` + `sessions.ts`; keep `docs/schema.md` in sync. Behavior test the roundtrip.
+4. **The provider.** New `src/lib/agent-runtime/harness-provider.ts` — a `ComputeProvider` (`id: "vercel"` or `"claude-code"`) whose `runTurn` constructs/reuses the module-scope `HarnessAgent`, creates/reattaches a session (from persisted `sessionId`+`resumeFrom`), streams, maps `fullStream` parts → `StreamChunk`, and on turn end calls `detach()`/`stop()` and persists the new `resumeFrom`+`sessionId`. Register in `provider.ts`. **Log raw stream parts on the first run** to confirm the reasoning-delta field name and which extras surface (§2 caveats).
+5. **Activate selection.** Flip `startSession` off hardcoded `"mock"` when creds present (fall back to mock otherwise). Optionally optimize `resolveTurn` to use the new cursor (folds in the #773 carry-over).
+6. **Real turn + evidence.** Send a real coding message in the live app; confirm prose + reasoning + tool cards + diff + end-of-turn stats render in Folio, **both themes**. Capture **video** of a real turn (edit lands, tests run), light + dark. Record **TTFT** and the **across-turn sandbox-reuse delta** (turn 2 shouldn't re-clone). Run a **follow-up turn** to prove resume, and a **tab-close mid-turn → reopen** to prove durable replay still works.
+
+---
+
+## 7. Acceptance criteria (from #750) + process
+
+**Acceptance — all required:**
+- [ ] A real Claude Code turn streams (prose + tool cards + diff + end-of-turn stats) into Folio, both themes.
+- [ ] Follow-up turns resume the harness session; durable resume across tab-close still works.
+- [ ] Versions exact-pinned; harness confined to one provider file behind `ComputeProvider`.
+- [ ] Evidence: **video** of a real coding turn (edit lands, tests run), light + dark; pinned versions listed.
+- [ ] Perf: real TTFT recorded; across-turn sandbox-reuse delta shown.
+
+**⚠️ Open gate — clean build (was #780).** A clean `pnpm -C web-next install && pnpm -C web-next build` currently **fails** at prerender of `/500` and `/_error` with `<Html> should not be imported outside of pages/_document`, even after `rm -rf .next` (verified 2026-07-05 on this branch). #780 is closed but reproduces from clean — it's unrelated to any diff (Next's built-in error pages). `typecheck`/`lint`/unit tests are green. Settle this (reopen #780) before the real-runtime PR can claim a green build; if `web-next` CI is currently green on main, confirm whether the CI lane actually runs the prod build or is masking this.
+
+**Process (from the execution brief + repo CLAUDE.md):**
+- **One issue at a time, in order.** Full autonomous mandate; **self-merge** PRs scoped to `web-next/` (+ own CI/docs) that meet the Definition of Done.
+- **Escalate, don't work around:** open the PR but do **not** merge when a change incurs recurring cost, needs secrets, makes a one-way architectural call, has a security dimension, or CI fails the same way 3× — **and treat any harness API surprise (rename, missing capability, doc-contradicting behavior) as escalation-worthy.** #750 hits the "needs secrets + recurring cost" trigger directly.
+- **Reviewer gate:** every PR touching the runtime/backend seam → run `/code-review` via a **separate reviewer subagent on Opus** before merge.
+- **Author label:** add `author:fable-orchestrator` (or your agent slug) to the PR — the GitHub account is shared.
+- **Evidence is a merge gate.** Upload via `evidence.sh`/`mise run web:evidence -- --pr <N> --name <slug>`; paste hosted URLs into the PR body. Light+dark screenshots for UI; before/after/delta for perf. Remote sessions: see `docs/development/remote-sessions.md` for the sanctioned workarounds.
+- **DoD:** green `web-next` CI (lint/typecheck/unit/build/Playwright/perf, no skips), self-verification (drove the real flow), `/simplify` pass, behavior tests, `Closes #750`.
+- **Env note:** Node 22 + **pnpm 10** (pnpm 11 breaks `pnpm run` here — delete any stray `web-next/pnpm-workspace.yaml`).
+
+---
+
+## 8. Canonical references
+
+- **Issue:** #750 (open) · companions #784/#785/#780 (closed) · merged #777/#779/#781/#787/#793/#796/#797/#803.
+- **ADR:** `docs/decisions/web-next-harness-runtime.md` — the governing spec (additive `ComputeProvider`, harness owns projection/sandbox/auth/resume; we own the wrapper + persistence + terminal + UI; exit strategy = hand-roll the same contract).
+- **Contract:** `backlog/web-next-execution-brief.md` — autonomy, escalation, DoD.
+- **Design:** `web-next/docs/design.md` (Folio; calm/iA-Writer).
+- **Architecture + turn anatomy:** `web-next/docs/architecture.html` (#803).
+- **Deploy/creds:** `web-next/docs/deploy.md`; template `web-next/.env.local.example`; `web-next/CONTRIBUTING.md`.
+- **Schema doc:** `web-next/docs/schema.md` (keep in sync with the new migration).
+- **Harness typings (local):** `scratchpad/harness-inspect/*/package/dist/*.d.ts`.
+
+**Open questions to resolve empirically on the first real turn:** reasoning-delta field name (`delta` vs `text`); whether `file-change`/`compaction` reach the consumer stream; exact managed-sandbox snapshot behavior (does turn-2 truly skip re-clone). Instrument, don't guess — this repo's own lesson: "ship a diagnostic probe instead of your third guess."

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -23,7 +23,7 @@
 		"@radix-ui/react-collapsible": "^1.1.15",
 		"@radix-ui/react-use-controllable-state": "^1.2.3",
 		"@vercel/sandbox": "2.4.0",
-		"ai": "^7.0.14",
+		"ai": "7.0.15",
 		"better-auth": "1.6.20",
 		"kysely": "^0.28.17",
 		"next": "^15.5.19",

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -19,6 +19,7 @@
 		"@libsql/client": "^0.17.4",
 		"@radix-ui/react-collapsible": "^1.1.15",
 		"@radix-ui/react-use-controllable-state": "^1.2.3",
+		"@vercel/sandbox": "2.4.0",
 		"ai": "^7.0.14",
 		"better-auth": "1.6.20",
 		"kysely": "^0.28.17",

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -15,7 +15,10 @@
 		"perf": "node perf/run.mjs"
 	},
 	"dependencies": {
+		"@ai-sdk/harness": "1.0.18",
+		"@ai-sdk/harness-claude-code": "1.0.18",
 		"@ai-sdk/react": "^4.0.15",
+		"@ai-sdk/sandbox-vercel": "1.0.18",
 		"@libsql/client": "^0.17.4",
 		"@radix-ui/react-collapsible": "^1.1.15",
 		"@radix-ui/react-use-controllable-state": "^1.2.3",
@@ -26,6 +29,7 @@
 		"next": "^15.5.19",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
+		"ws": "^8.21.0",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: 2.4.0
         version: 2.4.0
       ai:
-        specifier: ^7.0.14
-        version: 7.0.14(zod@4.4.3)
+        specifier: 7.0.15
+        version: 7.0.15(zod@4.4.3)
       better-auth:
         specifier: 1.6.20
         version: 1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)))

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/harness':
+        specifier: 1.0.18
+        version: 1.0.18(ws@8.21.0)(zod@4.4.3)
+      '@ai-sdk/harness-claude-code':
+        specifier: 1.0.18
+        version: 1.0.18(zod@4.4.3)
       '@ai-sdk/react':
         specifier: ^4.0.15
         version: 4.0.15(react@19.2.7)(zod@4.4.3)
+      '@ai-sdk/sandbox-vercel':
+        specifier: 1.0.18
+        version: 1.0.18(ws@8.21.0)(zod@4.4.3)
       '@libsql/client':
         specifier: ^0.17.4
         version: 0.17.4
@@ -41,6 +50,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.7(react@19.2.7)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -90,6 +102,28 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.12':
+    resolution: {integrity: sha512-Y7Fy8xJwPz7ZC0DhSQG3HIVk+drup42hrIj6yqKlib3CxwiR0F7nYyUI8+kPrEtbZEoyKoRstvT4/o0HEyFBHA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/harness-claude-code@1.0.18':
+    resolution: {integrity: sha512-XJ2yHiLYRl6oB7wPGWUf8Q3Tcg/1WNKSumO5MQtosdbvwqjbENtMsIWqpPGegWgsfiP8VrmHX+SQ8gy0MgnrGA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/harness@1.0.18':
+    resolution: {integrity: sha512-zJCufxLWZAg8Nmucive5CT6wb4OAELycrwbF1FviRM7M+NSHSqU56HgAhMMcSVPvles0ZzkIsYomqiZ6e0PQYQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      ws: ^8.21.0
+      zod: ^3.25.76 || ^4.1.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+
   '@ai-sdk/mcp@2.0.7':
     resolution: {integrity: sha512-DX1v5M/R4RD2yi1KSH2ERLKcb6h2qJF0DKt0PGTTpNJNK+meXMmouwSRZS8Y+JocbyHk7U9p6PgqVmKU/e5XhQ==}
     engines: {node: '>=22'}
@@ -111,6 +145,10 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+
+  '@ai-sdk/sandbox-vercel@1.0.18':
+    resolution: {integrity: sha512-g854+zmgjH2UDCHgl6LrIuOHVn+5mt1e+nqRkMH5EGIjHSV2ClUNCmwrnoJ3y/9fHCtokBBKs9SqMEBFho9U9w==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1291,6 +1329,12 @@ packages:
 
   ai@7.0.14:
     resolution: {integrity: sha512-qA82fZyD4xh9IDB+s3SvwbjwjR+GGRmJjTYMwON1uROj8vPDIQbPTZLLq6ZWTVESn9daeH1GMv0zKfVLwNU2sQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.15:
+    resolution: {integrity: sha512-7406MUy9O5sIhwOgxEWuoj+td3XUGgG96SBt6pmBU4t4sQ2fpnDx5UnHaXT2HUTXl5GorbWz/MfCrSPRz0QJqw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2843,6 +2887,32 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.12(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/harness-claude-code@1.0.18(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/harness': 1.0.18(ws@8.21.0)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      ws: 8.21.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@ai-sdk/harness@1.0.18(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      ai: 7.0.15(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      ws: 8.21.0
+
   '@ai-sdk/mcp@2.0.7(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -2872,6 +2942,17 @@ snapshots:
       swr: 2.4.2(react@19.2.7)
       throttleit: 2.1.0
     transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/sandbox-vercel@1.0.18(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/harness': 1.0.18(ws@8.21.0)(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      '@vercel/sandbox': 2.4.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - ws
       - zod
 
   '@alloc/quick-lru@5.2.0': {}
@@ -3831,6 +3912,13 @@ snapshots:
   ai@7.0.14(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 4.0.11(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.2
+      '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      zod: 4.4.3
+
+  ai@7.0.15(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.12(zod@4.4.3)
       '@ai-sdk/provider': 4.0.2
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@vercel/sandbox':
+        specifier: 2.4.0
+        version: 2.4.0
       ai:
         specifier: ^7.0.14
         version: 7.0.14(zod@4.4.3)
@@ -1238,6 +1241,9 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/sandbox@2.4.0':
+    resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
+
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -1269,6 +1275,9 @@ packages:
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1343,6 +1352,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1355,12 +1367,28 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   better-auth@1.6.20:
     resolution: {integrity: sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==}
@@ -1737,6 +1765,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -1747,6 +1778,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2052,6 +2086,9 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
 
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -2270,6 +2307,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2386,6 +2427,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2488,6 +2533,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -2551,6 +2599,12 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -2623,6 +2677,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -2760,6 +2818,14 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3694,6 +3760,23 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/sandbox@2.4.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.28.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3736,6 +3819,8 @@ snapshots:
       tinyrainbow: 3.1.0
 
   '@workflow/serde@4.1.0': {}
+
+  '@workflow/serde@4.1.0-beta.2': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -3838,6 +3923,10 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -3846,9 +3935,13 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
 
   better-auth@1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))):
     dependencies:
@@ -4361,11 +4454,19 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.1.0: {}
 
   expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -4674,6 +4775,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  jsonlines@0.1.1: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -4889,6 +4992,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-paths@4.4.0: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -5000,6 +5105,8 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -5160,6 +5267,15 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.9
@@ -5235,6 +5351,21 @@ snapshots:
   tailwindcss@4.3.2: {}
 
   tapable@2.3.3: {}
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   throttleit@2.1.0: {}
 
@@ -5319,6 +5450,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.28.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:
@@ -5449,6 +5582,14 @@ snapshots:
   word-wrap@1.2.5: {}
 
   ws@8.21.0: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
 
   yocto-queue@0.1.0: {}
 

--- a/web-next/scripts/drive-turn.ts
+++ b/web-next/scripts/drive-turn.ts
@@ -1,0 +1,55 @@
+/*
+ * Local driver for the real "vercel" compute provider: runs one turn end-to-end
+ * (mint token → sandbox → Claude Code → clone/commit/push/PR) and prints the
+ * StreamChunks as they arrive. Not part of the app — a manual smoke harness.
+ *
+ *   node --env-file=.env.local --import tsx scripts/drive-turn.ts "your message"
+ */
+import { vercelProvider } from "../src/lib/agent-runtime/vercel-provider";
+
+const userMessage = process.argv[2] ?? "Open a smoke-test PR to prove the runtime works.";
+
+const started = Date.now();
+const t = () => `${((Date.now() - started) / 1000).toFixed(1)}s`;
+
+async function main() {
+	for await (const chunk of vercelProvider.runTurn({
+		sessionId: "local-drive",
+		userMessage,
+	})) {
+		switch (chunk.type) {
+		case "status":
+			console.log(`[${t()}] ● status: ${chunk.content}`);
+			break;
+		case "reasoning":
+			process.stdout.write(chunk.content);
+			break;
+		case "text":
+			process.stdout.write(chunk.content);
+			break;
+		case "tool_use":
+			console.log(
+				`\n[${t()}] → tool ${chunk.content} ${JSON.stringify(chunk.metadata?.input ?? {}).slice(0, 200)}`,
+			);
+			break;
+		case "tool_result":
+			console.log(
+				`[${t()}] ← result${chunk.metadata?.isError ? " (error)" : ""}: ${chunk.content.slice(0, 300)}`,
+			);
+			break;
+		case "error":
+			console.log(`\n[${t()}] ✗ error: ${chunk.content}`);
+			break;
+		case "done":
+			console.log(
+				`\n[${t()}] ✓ done — ${JSON.stringify(chunk.metadata ?? {})}`,
+			);
+			break;
+		}
+	}
+}
+
+main().catch((err) => {
+	console.error("\n[driver] fatal:", err);
+	process.exit(1);
+});

--- a/web-next/scripts/prewarm.ts
+++ b/web-next/scripts/prewarm.ts
@@ -1,0 +1,22 @@
+/*
+ * Local driver for prewarmVercelTemplate(): builds (or refreshes) the harness
+ * sandbox template and prints how long it took. Run it twice to confirm the
+ * second call is a fast idempotent no-op — the reuse guarantee runTurn depends on.
+ *
+ *   HARNESS_DEBUG=1 node --env-file=.env.local --import tsx scripts/prewarm.ts
+ */
+import { prewarmVercelTemplate } from "../src/lib/agent-runtime/vercel-provider";
+
+async function main() {
+	const started = Date.now();
+	console.log("[prewarm] building/refreshing template…");
+	const { tookMs } = await prewarmVercelTemplate();
+	console.log(
+		`[prewarm] done in ${(tookMs / 1000).toFixed(1)}s (wall ${((Date.now() - started) / 1000).toFixed(1)}s)`,
+	);
+}
+
+main().catch((err) => {
+	console.error("[prewarm] fatal:", err);
+	process.exit(1);
+});

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -15,7 +15,7 @@ import {
 	SessionView,
 	type SessionViewData,
 } from "@/components/folio/session-view";
-import type { FolioMessage } from "@/components/folio/types";
+import type { FolioDataParts, FolioMessage } from "@/components/folio/types";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
 const TOKEN_THROTTLE_MS = 50;
@@ -75,7 +75,10 @@ export function LiveSessionView({
 		experimental_throttle: TOKEN_THROTTLE_MS,
 		onData: (part) => {
 			if (part.type === "data-status") {
-				setSteps((current) => [...current, part.data.message]);
+				// ai@7.0.15's DataUIPart union stopped narrowing `data` on the
+				// literal type; our FolioDataParts contract fixes the shape.
+				const { message } = part.data as FolioDataParts["status"];
+				setSteps((current) => [...current, message]);
 			}
 		},
 	});

--- a/web-next/src/app/api/diag/preflight/route.ts
+++ b/web-next/src/app/api/diag/preflight/route.ts
@@ -1,0 +1,28 @@
+/*
+ * GET /api/diag/preflight — auth-gated environment health check for the #750
+ * real runtime. Default run proves model inference, GitHub App clone
+ * credentials, and Vercel access (cheap, no sandbox cost). Add `?sandbox=1` to
+ * also spin a live Vercel sandbox that runs bash and clones the repo inside it.
+ * Never returns secret values — only status and non-secret metadata. Returns
+ * 200 when every check passes/skips, 503 otherwise.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+import { runPreflight } from "@/lib/diag/preflight";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+export async function GET(request: Request) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const includeSandbox =
+		new URL(request.url).searchParams.get("sandbox") === "1";
+	const report = await runPreflight({ includeSandbox });
+	return Response.json(report, { status: report.ok ? 200 : 503 });
+}

--- a/web-next/src/app/api/diag/prewarm/route.ts
+++ b/web-next/src/app/api/diag/prewarm/route.ts
@@ -1,0 +1,37 @@
+/*
+ * GET /api/diag/prewarm — auth-gated trigger that builds (or refreshes) the
+ * harness sandbox template out of band, so the first real session turn resumes
+ * from a snapshot instead of paying the ~1–4 min claude-CLI install inside its
+ * own request budget (the chat route caps at maxDuration=300). Idempotent — a
+ * fast no-op once the snapshot exists. Hit it once after each deploy that
+ * changes the bootstrap recipe. Never returns secret values.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+import { prewarmVercelTemplate } from "@/lib/agent-runtime/vercel-provider";
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+export async function GET() {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	try {
+		const { tookMs } = await prewarmVercelTemplate();
+		return Response.json({ ok: true, onVercel: !!process.env.VERCEL, tookMs });
+	} catch (error) {
+		return Response.json(
+			{
+				ok: false,
+				onVercel: !!process.env.VERCEL,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			{ status: 503 },
+		);
+	}
+}

--- a/web-next/src/app/api/sessions/[id]/chat/route.ts
+++ b/web-next/src/app/api/sessions/[id]/chat/route.ts
@@ -12,6 +12,11 @@ import { runSessionTurn } from "@/lib/agent-runtime/run-turn";
 import { getDatabase } from "@/lib/db/client";
 import { getSession } from "@/lib/db/sessions";
 
+// The real (vercel) provider boots a sandbox and runs a full agent turn; give
+// the invocation room to settle via after(). The mock turn finishes in seconds.
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
 export async function POST(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> },

--- a/web-next/src/lib/agent-runtime/provider.ts
+++ b/web-next/src/lib/agent-runtime/provider.ts
@@ -7,6 +7,7 @@
  */
 import { mockProvider } from "./mock-provider";
 import type { StreamChunk } from "./stream-chunk";
+import { vercelProvider } from "./vercel-provider";
 
 export interface TurnRequest {
 	sessionId: string;
@@ -22,6 +23,7 @@ export interface ComputeProvider {
 
 const providers: Record<string, ComputeProvider> = {
 	[mockProvider.id]: mockProvider,
+	[vercelProvider.id]: vercelProvider,
 };
 
 export function getProvider(id: string): ComputeProvider {

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import { mapFullStream } from "./vercel-provider";
+import type { StreamChunk } from "./stream-chunk";
+
+type Part = { type: string; [k: string]: unknown };
+
+async function collect(parts: Part[]): Promise<StreamChunk[]> {
+	async function* source(): AsyncIterable<Part> {
+		for (const part of parts) yield part;
+	}
+	const out: StreamChunk[] = [];
+	for await (const chunk of mapFullStream(source(), 0)) out.push(chunk);
+	return out;
+}
+
+describe("mapFullStream", () => {
+	test("maps deltas and tool parts onto StreamChunks", async () => {
+		const chunks = await collect([
+			{ type: "start" }, // structural — dropped
+			{ type: "reasoning-delta", id: "r1", text: "thinking" },
+			{ type: "text-delta", id: "t1", text: "hello " },
+			{ type: "text-delta", id: "t1", text: "world" },
+			{
+				type: "tool-call",
+				toolCallId: "c1",
+				toolName: "bash",
+				input: { command: "ls" },
+			},
+			{ type: "tool-result", toolCallId: "c1", toolName: "bash", output: "a\nb" },
+			{ type: "finish", finishReason: "stop", totalUsage: { outputTokens: 42 } },
+		]);
+
+		expect(chunks.map((c) => c.type)).toEqual([
+			"reasoning",
+			"text",
+			"text",
+			"tool_use",
+			"tool_result",
+			"done",
+		]);
+
+		const toolUse = chunks.find((c) => c.type === "tool_use");
+		expect(toolUse?.content).toBe("bash");
+		expect(toolUse?.metadata).toMatchObject({
+			toolUseId: "c1",
+			toolName: "bash",
+			input: { command: "ls" },
+		});
+
+		const toolResult = chunks.find((c) => c.type === "tool_result");
+		expect(toolResult?.content).toBe("a\nb");
+		expect(toolResult?.metadata).toMatchObject({ toolUseId: "c1" });
+	});
+
+	test("carries finish outputTokens into the terminal done chunk", async () => {
+		const chunks = await collect([
+			{ type: "text-delta", id: "t1", text: "hi" },
+			{ type: "finish", finishReason: "stop", totalUsage: { outputTokens: 7 } },
+		]);
+		const done = chunks.at(-1);
+		expect(done?.type).toBe("done");
+		expect(done?.metadata).toMatchObject({ tokenCount: 7 });
+		expect(typeof done?.metadata?.durationMs).toBe("number");
+	});
+
+	test("tool-error maps to an errored tool_result", async () => {
+		const chunks = await collect([
+			{ type: "tool-error", toolCallId: "c1", error: "boom" },
+		]);
+		const result = chunks.find((c) => c.type === "tool_result");
+		expect(result?.content).toBe("boom");
+		expect(result?.metadata).toMatchObject({ toolUseId: "c1", isError: true });
+	});
+
+	test("error and abort parts both surface as error chunks", async () => {
+		const errChunks = await collect([{ type: "error", error: "kaput" }]);
+		expect(errChunks[0]).toMatchObject({ type: "error", content: "kaput" });
+
+		const abortChunks = await collect([{ type: "abort", reason: "cancelled" }]);
+		expect(abortChunks[0]).toMatchObject({
+			type: "error",
+			content: "aborted: cancelled",
+		});
+	});
+
+	test("always ends with exactly one done chunk, even with no finish part", async () => {
+		const chunks = await collect([{ type: "text-delta", id: "t1", text: "x" }]);
+		const dones = chunks.filter((c) => c.type === "done");
+		expect(dones).toHaveLength(1);
+		expect(chunks.at(-1)?.type).toBe("done");
+		expect(dones[0]?.metadata?.tokenCount).toBeUndefined();
+	});
+});

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -9,15 +9,34 @@
  * the AI Gateway. Heavy deps load lazily so the seam stays light for the mock
  * path; sessions opt in via sessions.provider = "vercel".
  */
+import type { HarnessAgentSandboxConfig } from "@ai-sdk/harness/agent";
 import { mintInstallationToken } from "../diag/github-app";
 import type { ComputeProvider, TurnRequest } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
+
+// Type-only imports of the lazily-loaded factories keep the seam light (no
+// eager harness load) while giving the shared builders real signatures.
+type CreateClaudeCode =
+	typeof import("@ai-sdk/harness-claude-code")["createClaudeCode"];
+type CreateVercelSandbox =
+	typeof import("@ai-sdk/sandbox-vercel")["createVercelSandbox"];
 
 /** Repo the agent clones and opens its PR against. */
 const TARGET_REPO = process.env.AGENT_TARGET_REPO ?? "fairchild/workspaces";
 /** Port the in-sandbox harness bridge binds; must be declared on the sandbox. */
 const BRIDGE_PORT = 4000;
 const SANDBOX_TIMEOUT_MS = 15 * 60 * 1000;
+/**
+ * Stable template name so `runTurn` and `prewarmVercelTemplate` target the same
+ * named snapshot; the harness reuses a template only when the sandbox identity
+ * matches, and the name is part of that identity.
+ */
+const TEMPLATE_NAME = "web-next-claude-code";
+/**
+ * Bump whenever the `onBootstrap` side effects change — it invalidates the
+ * reusable snapshot so the next prewarm (or first turn) rebuilds the template.
+ */
+const BOOTSTRAP_HASH = "claude-code-cli-v1";
 
 /**
  * A self-contained setup script written into the sandbox and run once per
@@ -145,6 +164,98 @@ function buildPrompt(userMessage: string): string {
 	].join("\n");
 }
 
+/**
+ * The model credential, anthropic-preferred. The claude CLI consumes
+ * ANTHROPIC_API_KEY natively (the most reliable in-sandbox path); the AI Gateway
+ * key is the fallback. Part of the template identity, so both `runTurn` and the
+ * prewarm path resolve it through this one function.
+ */
+function resolveAuth() {
+	const anthropicKey = process.env.ANTHROPIC_API_KEY;
+	const gatewayKey = process.env.AI_GATEWAY_API_KEY;
+	return anthropicKey
+		? { anthropic: { apiKey: anthropicKey } }
+		: gatewayKey
+			? { gateway: { apiKey: gatewayKey } }
+			: undefined;
+}
+
+/** The claude-code harness adapter. Identical inputs on both paths. */
+function createHarness(
+	createClaudeCode: CreateClaudeCode,
+	auth: ReturnType<typeof resolveAuth>,
+) {
+	return createClaudeCode({ auth, thinking: "on" });
+}
+
+/**
+ * The Vercel sandbox provider, built via the factory path with a stable `name`
+ * so `runTurn` and prewarm target the same named template snapshot.
+ */
+function createSandboxProvider(createVercelSandbox: CreateVercelSandbox) {
+	return createVercelSandbox({
+		runtime: "node22",
+		ports: [BRIDGE_PORT],
+		resources: { vcpus: 4 },
+		timeout: SANDBOX_TIMEOUT_MS,
+		token: process.env.VERCEL_TOKEN,
+		teamId: process.env.VERCEL_TEAM_ID,
+		projectId: process.env.VERCEL_PROJECT_ID,
+		name: TEMPLATE_NAME,
+	});
+}
+
+/**
+ * The bootstrap baked into the reusable snapshot: install the claude CLI so the
+ * bridge finds it on PATH. This is the template-identity-affecting config shared
+ * by `runTurn` and prewarm — no `onSession` here, since the per-turn credential
+ * injection is not part of the snapshot and must not enter the template identity.
+ */
+const SANDBOX_BOOTSTRAP: Omit<HarnessAgentSandboxConfig, "onSession"> = {
+	// Bake the claude CLI into the reusable snapshot so the bridge finds it on
+	// PATH; a verifiable install beats relying on the adapter's implicit
+	// first-start install (which was leaving `claude` missing).
+	bootstrapHash: BOOTSTRAP_HASH,
+	onBootstrap: async ({ session }) => {
+		const r = await session.run({
+			command:
+				"command -v claude >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code",
+		});
+		if (r.exitCode !== 0)
+			throw new Error(
+				`claude CLI install failed (exit ${r.exitCode}): ${r.stderr.slice(0, 400)}`,
+			);
+		if (process.env.HARNESS_DEBUG === "1") {
+			const v = await session.run({ command: "claude --version" });
+			console.error(`[dbg onBootstrap] claude installed: ${v.stdout.trim()}`);
+		}
+	},
+};
+
+/**
+ * Build (or refresh) the sandbox template out of band so the first user turn
+ * resumes from a snapshot instead of paying the ~1–4 min claude-CLI install
+ * inside its own request budget. Idempotent — a fast no-op once the snapshot
+ * exists. MUST build the harness adapter, sandbox provider, and bootstrap config
+ * through the same shared builders `runTurn` uses, or it warms a template the
+ * turn never reuses.
+ */
+export async function prewarmVercelTemplate(): Promise<{ tookMs: number }> {
+	const started = Date.now();
+	const [{ prepareHarnessSandboxTemplate }, { createClaudeCode }, { createVercelSandbox }] =
+		await Promise.all([
+			import("@ai-sdk/harness/agent"),
+			import("@ai-sdk/harness-claude-code"),
+			import("@ai-sdk/sandbox-vercel"),
+		]);
+	await prepareHarnessSandboxTemplate({
+		harness: createHarness(createClaudeCode, resolveAuth()),
+		sandboxProvider: createSandboxProvider(createVercelSandbox),
+		sandboxConfig: SANDBOX_BOOTSTRAP,
+	});
+	return { tookMs: Date.now() - started };
+}
+
 export const vercelProvider: ComputeProvider = {
 	id: "vercel",
 	async *runTurn(request: TurnRequest): AsyncIterable<StreamChunk> {
@@ -161,49 +272,16 @@ export const vercelProvider: ComputeProvider = {
 				import("@ai-sdk/sandbox-vercel"),
 			]);
 
-		const gatewayKey = process.env.AI_GATEWAY_API_KEY;
-		const anthropicKey = process.env.ANTHROPIC_API_KEY;
-		// Prefer the direct Anthropic key — the claude CLI consumes ANTHROPIC_API_KEY
-		// natively, the most reliable path in-sandbox; gateway is the fallback.
-		const auth = anthropicKey
-			? { anthropic: { apiKey: anthropicKey } }
-			: gatewayKey
-				? { gateway: { apiKey: gatewayKey } }
-				: undefined;
-
 		const debugHarness = process.env.HARNESS_DEBUG === "1";
 
 		const agent = new HarnessAgent({
 			id: `web-next-${request.sessionId}`,
-			harness: createClaudeCode({ auth, thinking: "on" }),
-			sandbox: createVercelSandbox({
-				runtime: "node22",
-				ports: [BRIDGE_PORT],
-				resources: { vcpus: 4 },
-				timeout: SANDBOX_TIMEOUT_MS,
-				token: process.env.VERCEL_TOKEN,
-				teamId: process.env.VERCEL_TEAM_ID,
-				projectId: process.env.VERCEL_PROJECT_ID,
-			}),
+			harness: createHarness(createClaudeCode, resolveAuth()),
+			sandbox: createSandboxProvider(createVercelSandbox),
 			sandboxConfig: {
-				// Bake the claude CLI into the reusable snapshot so the bridge finds
-				// it on PATH; a verifiable install beats relying on the adapter's
-				// implicit first-start install (which was leaving `claude` missing).
-				bootstrapHash: "claude-code-cli-v1",
-				onBootstrap: async ({ session }) => {
-					const r = await session.run({
-						command:
-							"command -v claude >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code",
-					});
-					if (r.exitCode !== 0)
-						throw new Error(
-							`claude CLI install failed (exit ${r.exitCode}): ${r.stderr.slice(0, 400)}`,
-						);
-					if (debugHarness) {
-						const v = await session.run({ command: "claude --version" });
-						console.error(`[dbg onBootstrap] claude installed: ${v.stdout.trim()}`);
-					}
-				},
+				// Same template-identity bootstrap as prewarm, plus the per-session
+				// credential hook (which is deliberately excluded from the snapshot).
+				...SANDBOX_BOOTSTRAP,
 				onSession: async ({ session }) => {
 					await session.writeTextFile({
 						path: "/tmp/git-setup.sh",

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -1,0 +1,252 @@
+/*
+ * The real compute provider: runs one Claude Code turn inside a Vercel sandbox
+ * via @ai-sdk/harness and streams its parts back as StreamChunks. The sandbox is
+ * created through the harness factory so its bootstrap installs the `claude` CLI
+ * (and reuses a snapshot template across turns); a per-session `onSession` hook
+ * injects the GitHub App installation token as a git credential — the token
+ * rides in via the command `env`, never the transcript — so the agent can clone,
+ * push, and open a PR against the target repo. The model authenticates through
+ * the AI Gateway. Heavy deps load lazily so the seam stays light for the mock
+ * path; sessions opt in via sessions.provider = "vercel".
+ */
+import { mintInstallationToken } from "../diag/github-app";
+import type { ComputeProvider, TurnRequest } from "./provider";
+import type { StreamChunk } from "./stream-chunk";
+
+/** Repo the agent clones and opens its PR against. */
+const TARGET_REPO = process.env.AGENT_TARGET_REPO ?? "fairchild/workspaces";
+/** Port the in-sandbox harness bridge binds; must be declared on the sandbox. */
+const BRIDGE_PORT = 4000;
+const SANDBOX_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * A self-contained setup script written into the sandbox and run once per
+ * session. It configures git identity and a credential store from $GH_TOKEN
+ * (passed via the command environment, not interpolated here) so clone/push
+ * authenticate, and drops the same token at /tmp/gh_token for the PR API call.
+ */
+const GIT_SETUP_SCRIPT = [
+	"set -e",
+	"umask 077",
+	'printf "https://x-access-token:%s@github.com\\n" "$GH_TOKEN" > "$HOME/.git-credentials"',
+	"git config --global credential.helper store",
+	"git config --global user.name 'web-next agent'",
+	"git config --global user.email 'agent@users.noreply.github.com'",
+	'printf "%s" "$GH_TOKEN" > /tmp/gh_token',
+	"",
+].join("\n");
+
+function asText(value: unknown): string {
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+/**
+ * Maps the AI SDK `fullStream` parts a harness turn produces onto the runtime's
+ * StreamChunk protocol. Structural parts (text/reasoning start-end, steps,
+ * tool-input deltas, raw) are dropped — the chunk adapter derives that framing
+ * from the deltas itself. A single terminal `done` closes the turn.
+ */
+async function* mapFullStream(
+	fullStream: AsyncIterable<{ type: string; [k: string]: unknown }>,
+	startedAt: number,
+): AsyncGenerator<StreamChunk> {
+	let outputTokens: number | undefined;
+	for await (const part of fullStream) {
+		if (process.env.HARNESS_DEBUG === "1")
+			console.error(`[dbg part] ${part.type} ${JSON.stringify(part).slice(0, 240)}`);
+		switch (part.type) {
+			case "text-delta":
+				if (part.text) yield { type: "text", content: part.text as string };
+				break;
+			case "reasoning-delta":
+				if (part.text)
+					yield { type: "reasoning", content: part.text as string };
+				break;
+			case "tool-call":
+				yield {
+					type: "tool_use",
+					content: asText(part.toolName),
+					metadata: {
+						toolUseId: part.toolCallId,
+						toolName: part.toolName,
+						input: part.input,
+					},
+				};
+				break;
+			case "tool-result":
+				yield {
+					type: "tool_result",
+					content: asText(part.output),
+					metadata: { toolUseId: part.toolCallId, output: part.output },
+				};
+				break;
+			case "tool-error":
+				yield {
+					type: "tool_result",
+					content: asText(part.error),
+					metadata: { toolUseId: part.toolCallId, isError: true },
+				};
+				break;
+			case "error":
+				yield { type: "error", content: asText(part.error) };
+				break;
+			case "abort":
+				yield {
+					type: "error",
+					content: `aborted${part.reason ? `: ${asText(part.reason)}` : ""}`,
+				};
+				break;
+			case "finish": {
+				const usage = part.totalUsage as { outputTokens?: number } | undefined;
+				outputTokens = usage?.outputTokens;
+				break;
+			}
+			default:
+				break; // structural parts — the adapter reconstructs framing
+		}
+	}
+	yield {
+		type: "done",
+		content: "",
+		metadata: { durationMs: Date.now() - startedAt, tokenCount: outputTokens },
+	};
+}
+
+/**
+ * The turn instructions: clone, branch, make a tiny marked change, push, and
+ * open a PR. Credentials are pre-wired globally (git credential store) with the
+ * raw token at /tmp/gh_token for the PR API — so the prompt names no secret.
+ */
+function buildPrompt(userMessage: string): string {
+	const stamp = new Date().toISOString();
+	const suffix = Math.random().toString(36).slice(2, 8);
+	const branch = `agent/runtime-smoke-${suffix}`;
+	// A fixed absolute repo dir keeps the file-edit builtins and bash in
+	// agreement — they resolve different working directories otherwise.
+	const repoDir = `/vercel/sandbox/repo-${suffix}`;
+	const line = `- ${stamp} — first PR opened by the web-next harness runtime. Request: ${userMessage.replace(/`/g, "'").slice(0, 200)}`;
+	return [
+		`Open a real pull request against the GitHub repository ${TARGET_REPO}. Use the ABSOLUTE path ${repoDir} for the working copy and absolute paths for every file operation and git command (git tool calls and the file-edit tools resolve different working directories, so absolute paths keep them consistent). Work through the steps in order and stop if any command fails, showing its output.`,
+		``,
+		`1. Clone the repo: \`git clone https://github.com/${TARGET_REPO}.git ${repoDir}\`. Credentials are configured globally, so this authenticates automatically.`,
+		`2. Create the branch: \`git -C ${repoDir} checkout -b ${branch}\`.`,
+		`3. Create the file \`${repoDir}/web-next/RUNTIME-SMOKE.md\` (use an absolute path) containing exactly this line:`,
+		`   ${line}`,
+		`4. Commit: \`git -C ${repoDir} add -A && git -C ${repoDir} commit -m "chore(web-next): runtime smoke — harness-opened PR"\`.`,
+		`5. Push the branch: \`git -C ${repoDir} push -u origin HEAD\`.`,
+		`6. Open a pull request against \`main\` via the GitHub API (the token is in /tmp/gh_token):`,
+		`   curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${TARGET_REPO}/pulls -d '{"title":"chore(web-next): runtime smoke — harness-opened PR","head":"${branch}","base":"main","body":"Opened automatically by the web-next harness runtime — a real PR from a session. Safe to review and close."}'`,
+		`7. Report the pull request URL (the \`html_url\` field of the API response).`,
+	].join("\n");
+}
+
+export const vercelProvider: ComputeProvider = {
+	id: "vercel",
+	async *runTurn(request: TurnRequest): AsyncIterable<StreamChunk> {
+		const startedAt = Date.now();
+
+		yield { type: "status", content: "Minting GitHub credential" };
+		const { token } = await mintInstallationToken(TARGET_REPO);
+
+		yield { type: "status", content: "Preparing sandbox runtime" };
+		const [{ HarnessAgent }, { createClaudeCode }, { createVercelSandbox }] =
+			await Promise.all([
+				import("@ai-sdk/harness/agent"),
+				import("@ai-sdk/harness-claude-code"),
+				import("@ai-sdk/sandbox-vercel"),
+			]);
+
+		const gatewayKey = process.env.AI_GATEWAY_API_KEY;
+		const anthropicKey = process.env.ANTHROPIC_API_KEY;
+		// Prefer the direct Anthropic key — the claude CLI consumes ANTHROPIC_API_KEY
+		// natively, the most reliable path in-sandbox; gateway is the fallback.
+		const auth = anthropicKey
+			? { anthropic: { apiKey: anthropicKey } }
+			: gatewayKey
+				? { gateway: { apiKey: gatewayKey } }
+				: undefined;
+
+		const debugHarness = process.env.HARNESS_DEBUG === "1";
+
+		const agent = new HarnessAgent({
+			id: `web-next-${request.sessionId}`,
+			harness: createClaudeCode({ auth, thinking: "on" }),
+			sandbox: createVercelSandbox({
+				runtime: "node22",
+				ports: [BRIDGE_PORT],
+				resources: { vcpus: 4 },
+				timeout: SANDBOX_TIMEOUT_MS,
+				token: process.env.VERCEL_TOKEN,
+				teamId: process.env.VERCEL_TEAM_ID,
+				projectId: process.env.VERCEL_PROJECT_ID,
+			}),
+			sandboxConfig: {
+				// Bake the claude CLI into the reusable snapshot so the bridge finds
+				// it on PATH; a verifiable install beats relying on the adapter's
+				// implicit first-start install (which was leaving `claude` missing).
+				bootstrapHash: "claude-code-cli-v1",
+				onBootstrap: async ({ session }) => {
+					const r = await session.run({
+						command:
+							"command -v claude >/dev/null 2>&1 || npm install -g @anthropic-ai/claude-code",
+					});
+					if (r.exitCode !== 0)
+						throw new Error(
+							`claude CLI install failed (exit ${r.exitCode}): ${r.stderr.slice(0, 400)}`,
+						);
+					if (debugHarness) {
+						const v = await session.run({ command: "claude --version" });
+						console.error(`[dbg onBootstrap] claude installed: ${v.stdout.trim()}`);
+					}
+				},
+				onSession: async ({ session }) => {
+					await session.writeTextFile({
+						path: "/tmp/git-setup.sh",
+						content: GIT_SETUP_SCRIPT,
+					});
+					const res = await session.run({
+						command: "bash /tmp/git-setup.sh",
+						env: { GH_TOKEN: token },
+					});
+					if (res.exitCode !== 0)
+						throw new Error(
+							`git credential setup failed (exit ${res.exitCode}): ${res.stderr.slice(0, 300)}`,
+						);
+					if (debugHarness) {
+						const chk = await session.run({ command: "which claude" });
+						console.error(
+							`[dbg onSession] git configured; claude=${chk.stdout.trim() || "MISSING"} (exit ${chk.exitCode})`,
+						);
+					}
+				},
+			},
+			...(debugHarness
+				? {
+						debug: { enabled: true, level: "debug" as const },
+						onLog: (e: { level: string; subsystem: string; message: string }) =>
+							console.error(`[harness ${e.level}] ${e.subsystem}: ${e.message}`),
+					}
+				: {}),
+		});
+
+		yield { type: "status", content: "Booting Claude Code in sandbox" };
+		const session = await agent.createSession();
+		try {
+			const result = await agent.stream({
+				session,
+				prompt: buildPrompt(request.userMessage),
+			});
+			yield* mapFullStream(
+				result.fullStream as AsyncIterable<{ type: string; [k: string]: unknown }>,
+				startedAt,
+			);
+		} finally {
+			await session.destroy().catch(() => {});
+		}
+	},
+};

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -70,7 +70,7 @@ function asText(value: unknown): string {
  * tool-input deltas, raw) are dropped — the chunk adapter derives that framing
  * from the deltas itself. A single terminal `done` closes the turn.
  */
-async function* mapFullStream(
+export async function* mapFullStream(
 	fullStream: AsyncIterable<{ type: string; [k: string]: unknown }>,
 	startedAt: number,
 ): AsyncGenerator<StreamChunk> {
@@ -137,9 +137,15 @@ async function* mapFullStream(
 }
 
 /**
- * The turn instructions: clone, branch, make a tiny marked change, push, and
- * open a PR. Credentials are pre-wired globally (git credential store) with the
- * raw token at /tmp/gh_token for the PR API — so the prompt names no secret.
+ * TEMPORARY (#826): a fixed clone→branch→create-marker→push→open-PR smoke
+ * script. It proves the runtime plumbing end to end but does NOT yet drive the
+ * turn from the user's message — `userMessage` rides in only as a marker line,
+ * not as the instruction. Replacing this with a prompt driven by the user's
+ * actual request (against the session's working copy) is #826, which also
+ * carries the #750 render/resume/perf acceptance evidence.
+ *
+ * Credentials are pre-wired globally (git credential store) with the raw token
+ * at /tmp/gh_token for the PR API — so the prompt names no secret.
  */
 function buildPrompt(userMessage: string): string {
 	const stamp = new Date().toISOString();

--- a/web-next/src/lib/db/start-session.ts
+++ b/web-next/src/lib/db/start-session.ts
@@ -18,9 +18,18 @@ export function isValidRepoFullName(value: string): boolean {
 }
 
 /**
+ * Which compute provider new sessions run on. Defaults to the mock; set
+ * `WEB_NEXT_COMPUTE_PROVIDER=vercel` to route new sessions to the real
+ * harness-backed sandbox runtime.
+ */
+export function defaultComputeProvider(): string {
+	return process.env.WEB_NEXT_COMPUTE_PROVIDER ?? "mock";
+}
+
+/**
  * Creates (or reuses) the repo and starts an empty session on it.
- * Title stays empty until a first turn names it; provider is the mock
- * until #748 wires real compute.
+ * Title stays empty until a first turn names it; the provider comes from
+ * `defaultComputeProvider()` (mock unless configured otherwise).
  */
 export async function startSession(
 	handle: DatabaseHandle,
@@ -34,6 +43,6 @@ export async function startSession(
 	return createSession(handle, {
 		id: crypto.randomUUID(),
 		repoId: repo.id,
-		provider: "mock",
+		provider: defaultComputeProvider(),
 	});
 }

--- a/web-next/src/lib/diag/github-app.test.ts
+++ b/web-next/src/lib/diag/github-app.test.ts
@@ -1,0 +1,57 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { generateAppJWT, normalizePrivateKey } from "./github-app";
+
+// A throwaway RSA keypair — the App private-key handling and RS256 signing are
+// the error-prone parts (base64 vs PEM, correct signature), so verify them
+// end-to-end without any network.
+const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: "spki", format: "pem" },
+	privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+describe("normalizePrivateKey", () => {
+	it("passes a real multi-line PEM through unchanged", () => {
+		expect(normalizePrivateKey(privateKey)).toBe(privateKey.trim());
+	});
+
+	it("restores newlines from a single-line escaped PEM", () => {
+		const escaped = privateKey.trim().replace(/\n/g, "\\n");
+		expect(normalizePrivateKey(escaped)).toBe(privateKey.trim());
+	});
+
+	it("decodes a base64-encoded PEM (web-next's .env convention)", () => {
+		const b64 = Buffer.from(privateKey).toString("base64");
+		expect(normalizePrivateKey(b64)).toBe(privateKey);
+	});
+});
+
+describe("generateAppJWT", () => {
+	it("produces a three-part token with a valid RS256 signature and claims", () => {
+		const jwt = generateAppJWT("123456", privateKey);
+		const [header, payload, signature] = jwt.split(".");
+		expect(header && payload && signature).toBeTruthy();
+
+		const verifier = crypto.createVerify("RSA-SHA256");
+		verifier.update(`${header}.${payload}`);
+		expect(
+			verifier.verify(publicKey, Buffer.from(signature, "base64url")),
+		).toBe(true);
+
+		const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+		expect(claims.iss).toBe("123456");
+		expect(claims.exp - claims.iat).toBe(660); // 10min window + 60s backdate
+	});
+
+	it("accepts a base64-encoded key (signature still verifies)", () => {
+		const b64 = Buffer.from(privateKey).toString("base64");
+		const jwt = generateAppJWT("123456", b64);
+		const [header, payload, signature] = jwt.split(".");
+		const verifier = crypto.createVerify("RSA-SHA256");
+		verifier.update(`${header}.${payload}`);
+		expect(
+			verifier.verify(publicKey, Buffer.from(signature, "base64url")),
+		).toBe(true);
+	});
+});

--- a/web-next/src/lib/diag/github-app.ts
+++ b/web-next/src/lib/diag/github-app.ts
@@ -86,6 +86,24 @@ export async function getInstallationToken(
 	};
 }
 
+/**
+ * End-to-end: read the App id + key from the environment, discover the repo's
+ * installation, and mint a short-lived installation token. The credential the
+ * real runtime hands a sandbox to clone, push, and open PRs against `repo`.
+ */
+export async function mintInstallationToken(repo: string): Promise<InstallationToken> {
+	const appId = process.env.GITHUB_WEB_WORKSPACES_APP_ID;
+	const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+	if (!appId || !privateKey) {
+		throw new Error(
+			"GITHUB_WEB_WORKSPACES_APP_ID and GITHUB_APP_PRIVATE_KEY are required to mint an installation token",
+		);
+	}
+	const jwt = generateAppJWT(appId, privateKey);
+	const installationId = await findInstallationId(jwt, repo);
+	return getInstallationToken(jwt, installationId);
+}
+
 /** Prove the token can read the repo — i.e. it can clone it. */
 export async function verifyRepoAccess(
 	token: string,

--- a/web-next/src/lib/diag/github-app.ts
+++ b/web-next/src/lib/diag/github-app.ts
@@ -1,0 +1,108 @@
+/*
+ * GitHub App auth, hand-rolled with node:crypto (no external dep). Mints an App
+ * JWT, discovers the target repo's installation, and exchanges it for a
+ * short-lived, repo-scoped installation token — the credential a sandbox uses
+ * to clone. Used by the preflight probe now; reusable by the #750 provider.
+ */
+import crypto from "node:crypto";
+
+function base64url(input: Buffer | string): string {
+	const buf = typeof input === "string" ? Buffer.from(input) : input;
+	return buf.toString("base64url");
+}
+
+/**
+ * Accepts either a raw PEM (optionally single-line with escaped `\n`, as `web/`
+ * stores it) or a base64-encoded PEM (as web-next's `.env.local.example`
+ * prescribes). Returns a real multi-line PEM either way.
+ */
+export function normalizePrivateKey(raw: string): string {
+	const s = raw.trim();
+	if (s.includes("BEGIN")) return s.replace(/\\n/g, "\n");
+	return Buffer.from(s, "base64").toString("utf8");
+}
+
+export function generateAppJWT(appId: string, privateKeyPem: string): string {
+	const now = Math.floor(Date.now() / 1000);
+	const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+	const payload = base64url(
+		JSON.stringify({ iss: appId, iat: now - 60, exp: now + 600 }),
+	);
+	const data = `${header}.${payload}`;
+	const signature = crypto.sign(
+		"sha256",
+		Buffer.from(data),
+		normalizePrivateKey(privateKeyPem),
+	);
+	return `${data}.${base64url(signature)}`;
+}
+
+const GH = "https://api.github.com";
+const HEADERS = {
+	Accept: "application/vnd.github+json",
+	"User-Agent": "web-next-preflight",
+	"X-GitHub-Api-Version": "2022-11-28",
+};
+
+async function ghError(res: Response, label: string): Promise<never> {
+	const body = await res.text().catch(() => "");
+	throw new Error(`${label} (${res.status}): ${body.slice(0, 300)}`);
+}
+
+/** Which installation covers this repo — avoids needing an installation-id env var. */
+export async function findInstallationId(jwt: string, repo: string): Promise<number> {
+	const res = await fetch(`${GH}/repos/${repo}/installation`, {
+		headers: { Authorization: `Bearer ${jwt}`, ...HEADERS },
+	});
+	if (!res.ok) return ghError(res, `installation lookup for ${repo}`);
+	const json = (await res.json()) as { id: number };
+	return json.id;
+}
+
+export interface InstallationToken {
+	token: string;
+	expiresAt: string;
+	permissions: Record<string, string>;
+}
+
+export async function getInstallationToken(
+	jwt: string,
+	installationId: number,
+): Promise<InstallationToken> {
+	const res = await fetch(
+		`${GH}/app/installations/${installationId}/access_tokens`,
+		{ method: "POST", headers: { Authorization: `Bearer ${jwt}`, ...HEADERS } },
+	);
+	if (!res.ok) return ghError(res, "installation token exchange");
+	const json = (await res.json()) as {
+		token: string;
+		expires_at: string;
+		permissions: Record<string, string>;
+	};
+	return {
+		token: json.token,
+		expiresAt: json.expires_at,
+		permissions: json.permissions,
+	};
+}
+
+/** Prove the token can read the repo — i.e. it can clone it. */
+export async function verifyRepoAccess(
+	token: string,
+	repo: string,
+): Promise<{ fullName: string; defaultBranch: string; private: boolean }> {
+	const res = await fetch(`${GH}/repos/${repo}`, {
+		headers: { Authorization: `token ${token}`, ...HEADERS },
+	});
+	if (!res.ok) return ghError(res, `repo read for ${repo}`);
+	const json = (await res.json()) as {
+		full_name: string;
+		default_branch: string;
+		private: boolean;
+	};
+	return {
+		fullName: json.full_name,
+		defaultBranch: json.default_branch,
+		private: json.private,
+	};
+}

--- a/web-next/src/lib/diag/preflight.ts
+++ b/web-next/src/lib/diag/preflight.ts
@@ -1,0 +1,344 @@
+/*
+ * Environment preflight: one call that proves every capability a real #750 turn
+ * needs — model inference, GitHub App clone credentials, Vercel access, and
+ * (opt-in) a live sandbox that runs bash and clones the repo. Each check is
+ * isolated so one failure still reports the rest. Secret values are never
+ * returned — only presence, status, and non-secret metadata.
+ */
+import {
+	generateAppJWT,
+	findInstallationId,
+	getInstallationToken,
+	verifyRepoAccess,
+} from "./github-app";
+
+export interface CheckResult {
+	name: string;
+	ok: boolean;
+	/** A pass that did nothing (e.g. on-platform OIDC, or sandbox not requested). */
+	skipped?: boolean;
+	detail?: Record<string, unknown>;
+	error?: string;
+	latencyMs?: number;
+}
+
+export interface PreflightReport {
+	ok: boolean;
+	ranAt: string;
+	onVercel: boolean;
+	cloneRepo: string;
+	checks: CheckResult[];
+	tookMs: number;
+}
+
+/** Repo the GitHub + sandbox-clone checks target. */
+const CLONE_REPO = process.env.PREFLIGHT_CLONE_REPO ?? "fairchild/workspaces";
+
+type CheckBody = Omit<CheckResult, "name" | "latencyMs">;
+
+async function timed(
+	name: string,
+	fn: () => Promise<CheckBody>,
+): Promise<CheckResult> {
+	const started = Date.now();
+	try {
+		return { name, latencyMs: Date.now() - started, ...(await fn()) };
+	} catch (e) {
+		return {
+			name,
+			ok: false,
+			latencyMs: Date.now() - started,
+			error: e instanceof Error ? e.message : String(e),
+		};
+	}
+}
+
+/** Redact an inline clone credential from any captured sandbox output. */
+function redact(s: string): string {
+	return s.replace(/x-access-token:[^@\s]*@/g, "x-access-token:***@");
+}
+
+function checkEnv(): CheckResult {
+	const all = [
+		"AI_GATEWAY_API_KEY",
+		"ANTHROPIC_API_KEY",
+		"VERCEL_TOKEN",
+		"VERCEL_TEAM_ID",
+		"VERCEL_PROJECT_ID",
+		"VERCEL_OIDC_TOKEN",
+		"GITHUB_WEB_WORKSPACES_APP_ID",
+		"GITHUB_APP_PRIVATE_KEY",
+	];
+	const present = all.filter((v) => !!process.env[v]);
+	const missing = all.filter((v) => !process.env[v]);
+	const hasModel = !!(
+		process.env.AI_GATEWAY_API_KEY || process.env.ANTHROPIC_API_KEY
+	);
+	const hasVercel = !!(
+		process.env.VERCEL_OIDC_TOKEN ||
+		(process.env.VERCEL_TOKEN &&
+			process.env.VERCEL_TEAM_ID &&
+			process.env.VERCEL_PROJECT_ID)
+	);
+	const hasGithub = !!(
+		process.env.GITHUB_WEB_WORKSPACES_APP_ID &&
+		process.env.GITHUB_APP_PRIVATE_KEY
+	);
+	return {
+		name: "env",
+		ok: hasModel && hasVercel && hasGithub,
+		detail: { present, missing, hasModel, hasVercel, hasGithub },
+	};
+}
+
+async function checkLlm(): Promise<CheckBody> {
+	const gateway = process.env.AI_GATEWAY_API_KEY;
+	if (gateway) {
+		const res = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${gateway}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				model: "anthropic/claude-haiku-4.5",
+				messages: [{ role: "user", content: "Reply with exactly: gateway live" }],
+				max_tokens: 10,
+			}),
+		});
+		const body = await res.json().catch(() => null);
+		if (!res.ok) throw new Error(`gateway ${res.status}: ${JSON.stringify(body).slice(0, 300)}`);
+		return {
+			ok: true,
+			detail: {
+				via: "ai-gateway",
+				model: body?.model,
+				reply: body?.choices?.[0]?.message?.content,
+			},
+		};
+	}
+	const anthropic = process.env.ANTHROPIC_API_KEY;
+	if (anthropic) {
+		const res = await fetch("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: {
+				"x-api-key": anthropic,
+				"anthropic-version": "2023-06-01",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				model: "claude-haiku-4-5-20251001",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "Reply with exactly: anthropic live" }],
+			}),
+		});
+		const body = await res.json().catch(() => null);
+		if (!res.ok) throw new Error(`anthropic ${res.status}: ${JSON.stringify(body).slice(0, 300)}`);
+		return {
+			ok: true,
+			detail: {
+				via: "anthropic-direct",
+				model: body?.model,
+				reply: body?.content?.[0]?.text,
+			},
+		};
+	}
+	return { ok: false, error: "no model credential (AI_GATEWAY_API_KEY or ANTHROPIC_API_KEY)" };
+}
+
+async function checkVercel(): Promise<CheckBody> {
+	const token = process.env.VERCEL_TOKEN;
+	const teamId = process.env.VERCEL_TEAM_ID;
+	const projectId = process.env.VERCEL_PROJECT_ID;
+	if (!token) {
+		if (process.env.VERCEL_OIDC_TOKEN) {
+			return {
+				ok: true,
+				skipped: true,
+				detail: {
+					mode: "oidc",
+					note: "on-platform OIDC token present; the sandbox check validates it end-to-end",
+				},
+			};
+		}
+		return { ok: false, error: "VERCEL_TOKEN unset and no VERCEL_OIDC_TOKEN" };
+	}
+	const scope = teamId ? `?teamId=${teamId}` : "";
+	const userRes = await fetch(`https://api.vercel.com/v2/user${scope}`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!userRes.ok) throw new Error(`VERCEL_TOKEN invalid (${userRes.status})`);
+	const user = (await userRes.json().catch(() => null)) as {
+		user?: { username?: string };
+	} | null;
+	let project: string | undefined;
+	if (projectId) {
+		const pRes = await fetch(
+			`https://api.vercel.com/v9/projects/${projectId}${scope}`,
+			{ headers: { Authorization: `Bearer ${token}` } },
+		);
+		if (!pRes.ok) {
+			throw new Error(
+				`project ${projectId} unreachable (${pRes.status}) — check the token's team scope`,
+			);
+		}
+		const p = (await pRes.json().catch(() => null)) as { name?: string } | null;
+		project = p?.name ?? projectId;
+	}
+	return {
+		ok: true,
+		detail: { mode: "token", user: user?.user?.username, teamId, project },
+	};
+}
+
+/** Mint + verify the GitHub App token, returning it (out of band) for the clone check. */
+async function mintGithub(): Promise<{ result: CheckResult; token?: string }> {
+	const started = Date.now();
+	const appId = process.env.GITHUB_WEB_WORKSPACES_APP_ID;
+	const pk = process.env.GITHUB_APP_PRIVATE_KEY;
+	if (!appId || !pk) {
+		return {
+			result: {
+				name: "github",
+				ok: false,
+				latencyMs: Date.now() - started,
+				error: "GITHUB_WEB_WORKSPACES_APP_ID or GITHUB_APP_PRIVATE_KEY unset",
+			},
+		};
+	}
+	try {
+		const jwt = generateAppJWT(appId, pk);
+		const installationId = await findInstallationId(jwt, CLONE_REPO);
+		const tok = await getInstallationToken(jwt, installationId);
+		const repo = await verifyRepoAccess(tok.token, CLONE_REPO);
+		return {
+			token: tok.token,
+			result: {
+				name: "github",
+				ok: true,
+				latencyMs: Date.now() - started,
+				detail: {
+					repo: repo.fullName,
+					defaultBranch: repo.defaultBranch,
+					private: repo.private,
+					installationId,
+					tokenExpiresAt: tok.expiresAt,
+					permissions: tok.permissions,
+				},
+			},
+		};
+	} catch (e) {
+		return {
+			result: {
+				name: "github",
+				ok: false,
+				latencyMs: Date.now() - started,
+				error: e instanceof Error ? e.message : String(e),
+			},
+		};
+	}
+}
+
+/** Opt-in: create a live sandbox, run bash, and clone the repo inside it. */
+async function checkSandbox(cloneToken?: string): Promise<CheckResult> {
+	const started = Date.now();
+	const detail: Record<string, unknown> = {};
+	let sandbox: Awaited<ReturnType<typeof import("@vercel/sandbox").Sandbox.create>> | undefined;
+	try {
+		const mod = await import("@vercel/sandbox").catch(() => null);
+		if (!mod) {
+			return {
+				name: "sandbox",
+				ok: false,
+				skipped: true,
+				latencyMs: Date.now() - started,
+				error: "@vercel/sandbox not installed",
+			};
+		}
+		sandbox = await mod.Sandbox.create({
+			token: process.env.VERCEL_TOKEN,
+			teamId: process.env.VERCEL_TEAM_ID,
+			projectId: process.env.VERCEL_PROJECT_ID,
+			runtime: "node22",
+			resources: { vcpus: 2 },
+			timeout: 5 * 60 * 1000,
+		});
+		detail.created = true;
+
+		const bash = await sandbox.runCommand({
+			cmd: "bash",
+			args: ["-lc", "echo preflight-bash-ok && uname -s && (node --version || true)"],
+		});
+		detail.bash = {
+			exitCode: bash.exitCode,
+			output: redact((await bash.output("both")).trim()).slice(0, 500),
+		};
+
+		if (cloneToken) {
+			const url = `https://x-access-token:${cloneToken}@github.com/${CLONE_REPO}.git`;
+			const clone = await sandbox.runCommand({
+				cmd: "git",
+				args: ["clone", "--depth", "1", url, "/tmp/preflight-repo"],
+			});
+			const probe =
+				clone.exitCode === 0
+					? await sandbox.runCommand({
+							cmd: "bash",
+							args: [
+								"-lc",
+								"ls /tmp/preflight-repo | head -20 && echo --- && git -C /tmp/preflight-repo rev-parse HEAD",
+							],
+						})
+					: clone;
+			detail.clone = {
+				exitCode: clone.exitCode,
+				ok: clone.exitCode === 0,
+				sample: redact((await probe.output("both")).trim()).slice(0, 500),
+			};
+		} else {
+			detail.clone = { skipped: true, reason: "github check yielded no token to clone with" };
+		}
+
+		const bashOk = (detail.bash as { exitCode: number }).exitCode === 0;
+		const cloneOk = !cloneToken || (detail.clone as { ok?: boolean }).ok === true;
+		return {
+			name: "sandbox",
+			ok: detail.created === true && bashOk && cloneOk,
+			latencyMs: Date.now() - started,
+			detail,
+		};
+	} catch (e) {
+		return {
+			name: "sandbox",
+			ok: false,
+			latencyMs: Date.now() - started,
+			detail,
+			error: e instanceof Error ? e.message : String(e),
+		};
+	} finally {
+		if (sandbox) await sandbox.stop().catch(() => {});
+	}
+}
+
+export async function runPreflight({
+	includeSandbox,
+}: {
+	includeSandbox: boolean;
+}): Promise<PreflightReport> {
+	const started = Date.now();
+	const [llm, vercel, gh] = await Promise.all([
+		timed("llm", checkLlm),
+		timed("vercel", checkVercel),
+		mintGithub(),
+	]);
+	const checks: CheckResult[] = [checkEnv(), llm, vercel, gh.result];
+	if (includeSandbox) checks.push(await checkSandbox(gh.token));
+	return {
+		ok: checks.every((c) => c.ok || c.skipped),
+		ranAt: new Date().toISOString(),
+		onVercel: !!process.env.VERCEL,
+		cloneRepo: CLONE_REPO,
+		checks,
+		tookMs: Date.now() - started,
+	};
+}


### PR DESCRIPTION
## Summary

Stands up the real, harness-backed agent runtime for web-next and de-risks its
production cold start. Sessions can now run a live Claude Code turn inside a
Vercel sandbox and open a real PR against the target repo — proven end to end
(a session opened [#821](https://github.com/fairchild/workspaces/pull/821)).

Three coherent pieces, behind the existing `ComputeProvider` seam (mock stays
the default; sessions opt in via `WEB_NEXT_COMPUTE_PROVIDER=vercel`):

- **Environment preflight** (`GET /api/diag/preflight`, `src/lib/diag/preflight.ts`,
  `github-app.ts`) — auth-gated health check proving model inference, GitHub App
  clone credentials, and Vercel access; `?sandbox=1` also spins a live sandbox and
  clones inside it. Never returns secret values.
- **Real `vercel` ComputeProvider** (`src/lib/agent-runtime/vercel-provider.ts`) —
  boots Claude Code through the harness **factory path** so the bootstrap installs
  the `claude` CLI into a reusable snapshot; a per-session `onSession` hook injects
  the GitHub App installation token as a git credential (the token rides in via the
  command `env`, never the transcript) so the agent can clone/push/open a PR. Maps
  the AI SDK `fullStream` onto the runtime's `StreamChunk` protocol.
- **Template prewarm** (`prewarmVercelTemplate()`, `GET /api/diag/prewarm`) — the
  factory builds the snapshot (installing the CLI, ~1–4 min) inside `createSession`
  on the first turn; on Vercel the chat route caps at `maxDuration=300`, so a cold
  first prod turn risks timing out mid-build. `prepareHarnessSandboxTemplate` builds
  it **out of band** via an auth-gated route hit once after a deploy. `runTurn` and
  the prewarm path share the same builders (`resolveAuth` / `createHarness` /
  `createSandboxProvider` / `SANDBOX_BOOTSTRAP`, stable `TEMPLATE_NAME` +
  `BOOTSTRAP_HASH`) so the recipe identity matches and the snapshot is actually
  reused; `onSession` stays out of the shared bootstrap so per-turn credentials
  never enter the snapshot identity.

**Advances #750** (does not close it). This lands the runtime **plumbing** —
preflight, the `vercel` provider, and template prewarm — behind an opt-in env
gate. The #750 acceptance criteria (a real turn driven by the user's message
streaming into Folio; session resume across tab-close; a dual-theme video;
real TTFT) are deliberately **not** met here and move to **#826**. `buildPrompt`
is currently a fixed smoke script, marked `TEMPORARY (#826)` in the code.

## Mergeability

- Surface: web / agent-runtime — compute provider, sandbox bootstrap, and two auth-gated diagnostic routes.
- User-facing behavior changed: No default change — mock remains the default provider. New sessions run on the real sandbox only when `WEB_NEXT_COMPUTE_PROVIDER=vercel`; the new routes are auth-gated diagnostics.
- Non-happy paths considered: missing model/GitHub/Vercel credentials surface as explicit preflight failures (503, no secret values); sandbox `run`/credential-setup non-zero exits throw with truncated stderr; harness `error`/`abort` stream parts map to `error` chunks; the session is destroyed in `finally`; prewarm failures return 503 with the message. GitHub-sourced text stays untrusted across the sandbox execution boundary.
- Release/ops preconditions: none — no release/signing/CI-runner files touched. Prod requires `WEB_NEXT_COMPUTE_PROVIDER=vercel` + `ANTHROPIC_API_KEY` (already set) and a one-time `GET /api/diag/prewarm` after each recipe-changing deploy to warm the snapshot.
- Residual risk or follow-up: **#826** carries the real turn-driving prompt and the #750 render/resume/perf acceptance evidence; `buildPrompt` is a `TEMPORARY (#826)` smoke script until then. First prod turn is only warm after the manual prewarm hit (auto-trigger via deploy hook is a noted follow-up); bumping `onBootstrap`/`BOOTSTRAP_HASH`/sandbox `name` invalidates the snapshot and needs a re-warm. #780 is a local-only dev-build annoyance (prod build passes) and does not gate this.

## Validation

Scope of this PR is runtime plumbing; evidence matches that scope. The #750
acceptance evidence (dual-theme render video, resume, TTFT) lands with #826.

- `pnpm exec tsc --noEmit` — clean (exit 0)
- `pnpm run lint` (eslint) — clean (exit 0)
- `pnpm run test` (vitest) — **127 passed** (16 files; +5 new `mapFullStream` unit tests)
- Prewarm reuse proved locally: cold build 28.3s (claude 2.1.201 installed via `onBootstrap`) → warm re-run 9.0s with `onBootstrap` short-circuited (snapshot found/reused via the identical builders) — the across-turn snapshot-reuse half of criterion 5. TTFT moves to #826.
- Deployed to production (READY); `GET /api/diag/prewarm` returns 307→OAuth, same as the `/preflight` control (route live, gate working).

## Evidence

- [x] Test evidence attached (typecheck + lint + 127 vitest + prewarm reuse timings)

Evidence links:

- [Verification: typecheck + lint + 127 vitest + prewarm reuse](https://evidence.cloudcompute.com/workspaces/pr-822/20260706-170318-prewarm-verification-v2.png)

![prewarm verification](https://evidence.cloudcompute.com/workspaces/pr-822/20260706-170318-prewarm-verification-v2.png)

## Blockers

- [x] None
