### PR TITLE
refactor: extract the session-retirement close state machine (#710 slice 1)

### DIFF
--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -260,10 +260,10 @@ final class SurfaceStore {
     /// Run the terminal's session-retirement close (process-alive teardown) if a surface is mounted.
     @discardableResult
     func closeForSessionRetirement(sessionID: UUID) async throws -> Bool {
-        guard let surfaceView = terminalSurface(forSession: sessionID)?.surfaceView else {
+        guard let surface = terminalSurface(forSession: sessionID) else {
             return false
         }
-        try await surfaceView.requestCloseForSessionRetirement()
+        try await surface.closeForSessionRetirement()
         return true
     }
 

--- a/Sources/WorkspaceManager/Surface/TerminalSurface.swift
+++ b/Sources/WorkspaceManager/Surface/TerminalSurface.swift
@@ -79,6 +79,13 @@ final class TerminalSurface: Surface {
         surfaceView.requestClose()
     }
 
+    /// Session-retirement close (process-alive teardown with confirmation-as-error semantics),
+    /// driven through the tested `GhosttySurfaceRetirementCloser` state machine. The surface
+    /// conformer owns this lifecycle so callers never reach into the libghostty view (#710).
+    func closeForSessionRetirement() async throws {
+        try await GhosttySurfaceRetirementCloser().close(surfaceView)
+    }
+
     func tearDown() {
         // Detach the view and drop the title hook; the libghostty C handle frees via ARC/`deinit`
         // (no explicit free exists today). The title hook holds a strong `self`-capture into the

--- a/Sources/WorkspaceManager/Surface/TerminalSurface.swift
+++ b/Sources/WorkspaceManager/Surface/TerminalSurface.swift
@@ -82,9 +82,22 @@ final class TerminalSurface: Surface {
     /// Session-retirement close (process-alive teardown with confirmation-as-error semantics),
     /// driven through the tested `GhosttySurfaceRetirementCloser` state machine. The surface
     /// conformer owns this lifecycle so callers never reach into the libghostty view (#710).
+    ///
+    /// Concurrent calls coalesce onto one in-flight drive: the closer temporarily swaps the
+    /// view's close-confirmation hook, so two overlapping drives would restore each other's
+    /// captures out of order and strand a stale hook (codex review finding, inherited from the
+    /// pre-seam implementation).
     func closeForSessionRetirement() async throws {
-        try await GhosttySurfaceRetirementCloser().close(surfaceView)
+        if let inFlightRetirementClose {
+            return try await inFlightRetirementClose.value
+        }
+        let drive = Task { try await GhosttySurfaceRetirementCloser().close(surfaceView) }
+        inFlightRetirementClose = drive
+        defer { inFlightRetirementClose = nil }
+        try await drive.value
     }
+
+    private var inFlightRetirementClose: Task<Void, Error>?
 
     func tearDown() {
         // Detach the view and drop the title hook; the libghostty C handle frees via ARC/`deinit`

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceRetirementCloser.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceRetirementCloser.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The graceful-close contract a terminal surface offers session retirement: liveness and
+/// process-exit observation, a close request, and the close-confirmation hook the runtime fires
+/// when the shell still has a foreground process. `GhosttySurfaceView` conforms over libghostty;
+/// tests conform with a fake — this seam is what makes the retirement state machine testable
+/// without a live surface (#710).
+@MainActor
+protocol RetirementClosableSurface: AnyObject {
+    /// Whether the libghostty surface still exists (freed surfaces read false).
+    var isSurfaceAlive: Bool { get }
+    /// Whether the surface's child process has exited.
+    var hasProcessExited: Bool { get }
+    /// Ask the runtime to close the surface (may trigger the confirmation hook instead).
+    func requestSurfaceClose()
+    /// Runtime hook fired when close needs user confirmation because a process is alive.
+    var onCloseConfirmationRequired: (() -> Void)? { get set }
+    /// Human-readable title for retirement errors.
+    var retirementDisplayTitle: String { get }
+}
+
+/// Session-retirement close: request a graceful close and poll until the process exits, the
+/// surface is freed, the runtime asks for confirmation (a foreground process is still running —
+/// surfaced as an error, never a dialog), or the deadline passes. Extracted from
+/// `GhosttySurfaceView` so the state machine is unit-tested against a fake surface.
+@MainActor
+struct GhosttySurfaceRetirementCloser {
+    var timeout: Duration = .seconds(5)
+    var pollInterval: Duration = .milliseconds(50)
+
+    func close(_ surface: any RetirementClosableSurface) async throws {
+        guard surface.isSurfaceAlive else { return }
+        guard !surface.hasProcessExited else { return }
+
+        var processStillRunning = false
+        let previousCloseConfirmation = surface.onCloseConfirmationRequired
+        surface.onCloseConfirmationRequired = {
+            processStillRunning = true
+        }
+        defer {
+            surface.onCloseConfirmationRequired = previousCloseConfirmation
+        }
+
+        surface.requestSurfaceClose()
+
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if !surface.isSurfaceAlive || surface.hasProcessExited {
+                return
+            }
+            if processStillRunning {
+                throw GhosttySurfaceRetirementCloseError.processStillRunning(
+                    title: surface.retirementDisplayTitle)
+            }
+            try await Task.sleep(for: pollInterval)
+        }
+
+        if !surface.isSurfaceAlive || surface.hasProcessExited {
+            return
+        }
+        throw GhosttySurfaceRetirementCloseError.timedOut(title: surface.retirementDisplayTitle)
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -24,7 +24,7 @@ enum GhosttySurfaceRetirementCloseError: LocalizedError {
 }
 
 @MainActor
-final class GhosttySurfaceView: NSView {
+final class GhosttySurfaceView: NSView, RetirementClosableSurface {
     private let workingDirectory: URL
     var onProcessExit: (() -> Void)?
     var onCloseConfirmationRequired: (() -> Void)?
@@ -277,42 +277,23 @@ final class GhosttySurfaceView: NSView {
         ghostty_surface_request_close(surface)
     }
 
-    func requestCloseForSessionRetirement(
-        timeout: Duration = .seconds(5),
-        pollInterval: Duration = .milliseconds(50)
-    ) async throws {
-        guard let surface else { return }
-        guard !ghostty_surface_process_exited(surface) else { return }
+    // MARK: - Retirement close seam
 
-        var processStillRunning = false
-        let previousCloseConfirmation = onCloseConfirmationRequired
-        onCloseConfirmationRequired = {
-            processStillRunning = true
-        }
-        defer {
-            onCloseConfirmationRequired = previousCloseConfirmation
-        }
-
-        ghostty_surface_request_close(surface)
-
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while ContinuousClock.now < deadline {
-            if self.surface == nil || ghostty_surface_process_exited(surface) {
-                return
-            }
-            if processStillRunning {
-                throw GhosttySurfaceRetirementCloseError.processStillRunning(title: displayTitleForLifecycleError)
-            }
-            try await Task.sleep(for: pollInterval)
-        }
-
-        if self.surface == nil || ghostty_surface_process_exited(surface) {
-            return
-        }
-        throw GhosttySurfaceRetirementCloseError.timedOut(title: displayTitleForLifecycleError)
+    var isSurfaceAlive: Bool {
+        surface != nil
     }
 
-    private var displayTitleForLifecycleError: String {
+    var hasProcessExited: Bool {
+        guard let surface else { return false }
+        return ghostty_surface_process_exited(surface)
+    }
+
+    func requestSurfaceClose() {
+        guard let surface else { return }
+        ghostty_surface_request_close(surface)
+    }
+
+    var retirementDisplayTitle: String {
         let title = terminalTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         if !title.isEmpty {
             return title

--- a/Tests/WorkspaceManagerAppTests/GhosttySurfaceRetirementCloserTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttySurfaceRetirementCloserTests.swift
@@ -90,8 +90,17 @@ struct GhosttySurfaceRetirementCloserTests {
             surface.onCloseConfirmationRequired?()
         }
 
-        await #expect(throws: GhosttySurfaceRetirementCloseError.self) {
+        do {
             try await makeCloser().close(surface)
+            Issue.record("Expected processStillRunning")
+        } catch let error as GhosttySurfaceRetirementCloseError {
+            guard case .processStillRunning(let title) = error else {
+                Issue.record("Expected processStillRunning, got \(error)")
+                return
+            }
+            #expect(title == "fake-terminal")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
         }
     }
 

--- a/Tests/WorkspaceManagerAppTests/GhosttySurfaceRetirementCloserTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttySurfaceRetirementCloserTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+private final class FakeRetirementSurface: RetirementClosableSurface {
+    var aliveValue = true
+    var exitedValue = false
+    var onCloseConfirmationRequired: (() -> Void)?
+    var retirementDisplayTitle = "fake-terminal"
+
+    private(set) var closeRequests = 0
+    private(set) var livenessChecks = 0
+    /// Runs when the closer requests a close — the fake's stand-in for runtime behavior.
+    var onCloseRequested: (() -> Void)?
+    /// Runs on every liveness read — lets tests flip state after N polls, deterministically
+    /// (no wall-clock timers to race a loaded test runner).
+    var onLivenessCheck: ((Int) -> Void)?
+
+    var isSurfaceAlive: Bool {
+        livenessChecks += 1
+        onLivenessCheck?(livenessChecks)
+        return aliveValue
+    }
+
+    var hasProcessExited: Bool {
+        exitedValue
+    }
+
+    func requestSurfaceClose() {
+        closeRequests += 1
+        onCloseRequested?()
+    }
+}
+
+@MainActor
+@Suite("GhosttySurfaceRetirementCloser")
+struct GhosttySurfaceRetirementCloserTests {
+    private func makeCloser(
+        timeout: Duration = .milliseconds(300),
+        pollInterval: Duration = .milliseconds(10)
+    ) -> GhosttySurfaceRetirementCloser {
+        GhosttySurfaceRetirementCloser(timeout: timeout, pollInterval: pollInterval)
+    }
+
+    @Test("A freed surface is a no-op — no close request")
+    func freedSurfaceNoOp() async throws {
+        let surface = FakeRetirementSurface()
+        surface.aliveValue = false
+
+        try await makeCloser().close(surface)
+        #expect(surface.closeRequests == 0)
+    }
+
+    @Test("An already-exited process is a no-op — no close request")
+    func exitedProcessNoOp() async throws {
+        let surface = FakeRetirementSurface()
+        surface.exitedValue = true
+
+        try await makeCloser().close(surface)
+        #expect(surface.closeRequests == 0)
+    }
+
+    @Test("Process exiting after the close request returns cleanly and restores the hook")
+    func exitAfterCloseReturns() async throws {
+        let surface = FakeRetirementSurface()
+        var originalHookFired = false
+        surface.onCloseConfirmationRequired = { originalHookFired = true }
+        // The shell "exits" on the third liveness poll after the close request.
+        surface.onLivenessCheck = { checks in
+            if surface.closeRequests > 0, checks >= 3 {
+                surface.exitedValue = true
+            }
+        }
+
+        try await makeCloser(timeout: .seconds(5)).close(surface)
+
+        #expect(surface.closeRequests == 1)
+        // The original confirmation hook is restored, not lost to the closer's temporary capture.
+        surface.onCloseConfirmationRequired?()
+        #expect(originalHookFired)
+    }
+
+    @Test("A close-confirmation request means a live process — throws, never shows a dialog")
+    func confirmationBecomesProcessStillRunning() async {
+        let surface = FakeRetirementSurface()
+        surface.onCloseRequested = {
+            // The runtime answers the close request by asking for confirmation.
+            surface.onCloseConfirmationRequired?()
+        }
+
+        await #expect(throws: GhosttySurfaceRetirementCloseError.self) {
+            try await makeCloser().close(surface)
+        }
+    }
+
+    @Test("Deadline passing with a live process throws timedOut")
+    func deadlineThrowsTimedOut() async {
+        let surface = FakeRetirementSurface()
+
+        do {
+            try await makeCloser(timeout: .milliseconds(80)).close(surface)
+            Issue.record("Expected timedOut")
+        } catch let error as GhosttySurfaceRetirementCloseError {
+            guard case .timedOut(let title) = error else {
+                Issue.record("Expected timedOut, got \(error)")
+                return
+            }
+            #expect(title == "fake-terminal")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("Surface freed mid-poll returns cleanly")
+    func surfaceFreedMidPollReturns() async throws {
+        let surface = FakeRetirementSurface()
+        // The surface is "freed" on the third liveness poll after the close request.
+        surface.onLivenessCheck = { checks in
+            if surface.closeRequests > 0, checks >= 3 {
+                surface.aliveValue = false
+            }
+        }
+
+        try await makeCloser(timeout: .seconds(5)).close(surface)
+        #expect(surface.closeRequests == 1)
+    }
+
+    @Test("The confirmation hook is restored even on the throwing paths")
+    func hookRestoredAfterThrow() async {
+        let surface = FakeRetirementSurface()
+        var originalHookFired = false
+        surface.onCloseConfirmationRequired = { originalHookFired = true }
+        surface.onCloseRequested = {
+            surface.onCloseConfirmationRequired?()
+        }
+
+        _ = try? await makeCloser().close(surface)
+
+        surface.onCloseConfirmationRequired?()
+        #expect(originalHookFired)
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of #710 (Ghostty boundary seam): the session-retirement close — request a graceful close, poll for exit/free, treat a close-confirmation callback as a process-still-running error — was a state machine tangled with raw libghostty calls inside `GhosttySurfaceView`, untestable without a live surface. It now lives in `GhosttySurfaceRetirementCloser` behind a `RetirementClosableSurface` seam, with seven unit tests over a fake (no-op paths, clean exit, freed-mid-poll, confirmation-as-error, timeout, hook restoration).

Ownership moves where the issue asks: `TerminalSurface` (the tile-tree epic's surface conformer) now drives retirement via `closeForSessionRetirement()`, and `SurfaceStore` no longer reaches through to the libghostty view. Concurrent drives coalesce onto one in-flight task, closing an inherited stale-hook interleaving. The view keeps only primitive accessors; its old public retirement method is removed with its sole caller migrated.

**Scoping note vs the issue text:** survey showed the attach/geometry glue the issue also lists is already thin — each override delegates to previously-extracted tested helpers (`GhosttySurfaceScaleCalculator`, `GhosttySurfaceInputRouter`, #387/#394). The dense untested remainder was this close/retirement flow; extraction plan and inventory are on the issue. Whether a slice 2 (first-responder/focus handoff) pays for itself is a judgment call I'll make after this lands — the issue stays open until then.

## Review loop

Reflect pass (caught and removed the dead duplicate view method), then codex (`gpt-5.5`, xhigh) with a falsifiable stale-hook question. **Merge-ready**; it independently verified check-ordering/default/error-taxonomy preservation against `HEAD~1`, nil-surface safety, and zero remaining callers of the removed method. Two findings, both addressed: overlapping-drive stale hook (inherited — fixed via coalescing at the owner), and a loose error-type assertion (pinned to `.processStillRunning` with title).

## Mergeability

- Surface: desktop
- User-facing behavior changed: none — behavior-preserving refactor; ordering, defaults (5s/50ms), and error taxonomy replicated exactly (codex-verified against the removed implementation). The only semantic change is concurrent retirement drives now coalescing instead of racing, which can only remove a failure mode.
- Non-happy paths considered: freed surface and already-exited process are no-ops; confirmation-during-retirement throws instead of showing a dialog (unchanged contract); the confirmation hook is restored on success and throw paths (tested); a surface freed mid-poll returns cleanly.
- Release/ops preconditions: none.
- Residual risk or follow-up: whether slice 2 (focus handoff extraction) pays for itself — decided on the issue after this lands.
- Note: two of the new async tests initially raced wall-clock timers and flaked under full-suite load; rewritten to flip state from the closer's own polls (deterministic), then passed two consecutive full-suite runs.

## Validation

- [x] `swift build`
- [x] `swift test` — 1134 passed / 175 suites (×2 consecutive runs for flake check)
- [x] Other checks run: `mise run lint` clean; `./scripts/desktop-ui-smoke.sh` green on the refactored teardown path (run 20260707-020222)

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached

Evidence links:

- ![710-verification](https://evidence.cloudcompute.com/workspaces/pr-877/20260707-090855-710-retirement-seam.png)

## Blockers

- [x] None

Part of #710 (slice 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
