### PR TITLE
docs(skills): codex-review-loop — the pre-PR reflect → codex → react discipline

### DIFF
--- a/.claude/skills/codex-review-loop/SKILL.md
+++ b/.claude/skills/codex-review-loop/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: codex-review-loop
+description: Pre-PR review loop for this repo — self-reflect, then a directed codex CLI (gpt-5.5 xhigh) review, then react with attributed commits. Use before opening any substantive PR, when asked to "run the review loop", "codex review this", or when a PR is about to be declared ready. Skip for metadata/docs-only diffs.
+---
+
+# Codex Review Loop
+
+Every substantive PR goes through **reflect → codex → react** before it opens. The loop exists
+because the two passes catch disjoint defect sets (measured 2026-07-06: the deepest bug of the
+tile-tree epic came from reflection; codex caught four real gaps reflection missed), and because
+attributed reactions make the review approach itself auditable on the PR.
+
+## Scope gate
+
+Run the loop for code-bearing diffs. **Skip codex** (reflection still applies) for metadata,
+changelog, or docs-only diffs — measured worst value per minute; a 2-file version bump does not
+need a 10-minute xhigh review.
+
+## The loop
+
+1. **Reflect first, with your full context.** Walk the diff with fresh eyes before invoking
+   anything: lifecycle ordering (SwiftUI `onDisappear` vs mounts), eviction/teardown pairing,
+   persisted-identifier changes, claims your PR body makes that the diff doesn't back. Fix what
+   you find; don't outsource what your context already knows.
+
+2. **Codex, directed.** Run against the committed diff:
+
+   ```bash
+   codex exec -c model="gpt-5.5" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"
+   ```
+
+   Prompt quality determines finding quality — give it the diff command, named focus areas, and
+   at least one falsifiable completeness challenge. Patterns that measurably worked (rename
+   neutrality proof, adversarial audit, completeness challenge) and the timeout/resume mechanics:
+   see [references/prompt-patterns.md](references/prompt-patterns.md).
+
+3. **Adjudicate — severity is advisory, attribution is yours.** Codex applies the letter of your
+   gates ("no old names anywhere" → historical doc mentions become "blocks merge") and does not
+   check whether *this* diff introduced a finding. Before acting: `git log <base>..HEAD -- <files>`
+   to attribute; pre-existing findings become issues, not scope creep. Declining a finding is a
+   valid reaction — say why in the PR.
+
+4. **React with attribution.** Fixes land as commits whose messages open with
+   `In response to codex (gpt-5.5, xhigh) ...`; the PR body carries a `## Review loop` section
+   naming what codex found and what was done with each finding. This attribution is the
+   measurement signal for whether the loop is working — never fold review reactions silently
+   into other commits.
+
+5. **Merge policy.** Green CI + no unaddressed human comments + codex pass (or findings all
+   adjudicated) → merge per the delegated authority. Evidence and the Mergeability section still
+   gate per AGENTS.md; this loop replaces the paused GitHub review agents, not the evidence bar.

--- a/.claude/skills/codex-review-loop/references/prompt-patterns.md
+++ b/.claude/skills/codex-review-loop/references/prompt-patterns.md
@@ -1,0 +1,71 @@
+# Codex prompt patterns + mechanics
+
+Patterns proven on the tile-tree epic (PRs #841/#842/#849/#853, 2026-07-06). Findings-per-review
+was highest when the prompt named failure modes and asked falsifiable questions; "review this"
+prompts produce checklists, directed prompts produce bugs.
+
+## Mechanics
+
+- Invoke: `codex exec -c model="gpt-5.5" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"`.
+  Tell the prompt which diff to read (`git diff main...HEAD`, `git show HEAD`, or an explicit
+  range) — plain `exec` doesn't infer it.
+- `codex exec review --base main` exists but **cannot combine with a custom prompt**; use plain
+  `exec` when you want directed instructions (almost always).
+- **Latency**: 8–12 min typical at xhigh; budget the Bash timeout ≥ 600s. On timeout the session
+  survives — recover the verdict with:
+  ```bash
+  codex exec resume --last "Output your final verdict now — findings ranked, merge-ready or not."
+  ```
+- Ask for output shape: "findings ranked by severity (blocker/important/minor) with file:line and
+  a concrete failure scenario; say explicitly if nothing blocks merge."
+- Codex runs its own verification (filtered `swift test`, normalized diffs) when the prompt
+  invites it — that verification is often more valuable than the findings list. Also ask for a
+  "what looks sound" list on audits; negative results are confidence you can cite in the PR.
+
+## Pattern: directed feature review (pre-PR)
+
+Name the focus areas as numbered failure modes, not topics:
+
+> You are doing a rigorous pre-merge code review. Run 'git diff main...HEAD' … Focus areas:
+> (1) WKWebView lifecycle — deferred release via tearDown → scheduleInactiveRelease; any leak,
+> use-after-release, or reload regression vs the previous behavior. (2) SwiftUI correctness —
+> NSViewRepresentable identity across source switches, publishing-during-update hazards,
+> onDisappear sync semantics. (3) [guard placement + error-code choice] … Report concrete
+> findings with file:line, severity-ranked; call out anything that should block merge.
+
+## Pattern: behavior-neutrality proof (renames / mechanical sweeps)
+
+Ask for proof, not opinion — codex will normalize the rename out of the diff and compare
+against the parent commit:
+
+> Verify: (1) it is behavior-neutral — no logic edits smuggled in, no persisted keys /
+> notification names / serialized identifiers renamed; (2) no remaining references to the old
+> names anywhere (rg the tree); (3) these kept types were not touched: [...]
+
+Caveat: literal gates get literal enforcement — historical mentions in ADRs/backlog will be
+flagged as blockers. Adjudicate; keep the historical record.
+
+## Pattern: adversarial audit (epic/arc close)
+
+Frame as a bug hunt with a named hunt list, over the full arc diff, and demand failure scenarios:
+
+> Adversarial bug hunt over the completed epic, not a style review. The diff under audit is
+> 'git diff <pre-epic-sha>..HEAD'. Hunt specifically for: (1) lifecycle leaks or double-teardown
+> [named interplay]; (2) focus regressions [named seams]; (3) state restoration [named ordering];
+> … For each finding: file:line, severity, and a concrete failure scenario. State explicitly if
+> the epic looks sound.
+
+Expect ~200k+ tokens and the strongest findings of the loop. Attribution check is mandatory
+here — an arc-wide diff surfaces pre-existing defects as if they were yours.
+
+## Pattern: completeness challenge (small fixes)
+
+The best small-diff prompt is one falsifiable question:
+
+> Question to answer hard: is selection-transition-driven eviction complete — is there ANY path
+> where the web pane unmounts but the selection never transitions to nil (window close, app
+> quit, fixture/bootstrap paths)? Check how [state] interacts with [state] in this codebase.
+> Short verdict with any gaps.
+
+This pattern found the window-close teardown gap that a generic "review this commit" pass on the
+same diff did not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Mac-native app for managing AI coding sessions with embedded terminal.
 
 ## Quality and Mergeability
 
-Craft matters. Plan work so it can land mergeably: correct, coherent with the product, reviewable, verified, and leaving the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist.
+Craft matters. Plan work so it can land mergeably: correct, coherent with the product, reviewable, verified, and leaving the system easier to operate. Keep changes native-feeling, tightly scoped, evidence-backed, and consistent with existing architecture and UI patterns. Before opening or reviewing a PR, use `docs/development/mergeability-standard.md` for the surface-specific checklist. Substantive PRs run the `codex-review-loop` skill before opening (reflect → directed codex review → attributed reactions; skip codex for metadata/docs-only diffs).
 
 When the user asks to implement a change, default to carrying it through to a PR: branch if needed, make the edit, verify it, commit, rebase on the latest `origin/main`, push, open the PR, and report its status. Treat this as a strong default, not a mandate; pause short of PR creation when the user asks for exploration only, says not to publish, or evidence/permissions are blocked. At the start of a multi-PR working session, propose the authority contract explicitly (who reviews, who flips ready, who merges) instead of discovering it one approval at a time — it was the single biggest cycle-time lever in the 2026-07-02 cycle.
 


### PR DESCRIPTION
## Summary

Encodes the review workflow validated on the tile-tree epic (#841/#842/#849/#853) as a project skill: `.claude/skills/codex-review-loop/` — reflect first, then a **directed** codex CLI review (gpt-5.5, xhigh), then react with attributed commits and a PR `## Review loop` section. The four prompt patterns that measurably produced findings (directed feature review, rename behavior-neutrality proof, adversarial epic audit, completeness challenge) plus timeout/resume mechanics live in `references/prompt-patterns.md`, so the skill can grow per-review-type references and scripts without inflating SKILL.md. One sentence added to AGENTS.md at the PR moment.

Session evidence for the encoded lessons: 9 findings across 6 reviews, 6 real and acted on, 0 hallucinated; reflection and codex caught disjoint bug sets; metadata-only reviews were the worst value (hence the scope gate).

## Review loop

Docs-only diff — per this skill's own scope gate, codex was skipped; reflection pass done (AGENTS.md stays within its instruction budget: +1 sentence; skill name avoids colliding with the global `/codex-review` command).

## Mergeability

- Surface: docs
- User-facing behavior changed: none (agent workflow docs).
- Non-happy paths considered: skill misfire risk bounded by the description's scope gate; the AGENTS.md line names the skip condition inline.
- Release/ops preconditions: none.
- Residual risk or follow-up: revisit invocation policy (auto vs user-only) as review types accumulate — discussed with Michael in-session.

## Validation

- [x] Not a code change; `rg` confirmed no stale references. Skill registers and loads (verified in-session).

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)