### PR TITLE
fix: cap lingering web pages LRU in SurfaceStore

### DIFF
--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -18,8 +18,16 @@ final class SurfaceStore {
     /// `WebSurfaceStore` — and its `WKWebView` — belongs to the `WebSource`, not to any one tile
     /// binding, so an evicted web surface's page survives the release grace window and a re-bound
     /// tile picks it up without a reload. Entries are dropped by `releaseWebResources(forSourceID:)`
-    /// (source deleted); an idle entry otherwise holds no `WKWebView` after its deferred release fires.
+    /// (source deleted) or by the lingering-page trim; an idle entry otherwise holds no `WKWebView`
+    /// after its deferred release fires.
     private var webStoresBySourceID: [UUID: WebSurfaceStore] = [:]
+
+    /// Most-recently-used order of web sources, oldest first. Bounds the deferred-release policy:
+    /// rapid switching across many sources would otherwise keep one live `WKWebView` per source for
+    /// the whole grace window (unbounded transient memory). Beyond the cap, the least-recently-used
+    /// *unbound* page is hard-released — reopening it reloads, which is the pre-seam behavior.
+    private var webSourceUseOrder: [UUID] = []
+    private static let maxLingeringWebPages = 3
 
     /// Forwarded to terminal surfaces at creation so libghostty can reach the agent hook socket.
     var hooksSocketPath: String?
@@ -115,6 +123,7 @@ final class SurfaceStore {
     ) -> WebSurface {
         if let existing = surfaces[tileID] as? WebSurface, existing.source.id == source.id {
             existing.onBlockedNavigation = onBlockedNavigation
+            touchWebSource(source.id)
             return existing
         }
 
@@ -129,6 +138,7 @@ final class SurfaceStore {
         )
         surfaces[tileID] = created
         onSurfaceCreated?(tileID)
+        touchWebSource(source.id)
         return created
     }
 
@@ -157,8 +167,25 @@ final class SurfaceStore {
                 invalidate(tileID: tileID)
             }
         }
+        webSourceUseOrder.removeAll { $0 == sourceID }
         guard let store = webStoresBySourceID.removeValue(forKey: sourceID) else { return }
         store.releaseInactiveSurface()
+    }
+
+    /// Marks `sourceID` most-recently-used and trims lingering pages beyond the cap. A page is
+    /// "lingering" when its source has a live `WKWebView` but no surface currently bound to a tile —
+    /// exactly the flip-back candidates the deferred-release policy exists for.
+    private func touchWebSource(_ sourceID: UUID) {
+        webSourceUseOrder.removeAll { $0 == sourceID }
+        webSourceUseOrder.append(sourceID)
+
+        let boundSourceIDs = Set(surfaces.values.compactMap { ($0 as? WebSurface)?.source.id })
+        var lingering = webSourceUseOrder.filter { id in
+            !boundSourceIDs.contains(id) && webStoresBySourceID[id]?.hasActiveSurface == true
+        }
+        while lingering.count > Self.maxLingeringWebPages {
+            releaseWebResources(forSourceID: lingering.removeFirst())
+        }
     }
 
     // MARK: - Resolver

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -180,6 +180,17 @@ final class SurfaceStore {
         webSourceUseOrder.append(sourceID)
 
         let boundSourceIDs = Set(surfaces.values.compactMap { ($0 as? WebSurface)?.source.id })
+
+        // Housekeeping: an unbound store whose deferred release already fired holds no page —
+        // drop its registry/order entries so slow drift across many sources leaves no metadata.
+        let expired = webStoresBySourceID.filter { id, store in
+            !boundSourceIDs.contains(id) && !store.hasActiveSurface
+        }.keys
+        for id in expired {
+            webStoresBySourceID.removeValue(forKey: id)
+            webSourceUseOrder.removeAll { $0 == id }
+        }
+
         var lingering = webSourceUseOrder.filter { id in
             !boundSourceIDs.contains(id) && webStoresBySourceID[id]?.hasActiveSurface == true
         }

--- a/Tests/WorkspaceManagerAppTests/SurfaceStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SurfaceStoreTests.swift
@@ -282,6 +282,31 @@ struct SurfaceConformerTests {
         #expect(store.webStore(forSourceID: source.id) !== webStore)
     }
 
+    @Test("Lingering web pages are capped LRU — rapid source switching cannot pile up WKWebViews")
+    func lingeringWebPagesCappedLRU() {
+        let store = SurfaceStore()
+        let tile = TileID()
+        let sources = (0..<6).map { makeWebSource(name: "S\($0)", host: "s\($0).example.com") }
+
+        // Visit each source on the same tile, instantiating its page (as mounting would).
+        for source in sources {
+            _ = store.webSurface(for: tile, source: source).webView
+        }
+
+        // The bound tile holds the last source; lingering (unbound, live-page) sources are capped.
+        let lingering = sources.dropLast().filter {
+            store.webStore(forSourceID: $0.id).hasActiveSurface
+        }
+        #expect(lingering.count == 3)
+        // LRU: the survivors are the most recently visited, the oldest were hard-released.
+        #expect(lingering.map(\.name) == ["S2", "S3", "S4"])
+        #expect(!store.webStore(forSourceID: sources[0].id).hasActiveSurface)
+
+        // Flip-back inside the cap still resumes the live page.
+        let s4View = store.webStore(forSourceID: sources[4].id).ensureSurface(for: sources[4])
+        #expect(store.webSurface(for: tile, source: sources[4]).webView === s4View)
+    }
+
     private func makeWebSource(name: String, host: String) -> WebSource {
         WebSource(name: name, baseURLString: "https://\(host)", allowedHost: host)
     }


### PR DESCRIPTION
## Summary

Post-epic validation-loop fix for #627: the P6 deferred-release policy let rapid switching across many web sources keep one live `WKWebView` per source for the whole 30s grace window — unbounded transient memory (Important finding from the codex adversarial audit of the full epic diff).

`SurfaceStore` now tracks source use order and hard-releases the least-recently-used **unbound** page beyond a cap of 3; reopening a trimmed source reloads, which is exactly the pre-seam behavior. Bound tiles are never trimmed. The same touch path purges registry/order metadata for stores whose deferred release already fired (codex minor), closing the empty-store accumulation noted in #841.

The audit's other Important finding (last-surface restore vs late `@Query` delivery) is pre-existing, epic-untouched, and theoretical for a local SwiftData store — filed as #845 instead of fixed here.

## Review loop

Codex (`gpt-5.5`, xhigh) reviewed the cap commit: **merge-ready, no important/blocker findings**; its one minor (expired-store metadata) is fixed in the second commit.

## Mergeability

- Surface: desktop
- User-facing behavior changed: only beyond the cap — flipping back to a web source visited more than 3 sources ago now reloads instead of resuming; within the cap the P6 no-reload behavior is unchanged.
- Non-happy paths considered: bound tiles excluded from trimming (a visible page can never be released under it); `releaseWebResources` reentry from the trim loop is safe (operates on unbound sources only, dictionary iterated as a value copy); trimming cancels any pending deferred-release timer via the hard-release path.
- Release/ops preconditions: none.
- Residual risk or follow-up: cap constant (3) is a judgement value; revisit if real usage wants deeper flip-back memory.

## Validation

- [x] `swift build`
- [x] `swift test` — 1118 passed / 174 suites (new LRU cap test included)
- [x] Other checks run: `mise run lint` clean; `./scripts/desktop-ui-smoke.sh` green (run 20260706-230535)

## Performance

- [x] Not a performance-sensitive change

(This bounds worst-case memory; steady-state allocation behavior is unchanged.)

## Evidence

- [x] Test evidence attached

Evidence links:

- ![cap-verification](https://evidence.cloudcompute.com/workspaces/pr-849/20260707-062102-cap-verification.png)

## Blockers

- [x] None

Part of the #627 validation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

