### PR TITLE
docs(web-next): reconcile design.md Identity fonts with shipped Newsreader / IBM Plex Mono

### DIFF
--- a/web-next/docs/design.md
+++ b/web-next/docs/design.md
@@ -82,8 +82,8 @@ Each is a specific call and the reason for it.
 
 ## Identity
 
-- **Type:** Instrument Serif (display / session title, italic) with JetBrains
-  Mono (UI, code, metadata). The serif carries the personality; the mono carries
+- **Type:** Newsreader (display / session title, italic) with IBM Plex Mono
+  (UI, code, metadata). The serif carries the personality; the mono carries
   the machinery.
 - **Color:** warm paper in light, warm charcoal in dark, a single restrained
   accent. Semantic color (diff add/remove, live/error) is desaturated — it


### PR DESCRIPTION
Closes #812

## Summary

`web-next/docs/design.md` §Identity named **Instrument Serif** / **JetBrains Mono** as the type system, but the shipped app loads **Newsreader** + **IBM Plex Mono**:

- `web-next/src/app/layout.tsx` — `import { IBM_Plex_Mono, Newsreader } from "next/font/google"`
- `web-next/src/app/globals.css` — `--font-serif: var(--font-newsreader), ...` / `--font-mono: var(--font-plex-mono), ...`
- The canonical Folio prototype (`prototypes/web-session-redesign/refine-folio.html`) also uses Newsreader / IBM Plex Mono, confirming the code (not the doc) reflects the settled design decision.

Verified this is a pure doc-lag, not an unintentional code regression — the prototype the doc calls "canonical" already uses the shipped fonts. Updated the Identity section's Type line to match; no other Instrument Serif / JetBrains Mono references existed elsewhere in `web-next/`.

## Mergeability

Surface: `web-next/docs/design.md` — documentation only, no code changed.
User-facing behavior changed: None. No code, fonts, or UI touched — this is a docs-truth correction.
Non-happy paths considered: Confirmed no other doc or code references to "Instrument Serif" / "JetBrains Mono" remain in `web-next/` (`rg` clean). Cross-checked against the canonical Folio prototype to confirm the code is the intended source of truth, not a regression to flag instead.
Residual risk or follow-up: None — single-line factual correction, diff is self-verifying.

## Evidence

Not a testable change — docs-only diff, skipping the codex-review-loop per repo convention. The diff itself is the evidence:

\`\`\`diff
-- **Type:** Instrument Serif (display / session title, italic) with JetBrains
-  Mono (UI, code, metadata). The serif carries the personality; the mono carries
++ **Type:** Newsreader (display / session title, italic) with IBM Plex Mono
++  (UI, code, metadata). The serif carries the personality; the mono carries
   the machinery.
\`\`\`