### PR TITLE
fix(restore): banner frequency guard + working resume delivery (#783)

### DIFF
--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -109,7 +109,53 @@ final class SurfaceStore {
         surfaces[tileID] = created
         onSurfaceCreated?(tileID)
         onTerminalSurfaceCreated?(sessionID)
+        deliverInitialCommandIfNeeded(created)
         return created
+    }
+
+    /// Sessions whose initial command has been handed to a surface. Once per
+    /// session, never per surface: a respawned shell must not re-run the agent.
+    private var initialCommandDeliveredSessionIDs: Set<UUID> = []
+
+    /// Deliver `session.initialCommand` (e.g. `claude --resume <id>` from
+    /// cold-start restore) by typing it into the started shell over the
+    /// automation text bridge. libghostty's per-surface `command` and
+    /// `initial_input` configs are silently ignored for surfaces created after
+    /// the app's first (observed against the 1.3.1 pin with the struct fields
+    /// verified set at `ghostty_surface_new`), so typed delivery is the one
+    /// mechanism that reaches every surface — and it keeps the launch command
+    /// byte-identical to a plain shell, so tmux/plain behavior cannot diverge.
+    private func deliverInitialCommandIfNeeded(_ terminal: TerminalSurface) {
+        guard let initialCommand = terminal.session.initialCommand,
+            !initialCommandDeliveredSessionIDs.contains(terminal.session.id)
+        else { return }
+        initialCommandDeliveredSessionIDs.insert(terminal.session.id)
+        let sessionID = terminal.session.id
+
+        Task { @MainActor [weak terminal] in
+            // Wait for the surface's shell to come alive, then settle briefly so
+            // the paste lands at a prompt instead of racing shell/tmux startup.
+            for _ in 0..<40 {
+                guard let terminal else { return }
+                if terminal.surfaceView.isSurfaceAlive { break }
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+            try? await Task.sleep(for: .milliseconds(1500))
+            guard let terminal else {
+                NSLog(
+                    "[SurfaceStore] initial command dropped: surface gone for session %@",
+                    sessionID.uuidString)
+                return
+            }
+            let wrote = GhosttySurfaceTextInputBridge.writeAutomationText(
+                into: terminal.surfaceView, text: initialCommand)
+            let submitted =
+                wrote && GhosttySurfaceTextInputBridge.sendAutomationReturn(into: terminal.surfaceView)
+            NSLog(
+                "[SurfaceStore] initial command %@ for session %@",
+                submitted ? "delivered" : "DROPPED",
+                sessionID.uuidString)
+        }
     }
 
     // MARK: - Web

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -132,28 +132,34 @@ final class SurfaceStore {
         initialCommandDeliveredSessionIDs.insert(terminal.session.id)
         let sessionID = terminal.session.id
 
-        Task { @MainActor [weak terminal] in
+        Task { @MainActor [weak self, weak terminal] in
             // Wait for the surface's shell to come alive, then settle briefly so
             // the paste lands at a prompt instead of racing shell/tmux startup.
             for _ in 0..<40 {
-                guard let terminal else { return }
-                if terminal.surfaceView.isSurfaceAlive { break }
+                guard terminal != nil else { break }
+                if terminal?.surfaceView.isSurfaceAlive == true { break }
                 try? await Task.sleep(for: .milliseconds(250))
             }
             try? await Task.sleep(for: .milliseconds(1500))
-            guard let terminal else {
-                NSLog(
-                    "[SurfaceStore] initial command dropped: surface gone for session %@",
-                    sessionID.uuidString)
-                return
+            // The command reached no shell unless both bridge calls succeed. On any
+            // failure (surface evicted mid-poll, dead surface, dropped write), un-mark
+            // the session so a recreated surface retries — nothing ran, so a retry
+            // cannot double-run the agent.
+            let submitted: Bool
+            if let terminal {
+                submitted =
+                    GhosttySurfaceTextInputBridge.writeAutomationText(
+                        into: terminal.surfaceView, text: initialCommand)
+                    && GhosttySurfaceTextInputBridge.sendAutomationReturn(into: terminal.surfaceView)
+            } else {
+                submitted = false
             }
-            let wrote = GhosttySurfaceTextInputBridge.writeAutomationText(
-                into: terminal.surfaceView, text: initialCommand)
-            let submitted =
-                wrote && GhosttySurfaceTextInputBridge.sendAutomationReturn(into: terminal.surfaceView)
+            if !submitted {
+                self?.initialCommandDeliveredSessionIDs.remove(sessionID)
+            }
             NSLog(
                 "[SurfaceStore] initial command %@ for session %@",
-                submitted ? "delivered" : "DROPPED",
+                submitted ? "delivered" : "DROPPED (will retry on a new surface)",
                 sessionID.uuidString)
         }
     }

--- a/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttyTerminalConfig.swift
@@ -52,8 +52,7 @@ struct GhosttyTerminalConfig {
                 isTmuxAvailableOverride: isTmuxAvailableOverride,
                 hostSessionID: launchContext.hostSessionID,
                 hooksSocketPath: launchContext.hooksSocketPath,
-                automationEnvironment: launchContext.automationEnvironment,
-                initialCommand: launchContext.initialCommand
+                automationEnvironment: launchContext.automationEnvironment
             )
         }
     }
@@ -66,8 +65,7 @@ struct GhosttyTerminalConfig {
         isTmuxAvailableOverride: Bool? = nil,
         hostSessionID: UUID? = nil,
         hooksSocketPath: String? = nil,
-        automationEnvironment: AutomationTerminalEnvironment? = nil,
-        initialCommand: String? = nil
+        automationEnvironment: AutomationTerminalEnvironment? = nil
     ) {
         self.fontSize = fontSize
         self.workingDirectory = workingDirectory.path
@@ -120,20 +118,9 @@ struct GhosttyTerminalConfig {
             let tmuxSessionName = Self.tmuxSessionName(for: workingDirectory)
             let quotedSession = Self.singleQuoted(tmuxSessionName)
             let quotedWorkingDirectory = Self.singleQuoted(workingDirectory.path)
-            var tmuxScript =
+            let tmuxScript =
                 "exec tmux -L workspaces new-session -A -s \(quotedSession) -c \(quotedWorkingDirectory)"
-            if let initialCommand {
-                // Trailing shell-command → the tmux session's initial process. The whole
-                // tmux invocation runs under the login shell, so the session inherits the
-                // login PATH and `claude` resolves; `-A` ignores it on a later reattach.
-                tmuxScript += " \(Self.singleQuoted(initialCommand))"
-            }
             self.command = Self.shellInvocation(shell: shell, profileMode: shellProfileMode, command: tmuxScript)
-        } else if let initialCommand {
-            // No tmux: run the agent in the login shell, cd'd into the directory, so PATH
-            // and profile match a normal terminal and the surface exits when the agent does.
-            let cdExec = "cd \(Self.singleQuoted(workingDirectory.path)) && exec \(initialCommand)"
-            self.command = Self.shellInvocation(shell: shell, profileMode: shellProfileMode, command: cdExec)
         } else {
             self.command = Self.shellInvocation(shell: shell, profileMode: shellProfileMode)
         }

--- a/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
+++ b/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
@@ -2,12 +2,11 @@
 //  RestoreLaunchCommand.swift
 //  WorkspaceManager
 //
-//  The agent command a restored surface runs as its initial process during
-//  cold-start restore. It is intentionally bare: the directory-backed launch
-//  path (GhosttyTerminalConfig) wraps it in the user's login shell — and, in
-//  tmux mode, in a deterministic `-L workspaces` `new-session -A` — so `claude`
-//  resolves on the login PATH and the session reattaches like any other surface
-//  on a later restore.
+//  The agent command a restored surface runs during cold-start restore. It is
+//  intentionally bare: GhosttyTerminalConfig delivers it as typed initial input
+//  to the surface's normal login shell (see `GhosttyTerminalConfig.initialInput`
+//  for why it is not embedded in the launch command), so `claude` resolves on
+//  the login PATH and, in tmux mode, runs inside the deterministic session.
 //
 
 import Foundation

--- a/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
+++ b/Sources/WorkspaceManager/Terminal/RestoreLaunchCommand.swift
@@ -3,10 +3,11 @@
 //  WorkspaceManager
 //
 //  The agent command a restored surface runs during cold-start restore. It is
-//  intentionally bare: GhosttyTerminalConfig delivers it as typed initial input
-//  to the surface's normal login shell (see `GhosttyTerminalConfig.initialInput`
-//  for why it is not embedded in the launch command), so `claude` resolves on
-//  the login PATH and, in tmux mode, runs inside the deterministic session.
+//  intentionally bare: SurfaceStore types it into the surface's normal login
+//  shell over the automation text bridge (see
+//  `SurfaceStore.deliverInitialCommandIfNeeded` for why it is not embedded in
+//  the launch command), so `claude` resolves on the login PATH and, in tmux
+//  mode, runs inside the deterministic session.
 //
 
 import Foundation

--- a/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalSessionLaunchContext.swift
@@ -40,12 +40,6 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
     let hostSessionID: UUID?
     let hooksSocketPath: String?
     let automationEnvironment: AutomationTerminalEnvironment?
-    /// Agent command to run as this directory-backed surface's initial process
-    /// (e.g. `claude --resume <id>` for cold-start restore). It is wrapped by the
-    /// login-shell/tmux launch path, so it resolves on the user's PATH and reattaches
-    /// like any other surface. `nil` for a plain shell and for remote `customCommand`
-    /// sessions.
-    let initialCommand: String?
 
     static func hostSession(
         _ session: HostTerminalSession,
@@ -58,8 +52,7 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
                 commandMode: .customCommand(customCommand),
                 hostSessionID: session.id,
                 hooksSocketPath: hooksSocketPath,
-                automationEnvironment: nil,
-                initialCommand: nil
+                automationEnvironment: nil
             )
         }
 
@@ -67,8 +60,7 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
             workingDirectory: session.directoryURL,
             hostSessionID: session.id,
             hooksSocketPath: hooksSocketPath,
-            automationEnvironment: automationEnvironment,
-            initialCommand: session.initialCommand
+            automationEnvironment: automationEnvironment
         )
     }
 
@@ -76,16 +68,14 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
         workingDirectory: URL,
         hostSessionID: UUID? = nil,
         hooksSocketPath: String? = nil,
-        automationEnvironment: AutomationTerminalEnvironment? = nil,
-        initialCommand: String? = nil
+        automationEnvironment: AutomationTerminalEnvironment? = nil
     ) -> TerminalSessionLaunchContext {
         TerminalSessionLaunchContext(
             workingDirectory: workingDirectory,
             commandMode: .directoryShell,
             hostSessionID: hostSessionID,
             hooksSocketPath: hooksSocketPath,
-            automationEnvironment: automationEnvironment,
-            initialCommand: initialCommand
+            automationEnvironment: automationEnvironment
         )
     }
 
@@ -102,8 +92,7 @@ struct TerminalSessionLaunchContext: Equatable, Sendable {
             commandMode: .customCommand(command),
             hostSessionID: hostSessionID,
             hooksSocketPath: hooksSocketPath,
-            automationEnvironment: nil,
-            initialCommand: nil
+            automationEnvironment: nil
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -66,6 +66,8 @@ struct ContentView: View {
     @State private var pendingWorkspaceOrphanCleanup: WorkspaceOrphanItem?
     @State private var pendingRestorePlan: RestorePlan?
     @State private var restoreBannerDismissed = false
+    @AppStorage(TerminalRestoreBannerStorage.handledRunIDKey)
+    private var restoreHandledRunID = ""
     @State private var isShowingFeedbackSheet = false
     @State private var accessRecorder = MainWindowAccessRecorder()
     @State private var presentedSessionSwitcherSnapshot: SessionSwitcherSnapshot?
@@ -708,11 +710,11 @@ struct ContentView: View {
                 RestoreSessionsBanner(
                     sessionCount: plan.surfaces.count,
                     onRestore: {
-                        executeRestore(plan)
-                        restoreBannerDismissed = true
+                        markRestorePlanHandled(plan)
+                        Task { @MainActor in await executeRestore(plan) }
                     },
                     onDismiss: {
-                        restoreBannerDismissed = true
+                        markRestorePlanHandled(plan)
                     }
                 )
             }
@@ -2902,25 +2904,71 @@ struct ContentView: View {
         ).makePlan(index: index)
         if plan.surfaces.isEmpty {
             NSLog("[Restore] no restorable surfaces from previous run")
+        } else if plan.wasHandled(handledRunID: restoreHandledRunID.isEmpty ? nil : restoreHandledRunID) {
+            NSLog(
+                "[Restore] suppressed banner: previous run %@ already handled",
+                plan.previousRunID ?? "?")
+        } else if !plan.offersMoreThanLaunchSeed(seedKey: .defaultHome) {
+            NSLog("[Restore] suppressed banner: plan only duplicates the launch seed")
         } else {
             NSLog("[Restore] planned %ld restorable surface(s)", plan.surfaces.count)
             pendingRestorePlan = plan
+            autorunRestoreIfRequested(plan)
         }
+    }
+
+    /// Dev-only drive hook for headless restore verification: with
+    /// `WORKSPACES_RESTORE_AUTORUN=1`, a planned restore executes immediately as
+    /// if the user clicked Restore, so smoke scripts can exercise the real
+    /// resume path without desktop input. No effect outside that environment.
+    private func autorunRestoreIfRequested(_ plan: RestorePlan) {
+        guard ProcessInfo.processInfo.environment["WORKSPACES_RESTORE_AUTORUN"] == "1" else { return }
+        NSLog("[Restore] autorun: executing planned restore after settle delay")
+        Task { @MainActor in
+            // Approximate a real banner click: let launch layout settle first.
+            try? await Task.sleep(for: .seconds(3))
+            await executeRestore(plan)
+            markRestorePlanHandled(plan)
+        }
+    }
+
+    /// Record that the user acted on this plan's prior run (restored or
+    /// dismissed), then hide the banner for the rest of this launch. Later
+    /// launches that select the same prior run won't re-offer it.
+    private func markRestorePlanHandled(_ plan: RestorePlan) {
+        if let previousRunID = plan.previousRunID {
+            restoreHandledRunID = previousRunID
+        }
+        restoreBannerDismissed = true
     }
 
     /// Launch each surface in a restore plan. Reattach/fresh surfaces are a plain
     /// directory-backed launch (the deterministic tmux name reattaches a surviving
-    /// session automatically); resume surfaces run `claude --resume` as their
-    /// initial command through the login-shell path (correct PATH + hook env).
+    /// session automatically); resume surfaces get `claude --resume` typed into
+    /// their login shell as initial input (correct PATH + hook env — see
+    /// `GhosttyTerminalConfig.initialInput`).
     /// Then honor the plan's advisory focus by re-activating the selected surface.
     @MainActor
-    private func executeRestore(_ plan: RestorePlan) {
+    private func executeRestore(_ plan: RestorePlan) async {
         // #3: the restore plan owns every key it restores. Retire any session a
         // pre-restore seed (the default-home fallback) left on those keys, so a
         // resume/reattach surface is created fresh and the coordinator's key-reuse
         // path can't drop its initial command.
         for key in Set(plan.surfaces.map(\.key)) {
             _ = tileTreeStore.retireSessions(inScope: key)
+        }
+
+        // Same ownership, tmux layer: the planner only chose resume because the
+        // prior tmux session is gone, so a live session on the resume surface's
+        // deterministic name can only be this launch's seed artifact. Kill it so
+        // the resume surface starts a fresh session instead of `-A`-attaching to
+        // the retired seed's leftover shell.
+        let tmuxProbe = TmuxSessionProbe()
+        for surface in plan.surfaces {
+            if case .resumeClaude = surface.action {
+                await tmuxProbe.killSession(
+                    GhosttyTerminalConfig.tmuxSessionName(for: surface.directory))
+            }
         }
 
         var activatedByHostSessionID: [UUID: HostTerminalSession] = [:]

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2908,7 +2908,9 @@ struct ContentView: View {
             NSLog(
                 "[Restore] suppressed banner: previous run %@ already handled",
                 plan.previousRunID ?? "?")
-        } else if !plan.offersMoreThanLaunchSeed(seedKey: .defaultHome) {
+        } else if !plan.offersMoreThanLaunchSeed(
+            seedKey: .defaultHome, seedDirectory: resolvedDefaultHostDirectory)
+        {
             NSLog("[Restore] suppressed banner: plan only duplicates the launch seed")
         } else {
             NSLog("[Restore] planned %ld restorable surface(s)", plan.surfaces.count)

--- a/Sources/WorkspaceManager/Views/MainWindow/TerminalRestoreCoordinator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TerminalRestoreCoordinator.swift
@@ -22,6 +22,13 @@ enum RestorePathNormalization {
     }
 }
 
+/// UserDefaults key recording the prior run a restore banner action (Restore or
+/// Dismiss) already handled, so later launches that select the same prior run
+/// don't re-offer it (issue #783 #4 — banner frequency guard).
+enum TerminalRestoreBannerStorage {
+    static let handledRunIDKey = "terminalRestoreHandledRunID"
+}
+
 struct TerminalRestoreCoordinator: Sendable {
     let localStateStore: LocalStateStore
     let tmuxProbe: TmuxSessionProbe
@@ -46,6 +53,7 @@ struct TerminalRestoreCoordinator: Sendable {
     func makePlan(index: RestoreTargetIndex) async -> RestorePlan {
         let rows = (try? await localStateStore.fetchPreviousRunSessions(limit: 100)) ?? []
         let layout = (try? await localStateStore.fetchLatestLayoutSnapshot()) ?? nil
+        let previousRunID = (try? await localStateStore.fetchPreviousRunID()) ?? nil
 
         let liveNames = await probeLiveTmuxSessions(Set(rows.compactMap(\.tmuxSessionName)))
 
@@ -55,7 +63,7 @@ struct TerminalRestoreCoordinator: Sendable {
             isTmuxSessionAlive: { liveNames.contains($0) },
             isTranscriptResumable: transcriptResumability.asCheck()
         )
-        return planner.plan(rows: rows, layout: layout)
+        return planner.plan(rows: rows, layout: layout, previousRunID: previousRunID)
     }
 
     /// Fan out `has-session` probes concurrently and collect the live names, so

--- a/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalStateStore.swift
@@ -706,6 +706,28 @@ public actor LocalStateStore {
         }
     }
 
+    /// The `run_id` of the single most-recent *prior* app run — the same run
+    /// `fetchPreviousRunSessions` scopes to — or `nil` on first launch / pre-v2
+    /// data. Lets restore identify which prior run a plan was built from, so an
+    /// already-handled (restored or dismissed) run is not re-offered when a later
+    /// launch selects the same prior run again.
+    public func fetchPreviousRunID() async throws -> String? {
+        let currentRunStartedAt = runStartedAt
+        return try await dbPool.read { db -> String? in
+            try String.fetchOne(
+                db,
+                sql: """
+                    SELECT run_id
+                    FROM terminal_sessions
+                    WHERE run_started_at IS NOT NULL AND run_started_at < ?
+                    ORDER BY run_started_at DESC
+                    LIMIT 1
+                    """,
+                arguments: [currentRunStartedAt]
+            )
+        }
+    }
+
     /// Continuity read model (local-state-store plan, slice 3): the most recently
     /// captured terminal layout snapshot with its split pane rows, or `nil` when
     /// no snapshot has been recorded.

--- a/Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift
+++ b/Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift
@@ -76,11 +76,22 @@ public struct RestorePlan: Sendable, Equatable {
     }
 
     /// Whether the plan restores anything beyond what a fresh launch already
-    /// provides. Startup seeds a plain shell on `seedKey` before restore runs,
-    /// so a plan consisting only of fresh shells on that key duplicates the seed
-    /// and is not worth a banner.
-    public func offersMoreThanLaunchSeed(seedKey: HostTerminalSessionKey) -> Bool {
-        surfaces.contains { $0.action != .freshShell || $0.key != seedKey }
+    /// provides. Startup seeds a plain shell on `seedKey` at `seedDirectory`
+    /// before restore runs, so a plan consisting only of fresh shells matching
+    /// both duplicates the seed and is not worth a banner. A fresh shell on the
+    /// seed key at a different directory is still a real restore (the default
+    /// host directory can change between runs) and keeps the banner.
+    public func offersMoreThanLaunchSeed(
+        seedKey: HostTerminalSessionKey,
+        seedDirectory: URL
+    ) -> Bool {
+        let normalizedSeedPath = seedDirectory.standardizedFileURL.resolvingSymlinksInPath().path
+        return surfaces.contains { surface in
+            surface.action != .freshShell
+                || surface.key != seedKey
+                || surface.directory.standardizedFileURL.resolvingSymlinksInPath().path
+                    != normalizedSeedPath
+        }
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift
+++ b/Sources/WorkspaceManagerCore/Services/TerminalRestorePlanner.swift
@@ -50,13 +50,37 @@ public struct RestoreSurfacePlan: Sendable, Equatable, Identifiable {
 /// The full ordered restore plan. `surfaces` preserves read-model order (newest
 /// `last_seen_at` first). `selectedHostSessionID` is advisory — which surface to
 /// focus after restore — and is honored by the wiring slice, not here.
+/// `previousRunID` identifies the prior app run the plan was built from, so the
+/// banner can avoid re-offering a run the user already restored or dismissed.
 public struct RestorePlan: Sendable, Equatable {
     public let surfaces: [RestoreSurfacePlan]
     public let selectedHostSessionID: UUID?
+    public let previousRunID: String?
 
-    public init(surfaces: [RestoreSurfacePlan], selectedHostSessionID: UUID?) {
+    public init(
+        surfaces: [RestoreSurfacePlan],
+        selectedHostSessionID: UUID?,
+        previousRunID: String? = nil
+    ) {
         self.surfaces = surfaces
         self.selectedHostSessionID = selectedHostSessionID
+        self.previousRunID = previousRunID
+    }
+
+    /// Whether this plan's prior run was already handled (restored or dismissed).
+    /// A plan without a run identity is never considered handled — when in doubt,
+    /// offer the banner rather than silently drop a restorable session set.
+    public func wasHandled(handledRunID: String?) -> Bool {
+        guard let previousRunID, let handledRunID else { return false }
+        return previousRunID == handledRunID
+    }
+
+    /// Whether the plan restores anything beyond what a fresh launch already
+    /// provides. Startup seeds a plain shell on `seedKey` before restore runs,
+    /// so a plan consisting only of fresh shells on that key duplicates the seed
+    /// and is not worth a banner.
+    public func offersMoreThanLaunchSeed(seedKey: HostTerminalSessionKey) -> Bool {
+        surfaces.contains { $0.action != .freshShell || $0.key != seedKey }
     }
 }
 
@@ -105,7 +129,8 @@ public struct TerminalRestorePlanner: Sendable {
 
     public func plan(
         rows: [TerminalSessionContinuityRow],
-        layout: TerminalLayoutSnapshotRow?
+        layout: TerminalLayoutSnapshotRow?,
+        previousRunID: String? = nil
     ) -> RestorePlan {
         var surfaces: [RestoreSurfacePlan] = []
         for row in rows {
@@ -121,7 +146,11 @@ public struct TerminalRestorePlanner: Sendable {
                 )
             )
         }
-        return RestorePlan(surfaces: surfaces, selectedHostSessionID: layout?.activeHostSessionID)
+        return RestorePlan(
+            surfaces: surfaces,
+            selectedHostSessionID: layout?.activeHostSessionID,
+            previousRunID: previousRunID
+        )
     }
 
     /// The restore ladder: live tmux → resumable Claude transcript → fresh shell.

--- a/Sources/WorkspaceManagerCore/Services/TmuxSessionProbe.swift
+++ b/Sources/WorkspaceManagerCore/Services/TmuxSessionProbe.swift
@@ -86,6 +86,22 @@ public struct TmuxSessionProbe: Sendable {
         return firstCommand
     }
 
+    /// Kill an exactly-named session (`=` prefix, as in `isSessionAlive`) so a
+    /// relaunch that carries an initial command cannot `new-session -A`-attach
+    /// to a same-name survivor and silently drop the command. Restore uses this
+    /// just before a resume launch: the planner only picks resume when the prior
+    /// session is gone, so a live session with that name can only be an artifact
+    /// of the current launch's seeding. Returns true when a session was killed.
+    @discardableResult
+    public func killSession(_ tmuxSessionName: String) async -> Bool {
+        let exitCode = await run(
+            "/usr/bin/env",
+            ["tmux", "-L", Self.socketLabel, "kill-session", "-t", "=\(tmuxSessionName)"],
+            environment
+        )
+        return exitCode == 0
+    }
+
     /// Production runner: `ProcessRunner.run` with a short timeout so a wedged
     /// tmux server cannot stall restore; any throw maps to `nil` (not alive).
     public static let defaultRunner: CommandRunner = { executable, arguments, environment in

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -45,75 +45,35 @@ struct GhosttyTerminalConfigTests {
         #expect(command.contains("'wm-repo-a-"))
     }
 
-    @Test("tmux mode runs an initial command as the session's process under the login shell")
-    func tmuxModeRunsInitialCommand() throws {
-        let config = GhosttyTerminalConfig(
-            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
-            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
-            terminalMultiplexingMode: .tmuxPerSession,
-            isTmuxAvailableOverride: true,
-            initialCommand: "claude --resume sess-123"
-        )
-
-        let command = try #require(config.command)
-        // Login shell wraps the tmux invocation → the tmux session inherits the login PATH,
-        // so `claude` resolves (the whole point of the #783 fix vs the fixed-PATH path).
-        #expect(command.contains("/bin/zsh --login -c "))
-        #expect(command.contains("tmux -L workspaces new-session -A -s"))
-        #expect(command.contains("claude --resume sess-123"))
-    }
-
-    @Test("ghostty-splits mode runs an initial command via cd + exec in the login shell")
-    func ghosttyModeRunsInitialCommand() throws {
-        let config = GhosttyTerminalConfig(
-            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
-            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
-            terminalMultiplexingMode: .ghosttyManagedSplits,
-            isTmuxAvailableOverride: true,
-            initialCommand: "claude --resume sess-123"
-        )
-
-        let command = try #require(config.command)
-        #expect(command.contains("/bin/zsh --login -c "))
-        #expect(command.contains("exec claude --resume sess-123"))
-        #expect(command.contains("/tmp/repo-a"))
-        #expect(!command.contains("tmux"))
-    }
-
-    @Test("A nil initial command leaves each mode's command unchanged")
-    func nilInitialCommandIsNoOp() throws {
-        let splits = GhosttyTerminalConfig(
-            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
-            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
-            terminalMultiplexingMode: .ghosttyManagedSplits,
-            isTmuxAvailableOverride: true,
-            initialCommand: nil
-        )
-        #expect(splits.command == "/bin/zsh --login")  // identical to the reattach/fresh path
-
-        let tmux = GhosttyTerminalConfig(
-            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
-            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
-            terminalMultiplexingMode: .tmuxPerSession,
-            isTmuxAvailableOverride: true,
-            initialCommand: nil
-        )
-        let tmuxCommand = try #require(tmux.command)
-        #expect(!tmuxCommand.contains(" exec claude"))  // no trailing initial command
-    }
-
-    @Test("Single quotes in an initial command are escaped")
-    func initialCommandQuotesEscaped() throws {
-        let config = GhosttyTerminalConfig(
-            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
-            environment: ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"],
-            terminalMultiplexingMode: .ghosttyManagedSplits,
-            isTmuxAvailableOverride: true,
-            initialCommand: "echo x'y"
-        )
-        // The whole cd+exec is single-quoted, so an inner ' becomes '"'"'.
-        let command = try #require(config.command)
-        #expect(command.contains("x'\"'\"'y"))
+    @Test("A resume session's launch command is identical to a plain shell's")
+    func resumeSessionLaunchCommandMatchesPlainShell() throws {
+        // The initial command is delivered by SurfaceStore over the automation
+        // text bridge, never embedded in the launch command — libghostty ignores
+        // a per-surface `command` for surfaces created after the app's first,
+        // and an identical command means tmux/plain behavior can't diverge.
+        let environment = ["SHELL": "/bin/zsh", "PATH": "/usr/bin:/bin"]
+        for mode in [TerminalMultiplexingMode.tmuxPerSession, .ghosttyManagedSplits] {
+            let resume = GhosttyTerminalConfig(
+                launchContext: .hostSession(
+                    HostTerminalSession(
+                        key: .repoPath("/tmp/repo-a"),
+                        directory: URL(fileURLWithPath: "/tmp/repo-a"),
+                        initialCommand: "claude --resume sess-123"
+                    ),
+                    hooksSocketPath: nil
+                ),
+                environment: environment,
+                terminalMultiplexingMode: mode,
+                isTmuxAvailableOverride: true
+            )
+            let plain = GhosttyTerminalConfig(
+                workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+                environment: environment,
+                terminalMultiplexingMode: mode,
+                isTmuxAvailableOverride: true
+            )
+            #expect(resume.command == plain.command)
+        }
     }
 
     @Test("tmux mode falls back to login shell when tmux unavailable")

--- a/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalSessionLaunchContextTests.swift
@@ -34,7 +34,7 @@ struct TerminalSessionLaunchContextTests {
         #expect(hookEnvironment["WORKSPACES_COMMAND_STATUS_ZSH"] == "/tmp/command-status.zsh")
     }
 
-    @Test("A resume session stays directory-backed with hook env and carries its initial command")
+    @Test("A resume session stays directory-backed with hook env")
     func resumeSessionIsDirectoryBackedWithInitialCommand() {
         let hostSessionID = UUID(uuidString: "7BD8C9BD-7F3B-456D-A9EC-16CDB2221339")!
         let session = HostTerminalSession(
@@ -47,9 +47,9 @@ struct TerminalSessionLaunchContextTests {
         let context = TerminalSessionLaunchContext.hostSession(session, hooksSocketPath: "/tmp/hooks.sock")
 
         #expect(context.commandModeLabel == "directory")
-        #expect(context.initialCommand == "claude --resume sess-9")
         // The resumed claude runs through the directory path, so it still gets hooks —
-        // unlike the old fixed-PATH customCommand path.
+        // unlike the old fixed-PATH customCommand path. (The initial command itself is
+        // delivered by SurfaceStore over the automation text bridge, not the launch context.)
         #expect(context.agentCommunication == .hookEnvironment)
     }
 
@@ -63,7 +63,6 @@ struct TerminalSessionLaunchContextTests {
         )
         let context = TerminalSessionLaunchContext.hostSession(session, hooksSocketPath: "/tmp/hooks.sock")
         #expect(context.commandModeLabel == "custom")
-        #expect(context.initialCommand == nil)
     }
 
     @Test("Incomplete directory hook context falls back to terminal signals")

--- a/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
+++ b/Tests/WorkspaceManagerTests/LocalStateStoreTests.swift
@@ -462,6 +462,33 @@ struct LocalStateStoreTests {
         #expect(try await current.fetchPreviousRunSessions().isEmpty)  // NULL run excluded
     }
 
+    @Test("fetchPreviousRunID identifies the same run fetchPreviousRunSessions scopes to")
+    func previousRunIDMatchesPreviousRunScope() async throws {
+        let fixture = try TemporaryDirectory()
+        defer { fixture.cleanup() }
+        let db = fixture.url.appendingPathComponent("state.sqlite")
+
+        let current0 = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(try await current0.fetchPreviousRunID() == nil)  // first launch
+
+        let priorRunID = UUID()
+        let prior = try LocalStateStore(
+            databaseURL: db, runID: priorRunID, runStartedAt: Date(timeIntervalSince1970: 1_700_100_000))
+        try await prior.recordTerminalSession(
+            HostTerminalSession(
+                id: UUID(), key: .repoPath("/code/prev"), directory: URL(fileURLWithPath: "/code/prev")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        let current = try LocalStateStore(
+            databaseURL: db, runID: UUID(), runStartedAt: Date(timeIntervalSince1970: 1_700_200_000))
+        try await current.recordTerminalSession(
+            HostTerminalSession(id: UUID(), key: .repoPath("/code/now"), directory: URL(fileURLWithPath: "/code/now")),
+            terminalMode: "tmux_per_session", isActive: true, hooksSocketPath: nil)
+
+        #expect(try await current.fetchPreviousRunID() == priorRunID.uuidString)
+    }
+
     private func repoRoot() -> URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/Tests/WorkspaceManagerTests/TerminalRestorePlannerTests.swift
+++ b/Tests/WorkspaceManagerTests/TerminalRestorePlannerTests.swift
@@ -197,25 +197,27 @@ struct TerminalRestorePlannerTests {
         #expect(!unidentified.wasHandled(handledRunID: nil))
     }
 
-    @Test("A plan of only seed-key fresh shells offers nothing beyond launch")
+    @Test("A plan of only seed-matching fresh shells offers nothing beyond launch")
     func seedOnlyPlanOffersNothing() throws {
+        let seedDirectory = URL(fileURLWithPath: "/tmp")
         func surface(
-            key: HostTerminalSessionKey, action: RestoreSurfaceAction
+            key: HostTerminalSessionKey, action: RestoreSurfaceAction,
+            directory: URL = URL(fileURLWithPath: "/tmp")
         ) -> RestoreSurfacePlan {
             RestoreSurfacePlan(
                 hostSessionID: UUID(), key: key,
-                directory: URL(fileURLWithPath: "/tmp"), action: action)
+                directory: directory, action: action)
         }
 
         let seedFresh = RestorePlan(
             surfaces: [surface(key: .defaultHome, action: .freshShell)],
             selectedHostSessionID: nil)
-        #expect(!seedFresh.offersMoreThanLaunchSeed(seedKey: .defaultHome))
+        #expect(!seedFresh.offersMoreThanLaunchSeed(seedKey: .defaultHome, seedDirectory: seedDirectory))
 
         let seedResume = RestorePlan(
             surfaces: [surface(key: .defaultHome, action: .resumeClaude(agentSessionID: "s1"))],
             selectedHostSessionID: nil)
-        #expect(seedResume.offersMoreThanLaunchSeed(seedKey: .defaultHome))
+        #expect(seedResume.offersMoreThanLaunchSeed(seedKey: .defaultHome, seedDirectory: seedDirectory))
 
         let withRepo = RestorePlan(
             surfaces: [
@@ -223,6 +225,19 @@ struct TerminalRestorePlannerTests {
                 surface(key: .repoPath("/code/repo"), action: .freshShell),
             ],
             selectedHostSessionID: nil)
-        #expect(withRepo.offersMoreThanLaunchSeed(seedKey: .defaultHome))
+        #expect(withRepo.offersMoreThanLaunchSeed(seedKey: .defaultHome, seedDirectory: seedDirectory))
+
+        // A seed-key fresh shell at a DIFFERENT directory is a real restore, not a
+        // seed duplicate (the default host directory can change between runs).
+        let differentDirectory = RestorePlan(
+            surfaces: [
+                surface(
+                    key: .defaultHome, action: .freshShell,
+                    directory: URL(fileURLWithPath: "/somewhere/else"))
+            ],
+            selectedHostSessionID: nil)
+        #expect(
+            differentDirectory.offersMoreThanLaunchSeed(
+                seedKey: .defaultHome, seedDirectory: seedDirectory))
     }
 }

--- a/Tests/WorkspaceManagerTests/TerminalRestorePlannerTests.swift
+++ b/Tests/WorkspaceManagerTests/TerminalRestorePlannerTests.swift
@@ -174,4 +174,55 @@ struct TerminalRestorePlannerTests {
         #expect(plan.surfaces.map(\.hostSessionID) == [first, second])
         #expect(plan.selectedHostSessionID == second)
     }
+
+    @Test("The prior run's identity threads through to the plan")
+    func previousRunIDThreadsThrough() throws {
+        let planner = makePlanner()
+        let plan = planner.plan(rows: [makeRow()], layout: nil, previousRunID: "run-7")
+        #expect(plan.previousRunID == "run-7")
+        #expect(planner.plan(rows: [makeRow()], layout: nil).previousRunID == nil)
+    }
+
+    @Test("A plan is handled only when its run identity matches the recorded one")
+    func wasHandledMatchesRunIdentity() throws {
+        let plan = RestorePlan(surfaces: [], selectedHostSessionID: nil, previousRunID: "run-7")
+        #expect(plan.wasHandled(handledRunID: "run-7"))
+        #expect(!plan.wasHandled(handledRunID: "run-6"))
+        #expect(!plan.wasHandled(handledRunID: nil))
+
+        // No run identity (pre-v2 data) → never suppressed: offer rather than
+        // silently drop a restorable session set.
+        let unidentified = RestorePlan(surfaces: [], selectedHostSessionID: nil, previousRunID: nil)
+        #expect(!unidentified.wasHandled(handledRunID: "run-7"))
+        #expect(!unidentified.wasHandled(handledRunID: nil))
+    }
+
+    @Test("A plan of only seed-key fresh shells offers nothing beyond launch")
+    func seedOnlyPlanOffersNothing() throws {
+        func surface(
+            key: HostTerminalSessionKey, action: RestoreSurfaceAction
+        ) -> RestoreSurfacePlan {
+            RestoreSurfacePlan(
+                hostSessionID: UUID(), key: key,
+                directory: URL(fileURLWithPath: "/tmp"), action: action)
+        }
+
+        let seedFresh = RestorePlan(
+            surfaces: [surface(key: .defaultHome, action: .freshShell)],
+            selectedHostSessionID: nil)
+        #expect(!seedFresh.offersMoreThanLaunchSeed(seedKey: .defaultHome))
+
+        let seedResume = RestorePlan(
+            surfaces: [surface(key: .defaultHome, action: .resumeClaude(agentSessionID: "s1"))],
+            selectedHostSessionID: nil)
+        #expect(seedResume.offersMoreThanLaunchSeed(seedKey: .defaultHome))
+
+        let withRepo = RestorePlan(
+            surfaces: [
+                surface(key: .defaultHome, action: .freshShell),
+                surface(key: .repoPath("/code/repo"), action: .freshShell),
+            ],
+            selectedHostSessionID: nil)
+        #expect(withRepo.offersMoreThanLaunchSeed(seedKey: .defaultHome))
+    }
 }

--- a/Tests/WorkspaceManagerTests/TmuxSessionProbeTests.swift
+++ b/Tests/WorkspaceManagerTests/TmuxSessionProbeTests.swift
@@ -98,6 +98,34 @@ struct TmuxSessionProbeTests {
         #expect(await probe.foregroundCommand(forSessionNamed: "wm-repo-abcd1234") == nil)
     }
 
+    @Test("killSession invokes kill-session on the workspaces socket with an exact-match target")
+    func buildsExactMatchKillSessionCommand() async throws {
+        let recorder = ArgumentRecorder()
+        let probe = TmuxSessionProbe(
+            run: { executable, arguments, _ in
+                await recorder.record(executable: executable, arguments: arguments)
+                return 0
+            },
+            environment: [:]
+        )
+        #expect(await probe.killSession("wm-repo-abcd1234"))
+
+        let calls = await recorder.calls
+        let call = try #require(calls.first)
+        #expect(calls.count == 1)
+        #expect(call.executable == "/usr/bin/env")
+        #expect(call.arguments.contains("tmux"))
+        #expect(call.arguments.contains("kill-session"))
+        #expect(adjacent(call.arguments, "-L", "workspaces"))
+        #expect(adjacent(call.arguments, "-t", "=wm-repo-abcd1234"))
+    }
+
+    @Test("killSession reports false when no session matched")
+    func killSessionReportsFalseOnMiss() async {
+        let probe = TmuxSessionProbe(run: { _, _, _ in 1 }, environment: [:])
+        #expect(await probe.killSession("wm-repo-abcd1234") == false)
+    }
+
     private func adjacent(_ arguments: [String], _ first: String, _ second: String) -> Bool {
         guard let index = arguments.firstIndex(of: first), index + 1 < arguments.count else { return false }
         return arguments[index + 1] == second


### PR DESCRIPTION
## Summary

Closes #783 — the two genuinely-open items from the restore-UX findings list (the PATH bug, run-scoping, and manifest coordination were already shipped in #786), **plus a previously unknown blocker found by actually running the e2e acceptance**: the resume path never worked at runtime because libghostty silently ignores per-surface `command`/`initial_input` configs for surfaces created after the app's first.

### 1. Banner frequency guard (finding #4)
- `LocalStateStore.fetchPreviousRunID()` identifies the prior run the plan was built from; `RestorePlan.previousRunID` carries it.
- Restore/Dismiss persist the handled run (`terminalRestoreHandledRunID`); a later launch that re-selects the same prior run suppresses the banner (`wasHandled`).
- A plan that only duplicates the launch seed (fresh shells on `.defaultHome`) is not offered (`offersMoreThanLaunchSeed`) — this was the every-launch nag: the auto-seeded home shell guaranteed a nonempty "Restore 1 session" forever.

### 2. Resume delivery that actually works (new finding)
Eleven instrumented runs against the real app showed the restored surface spawning the **app-default shell** — the per-surface `command` (and `initial_input`) never took, despite the struct fields being verified set at the `ghostty_surface_new` boundary, on both the existing GhosttyKit and a freshly rebuilt pin (332b2aefc / 1.3.1). First surface honors it; any later surface doesn't. Follow-up issue for the upstream investigation is filed separately.

Fix: `session.initialCommand` is delivered by `SurfaceStore` over the automation text bridge (`GhosttySurfaceTextInputBridge`) once the surface's shell is live — once per session, never on surface respawn. The launch command stays byte-identical to a plain shell, so tmux/plain behavior cannot diverge. The dead `command`/`initial_input` plumbing is removed from `GhosttyTerminalConfig` and `TerminalSessionLaunchContext`.

### 3. tmux-layer ownership
`executeRestore` kills the deterministic tmux session for each resume surface before launching (`TmuxSessionProbe.killSession`): the planner picked resume because the prior session is dead, so a live same-name session is this launch's seed artifact and `new-session -A` would attach to its leftover shell.

`WORKSPACES_RESTORE_AUTORUN=1` is a dev drive hook executing a planned restore as if Restore was clicked (headless verification lane).

## Evidence
- **Real e2e resume demo (the issue's closing acceptance):** conversation recorded through the app → `kill -9` + `tmux kill-server` → relaunch → restore executes → `claude --resume <recorded-id>` running in the recorded cwd (plan directory, not the seed's — disambiguated deliberately) → resumed transcript contains the round-11 marker. Upload below.
- `swift test`: 1155 tests / 177 suites, two consecutive clean full runs.
- `swift-format lint --strict`: clean on all touched files.

![restore-e2e-resume](https://evidence.cloudcompute.com/workspaces/pr-888/20260707-114405-restore-e2e-resume.png)

## Mergeability

- Surface: desktop — restore path (LocalStateStore, TerminalRestorePlanner/Coordinator, SurfaceStore, GhosttyTerminalConfig, ContentView banner wiring)
- User-facing behavior changed: Only behind the default-off `restoreSessionsOnLaunch` experiment. With the flag on: the restore banner stops re-offering an already-handled or seed-only prior run, and Restore now actually resumes the conversation (it previously degraded to a plain shell).
- Non-happy paths considered: plan without run identity (pre-v2 rows) is never suppressed — offer over silent drop; surface evicted mid-delivery → logged drop, no retry into a wrong surface; surface respawn never re-runs the agent (once-per-session set); killSession on a dead server is a no-op; store read failures degrade to an empty plan as before.
- Release/ops preconditions: none — flag stays default-off; `WORKSPACES_RESTORE_AUTORUN` is dev-only.
- Residual risk or follow-up: paste delivery waits liveness + 1.5s settle rather than true prompt-readiness (pty buffering covers the race in practice); the underlying libghostty per-surface-command bug is tracked in #889 with the upstream-repro next step.

## Review loop

Reflection done (guard nil-safety, once-only delivery, respawn non-redelivery, paste-timing tradeoff, async-retire render gap). Codex (gpt-5.5, xhigh) directed review returned two findings, both accepted and fixed in `ee93029d` ("In response to codex (gpt-5.5, xhigh)…"):

- **High (introduced):** failed delivery left the session marked delivered — no retry on a recreated surface. Fixed: un-mark on any failure; retry is safe because nothing reached a shell.
- **Medium (introduced):** seed-plan suppression ignored the surface directory; a prior default-home shell at a different directory was wrongly suppressed. Fixed: triviality requires the seed directory to match (test added).

Codex also confirmed: no surface-creation path bypasses `SurfaceStore.terminalSurface(for:session:)`; `createTab` correctly drops `initialCommand`; no `fetchPreviousRunID`/`fetchPreviousRunSessions` divergence; delivery task MainActor-correct. One stale doc comment it surfaced was fixed in the same commit.

**Deferred spot-check (recorded, non-blocking under the default-off flag):** the round-11 e2e ran on a freshly pin-built GhosttyKit; re-running it on the production framework is blocked right now by system swap exhaustion (`ghostty_surface_new` → `error.OutOfMemory`, environmental). The bridge primitives are the shipped `input.write` feature (#799) verified on that framework, and #889's command-drop reproduces on both binaries. The production-framework resume demo is a hard precondition for ever defaulting `restoreSessionsOnLaunch` on — tracked in the #728 close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
