### PR TITLE
perf(sidebar): coalesce agent-event status aggregation (#637)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -83,6 +83,7 @@ struct ContentView: View {
     private let bootstrapController = MainWindowBootstrapController()
     private let inspectorStateController = InspectorStateController()
     @State private var mainSelectionCoordinator = MainSelectionCoordinator()
+    @State private var statusAggregationCoalescer = WorkspaceStatusAggregationCoalescer()
     private let navigationStateController = MainWindowNavigationStateController()
     private let surfaceResolutionController = MainWindowSurfaceResolutionController()
     private let launchActionHandler = MainWindowLaunchActionHandler()
@@ -762,11 +763,11 @@ struct ContentView: View {
                 }
             }
             .onChange(of: agentSessionRegistry.statuses) { _, _ in
-                refreshWorkspaceStatusAggregator()
+                scheduleWorkspaceStatusAggregatorRefresh()
                 refreshSessionSwitcherSnapshotIfPresented()
             }
             .onChange(of: tileTreeStore.sessions) { _, _ in
-                refreshWorkspaceStatusAggregator()
+                scheduleWorkspaceStatusAggregatorRefresh()
                 refreshSessionSwitcherSnapshotIfPresented()
                 persistTerminalContinuitySnapshot()
             }
@@ -780,6 +781,7 @@ struct ContentView: View {
             }
             .onDisappear {
                 ShortcutRoutingPolicy.shared.setOverride(nil, for: AppChromeShortcut.openInEditor.chord)
+                statusAggregationCoalescer.cancel()
             }
             .onChange(of: deepLinkState.pendingRequest) { _, _ in
                 resolveSurfaceLifecycle()
@@ -2954,6 +2956,14 @@ struct ContentView: View {
             _ = activateHostSession(key: target.key, directory: target.directoryURL)
         }
         NSLog("[Restore] executed %ld surface(s)", plan.surfaces.count)
+    }
+
+    /// Coalesces the high-frequency agent-event refresh path: bursts of status or
+    /// session changes collapse to one trailing-edge aggregation pass. Immediate
+    /// call sites (launch, model changes, user acknowledgement) stay direct so the
+    /// sidebar updates without the window's delay.
+    private func scheduleWorkspaceStatusAggregatorRefresh() {
+        statusAggregationCoalescer.schedule { refreshWorkspaceStatusAggregator() }
     }
 
     private func refreshWorkspaceStatusAggregator() {

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceStatusAggregationCoalescer.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceStatusAggregationCoalescer.swift
@@ -35,6 +35,7 @@ final class WorkspaceStatusAggregationCoalescer {
         flushTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.sleep(self.window)
+            guard !Task.isCancelled else { return }
             self.flushTask = nil
             let pending = self.pendingWork
             self.pendingWork = nil

--- a/Sources/WorkspaceManager/Views/MainWindow/WorkspaceStatusAggregationCoalescer.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WorkspaceStatusAggregationCoalescer.swift
@@ -1,0 +1,52 @@
+//
+//  WorkspaceStatusAggregationCoalescer.swift
+//  WorkspaceManager
+//
+//  Coalesces high-frequency sidebar status-aggregation requests into one
+//  trailing-edge pass per window. Agent status events arrive several times a
+//  second during active sessions, and each aggregation is an
+//  O(repos × workspaces × sessions) rebuild, so collapsing a burst into a single
+//  pass bounds the work under sustained load. The last request in a window always
+//  runs, so the sidebar never settles on stale status.
+//
+
+import Foundation
+
+@MainActor
+final class WorkspaceStatusAggregationCoalescer {
+    private let window: Duration
+    private let sleep: @Sendable (Duration) async -> Void
+    private var pendingWork: (@MainActor () -> Void)?
+    private var flushTask: Task<Void, Never>?
+
+    init(
+        window: Duration = .milliseconds(100),
+        sleep: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
+    ) {
+        self.window = window
+        self.sleep = sleep
+    }
+
+    /// Requests an aggregation pass. Rapid calls within the window collapse to a
+    /// single trailing-edge execution of the most recently supplied `work`.
+    func schedule(_ work: @escaping @MainActor () -> Void) {
+        pendingWork = work
+        guard flushTask == nil else { return }
+        flushTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.sleep(self.window)
+            self.flushTask = nil
+            let pending = self.pendingWork
+            self.pendingWork = nil
+            pending?()
+        }
+    }
+
+    /// Drops any queued pass without running it. Used on teardown so a parked
+    /// window can't fire against a torn-down view.
+    func cancel() {
+        flushTask?.cancel()
+        flushTask = nil
+        pendingWork = nil
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/WorkspaceStatusAggregationCoalescerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceStatusAggregationCoalescerTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("WorkspaceStatusAggregationCoalescer")
+struct WorkspaceStatusAggregationCoalescerTests {
+    /// Deterministic stand-in for the coalescer's window timer. The injected sleep
+    /// announces on `parked` when a flush task has reached the window, then suspends
+    /// until the test calls `release()`. Driving both sides through explicit signals
+    /// keeps the tests free of wall-clock or yield-budget timing assumptions, which
+    /// otherwise flake under the parallel `@MainActor` suite.
+    private final class WindowClock: @unchecked Sendable {
+        let parked: AsyncStream<Void>
+        private let parkedContinuation: AsyncStream<Void>.Continuation
+        private let gate = Gate()
+
+        init() {
+            (parked, parkedContinuation) = AsyncStream<Void>.makeStream()
+        }
+
+        func sleep() async {
+            parkedContinuation.yield(())
+            await gate.wait()
+        }
+
+        func release() async {
+            await gate.release()
+        }
+
+        /// Async counting semaphore starting at zero. `release()` before a matching
+        /// `wait()` is banked rather than lost, so the test never hangs on the order
+        /// in which the flush task registers versus when the test releases.
+        private actor Gate {
+            private var pendingReleases = 0
+            private var waiters: [CheckedContinuation<Void, Never>] = []
+
+            func wait() async {
+                if pendingReleases > 0 {
+                    pendingReleases -= 1
+                    return
+                }
+                await withCheckedContinuation { waiters.append($0) }
+            }
+
+            func release() {
+                if waiters.isEmpty {
+                    pendingReleases += 1
+                } else {
+                    waiters.removeFirst().resume()
+                }
+            }
+        }
+    }
+
+    @Test("Rapid schedules collapse to a single trailing-edge pass on the final state")
+    @MainActor
+    func rapidSchedulesCollapseToSingleTrailingPass() async {
+        let clock = WindowClock()
+        let coalescer = WorkspaceStatusAggregationCoalescer(sleep: { _ in await clock.sleep() })
+        var parkedIterator = clock.parked.makeAsyncIterator()
+        let (ran, ranContinuation) = AsyncStream<Int>.makeStream()
+        var ranIterator = ran.makeAsyncIterator()
+
+        var runCount = 0
+
+        // Each closure carries its own value (captured at schedule time), so the
+        // recorded value proves *which* request ran, not merely how many.
+        for value in 1...5 {
+            coalescer.schedule {
+                runCount += 1
+                ranContinuation.yield(value)
+            }
+        }
+
+        // Nothing runs while the window is still open.
+        #expect(runCount == 0)
+
+        await parkedIterator.next()
+        await clock.release()
+
+        // Five rapid requests produce exactly one aggregation, and it observes the
+        // final state (trailing edge) — the sidebar cannot settle on stale status.
+        let observed = await ranIterator.next()
+        #expect(observed == 5)
+        #expect(runCount == 1)
+    }
+
+    @Test("A request after a completed window runs its own trailing-edge pass")
+    @MainActor
+    func requestAfterWindowRunsAgain() async {
+        let clock = WindowClock()
+        let coalescer = WorkspaceStatusAggregationCoalescer(sleep: { _ in await clock.sleep() })
+        var parkedIterator = clock.parked.makeAsyncIterator()
+        let (ran, ranContinuation) = AsyncStream<Int>.makeStream()
+        var ranIterator = ran.makeAsyncIterator()
+
+        var runCount = 0
+
+        for value in 1...3 {
+            coalescer.schedule {
+                runCount += 1
+                ranContinuation.yield(value)
+            }
+        }
+        await parkedIterator.next()
+        await clock.release()
+        let firstObserved = await ranIterator.next()
+
+        // A later burst is not swallowed by the first window: the final update always runs.
+        coalescer.schedule {
+            runCount += 1
+            ranContinuation.yield(9)
+        }
+        await parkedIterator.next()
+        await clock.release()
+        let secondObserved = await ranIterator.next()
+
+        #expect(firstObserved == 3)
+        #expect(secondObserved == 9)
+        #expect(runCount == 2)
+    }
+
+    @Test("Cancel drops the queued pass; a later request still runs")
+    @MainActor
+    func cancelDropsQueuedPass() async {
+        let clock = WindowClock()
+        let coalescer = WorkspaceStatusAggregationCoalescer(sleep: { _ in await clock.sleep() })
+        var parkedIterator = clock.parked.makeAsyncIterator()
+        let (ran, ranContinuation) = AsyncStream<Int>.makeStream()
+        var ranIterator = ran.makeAsyncIterator()
+
+        var runCount = 0
+
+        coalescer.schedule {
+            runCount += 1
+            ranContinuation.yield(1)
+        }
+        await parkedIterator.next()
+        coalescer.cancel()
+        await clock.release()
+
+        // The cancelled pass must not run. Prove it positively: a fresh request runs
+        // and observes only its own value — the dropped one left no trace.
+        coalescer.schedule {
+            runCount += 1
+            ranContinuation.yield(2)
+        }
+        await parkedIterator.next()
+        await clock.release()
+        let observed = await ranIterator.next()
+
+        #expect(observed == 2)
+        #expect(runCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Narrows #637 to the one structural fix that's still open and measurably worth doing, after re-verifying that most of the issue has already shipped.

`refreshWorkspaceStatusAggregator` rebuilds sidebar/repo status in O(repos × workspaces × sessions) and fired directly on every `agentSessionRegistry.statuses` and `tileTreeStore.sessions` change — several times a second during active agent sessions. This routes those two high-frequency triggers through a small trailing-edge coalescer (`WorkspaceStatusAggregationCoalescer`, ~100 ms window) so a burst collapses to a single pass. The last request in a window always runs, so the sidebar never settles on stale status.

Immediate call sites stay direct — launch (`onAppear`), the carefully-ordered `modelSnapshot` cascade, and user-driven attention acknowledgement — none are high-frequency and delaying them would add visible latency.

### What was already done (verified against fresh main; posted as a comment on #637)

- **Steps 1-2 (scenarios + baselines): merged in #655** (2026-06-10). All four scenarios are in `config/performance/contract.json`.
- **Fix #3 (diagnostics visibility gate): already in code** — `DiagnosticsTabView` starts/stops `RuntimeDiagnosticsViewModel` polling on appear/disappear, so the 5s `ps`+`lsof` sampling only runs while the pane is visible.
- **All baselines pass their budgets** — agent-activity-burst 1.51 ms median vs 10 ms gate; memory 252 MB vs 1500 MB; idle CPU 0.45% vs 3%.

### Deliberately not done

- **Fix #2 (modelSnapshot cascade split): declined** — that handler has carefully-ordered semantics (cache rebuild → `releaseRemovedWebSources` → `reconcileSelectionAfterModelChange` → `resolveSurfaceLifecycle` → `pruneRepoSessions` → aggregate); splitting it risks selection/surface-lifecycle correctness for a metric that isn't breaching.
- **Fix #4 (terminal surface memory): deferred-to-data** per the issue, coordinated with the `SurfaceStore` eviction seam under #627.

Closes #637

## Mergeability

- Surface: desktop
- User-facing behavior changed: No functional change. Sidebar agent-status bubbles now update at most once per ~100 ms window during bursts instead of on every event; the final state in each window always renders, so there's no observable staleness. Selection, status bubbles, and attention acknowledgement are unaffected.
- Non-happy paths considered: trailing-edge guarantee (last request in a window always runs), a request arriving after a window completes starts its own pass, and teardown (`onDisappear` cancels a parked window so it can't fire against a torn-down view) — all covered by unit tests. The coalescer is main-actor confined; work closures re-read live state at execution time, so a coalesced pass reflects the newest status, not a snapshot from schedule time.
- Release/ops preconditions: none — no schema, migration, or config change.
- Residual risk or follow-up: low. Only the two high-frequency `onChange` handlers changed; every other aggregation call site is untouched and still immediate. The merged `main_window_agent_activity_burst` scenario stands as the regression guard.

## Validation

- [x] `swift build`
- [x] `swift test` — 1123 tests / 175 suites pass (run twice back-to-back; no flakiness). The coalescer tests are driven by a deterministic parked/release handshake (async counting semaphore), not wall-clock or yield-budget timing.
- [x] Other checks run: `mise run lint` (swift-format --strict) clean

No sidebar selection / status-bubble regressions: `SidebarWorkspaceControllerBehavior`, `SidebarWorkspacePresentationController`, `WorkspaceStatusAggregator`, and `SidebarView` suites all pass.

**Mutation check:** changed `pendingWork = work` to `if pendingWork == nil { pendingWork = work }` (breaking the trailing-edge guarantee — keep the first request's state instead of the latest). Both data-carrying tests failed as intended (`observed → 1` instead of `5`; `firstObserved → 1` instead of `3`), proving they pin the trailing-edge contract. Reverted; all pass.

**On perf deltas:** this is intentionally not a budget-delta PR. The agent-activity-burst baseline (1.51 ms median on a small fixture, 6.6x under its 10 ms gate) measures one rebuild, not the sustained multi-per-second load the issue flagged; a before/after on that scenario would land inside the noise floor by design. The value is bounded work under sustained load, and the guarantee is proven by unit test, not a perf claim.

## Performance

- [x] Not a performance-sensitive change

(No budget crosses; the change reduces redundant work rather than moving a measured metric. Per the perf contract's own posture — "fix what breaches budget" — nothing here breaches; this is defensive structural hygiene with the merged scenario as its guard.)

## Evidence

- [x] Test evidence attached (test output)

`WorkspaceStatusAggregationCoalescer` suite — 3/3 pass (collapse-to-one trailing-edge, post-window re-run, cancel-drops-then-reruns):

![637-coalesce-fix](https://evidence.cloudcompute.com/workspaces/pr-876/20260707-090253-637-coalesce-fix.png)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-876/20260707-090253-637-coalesce-fix.png

## Blockers

- [x] None
