### PR TITLE
test(archive): extend the archive/unarchive lifecycle regression net (#709)

### DIFF
--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -710,6 +710,96 @@ struct SidebarWorkspaceControllerBehaviorTests {
         #expect(workspace.path == liveURL.path)
     }
 
+    @Test("Unarchiving a provider-backed workspace flips status without touching the local archiver")
+    @MainActor
+    func unarchivingProviderBackedWorkspaceIsStatusOnly() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(
+            name: "api",
+            localPath: URL(fileURLWithPath: "/tmp/api"),
+            remoteURL: "git@github.com:acme/api.git"
+        )
+        // Non-local archive never relocates host files, so the path stays at the live
+        // location. Unarchive must stay a pure status flip and never route through the
+        // local directory archiver — otherwise a remote workspace could hit the #663
+        // path-walk corruption that only ever made sense for local directories.
+        let liveURL = URL(fileURLWithPath: "/tmp/api/workspaces/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: liveURL,
+            sourceRepo: repo,
+            status: .archived,
+            backendIdentifier: DaytonaWorkspaceProvider.identifier,
+            remoteId: "daytona-123"
+        )
+        workspace.archivedAt = Date()
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let workspaceService = MockWorkspaceService()
+        let provider = MockWorkspaceProvider(
+            descriptor: WorkspaceProviderDescriptor(
+                id: DaytonaWorkspaceProvider.identifier,
+                displayName: "Daytona",
+                description: "Remote Linux workspaces.",
+                supportsArchive: true,
+                requiresRemoteRepository: true
+            )
+        )
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider(), provider]
+        )
+
+        try await controller.unarchive(workspace)
+
+        #expect(workspaceService.unarchiveWorkspaceCalls.isEmpty)
+        #expect(workspace.status == .active)
+        #expect(workspace.archivedAt == nil)
+        #expect(workspace.path == liveURL.path)
+    }
+
+    @Test("Deleting an archived local workspace targets its moved .archived path")
+    @MainActor
+    func deletingArchivedLocalWorkspaceTargetsArchivedPath() async throws {
+        let fixture = try makeModelContext()
+        let context = fixture.context
+        let repo = Repo(name: "api", localPath: URL(fileURLWithPath: "/tmp/api"))
+        let liveURL = URL(fileURLWithPath: "/tmp/workspaces/api/feature-a")
+        let workspace = Workspace(
+            name: "feature-a",
+            path: liveURL,
+            sourceRepo: repo,
+            status: .active,
+            backendIdentifier: LocalWorkspaceProvider.identifier
+        )
+        context.insert(repo)
+        context.insert(workspace)
+        try context.save()
+
+        let workspaceService = MockWorkspaceService()
+        let controller = makeController(
+            context: context,
+            workspaceService: workspaceService,
+            providers: [LocalWorkspaceProvider()]
+        )
+
+        try await controller.archive(workspace)
+        let archivedPath = "/tmp/workspaces/.archived/api/feature-a"
+        #expect(workspace.path == archivedPath)
+
+        try await controller.deleteWorkspace(workspace, deleteFiles: true)
+
+        // Delete follows the workspace's current (post-archive) location, not the
+        // pre-archive live path — deleting an archived workspace must clean up where
+        // the files actually moved to.
+        #expect(workspaceService.deleteWorkspaceCalls.count == 1)
+        #expect(workspaceService.deleteWorkspaceCalls.first?.workspaceURL.path == archivedPath)
+    }
+
     @Test("Archiving local workspace retires terminal sessions before service lifecycle")
     @MainActor
     func archivingLocalWorkspaceRetiresTerminalSessionsBeforeServiceLifecycle() async throws {

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -901,6 +901,23 @@ struct WorkspaceServiceTests {
         #expect(restored.path == source.path)
     }
 
+    // restoredDestination assumes its input is an archived path shaped
+    // `<root>/.archived/<repo>/<name>` and walks three levels up to recover `<root>`.
+    // Handed a pre-#661 legacy path (files never relocated, still at the live
+    // `<root>/<repo>/<name>`), that same walk overshoots by one level and lands
+    // *outside* the workspaces root — the corruption behind #663. This pins that
+    // hazard so the invariant stays visible: callers must not route a live path
+    // through restoredDestination (SidebarWorkspaceController.unarchive guards on the
+    // positional `.archived` shape for exactly this reason).
+    @Test("restoredDestination overshoots the root for a legacy live-path source")
+    func restoredDestinationOvershootsForLivePathSource() {
+        let livePath = URL(fileURLWithPath: "/tmp/roots/myrepo/feature-x", isDirectory: true)
+        let restored = WorkspaceDirectoryArchiver.restoredDestination(for: livePath)
+        // Walks past `/tmp/roots` to `/tmp` — one level above the workspaces root.
+        #expect(restored.path == "/tmp/myrepo/feature-x")
+        #expect(restored.path != livePath.path)
+    }
+
     @Test("archiveWorkspace moves a linked worktree and updates git metadata")
     func archiveWorkspaceMovesLinkedWorktree() async throws {
         let service = WorkspaceService()


### PR DESCRIPTION
## Summary

Locks the archive/unarchive/purge lifecycle down with the behavioral coverage its edge cases were missing (#709). Pure test-net: **no production code changed, no defect found** — I re-verified the issue's claims against fresh `origin/main` (which now includes #863's positional-`.archived` unarchive guard and #865's badge fix) and most of the requested matrix already exists, so this extends rather than duplicates.

### Coverage delta

**Added (3 tests, all no-production-change):**
- `restoredDestination overshoots the root for a legacy live-path source` (WorkspaceServiceTests) — the one genuinely-uncovered archiver behavior the issue names: `restoredDestination` on a pre-#661 live path (not under `.archived/`) walks one level too far and resolves *outside* the workspaces root. Pins the #663 root cause at the pure-function level and documents why `SidebarWorkspaceController.unarchive` guards on the positional `.archived` shape.
- `Unarchiving a provider-backed workspace flips status without touching the local archiver` (SidebarWorkspaceControllerBehaviorTests) — non-local unarchive must stay a pure status flip; guards that a remote workspace can never route through the local directory archiver and hit the #663 path-walk. No prior non-local unarchive test existed.
- `Deleting an archived local workspace targets its moved .archived path` (SidebarWorkspaceControllerBehaviorTests) — archive→delete interplay: delete follows the workspace's post-archive `.archived/` path, not the pre-archive live path.

**Already covered, left intact (not duplicated):**
- Controller unarchive: legacy in-place (#663), modern move-back, and the literal-`.archived`-named edge — `SidebarWorkspaceControllerBehaviorTests`.
- Archive teardown ordering (terminals retire before service lifecycle; fails closed when retirement fails).
- Service-level real-filesystem archive/unarchive incl. linked-worktree git-metadata moves, and the modern `archivedDestination`/`restoredDestination` round-trip — `WorkspaceServiceTests`.
- Purge selection guards including `archivedAt == nil` legacy exclusion and local-only/boundary rules — `ArchivedWorkspacePurgeTests`.
- Active-vs-archived badge count (#664) via `SidebarWorkspaceController.activeWorkspaceCount` — `SidebarViewTests`. The section-partition funcs (`activeWorkspaces`/`archivedWorkspaces`) are `private` in `SidebarView` and share the identical `status == .archived` predicate the count test already exercises, so they aren't separately tested (would require a production change for no new signal).

## Mergeability

- Surface: desktop
- User-facing behavior changed: No. Tests only; zero source changes.
- Non-happy paths considered: the additions specifically target the edge cases the #663/#664/#666 review bugs came from — legacy `archivedAt == nil` path resolution, non-local vs local routing, and archive/delete path interplay. Each new test was mutation-verified (below).
- Release/ops preconditions: none.
- Residual risk or follow-up: none for this PR. One observation worth recording (not a defect): the provider protocol has `archiveWorkspace` but no `unarchiveWorkspace`, so non-local unarchive is a status flip only (resuming a remote VM is `start`'s job) — the new test pins that current contract.

## Validation

- [x] `swift build`
- [x] `swift test` — 1130 tests / 174 suites pass (+3 new)
- [x] Other checks run: `mise run lint` (swift-format --strict) clean

**Mutation check (3 of 3 new tests, each against distinct production code):**
- Non-local test: changed `unarchive`'s guard to `if true` (always route through the local archiver) → test failed (`unarchiveWorkspaceCalls` non-empty). Reverted.
- Delete-after-archive test: dropped `workspace.path = archivedURL.path` in `archive` → test failed (delete targeted the pre-archive live path). Reverted.
- Archiver live-path test: changed `restoredDestination` to walk two levels instead of three → test failed. Reverted.

All three would have caught a regression of the behavior they pin; production diff is empty after reverts.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

The three new tests passing:

![709-archive-net](https://evidence.cloudcompute.com/workspaces/pr-881/20260707-094020-709-archive-net.png)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-881/20260707-094020-709-archive-net.png

## Blockers

- [x] None
