### PR TITLE
fix: web-detail eviction authority — selection state, not view lifecycle

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1027,6 +1027,11 @@ struct ContentView: View {
             .onDisappear {
                 clearAppCommands()
                 accessRecorder.flushPendingSave(modelContext: modelContext)
+                // Window close: the app outlives its last window, so tear the web-detail domain
+                // down deterministically instead of leaning on ARC scene disposal. This is the
+                // root view — a new window gets a fresh @State store, so this can never race a
+                // remount the way the pane-level onDisappear could.
+                webDetailSurfaceStore.sync(activeLeafIDs: [])
             }
             .onReceive(NotificationCenter.default.publisher(for: .showFeedbackSheet)) { _ in
                 isShowingFeedbackSheet = true

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -800,6 +800,14 @@ struct ContentView: View {
             .onChange(of: inspectorTargetIDSet) { _, _ in
                 pruneRightPaneState()
             }
+            .onChange(of: currentSelectedWebSource?.id) { _, newSourceID in
+                // Selection is the eviction authority for the web-detail tile domain: deselecting
+                // web empties it (deferred release keeps the page for quick flip-back). A source
+                // switch needs nothing here — mounting rebinds the tile via the identity guard.
+                if newSourceID == nil {
+                    webDetailSurfaceStore.sync(activeLeafIDs: [])
+                }
+            }
             .onChange(of: currentSelectedWorkspace?.id) { _, _ in
                 syncNotificationStreamForSelection()
             }

--- a/Sources/WorkspaceManager/Views/MainWindow/WebSourceDetailView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WebSourceDetailView.swift
@@ -66,12 +66,10 @@ struct WebSourceDetailView: View {
         .onChange(of: source.id) { _, _ in
             lastBlockedURL = nil
         }
-        .onDisappear {
-            // Leaving the web pane empties this one-tile domain. Web tearDown is deferred
-            // (shared per-source store keeps the page through the release grace window), so
-            // flipping back shortly after does not reload.
-            surfaceStore.sync(activeLeafIDs: [])
-        }
+        // Eviction is NOT tied to this view's lifecycle: `onDisappear` is unordered against the
+        // replacement view's mount, so a late fire could evict a freshly re-mounted surface and
+        // leave its visible WKWebView without a navigation policy after the deferred release.
+        // ContentView empties the domain from the selection transition instead (ordered).
     }
 }
 


### PR DESCRIPTION
## Summary

Reflection-pass fix on the P6 seam (#627 follow-up): web-detail surface eviction moves from `WebSourceDetailView.onDisappear` to a ContentView `.onChange(of: currentSelectedWebSource?.id)`.

`onDisappear` is unordered against the replacement view's mount. A late fire could evict a freshly re-mounted web surface — its `WKWebView` stays visible in the hierarchy while the 30s deferred release later detaches the navigation delegate, silently dropping domain-allowlist enforcement on a live page. Selection transitions are ordered with updates, so the race is structurally impossible; source switches still rebind through the store's identity guard at mount. Root `onDisappear` (window close — the app outlives its last window) still empties the domain deterministically, which cannot race: a new window carries a fresh `@State` store.

## Review loop

Codex (`gpt-5.5`, xhigh) reviewed with a completeness challenge ("any path where the pane unmounts without a selection transition?"): confirmed in-app transitions covered, flagged window-close as a Medium gap — fixed in the second commit. Its Low (a selected source's `baseURL` mutating to invalid) is corrupted-state territory, not a mainline path; not addressed.

## Mergeability

- Surface: desktop
- User-facing behavior changed: none intended — same eviction outcomes, ordered triggers.
- Non-happy paths considered: window close now tears the domain down explicitly; rapid web→terminal→web flips can no longer strand a policy-less page; A→B source switches unchanged (identity-guard rebinding).
- Release/ops preconditions: none.
- Residual risk or follow-up: pre-existing quirk noted by codex — inactive provider-backed workspace selection from non-sidebar paths can leave `selectedWebSource` non-nil (keeps the pane mounted; navigation behavior, not an eviction bug).
- Note: 0.23.0-beta.2 (PR #851) was cut just before this fix; the hazard is a narrow race never observed live, fine for a tester build. Include this in beta.3 or a beta.2 respin if testing surfaces it.

## Validation

- [x] `swift build`
- [x] `swift test` — 1118 passed / 174 suites
- [x] Other checks run: `mise run lint` clean; `./scripts/desktop-ui-smoke.sh` green (run 20260707-000305) — Flow 3's web→workspace step exercises the new selection-driven eviction path live

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached

Evidence links:

- ![evict-verification](https://evidence.cloudcompute.com/workspaces/pr-853/20260707-071011-evict-verification.png)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
