### PR TITLE
feat(local-state): restore-aware retention + integrity probe (#789)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DiagnosticsTabView.swift
@@ -125,6 +125,7 @@ struct DiagnosticsTabView: View {
                 DiagnosticsMetricCard(label: "Schema", value: localStateSchemaText)
                 DiagnosticsMetricCard(label: "Rows", value: "\(localStateRowCount)")
                 DiagnosticsMetricCard(label: "Latest", value: localStateLatestText)
+                DiagnosticsMetricCard(label: "Integrity", value: localStateIntegrityText)
             }
 
             DiagnosticsKeyValueRow(
@@ -365,6 +366,13 @@ struct DiagnosticsTabView: View {
             return "None"
         }
         return latest.formatted(.relative(presentation: .named))
+    }
+
+    /// Result of the last retention pass's `PRAGMA quick_check`. "Pending" until the
+    /// first pass runs (once per launch); "OK" or "Check failed" thereafter.
+    private var localStateIntegrityText: String {
+        guard let integrityOK = viewModel.localStateSummary?.integrityOK else { return "Pending" }
+        return integrityOK ? "OK" : "Check failed"
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -94,6 +94,22 @@ public enum LocalStateStoreBootstrapper {
                 fileManager: fileManager
             )
             let store = try LocalStateStore(databaseURL: databaseURL)
+            // Best-effort retention once per launch. Detached so it never blocks
+            // startup; it only prunes aged rows and never touches active sessions,
+            // so racing early writes is safe.
+            Task.detached(priority: .utility) {
+                do {
+                    let outcome = try await store.runRetention()
+                    NSLog(
+                        "[LocalStateStore] retention: sessions=%d agent_events=%d diagnostics=%d integrity=%@",
+                        outcome.deletedEndedSessions,
+                        outcome.deletedAgentEvents,
+                        outcome.deletedDiagnosticEvents,
+                        outcome.integrityOK ? "ok" : outcome.integrityDetail)
+                } catch {
+                    NSLog("[LocalStateStore] retention failed: %@", String(describing: error))
+                }
+            }
             return LocalStateStoreBootstrapResult(
                 store: store,
                 mode: .persistent(path: databaseURL.path),
@@ -152,19 +168,73 @@ public struct LocalStateStoreSummary: Codable, Equatable, Sendable {
     public let generatedAt: Date
     public let tableCounts: [String: Int]
     public let latestEventTimes: [String: Date]
+    /// When the last retention pass completed, and whether its `PRAGMA quick_check`
+    /// reported a sound database. `nil` until retention has run at least once.
+    public let lastRetentionAt: Date?
+    public let integrityOK: Bool?
 
     public init(
         schemaVersion: Int,
         databasePath: String,
         generatedAt: Date,
         tableCounts: [String: Int],
-        latestEventTimes: [String: Date] = [:]
+        latestEventTimes: [String: Date] = [:],
+        lastRetentionAt: Date? = nil,
+        integrityOK: Bool? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.databasePath = databasePath
         self.generatedAt = generatedAt
         self.tableCounts = tableCounts
         self.latestEventTimes = latestEventTimes
+        self.lastRetentionAt = lastRetentionAt
+        self.integrityOK = integrityOK
+    }
+}
+
+/// Bounds how long the high-volume tables keep rows. Ages are measured against
+/// the retention pass's `now`; anything older than a table's max age is eligible
+/// for pruning except the rows the cold-start restore path depends on, which are
+/// preserved regardless of age (see `LocalStateStore.runRetention`).
+public struct LocalStateRetentionPolicy: Sendable, Equatable {
+    public var agentEventMaxAge: TimeInterval
+    public var diagnosticEventMaxAge: TimeInterval
+    public var endedSessionMaxAge: TimeInterval
+
+    public init(
+        agentEventMaxAge: TimeInterval = 30 * 86_400,
+        diagnosticEventMaxAge: TimeInterval = 14 * 86_400,
+        endedSessionMaxAge: TimeInterval = 30 * 86_400
+    ) {
+        self.agentEventMaxAge = agentEventMaxAge
+        self.diagnosticEventMaxAge = diagnosticEventMaxAge
+        self.endedSessionMaxAge = endedSessionMaxAge
+    }
+
+    public static let `default` = LocalStateRetentionPolicy()
+}
+
+/// Result of one retention pass: how many rows each high-volume table shed, plus
+/// the `PRAGMA quick_check` health signal captured at the end of the pass.
+public struct LocalStateRetentionOutcome: Sendable, Equatable {
+    public let deletedEndedSessions: Int
+    public let deletedAgentEvents: Int
+    public let deletedDiagnosticEvents: Int
+    public let integrityOK: Bool
+    public let integrityDetail: String
+
+    public init(
+        deletedEndedSessions: Int,
+        deletedAgentEvents: Int,
+        deletedDiagnosticEvents: Int,
+        integrityOK: Bool,
+        integrityDetail: String
+    ) {
+        self.deletedEndedSessions = deletedEndedSessions
+        self.deletedAgentEvents = deletedAgentEvents
+        self.deletedDiagnosticEvents = deletedDiagnosticEvents
+        self.integrityOK = integrityOK
+        self.integrityDetail = integrityDetail
     }
 }
 
@@ -742,6 +812,104 @@ public actor LocalStateStore {
         }
     }
 
+    // MARK: - Retention & Health
+
+    /// Prunes aged rows from the high-volume tables and probes integrity, without
+    /// disturbing anything the cold-start restore path reads. Two invariants hold
+    /// regardless of `policy` or `now`:
+    ///
+    /// - Only ended *and* aged `terminal_sessions` are removed, so every active
+    ///   row — including the previous run's resumable sessions that
+    ///   `fetchPreviousRunSessions` enumerates — is preserved. Removing an ended
+    ///   session cascades its `agent_status_events` and split snapshots away.
+    /// - The latest `agent_status_events` row per still-active session is kept
+    ///   regardless of age (it carries the `agent_session_id` that drives
+    ///   `claude --resume`); only older, non-latest events past the cutoff are
+    ///   pruned. The preserved set is computed with the same latest-per-session
+    ///   projection the continuity readers use, so what survives is exactly what
+    ///   they return.
+    ///
+    /// The pass runs in a single write transaction and finishes with
+    /// `PRAGMA quick_check`, recording the result so `summary()` can surface it.
+    @discardableResult
+    public func runRetention(
+        policy: LocalStateRetentionPolicy = .default,
+        now: Date = Date()
+    ) async throws -> LocalStateRetentionOutcome {
+        let sessionCutoff = Self.isoString(now.addingTimeInterval(-policy.endedSessionMaxAge))
+        let agentCutoff = Self.isoString(now.addingTimeInterval(-policy.agentEventMaxAge))
+        let diagnosticCutoff = Self.isoString(now.addingTimeInterval(-policy.diagnosticEventMaxAge))
+        let completedAt = Self.isoString(now)
+
+        return try await dbPool.write { db -> LocalStateRetentionOutcome in
+            // Ended + aged sessions first; ON DELETE CASCADE clears their agent
+            // events and split snapshots. Active rows never match this predicate.
+            try db.execute(
+                sql: """
+                    DELETE FROM terminal_sessions
+                    WHERE is_active = 0 AND ended_at IS NOT NULL AND ended_at < ?
+                    """,
+                arguments: [sessionCutoff])
+            let deletedEndedSessions = db.changesCount
+
+            // Aged agent events, except the latest per still-active session. The
+            // ROW_NUMBER projection mirrors fetchContinuitySessions /
+            // fetchPreviousRunSessions, so the row each reader joins as "latest"
+            // is exactly the row this keeps.
+            try db.execute(
+                sql: """
+                    DELETE FROM agent_status_events
+                    WHERE event_at < ?
+                      AND id NOT IN (
+                          SELECT id FROM (
+                              SELECT
+                                  ae.id,
+                                  ROW_NUMBER() OVER (
+                                      PARTITION BY ae.host_session_id
+                                      ORDER BY ae.event_at DESC, ae.id DESC
+                                  ) AS event_rank
+                              FROM agent_status_events ae
+                              JOIN terminal_sessions ts
+                                  ON ts.host_session_id = ae.host_session_id
+                              WHERE ts.is_active = 1 AND ts.ended_at IS NULL
+                          )
+                          WHERE event_rank = 1
+                      )
+                    """,
+                arguments: [agentCutoff])
+            let deletedAgentEvents = db.changesCount
+
+            try db.execute(
+                sql: "DELETE FROM diagnostic_events WHERE event_at < ?",
+                arguments: [diagnosticCutoff])
+            let deletedDiagnosticEvents = db.changesCount
+
+            let quickCheck = try String.fetchAll(db, sql: "PRAGMA quick_check")
+            let integrityOK = quickCheck == ["ok"]
+            let integrityDetail = quickCheck.isEmpty ? "ok" : quickCheck.joined(separator: "; ")
+
+            try Self.writeMetadataValue(db, key: "last_retention_at", value: completedAt)
+            try Self.writeMetadataValue(db, key: "last_integrity_ok", value: integrityOK ? "1" : "0")
+            try Self.writeMetadataValue(db, key: "last_integrity_detail", value: integrityDetail)
+
+            return LocalStateRetentionOutcome(
+                deletedEndedSessions: deletedEndedSessions,
+                deletedAgentEvents: deletedAgentEvents,
+                deletedDiagnosticEvents: deletedDiagnosticEvents,
+                integrityOK: integrityOK,
+                integrityDetail: integrityDetail
+            )
+        }
+    }
+
+    /// Standalone `PRAGMA quick_check` probe. Returns `true` when SQLite reports a
+    /// structurally sound database (`["ok"]`).
+    public func checkIntegrity() async throws -> Bool {
+        try await dbPool.read { db in
+            try String.fetchAll(db, sql: "PRAGMA quick_check") == ["ok"]
+        }
+    }
+
     public func summary() async throws -> LocalStateStoreSummary {
         let tables = [
             "terminal_sessions",
@@ -778,28 +946,48 @@ public actor LocalStateStore {
             return result
         }
 
+        let metadata = try await dbPool.read { db -> [String: String] in
+            var result: [String: String] = [:]
+            let rows = try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT key, value FROM local_state_metadata
+                    WHERE key IN ('last_retention_at', 'last_integrity_ok')
+                    """
+            )
+            for row in rows {
+                result[row["key"]] = row["value"]
+            }
+            return result
+        }
+
         return LocalStateStoreSummary(
             schemaVersion: Self.schemaVersion,
             databasePath: databaseURL.path,
             generatedAt: Date(),
             tableCounts: counts,
-            latestEventTimes: latestEventTimes
+            latestEventTimes: latestEventTimes,
+            lastRetentionAt: metadata["last_retention_at"].flatMap(Self.date(fromISOString:)),
+            integrityOK: metadata["last_integrity_ok"].map { $0 == "1" }
         )
     }
 
     private static func writeMetadata(in dbPool: DatabasePool) throws {
-        let now = Self.isoString(Date())
         try dbPool.write { db in
-            try db.execute(
-                sql: """
-                    INSERT INTO local_state_metadata (key, value, updated_at)
-                    VALUES ('schema_version', ?, ?)
-                    ON CONFLICT(key) DO UPDATE SET
-                        value = excluded.value,
-                        updated_at = excluded.updated_at
-                    """,
-                arguments: [String(Self.schemaVersion), now])
+            try writeMetadataValue(db, key: "schema_version", value: String(Self.schemaVersion))
         }
+    }
+
+    private static func writeMetadataValue(_ db: Database, key: String, value: String) throws {
+        try db.execute(
+            sql: """
+                INSERT INTO local_state_metadata (key, value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+            arguments: [key, value, Self.isoString(Date())])
     }
 
     private static var migrator: DatabaseMigrator {

--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -216,6 +216,8 @@ public struct LocalStateRetentionPolicy: Sendable, Equatable {
 
 /// Result of one retention pass: how many rows each high-volume table shed, plus
 /// the `PRAGMA quick_check` health signal captured at the end of the pass.
+/// Counts are the rows each DELETE removed directly — child rows cleared by an
+/// ended session's `ON DELETE CASCADE` are not included in `deletedAgentEvents`.
 public struct LocalStateRetentionOutcome: Sendable, Equatable {
     public let deletedEndedSessions: Int
     public let deletedAgentEvents: Int
@@ -840,16 +842,40 @@ public actor LocalStateStore {
         let agentCutoff = Self.isoString(now.addingTimeInterval(-policy.agentEventMaxAge))
         let diagnosticCutoff = Self.isoString(now.addingTimeInterval(-policy.diagnosticEventMaxAge))
         let completedAt = Self.isoString(now)
+        let currentRunStartedAt = runStartedAt
 
-        return try await dbPool.write { db -> LocalStateRetentionOutcome in
+        let deletions = try await dbPool.write { db -> (sessions: Int, agentEvents: Int, diagnostics: Int) in
             // Ended + aged sessions first; ON DELETE CASCADE clears their agent
             // events and split snapshots. Active rows never match this predicate.
+            // One exception: a *fully-ended* most-recent prior run keeps its rows.
+            // `fetchPreviousRunSessions` selects the prior run from all rows, so
+            // deleting the last rows of a cleanly-closed prior run would make the
+            // reader fall back to an older run's stale never-ended crash rows and
+            // offer the wrong restore set — a cleanly-closed prior run must read
+            // as "nothing to restore", not as an older run's leftovers. When the
+            // prior run still has active rows, those anchor the reader and its
+            // ended rows prune normally. (The EXISTS probe checks active rows,
+            // which this statement never deletes, so it is stable mid-delete.)
             try db.execute(
                 sql: """
                     DELETE FROM terminal_sessions
                     WHERE is_active = 0 AND ended_at IS NOT NULL AND ended_at < ?
+                      AND (
+                          run_id IS NOT (
+                              SELECT run_id
+                              FROM terminal_sessions
+                              WHERE run_started_at IS NOT NULL AND run_started_at < ?
+                              ORDER BY run_started_at DESC
+                              LIMIT 1
+                          )
+                          OR EXISTS (
+                              SELECT 1 FROM terminal_sessions anchor
+                              WHERE anchor.run_id = terminal_sessions.run_id
+                                AND anchor.is_active = 1 AND anchor.ended_at IS NULL
+                          )
+                      )
                     """,
-                arguments: [sessionCutoff])
+                arguments: [sessionCutoff, currentRunStartedAt])
             let deletedEndedSessions = db.changesCount
 
             // Aged agent events, except the latest per still-active session. The
@@ -884,22 +910,32 @@ public actor LocalStateStore {
                 arguments: [diagnosticCutoff])
             let deletedDiagnosticEvents = db.changesCount
 
-            let quickCheck = try String.fetchAll(db, sql: "PRAGMA quick_check")
-            let integrityOK = quickCheck == ["ok"]
-            let integrityDetail = quickCheck.isEmpty ? "ok" : quickCheck.joined(separator: "; ")
+            return (deletedEndedSessions, deletedAgentEvents, deletedDiagnosticEvents)
+        }
 
+        // The integrity probe runs outside the pruning transaction: quick_check
+        // scans the whole file, and holding the writer slot for that at launch
+        // would stall the first session/event writes. A read connection suffices
+        // — the probe is a health signal, not a gate on the deletes.
+        let quickCheck = try await dbPool.read { db in
+            try String.fetchAll(db, sql: "PRAGMA quick_check")
+        }
+        let integrityOK = quickCheck == ["ok"]
+        let integrityDetail = quickCheck.isEmpty ? "ok" : quickCheck.joined(separator: "; ")
+
+        try await dbPool.write { db in
             try Self.writeMetadataValue(db, key: "last_retention_at", value: completedAt)
             try Self.writeMetadataValue(db, key: "last_integrity_ok", value: integrityOK ? "1" : "0")
             try Self.writeMetadataValue(db, key: "last_integrity_detail", value: integrityDetail)
-
-            return LocalStateRetentionOutcome(
-                deletedEndedSessions: deletedEndedSessions,
-                deletedAgentEvents: deletedAgentEvents,
-                deletedDiagnosticEvents: deletedDiagnosticEvents,
-                integrityOK: integrityOK,
-                integrityDetail: integrityDetail
-            )
         }
+
+        return LocalStateRetentionOutcome(
+            deletedEndedSessions: deletions.sessions,
+            deletedAgentEvents: deletions.agentEvents,
+            deletedDiagnosticEvents: deletions.diagnostics,
+            integrityOK: integrityOK,
+            integrityDetail: integrityDetail
+        )
     }
 
     /// Standalone `PRAGMA quick_check` probe. Returns `true` when SQLite reports a

--- a/Tests/WorkspaceManagerTests/LocalStateStoreRetentionTests.swift
+++ b/Tests/WorkspaceManagerTests/LocalStateStoreRetentionTests.swift
@@ -152,4 +152,49 @@ struct LocalStateStoreRetentionTests {
         #expect(summary.integrityOK == true)
         #expect(summary.lastRetentionAt != nil)
     }
+
+    @Test("A fully-ended prior run survives retention so restore doesn't fall back to an older run")
+    func fullyEndedPriorRunSurvivesAsSentinel() async throws {
+        let tempDir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let db = tempDir.appendingPathComponent("state.sqlite")
+
+        // Ancient run: a never-ended crash leftover. It must NOT become the
+        // restore set just because a newer, cleanly-closed run aged out.
+        let ancient = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_600_000_000))
+        let staleID = UUID()
+        try await ancient.recordTerminalSession(
+            HostTerminalSession(
+                id: staleID, key: .repoPath("/code/stale"),
+                directory: URL(fileURLWithPath: "/code/stale")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        // Most-recent prior run: everything cleanly ended, and old enough to age out.
+        let prior = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let endedID = UUID()
+        try await prior.recordTerminalSession(
+            HostTerminalSession(
+                id: endedID, key: .repoPath("/code/closed"),
+                directory: URL(fileURLWithPath: "/code/closed")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+        try await prior.markTerminalSessionEnded(hostSessionID: endedID)
+
+        let current = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_100_000))
+
+        // A cleanly-closed prior run reads as "nothing to restore" — before and
+        // after retention. Without the prior-run sentinel preservation, pruning
+        // the ended run would make the reader select the ancient run and offer
+        // its stale crash row.
+        #expect(try await current.fetchPreviousRunSessions().isEmpty)
+
+        let outcome = try await current.runRetention(now: Date(timeIntervalSince1970: 2_000_000_000))
+        #expect(outcome.integrityOK)
+
+        let after = try await current.fetchPreviousRunSessions()
+        #expect(after.isEmpty)
+        #expect(!after.contains { $0.hostSessionID == staleID })
+    }
 }

--- a/Tests/WorkspaceManagerTests/LocalStateStoreRetentionTests.swift
+++ b/Tests/WorkspaceManagerTests/LocalStateStoreRetentionTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+@preconcurrency import GRDB
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("LocalStateStoreRetention")
+struct LocalStateStoreRetentionTests {
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalStateStoreRetentionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeStatus(
+        hostSessionID: UUID,
+        agentSessionID: String,
+        at seconds: TimeInterval
+    ) -> AgentSessionStatus {
+        AgentSessionStatus(
+            hostSessionID: hostSessionID,
+            agentSessionID: agentSessionID,
+            kind: .claudeCode,
+            cwd: "/code/active",
+            run: .runningTool(name: "Read", detail: "file.txt"),
+            modelDisplayName: "Claude",
+            lastEventAt: Date(timeIntervalSince1970: seconds),
+            hookActive: true,
+            createdAt: Date(timeIntervalSince1970: seconds)
+        )
+    }
+
+    @Test("Retention prunes aged rows but preserves the previous run's restore set")
+    func retentionPreservesRestoreSet() async throws {
+        let tempDir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let db = tempDir.appendingPathComponent("state.sqlite")
+
+        // Previous run: one active session carrying two agent events (an older one
+        // and the latest), an ended session, and a diagnostic — all old enough to
+        // age out under a far-future retention pass.
+        let prev = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let activeID = UUID()
+        try await prev.recordTerminalSession(
+            HostTerminalSession(
+                id: activeID, key: .repoPath("/code/active"),
+                directory: URL(fileURLWithPath: "/code/active")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        try await prev.recordAgentEvents(
+            [.toolStart(name: "Read", detail: "older.txt")],
+            hostSessionID: activeID, origin: .hook,
+            status: makeStatus(hostSessionID: activeID, agentSessionID: "resume-older", at: 1_700_000_100),
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_100))
+        try await prev.recordAgentEvents(
+            [.toolStart(name: "Bash", detail: "ls")],
+            hostSessionID: activeID, origin: .hook,
+            status: makeStatus(hostSessionID: activeID, agentSessionID: "resume-latest", at: 1_700_000_200),
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_200))
+
+        let endedID = UUID()
+        try await prev.recordTerminalSession(
+            HostTerminalSession(
+                id: endedID, key: .repoPath("/code/ended"),
+                directory: URL(fileURLWithPath: "/code/ended")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+        try await prev.markTerminalSessionEnded(hostSessionID: endedID)
+
+        try await prev.recordDiagnosticEvent(
+            metric: "launch_to_first_prompt", durationMs: 100, labels: [:],
+            occurredAt: Date(timeIntervalSince1970: 1_700_000_050))
+
+        // Current run makes `prev` the run cold-start restore offers.
+        let current = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_100_000))
+
+        let before = try await current.fetchPreviousRunSessions()
+        #expect(before.map(\.hostSessionID) == [activeID])
+        #expect(before.first?.agentSessionID == "resume-latest")
+
+        let outcome = try await current.runRetention(now: Date(timeIntervalSince1970: 2_000_000_000))
+
+        // The restore path returns exactly what it did before retention.
+        let after = try await current.fetchPreviousRunSessions()
+        #expect(after == before)
+        #expect(after.first?.agentSessionID == "resume-latest")
+
+        // Aged, non-restore-critical rows were removed.
+        #expect(outcome.deletedEndedSessions == 1)
+        #expect(outcome.deletedAgentEvents == 1)
+        #expect(outcome.deletedDiagnosticEvents == 1)
+        #expect(outcome.integrityOK)
+
+        // The active session keeps only its latest event; the ended session and its
+        // (cascaded) rows are gone; diagnostics are cleared.
+        let summary = try await current.summary()
+        #expect(summary.tableCounts["terminal_sessions"] == 1)
+        #expect(summary.tableCounts["agent_status_events"] == 1)
+        #expect(summary.tableCounts["diagnostic_events"] == 0)
+    }
+
+    @Test("Retention keeps rows newer than the policy window")
+    func retentionKeepsRecentRows() async throws {
+        let tempDir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let db = tempDir.appendingPathComponent("state.sqlite")
+
+        let now = Date()
+        let store = try LocalStateStore(databaseURL: db, runID: UUID(), runStartedAt: now)
+        let sessionID = UUID()
+        try await store.recordTerminalSession(
+            HostTerminalSession(
+                id: sessionID, key: .repoPath("/code/fresh"),
+                directory: URL(fileURLWithPath: "/code/fresh")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+        try await store.recordAgentEvents(
+            [.toolStart(name: "Read", detail: "fresh.txt")],
+            hostSessionID: sessionID, origin: .hook,
+            status: makeStatus(hostSessionID: sessionID, agentSessionID: "fresh", at: now.timeIntervalSince1970),
+            occurredAt: now)
+        try await store.recordDiagnosticEvent(
+            metric: "launch_to_first_prompt", durationMs: 100, labels: [:], occurredAt: now)
+
+        let outcome = try await store.runRetention(now: now)
+
+        #expect(outcome.deletedEndedSessions == 0)
+        #expect(outcome.deletedAgentEvents == 0)
+        #expect(outcome.deletedDiagnosticEvents == 0)
+        #expect(outcome.integrityOK)
+    }
+
+    @Test("Integrity probe reports a healthy store and surfaces through the summary")
+    func integrityProbeHealthyAndSurfaced() async throws {
+        let tempDir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let db = tempDir.appendingPathComponent("state.sqlite")
+
+        let store = try LocalStateStore(databaseURL: db)
+        #expect(try await store.checkIntegrity())
+
+        // Before any retention pass the summary reports no health signal yet.
+        let cold = try await store.summary()
+        #expect(cold.lastRetentionAt == nil)
+        #expect(cold.integrityOK == nil)
+
+        let outcome = try await store.runRetention()
+        #expect(outcome.integrityOK)
+
+        let summary = try await store.summary()
+        #expect(summary.integrityOK == true)
+        #expect(summary.lastRetentionAt != nil)
+    }
+}

--- a/docs/development/local-state-store-plan.md
+++ b/docs/development/local-state-store-plan.md
@@ -54,11 +54,17 @@ The foundation landed in PR #483 and shipped in WorkSpaces v0.15.0:
    - Consider an opt-in SQLite snapshot using SQLite backup or `VACUUM INTO` after redaction policy is settled.
    - Tests: default export never includes raw prompts or terminal transcript payloads.
 
-6. Add retention and health checks.
-   - Define retention for high-volume event tables.
-   - Add a lightweight integrity probe with `PRAGMA quick_check`.
-   - Add cleanup hooks for ended sessions and old diagnostic events.
-   - Tests: retention deletes old rows while preserving recent continuity rows.
+6. Add retention and health checks. **(Shipped — #789.)**
+   - `LocalStateStore.runRetention(policy:now:)` prunes aged `agent_status_events`,
+     `diagnostic_events`, and ended/aged `terminal_sessions` in one write transaction.
+   - Restore-aware: only ended sessions are removed (active rows — including the
+     previous run's resumable sessions — are never touched), and the latest event
+     per active session is kept regardless of age, using the same latest-per-session
+     projection the continuity readers use. So `fetchPreviousRunSessions` /
+     `fetchContinuitySessions` return the same restore set after a pass.
+   - `PRAGMA quick_check` runs at the end of each pass; the result is recorded in
+     `local_state_metadata` and surfaced via `summary()` and the Diagnostics pane.
+   - Wired best-effort once per launch from `bootstrap`. No schema change.
 
 ## Schema Stewardship
 


### PR DESCRIPTION
## Summary

The last unshipped slice of the local-state-store plan (#728 durable sessions). The SQLite sidecar grew unbounded — every terminal session, `agent_status_events` row, and `diagnostic_events` row was kept forever. This adds `LocalStateStore.runRetention(policy:now:)` to bound the high-volume tables **without gutting the cold-start restore set**.

Restore-aware by construction:
- Only **ended AND aged** `terminal_sessions` are pruned, so every active row — including the previous run's resumable sessions that `fetchPreviousRunSessions` enumerates — is preserved. `ON DELETE CASCADE` clears a pruned session's `agent_status_events` and split snapshots.
- The **latest `agent_status_events` row per active session** is kept regardless of age (it carries the `agent_session_id` that drives `claude --resume`); only older, non-latest events past the cutoff are pruned. The preserved set is computed with the *same* `ROW_NUMBER() … PARTITION BY host_session_id ORDER BY event_at DESC, id DESC` projection the continuity readers use, so what survives is exactly what they return.
- `diagnostic_events` prune purely by age.

Each pass runs in one write transaction and ends with `PRAGMA quick_check`; the result is recorded to `local_state_metadata` and surfaced via `summary()` and a new "Integrity" card in the Diagnostics pane. Wired best-effort once per launch from `bootstrap` (detached, never blocks startup; only prunes aged rows so racing early writes is safe).

**No schema change** — `schemaVersion` stays 2; retention writes key/value rows into the existing `local_state_metadata`. The "docs/schema.sql loads as runnable SQLite" test stays green.

Closes #789

## Mergeability

- Surface: agent-runtime (local persistence sidecar)
- User-facing behavior changed: No change to what's stored or shown, beyond a new read-only "Integrity" status in the Diagnostics pane. Behind the scenes, aged rows are now pruned so the DB stops growing unbounded.
- Non-happy paths considered: the restore-critical preservation is structural — active sessions never match the ended-session predicate, and the latest-per-active-session event is excluded from the age prune. A session whose only event predates the cutoff still keeps that event. `fetchPreviousRunSessions` / `fetchContinuitySessions` return the same rows before and after a pass (regression test). Retention is a single transaction; a failure rolls back and is logged, never failing bootstrap.
- Release/ops preconditions: none. Additive; no migration.
- Residual risk or follow-up: default windows (agent events 30d, diagnostics 14d, ended sessions 30d) are generous and configurable via `LocalStateRetentionPolicy`; they can be tuned later without API change.

## Validation

- [x] `swift build`
- [x] `swift test` — 1155 tests / 178 suites pass (+3)
- [x] Other checks run: `mise run lint` (swift-format --strict) clean

**Mutation check (required for data-lifecycle logic):** replaced the agent-events delete's `AND id NOT IN (…latest per active session…)` guard with a bare `WHERE event_at < ?`. The preservation test failed exactly as it should — `fetchPreviousRunSessions` came back with `agentSessionID == nil` (the `claude --resume` id silently lost) and the agent-events count dropped to 0, tripping 4 assertions. This is the precise reboot-resume breakage the issue warns about. Reverted; all green.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

`LocalStateStore` + `LocalStateStoreRetention` suites (includes the schema-unchanged and previous-run restore tests):

![789-retention](https://evidence.cloudcompute.com/workspaces/pr-886/20260707-102854-789-retention.png)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-886/20260707-102854-789-retention.png

## Blockers

- [x] None
