### PR TITLE
chore(release): 0.23.0-beta.2 tester prerelease (tile-tree epic complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.23.0-beta.2] - 2026-07-06
+
+Tester prerelease. Headline: the Tile Tree + Surface abstraction epic (#627) is complete — the terminal layout is a recursive tile tree end to end, and web sources render through the same surface seam.
+
+### Added
+- Tile-tree epic completed (#627): `SurfaceStore` is the live surface owner and single eviction authority (P5, #701); web main content renders through the `Surface` seam with per-source page persistence — flipping away from a web source and back within ~30s no longer reloads (P6, #841); `TileTreeStore` rename + domain glossary (P7/P8, #842). Lingering web pages are LRU-capped at 3 (#849).
+- Durable terminal sessions across app restarts, behind an experimental flag: cold-start restore planning, restore banner + execution, session-history read models and browser window (#730, #742, #743, #755, #758, #763, #782); reboot-resume fixes (#786).
+- Guarded native text editing: editable buffer for small UTF-8 files with save command and hardened save path (#713, #720, and follow-ups).
+- WorkSpaces automation: experimental caller-scoped `input.write` capability (#799); `ws race` fans one prompt across N worktree workspaces (#801).
+- Desktop UI smoke now hard-gates web-through-the-seam (Flow 3, #841).
+- Attention summary resolver extracted to core; acknowledged Needs You notifications clear (#722 and follow-ups).
+
+### Fixed
+- Renderer falls back to a real renderer outside the WorkSpaces app (#788).
+- Cap lingering web pages LRU in `SurfaceStore` (#849).
+
+### Web & infrastructure
+- web-next sessions-first redesign: Folio design system, durable resumable turns, real harness-backed agent runtime, reasoning traces, session resume (#741, #769–#787, #822, #826–#833).
+- Web dashboard: middleware session freshness (#727), narrow-viewport sidebar drawer (#732), component-test lane (#731), Chat SDK bot retirement (#725).
+- Agents/infra: repo settings as code with drift gate (#835), author labels on agent PRs (#792), Fable orchestrator v1 (#768), curated repo memory read side (#765), managed-review reruns flag (#738), token-handling hardening (#762, #791), feedback-store dedup + audit (#766), sandbox mise pin bump (#840).
+
 ## [0.23.0-beta.1] - 2026-06-30
 
 ### Added

--- a/Sources/WorkspaceManager/Resources/Info.plist
+++ b/Sources/WorkspaceManager/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.23.0-beta.1</string>
+	<string>0.23.0-beta.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>29</string>
+	<string>30</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSArchitecturePriority</key>


### PR DESCRIPTION
## Summary

Tester prerelease **0.23.0-beta.2** — the build for validating the completed tile-tree epic (#627) end to end. Metadata prepared with `scripts/prepare-prerelease.sh --version 0.23.0-beta.2` (Info.plist `0.23.0-beta.2` / build `30`); CHANGELOG curated desktop-first with the epic as the headline.

What a tester should exercise (also the epic's manual checklist):
- `Cmd+D` / `Cmd+Shift+D` repeatedly — 3+ panes, nested splits, drag-resize the enclosing divider, close panes back down.
- Select a web source → workspace → same web source within ~30s: the page should **not** reload. Beyond ~4 recently-visited sources, the oldest reloads by design (LRU cap).
- Delete a web source while another is selected; no lingering page.
- Terminal daily-driver flows (create workspace, selection switching) — unchanged.

## Review loop

Codex (`gpt-5.5`, xhigh): "merge-ready for release prep; normal signing/notarization/release verification still needs to run before publishing." No findings.

## Mergeability

- Surface: desktop (release metadata + changelog only)
- User-facing behavior changed: none in this PR; it versions the already-merged work.
- Non-happy paths considered: version/tag/artifact consistency is enforced by `release-version.sh assert-tag-match` in the tag-triggered release workflow; prepare script keeps Info.plist and changelog in lockstep (one-source-of-truth rule).
- Release/ops preconditions: after merge, push tag `workspaces-v0.23.0-beta.2-main.<run>` via the Release workflow from main (signing-host lane) to publish the tester prerelease.
- Residual risk or follow-up: none beyond the release pipeline itself.

## Validation

- [x] `swift build`
- [x] `swift test` — suite green on the underlying merged commits (1118/174 on #849's HEAD)
- [x] Other checks run: `scripts/validate-release-changes.py` (no release-sensitive violations); codex release-prep review

## Performance

- [x] Not a performance-sensitive change

Epic-level note: like-for-like `debug_no_activate` comparison showed the epic tree faster than pre-epic main (median 1009ms vs 1229ms launch-to-first-prompt); the absolute 740ms budget miss reproduces on pre-epic main under identical machine load (ambient, not a regression).

## Evidence

- [x] Not a testable change (docs-only, config) — release metadata; the built artifact is validated by the release workflow's bundle verification.

Evidence links:

- Epic verification evidence lives on the implementing PRs: [#841](https://github.com/fairchild/workspaces/pull/841), [#842](https://github.com/fairchild/workspaces/pull/842), [#849](https://github.com/fairchild/workspaces/pull/849).

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
