### PR TITLE
feat(review): native diff review surface (slice 1, #704 Phase 3)

### DIFF
--- a/Sources/WorkspaceManager/Views/Components/DiffReviewSheet.swift
+++ b/Sources/WorkspaceManager/Views/Components/DiffReviewSheet.swift
@@ -1,0 +1,71 @@
+//
+//  DiffReviewSheet.swift
+//  WorkspaceManager
+//
+//  Presents the native `DiffReviewView` for one changed file: loads the working-tree diff
+//  via `GitService`, provides the scroll container the render view expects, and shows quiet
+//  loading / empty / error states. Reused from the Changes tab and the just-saved edit path
+//  (see #704 Phase 3). Staging/discard controls are a later slice.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+struct DiffReviewSheet: View {
+    let filePath: String
+    let directoryURL: URL
+    let onClose: () -> Void
+
+    @Environment(\.gitService) private var gitService
+    @State private var phase: Phase = .loading
+
+    private enum Phase {
+        case loading
+        case loaded(UnifiedDiff)
+        case failed(String)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Review Diff")
+                    .font(.headline)
+                Spacer()
+                Button("Done", action: onClose)
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(12)
+            Divider()
+
+            switch phase {
+            case .loading:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .loaded(let diff):
+                ScrollView([.vertical, .horizontal]) {
+                    DiffReviewView(diff: diff)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            case .failed(let message):
+                ContentUnavailableView(
+                    "Could not load diff",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(message)
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .frame(minWidth: 480, minHeight: 360)
+        .task(id: filePath) { await load() }
+    }
+
+    private func load() async {
+        phase = .loading
+        do {
+            let diff = try await gitService.diff(file: filePath, at: directoryURL)
+            phase = .loaded(diff)
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/Components/DiffReviewView.swift
+++ b/Sources/WorkspaceManager/Views/Components/DiffReviewView.swift
@@ -1,0 +1,125 @@
+//
+//  DiffReviewView.swift
+//  WorkspaceManager
+//
+//  Native, read-only diff review surface: renders a parsed `UnifiedDiff` as coloured
+//  addition / removal / context rows with old|new line-number gutters. Staging, unstaging,
+//  and discard controls are intentionally absent in this slice — they land beside the review
+//  in a later slice (see #704 Phase 3).
+//
+//  The view lays out header + all rows in a plain stack; the presenting container provides
+//  scrolling (a `ScrollView`), which keeps this renderable under `ImageRenderer` for evidence.
+//
+
+import SwiftUI
+import WorkspaceManagerCore
+
+struct DiffReviewView: View {
+    let diff: UnifiedDiff
+
+    private var rows: [DiffReviewRow] { DiffReviewRowBuilder.rows(from: diff) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            if rows.isEmpty {
+                emptyState
+            } else {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(rows) { row in
+                        DiffReviewRowView(row: row)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "plusminus.circle")
+                .foregroundStyle(.secondary)
+            Text(diff.path)
+                .font(.callout.weight(.medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text("+\(diff.addedLines)")
+                .foregroundStyle(.green)
+            Text("-\(diff.removedLines)")
+                .foregroundStyle(.red)
+        }
+        .font(.callout)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "text.badge.checkmark")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("No changes to review")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+}
+
+private struct DiffReviewRowView: View {
+    let row: DiffReviewRow
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            gutter(row.oldLineNumber)
+            gutter(row.newLineNumber)
+            Text(marker)
+                .frame(width: 14, alignment: .center)
+                .foregroundStyle(markerColor)
+            Text(row.content.isEmpty ? " " : row.content)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, 8)
+        }
+        .font(.system(.caption, design: .monospaced))
+        .padding(.vertical, 1)
+        .background(background)
+        .foregroundStyle(row.kind == .hunkHeader ? Color.secondary : Color.primary)
+    }
+
+    private func gutter(_ number: Int?) -> some View {
+        Text(number.map(String.init) ?? "")
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .frame(width: 34, alignment: .trailing)
+            .padding(.trailing, 4)
+    }
+
+    private var marker: String {
+        switch row.kind {
+        case .addition: return "+"
+        case .removal: return "-"
+        case .context: return " "
+        case .hunkHeader: return ""
+        }
+    }
+
+    private var markerColor: Color {
+        switch row.kind {
+        case .addition: return .green
+        case .removal: return .red
+        default: return .secondary
+        }
+    }
+
+    private var background: Color {
+        switch row.kind {
+        case .addition: return Color.green.opacity(0.14)
+        case .removal: return Color.red.opacity(0.14)
+        case .hunkHeader: return Color.secondary.opacity(0.10)
+        case .context: return .clear
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
@@ -39,6 +39,7 @@ struct CodeFilePreviewView: View {
     @State private var state: LoadState = .loading
     @State private var isSaving = false
     @State private var saveErrorMessage: String?
+    @State private var isShowingDiffReview = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -107,6 +108,15 @@ struct CodeFilePreviewView: View {
                     .disabled(!canSaveDocument)
                     .help(canSaveDocument ? "Save File (Cmd+S)" : "No changes to save")
                     .accessibilityLabel("Save File")
+
+                    Button {
+                        isShowingDiffReview = true
+                    } label: {
+                        Image(systemName: "plusminus.circle")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Review working-tree diff")
+                    .accessibilityLabel("Review Diff")
                 }
 
                 if let defaultEditor {
@@ -214,6 +224,13 @@ struct CodeFilePreviewView: View {
         }
         .onChange(of: isSaving) { _, _ in
             syncSaveCommand()
+        }
+        .sheet(isPresented: $isShowingDiffReview) {
+            DiffReviewSheet(
+                filePath: selection.relativePath,
+                directoryURL: selection.rootURL,
+                onClose: { isShowingDiffReview = false }
+            )
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -138,6 +138,7 @@ struct RightPaneView: View {
     @EnvironmentObject private var workspaceJournal: WorkspaceJournal
     @ObservedObject private var state: RightPaneSessionState
     @ObservedObject private var notificationCoordinator = NotificationCoordinator.shared
+    @State private var reviewDiffTarget: FileChange?
 
     enum Tab: String, CaseIterable {
         case files = "Files"
@@ -250,7 +251,8 @@ struct RightPaneView: View {
                     ChangedFilesTabView(
                         changes: state.changedFiles,
                         isLoading: state.isLoading,
-                        onFileSelected: selectFile
+                        onFileSelected: selectFile,
+                        onReviewDiff: { reviewDiffTarget = $0 }
                     )
                 case .timeline:
                     TimelineTabView(
@@ -345,6 +347,15 @@ struct RightPaneView: View {
         }
         .onChange(of: notificationsEnabled) { _, _ in
             normalizeSelectedTab()
+        }
+        .sheet(item: $reviewDiffTarget) { change in
+            if let directoryURL {
+                DiffReviewSheet(
+                    filePath: change.path,
+                    directoryURL: directoryURL,
+                    onClose: { reviewDiffTarget = nil }
+                )
+            }
         }
     }
 
@@ -666,6 +677,7 @@ struct ChangedFilesTabView: View {
     let changes: [FileChange]
     let isLoading: Bool
     let onFileSelected: (String) -> Void
+    var onReviewDiff: (FileChange) -> Void = { _ in }
 
     var body: some View {
         if changes.isEmpty && !isLoading {
@@ -676,24 +688,35 @@ struct ChangedFilesTabView: View {
             )
         } else {
             List(changes) { change in
-                Button {
-                    onFileSelected(change.path)
-                } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: change.status.icon)
-                            .foregroundStyle(change.status.color)
-                            .frame(width: 16)
+                HStack(spacing: 6) {
+                    Button {
+                        onFileSelected(change.path)
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: change.status.icon)
+                                .foregroundStyle(change.status.color)
+                                .frame(width: 16)
 
-                        Text(change.path)
-                            .font(.system(.body, design: .monospaced))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                            Text(change.path)
+                                .font(.system(.body, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
 
-                        Spacer()
+                            Spacer(minLength: 4)
+                        }
+                        .contentShape(Rectangle())
+                        .padding(.vertical, 2)
                     }
-                    .padding(.vertical, 2)
+                    .buttonStyle(.plain)
+
+                    Button {
+                        onReviewDiff(change)
+                    } label: {
+                        Image(systemName: "plusminus.circle")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Review diff")
                 }
-                .buttonStyle(.plain)
             }
             .listStyle(.plain)
         }

--- a/Sources/WorkspaceManagerCore/Models/DiffReviewRow.swift
+++ b/Sources/WorkspaceManagerCore/Models/DiffReviewRow.swift
@@ -1,0 +1,86 @@
+//
+//  DiffReviewRow.swift
+//  WorkspaceManagerCore
+//
+//  Flat, render-ready row model for the native diff review surface. `DiffReviewRowBuilder`
+//  turns a parsed `UnifiedDiff` into a sequence of hunk-header and line rows, each tagged
+//  addition / removal / context and carrying the old/new line numbers a gutter shows. This
+//  transform is pure so the view stays a thin renderer (see #704 Phase 3).
+//
+
+import Foundation
+
+public struct DiffReviewRow: Identifiable, Equatable, Sendable {
+    public enum Kind: Equatable, Sendable {
+        case hunkHeader
+        case addition
+        case removal
+        case context
+    }
+
+    /// Stable position in the flattened row list.
+    public let id: Int
+    public let kind: Kind
+    public let content: String
+    /// Line number in the old file (nil for additions and hunk headers).
+    public let oldLineNumber: Int?
+    /// Line number in the new file (nil for removals and hunk headers).
+    public let newLineNumber: Int?
+
+    public init(id: Int, kind: Kind, content: String, oldLineNumber: Int?, newLineNumber: Int?) {
+        self.id = id
+        self.kind = kind
+        self.content = content
+        self.oldLineNumber = oldLineNumber
+        self.newLineNumber = newLineNumber
+    }
+}
+
+public enum DiffReviewRowBuilder {
+    /// Flatten `diff` into render rows, assigning per-side line numbers as the hunk advances.
+    public static func rows(from diff: UnifiedDiff) -> [DiffReviewRow] {
+        var rows: [DiffReviewRow] = []
+        for hunk in diff.hunks {
+            rows.append(
+                DiffReviewRow(
+                    id: rows.count,
+                    kind: .hunkHeader,
+                    content: hunkHeaderText(hunk),
+                    oldLineNumber: nil,
+                    newLineNumber: nil
+                )
+            )
+            var oldLine = hunk.oldStart
+            var newLine = hunk.newStart
+            for line in hunk.lines {
+                switch line.kind {
+                case .context:
+                    rows.append(
+                        DiffReviewRow(
+                            id: rows.count, kind: .context, content: line.content,
+                            oldLineNumber: oldLine, newLineNumber: newLine))
+                    oldLine += 1
+                    newLine += 1
+                case .added:
+                    rows.append(
+                        DiffReviewRow(
+                            id: rows.count, kind: .addition, content: line.content,
+                            oldLineNumber: nil, newLineNumber: newLine))
+                    newLine += 1
+                case .removed:
+                    rows.append(
+                        DiffReviewRow(
+                            id: rows.count, kind: .removal, content: line.content,
+                            oldLineNumber: oldLine, newLineNumber: nil))
+                    oldLine += 1
+                }
+            }
+        }
+        return rows
+    }
+
+    /// The `@@ -old,count +new,count @@` header line for a hunk.
+    public static func hunkHeaderText(_ hunk: UnifiedDiff.Hunk) -> String {
+        "@@ -\(hunk.oldStart),\(hunk.oldCount) +\(hunk.newStart),\(hunk.newCount) @@"
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/DiffReviewRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DiffReviewRenderTests.swift
@@ -1,0 +1,54 @@
+import AppKit
+import SwiftUI
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("DiffReviewView render")
+struct DiffReviewRenderTests {
+    /// Renders the native diff review surface for a sample UnifiedDiff to a non-empty image
+    /// (layout smoke) and, when `WORKSPACES_EVIDENCE_DIR` is set, writes a PNG for PR evidence
+    /// without launching the app.
+    @Test("Diff review renders additions/removals/context to a non-empty image")
+    func rendersDiff() throws {
+        let diff = UnifiedDiff(
+            path: "Sources/App/Feature.swift",
+            hunks: [
+                UnifiedDiff.Hunk(
+                    oldStart: 10, oldCount: 4, newStart: 10, newCount: 5,
+                    lines: [
+                        UnifiedDiff.Line(kind: .context, content: "func greet(_ name: String) {"),
+                        UnifiedDiff.Line(kind: .removed, content: "    print(\"hi \\(name)\")"),
+                        UnifiedDiff.Line(kind: .added, content: "    let message = \"hello, \\(name)\""),
+                        UnifiedDiff.Line(kind: .added, content: "    print(message)"),
+                        UnifiedDiff.Line(kind: .context, content: "}"),
+                    ]
+                )
+            ]
+        )
+
+        let view =
+            DiffReviewView(diff: diff)
+            .frame(width: 460, height: 200)
+            .background(Color(nsColor: .textBackgroundColor))
+            .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("diff-review.png")
+        try png.write(to: url)
+    }
+}

--- a/Tests/WorkspaceManagerTests/DiffReviewRowBuilderTests.swift
+++ b/Tests/WorkspaceManagerTests/DiffReviewRowBuilderTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("DiffReviewRowBuilder")
+struct DiffReviewRowBuilderTests {
+    private func sampleDiff() -> UnifiedDiff {
+        // @@ -1,3 +1,4 @@ : context, remove, add, add, context
+        UnifiedDiff(
+            path: "src/app.swift",
+            hunks: [
+                UnifiedDiff.Hunk(
+                    oldStart: 1, oldCount: 3, newStart: 1, newCount: 4,
+                    lines: [
+                        UnifiedDiff.Line(kind: .context, content: "let a = 1"),
+                        UnifiedDiff.Line(kind: .removed, content: "let b = 2"),
+                        UnifiedDiff.Line(kind: .added, content: "let b = 3"),
+                        UnifiedDiff.Line(kind: .added, content: "let c = 4"),
+                        UnifiedDiff.Line(kind: .context, content: "return a"),
+                    ]
+                )
+            ]
+        )
+    }
+
+    @Test("A hunk becomes a header row followed by its line rows in order")
+    func flattensHunkWithHeader() {
+        let rows = DiffReviewRowBuilder.rows(from: sampleDiff())
+        #expect(rows.count == 6)
+        #expect(rows[0].kind == .hunkHeader)
+        #expect(rows[0].content == "@@ -1,3 +1,4 @@")
+        #expect(rows.map(\.kind) == [.hunkHeader, .context, .removal, .addition, .addition, .context])
+        // Ids are the stable flattened positions.
+        #expect(rows.map(\.id) == [0, 1, 2, 3, 4, 5])
+    }
+
+    @Test("Removals carry only an old line number; additions carry only a new line number")
+    func lineNumbersMatchSide() {
+        let rows = DiffReviewRowBuilder.rows(from: sampleDiff())
+        let context1 = rows[1]
+        #expect(context1.kind == .context)
+        #expect(context1.oldLineNumber == 1 && context1.newLineNumber == 1)
+
+        let removal = rows[2]
+        #expect(removal.kind == .removal)
+        #expect(removal.oldLineNumber == 2 && removal.newLineNumber == nil)
+
+        let addition = rows[3]
+        #expect(addition.kind == .addition)
+        #expect(addition.oldLineNumber == nil && addition.newLineNumber == 2)
+
+        // After one removal + two additions, the trailing context advances both sides.
+        let context2 = rows[5]
+        #expect(context2.oldLineNumber == 3 && context2.newLineNumber == 4)
+    }
+
+    @Test("An empty diff produces no rows")
+    func emptyDiffHasNoRows() {
+        #expect(DiffReviewRowBuilder.rows(from: UnifiedDiff(path: "x", hunks: [])).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

First slice of #704's open half (Phase 3 native diff review). Adds a **native** diff review surface — no `WKWebView`, no web bundle — as the primary v1 review path.

- **`DiffReviewRowBuilder`** (Core) — a pure transform from a parsed `UnifiedDiff` to flat, render-ready rows: a hunk-header row per hunk, then addition / removal / context line rows, each carrying the old/new line numbers a gutter shows. Fully unit-tested.
- **`DiffReviewView`** (App) — a thin renderer over those rows (green additions, red removals, context, `@@` hunk headers, old|new gutters). Lays out header + rows in a plain stack so the presenting container owns scrolling (which keeps it renderable under `ImageRenderer`).
- **`DiffReviewSheet`** — loads a file's working-tree diff via `GitService.diff(file:at:)`, provides the scroll container, and shows quiet loading / empty / error states.

Opened from the two entry points the issue asks for:
- **Changes tab** — a per-row "Review diff" button (`ChangedFilesTabView.onReviewDiff` → sheet in `RightPaneView`).
- **Just-saved edit path** — a "Review Diff" button in the file preview/editor header (`CodeFilePreviewView`).

**Explicitly out of this slice:** stage / unstage / discard controls (slice 2 — the issue's "review controls are separate from editing" lane) and the Phase 4 dirty-navigation guard (slice 3, orchestrator-grade). #704 stays open for those; Phases 0-2 already shipped via #713/#720 (see the audit comment on the issue).

Refs #704 (not Closes).

## Mergeability

- Surface: desktop (right-pane review + a Core diff-row transform)
- User-facing behavior changed: yes, additive — a "Review diff" affordance in the Changes tab and the file preview header opens a native diff view for that file. No existing flow is altered (the Changes-tab file-open button and editor save/discard are unchanged; the review is a separate button and a sheet).
- Non-happy paths considered: empty diff → "No changes to review"; diff load failure → error state with the message; the transform handles hunks with only additions/only removals and empty-content context lines; the render view has no internal `ScrollView`, so `ImageRenderer` evidence is reliable.
- Release/ops preconditions: none. No schema/persistence change; uses the existing `GitService.diff` seam.
- Residual risk or follow-up: the two sheet triggers (button → `.sheet`) are standard SwiftUI and build-verified but were **not** live-validated (screen locked / swap tight per the current environment); the rendered content and the diff transform are covered by tests + ImageRenderer. Stage/unstage/discard and dirty-nav are deliberate follow-on slices.

## Validation

- [x] `swift build`
- [x] `swift test` — **1175 tests in 182 suites passed**; new coverage: `DiffReviewRowBuilder` (header + ordered rows, side-specific line numbers, empty diff) + `DiffReviewView` render smoke.
- [x] `swift-format lint --strict` (`mise run lint`) clean
- [x] UI evidence via `ImageRenderer` (native diff review render) — the sanctioned route for this environment (screen locked).

**Mutation check (reverted):** misclassified removed lines as context in `DiffReviewRowBuilder` → "hunk becomes header + ordered rows" and "removals carry only an old line number" both failed.

Live end-to-end (clicking Review in the running app against a real repo diff) was not run — screen locked; the transform is proven against a fixture `UnifiedDiff`, the view by the render test, and the diff fetch uses the existing tested `GitService.diff`.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] UI evidence attached (native diff review render) + test output + mutation check

Evidence links:

- Native diff review surface: ![diff-review](https://evidence.cloudcompute.com/workspaces/pr-894/20260707-130549-704-diff-review-render.png)
- Test output (diff-review suites + full suite): ![704-tests](https://evidence.cloudcompute.com/workspaces/pr-894/20260707-130550-704-tests.png)

## Blockers

- [x] None
