### PR TITLE
docs(skills): trim codex-review-loop to behavior drivers

### DIFF
--- a/.claude/skills/codex-review-loop/SKILL.md
+++ b/.claude/skills/codex-review-loop/SKILL.md
@@ -1,51 +1,42 @@
 ---
 name: codex-review-loop
-description: Pre-PR review loop for this repo — self-reflect, then a directed codex CLI (gpt-5.5 xhigh) review, then react with attributed commits. Use before opening any substantive PR, when asked to "run the review loop", "codex review this", or when a PR is about to be declared ready. Skip for metadata/docs-only diffs.
+description: Pre-PR review loop — self-reflect, then a directed codex CLI (gpt-5.5 xhigh) review, then react with attributed commits. Use before opening any substantive PR or when asked to "run the review loop" / "codex review this". Skip for metadata/docs-only diffs.
 ---
 
 # Codex Review Loop
 
-Every substantive PR goes through **reflect → codex → react** before it opens. The loop exists
-because the two passes catch disjoint defect sets (measured 2026-07-06: the deepest bug of the
-tile-tree epic came from reflection; codex caught four real gaps reflection missed), and because
-attributed reactions make the review approach itself auditable on the PR.
+Substantive PRs go through **reflect → codex → react** before opening. The two passes catch
+disjoint defects; attributed reactions make the review auditable on the PR.
 
 ## Scope gate
 
-Run the loop for code-bearing diffs. **Skip codex** (reflection still applies) for metadata,
-changelog, or docs-only diffs — measured worst value per minute; a 2-file version bump does not
-need a 10-minute xhigh review.
+Code-bearing diffs only. Skip codex (reflection still applies) for metadata, changelog, or
+docs-only diffs.
 
 ## The loop
 
-1. **Reflect first, with your full context.** Walk the diff with fresh eyes before invoking
-   anything: lifecycle ordering (SwiftUI `onDisappear` vs mounts), eviction/teardown pairing,
-   persisted-identifier changes, claims your PR body makes that the diff doesn't back. Fix what
-   you find; don't outsource what your context already knows.
+1. **Reflect first.** Walk the diff with fresh eyes before invoking codex: lifecycle ordering
+   (e.g. SwiftUI `onDisappear` vs replacement mounts), eviction/teardown pairing,
+   persisted-identifier changes, PR-body claims the diff doesn't back. Fix what you find.
 
-2. **Codex, directed.** Run against the committed diff:
+2. **Codex, directed.**
 
    ```bash
    codex exec -c model="gpt-5.5" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"
    ```
 
-   Prompt quality determines finding quality — give it the diff command, named focus areas, and
-   at least one falsifiable completeness challenge. Patterns that measurably worked (rename
-   neutrality proof, adversarial audit, completeness challenge) and the timeout/resume mechanics:
-   see [references/prompt-patterns.md](references/prompt-patterns.md).
+   Give it the diff command, named failure modes, and one falsifiable completeness question —
+   directed prompts produce bugs; "review this" produces checklists. Templates and
+   timeout/resume mechanics: [references/prompt-patterns.md](references/prompt-patterns.md).
 
-3. **Adjudicate — severity is advisory, attribution is yours.** Codex applies the letter of your
-   gates ("no old names anywhere" → historical doc mentions become "blocks merge") and does not
-   check whether *this* diff introduced a finding. Before acting: `git log <base>..HEAD -- <files>`
-   to attribute; pre-existing findings become issues, not scope creep. Declining a finding is a
-   valid reaction — say why in the PR.
+3. **Adjudicate.** Severity labels are advisory, and codex doesn't check whether *this* diff
+   introduced a finding — run `git log <base>..HEAD -- <files>` before acting. Pre-existing
+   findings become issues, not scope creep. Declining a finding is valid; say why in the PR.
 
-4. **React with attribution.** Fixes land as commits whose messages open with
-   `In response to codex (gpt-5.5, xhigh) ...`; the PR body carries a `## Review loop` section
-   naming what codex found and what was done with each finding. This attribution is the
-   measurement signal for whether the loop is working — never fold review reactions silently
-   into other commits.
+4. **React with attribution.** Fix commits open with `In response to codex (gpt-5.5, xhigh) ...`;
+   the PR body carries a `## Review loop` section listing each finding and its disposition.
+   Never fold review reactions silently into other commits — attribution is how the loop's
+   value is measured.
 
-5. **Merge policy.** Green CI + no unaddressed human comments + codex pass (or findings all
-   adjudicated) → merge per the delegated authority. Evidence and the Mergeability section still
-   gate per AGENTS.md; this loop replaces the paused GitHub review agents, not the evidence bar.
+5. **Merge.** Green CI + no unaddressed human comments + adjudicated codex pass → merge per the
+   delegated authority. Evidence and the Mergeability section still gate per AGENTS.md.

--- a/.claude/skills/codex-review-loop/references/prompt-patterns.md
+++ b/.claude/skills/codex-review-loop/references/prompt-patterns.md
@@ -1,71 +1,63 @@
 # Codex prompt patterns + mechanics
 
-Patterns proven on the tile-tree epic (PRs #841/#842/#849/#853, 2026-07-06). Findings-per-review
-was highest when the prompt named failure modes and asked falsifiable questions; "review this"
-prompts produce checklists, directed prompts produce bugs.
+Directed prompts produce bugs; "review this" produces checklists. Pick the pattern by diff type.
 
 ## Mechanics
 
-- Invoke: `codex exec -c model="gpt-5.5" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"`.
-  Tell the prompt which diff to read (`git diff main...HEAD`, `git show HEAD`, or an explicit
-  range) — plain `exec` doesn't infer it.
-- `codex exec review --base main` exists but **cannot combine with a custom prompt**; use plain
-  `exec` when you want directed instructions (almost always).
-- **Latency**: 8–12 min typical at xhigh; budget the Bash timeout ≥ 600s. On timeout the session
-  survives — recover the verdict with:
+- `codex exec -c model="gpt-5.5" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"`
+  — tell the prompt which diff to read (`git diff main...HEAD`, `git show HEAD`); plain `exec`
+  doesn't infer it. (`codex exec review --base main` exists but cannot combine with a custom prompt.)
+- 8–12 min typical at xhigh; set Bash timeout ≥ 600s. On timeout the session survives:
   ```bash
   codex exec resume --last "Output your final verdict now — findings ranked, merge-ready or not."
   ```
-- Ask for output shape: "findings ranked by severity (blocker/important/minor) with file:line and
-  a concrete failure scenario; say explicitly if nothing blocks merge."
-- Codex runs its own verification (filtered `swift test`, normalized diffs) when the prompt
-  invites it — that verification is often more valuable than the findings list. Also ask for a
-  "what looks sound" list on audits; negative results are confidence you can cite in the PR.
+- Ask for output shape: "findings ranked (blocker/important/minor) with file:line and a concrete
+  failure scenario; say explicitly if nothing blocks merge."
+- Invite verification ("run the relevant tests", "prove it") — codex will run filtered `swift test`
+  and normalized diffs itself. On audits, also ask for a "what looks sound" list; cite the
+  negative results in the PR.
 
-## Pattern: directed feature review (pre-PR)
+## Directed feature review (pre-PR)
 
-Name the focus areas as numbered failure modes, not topics:
+Number the failure modes, not the topics:
 
-> You are doing a rigorous pre-merge code review. Run 'git diff main...HEAD' … Focus areas:
+> You are doing a rigorous pre-merge code review. Run 'git diff main...HEAD'. Focus areas:
 > (1) WKWebView lifecycle — deferred release via tearDown → scheduleInactiveRelease; any leak,
 > use-after-release, or reload regression vs the previous behavior. (2) SwiftUI correctness —
 > NSViewRepresentable identity across source switches, publishing-during-update hazards,
-> onDisappear sync semantics. (3) [guard placement + error-code choice] … Report concrete
-> findings with file:line, severity-ranked; call out anything that should block merge.
+> onDisappear sync semantics. (3) [guard placement + error-code choice] … Report findings with
+> file:line, severity-ranked; call out anything that should block merge.
 
-## Pattern: behavior-neutrality proof (renames / mechanical sweeps)
+## Behavior-neutrality proof (renames / mechanical sweeps)
 
-Ask for proof, not opinion — codex will normalize the rename out of the diff and compare
-against the parent commit:
+Ask for proof, not opinion — codex will normalize the rename out of the diff and compare against
+the parent commit:
 
-> Verify: (1) it is behavior-neutral — no logic edits smuggled in, no persisted keys /
-> notification names / serialized identifiers renamed; (2) no remaining references to the old
-> names anywhere (rg the tree); (3) these kept types were not touched: [...]
+> Verify: (1) behavior-neutral — no logic edits smuggled in, no persisted keys / notification
+> names / serialized identifiers renamed; (2) no remaining old-name references (rg the tree);
+> (3) these kept types untouched: [...]
 
-Caveat: literal gates get literal enforcement — historical mentions in ADRs/backlog will be
-flagged as blockers. Adjudicate; keep the historical record.
+Literal gates get literal enforcement — historical mentions in ADRs/backlog will be flagged as
+blockers. Adjudicate; keep the historical record.
 
-## Pattern: adversarial audit (epic/arc close)
+## Adversarial audit (epic/arc close)
 
-Frame as a bug hunt with a named hunt list, over the full arc diff, and demand failure scenarios:
+Bug hunt over the full arc diff with a named hunt list; demand failure scenarios:
 
 > Adversarial bug hunt over the completed epic, not a style review. The diff under audit is
 > 'git diff <pre-epic-sha>..HEAD'. Hunt specifically for: (1) lifecycle leaks or double-teardown
 > [named interplay]; (2) focus regressions [named seams]; (3) state restoration [named ordering];
-> … For each finding: file:line, severity, and a concrete failure scenario. State explicitly if
-> the epic looks sound.
+> … For each finding: file:line, severity, concrete failure scenario. State explicitly if the
+> epic looks sound.
 
-Expect ~200k+ tokens and the strongest findings of the loop. Attribution check is mandatory
-here — an arc-wide diff surfaces pre-existing defects as if they were yours.
+Expect ~200k+ tokens. Attribution check is mandatory — an arc-wide diff surfaces pre-existing
+defects as if they were yours.
 
-## Pattern: completeness challenge (small fixes)
+## Completeness challenge (small fixes)
 
-The best small-diff prompt is one falsifiable question:
+One falsifiable question:
 
 > Question to answer hard: is selection-transition-driven eviction complete — is there ANY path
 > where the web pane unmounts but the selection never transitions to nil (window close, app
-> quit, fixture/bootstrap paths)? Check how [state] interacts with [state] in this codebase.
-> Short verdict with any gaps.
-
-This pattern found the window-close teardown gap that a generic "review this commit" pass on the
-same diff did not.
+> quit, fixture/bootstrap paths)? Check how [state] interacts with [state]. Short verdict with
+> any gaps.


### PR DESCRIPTION
## Summary

Token-efficiency pass on the just-merged skill (#859), prompted by the question "what here actually changes model behavior?" Cut: provenance anecdotes (dates, epic history, "this pattern found X"), justification sentences behind rules that already state themselves, and rhetorical framing. Kept: command lines, the four example prompts (what models copy), named checklists, the exact attribution format, and one short why-clause per rule (aids compliance when a model is tempted to skip). ~30% fewer tokens per invocation, same driven behavior.

## Review loop

Docs-only — codex skipped per the skill's own scope gate; reflection pass done.

## Mergeability

- Surface: docs
- User-facing behavior changed: none.
- Non-happy paths considered: trigger description preserved verbatim in intent (same triggers, same skip condition).
- Release/ops preconditions: none.
- Residual risk or follow-up: none.

## Validation

- [x] Skill re-registers with the trimmed description (verified in-session).

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)