### PR TITLE
feat(sidebar): real foreground-process names for plain terminal tabs (tmux mode) (#666)

### DIFF
--- a/Sources/WorkspaceManager/Terminal/TerminalForegroundProcessResolver.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalForegroundProcessResolver.swift
@@ -3,10 +3,20 @@
 //  WorkspaceManager
 //
 //  Resolves the real foreground process name of a plain terminal tab (e.g. `vim`,
-//  `python`, `zsh`) so the sidebar hover card can show what is actually running rather
-//  than the terminal title, which only approximates it. Only tmux-per-session mode is
-//  resolvable: libghostty exposes no child PID or PTY fd, so ghostty-managed-splits
-//  surfaces fall back to the title/directory (see #666 and the upstream pid/fd gap).
+//  `python`) so the sidebar hover card can show what is actually running rather than the
+//  terminal title, which only approximates it.
+//
+//  Resolution ladder, tried in order:
+//    1. tmux mode only — the session's active pane command (`pane_current_command`),
+//       which disambiguates tabs that share a working directory.
+//    2. all modes — the non-shell program running in the session's directory, via
+//       WorkspaceProcessMonitor's `lsof` cwd match. This is what covers the DEFAULT
+//       ghostty-managed-splits mode, where libghostty exposes no child PID or PTY fd to
+//       do true per-surface detection (see #666; upstream fd/pid ask filed separately).
+//  A `nil` result means the caller falls back to the terminal title / directory. The
+//  cwd match is directory-scoped, so sibling tabs in one directory can't be told apart
+//  outside tmux mode — an acceptable limit for an advisory hover card.
+//
 //  Resolution is async and lazy; results are cached briefly per session.
 //
 
@@ -19,39 +29,56 @@ struct TerminalForegroundProcessResolver: Sendable {
 
     private let probe: TmuxSessionProbe
     private let tmuxSessionName: @Sendable (URL) -> String
+    /// The non-shell program running in a directory (via `lsof` cwd match), or nil.
+    private let cwdProgramName: @Sendable (URL) async -> String?
 
     init(
         probe: TmuxSessionProbe = TmuxSessionProbe(),
-        tmuxSessionName: @escaping @Sendable (URL) -> String = { GhosttyTerminalConfig.tmuxSessionName(for: $0) }
+        tmuxSessionName: @escaping @Sendable (URL) -> String = { GhosttyTerminalConfig.tmuxSessionName(for: $0) },
+        cwdProgramName: @escaping @Sendable (URL) async -> String? = TerminalForegroundProcessResolver
+            .defaultCwdProgramName
     ) {
         self.probe = probe
         self.tmuxSessionName = tmuxSessionName
+        self.cwdProgramName = cwdProgramName
     }
 
-    /// The foreground process name for `session`, or `nil` when it cannot be resolved:
-    /// ghostty-splits mode (no PID/fd exposure), no live tmux session, or tmux
-    /// unavailable. Cached per session id for `cacheTTL`.
+    /// The foreground process name for `session`, or `nil` when nothing resolves (the
+    /// caller then falls back to the terminal title / directory). Cached per session id
+    /// for `cacheTTL`.
     func foregroundName(
         for session: HostTerminalSession,
         mode: TerminalMultiplexingMode
     ) async -> String? {
-        guard mode == .tmuxPerSession else { return nil }
         if let cached = Self.cache.read(sessionID: session.id, ttl: Self.cacheTTL) {
             return cached
         }
-        let name = await probe.foregroundCommand(forSessionNamed: tmuxSessionName(session.directoryURL))
-        Self.cache.write(sessionID: session.id, name: name)
-        return name
+        var resolved: String?
+        if mode == .tmuxPerSession {
+            resolved = await probe.foregroundCommand(forSessionNamed: tmuxSessionName(session.directoryURL))
+        }
+        if resolved == nil {
+            resolved = await cwdProgramName(session.directoryURL)
+        }
+        Self.cache.write(sessionID: session.id, name: resolved)
+        return resolved
     }
 
-    /// Fallback ladder for a plain tab's display string: the real foreground process
-    /// name when resolved, otherwise the existing terminal title (which already falls
-    /// back to the directory).
+    /// Fallback ladder tail: the resolved foreground process name when present, otherwise
+    /// the existing terminal title (which already falls back to the directory).
     static func preferredTabTitle(foregroundName: String?, terminalTitle: String) -> String {
         if let foregroundName, !foregroundName.trimmingCharacters(in: .whitespaces).isEmpty {
             return foregroundName
         }
         return terminalTitle
+    }
+
+    /// Production cwd resolver: the first non-agent program whose cwd is the session's
+    /// directory, per `WorkspaceProcessMonitor` (which ignores shells and known agents).
+    /// Returns nil for a bare shell so the caller falls back to the title.
+    static let defaultCwdProgramName: @Sendable (URL) async -> String? = { directory in
+        let status = await WorkspaceProcessMonitor().detectAgentSession(in: directory)
+        return status.processes.first { !$0.isKnownAgent }?.displayName
     }
 
     private final class CacheBox: @unchecked Sendable {

--- a/Sources/WorkspaceManager/Terminal/TerminalForegroundProcessResolver.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalForegroundProcessResolver.swift
@@ -1,0 +1,80 @@
+//
+//  TerminalForegroundProcessResolver.swift
+//  WorkspaceManager
+//
+//  Resolves the real foreground process name of a plain terminal tab (e.g. `vim`,
+//  `python`, `zsh`) so the sidebar hover card can show what is actually running rather
+//  than the terminal title, which only approximates it. Only tmux-per-session mode is
+//  resolvable: libghostty exposes no child PID or PTY fd, so ghostty-managed-splits
+//  surfaces fall back to the title/directory (see #666 and the upstream pid/fd gap).
+//  Resolution is async and lazy; results are cached briefly per session.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+struct TerminalForegroundProcessResolver: Sendable {
+    static let cacheTTL: TimeInterval = 2.0
+    private static let cache = CacheBox()
+
+    private let probe: TmuxSessionProbe
+    private let tmuxSessionName: @Sendable (URL) -> String
+
+    init(
+        probe: TmuxSessionProbe = TmuxSessionProbe(),
+        tmuxSessionName: @escaping @Sendable (URL) -> String = { GhosttyTerminalConfig.tmuxSessionName(for: $0) }
+    ) {
+        self.probe = probe
+        self.tmuxSessionName = tmuxSessionName
+    }
+
+    /// The foreground process name for `session`, or `nil` when it cannot be resolved:
+    /// ghostty-splits mode (no PID/fd exposure), no live tmux session, or tmux
+    /// unavailable. Cached per session id for `cacheTTL`.
+    func foregroundName(
+        for session: HostTerminalSession,
+        mode: TerminalMultiplexingMode
+    ) async -> String? {
+        guard mode == .tmuxPerSession else { return nil }
+        if let cached = Self.cache.read(sessionID: session.id, ttl: Self.cacheTTL) {
+            return cached
+        }
+        let name = await probe.foregroundCommand(forSessionNamed: tmuxSessionName(session.directoryURL))
+        Self.cache.write(sessionID: session.id, name: name)
+        return name
+    }
+
+    /// Fallback ladder for a plain tab's display string: the real foreground process
+    /// name when resolved, otherwise the existing terminal title (which already falls
+    /// back to the directory).
+    static func preferredTabTitle(foregroundName: String?, terminalTitle: String) -> String {
+        if let foregroundName, !foregroundName.trimmingCharacters(in: .whitespaces).isEmpty {
+            return foregroundName
+        }
+        return terminalTitle
+    }
+
+    private final class CacheBox: @unchecked Sendable {
+        private struct Entry {
+            let name: String?
+            let recordedAt: Date
+        }
+        private var entries: [UUID: Entry] = [:]
+        private let lock = NSLock()
+
+        func read(sessionID: UUID, ttl: TimeInterval) -> String?? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard let entry = entries[sessionID],
+                Date().timeIntervalSince(entry.recordedAt) < ttl
+            else { return nil }
+            return .some(entry.name)
+        }
+
+        func write(sessionID: UUID, name: String?) {
+            lock.lock()
+            defer { lock.unlock() }
+            entries[sessionID] = Entry(name: name, recordedAt: Date())
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Terminal/TerminalForegroundProcessResolver.swift
+++ b/Sources/WorkspaceManager/Terminal/TerminalForegroundProcessResolver.swift
@@ -73,12 +73,18 @@ struct TerminalForegroundProcessResolver: Sendable {
         return terminalTitle
     }
 
-    /// Production cwd resolver: the first non-agent program whose cwd is the session's
-    /// directory, per `WorkspaceProcessMonitor` (which ignores shells and known agents).
-    /// Returns nil for a bare shell so the caller falls back to the title.
+    /// The program to surface from a directory's detected processes: the first non-agent
+    /// program. Known agents are surfaced through the agent path (and their tabs are not
+    /// plain), and `WorkspaceProcessMonitor` already drops shells, so a bare shell yields
+    /// no processes here and resolves to nil (title fallback).
+    static func programName(from status: WorkspaceProcessMonitor.AgentStatus) -> String? {
+        status.processes.first { !$0.isKnownAgent }?.displayName
+    }
+
+    /// Production cwd resolver: the non-agent program whose cwd is the session's directory,
+    /// per `WorkspaceProcessMonitor` (which ignores shells and known noise).
     static let defaultCwdProgramName: @Sendable (URL) async -> String? = { directory in
-        let status = await WorkspaceProcessMonitor().detectAgentSession(in: directory)
-        return status.processes.first { !$0.isKnownAgent }?.displayName
+        programName(from: await WorkspaceProcessMonitor().detectAgentSession(in: directory))
     }
 
     private final class CacheBox: @unchecked Sendable {

--- a/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
+++ b/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
@@ -4,9 +4,9 @@
 //
 //  Hover card for a sidebar item (repo root or workspace): the git branch and a
 //  one-line summary of each open terminal tab — agent tabs show the agent icon
-//  and run state, plain tabs show their terminal title. When a single agent is
-//  running, its telemetry (model, context, cost, last active) is shown too.
-//  Styled to match WorkspaceCardView.
+//  and run state, plain tabs show their real foreground process (tmux mode) or fall
+//  back to the terminal title. When a single agent is running, its telemetry (model,
+//  context, cost, last active) is shown too. Styled to match WorkspaceCardView.
 //
 
 import SwiftUI

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -90,6 +90,12 @@ struct SidebarView: View {
     @State private var repoLastAccessedSnapshotByID: [UUID: Date] = [:]
     @State private var isPreparingNewWorkspaceSheet = false
 
+    /// Real foreground process name per plain terminal tab, resolved lazily when a hover
+    /// card opens and preferred over the terminal title. Populated by
+    /// `refreshForegroundProcessNames`; empty in ghostty-splits mode (see #666).
+    @State private var foregroundNameBySessionID: [UUID: String] = [:]
+    private let foregroundResolver = TerminalForegroundProcessResolver()
+
     private var isUIFixtureMode: Bool {
         ProcessInfo.processInfo.environment["WORKSPACES_UI_FIXTURE"] == "1"
     }
@@ -471,7 +477,10 @@ struct SidebarView: View {
             onNewWebView: {
                 onRequestWebSourceCreation(.repo(repo))
             },
-            tabsProvider: { tabSummaries(for: repoSessionKey) }
+            tabsProvider: {
+                refreshForegroundProcessNames(for: repoSessionKey)
+                return tabSummaries(for: repoSessionKey)
+            }
         )
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
@@ -560,7 +569,10 @@ struct SidebarView: View {
             isNested: true,
             isExpanded: isWorkspaceExpanded(workspace),
             showsDisclosure: !workspace.webSources.isEmpty,
-            tabsProvider: { tabSummaries(for: workspace) },
+            tabsProvider: {
+                refreshForegroundProcessNames(for: sessionKey(for: workspace))
+                return tabSummaries(for: workspace)
+            },
             onToggleExpansion: {
                 toggleWorkspaceExpansion(workspace)
             },
@@ -1469,16 +1481,52 @@ struct SidebarView: View {
             hostSessions
             .filter { $0.key == normalizedKey }
             .map { session in
-                SidebarTabSummary(
+                let agentStatus = agentStatusBySessionID[session.id]
+                let title = titleForSession(session)
+                // Plain tabs prefer the real foreground process name; agent tabs keep their
+                // agent-driven title unchanged.
+                let displayTitle =
+                    agentStatus == nil
+                    ? TerminalForegroundProcessResolver.preferredTabTitle(
+                        foregroundName: foregroundNameBySessionID[session.id],
+                        terminalTitle: title)
+                    : title
+                return SidebarTabSummary(
                     id: session.id,
-                    title: titleForSession(session),
-                    agentStatus: agentStatusBySessionID[session.id]
+                    title: displayTitle,
+                    agentStatus: agentStatus
                 )
             }
     }
 
     private func tabSummaries(for workspace: Workspace) -> [SidebarTabSummary] {
         tabSummaries(for: sessionKey(for: workspace))
+    }
+
+    /// Kicks off async foreground-process resolution for the plain (non-agent) tabs under
+    /// `key`, updating `foregroundNameBySessionID` when a name resolves. Fire-and-forget and
+    /// idempotent — the resolver caches for ~2s and this writes only on change — so it is safe
+    /// to call from the hover card's lazy `tabsProvider`. No-ops outside tmux-per-session mode,
+    /// where foreground detection is not available (see #666).
+    private func refreshForegroundProcessNames(for key: HostTerminalSessionKey) {
+        let mode = TerminalMultiplexingMode.resolve()
+        guard mode == .tmuxPerSession else { return }
+        let normalizedKey = key.normalized()
+        let plainSessions = hostSessions.filter {
+            $0.key == normalizedKey && agentStatusBySessionID[$0.id] == nil
+        }
+        guard !plainSessions.isEmpty else { return }
+        let resolver = foregroundResolver
+        Task { @MainActor in
+            for session in plainSessions {
+                let name = await resolver.foregroundName(for: session, mode: mode)
+                if let name, foregroundNameBySessionID[session.id] != name {
+                    foregroundNameBySessionID[session.id] = name
+                } else if name == nil, foregroundNameBySessionID[session.id] != nil {
+                    foregroundNameBySessionID.removeValue(forKey: session.id)
+                }
+            }
+        }
     }
 
     /// Merge the repo's own-session baseline with the aggregator-bubbled state derived

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -1506,11 +1506,10 @@ struct SidebarView: View {
     /// Kicks off async foreground-process resolution for the plain (non-agent) tabs under
     /// `key`, updating `foregroundNameBySessionID` when a name resolves. Fire-and-forget and
     /// idempotent — the resolver caches for ~2s and this writes only on change — so it is safe
-    /// to call from the hover card's lazy `tabsProvider`. No-ops outside tmux-per-session mode,
-    /// where foreground detection is not available (see #666).
+    /// to call from the hover card's lazy `tabsProvider`. Resolves in every multiplexing mode
+    /// (tmux pane command when available, otherwise the directory's running program).
     private func refreshForegroundProcessNames(for key: HostTerminalSessionKey) {
         let mode = TerminalMultiplexingMode.resolve()
-        guard mode == .tmuxPerSession else { return }
         let normalizedKey = key.normalized()
         let plainSessions = hostSessions.filter {
             $0.key == normalizedKey && agentStatusBySessionID[$0.id] == nil

--- a/Sources/WorkspaceManagerCore/Services/TmuxSessionProbe.swift
+++ b/Sources/WorkspaceManagerCore/Services/TmuxSessionProbe.swift
@@ -18,14 +18,22 @@ public struct TmuxSessionProbe: Sendable {
     public typealias CommandRunner =
         @Sendable (_ executable: String, _ arguments: [String], _ environment: [String: String]?) async -> Int32?
 
+    /// Runs a command and yields its stdout on success, or `nil` on non-zero exit,
+    /// launch failure, or timeout.
+    public typealias OutputCommandRunner =
+        @Sendable (_ executable: String, _ arguments: [String], _ environment: [String: String]?) async -> String?
+
     private let run: CommandRunner
+    private let runForOutput: OutputCommandRunner
     private let environment: [String: String]
 
     public init(
         run: @escaping CommandRunner = TmuxSessionProbe.defaultRunner,
+        runForOutput: @escaping OutputCommandRunner = TmuxSessionProbe.defaultOutputRunner,
         environment: [String: String] = TmuxSessionProbe.defaultEnvironment
     ) {
         self.run = run
+        self.runForOutput = runForOutput
         self.environment = environment
     }
 
@@ -41,6 +49,43 @@ public struct TmuxSessionProbe: Sendable {
         return exitCode == 0
     }
 
+    /// The foreground command running in the session's active pane (its
+    /// `pane_current_command`, e.g. `vim`, `python`, `zsh`), or `nil` when the
+    /// session is not live or tmux is unavailable. Names what a plain terminal tab
+    /// is actually running, which the terminal title only approximates. The `=`
+    /// prefix forces an exact session-name match.
+    public func foregroundCommand(forSessionNamed tmuxSessionName: String) async -> String? {
+        let output = await runForOutput(
+            "/usr/bin/env",
+            [
+                "tmux", "-L", Self.socketLabel, "list-panes",
+                "-t", "=\(tmuxSessionName)",
+                "-F", "#{pane_active} #{pane_current_command}",
+            ],
+            environment
+        )
+        return Self.parseForegroundCommand(fromListPanes: output)
+    }
+
+    /// Picks the foreground command from `tmux list-panes -F '#{pane_active}
+    /// #{pane_current_command}'` output: the active pane wins; otherwise the first
+    /// pane with a non-empty command. Returns `nil` for empty/absent output.
+    static func parseForegroundCommand(fromListPanes output: String?) -> String? {
+        guard let output else { return nil }
+        var firstCommand: String?
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard let spaceIndex = line.firstIndex(of: " ") else { continue }
+            let isActive = line[..<spaceIndex] == "1"
+            let command = line[line.index(after: spaceIndex)...]
+                .trimmingCharacters(in: .whitespaces)
+            guard !command.isEmpty else { continue }
+            if isActive { return command }
+            if firstCommand == nil { firstCommand = command }
+        }
+        return firstCommand
+    }
+
     /// Production runner: `ProcessRunner.run` with a short timeout so a wedged
     /// tmux server cannot stall restore; any throw maps to `nil` (not alive).
     public static let defaultRunner: CommandRunner = { executable, arguments, environment in
@@ -52,6 +97,22 @@ public struct TmuxSessionProbe: Sendable {
                 timeout: 5
             )
             return result.exitCode
+        } catch {
+            return nil
+        }
+    }
+
+    /// Production output runner: `ProcessRunner.run` with a short timeout; returns
+    /// stdout only on success so a wedged/missing tmux server maps to `nil`.
+    public static let defaultOutputRunner: OutputCommandRunner = { executable, arguments, environment in
+        do {
+            let result = try await ProcessRunner.run(
+                executable: executable,
+                arguments: arguments,
+                environment: environment,
+                timeout: 5
+            )
+            return result.success ? result.stdout : nil
         } catch {
             return nil
         }

--- a/Tests/WorkspaceManagerAppTests/SidebarForegroundProcessRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarForegroundProcessRenderTests.swift
@@ -1,0 +1,45 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("SidebarInfoCard foreground-process render")
+struct SidebarForegroundProcessRenderTests {
+    /// Renders the hover card with plain tabs whose titles are the real foreground process
+    /// names (`vim`, `python`) that tmux-mode detection resolves. Asserts a non-empty image
+    /// (layout smoke) and, when `WORKSPACES_EVIDENCE_DIR` is set, writes a PNG for PR evidence
+    /// without launching the app.
+    @Test("Hover card renders real foreground process names for plain tabs")
+    func rendersForegroundProcessNames() throws {
+        let card = SidebarInfoCard(
+            name: "my-repo",
+            branch: "feature/foreground-detection",
+            tabs: [
+                SidebarTabSummary(id: UUID(), title: "vim"),
+                SidebarTabSummary(id: UUID(), title: "python"),
+            ]
+        )
+        .padding(16)
+        .frame(width: 260, alignment: .leading)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: card)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("sidebar-foreground-process.png")
+        try png.write(to: url)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/TerminalForegroundProcessResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalForegroundProcessResolverTests.swift
@@ -69,4 +69,25 @@ struct TerminalForegroundProcessResolverTests {
         let resolver = resolver(tmuxOutput: nil, cwdProgram: nil)
         #expect(await resolver.foregroundName(for: session(), mode: .ghosttyManagedSplits) == nil)
     }
+
+    // MARK: - cwd program selection (shell/agent filtering)
+
+    @Test("cwd selection skips known agents and picks the plain program")
+    func cwdSelectionSkipsKnownAgents() {
+        let status = WorkspaceProcessMonitor.AgentStatus(processes: [
+            WorkspaceProcessMonitor.DetectedProcess(displayName: "Claude", isKnownAgent: true),
+            WorkspaceProcessMonitor.DetectedProcess(displayName: "vim", isKnownAgent: false),
+        ])
+        #expect(TerminalForegroundProcessResolver.programName(from: status) == "vim")
+    }
+
+    @Test("cwd selection yields nil when only agents run and for a bare shell")
+    func cwdSelectionNilForAgentOnlyOrBareShell() {
+        let agentOnly = WorkspaceProcessMonitor.AgentStatus(processes: [
+            WorkspaceProcessMonitor.DetectedProcess(displayName: "Claude", isKnownAgent: true)
+        ])
+        #expect(TerminalForegroundProcessResolver.programName(from: agentOnly) == nil)
+        // WorkspaceProcessMonitor already drops shells, so a bare shell yields no processes.
+        #expect(TerminalForegroundProcessResolver.programName(from: .inactive) == nil)
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/TerminalForegroundProcessResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalForegroundProcessResolverTests.swift
@@ -13,6 +13,17 @@ struct TerminalForegroundProcessResolverTests {
         )
     }
 
+    private func resolver(
+        tmuxOutput: String?,
+        cwdProgram: String?
+    ) -> TerminalForegroundProcessResolver {
+        TerminalForegroundProcessResolver(
+            probe: TmuxSessionProbe(runForOutput: { _, _, _ in tmuxOutput }, environment: [:]),
+            tmuxSessionName: { _ in "wm-repo-abcd1234" },
+            cwdProgramName: { _ in cwdProgram }
+        )
+    }
+
     // MARK: - Fallback ladder
 
     @Test("A resolved foreground name is preferred over the terminal title")
@@ -32,36 +43,30 @@ struct TerminalForegroundProcessResolverTests {
                 foregroundName: "   ", terminalTitle: "~/repo") == "~/repo")
     }
 
-    // MARK: - Mode gating
+    // MARK: - Resolution ladder
 
-    @Test("tmux mode resolves the real foreground command")
-    func tmuxModeResolves() async {
-        let resolver = TerminalForegroundProcessResolver(
-            probe: TmuxSessionProbe(runForOutput: { _, _, _ in "1 vim\n" }, environment: [:]),
-            tmuxSessionName: { _ in "wm-repo-abcd1234" }
-        )
-        let name = await resolver.foregroundName(for: session(), mode: .tmuxPerSession)
-        #expect(name == "vim")
+    @Test("tmux mode prefers the exact per-pane command over the cwd program")
+    func tmuxModePrefersPaneCommand() async {
+        let resolver = resolver(tmuxOutput: "1 vim\n", cwdProgram: "python")
+        #expect(await resolver.foregroundName(for: session(), mode: .tmuxPerSession) == "vim")
     }
 
-    @Test("ghostty-splits mode does not attempt detection and returns nil")
-    func ghosttyModeReturnsNil() async {
-        // The probe would return "vim", but the mode gate must short-circuit before calling it.
-        let resolver = TerminalForegroundProcessResolver(
-            probe: TmuxSessionProbe(runForOutput: { _, _, _ in "1 vim\n" }, environment: [:]),
-            tmuxSessionName: { _ in "wm-repo-abcd1234" }
-        )
-        let name = await resolver.foregroundName(for: session(), mode: .ghosttyManagedSplits)
-        #expect(name == nil)
+    @Test("tmux mode falls back to the cwd program when the pane query is unavailable")
+    func tmuxModeFallsBackToCwd() async {
+        let resolver = resolver(tmuxOutput: nil, cwdProgram: "python")
+        #expect(await resolver.foregroundName(for: session(), mode: .tmuxPerSession) == "python")
     }
 
-    @Test("An unavailable tmux session resolves to nil (title fallback upstream)")
-    func unavailableSessionReturnsNil() async {
-        let resolver = TerminalForegroundProcessResolver(
-            probe: TmuxSessionProbe(runForOutput: { _, _, _ in nil }, environment: [:]),
-            tmuxSessionName: { _ in "wm-repo-abcd1234" }
-        )
-        let name = await resolver.foregroundName(for: session(), mode: .tmuxPerSession)
-        #expect(name == nil)
+    @Test("ghostty-splits mode (default) resolves via the cwd program")
+    func ghosttyModeResolvesViaCwd() async {
+        // No tmux query in this mode; the directory's running program still resolves.
+        let resolver = resolver(tmuxOutput: "1 vim\n", cwdProgram: "python")
+        #expect(await resolver.foregroundName(for: session(), mode: .ghosttyManagedSplits) == "python")
+    }
+
+    @Test("A bare shell (no non-shell program, no tmux) resolves to nil for title fallback")
+    func bareShellResolvesNil() async {
+        let resolver = resolver(tmuxOutput: nil, cwdProgram: nil)
+        #expect(await resolver.foregroundName(for: session(), mode: .ghosttyManagedSplits) == nil)
     }
 }

--- a/Tests/WorkspaceManagerAppTests/TerminalForegroundProcessResolverTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TerminalForegroundProcessResolverTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@Suite("TerminalForegroundProcessResolver")
+struct TerminalForegroundProcessResolverTests {
+    private func session() -> HostTerminalSession {
+        HostTerminalSession(
+            key: .repoPath("/tmp/repo-\(UUID().uuidString)"),
+            directory: URL(fileURLWithPath: "/tmp/repo-\(UUID().uuidString)")
+        )
+    }
+
+    // MARK: - Fallback ladder
+
+    @Test("A resolved foreground name is preferred over the terminal title")
+    func prefersForegroundName() {
+        #expect(
+            TerminalForegroundProcessResolver.preferredTabTitle(
+                foregroundName: "vim", terminalTitle: "~/repo") == "vim")
+    }
+
+    @Test("Falls back to the terminal title when no name resolved")
+    func fallsBackToTitle() {
+        #expect(
+            TerminalForegroundProcessResolver.preferredTabTitle(
+                foregroundName: nil, terminalTitle: "~/repo") == "~/repo")
+        #expect(
+            TerminalForegroundProcessResolver.preferredTabTitle(
+                foregroundName: "   ", terminalTitle: "~/repo") == "~/repo")
+    }
+
+    // MARK: - Mode gating
+
+    @Test("tmux mode resolves the real foreground command")
+    func tmuxModeResolves() async {
+        let resolver = TerminalForegroundProcessResolver(
+            probe: TmuxSessionProbe(runForOutput: { _, _, _ in "1 vim\n" }, environment: [:]),
+            tmuxSessionName: { _ in "wm-repo-abcd1234" }
+        )
+        let name = await resolver.foregroundName(for: session(), mode: .tmuxPerSession)
+        #expect(name == "vim")
+    }
+
+    @Test("ghostty-splits mode does not attempt detection and returns nil")
+    func ghosttyModeReturnsNil() async {
+        // The probe would return "vim", but the mode gate must short-circuit before calling it.
+        let resolver = TerminalForegroundProcessResolver(
+            probe: TmuxSessionProbe(runForOutput: { _, _, _ in "1 vim\n" }, environment: [:]),
+            tmuxSessionName: { _ in "wm-repo-abcd1234" }
+        )
+        let name = await resolver.foregroundName(for: session(), mode: .ghosttyManagedSplits)
+        #expect(name == nil)
+    }
+
+    @Test("An unavailable tmux session resolves to nil (title fallback upstream)")
+    func unavailableSessionReturnsNil() async {
+        let resolver = TerminalForegroundProcessResolver(
+            probe: TmuxSessionProbe(runForOutput: { _, _, _ in nil }, environment: [:]),
+            tmuxSessionName: { _ in "wm-repo-abcd1234" }
+        )
+        let name = await resolver.foregroundName(for: session(), mode: .tmuxPerSession)
+        #expect(name == nil)
+    }
+}

--- a/Tests/WorkspaceManagerTests/TmuxSessionProbeTests.swift
+++ b/Tests/WorkspaceManagerTests/TmuxSessionProbeTests.swift
@@ -47,6 +47,57 @@ struct TmuxSessionProbeTests {
         #expect(adjacent(call.arguments, "-t", "=wm-repo-abcd1234"))
     }
 
+    // MARK: - Foreground command
+
+    @Test("parseForegroundCommand prefers the active pane's command")
+    func parsePrefersActivePane() {
+        let output = "0 zsh\n1 vim\n0 python\n"
+        #expect(TmuxSessionProbe.parseForegroundCommand(fromListPanes: output) == "vim")
+    }
+
+    @Test("parseForegroundCommand falls back to the first pane when none is marked active")
+    func parseFallsBackToFirstPane() {
+        #expect(TmuxSessionProbe.parseForegroundCommand(fromListPanes: "0 python\n0 zsh\n") == "python")
+    }
+
+    @Test("parseForegroundCommand reports a bare shell as its command")
+    func parseReportsBareShell() {
+        #expect(TmuxSessionProbe.parseForegroundCommand(fromListPanes: "1 zsh\n") == "zsh")
+    }
+
+    @Test("parseForegroundCommand returns nil for empty or absent output")
+    func parseReturnsNilForEmpty() {
+        #expect(TmuxSessionProbe.parseForegroundCommand(fromListPanes: nil) == nil)
+        #expect(TmuxSessionProbe.parseForegroundCommand(fromListPanes: "") == nil)
+        #expect(TmuxSessionProbe.parseForegroundCommand(fromListPanes: "1 \n") == nil)
+    }
+
+    @Test("foregroundCommand queries list-panes on the workspaces socket with an exact target")
+    func buildsListPanesCommand() async throws {
+        let recorder = ArgumentRecorder()
+        let probe = TmuxSessionProbe(
+            runForOutput: { executable, arguments, _ in
+                await recorder.record(executable: executable, arguments: arguments)
+                return "1 vim\n"
+            },
+            environment: [:]
+        )
+        let command = await probe.foregroundCommand(forSessionNamed: "wm-repo-abcd1234")
+
+        #expect(command == "vim")
+        let call = try #require(await recorder.calls.first)
+        #expect(call.executable == "/usr/bin/env")
+        #expect(call.arguments.contains("list-panes"))
+        #expect(adjacent(call.arguments, "-L", "workspaces"))
+        #expect(adjacent(call.arguments, "-t", "=wm-repo-abcd1234"))
+    }
+
+    @Test("foregroundCommand returns nil when tmux output is unavailable")
+    func foregroundCommandNilWhenUnavailable() async {
+        let probe = TmuxSessionProbe(runForOutput: { _, _, _ in nil }, environment: [:])
+        #expect(await probe.foregroundCommand(forSessionNamed: "wm-repo-abcd1234") == nil)
+    }
+
     private func adjacent(_ arguments: [String], _ first: String, _ second: String) -> Bool {
         guard let index = arguments.firstIndex(of: first), index + 1 < arguments.count else { return false }
         return arguments[index + 1] == second


### PR DESCRIPTION
## Summary

The sidebar hover card showed a plain (non-agent) terminal tab's **terminal title** as the "what's running here" signal — a proxy, not the actual foreground process. This resolves the real process name (`vim`, `python`) and prefers it over the title for plain tabs, **in every multiplexing mode**; agent tabs are unchanged.

Closes #666.

### Approach (and the feasibility finding behind it)

The issue sketched `tcgetpgrp` / `proc_listpids` per-surface detection. I verified those are **not possible in the default mode**: GhosttyKit exposes no per-surface child PID and no PTY fd (`ghostty.h` has only `pwd` + a `child_exited` message), the app captures no shell PID, and the default `ghosttyManagedSplits` mode spawns shells inside libghostty — so there's no PID/fd anchor to attribute a shell to a surface.

The resolution ladder that *does* work:

1. **tmux-per-session mode →** the session's active pane command via `tmux -L workspaces list-panes -t '=<name>' -F '#{pane_active} #{pane_current_command}'`. Exact per-pane, so it disambiguates tabs that share a directory.
2. **All modes (incl. the default) →** the non-shell program running in the session's directory, reusing `WorkspaceProcessMonitor`'s `lsof -d cwd` match (the same mechanism the app already uses for agent detection). This is what gives the **default ghostty-splits mode** real detection rather than leaving it on the title.
3. terminal title → 4. directory basename (both already in the existing title path).

A bare shell resolves to nothing in the cwd path (shells are ignored) → title fallback; in tmux mode `pane_current_command` reports the shell name — both per the issue's acceptance.

**Limitation (honest):** the cwd path is directory-scoped, so sibling tabs in one directory can't be told apart outside tmux mode. True per-surface detection stays blocked on an upstream libghostty pid/fd exposure, filed as **#892** (related to but distinct from #889's investigation). I did not body-swap `PTYForegroundProbe`'s `AgentKind` stub — this is a new process-name capability, which is the correct read.

### What changed

- **`TmuxSessionProbe.foregroundCommand(forSessionNamed:)`** (Core) + pure `parseForegroundCommand` (active-pane preference, first-pane fallback). Adds an output-capturing runner alongside the existing exit-code one; all call sites use labels, so no breakage.
- **`TerminalForegroundProcessResolver`** (App) runs the ladder: tmux pane (tmux mode) → injected cwd resolver (`WorkspaceProcessMonitor` by default) → nil. 2s-cached per session; `preferredTabTitle` is the ladder tail.
- **`SidebarView`** resolves lazily when a hover card opens (fired from the card's `tabsProvider`, idempotent + cached, off the render hot path) and prefers the name for plain tabs in all modes. Session identity (directory + mode) is threaded in — not the unwired `surfaceID: 0`.

## Mergeability

- Surface: desktop (terminal sidebar + a Core probe helper)
- User-facing behavior changed: yes — a plain tab's hover-card line shows the real foreground program (e.g. `vim`) instead of the terminal title, in both multiplexing modes; a bare shell shows the shell name (tmux) or the title (cwd path); agent tabs unchanged.
- Non-happy paths considered: tmux query fails → cwd fallback; cwd has no non-shell program (bare shell) → nil → title/dir; empty/whitespace `pane_current_command` → nil; resolution is 2s-cached and idempotent so re-renders neither hammer `lsof`/tmux nor loop; the 5s `ProcessRunner` timeout bounds a wedged tmux server and the async resolve keeps it off the main-render path.
- Release/ops preconditions: none. No schema/persistence change.
- Residual risk or follow-up: directory-scoped ambiguity for sibling tabs outside tmux mode (advisory hover card; acceptable) — true per-surface detection tracked by #892. `lsof` cwd scanning runs only on hover and behind the 2s cache.

## Validation

- [x] `swift build`
- [x] `swift test` — **1171 tests in 180 suites passed**; new coverage: `TmuxSessionProbe` foreground parsing (active-pane preference, first-pane fallback, bare shell, empty→nil, command shape) + `TerminalForegroundProcessResolver` (ladder tail, tmux-prefers-pane, tmux→cwd fallback, ghostty→cwd resolves, bare-shell→nil, and cwd program selection skipping known agents)
- [x] `swift-format lint --strict` (`mise run lint`) clean
- [x] UI evidence via `ImageRenderer` (hover card with resolved names, headless — the sanctioned route for transient hover surfaces; screen locked)

**Mutation checks (all reverted):**
- `parseForegroundCommand` made to ignore `pane_active` → active-pane test failed (`zsh != vim`).
- `TerminalForegroundProcessResolver` cwd fallback removed → "ghostty-splits resolves via cwd" and "tmux falls back to cwd" failed (`nil != python`).
- `programName(from:)` agent-skip filter dropped → "cwd selection skips known agents" failed (`Claude != vim`).

Live end-to-end capture (driving a program into a real session and screenshotting the running app) was not run — the screen is locked and the brief directed the ImageRenderer route. The tmux-output→name and cwd→name paths are proven by unit tests against realistic inputs; the card display by the render test.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] UI evidence attached (hover card render) + test output + mutation checks

Evidence links:

- Hover card with real foreground process names: ![sidebar-foreground-process](https://evidence.cloudcompute.com/workspaces/pr-893/20260707-121448-666-foreground-card.png)
- Test output (foreground suites + full suite): ![666-tests](https://evidence.cloudcompute.com/workspaces/pr-893/20260707-122538-666-tests-v3.png)

## Blockers

- [x] None
