### PR TITLE
feat(infra): Vercel env vars as config-as-code (spaces-web + web-next)

### DIFF
--- a/.github/workflows/vercel-settings-drift.yml
+++ b/.github/workflows/vercel-settings-drift.yml
@@ -21,7 +21,7 @@ jobs:
   drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Check live Vercel env against config/vercel/
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/vercel-settings-drift.yml
+++ b/.github/workflows/vercel-settings-drift.yml
@@ -1,0 +1,34 @@
+# Drift gate for config/vercel/ — verifies live Vercel env vars still match
+# the committed manifests. Read-only: reconciling is a deliberate local act
+# via `scripts/vercel-settings.py apply`. Soft-skips until the VERCEL_TOKEN
+# repo secret exists (mint at vercel.com/account/tokens, scope cloudcompute).
+name: Vercel Settings Drift
+
+on:
+  schedule:
+    - cron: "41 13 * * *"
+  pull_request:
+    paths:
+      - "config/vercel/**"
+      - "scripts/vercel-settings.py"
+      - ".github/workflows/vercel-settings-drift.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check live Vercel env against config/vercel/
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_BIN: npx --yes vercel@latest
+        run: |
+          if [ -z "$VERCEL_TOKEN" ]; then
+            echo "::notice::VERCEL_TOKEN secret not configured; skipping Vercel drift check"
+            exit 0
+          fi
+          python3 scripts/vercel-settings.py check

--- a/.mise.toml
+++ b/.mise.toml
@@ -115,3 +115,11 @@ run = "uv run --script scripts/github-settings.py check"
 [tasks."repo-settings-apply"]
 description = "Push config/github/ ruleset files to GitHub (needs repo admin)."
 run = "uv run --script scripts/github-settings.py apply"
+
+[tasks."vercel-settings-check"]
+description = "Diff live Vercel env vars (both projects) against config/vercel/; exit 1 on drift."
+run = "uv run --script scripts/vercel-settings.py check"
+
+[tasks."vercel-settings-apply"]
+description = "Reconcile config/vercel/ manifest values to Vercel (secrets untouched; redeploy to activate)."
+run = "uv run --script scripts/vercel-settings.py apply"

--- a/config/vercel/README.md
+++ b/config/vercel/README.md
@@ -1,0 +1,31 @@
+# Vercel env vars as code
+
+Desired state for the two Vercel projects' production env vars: `spaces-web`
+(dir `web/`) and `web-next` (dir `web-next/`), one manifest each. Two tiers:
+
+- **`values`** — non-secret operational flags and debug-friendly config
+  (`COMPUTE_PROVIDER`, `PR_REVIEWER_ENABLED`, IDs, URLs), checked by value.
+  Membership is explicit curation, never inferred from readability — a
+  secret with a misconfigured sensitive flag must not get snapshotted into
+  the repo.
+- **`present`** — secrets, checked by name only. Values never appear in-repo
+  or in script output. Stored as sensitive-type vars in Vercel (unreadable
+  after creation; recovery is rotation).
+
+```bash
+uv run --script scripts/vercel-settings.py check      # diff live vs. manifests, exit 1 on drift
+uv run --script scripts/vercel-settings.py apply      # reconcile `values` keys (secrets untouched)
+uv run --script scripts/vercel-settings.py snapshot   # refresh manifest values from live
+```
+
+Changing a flag is a PR that edits the manifest, then `apply` after merge —
+and a **redeploy**: env changes only take effect on the next deployment.
+
+Vars not listed in a manifest are ignored (Vercel injects `VERCEL_*`/`TURBO_*`
+system vars; unmanaged vars are not drift). The script auto-links each project
+dir when `.vercel/` is missing (fresh worktrees always are). Auth: logged-in
+`vercel` CLI locally, `VERCEL_TOKEN` in CI. `VERCEL_BIN` overrides the CLI
+command (e.g. `npx --yes vercel`).
+
+`.github/workflows/vercel-settings-drift.yml` runs `check` daily; it soft-skips
+until a `VERCEL_TOKEN` repo secret is configured.

--- a/config/vercel/spaces-web.json
+++ b/config/vercel/spaces-web.json
@@ -1,0 +1,33 @@
+{
+  "dir": "web",
+  "environment": "production",
+  "present": [
+    "ANTHROPIC_API_KEY",
+    "BETTER_AUTH_SECRET",
+    "CRON_SECRET",
+    "GITHUB_TOKEN",
+    "GITHUB_WEB_WORKSPACES_CLIENT_ID",
+    "GITHUB_WEB_WORKSPACES_CLIENT_SECRET",
+    "GITHUB_WEB_WORKSPACES_WEBHOOK_SECRET",
+    "PR_REVIEWER_PRIVATE_KEY",
+    "TURSO_AUTH_TOKEN",
+    "VERCEL_TOKEN",
+    "WORKSPACES_WEBHOOK_CANARY_SECRET"
+  ],
+  "project": "spaces-web",
+  "scope": "cloudcompute",
+  "values": {
+    "ALLOWED_AGENT_LOGINS": "fairchild",
+    "BETTER_AUTH_URL": "https://spaces.cloudcompute.com",
+    "COMPUTE_PROVIDER": "vercel-sandbox",
+    "GITHUB_WEB_WORKSPACES_APP_ID": "3158670",
+    "NEXT_PUBLIC_POSTHOG_TOKEN": "phc_Aqr4HEAt3wstv4BYUdN8R5u8NePijXHq6UnxSySK2D7J",
+    "PR_REVIEWER_APP_ID": "3504942",
+    "PR_REVIEWER_ENABLED": "0",
+    "PR_REVIEWER_INSTALLATION_ID": "127114212",
+    "PR_REVIEWER_VAULT_ID": "vlt_011CaBYVtrPtNTuxqSpyTVyL",
+    "TURSO_DATABASE_URL": "libsql://spaces-web-fairchild.aws-us-west-2.turso.io",
+    "VERCEL_PROJECT_ID": "prj_oBvZL4mnAKE0QTLbNQWQ4a0DE2U0",
+    "VERCEL_TEAM_ID": "team_oGt9u60VkiPutA2CiKDDGQKV"
+  }
+}

--- a/config/vercel/web-next.json
+++ b/config/vercel/web-next.json
@@ -15,7 +15,7 @@
   "values": {
     "ALLOWED_LOGINS": "fairchild",
     "BETTER_AUTH_URL": "https://web-next-ivory-six.vercel.app",
-    "GITHUB_OAUTH_CLIENT_ID": "Iv23liSWNRsPl1YzIdyK",
+    "GITHUB_OAUTH_CLIENT_ID": "Ov23liLrhAxZKk9Ob8HX",
     "GITHUB_WEB_WORKSPACES_APP_ID": "3158670",
     "WEB_NEXT_COMPUTE_PROVIDER": "vercel"
   }

--- a/config/vercel/web-next.json
+++ b/config/vercel/web-next.json
@@ -1,0 +1,22 @@
+{
+  "dir": "web-next",
+  "environment": "production",
+  "present": [
+    "AI_GATEWAY_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "BETTER_AUTH_SECRET",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_OAUTH_CLIENT_SECRET",
+    "SESSIONS_DATABASE_AUTH_TOKEN",
+    "SESSIONS_DATABASE_URL"
+  ],
+  "project": "web-next",
+  "scope": "cloudcompute",
+  "values": {
+    "ALLOWED_LOGINS": "fairchild",
+    "BETTER_AUTH_URL": "https://web-next-ivory-six.vercel.app",
+    "GITHUB_OAUTH_CLIENT_ID": "Iv23liSWNRsPl1YzIdyK",
+    "GITHUB_WEB_WORKSPACES_APP_ID": "3158670",
+    "WEB_NEXT_COMPUTE_PROVIDER": "vercel"
+  }
+}

--- a/docs/pr-review/pr-reviewer.md
+++ b/docs/pr-review/pr-reviewer.md
@@ -17,7 +17,9 @@ completions with no evidence it catches what other gates miss). Two settings
 changed, both outside the repo:
 
 - `PR_REVIEWER_ENABLED=0` in Vercel production — webhooks no longer start
-  review sessions.
+  review sessions. This flag (and the other non-secret Vercel env vars) is
+  pinned as config-as-code in `config/vercel/`; check/apply via
+  `scripts/vercel-settings.py`.
 - `WorkSpaces Managed Review` is not in the required status checks for `main`
   (the `main-merge` ruleset) — with the reviewer off, the check otherwise sits
   at "Expected — waiting for status" forever and blocks merges.

--- a/scripts/vercel-settings.py
+++ b/scripts/vercel-settings.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Config-as-code for Vercel env vars (spaces-web + web-next projects).
+
+Desired state lives in config/vercel/<project>.json: `values` are non-secret
+flags checked by value; `present` are secrets checked by name only (their
+values never appear in-repo or in output). `check` exits 1 on drift; `apply`
+reconciles `values` keys (then a redeploy is needed to take effect);
+`snapshot` refreshes manifest values from live. Auth via logged-in `vercel`
+CLI or VERCEL_TOKEN. Membership in `values` is explicit curation — never
+classify by readability, since a var's sensitive flag can be misconfigured.
+"""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_DIR = REPO_ROOT / "config" / "vercel"
+ENV_LINE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*)="(.*)"$')
+
+
+def vercel_cmd(*args: str) -> list[str]:
+    cmd = shlex.split(os.environ.get("VERCEL_BIN", "vercel")) + list(args)
+    if token := os.environ.get("VERCEL_TOKEN"):
+        cmd += ["--token", token]
+    return cmd
+
+
+def run(cmd: list[str], cwd: Path, input_text: str | None = None) -> str:
+    result = subprocess.run(cmd, cwd=cwd, input=input_text, capture_output=True, text=True)
+    if result.returncode != 0:
+        redacted = [a for a in cmd if a != os.environ.get("VERCEL_TOKEN")]
+        sys.exit(f"command failed: {' '.join(redacted)}\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def manifests() -> list[dict]:
+    files = sorted(MANIFEST_DIR.glob("*.json"))
+    if not files:
+        sys.exit(f"no manifests in {MANIFEST_DIR}")
+    return [{"path": f, **json.loads(f.read_text())} for f in files]
+
+
+def ensure_link(m: dict) -> Path:
+    project_dir = REPO_ROOT / m["dir"]
+    link = project_dir / ".vercel" / "project.json"
+    if link.exists() and json.loads(link.read_text()).get("projectName") == m["project"]:
+        return project_dir
+    run(vercel_cmd("link", "--yes", "--scope", m["scope"], "--project", m["project"]), cwd=project_dir)
+    return project_dir
+
+
+def pull_env(m: dict) -> dict[str, str]:
+    project_dir = ensure_link(m)
+    with tempfile.TemporaryDirectory() as tmp:
+        env_file = Path(tmp) / "pulled.env"
+        run(
+            vercel_cmd("env", "pull", str(env_file), "--environment", m["environment"], "--yes"),
+            cwd=project_dir,
+        )
+        pairs = {}
+        for line in env_file.read_text().splitlines():
+            if match := ENV_LINE.match(line):
+                pairs[match.group(1)] = match.group(2)
+        return pairs
+
+
+def check(m: dict) -> int:
+    live = pull_env(m)
+    drift = 0
+    for key, expected in m["values"].items():
+        if key not in live:
+            print(f"DRIFT [{m['project']}] {key}: missing in {m['environment']}")
+            drift = 1
+        elif live[key] != expected:
+            print(f"DRIFT [{m['project']}] {key}: live={live[key]!r} expected={expected!r}")
+            drift = 1
+    for key in m["present"]:
+        if key not in live:
+            print(f"DRIFT [{m['project']}] {key}: secret missing in {m['environment']}")
+            drift = 1
+    if not drift:
+        print(f"OK [{m['project']}] {len(m['values'])} values + {len(m['present'])} secrets match")
+    return drift
+
+
+def apply(m: dict) -> int:
+    live = pull_env(m)
+    project_dir = REPO_ROOT / m["dir"]
+    changed = []
+    for key, expected in m["values"].items():
+        if live.get(key) == expected:
+            continue
+        if key in live:
+            run(vercel_cmd("env", "rm", key, m["environment"], "--yes"), cwd=project_dir)
+        run(vercel_cmd("env", "add", key, m["environment"]), cwd=project_dir, input_text=expected)
+        changed.append(key)
+        print(f"applied [{m['project']}] {key}")
+    if changed:
+        print(f"NOTE [{m['project']}]: env changes take effect on the NEXT deploy — redeploy to activate")
+    else:
+        print(f"no-op [{m['project']}]: all values already match")
+    return 0
+
+
+def snapshot(m: dict) -> int:
+    live = pull_env(m)
+    for key in m["values"]:
+        if key not in live:
+            sys.exit(f"[{m['project']}] {key} not in live {m['environment']} env; cannot snapshot")
+        m["values"][key] = live[key]
+    manifest = {k: m[k] for k in ("project", "scope", "dir", "environment", "values", "present")}
+    manifest["present"] = sorted(manifest["present"])
+    m["path"].write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(f"snapshot [{m['project']}] -> {m['path'].name}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["check", "apply", "snapshot"])
+    args = parser.parse_args()
+    action = {"check": check, "apply": apply, "snapshot": snapshot}[args.command]
+    return max(action(m) for m in manifests())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web-next/.gitignore
+++ b/web-next/.gitignore
@@ -14,3 +14,4 @@ perf/results.md
 
 # Local libSQL database files (dev default + e2e)
 .data/
+.vercel


### PR DESCRIPTION
## Summary

Closes #844. The other half of the 2026-07-06 pause becomes config-as-code: the non-secret env vars of both Vercel projects are pinned in-repo, completing the pattern PR #835 started for GitHub rulesets.

- `config/vercel/spaces-web.json` + `config/vercel/web-next.json` — curated manifests: `values` (non-secret flags/IDs/URLs, checked by value) and `present` (secrets, checked by name only; values never in-repo or in output). Membership is explicit curation, never inferred from readability.
- `scripts/vercel-settings.py` — `check` / `apply` / `snapshot`; auto-links each project dir when `.vercel/` is missing; `apply` touches only `values` keys and reminds that env changes need a redeploy. mise tasks: `vercel-settings-check` / `vercel-settings-apply`.
- `.github/workflows/vercel-settings-drift.yml` — daily + PR-path drift check; soft-skips with a notice until a `VERCEL_TOKEN` repo secret is minted.
- `web-next/.gitignore` gains `.vercel` (bare `vercel link` was side-effect-editing it).
- Standing-state doc now points at the pinned flags.

Bootstrap immediately caught real drift: `ALLOWED_AGENT_LOGINS` and `GITHUB_WEB_WORKSPACES_APP_ID` on spaces-web carried literal trailing newlines (the `echo`-vs-`printf` footgun the docs warn about, sitting there ~98 days). Fixed via `apply` — the tool's first real reconciliation.

## Mergeability

- Surface: infra
- User-facing behavior changed: none in the product; two spaces-web env values had trailing newlines stripped (takes effect on next deploy — strictly a correction)
- Non-happy paths considered: unlisted/system vars are never drift; missing manifest key in live → drift; secrets misconfigured as readable never get snapshotted into `values` (explicit curation rule, stated in code and README); `vercel` CLI failures exit with stderr, token redacted from error output
- Release/ops preconditions: none to merge; CI drift lane activates when `VERCEL_TOKEN` (scope cloudcompute) is added as a repo secret
- Residual risk or follow-up: development/preview targets are out of scope (production only); apply is rm+add, so a crash between the two calls could leave a `values` key briefly absent — rerunning `apply` heals it

## Validation

- [x] Other checks run: `snapshot` → `check` (green both projects) → real drift fix via `apply` → `check` green; in-memory drift demo exits 1 with named diff; `mise run vercel-settings-check` green

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (Playwright report, test output, or equivalent)

Full verification loop (check green both projects, the real trailing-newline drift fix, in-memory drift demo with exit 1, final green):

![vercel-settings-verification](https://evidence.cloudcompute.com/workspaces/pr-847/20260707-061929-vercel-settings-verification.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
