### PR TITLE
feat(web-next): GitHub-backed repo picker with validation + default branch

### DIFF
--- a/web-next/src/app/(app)/actions.ts
+++ b/web-next/src/app/(app)/actions.ts
@@ -7,12 +7,34 @@
 import { redirect } from "next/navigation";
 import { requireAuthorizedUser } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
-import { startSession } from "@/lib/db/start-session";
+import { RepoUnavailableError, startSession } from "@/lib/db/start-session";
 
-/** New-session flow: `repo` is an `owner/name`; creates the row and routes. */
-export async function createSessionAction(formData: FormData): Promise<void> {
+export interface CreateSessionState {
+	error?: string;
+}
+
+/**
+ * New-session flow: `repo` is an `owner/name`, validated against GitHub in
+ * `startSession`. On success it creates the row and redirects; on a repo
+ * GitHub can't find or the App can't access, it returns a calm inline error
+ * instead of throwing (paired with `useActionState` in `new-session.tsx`).
+ */
+export async function createSessionAction(
+	_prevState: CreateSessionState | null,
+	formData: FormData,
+): Promise<CreateSessionState> {
 	await requireAuthorizedUser();
 	const repo = String(formData.get("repo") ?? "");
-	const session = await startSession(getDatabase(), repo);
+	let session: Awaited<ReturnType<typeof startSession>>;
+	try {
+		session = await startSession(getDatabase(), repo);
+	} catch (error) {
+		if (error instanceof RepoUnavailableError) {
+			return {
+				error: `${repo} doesn't exist or isn't accessible — check the name and try again.`,
+			};
+		}
+		throw error;
+	}
 	redirect(`/sessions/${session.id}`);
 }

--- a/web-next/src/app/(app)/actions.ts
+++ b/web-next/src/app/(app)/actions.ts
@@ -7,7 +7,11 @@
 import { redirect } from "next/navigation";
 import { requireAuthorizedUser } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
-import { RepoUnavailableError, startSession } from "@/lib/db/start-session";
+import {
+	isValidRepoFullName,
+	RepoUnavailableError,
+	startSession,
+} from "@/lib/db/start-session";
 
 export interface CreateSessionState {
 	error?: string;
@@ -24,7 +28,12 @@ export async function createSessionAction(
 	formData: FormData,
 ): Promise<CreateSessionState> {
 	await requireAuthorizedUser();
-	const repo = String(formData.get("repo") ?? "");
+	const repo = String(formData.get("repo") ?? "").trim();
+	// The input's pattern blocks this in the UI; a direct POST gets the same
+	// calm state instead of an unhandled server-action throw.
+	if (!isValidRepoFullName(repo)) {
+		return { error: `${repo || "(empty)"} isn't an owner/name repository.` };
+	}
 	let session: Awaited<ReturnType<typeof startSession>>;
 	try {
 		session = await startSession(getDatabase(), repo);

--- a/web-next/src/app/(app)/new-session.tsx
+++ b/web-next/src/app/(app)/new-session.tsx
@@ -26,10 +26,10 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 	const [repos, setRepos] = useState<PickerRepo[] | null>(null);
 	const [degraded, setDegraded] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
-	const [state, formAction] = useActionState<CreateSessionState | null, FormData>(
-		createSessionAction,
-		null,
-	);
+	const [state, formAction, isPending] = useActionState<
+		CreateSessionState | null,
+		FormData
+	>(createSessionAction, null);
 
 	// Focus the owner/name field when the picker is revealed by hand (not on
 	// the empty home, where stealing focus would be presumptuous).
@@ -89,7 +89,8 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 								<input type="hidden" name="repo" value={repo.fullName} />
 								<button
 									type="submit"
-									className="w-full rounded-md px-2.5 py-2 text-left font-mono text-[13px] text-item-ink transition-colors hover:bg-hover-bg hover:text-accent"
+									disabled={isPending}
+									className="w-full rounded-md px-2.5 py-2 text-left font-mono text-[13px] text-item-ink transition-colors hover:bg-hover-bg hover:text-accent disabled:pointer-events-none disabled:opacity-60"
 								>
 									{repo.fullName}
 								</button>
@@ -98,7 +99,16 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 					))}
 				</ul>
 			)}
-			<form action={formAction} className="flex items-center gap-2.5 px-2.5 py-2">
+			<form
+				action={formAction}
+				// One shared action across every row form and this one: swallow
+				// re-submits while a create is in flight (double-Enter would queue
+				// a second session) without disabling the input and losing focus.
+				onSubmit={(event) => {
+					if (isPending) event.preventDefault();
+				}}
+				className="flex items-center gap-2.5 px-2.5 py-2"
+			>
 				<span aria-hidden className="font-mono text-[13px] text-accent">
 					›
 				</span>
@@ -118,7 +128,7 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 					className="min-w-0 flex-1 border-b border-line bg-transparent pb-1 font-mono text-[13px] text-ink transition-colors outline-none placeholder:text-faint focus:border-focus-line"
 				/>
 			</form>
-			{state?.error && (
+			{state?.error && !isPending && (
 				<p
 					data-testid="new-session-error"
 					className="px-2.5 pt-1 font-mono text-caption text-faint italic"

--- a/web-next/src/app/(app)/new-session.tsx
+++ b/web-next/src/app/(app)/new-session.tsx
@@ -14,16 +14,16 @@
 import { useActionState, useEffect, useRef, useState } from "react";
 import { createSessionAction, type CreateSessionState } from "./actions";
 
-interface DirectoryRepo {
+/** Mirror of the /api/repos response item (see mergeRepoLists). */
+interface PickerRepo {
 	fullName: string;
-	defaultBranch: string;
-	private: boolean;
+	defaultBranch: string | null;
 }
 
 export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 	const [open, setOpen] = useState(startOpen);
 	const [query, setQuery] = useState("");
-	const [repos, setRepos] = useState<DirectoryRepo[] | null>(null);
+	const [repos, setRepos] = useState<PickerRepo[] | null>(null);
 	const [degraded, setDegraded] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [state, formAction] = useActionState<CreateSessionState | null, FormData>(
@@ -37,13 +37,14 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 		if (open && !startOpen) inputRef.current?.focus();
 	}, [open, startOpen]);
 
-	// Fetch the installation's repos once, the first time the picker opens.
+	// Fetch the pickable repos (installation directory + already connected)
+	// once, the first time the picker opens.
 	useEffect(() => {
 		if (!open || repos !== null) return;
 		let cancelled = false;
 		fetch("/api/repos")
 			.then((res) => res.json())
-			.then((data: { repos: DirectoryRepo[]; degraded: boolean }) => {
+			.then((data: { repos: PickerRepo[]; degraded: boolean }) => {
 				if (cancelled) return;
 				setRepos(data.repos);
 				setDegraded(data.degraded);

--- a/web-next/src/app/(app)/new-session.tsx
+++ b/web-next/src/app/(app)/new-session.tsx
@@ -2,35 +2,59 @@
 
 /*
  * The new-session flow: a quiet "+ new session" affordance that reveals a
- * repo picker inline — known repos as one-click rows, plus an owner/name
- * field for connecting a repo that isn't in the table yet (no GitHub API
- * validation; single-user). Starts open when the home has nothing else to
- * show. Submission goes through the createSessionAction server action,
- * which creates the row and routes to the new session.
+ * repo picker inline — the GitHub App installation's repos as one-click rows
+ * (fetched from /api/repos, filtered live by the same field used to type a
+ * freetext owner/name), plus that field as the escape hatch for a repo not
+ * yet surfaced. Starts open when the home has nothing else to show.
+ * Submission goes through createSessionAction (via useActionState, shared
+ * across every row's form and the freetext form), which validates the repo
+ * against GitHub, creates the row, and routes to the new session — or
+ * returns a calm inline error if GitHub can't find or access it.
  */
-import { useEffect, useRef, useState } from "react";
-import { createSessionAction } from "./actions";
+import { useActionState, useEffect, useRef, useState } from "react";
+import { createSessionAction, type CreateSessionState } from "./actions";
 
-export interface PickableRepo {
-	id: string;
+interface DirectoryRepo {
 	fullName: string;
+	defaultBranch: string;
+	private: boolean;
 }
 
-export function NewSession({
-	repos,
-	startOpen = false,
-}: {
-	repos: PickableRepo[];
-	startOpen?: boolean;
-}) {
+export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 	const [open, setOpen] = useState(startOpen);
+	const [query, setQuery] = useState("");
+	const [repos, setRepos] = useState<DirectoryRepo[] | null>(null);
+	const [degraded, setDegraded] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const [state, formAction] = useActionState<CreateSessionState | null, FormData>(
+		createSessionAction,
+		null,
+	);
 
 	// Focus the owner/name field when the picker is revealed by hand (not on
 	// the empty home, where stealing focus would be presumptuous).
 	useEffect(() => {
 		if (open && !startOpen) inputRef.current?.focus();
 	}, [open, startOpen]);
+
+	// Fetch the installation's repos once, the first time the picker opens.
+	useEffect(() => {
+		if (!open || repos !== null) return;
+		let cancelled = false;
+		fetch("/api/repos")
+			.then((res) => res.json())
+			.then((data: { repos: DirectoryRepo[]; degraded: boolean }) => {
+				if (cancelled) return;
+				setRepos(data.repos);
+				setDegraded(data.degraded);
+			})
+			.catch(() => {
+				if (!cancelled) setRepos([]);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, repos]);
 
 	if (!open) {
 		return (
@@ -44,6 +68,10 @@ export function NewSession({
 		);
 	}
 
+	const visible = (repos ?? []).filter((repo) =>
+		repo.fullName.toLowerCase().includes(query.trim().toLowerCase()),
+	);
+
 	return (
 		<div
 			data-testid="new-session-picker"
@@ -52,11 +80,11 @@ export function NewSession({
 				if (event.key === "Escape" && !startOpen) setOpen(false);
 			}}
 		>
-			{repos.length > 0 && (
+			{visible.length > 0 && (
 				<ul className="mb-1">
-					{repos.map((repo) => (
-						<li key={repo.id}>
-							<form action={createSessionAction}>
+					{visible.map((repo) => (
+						<li key={repo.fullName}>
+							<form action={formAction}>
 								<input type="hidden" name="repo" value={repo.fullName} />
 								<button
 									type="submit"
@@ -69,10 +97,7 @@ export function NewSession({
 					))}
 				</ul>
 			)}
-			<form
-				action={createSessionAction}
-				className="flex items-center gap-2.5 px-2.5 py-2"
-			>
+			<form action={formAction} className="flex items-center gap-2.5 px-2.5 py-2">
 				<span aria-hidden className="font-mono text-[13px] text-accent">
 					›
 				</span>
@@ -80,16 +105,32 @@ export function NewSession({
 					ref={inputRef}
 					type="text"
 					name="repo"
+					value={query}
+					onChange={(event) => setQuery(event.target.value)}
 					required
 					pattern="[A-Za-z0-9][A-Za-z0-9_.\-]*\/[A-Za-z0-9_.\-]+"
 					title="owner/repository"
 					aria-label="Repository (owner/name)"
-					placeholder="owner/repository"
+					placeholder="owner/repository — search or connect"
 					autoComplete="off"
 					spellCheck={false}
 					className="min-w-0 flex-1 border-b border-line bg-transparent pb-1 font-mono text-[13px] text-ink transition-colors outline-none placeholder:text-faint focus:border-focus-line"
 				/>
 			</form>
+			{state?.error && (
+				<p
+					data-testid="new-session-error"
+					className="px-2.5 pt-1 font-mono text-caption text-faint italic"
+				>
+					{state.error}
+				</p>
+			)}
+			{degraded && !state?.error && (
+				<p className="px-2.5 pt-1 font-mono text-caption text-faint italic">
+					Repositories aren&apos;t verified against GitHub right now — entries
+					are accepted unverified.
+				</p>
+			)}
 		</div>
 	);
 }

--- a/web-next/src/app/(app)/page.tsx
+++ b/web-next/src/app/(app)/page.tsx
@@ -6,7 +6,6 @@
 import Link from "next/link";
 import { ThemeToggle } from "@/components/folio/theme-toggle";
 import { getDatabase } from "@/lib/db/client";
-import { listRepos } from "@/lib/db/repos";
 import { listSessions, type SessionListItem } from "@/lib/db/sessions";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { NewSession } from "./new-session";
@@ -48,10 +47,7 @@ function SessionRow({ session, index }: { session: SessionListItem; index: numbe
 
 export default async function SessionsHome() {
 	const handle = getDatabase();
-	const [sessions, repos] = await Promise.all([
-		listSessions(handle),
-		listRepos(handle),
-	]);
+	const sessions = await listSessions(handle);
 	const isEmpty = sessions.length === 0;
 
 	return (
@@ -73,7 +69,7 @@ export default async function SessionsHome() {
 							Start one on a repository.
 						</p>
 						<div className="w-full max-w-[380px]">
-							<NewSession repos={repos} startOpen />
+							<NewSession startOpen />
 						</div>
 					</div>
 				) : (
@@ -88,7 +84,7 @@ export default async function SessionsHome() {
 						</ul>
 						{/* The list ends in a quiet invitation, not a persistent button. */}
 						<div className="mt-4 px-2.5">
-							<NewSession repos={repos} />
+							<NewSession />
 						</div>
 					</>
 				)}

--- a/web-next/src/app/(app)/sessions/[id]/page.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/page.tsx
@@ -65,7 +65,8 @@ export default async function SessionPage({
 			session={{
 				masthead: {
 					repo: repoName,
-					branch: repo?.defaultBranch ?? "main",
+					// null (unknown/unverified) omits the segment — never claim "main".
+					branch: repo?.defaultBranch ?? null,
 					title: session.title || "New session",
 					agentName: "Claude",
 					stateLabel: "idle",

--- a/web-next/src/app/api/repos/route.ts
+++ b/web-next/src/app/api/repos/route.ts
@@ -1,15 +1,18 @@
 /*
  * GET /api/repos?q=<query> — auth-gated feed for the new-session picker's
- * searchable repo list. Backed by the GitHub App installation in real/bypass
- * mode (see `@/lib/github/repo-directory`); returns an empty list with
- * `degraded: true` when the App has no credentials configured, so the client
- * can fall back to an unverified-freetext note instead of an empty-looking
- * error.
+ * searchable repo list: the GitHub App installation's repos merged with the
+ * already-connected ones (see mergeRepoLists), so one-click rows survive
+ * even when the directory is empty. `degraded: true` when the App has no
+ * credentials configured, so the client can show the quiet unverified note
+ * instead of an empty-looking error.
  */
 import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { listRepos } from "@/lib/db/repos";
 import {
 	isDirectoryDegraded,
 	listDirectoryRepos,
+	mergeRepoLists,
 } from "@/lib/github/repo-directory";
 
 export const runtime = "nodejs";
@@ -23,8 +26,13 @@ export async function GET(request: Request) {
 		);
 	}
 
+	const [directory, connected] = await Promise.all([
+		listDirectoryRepos(),
+		listRepos(getDatabase()),
+	]);
+	const repos = mergeRepoLists(directory, connected);
+
 	const q = new URL(request.url).searchParams.get("q")?.trim().toLowerCase() ?? "";
-	const repos = await listDirectoryRepos();
 	const filtered = q
 		? repos.filter((repo) => repo.fullName.toLowerCase().includes(q))
 		: repos;

--- a/web-next/src/app/api/repos/route.ts
+++ b/web-next/src/app/api/repos/route.ts
@@ -1,0 +1,33 @@
+/*
+ * GET /api/repos?q=<query> — auth-gated feed for the new-session picker's
+ * searchable repo list. Backed by the GitHub App installation in real/bypass
+ * mode (see `@/lib/github/repo-directory`); returns an empty list with
+ * `degraded: true` when the App has no credentials configured, so the client
+ * can fall back to an unverified-freetext note instead of an empty-looking
+ * error.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+import {
+	isDirectoryDegraded,
+	listDirectoryRepos,
+} from "@/lib/github/repo-directory";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const q = new URL(request.url).searchParams.get("q")?.trim().toLowerCase() ?? "";
+	const repos = await listDirectoryRepos();
+	const filtered = q
+		? repos.filter((repo) => repo.fullName.toLowerCase().includes(q))
+		: repos;
+
+	return Response.json({ repos: filtered, degraded: isDirectoryDegraded() });
+}

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -7,7 +7,8 @@ import { ThemeToggle } from "./theme-toggle";
 
 export interface MastheadData {
 	repo: string;
-	branch: string;
+	/** `null` = unknown (repo connected unverified); the segment is omitted. */
+	branch: string | null;
 	title: string;
 	agentName: string;
 	/** e.g. "sandbox active"; `live` adds the green halo dot. */
@@ -24,8 +25,12 @@ export function SessionMasthead({ session }: { session: MastheadData }) {
 		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between gap-3 border-b border-line bg-mast-bg px-5 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1] sm:px-8">
 			<span className="min-w-0 truncate whitespace-nowrap">
 				<b className="font-medium text-ink">{session.repo}</b>
-				<Separator />
-				{session.branch}
+				{session.branch && (
+					<>
+						<Separator />
+						{session.branch}
+					</>
+				)}
 			</span>
 			<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint md:block">
 				{session.title}

--- a/web-next/src/lib/db/repos.ts
+++ b/web-next/src/lib/db/repos.ts
@@ -47,10 +47,16 @@ export async function getRepo(
 	return row ? rowToRepo(row) : undefined;
 }
 
-/** The repo named `fullName`, created if this is its first mention. */
+/**
+ * The repo named `fullName`, created if this is its first mention.
+ * `defaultBranch`, when given, is recorded on creation and backfilled onto an
+ * already-connected repo whose branch is still unknown or has since changed
+ * (e.g. a repo connected before GitHub validation existed, or renamed since).
+ */
 export async function ensureRepo(
 	handle: DatabaseHandle,
 	fullName: string,
+	defaultBranch: string | null = null,
 ): Promise<Repo> {
 	await ensureSchema(handle);
 	const existing = await handle.db
@@ -58,12 +64,22 @@ export async function ensureRepo(
 		.selectAll()
 		.where("full_name", "=", fullName)
 		.executeTakeFirst();
-	if (existing) return rowToRepo(existing);
+	if (existing) {
+		if (defaultBranch && existing.default_branch !== defaultBranch) {
+			await handle.db
+				.updateTable("repos")
+				.set({ default_branch: defaultBranch })
+				.where("id", "=", existing.id)
+				.execute();
+			return rowToRepo({ ...existing, default_branch: defaultBranch });
+		}
+		return rowToRepo(existing);
+	}
 
 	const row: ReposTable = {
 		id: fullName,
 		full_name: fullName,
-		default_branch: null,
+		default_branch: defaultBranch,
 		created_at: new Date().toISOString(),
 	};
 	await handle.db.insertInto("repos").values(row).execute();

--- a/web-next/src/lib/db/start-session.test.ts
+++ b/web-next/src/lib/db/start-session.test.ts
@@ -1,12 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { DEFAULT_MODEL } from "../agent-runtime/models";
 import { type DatabaseHandle, openDatabase } from "./client";
 import { ensureRepo, listRepos } from "./repos";
 import { listSessions } from "./sessions";
-import { isValidRepoFullName, startSession } from "./start-session";
+import { isValidRepoFullName, RepoUnavailableError, startSession } from "./start-session";
 
 let open: DatabaseHandle | undefined;
 let dir: string | undefined;
@@ -22,6 +22,7 @@ afterEach(async () => {
 	open = undefined;
 	if (dir) rmSync(dir, { recursive: true, force: true });
 	dir = undefined;
+	vi.unstubAllEnvs();
 });
 
 describe("isValidRepoFullName", () => {
@@ -43,6 +44,37 @@ describe("isValidRepoFullName", () => {
 		]) {
 			expect(isValidRepoFullName(bad), bad).toBe(false);
 		}
+	});
+});
+
+describe("ensureRepo (default_branch recording)", () => {
+	test("records the given default branch on a new repo", async () => {
+		const handle = freshDb();
+		const repo = await ensureRepo(handle, "fairchild/workspaces", "develop");
+		expect(repo.defaultBranch).toBe("develop");
+	});
+
+	test("backfills the default branch onto an existing repo that lacks one", async () => {
+		const handle = freshDb();
+		await ensureRepo(handle, "fairchild/workspaces");
+		const updated = await ensureRepo(handle, "fairchild/workspaces", "develop");
+		expect(updated.defaultBranch).toBe("develop");
+		const [persisted] = await listRepos(handle);
+		expect(persisted.defaultBranch).toBe("develop");
+	});
+
+	test("updates the default branch when it has changed since last connect", async () => {
+		const handle = freshDb();
+		await ensureRepo(handle, "fairchild/workspaces", "main");
+		const updated = await ensureRepo(handle, "fairchild/workspaces", "trunk");
+		expect(updated.defaultBranch).toBe("trunk");
+	});
+
+	test("leaves an existing branch alone when called without one", async () => {
+		const handle = freshDb();
+		await ensureRepo(handle, "fairchild/workspaces", "main");
+		const untouched = await ensureRepo(handle, "fairchild/workspaces");
+		expect(untouched.defaultBranch).toBe("main");
 	});
 });
 
@@ -80,6 +112,48 @@ describe("startSession", () => {
 		);
 		expect(await listRepos(handle)).toHaveLength(0);
 		expect(await listSessions(handle)).toHaveLength(0);
+	});
+
+	// The GitHub validation step (see ../github/repo-directory): bypass mode
+	// gives deterministic fixtures, so these stay hermetic unit tests.
+	describe("GitHub validation (bypass fixtures)", () => {
+		test("records the real default_branch from the fixture on first connect", async () => {
+			vi.stubEnv("AUTH_BYPASS", "1");
+			const handle = freshDb();
+			await startSession(handle, "fairchild/web-next-fixtures");
+			const [repo] = await listRepos(handle);
+			expect(repo.defaultBranch).toBe("trunk");
+		});
+
+		test("rejects a repo the fixture directory doesn't recognize, writing nothing", async () => {
+			vi.stubEnv("AUTH_BYPASS", "1");
+			const handle = freshDb();
+			await expect(
+				startSession(handle, "fairchild/not-a-real-repo"),
+			).rejects.toBeInstanceOf(RepoUnavailableError);
+			expect(await listRepos(handle)).toHaveLength(0);
+			expect(await listSessions(handle)).toHaveLength(0);
+		});
+
+		test("backfills the default_branch onto a repo connected before validation existed", async () => {
+			vi.stubEnv("AUTH_BYPASS", "1");
+			const handle = freshDb();
+			await ensureRepo(handle, "fairchild/web-next-fixtures"); // no branch yet
+			await startSession(handle, "fairchild/web-next-fixtures");
+			const [repo] = await listRepos(handle);
+			expect(repo.defaultBranch).toBe("trunk");
+		});
+	});
+
+	// No AUTH_BYPASS and no App creds in this test run (see vitest.config.ts /
+	// CI): startSession runs in degraded mode here, same as unset env in prod
+	// local dev — freetext is accepted unverified rather than blocked.
+	test("degraded mode (no App creds) accepts any shape-valid repo unverified", async () => {
+		const handle = freshDb();
+		const session = await startSession(handle, "anyone/anything");
+		expect(session.repoId).toBe("anyone/anything");
+		const [repo] = await listRepos(handle);
+		expect(repo.defaultBranch).toBeNull();
 	});
 });
 

--- a/web-next/src/lib/db/start-session.ts
+++ b/web-next/src/lib/db/start-session.ts
@@ -5,12 +5,15 @@
  * stays a thin auth-gated shell.
  */
 import type { DatabaseHandle } from "./client";
+import { RepoUnavailableError, resolveRepo } from "../github/repo-directory";
 import { ensureRepo } from "./repos";
 import { createSession, type Session } from "./sessions";
 
+export { RepoUnavailableError };
+
 // GitHub's rules, loosely: owner and name from [A-Za-z0-9_.-], no slashes
-// beyond the separator. No API validation yet (single-user; typos are the
-// user's own repos to correct).
+// beyond the separator. This is the shape check only; existence + access are
+// confirmed against GitHub by resolveRepo() below.
 const REPO_FULL_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+$/;
 
 export function isValidRepoFullName(value: string): boolean {
@@ -27,8 +30,11 @@ export function defaultComputeProvider(): string {
 }
 
 /**
- * Creates (or reuses) the repo and starts an empty session on it.
- * Title stays empty until a first turn names it; the provider comes from
+ * Creates (or reuses) the repo and starts an empty session on it. Validates
+ * `repoFullName` against GitHub first (see `../github/repo-directory`) —
+ * throws `RepoUnavailableError` if it doesn't exist or isn't accessible to
+ * the App — and records the real default branch on connect. Title stays
+ * empty until a first turn names it; the provider comes from
  * `defaultComputeProvider()` (mock unless configured otherwise).
  */
 export async function startSession(
@@ -39,7 +45,8 @@ export async function startSession(
 	if (!isValidRepoFullName(trimmed)) {
 		throw new Error(`not an owner/name repository: ${JSON.stringify(trimmed)}`);
 	}
-	const repo = await ensureRepo(handle, trimmed);
+	const { defaultBranch } = await resolveRepo(trimmed);
+	const repo = await ensureRepo(handle, trimmed, defaultBranch);
 	return createSession(handle, {
 		id: crypto.randomUUID(),
 		repoId: repo.id,

--- a/web-next/src/lib/diag/github-app.test.ts
+++ b/web-next/src/lib/diag/github-app.test.ts
@@ -1,6 +1,11 @@
 import crypto from "node:crypto";
-import { describe, expect, it } from "vitest";
-import { generateAppJWT, normalizePrivateKey } from "./github-app";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	generateAppJWT,
+	listAppInstallations,
+	listInstallationRepositories,
+	normalizePrivateKey,
+} from "./github-app";
 
 // A throwaway RSA keypair — the App private-key handling and RS256 signing are
 // the error-prone parts (base64 vs PEM, correct signature), so verify them
@@ -53,5 +58,71 @@ describe("generateAppJWT", () => {
 		expect(
 			verifier.verify(publicKey, Buffer.from(signature, "base64url")),
 		).toBe(true);
+	});
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("listAppInstallations", () => {
+	it("maps the installations list to id + account login", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				Response.json([
+					{ id: 42, account: { login: "fairchild" } },
+					{ id: 43, account: { login: "some-org" } },
+				]),
+			),
+		);
+		await expect(listAppInstallations("jwt")).resolves.toEqual([
+			{ id: 42, account: "fairchild" },
+			{ id: 43, account: "some-org" },
+		]);
+	});
+
+	it("throws with the response status and body on failure", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("nope", { status: 401 })),
+		);
+		await expect(listAppInstallations("jwt")).rejects.toThrow(/401/);
+	});
+});
+
+describe("listInstallationRepositories", () => {
+	it("maps the repositories list to fullName/defaultBranch/private", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				Response.json({
+					repositories: [
+						{
+							full_name: "fairchild/workspaces",
+							default_branch: "main",
+							private: false,
+						},
+						{
+							full_name: "fairchild/dotfiles",
+							default_branch: "master",
+							private: true,
+						},
+					],
+				}),
+			),
+		);
+		await expect(listInstallationRepositories("token")).resolves.toEqual([
+			{ fullName: "fairchild/workspaces", defaultBranch: "main", private: false },
+			{ fullName: "fairchild/dotfiles", defaultBranch: "master", private: true },
+		]);
+	});
+
+	it("throws with the response status and body on failure", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("forbidden", { status: 403 })),
+		);
+		await expect(listInstallationRepositories("token")).rejects.toThrow(/403/);
 	});
 });

--- a/web-next/src/lib/diag/github-app.ts
+++ b/web-next/src/lib/diag/github-app.ts
@@ -59,6 +59,28 @@ export async function findInstallationId(jwt: string, repo: string): Promise<num
 	return json.id;
 }
 
+/**
+ * Every installation of this App — the repo-picker's route in when there is
+ * no specific repo to key off yet (unlike findInstallationId). Single-user
+ * product: callers take the first installation and don't expect more than one.
+ */
+export async function listAppInstallations(
+	jwt: string,
+): Promise<Array<{ id: number; account: string }>> {
+	const res = await fetch(`${GH}/app/installations`, {
+		headers: { Authorization: `Bearer ${jwt}`, ...HEADERS },
+	});
+	if (!res.ok) return ghError(res, "list app installations");
+	const json = (await res.json()) as Array<{
+		id: number;
+		account: { login: string } | null;
+	}>;
+	return json.map((installation) => ({
+		id: installation.id,
+		account: installation.account?.login ?? "",
+	}));
+}
+
 export interface InstallationToken {
 	token: string;
 	expiresAt: string;
@@ -123,4 +145,58 @@ export async function verifyRepoAccess(
 		defaultBranch: json.default_branch,
 		private: json.private,
 	};
+}
+
+export interface DirectoryRepo {
+	fullName: string;
+	defaultBranch: string;
+	private: boolean;
+}
+
+/** Every repo the installation token's installation can see — the picker's raw feed. */
+export async function listInstallationRepositories(
+	token: string,
+): Promise<DirectoryRepo[]> {
+	const res = await fetch(`${GH}/installation/repositories?per_page=100`, {
+		headers: { Authorization: `token ${token}`, ...HEADERS },
+	});
+	if (!res.ok) return ghError(res, "list installation repositories");
+	const json = (await res.json()) as {
+		repositories: Array<{
+			full_name: string;
+			default_branch: string;
+			private: boolean;
+		}>;
+	};
+	return json.repositories.map((repo) => ({
+		fullName: repo.full_name,
+		defaultBranch: repo.default_branch,
+		private: repo.private,
+	}));
+}
+
+/**
+ * End-to-end for listing (mintInstallationToken above is end-to-end for one
+ * known repo): read the App id + key, take the App's first installation —
+ * this product installs the App on one account — and mint a token scoped to
+ * everything that installation can see.
+ */
+export async function mintDirectoryToken(): Promise<{
+	token: string;
+	installationId: number;
+}> {
+	const appId = process.env.GITHUB_WEB_WORKSPACES_APP_ID;
+	const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+	if (!appId || !privateKey) {
+		throw new Error(
+			"GITHUB_WEB_WORKSPACES_APP_ID and GITHUB_APP_PRIVATE_KEY are required to mint an installation token",
+		);
+	}
+	const jwt = generateAppJWT(appId, privateKey);
+	const installations = await listAppInstallations(jwt);
+	if (installations.length === 0) {
+		throw new Error("the GitHub App has no installations");
+	}
+	const { token } = await getInstallationToken(jwt, installations[0].id);
+	return { token, installationId: installations[0].id };
 }

--- a/web-next/src/lib/github/repo-directory.test.ts
+++ b/web-next/src/lib/github/repo-directory.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Covers all three repo-directory modes: bypass fixtures (the hermetic e2e
+ * seam), degraded (no App creds — never blocks), and configured (real GitHub
+ * calls, network mocked here so these stay unit tests).
+ */
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	isDirectoryDegraded,
+	listDirectoryRepos,
+	resolveRepo,
+	RepoUnavailableError,
+	validateDirectoryRepo,
+} from "./repo-directory";
+
+const { privateKey } = crypto.generateKeyPairSync("rsa", {
+	modulusLength: 2048,
+	publicKeyEncoding: { type: "spki", format: "pem" },
+	privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.unstubAllEnvs();
+});
+
+describe("bypass mode (AUTH_BYPASS=1)", () => {
+	it("lists the deterministic fixture repos, alphabetical", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
+		await expect(listDirectoryRepos()).resolves.toEqual([
+			{ fullName: "fairchild/dotfiles", defaultBranch: "main", private: false },
+			{
+				fullName: "fairchild/web-next-fixtures",
+				defaultBranch: "trunk",
+				private: true,
+			},
+			{ fullName: "fairchild/workspaces", defaultBranch: "main", private: false },
+		]);
+	});
+
+	it("validates a fixture repo as ok, case-insensitively", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
+		await expect(validateDirectoryRepo("Fairchild/Workspaces")).resolves.toEqual({
+			kind: "ok",
+			fullName: "fairchild/workspaces",
+			defaultBranch: "main",
+			private: false,
+		});
+	});
+
+	it("resolves a non-fixture repo as not-found without touching the network", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
+		const fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+		await expect(
+			validateDirectoryRepo("fairchild/does-not-exist"),
+		).resolves.toEqual({ kind: "not-found", fullName: "fairchild/does-not-exist" });
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("is never degraded", () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
+		expect(isDirectoryDegraded()).toBe(false);
+	});
+});
+
+describe("degraded mode (no App creds, no bypass)", () => {
+	it("reports degraded", () => {
+		vi.stubEnv("AUTH_BYPASS", "");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		expect(isDirectoryDegraded()).toBe(true);
+	});
+
+	it("lists no repos rather than throwing", async () => {
+		vi.stubEnv("AUTH_BYPASS", "");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		await expect(listDirectoryRepos()).resolves.toEqual([]);
+	});
+
+	it("validates any shape-valid repo as unverified, not blocking", async () => {
+		vi.stubEnv("AUTH_BYPASS", "");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		await expect(validateDirectoryRepo("anyone/anything")).resolves.toEqual({
+			kind: "unverified",
+			fullName: "anyone/anything",
+		});
+	});
+
+	it("resolveRepo accepts unverified without a default branch", async () => {
+		vi.stubEnv("AUTH_BYPASS", "");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		await expect(resolveRepo("anyone/anything")).resolves.toEqual({
+			defaultBranch: null,
+		});
+	});
+});
+
+describe("configured mode (App creds present, GitHub mocked)", () => {
+	function stubEnv() {
+		vi.stubEnv("AUTH_BYPASS", "");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "123456");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", privateKey);
+	}
+
+	it("validates an accessible repo as ok with its real default branch", async () => {
+		stubEnv();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/repos/fairchild/workspaces/installation")) {
+					return Response.json({ id: 99 });
+				}
+				if (url.endsWith("/app/installations/99/access_tokens")) {
+					return Response.json({
+						token: "ghs_token",
+						expires_at: "2026-01-01T00:00:00Z",
+						permissions: { contents: "read" },
+					});
+				}
+				if (url.endsWith("/repos/fairchild/workspaces")) {
+					return Response.json({
+						full_name: "fairchild/workspaces",
+						default_branch: "main",
+						private: false,
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		await expect(resolveRepo("fairchild/workspaces")).resolves.toEqual({
+			defaultBranch: "main",
+		});
+	});
+
+	it("rejects a repo that doesn't exist (no installation covers it)", async () => {
+		stubEnv();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("not found", { status: 404 })),
+		);
+		await expect(resolveRepo("fairchild/does-not-exist")).rejects.toBeInstanceOf(
+			RepoUnavailableError,
+		);
+	});
+
+	it("rejects a repo the installation can't read, even once a token is minted", async () => {
+		stubEnv();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/installation")) return Response.json({ id: 99 });
+				if (url.endsWith("/access_tokens")) {
+					return Response.json({
+						token: "ghs_token",
+						expires_at: "2026-01-01T00:00:00Z",
+						permissions: {},
+					});
+				}
+				// The repo-read call: access revoked / private and not granted.
+				return new Response("not found", { status: 404 });
+			}),
+		);
+		await expect(
+			resolveRepo("fairchild/no-longer-granted"),
+		).rejects.toBeInstanceOf(RepoUnavailableError);
+	});
+
+	it("lists the installation's repos via the directory token", async () => {
+		stubEnv();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/app/installations")) {
+					return Response.json([{ id: 7, account: { login: "fairchild" } }]);
+				}
+				if (url.endsWith("/app/installations/7/access_tokens")) {
+					return Response.json({
+						token: "ghs_dir_token",
+						expires_at: "2026-01-01T00:00:00Z",
+						permissions: {},
+					});
+				}
+				if (url.includes("/installation/repositories")) {
+					return Response.json({
+						repositories: [
+							{
+								full_name: "fairchild/zeta",
+								default_branch: "main",
+								private: false,
+							},
+							{
+								full_name: "fairchild/alpha",
+								default_branch: "main",
+								private: false,
+							},
+						],
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		await expect(listDirectoryRepos()).resolves.toEqual([
+			{ fullName: "fairchild/alpha", defaultBranch: "main", private: false },
+			{ fullName: "fairchild/zeta", defaultBranch: "main", private: false },
+		]);
+	});
+});

--- a/web-next/src/lib/github/repo-directory.test.ts
+++ b/web-next/src/lib/github/repo-directory.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	isDirectoryDegraded,
 	listDirectoryRepos,
+	mergeRepoLists,
 	resolveRepo,
 	RepoUnavailableError,
 	validateDirectoryRepo,
@@ -61,6 +62,23 @@ describe("bypass mode (AUTH_BYPASS=1)", () => {
 	it("is never degraded", () => {
 		vi.stubEnv("AUTH_BYPASS", "1");
 		expect(isDirectoryDegraded()).toBe(false);
+	});
+
+	// The double lock, proven through this seam (not just config.test.ts):
+	// AUTH_BYPASS=1 with real OAuth configured must NOT serve fixtures —
+	// a leaked bypass flag in production falls through to the real path.
+	it("fixtures cannot activate when real OAuth is configured", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubEnv("GITHUB_OAUTH_CLIENT_ID", "Iv1.real");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		// Without App creds the fall-through lands in degraded, not fixtures.
+		expect(isDirectoryDegraded()).toBe(true);
+		await expect(listDirectoryRepos()).resolves.toEqual([]);
+		await expect(validateDirectoryRepo("fairchild/workspaces")).resolves.toEqual({
+			kind: "unverified",
+			fullName: "fairchild/workspaces",
+		});
 	});
 });
 
@@ -210,5 +228,42 @@ describe("configured mode (App creds present, GitHub mocked)", () => {
 			{ fullName: "fairchild/alpha", defaultBranch: "main", private: false },
 			{ fullName: "fairchild/zeta", defaultBranch: "main", private: false },
 		]);
+	});
+});
+
+describe("mergeRepoLists", () => {
+	it("keeps connected-only repos so one-click rows survive an empty directory", () => {
+		expect(
+			mergeRepoLists(
+				[],
+				[{ fullName: "fairchild/unverified", defaultBranch: null }],
+			),
+		).toEqual([{ fullName: "fairchild/unverified", defaultBranch: null }]);
+	});
+
+	it("dedupes by name (case-insensitive), the directory's fresher branch winning", () => {
+		expect(
+			mergeRepoLists(
+				[{ fullName: "fairchild/workspaces", defaultBranch: "trunk", private: false }],
+				[
+					{ fullName: "Fairchild/Workspaces", defaultBranch: "main" },
+					{ fullName: "fairchild/alpha", defaultBranch: null },
+				],
+			),
+		).toEqual([
+			{ fullName: "fairchild/alpha", defaultBranch: null },
+			{ fullName: "fairchild/workspaces", defaultBranch: "trunk" },
+		]);
+	});
+
+	it("sorts the union alphabetically", () => {
+		const merged = mergeRepoLists(
+			[{ fullName: "b/b", defaultBranch: "main", private: false }],
+			[
+				{ fullName: "c/c", defaultBranch: null },
+				{ fullName: "a/a", defaultBranch: null },
+			],
+		);
+		expect(merged.map((repo) => repo.fullName)).toEqual(["a/a", "b/b", "c/c"]);
 	});
 });

--- a/web-next/src/lib/github/repo-directory.ts
+++ b/web-next/src/lib/github/repo-directory.ts
@@ -106,3 +106,37 @@ export async function resolveRepo(
 	if (result.kind === "unverified") return { defaultBranch: null };
 	return { defaultBranch: result.defaultBranch };
 }
+
+/** What the picker renders: already-connected repos may lack a known branch. */
+export interface PickerRepo {
+	fullName: string;
+	defaultBranch: string | null;
+}
+
+/**
+ * The picker's full list: the GitHub directory plus the repos already
+ * connected in the database (which may include entries the directory can't
+ * see — unverified degraded-mode connects, or repos whose App grant was
+ * since revoked). Deduped by full name — the directory entry wins, its
+ * branch is fresher — and sorted. Keeps one-click rows available even when
+ * the directory is empty (degraded mode).
+ */
+export function mergeRepoLists(
+	directory: DirectoryRepo[],
+	connected: PickerRepo[],
+): PickerRepo[] {
+	const byName = new Map<string, PickerRepo>();
+	for (const repo of connected) {
+		byName.set(repo.fullName.toLowerCase(), {
+			fullName: repo.fullName,
+			defaultBranch: repo.defaultBranch,
+		});
+	}
+	for (const repo of directory) {
+		byName.set(repo.fullName.toLowerCase(), {
+			fullName: repo.fullName,
+			defaultBranch: repo.defaultBranch,
+		});
+	}
+	return [...byName.values()].sort((a, b) => a.fullName.localeCompare(b.fullName));
+}

--- a/web-next/src/lib/github/repo-directory.ts
+++ b/web-next/src/lib/github/repo-directory.ts
@@ -1,0 +1,108 @@
+/*
+ * GitHub-backed repo directory for the new-session picker: lists the App
+ * installation's repositories and validates a freetext `owner/name`, sitting
+ * in front of the raw App-auth mechanics in `../diag/github-app`. Three modes,
+ * resolved once per call so callers never branch on environment themselves:
+ *
+ *  - bypass (`AUTH_BYPASS=1`, no real OAuth configured — see `../auth/config`):
+ *    a small deterministic fixture set, so e2e/evidence/perf runs never touch
+ *    the real GitHub API.
+ *  - configured (App creds present): the real installation-repos + repo-read
+ *    endpoints.
+ *  - degraded (App creds absent, e.g. local dev without `.env.local`): listing
+ *    comes back empty and validation always resolves "unverified" rather than
+ *    blocking — freetext still works, just unproven.
+ */
+import { authBypassEnabled } from "../auth/config";
+import {
+	type DirectoryRepo,
+	listInstallationRepositories,
+	mintDirectoryToken,
+	mintInstallationToken,
+	verifyRepoAccess,
+} from "../diag/github-app";
+
+export type { DirectoryRepo };
+
+/** Thrown by `resolveRepo` when GitHub says a repo doesn't exist or isn't accessible to the App. */
+export class RepoUnavailableError extends Error {
+	constructor(public readonly fullName: string) {
+		super(`${fullName} doesn't exist or isn't accessible to the GitHub App`);
+		this.name = "RepoUnavailableError";
+	}
+}
+
+export type RepoValidation =
+	| ({ kind: "ok" } & DirectoryRepo)
+	| { kind: "not-found"; fullName: string }
+	/** Degraded mode: no App creds to check against, so we don't block. */
+	| { kind: "unverified"; fullName: string };
+
+const FIXTURE_REPOS: DirectoryRepo[] = [
+	{ fullName: "fairchild/workspaces", defaultBranch: "main", private: false },
+	{ fullName: "fairchild/dotfiles", defaultBranch: "main", private: false },
+	{
+		fullName: "fairchild/web-next-fixtures",
+		defaultBranch: "trunk",
+		private: true,
+	},
+];
+
+function hasAppCredentials(): boolean {
+	return Boolean(
+		process.env.GITHUB_WEB_WORKSPACES_APP_ID && process.env.GITHUB_APP_PRIVATE_KEY,
+	);
+}
+
+/** True when the picker has nothing but the freetext escape hatch to offer. */
+export function isDirectoryDegraded(): boolean {
+	return !authBypassEnabled() && !hasAppCredentials();
+}
+
+/** The installation's repos, alphabetical — empty (not thrown) when degraded. */
+export async function listDirectoryRepos(): Promise<DirectoryRepo[]> {
+	if (authBypassEnabled()) {
+		return [...FIXTURE_REPOS].sort((a, b) => a.fullName.localeCompare(b.fullName));
+	}
+	if (!hasAppCredentials()) return [];
+	const { token } = await mintDirectoryToken();
+	const repos = await listInstallationRepositories(token);
+	return repos.sort((a, b) => a.fullName.localeCompare(b.fullName));
+}
+
+/** Validates `fullName` against GitHub (or the fixture/degraded stand-ins). */
+export async function validateDirectoryRepo(
+	fullName: string,
+): Promise<RepoValidation> {
+	if (authBypassEnabled()) {
+		const fixture = FIXTURE_REPOS.find(
+			(repo) => repo.fullName.toLowerCase() === fullName.toLowerCase(),
+		);
+		return fixture ? { kind: "ok", ...fixture } : { kind: "not-found", fullName };
+	}
+	if (!hasAppCredentials()) return { kind: "unverified", fullName };
+	try {
+		const { token } = await mintInstallationToken(fullName);
+		const repo = await verifyRepoAccess(token, fullName);
+		return { kind: "ok", ...repo };
+	} catch {
+		// GitHub 404s a repo the App has no access to the same way it 404s one
+		// that doesn't exist at all (deliberate, to avoid leaking private-repo
+		// existence) — this directory can't distinguish the two either.
+		return { kind: "not-found", fullName };
+	}
+}
+
+/**
+ * The write path's entry point: validate `fullName` and return the
+ * `default_branch` to record, or throw `RepoUnavailableError` for the caller
+ * to turn into a calm inline message. Degraded mode never throws.
+ */
+export async function resolveRepo(
+	fullName: string,
+): Promise<{ defaultBranch: string | null }> {
+	const result = await validateDirectoryRepo(fullName);
+	if (result.kind === "not-found") throw new RepoUnavailableError(fullName);
+	if (result.kind === "unverified") return { defaultBranch: null };
+	return { defaultBranch: result.defaultBranch };
+}

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -269,3 +269,42 @@ test("closing the tab mid-turn does not kill it — a fresh tab catches up", asy
 	);
 	await expect(reopened.getByTestId("activity-line")).toHaveCount(0);
 });
+
+// GitHub-backed repo picker (#825): the /api/repos fixture list under
+// AUTH_BYPASS covers both a real (non-"main") default branch landing in the
+// masthead and a calm inline error for a repo the fixture directory doesn't
+// recognize — the two behaviors #825 added over the old freetext-only flow.
+
+test("connecting a repo via freetext records and shows its real default branch", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await page.getByRole("button", { name: "+ new session" }).click();
+	await page
+		.getByRole("textbox", { name: "Repository (owner/name)" })
+		.fill("fairchild/web-next-fixtures");
+	await page.keyboard.press("Enter");
+
+	await expect(page).toHaveURL(SESSION_URL);
+	await expect(page.locator("header")).toContainText("fairchild/web-next-fixtures");
+	// The fixture's default_branch is "trunk" — distinct from the "main"
+	// fallback, so this proves the real value was recorded and rendered.
+	await expect(page.locator("header")).toContainText("trunk");
+});
+
+test("an owner/name the fixture directory doesn't recognize shows a calm inline error", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await page.getByRole("button", { name: "+ new session" }).click();
+	const input = page.getByRole("textbox", { name: "Repository (owner/name)" });
+	await input.fill("fairchild/does-not-exist");
+	await page.keyboard.press("Enter");
+
+	// No navigation — the picker stays put with a quiet inline message.
+	await expect(page).toHaveURL("/");
+	await expect(page.getByTestId("new-session-error")).toContainText(
+		"fairchild/does-not-exist",
+	);
+	await expect(page.getByTestId("new-session-picker")).toBeVisible();
+});


### PR DESCRIPTION
Closes #825

## Summary

The new-session picker only listed already-connected repos and let any
`owner/name`-shaped freetext through with no GitHub check, so
`repos.default_branch` never got a real value and the session masthead
always fell back to `"main"`.

- `src/lib/github/repo-directory.ts` (new): the GitHub-backed directory —
  lists the App installation's repos and validates a freetext `owner/name`,
  in three modes resolved once per call (bypass fixtures / real GitHub /
  degraded no-creds). Sits in front of `src/lib/diag/github-app.ts`, which
  gained two primitives it needed: `listAppInstallations` and
  `listInstallationRepositories` (plus `mintDirectoryToken`, which finds the
  App's installation and mints a token scoped to everything it can see —
  `mintInstallationToken` already did this for one *known* repo via
  `/repos/{repo}/installation`, but listing needs a token before any repo is
  named).
- `src/app/api/repos/route.ts` (new): auth-gated `GET /api/repos?q=` — the
  picker's live feed, server-side substring search, `degraded: true` when
  the App has no creds configured.
- `src/lib/db/repos.ts`: `ensureRepo` now takes an optional `defaultBranch`,
  recorded on first connect and backfilled onto an already-connected repo
  that doesn't have one yet (or whose branch has since changed).
- `src/lib/db/start-session.ts`: validates against GitHub via
  `resolveRepo()` before creating the repo row; throws `RepoUnavailableError`
  for a repo GitHub can't find or the App can't access. Kept additive/minimal
  per the heads-up about a concurrent branch touching this file.
- `src/app/(app)/new-session.tsx`: now a client component. Fetches
  `/api/repos` once per open, the same `owner/name` field both filters that
  list live (search) and serves as the freetext escape hatch on submit.
  Wired through `useActionState` so a rejected repo shows a calm inline
  message instead of a thrown error or silent no-op.
- `src/app/(app)/actions.ts`: `createSessionAction` takes the
  `useActionState` `(prevState, formData)` shape and returns `{ error }` on
  `RepoUnavailableError` instead of throwing.

## Mergeability

- Surface: web (web-next/) — new-session flow, repo persistence, one new API route
- User-facing behavior changed: Yes. The new-session picker now lists the GitHub App installation's repos (searchable via the same owner/name field) instead of only previously-connected repos; a freetext entry is validated against GitHub before a session is created, and the session masthead now shows the repo's real default branch instead of always falling back to "main". A repo GitHub can't find or the App can't access now shows a calm inline message instead of silently creating an unusable session.
- Non-happy paths considered: repo doesn't exist or isn't accessible to the App (GitHub 404s both identically by design — this directory can't distinguish "not found" from "no access" either, and neither can leak private-repo existence); GitHub App creds absent at runtime (degraded mode — listing returns empty, freetext is accepted unverified rather than blocked, `degraded: true` surfaces a quiet note); AUTH_BYPASS e2e/evidence runs (deterministic fixture directory, no real network calls); an already-connected repo whose branch was recorded before this change, or has since changed (backfilled on next connect); unauthenticated/forbidden requests to `/api/repos` (401/403, same pattern as `/api/diag/preflight`).
- Residual risk or follow-up: `listDirectoryRepos()` takes the App's *first* installation (`listAppInstallations()[0]`) — correct for this single-account product but would need real multi-installation handling if the App is ever installed on more than one account. `/installation/repositories` is capped at `per_page=100` with no pagination follow-through yet; fine for the installation's current size, worth revisiting if it grows. Search is a client-side filter over one fetched batch rather than a server round-trip per keystroke — simpler and sufficient at this scale, would need to move server-side if the repo list gets large.

## Evidence

- Unit tests: `pnpm run test` — 189 passed (19 files), including new coverage in `src/lib/github/repo-directory.test.ts` (bypass fixtures, degraded mode, configured mode with mocked GitHub responses covering validate-ok / not-found / no-longer-granted-access), `src/lib/diag/github-app.test.ts` (new `listAppInstallations` / `listInstallationRepositories` cases), and `src/lib/db/start-session.test.ts` (default_branch recording + backfill, fixture rejection, degraded-mode acceptance).
- Typecheck: `pnpm run typecheck` — clean.
- Lint: `pnpm run lint` — clean.
- E2E: `pnpm run test:e2e` — 24/24 passed, including two new cases extending `tests/e2e/sessions.spec.ts`: connecting a fixture repo via freetext shows its real (non-"main") default branch in the masthead, and an unrecognized freetext repo shows the calm inline error with no navigation.
- Evidence screenshots (light + dark, empty home showing the new GitHub-backed picker with search): captured via `pnpm run evidence` — local-only this session (`docs/development/remote-sessions.md` sanctioned local-evidence path; this is an interactive session, not a remote claude.ai one). Files at `web-next/output/evidence/home-empty-{light,dark}.png` and the rest of the standard evidence set.
- CI: green quality lane (lint/typecheck/unit/build/e2e/perf; 210/210 unit, 25/25 e2e post-rebase over #903) on faa1e7c: https://github.com/fairchild/workspaces/actions/runs/28881528886/job/85670744575 — UI evidence in the run's web-next-evidence artifact
- Gate note: orchestrator read the auth-sensitive hunks (api/repos gate-first handler, bypass double-lock negative test) and the #903 composition test (one session carries validated repoId + model stamp); codex loop ran (5 findings fixed, directions 1-4 cleared with cited negative results); Vercel preview failed on the account's daily build rate limit (not a required check); merged on delegated authority.

## Mutation check

Reverted a one-line mutation in `startSession` (`ensureRepo(handle, trimmed)` instead of `ensureRepo(handle, trimmed, defaultBranch)` — simulating "forgot to thread the branch through") and confirmed it broke exactly the two tests that cover default-branch recording (`records the real default_branch from the fixture on first connect`, `backfills the default_branch onto a repo connected before validation existed`) while the other 12 tests in that file stayed green. Reverted after confirming.

## Notes / deviations

- The issue's file list named `src/lib/db/repos.ts` as the home for "GitHub-backed listing/validation". I kept `repos.ts` as pure Kysely persistence and put the mode-aware (bypass/real/degraded) GitHub logic in a new `src/lib/github/repo-directory.ts`, matching the existing separation between `lib/diag/github-app.ts` (raw App-auth mechanics) and `lib/db/*.ts` (persistence only). `repos.ts` only gained the `defaultBranch` parameter on `ensureRepo`.
- Bypass-mode fixture seam: `authBypassEnabled()` (already existing, double-locked — explicit `AUTH_BYPASS=1` and inert whenever real OAuth is configured) gates a small deterministic fixture list (`fairchild/workspaces`, `fairchild/dotfiles`, `fairchild/web-next-fixtures` with a distinct `defaultBranch: "trunk"` to make the "real branch got recorded" behavior provable in tests) in both `listDirectoryRepos()` and `validateDirectoryRepo()`.
- Degraded-mode behavior (no App creds at runtime, e.g. local dev without `.env.local`): listing returns an empty array (not an error) and validation resolves `{ kind: "unverified" }`, which `resolveRepo()` turns into `{ defaultBranch: null }` rather than throwing — freetext session creation keeps working, just unverified. `isDirectoryDegraded()` also drives a quiet inline note in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review loop

Reflect → codex (gpt-5.5, xhigh) → react, per the codex-review-loop skill.

**Self-reflection pass** (commit `2bfb6a1b`):
- R1 (fixed): the picker dropped already-connected repos when it switched to the GitHub directory — an empty one-click list in degraded mode. `/api/repos` now serves `mergeRepoLists(directory, connected)` (deduped case-insensitively, directory's fresher branch wins), unit-tested.
- R2 (fixed): the bypass double lock was only proven in `config.test.ts`, not through this seam — added a test proving `AUTH_BYPASS=1` + real OAuth configured serves no fixtures (falls through to degraded/real).

**Codex findings** (directed at: /api/repos auth gating; bypass-seam inertness under real OAuth; RepoUnavailableError write-path; degraded-mode honesty; plus a completeness question over every repos-table writer) — 3 findings, all accepted and fixed in commit `b0775d8e`:
1. **Important — masthead claimed `main` when the branch was unknown.** `repo?.defaultBranch ?? "main"` predates this PR, but this PR is what makes `null` mean "connected unverified" — fabricating a branch for it breaks the degraded-mode honesty contract. `MastheadData.branch` is now nullable and the segment is omitted when unknown.
2. **Minor — malformed `owner/name` via a direct authorized POST threw an unhandled server-action error** (the input's `pattern` blocks it in the UI; no rows were ever written). The action now pre-validates shape and returns the same calm inline state.
3. **Minor — no pending guard on the shared `formAction`:** fast double-submit could create multiple sessions; a stale error stayed visible during a retry. Row buttons disable while pending, the freetext form swallows re-submits (input stays enabled so focus survives), the error hides while in flight.

**Codex confirmed sound** (cited as negative results): `/api/repos` gating — no request shape reaches the GitHub/DB listing without an authorized verdict, 401/403 bodies carry only `{ error }`; the bypass fixture seam cannot activate when `GITHUB_OAUTH_CLIENT_ID` is set (both with and without App creds); `resolveRepo()` failure writes neither repo nor session row; `ensureRepo` is the only production repos-table writer and its only production caller passes the resolved branch whenever one is knowable.

**Pre-existing, out of scope:** the vercel provider still clones a hard-coded `TARGET_REPO` regardless of the session's picked repo (`vercel-provider.ts:35`) — a known #750-arc limitation that predates this PR, not introduced or worsened by it.

Post-review gates: 193 unit tests, 24/24 e2e, lint + typecheck clean; rebased on `origin/main` (now includes #900's NODE_ENV=production build fix).

