### PR TITLE
fix: geometric directional tile focus at depth ≥ 2 (closes #690)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/TileTreeStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TileTreeStore.swift
@@ -700,9 +700,9 @@ final class TileTreeStore: ObservableObject {
     }
 
     /// Resolves the focus target for `goto_split` by reducing from the source pane's tile: directional
-    /// moves use the reducer's geometric traversal, previous/next cycle the depth-first leaf order. The
-    /// reducer reproduces the legacy two-pane table exactly at depth 1; deeper traversal is new (and
-    /// flagged not-hardened). Persists the moved focus so a following split grows from the right tile.
+    /// moves use the reducer's geometric traversal (unit-square frames, edge adjacency, max
+    /// perpendicular overlap — hardened for depth ≥ 2 in #690), previous/next cycle the depth-first
+    /// leaf order. Persists the moved focus so a following split grows from the right tile.
     func splitFocusTarget(
         from sourceSessionID: UUID,
         direction: GhosttyAppManager.SplitFocusDirection

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeGeometry.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeGeometry.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Unit-square layout model for a tile tree: each leaf's rectangle inside [0,1]×[0,1], derived by
+/// dividing every split's rect along its axis at its ratio. Directional focus resolves neighbors
+/// against these frames, so "which pane is to the right" is geometry, not tree shape.
+///
+/// Adjacency comparisons use exact `Double` equality deliberately: a boundary coordinate is
+/// computed once at its split and inherited unchanged by both subtrees, so leaves that share an
+/// edge carry bit-identical values — and clamped ratios keep any *other* split line strictly
+/// inside its own rect, so distinct lines can never collide. Divider thickness is a render
+/// concern and does not exist in this model.
+struct TileUnitRect: Equatable {
+    let minX: Double
+    let maxX: Double
+    let minY: Double
+    let maxY: Double
+
+    static let unit = TileUnitRect(minX: 0, maxX: 1, minY: 0, maxY: 1)
+}
+
+extension TileTree {
+    /// Every leaf's unit-square frame, keyed by tile id.
+    func unitLeafFrames() -> [TileID: TileUnitRect] {
+        var frames: [TileID: TileUnitRect] = [:]
+        collectLeafFrames(in: .unit, into: &frames)
+        return frames
+    }
+
+    private func collectLeafFrames(in rect: TileUnitRect, into frames: inout [TileID: TileUnitRect]) {
+        switch self {
+        case .tile(let id):
+            frames[id] = rect
+        case .split(_, let axis, let ratio, let first, let second):
+            switch axis {
+            case .leadingTrailing:
+                let mid = rect.minX + (rect.maxX - rect.minX) * ratio
+                first.collectLeafFrames(
+                    in: TileUnitRect(minX: rect.minX, maxX: mid, minY: rect.minY, maxY: rect.maxY),
+                    into: &frames
+                )
+                second.collectLeafFrames(
+                    in: TileUnitRect(minX: mid, maxX: rect.maxX, minY: rect.minY, maxY: rect.maxY),
+                    into: &frames
+                )
+            case .topBottom:
+                let mid = rect.minY + (rect.maxY - rect.minY) * ratio
+                first.collectLeafFrames(
+                    in: TileUnitRect(minX: rect.minX, maxX: rect.maxX, minY: rect.minY, maxY: mid),
+                    into: &frames
+                )
+                second.collectLeafFrames(
+                    in: TileUnitRect(minX: rect.minX, maxX: rect.maxX, minY: mid, maxY: rect.maxY),
+                    into: &frames
+                )
+            }
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeGeometry.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeGeometry.swift
@@ -9,6 +9,11 @@ import Foundation
 /// edge carry bit-identical values — and clamped ratios keep any *other* split line strictly
 /// inside its own rect, so distinct lines can never collide. Divider thickness is a render
 /// concern and does not exist in this model.
+///
+/// Deliberately ratio-tree geometry, not rendered geometry: the renderer's minimum-pane clamping
+/// (`TileTreeView.constrainedFraction`) can visually distort extreme ratios in small windows, but
+/// navigation resolves against the model so the same keystroke lands on the same pane regardless
+/// of window size.
 struct TileUnitRect: Equatable {
     let minX: Double
     let maxX: Double

--- a/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeReducer.swift
+++ b/Sources/WorkspaceManagerCore/Services/TileTree/TileTreeReducer.swift
@@ -104,36 +104,63 @@ public struct TileTreeReducer {
         return next
     }
 
-    /// Recursive ancestor walk: rise from `from` to the root and take the first split whose axis
-    /// matches `direction` and where `from` sits on the side you can move away from, then descend
-    /// into the other child toward the entering edge. Reproduces the legacy two-pane `splitFocusTarget`
-    /// exactly at depth 1; the deeper-than-1 traversal is a deliberate not-hardened fallback.
+    /// Geometric neighbor resolution over the unit-square layout (`unitLeafFrames`): the target is
+    /// the leaf that (1) faces `from` across the crossed edge — its opposite edge lies exactly on
+    /// `from`'s edge in `direction` — and (2) overlaps `from` the most along the perpendicular
+    /// axis, ties breaking toward the top/left. No adjacent overlapping leaf ⇒ a true edge ⇒ `nil`.
+    ///
+    /// Depth-1 behavior is unchanged. This replaces the ancestor-walk descent that ignored
+    /// perpendicular position — in a 2×2 grid, moving down from the top-right pane used to land
+    /// bottom-left (#690). Exact edge equality is sound because shared boundaries are computed
+    /// once and inherited (see `TileTreeGeometry.swift`).
     private func directionalTarget(
         from: TileID,
         direction: TileFocusDirection,
         in root: TileTree
     ) -> TileID? {
-        guard let frames = ancestors(of: from, in: root) else { return nil }
+        let frames = root.unitLeafFrames()
+        guard let origin = frames[from] else { return nil }
 
-        let requiredAxis: SplitAxis
-        let requiredSide: ChildSide
-        let descendToLastLeaf: Bool
+        let crossedEdge: Double
+        let facingEdge: (TileUnitRect) -> Double
+        let perpendicularSpan: (TileUnitRect) -> (lo: Double, hi: Double)
         switch direction {
         case .right:
-            (requiredAxis, requiredSide, descendToLastLeaf) = (.leadingTrailing, .first, false)
+            crossedEdge = origin.maxX
+            facingEdge = { $0.minX }
+            perpendicularSpan = { ($0.minY, $0.maxY) }
         case .left:
-            (requiredAxis, requiredSide, descendToLastLeaf) = (.leadingTrailing, .second, true)
+            crossedEdge = origin.minX
+            facingEdge = { $0.maxX }
+            perpendicularSpan = { ($0.minY, $0.maxY) }
         case .down:
-            (requiredAxis, requiredSide, descendToLastLeaf) = (.topBottom, .first, false)
+            crossedEdge = origin.maxY
+            facingEdge = { $0.minY }
+            perpendicularSpan = { ($0.minX, $0.maxX) }
         case .up:
-            (requiredAxis, requiredSide, descendToLastLeaf) = (.topBottom, .second, true)
+            crossedEdge = origin.minY
+            facingEdge = { $0.maxY }
+            perpendicularSpan = { ($0.minX, $0.maxX) }
         }
 
-        for frame in frames.reversed() where frame.axis == requiredAxis && frame.side == requiredSide {
-            let otherChild = requiredSide == .first ? frame.second : frame.first
-            return descendToLastLeaf ? otherChild.lastLeafID : otherChild.firstLeafID
+        let originSpan = perpendicularSpan(origin)
+        var best: (id: TileID, overlap: Double, position: Double)?
+        for (id, rect) in frames where id != from {
+            guard facingEdge(rect) == crossedEdge else { continue }
+            let span = perpendicularSpan(rect)
+            let overlap = min(span.hi, originSpan.hi) - max(span.lo, originSpan.lo)
+            guard overlap > 0 else { continue }
+            // Two facing candidates can never share both overlap and position (they would occupy
+            // the same region), so this ordering is deterministic despite dictionary iteration.
+            if let current = best,
+                !(overlap > current.overlap
+                    || (overlap == current.overlap && span.lo < current.position))
+            {
+                continue
+            }
+            best = (id, overlap, span.lo)
         }
-        return nil
+        return best?.id
     }
 
     private func relativeTarget(
@@ -274,33 +301,4 @@ public struct TileTreeReducer {
         }
     }
 
-    // MARK: - Ancestor path
-
-    private enum ChildSide: Equatable {
-        case first
-        case second
-    }
-
-    private struct AncestorFrame {
-        let axis: SplitAxis
-        let first: TileTree
-        let second: TileTree
-        let side: ChildSide
-    }
-
-    /// Ancestors of `target` from the root down to its parent split, or `nil` if `target` is absent.
-    private func ancestors(of target: TileID, in node: TileTree) -> [AncestorFrame]? {
-        switch node {
-        case .tile(let id):
-            return id == target ? [] : nil
-        case .split(_, let axis, _, let first, let second):
-            if let deeper = ancestors(of: target, in: first) {
-                return [AncestorFrame(axis: axis, first: first, second: second, side: .first)] + deeper
-            }
-            if let deeper = ancestors(of: target, in: second) {
-                return [AncestorFrame(axis: axis, first: first, second: second, side: .second)] + deeper
-            }
-            return nil
-        }
-    }
 }

--- a/Tests/WorkspaceManagerAppTests/TileTreeStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TileTreeStoreTests.swift
@@ -325,6 +325,34 @@ struct TileTreeStoreTests {
         #expect(store.splitFocusTarget(from: splitID, direction: .up) == primaryID)
     }
 
+    @Test("Directional focus in a 2×2 grid resolves the geometric neighbor's session")
+    func directionalFocusGridResolvesGeometricNeighbor() throws {
+        let store = TileTreeStore()
+        let activation = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test/code")
+        )
+        let a = activation.session.id
+        let topBottom = TileTreeStore.SplitPaneLayout(axis: .topBottom, splitBeforePrimary: false)
+
+        // a | b, then split each column down: (a over c) | (b over d) — a 2×2 grid.
+        let b = try #require(store.splitFocusedTile(inTabContaining: a)).id
+        let c = try #require(store.splitFocusedTile(inTabContaining: a, preferredLayout: topBottom)).id
+        let d = try #require(store.splitFocusedTile(inTabContaining: b, preferredLayout: topBottom)).id
+
+        // Same-row horizontal moves — bottom-left → right must land bottom-right (the pre-#690
+        // ancestor walk landed on b, the first leaf of the right column).
+        #expect(store.splitFocusTarget(from: c, direction: .right) == d)
+        #expect(store.splitFocusTarget(from: d, direction: .left) == c)
+        #expect(store.splitFocusTarget(from: a, direction: .right) == b)
+        // Same-column vertical moves.
+        #expect(store.splitFocusTarget(from: b, direction: .down) == d)
+        #expect(store.splitFocusTarget(from: d, direction: .up) == b)
+        // True edges.
+        #expect(store.splitFocusTarget(from: a, direction: .left) == nil)
+        #expect(store.splitFocusTarget(from: d, direction: .down) == nil)
+    }
+
     @Test("Process exit in split pane keeps primary session alive")
     func processExitInSplitKeepsPrimarySessionAlive() throws {
         let store = TileTreeStore()

--- a/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
@@ -108,6 +108,72 @@ struct TileTreePropertyTests {
         }
     }
 
+    @Test("Directional focus is a true geometric neighbor — or a true edge", arguments: 0..<48)
+    func directionalFocusIsGeometric(seed: Int) {
+        var rng = SeededGenerator(seed: UInt64(seed) &+ 5000)
+        let gen = IDGen()
+        let reducer = TileTreeReducer(makeTileID: gen.tile, makeSplitID: gen.split)
+        var state = TileTreeState(singleTile: gen.tile())
+
+        // Grow a random tree (splits/resizes only, biased deep), then probe every leaf × direction.
+        for _ in 0..<10 {
+            let action = randomAction(for: state, using: &rng)
+            switch action {
+            case .split, .resize, .setRatio:
+                state = reducer.reduce(state, action)
+            default:
+                break
+            }
+        }
+
+        let frames = state.root.unitLeafFrames()
+        let directions: [TileFocusDirection] = [.up, .down, .left, .right]
+        for from in state.leafIDs {
+            let origin = frames[from]!
+            for direction in directions {
+                let next = reducer.reduce(
+                    reducer.reduce(state, .setFocus(from)),
+                    .focusDirectional(from: from, direction: direction)
+                )
+                let target = next.focusedTileID == from ? nil : next.focusedTileID
+
+                // Independently derive the facing candidates from the frames.
+                let candidates = frames.filter { id, rect in
+                    guard id != from else { return false }
+                    let facing: Bool
+                    let overlap: Double
+                    switch direction {
+                    case .right:
+                        facing = rect.minX == origin.maxX
+                        overlap = min(rect.maxY, origin.maxY) - max(rect.minY, origin.minY)
+                    case .left:
+                        facing = rect.maxX == origin.minX
+                        overlap = min(rect.maxY, origin.maxY) - max(rect.minY, origin.minY)
+                    case .down:
+                        facing = rect.minY == origin.maxY
+                        overlap = min(rect.maxX, origin.maxX) - max(rect.minX, origin.minX)
+                    case .up:
+                        facing = rect.maxY == origin.minY
+                        overlap = min(rect.maxX, origin.maxX) - max(rect.minX, origin.minX)
+                    }
+                    return facing && overlap > 0
+                }
+
+                if let target {
+                    #expect(
+                        candidates.keys.contains(target),
+                        "seed=\(seed) \(direction): target \(target) is not a facing neighbor of \(from)"
+                    )
+                } else {
+                    #expect(
+                        candidates.isEmpty,
+                        "seed=\(seed) \(direction): move from \(from) was blocked despite facing neighbors \(Array(candidates.keys))"
+                    )
+                }
+            }
+        }
+    }
+
     @Test("Split grows the leaf set by exactly one and focuses the new tile", arguments: 0..<32)
     func splitAddsOneLeaf(seed: Int) {
         var rng = SeededGenerator(seed: UInt64(seed) &+ 1000)

--- a/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreePropertyTests.swift
@@ -137,37 +137,57 @@ struct TileTreePropertyTests {
                 )
                 let target = next.focusedTileID == from ? nil : next.focusedTileID
 
-                // Independently derive the facing candidates from the frames.
-                let candidates = frames.filter { id, rect in
-                    guard id != from else { return false }
+                // Independently derive the facing candidates (with overlap and perpendicular
+                // position) from the frames.
+                let candidates: [(id: TileID, overlap: Double, position: Double)] = frames.compactMap {
+                    id, rect in
+                    guard id != from else { return nil }
                     let facing: Bool
                     let overlap: Double
+                    let position: Double
                     switch direction {
                     case .right:
                         facing = rect.minX == origin.maxX
                         overlap = min(rect.maxY, origin.maxY) - max(rect.minY, origin.minY)
+                        position = rect.minY
                     case .left:
                         facing = rect.maxX == origin.minX
                         overlap = min(rect.maxY, origin.maxY) - max(rect.minY, origin.minY)
+                        position = rect.minY
                     case .down:
                         facing = rect.minY == origin.maxY
                         overlap = min(rect.maxX, origin.maxX) - max(rect.minX, origin.minX)
+                        position = rect.minX
                     case .up:
                         facing = rect.maxY == origin.minY
                         overlap = min(rect.maxX, origin.maxX) - max(rect.minX, origin.minX)
+                        position = rect.minX
                     }
-                    return facing && overlap > 0
+                    guard facing, overlap > 0 else { return nil }
+                    return (id, overlap, position)
                 }
 
                 if let target {
+                    let chosen = candidates.first { $0.id == target }
                     #expect(
-                        candidates.keys.contains(target),
+                        chosen != nil,
                         "seed=\(seed) \(direction): target \(target) is not a facing neighbor of \(from)"
                     )
+                    // The winner must be overlap-optimal, ties broken toward the top/left.
+                    if let chosen {
+                        let beaten = candidates.allSatisfy { candidate in
+                            candidate.overlap < chosen.overlap
+                                || (candidate.overlap == chosen.overlap && candidate.position >= chosen.position)
+                        }
+                        #expect(
+                            beaten,
+                            "seed=\(seed) \(direction): \(target) is not the max-overlap/top-left candidate"
+                        )
+                    }
                 } else {
                     #expect(
                         candidates.isEmpty,
-                        "seed=\(seed) \(direction): move from \(from) was blocked despite facing neighbors \(Array(candidates.keys))"
+                        "seed=\(seed) \(direction): move from \(from) was blocked despite facing neighbors \(candidates.map(\.id))"
                     )
                 }
             }

--- a/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
+++ b/Tests/WorkspaceManagerTests/TileTreeReducerTests.swift
@@ -265,10 +265,10 @@ struct TileTreeReducerTests {
 
     // MARK: - Directional focus (depth ≥ 2, cross-axis)
     //
-    // Depth-1 directional focus is depth-1 parity above; the geometric ancestor-walk at depth ≥ 2 is
-    // new behavior with no legacy baseline (PR #658 review follow-up). These pin the cross-axis cases —
-    // moving across a split whose axis differs from the one being navigated — which exercise the
-    // "rise to the nearest matching-axis ancestor, then descend into the entering edge" traversal.
+    // Depth-1 directional focus is depth-1 parity above; depth ≥ 2 resolves against unit-square
+    // geometry (edge adjacency + max perpendicular overlap, ties toward top/left — #690). These pin
+    // the cross-axis cases, the 2×2 grid the pre-geometric ancestor walk got wrong, overlap
+    // selection, and true-edge blocking.
 
     /// Focus `from`, then navigate `direction`; returns the resulting focused tile (== `from` when the
     /// move is blocked, since the reducer leaves focus put when there is no neighbor).
@@ -345,6 +345,103 @@ struct TileTreeReducerTests {
         #expect(directional(state, reducer: reducer, from: b, .left) == b)
         #expect(directional(state, reducer: reducer, from: c, .down) == c)
         #expect(directional(state, reducer: reducer, from: a, .left) == a)
+    }
+
+    @Test("Directional focus in a 2×2 grid respects perpendicular position")
+    func directionalGridRespectsPosition() {
+        // (a | b) over (c | d): a top-left, b top-right, c bottom-left, d bottom-right.
+        let reducer = TileTreeReducer()
+        let a = TileID()
+        let b = TileID()
+        let c = TileID()
+        let d = TileID()
+        let state = TileTreeState(
+            root: .split(
+                id: SplitID(),
+                axis: .topBottom,
+                ratio: 0.5,
+                first: .split(id: SplitID(), axis: .leadingTrailing, ratio: 0.5, first: .tile(a), second: .tile(b)),
+                second: .split(id: SplitID(), axis: .leadingTrailing, ratio: 0.5, first: .tile(c), second: .tile(d))
+            ),
+            focusedTileID: a
+        )
+
+        // Vertical moves land in the same column — the case the pre-geometric walk got wrong
+        // (down from b used to land on c, the first leaf of the bottom subtree).
+        #expect(directional(state, reducer: reducer, from: b, .down) == d)
+        #expect(directional(state, reducer: reducer, from: a, .down) == c)
+        #expect(directional(state, reducer: reducer, from: d, .up) == b)
+        #expect(directional(state, reducer: reducer, from: c, .up) == a)
+        // Horizontal moves stay in the same row.
+        #expect(directional(state, reducer: reducer, from: a, .right) == b)
+        #expect(directional(state, reducer: reducer, from: d, .left) == c)
+        // True edges are blocked in all four corners.
+        #expect(directional(state, reducer: reducer, from: a, .left) == a)
+        #expect(directional(state, reducer: reducer, from: b, .up) == b)
+        #expect(directional(state, reducer: reducer, from: c, .down) == c)
+        #expect(directional(state, reducer: reducer, from: d, .right) == d)
+    }
+
+    @Test("Directional focus picks the neighbor with the largest perpendicular overlap")
+    func directionalMaxOverlap() {
+        // a over (c | d) with the bottom split off-center at 0.3: a spans the full width, so both
+        // bottom panes face it — d overlaps 0.7 vs c's 0.3 and must win.
+        let reducer = TileTreeReducer()
+        let a = TileID()
+        let c = TileID()
+        let d = TileID()
+        let state = TileTreeState(
+            root: .split(
+                id: SplitID(),
+                axis: .topBottom,
+                ratio: 0.5,
+                first: .tile(a),
+                second: .split(id: SplitID(), axis: .leadingTrailing, ratio: 0.3, first: .tile(c), second: .tile(d))
+            ),
+            focusedTileID: a
+        )
+
+        #expect(directional(state, reducer: reducer, from: a, .down) == d)
+        // Ties (equal overlap) break toward the top/left: both bottom panes reach a going up.
+        #expect(directional(state, reducer: reducer, from: c, .up) == a)
+        #expect(directional(state, reducer: reducer, from: d, .up) == a)
+    }
+
+    @Test("Directional focus at depth 3 crosses only true shared edges")
+    func directionalDepthThree() {
+        // a | (b over (c | d)): a is a full-height column; the right column stacks b over a
+        // nested row of c | d. d does not touch a, so d ← must land on c, not skip to a.
+        let reducer = TileTreeReducer()
+        let a = TileID()
+        let b = TileID()
+        let c = TileID()
+        let d = TileID()
+        let state = TileTreeState(
+            root: .split(
+                id: SplitID(),
+                axis: .leadingTrailing,
+                ratio: 0.5,
+                first: .tile(a),
+                second: .split(
+                    id: SplitID(),
+                    axis: .topBottom,
+                    ratio: 0.5,
+                    first: .tile(b),
+                    second: .split(
+                        id: SplitID(), axis: .leadingTrailing, ratio: 0.5, first: .tile(c), second: .tile(d))
+                )
+            ),
+            focusedTileID: a
+        )
+
+        #expect(directional(state, reducer: reducer, from: d, .left) == c)
+        #expect(directional(state, reducer: reducer, from: c, .left) == a)
+        #expect(directional(state, reducer: reducer, from: d, .up) == b)
+        #expect(directional(state, reducer: reducer, from: c, .up) == b)
+        // From a, both b (0.5 overlap) and c (0.5 overlap) face right; tie breaks to the top: b.
+        #expect(directional(state, reducer: reducer, from: a, .right) == b)
+        // b spans the full right column width; moving down, c and d tie — top/left wins: c.
+        #expect(directional(state, reducer: reducer, from: b, .down) == c)
     }
 
     // MARK: - Relative focus


### PR DESCRIPTION
## Summary

Closes #690 — the last open line of epic #627. Directional tile focus (`⌘⌥` arrows → `goto_split`) at depth ≥ 2 now resolves against real geometry instead of tree shape.

The old traversal rose to the nearest matching-axis ancestor and blindly descended the other child to its first/last leaf. Correct at depth 1 and in L-shapes; wrong wherever perpendicular position matters — in a 2×2 grid, down from the top-**right** pane landed bottom-**left**. The new resolution computes unit-square frames (`TileTreeGeometry`), then picks the leaf facing the crossed edge with the largest perpendicular overlap, ties toward top/left, `nil` at true edges. Exact edge equality is sound because a boundary coordinate is computed once at its split and inherited bit-identically by both subtrees (documented in the file). Ambiguous-neighbor policy is thereby decided and documented (issue scope item 3).

## Review loop

Reflect pass, then codex (`gpt-5.5`, xhigh) with named failure modes + a falsifiable regression question. **No blockers.** Codex independently proved: exact equality holds across all reducer paths + Codable round-trip; no dictionary-nondeterminism counter-example exists (facing candidates can't tie on both overlap and position without overlapping spatially); no reachable tree where the new rule blocks a move the old walk allowed. Two findings, both addressed in the follow-up commit:
- *Important (caveat)*: model-vs-rendered geometry divergence under minimum-pane clamping — **accepted as design** (navigating pixels would make the same keystroke window-size-dependent); now documented in `TileTreeGeometry.swift`.
- *Minor*: property test only proved the target was *a* facing neighbor — strengthened to prove it is the overlap-optimal, tie-broken winner.

## Mergeability

- Surface: desktop
- User-facing behavior changed: yes, deliberately — depth ≥ 2 directional focus lands on the geometrically-correct neighbor (grid columns stay aligned; widest-overlap pane wins when entering a subtree). Depth-1 and L-shape behavior is byte-identical (existing tests unchanged and green). `previous`/`next` cycling untouched.
- Non-happy paths considered: true edges still block (focus stays put); blocked ⇔ no facing neighbor is now a proven property, so no move regressed from navigable to blocked; automation `tile.focus` and the intent router delegate through the same `splitFocusTarget` and inherit the fix.
- Release/ops preconditions: none — no persisted formats involved (`TileUnitRect` is never serialized).
- Residual risk or follow-up: under extreme window sizes the renderer's minimum-pane clamp can make the *visual* layout diverge from model ratios, so a keystroke follows the model, not pixels — deliberate, documented, revisit only if real usage complains.

## Validation

- [x] `swift build`
- [x] `swift test` — 1123 passed / 174 suites (5 new: 2×2 grid, max-overlap, depth-3, store-level grid session mapping, 48-seed geometric property)
- [x] Other checks run: `mise run lint` clean

## Performance

- [x] Not a performance-sensitive change

(`unitLeafFrames()` allocates one small dictionary per user-initiated focus keystroke.)

## Evidence

- [x] Test evidence attached

Evidence links:

- ![690-verification](https://evidence.cloudcompute.com/workspaces/pr-867/20260707-082959-690-geometric-focus.png)

## Blockers

- [x] None

With this merged, epic #627 has no remaining phase or hardening line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
