### PR TITLE
fix(xcode-cloud): resolve Homebrew zig via brew --prefix, not a hardcoded path

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -43,6 +43,14 @@ fi
 homebrew_zig_bin="/opt/homebrew/opt/zig@0.15/bin/zig"
 if [ ! -x "$homebrew_zig_bin" ]; then
   brew install zig@0.15
+
+  # Some Xcode Cloud macOS images run Homebrew from /usr/local instead of the
+  # standard Apple Silicon /opt/homebrew prefix; only resolve dynamically when
+  # the standard path isn't already there.
+  zig_prefix="$(brew --prefix zig@0.15 2>/dev/null || true)"
+  if [ -n "$zig_prefix" ] && [ -x "$zig_prefix/bin/zig" ]; then
+    homebrew_zig_bin="$zig_prefix/bin/zig"
+  fi
 fi
 
 if ! command -v msgfmt >/dev/null 2>&1; then

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -223,6 +223,9 @@ Homebrew's `zig@0.15` formula carries the Darwin linker patch needed on Tahoe
 hosts, so `scripts/build-ghosttykit.sh` prefers:
 - `GHOSTTY_ZIG_BIN`, if set
 - `/opt/homebrew/opt/zig@0.15/bin/zig`, if installed
+- `$(brew --prefix zig@0.15)/bin/zig`, if installed — covers Xcode Cloud
+  macOS images that run Homebrew from `/usr/local` instead of the standard
+  Apple Silicon `/opt/homebrew` prefix
 - `mise exec zig@0.15.2` as a fallback
 
 Do not bump Ghostty to Zig `0.16.0` for this release line: Ghostty `v1.3.1`

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -74,6 +74,19 @@ resolve_zig_runner() {
     return
   fi
 
+  # Some Xcode Cloud macOS images run Homebrew from /usr/local instead of the
+  # standard Apple Silicon /opt/homebrew prefix. Only used as a fallback here
+  # so a host with a real /opt/homebrew zig@0.15 (checked above) never gets
+  # overridden by a different-prefix (and potentially different-arch) one.
+  if command -v brew >/dev/null 2>&1; then
+    local brew_zig_prefix
+    brew_zig_prefix="$(brew --prefix zig@0.15 2>/dev/null || true)"
+    if [[ -n "$brew_zig_prefix" && -x "$brew_zig_prefix/bin/zig" ]]; then
+      ZIG_RUNNER=("$brew_zig_prefix/bin/zig")
+      return
+    fi
+  fi
+
   if command -v mise >/dev/null 2>&1; then
     ZIG_RUNNER=(
       env


### PR DESCRIPTION
## Why

The diagnostic instrumentation from #795 worked exactly as intended: the first real Xcode Cloud build after the Apple Developer license got re-accepted (it had been silently blocking every build since ~2026-07-05) produced a legible log, and the actual root cause is now visible:

```
+ /opt/homebrew/opt/zig@0.15/bin/zig version
ci_post_clone.sh: line 63: /opt/homebrew/opt/zig@0.15/bin/zig: No such file or directory
+ status=1
```

`brew install zig@0.15` succeeds right above that line, installing into `/usr/local/Cellar/zig@0.15/0.15.2` — this Xcode Cloud macOS image runs Homebrew from `/usr/local`, not the Apple-Silicon-standard `/opt/homebrew` the script hardcodes. The same hardcoded-path assumption existed in `scripts/build-ghosttykit.sh`'s `HOMEBREW_ZIG_BIN`, masked there only by its existing `mise` fallback (which would still work, just redundantly reinstall zig via mise instead of reusing the one Homebrew already fetched).

## What

Mirrors the `gettext`-prefix pattern already in `ci_post_clone.sh`: resolve the real path via `brew --prefix zig@0.15` as a fallback, **only** when the hardcoded `/opt/homebrew` path isn't already present. That ordering matters — a machine with a valid existing `/opt/homebrew` zig@0.15 (the common Apple Silicon case, including GitHub Actions' `macos-15` runner) never gets overridden by a different-prefix, potentially different-architecture one.

Also updated the priority list in `docs/development/libghostty-integration.md` to match.

## Review

Two `codex review` passes (`gpt-5.5`, `xhigh reasoning`) per the reflect → codex → react loop:
- **First pass** caught two real issues: (1) a security-hardening test (`test_mise_invocations_are_locked_and_pinned`) pins the literal string `[[ -x "$HOMEBREW_ZIG_BIN" ]]` to assert Homebrew-before-mise ordering — my initial edit renamed that line and broke the test; (2) the initial fix unconditionally overrode an existing `/opt/homebrew` zig with the `brew --prefix` result, which could select the wrong architecture on a machine with both Homebrew prefixes installed. Fixed by keeping the original `HOMEBREW_ZIG_BIN` check as the untouched first branch and adding the dynamic resolution strictly as a fallback — this satisfies the test's ordering assertion without changing it, and fixes the architecture-safety issue at the same time.
- **Second pass**: clean, no regressions identified.

## Evidence

- `sh -n ci_scripts/ci_post_clone.sh` / `bash -n scripts/build-ghosttykit.sh` — syntax clean
- `uv run --script scripts/tests/test_security_hardening.py` — 29/29 passing
- Local simulation of the `/usr/local`-only case (matching the real Xcode Cloud VM log) — resolves to the correct dynamic path
- Local simulation of a mixed-prefix case (both `/opt/homebrew` and `/usr/local` zig present) — correctly keeps the existing `/opt/homebrew` binary, doesn't override

## Mergeability

- Surface: Infrastructure, CI, and Release — Xcode Cloud + local/CI Ghostty build tooling (`ci_scripts/ci_post_clone.sh`, `scripts/build-ghosttykit.sh`, one doc)
- User-facing behavior changed: No — same priority order and same binary selection on every machine that already works today (`/opt/homebrew` present); only adds a fallback path for machines where it's absent
- Non-happy paths considered: Yes — dynamic resolution only fires when the hardcoded path is missing, so it can't regress the common case; verified via the mixed-prefix simulation above; `brew --prefix` failures fall through to `|| true` and leave the original hardcoded default in place
- Residual risk or follow-up: None to the app. This should be the fix that finally gets a green (or at least past-post-clone) Xcode Cloud build; follow-up is watching the next build to confirm it proceeds into the actual Ghostty/zig build stage, and separately deleting the duplicate `Untitled Workflow` Xcode Cloud workflow noted in #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
