### PR TITLE
fix(sidebar): exclude archived workspaces from repo count badge

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarRows.swift
@@ -212,6 +212,9 @@ private struct SessionActivityIndicator: View {
 
 struct RepoRow: View {
     let repo: Repo
+    /// Non-archived workspace count; archived workspaces live in a separate collapsed
+    /// section, so the badge counts only the rows shown when the repo is expanded.
+    let activeWorkspaceCount: Int
     let sessionActivity: SidebarSessionActivity
     let paneCount: Int
     let isSelected: Bool
@@ -232,7 +235,7 @@ struct RepoRow: View {
 
     var body: some View {
         let repoName = repo.name
-        let workspaceCount = repo.workspaces.count
+        let workspaceCount = activeWorkspaceCount
         let showsVisibleQuickActions = showsQuickActions && isHovering
         let accessibilityDescription =
             "\(repoName), \(workspaceCount) workspace\(workspaceCount == 1 ? "" : "s"), \(sessionActivity.accessibilityDescription)"

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -441,6 +441,7 @@ struct SidebarView: View {
 
         RepoRow(
             repo: repo,
+            activeWorkspaceCount: SidebarWorkspaceController.activeWorkspaceCount(in: repo.workspaces),
             sessionActivity: bubbledActivity,
             paneCount: paneCount(for: repoSessionKey),
             isSelected: selectedRepo?.id == repo.id,

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -67,6 +67,13 @@ struct SidebarWorkspaceController {
         return repos.first
     }
 
+    /// Count of workspaces shown in a repo's active section — archived workspaces live in
+    /// their own collapsed section, so the collapsed-repo badge must exclude them to match
+    /// the rows listed when the repo is expanded.
+    nonisolated static func activeWorkspaceCount(in workspaces: [Workspace]) -> Int {
+        workspaces.filter { $0.status != .archived }.count
+    }
+
     nonisolated static func localCreationMessage(for phase: WorkspaceCreationPhase) -> String {
         switch phase {
         case .preparing:

--- a/Tests/WorkspaceManagerAppTests/SidebarViewTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarViewTests.swift
@@ -72,6 +72,46 @@ struct SidebarViewTests {
         #expect(preferredRepo?.id == repoA.id)
     }
 
+    @Test("Active workspace count excludes archived workspaces from the badge")
+    func activeWorkspaceCountExcludesArchived() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let active1 = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/workspaces/alpha/feature-a"),
+            sourceRepo: repo,
+            status: .active
+        )
+        let active2 = Workspace(
+            name: "feature-b",
+            path: URL(fileURLWithPath: "/tmp/workspaces/alpha/feature-b"),
+            sourceRepo: repo,
+            status: .stopped
+        )
+        let archived = Workspace(
+            name: "old-feature",
+            path: URL(fileURLWithPath: "/tmp/workspaces/alpha/.archived/old-feature"),
+            sourceRepo: repo,
+            status: .archived
+        )
+        repo.workspaces = [active1, active2, archived]
+
+        #expect(SidebarWorkspaceController.activeWorkspaceCount(in: repo.workspaces) == 2)
+    }
+
+    @Test("Active workspace count is zero for an archived-only repo")
+    func activeWorkspaceCountZeroWhenAllArchived() {
+        let repo = Repo(name: "beta", localPath: URL(fileURLWithPath: "/tmp/beta"))
+        let archived = Workspace(
+            name: "old-feature",
+            path: URL(fileURLWithPath: "/tmp/workspaces/beta/.archived/old-feature"),
+            sourceRepo: repo,
+            status: .archived
+        )
+        repo.workspaces = [archived]
+
+        #expect(SidebarWorkspaceController.activeWorkspaceCount(in: repo.workspaces) == 0)
+    }
+
     @Test("Local creation message matches progress phase")
     func localCreationMessageMatchesPhase() {
         #expect(SidebarWorkspaceController.localCreationMessage(for: .preparing) == "Preparing workspace...")


### PR DESCRIPTION
## Summary

- Fixes #664: the collapsed-repo count badge over-counted because it read `repo.workspaces.count`, but #661 moved archived workspaces into a separate collapsed "Archived (N)" section — so a collapsed repo could badge `5` while only `2` active rows show when expanded.
- `RepoRow` now takes an explicit `activeWorkspaceCount`, supplied by `SidebarView` via `SidebarWorkspaceController.activeWorkspaceCount(in:)` (filters out `.archived`). This is the same partition (`status != .archived`) that lists the active rows, so the badge, the listed sections, and the accessibility label share one source of truth.

Closes #664

## Mergeability

- Surface: desktop
- User-facing behavior changed: yes — a collapsed repo's workspace-count badge and its "N workspaces" accessibility label now count only active (non-archived) workspaces, matching the rows shown when the repo is expanded. Archived-only repos no longer show an inflated badge (and since the badge only appears for `count > 1`, an archived-only repo shows none).
- Non-happy paths considered: mixed active+archived (badge = active only), archived-only repo (count 0, no badge), single active workspace (no badge, unchanged `> 1` gate). The badge derives from the identical predicate as `activeWorkspaces(for:)`, so it can't drift from the listed rows.
- Release/ops preconditions: none — pure view-layer count, no schema, migration, or persisted-state change.
- Residual risk or follow-up: low. Minimal diff; the count decision is now a pure, unit-tested static helper rather than inline view logic.

## Validation

- [x] `swift build`
- [x] `swift test` (`--filter activeWorkspaceCount`, plus the existing `SidebarWorkspaceController` suites stay green)
- [x] Other checks run: `mise run lint` (swift-format `--strict`) clean

**Mutation check (mandatory):** reverted the helper to `workspaces.count` (counting archived) and re-ran the tests — both failed as expected (`activeWorkspaceCount -> 3 == 2` and `-> 1 == 0`), then restored `filter { $0.status != .archived }` and confirmed green. This proves the tests guard the behavior rather than passing vacuously.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output + mutation-check, rendered and uploaded)

Evidence links:

- ![664-badge-count](https://evidence.cloudcompute.com/workspaces/pr-865/20260707-082236-664-badge-count.png)

## Blockers

- [x] None
