### PR TITLE
chore: gitignore .agents/inbox/ (local coordination messages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ docs/papers/*.pdf
 .claude/skills/sandbox/
 .pi/skills/sandbox/
 
+# Agent inbox — local file-based coordination messages, not shared state
+.agents/inbox/
+
 # Playwright
 web/.auth/
 web/output/preview-qa/


### PR DESCRIPTION
## Summary

Add `.agents/inbox/` to `.gitignore`. The agent-inbox skill writes file-based
coordination messages there at runtime; it's local scratch, not shared state, and
kept surfacing as untracked in `git status`. Matches the existing
`.agents/skills/sandbox/` precedent (specific `.agents/` subpath, not the whole
directory — 86 other files under `.agents/` stay tracked).

## Mergeability

- Surface: infra — repo `.gitignore` only
- User-facing behavior changed: No
- Non-happy paths considered: n/a — ignores an untracked runtime path; no tracked file matches `.agents/inbox/` (verified `git ls-files .agents/inbox/` empty), so nothing is removed from the index
- Release/ops preconditions: none
- Residual risk or follow-up: none

## Validation

- [x] Other checks run: confirmed `.agents/inbox/` is untracked and the rest of `.agents/` (86 files) remains tracked; scoped so no tracked path is affected.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None
