### PR TITLE
fix(web): accept BETTER_AUTH_SECRET for terminal signing in prod agent config

### DIFF
--- a/web/src/lib/agent-runtime/__tests__/config.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/config.test.ts
@@ -42,6 +42,32 @@ describe("agent runtime config", () => {
 		).not.toThrow();
 	});
 
+	it("accepts BETTER_AUTH_SECRET as the terminal-signing secret when TTYD_TOKEN_SECRET is unset", () => {
+		expect(() =>
+			validateProductionAgentRuntimeConfig({
+				NODE_ENV: "production",
+				ALLOWED_AGENT_LOGINS: "fairchild",
+				BETTER_AUTH_SECRET: "auth-secret",
+				// TTYD_TOKEN_SECRET intentionally unset — the signer falls back
+				// to BETTER_AUTH_SECRET, so the runtime config is valid.
+				VERCEL_OIDC_TOKEN: "oidc-token",
+				ANTHROPIC_API_KEY: "sk-test",
+			}),
+		).not.toThrow();
+	});
+
+	it("still fails closed when neither terminal-signing secret is present", () => {
+		expect(() =>
+			validateProductionAgentRuntimeConfig({
+				NODE_ENV: "production",
+				ALLOWED_AGENT_LOGINS: "fairchild",
+				// Both BETTER_AUTH_SECRET and TTYD_TOKEN_SECRET missing.
+				VERCEL_OIDC_TOKEN: "oidc-token",
+				ANTHROPIC_API_KEY: "sk-test",
+			}),
+		).toThrow(/TTYD_TOKEN_SECRET or BETTER_AUTH_SECRET/);
+	});
+
 	it("requires GitHub App credentials when the PR reviewer is enabled", () => {
 		expect(() =>
 			validateProductionAgentRuntimeConfig({

--- a/web/src/lib/agent-runtime/config.ts
+++ b/web/src/lib/agent-runtime/config.ts
@@ -113,12 +113,15 @@ export function validateProductionAgentRuntimeConfig(
 		"for authenticated app sessions",
 		errors,
 	);
-	requireEnv(
-		env,
-		"TTYD_TOKEN_SECRET",
-		"for terminal URL signing in production",
-		errors,
-	);
+	// Terminal URL signing uses TTYD_TOKEN_SECRET and falls back to
+	// BETTER_AUTH_SECRET (resolveTtydTokenSecret in vercel-sandbox.ts). Either
+	// secret satisfies the runtime, so accept either here rather than demanding
+	// a dedicated TTYD_TOKEN_SECRET the signer never requires.
+	if (!env.TTYD_TOKEN_SECRET && !env.BETTER_AUTH_SECRET) {
+		errors.push(
+			"TTYD_TOKEN_SECRET or BETTER_AUTH_SECRET is required for terminal URL signing in production",
+		);
+	}
 
 	if (!hasVercelCredentials(env)) {
 		errors.push(


### PR DESCRIPTION
## Summary

Production agent turns on spaces.cloudcompute.com failed before any sandbox was
created. `validateProductionAgentRuntimeConfig` (run unconditionally by
`getRegistry()` at `provider-registry.ts:60`) hard-required `TTYD_TOKEN_SECRET`,
which is not set in spaces-web prod — while `BETTER_AUTH_SECRET` is. Every
`@mention` chat turn and terminal start/resume returned:

```
Invalid production agent runtime config:
- TTYD_TOKEN_SECRET is required for terminal URL signing in production
```

The terminal-URL signer already accepts either secret —
`resolveTtydTokenSecret()` does `TTYD_TOKEN_SECRET ?? BETTER_AUTH_SECRET`
(`vercel-sandbox.ts:211-222`) — so the validator was stricter than the runtime it
guards. This relaxes the validator to match: it errors only when **neither**
secret is present. Found while verifying the 2026-07-06 runtime changes in prod
(#843); the break is provider-independent (the throw precedes provider selection).

## Mergeability

- Surface: web / agent-runtime — `config.ts` production config validation
- User-facing behavior changed: Yes — unblocks interactive agents (chat `@mention` + terminal) in production once deployed; no UI change; no effect on preview/dev or the managed PR-reviewer path (bypasses `getRegistry`)
- Non-happy paths considered: neither secret set in production → still fails closed (covered by test); preview builds still skip the gate; dev falls back as before
- Release/ops preconditions: none — no new env var, migration, or secret; prod already has `BETTER_AUTH_SECRET`; takes effect on next spaces-web deploy; reversible by revert
- Residual risk or follow-up: low — terminal signing already used `BETTER_AUTH_SECRET` as its prod fallback, so only the pre-flight check changes, not the signing key material. Dedicated-key alternative tracked in #855.

## Validation

- [x] Other checks run: `mise run web:check` (tsc typecheck + biome lint + vitest 375/375). Not a Swift change.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

![web:check green — 375 tests pass, config suite 12/12](https://evidence.cloudcompute.com/workspaces/pr-857/20260707-073533-relax-ttyd-validator-tests.png)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-857/20260707-073533-relax-ttyd-validator-tests.png — `mise run web:check` green (typecheck ✓, biome ✓, 375 tests incl. config suite 12/12 with the two new regression tests)

## Blockers

- [x] None

Closes #855. Context: #843.
