### PR TITLE
fix(web-next): force NODE_ENV=production on next build/e2e:server (#780)

### DIFF
--- a/web-next/package.json
+++ b/web-next/package.json
@@ -4,9 +4,9 @@
 	"private": true,
 	"scripts": {
 		"dev": "next dev --port 3100",
-		"build": "next build",
+		"build": "NODE_ENV=production next build",
 		"start": "next start --port 3100",
-		"e2e:server": "rm -f .data/e2e.db* && { test -f .next/BUILD_ID || next build; } && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port 3100",
+		"e2e:server": "rm -f .data/e2e.db* && { test -f .next/BUILD_ID || NODE_ENV=production next build; } && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port 3100",
 		"test": "vitest run",
 		"test:e2e": "playwright test",
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #780

## Problem

`next build` intermittently fails prerendering the built-in pages-router error surfaces (`/404`, `/500`, `/_error`) with:

```
Error: <Html> should not be imported outside of pages/_document.
```

## Root cause

Reproduced 100% (3/3 clean `.next` removals) locally. The trigger is the ambient shell's `NODE_ENV`. When `NODE_ENV=development` is set in the invoking shell — which is exactly what Claude Code (and likely other Node-based dev tooling) sets on its own process environment, and which leaks into any child `pnpm run build` invocation — Next's internal `pages/_document` compat module (`Html`/`Head`/`Main`/`NextScript`) ends up bundled into the shared error-page chunk in a way that breaks prerendering of `/_error`.

`next build` warns about this ("You are using a non-standard NODE_ENV value") but does not hard-fail on it, and does not fully override it either.

This explains the "CI is green but local build fails" mystery from the issue thread: GitHub Actions runners and Vercel's build environment never set `NODE_ENV=development` ambiently, so they were never exposed to this failure mode. `env -u NODE_ENV pnpm run build` reproduces CI's clean pass locally every time; `pnpm run build` under a Claude Code shell (ambient `NODE_ENV=development`) reproduces the failure every time.

## Fix

Force `NODE_ENV=production` explicitly on the `build` script and on the conditional `next build` inside `e2e:server`, so the build is deterministic regardless of the invoking shell's ambient environment. Minimal, two-line change to `web-next/package.json` — no application code touched.

## Mergeability

- Surface: web-next build tooling (`web-next/package.json` scripts only) — no application/runtime code changed.
- User-facing behavior changed: No. `next build` and `next start` already run in production mode; this only makes that explicit instead of implicit, closing a hole where an ambient dev-mode env var could corrupt the build.
- Non-happy paths considered: Verified the fix holds under the exact failure condition (ambient `NODE_ENV=development`, matching a Claude Code shell) and under a clean/CI-like shell (`NODE_ENV` unset). Also verified `e2e:server`'s conditional build path (used by local Playwright e2e) with the same guard.
- Residual risk or follow-up: None expected — inline `VAR=value cmd` works on macOS/Linux (bash/zsh), matching this repo's dev and CI platforms; no Windows dev workflow to break. A separate, pre-existing local-only e2e flake (`sessions.spec.ts` "empty home" test occasionally racing the lazy sqlite-file creation under high local worker concurrency) was found during verification — confirmed to reproduce identically with and without this fix, and confirmed CI (2 workers) has run it green in all 8 recent `web-next-ci` runs. Unrelated to #780; not addressed here.

## Evidence

**Build — reproduced (3/3 clean, ambient `NODE_ENV=development`, pre-fix):**
```
✓ Compiled successfully in ~17-29s
  Generating static pages (0/6) ...
Error: <Html> should not be imported outside of pages/_document.
Error occurred prerendering page "/404".
Export encountered an error on /_error: /404, exiting the build.
```

**Build — clean shell, `NODE_ENV` unset, pre-fix (matches CI):** 3/3 clean, all 6 routes generated, `/_not-found` static.

**Build — fixed `package.json`, ambient `NODE_ENV=development` restored (the actual failure condition): 3/3 clean**, all routes generated.

**`pnpm run lint`**: exit 0
**`pnpm run typecheck`**: exit 0
**`pnpm run test`**: 17 files / 159 tests passed

**`pnpm run test:e2e`** (against `next start`, built via the fixed `e2e:server` script): 22/22 passed on a single clean invocation (`.data`/`.next` removed, no stale server processes). Full logs captured locally during investigation (not uploaded — text-only build/test logs, no UI change to screenshot).

- CI: green quality lane (lint/typecheck/unit/build/e2e/perf) on e929819: https://github.com/fairchild/workspaces/actions/runs/28879521018/job/85663624820
- Gate note: orchestrator read the full 2-line diff; root-cause evidence (ambient NODE_ENV=development corrupts the pages-router error chunk; env -u NODE_ENV passes 3/3, re-adding it fails 3/3) reviewed; trivial diff so codex loop skipped per contract; merged on delegated authority.



<!-- readiness re-fire -->
