### PR TITLE
fix(lume): clarify orphan-cleanup failure when workspaces storage is missing

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2318,7 +2318,16 @@ struct ContentView: View {
             throw WorkspaceOrphanReconciliationError.unsupportedCleanupItem
         }
 
-        try await provider.deleteWorkspace(target)
+        do {
+            try await provider.deleteWorkspace(target)
+        } catch {
+            // The VM directory was just found on disk, so a Lume not-found here means the
+            // `workspaces` storage location isn't registered — surface that instead of "Not found".
+            guard let diagnostic = LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for: error) else {
+                throw error
+            }
+            throw WorkspaceProviderError.unavailable(diagnostic)
+        }
     }
 
     private func workspaceOrphanCleanupTitle(for item: WorkspaceOrphanItem?) -> String {

--- a/Sources/WorkspaceManagerCore/Services/LumeErrorHeuristics.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeErrorHeuristics.swift
@@ -7,7 +7,24 @@
 
 import Foundation
 
-enum LumeErrorHeuristics {
+public enum LumeErrorHeuristics {
+    /// User-facing diagnostic for a Lume "not found" failure during workspace-VM cleanup. The
+    /// orphan reconciler only offers a VM for cleanup after finding its directory in the workspace
+    /// VM storage, and cleanup always addresses it through the `workspaces` storage selector — so a
+    /// not-found from Lume means that storage location is not registered in Lume, not that the VM
+    /// is gone. A generic "Not found" hid that distinction. Returns nil for other errors so the
+    /// original error stands.
+    public static func missingWorkspacesStorageDiagnostic(for error: Error) -> String? {
+        guard contains(error, fragments: ["not found", "404"]) else {
+            return nil
+        }
+        return workspacesStorageMissingMessage
+    }
+
+    public static let workspacesStorageMissingMessage =
+        "The 'workspaces' storage location is not configured in Lume. "
+        + "Run `lume storage list` to verify it exists, then add it before retrying cleanup."
+
     static func shouldFallbackToStockImage(_ error: Error) -> Bool {
         contains(
             error,

--- a/Tests/WorkspaceManagerTests/LumeErrorHeuristicsTests.swift
+++ b/Tests/WorkspaceManagerTests/LumeErrorHeuristicsTests.swift
@@ -1,0 +1,46 @@
+//
+//  LumeErrorHeuristicsTests.swift
+//  WorkspaceManagerTests
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("LumeErrorHeuristics")
+struct LumeErrorHeuristicsTests {
+    // The orphan reconciler deletes a VM it just found on disk, addressed through the `workspaces`
+    // storage selector — so a Lume not-found means that storage location isn't registered, and the
+    // generic "Not found" should become the actionable storage diagnostic.
+
+    @Test("A Lume not-found during cleanup maps to the workspaces-storage diagnostic")
+    func notFoundMapsToStorageDiagnostic() {
+        let error = LumeHTTPClientError.server("Not found")
+        #expect(
+            LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for: error)
+                == LumeErrorHeuristics.workspacesStorageMissingMessage
+        )
+    }
+
+    @Test("A raw HTTP 404 body maps to the workspaces-storage diagnostic")
+    func http404MapsToStorageDiagnostic() {
+        let error = LumeHTTPClientError.server("HTTP 404")
+        #expect(
+            LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for: error)
+                == LumeErrorHeuristics.workspacesStorageMissingMessage
+        )
+    }
+
+    @Test("The diagnostic points users at `lume storage list`")
+    func diagnosticIsActionable() {
+        #expect(LumeErrorHeuristics.workspacesStorageMissingMessage.contains("lume storage list"))
+        #expect(LumeErrorHeuristics.workspacesStorageMissingMessage.contains("workspaces"))
+    }
+
+    @Test("Unrelated Lume failures are left untouched")
+    func unrelatedErrorNotMapped() {
+        let error = LumeHTTPClientError.server("connection refused")
+        #expect(LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for: error) == nil)
+    }
+}

--- a/docs/development/lume-integration.md
+++ b/docs/development/lume-integration.md
@@ -113,6 +113,12 @@ This isolation keeps three classes of VM separate:
 - disposable validator clones
 - user-facing workspace VMs
 
+### Missing `workspaces` storage location
+
+Lifecycle calls for workspace VMs address them through the `workspaces` storage selector (see the storage-selector mapping in `LumeWorkspaceProvider`). That selector only resolves if a `workspaces` storage location is registered in Lume pointing at `workspace-vms/`. If it is not, Lume answers with a 404 that used to surface as a generic "Not found" — most visibly when cleaning up an orphaned VM, where the reconciler has already confirmed the VM directory exists on disk.
+
+Workspace-VM cleanup now maps that not-found to an actionable diagnostic (`LumeErrorHeuristics.missingWorkspacesStorageDiagnostic`): _"The 'workspaces' storage location is not configured in Lume. Run `lume storage list` to verify it exists, then add it before retrying cleanup."_ Run `lume storage list` and confirm a `workspaces` entry resolves to the `workspace-vms/` directory above; if it is absent, re-add it before retrying.
+
 ## Standalone Validation Flow
 
 The canonical gate is `./scripts/lume-standalone-validate.sh`.


### PR DESCRIPTION
## Summary

Fixes #670. When a user's Lume install has no `workspaces` storage location configured, workspace-VM lifecycle calls — which address VMs through the `workspaces` storage selector introduced in #665 — fail with a Lume 404 that surfaced as a generic **"Not found"**. This replaces that with an actionable diagnostic in the path where it actually reaches users.

- New pure helper `LumeErrorHeuristics.missingWorkspacesStorageDiagnostic(for:)` maps a Lume not-found / `HTTP 404` to: *"The 'workspaces' storage location is not configured in Lume. Run `lume storage list` to verify it exists, then add it before retrying cleanup."*
- Applied in `ContentView.cleanupLumeVMOrphan` — it wraps the `provider.deleteWorkspace` failure so the orphan-cleanup alert reads *"Could not clean 'vm': The 'workspaces' storage location is not configured…"* instead of *"…: Not found"*.
- The #665 storage-selector mapping (`lumeStorageSelector`) is **unchanged**.

Closes #670.

### Why scoped to the orphan-cleanup path (not all deletes)

A Lume 404 is only an unambiguous "storage not configured" signal in the orphan-cleanup path: the reconciler offers a VM for cleanup *only after finding its directory on disk* in the workspace VM storage, and cleanup always addresses it via the `workspaces` selector. So a not-found there means Lume can't resolve that storage location — the VM demonstrably exists.

A normal delete of a workspace whose VM is genuinely already gone *also* 404s, and remapping that to "storage not configured" would mislead (the storage was working, or the workspace couldn't have been created/tracked). So the mapping is deliberately applied only at `cleanupLumeVMOrphan`, not inside the shared `deleteVM` request path. Terminal launch was assessed and left alone for the same reason: a tracked workspace implies the storage already resolved, so a 404 there is not a reliable storage-missing signal.

### Grounded-facts re-verification

Re-verified against current code (issue is from late June): the 404 still surfaces as `LumeHTTPClientError.server("Not found")` / `"HTTP 404"` (LumeHTTPClient), still propagates unmapped through `deleteWorkspace → deleteVM` (HTTP DELETE, linux guest) to `cleanupLumeVMOrphan`, and the orphan cleanup target's `storagePath` still maps to the `workspaces` selector. The generic-not-found reproduces in code reading, so the premise holds. No live Lume commands or daemon lanes were run — this is provable by unit tests over the heuristic with fixture payloads.

## Mergeability

- Surface: agent-runtime (Lume) + a one-line desktop call-site
- User-facing behavior changed: yes — the orphan "Delete Orphaned Lume VM?" cleanup failure now shows a storage-config diagnostic pointing at `lume storage list` instead of a bare "Not found". No other flow changes; non-not-found errors pass through untouched.
- Non-happy paths considered: non-404 Lume errors (connection refused, etc.) are not remapped (test); normal/best-effort deletes and terminal launch are intentionally out of scope to avoid false "storage missing" diagnostics; the #665 selector mapping is untouched.
- Release/ops preconditions: none.
- Residual risk or follow-up: low. The heuristic is a message-classification over `localizedDescription`; if Lume's 404 body ever stops containing "not found"/"404" the mapping silently no-ops (falls back to the original error), which is safe.

## Validation

- [x] `swift build`
- [x] `swift test` — **1152 tests in 178 suites passed**; new `LumeErrorHeuristics` suite is 4 tests (not-found → diagnostic, raw HTTP 404 → diagnostic, message is actionable, unrelated error untouched)
- [x] Other checks run: `mise run lint` (swift-format `--strict`) clean

**Mutation check (reverted after):** made `missingWorkspacesStorageDiagnostic(for:)` always return `nil` → both mapping tests failed (`diagnostic(for: server("Not found")) == nil` vs. the storage message), proving the mapping is what surfaces the diagnostic rather than a vacuous pass.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (heuristic suite + full suite + mutation check, rendered and uploaded)

No UI screenshot: the change swaps the message string inside an existing alert; no visual/layout change, and rendering the alert needs a live missing-storage Lume install (out of scope per the issue's "no live Lume" constraint).

Evidence links:

- ![670-lume-storage](https://evidence.cloudcompute.com/workspaces/pr-884/20260707-095232-670-lume-storage.png)

## Blockers

- [x] None
