### PR TITLE
diag(ghostty): add toggleable GhosttyKit architecture diagnostics

### DIFF
--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -23,6 +23,12 @@ set -euo pipefail
 #   GHOSTTY_CACHE_DIR Cache root for auto-cloned Ghostty checkout.
 #   GHOSTTY_ZIG_BIN   Zig executable to use for building Ghostty.
 #   GHOSTTY_ZIG_CACHE_DIR Zig cache root for building Ghostty.
+#   GHOSTTY_ARCH_DIAGNOSTICS  Set to 0 to silence the post-build architecture
+#                     report (host arch, zig binary arch, xcframework slice
+#                     info). Defaults to 1. Added to chase down a "no such
+#                     module 'GhosttyKit'" failure suspected to be a Rosetta/
+#                     x86_64 zig producing a slice that doesn't match an
+#                     arm64 build; safe to flip off once that's resolved.
 # -----------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,6 +39,7 @@ OUT_DIR="$PROJECT_DIR/Frameworks"
 GHOSTTY_COMMIT="332b2aefc6e72d363aa93ab6ecfc86eeeeb5ed28"
 ZIG_VERSION="0.15.2"
 HOMEBREW_ZIG_BIN="/opt/homebrew/opt/zig@0.15/bin/zig"
+GHOSTTY_ARCH_DIAGNOSTICS="${GHOSTTY_ARCH_DIAGNOSTICS:-1}"
 
 GHOSTTY_REPO_URL="https://github.com/ghostty-org/ghostty.git"
 CACHE_DIR="${GHOSTTY_CACHE_DIR:-$HOME/.cache/workspacemanager}"
@@ -205,6 +212,40 @@ postprocess_xcframework() {
   done < <(find "$framework_dir" -type f -name "libghostty-fat.a")
 }
 
+log_arch_diagnostics() {
+  local framework_dir="$1"
+
+  if [[ "$GHOSTTY_ARCH_DIAGNOSTICS" != "1" ]]; then
+    return
+  fi
+
+  echo "--- GhosttyKit architecture diagnostics (set GHOSTTY_ARCH_DIAGNOSTICS=0 to disable) ---"
+  echo "host arch (uname -m): $(uname -m)"
+
+  local zig_bin="${ZIG_RUNNER[0]}"
+  if [[ -x "$zig_bin" ]]; then
+    echo "zig runner binary: $zig_bin"
+    file "$zig_bin" 2>&1 || true
+  else
+    echo "zig runner: ${ZIG_RUNNER[*]} (mise-wrapped invocation, not a direct binary path)"
+  fi
+
+  local info_plist="$framework_dir/Info.plist"
+  if [[ -f "$info_plist" ]]; then
+    echo "xcframework Info.plist ($info_plist):"
+    plutil -p "$info_plist" 2>&1 || cat "$info_plist"
+  fi
+
+  local archive
+  while IFS= read -r archive; do
+    echo "xcframework archive: $archive"
+    file "$archive" 2>&1 || true
+    lipo -info "$archive" 2>&1 || true
+  done < <(find "$framework_dir" -type f -name "libghostty-fat.a" 2>/dev/null)
+
+  echo "--- end GhosttyKit architecture diagnostics ---"
+}
+
 resolve_ghostty_dir() {
   if [[ -n "$EXPLICIT_GHOSTTY_DIR" ]]; then
     GHOSTTY_DIR="$EXPLICIT_GHOSTTY_DIR"
@@ -304,6 +345,7 @@ main() {
 
   install_xcframework "$xcframework_src"
   postprocess_xcframework "$OUT_DIR/GhosttyKit.xcframework"
+  log_arch_diagnostics "$OUT_DIR/GhosttyKit.xcframework"
   echo "Built GhosttyKit.xcframework -> $OUT_DIR/GhosttyKit.xcframework"
 }
 


### PR DESCRIPTION
## Why

Build 504 — the first Xcode Cloud run to get past `ci_post_clone.sh` after #795 and #854 — got much further than any prior attempt: it built `GhosttyKit.xcframework` successfully and even linked the CLI target. Then it hit a new, later-stage failure in the GUI target:

```
Sources/WorkspaceManager/Terminal/GhosttyAppManager.swift:8:8: error: no such module 'GhosttyKit'
```

This isn't a repeat of the zig-path bug — the xcframework unquestionably existed at the exact path `Package.swift` expects when this failed.

**Working hypothesis (unconfirmed):** this Xcode Cloud image's Homebrew lives at `/usr/local` (established in #854). On Apple Silicon, `/usr/local` is conventionally reserved for a Rosetta-translated x86_64 Homebrew install — canonical arm64 Homebrew lives at `/opt/homebrew`. If the `zig@0.15` bottle installed there is itself x86_64 running under Rosetta, `-Dxcframework-target=native` may resolve "native" as x86_64, producing an xcframework slice tagged for the wrong platform identifier. SwiftPM would then treat the framework as unavailable for an arm64 build — which surfaces as "no such module" at compile time, not a link error. That's consistent with what we saw.

I can't SSH into the (already-torn-down) Xcode Cloud VM to check this directly, so per the repo's own lesson, this ships a diagnostic probe instead of a third guess.

## What

Adds `log_arch_diagnostics()` to `scripts/build-ghosttykit.sh`, called right after the xcframework is built and post-processed. Reports:
- Host `uname -m`
- `file` on the resolved zig binary (direct evidence of Rosetta translation)
- The built xcframework's `Info.plist` (`plutil -p`) — the declared per-slice architectures/platforms, which is what SwiftPM actually consults
- `file` / `lipo -info` on each `libghostty-fat.a` inside it

Gated by `GHOSTTY_ARCH_DIAGNOSTICS` (default `1`) so it's a one-line env var flip to silence later: `GHOSTTY_ARCH_DIAGNOSTICS=0`. No change to the build path, artifact processing, or any existing behavior.

## Review

`codex review` (`gpt-5.5`, `xhigh`): clean, no regression — diagnostics-only, opt-out.

## Evidence

- `bash -n scripts/build-ghosttykit.sh` — syntax clean
- Local simulation of `log_arch_diagnostics()` against a fake xcframework (Info.plist + archive) — correct full report with the toggle on, correct single-line silence with it off
- `scripts/tests/test_security_hardening.py` — 28 of 29 tests passed; the one failure (`milestone-legibility.yml` floating action refs) is confirmed pre-existing on `origin/main` via a `git stash` before/after comparison, unrelated to this change

## Mergeability

- Surface: Infrastructure, CI, and Release — Ghostty build tooling (`scripts/build-ghosttykit.sh`), used by Xcode Cloud, GitHub Actions, and local dev
- User-facing behavior changed: No — purely additive diagnostic logging after a successful build; the build path, artifact contents, and exit behavior are unchanged
- Non-happy paths considered: Yes — every diagnostic command is best-effort (`|| true` / fallback branches) so a missing `plutil`/`lipo`/`file`, a non-path zig runner (the mise-fallback case), or a malformed archive can't turn a successful build into a failure; verified via local simulation including a deliberately malformed fake archive
- Residual risk or follow-up: None. Follow-up is reading the next Xcode Cloud build's log for this report, confirming or refuting the Rosetta-zig hypothesis, and then either fixing the real arch-selection bug or flipping `GHOSTTY_ARCH_DIAGNOSTICS=0` once it's no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋

