### PR TITLE
refactor(main-window): dedup bootstrap controller + error-presentation seam (PR 1/2)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -53,6 +53,7 @@ struct ContentView: View {
     @ObservedObject private var notificationCoordinator = NotificationCoordinator.shared
 
     @State private var viewState = MainWindowViewState()
+    @State private var errorPresenter = MainWindowErrorPresenter()
     @State private var repoForNewWorkspaceFromLanding: Repo?
     @State private var isPreparingLandingNewWorkspaceSheet = false
     @State private var webSourceCreationTarget: WebSourceCreationTarget?
@@ -494,12 +495,12 @@ struct ContentView: View {
         workspaceEnvironmentSheetState.lumeRuntimeSnapshot
     }
 
-    private var isShowingOpenInEditorError: Binding<Bool> {
+    private var isPresentingError: Binding<Bool> {
         Binding(
-            get: { viewState.openInEditorErrorMessage != nil },
+            get: { errorPresenter.isPresented },
             set: { isPresented in
                 if !isPresented {
-                    viewState.openInEditorErrorMessage = nil
+                    errorPresenter.dismiss()
                 }
             }
         )
@@ -863,14 +864,15 @@ struct ContentView: View {
     private var splitViewWithFocusAndAlerts: some View {
         splitViewWithLifecycleHandlers
             .alert(
-                "Could Not Open Editor",
-                isPresented: isShowingOpenInEditorError
-            ) {
+                errorPresenter.current?.title ?? "Error",
+                isPresented: isPresentingError,
+                presenting: errorPresenter.current
+            ) { _ in
                 Button("OK", role: .cancel) {
-                    viewState.openInEditorErrorMessage = nil
+                    errorPresenter.dismiss()
                 }
-            } message: {
-                Text(viewState.openInEditorErrorMessage ?? "Unknown error.")
+            } message: { error in
+                Text(error.message)
             }
             .alert(
                 "Could Not Open Workspace",
@@ -1241,7 +1243,8 @@ struct ContentView: View {
                     webConfiguration: fixtureWebBootstrapConfiguration,
                     repos: repos,
                     webSources: webSources
-                )
+                ),
+                bootstrapController: bootstrapController
             )
 
             guard applySurfaceResolutionAction(action) else { break }
@@ -2814,12 +2817,13 @@ struct ContentView: View {
 
     @MainActor
     private func presentOpenInEditorError(_ error: Error) {
+        let message: String
         if let externalEditorError = error as? ExternalEditorError {
-            viewState.openInEditorErrorMessage =
-                externalEditorError.errorDescription ?? "Could not open the selected file."
+            message = externalEditorError.errorDescription ?? "Could not open the selected file."
         } else {
-            viewState.openInEditorErrorMessage = error.localizedDescription
+            message = error.localizedDescription
         }
+        errorPresenter.present(title: "Could Not Open Editor", message: message)
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowErrorPresenter.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowErrorPresenter.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// One presentation model for main-window errors. Producers build a `MainWindowError` and
+/// hand it to the presenter; the view renders a single alert from `current`. This is the seam
+/// the main window converges its previously ad-hoc error paths (transient `.alert`, inline
+/// banner, log-only) onto, so every surfaced error flows through one entry point.
+///
+/// Latest-wins: presenting while an error is showing replaces it, matching SwiftUI's behavior
+/// of showing a single alert at a time.
+struct MainWindowError: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    let message: String
+
+    init(id: UUID = UUID(), title: String, message: String) {
+        self.id = id
+        self.title = title
+        self.message = message
+    }
+}
+
+struct MainWindowErrorPresenter {
+    private(set) var current: MainWindowError?
+
+    var isPresented: Bool { current != nil }
+
+    mutating func present(_ error: MainWindowError) {
+        current = error
+    }
+
+    mutating func present(title: String, message: String) {
+        current = MainWindowError(title: title, message: message)
+    }
+
+    mutating func dismiss() {
+        current = nil
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowSurfaceResolutionController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowSurfaceResolutionController.swift
@@ -33,9 +33,12 @@ enum MainWindowSurfaceResolutionAction {
 }
 
 struct MainWindowSurfaceResolutionController {
-    private let bootstrapController = MainWindowBootstrapController()
-
-    func nextAction(context: MainWindowSurfaceResolutionContext) -> MainWindowSurfaceResolutionAction {
+    /// The bootstrap controller is injected per call rather than constructed here, so the
+    /// root view's single instance is the only one driving startup/selection-restore logic.
+    func nextAction(
+        context: MainWindowSurfaceResolutionContext,
+        bootstrapController: MainWindowBootstrapController
+    ) -> MainWindowSurfaceResolutionAction {
         switch bootstrapController.deepLinkDecision(
             pendingRequest: context.pendingRequest,
             repos: context.repos,

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
@@ -58,7 +58,6 @@ struct MainWindowViewState {
     var didApplyFixtureDiagnosticsBootstrap = false
     var didApplyFixtureSessionSwitcherBootstrap = false
     var didResolveInitialSurface = false
-    var openInEditorErrorMessage: String?
     var workspaceOperationErrorMessage: String?
     var connectingWorkspaceID: UUID?
     var terminalCloseConfirmation: TerminalCloseConfirmation?

--- a/Tests/WorkspaceManagerAppTests/MainWindowErrorPresenterTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowErrorPresenterTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("MainWindowErrorPresenter")
+struct MainWindowErrorPresenterTests {
+    @Test("A fresh presenter has nothing to show")
+    func startsEmpty() {
+        let presenter = MainWindowErrorPresenter()
+        #expect(presenter.current == nil)
+        #expect(presenter.isPresented == false)
+    }
+
+    @Test("Presenting an error makes it the current surfaced error")
+    func presentSurfacesError() {
+        var presenter = MainWindowErrorPresenter()
+        presenter.present(title: "Could Not Open Editor", message: "boom")
+
+        #expect(presenter.isPresented)
+        #expect(presenter.current?.title == "Could Not Open Editor")
+        #expect(presenter.current?.message == "boom")
+    }
+
+    @Test("Presenting while an error is shown replaces it (latest wins)")
+    func presentReplacesLatest() {
+        var presenter = MainWindowErrorPresenter()
+        presenter.present(title: "First", message: "one")
+        presenter.present(title: "Second", message: "two")
+
+        #expect(presenter.current?.title == "Second")
+        #expect(presenter.current?.message == "two")
+    }
+
+    @Test("Dismiss clears the current error")
+    func dismissClears() {
+        var presenter = MainWindowErrorPresenter()
+        presenter.present(title: "Could Not Open Editor", message: "boom")
+        presenter.dismiss()
+
+        #expect(presenter.current == nil)
+        #expect(presenter.isPresented == false)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/MainWindowSurfaceResolutionControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowSurfaceResolutionControllerTests.swift
@@ -7,6 +7,7 @@ import WorkspaceManagerCore
 @Suite("MainWindowSurfaceResolutionController")
 struct MainWindowSurfaceResolutionControllerTests {
     private let controller = MainWindowSurfaceResolutionController()
+    private let bootstrapController = MainWindowBootstrapController()
 
     @Test("Deep link resolution takes precedence over perf auto-select and restore")
     func deepLinkTakesPrecedence() {
@@ -33,7 +34,8 @@ struct MainWindowSurfaceResolutionControllerTests {
                 webConfiguration: nil,
                 repos: [repo],
                 webSources: []
-            )
+            ),
+            bootstrapController: bootstrapController
         )
 
         switch action {
@@ -66,7 +68,8 @@ struct MainWindowSurfaceResolutionControllerTests {
                 webConfiguration: nil,
                 repos: [repo],
                 webSources: []
-            )
+            ),
+            bootstrapController: bootstrapController
         )
 
         switch action {
@@ -98,7 +101,8 @@ struct MainWindowSurfaceResolutionControllerTests {
                 webConfiguration: nil,
                 repos: [],
                 webSources: []
-            )
+            ),
+            bootstrapController: bootstrapController
         )
 
         switch action {
@@ -128,7 +132,8 @@ struct MainWindowSurfaceResolutionControllerTests {
                 webConfiguration: nil,
                 repos: [repo],
                 webSources: []
-            )
+            ),
+            bootstrapController: bootstrapController
         )
 
         switch action {
@@ -157,7 +162,8 @@ struct MainWindowSurfaceResolutionControllerTests {
                 webConfiguration: nil,
                 repos: [repo],
                 webSources: []
-            )
+            ),
+            bootstrapController: bootstrapController
         )
 
         switch action {
@@ -195,7 +201,8 @@ struct MainWindowSurfaceResolutionControllerTests {
                 webConfiguration: nil,
                 repos: [repo],
                 webSources: []
-            )
+            ),
+            bootstrapController: bootstrapController
         )
 
         switch action {
@@ -205,6 +212,48 @@ struct MainWindowSurfaceResolutionControllerTests {
             #expect(selection.relativePath == "README.md")
         default:
             Issue.record("Expected preview bootstrap to run before restore")
+        }
+    }
+
+    @Test("Resolution routes through the injected bootstrap controller and settles in one pass")
+    func resolutionRoutesThroughInjectedBootstrapControllerOncePerLifecycle() {
+        let repo = Repo(name: "alpha", localPath: URL(fileURLWithPath: "/tmp/alpha"))
+        let savedSurface = MainWindowLastSurface(kind: .repoOverview, id: repo.id)
+
+        func action(didResolveInitialSurface: Bool) -> MainWindowSurfaceResolutionAction {
+            controller.nextAction(
+                context: MainWindowSurfaceResolutionContext(
+                    environment: [:],
+                    didRunPerfAutoSelection: false,
+                    didApplyFixturePreviewBootstrap: false,
+                    didApplyFixtureWebBootstrap: false,
+                    didResolveInitialSurface: didResolveInitialSurface,
+                    pendingRequest: nil,
+                    lastSurfaceRawValue: savedSurface.rawValue,
+                    previewConfiguration: nil,
+                    webConfiguration: nil,
+                    repos: [repo],
+                    webSources: []
+                ),
+                bootstrapController: bootstrapController
+            )
+        }
+
+        // First pass: the injected bootstrap controller restores the saved surface.
+        switch action(didResolveInitialSurface: false) {
+        case .restore(.repoOverview(let restoredRepo)):
+            #expect(restoredRepo.id == repo.id)
+        default:
+            Issue.record("Expected the injected bootstrap controller to restore the saved surface")
+        }
+
+        // After the initial surface resolves, the same injected controller performs no
+        // further bootstrap work — one bootstrap pass per launch / window restore.
+        switch action(didResolveInitialSurface: true) {
+        case .none:
+            break
+        default:
+            Issue.record("Expected no further bootstrap action once the initial surface is resolved")
         }
     }
 


### PR DESCRIPTION
## Summary

Maintainability work on the main-window integration layer (issue #708), split into two PRs as the brief anticipated. **This is PR 1 of 2.**

- **Part 1 — duplicate bootstrap instantiation (complete).** `MainWindowSurfaceResolutionController` constructed its own `MainWindowBootstrapController` instead of using the one `ContentView` already owns. `nextAction` now takes the bootstrap controller as a **required parameter**, so the surface controller holds none and cannot self-construct a second one — `ContentView`'s single instance is the only one driving startup/selection-restore. The 6 existing surface-resolution tests inject a shared instance; a new focused test asserts resolution routes through the injected controller and settles in one pass.
- **Part 2 — error-presentation seam (seam + first integration).** New `MainWindowErrorPresenter` (title/message, latest-wins `present`/`dismiss`) is the single seam main-window errors route through. `ContentView`'s "Could Not Open Editor" alert is migrated onto it as the reference integration, and the now-unused `viewState.openInEditorErrorMessage` field is removed. The remaining call sites migrate in **PR 2** (survey below).

Part of #708 (does not close it — PR 2 completes the error-surface migration).

### Error-presentation survey (as requested before unifying)

Three patterns exist today across `Sources/WorkspaceManager/Views/MainWindow/`:

| Pattern | Where | Notes |
|---|---|---|
| Transient `.alert` | `ContentView` (4 error alerts: open-editor, workspace-op, provider-setup, landing) + `SidebarView` (1 "Error" alert, ~20 producer sites) | The core fragmentation. |
| Inline banner | `DiagnosticsTabView` (`DiagnosticsInlineError`), `CodeFilePreviewView` (`saveErrorMessage`) | Scoped to their own subviews. |
| Log-only | scattered `log.error` | Not user-surfaced. |

Two nuances the migration must preserve (why PR 2 is separate, not just laziness):
- `viewState.workspaceOperationErrorMessage` and `SidebarView.errorMessage` each drive a `.onChange` that calls `hostLumeSmokeAutomation.noteFailure(...)` — a real side-effect on error.
- `SidebarView`'s alert conditionally shows **Lume recovery buttons** ("Open VM Runtime", "Open Lume Log"). The presenter model gains recovery-action support in PR 2 (kept out of PR 1 to avoid unused machinery).

Non-error alerts (orphan-cleanup, "Close Terminal?", "Delete Workspace" confirmation) are intentionally **not** touched — they are confirmations, not error surfaces.

**PR 2 plan:** extend `MainWindowError` with named recovery actions; migrate `workspaceOperationErrorMessage` (preserving its `noteFailure` onChange), `landingErrorMessage`, the provider-setup alert, and `SidebarView`'s alert (preserving Lume recovery buttons + `noteFailure`) onto the presenter; delete the three ad-hoc paths.

## Mergeability

- Surface: desktop
- User-facing behavior changed: **no.** Part 1 is pure construction-seam dedup (stateless value structs — same decisions, one instance). Part 2 keeps the "Could Not Open Editor" alert identical in title, message, and OK-to-dismiss; only the state plumbing behind it changed (a dedicated `viewState` field → the presenter). No navigation, workspace-creation, split, or inspector behavior is affected.
- Non-happy paths considered: presenter is latest-wins, matching SwiftUI's single-alert-at-a-time behavior; `dismiss()` clears; open-editor failures still surface via the single dedicated producer (`presentOpenInEditorError`), external-editor vs. generic error messages preserved. The surface controller's single-bootstrap-pass guard is unchanged and now covered by two tests.
- Release/ops preconditions: none — no schema, migration, or persisted-state change.
- Residual risk or follow-up: low, and deliberately bounded. The larger error-surface migration (with its `noteFailure` side-effects and Lume recovery actions) is deferred to PR 2 rather than risked here. `ContentView` still owns 3 other error alerts until then; they are unchanged and functional.

## Validation

- [x] `swift build`
- [x] `swift test` — **1125 tests in 175 suites passed**; affected suites `MainWindowSurfaceResolutionController` (7), `MainWindowErrorPresenter` (4, new), `MainWindowBootstrapController` (27, unchanged)
- [x] Other checks run: `mise run lint` (swift-format `--strict`) clean

**Mutation checks (both reverted after):**
- Part 1 — removed the `guard !context.didResolveInitialSurface` single-pass guard: the new *"Resolution routes through the injected bootstrap controller and settles in one pass"* test failed, as did the pre-existing *"Resolved initial surface blocks later launch-resolution actions"* test.
- Part 2 — made `MainWindowErrorPresenter.dismiss()` a no-op: *"Dismiss clears the current error"* failed (`current` still non-nil, `isPresented` still true).

Note on the Part 1 test: `MainWindowBootstrapController` is a stateless value struct, so instance *identity* is behaviorally invisible — two instances produce identical output. The "single instance" guarantee is therefore enforced **structurally** (the surface controller no longer holds or constructs one; the parameter is required), and the test locks the observable **single-pass** invariant that the dedup protects.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (full suite pass + both mutation checks, rendered and uploaded)

Evidence links:

- ![708-maintainability](https://evidence.cloudcompute.com/workspaces/pr-875/20260707-085640-708-maintainability.png)

## Blockers

- [x] None
