### PR TITLE
fix(web): bound managed-agents transcript SSE lifecycle

### DIFF
--- a/web/src/app/api/managed-agents/transcript/route.test.ts
+++ b/web/src/app/api/managed-agents/transcript/route.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getSessionByInstanceId: vi.fn(),
+	getPrReviewRunBySessionId: vi.fn(),
+	authorizeRepoAccess: vi.fn(),
+	session: { user: { id: "user-1" } } as { user: { id: string } } | null,
+	retrieve: vi.fn(),
+	eventsList: vi.fn(),
+	eventsStream: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-sessions", () => ({
+	getSessionByInstanceId: mocks.getSessionByInstanceId,
+}));
+
+vi.mock("@/lib/agent-runtime/pr-review-runs", () => ({
+	getPrReviewRunBySessionId: mocks.getPrReviewRunBySessionId,
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+	authorizeRepoAccess: mocks.authorizeRepoAccess,
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+	getSession: async () => mocks.session,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+	default: class {
+		beta = {
+			sessions: {
+				retrieve: mocks.retrieve,
+				events: {
+					list: mocks.eventsList,
+					stream: mocks.eventsStream,
+				},
+			},
+		};
+	},
+}));
+
+async function* asyncIterable<T>(items: T[]): AsyncGenerator<T> {
+	for (const item of items) yield item;
+}
+
+const toolUseEvent = {
+	type: "agent.tool_use",
+	id: "ev-1",
+	name: "bash",
+	input: { command: "ls" },
+};
+
+const terminalIdleEvent = {
+	type: "session.status_idle",
+	id: "ev-idle",
+	stop_reason: { type: "end_turn" },
+};
+
+function requestFor(sessionId: string): Request {
+	return new Request(
+		`http://localhost/api/managed-agents/transcript?sessionId=${sessionId}`,
+	);
+}
+
+describe("/api/managed-agents/transcript", () => {
+	beforeEach(() => {
+		vi.stubEnv("ANTHROPIC_API_KEY", "test-key");
+		mocks.session = { user: { id: "user-1" } };
+		mocks.getSessionByInstanceId.mockReset();
+		mocks.getSessionByInstanceId.mockResolvedValue(null);
+		mocks.getPrReviewRunBySessionId.mockReset();
+		mocks.getPrReviewRunBySessionId.mockResolvedValue(null);
+		mocks.authorizeRepoAccess.mockReset();
+		mocks.authorizeRepoAccess.mockResolvedValue(null);
+		mocks.retrieve.mockReset();
+		mocks.eventsList.mockReset();
+		mocks.eventsList.mockReturnValue(asyncIterable([toolUseEvent]));
+		mocks.eventsStream.mockReset();
+		mocks.eventsStream.mockResolvedValue(asyncIterable([]));
+	});
+
+	it("requires a signed-in user", async () => {
+		mocks.session = null;
+		const { GET } = await import("./route");
+
+		const response = await GET(requestFor("sess-1"));
+
+		expect(response.status).toBe(401);
+	});
+
+	it("ends after backfill for a finished review run without opening a live tail", async () => {
+		mocks.getPrReviewRunBySessionId.mockResolvedValue({
+			repoFullName: "fairchild/workspaces",
+			status: "completed",
+		});
+		const { GET } = await import("./route");
+
+		const response = await GET(requestFor("sess-1"));
+		const body = await response.text();
+
+		expect(body).toContain('"kind":"command"');
+		expect(body).toContain("event: end");
+		expect(mocks.retrieve).not.toHaveBeenCalled();
+		expect(mocks.eventsStream).not.toHaveBeenCalled();
+	});
+
+	it("ends a live-tailed review run when the session reaches terminal idle", async () => {
+		mocks.getPrReviewRunBySessionId.mockResolvedValue({
+			repoFullName: "fairchild/workspaces",
+			status: "started",
+		});
+		mocks.retrieve.mockResolvedValue({ status: "running" });
+		mocks.eventsStream.mockResolvedValue(
+			asyncIterable([toolUseEvent, terminalIdleEvent]),
+		);
+		const { GET } = await import("./route");
+
+		const response = await GET(requestFor("sess-1"));
+		const body = await response.text();
+
+		expect(mocks.eventsStream).toHaveBeenCalledWith("sess-1");
+		expect(body).toContain("event: end");
+	});
+
+	it("ends without live tail when the underlying session is terminated", async () => {
+		mocks.getSessionByInstanceId.mockResolvedValue({
+			repo: "fairchild/workspaces",
+		});
+		mocks.retrieve.mockResolvedValue({ status: "terminated" });
+		const { GET } = await import("./route");
+
+		const response = await GET(requestFor("sess-1"));
+		const body = await response.text();
+
+		expect(body).toContain("event: end");
+		expect(mocks.eventsStream).not.toHaveBeenCalled();
+	});
+
+	it("live-tails an idle chat session so follow-up turns still stream", async () => {
+		mocks.getSessionByInstanceId.mockResolvedValue({
+			repo: "fairchild/workspaces",
+		});
+		mocks.retrieve.mockResolvedValue({ status: "idle" });
+		const { GET } = await import("./route");
+
+		const response = await GET(requestFor("sess-1"));
+		const body = await response.text();
+
+		expect(mocks.eventsStream).toHaveBeenCalledWith("sess-1");
+		expect(body).not.toContain("event: end");
+	});
+
+	it("bounds the function lifetime as a billing backstop", async () => {
+		const { maxDuration } = await import("./route");
+		expect(maxDuration).toBe(300);
+	});
+});

--- a/web/src/app/api/managed-agents/transcript/route.ts
+++ b/web/src/app/api/managed-agents/transcript/route.ts
@@ -6,12 +6,16 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { BetaManagedAgentsStreamSessionEvents } from "@anthropic-ai/sdk/resources/beta/sessions/events";
 
 export const dynamic = "force-dynamic";
+// Backstop: Fluid Compute bills wall-clock while this function is warm, so an
+// orphaned stream must not run indefinitely. Clients reconnect if still live.
+export const maxDuration = 300;
 
 /**
  * SSE endpoint that streams a Managed Agents session's `agent.tool_use` and
  * `agent.tool_result` events as compact JSON lines, consumed by the
  * `TranscriptTerminal` client component. Read-only: there is no way to
- * drive the container from this route.
+ * drive the container from this route. Finished sessions get an `end`
+ * sentinel instead of a live tail so the client stops reconnecting.
  */
 export async function GET(request: Request): Promise<Response> {
 	const authed = await getSession();
@@ -58,6 +62,30 @@ export async function GET(request: Request): Promise<Response> {
 			};
 			request.signal.addEventListener("abort", onAbort);
 
+			// Tell the client no further events will ever arrive, so it closes
+			// its EventSource instead of auto-reconnecting forever.
+			const sendEnd = () => {
+				if (closed) return;
+				controller.enqueue(encoder.encode("event: end\ndata: {}\n\n"));
+			};
+
+			// Live-tailing only makes sense while the session can still emit
+			// events. Review runs are one-shot: once the run record or the
+			// session itself is no longer active, the transcript is complete.
+			// Chat sessions stay tailable while idle — a follow-up user turn
+			// can produce more tool calls on the same session.
+			const shouldLiveTail = async (): Promise<boolean> => {
+				if (reviewRun && reviewRun.status !== "started") return false;
+				try {
+					const session = await client.beta.sessions.retrieve(sessionId);
+					if (session.status === "terminated") return false;
+					if (reviewRun && session.status === "idle") return false;
+				} catch {
+					return false;
+				}
+				return true;
+			};
+
 			try {
 				// Backfill existing history first so the user sees prior calls
 				// immediately when they open the tab.
@@ -71,12 +99,25 @@ export async function GET(request: Request): Promise<Response> {
 					if (line) send(line);
 				}
 
-				// Then live-tail new events. session.status_idle does NOT close
-				// the stream on our side — a follow-up user turn can make the
-				// agent produce more tool calls on the same session.
+				if (!(await shouldLiveTail())) {
+					sendEnd();
+					return;
+				}
+
 				const live = await client.beta.sessions.events.stream(sessionId);
 				for await (const event of live) {
 					if (closed) return;
+					// A review session reaching terminal idle is done for good —
+					// the broker never sends it another turn.
+					if (
+						reviewRun &&
+						event.type === "session.status_idle" &&
+						(event.stop_reason?.type === "end_turn" ||
+							event.stop_reason?.type === "retries_exhausted")
+					) {
+						sendEnd();
+						return;
+					}
 					const line = toTranscriptLine(event);
 					if (line) send(line);
 				}

--- a/web/src/app/dashboard/components/transcript-terminal.tsx
+++ b/web/src/app/dashboard/components/transcript-terminal.tsx
@@ -29,11 +29,13 @@ export function TranscriptTerminal({
 }: TranscriptTerminalProps) {
 	const [lines, setLines] = useState<TranscriptLine[]>([]);
 	const [error, setError] = useState<string | null>(null);
+	const [ended, setEnded] = useState(false);
 	const scrollRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		setLines([]);
 		setError(null);
+		setEnded(false);
 		const url = `/api/managed-agents/transcript?sessionId=${encodeURIComponent(sessionId)}`;
 		const source = new EventSource(url);
 		source.onmessage = (ev) => {
@@ -44,6 +46,13 @@ export function TranscriptTerminal({
 				// ignore malformed line
 			}
 		};
+		// The server sends `end` when the session can emit no further events;
+		// close for real so the browser doesn't auto-reconnect forever.
+		source.addEventListener("end", () => {
+			setEnded(true);
+			setError(null);
+			source.close();
+		});
 		source.onerror = () => {
 			setError("transcript stream disconnected");
 		};
@@ -96,6 +105,11 @@ export function TranscriptTerminal({
 						)}
 					</div>
 				))}
+				{ended && (
+					<div className={styles["line-status"]}>
+						<span className={styles.statusText}>transcript complete</span>
+					</div>
+				)}
 				{error && <div className={styles["line-error"]}>{error}</div>}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

- The managed-agents transcript SSE route (`/api/managed-agents/transcript`) live-tailed every session forever with no `maxDuration`, and the browser `EventSource` auto-reconnects on any drop — so a dashboard tab left open on a finished session (terminal panel or a `review-runs/[fingerprint]` page) billed Vercel Fluid Compute continuously. This is the dominant contributor to the ~820 GB-Hrs/30d spike on `spaces-web`.
- The route now ends the stream with an SSE `end` sentinel once the session can emit no further events: finished review runs (`status !== "started"`) skip the live tail entirely; live-tailed review runs close on terminal idle (`end_turn` / `retries_exhausted`, matching the broker's own done-detection); `terminated` sessions end for all kinds. Chat sessions still live-tail while idle, since a follow-up turn can produce more tool calls.
- `maxDuration = 300` backstops anything orphaned. `TranscriptTerminal` closes its `EventSource` on `end` (breaking the reconnect chain) and renders a `transcript complete` status line.
- Deliberately deferred: mounting `TranscriptTerminal` only for the active sub-tab in `terminal-panel.tsx` (currently one SSE connection per running managed-agents session). That refactor is on hold pending the managed-agents value decision — the PR reviewer is paused via `PR_REVIEWER_ENABLED=0` in production as of 2026-07-06.

## Mergeability

- Surface: web / agent-runtime
- User-facing behavior changed: finished managed-agents transcripts now show `transcript complete` and stop streaming instead of silently holding an open connection; active sessions behave as before.
- Non-happy paths considered: `sessions.retrieve` failure ends the stream rather than tailing forever; client `end` handler clears any stale disconnect error; abort/unmount path unchanged.
- Release/ops preconditions: none — no env or schema changes in this PR.
- Residual risk or follow-up: an idle *chat* session still live-tails by design, so an open dashboard tab with a managed-agents chat session keeps a bounded-but-reconnecting stream; covered by the deferred mounting/visibility work if managed-agents survives the value review.

## Validation

- [x] `pnpm vitest run src/app/api/managed-agents/transcript/route.test.ts` — 6 new tests covering: auth gate, finished-review end-after-backfill (no live stream opened), live-tail close on terminal idle, terminated-session end, idle-chat live-tail preserved, `maxDuration` export.
- [x] `mise run web:check` — typecheck + biome + 373 unit tests, all green.
- Evidence: [transcript route test run](https://evidence.cloudcompute.com/workspaces/pr-833/20260706-235903-transcript-route-tests.png)

## Performance

- [x] Not a performance-sensitive change (app-perf sense; the billing effect is the point of the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
