### PR TITLE
feat(roadmap): milestone legibility — lane/order title prefixes + drift gate

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -263,6 +263,33 @@ class RunPlannerTests(unittest.TestCase):
             "Isolate intrusive CI jobs onto a Tart VM runner lane",
         )
 
+    def test_strip_milestone_prefix_removes_lane_order_tag(self) -> None:
+        self.assertEqual(
+            run_planner.strip_milestone_prefix("[D1] v0.23 — Tile-tree completion"),
+            "v0.23 — Tile-tree completion",
+        )
+        self.assertEqual(
+            run_planner.strip_milestone_prefix("[W12] Sessions-first web"),
+            "Sessions-first web",
+        )
+
+    def test_strip_milestone_prefix_leaves_unprefixed_titles_untouched(self) -> None:
+        # A derived milestone name (no prefix) must round-trip unchanged so that a
+        # prefixed live milestone still matches it after stripping.
+        for title in ("Sessions-first web (web-next)", "", None):
+            self.assertEqual(
+                run_planner.strip_milestone_prefix(title),
+                title or "",
+            )
+
+    def test_strip_milestone_prefix_preserves_bracketed_non_tag_titles(self) -> None:
+        # Only lane/order tags ([letters+digits]) are stripped — an arbitrary
+        # bracketed word is left alone so real milestone names survive.
+        self.assertEqual(
+            run_planner.strip_milestone_prefix("[Q3 Planning] Roadmap"),
+            "[Q3 Planning] Roadmap",
+        )
+
     def test_normalize_plan_preserves_blocked_by_and_requested_evidence(self) -> None:
         discussion = self.make_discussion()
         plan = self.make_plan(

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -320,6 +320,20 @@ def derive_milestone_name(title: str) -> str:
     return strip_discussion_tags(title)
 
 
+MILESTONE_PREFIX_RE = re.compile(r"^\[[A-Za-z]+\d+\]\s*")
+
+
+def strip_milestone_prefix(title: str | None) -> str:
+    """Drop a leading lane/order tag like ``[D1] `` or ``[W3] `` from a milestone
+    title. The roadmap prefixes milestone titles so execution order is legible on
+    sight (D = desktop, W = web-next); peter derives its name from the discussion
+    title without that prefix, so it matches on the descriptive remainder and stays
+    stable when a milestone is re-lettered."""
+    if not title:
+        return ""
+    return MILESTONE_PREFIX_RE.sub("", title).strip()
+
+
 def comment_marker(discussion_number: int, status: str) -> str:
     return f"<!-- peter-planner:discussion={discussion_number};status={status} -->"
 
@@ -971,7 +985,7 @@ def build_execution_state(
                 break
         if milestone is None:
             for candidate in existing_milestones:
-                if candidate.get("title") == plan.milestone_name:
+                if strip_milestone_prefix(candidate.get("title")) == plan.milestone_name:
                     milestone = candidate
                     break
 
@@ -1127,7 +1141,7 @@ def create_or_reuse_milestone(
     for milestone in milestones:
         if has_milestone_marker(milestone.get("description"), discussion_number):
             return milestone
-        if milestone.get("title") == plan.milestone_name:
+        if strip_milestone_prefix(milestone.get("title")) == plan.milestone_name:
             return milestone
     raise PlannerError(
         f"milestone '{plan.milestone_name}' was not available after creation attempt"
@@ -1358,6 +1372,10 @@ def main() -> int:
         add_discussion_comment(discussion["id"], compose_ack_comment(number, env), env)
 
     milestone = create_or_reuse_milestone(repo, number, normalized, execution, env)
+    # Assign issues by the resolved milestone's actual title, not the derived
+    # plan name — the two diverge once a milestone carries a roadmap lane/order
+    # prefix (`[D1] …`), and `gh issue --milestone` resolves by exact title.
+    assigned_milestone_title = milestone["title"] if milestone else None
     plan_priorities = {issue.priority for issue in normalized.issues}
     resolved_by_priority: dict[int, int] = {}
     resolved_issues: list[dict[str, Any]] = []
@@ -1370,7 +1388,7 @@ def main() -> int:
         resolved_issue = ensure_issue(
             item.issue,
             item.existing_issue,
-            normalized.milestone_name,
+            assigned_milestone_title,
             normalized.discussion_url,
             normalized.discussion_number,
             blocked_by_numbers,

--- a/.github/workflows/milestone-legibility.yml
+++ b/.github/workflows/milestone-legibility.yml
@@ -1,0 +1,32 @@
+# Drift gate for milestone legibility — verifies every OPEN milestone is
+# self-describing (lane/order title prefix + [LANE: …] posture header) so
+# relative priority and roadmap order read straight from the milestone list.
+# Read-only. Milestones are GitHub state (not files), so a PR can't catch an
+# edit — this runs on a schedule and on demand, and validates the check script
+# itself on PRs that touch it. Convention: backlog/ROADMAP.md § "Active
+# milestone stack".
+name: Milestone Legibility
+
+on:
+  schedule:
+    - cron: "37 13 * * *"
+  pull_request:
+    paths:
+      - "scripts/milestone-legibility-check.py"
+      - ".github/workflows/milestone-legibility.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  legibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - name: Check open milestones are legible
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uv run scripts/milestone-legibility-check.py

--- a/backlog/ROADMAP.md
+++ b/backlog/ROADMAP.md
@@ -229,6 +229,8 @@ Roadmap and GitHub milestones play different roles:
 
 ### Active milestone stack
 
+**Milestone titles are self-describing (2026-07-07).** Each open milestone carries a `[<lane><order>]` title prefix — `D` = desktop, `W` = web-next, number = execution order within the lane — so the stack below reads straight off the milestone list, and the number-vs-order inversion (execution runs `[W1]#11 → [W2]#14 → [W3]#13 → [W4]#12`, not by issue number) is visible on sight. Each milestone description also leads with a `[LANE: … · ACTIVE|QUEUED]` posture header. A read-only drift gate (`scripts/milestone-legibility-check.py`, `.github/workflows/milestone-legibility.yml`) fails if any open milestone loses its prefix or posture tag. `peter-planner` matches milestones by the prefix-stripped name, so the convention doesn't disturb automated planning.
+
 | Lane | Active now | Queued next | Sequencing note |
 |---|---|---|---|
 | **Desktop** | **[#9](https://github.com/fairchild/workspaces/milestone/9) — v0.23 tile-tree completion + daily-driver reliability** | **[#10](https://github.com/fairchild/workspaces/milestone/10) — durable sessions** | Epic #627 is all but done — P0–P8 landed (P8 = #842, 2026-07-07); only #690 (depth-≥2 directional focus) remains before it closes. Then the debt: maintainability seams #708/#710, perf contract #637, lifecycle bugs #663/#664/#666/#670/#696 + archive net #709. #10 starts **after** #9's debt is paid — pay maintainability down before adding cross-session continuity to the same files (2026-07-07 decision). |
@@ -236,7 +238,7 @@ Roadmap and GitHub milestones play different roles:
 
 **Personal-tool scope cut (2026-07-07).** web-next serves the owner only for now. **#829** (owner-scoped session sharing) is parked (`idea`, out of #14) until a real second login is wanted — it's the clean prerequisite to sharing, deferred not cancelled. Within **#12**, keyboard/contrast/visible-failure/compose work (#805/#806/#808/#807) stays because it helps the owner; assistive-tech announcements (#804) and mobile touch targets (#809) defer until web-next has an audience beyond one person. Craft aimed at users who don't exist yet is breadth, not quality.
 
-**Open gap — web-next has no performance budget.** Desktop performance is a system (`config/performance/contract.json` + `workspaces-performance-system` skill); web-next, the surface intended to become *primary* (#754), carries no perf scenario or budget in any milestone. Establish a minimal web-next perf floor before the #754 cutover, or the "performance over breadth" principle has an unguarded flank on the newer surface.
+**Open gap — web-next has no performance budget** ([#856](https://github.com/fairchild/workspaces/issues/856)). Desktop performance is a system (`config/performance/contract.json` + `workspaces-performance-system` skill); web-next, the surface intended to become *primary* (#754), carries no perf scenario or budget. Tracked as #856 (`idea`, in #11), gating the #754 cutover — establish a minimal web-next perf floor first, or the "performance over breadth" principle has an unguarded flank on the newer surface.
 
 Theme-to-milestone map:
 

--- a/scripts/milestone-legibility-check.py
+++ b/scripts/milestone-legibility-check.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Drift gate for milestone legibility.
+
+Every OPEN GitHub milestone must be self-describing from inspection alone, so a
+cold session can read relative priority and roadmap order straight from the
+milestone list without opening the roadmap doc:
+
+  1. the title carries a lane/order prefix — ``[D1]``, ``[W3]`` (D = desktop,
+     W = web-next) — so execution order is visible on sight, and
+  2. the description leads with a ``[LANE: …]`` posture tag (lane + active/queued).
+
+The convention and its rationale live in ``backlog/ROADMAP.md`` §
+"Active milestone stack"; this check keeps the live milestones honest to it.
+Read-only — it never edits milestones. Exit 0 when every open milestone conforms,
+1 (with a per-milestone reason) otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Title must open with a lane/order tag then real text: "[D1] v0.23 — …".
+TITLE_RE = re.compile(r"^\[[A-Za-z]+\d+\]\s+\S")
+# Description's first non-empty line must carry a lane posture tag.
+POSTURE_RE = re.compile(r"\[LANE:\s*[A-Za-z]", re.IGNORECASE)
+
+
+def fetch_open_milestones(repo: str) -> list[dict]:
+    # Open milestones are few (one active + a short queue per lane); a single
+    # per_page=100 page is always enough, which keeps parsing to one json.loads.
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/milestones?state=open&per_page=100"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"error: failed to fetch milestones for {repo}:\n{result.stderr.strip()}")
+    return json.loads(result.stdout or "[]")
+
+
+def first_nonempty_line(text: str | None) -> str:
+    for line in (text or "").splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def check(milestones: list[dict]) -> list[str]:
+    failures: list[str] = []
+    for ms in milestones:
+        title = str(ms.get("title", ""))
+        num = ms.get("number")
+        if not TITLE_RE.match(title):
+            failures.append(
+                f"#{num} {title!r}: title is missing a lane/order prefix "
+                f"(expected e.g. '[D1] …' or '[W3] …')."
+            )
+        if not POSTURE_RE.search(first_nonempty_line(ms.get("description"))):
+            failures.append(
+                f"#{num} {title!r}: description does not lead with a '[LANE: …]' "
+                f"posture tag (lane + active/queued)."
+            )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "fairchild/workspaces"),
+        help="owner/name (default: $GITHUB_REPOSITORY or fairchild/workspaces)",
+    )
+    args = parser.parse_args()
+
+    milestones = fetch_open_milestones(args.repo)
+    if not milestones:
+        print(f"No open milestones on {args.repo}; nothing to check.")
+        return 0
+
+    failures = check(milestones)
+    if failures:
+        print(f"Milestone legibility drift on {args.repo} ({len(failures)} issue(s)):\n")
+        for line in failures:
+            print(f"  - {line}")
+        print(
+            "\nFix: give each open milestone a '[<lane><order>]' title prefix and a "
+            "'[LANE: …]' posture header (see backlog/ROADMAP.md § 'Active milestone stack')."
+        )
+        return 1
+
+    print(f"All {len(milestones)} open milestone(s) on {args.repo} are legible (title prefix + posture tag).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web-next/docs/roadmap.md
+++ b/web-next/docs/roadmap.md
@@ -38,9 +38,9 @@ app, can:
 > (owner) tool** until a second allowlist login is wanted: sharing (#829) and
 > assistive-tech/mobile a11y (#804/#809) are deferred, while contrast/keyboard/
 > visible-failure work (#805/#806/#808) stays because it serves the owner.
-> **Open gap:** the surface meant to become *primary* (#754) has no performance
-> budget — establish a minimal perf floor before cutover, matching the desktop
-> performance contract.
+> **Open gap ([#856](https://github.com/fairchild/workspaces/issues/856)):** the
+> surface meant to become *primary* (#754) has no performance budget — establish
+> a minimal perf floor before cutover, matching the desktop performance contract.
 
 ## Current state (2026-07-06)
 
@@ -134,7 +134,7 @@ Production already exists (real OAuth + allowlist, verified); what remains is
 making it *primary*, and keeping it proven. Shareability is deferred with #829.
 - **#828** API routes answer 401 JSON, not a sign-in redirect
 - **#754** cutover to the primary session surface (demote old chat/terminal) —
-  gate on a minimal web-next perf floor first (open gap: no perf budget yet)
+  gate on a minimal web-next perf floor first (#856 — no perf budget yet)
 - **#820** agent opens a PR from a session — *after its design pass*
 - **#829** per-user session ownership — *parked `idea`; the prerequisite to
   adding anyone else to the allowlist. Reinstate this phase when sharing is on


### PR DESCRIPTION
## What

Makes relative priority and roadmap order readable **straight from the GitHub milestone list**, not only the roadmap doc. Follow-up to the 2026-07-07 grooming ([#848](https://github.com/fairchild/workspaces/pull/848)) that structured work into two lanes.

## Changes

**Milestone titles carry a `[<lane><order>]` prefix** (`D` = desktop, `W` = web-next; number = execution order). Applied live to the six open milestones, so the order — including the number-vs-order inversion — reads on sight:

| | Desktop | web-next |
|---|---|---|
| active | `[D1]` #9 | `[W1]` #11 |
| queued | `[D2]` #10 | `[W2]` #14 → `[W3]` #13 → `[W4]` #12 |

(Descriptions already lead with a `[LANE: … · ACTIVE\|QUEUED]` posture header from the grooming pass.)

**Drift gate** — `scripts/milestone-legibility-check.py` + `.github/workflows/milestone-legibility.yml`. Read-only; fails if any open milestone loses its prefix or posture tag. Scheduled + `workflow_dispatch` (milestones are GitHub state, not files, so a PR can't catch an edit), and PR-validated when the check script itself changes. Passes against live state today (6/6 legible).

**peter-planner made prefix-safe** — the automated planner derives an *unprefixed* milestone name from the discussion title and used it to (a) match existing milestones by exact title and (b) assign issues via `--milestone <name>`. A prefix would have broken both — duplicate-milestone creation and misassignment. Fix: new `strip_milestone_prefix` helper used at both match sites, and issue assignment now uses the *resolved* milestone's actual title. 3 unit tests added; **110/110 pass**.

**Docs** — record the title convention in `backlog/ROADMAP.md`; cite the newly filed web-next perf-budget gap ([#856](https://github.com/fairchild/workspaces/issues/856)) in both roadmaps.

## Live backlog changes already applied (not in this diff)

Milestone renames (×6), and from the prior turn: #804/#809 deferred to `idea` (out of #12), #856 filed. This PR is the code/docs that make those durable and enforced.

## Note

Peter-created milestones are created unprefixed, so the drift gate will flag a freshly auto-created milestone until a human adds its `[D#]`/`[W#]` prefix — an intentional nudge toward the convention, not a bug.

## Evidence

- `uv run .agents/scripts/test_run_planner.py` → `Ran 110 tests … OK`
- `uv run scripts/milestone-legibility-check.py` → `All 6 open milestone(s) … are legible`, exit 0
- No Python lint gate configured in-repo (no ruff/flake8/black in workflows).

## Mergeability

- Surface: agent-automation (`peter-planner`) + tooling (drift-check script + workflow) + docs (both roadmaps). No app/web runtime touched.
- User-facing behavior changed: No product surface. Behavior change is internal: milestone titles now carry prefixes, and peter-planner resolves milestones prefix-tolerantly.
- Non-happy paths considered: peter's duplicate-creation and misassignment paths under a prefix are the whole point of the fix, covered by the resolved-title threading + `strip_milestone_prefix` tests (prefixed, unprefixed, empty/None, and a bracketed-non-tag title that must be preserved); drift-check handles zero-milestones and gh-API-failure explicitly.
- Residual risk or follow-up: auto-created milestones need a manual prefix (drift gate nudges this); the drift gate can't run on milestone-edit events (GitHub limitation) so a bad edit is caught on the daily schedule, not instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)