### PR TITLE
feat(web-next): per-session model selection — pick, persist, route, display

### DIFF
--- a/web-next/docs/schema.md
+++ b/web-next/docs/schema.md
@@ -47,6 +47,7 @@ that log, never stored here.
 | `status` | text | Lifecycle — `active` \| `idle` \| `archived` (owned by #749/#750). |
 | `claude_session_id` | text? | Harness/Claude session id for resume; null until a real turn parks one. |
 | `resume_state` | text? | JSON harness resume payload from the last turn's `detach()` (migration `0003_session_resume_state`); null until a real turn parks, cleared when the parked sandbox expires. Session-row state, deliberately not in the event log. |
+| `model` | text | Claude model id this session's turns run on (migration `0004_session_model`, #824); NOT NULL, defaulting to `DEFAULT_MODEL` (`src/lib/agent-runtime/models.ts` — the single source of truth for the selectable set). Threaded into `TurnRequest.model` on every turn; changed via the status line's picker (`PATCH /api/sessions/[id]`). |
 | `created_at` | text | ISO-8601. |
 | `last_activity_at` | text | ISO-8601; bumped on every event append. |
 

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -16,7 +16,7 @@
  */
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { modelLabel } from "@/lib/agent-runtime/models";
 import {
 	type ActiveTurnData,
@@ -59,20 +59,39 @@ export function LiveSessionView({
 	const [steps, setSteps] = useState<string[]>([]);
 
 	// The selected model: seeded from the server-resolved session, updated
-	// optimistically on change (reverted if the PATCH fails).
+	// optimistically on change (reverted if its PATCH fails while it is still
+	// the latest choice). Two orderings matter beyond the optimistic paint:
+	// - PATCHes are chained (each awaits its predecessor), so rapid B→C changes
+	//   cannot land in the DB out of order;
+	// - `send` awaits the chain before posting, so a turn sent right after a
+	//   model change runs on the model the status line shows, not the old row.
+	// The chain always resolves (each link swallows its own failure), so one
+	// failed PATCH never wedges later changes or sends.
 	const [model, setModel] = useState(session.statusLine.model);
+	const latestModelRef = useRef(session.statusLine.model);
+	const modelPatchChain = useRef<Promise<void>>(Promise.resolve());
 	const handleModelChange = (nextModel: string) => {
-		const previous = model;
+		const previous = latestModelRef.current;
+		latestModelRef.current = nextModel;
 		setModel(nextModel);
-		fetch(`/api/sessions/${sessionId}`, {
-			method: "PATCH",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ model: nextModel }),
-		})
-			.then((res) => {
-				if (!res.ok) setModel(previous);
+		const revert = () => {
+			// Only revert if no newer choice superseded this one meanwhile.
+			if (latestModelRef.current === nextModel) {
+				latestModelRef.current = previous;
+				setModel(previous);
+			}
+		};
+		modelPatchChain.current = modelPatchChain.current.then(() =>
+			fetch(`/api/sessions/${sessionId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ model: nextModel }),
 			})
-			.catch(() => setModel(previous));
+				.then((res) => {
+					if (!res.ok) revert();
+				})
+				.catch(revert),
+		);
 	};
 
 	const transport = useMemo(
@@ -112,7 +131,11 @@ export function LiveSessionView({
 	const busy = status === "submitted" || status === "streaming";
 	const send = (text: string) => {
 		setSteps([]);
-		sendMessage({ text, metadata: { author } });
+		// Await any in-flight model PATCH first, so the turn the server starts
+		// reads the session row this send was composed against.
+		void modelPatchChain.current.then(() =>
+			sendMessage({ text, metadata: { author } }),
+		);
 	};
 
 	// The reply message exists (empty) as soon as the stream starts; keep it

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -6,16 +6,25 @@
  * from the server-projected event log, so what streamed live and what a
  * reload renders are the same messages. Token application is batched
  * (experimental_throttle), not per-chunk state.
+ *
+ * The model picker (#824) is owned here as client state seeded from the
+ * server-resolved session: changing it PATCHes the session row and updates
+ * the status line immediately, without waiting for a reload — a reload (or a
+ * fresh tab) reflects the same value because page.tsx reads it back from the
+ * DB. The context figure is recomputed from the live transcript on every
+ * render, so it advances turn-by-turn instead of only after a reload.
  */
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useMemo, useState } from "react";
+import { modelLabel } from "@/lib/agent-runtime/models";
 import {
 	type ActiveTurnData,
 	SessionView,
 	type SessionViewData,
 } from "@/components/folio/session-view";
 import type { FolioDataParts, FolioMessage } from "@/components/folio/types";
+import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
 const TOKEN_THROTTLE_MS = 50;
@@ -48,6 +57,23 @@ export function LiveSessionView({
 }) {
 	// Transient provider statuses of the in-flight turn, oldest first.
 	const [steps, setSteps] = useState<string[]>([]);
+
+	// The selected model: seeded from the server-resolved session, updated
+	// optimistically on change (reverted if the PATCH fails).
+	const [model, setModel] = useState(session.statusLine.model);
+	const handleModelChange = (nextModel: string) => {
+		const previous = model;
+		setModel(nextModel);
+		fetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ model: nextModel }),
+		})
+			.then((res) => {
+				if (!res.ok) setModel(previous);
+			})
+			.catch(() => setModel(previous));
+	};
 
 	const transport = useMemo(
 		() =>
@@ -114,9 +140,20 @@ export function LiveSessionView({
 
 	return (
 		<SessionView
-			session={{ ...session, messages: visibleMessages, activeTurn }}
+			session={{
+				...session,
+				messages: visibleMessages,
+				activeTurn,
+				statusLine: {
+					...session.statusLine,
+					model,
+					modelLabel: modelLabel(model),
+					contextLabel: deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
+				},
+			}}
 			onSend={send}
 			composeDisabled={busy}
+			onModelChange={handleModelChange}
 		/>
 	);
 }

--- a/web-next/src/app/(app)/sessions/[id]/page.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/page.tsx
@@ -12,12 +12,14 @@
  * full-replay against an SSR'd prefix would duplicate it.
  */
 import { notFound } from "next/navigation";
+import { MODEL_OPTIONS, modelLabel } from "@/lib/agent-runtime/models";
 import { resolveTurn } from "@/lib/agent-runtime/turn-tail";
 import type { FolioMessage } from "@/components/folio/types";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
 import { getRepo } from "@/lib/db/repos";
 import { getSession, readTranscript } from "@/lib/db/sessions";
+import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 import { LiveSessionView } from "./live-session-view";
 
 export default async function SessionPage({
@@ -68,7 +70,12 @@ export default async function SessionPage({
 					agentName: "Claude",
 					stateLabel: "idle",
 				},
-				statusLine: { model: "opus-4.8", contextLabel: "0 ctx" },
+				statusLine: {
+					model: session.model,
+					modelLabel: modelLabel(session.model),
+					models: MODEL_OPTIONS,
+					contextLabel: deriveContextLabel(transcript),
+				},
 				empty: {
 					title: "No turns yet.",
 					hint: `Ask below — this session runs on ${repoName}.`,

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -1,0 +1,45 @@
+/*
+ * PATCH /api/sessions/[id] — update a session's mutable settings. Currently
+ * just `model` (#824's picker): auth-gated same as the chat route, validated
+ * against the single source of truth in agent-runtime/models.ts so an unknown
+ * or retired id is a 400, not a silent write.
+ */
+import { isSelectableModel } from "@/lib/agent-runtime/models";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { getSession, updateSession } from "@/lib/db/sessions";
+
+export async function PATCH(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	const body: unknown = await request.json().catch(() => undefined);
+	const model =
+		typeof body === "object" && body !== null && "model" in body
+			? String((body as { model: unknown }).model)
+			: undefined;
+	if (model === undefined) {
+		return Response.json({ error: "model is required" }, { status: 400 });
+	}
+	if (!isSelectableModel(model)) {
+		return Response.json({ error: `unknown model: ${model}` }, { status: 400 });
+	}
+
+	await updateSession(handle, id, { model });
+	return Response.json({ model });
+}

--- a/web-next/src/components/folio/ledger.ts
+++ b/web-next/src/components/folio/ledger.ts
@@ -161,7 +161,8 @@ export function highlightTestOutput(content: string): OutputSegment[][] {
 
 // --- end-of-turn receipt ----------------------------------------------------
 
-function formatTokenCount(count: number): string {
+/** "820" / "3.2k" — shared with the status line's context figure (#824). */
+export function formatTokenCount(count: number): string {
 	if (count < 1000) return String(count);
 	return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
 }

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -76,9 +76,17 @@ export interface SessionViewProps {
 	onSend?: (text: string) => void;
 	/** Holds sends (keeping the draft) while a turn is streaming. */
 	composeDisabled?: boolean;
+	/** Model picker handler (client wrappers wire this; fixtures omit it, which
+	 * leaves the status line's model as static text — see status-line.tsx). */
+	onModelChange?: (id: string) => void;
 }
 
-export function SessionView({ session, onSend, composeDisabled }: SessionViewProps) {
+export function SessionView({
+	session,
+	onSend,
+	composeDisabled,
+	onModelChange,
+}: SessionViewProps) {
 	const isEmpty = session.messages.length === 0 && !session.activeTurn;
 	return (
 		<>
@@ -150,7 +158,7 @@ export function SessionView({ session, onSend, composeDisabled }: SessionViewPro
 					onSend={onSend}
 					disabled={composeDisabled}
 				/>
-				<StatusLine status={session.statusLine} />
+				<StatusLine status={session.statusLine} onModelChange={onModelChange} />
 			</footer>
 		</>
 	);

--- a/web-next/src/components/folio/status-line.tsx
+++ b/web-next/src/components/folio/status-line.tsx
@@ -4,16 +4,41 @@
  * Model status line: model + quiet context figures pinned under the
  * compose. ✕ collapses it to a small corner dot (the handle); the dot
  * brings it back. Expects a positioned ancestor for the handle.
+ *
+ * The model segment doubles as the picker (#824) whenever the caller supplies
+ * both `models` (the selectable set) and `onModelChange`: it renders as a bare
+ * native `<select>` styled to read as the same plain text — no visible
+ * dropdown chrome, matching docs/design.md's "stated once, quietly" status
+ * line. Callers that omit either (fixtures, demo pages) get the old static
+ * text, unchanged.
  */
 import { useState } from "react";
 
-export interface StatusLineData {
-	model: string;
-	/** Preformatted context figure (e.g. "2.1k ctx"). */
-	contextLabel: string;
+export interface StatusLineModelOption {
+	id: string;
+	label: string;
 }
 
-export function StatusLine({ status }: { status: StatusLineData }) {
+export interface StatusLineData {
+	/** Current model id. */
+	model: string;
+	/** Display label for `model` (falls back to the raw id). */
+	modelLabel?: string;
+	/** The selectable set; present + `onModelChange` given turns on the picker. */
+	models?: readonly StatusLineModelOption[];
+	/** Preformatted context figure (e.g. "2.1k ctx"), or undefined to hide it —
+	 * a real figure isn't known yet (no completed turn), never a fake 0. */
+	contextLabel?: string;
+}
+
+export function StatusLine({
+	status,
+	onModelChange,
+}: {
+	status: StatusLineData;
+	/** Wired by the live session view; omitted on fixtures/demo pages. */
+	onModelChange?: (id: string) => void;
+}) {
 	const [dismissed, setDismissed] = useState(false);
 
 	if (dismissed) {
@@ -29,6 +54,8 @@ export function StatusLine({ status }: { status: StatusLineData }) {
 		);
 	}
 
+	const picker = status.models && onModelChange;
+
 	return (
 		<div
 			data-testid="status-line"
@@ -36,10 +63,31 @@ export function StatusLine({ status }: { status: StatusLineData }) {
 		>
 			<div className="mx-auto flex h-full max-w-[680px] items-center px-0.5">
 				<span className="font-medium text-muted before:mr-2 before:inline-block before:h-[5px] before:w-[5px] before:rounded-full before:bg-accent before:align-[2px] before:opacity-75 before:content-['']">
-					{status.model}
+					{picker ? (
+						<select
+							data-testid="model-select"
+							aria-label="Model"
+							title="Change model"
+							value={status.model}
+							onChange={(event) => onModelChange(event.target.value)}
+							className="cursor-pointer appearance-none border-none bg-transparent p-0 font-mono font-medium text-muted outline-none"
+						>
+							{status.models?.map((option) => (
+								<option key={option.id} value={option.id}>
+									{option.label}
+								</option>
+							))}
+						</select>
+					) : (
+						(status.modelLabel ?? status.model)
+					)}
 				</span>
-				<span className="mx-[9px] opacity-55">·</span>
-				{status.contextLabel}
+				{status.contextLabel && (
+					<>
+						<span className="mx-[9px] opacity-55">·</span>
+						{status.contextLabel}
+					</>
+				)}
 				<button
 					type="button"
 					title="Hide status line"

--- a/web-next/src/components/folio/types.ts
+++ b/web-next/src/components/folio/types.ts
@@ -13,6 +13,13 @@ import type { UIMessage } from "ai";
 export interface TurnStatsData {
 	toolCount: number;
 	tokenCount?: number;
+	/**
+	 * The turn's total input (context) tokens — the real figure the session
+	 * status line's "N ctx" reads (#824), reported by the provider's `done`
+	 * chunk. Undefined for turns that predate this field or ran on a provider
+	 * that doesn't report it (the status line hides the figure, not a fake 0).
+	 */
+	contextTokens?: number;
 	durationMs: number;
 	/** Distinct files changed by Edit/Write calls. */
 	filesChanged?: number;

--- a/web-next/src/lib/agent-runtime/mock-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "vitest";
 import { deriveTurnStats } from "../transcript/turn-stats";
 import { mockCodingTurn, mockProvider } from "./mock-provider";
+import { DEFAULT_MODEL } from "./models";
 import type { StreamChunk } from "./stream-chunk";
 
 /** The whole scripted turn, without waiting out the streaming pace. */
-async function fullTurn(userMessage: string): Promise<StreamChunk[]> {
+async function fullTurn(userMessage: string, model?: string): Promise<StreamChunk[]> {
 	const chunks: StreamChunk[] = [];
-	for await (const chunk of mockCodingTurn(userMessage, () => Promise.resolve())) {
+	for await (const chunk of mockCodingTurn(
+		userMessage,
+		() => Promise.resolve(),
+		model,
+	)) {
 		chunks.push(chunk);
 	}
 	return chunks;
@@ -95,5 +100,23 @@ describe("mockCodingTurn", () => {
 		const first = await iterator.next();
 		expect(first.value).toEqual({ type: "status", content: "Starting sandbox" });
 		await iterator.return?.(undefined);
+	});
+
+	test("records the default model on the terminal done chunk when none is requested (#824)", async () => {
+		const chunks = await fullTurn("go");
+		const done = chunks.find((chunk) => chunk.type === "done");
+		expect(done?.metadata?.model).toBe(DEFAULT_MODEL);
+	});
+
+	test("records an explicit model override on the terminal done chunk (#824)", async () => {
+		const chunks = await fullTurn("go", "claude-haiku-4-5");
+		const done = chunks.find((chunk) => chunk.type === "done");
+		expect(done?.metadata?.model).toBe("claude-haiku-4-5");
+	});
+
+	test("also records a plausible contextTokens figure alongside tokenCount", async () => {
+		const chunks = await fullTurn("go");
+		const done = chunks.find((chunk) => chunk.type === "done");
+		expect(done?.metadata?.contextTokens).toBeGreaterThan(0);
 	});
 });

--- a/web-next/src/lib/agent-runtime/mock-provider.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.ts
@@ -4,7 +4,11 @@
  * diff → done with usage figures) that exercises the whole Folio apparatus —
  * including the thinking block and the error tool path — without a sandbox.
  * Paced with small delays so streaming behavior is observable and measurable.
+ * The requested model is recorded (not used — there's no real model call
+ * here) on the terminal `done` chunk, so #824's routing is unit-testable
+ * against this provider without a sandbox.
  */
+import { DEFAULT_MODEL } from "./models";
 import type { ComputeProvider, TurnRequest } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -58,6 +62,7 @@ const TEST_RUN_OUTPUT = [
 export async function* mockCodingTurn(
 	userMessage: string,
 	sleep: Sleep = defaultSleep,
+	model: string = DEFAULT_MODEL,
 ): AsyncGenerator<StreamChunk> {
 	const startedAt = Date.now();
 	let proseChars = 0;
@@ -182,11 +187,17 @@ export async function* mockCodingTurn(
 			durationMs: Date.now() - startedAt,
 			// A plausible usage figure for the receipt: ~4 chars per token.
 			tokenCount: Math.ceil(proseChars / 4),
+			// A plausible context-window figure (conversation so far, ~3.2
+			// chars/token) — deterministic so the status line's real-figure wiring
+			// is testable without a sandbox call.
+			contextTokens: Math.ceil((userMessage.length + proseChars) / 3.2),
+			model,
 		},
 	};
 }
 
 export const mockProvider: ComputeProvider = {
 	id: "mock",
-	runTurn: (request: TurnRequest) => mockCodingTurn(request.userMessage),
+	runTurn: (request: TurnRequest) =>
+		mockCodingTurn(request.userMessage, undefined, request.model),
 };

--- a/web-next/src/lib/agent-runtime/models.test.ts
+++ b/web-next/src/lib/agent-runtime/models.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { DEFAULT_MODEL, isSelectableModel, MODEL_OPTIONS, modelLabel } from "./models";
+
+describe("models", () => {
+	test("the default model is one of the selectable options", () => {
+		expect(MODEL_OPTIONS.some((option) => option.id === DEFAULT_MODEL)).toBe(true);
+	});
+
+	test("every option has a unique id and a non-empty label", () => {
+		const ids = MODEL_OPTIONS.map((option) => option.id);
+		expect(new Set(ids).size).toBe(ids.length);
+		for (const option of MODEL_OPTIONS) {
+			expect(option.label.length).toBeGreaterThan(0);
+		}
+	});
+
+	test("isSelectableModel accepts known ids and rejects everything else", () => {
+		expect(isSelectableModel(DEFAULT_MODEL)).toBe(true);
+		expect(isSelectableModel("claude-opus-4-8")).toBe(true);
+		expect(isSelectableModel("gpt-5")).toBe(false);
+		expect(isSelectableModel("")).toBe(false);
+	});
+
+	test("modelLabel resolves known ids and falls back to the raw id otherwise", () => {
+		expect(modelLabel("claude-haiku-4-5")).toBe("Haiku 4.5");
+		expect(modelLabel("some-retired-model")).toBe("some-retired-model");
+	});
+});

--- a/web-next/src/lib/agent-runtime/models.ts
+++ b/web-next/src/lib/agent-runtime/models.ts
@@ -1,0 +1,59 @@
+/*
+ * Single source of truth for selectable Claude models — the picker
+ * (session-view/status-line), the session-creation default, and TurnRequest
+ * threading all read this one list, so #816's validation stage can later read
+ * the same set instead of a second copy.
+ *
+ * Grounded against the sandboxed Claude Code harness's own model resolution,
+ * not invented: `createClaudeCode({ model })` (@ai-sdk/harness-claude-code)
+ * forwards the string unchanged onto `claudeSdk.query({ options: { model } })`
+ * inside the sandbox bridge — no enum/allowlist at that layer — and the
+ * installed `claude` CLI (`--model <model>`, `claude --help`) documents
+ * exactly these ids as current: aliases `fable` / `opus` / `sonnet` / `haiku`,
+ * full ids `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-5`,
+ * `claude-haiku-4-5`. Full ids are stored (not bare aliases) so the value in
+ * `sessions.model` is unambiguous. Fable 5 is the CLI's own "most advanced
+ * generally available model" — the literal "current best", so it is the
+ * default new sessions stamp.
+ */
+export interface ModelOption {
+	id: string;
+	label: string;
+	description: string;
+}
+
+export const MODEL_OPTIONS: readonly ModelOption[] = [
+	{
+		id: "claude-fable-5",
+		label: "Fable 5",
+		description: "Most capable — for hard or high-stakes changes.",
+	},
+	{
+		id: "claude-opus-4-8",
+		label: "Opus 4.8",
+		description: "Deep reasoning for complex work.",
+	},
+	{
+		id: "claude-sonnet-5",
+		label: "Sonnet 5",
+		description: "Fast and capable — a strong everyday default.",
+	},
+	{
+		id: "claude-haiku-4-5",
+		label: "Haiku 4.5",
+		description: "Fastest and cheapest, for small or routine turns.",
+	},
+];
+
+/** The current best model — new sessions stamp this unless overridden. */
+export const DEFAULT_MODEL: string = MODEL_OPTIONS[0].id;
+
+export function isSelectableModel(id: string): boolean {
+	return MODEL_OPTIONS.some((option) => option.id === id);
+}
+
+/** Display label for a model id; falls back to the raw id if unrecognized
+ * (an org-restricted or retired model a session was created with earlier). */
+export function modelLabel(id: string): string {
+	return MODEL_OPTIONS.find((option) => option.id === id)?.label ?? id;
+}

--- a/web-next/src/lib/agent-runtime/provider.ts
+++ b/web-next/src/lib/agent-runtime/provider.ts
@@ -25,6 +25,12 @@ export interface TurnRequest {
 	userMessage: string;
 	/** Prior parked session to resume, or null/undefined for a fresh turn. */
 	resume?: SessionResumeHandle | null;
+	/**
+	 * The session's selected Claude model id (see `./models.ts`). Providers
+	 * that drive a real model (vercel) thread it into the harness; providers
+	 * that don't (mock) record it for testability but otherwise ignore it.
+	 */
+	model?: string;
 }
 
 export interface ComputeProvider {

--- a/web-next/src/lib/agent-runtime/run-turn.test.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.test.ts
@@ -175,6 +175,29 @@ describe("runSessionTurn", () => {
 		});
 	});
 
+	test("threads the session's selected model into the provider request (#824)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "s1",
+			provider: "vercel",
+			model: "claude-opus-4-8",
+		});
+
+		let seen: TurnRequest | undefined;
+		const capturing: ComputeProvider = {
+			id: "vercel",
+			runTurn: async function* (request) {
+				seen = request;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+		const turn = await runSessionTurn(handle, session, "go", capturing);
+		await drain(turn.stream);
+		await turn.ingest;
+
+		expect(seen?.model).toBe("claude-opus-4-8");
+	});
+
 	test("persists a parked handle from the done chunk and strips it from the log", async () => {
 		const handle = freshDb();
 		const session = await createSession(handle, { id: "s1", provider: "vercel" });

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -120,6 +120,7 @@ async function ingestTurn(
 			sessionId: session.id,
 			userMessage: userText,
 			resume: resumeHandle(session),
+			model: session.model,
 		})) {
 			// A terminal `done` may carry the harness handle the turn parked with
 			// detach(); persist it to the session row (not the transcript) so the

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
 	canonicalToolName,
+	createHarness,
 	errorText,
 	mapFullStream,
 	parseGitDiff,
@@ -33,7 +34,11 @@ describe("mapFullStream", () => {
 				input: { command: "ls" },
 			},
 			{ type: "tool-result", toolCallId: "c1", toolName: "bash", output: "a\nb" },
-			{ type: "finish", finishReason: "stop", totalUsage: { outputTokens: 42 } },
+			{
+				type: "finish",
+				finishReason: "stop",
+				totalUsage: { outputTokens: { total: 42 }, inputTokens: { total: 100 } },
+			},
 		]);
 
 		expect(chunks.map((c) => c.type)).toEqual([
@@ -76,12 +81,32 @@ describe("mapFullStream", () => {
 	test("carries finish outputTokens into the terminal done chunk", async () => {
 		const chunks = await collect([
 			{ type: "text-delta", id: "t1", text: "hi" },
-			{ type: "finish", finishReason: "stop", totalUsage: { outputTokens: 7 } },
+			{
+				type: "finish",
+				finishReason: "stop",
+				totalUsage: { outputTokens: { total: 7 } },
+			},
 		]);
 		const done = chunks.at(-1);
 		expect(done?.type).toBe("done");
 		expect(done?.metadata).toMatchObject({ tokenCount: 7 });
 		expect(typeof done?.metadata?.durationMs).toBe("number");
+	});
+
+	test("carries finish inputTokens into the terminal done chunk as contextTokens (#824)", async () => {
+		const chunks = await collect([
+			{ type: "text-delta", id: "t1", text: "hi" },
+			{
+				type: "finish",
+				finishReason: "stop",
+				totalUsage: {
+					outputTokens: { total: 7 },
+					inputTokens: { total: 1234 },
+				},
+			},
+		]);
+		const done = chunks.at(-1);
+		expect(done?.metadata).toMatchObject({ tokenCount: 7, contextTokens: 1234 });
 	});
 
 	test("tool-error maps to an errored tool_result", async () => {
@@ -110,6 +135,31 @@ describe("mapFullStream", () => {
 		expect(dones).toHaveLength(1);
 		expect(chunks.at(-1)?.type).toBe("done");
 		expect(dones[0]?.metadata?.tokenCount).toBeUndefined();
+	});
+});
+
+describe("createHarness", () => {
+	test("forwards the session's model override into createClaudeCode settings (#824)", () => {
+		const calls: unknown[] = [];
+		const fakeCreateClaudeCode = ((settings: unknown) => {
+			calls.push(settings);
+			return {};
+			// biome-ignore-like cast: only the settings arg matters to this test.
+		}) as unknown as Parameters<typeof createHarness>[0];
+
+		createHarness(fakeCreateClaudeCode, undefined, "claude-opus-4-8");
+		expect(calls[0]).toMatchObject({ thinking: "on", model: "claude-opus-4-8" });
+	});
+
+	test("omits model entirely when none is given, deferring to the CLI default", () => {
+		const calls: unknown[] = [];
+		const fakeCreateClaudeCode = ((settings: unknown) => {
+			calls.push(settings);
+			return {};
+		}) as unknown as Parameters<typeof createHarness>[0];
+
+		createHarness(fakeCreateClaudeCode, undefined);
+		expect(calls[0]).not.toHaveProperty("model");
 	});
 });
 

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -156,6 +156,7 @@ export async function* mapFullStream(
 	startedAt: number,
 ): AsyncGenerator<StreamChunk> {
 	let outputTokens: number | undefined;
+	let contextTokens: number | undefined;
 	for await (const part of fullStream) {
 		if (process.env.HARNESS_DEBUG === "1") {
 			const detail =
@@ -211,8 +212,21 @@ export async function* mapFullStream(
 				};
 				break;
 			case "finish": {
-				const usage = part.totalUsage as { outputTokens?: number } | undefined;
-				outputTokens = usage?.outputTokens;
+				// `LanguageModelV4Usage` (@ai-sdk/provider) nests both figures under
+				// `{ total, ... }`, not a bare number — confirmed against the
+				// installed harness's own zod schema (harnessV1FinishPartSchema).
+				const usage = part.totalUsage as
+					| {
+							inputTokens?: { total?: number };
+							outputTokens?: { total?: number };
+					  }
+					| undefined;
+				outputTokens = usage?.outputTokens?.total;
+				// The turn's total input tokens is the best available proxy for
+				// "current context window usage" — it's what the model actually saw
+				// on this call, which for a resumed conversation is the accumulated
+				// history. Real, not a placeholder; see status-line wiring in #824.
+				contextTokens = usage?.inputTokens?.total;
 				break;
 			}
 			default:
@@ -222,7 +236,11 @@ export async function* mapFullStream(
 	yield {
 		type: "done",
 		content: "",
-		metadata: { durationMs: Date.now() - startedAt, tokenCount: outputTokens },
+		metadata: {
+			durationMs: Date.now() - startedAt,
+			tokenCount: outputTokens,
+			contextTokens,
+		},
 	};
 }
 
@@ -269,12 +287,23 @@ function resolveAuth() {
 			: undefined;
 }
 
-/** The claude-code harness adapter. Identical inputs on both paths. */
-function createHarness(
+/**
+ * The claude-code harness adapter. Identical inputs on both paths, plus an
+ * optional per-turn model override (#824): `settings.model` forwards
+ * unchanged onto the sandbox bridge's `claudeSdk.query({ options: { model } })`
+ * call (verified against the installed `@ai-sdk/harness-claude-code` bundle —
+ * no enum/allowlist at that layer), so any id from `./models.ts` works. Model
+ * is deliberately NOT part of the reusable sandbox template identity
+ * (`SANDBOX_BOOTSTRAP`/`BOOTSTRAP_HASH`) — it only affects which model the CLI
+ * invokes inside an already-warm sandbox, so per-session model choice never
+ * invalidates the shared snapshot prewarm builds.
+ */
+export function createHarness(
 	createClaudeCode: CreateClaudeCode,
 	auth: ReturnType<typeof resolveAuth>,
+	model?: string,
 ) {
-	return createClaudeCode({ auth, thinking: "on" });
+	return createClaudeCode({ auth, thinking: "on", ...(model ? { model } : {}) });
 }
 
 /** The Vercel sandbox naming scheme the adapter uses for per-session sandboxes. */
@@ -407,7 +436,7 @@ export const vercelProvider: ComputeProvider = {
 
 		const agent = new HarnessAgent({
 			id: `web-next-${request.sessionId}`,
-			harness: createHarness(createClaudeCode, resolveAuth()),
+			harness: createHarness(createClaudeCode, resolveAuth(), request.model),
 			sandbox: createSandboxProvider(createVercelSandbox),
 			sandboxConfig: {
 				// Same template-identity bootstrap as prewarm, plus the per-session

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -50,6 +50,8 @@ export interface SessionsTable {
 	 * this on the next turn so the conversation and warm sandbox continue.
 	 */
 	resume_state: string | null;
+	/** Claude model id this session's turns run on (migration `0004_session_model`, #824). */
+	model: string;
 	created_at: string;
 	last_activity_at: string;
 }

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -11,6 +11,7 @@
  * cleanly and two cold starts can overlap.
  */
 import { type Kysely, sql } from "kysely";
+import { DEFAULT_MODEL } from "../agent-runtime/models";
 import type { Database } from "./client";
 
 /** One tracked migration: a stable `id` and an idempotent `up`. */
@@ -166,8 +167,33 @@ const sessionResumeState: Migration = {
 	},
 };
 
+/**
+ * Adds `sessions.model` — the Claude model this session's turns run on
+ * (#824). Defaults existing and new rows to `DEFAULT_MODEL` (the current best
+ * model per `agent-runtime/models.ts`) via a SQL constant default, so the
+ * backfill for pre-existing sessions and the default for new ones are the
+ * same value without a second write. Idempotent via the same column-probe
+ * pattern as `0003_session_resume_state`.
+ */
+const sessionModel: Migration = {
+	id: "0004_session_model",
+	async up(db) {
+		const info = await sql<{
+			name: string;
+		}>`PRAGMA table_info(sessions)`.execute(db);
+		const hasColumn = info.rows.some((row) => row.name === "model");
+		if (!hasColumn) {
+			await db.schema
+				.alterTable("sessions")
+				.addColumn("model", "text", (col) => col.notNull().defaultTo(DEFAULT_MODEL))
+				.execute();
+		}
+	},
+};
+
 export const MIGRATIONS: Migration[] = [
 	baseline,
 	authTables,
 	sessionResumeState,
+	sessionModel,
 ];

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import { DEFAULT_MODEL } from "../agent-runtime/models";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
 import { type DatabaseHandle, openDatabase } from "./client";
 import {
@@ -50,6 +51,7 @@ describe("session store", () => {
 			"0001_baseline",
 			"0002_auth_tables",
 			"0003_session_resume_state",
+			"0004_session_model",
 		]);
 	});
 
@@ -71,6 +73,27 @@ describe("session store", () => {
 		expect(created.resumeState).toBeNull();
 		expect(await getSession(handle, "s1")).toEqual(created);
 		expect(await getSession(handle, "missing")).toBeUndefined();
+	});
+
+	test("stamps the current-best model by default, and honors an explicit override (#824)", async () => {
+		const handle = freshDb();
+		const defaulted = await createSession(handle, { id: "s1", provider: "mock" });
+		expect(defaulted.model).toBe(DEFAULT_MODEL);
+
+		const overridden = await createSession(handle, {
+			id: "s2",
+			provider: "mock",
+			model: "claude-haiku-4-5",
+		});
+		expect(overridden.model).toBe("claude-haiku-4-5");
+		expect((await getSession(handle, "s2"))?.model).toBe("claude-haiku-4-5");
+	});
+
+	test("updateSession persists a model change (#824's picker)", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+		await updateSession(handle, "s1", { model: "claude-opus-4-8" });
+		expect((await getSession(handle, "s1"))?.model).toBe("claude-opus-4-8");
 	});
 
 	test("updateSession persists and clears the harness resume handle", async () => {

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -9,6 +9,7 @@
  * the raw log as the source of truth lets projection improve across adapter
  * versions and keeps #749's ingest a dumb append.
  */
+import { DEFAULT_MODEL } from "../agent-runtime/models";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
 import type {
 	ProjectedEvent,
@@ -25,6 +26,8 @@ export interface NewSession {
 	provider: string;
 	status?: string;
 	claudeSessionId?: string | null;
+	/** Claude model id to stamp; defaults to `DEFAULT_MODEL` when omitted. */
+	model?: string;
 }
 
 export interface Session {
@@ -36,6 +39,8 @@ export interface Session {
 	claudeSessionId: string | null;
 	/** JSON harness resume payload from the last turn's detach(), or null. */
 	resumeState: string | null;
+	/** Claude model id this session's turns run on (#824). */
+	model: string;
 	createdAt: string;
 	lastActivityAt: string;
 }
@@ -55,6 +60,7 @@ function rowToSession(row: SessionsTable): Session {
 		status: row.status,
 		claudeSessionId: row.claude_session_id,
 		resumeState: row.resume_state,
+		model: row.model,
 		createdAt: row.created_at,
 		lastActivityAt: row.last_activity_at,
 	};
@@ -74,6 +80,7 @@ export async function createSession(
 		status: session.status ?? "active",
 		claude_session_id: session.claudeSessionId ?? null,
 		resume_state: null,
+		model: session.model ?? DEFAULT_MODEL,
 		created_at: now,
 		last_activity_at: now,
 	};
@@ -82,19 +89,24 @@ export async function createSession(
 }
 
 /**
- * Persists the harness handle a turn parked with `detach()`: the claude session
- * id and the JSON resume payload the next turn reconnects from. `resumeState`
- * of `null` clears it (the parked sandbox expired or the turn didn't detach).
+ * Persists the harness handle a turn parked with `detach()` (claude session id
+ * + JSON resume payload; `resumeState` of `null` clears a stale handle) and/or
+ * the session's selected model (#824's picker).
  */
 export async function updateSession(
 	handle: DatabaseHandle,
 	id: string,
-	fields: { claudeSessionId?: string | null; resumeState?: string | null },
+	fields: {
+		claudeSessionId?: string | null;
+		resumeState?: string | null;
+		model?: string;
+	},
 ): Promise<void> {
 	await ensureSchema(handle);
 	const set: Partial<SessionsTable> = {};
 	if ("claudeSessionId" in fields) set.claude_session_id = fields.claudeSessionId ?? null;
 	if ("resumeState" in fields) set.resume_state = fields.resumeState ?? null;
+	if ("model" in fields && fields.model) set.model = fields.model;
 	if (Object.keys(set).length === 0) return;
 	await handle.db.updateTable("sessions").set(set).where("id", "=", id).execute();
 }

--- a/web-next/src/lib/db/start-session.test.ts
+++ b/web-next/src/lib/db/start-session.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import { DEFAULT_MODEL } from "../agent-runtime/models";
 import { type DatabaseHandle, openDatabase } from "./client";
 import { ensureRepo, listRepos } from "./repos";
 import { listSessions } from "./sessions";
@@ -54,6 +55,7 @@ describe("startSession", () => {
 			title: "",
 			provider: "mock",
 			status: "active",
+			model: DEFAULT_MODEL,
 		});
 		expect(session.id).toBeTruthy();
 		expect((await listRepos(handle)).map((r) => r.fullName)).toEqual([

--- a/web-next/src/lib/transcript/turn-stats.test.ts
+++ b/web-next/src/lib/transcript/turn-stats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
+import type { FolioMessage } from "@/components/folio/types";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
-import { deriveTurnStats, folioTurnMetadata } from "./turn-stats";
+import { deriveContextLabel, deriveTurnStats, folioTurnMetadata } from "./turn-stats";
 
 const done = (metadata?: Record<string, unknown>): StreamChunk => ({
 	type: "done",
@@ -71,6 +72,41 @@ describe("deriveTurnStats", () => {
 			toolCount: 0,
 			durationMs: 0,
 		});
+	});
+
+	test("extracts the real contextTokens figure from done metadata (#824)", () => {
+		const stats = deriveTurnStats([done({ durationMs: 10, contextTokens: 2000 })]);
+		expect(stats).toMatchObject({ contextTokens: 2000 });
+	});
+});
+
+describe("deriveContextLabel", () => {
+	function assistantMessage(contextTokens?: number): FolioMessage {
+		return {
+			id: "m",
+			role: "assistant",
+			parts: [],
+			metadata:
+				contextTokens === undefined
+					? { author: "Claude" }
+					: { author: "Claude", turnStats: { toolCount: 0, durationMs: 0, contextTokens } },
+		};
+	}
+
+	test("undefined when no turn has reported a context figure", () => {
+		expect(deriveContextLabel([assistantMessage()])).toBeUndefined();
+	});
+
+	test("formats the most recent completed turn's figure", () => {
+		expect(
+			deriveContextLabel([assistantMessage(500), assistantMessage(2300)]),
+		).toBe("2.3k ctx");
+	});
+
+	test("looks back past a trailing turn that hasn't reported one yet", () => {
+		expect(deriveContextLabel([assistantMessage(500), assistantMessage()])).toBe(
+			"500 ctx",
+		);
 	});
 });
 

--- a/web-next/src/lib/transcript/turn-stats.ts
+++ b/web-next/src/lib/transcript/turn-stats.ts
@@ -5,7 +5,12 @@
  * chunk adapter's messageMetadata hook, so live streams and replayed logs
  * produce identical stats (the numbers are in the persisted events).
  */
-import type { FolioMetadata, TurnStatsData } from "@/components/folio/types";
+import { formatTokenCount } from "@/components/folio/ledger";
+import type {
+	FolioMessage,
+	FolioMetadata,
+	TurnStatsData,
+} from "@/components/folio/types";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
 
 /** The agent's display name on assistant messages (single-agent for now). */
@@ -75,6 +80,7 @@ export function deriveTurnStats(
 		toolCount,
 		durationMs: asNumber(done.metadata?.durationMs) ?? 0,
 		tokenCount: asNumber(done.metadata?.tokenCount),
+		contextTokens: asNumber(done.metadata?.contextTokens),
 		filesChanged: changedFiles.size > 0 ? changedFiles.size : undefined,
 		additions,
 		deletions,
@@ -91,4 +97,21 @@ export function folioTurnMetadata(
 ): FolioMetadata {
 	const turnStats = deriveTurnStats(chunks);
 	return turnStats ? { author: AGENT_AUTHOR, turnStats } : { author: AGENT_AUTHOR };
+}
+
+/**
+ * The status line's real "N ctx" figure (#824): the most recent completed
+ * turn's total input tokens — what the model actually saw last, the best
+ * available proxy for current context usage. Undefined when no turn has
+ * completed yet, or none reported the figure — the status line hides the
+ * segment rather than showing a fake "0 ctx".
+ */
+export function deriveContextLabel(
+	messages: readonly FolioMessage[],
+): string | undefined {
+	for (let i = messages.length - 1; i >= 0; i -= 1) {
+		const contextTokens = messages[i].metadata?.turnStats?.contextTokens;
+		if (contextTokens !== undefined) return `${formatTokenCount(contextTokens)} ctx`;
+	}
+	return undefined;
 }

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -183,6 +183,28 @@ test("a reload renders the same turn from the persisted event log", async ({
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
 });
 
+test("the status line's model picker changes the model and persists across reload (#824)", async ({
+	page,
+}) => {
+	await page.goto(turnSessionUrl);
+	const select = page.getByTestId("model-select");
+
+	// New sessions stamp the current-best model — Fable 5.
+	await expect(select).toHaveValue("claude-fable-5");
+	await expect(page.getByTestId("status-line")).toContainText("Fable 5");
+
+	await select.selectOption("claude-sonnet-5");
+	await expect(page.getByTestId("status-line")).toContainText("Sonnet 5");
+
+	// The end-of-turn receipt from the earlier mock turn also gave the status
+	// line a real context figure — no more fake "0 ctx" placeholder.
+	await expect(page.getByTestId("status-line")).toContainText("ctx");
+
+	await page.reload();
+	await expect(page.getByTestId("model-select")).toHaveValue("claude-sonnet-5");
+	await expect(page.getByTestId("status-line")).toContainText("Sonnet 5");
+});
+
 test("a turn survives a mid-stream reload and resumes to completion", async ({
 	page,
 }) => {

--- a/web-next/vitest.config.ts
+++ b/web-next/vitest.config.ts
@@ -1,6 +1,14 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	// Mirrors tsconfig.json's "@/*" path so a value import (not just `import
+	// type`) across the lib/ ↔ components/ boundary resolves under vitest too
+	// (#824: lib/transcript/turn-stats.ts reuses components/folio/ledger.ts's
+	// token formatter).
+	resolve: {
+		alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+	},
 	test: {
 		environment: "node",
 		include: ["src/**/*.test.ts", "scripts/**/*.test.mjs", "perf/**/*.test.mjs"],


### PR DESCRIPTION
Closes #824

## What

Per-session Claude model selection, end to end:

- **Persist** — `sessions.model` via appended migration `0004_session_model` (NOT NULL, SQL `DEFAULT` = the current-best model, so existing rows backfill and new rows default in one stroke; idempotent column-probe pattern matching `0003`). `docs/schema.md` updated.
- **Single source of truth** — `src/lib/agent-runtime/models.ts` exports `MODEL_OPTIONS` (Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5 — full ids), `DEFAULT_MODEL` (`claude-fable-5`), `isSelectableModel`, `modelLabel`. The picker, session-creation default, PATCH validation, and turn threading all read this one module, so validation stage #816 can later read the same set.
- **Pick** — the status line's model segment becomes a chrome-free native `<select>` styled as the same plain text (Folio: "the model lives in a dismissible status line, stated once"). Fixtures/demo pages that pass no handler keep static text. `PATCH /api/sessions/[id]` (new route) validates against `isSelectableModel` and persists.
- **Route** — `TurnRequest.model` threads `session.model` through `turn-ingest` into providers. The real provider passes it as `createClaudeCode({ model })`; the installed `@ai-sdk/harness-claude-code@1.0.18` bundle forwards that string unchanged onto the in-sandbox bridge's `claudeSdk.query({ options: { model } })` (verified by reading the shipped `dist/index.js` and `dist/bridge/index.mjs`). Model is deliberately **not** part of the sandbox template identity, so switching models never invalidates the prewarm snapshot. `mock-provider` records the requested model on its terminal `done` chunk, making routing unit-testable.
- **Display** — the status line shows the session's real model (label via `modelLabel`), not the hardcoded `"opus-4.8"` string.

**Real context figure.** The issue also asked to replace the placeholder `0 ctx`. This turn: `mapFullStream`'s `finish` handler had a latent shape bug — `LanguageModelV4Usage` nests token totals (`{ outputTokens: { total } }`), and the old code read `totalUsage.outputTokens` as a bare number, so `tokenCount` was always undefined on real turns. Fixed per the installed `@ai-sdk/provider@4.0.2` types, and the corrected `inputTokens.total` now rides the `done` chunk as `contextTokens` — the most recent completed turn's input-token total is the status line's `N ctx` (what the model actually saw last). When no completed turn has reported one, the segment is hidden rather than faked.

## Review loop

Self-reflection pass, then a directed codex review (`gpt-5.5`, `xhigh`) over the diff with five named failure modes (migration backfill, leftover flat-usage-shape assumptions, picker optimistic-update races, end-to-end model threading, NOT NULL coverage of all session inserts).

| Finding | Severity | Disposition |
|---|---|---|
| Picker PATCH not sequenced against sends or later changes: a send fired immediately after a model change could start the turn from the old session row (turn on A while the status line says B); rapid B→C changes could land in the DB in completion order | High | **Fixed** in `fix(web-next): sequence model PATCHes and gate sends on them` — PATCHes chain sequentially, `send` awaits the chain before posting, revert-on-failure only applies while that choice is still the latest |
| Migration/backfill, usage-shape call sites, TurnRequest threading (mock + vercel), non-null model across all session inserts | — | Explicitly cleared by the review ("no findings for the other named areas"); it also independently confirmed libSQL backfills existing rows for `ADD COLUMN ... NOT NULL DEFAULT` |

## Evidence

- Unit: **before** 105 tests / 11 files → **after** 176 tests passed / 18 files on the feature branch (182 / 19 after rebasing onto #887, which added perf-script tests). New coverage: migration presence (`0004_session_model` in the applied list), default stamping + explicit override at session creation, `updateSession` model persistence, model threading into `TurnRequest` (capturing provider + mock provider records it on `done`), the model-set module, `contextTokens` extraction, and `deriveContextLabel`.
- E2E: **23 passed** (`pnpm run test:e2e`, production build) including the new spec `the status line's model picker changes the model and persists across reload (#824)` — asserts the default (Fable 5), a change to Sonnet 5, a real `ctx` figure present, and persistence across reload.
- Mutation check: replaced `createSession`'s `model: session.model ?? DEFAULT_MODEL` with a wrong constant — 2 tests failed (`sessions.test.ts` default-stamping, `start-session.test.ts` create-flow), reverted, suite green again.
- Screenshots: regenerated via `pnpm run evidence` → `web-next/output/evidence/` (24 images, light+dark). Key frames uploaded — the status line rendering "Fable 5 · 123 ctx" (real model + real context figure):
  ![model-picker-status-line](https://evidence.cloudcompute.com/workspaces/pr-903/20260707-160235-model-picker-status-line.png)
  ![model-picker-status-line-dark](https://evidence.cloudcompute.com/workspaces/pr-903/20260707-160244-model-picker-status-line-dark.png)
- CI: green quality lane (lint/typecheck/unit/build/e2e/perf, perf under the #887 ratcheted budgets) on 6499a25: https://github.com/fairchild/workspaces/actions/runs/28880457221/job/85666959440
- Gate note: orchestrator read the sensitive hunks (0004 migration idempotence + SQL-default backfill, PATCH route auth+model validation, TurnRequest threading, usage-shape fix vs harness zod schema); codex loop ran with one High finding fixed (PATCH/send sequencing); merged on delegated authority.

## Mergeability

- Surface: web (web-next sessions UI, status line, chat/turn runtime seam, local SQLite schema) — no desktop, infra, or legacy `web/` changes.
- User-facing behavior changed: Yes — the session status line now shows the session's real model as a quiet picker (was a hardcoded "opus-4.8" string), the fake "0 ctx" placeholder is replaced by a real input-token figure (hidden until a turn reports one), and new sessions run on Fable 5 by default with per-session override persisted across reloads.
- Non-happy paths considered: PATCH with unknown/missing model → 400 (validated against the model module); unauthenticated/forbidden → 401/403; unknown session → 404; failed PATCH reverts the optimistic UI only while that choice is still the latest; rapid successive changes serialize so DB order matches selection order; sends await any in-flight model PATCH; providers that report no usage yield an absent context figure (segment hidden, never a fake 0); sessions created before the migration backfill to the default via the SQL column default; `modelLabel` falls back to the raw id for a stored model no longer in the selectable set.
- Residual risk or follow-up: model ids are grounded in the installed harness bundle + Claude Code CLI 2.1.202 strings (no enum at the harness layer — any current id passes through), but no paid real-sandbox turn was run to observe each id end-to-end (hermetic verification only, per the task constraints); if Anthropic retires an id, the set is one small module to update, and #816's validation stage can read the same module. The context figure is per-turn input tokens (the standard proxy), not a live mid-turn window gauge.

