### PR TITLE
refactor(main-window): migrate error call sites onto the presenter seam (PR 2/2)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -57,7 +57,6 @@ struct ContentView: View {
     @State private var repoForNewWorkspaceFromLanding: Repo?
     @State private var isPreparingLandingNewWorkspaceSheet = false
     @State private var webSourceCreationTarget: WebSourceCreationTarget?
-    @State private var landingErrorMessage: String?
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
     @State private var didScheduleInitialWorkspaceStatusSync = false
     @State private var didPrewarmPerfTerminalSurfaces = false
@@ -496,17 +495,6 @@ struct ContentView: View {
         workspaceEnvironmentSheetState.lumeRuntimeSnapshot
     }
 
-    private var isPresentingError: Binding<Bool> {
-        Binding(
-            get: { errorPresenter.isPresented },
-            set: { isPresented in
-                if !isPresented {
-                    errorPresenter.dismiss()
-                }
-            }
-        )
-    }
-
     @ViewBuilder
     private var terminalDetailContent: some View {
         MainTerminalDetailView(
@@ -865,28 +853,7 @@ struct ContentView: View {
 
     private var splitViewWithFocusAndAlerts: some View {
         splitViewWithLifecycleHandlers
-            .alert(
-                errorPresenter.current?.title ?? "Error",
-                isPresented: isPresentingError,
-                presenting: errorPresenter.current
-            ) { _ in
-                Button("OK", role: .cancel) {
-                    errorPresenter.dismiss()
-                }
-            } message: { error in
-                Text(error.message)
-            }
-            .alert(
-                "Could Not Open Workspace",
-                isPresented: Binding(
-                    get: { viewState.workspaceOperationErrorMessage != nil },
-                    set: { if !$0 { viewState.workspaceOperationErrorMessage = nil } }
-                )
-            ) {
-                Button("OK", role: .cancel) { viewState.workspaceOperationErrorMessage = nil }
-            } message: {
-                Text(viewState.workspaceOperationErrorMessage ?? "Unknown error.")
-            }
+            .mainWindowErrorAlert($errorPresenter)
             .alert(
                 workspaceOrphanCleanupTitle(for: pendingWorkspaceOrphanCleanup),
                 isPresented: Binding(
@@ -996,7 +963,7 @@ struct ContentView: View {
                     )
                 }
             }
-            .onChange(of: viewState.workspaceOperationErrorMessage) { _, message in
+            .onChange(of: errorPresenter.message(from: .workspaceOperation)) { _, message in
                 guard let message else { return }
                 Task { @MainActor in
                     await hostLumeSmokeAutomation.noteFailure(
@@ -1116,17 +1083,6 @@ struct ContentView: View {
                     notificationCoordinator: notificationCoordinator,
                     onDismiss: { isShowingFeedbackSheet = false }
                 )
-            }
-            .alert(
-                "Error",
-                isPresented: Binding(
-                    get: { landingErrorMessage != nil },
-                    set: { if !$0 { landingErrorMessage = nil } }
-                )
-            ) {
-                Button("OK", role: .cancel) { landingErrorMessage = nil }
-            } message: {
-                Text(landingErrorMessage ?? "Unknown error.")
             }
     }
 
@@ -1611,8 +1567,9 @@ struct ContentView: View {
     @MainActor
     private func handleProviderBackedWorkspaceSelection(_ workspace: Workspace) {
         guard let provider = workspaceProviderRegistry.provider(for: workspace) else {
-            viewState.workspaceOperationErrorMessage =
+            presentWorkspaceOperationError(
                 "No workspace provider is registered for '\(workspace.backendIdentifier)'."
+            )
             return
         }
 
@@ -1644,7 +1601,7 @@ struct ContentView: View {
                     await connectToProviderBackedWorkspace(workspace, provider: provider)
                 }
             } catch {
-                viewState.workspaceOperationErrorMessage = error.localizedDescription
+                presentWorkspaceOperationError(error.localizedDescription)
             }
         }
     }
@@ -1689,7 +1646,7 @@ struct ContentView: View {
             )
             guard viewState.connectingWorkspaceID == workspace.id else { return }
             viewState.connectingWorkspaceID = nil
-            viewState.workspaceOperationErrorMessage = error.localizedDescription
+            presentWorkspaceOperationError(error.localizedDescription)
         }
     }
 
@@ -1722,7 +1679,7 @@ struct ContentView: View {
     ) async {
         do {
             guard let provider = workspaceProviderRegistry.provider(for: providerID) else {
-                landingErrorMessage = "Workspace provider '\(providerID)' is not registered."
+                presentLandingError("Workspace provider '\(providerID)' is not registered.")
                 return
             }
 
@@ -1740,7 +1697,7 @@ struct ContentView: View {
                         skipSetup: true
                     )
                 } catch {
-                    landingErrorMessage = "Failed to create workspace: \(error.localizedDescription)"
+                    presentLandingError("Failed to create workspace: \(error.localizedDescription)")
                 }
             } perform: {
                 do {
@@ -1753,11 +1710,11 @@ struct ContentView: View {
                         skipSetup: true
                     )
                 } catch {
-                    landingErrorMessage = "Failed to create workspace: \(error.localizedDescription)"
+                    presentLandingError("Failed to create workspace: \(error.localizedDescription)")
                 }
             }
         } catch {
-            landingErrorMessage = "Failed to create workspace: \(error.localizedDescription)"
+            presentLandingError("Failed to create workspace: \(error.localizedDescription)")
         }
     }
 
@@ -1811,7 +1768,7 @@ struct ContentView: View {
         do {
             try await controller.archive(workspace)
         } catch {
-            landingErrorMessage = "Failed to archive workspace: \(error.localizedDescription)"
+            presentLandingError("Failed to archive workspace: \(error.localizedDescription)")
         }
     }
 
@@ -1850,9 +1807,11 @@ struct ContentView: View {
             handleWebSourceSelection(source)
         } catch {
             if let validationError = error as? WebSourceValidationError {
-                landingErrorMessage = validationError.errorDescription
+                if let description = validationError.errorDescription {
+                    presentLandingError(description)
+                }
             } else {
-                landingErrorMessage = error.localizedDescription
+                presentLandingError(error.localizedDescription)
             }
             modelContext.rollback()
         }
@@ -2328,8 +2287,9 @@ struct ContentView: View {
             dismissedWorkspaceOrphanItemIDs.remove(item.id)
             await refreshWorkspaceOrphans(trigger: "cleanup")
         } catch {
-            viewState.workspaceOperationErrorMessage =
+            presentWorkspaceOperationError(
                 "Could not clean '\(item.resourceName)': \(error.localizedDescription)"
+            )
         }
     }
 
@@ -2390,8 +2350,9 @@ struct ContentView: View {
     @MainActor
     private func openDesktop(for workspace: Workspace) {
         guard let provider = workspaceProviderRegistry.provider(for: workspace) else {
-            viewState.workspaceOperationErrorMessage =
+            presentWorkspaceOperationError(
                 "No workspace provider is registered for '\(workspace.backendIdentifier)'."
+            )
             return
         }
 
@@ -2404,7 +2365,7 @@ struct ContentView: View {
                     await openDesktopAfterSetup(workspace, provider: provider)
                 }
             } catch {
-                viewState.workspaceOperationErrorMessage = error.localizedDescription
+                presentWorkspaceOperationError(error.localizedDescription)
             }
         }
     }
@@ -2438,7 +2399,7 @@ struct ContentView: View {
         } catch {
             guard viewState.connectingWorkspaceID == workspace.id else { return }
             viewState.connectingWorkspaceID = nil
-            viewState.workspaceOperationErrorMessage = error.localizedDescription
+            presentWorkspaceOperationError(error.localizedDescription)
         }
     }
 
@@ -2825,7 +2786,21 @@ struct ContentView: View {
         } else {
             message = error.localizedDescription
         }
-        errorPresenter.present(title: "Could Not Open Editor", message: message)
+        errorPresenter.present(source: .openInEditor, title: "Could Not Open Editor", message: message)
+    }
+
+    /// Surfaces a workspace-operation failure through the shared error presenter. Only this
+    /// source notifies the host-Lume smoke automation (see the `.workspaceOperation` onChange).
+    @MainActor
+    private func presentWorkspaceOperationError(_ message: String) {
+        errorPresenter.present(source: .workspaceOperation, title: "Could Not Open Workspace", message: message)
+    }
+
+    /// Surfaces a landing-flow failure (repo import, workspace creation from the landing view)
+    /// through the shared error presenter.
+    @MainActor
+    private func presentLandingError(_ message: String) {
+        errorPresenter.present(source: .landing, title: "Error", message: message)
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowErrorPresenter.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowErrorPresenter.swift
@@ -1,21 +1,72 @@
-import Foundation
+import SwiftUI
 
 /// One presentation model for main-window errors. Producers build a `MainWindowError` and
-/// hand it to the presenter; the view renders a single alert from `current`. This is the seam
-/// the main window converges its previously ad-hoc error paths (transient `.alert`, inline
-/// banner, log-only) onto, so every surfaced error flows through one entry point.
+/// hand it to the presenter; a view renders a single alert from `current` via
+/// `mainWindowErrorAlert`. This is the seam the main window and its sibling views (ContentView,
+/// SidebarView) converge their previously ad-hoc transient `.alert` paths onto, so every
+/// surfaced error flows through one entry point and one renderer.
 ///
 /// Latest-wins: presenting while an error is showing replaces it, matching SwiftUI's behavior
-/// of showing a single alert at a time.
+/// of showing a single alert at a time. `dismiss()` clears `current`.
 struct MainWindowError: Identifiable, Equatable {
     let id: UUID
+    /// Where the error originated. Routes source-specific side effects (e.g. only
+    /// workspace-operation failures notify the host-Lume smoke automation) without the view
+    /// keeping a separate per-source message field.
+    let source: MainWindowErrorSource
     let title: String
     let message: String
+    /// Named recovery affordances the view maps to handlers, kept as data (not closures) so the
+    /// model stays value-comparable and testable.
+    let recoveryActions: [MainWindowErrorRecoveryAction]
 
-    init(id: UUID = UUID(), title: String, message: String) {
+    init(
+        id: UUID = UUID(),
+        source: MainWindowErrorSource,
+        title: String,
+        message: String,
+        recoveryActions: [MainWindowErrorRecoveryAction] = []
+    ) {
         self.id = id
+        self.source = source
         self.title = title
         self.message = message
+        self.recoveryActions = recoveryActions
+    }
+}
+
+enum MainWindowErrorSource: Equatable {
+    case openInEditor
+    case workspaceOperation
+    case landing
+    case sidebar
+}
+
+struct MainWindowErrorRecoveryAction: Identifiable, Equatable {
+    enum Kind: Equatable {
+        case openVMRuntime
+        case openLumeLog
+    }
+
+    let id: UUID
+    let title: String
+    let kind: Kind
+
+    init(id: UUID = UUID(), title: String, kind: Kind) {
+        self.id = id
+        self.title = title
+        self.kind = kind
+    }
+
+    /// The Lume recovery affordances offered for a failure message — the "Open VM Runtime" /
+    /// "Open Lume Log" pair the sidebar showed whenever the message carried host-Lume recovery
+    /// hints. Empty when the message has no such hints.
+    static func lumeRecoveryActions(forMessage message: String?) -> [MainWindowErrorRecoveryAction] {
+        guard !hostLumeSmokeRecoveryHints(for: message).isEmpty else { return [] }
+        return [
+            MainWindowErrorRecoveryAction(title: "Open VM Runtime", kind: .openVMRuntime),
+            MainWindowErrorRecoveryAction(title: "Open Lume Log", kind: .openLumeLog),
+        ]
     }
 }
 
@@ -28,11 +79,73 @@ struct MainWindowErrorPresenter {
         current = error
     }
 
-    mutating func present(title: String, message: String) {
-        current = MainWindowError(title: title, message: message)
+    mutating func present(
+        source: MainWindowErrorSource,
+        title: String,
+        message: String,
+        recoveryActions: [MainWindowErrorRecoveryAction] = []
+    ) {
+        current = MainWindowError(
+            source: source,
+            title: title,
+            message: message,
+            recoveryActions: recoveryActions
+        )
     }
 
     mutating func dismiss() {
         current = nil
+    }
+
+    /// The currently-presented message iff it came from `source`, else nil. Views observe this
+    /// (an `Equatable` `String?`) to preserve each side effect's exact "message becomes non-nil"
+    /// trigger semantics when several sources share one presenter.
+    func message(from source: MainWindowErrorSource) -> String? {
+        guard let current, current.source == source else { return nil }
+        return current.message
+    }
+}
+
+extension View {
+    /// Renders `presenter`'s current error as the single main-window error alert. Recovery
+    /// buttons come from the error's `recoveryActions`; `onRecoveryAction` maps a chosen action's
+    /// kind to the view's handler. Any button dismisses the alert (SwiftUI clears the
+    /// `isPresented` binding), which clears the presenter.
+    func mainWindowErrorAlert(
+        _ presenter: Binding<MainWindowErrorPresenter>,
+        onRecoveryAction: @escaping (MainWindowErrorRecoveryAction.Kind) -> Void = { _ in }
+    ) -> some View {
+        modifier(MainWindowErrorAlertModifier(presenter: presenter, onRecoveryAction: onRecoveryAction))
+    }
+}
+
+private struct MainWindowErrorAlertModifier: ViewModifier {
+    @Binding var presenter: MainWindowErrorPresenter
+    let onRecoveryAction: (MainWindowErrorRecoveryAction.Kind) -> Void
+
+    func body(content: Content) -> some View {
+        content.alert(
+            presenter.current?.title ?? "Error",
+            isPresented: Binding(
+                get: { presenter.isPresented },
+                set: { isPresented in
+                    if !isPresented {
+                        presenter.dismiss()
+                    }
+                }
+            ),
+            presenting: presenter.current
+        ) { error in
+            ForEach(error.recoveryActions) { action in
+                Button(action.title) {
+                    onRecoveryAction(action.kind)
+                }
+            }
+            Button("OK", role: .cancel) {
+                presenter.dismiss()
+            }
+        } message: { error in
+            Text(error.message)
+        }
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowErrorPresenter.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowErrorPresenter.swift
@@ -104,6 +104,15 @@ struct MainWindowErrorPresenter {
         guard let current, current.source == source else { return nil }
         return current.message
     }
+
+    /// Whether a newly-surfaced sidebar failure should re-notify the smoke automation. Before the
+    /// seam, the sidebar's `errorMessage` was sticky (never cleared on dismiss), so an identical
+    /// consecutive message did not re-fire `noteFailure`. The presenter clears on dismiss, so the
+    /// sidebar tracks the last-notified message and consults this to keep that exact contract.
+    static func shouldNoteFailure(message: String?, lastNoted: String?) -> Bool {
+        guard let message else { return false }
+        return message != lastNoted
+    }
 }
 
 extension View {

--- a/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/MainWindowViewState.swift
@@ -58,7 +58,6 @@ struct MainWindowViewState {
     var didApplyFixtureDiagnosticsBootstrap = false
     var didApplyFixtureSessionSwitcherBootstrap = false
     var didResolveInitialSurface = false
-    var workspaceOperationErrorMessage: String?
     var connectingWorkspaceID: UUID?
     var terminalCloseConfirmation: TerminalCloseConfirmation?
     var isShowingSessionSwitcher = false

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -71,9 +71,11 @@ struct SidebarView: View {
     @State private var newWorkspaceSheetContext: NewWorkspaceSheetContext?
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
 
-    // Error alert state
-    @State private var errorMessage: String?
-    @State private var showingError = false
+    // Error alert state — routes through the shared main-window error presenter seam.
+    @State private var errorPresenter = MainWindowErrorPresenter()
+    /// Last failure handed to the smoke automation, so an identical consecutive error does not
+    /// re-notify it (the pre-seam `errorMessage` was sticky; the presenter clears on dismiss).
+    @State private var lastNotedFailureMessage: String?
 
     // Delete confirmation state
     @State private var workspaceToDelete: Workspace?
@@ -189,20 +191,13 @@ struct SidebarView: View {
                 }
             }
         }
-        .alert("Error", isPresented: $showingError) {
-            Button("OK", role: .cancel) {}
-
-            if shouldOfferLumeRecoveryActions {
-                Button("Open VM Runtime") {
-                    openSettingsWindow()
-                }
-
-                Button("Open Lume Log") {
-                    openLumeLog()
-                }
+        .mainWindowErrorAlert($errorPresenter) { kind in
+            switch kind {
+            case .openVMRuntime:
+                openSettingsWindow()
+            case .openLumeLog:
+                openLumeLog()
             }
-        } message: {
-            Text(errorMessage ?? "An unknown error occurred")
         }
         .confirmationDialog(
             "Delete Workspace",
@@ -266,8 +261,15 @@ struct SidebarView: View {
             await maybeDriveHostLumeSmokeAutomation()
             await maybeDriveDesktopUISmokeAutomation()
         }
-        .onChange(of: errorMessage) { _, message in
-            guard let message else { return }
+        .onChange(of: errorPresenter.current?.message) { _, message in
+            guard
+                MainWindowErrorPresenter.shouldNoteFailure(
+                    message: message,
+                    lastNoted: lastNotedFailureMessage
+                ),
+                let message
+            else { return }
+            lastNotedFailureMessage = message
             Task { @MainActor in
                 await hostLumeSmokeAutomation.noteFailure(
                     message: message,
@@ -690,8 +692,7 @@ struct SidebarView: View {
         let gitDir = url.appendingPathComponent(".git")
         guard FileManager.default.fileExists(atPath: gitDir.path) else {
             await MainActor.run {
-                errorMessage = "The selected folder is not a Git repository.\n\nPath: \(url.lastPathComponent)"
-                showingError = true
+                presentSidebarError("The selected folder is not a Git repository.\n\nPath: \(url.lastPathComponent)")
             }
             return
         }
@@ -740,8 +741,15 @@ struct SidebarView: View {
         NSWorkspace.shared.open(url)
     }
 
-    private var shouldOfferLumeRecoveryActions: Bool {
-        !hostLumeSmokeRecoveryHints(for: errorMessage).isEmpty
+    /// Surfaces a sidebar failure through the shared error presenter, offering the Lume recovery
+    /// actions whenever the message carries host-Lume recovery hints (same condition as before).
+    private func presentSidebarError(_ message: String) {
+        errorPresenter.present(
+            source: .sidebar,
+            title: "Error",
+            message: message,
+            recoveryActions: MainWindowErrorRecoveryAction.lumeRecoveryActions(forMessage: message)
+        )
     }
 
     private func openSettingsWindow() {
@@ -763,8 +771,7 @@ struct SidebarView: View {
             }
         }
 
-        errorMessage = "No Lume log file is available yet."
-        showingError = true
+        presentSidebarError("No Lume log file is available yet.")
     }
 
     private func creationStatus(for repoID: UUID) -> WorkspaceCreationStatus? {
@@ -790,8 +797,7 @@ struct SidebarView: View {
         guestOS: WorkspaceGuestOS? = nil
     ) async {
         guard let provider = workspaceProviderRegistry.provider(for: providerID) else {
-            errorMessage = "Workspace provider '\(providerID)' is not registered."
-            showingError = true
+            presentSidebarError("Workspace provider '\(providerID)' is not registered.")
             return
         }
 
@@ -818,8 +824,7 @@ struct SidebarView: View {
                 )
             }
         } catch {
-            errorMessage = error.localizedDescription
-            showingError = true
+            presentSidebarError(error.localizedDescription)
         }
     }
 
@@ -889,8 +894,7 @@ struct SidebarView: View {
             )
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             let providerName = providerDisplayName(for: providerID)
-            errorMessage = "Failed to create \(providerName) workspace: \(error.localizedDescription)"
-            showingError = true
+            presentSidebarError("Failed to create \(providerName) workspace: \(error.localizedDescription)")
         }
     }
 
@@ -908,8 +912,7 @@ struct SidebarView: View {
                 selectedWorkspace = nil
             }
         } catch {
-            errorMessage = "Failed to delete workspace: \(error.localizedDescription)"
-            showingError = true
+            presentSidebarError("Failed to delete workspace: \(error.localizedDescription)")
         }
         workspaceToDelete = nil
     }
@@ -971,8 +974,7 @@ struct SidebarView: View {
                 workspaceAction = nil
             } catch {
                 workspaceAction = nil
-                errorMessage = "Failed to unarchive workspace: \(error.localizedDescription)"
-                showingError = true
+                presentSidebarError("Failed to unarchive workspace: \(error.localizedDescription)")
             }
         }
     }
@@ -986,8 +988,7 @@ struct SidebarView: View {
                 workspaceAction = nil
             } catch {
                 workspaceAction = nil
-                errorMessage = "Failed to stop workspace: \(error.localizedDescription)"
-                showingError = true
+                presentSidebarError("Failed to stop workspace: \(error.localizedDescription)")
             }
         }
     }
@@ -995,8 +996,7 @@ struct SidebarView: View {
     private func performStart(_ workspace: Workspace) {
         Task { @MainActor in
             guard let provider = workspaceProviderRegistry.provider(for: workspace) else {
-                errorMessage = "No workspace provider is registered for '\(workspace.backendIdentifier)'."
-                showingError = true
+                presentSidebarError("No workspace provider is registered for '\(workspace.backendIdentifier)'.")
                 return
             }
 
@@ -1009,8 +1009,7 @@ struct SidebarView: View {
                     await performStartAfterSetup(workspace)
                 }
             } catch {
-                errorMessage = error.localizedDescription
-                showingError = true
+                presentSidebarError(error.localizedDescription)
             }
         }
     }
@@ -1025,8 +1024,7 @@ struct SidebarView: View {
             selectedWorkspace = workspace
         } catch {
             workspaceAction = nil
-            errorMessage = "Failed to start workspace: \(error.localizedDescription)"
-            showingError = true
+            presentSidebarError("Failed to start workspace: \(error.localizedDescription)")
         }
     }
 
@@ -1039,8 +1037,7 @@ struct SidebarView: View {
                 workspaceAction = nil
             } catch {
                 workspaceAction = nil
-                errorMessage = "Failed to archive workspace: \(error.localizedDescription)"
-                showingError = true
+                presentSidebarError("Failed to archive workspace: \(error.localizedDescription)")
             }
         }
     }
@@ -1048,8 +1045,7 @@ struct SidebarView: View {
     private func openDesktop(for workspace: Workspace) {
         Task { @MainActor in
             guard let provider = workspaceProviderRegistry.provider(for: workspace) else {
-                errorMessage = "No workspace provider is registered for '\(workspace.backendIdentifier)'."
-                showingError = true
+                presentSidebarError("No workspace provider is registered for '\(workspace.backendIdentifier)'.")
                 return
             }
 
@@ -1062,8 +1058,7 @@ struct SidebarView: View {
                     await openDesktopAfterSetup(workspace)
                 }
             } catch {
-                errorMessage = error.localizedDescription
-                showingError = true
+                presentSidebarError(error.localizedDescription)
             }
         }
     }
@@ -1071,8 +1066,7 @@ struct SidebarView: View {
     @MainActor
     private func openDesktopAfterSetup(_ workspace: Workspace) async {
         guard let provider = workspaceProviderRegistry.provider(for: workspace) else {
-            errorMessage = "No workspace provider is registered for '\(workspace.backendIdentifier)'."
-            showingError = true
+            presentSidebarError("No workspace provider is registered for '\(workspace.backendIdentifier)'.")
             return
         }
 
@@ -1086,8 +1080,7 @@ struct SidebarView: View {
             NSWorkspace.shared.open(spec.vncURL)
         } catch {
             workspaceAction = nil
-            errorMessage = "Failed to open desktop: \(error.localizedDescription)"
-            showingError = true
+            presentSidebarError("Failed to open desktop: \(error.localizedDescription)")
         }
     }
 
@@ -1106,14 +1099,12 @@ struct SidebarView: View {
                 normalizeRepoPath: normalizePath(_:)
             )
         else {
-            errorMessage = "Add a repository first, then create a workspace."
-            showingError = true
+            presentSidebarError("Add a repository first, then create a workspace.")
             return
         }
 
         guard !isCreatingWorkspace(for: preferredRepo.id) else {
-            errorMessage = "A workspace is already being created for '\(preferredRepo.name)'."
-            showingError = true
+            presentSidebarError("A workspace is already being created for '\(preferredRepo.name)'.")
             return
         }
 
@@ -1217,8 +1208,7 @@ struct SidebarView: View {
 
         guard FileManager.default.fileExists(atPath: targetRepoURL.path) else {
             let message = "Smoke repo path does not exist: \(targetRepoURL.path)"
-            errorMessage = message
-            showingError = true
+            presentSidebarError(message)
             return
         }
 
@@ -1244,8 +1234,7 @@ struct SidebarView: View {
         else {
             guard FileManager.default.fileExists(atPath: targetRepoURL.path) else {
                 let message = "Desktop UI smoke repo path does not exist: \(targetRepoURL.path)"
-                errorMessage = message
-                showingError = true
+                presentSidebarError(message)
                 return
             }
             await addRepo(from: targetRepoURL)
@@ -1386,8 +1375,7 @@ struct SidebarView: View {
             try modelContext.save()
             return true
         } catch {
-            errorMessage = "Failed to \(action): \(error.localizedDescription)"
-            showingError = true
+            presentSidebarError("Failed to \(action): \(error.localizedDescription)")
             return false
         }
     }

--- a/Tests/WorkspaceManagerAppTests/MainWindowErrorPresenterTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowErrorPresenterTests.swift
@@ -91,7 +91,19 @@ struct MainWindowErrorPresenterTests {
 
     @Test("No recovery actions for a message without Lume hints")
     func noRecoveryActionsForPlainMessage() {
-        #expect(MainWindowErrorRecoveryAction.lumeRecoveryActions(forMessage: "Failed to delete workspace: boom").isEmpty)
+        let plain = MainWindowErrorRecoveryAction.lumeRecoveryActions(forMessage: "Failed to delete workspace: boom")
+        #expect(plain.isEmpty)
         #expect(MainWindowErrorRecoveryAction.lumeRecoveryActions(forMessage: nil).isEmpty)
+    }
+
+    // Sidebar sticky re-fire contract — an identical consecutive failure does not re-notify the
+    // smoke automation, but a new or different message does.
+
+    @Test("shouldNoteFailure fires for a new message and skips an identical repeat")
+    func shouldNoteFailureContract() {
+        #expect(MainWindowErrorPresenter.shouldNoteFailure(message: "boom", lastNoted: nil))
+        #expect(MainWindowErrorPresenter.shouldNoteFailure(message: "boom", lastNoted: "boom") == false)
+        #expect(MainWindowErrorPresenter.shouldNoteFailure(message: "kaboom", lastNoted: "boom"))
+        #expect(MainWindowErrorPresenter.shouldNoteFailure(message: nil, lastNoted: "boom") == false)
     }
 }

--- a/Tests/WorkspaceManagerAppTests/MainWindowErrorPresenterTests.swift
+++ b/Tests/WorkspaceManagerAppTests/MainWindowErrorPresenterTests.swift
@@ -15,9 +15,10 @@ struct MainWindowErrorPresenterTests {
     @Test("Presenting an error makes it the current surfaced error")
     func presentSurfacesError() {
         var presenter = MainWindowErrorPresenter()
-        presenter.present(title: "Could Not Open Editor", message: "boom")
+        presenter.present(source: .openInEditor, title: "Could Not Open Editor", message: "boom")
 
         #expect(presenter.isPresented)
+        #expect(presenter.current?.source == .openInEditor)
         #expect(presenter.current?.title == "Could Not Open Editor")
         #expect(presenter.current?.message == "boom")
     }
@@ -25,9 +26,10 @@ struct MainWindowErrorPresenterTests {
     @Test("Presenting while an error is shown replaces it (latest wins)")
     func presentReplacesLatest() {
         var presenter = MainWindowErrorPresenter()
-        presenter.present(title: "First", message: "one")
-        presenter.present(title: "Second", message: "two")
+        presenter.present(source: .workspaceOperation, title: "First", message: "one")
+        presenter.present(source: .landing, title: "Second", message: "two")
 
+        #expect(presenter.current?.source == .landing)
         #expect(presenter.current?.title == "Second")
         #expect(presenter.current?.message == "two")
     }
@@ -35,10 +37,61 @@ struct MainWindowErrorPresenterTests {
     @Test("Dismiss clears the current error")
     func dismissClears() {
         var presenter = MainWindowErrorPresenter()
-        presenter.present(title: "Could Not Open Editor", message: "boom")
+        presenter.present(source: .openInEditor, title: "Could Not Open Editor", message: "boom")
         presenter.dismiss()
 
         #expect(presenter.current == nil)
         #expect(presenter.isPresented == false)
+    }
+
+    // Source routing — a side effect observes only its own source's message, so several sources
+    // can share one presenter without cross-firing each other's onChange hooks.
+
+    @Test("message(from:) returns the message only for the matching source")
+    func sourceRoutingMatches() {
+        var presenter = MainWindowErrorPresenter()
+        presenter.present(source: .workspaceOperation, title: "Could Not Open Workspace", message: "boom")
+
+        #expect(presenter.message(from: .workspaceOperation) == "boom")
+        #expect(presenter.message(from: .openInEditor) == nil)
+        #expect(presenter.message(from: .landing) == nil)
+    }
+
+    @Test("message(from:) is nil once the error is dismissed")
+    func sourceRoutingClearsOnDismiss() {
+        var presenter = MainWindowErrorPresenter()
+        presenter.present(source: .workspaceOperation, title: "Could Not Open Workspace", message: "boom")
+        presenter.dismiss()
+
+        #expect(presenter.message(from: .workspaceOperation) == nil)
+    }
+
+    @Test("message(from:) follows a latest-wins replacement to the new source")
+    func sourceRoutingFollowsReplacement() {
+        var presenter = MainWindowErrorPresenter()
+        presenter.present(source: .workspaceOperation, title: "Workspace", message: "boom")
+        presenter.present(source: .openInEditor, title: "Editor", message: "kaboom")
+
+        #expect(presenter.message(from: .workspaceOperation) == nil)
+        #expect(presenter.message(from: .openInEditor) == "kaboom")
+    }
+
+    // Recovery actions modeled as data — the sidebar's "Open VM Runtime" / "Open Lume Log" pair
+    // is offered exactly when the message carries host-Lume recovery hints.
+
+    @Test("Lume recovery actions are offered for a Lume failure message")
+    func lumeRecoveryActionsForLumeMessage() {
+        let actions = MainWindowErrorRecoveryAction.lumeRecoveryActions(
+            forMessage: "Failed to start Lume VM: boom"
+        )
+
+        #expect(actions.map(\.kind) == [.openVMRuntime, .openLumeLog])
+        #expect(actions.map(\.title) == ["Open VM Runtime", "Open Lume Log"])
+    }
+
+    @Test("No recovery actions for a message without Lume hints")
+    func noRecoveryActionsForPlainMessage() {
+        #expect(MainWindowErrorRecoveryAction.lumeRecoveryActions(forMessage: "Failed to delete workspace: boom").isEmpty)
+        #expect(MainWindowErrorRecoveryAction.lumeRecoveryActions(forMessage: nil).isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

**PR 2 of 2 for #708** — migrates the main window's transient error `.alert` call sites onto the single `MainWindowErrorPresenter` seam introduced in PR 1. Behavior-preserving structure work: **no visual change** (same alert titles, messages, and buttons), no navigation/creation/split/inspector change.

> Follows PR 1 (#875, merged). This branch was rebased onto `main` after PR 1 merged, so the diff is only PR 2's two commits.

What changed:
- **Extended the seam** — `MainWindowError` now carries a `source` and data-modeled `recoveryActions`; a `mainWindowErrorAlert` view modifier renders any presenter uniformly; `message(from:)` lets a side effect observe only its own source's message so several sources share one presenter without cross-firing each other's `onChange` hooks.
- **ContentView** — open-in-editor (from PR 1), workspace-operation, and landing errors now route through one `errorPresenter` + the modifier. Per-family helpers (`presentWorkspaceOperationError`, `presentLandingError`) centralize title + source. Removed `viewState.workspaceOperationErrorMessage` and the `landingErrorMessage` @State.
- **SidebarView** — replaced the `errorMessage`/`showingError` pair and its bespoke `.alert` (with inline Lume recovery buttons) with the shared presenter + modifier. The "Open VM Runtime" / "Open Lume Log" affordances are now data (`MainWindowErrorRecoveryAction.lumeRecoveryActions`), offered under the same condition as before; the modifier maps a chosen action's kind back to `openSettingsWindow()` / `openLumeLog()`. All ~21 producers now call `presentSidebarError`.

Commits are one producer-family per commit so the diff reviews as a sequence.

Part of #708.

### Side-effect preservation (the risk center)

Both `hostLumeSmokeAutomation` / `desktopUISmokeAutomation` `noteFailure` hooks are preserved with their exact trigger semantics, which I pinned before migrating:

- **workspace-operation** (ContentView, host-Lume only): keyed on `errorPresenter.message(from: .workspaceOperation)` — only that source fires it, same "message becomes non-nil" trigger. Confirmed no other ContentView source (open-in-editor, landing) fires it.
- **sidebar** (host-Lume + desktop-UI): the pre-seam `errorMessage` was **sticky** — never cleared on dismiss — so an identical consecutive error did **not** re-fire `noteFailure`. The presenter clears on dismiss, so the view tracks the last-notified message and gates re-notify through `MainWindowErrorPresenter.shouldNoteFailure(message:lastNoted:)` to keep that exact contract. (Different sources: workspace-operation is non-sticky, sidebar is sticky — a single shared instance can't preserve both via one `dismiss()`, which is why the presenter is non-sticky and the sidebar carries the small guard.)

### Latest-wins vs. the old per-`.alert` semantics

The presenter is latest-wins (a new `present` replaces the current error), which matches SwiftUI showing one alert at a time. The migrated ContentView sources (open-in-editor / workspace-operation / landing) are mutually exclusive in practice — each is a distinct user action's failure path — so collapsing their separate `.alert` modifiers into one presenter-driven alert changes no observable behavior. No migrated site relied on queueing a second alert behind a first.

### Deferred (reported, not forced): provider-setup

The **"Could Not Complete Provider Setup"** alert is left exactly as-is. Its message is set inside an async `Task` on `WorkspaceProviderSetupCoordinator` (`@Published var errorMessage`) — the "alert driven from a background task" corner. A faithful migration means either a small `onChange` bridge (present into the seam, then `clearError()` to avoid dual state) or a coordinator refactor to surface errors via a callback; both want running-UI validation of the SwiftUI update cycle, so I'm proposing it as a focused follow-up rather than forcing it blind. Confirmation dialogs (orphan-cleanup, Close Terminal, Delete Workspace) are intentionally untouched — they are confirmations, not errors.

## Mergeability

- Surface: desktop
- User-facing behavior changed: **no.** Same alerts, same wording, same recovery buttons under the same conditions. This is a structural convergence of three ad-hoc patterns onto one seam.
- Non-happy paths considered: latest-wins replacement across sources; source-scoped side effects; sticky vs. non-sticky `noteFailure` re-fire; optional `validationError.errorDescription` (only presents when non-nil, matching the old `= errorDescription` assignment); recovery buttons render from data and dismiss via the shared modifier.
- Release/ops preconditions: none — view-layer only, no schema/persistence change.
- Residual risk or follow-up: provider-setup migration (above) as a focused follow-up. The presenter type is now proven across two sibling views, so that migration is small once its background-task bridge is validated in the UI.

## Validation

- [x] `swift build`
- [x] `swift test` — **1131 tests in 175 suites passed**; `MainWindowErrorPresenter` suite is 10 tests (present/latest-wins/dismiss, source routing, recovery-action data, sticky re-fire)
- [x] Other checks run: `mise run lint` (swift-format `--strict`) clean

**Mutation checks (both reverted after):**
- `message(from:)` made to ignore source → *"…returns the message only for the matching source"* and *"…follows a latest-wins replacement to the new source"* failed → proves side effects can't cross-fire between sources sharing one presenter.
- `shouldNoteFailure` made to always fire → *"shouldNoteFailure fires for a new message and skips an identical repeat"* failed → proves the sticky no-re-fire contract is guarded.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (full suite + presenter suite + both mutation checks, rendered and uploaded)

No UI screenshot: this is behavior-preserving with no visual change (identical alert titles, messages, and buttons). The alerts render exactly as before.

Evidence links:

- ![708-error-migration](https://evidence.cloudcompute.com/workspaces/pr-879/20260707-093322-708-error-migration.png)

## Blockers

- [x] None
