### PR TITLE
feat(web-next): real message-driven turns + durable session resume, and unbreak the runtime inside Next.js (#826, #750)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ web/test-results/
 # macOS
 .DS_Store
 *.swp
+.vercel

--- a/web-next/next.config.ts
+++ b/web-next/next.config.ts
@@ -1,5 +1,19 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+	// The real (vercel) compute provider talks to the in-sandbox harness bridge
+	// over a WebSocket. Bundling `ws` (and its native `bufferutil`) breaks that
+	// path with "bufferUtil.mask is not a function", so keep the harness stack
+	// external and let Node require it at runtime.
+	serverExternalPackages: [
+		"ws",
+		"bufferutil",
+		"utf-8-validate",
+		"@ai-sdk/harness",
+		"@ai-sdk/harness-claude-code",
+		"@ai-sdk/sandbox-vercel",
+		"@vercel/sandbox",
+	],
+};
 
 export default nextConfig;

--- a/web-next/scripts/drive-turn.ts
+++ b/web-next/scripts/drive-turn.ts
@@ -1,52 +1,89 @@
 /*
- * Local driver for the real "vercel" compute provider: runs one turn end-to-end
- * (mint token → sandbox → Claude Code → clone/commit/push/PR) and prints the
- * StreamChunks as they arrive. Not part of the app — a manual smoke harness.
+ * Local driver for the real "vercel" compute provider. Runs TWO turns against
+ * one session id, threading the resume handle the first turn parks into the
+ * second — so it exercises the whole path end-to-end: real message-driven turn,
+ * detach/park, reconnect, and conversational continuity. Prints the StreamChunks
+ * as they arrive. Not part of the app — a manual smoke harness.
  *
- *   node --env-file=.env.local --import tsx scripts/drive-turn.ts "your message"
+ *   HARNESS_DEBUG=1 node --env-file=.env.local --import tsx scripts/drive-turn.ts
+ *   node --env-file=.env.local --import tsx scripts/drive-turn.ts "turn 1" "turn 2"
  */
 import { vercelProvider } from "../src/lib/agent-runtime/vercel-provider";
+import type { SessionResumeHandle } from "../src/lib/agent-runtime/provider";
 
-const userMessage = process.argv[2] ?? "Open a smoke-test PR to prove the runtime works.";
+const turn1 =
+	process.argv[2] ??
+	"In web-next/, create or update a file RUNTIME-NOTE.md with a single line: 'harness runtime online'. Then show me `git -C /vercel/sandbox/workspace diff`. Do not open a PR.";
+const turn2 =
+	process.argv[3] ??
+	"Which file did you just edit? Append a second line to it saying 'resumed turn ok', then show the diff again. Do not open a PR.";
 
+// Unique per run so a leftover parked sandbox from a prior run can't collide.
+const sessionId = `local-drive-${Date.now().toString(36)}`;
+console.log(
+	`sandbox: ai-sdk-harness-session-${sessionId} (clean up with scripts/sandbox-cleanup.ts if it lingers)`,
+);
 const started = Date.now();
 const t = () => `${((Date.now() - started) / 1000).toFixed(1)}s`;
 
-async function main() {
+async function runTurn(
+	label: string,
+	userMessage: string,
+	resume: SessionResumeHandle | null,
+): Promise<SessionResumeHandle | null> {
+	console.log(`\n=== ${label} ===`);
+	let firstToken: number | null = null;
+	let parked: SessionResumeHandle | null = null;
 	for await (const chunk of vercelProvider.runTurn({
-		sessionId: "local-drive",
+		sessionId,
 		userMessage,
+		resume,
 	})) {
 		switch (chunk.type) {
-		case "status":
-			console.log(`[${t()}] ● status: ${chunk.content}`);
-			break;
-		case "reasoning":
-			process.stdout.write(chunk.content);
-			break;
-		case "text":
-			process.stdout.write(chunk.content);
-			break;
-		case "tool_use":
-			console.log(
-				`\n[${t()}] → tool ${chunk.content} ${JSON.stringify(chunk.metadata?.input ?? {}).slice(0, 200)}`,
-			);
-			break;
-		case "tool_result":
-			console.log(
-				`[${t()}] ← result${chunk.metadata?.isError ? " (error)" : ""}: ${chunk.content.slice(0, 300)}`,
-			);
-			break;
-		case "error":
-			console.log(`\n[${t()}] ✗ error: ${chunk.content}`);
-			break;
-		case "done":
-			console.log(
-				`\n[${t()}] ✓ done — ${JSON.stringify(chunk.metadata ?? {})}`,
-			);
-			break;
+			case "status":
+				console.log(`[${t()}] ● ${chunk.content}`);
+				break;
+			case "reasoning":
+			case "text":
+				if (firstToken === null) {
+					firstToken = Date.now() - started;
+					console.log(`[${t()}] ⏱ first token (TTFT this turn)`);
+				}
+				process.stdout.write(chunk.content);
+				break;
+			case "tool_use":
+				console.log(
+					`\n[${t()}] → ${chunk.content} ${JSON.stringify(chunk.metadata?.input ?? {}).slice(0, 200)}`,
+				);
+				break;
+			case "tool_result":
+				console.log(
+					`[${t()}] ← ${chunk.metadata?.isError ? "(error) " : ""}${chunk.content.slice(0, 240)}`,
+				);
+				break;
+			case "error":
+				console.log(`\n[${t()}] ✗ error: ${chunk.content}`);
+				break;
+			case "done": {
+				const resumeOut = chunk.metadata?.resume as SessionResumeHandle | null | undefined;
+				parked = resumeOut ?? null;
+				console.log(
+					`\n[${t()}] ✓ done — durationMs=${chunk.metadata?.durationMs} tokens=${chunk.metadata?.tokenCount} parked=${parked ? "yes" : "no"}`,
+				);
+				break;
+			}
 		}
 	}
+	return parked;
+}
+
+async function main() {
+	const parked = await runTurn("TURN 1 (fresh)", turn1, null);
+	if (!parked) {
+		console.log("\n[driver] turn 1 did not park a resume handle — skipping resume turn.");
+		return;
+	}
+	await runTurn("TURN 2 (resumed)", turn2, parked);
 }
 
 main().catch((err) => {

--- a/web-next/scripts/sandbox-cleanup.ts
+++ b/web-next/scripts/sandbox-cleanup.ts
@@ -8,6 +8,14 @@
  */
 import { Sandbox } from "@vercel/sandbox";
 
+// Sandbox.get is scoped by credentials; pass them explicitly (name-only 404s
+// against a team-scoped sandbox, the same gap the provider's resume shim fixes).
+const creds = {
+	token: process.env.VERCEL_TOKEN,
+	teamId: process.env.VERCEL_TEAM_ID,
+	projectId: process.env.VERCEL_PROJECT_ID,
+};
+
 async function main() {
 	const names = process.argv.slice(2);
 	if (names.length === 0) {
@@ -16,7 +24,7 @@ async function main() {
 	}
 	for (const name of names) {
 		try {
-			const sandbox = await Sandbox.get({ name });
+			const sandbox = await Sandbox.get({ name, ...creds } as never);
 			await sandbox.stop().catch(() => {});
 			await sandbox.delete();
 			console.log(`deleted ${name}`);

--- a/web-next/scripts/sandbox-cleanup.ts
+++ b/web-next/scripts/sandbox-cleanup.ts
@@ -1,0 +1,32 @@
+/*
+ * Deletes leftover harness session sandboxes left running by local drive-turn
+ * smoke runs (they park with detach() and live until their timeout, costing
+ * money). Pass sandbox names, or a name prefix to match. Not part of the app.
+ *
+ *   node --env-file=.env.local --import tsx scripts/sandbox-cleanup.ts <name...>
+ *   node --env-file=.env.local --import tsx scripts/sandbox-cleanup.ts ai-sdk-harness-session-local-drive
+ */
+import { Sandbox } from "@vercel/sandbox";
+
+async function main() {
+	const names = process.argv.slice(2);
+	if (names.length === 0) {
+		console.log("usage: sandbox-cleanup.ts <sandbox-name-or-exact-name>…");
+		return;
+	}
+	for (const name of names) {
+		try {
+			const sandbox = await Sandbox.get({ name });
+			await sandbox.stop().catch(() => {});
+			await sandbox.delete();
+			console.log(`deleted ${name}`);
+		} catch (err) {
+			console.log(`skip ${name}: ${(err as Error)?.message ?? err}`);
+		}
+	}
+}
+
+main().catch((err) => {
+	console.error("fatal:", err);
+	process.exit(1);
+});

--- a/web-next/src/lib/agent-runtime/provider.ts
+++ b/web-next/src/lib/agent-runtime/provider.ts
@@ -9,9 +9,22 @@ import { mockProvider } from "./mock-provider";
 import type { StreamChunk } from "./stream-chunk";
 import { vercelProvider } from "./vercel-provider";
 
+/**
+ * A parked harness session to reconnect on this turn: the harness session id
+ * plus the JSON resume payload a prior turn's `detach()` returned. Providers
+ * that don't resume (mock) ignore it; the real provider reconnects the warm
+ * sandbox and continues the conversation.
+ */
+export interface SessionResumeHandle {
+	harnessSessionId: string;
+	resumeState: string;
+}
+
 export interface TurnRequest {
 	sessionId: string;
 	userMessage: string;
+	/** Prior parked session to resume, or null/undefined for a fresh turn. */
+	resume?: SessionResumeHandle | null;
 }
 
 export interface ComputeProvider {

--- a/web-next/src/lib/agent-runtime/run-turn.test.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.test.ts
@@ -3,8 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { type DatabaseHandle, openDatabase } from "../db/client";
-import { createSession, readEvents, type Session } from "../db/sessions";
-import type { ComputeProvider } from "./provider";
+import {
+	createSession,
+	getSession,
+	readEvents,
+	type Session,
+	updateSession,
+} from "../db/sessions";
+import type { ComputeProvider, TurnRequest } from "./provider";
 import { runSessionTurn } from "./run-turn";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -139,5 +145,81 @@ describe("runSessionTurn", () => {
 			"Unknown compute provider: nope",
 		);
 		expect(await readEvents(handle, "s2")).toEqual([]);
+	});
+
+	test("passes a stored resume handle into the provider request", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "vercel" });
+		await updateSession(handle, "s1", {
+			claudeSessionId: "harness-1",
+			resumeState: '{"type":"resume-session"}',
+		});
+		const fresh = (await getSession(handle, "s1")) as Session;
+
+		let seen: TurnRequest | undefined;
+		const capturing: ComputeProvider = {
+			id: "vercel",
+			runTurn: async function* (request) {
+				seen = request;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+		const turn = await runSessionTurn(handle, fresh, "again", capturing);
+		await drain(turn.stream);
+		await turn.ingest;
+
+		expect(seen?.resume).toEqual({
+			harnessSessionId: "harness-1",
+			resumeState: '{"type":"resume-session"}',
+		});
+	});
+
+	test("persists a parked handle from the done chunk and strips it from the log", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, { id: "s1", provider: "vercel" });
+		const parking = stubProvider([
+			{ type: "text", content: "done" },
+			{
+				type: "done",
+				content: "",
+				metadata: {
+					durationMs: 5,
+					resume: { harnessSessionId: "harness-9", resumeState: '{"data":1}' },
+				},
+			},
+		]);
+		const turn = await runSessionTurn(handle, session, "go", parking);
+		await drain(turn.stream);
+		await turn.ingest;
+
+		// The handle landed on the session row for the next turn to resume from.
+		const after = await getSession(handle, "s1");
+		expect(after?.claudeSessionId).toBe("harness-9");
+		expect(after?.resumeState).toBe('{"data":1}');
+
+		// …and the private handle is not left in the transcript's done event.
+		const events = await readEvents(handle, "s1");
+		const done = events.find((e) => e.chunk.type === "done");
+		expect(done?.chunk.metadata).not.toHaveProperty("resume");
+		expect(done?.chunk.metadata).toMatchObject({ durationMs: 5 });
+	});
+
+	test("a null resume on the done chunk clears a stale stored handle", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, { id: "s1", provider: "vercel" });
+		await updateSession(handle, "s1", {
+			claudeSessionId: "old",
+			resumeState: '{"stale":true}',
+		});
+		const clearing = stubProvider([
+			{ type: "done", content: "", metadata: { resume: null } },
+		]);
+		const turn = await runSessionTurn(handle, session, "go", clearing);
+		await drain(turn.stream);
+		await turn.ingest;
+
+		const after = await getSession(handle, "s1");
+		expect(after?.claudeSessionId).toBeNull();
+		expect(after?.resumeState).toBeNull();
 	});
 });

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -20,8 +20,13 @@
  */
 import { EventEmitter } from "node:events";
 import type { DatabaseHandle } from "../db/client";
-import { appendEvents, type Session } from "../db/sessions";
-import { type ComputeProvider, getProvider } from "./provider";
+import { appendEvents, type Session, updateSession } from "../db/sessions";
+import {
+	type ComputeProvider,
+	getProvider,
+	type SessionResumeHandle,
+} from "./provider";
+import type { StreamChunk } from "./stream-chunk";
 
 /** One in-flight turn: where its assistant message starts, and when it began. */
 interface ActiveTurn {
@@ -114,8 +119,16 @@ async function ingestTurn(
 		for await (const chunk of provider.runTurn({
 			sessionId: session.id,
 			userMessage: userText,
+			resume: resumeHandle(session),
 		})) {
-			await appendEvents(handle, session.id, [{ role: "assistant", chunk }]);
+			// A terminal `done` may carry the harness handle the turn parked with
+			// detach(); persist it to the session row (not the transcript) so the
+			// next turn reconnects, and store the chunk without that private blob.
+			const stored =
+				chunk.type === "done"
+					? await persistResume(handle, session.id, chunk)
+					: chunk;
+			await appendEvents(handle, session.id, [{ role: "assistant", chunk: stored }]);
 			if (chunk.type === "done") closed = true;
 			notify(session.id);
 		}
@@ -133,4 +146,40 @@ async function ingestTurn(
 		]);
 		notify(session.id);
 	}
+}
+
+/** The parked-session handle to resume this turn from, or null for a fresh run. */
+function resumeHandle(session: Session): SessionResumeHandle | null {
+	if (!session.claudeSessionId || !session.resumeState) return null;
+	return {
+		harnessSessionId: session.claudeSessionId,
+		resumeState: session.resumeState,
+	};
+}
+
+/**
+ * Moves the harness resume handle a turn parked (on `done.metadata.resume`) out
+ * of the transcript and onto the session row: a `SessionResumeHandle` is stored
+ * for the next turn, an explicit `null` clears a stale handle (the parked
+ * sandbox expired), and an absent field leaves the row untouched (mock turns).
+ * Returns the chunk with the private handle stripped so the log stays clean.
+ */
+async function persistResume(
+	handle: DatabaseHandle,
+	sessionId: string,
+	chunk: StreamChunk,
+): Promise<StreamChunk> {
+	if (!chunk.metadata || !("resume" in chunk.metadata)) return chunk;
+	const { resume, ...rest } = chunk.metadata as {
+		resume?: SessionResumeHandle | null;
+	} & Record<string, unknown>;
+	if (resume === null) {
+		await updateSession(handle, sessionId, { claudeSessionId: null, resumeState: null });
+	} else if (resume) {
+		await updateSession(handle, sessionId, {
+			claudeSessionId: resume.harnessSessionId,
+			resumeState: resume.resumeState,
+		});
+	}
+	return { ...chunk, metadata: rest };
 }

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { mapFullStream } from "./vercel-provider";
+import {
+	canonicalToolName,
+	mapFullStream,
+	parseGitDiff,
+	toolResultContent,
+} from "./vercel-provider";
 import type { StreamChunk } from "./stream-chunk";
 
 type Part = { type: string; [k: string]: unknown };
@@ -39,17 +44,32 @@ describe("mapFullStream", () => {
 			"done",
 		]);
 
+		// Tool names are canonicalized to the Capitalized form Folio keys on.
 		const toolUse = chunks.find((c) => c.type === "tool_use");
-		expect(toolUse?.content).toBe("bash");
+		expect(toolUse?.content).toBe("Bash");
 		expect(toolUse?.metadata).toMatchObject({
 			toolUseId: "c1",
-			toolName: "bash",
+			toolName: "Bash",
 			input: { command: "ls" },
 		});
 
 		const toolResult = chunks.find((c) => c.type === "tool_result");
 		expect(toolResult?.content).toBe("a\nb");
 		expect(toolResult?.metadata).toMatchObject({ toolUseId: "c1" });
+	});
+
+	test("extracts stdout from a bash-style object tool result", async () => {
+		const chunks = await collect([
+			{
+				type: "tool-result",
+				toolCallId: "c9",
+				toolName: "bash",
+				output: { exitCode: 0, stdout: "12 passed\n", stderr: "" },
+			},
+		]);
+		const result = chunks.find((c) => c.type === "tool_result");
+		expect(result?.content).toBe("12 passed");
+		expect(result?.metadata).toMatchObject({ toolUseId: "c9", output: "12 passed" });
 	});
 
 	test("carries finish outputTokens into the terminal done chunk", async () => {
@@ -89,5 +109,85 @@ describe("mapFullStream", () => {
 		expect(dones).toHaveLength(1);
 		expect(chunks.at(-1)?.type).toBe("done");
 		expect(dones[0]?.metadata?.tokenCount).toBeUndefined();
+	});
+});
+
+describe("canonicalToolName", () => {
+	test("capitalizes the harness's lowercase tool names", () => {
+		expect(canonicalToolName("write")).toBe("Write");
+		expect(canonicalToolName("edit")).toBe("Edit");
+		expect(canonicalToolName("bash")).toBe("Bash");
+		expect(canonicalToolName("read")).toBe("Read");
+	});
+	test("leaves already-capitalized and empty names alone", () => {
+		expect(canonicalToolName("Grep")).toBe("Grep");
+		expect(canonicalToolName("")).toBe("");
+	});
+});
+
+describe("toolResultContent", () => {
+	test("surfaces stdout/stderr from a command result object", () => {
+		expect(toolResultContent({ exitCode: 0, stdout: "ok\n", stderr: "" })).toBe("ok");
+		expect(toolResultContent({ exitCode: 1, stdout: "", stderr: "boom\n" })).toBe("boom");
+		expect(toolResultContent({ exitCode: 2, stdout: "", stderr: "" })).toBe("exited 2");
+	});
+	test("passes plain string results through", () => {
+		expect(toolResultContent("File created successfully")).toBe(
+			"File created successfully",
+		);
+	});
+});
+
+describe("parseGitDiff", () => {
+	test("parses a new-file diff into one card with counts and hunk lines", () => {
+		const raw = [
+			"diff --git a/web-next/NOTE.md b/web-next/NOTE.md",
+			"new file mode 100644",
+			"index 0000000..376c071",
+			"--- /dev/null",
+			"+++ b/web-next/NOTE.md",
+			"@@ -0,0 +1,2 @@",
+			"+harness runtime online",
+			"+resumed turn ok",
+			"\\ No newline at end of file",
+		].join("\n");
+		const cards = parseGitDiff(raw);
+		expect(cards).toHaveLength(1);
+		expect(cards[0]).toMatchObject({
+			file: "web-next/NOTE.md",
+			additions: 2,
+			deletions: 0,
+		});
+		expect(cards[0].lines).toEqual([
+			{ kind: "add", text: "+harness runtime online" },
+			{ kind: "add", text: "+resumed turn ok" },
+		]);
+	});
+
+	test("splits a multi-file diff and counts add/del/context per file", () => {
+		const raw = [
+			"diff --git a/a.ts b/a.ts",
+			"--- a/a.ts",
+			"+++ b/a.ts",
+			"@@ -1,3 +1,3 @@",
+			" const x = 1;",
+			"-const y = 2;",
+			"+const y = 3;",
+			" const z = 4;",
+			"diff --git a/b.ts b/b.ts",
+			"--- a/b.ts",
+			"+++ b/b.ts",
+			"@@ -0,0 +1 @@",
+			"+export const flag = true;",
+		].join("\n");
+		const cards = parseGitDiff(raw);
+		expect(cards.map((c) => c.file)).toEqual(["a.ts", "b.ts"]);
+		expect(cards[0]).toMatchObject({ additions: 1, deletions: 1 });
+		expect(cards[0].lines).toHaveLength(4); // 2 context + 1 add + 1 del
+		expect(cards[1]).toMatchObject({ additions: 1, deletions: 0 });
+	});
+
+	test("returns no cards for an empty diff", () => {
+		expect(parseGitDiff("")).toEqual([]);
 	});
 });

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
 	canonicalToolName,
+	errorText,
 	mapFullStream,
 	parseGitDiff,
 	toolResultContent,
@@ -109,6 +110,25 @@ describe("mapFullStream", () => {
 		expect(dones).toHaveLength(1);
 		expect(chunks.at(-1)?.type).toBe("done");
 		expect(dones[0]?.metadata?.tokenCount).toBeUndefined();
+	});
+});
+
+describe("errorText", () => {
+	test("reads .message from an Error, which JSON.stringify hides as {}", () => {
+		expect(errorText(new Error("bufferUtil.mask is not a function"))).toBe(
+			"bufferUtil.mask is not a function",
+		);
+		expect(JSON.stringify(new Error("x"))).toBe("{}"); // the trap this avoids
+	});
+	test("unwraps common nested error shapes", () => {
+		expect(errorText({ message: "top" })).toBe("top");
+		expect(errorText({ error: { message: "nested" } })).toBe("nested");
+		expect(errorText({ cause: new Error("caused") })).toBe("caused");
+	});
+	test("falls back for strings, empties, and null", () => {
+		expect(errorText("plain")).toBe("plain");
+		expect(errorText(null)).toBe("unknown error");
+		expect(errorText({})).toBe("[object Object]");
 	});
 });
 

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -41,8 +41,10 @@ const BRIDGE_PORT = 4000;
  * conversation can idle between turns before the next turn re-clones fresh.
  */
 const SANDBOX_TIMEOUT_MS = 30 * 60 * 1000;
-/** The persistent per-session working copy inside the sandbox. */
-const WORKSPACE_DIR = "/vercel/sandbox/workspace";
+/** The persistent per-session working copy: name under the sandbox default cwd. */
+const WORKSPACE_DIR_NAME = "workspace";
+/** Absolute path to that working copy (sandbox default cwd is /vercel/sandbox). */
+const WORKSPACE_DIR = `/vercel/sandbox/${WORKSPACE_DIR_NAME}`;
 /**
  * Stable template name so `runTurn` and `prewarmVercelTemplate` target the same
  * named snapshot; the harness reuses a template only when the sandbox identity
@@ -96,6 +98,27 @@ function asText(value: unknown): string {
 }
 
 /**
+ * A human-readable string for an error value. `JSON.stringify(new Error(...))`
+ * is `"{}"` — message/stack are non-enumerable — so error parts must be read
+ * for their `.message` (and common nested `.cause`/`.error`) before falling
+ * back to a plain string, or the transcript shows an empty `{}`.
+ */
+export function errorText(value: unknown): string {
+	if (value == null) return "unknown error";
+	if (typeof value === "string") return value;
+	if (value instanceof Error) return value.message || value.name;
+	if (typeof value === "object") {
+		const o = value as { message?: unknown; error?: unknown; cause?: unknown };
+		if (typeof o.message === "string" && o.message) return o.message;
+		if (o.error != null && o.error !== value) return errorText(o.error);
+		if (o.cause != null && o.cause !== value) return errorText(o.cause);
+		const json = asText(value);
+		if (json && json !== "{}") return json;
+	}
+	return String(value);
+}
+
+/**
  * Canonicalizes the harness's lowercase tool names (`write`, `bash`, `edit`) to
  * the Capitalized form the Folio ledger and turn-stats key on (`Write`, `Bash`,
  * `Edit`) — so the real provider's tool cards, verbs, and file/diff stats match
@@ -134,8 +157,13 @@ export async function* mapFullStream(
 ): AsyncGenerator<StreamChunk> {
 	let outputTokens: number | undefined;
 	for await (const part of fullStream) {
-		if (process.env.HARNESS_DEBUG === "1")
-			console.error(`[dbg part] ${part.type} ${JSON.stringify(part).slice(0, 240)}`);
+		if (process.env.HARNESS_DEBUG === "1") {
+			const detail =
+				part.type === "error" || part.type === "tool-error"
+					? errorText(part.error)
+					: JSON.stringify(part).slice(0, 240);
+			console.error(`[dbg part] ${part.type} ${detail}`);
+		}
 		switch (part.type) {
 			case "text-delta":
 				if (part.text) yield { type: "text", content: part.text as string };
@@ -169,17 +197,17 @@ export async function* mapFullStream(
 			case "tool-error":
 				yield {
 					type: "tool_result",
-					content: asText(part.error),
+					content: errorText(part.error),
 					metadata: { toolUseId: part.toolCallId, isError: true },
 				};
 				break;
 			case "error":
-				yield { type: "error", content: asText(part.error) };
+				yield { type: "error", content: errorText(part.error) };
 				break;
 			case "abort":
 				yield {
 					type: "error",
-					content: `aborted${part.reason ? `: ${asText(part.reason)}` : ""}`,
+					content: `aborted${part.reason ? `: ${errorText(part.reason)}` : ""}`,
 				};
 				break;
 			case "finish": {
@@ -213,11 +241,11 @@ function buildPrompt(
 	if (!firstTurn) return userMessage;
 	const branch = sessionBranch(sessionId);
 	return [
-		`You are working inside a persistent clone of the GitHub repository ${TARGET_REPO} at ${WORKSPACE_DIR}, checked out on branch \`${branch}\`. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
+		`You are working inside a persistent clone of the GitHub repository ${TARGET_REPO}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
 		``,
 		`Working notes:`,
-		`- Use absolute paths under ${WORKSPACE_DIR} for file operations, and \`git -C ${WORKSPACE_DIR} …\` for git (the file-edit tools and bash can resolve different working directories, so absolute paths keep them consistent).`,
-		`- To open or update a pull request: commit, \`git -C ${WORKSPACE_DIR} push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token, e.g. \`curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${TARGET_REPO}/pulls -d '{"title":"…","head":"${branch}","base":"main","body":"…"}'\`. Report the \`html_url\`.`,
+		`- Relative paths and git commands resolve against the repo (you are inside it) — edit and \`git status\`/\`git diff\` normally.`,
+		`- To open or update a pull request: commit, \`git push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token, e.g. \`curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${TARGET_REPO}/pulls -d '{"title":"…","head":"${branch}","base":"main","body":"…"}'\`. Report the \`html_url\`.`,
 		`- Only open a PR when the request calls for one; otherwise just do the work and summarize it.`,
 		``,
 		`The user's request:`,
@@ -385,6 +413,11 @@ export const vercelProvider: ComputeProvider = {
 				// Same template-identity bootstrap as prewarm, plus the per-session
 				// credential hook (which is deliberately excluded from the snapshot).
 				...SANDBOX_BOOTSTRAP,
+				// Run the agent inside the cloned workspace so its relative paths and
+				// git commands resolve against the repo — without this the CLI's cwd
+				// is a scratch dir and edits land outside the clone. Relative to the
+				// sandbox default (/vercel/sandbox), so this is WORKSPACE_DIR.
+				workDir: WORKSPACE_DIR_NAME,
 				onSession: async ({ session }) => {
 					sandbox = session as RunnableSandbox;
 					await session.writeTextFile({
@@ -479,12 +512,25 @@ export const vercelProvider: ComputeProvider = {
 				yield chunk;
 			}
 			// Synthesize a diff card per changed file from the working tree (the
-			// Edit/Write results carry no patch; the real diff lives in git).
+			// Edit/Write results carry no patch; the real diff lives in git). Emit
+			// each as a tool_use + tool_result pair — the Folio adapter renders the
+			// DiffCard from a tool_result's metadata.diff, and the AI SDK only keeps
+			// a tool result that has a matching opened call.
 			for (const diff of await changedFileDiffs(sandbox)) {
+				const toolUseId = `diff:${diff.file}`;
+				yield {
+					type: "tool_use",
+					content: "Diff",
+					metadata: {
+						toolUseId,
+						toolName: "Diff",
+						input: { file_path: diff.file },
+					},
+				};
 				yield {
 					type: "tool_result",
 					content: "",
-					metadata: { toolUseId: `diff:${diff.file}`, output: "", diff },
+					metadata: { toolUseId, output: "", diff },
 				};
 			}
 			// Park the session so the next turn reconnects it; carry the resume

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -4,14 +4,24 @@
  * created through the harness factory so its bootstrap installs the `claude` CLI
  * (and reuses a snapshot template across turns); a per-session `onSession` hook
  * injects the GitHub App installation token as a git credential — the token
- * rides in via the command `env`, never the transcript — so the agent can clone,
- * push, and open a PR against the target repo. The model authenticates through
- * the AI Gateway. Heavy deps load lazily so the seam stays light for the mock
- * path; sessions opt in via sessions.provider = "vercel".
+ * rides in via the command `env`, never the transcript — and clones the target
+ * repo into a persistent per-session workspace, so the agent can edit, push, and
+ * open a PR against it. The turn is driven by the user's actual message.
+ *
+ * Sessions are durable: after each turn the harness session is `detach()`-ed
+ * (parked with the sandbox left running) and its resume payload persisted; the
+ * next turn reconnects that warm session so the conversation and working copy
+ * continue. Reconnect is bounded by the sandbox lifetime — once it expires the
+ * turn falls back to a fresh clone. Heavy deps load lazily so the seam stays
+ * light for the mock path; sessions opt in via sessions.provider = "vercel".
  */
 import type { HarnessAgentSandboxConfig } from "@ai-sdk/harness/agent";
 import { mintInstallationToken } from "../diag/github-app";
-import type { ComputeProvider, TurnRequest } from "./provider";
+import type {
+	ComputeProvider,
+	SessionResumeHandle,
+	TurnRequest,
+} from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
 // Type-only imports of the lazily-loaded factories keep the seam light (no
@@ -21,11 +31,18 @@ type CreateClaudeCode =
 type CreateVercelSandbox =
 	typeof import("@ai-sdk/sandbox-vercel")["createVercelSandbox"];
 
-/** Repo the agent clones and opens its PR against. */
+/** Repo the agent clones into its workspace and opens its PR against. */
 const TARGET_REPO = process.env.AGENT_TARGET_REPO ?? "fairchild/workspaces";
 /** Port the in-sandbox harness bridge binds; must be declared on the sandbox. */
 const BRIDGE_PORT = 4000;
-const SANDBOX_TIMEOUT_MS = 15 * 60 * 1000;
+/**
+ * Max sandbox lifetime. Also the resume window: a parked (detached) session
+ * reconnects only while its sandbox is still alive, so this bounds how long a
+ * conversation can idle between turns before the next turn re-clones fresh.
+ */
+const SANDBOX_TIMEOUT_MS = 30 * 60 * 1000;
+/** The persistent per-session working copy inside the sandbox. */
+const WORKSPACE_DIR = "/vercel/sandbox/workspace";
 /**
  * Stable template name so `runTurn` and `prewarmVercelTemplate` target the same
  * named snapshot; the harness reuses a template only when the sandbox identity
@@ -38,22 +55,36 @@ const TEMPLATE_NAME = "web-next-claude-code";
  */
 const BOOTSTRAP_HASH = "claude-code-cli-v1";
 
+/** A stable per-session branch the agent commits and opens its PR from. */
+function sessionBranch(sessionId: string): string {
+	return `agent/session-${sessionId.slice(0, 8)}`;
+}
+
 /**
- * A self-contained setup script written into the sandbox and run once per
- * session. It configures git identity and a credential store from $GH_TOKEN
- * (passed via the command environment, not interpolated here) so clone/push
- * authenticate, and drops the same token at /tmp/gh_token for the PR API call.
+ * The per-session setup script, run on every turn (fresh and resumed). It
+ * configures git identity + a credential store from $GH_TOKEN (passed via the
+ * command environment, never interpolated), drops the token at /tmp/gh_token for
+ * the PR API, then clones the target repo into the persistent workspace and
+ * creates the session branch — all idempotent, so a resumed sandbox with the
+ * clone already present is a no-op and a fresh fallback sandbox re-clones.
  */
-const GIT_SETUP_SCRIPT = [
-	"set -e",
-	"umask 077",
-	'printf "https://x-access-token:%s@github.com\\n" "$GH_TOKEN" > "$HOME/.git-credentials"',
-	"git config --global credential.helper store",
-	"git config --global user.name 'web-next agent'",
-	"git config --global user.email 'agent@users.noreply.github.com'",
-	'printf "%s" "$GH_TOKEN" > /tmp/gh_token',
-	"",
-].join("\n");
+function buildSessionSetupScript(sessionId: string): string {
+	const branch = sessionBranch(sessionId);
+	return [
+		"set -e",
+		"umask 077",
+		'printf "https://x-access-token:%s@github.com\\n" "$GH_TOKEN" > "$HOME/.git-credentials"',
+		"git config --global credential.helper store",
+		"git config --global user.name 'web-next agent'",
+		"git config --global user.email 'agent@users.noreply.github.com'",
+		'printf "%s" "$GH_TOKEN" > /tmp/gh_token',
+		`if [ ! -d ${WORKSPACE_DIR}/.git ]; then`,
+		`  git clone --depth 50 https://github.com/${TARGET_REPO}.git ${WORKSPACE_DIR}`,
+		`  git -C ${WORKSPACE_DIR} checkout -b ${branch}`,
+		"fi",
+		"",
+	].join("\n");
+}
 
 function asText(value: unknown): string {
 	if (typeof value === "string") return value;
@@ -62,6 +93,33 @@ function asText(value: unknown): string {
 	} catch {
 		return String(value);
 	}
+}
+
+/**
+ * Canonicalizes the harness's lowercase tool names (`write`, `bash`, `edit`) to
+ * the Capitalized form the Folio ledger and turn-stats key on (`Write`, `Bash`,
+ * `Edit`) — so the real provider's tool cards, verbs, and file/diff stats match
+ * what the mock provider and UI were built against.
+ */
+export function canonicalToolName(name: unknown): string {
+	const raw = typeof name === "string" ? name : asText(name);
+	return raw.length === 0 ? raw : raw[0].toUpperCase() + raw.slice(1);
+}
+
+/**
+ * Renders a tool result to display text. Bash-style results arrive as
+ * `{ exitCode, stdout, stderr }`; surface stdout/stderr (what the ledger and the
+ * "N passed" test-detection read) rather than the raw JSON. String results
+ * (Edit/Write success messages) pass through.
+ */
+export function toolResultContent(output: unknown): string {
+	if (output && typeof output === "object" && "stdout" in output) {
+		const o = output as { stdout?: string; stderr?: string; exitCode?: number };
+		const text = [o.stdout, o.stderr].filter(Boolean).join("\n").trim();
+		if (text.length > 0) return text;
+		return o.exitCode && o.exitCode !== 0 ? `exited ${o.exitCode}` : "";
+	}
+	return asText(output);
 }
 
 /**
@@ -86,24 +144,28 @@ export async function* mapFullStream(
 				if (part.text)
 					yield { type: "reasoning", content: part.text as string };
 				break;
-			case "tool-call":
+			case "tool-call": {
+				const toolName = canonicalToolName(part.toolName);
 				yield {
 					type: "tool_use",
-					content: asText(part.toolName),
+					content: toolName,
 					metadata: {
 						toolUseId: part.toolCallId,
-						toolName: part.toolName,
+						toolName,
 						input: part.input,
 					},
 				};
 				break;
-			case "tool-result":
+			}
+			case "tool-result": {
+				const content = toolResultContent(part.output);
 				yield {
 					type: "tool_result",
-					content: asText(part.output),
-					metadata: { toolUseId: part.toolCallId, output: part.output },
+					content,
+					metadata: { toolUseId: part.toolCallId, output: content },
 				};
 				break;
+			}
 			case "tool-error":
 				yield {
 					type: "tool_result",
@@ -137,36 +199,29 @@ export async function* mapFullStream(
 }
 
 /**
- * TEMPORARY (#826): a fixed clone→branch→create-marker→push→open-PR smoke
- * script. It proves the runtime plumbing end to end but does NOT yet drive the
- * turn from the user's message — `userMessage` rides in only as a marker line,
- * not as the instruction. Replacing this with a prompt driven by the user's
- * actual request (against the session's working copy) is #826, which also
- * carries the #750 render/resume/perf acceptance evidence.
- *
- * Credentials are pre-wired globally (git credential store) with the raw token
- * at /tmp/gh_token for the PR API — so the prompt names no secret.
+ * The turn prompt. It drives the agent with the user's actual message against
+ * the persistent workspace clone. A fresh session gets a one-time preamble
+ * establishing where the working copy lives and how to open a PR; a resumed
+ * session already carries that context in its harness conversation, so it
+ * receives the user's message alone.
  */
-function buildPrompt(userMessage: string): string {
-	const stamp = new Date().toISOString();
-	const suffix = Math.random().toString(36).slice(2, 8);
-	const branch = `agent/runtime-smoke-${suffix}`;
-	// A fixed absolute repo dir keeps the file-edit builtins and bash in
-	// agreement — they resolve different working directories otherwise.
-	const repoDir = `/vercel/sandbox/repo-${suffix}`;
-	const line = `- ${stamp} — first PR opened by the web-next harness runtime. Request: ${userMessage.replace(/`/g, "'").slice(0, 200)}`;
+function buildPrompt(
+	userMessage: string,
+	sessionId: string,
+	firstTurn: boolean,
+): string {
+	if (!firstTurn) return userMessage;
+	const branch = sessionBranch(sessionId);
 	return [
-		`Open a real pull request against the GitHub repository ${TARGET_REPO}. Use the ABSOLUTE path ${repoDir} for the working copy and absolute paths for every file operation and git command (git tool calls and the file-edit tools resolve different working directories, so absolute paths keep them consistent). Work through the steps in order and stop if any command fails, showing its output.`,
+		`You are working inside a persistent clone of the GitHub repository ${TARGET_REPO} at ${WORKSPACE_DIR}, checked out on branch \`${branch}\`. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
 		``,
-		`1. Clone the repo: \`git clone https://github.com/${TARGET_REPO}.git ${repoDir}\`. Credentials are configured globally, so this authenticates automatically.`,
-		`2. Create the branch: \`git -C ${repoDir} checkout -b ${branch}\`.`,
-		`3. Create the file \`${repoDir}/web-next/RUNTIME-SMOKE.md\` (use an absolute path) containing exactly this line:`,
-		`   ${line}`,
-		`4. Commit: \`git -C ${repoDir} add -A && git -C ${repoDir} commit -m "chore(web-next): runtime smoke — harness-opened PR"\`.`,
-		`5. Push the branch: \`git -C ${repoDir} push -u origin HEAD\`.`,
-		`6. Open a pull request against \`main\` via the GitHub API (the token is in /tmp/gh_token):`,
-		`   curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${TARGET_REPO}/pulls -d '{"title":"chore(web-next): runtime smoke — harness-opened PR","head":"${branch}","base":"main","body":"Opened automatically by the web-next harness runtime — a real PR from a session. Safe to review and close."}'`,
-		`7. Report the pull request URL (the \`html_url\` field of the API response).`,
+		`Working notes:`,
+		`- Use absolute paths under ${WORKSPACE_DIR} for file operations, and \`git -C ${WORKSPACE_DIR} …\` for git (the file-edit tools and bash can resolve different working directories, so absolute paths keep them consistent).`,
+		`- To open or update a pull request: commit, \`git -C ${WORKSPACE_DIR} push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token, e.g. \`curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${TARGET_REPO}/pulls -d '{"title":"…","head":"${branch}","base":"main","body":"…"}'\`. Report the \`html_url\`.`,
+		`- Only open a PR when the request calls for one; otherwise just do the work and summarize it.`,
+		``,
+		`The user's request:`,
+		userMessage,
 	].join("\n");
 }
 
@@ -194,21 +249,57 @@ function createHarness(
 	return createClaudeCode({ auth, thinking: "on" });
 }
 
+/** The Vercel sandbox naming scheme the adapter uses for per-session sandboxes. */
+const SESSION_SANDBOX_PREFIX = "ai-sdk-harness-session";
+
 /**
  * The Vercel sandbox provider, built via the factory path with a stable `name`
  * so `runTurn` and prewarm target the same named template snapshot.
+ *
+ * Resume shim: the adapter's `resumeSession` calls `Sandbox.get({ name })`
+ * without the token/teamId/projectId it was configured with, so it relies on
+ * ambient credentials — the auto-injected OIDC token in prod (works), but
+ * nothing locally, where the reconnect 404s. When we hold explicit credentials
+ * we override `resumeSession` to `Sandbox.get` with them, then re-wrap the raw
+ * sandbox through the adapter's own wrap path so resume works in both places.
  */
 function createSandboxProvider(createVercelSandbox: CreateVercelSandbox) {
-	return createVercelSandbox({
+	const token = process.env.VERCEL_TOKEN;
+	const teamId = process.env.VERCEL_TEAM_ID;
+	const projectId = process.env.VERCEL_PROJECT_ID;
+	const provider = createVercelSandbox({
 		runtime: "node22",
 		ports: [BRIDGE_PORT],
 		resources: { vcpus: 4 },
 		timeout: SANDBOX_TIMEOUT_MS,
-		token: process.env.VERCEL_TOKEN,
-		teamId: process.env.VERCEL_TEAM_ID,
-		projectId: process.env.VERCEL_PROJECT_ID,
+		token,
+		teamId,
+		projectId,
 		name: TEMPLATE_NAME,
 	});
+	if (!(token && teamId && projectId)) return provider;
+	// The provider's methods are bound instance fields, so a spread preserves
+	// them; only resumeSession is replaced with the credential-forwarding form.
+	return {
+		...provider,
+		resumeSession: async ({
+			sessionId,
+			abortSignal,
+		}: {
+			sessionId: string;
+			abortSignal?: AbortSignal;
+		}) => {
+			const { Sandbox } = await import("@vercel/sandbox");
+			const sandbox = await Sandbox.get({
+				name: `${SESSION_SANDBOX_PREFIX}-${sessionId}`,
+				token,
+				teamId,
+				projectId,
+				...(abortSignal ? { signal: abortSignal } : {}),
+			});
+			return createVercelSandbox({ sandbox }).createSession();
+		},
+	};
 }
 
 /**
@@ -280,6 +371,12 @@ export const vercelProvider: ComputeProvider = {
 
 		const debugHarness = process.env.HARNESS_DEBUG === "1";
 
+		// The sandbox session is captured here so the turn can run `git diff` after
+		// streaming to synthesize diff cards (the harness session drives turns, not
+		// arbitrary commands). The sandbox stays alive until detach, so it is valid
+		// through the end of the turn.
+		let sandbox: RunnableSandbox | undefined;
+
 		const agent = new HarnessAgent({
 			id: `web-next-${request.sessionId}`,
 			harness: createHarness(createClaudeCode, resolveAuth()),
@@ -289,22 +386,25 @@ export const vercelProvider: ComputeProvider = {
 				// credential hook (which is deliberately excluded from the snapshot).
 				...SANDBOX_BOOTSTRAP,
 				onSession: async ({ session }) => {
+					sandbox = session as RunnableSandbox;
 					await session.writeTextFile({
-						path: "/tmp/git-setup.sh",
-						content: GIT_SETUP_SCRIPT,
+						path: "/tmp/session-setup.sh",
+						content: buildSessionSetupScript(request.sessionId),
 					});
 					const res = await session.run({
-						command: "bash /tmp/git-setup.sh",
+						command: "bash /tmp/session-setup.sh",
 						env: { GH_TOKEN: token },
 					});
 					if (res.exitCode !== 0)
 						throw new Error(
-							`git credential setup failed (exit ${res.exitCode}): ${res.stderr.slice(0, 300)}`,
+							`session setup failed (exit ${res.exitCode}): ${res.stderr.slice(0, 300)}`,
 						);
 					if (debugHarness) {
-						const chk = await session.run({ command: "which claude" });
+						const chk = await session.run({
+							command: `which claude; git -C ${WORKSPACE_DIR} rev-parse --abbrev-ref HEAD 2>&1`,
+						});
 						console.error(
-							`[dbg onSession] git configured; claude=${chk.stdout.trim() || "MISSING"} (exit ${chk.exitCode})`,
+							`[dbg onSession] setup ok; ${chk.stdout.trim().replace(/\n/g, " | ")}`,
 						);
 					}
 				},
@@ -318,19 +418,194 @@ export const vercelProvider: ComputeProvider = {
 				: {}),
 		});
 
-		yield { type: "status", content: "Booting Claude Code in sandbox" };
-		const session = await agent.createSession();
+		// The stable id that names the sandbox: reuse the parked session's id on
+		// resume (so `Sandbox.get` finds the running sandbox), else the web-next
+		// session id. On a fresh boot that collides with a lingering sandbox, fall
+		// back to a unique id so the turn still runs.
+		let sandboxSessionId = request.resume?.harnessSessionId ?? request.sessionId;
+
+		// Reconnect the parked session when its sandbox is still alive; otherwise
+		// boot fresh. A resumed session keeps the conversation and working copy, so
+		// buildPrompt then sends the user's message alone.
+		let session: Awaited<ReturnType<typeof agent.createSession>> | undefined;
+		let resumed = false;
+		if (request.resume) {
+			yield { type: "status", content: "Resuming session" };
+			try {
+				session = await agent.createSession({
+					sessionId: request.resume.harnessSessionId,
+					resumeFrom: JSON.parse(request.resume.resumeState),
+				});
+				resumed = true;
+			} catch (error) {
+				if (debugHarness)
+					console.error(`[dbg resume failed] ${asText((error as Error)?.message)}`);
+				yield {
+					type: "status",
+					content: "Previous sandbox expired — starting fresh",
+				};
+			}
+		}
+		if (!session) {
+			yield { type: "status", content: "Booting Claude Code in sandbox" };
+			sandboxSessionId = request.sessionId;
+			try {
+				session = await agent.createSession({ sessionId: sandboxSessionId });
+			} catch (error) {
+				// A parked sandbox under this name may still be alive (resume failed
+				// for another reason); a same-name create is rejected. Boot under a
+				// fresh unique name so the turn proceeds — the next turn resumes it.
+				if (!isNameCollision(error)) throw error;
+				sandboxSessionId = `${request.sessionId}-${Date.now().toString(36)}`;
+				session = await agent.createSession({ sessionId: sandboxSessionId });
+			}
+		}
+
+		let detached = false;
 		try {
 			const result = await agent.stream({
 				session,
-				prompt: buildPrompt(request.userMessage),
+				prompt: buildPrompt(request.userMessage, request.sessionId, !resumed),
 			});
-			yield* mapFullStream(
+			let doneChunk: StreamChunk | undefined;
+			for await (const chunk of mapFullStream(
 				result.fullStream as AsyncIterable<{ type: string; [k: string]: unknown }>,
 				startedAt,
-			);
+			)) {
+				if (chunk.type === "done") {
+					doneChunk = chunk;
+					break; // the terminal chunk — emit diff cards, then park, then it
+				}
+				yield chunk;
+			}
+			// Synthesize a diff card per changed file from the working tree (the
+			// Edit/Write results carry no patch; the real diff lives in git).
+			for (const diff of await changedFileDiffs(sandbox)) {
+				yield {
+					type: "tool_result",
+					content: "",
+					metadata: { toolUseId: `diff:${diff.file}`, output: "", diff },
+				};
+			}
+			// Park the session so the next turn reconnects it; carry the resume
+			// payload out on the done chunk for the ingest loop to persist. If
+			// parking fails, `resume: null` clears the stale handle and the session
+			// is torn down below.
+			const resume = await parkSession(session, sandboxSessionId, debugHarness);
+			detached = resume !== null;
+			yield {
+				...(doneChunk ?? { type: "done", content: "" }),
+				metadata: { ...doneChunk?.metadata, resume },
+			};
 		} finally {
-			await session.destroy().catch(() => {});
+			if (!detached) await session.destroy().catch(() => {});
 		}
 	},
 };
+
+/**
+ * Whether a sandbox-create error is a name collision (a parked sandbox under the
+ * same name is still alive). The Vercel APIError's `message` is only the status
+ * line ("Status code 400 …"); the reason lives in its `json`/`text`, so match
+ * across all of them.
+ */
+function isNameCollision(error: unknown): boolean {
+	const e = error as { message?: unknown; text?: unknown; json?: unknown };
+	const haystack = [asText(e?.message), asText(e?.text), asText(e?.json)].join(" ");
+	return /already exists/i.test(haystack);
+}
+
+/** A sandbox session that can run shell commands (the onSession surface). */
+interface RunnableSandbox {
+	run: (opts: {
+		command: string;
+	}) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+/** A rendered diff card: file, line counts, and the hunk lines. */
+interface DiffCard {
+	file: string;
+	additions: number;
+	deletions: number;
+	note: string;
+	lines: { kind: "add" | "del" | "context"; text: string }[];
+}
+
+/** Beyond this many hunk lines a single file's card is truncated. */
+const DIFF_LINE_CAP = 200;
+
+/**
+ * Runs `git diff` over the workspace (untracked files marked intent-to-add so
+ * new files show) and parses it into one diff card per changed file. Best-effort
+ * — any failure yields no cards, never breaking the turn.
+ */
+async function changedFileDiffs(sandbox: RunnableSandbox | undefined): Promise<DiffCard[]> {
+	if (!sandbox) return [];
+	try {
+		const res = await sandbox.run({
+			command: `git -C ${WORKSPACE_DIR} add -N . >/dev/null 2>&1; git -C ${WORKSPACE_DIR} diff`,
+		});
+		return parseGitDiff(res.stdout);
+	} catch {
+		return [];
+	}
+}
+
+/** Splits a multi-file unified diff into per-file cards. */
+export function parseGitDiff(raw: string): DiffCard[] {
+	const cards: DiffCard[] = [];
+	let current: DiffCard | undefined;
+	let inHunk = false;
+	for (const line of raw.split("\n")) {
+		if (line.startsWith("diff --git")) {
+			if (current && current.lines.length > 0) cards.push(current);
+			const file = line.match(/ b\/(.+)$/)?.[1] ?? "(file)";
+			current = { file, additions: 0, deletions: 0, note: "edit landed", lines: [] };
+			inHunk = false;
+			continue;
+		}
+		if (!current) continue;
+		if (line.startsWith("@@")) {
+			inHunk = true;
+			continue;
+		}
+		if (!inHunk || line.startsWith("+++") || line.startsWith("---")) continue;
+		if (line.startsWith("\\")) continue; // "\ No newline at end of file"
+		if (current.lines.length >= DIFF_LINE_CAP) continue;
+		if (line.startsWith("+")) {
+			current.additions += 1;
+			current.lines.push({ kind: "add", text: line });
+		} else if (line.startsWith("-")) {
+			current.deletions += 1;
+			current.lines.push({ kind: "del", text: line });
+		} else if (line.startsWith(" ")) {
+			current.lines.push({ kind: "context", text: line });
+		}
+	}
+	if (current && current.lines.length > 0) cards.push(current);
+	return cards;
+}
+
+/**
+ * Detaches the session (parks it with the sandbox left running) under the id
+ * that names its sandbox, and returns the handle to persist for the next turn —
+ * or null when parking fails, so the caller tears the session down and clears
+ * any stored handle.
+ */
+async function parkSession(
+	session: { detach: () => Promise<unknown> },
+	sandboxSessionId: string,
+	debug: boolean,
+): Promise<SessionResumeHandle | null> {
+	try {
+		const state = await session.detach();
+		return {
+			harnessSessionId: sandboxSessionId,
+			resumeState: JSON.stringify(state),
+		};
+	} catch (error) {
+		if (debug)
+			console.error(`[dbg detach failed] ${asText((error as Error)?.message)}`);
+		return null;
+	}
+}

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -44,6 +44,12 @@ export interface SessionsTable {
 	status: string;
 	/** Claude CLI session id for snapshot/resume; null until a turn runs. */
 	claude_session_id: string | null;
+	/**
+	 * JSON `HarnessAgentResumeSessionState` from the last turn's `detach()`, or
+	 * null. The real (vercel) provider reconnects the parked harness session with
+	 * this on the next turn so the conversation and warm sandbox continue.
+	 */
+	resume_state: string | null;
 	created_at: string;
 	last_activity_at: string;
 }

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -144,4 +144,30 @@ const authTables: Migration = {
 	},
 };
 
-export const MIGRATIONS: Migration[] = [baseline, authTables];
+/**
+ * Adds `sessions.resume_state` — the JSON harness resume payload a turn parks
+ * with `detach()` so the next turn reconnects the same session (#826/#750).
+ * Idempotent via a column probe: SQLite `ALTER TABLE ADD COLUMN` has no
+ * `IF NOT EXISTS`, and a partial run must re-apply cleanly.
+ */
+const sessionResumeState: Migration = {
+	id: "0003_session_resume_state",
+	async up(db) {
+		const info = await sql<{
+			name: string;
+		}>`PRAGMA table_info(sessions)`.execute(db);
+		const hasColumn = info.rows.some((row) => row.name === "resume_state");
+		if (!hasColumn) {
+			await db.schema
+				.alterTable("sessions")
+				.addColumn("resume_state", "text")
+				.execute();
+		}
+	},
+};
+
+export const MIGRATIONS: Migration[] = [
+	baseline,
+	authTables,
+	sessionResumeState,
+];

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -11,6 +11,7 @@ import {
 	getSession,
 	readEvents,
 	readTranscript,
+	updateSession,
 } from "./sessions";
 
 // A throwaway on-disk libSQL DB per test — isolated, and (unlike a bare
@@ -48,6 +49,7 @@ describe("session store", () => {
 		expect(recorded.rows.map((r) => String(r.id))).toEqual([
 			"0001_baseline",
 			"0002_auth_tables",
+			"0003_session_resume_state",
 		]);
 	});
 
@@ -66,8 +68,32 @@ describe("session store", () => {
 			provider: "mock",
 			status: "active",
 		});
+		expect(created.resumeState).toBeNull();
 		expect(await getSession(handle, "s1")).toEqual(created);
 		expect(await getSession(handle, "missing")).toBeUndefined();
+	});
+
+	test("updateSession persists and clears the harness resume handle", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "vercel" });
+
+		await updateSession(handle, "s1", {
+			claudeSessionId: "harness-abc",
+			resumeState: '{"type":"resume-session","data":{}}',
+		});
+		let session = await getSession(handle, "s1");
+		expect(session?.claudeSessionId).toBe("harness-abc");
+		expect(session?.resumeState).toBe('{"type":"resume-session","data":{}}');
+
+		// A null resumeState clears a stale handle without touching other fields.
+		await updateSession(handle, "s1", { resumeState: null });
+		session = await getSession(handle, "s1");
+		expect(session?.resumeState).toBeNull();
+		expect(session?.claudeSessionId).toBe("harness-abc");
+
+		// An empty patch is a no-op.
+		await updateSession(handle, "s1", {});
+		expect((await getSession(handle, "s1"))?.claudeSessionId).toBe("harness-abc");
 	});
 
 	test("appends events with a monotonic per-session seq and round-trips them", async () => {

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -34,6 +34,8 @@ export interface Session {
 	provider: string;
 	status: string;
 	claudeSessionId: string | null;
+	/** JSON harness resume payload from the last turn's detach(), or null. */
+	resumeState: string | null;
 	createdAt: string;
 	lastActivityAt: string;
 }
@@ -52,6 +54,7 @@ function rowToSession(row: SessionsTable): Session {
 		provider: row.provider,
 		status: row.status,
 		claudeSessionId: row.claude_session_id,
+		resumeState: row.resume_state,
 		createdAt: row.created_at,
 		lastActivityAt: row.last_activity_at,
 	};
@@ -70,11 +73,30 @@ export async function createSession(
 		provider: session.provider,
 		status: session.status ?? "active",
 		claude_session_id: session.claudeSessionId ?? null,
+		resume_state: null,
 		created_at: now,
 		last_activity_at: now,
 	};
 	await handle.db.insertInto("sessions").values(row).execute();
 	return rowToSession(row);
+}
+
+/**
+ * Persists the harness handle a turn parked with `detach()`: the claude session
+ * id and the JSON resume payload the next turn reconnects from. `resumeState`
+ * of `null` clears it (the parked sandbox expired or the turn didn't detach).
+ */
+export async function updateSession(
+	handle: DatabaseHandle,
+	id: string,
+	fields: { claudeSessionId?: string | null; resumeState?: string | null },
+): Promise<void> {
+	await ensureSchema(handle);
+	const set: Partial<SessionsTable> = {};
+	if ("claudeSessionId" in fields) set.claude_session_id = fields.claudeSessionId ?? null;
+	if ("resumeState" in fields) set.resume_state = fields.resumeState ?? null;
+	if (Object.keys(set).length === 0) return;
+	await handle.db.updateTable("sessions").set(set).where("id", "=", id).execute();
 }
 
 /** A sessions-home row: the session plus its repo's display name. */


### PR DESCRIPTION
## Summary

Turns the web-next real runtime into an actual conversational coding agent and
lands the #750 acceptance criteria #822 deferred. Two things: the turn is now
driven by the user's real message against a **persistent workspace**, and the
harness session is **durable across turns and tab-close** — a follow-up resumes
the same conversation and working copy.

It also fixes a set of bugs that only surfaced when driving a real turn through
the actual Next.js app (the node driver hid them — "green tests ≠ works in the
app"), the most important of which **also unbreaks #822's prewarm/real-provider
path in production**.

Closes #826. Closes #750.

### Real, message-driven turn
- `buildPrompt` drives the agent with the user's message against a persistent
  per-session clone (`onSession` clones idempotently into the workspace on a
  session branch). A fresh session gets a one-time preamble; a resumed one gets
  the message alone.
- `sandboxConfig.workDir` runs the agent **inside** the clone, so its relative
  paths and git resolve against the repo (without it, edits landed in a scratch
  dir outside the clone).

### Durable resume
- After each turn the harness session is `detach()`-ed (parked, sandbox left
  running) and its JSON resume payload persisted to the session row (new
  `sessions.resume_state` column + `updateSession`; `claude_session_id` holds
  the sandbox id). The next turn reconnects via `createSession({sessionId,
  resumeFrom})` so the conversation **and** working copy continue; reconnect is
  bounded by the sandbox lifetime and falls back to a fresh clone when it
  expires. `TurnRequest` carries the resume handle; the ingest loop reads it in
  and persists the parked handle off the `done` chunk (stripped from the log).
- **Resume shim**: `@ai-sdk/sandbox-vercel`'s `resumeSession` calls
  `Sandbox.get({name})` without forwarding the configured credentials, so it
  404s locally (prod's auto-injected OIDC token scopes it). When we hold
  explicit creds we override `resumeSession` to pass them, re-wrapping via the
  adapter's own wrap path.

### In-app fixes (found capturing the evidence)
- **`ws` bundling — prod-breaking.** The harness bridge uses WebSocket; Next.js
  bundled `ws` so every real turn died with `bufferUtil.mask is not a function`.
  `serverExternalPackages` keeps the harness stack external. **This is the fix
  #822's deployed prewarm/real-provider path needs too** — it fails the same way
  in prod today.
- **Error text.** `JSON.stringify(new Error(...))` is `"{}"` (message is
  non-enumerable), so error chunks showed an empty `{}` — the `ws` error was
  invisible until `errorText()` read `.message`.
- **Diff card render.** The synthesized per-file diff is emitted as a
  `tool_use`+`tool_result` pair (the AI SDK only keeps a result with a matching
  opened call), so the `DiffCard` actually renders. Tool names are canonicalized
  (`write`→`Write`) and command output unwrapped so tool cards and `N passed`
  detection read cleanly.

## Mergeability

- Surface: web / agent-runtime — compute provider lifecycle, session persistence, Folio render fidelity, one Next.js config change.
- User-facing behavior changed: real sessions (opt-in `WEB_NEXT_COMPUTE_PROVIDER=vercel`) now run the user's actual request and continue across turns; the mock remains the default so no default behavior changes. Error chunks now show a real message instead of `{}`.
- Non-happy paths considered: resume reconnect failure → status + fresh-clone fallback; sandbox name collision on fresh boot → unique-name retry; `detach()` failure → clears the stale handle so the next turn starts clean; `git diff`/diff-parse failure → no card, turn unaffected; harness errors now surface a readable message.
- Release/ops preconditions: none — no release/signing/CI-runner files. `serverExternalPackages` is a build-config change; prod still needs `WEB_NEXT_COMPUTE_PROVIDER=vercel` + `ANTHROPIC_API_KEY` (set) and a one-time prewarm after deploy.
- Residual risk or follow-up: durable resume is bounded by the sandbox lifetime (idle beyond it re-clones — an honest limit of the adapter's reconnect); the resume shim depends on the adapter's `resumeSession`/naming (documented). The `ws` externalization should be cherry-picked forward promptly since #822 is already on `main` and broken in prod without it.

## Validation

- `pnpm exec tsc --noEmit` — clean · `pnpm run lint` — clean · `pnpm run test` — **142 passed** (16 files; +15 over #822: resume round-trip through the ingest loop, git-diff parsing, tool-name/output/error normalization, `updateSession`, migration).
- **End-to-end through the running app** (real Vercel sandbox, `WEB_NEXT_COMPUTE_PROVIDER=vercel`): a real turn edits `README.md`, streams prose + tool cards (Read/Edit/Ran/Diff) + a rendered **DiffCard** + the stats receipt (`4 tools · 1 file · +2 −0 · 499 tokens · 20.4s`), in **light and dark** (screenshots below). A resumed follow-up stated the file it had edited *from memory* and continued in the same working copy.
- **TTFT / reuse** (local two-turn driver): turn 1 fresh ~11.7s to first token; resumed turn 2 ~5.2s — the warm-reconnect win. (The across-turn snapshot-reuse half of the perf criterion; #822 covered prewarm reuse 28.3s→9.0s.)

## Evidence

- [x] UI evidence attached (dual-theme render of a real turn) + test summary

Evidence links:

- [Real turn — light theme](https://evidence.cloudcompute.com/workspaces/pr-831/20260706-230954-real-turn-light.png)

![real turn light](https://evidence.cloudcompute.com/workspaces/pr-831/20260706-230954-real-turn-light.png)
- [Real turn — dark theme](https://evidence.cloudcompute.com/workspaces/pr-831/20260706-230955-real-turn-dark.png)

![real turn dark](https://evidence.cloudcompute.com/workspaces/pr-831/20260706-230955-real-turn-dark.png)

## Blockers

- [x] None
