### PR TITLE
fix(scripts): structured timeout outcomes in managed-review health scripts (#696)

### DIFF
--- a/scripts/pr-review-health.py
+++ b/scripts/pr-review-health.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import socket
 import subprocess
 import sys
 import urllib.error
@@ -60,6 +61,16 @@ from typing import Any
 
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+EX_TEMPFAIL = 75
+
+
+class TransientHealthError(RuntimeError):
+    """Raised when the audit cannot reach GitHub (timeout/transport failure).
+
+    The scheduled audit treats this as a soft retry (exit `EX_TEMPFAIL`) rather than a
+    projection-drift failure, so a network blip does not read as a stuck-pending status.
+    """
+
 MANAGED_REVIEWER_LOGINS = {
     "workspace-agents",
     "workspace-agents[bot]",
@@ -433,6 +444,10 @@ def graphql(token: str, variables: dict[str, Any]) -> dict[str, Any]:
     except urllib.error.HTTPError as error:
         body = error.read().decode(errors="replace")
         raise RuntimeError(f"GitHub GraphQL request failed ({error.code}): {body}") from error
+    except (TimeoutError, socket.timeout) as error:
+        raise TransientHealthError(f"GitHub GraphQL request timed out: {error}") from error
+    except urllib.error.URLError as error:
+        raise TransientHealthError(f"GitHub GraphQL request failed: {error.reason}") from error
 
     if data.get("errors"):
         raise RuntimeError(f"GitHub GraphQL returned errors: {json.dumps(data['errors'])}")
@@ -517,7 +532,11 @@ def main(argv: list[str]) -> int:
         if not token:
             print("GITHUB_TOKEN or GH_TOKEN is required when no --fixture is provided.", file=sys.stderr)
             return 2
-        prs = fetch_open_prs(args.repo, token=token, max_prs=args.max_prs)
+        try:
+            prs = fetch_open_prs(args.repo, token=token, max_prs=args.max_prs)
+        except TransientHealthError as error:
+            print(f"::warning::managed review projection audit deferred: {error}", file=sys.stderr)
+            return EX_TEMPFAIL
 
     report = evaluate(
         prs,

--- a/scripts/pr-reviewer-runs.py
+++ b/scripts/pr-reviewer-runs.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -53,10 +54,19 @@ from typing import Any
 
 CANARY_HEADER = "X-Workspace-Webhook-Canary"
 DEFAULT_MONITOR_URL = "https://spaces.cloudcompute.com/api/webhooks/github/pr-reviewer-monitor"
+EX_TEMPFAIL = 75
 
 
 class ReportError(RuntimeError):
-    """Raised when the report cannot be fetched or parsed."""
+    """Raised when the report cannot be fetched or parsed.
+
+    `transient` marks a timeout/transport failure the scheduled monitor should treat
+    as a soft retry (exit `EX_TEMPFAIL`) rather than a hard reviewer failure.
+    """
+
+    def __init__(self, message: str, *, transient: bool = False) -> None:
+        super().__init__(message)
+        self.transient = transient
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -122,8 +132,10 @@ def fetch_report(url: str, secret: str, timeout: float) -> tuple[int, dict[str, 
             return response.status, decode_json_response(response.read(256 * 1024))
     except urllib.error.HTTPError as error:
         return error.code, decode_json_response(error.read(256 * 1024))
+    except (TimeoutError, socket.timeout) as error:
+        raise ReportError(f"monitor request timed out: {error}", transient=True) from error
     except urllib.error.URLError as error:
-        raise ReportError(f"monitor request failed: {error.reason}") from error
+        raise ReportError(f"monitor request failed: {error.reason}", transient=True) from error
 
 
 def as_int(payload: dict[str, Any], key: str) -> int:
@@ -281,7 +293,7 @@ def main(argv: list[str]) -> int:
         status, payload = fetch_report(report_url(args), require_secret(), args.timeout)
     except ReportError as error:
         print(f"error: {error}", file=sys.stderr)
-        return 2
+        return EX_TEMPFAIL if error.transient else 2
 
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))

--- a/scripts/tests/test_pr_review_health.py
+++ b/scripts/tests/test_pr_review_health.py
@@ -13,10 +13,15 @@ ordinary review states that do not need operator intervention.
 from __future__ import annotations
 
 import importlib.util
+import io
+import socket
 import sys
 import unittest
+import urllib.error
+from contextlib import redirect_stderr
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -208,6 +213,49 @@ class PRReviewHealthTests(unittest.TestCase):
         self.assertIn("- Queue coverage: incomplete (1 skipped/unassessed PR)", rendered)
         self.assertIn("unassessed: not updated within 3d", rendered)
         self.assertNotIn("- Failures: 0", rendered)
+
+
+class ManagedReviewHealthTransportTests(unittest.TestCase):
+    """A timeout/transport failure reaching GitHub is a structured transient outcome
+    (exit EX_TEMPFAIL), so a network blip is not reported as projection drift."""
+
+    def test_graphql_timeout_raises_transient(self) -> None:
+        with patch.object(
+            pr_review_health.urllib.request,
+            "urlopen",
+            side_effect=socket.timeout("timed out"),
+        ):
+            with self.assertRaises(pr_review_health.TransientHealthError):
+                pr_review_health.graphql(
+                    "token",
+                    {"owner": "o", "name": "n", "first": 1, "after": None},
+                )
+
+    def test_graphql_url_error_raises_transient(self) -> None:
+        with patch.object(
+            pr_review_health.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with self.assertRaises(pr_review_health.TransientHealthError):
+                pr_review_health.graphql(
+                    "token",
+                    {"owner": "o", "name": "n", "first": 1, "after": None},
+                )
+
+    def test_main_returns_tempfail_on_transient(self) -> None:
+        with (
+            patch.object(pr_review_health, "get_token", return_value="token"),
+            patch.object(
+                pr_review_health.urllib.request,
+                "urlopen",
+                side_effect=TimeoutError("timed out"),
+            ),
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            code = pr_review_health.main(["--repo", "fairchild/workspaces"])
+        self.assertEqual(code, pr_review_health.EX_TEMPFAIL)
+        self.assertIn("deferred", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pr_reviewer_runs.py
+++ b/scripts/tests/test_pr_reviewer_runs.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import os
+import socket
 import sys
 import unittest
-from contextlib import redirect_stdout
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -110,6 +114,38 @@ class PRReviewerRunsTests(unittest.TestCase):
         self.assertIn("Running too long:", rendered)
         self.assertIn("details: https://spaces.cloudcompute.com/dashboard/review-runs/fp_slow", rendered)
         self.assertIn("slo: breached", rendered)
+
+
+class PRReviewerRunsTransportTests(unittest.TestCase):
+    """A timeout/transport failure reaching the monitor is a structured transient
+    outcome (exit EX_TEMPFAIL), not an uncaught traceback."""
+
+    def _run_with_urlopen_error(self, error: Exception) -> tuple[int, str]:
+        with (
+            patch.dict(os.environ, {"WORKSPACES_WEBHOOK_CANARY_SECRET": "runs-secret"}),
+            patch.object(
+                pr_reviewer_runs.urllib.request, "urlopen", side_effect=error
+            ),
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            code = pr_reviewer_runs.main([])
+        return code, stderr.getvalue()
+
+    def test_socket_timeout_returns_tempfail(self) -> None:
+        code, stderr = self._run_with_urlopen_error(socket.timeout("timed out"))
+        self.assertEqual(code, pr_reviewer_runs.EX_TEMPFAIL)
+        self.assertIn("timed out", stderr)
+
+    def test_timeout_error_returns_tempfail(self) -> None:
+        code, _ = self._run_with_urlopen_error(TimeoutError("timed out"))
+        self.assertEqual(code, pr_reviewer_runs.EX_TEMPFAIL)
+
+    def test_url_error_returns_tempfail(self) -> None:
+        code, stderr = self._run_with_urlopen_error(
+            urllib.error.URLError("connection refused")
+        )
+        self.assertEqual(code, pr_reviewer_runs.EX_TEMPFAIL)
+        self.assertIn("failed", stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #696 by finishing its one genuinely-open acceptance item. **Verify-before-plan finding up front:** most of #696 already shipped in **PR #698 (commit `afd87c88`, on `main`, authored the same afternoon #696 was filed)**. I re-verified each acceptance criterion against current code rather than the issue text (the issue's stated root cause no longer reproduces):

| Acceptance criterion | Status |
|---|---|
| #1 Stale started/no-session run detectable + retryable/markable-terminal by operator, no new push | **Already done (#698).** Broker query now selects stale `started` rows with `session_id is null` (`pr-review-runs.ts`); the broker throws "missing an agent session" → catch posts a GitHub **failure** status and marks the run `failed` (`pr-review.ts`), clearing the pending status and making operator `retry_execution` available. |
| #2 Broker **and health scripts** report timeouts as structured transient outcomes | **Broker half done (#698); this PR does the health-scripts half.** |
| #3 Broker workflow keeps polling after one route timeout | **Already done (#698).** `set +e` + `exit 75 && attempt<max → continue` in `managed-reviewer-broker.yml`. |
| #4 Health audit catches stale GitHub-pending after ReviewRun windows age out | **Already covered.** `pr-review-health.py` audits GitHub statuses directly on open PRs (independent of the ReviewRun table window) and flags pending-past-`--pending-timeout-min`. |

### What this PR changes (scripts only)

`scripts/pr-reviewer-runs.py` and `scripts/pr-review-health.py` caught `HTTPError` (and, for runs, `URLError`) but **not** `TimeoutError`/`socket.timeout` — so a socket timeout surfaced as an uncaught traceback, not a structured outcome. Both now:

- catch `(TimeoutError, socket.timeout)` and `URLError` as a **transient** failure, and
- exit `EX_TEMPFAIL` (75) for it — mirroring `pr-reviewer-broker.py` — so a network blip reads as a soft retry rather than a stuck reviewer / projection-drift failure.

`runs.py` gains a `transient` flag on `ReportError`; `health.py` gains a `TransientHealthError` caught in `main`.

## Mergeability

- Surface: scripts / CI (managed-reviewer health lane). No web/ or Swift changes.
- User-facing behavior changed: no. Operator-facing behavior improves: a monitor/audit run that hits a GitHub/monitor timeout now prints a clean transient message and exits 75 instead of dumping a traceback and exiting non-zero as a hard failure.
- Non-happy paths considered: timeout vs. `URLError` vs. `HTTPError` (unchanged) vs. non-ok payload (unchanged); the transient exit is distinct from real failures (2) and queue-attention (1), so a scheduled monitor won't page on a transient blip.
- Release/ops preconditions: none. The health workflow invokes both scripts directly; a 75 exit still fails the step today but with a structured, greppable message — a future step can treat 75 as soft, exactly as the broker workflow already does.
- Residual risk or follow-up: low. Unrelated pre-existing item surfaced while running the script test suite — `test_security_hardening.py` flags `.github/workflows/milestone-legibility.yml` using unpinned `actions/checkout@v4` + `astral-sh/setup-uv@v6`. Not touched by this PR (present on `main`); flagging for a separate one-line pin.

## Validation

- [x] `scripts/tests/test_pr_reviewer_runs.py` — 4 tests OK (adds socket.timeout / TimeoutError / URLError → `EX_TEMPFAIL`)
- [x] `scripts/tests/test_pr_review_health.py` — 17 tests OK (adds graphql timeout/URLError → `TransientHealthError`; `main` → `EX_TEMPFAIL`)
- [x] `scripts/tests/test_pr_reviewer_broker.py` — 2 tests OK (regression); both scripts `--help` OK
- [x] Run via `uv run --script` (scripts require Python ≥3.11)

`mise run web:check` is **N/A** — no `web/` changes. Live end-to-end validation is not possible while `PR_REVIEWER_ENABLED=0` (paused 2026-07-06); per the brief, this is proven by unit tests over the timeout paths (fixture-level `urlopen` side-effects).

**Mutation checks (both reverted):**
- `runs.py` timeout branch set `transient=False` → `test_socket_timeout_returns_tempfail` + `test_timeout_error_returns_tempfail` failed (`2 != 75`).
- `health.py` graphql timeout raising plain `RuntimeError` → `test_graphql_timeout_raises_transient` + `test_main_returns_tempfail_on_transient` failed.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (both suites + regression + mutation checks, rendered and uploaded)

Evidence links:

- ![696-timeout-hardening](https://evidence.cloudcompute.com/workspaces/pr-885/20260707-102536-696-timeout-hardening.png)

## Blockers

- [x] None
