### PR TITLE
fix(web): fold the mise pin into the base-snapshot cache key

### DIFF
--- a/scripts/tests/test_security_hardening.py
+++ b/scripts/tests/test_security_hardening.py
@@ -324,11 +324,15 @@ class SecurityHardeningTests(unittest.TestCase):
         self.assertIn("enable-global-virtual-store=true", web_npmrc)
 
         sandbox = (REPO_ROOT / "web/src/lib/agent-runtime/vercel-sandbox.ts").read_text()
-        self.assertIn("MISE_VERSION='v2026.7.1'", sandbox)
+        # The pin lives in TS constants (single source of truth) that feed both
+        # the install command and the base-snapshot fingerprint.
+        self.assertIn('const MISE_VERSION = "v2026.7.1"', sandbox)
         self.assertIn(
-            "MISE_SHA256='1fd2f4337ea305fff1971460ea57b977c70de04e8f6184368b7745251504c2d5'",
+            '"1fd2f4337ea305fff1971460ea57b977c70de04e8f6184368b7745251504c2d5"',
             sandbox,
         )
+        # The install command still wires the pinned constant and verifies it.
+        self.assertIn("MISE_VERSION='${MISE_VERSION}'", sandbox)
         self.assertIn("sha256sum -c -", sandbox)
         self.assertNotIn("mise-latest-linux-x64", sandbox)
 

--- a/scripts/verify-mise-security.sh
+++ b/scripts/verify-mise-security.sh
@@ -143,10 +143,14 @@ verify_latest_mise_pin() {
     echo "warning: sandbox mise pin $MISE_EXPECTED_VERSION is behind latest stable $latest_tag (mise-pin-refresh will open the bump PR)" >&2
   fi
 
-  grep -Fq "MISE_VERSION='$MISE_EXPECTED_VERSION'" web/src/lib/agent-runtime/vercel-sandbox.ts \
+  # The pin lives in TS constants (single source of truth) that feed both the
+  # install command and the base-snapshot fingerprint. Match the constant form.
+  grep -Fq "const MISE_VERSION = \"$MISE_EXPECTED_VERSION\"" web/src/lib/agent-runtime/vercel-sandbox.ts \
     || fail "sandbox mise version is not pinned to $MISE_EXPECTED_VERSION"
-  grep -Fq "MISE_SHA256='$MISE_EXPECTED_LINUX_X64_SHA256'" web/src/lib/agent-runtime/vercel-sandbox.ts \
+  grep -Fq "\"$MISE_EXPECTED_LINUX_X64_SHA256\"" web/src/lib/agent-runtime/vercel-sandbox.ts \
     || fail "sandbox mise sha256 does not match verifier"
+  grep -Fq "MISE_VERSION='\${MISE_VERSION}'" web/src/lib/agent-runtime/vercel-sandbox.ts \
+    || fail "sandbox install must wire the pinned MISE_VERSION constant"
   grep -Fq "sha256sum -c -" web/src/lib/agent-runtime/vercel-sandbox.ts \
     || fail "sandbox must verify mise checksum"
   grep -Fq "mise-latest-linux-x64" web/src/lib/agent-runtime/vercel-sandbox.ts \

--- a/web/src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts
+++ b/web/src/lib/agent-runtime/__tests__/vercel-sandbox.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	VercelSandboxProvider,
+	baseSnapshotFingerprint,
 	buildGitCloneArgs,
+	computeBaseSnapshotVersion,
 	terminalAnthropicApiKey,
 	ttydPathToken,
 } from "../vercel-sandbox";
@@ -181,5 +183,59 @@ describe("terminalAnthropicApiKey", () => {
 				TERMINAL_ANTHROPIC_API_KEY: "1",
 			}),
 		).toBe("sk-test");
+	});
+});
+
+describe("base snapshot cache key", () => {
+	const base = {
+		miseVersion: "v2026.7.1",
+		miseSha256: "a".repeat(64),
+		tmuxUrl: "https://example.com/tmux.gz",
+	};
+
+	it("produces a deterministic 12-char hex fingerprint", () => {
+		const a = baseSnapshotFingerprint(base);
+		const b = baseSnapshotFingerprint({ ...base });
+		expect(a).toBe(b);
+		expect(a).toMatch(/^[0-9a-f]{12}$/);
+	});
+
+	it("changes when the mise version changes", () => {
+		const before = baseSnapshotFingerprint(base);
+		const after = baseSnapshotFingerprint({
+			...base,
+			miseVersion: "v2026.7.2",
+		});
+		expect(after).not.toBe(before);
+	});
+
+	it("changes when the mise checksum changes", () => {
+		const before = baseSnapshotFingerprint(base);
+		const after = baseSnapshotFingerprint({
+			...base,
+			miseSha256: "b".repeat(64),
+		});
+		expect(after).not.toBe(before);
+	});
+
+	it("changes when a pinned binary URL changes", () => {
+		const before = baseSnapshotFingerprint(base);
+		const after = baseSnapshotFingerprint({
+			...base,
+			tmuxUrl: "https://example.com/other.gz",
+		});
+		expect(after).not.toBe(before);
+	});
+
+	it("prefixes the human label and appends the fingerprint", () => {
+		const version = computeBaseSnapshotVersion("v5-pi-skills", base);
+		expect(version).toBe(`v5-pi-skills-${baseSnapshotFingerprint(base)}`);
+		expect(version).toMatch(/^v5-pi-skills-[0-9a-f]{12}$/);
+	});
+
+	it("keeps the version stable for the same recipe (no accidental churn)", () => {
+		expect(computeBaseSnapshotVersion("v5-pi-skills", base)).toBe(
+			computeBaseSnapshotVersion("v5-pi-skills", { ...base }),
+		);
 	});
 });

--- a/web/src/lib/agent-runtime/vercel-sandbox.ts
+++ b/web/src/lib/agent-runtime/vercel-sandbox.ts
@@ -28,9 +28,12 @@ const FULL_TOOLS = "Read,Write,Edit,Bash,Glob,Grep,WebFetch";
 const CLAUDE_CONFIG_DIR = "/vercel/sandbox/claude-config";
 
 /**
- * Bump this version when the base snapshot contents change (new tools,
- * package updates, etc.). Old versions remain valid until manually deleted —
- * this lets us roll back without rebuilding.
+ * Human-readable label for the base snapshot recipe. The effective cache key is
+ * `BASE_SNAPSHOT_VERSION` below = `${LABEL}-${recipe fingerprint}`. Bump this
+ * label for structural recipe changes the fingerprint doesn't cover (new npm
+ * tools, banner, skill packs). Changes to pinned binary versions/checksums
+ * (mise, tmux) are folded into the fingerprint automatically, so those no longer
+ * need a manual label bump. Old versions remain valid until deleted/expired.
  *
  * v1:         node22 + @anthropic-ai/claude-code
  * v2-ttyd:    + ttyd for WebSocket terminal access
@@ -60,7 +63,7 @@ const CLAUDE_CONFIG_DIR = "/vercel/sandbox/claude-config";
  *                  Discovery: dnf IS available (Amazon Linux 2023)
  *                  for system packages — use `sudo: true`.
  */
-const BASE_SNAPSHOT_VERSION = "v5-pi-skills";
+const BASE_SNAPSHOT_LABEL = "v5-pi-skills";
 
 /**
  * Static tmux binary download URL. See
@@ -80,6 +83,51 @@ const GIT_CREDENTIAL_TOKEN_PATH = "/vercel/sandbox/github-clone-token";
 const GIT_CREDENTIAL_HELPER_PATH =
 	"/vercel/sandbox/github-credential-helper.sh";
 const DEV_TTYD_TOKEN_SECRET = "dev-only-fallback-do-not-use-in-prod";
+
+/**
+ * Pinned mise binary for sandbox tool installs. Single source of truth: these
+ * feed BOTH the checksum-verified install command in `resolveBaseSnapshot` and
+ * the base-snapshot fingerprint below, so a pin bump can't silently no-op
+ * against a stale cached snapshot. Keep in sync with
+ * `scripts/verify-mise-security.sh` (MISE_EXPECTED_*).
+ */
+const MISE_VERSION = "v2026.7.1";
+const MISE_SHA256 =
+	"1fd2f4337ea305fff1971460ea57b977c70de04e8f6184368b7745251504c2d5";
+
+/**
+ * Content fingerprint of the pinned tools baked into the base snapshot. Any
+ * change to a pinned version/checksum/URL changes this hash, so the effective
+ * `BASE_SNAPSHOT_VERSION` changes and the cached snapshot is rebuilt on next
+ * deploy — a pin bump can no longer read as shipped while sandboxes keep running
+ * the old binary. See docs/decisions and issue #864.
+ */
+export function baseSnapshotFingerprint(parts: {
+	miseVersion: string;
+	miseSha256: string;
+	tmuxUrl: string;
+}): string {
+	const recipe = [
+		`mise=${parts.miseVersion}`,
+		`mise-sha256=${parts.miseSha256}`,
+		`tmux-url=${parts.tmuxUrl}`,
+	].join("\n");
+	return crypto.createHash("sha256").update(recipe).digest("hex").slice(0, 12);
+}
+
+/** `<label>-<recipe fingerprint>`; the label stays human-readable for logs. */
+export function computeBaseSnapshotVersion(
+	label: string,
+	parts: { miseVersion: string; miseSha256: string; tmuxUrl: string },
+): string {
+	return `${label}-${baseSnapshotFingerprint(parts)}`;
+}
+
+const BASE_SNAPSHOT_VERSION = computeBaseSnapshotVersion(BASE_SNAPSHOT_LABEL, {
+	miseVersion: MISE_VERSION,
+	miseSha256: MISE_SHA256,
+	tmuxUrl: TMUX_STATIC_URL,
+});
 
 /**
  * Run a command in a sandbox and throw if it exits non-zero. The
@@ -348,8 +396,8 @@ async function resolveBaseSnapshot(): Promise<string> {
 			"-c",
 			[
 				"set -euo pipefail",
-				"MISE_VERSION='v2026.7.1'",
-				"MISE_SHA256='1fd2f4337ea305fff1971460ea57b977c70de04e8f6184368b7745251504c2d5'",
+				`MISE_VERSION='${MISE_VERSION}'`,
+				`MISE_SHA256='${MISE_SHA256}'`,
 				'MISE_URL="https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-x64"',
 				"echo '--- downloading mise ---'",
 				'curl -fsSL "$MISE_URL" -o /tmp/mise',


### PR DESCRIPTION
## Summary

The Vercel base snapshot was cached by `BASE_SNAPSHOT_VERSION` alone
(`"v5-pi-skills"`), with the mise pin (`MISE_VERSION`/`MISE_SHA256`) buried in an
inline install command and **not** part of the key. So #840/#850 bumped the pin
without invalidating the cached snapshot — the new mise only landed on the next
manual label bump or the 30-day snapshot expiry, while
`scripts/verify-mise-security.sh` stayed green (it only greps the source string).
A security-gated pin could read as "shipped" while sandboxes kept running the old
binary. Found while closing #843.

## Change

- `vercel-sandbox.ts`: extract `MISE_VERSION`/`MISE_SHA256` to TS constants (single
  source of truth) that feed BOTH the checksum-verified install command AND a
  recipe fingerprint. `BASE_SNAPSHOT_VERSION` becomes
  `${BASE_SNAPSHOT_LABEL}-${sha256(recipe).slice(0,12)}`, where the recipe covers
  the mise version+sha and the pinned tmux URL. Any pin change now changes the key.
- `verify-mise-security.sh` + `test_security_hardening.py`: match the new constant
  form and additionally assert the install still wires the pinned constant
  (`MISE_VERSION='${MISE_VERSION}'`) and verifies the checksum.
- New unit tests: the fingerprint changes on mise version / sha / pinned-URL
  change and is stable otherwise; the version is `label-<12 hex>`.

## Mergeability

- Surface: web / agent-runtime — base-snapshot cache key derivation + the mise security gate (script + python test)
- User-facing behavior changed: No direct UI change. Operationally, a future mise pin bump now deterministically rebuilds the sandbox base snapshot instead of silently reusing a stale one.
- Non-happy paths considered: security gate still fails closed if the pin constant/checksum/wiring is missing (asserted); unrelated recipe changes (npm tools, banner) still need a manual `BASE_SNAPSHOT_LABEL` bump, as before; recorded-snapshot-missing path already recreates.
- Release/ops preconditions: none — no new env var or secret. Forces exactly ONE base-snapshot rebuild on the next deploy (the key format changes), which is expected and correct — it guarantees the current pins are live. Per-session snapshot/resume is unaffected (per-session snapshot IDs, not the base key).
- Residual risk or follow-up: low. Fingerprint currently covers mise + tmux (the version/sha-pinned binaries); uv/ttyd use `latest` URLs and are out of scope. Old base-snapshot DB records orphan harmlessly (30-day expiry).

## Validation

- [x] Other checks run: `mise run web:check` (typecheck + biome + vitest, 381 tests incl. 6 new). `verify-mise-security.sh` source-grep checks pass (the local `installed mise 2026.7.0 != v2026.7.1` failure is the known Homebrew-lag quirk — CI installs the pinned binary). `test_security_hardening.py -k mise` 5/5. Not a Swift change.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

![web:check green — 381 tests incl. 6 new fingerprint tests; security gate source checks pass](https://evidence.cloudcompute.com/workspaces/pr-868/20260707-083306-base-snapshot-mise-key-tests.png)

## Blockers

- [x] None

Closes #864. Context: #843 (the verification that surfaced this), #855/#857 (sibling TTYD gate fix).
