### PR TITLE
docs(pr-review): PEM verify path changed — sensitive env var can't be pulled

### DIFF
--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -340,7 +340,7 @@ for line in sys.stdin:
 
 ### Session created but repo empty
 
-If using the GitHub App: check that `PR_REVIEWER_APP_ID`, `PR_REVIEWER_PRIVATE_KEY`, and `PR_REVIEWER_INSTALLATION_ID` are set correctly. The private key PEM must have real newlines (Vercel handles this, but verify with `vercel env pull`).
+If using the GitHub App: check that `PR_REVIEWER_APP_ID`, `PR_REVIEWER_PRIVATE_KEY`, and `PR_REVIEWER_INSTALLATION_ID` are set correctly. The private key PEM must have real newlines (Vercel handles this). `PR_REVIEWER_PRIVATE_KEY` is a sensitive env var (as of 2026-07-06), so `vercel env pull` returns it empty — if the PEM is suspect, re-add it from the GitHub App's key file rather than trying to inspect the stored value.
 
 ### Review not posted to GitHub
 


### PR DESCRIPTION
## Summary

On 2026-07-06 the real secrets in both Vercel projects were flipped to sensitive-type env vars (readable config flags and `*_ID` vars stay plain). That invalidated one documented debugging step: `pr-reviewer.md` suggested verifying the `PR_REVIEWER_PRIVATE_KEY` PEM's newlines via `vercel env pull`, which now returns it empty. The doc now says to re-add the key from the GitHub App's key file when in doubt.

## Mergeability

- Surface: docs
- User-facing behavior changed: none (doc-only)
- Non-happy paths considered: the replacement guidance (re-add from source) works regardless of var type
- Release/ops preconditions: none
- Residual risk or follow-up: the vercel-settings-as-code work (#844) will encode the sensitive/plain split per project

## Validation

- [x] Other checks run: docs-only; statement verified against live var types via Vercel API

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

Live state (Vercel API): `PR_REVIEWER_PRIVATE_KEY production -> sensitive` (flipped 2026-07-06, this session).

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
