### PR TITLE
feat(automation): browser.read web-surface listing (#679 slice 1)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -33,7 +33,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
     func configure(
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
-        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
+        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] }
     ) async {
         guard isEnabled else {
             tileTreeStore.configureAutomation(handleRegistry: nil, socketPath: nil)
@@ -44,7 +45,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             let socketPath = try await startIfNeeded(
                 tileTreeStore: tileTreeStore,
                 focusTerminal: focusTerminal,
-                requestCloseTerminal: requestCloseTerminal
+                requestCloseTerminal: requestCloseTerminal,
+                webSurfaceRecords: webSurfaceRecords
             )
             tileTreeStore.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
         } catch {
@@ -57,14 +59,23 @@ final class AutomationIntegrationLifecycle: ObservableObject {
     func startIfNeeded(
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
-        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
+        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] }
     ) async throws -> String {
+        // Compose the read-only web-surface list from the caller's live source records
+        // joined with the surface store's live WKWebView state (non-creating peek).
+        let webSurfaces = Self.makeWebSurfaces(
+            tileTreeStore: tileTreeStore,
+            webSurfaceRecords: webSurfaceRecords
+        )
+
         if let startTask {
             let socketPath = try await startTask.value
             controller?.update(
                 tileTreeStore: tileTreeStore,
                 focusTerminal: focusTerminal,
-                requestCloseTerminal: requestCloseTerminal
+                requestCloseTerminal: requestCloseTerminal,
+                webSurfaces: webSurfaces
             )
             return socketPath
         }
@@ -73,7 +84,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             controller?.update(
                 tileTreeStore: tileTreeStore,
                 focusTerminal: focusTerminal,
-                requestCloseTerminal: requestCloseTerminal
+                requestCloseTerminal: requestCloseTerminal,
+                webSurfaces: webSurfaces
             )
             guard let socketPath else {
                 throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
@@ -85,7 +97,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             handleRegistry: handleRegistry,
             tileTreeStore: tileTreeStore,
             focusTerminal: focusTerminal,
-            requestCloseTerminal: requestCloseTerminal
+            requestCloseTerminal: requestCloseTerminal,
+            webSurfaces: webSurfaces
         )
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
@@ -128,6 +141,20 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             Task { @MainActor [weak self] in await self?.stop() }
         }
         return listener.socketPath
+    }
+
+    private static func makeWebSurfaces(
+        tileTreeStore: TileTreeStore,
+        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord]
+    ) -> @MainActor () -> [AutomationWebSurfaceDescriptor] {
+        { [weak tileTreeStore] in
+            WebSurfaceEnumerator.descriptors(
+                records: webSurfaceRecords(),
+                liveState: { sourceID in
+                    tileTreeStore?.surfaceStore.liveWebState(forSourceID: sourceID)
+                }
+            )
+        }
     }
 
     func stop() async {

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -200,6 +200,13 @@ final class SurfaceStore {
         surfaces[tileID] as? WebSurface
     }
 
+    /// Live navigation state for an already-instantiated web surface, or `nil` when
+    /// none is live. A non-creating peek: unlike `webStore(forSourceID:)` it never
+    /// instantiates a store, so listing web surfaces can't spin up hidden WKWebViews.
+    func liveWebState(forSourceID sourceID: UUID) -> WebSurfaceLiveState? {
+        webStoresBySourceID[sourceID]?.liveState
+    }
+
     /// Get-or-create the shared per-source store backing `sourceID`'s web views.
     func webStore(forSourceID sourceID: UUID) -> WebSurfaceStore {
         if let store = webStoresBySourceID[sourceID] {

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -8,12 +8,14 @@ final class AutomationController: AutomationControlling {
     private var focusTerminal: @MainActor (UUID) -> Void
     private var requestCloseTerminal: @MainActor (UUID) -> Void
     private let isInputWriteEnabled: @MainActor () -> Bool
+    private var webSurfaces: @MainActor () -> [AutomationWebSurfaceDescriptor]
 
     init(
         handleRegistry: AutomationHandleRegistry,
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
+        webSurfaces: @escaping @MainActor () -> [AutomationWebSurfaceDescriptor] = { [] },
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
         }
@@ -22,17 +24,22 @@ final class AutomationController: AutomationControlling {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
         self.requestCloseTerminal = requestCloseTerminal
+        self.webSurfaces = webSurfaces
         self.isInputWriteEnabled = isInputWriteEnabled
     }
 
     func update(
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
-        requestCloseTerminal: @escaping @MainActor (UUID) -> Void
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
+        webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil
     ) {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
         self.requestCloseTerminal = requestCloseTerminal
+        if let webSurfaces {
+            self.webSurfaces = webSurfaces
+        }
     }
 
     func automationContext(for handle: String) throws -> AutomationContextResult {
@@ -44,6 +51,17 @@ final class AutomationController: AutomationControlling {
         let resolved = try resolve(handle, requiring: .surfacesRead)
         return AutomationSurfacesResult(
             surfaces: surfaceDescriptors(for: resolved),
+            system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
+        )
+    }
+
+    func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult {
+        // The caller is a terminal tile (resolve enforces that); browser.read lets it
+        // read the app's web surfaces, which are separate entities addressed by stable
+        // WebSource id, never the caller's own tile.
+        let resolved = try resolve(handle, requiring: .browserRead)
+        return AutomationWebSurfacesResult(
+            webSurfaces: webSurfaces(),
             system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
         )
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2035,7 +2035,8 @@ struct ContentView: View {
             },
             requestCloseTerminal: { sessionID in
                 requestCloseTerminalTabs([sessionID])
-            }
+            },
+            webSurfaceRecords: { webSources.map(WebSurfaceRecord.init(from:)) }
         )
     }
 

--- a/Sources/WorkspaceManager/Web/WebSurfaceEnumerator.swift
+++ b/Sources/WorkspaceManager/Web/WebSurfaceEnumerator.swift
@@ -1,0 +1,80 @@
+//
+//  WebSurfaceEnumerator.swift
+//  WorkspaceManager
+//
+//  Maps WorkSpaces web sources plus their live WKWebView state into the
+//  Automation API's read-only `AutomationWebSurfaceDescriptor` list. Pure and
+//  dependency-injected — records and live state are supplied by the caller — so
+//  the fail-closed rule (no live view → nil live fields, never a fabricated URL
+//  or title) is unit-testable without SwiftData or a WKWebView.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+/// Static, model-independent view of one WorkSpaces web source.
+struct WebSurfaceRecord: Sendable, Equatable {
+    let sourceID: UUID
+    let displayName: String
+    let configuredURL: String
+    let scope: AutomationWebSurfaceScope
+    let ownerID: UUID?
+}
+
+/// Live signal read from an instantiated web surface's `WKWebView`. Absent when
+/// no surface is currently backing the source.
+struct WebSurfaceLiveState: Sendable, Equatable {
+    let url: String?
+    let title: String?
+    let isLoading: Bool
+}
+
+extension WebSurfaceRecord {
+    init(from source: WebSource) {
+        let scope: AutomationWebSurfaceScope
+        let ownerID: UUID?
+        switch source.ownershipScope {
+        case .global:
+            scope = .global
+            ownerID = nil
+        case .repo(let id):
+            scope = .repo
+            ownerID = id
+        case .workspace(let id):
+            scope = .workspace
+            ownerID = id
+        }
+        self.init(
+            sourceID: source.id,
+            displayName: source.name,
+            configuredURL: source.baseURLString,
+            scope: scope,
+            ownerID: ownerID
+        )
+    }
+}
+
+enum WebSurfaceEnumerator {
+    /// Produces one descriptor per record, ordered as given. `liveState` returns the
+    /// live WKWebView signal for a source id, or `nil` when no surface is live — in
+    /// which case the descriptor reports `isLive == false` with nil live fields.
+    static func descriptors(
+        records: [WebSurfaceRecord],
+        liveState: (UUID) -> WebSurfaceLiveState?
+    ) -> [AutomationWebSurfaceDescriptor] {
+        records.map { record in
+            let live = liveState(record.sourceID)
+            return AutomationWebSurfaceDescriptor(
+                sourceID: record.sourceID,
+                scope: record.scope,
+                ownerID: record.ownerID,
+                displayName: record.displayName,
+                configuredURL: record.configuredURL,
+                liveURL: live?.url,
+                title: live?.title,
+                isLive: live != nil,
+                isLoading: live.map(\.isLoading)
+            )
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Web/WebSurfaceStore.swift
+++ b/Sources/WorkspaceManager/Web/WebSurfaceStore.swift
@@ -31,6 +31,19 @@ final class WebSurfaceStore: ObservableObject {
         activeSurface != nil
     }
 
+    /// Read-only snapshot of the live `WKWebView`'s navigation state for the
+    /// Automation API's browser-read list. Returns `nil` when no surface is
+    /// instantiated — the caller must not fabricate URL/title for a released view.
+    /// Does not instantiate a surface.
+    var liveState: WebSurfaceLiveState? {
+        guard let webView = activeSurface?.webView else { return nil }
+        return WebSurfaceLiveState(
+            url: webView.url?.absoluteString,
+            title: webView.title,
+            isLoading: webView.isLoading
+        )
+    }
+
     func ensureSurface(
         for source: WebSource,
         onBlockedNavigation: ((URL) -> Void)? = nil

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -12,6 +12,7 @@ public enum AutomationAPI {
         .tileFocus,
         .tileSplit,
         .tileClose,
+        .browserRead,
     ]
 
     /// V1 capabilities plus the experimental caller-scoped `input.write` grant.
@@ -28,6 +29,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case tileSplit = "tile.split"
     case tileClose = "tile.close"
     case inputWrite = "input.write"
+    case browserRead = "browser.read"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -122,6 +124,64 @@ public struct AutomationSurfaceDescriptor: Codable, Sendable, Equatable {
         self.isActive = isActive
         self.isVisible = isVisible
         self.capabilities = capabilities
+    }
+}
+
+public enum AutomationWebSurfaceScope: String, Codable, Sendable, Equatable {
+    case global
+    case repo
+    case workspace
+}
+
+/// Read-only descriptor for a WorkSpaces-owned embedded web surface (`browser.read`).
+/// Live fields (`liveURL`, `title`, `isLoading`) are populated only when an
+/// instantiated `WKWebView` backs the source; when none is live they are `nil` and
+/// `isLive` is `false` — the surface is never given a fabricated URL or title.
+/// `configuredURL` is the source's declared home, not a claim about the live page.
+public struct AutomationWebSurfaceDescriptor: Codable, Sendable, Equatable {
+    public let sourceID: UUID
+    public let scope: AutomationWebSurfaceScope
+    public let ownerID: UUID?
+    public let displayName: String
+    public let configuredURL: String
+    public let liveURL: String?
+    public let title: String?
+    public let isLive: Bool
+    public let isLoading: Bool?
+
+    public init(
+        sourceID: UUID,
+        scope: AutomationWebSurfaceScope,
+        ownerID: UUID?,
+        displayName: String,
+        configuredURL: String,
+        liveURL: String?,
+        title: String?,
+        isLive: Bool,
+        isLoading: Bool?
+    ) {
+        self.sourceID = sourceID
+        self.scope = scope
+        self.ownerID = ownerID
+        self.displayName = displayName
+        self.configuredURL = configuredURL
+        self.liveURL = liveURL
+        self.title = title
+        self.isLive = isLive
+        self.isLoading = isLoading
+    }
+}
+
+public struct AutomationWebSurfacesResult: Codable, Sendable, Equatable {
+    public let webSurfaces: [AutomationWebSurfaceDescriptor]
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        webSurfaces: [AutomationWebSurfaceDescriptor],
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor()
+    ) {
+        self.webSurfaces = webSurfaces
+        self.system = system
     }
 }
 
@@ -299,6 +359,7 @@ public struct AutomationServiceError: Error, Sendable, Equatable {
 public protocol AutomationControlling: AnyObject, Sendable {
     func automationContext(for handle: String) throws -> AutomationContextResult
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
+    func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult
     func automationFocusTile(
         for handle: String,
         direction: AutomationTileFocusDirection

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -59,6 +59,9 @@ enum AutomationHTTPRouter {
         case ("GET", "/v1/surfaces"):
             return try await controller.automationSurfaces(for: handle)
 
+        case ("GET", "/v1/web-surfaces"):
+            return try await controller.automationWebSurfaces(for: handle)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -91,6 +94,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/context.")
         case (_, "/v1/surfaces"):
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/surfaces.")
+        case (_, "/v1/web-surfaces"):
+            throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/web-surfaces.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -253,6 +258,7 @@ extension CodableSendableEquatable {
 extension AutomationHealthResult: CodableSendableEquatable {}
 extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
+extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationMutationResult: CodableSendableEquatable {}
 extension AutomationInputWriteResult: CodableSendableEquatable {}
 extension AutomationEmptyResult: CodableSendableEquatable {}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -196,6 +196,94 @@ struct AutomationControllerTests {
         }
     }
 
+    @Test("Web surface list returns provided descriptors for a browser.read handle")
+    func webSurfaceListReturnsDescriptors() throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "browser" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        let descriptor = AutomationWebSurfaceDescriptor(
+            sourceID: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+            scope: .global,
+            ownerID: nil,
+            displayName: "Docs",
+            configuredURL: "https://example.test",
+            liveURL: nil,
+            title: nil,
+            isLive: false,
+            isLoading: nil
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            webSurfaces: { [descriptor] }
+        )
+
+        let result = try controller.automationWebSurfaces(for: "browser")
+        #expect(result.webSurfaces == [descriptor])
+        #expect(result.system.capabilities.contains(.browserRead))
+    }
+
+    @Test("Web surface list denies handles without browser.read")
+    func webSurfaceListDeniesWithoutBrowserRead() throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "limited" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: [.contextRead]
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            webSurfaces: {
+                [
+                    AutomationWebSurfaceDescriptor(
+                        sourceID: UUID(),
+                        scope: .global,
+                        ownerID: nil,
+                        displayName: "Docs",
+                        configuredURL: "https://example.test",
+                        liveURL: nil,
+                        title: nil,
+                        isLive: false,
+                        isLoading: nil
+                    )
+                ]
+            }
+        )
+
+        do {
+            _ = try controller.automationWebSurfaces(for: "limited")
+            Issue.record("Expected browser.read to be required for web-surface listing")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+    }
+
     @Test("Input write requires the input.write capability")
     func inputWriteRequiresCapability() throws {
         let fixture = makeFixture()

--- a/Tests/WorkspaceManagerAppTests/WebSurfaceEnumeratorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WebSurfaceEnumeratorTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@Suite("WebSurfaceEnumerator")
+struct WebSurfaceEnumeratorTests {
+    private func record(
+        _ id: UUID,
+        name: String,
+        scope: AutomationWebSurfaceScope,
+        ownerID: UUID?
+    ) -> WebSurfaceRecord {
+        WebSurfaceRecord(
+            sourceID: id,
+            displayName: name,
+            configuredURL: "https://example.test/\(name)",
+            scope: scope,
+            ownerID: ownerID
+        )
+    }
+
+    @Test("A source with no live surface lists inactive with no fabricated URL or title")
+    func inactiveSourceFailsClosed() {
+        let id = UUID()
+        let descriptors = WebSurfaceEnumerator.descriptors(
+            records: [record(id, name: "docs", scope: .global, ownerID: nil)],
+            liveState: { _ in nil }
+        )
+
+        let descriptor = try! #require(descriptors.first)
+        #expect(descriptor.sourceID == id)
+        #expect(descriptor.scope == .global)
+        #expect(descriptor.configuredURL == "https://example.test/docs")
+        #expect(descriptor.isLive == false)
+        #expect(descriptor.liveURL == nil)
+        #expect(descriptor.title == nil)
+        #expect(descriptor.isLoading == nil)
+    }
+
+    @Test("A source with a live surface reports its live URL, title, and loading state")
+    func liveSourceReportsLiveState() {
+        let liveID = UUID()
+        let repoOwner = UUID()
+        let descriptors = WebSurfaceEnumerator.descriptors(
+            records: [record(liveID, name: "app", scope: .repo, ownerID: repoOwner)],
+            liveState: { id in
+                id == liveID
+                    ? WebSurfaceLiveState(url: "https://example.test/app/home", title: "Home", isLoading: true)
+                    : nil
+            }
+        )
+
+        let descriptor = try! #require(descriptors.first)
+        #expect(descriptor.scope == .repo)
+        #expect(descriptor.ownerID == repoOwner)
+        #expect(descriptor.isLive)
+        #expect(descriptor.liveURL == "https://example.test/app/home")
+        #expect(descriptor.title == "Home")
+        #expect(descriptor.isLoading == true)
+    }
+
+    @Test("Enumeration preserves order and maps each record independently")
+    func enumerationPreservesOrder() {
+        let liveID = UUID()
+        let inactiveID = UUID()
+        let descriptors = WebSurfaceEnumerator.descriptors(
+            records: [
+                record(liveID, name: "live", scope: .workspace, ownerID: UUID()),
+                record(inactiveID, name: "cold", scope: .global, ownerID: nil),
+            ],
+            liveState: { id in
+                id == liveID ? WebSurfaceLiveState(url: "https://example.test/live", title: "L", isLoading: false) : nil
+            }
+        )
+
+        #expect(descriptors.map(\.sourceID) == [liveID, inactiveID])
+        #expect(descriptors[0].isLive)
+        #expect(descriptors[1].isLive == false)
+    }
+}

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -48,6 +48,31 @@ private final class FakeAutomationController: AutomationControlling {
         return AutomationSurfacesResult(surfaces: [])
     }
 
+    var webSurfaceCalls: [String] = []
+
+    func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult {
+        guard handle != "nobrowser" else {
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include browser.read.")
+        }
+        _ = try automationContext(for: handle)
+        webSurfaceCalls.append(handle)
+        return AutomationWebSurfacesResult(
+            webSurfaces: [
+                AutomationWebSurfaceDescriptor(
+                    sourceID: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                    scope: .repo,
+                    ownerID: UUID(uuidString: "44444444-4444-4444-4444-444444444444"),
+                    displayName: "Docs",
+                    configuredURL: "https://example.test/docs",
+                    liveURL: nil,
+                    title: nil,
+                    isLive: false,
+                    isLoading: nil
+                )
+            ]
+        )
+    }
+
     func automationFocusTile(
         for handle: String,
         direction: AutomationTileFocusDirection
@@ -95,7 +120,7 @@ struct AutomationAPITests {
         let successText = String(data: successData, encoding: .utf8)
         #expect(
             successText
-                == #"{"ok":true,"result":{"status":"ok","system":{"capabilities":["context.read","surfaces.read","tile.focus","tile.split","tile.close"]}},"v":1}"#
+                == #"{"ok":true,"result":{"status":"ok","system":{"capabilities":["context.read","surfaces.read","tile.focus","tile.split","tile.close","browser.read"]}},"v":1}"#
         )
 
         let failure = AutomationResponseEnvelope<AutomationEmptyResult>(
@@ -379,6 +404,68 @@ struct AutomationAPITests {
         #expect(response.status == 403)
         #expect(envelope.error?.code == .capabilityDenied)
         #expect(controller.inputWrites.isEmpty)
+    }
+
+    @Test("Router lists web surfaces, denies under-capable handles, and rejects non-GET")
+    @MainActor
+    func routerWebSurfaces() async throws {
+        let controller = FakeAutomationController()
+
+        let listed = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/web-surfaces",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let listedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWebSurfacesResult>.self,
+            from: listed.body
+        )
+        #expect(listed.status == 200)
+        #expect(listedEnvelope.result?.webSurfaces.count == 1)
+        #expect(listedEnvelope.result?.webSurfaces.first?.displayName == "Docs")
+        // Fail-closed: an inactive source lists without a fabricated live URL/title.
+        #expect(listedEnvelope.result?.webSurfaces.first?.isLive == false)
+        #expect(listedEnvelope.result?.webSurfaces.first?.liveURL == nil)
+        #expect(controller.webSurfaceCalls == ["live"])
+
+        let denied = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/web-surfaces",
+                headers: [AutomationAPI.handleHeader: "nobrowser"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: denied.body
+        )
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/web-surfaces",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
     }
 
     @Test("CLI formatter emits result JSON and surfaces envelope errors")

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -54,7 +54,9 @@ not terminal input or output.
   `hostSessionID`.
 - Capabilities are enforced before each scoped operation.
 - Mutation routes are stable product verbs, not raw `TileTreeAction` exposure.
-- Browser mutation, resize/equalize, and global control are out of V1.
+- Browser **read** (listing WorkSpaces-owned web surfaces) is supported; browser
+  **mutation** (navigating, clicking, evaluating JS), resize/equalize, and global
+  control remain out of V1.
 - Input injection is caller-scoped only and double-gated behind the
   `Automation Input Write` experiment; see
   [Automation Input Write Decision](../decisions/automation-input-write.md).
@@ -86,6 +88,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | --- | --- |
 | `GET /v1/context` | Returns the caller's resolved context and capabilities. |
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
+| `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
 | `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Each successful split creates a new terminal surface in the caller's tab. Secondary split-tile callers return `unsupported` in V1. |
 | `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
@@ -111,6 +114,7 @@ handle.
 | --- | --- |
 | `context.read` | `GET /v1/context` |
 | `surfaces.read` | `GET /v1/surfaces` |
+| `browser.read` | `GET /v1/web-surfaces` (read-only web-surface listing; granted to default handles under the Automation API experiment) |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -189,9 +193,15 @@ If docs or public examples changed, also run the docs checks listed in
 
 ## V1 Non-Goals
 
-V1 does not support browser mutation, opening web URLs, tab title or metadata
+V1 does not support browser mutation (navigating, clicking, filling, or
+evaluating JavaScript in a web surface), opening web URLs, tab title or metadata
 changes, writing into other tiles, resize/equalize, or global cross-workspace
 control. Those capabilities require separate product and safety review before
-they can be added. Caller-scoped input injection is the one reviewed
-exception: it ships as the experimental, double-gated `input.write` capability
-(see [Automation Input Write Decision](../decisions/automation-input-write.md)).
+they can be added. Two reviewed exceptions widen the read/write surface
+deliberately: caller-scoped input injection ships as the experimental,
+double-gated `input.write` capability (see
+[Automation Input Write Decision](../decisions/automation-input-write.md)), and
+read-only web-surface listing ships as `browser.read` (`GET /v1/web-surfaces`),
+granted to default handles under the Automation API experiment. Web-surface
+snapshotting and any browser interaction remain out of scope pending the
+JavaScript-evaluation trust-boundary review.


### PR DESCRIPTION
## Summary

Slice 1 of #679: a **read-only browser plane** on the existing local Automation API. An agent running in a WorkSpaces terminal tile can now enumerate the app's WorkSpaces-owned web surfaces without scraping the UI — the first step toward agents verifying their own web changes against the same browser surface the user sees.

Rather than build a new control plane, this extends the mature Automation API V1 (local `automation.sock`, opaque capability-handle model, fail-closed scoping, audit log, experiment-gated) whose declared V1 non-goal was browser access. New:

- **`browser.read` capability** + **`GET /v1/web-surfaces`** returning, per source: stable `sourceID`, `scope` (global/repo/workspace) + `ownerID`, `displayName`, `configuredURL`, and — only when a `WKWebView` is live — `liveURL`, `title`, `isLoading`.
- **Fail-closed by construction:** a source with no instantiated surface lists with `isLive == false` and nil live fields — never a fabricated URL or title. Enumeration is a pure `WebSurfaceEnumerator` joining web-source records with a **non-creating** peek at live store state (`SurfaceStore.liveWebState` / `WebSurfaceStore.liveState`), so listing can't spin up hidden WKWebViews.
- `browser.read` is granted to default handles **under the existing Automation API experiment** — a read-only list doesn't warrant a sibling flag (noted here as a deliberate call). Browser **mutation** (navigate/click/JS eval) and snapshotting stay out, deferred behind the JS-eval trust-boundary review.

The rescope + phased plan is documented on the issue: [#679 comment](https://github.com/fairchild/workspaces/issues/679#issuecomment-4904764596). Not consolidated with #872 (layout vs. inspection — orthogonal, compose cleanly).

Refs #679

## Mergeability

- Surface: desktop (app-shell automation control plane) + agent-runtime seam
- User-facing behavior changed: No. New experimental, off-by-default read-only route; no UI change and no change for users who don't invoke automation.
- Non-happy paths considered: capability-denial (handle without `browser.read` → `capability_denied`), method-not-allowed (non-GET → 405), disabled experiment (→ `disabled`), and the core fail-closed rule (released/inactive `WKWebView` → inactive descriptor, never fabricated state). The list can't instantiate surfaces (non-creating peek), so it can't perturb the UI or steal focus. Caller identity stays resolved from the handle; web sources are addressed by stable id, never inferred from cwd/title.
- Release/ops preconditions: none. Additive route + capability; the capability joins the default grant only while the Automation API experiment is enabled.
- Residual risk or follow-up: slice 2 (bounded snapshot) and slice 3 (interact, gated) are separate follow-ups. The live URL/title path is exercised only by the app at runtime (see Evidence).

## Validation

- [x] `swift build`
- [x] `swift test` — 1182 tests / 184 suites pass
- [x] Other checks run: `mise run lint` (swift-format --strict) clean

**Mutation check:** weakened the gate in `automationWebSurfaces` from `requiring: .browserRead` to `.contextRead` (a capability the limited handle holds). The denial test `webSurfaceListDeniesWithoutBrowserRead` failed as intended (the under-capable handle was let through). Reverted; all green.

**Honest gap (live e2e):** the router/controller/enumerator logic — routing, capability-denial, and the fail-closed enumeration shape — is fully unit-tested behind protocols with no `WKWebView`. Proving live `liveURL`/`title` against a real released-on-inactive `WKWebView` needs the debug app on an unlocked desktop; that pass is queued (same convention as #893/#894). Slice 2's end-to-end snapshot verification waits for that desktop pass.

## Performance

- [x] Not a performance-sensitive change

## Evidence

- [x] Test evidence attached (test output)

Automation router + controller + enumerator suites (incl. the browser.read gate and fail-closed enumeration):

![679-browser-read](https://evidence.cloudcompute.com/workspaces/pr-898/20260707-141512-679-browser-read.png)

Evidence links:

- https://evidence.cloudcompute.com/workspaces/pr-898/20260707-141512-679-browser-read.png

## Blockers

- [x] None
