### PR TITLE
feat(infra): GitHub repo settings as code (rulesets + drift gate)

### DIFF
--- a/.github/workflows/repo-settings-drift.yml
+++ b/.github/workflows/repo-settings-drift.yml
@@ -1,0 +1,27 @@
+# Drift gate for config/github/ — verifies live GitHub repo settings (rulesets)
+# still match the committed desired state. Read-only: applying changes is a
+# deliberate local act via `scripts/github-settings.py apply` (repo admin).
+name: Repo Settings Drift
+
+on:
+  schedule:
+    - cron: "23 13 * * *"
+  pull_request:
+    paths:
+      - "config/github/**"
+      - "scripts/github-settings.py"
+      - ".github/workflows/repo-settings-drift.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check live settings against config/github/
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/github-settings.py check

--- a/.mise.toml
+++ b/.mise.toml
@@ -107,3 +107,11 @@ run = "./scripts/lume-host-macos-smoke.sh"
 description = "Capture screenshot and upload to R2 evidence store."
 run = "./scripts/evidence.sh"
 usage = "--pr <number> --name <slug> [--file <path>] [--no-capture]"
+
+[tasks."repo-settings-check"]
+description = "Diff live GitHub repo settings (rulesets) against config/github/; exit 1 on drift."
+run = "uv run --script scripts/github-settings.py check"
+
+[tasks."repo-settings-apply"]
+description = "Push config/github/ ruleset files to GitHub (needs repo admin)."
+run = "uv run --script scripts/github-settings.py apply"

--- a/config/github/README.md
+++ b/config/github/README.md
@@ -1,0 +1,24 @@
+# GitHub repo settings as code
+
+Desired state for this repo's GitHub-side settings. `rulesets/<name>.json`
+holds one repository ruleset each (the writable fields of the
+[rulesets API](https://docs.github.com/en/rest/repos/rules) object), matched
+to the live ruleset by its `name` field. All `main` merge gates — required
+status checks, PR rules, linear history, deletion/force-push protection —
+live in the `main-merge` ruleset; classic branch protection is not used.
+
+```bash
+uv run --script scripts/github-settings.py check      # diff live vs. files, exit 1 on drift
+uv run --script scripts/github-settings.py apply      # push files to GitHub (needs repo admin)
+uv run --script scripts/github-settings.py snapshot   # overwrite files from live state
+```
+
+Changing a setting is a PR that edits the JSON, then `apply` after merge.
+`.github/workflows/repo-settings-drift.yml` runs `check` on a schedule and on
+PRs touching these files, so a settings change made in the GitHub UI without a
+matching commit here shows up as a failing drift run. Reads work with the
+default Actions token (rulesets are visible to anyone with read access);
+`apply` needs an admin-authenticated `gh`, so it stays a deliberate local act.
+
+To manage an additional ruleset, create `rulesets/<name>.json` containing
+`{"name": "<live-name>"}` and run `snapshot`.

--- a/config/github/rulesets/main-merge.json
+++ b/config/github/rulesets/main-merge.json
@@ -1,0 +1,55 @@
+{
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "main-merge",
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "readiness",
+            "integration_id": 15368
+          },
+          {
+            "context": "release-change-validation",
+            "integration_id": 15368
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      },
+      "type": "required_status_checks"
+    }
+  ],
+  "target": "branch"
+}

--- a/config/github/rulesets/main-merge.json
+++ b/config/github/rulesets/main-merge.json
@@ -18,6 +18,9 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_linear_history"
+    },
+    {
       "parameters": {
         "allowed_merge_methods": [
           "merge",

--- a/scripts/github-settings.py
+++ b/scripts/github-settings.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Config-as-code for GitHub repo settings (currently: repository rulesets).
+
+Desired state lives in config/github/rulesets/<name>.json, matched to live
+rulesets by their "name" field. `check` exits 1 with a diff when live settings
+drift from the files; `apply` pushes the files to GitHub (admin token);
+`snapshot` overwrites the files from live state. Auth via `gh` / GH_TOKEN.
+"""
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+RULESETS_DIR = Path(__file__).resolve().parent.parent / "config" / "github" / "rulesets"
+WRITABLE_FIELDS = ("name", "target", "enforcement", "bypass_actors", "conditions", "rules")
+
+
+def gh_api(path: str, method: str = "GET", body: dict | None = None) -> dict | list:
+    cmd = ["gh", "api", "-X", method, path]
+    stdin = None
+    if body is not None:
+        cmd += ["--input", "-"]
+        stdin = json.dumps(body).encode()
+    try:
+        result = subprocess.run(cmd, input=stdin, capture_output=True, check=True)
+    except subprocess.CalledProcessError as err:
+        sys.exit(f"gh api {method} {path} failed: {err.stderr.decode().strip()}")
+    return json.loads(result.stdout)
+
+
+def repo_slug() -> str:
+    result = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def render(ruleset: dict) -> str:
+    desired = {key: ruleset[key] for key in WRITABLE_FIELDS if key in ruleset}
+    return json.dumps(desired, indent=2, sort_keys=True) + "\n"
+
+
+def desired_files() -> list[Path]:
+    files = sorted(RULESETS_DIR.glob("*.json"))
+    if not files:
+        sys.exit(f"no ruleset files in {RULESETS_DIR}")
+    return files
+
+
+def live_ids_by_name(repo: str) -> dict[str, int]:
+    return {r["name"]: r["id"] for r in gh_api(f"repos/{repo}/rulesets")}
+
+
+def check(repo: str) -> int:
+    live_ids = live_ids_by_name(repo)
+    drift = 0
+    for path in desired_files():
+        desired = json.loads(path.read_text())
+        name = desired["name"]
+        if name not in live_ids:
+            print(f"DRIFT: ruleset '{name}' ({path.name}) does not exist on {repo}")
+            drift = 1
+            continue
+        live = render(gh_api(f"repos/{repo}/rulesets/{live_ids[name]}"))
+        wanted = render(desired)
+        if live == wanted:
+            print(f"OK: ruleset '{name}' matches {path.name}")
+        else:
+            print(f"DRIFT: ruleset '{name}' differs from {path.name}:")
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    live.splitlines(keepends=True),
+                    wanted.splitlines(keepends=True),
+                    fromfile=f"live/{name}",
+                    tofile=f"config/github/rulesets/{path.name}",
+                )
+            )
+            drift = 1
+    return drift
+
+
+def apply(repo: str) -> int:
+    live_ids = live_ids_by_name(repo)
+    for path in desired_files():
+        desired = json.loads(render(json.loads(path.read_text())))
+        name = desired["name"]
+        if name in live_ids:
+            gh_api(f"repos/{repo}/rulesets/{live_ids[name]}", "PUT", desired)
+            print(f"applied: ruleset '{name}' <- {path.name}")
+        else:
+            gh_api(f"repos/{repo}/rulesets", "POST", desired)
+            print(f"created: ruleset '{name}' <- {path.name}")
+    return 0
+
+
+def snapshot(repo: str) -> int:
+    live_ids = live_ids_by_name(repo)
+    for path in desired_files():
+        name = json.loads(path.read_text())["name"]
+        if name not in live_ids:
+            sys.exit(f"ruleset '{name}' ({path.name}) does not exist on {repo}")
+        path.write_text(render(gh_api(f"repos/{repo}/rulesets/{live_ids[name]}")))
+        print(f"snapshot: {path.name} <- live ruleset '{name}'")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["check", "apply", "snapshot"])
+    args = parser.parse_args()
+    return {"check": check, "apply": apply, "snapshot": snapshot}[args.command](repo_slug())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/github-settings.py
+++ b/scripts/github-settings.py
@@ -47,6 +47,10 @@ def repo_slug() -> str:
 
 def render(ruleset: dict) -> str:
     desired = {key: ruleset[key] for key in WRITABLE_FIELDS if key in ruleset}
+    # Read-only tokens (e.g. the Actions token in the drift workflow) get the
+    # ruleset without bypass_actors; treat absent as empty so they compare
+    # cleanly. Actual bypass-actor drift is still caught by admin-side checks.
+    desired.setdefault("bypass_actors", [])
     return json.dumps(desired, indent=2, sort_keys=True) + "\n"
 
 


### PR DESCRIPTION
## Summary

GitHub-side repo settings become config-as-code. Today's reviewer-pause change was made in the GitHub UI/API with nothing in the tree to record or enforce it; this PR closes that gap for rulesets:

- **Consolidation (already live):** all `main` merge gates now live in the `main-merge` ruleset — required status checks (`readiness`, `release-change-validation`), PR rules + review-thread resolution, linear history, deletion/force-push protection. Classic branch protection is deleted; one mechanism instead of two.
- `config/github/rulesets/main-merge.json` — desired state, matched to the live ruleset by name.
- `scripts/github-settings.py` — single-file uv script: `check` (diff live vs. file, exit 1 on drift), `apply` (push file to GitHub, needs admin), `snapshot` (refresh file from live).
- `.github/workflows/repo-settings-drift.yml` — runs `check` daily and on PRs touching these files, so UI-side settings changes without a matching commit surface as a failing run.
- mise tasks: `repo-settings-check` / `repo-settings-apply`.

Changing a setting is now a PR that edits the JSON + `apply` after merge. The drift run on this very PR doubles as proof the CI read path works with the default Actions token.

## Mergeability

- Surface: infra
- User-facing behavior changed: none in the product; merge gates on `main` are unchanged in effect (same required checks), now enforced by the ruleset alone
- Non-happy paths considered: drift exits 1 with a unified diff; missing live ruleset reported as drift; `apply` creates the ruleset if absent; `gh api` failures exit with stderr surfaced; comparison is key-order-insensitive (`sort_keys`)
- Release/ops preconditions: none; `apply` requires admin-authenticated `gh` (deliberate — CI is read-only)
- Residual risk or follow-up: only rulesets are covered (repo metadata, labels, webhooks are not); read-only tokens don't see `bypass_actors`, so bypass-actor drift is only caught by admin-side `check` (noted in code); the default Actions token reads rulesets fine — verified by this PR's own drift run

## Validation

- [x] Other checks run: `snapshot` → `check` (OK) → `apply` (idempotent) → `check` (OK); drift demo (local edit → exit 1 with diff → restore); `mise run repo-settings-check` green

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

Full verification loop (consolidated ruleset state, classic protection 404, check/apply idempotence, drift demo with exit code):

![repo-settings-verification-v2](https://evidence.cloudcompute.com/workspaces/pr-835/20260707-040237-repo-settings-verification-v2.png)

Bonus real-world proof: the first commit accidentally included a demo-mutated ruleset file, and [this PR's own drift run caught it](https://github.com/fairchild/workspaces/actions/runs/28840513802/job/85533392769) — exactly the failure mode the gate exists for. Fixed in the follow-up commit.

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
