### PR TITLE
chore(web-next): arg-based clean script replaces ad-hoc rm -rf

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -52,6 +52,21 @@ probes reachability and auth/security posture with zero credentials, and
 credential-gated stages report themselves skipped rather than passing silently
 (see `docs/roadmap.md` Phase 2 / milestone #13).
 
+## Cleaning up
+
+```bash
+pnpm run clean              # build + data + artifacts (the safe everyday trio)
+pnpm run clean build        # just .next (clean-build reproduction)
+pnpm run clean all --dry-run
+```
+
+One entrypoint for deleting build/test state — `.next`, throwaway e2e/perf
+databases (`.data/`), and test artifacts (`output/`, reports, perf results).
+Use it instead of ad-hoc `rm -rf`: the fixed target map is safe by
+construction and the single command shape is shell-allowlistable, so
+unattended agent sessions don't stall on permission prompts. `deps`
+(node_modules) is only removed when named explicitly or via `all`.
+
 ## The feedback loop (owner review of in-flight work)
 
 The product is steered by the owner looking at a running instance, not at

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -11,6 +11,7 @@
 		"test:e2e": "playwright test",
 		"typecheck": "tsc --noEmit",
 		"lint": "eslint .",
+		"clean": "node scripts/clean.mjs",
 		"evidence": "node scripts/evidence.mjs",
 		"perf": "node perf/run.mjs",
 		"validate": "node scripts/validate.mjs"

--- a/web-next/scripts/clean-core.mjs
+++ b/web-next/scripts/clean-core.mjs
@@ -1,0 +1,60 @@
+/*
+ * Pure target-resolution core for scripts/clean.mjs — maps named clean
+ * targets onto the fixed set of web-next-relative paths they cover. Pure and
+ * I/O-free so the expansion/validation rules are unit-testable (see
+ * clean-core.test.mjs), mirroring the validate-core.mjs pattern.
+ */
+
+/** Named targets → the web-next-relative paths they remove. */
+export const TARGETS = {
+	build: [".next"],
+	data: [".data"],
+	artifacts: [
+		"output",
+		"playwright-report",
+		"test-results",
+		"perf/results.json",
+		"perf/results.md",
+		"perf/results-deployed.json",
+		"perf/results-deployed.md",
+	],
+	deps: ["node_modules"],
+};
+
+/** No-arg default: the safe everyday trio (never deps). */
+export const DEFAULT_TARGETS = ["build", "data", "artifacts"];
+
+export const USAGE =
+	"usage: pnpm run clean [build|data|artifacts|deps|all]... [--dry-run]";
+
+/**
+ * Expands target names into a deduplicated list of web-next-relative paths.
+ * No names → DEFAULT_TARGETS; `all` → every target. Throws on unknown names.
+ */
+export function expandTargets(names) {
+	const requested = names.length === 0 ? DEFAULT_TARGETS : names;
+	const expanded = requested.includes("all") ? Object.keys(TARGETS) : requested;
+	const unknown = expanded.filter((name) => !Object.hasOwn(TARGETS, name));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown target(s): ${unknown.join(", ")} — valid: ${[...Object.keys(TARGETS), "all"].join(", ")}`,
+		);
+	}
+	return [...new Set(expanded.flatMap((name) => TARGETS[name]))];
+}
+
+/**
+ * Resolves a relative path against the web-next root and refuses anything
+ * that escapes it. Paths come from the fixed TARGETS map, so escape is
+ * impossible by construction — this guard keeps that true if the map changes.
+ */
+export function resolveWithinRoot(root, relPath, resolve, sep) {
+	const abs = resolve(root, relPath);
+	if (abs !== root && !abs.startsWith(root + sep)) {
+		throw new Error(`refusing to touch a path outside the web-next root: ${abs}`);
+	}
+	if (abs === root) {
+		throw new Error("refusing to remove the web-next root itself");
+	}
+	return abs;
+}

--- a/web-next/scripts/clean-core.test.mjs
+++ b/web-next/scripts/clean-core.test.mjs
@@ -1,0 +1,58 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+	DEFAULT_TARGETS,
+	expandTargets,
+	resolveWithinRoot,
+	TARGETS,
+} from "./clean-core.mjs";
+
+describe("expandTargets", () => {
+	test("no args expands the safe default trio, never deps", () => {
+		const paths = expandTargets([]);
+		expect(DEFAULT_TARGETS).not.toContain("deps");
+		expect(paths).toContain(".next");
+		expect(paths).toContain(".data");
+		expect(paths).toContain("output");
+		expect(paths).not.toContain("node_modules");
+	});
+
+	test("all expands every target exactly once", () => {
+		const paths = expandTargets(["all"]);
+		const everyPath = Object.values(TARGETS).flat();
+		expect(new Set(paths)).toEqual(new Set(everyPath));
+		expect(paths.length).toBe(new Set(paths).size);
+	});
+
+	test("named targets expand to just their paths, deduplicated", () => {
+		expect(expandTargets(["build"])).toEqual([".next"]);
+		expect(expandTargets(["build", "build", "deps"])).toEqual([
+			".next",
+			"node_modules",
+		]);
+	});
+
+	test("unknown targets are rejected with the valid vocabulary", () => {
+		expect(() => expandTargets(["buld"])).toThrow(/unknown target.*buld.*valid/);
+		expect(() => expandTargets(["hasOwnProperty"])).toThrow(/unknown target/);
+	});
+});
+
+describe("resolveWithinRoot", () => {
+	const root = path.resolve("/tmp/web-next");
+
+	test("resolves a relative path inside the root", () => {
+		expect(resolveWithinRoot(root, ".next", path.resolve, path.sep)).toBe(
+			path.join(root, ".next"),
+		);
+	});
+
+	test("refuses escapes and the root itself", () => {
+		expect(() => resolveWithinRoot(root, "../elsewhere", path.resolve, path.sep)).toThrow(
+			/outside the web-next root/,
+		);
+		expect(() => resolveWithinRoot(root, ".", path.resolve, path.sep)).toThrow(
+			/root itself/,
+		);
+	});
+});

--- a/web-next/scripts/clean.mjs
+++ b/web-next/scripts/clean.mjs
@@ -1,0 +1,41 @@
+/*
+ * Deletes web-next build/test state through one entrypoint:
+ * `pnpm run clean [build|data|artifacts|deps|all]... [--dry-run]`.
+ * Exists so agents and unattended sessions never need ad-hoc `rm -rf`,
+ * which trips shell-permission prompts; one fixed, allowlistable command
+ * covers the recurring cases (clean builds, throwaway e2e/perf databases,
+ * test artifacts). Target map + safety rules live in clean-core.mjs.
+ */
+import { existsSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expandTargets, resolveWithinRoot, USAGE } from "./clean-core.mjs";
+
+const WEB_NEXT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const names = args.filter((arg) => arg !== "--dry-run");
+
+let relPaths;
+try {
+	relPaths = expandTargets(names);
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	console.error(USAGE);
+	process.exit(1);
+}
+
+for (const relPath of relPaths) {
+	const abs = resolveWithinRoot(WEB_NEXT_ROOT, relPath, path.resolve, path.sep);
+	if (!existsSync(abs)) {
+		console.log(`absent   ${relPath}`);
+		continue;
+	}
+	if (dryRun) {
+		console.log(`would rm ${relPath}`);
+		continue;
+	}
+	rmSync(abs, { recursive: true, force: true });
+	console.log(`removed  ${relPath}`);
+}


### PR DESCRIPTION
One entrypoint for deleting web-next build/test state — `pnpm run clean [build|data|artifacts|deps|all]... [--dry-run]` — so agents and unattended sessions never need ad-hoc `rm -rf`, which trips shell-permission prompts and stalls work when the owner is away.

- `scripts/clean-core.mjs` — pure target map + expansion/validation (unit-tested, validate-core pattern)
- `scripts/clean.mjs` — the runner: fixed internal paths resolved against the web-next root, escape guard, idempotent (absent paths reported, not errors)
- default (no args) = `build data artifacts`; `deps` (node_modules) only when named or via `all`
- CONTRIBUTING.md § "Cleaning up" documents the command and the no-`rm -rf` convention

## Mergeability
Surface: web-next dev tooling only — two new scripts, one test file, a package.json script entry, a CONTRIBUTING section. No app/runtime code touched.
User-facing behavior changed: none for app users; developers/agents gain `pnpm run clean`.
Non-happy paths considered: unknown target → usage + exit 1; path escaping the web-next root or resolving to the root itself → refusal (unit-tested); missing paths are reported "absent" and skipped, so the command is idempotent and safe to re-run.
Residual risk or follow-up: the target map is maintained by hand — a future artifact dir must be added to `TARGETS.artifacts`; the escape guard keeps mistakes contained to the web-next tree. Follow-up: owners may allowlist `pnpm run clean` in their shell permission config to fully remove prompts.

## Evidence
Tests passed: 171/171 unit tests passed locally (6 new in `clean-core.test.mjs`); lint clean. Live demo verified: `--dry-run` listing, real removal of `.data`/`output`/`test-results`, unknown-target rejection with exit 1.
- CI: green quality lane (lint/typecheck/unit/build/e2e/perf) on 5b515d9: https://github.com/fairchild/workspaces/actions/runs/28881400127/job/85670285564
- Note: the Vercel preview deploy failed on the account's daily build rate limit — not a required check, and this diff has no runtime surface to preview.

## Gate
Trivial tooling diff (no runtime surface) — codex loop skipped per contract; orchestrator authored and verified directly.

