### PR TITLE
docs(pr-review): record reviewer pause + required-check removal

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -18,19 +18,21 @@ changed, both outside the repo:
 
 - `PR_REVIEWER_ENABLED=0` in Vercel production — webhooks no longer start
   review sessions.
-- `WorkSpaces Managed Review` removed from the required status checks on
-  `main` branch protection — with the reviewer off, the check otherwise sits
-  at "Expected — waiting for status" forever and blocks merges. Branch
-  protection is not config-as-code; this doc is the record.
+- `WorkSpaces Managed Review` is not in the required status checks for `main`
+  (the `main-merge` ruleset) — with the reviewer off, the check otherwise sits
+  at "Expected — waiting for status" forever and blocks merges.
 
 The pipeline, GitHub App, and broker stay deployed. Revisit ~2026-07-20: if
 nobody missed the reviewer, that is the answer. To re-enable, set
-`PR_REVIEWER_ENABLED=1` (or remove it) and restore the required check:
+`PR_REVIEWER_ENABLED=1` (or remove it) and re-add the check to the
+`main-merge` ruleset's `required_status_checks` rule — preferably by editing
+`config/github/rulesets/main-merge.json` and running
+`scripts/github-settings.py apply`, or directly:
 
 ```bash
-gh api -X PATCH repos/fairchild/workspaces/branches/main/protection/required_status_checks --input - <<'EOF'
-{"strict": false, "checks": [{"context": "readiness", "app_id": 15368}, {"context": "release-change-validation", "app_id": 15368}, {"context": "WorkSpaces Managed Review", "app_id": 3504942}]}
-EOF
+gh api repos/fairchild/workspaces/rulesets --jq '.[] | select(.name=="main-merge") | .id'
+# add to the required_status_checks rule parameters and PUT the full ruleset:
+#   {"context": "WorkSpaces Managed Review", "integration_id": 3504942}
 ```
 
 ## Key Files

--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -10,6 +10,29 @@ operator triage surfaces, start with [`architecture.md`](architecture.md). This
 file is the runtime and operations reference: configuration, ingress canaries,
 broker scheduling, and debugging commands.
 
+## Standing State: Paused (2026-07-06)
+
+The reviewer is paused as a value-signal experiment (slow, unreliable
+completions with no evidence it catches what other gates miss). Two settings
+changed, both outside the repo:
+
+- `PR_REVIEWER_ENABLED=0` in Vercel production — webhooks no longer start
+  review sessions.
+- `WorkSpaces Managed Review` removed from the required status checks on
+  `main` branch protection — with the reviewer off, the check otherwise sits
+  at "Expected — waiting for status" forever and blocks merges. Branch
+  protection is not config-as-code; this doc is the record.
+
+The pipeline, GitHub App, and broker stay deployed. Revisit ~2026-07-20: if
+nobody missed the reviewer, that is the answer. To re-enable, set
+`PR_REVIEWER_ENABLED=1` (or remove it) and restore the required check:
+
+```bash
+gh api -X PATCH repos/fairchild/workspaces/branches/main/protection/required_status_checks --input - <<'EOF'
+{"strict": false, "checks": [{"context": "readiness", "app_id": 15368}, {"context": "release-change-validation", "app_id": 15368}, {"context": "WorkSpaces Managed Review", "app_id": 3504942}]}
+EOF
+```
+
 ## Key Files
 
 | File | Purpose |


### PR DESCRIPTION
## Summary

Records today's managed-reviewer pause in the runtime/ops doc, since the changes live outside the repo (Vercel env + GitHub ruleset) and nothing in the tree would otherwise say the reviewer is off:

- `PR_REVIEWER_ENABLED=0` in production (value-signal pause, revisit ~2026-07-20)
- `WorkSpaces Managed Review` removed from required status checks on `main` — with the reviewer off, PRs hung forever on "Expected — waiting for status"

Includes the restore path (via the `main-merge` ruleset, which now carries all `main` protections) for re-enabling.

## Mergeability

- Surface: docs
- User-facing behavior changed: none in the product; the merge gate on `main` no longer waits on the managed-review status (settings change made directly, this PR records it)
- Non-happy paths considered: restore instructions kept accurate after branch-protection→ruleset consolidation; doc states settings live outside the repo so readers don't expect the doc itself to enforce anything
- Release/ops preconditions: none
- Residual risk or follow-up: config-as-code for the ruleset lands separately (`config/github/` + `scripts/github-settings.py`); the doc references those paths and is accurate once that PR merges

## Validation

- [x] Other checks run: docs-only; verified doc content against live GitHub API state (below)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

Current required-checks state matches what the doc records:

```
$ gh api repos/fairchild/workspaces/rules/branches/main --jq '[.[] | select(.type=="required_status_checks")] | .[0].parameters.required_status_checks'
[{"context":"readiness","integration_id":15368},{"context":"release-change-validation","integration_id":15368}]
```

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
