### PR TITLE
refactor(mission-control): unify sidebar attention onto the shared severity ladder (#680 slice 2)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/AgentChromeProjection.swift
+++ b/Sources/WorkspaceManagerCore/Services/AgentChromeProjection.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Presentation policy for projecting Agent Run State into WorkSpaces chrome.
-/// Callers get labels, semantic tone, severity, Attention, and notification
+/// Callers get labels, semantic tone, sidebar priority, attention, and notification
 /// policy from one Module instead of re-encoding Run State in each surface.
 public struct AgentChromeProjection: Sendable, Equatable {
     public enum Tone: Sendable, Equatable {
@@ -19,7 +19,6 @@ public struct AgentChromeProjection: Sendable, Equatable {
     public let accessibilityDescription: String
     public let commandPaletteDescriptor: String?
     public let tone: Tone
-    public let severity: Int
     public let sidebarPriority: Int
     public let demandsAttention: Bool
 
@@ -34,7 +33,6 @@ public struct AgentChromeProjection: Sendable, Equatable {
                 accessibilityDescription: "agent idle",
                 commandPaletteDescriptor: nil,
                 tone: .neutral,
-                severity: 1,
                 sidebarPriority: 1,
                 demandsAttention: false
             )
@@ -45,7 +43,6 @@ public struct AgentChromeProjection: Sendable, Equatable {
                 accessibilityDescription: "agent thinking",
                 commandPaletteDescriptor: "thinking",
                 tone: .running,
-                severity: 2,
                 sidebarPriority: 3,
                 demandsAttention: false
             )
@@ -56,7 +53,6 @@ public struct AgentChromeProjection: Sendable, Equatable {
                 accessibilityDescription: "agent running tool",
                 commandPaletteDescriptor: "running tool",
                 tone: .running,
-                severity: 3,
                 sidebarPriority: 3,
                 demandsAttention: false
             )
@@ -67,7 +63,6 @@ public struct AgentChromeProjection: Sendable, Equatable {
                 accessibilityDescription: "agent awaiting input",
                 commandPaletteDescriptor: "awaiting input",
                 tone: .attention,
-                severity: 4,
                 sidebarPriority: 4,
                 demandsAttention: true
             )
@@ -78,7 +73,6 @@ public struct AgentChromeProjection: Sendable, Equatable {
                 accessibilityDescription: "agent complete",
                 commandPaletteDescriptor: nil,
                 tone: .neutral,
-                severity: 1,
                 sidebarPriority: 1,
                 demandsAttention: false
             )
@@ -89,15 +83,10 @@ public struct AgentChromeProjection: Sendable, Equatable {
                 accessibilityDescription: "agent errored (\(category.rawValue))",
                 commandPaletteDescriptor: "errored",
                 tone: .critical,
-                severity: 5,
                 sidebarPriority: 5,
                 demandsAttention: true
             )
         }
-    }
-
-    public static func severity(of state: AgentRunState) -> Int {
-        runState(state).severity
     }
 
     public static func demandsAttention(_ state: AgentRunState) -> Bool {

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceStatusAggregator.swift
@@ -110,8 +110,8 @@ public final class WorkspaceStatusAggregator: ObservableObject {
 
     @Published public private(set) var workspaceStatuses: [UUID: AgentSessionStatus] = [:]
     @Published public private(set) var repoStatuses: [UUID: AgentSessionStatus] = [:]
-    /// Resolved repo or workspace targets currently demanding attention,
-    /// ordered by `lastAccessedAt` descending with their exact agent state.
+    /// Resolved repo or workspace targets currently demanding attention, ordered
+    /// attention-first by `SessionActivity.severity`, then `lastAccessedAt` descending.
     @Published public private(set) var attentionItems: [AttentionItem] = []
     /// Repo or workspace targets currently demanding attention, ordered by
     /// `lastAccessedAt` descending.
@@ -181,6 +181,13 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         let attentionEntries =
             (workspaceAttention + repoAttention)
             .sorted { lhs, rhs in
+                // Attention-first (the shared `SessionActivity` ladder), then recency, then a
+                // stable key — so the pill leads with what most needs the user (#680 slice 2).
+                let lhsSeverity = SessionActivity.from(lhs.status).severity
+                let rhsSeverity = SessionActivity.from(rhs.status).severity
+                if lhsSeverity != rhsSeverity {
+                    return lhsSeverity > rhsSeverity
+                }
                 if lhs.lastAccessedAt != rhs.lastAccessedAt {
                     return lhs.lastAccessedAt > rhs.lastAccessedAt
                 }
@@ -221,13 +228,8 @@ public final class WorkspaceStatusAggregator: ObservableObject {
         pruneAcknowledgements(for: Array(workspaceStatuses.values) + Array(repoStatuses.values))
     }
 
-    /// Severity ordering — higher number wins when choosing the bubbled state.
-    /// Both active agent states render blue in the sidebar, but a running tool
-    /// outranks a merely thinking agent when choosing one bubbled status.
-    public static func severity(of state: AgentRunState) -> Int {
-        AgentChromeProjection.severity(of: state)
-    }
-
+    /// Whether a run state should surface in the attention list. Severity ordering (which
+    /// bubbled state wins, and attention-list order) lives on `SessionActivity.severity`.
     public static func demandsAttention(_ state: AgentRunState) -> Bool {
         AgentChromeProjection.demandsAttention(state)
     }
@@ -235,8 +237,8 @@ public final class WorkspaceStatusAggregator: ObservableObject {
     private static func mostSevere(among statuses: [AgentSessionStatus]) -> AgentSessionStatus? {
         statuses
             .max { lhs, rhs in
-                let ls = severity(of: lhs.run)
-                let rs = severity(of: rhs.run)
+                let ls = SessionActivity.from(lhs).severity
+                let rs = SessionActivity.from(rhs).severity
                 if ls != rs { return ls < rs }
                 return lhs.lastEventAt < rhs.lastEventAt
             }

--- a/Tests/WorkspaceManagerTests/AgentChromeProjectionTests.swift
+++ b/Tests/WorkspaceManagerTests/AgentChromeProjectionTests.swift
@@ -11,7 +11,6 @@ struct AgentChromeProjectionTests {
         #expect(idle.summaryText == "Idle")
         #expect(idle.commandPaletteDescriptor == nil)
         #expect(idle.tone == .neutral)
-        #expect(idle.severity == 1)
         #expect(idle.sidebarPriority == 1)
         #expect(!idle.demandsAttention)
 
@@ -20,7 +19,6 @@ struct AgentChromeProjectionTests {
         #expect(thinking.summaryText == "Thinking…")
         #expect(thinking.commandPaletteDescriptor == "thinking")
         #expect(thinking.tone == .running)
-        #expect(thinking.severity == 2)
         #expect(thinking.sidebarPriority == 3)
         #expect(!thinking.demandsAttention)
 
@@ -29,7 +27,6 @@ struct AgentChromeProjectionTests {
         #expect(running.summaryText == "Running: Bash")
         #expect(running.commandPaletteDescriptor == "running tool")
         #expect(running.tone == .running)
-        #expect(running.severity == 3)
         #expect(running.sidebarPriority == 3)
         #expect(!running.demandsAttention)
 
@@ -38,7 +35,6 @@ struct AgentChromeProjectionTests {
         #expect(awaiting.summaryText == "Awaiting input")
         #expect(awaiting.commandPaletteDescriptor == "awaiting input")
         #expect(awaiting.tone == .attention)
-        #expect(awaiting.severity == 4)
         #expect(awaiting.sidebarPriority == 4)
         #expect(awaiting.demandsAttention)
 
@@ -47,7 +43,6 @@ struct AgentChromeProjectionTests {
         #expect(complete.summaryText == "Done")
         #expect(complete.commandPaletteDescriptor == nil)
         #expect(complete.tone == .neutral)
-        #expect(complete.severity == 1)
         #expect(complete.sidebarPriority == 1)
         #expect(!complete.demandsAttention)
 
@@ -56,7 +51,6 @@ struct AgentChromeProjectionTests {
         #expect(errored.summaryText == "Rate limited")
         #expect(errored.commandPaletteDescriptor == "errored")
         #expect(errored.tone == .critical)
-        #expect(errored.severity == 5)
         #expect(errored.sidebarPriority == 5)
         #expect(errored.demandsAttention)
     }

--- a/Tests/WorkspaceManagerTests/WorkspaceStatusAggregatorTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceStatusAggregatorTests.swift
@@ -36,7 +36,7 @@ struct WorkspaceStatusAggregatorTests {
         #expect(aggregator.attentionCount == 0)
     }
 
-    @Test("Attention list collects awaiting + errored, ordered by recency")
+    @Test("Attention list orders attention-first by severity, then recency")
     func attentionList() {
         let aggregator = WorkspaceStatusAggregator()
         let now = Date()
@@ -72,8 +72,10 @@ struct WorkspaceStatusAggregatorTests {
         )
 
         #expect(aggregator.attentionCount == 2)
-        #expect(aggregator.attentionItems.map(\.target) == [.workspace(recentAwaiting), .workspace(olderErrored)])
-        #expect(aggregator.attentionWorkspaces == [recentAwaiting, olderErrored])
+        // Severity-first: the older errored session outranks the more recent awaiting one
+        // (errored > awaitingInput on the shared ladder); recency only breaks ties.
+        #expect(aggregator.attentionItems.map(\.target) == [.workspace(olderErrored), .workspace(recentAwaiting)])
+        #expect(aggregator.attentionWorkspaces == [olderErrored, recentAwaiting])
     }
 
     @Test("Repo-root attention contributes to the global attention list")
@@ -103,8 +105,10 @@ struct WorkspaceStatusAggregatorTests {
         )
 
         #expect(aggregator.attentionCount == 2)
-        #expect(aggregator.attentionItems.map(\.target) == [.repo(repoID), .workspace(wsID)])
-        #expect(aggregator.attentionTargets == [.repo(repoID), .workspace(wsID)])
+        // Severity-first: the errored workspace outranks the awaiting repo root despite the
+        // repo root being more recently accessed.
+        #expect(aggregator.attentionItems.map(\.target) == [.workspace(wsID), .repo(repoID)])
+        #expect(aggregator.attentionTargets == [.workspace(wsID), .repo(repoID)])
         #expect(aggregator.attentionRepos == [repoID])
         #expect(aggregator.attentionWorkspaces == [wsID])
     }
@@ -337,22 +341,28 @@ struct WorkspaceStatusAggregatorTests {
         }
     }
 
-    @Test("Severity ordering matches the documented hierarchy")
-    func severityOrdering() {
-        let errored = WorkspaceStatusAggregator.severity(
-            of: .errored(category: .unknown, message: nil))
-        let awaiting = WorkspaceStatusAggregator.severity(of: .awaitingInput(reason: .custom))
-        let runningTool = WorkspaceStatusAggregator.severity(
-            of: .runningTool(name: "x", detail: nil))
-        let thinking = WorkspaceStatusAggregator.severity(of: .thinking)
-        let idle = WorkspaceStatusAggregator.severity(of: .idle)
-        let complete = WorkspaceStatusAggregator.severity(of: .complete)
+    @Test("Repo status bubbles the most severe child on the shared ladder")
+    func repoStatusBubblesMostSevere() {
+        let aggregator = WorkspaceStatusAggregator()
+        let now = Date()
+        let repoID = UUID()
+        aggregator.update(
+            workspaces: [
+                .init(workspaceID: UUID(), repoID: repoID, lastAccessedAt: now, status: status(run: .thinking)),
+                .init(
+                    workspaceID: UUID(), repoID: repoID, lastAccessedAt: now,
+                    status: status(run: .errored(category: .server, message: nil))),
+                .init(
+                    workspaceID: UUID(), repoID: repoID, lastAccessedAt: now,
+                    status: status(run: .runningTool(name: "grep", detail: nil))),
+            ],
+            repos: [.init(repoID: repoID, status: nil)]
+        )
 
-        #expect(errored > awaiting)
-        #expect(awaiting > runningTool)
-        #expect(runningTool > thinking)
-        #expect(thinking > idle)
-        #expect(idle == complete)
+        // errored is the most severe child, so it represents the repo.
+        let bubbled = aggregator.repoStatuses[repoID]?.run
+        let isErrored: Bool = { if case .errored = bubbled { return true } else { return false } }()
+        #expect(isErrored)
     }
 
     @Test("Workspaces without status are absent from workspaceStatuses")


### PR DESCRIPTION
## Summary

Slice 2 of #680: unify the sidebar/attention-pill lane onto the shared `SessionActivity.severity` ladder introduced in slice 1 (#896), and delete the duplicate encoding.

Before this, two lanes had drifted onto separate encodings of the same attention ladder:
- `WorkspaceStatusAggregator.attentionItems` ordered by **recency only** (`lastAccessedAt`), ignoring severity.
- Its repo-status bubbler (`mostSevere`) used `AgentChromeProjection.severity` — a *second* priority field that disagreed with `sidebarPriority` on exactly one state: `thinking` (2 vs 3). That's precisely the drift class #680 exists to remove.

What changed:
- **`attentionItems` orders attention-first** by `SessionActivity.severity`, then `lastAccessedAt` desc, then a stable key.
- **`mostSevere` bubbles via `SessionActivity.severity`** (its `lastEventAt` tiebreak preserved).
- **Deleted the duplicate ladder**: `WorkspaceStatusAggregator.severity(of:)`, `AgentChromeProjection.severity(of:)`, and the projection's `.severity` field. Swept every consumer first (only the aggregator and these tests read it) — no orphaned half-migration; `sidebarPriority` / `SessionActivity.severity` is now the single encoding.

Refs #680 (not Closes — slice 3, the latest-message snippet, remains).

### Two user-visible changes (both intended)

1. **The attention pill leads with the most severe session** (severity-first) instead of the most recently accessed. An errored session now ranks above a more-recent awaiting-input one.
2. **`thinking` now ties `running-tool` in repo bubbling.** When a repo's children mix *thinking* and *running-tool*, they now tie (both "agent working") and recency breaks the tie, where *running-tool* previously won. The old distinction (the 2-vs-3 drift) carried no user meaning.

## Mergeability

- Surface: desktop (Core status aggregation + shared ladder cleanup; no new UI)
- User-facing behavior changed: yes — the two ordering changes above. No layout/visual change; only which item leads the attention pill and which status a repo row bubbles in the thinking/running-tool mix.
- Non-happy paths considered: severity comparison uses the same `SessionActivity.from(status).severity` everywhere; recency/stable-key tiebreaks preserved; the deleted field's consumers were fully swept (aggregator + tests) so there is no dangling reference.
- Release/ops preconditions: none. No schema/persistence change.
- Residual risk or follow-up: low — Core-only ordering/merge change under the full suite; slice 3 (latest-message snippet from local state) remains and wants running-UI validation.

## Validation

- [x] `swift build`
- [x] `swift test` — **1176 tests in 183 suites passed**; attention-list + repo-root ordering tests updated to severity-first; new "Repo status bubbles the most severe child" test; the retired `AgentChromeProjection`/aggregator severity-field assertions are covered by `SessionActivityTests` (the shared ladder).
- [x] `swift-format lint --strict` (`mise run lint`) clean

**Mutation checks (both reverted):**
- Dropped the severity tiebreak in the `attentionItems` sort → "Attention list orders attention-first by severity" and "Repo-root attention…" failed (reverted to recency order).
- Inverted the `mostSevere` severity comparison → "Repo status bubbles the most severe child on the shared ladder" failed (bubbled the least-severe child).

No UI screenshot: no visual/layout change — the change is ordering/merge semantics, covered by the Core tests above.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test output attached (Core suites + full suite)

Evidence links:

- Test output (WorkspaceStatusAggregator + AgentChromeProjection + SessionActivity + full suite): ![680-slice2-tests](https://evidence.cloudcompute.com/workspaces/pr-897/20260707-135411-680-slice2-tests.png)

## Blockers

- [x] None
