### PR TITLE
ci(web-next): label-gated opt-in Vercel preview; disable Git auto-deploy

### DIFF
--- a/.github/workflows/web-next-preview.yml
+++ b/.github/workflows/web-next-preview.yml
@@ -1,0 +1,144 @@
+name: Web Next Preview
+
+# Opt-in Vercel preview for web-next. Vercel's native Git deployments are
+# disabled for this project (web-next/vercel.json git.deploymentEnabled=false),
+# so previews are created only here — and only when a PR that touches web-next/**
+# (or this workflow) carries the `preview` label. Label the PR to deploy; remove
+# it to stop redeploying on subsequent pushes. `unlabeled` is in the trigger list
+# so removing the label enters this PR's concurrency group and cancels an
+# in-flight deploy (the run's own job then skips at the label `if`).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    paths:
+      - "web-next/**"
+      - ".github/workflows/web-next-preview.yml"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: web-next-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy Vercel preview
+    if: >-
+      ${{ !github.event.pull_request.draft
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && contains(github.event.pull_request.labels.*.name, 'preview') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      preview_url: ${{ steps.deploy.outputs.preview_url }}
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web-next/pnpm-lock.yaml
+
+      - name: Validate Vercel secrets
+        run: |
+          missing=()
+          for name in VERCEL_TOKEN VERCEL_ORG_ID; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Install web-next dependencies
+        working-directory: web-next
+        run: pnpm install --frozen-lockfile
+
+      # No VERCEL_PROJECT_ID secret exists for web-next (the repo's is spaces-web),
+      # so resolve the project by name. This writes .vercel/project.json, which the
+      # pull/build/deploy steps then read — including the project's Root Directory
+      # (web-next), so the commands run from the repo root.
+      - name: Link Vercel project
+        run: npx vercel@51 link --yes --project web-next --scope="$VERCEL_ORG_ID" --token="$VERCEL_TOKEN"
+
+      - name: Pull Vercel preview env + config
+        run: npx vercel@51 pull --yes --environment=preview --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
+
+      - name: Build preview artifact
+        run: npx vercel@51 build --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"
+
+      - name: Deploy prebuilt preview
+        id: deploy
+        run: |
+          URL=$(npx vercel@51 deploy --prebuilt --archive=tgz --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID")
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "::notice::Preview deployed to $URL"
+
+      - name: Comment preview URL
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = '<!-- web-next-preview -->';
+            const previewUrl = process.env.PREVIEW_URL;
+            const headSha = process.env.HEAD_SHA;
+            const shortSha = headSha.slice(0, 7);
+            const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+
+            const body = [
+              marker,
+              '### Vercel Preview: `web-next`',
+              '',
+              `- Raw deployment: ${previewUrl}`,
+              '- Protected by Vercel SSO + app auth; open it signed in to reach the app.',
+              `- Commit: \`${shortSha}\``,
+              `- Workflow: [run ${process.env.GITHUB_RUN_NUMBER}](${workflowUrl})`,
+              '',
+              'This preview is opt-in: it deploys only while the PR carries the `preview` label and touches `web-next/**`. Remove the label to stop redeploying on new pushes.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/web-next-preview.yml
+++ b/.github/workflows/web-next-preview.yml
@@ -73,11 +73,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # No VERCEL_PROJECT_ID secret exists for web-next (the repo's is spaces-web),
-      # so resolve the project by name. This writes .vercel/project.json, which the
-      # pull/build/deploy steps then read — including the project's Root Directory
-      # (web-next), so the commands run from the repo root.
+      # so resolve the project by name. `link` writes .vercel/project.json; export
+      # its projectId so the pull/build/deploy steps have both VERCEL_ORG_ID and
+      # VERCEL_PROJECT_ID — the CLI requires both once ORG_ID is set and otherwise
+      # errors ("you forgot to specify VERCEL_PROJECT_ID"). The project's Root
+      # Directory (web-next) comes from `pull`, so the commands run from repo root.
       - name: Link Vercel project
-        run: npx vercel@51 link --yes --project web-next --scope="$VERCEL_ORG_ID" --token="$VERCEL_TOKEN"
+        run: |
+          npx vercel@51 link --yes --project web-next --scope="$VERCEL_ORG_ID" --token="$VERCEL_TOKEN"
+          echo "VERCEL_PROJECT_ID=$(node -p "require('./.vercel/project.json').projectId")" >> "$GITHUB_ENV"
 
       - name: Pull Vercel preview env + config
         run: npx vercel@51 pull --yes --environment=preview --token="$VERCEL_TOKEN" --scope="$VERCEL_ORG_ID"

--- a/scripts/cd/README.md
+++ b/scripts/cd/README.md
@@ -23,9 +23,11 @@ After: every push to `main` produces a preview deployment, gets validated agains
 
 **Rolling failure issues, not per-failure issues.** One issue per validator (`CD: playwright failures on main`, `CD: lighthouse failures on main`), identified by hidden HTML markers. New failures append a comment; the issue auto-reopens if closed. Production validation uses one open `cd-failure:prod` issue for the prod surface, and the next green prod validation comments on and closes open auto-opened prod failure issues. Avoids issue-tracker flooding during a regression burst.
 
-**Configuration as code.** The Vercel Git auto-deploy guard lives in `web/vercel.json` (`git.deploymentEnabled = false`), not in dashboard settings. Vercel stays connected for metadata, while GitHub Actions owns PR previews and production promotion.
+**Configuration as code.** The Vercel Git auto-deploy guard lives in each project's `vercel.json` (`git.deploymentEnabled = false`) — `web/vercel.json` for `spaces-web`, `web-next/vercel.json` for `web-next` — not in dashboard settings. Vercel stays connected for metadata, while GitHub Actions owns PR previews and production promotion.
 
-**Targeted PR previews.** `.github/workflows/web-preview.yml` deploys Vercel previews only for PRs that touch `web/**`. Non-web PRs do not create Vercel deployments or preview comments.
+**Targeted PR previews (spaces-web).** `.github/workflows/web-preview.yml` deploys Vercel previews only for PRs that touch `web/**`. Non-web PRs do not create Vercel deployments or preview comments.
+
+**Opt-in PR previews (web-next).** `.github/workflows/web-next-preview.yml` deploys a `web-next` preview only when a PR that touches `web-next/**` (or the workflow itself) carries the `preview` label (label to deploy, remove to stop redeploying — `unlabeled` cancels an in-flight deploy). It resolves the project by name via `vercel link` since there's no `web-next` project-id secret, and skips the deployment smoke that `web/` runs because `web-next` has no `deployment-smoke` Playwright project and its prod is SSO-gated (headless can't reach it).
 
 ## Architecture
 

--- a/web-next/vercel.json
+++ b/web-next/vercel.json
@@ -1,0 +1,6 @@
+{
+	"git": {
+		"deploymentEnabled": false
+	},
+	"$schema": "https://openapi.vercel.sh/vercel.json"
+}


### PR DESCRIPTION
## Summary

Switch `web-next` Vercel previews from **on-by-default** to **opt-in**, mirroring the Actions-owned model already used for `spaces-web` (`web/`).

- **`web-next/vercel.json`** — `git.deploymentEnabled: false`. Today `web-next` deploys a preview on *every* push/PR via Vercel's native Git integration because it lacks this guard (which `web/` already has). This turns that off; Vercel stays connected for metadata only.
- **`.github/workflows/web-next-preview.yml`** — a new label-gated preview. It deploys only when a PR touches `web-next/**` (or the workflow itself) **and** carries the `preview` label. Label to deploy; remove to stop (`unlabeled` cancels an in-flight deploy via the concurrency group). Non-draft + same-repo guards match `web-preview.yml` so fork PRs never receive secrets. The project is resolved by name (`vercel link --project web-next`, exporting the projectId) since there's no `web-next` project-id secret; verified live that `rootDirectory=web-next`, so pull/build/deploy run from repo root exactly like `web-preview.yml`. No deployment-smoke job — `web-next` has no `deployment-smoke` Playwright project and its prod is SSO-gated.
- **`scripts/cd/README.md`** — documents the web-next opt-in policy next to web's. The `preview` label was created on the repo.

## Mergeability

- Surface: infra (CI / Vercel deploy policy for `web-next/`)
- User-facing behavior changed: No product behavior. Operationally, `web-next` PRs no longer auto-deploy a Vercel preview on every push; a preview now requires the `preview` label. `spaces-web` (`web/`) and its CD pipeline are untouched.
- Non-happy paths considered: Fork PRs (skipped before secrets via same-repo guard); draft PRs (skipped); non-`web-next` PRs (path filter, no deploy); label removed mid-deploy (`unlabeled` enters the concurrency group and cancels the in-flight run); missing Vercel secrets (validate step fails fast); no project-id secret (resolved by name, projectId exported so the CLI's "need both ORG_ID+PROJECT_ID" rule is satisfied).
- Release/ops preconditions: None. Uses existing `VERCEL_TOKEN` / `VERCEL_ORG_ID` repo secrets; no new secrets. Reversible by deleting the workflow + `web-next/vercel.json` (restores default-on).
- Residual risk or follow-up: The final `vercel deploy` step is the only piece not observed green here, blocked solely by the Vercel account's free-tier 100-deploys/day cap (evidence below) — a symptom of the default-on behavior this PR removes. The command is byte-identical to the proven `web-preview.yml` deploy; re-label after the daily reset to capture a live preview URL.

## Validation

- [x] Other checks run: `actionlint` clean on `web-next-preview.yml`; YAML + `web-next/vercel.json` JSON parse; live `vercel link --project web-next` + `vercel pull --environment=preview` resolved the project (`prj_ucOY3JKR5BCrbtbfz8DTSFJe5U9m`, `cloudcompute/web-next`) with no project-id secret.

## Evidence

Self-validated on this PR (it touches `web-next/**` + the workflow, so labeling it `preview` triggers the new workflow on itself). The run linked → pulled preview env → **built** the web-next artifact → **uploaded** 7.7 MB to `cloudcompute/web-next`; only the final deploy was blocked by the free-tier daily cap (`api-deployments-free-per-day`). Gate behavior confirmed correct: pre-label runs **skipped**, `labeled` run **executed**.

- Run: https://github.com/fairchild/workspaces/actions/runs/28882222890
- Evidence: ![web-next-preview-selfvalidation](https://evidence.cloudcompute.com/workspaces/pr-905/20260707-163517-web-next-preview-selfvalidation.png)

## Review loop

Reflected, then `codex exec` (gpt-5.5, xhigh) directed pass. No fail-open path found (the job-level `contains(labels, 'preview')` guard blocks all deploy steps when the label is absent); fork/draft guards and the root-directory approach confirmed correct.

- **Low — no `unlabeled` trigger** (accepted, fixed): removing `preview` mid-flight wouldn't cancel an in-flight deploy. Added `unlabeled` to the trigger types so label removal enters the concurrency group and cancels the run.
- **Low — `paths` includes the workflow file** (accepted as intentional): a labeled PR touching only the workflow deploys. Mirrors `web-preview.yml`'s self-validation and is still label-gated; docs adjusted for accuracy.

## Blockers

- [x] None
- [ ] Blocked on evidence

Substantive evidence is attached (build + upload proven against the correct project). The only step not observed green is the terminal `vercel deploy`, blocked by the Vercel account's free-tier 100/day cap (external quota, not code); re-label `preview` after the daily reset for a live URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
