### PR TITLE
feat(web-next): session titles — auto from first turn, inline editable

### DIFF
--- a/web-next/docs/schema.md
+++ b/web-next/docs/schema.md
@@ -42,7 +42,7 @@ that log, never stored here.
 |---|---|---|
 | `id` | text PK | Session id. |
 | `repo_id` | text? | `repos.id` this session runs against; null until bound. |
-| `title` | text | Display title (defaults to `""`). |
+| `title` | text | Display title; `""` until named. Auto-titled from the first user message's first line at turn-start (`titleSessionIfEmpty`, `src/lib/agent-runtime/turn-ingest.ts`, #823) via a `WHERE title = ''` conditional update — idempotent, and skipped when that line has no usable text (session stays untitled for a later turn). User edits go through `PATCH /api/sessions/[id]` (`updateSession`, unconditional) and are never overwritten by the auto-titler once set. Derivation rules (cleaning, length cap) live in `src/lib/session-title.ts`, shared by both paths. |
 | `provider` | text | Compute provider id — `mock` \| `vercel` \| `anthropic` \| … |
 | `status` | text | Lifecycle — `active` \| `idle` \| `archived` (owned by #749/#750). |
 | `claude_session_id` | text? | Harness/Claude session id for resume; null until a real turn parks one. |

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -13,10 +13,20 @@
  * fresh tab) reflects the same value because page.tsx reads it back from the
  * DB. The context figure is recomputed from the live transcript on every
  * render, so it advances turn-by-turn instead of only after a reload.
+ *
+ * The title (#823) follows the same seeded-client-state + PATCH-chain shape
+ * as the model, plus one addition: while the session has no persisted title
+ * yet, the masthead shows a *client-derived preview* — `deriveSessionTitle`
+ * run against the first visible user message, the exact pure function the
+ * server runs durably at turn-start (turn-ingest.ts) — so the title appears
+ * the instant the first message lands instead of waiting for a reload. A
+ * reload always agrees because both sides compute the same function over the
+ * same text; a user edit (or the eventual server write) replaces the preview
+ * with the real persisted string.
  */
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { modelLabel } from "@/lib/agent-runtime/models";
 import {
 	type ActiveTurnData,
@@ -24,6 +34,7 @@ import {
 	type SessionViewData,
 } from "@/components/folio/session-view";
 import type { FolioDataParts, FolioMessage } from "@/components/folio/types";
+import { deriveSessionTitle } from "@/lib/session-title";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
@@ -33,6 +44,16 @@ function lastUserText(messages: FolioMessage[]): string {
 	const last = [...messages].reverse().find((m) => m.role === "user");
 	return (
 		last?.parts
+			.filter((part) => part.type === "text")
+			.map((part) => part.text)
+			.join("") ?? ""
+	);
+}
+
+function firstUserText(messages: FolioMessage[]): string {
+	const first = messages.find((m) => m.role === "user");
+	return (
+		first?.parts
 			.filter((part) => part.type === "text")
 			.map((part) => part.text)
 			.join("") ?? ""
@@ -86,6 +107,34 @@ export function LiveSessionView({
 				method: "PATCH",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ model: nextModel }),
+			})
+				.then((res) => {
+					if (!res.ok) revert();
+				})
+				.catch(revert),
+		);
+	};
+
+	// The persisted title, "" until either the auto-titler or an edit sets one.
+	// Same seeded-state + chained-PATCH-with-revert shape as the model above.
+	const [title, setTitle] = useState(session.masthead.title);
+	const latestTitleRef = useRef(session.masthead.title);
+	const titlePatchChain = useRef<Promise<void>>(Promise.resolve());
+	const handleTitleChange = (nextTitle: string) => {
+		const previous = latestTitleRef.current;
+		latestTitleRef.current = nextTitle;
+		setTitle(nextTitle);
+		const revert = () => {
+			if (latestTitleRef.current === nextTitle) {
+				latestTitleRef.current = previous;
+				setTitle(previous);
+			}
+		};
+		titlePatchChain.current = titlePatchChain.current.then(() =>
+			fetch(`/api/sessions/${sessionId}`, {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ title: nextTitle }),
 			})
 				.then((res) => {
 					if (!res.ok) revert();
@@ -161,12 +210,25 @@ export function LiveSessionView({
 				}
 			: undefined;
 
+	// Before the session has a real title, show the same derivation the
+	// server will persist durably at turn-start — computed here purely for
+	// instant paint, never written from the client.
+	const displayTitle = useMemo(
+		() => title || deriveSessionTitle(firstUserText(visibleMessages)),
+		[title, visibleMessages],
+	);
+
+	useEffect(() => {
+		document.title = displayTitle ? `${displayTitle} — Spaces` : "Spaces";
+	}, [displayTitle]);
+
 	return (
 		<SessionView
 			session={{
 				...session,
 				messages: visibleMessages,
 				activeTurn,
+				masthead: { ...session.masthead, title: displayTitle },
 				statusLine: {
 					...session.statusLine,
 					model,
@@ -177,6 +239,7 @@ export function LiveSessionView({
 			onSend={send}
 			composeDisabled={busy}
 			onModelChange={handleModelChange}
+			onTitleChange={handleTitleChange}
 		/>
 	);
 }

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -136,8 +136,27 @@ export function LiveSessionView({
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ title: nextTitle }),
 			})
-				.then((res) => {
-					if (!res.ok) revert();
+				.then(async (res) => {
+					if (!res.ok) {
+						revert();
+						return;
+					}
+					// The route cleans the title server-side (trim + whitespace
+					// collapse), which can differ from the raw optimistic text (e.g.
+					// "Fix   the  bug" → "Fix the bug") — reconcile so the display
+					// matches what's actually persisted, unless a newer edit has
+					// already superseded this one.
+					const data = (await res.json().catch(() => null)) as {
+						title?: string;
+					} | null;
+					if (
+						data?.title &&
+						data.title !== nextTitle &&
+						latestTitleRef.current === nextTitle
+					) {
+						latestTitleRef.current = data.title;
+						setTitle(data.title);
+					}
 				})
 				.catch(revert),
 		);

--- a/web-next/src/app/(app)/sessions/[id]/page.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/page.tsx
@@ -11,6 +11,7 @@
  * double-rendering: the AI SDK continues an existing assistant message, so a
  * full-replay against an SSR'd prefix would duplicate it.
  */
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { MODEL_OPTIONS, modelLabel } from "@/lib/agent-runtime/models";
 import { resolveTurn } from "@/lib/agent-runtime/turn-tail";
@@ -21,6 +22,18 @@ import { getRepo } from "@/lib/db/repos";
 import { getSession, readTranscript } from "@/lib/db/sessions";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 import { LiveSessionView } from "./live-session-view";
+
+// The tab title (#823): the persisted title when there is one, otherwise the
+// app's own default — never "Untitled", matching the masthead/home rule.
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+	const { id } = await params;
+	const session = await getSession(getDatabase(), id);
+	return { title: session?.title ? `${session.title} — Spaces` : "Spaces" };
+}
 
 export default async function SessionPage({
 	params,
@@ -67,7 +80,10 @@ export default async function SessionPage({
 					repo: repoName,
 					// null (unknown/unverified) omits the segment — never claim "main".
 					branch: repo?.defaultBranch ?? null,
-					title: session.title || "New session",
+					// Raw — possibly "". LiveSessionView derives a client-side preview
+					// from the first user message when it's empty (#823), and the
+					// masthead itself falls back to "New session" display text.
+					title: session.title,
 					agentName: "Claude",
 					stateLabel: "idle",
 				},

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -1,0 +1,140 @@
+/*
+ * PATCH /api/sessions/[id] — auth gating, per-field validation (model,
+ * title), and the "unknown field is a 400" contract. `getAuthState` is
+ * mocked (it reaches into next/headers, which needs a real request scope);
+ * the DB is real, pointed at a throwaway file via SESSIONS_DATABASE_URL so
+ * `getDatabase()`'s module singleton (shared with the route under test)
+ * resolves to it.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { createSession, getSession } from "@/lib/db/sessions";
+import { MAX_TITLE_LENGTH } from "@/lib/session-title";
+
+vi.mock("@/lib/auth/auth-state", () => ({
+	getAuthState: vi.fn(),
+}));
+
+const dir = mkdtempSync(join(tmpdir(), "web-next-route-"));
+process.env.SESSIONS_DATABASE_URL = `file:${join(dir, "test.db")}`;
+
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const AUTHORIZED = {
+	kind: "authorized" as const,
+	user: { login: "fairchild", name: "Fairchild" },
+};
+
+beforeEach(() => {
+	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+});
+
+async function patch(id: string, body: unknown) {
+	const { PATCH } = await import("./route");
+	return PATCH(
+		new Request(`http://test/api/sessions/${id}`, {
+			method: "PATCH",
+			body: JSON.stringify(body),
+		}),
+		{ params: Promise.resolve({ id }) },
+	);
+}
+
+let seq = 0;
+/** A fresh session id per test — one shared DB, no cross-test collisions. */
+async function freshSession(): Promise<string> {
+	const id = `s-${++seq}`;
+	await createSession(getDatabase(), { id, provider: "mock" });
+	return id;
+}
+
+describe("PATCH /api/sessions/[id]", () => {
+	test("401s when unauthenticated", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "unauthenticated" });
+		const id = await freshSession();
+		const res = await patch(id, { title: "New title" });
+		expect(res.status).toBe(401);
+	});
+
+	test("403s when signed in but not allowlisted", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "forbidden", login: "nope" });
+		const id = await freshSession();
+		const res = await patch(id, { title: "New title" });
+		expect(res.status).toBe(403);
+	});
+
+	test("404s for an unknown session", async () => {
+		const res = await patch("does-not-exist", { title: "New title" });
+		expect(res.status).toBe(404);
+	});
+
+	test("rejects a field outside {model, title}", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { title: "Fine", nickname: "nope" });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/unknown field/);
+		// Nothing was written — the whole patch is rejected, not partially applied.
+		expect((await getSession(getDatabase(), id))?.title).toBe("");
+	});
+
+	test("sets the title, trimmed and whitespace-collapsed", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { title: "  Fix   the   bug  " });
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ title: "Fix the bug" });
+		expect((await getSession(getDatabase(), id))?.title).toBe("Fix the bug");
+	});
+
+	test("rejects an empty (or whitespace-only) title", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { title: "   " });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/empty/);
+	});
+
+	test("rejects a title over the length cap", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { title: "x".repeat(MAX_TITLE_LENGTH + 1) });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/characters/);
+	});
+
+	test("rejects a non-string title", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { title: 42 });
+		expect(res.status).toBe(400);
+	});
+
+	test("a title edit is never overwritten by a later auto-title write", async () => {
+		const id = await freshSession();
+		await patch(id, { title: "My own title" });
+
+		// Simulate the auto-titler's write, same guarded path turn-ingest.ts uses.
+		const { titleSessionIfEmpty } = await import("@/lib/db/sessions");
+		const wrote = await titleSessionIfEmpty(getDatabase(), id, "Derived from a message");
+		expect(wrote).toBe(false);
+		expect((await getSession(getDatabase(), id))?.title).toBe("My own title");
+	});
+
+	test("still validates model (#824), unaffected by the title addition", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { model: "not-a-real-model" });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/unknown model/);
+	});
+
+	test("accepts model and title together in one PATCH", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { model: "claude-opus-4-8", title: "Both at once" });
+		expect(res.status).toBe(200);
+		const session = await getSession(getDatabase(), id);
+		expect(session?.model).toBe("claude-opus-4-8");
+		expect(session?.title).toBe("Both at once");
+	});
+});

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -111,6 +111,13 @@ describe("PATCH /api/sessions/[id]", () => {
 		expect(res.status).toBe(400);
 	});
 
+	test("rejects a title made only of zero-width characters (review finding)", async () => {
+		const id = await freshSession();
+		const res = await patch(id, { title: "\u200B\u200C\u200D" });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/empty/);
+	});
+
 	test("rejects an empty body — no field is a no-op patch", async () => {
 		const id = await freshSession();
 		const res = await patch(id, {});

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -111,6 +111,13 @@ describe("PATCH /api/sessions/[id]", () => {
 		expect(res.status).toBe(400);
 	});
 
+	test("rejects an empty body — no field is a no-op patch", async () => {
+		const id = await freshSession();
+		const res = await patch(id, {});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/model or title is required/);
+	});
+
 	test("a title edit is never overwritten by a later auto-title write", async () => {
 		const id = await freshSession();
 		await patch(id, { title: "My own title" });

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -1,13 +1,19 @@
 /*
- * PATCH /api/sessions/[id] — update a session's mutable settings. Currently
- * just `model` (#824's picker): auth-gated same as the chat route, validated
- * against the single source of truth in agent-runtime/models.ts so an unknown
- * or retired id is a 400, not a silent write.
+ * PATCH /api/sessions/[id] — update a session's mutable settings: `model`
+ * (#824's picker) and/or `title` (#823's inline edit). Auth-gated same as the
+ * chat route. Each field validates against its own source of truth —
+ * `isSelectableModel` (agent-runtime/models.ts) and the title cap/cleaning in
+ * session-title.ts, shared with the auto-titler so both paths agree on what a
+ * valid title is. Any key outside {model, title} is a 400, not a silent
+ * no-op, so a typo'd field fails loudly instead of patching nothing.
  */
 import { isSelectableModel } from "@/lib/agent-runtime/models";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
 import { getSession, updateSession } from "@/lib/db/sessions";
+import { cleanTitleText, MAX_TITLE_LENGTH } from "@/lib/session-title";
+
+const ALLOWED_FIELDS = new Set(["model", "title"]);
 
 export async function PATCH(
 	request: Request,
@@ -29,17 +35,53 @@ export async function PATCH(
 	}
 
 	const body: unknown = await request.json().catch(() => undefined);
-	const model =
-		typeof body === "object" && body !== null && "model" in body
-			? String((body as { model: unknown }).model)
-			: undefined;
-	if (model === undefined) {
-		return Response.json({ error: "model is required" }, { status: 400 });
-	}
-	if (!isSelectableModel(model)) {
-		return Response.json({ error: `unknown model: ${model}` }, { status: 400 });
+	if (typeof body !== "object" || body === null) {
+		return Response.json({ error: "a JSON body is required" }, { status: 400 });
 	}
 
-	await updateSession(handle, id, { model });
-	return Response.json({ model });
+	const unknownFields = Object.keys(body).filter((key) => !ALLOWED_FIELDS.has(key));
+	if (unknownFields.length > 0) {
+		return Response.json(
+			{ error: `unknown field(s): ${unknownFields.join(", ")}` },
+			{ status: 400 },
+		);
+	}
+
+	const patch: { model?: string; title?: string } = {};
+	const response: { model?: string; title?: string } = {};
+
+	if ("model" in body) {
+		const model = String((body as { model: unknown }).model);
+		if (!isSelectableModel(model)) {
+			return Response.json({ error: `unknown model: ${model}` }, { status: 400 });
+		}
+		patch.model = model;
+		response.model = model;
+	}
+
+	if ("title" in body) {
+		const raw = (body as { title: unknown }).title;
+		if (typeof raw !== "string") {
+			return Response.json({ error: "title must be a string" }, { status: 400 });
+		}
+		const title = cleanTitleText(raw);
+		if (!title) {
+			return Response.json({ error: "title must not be empty" }, { status: 400 });
+		}
+		if (title.length > MAX_TITLE_LENGTH) {
+			return Response.json(
+				{ error: `title must be at most ${MAX_TITLE_LENGTH} characters` },
+				{ status: 400 },
+			);
+		}
+		patch.title = title;
+		response.title = title;
+	}
+
+	if (Object.keys(patch).length === 0) {
+		return Response.json({ error: "model or title is required" }, { status: 400 });
+	}
+
+	await updateSession(handle, id, patch);
+	return Response.json(response);
 }

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -1,14 +1,25 @@
+"use client";
+
 /*
  * Session masthead: identity kept to a whisper — repo/branch on the left,
  * the session title centered in serif italic, agent + sandbox state and
  * the theme toggle on the right. Sticky, translucent, blurred.
+ *
+ * The title is inline-editable (#823) whenever the caller supplies
+ * `onTitleChange`: it becomes a bare `<input>` styled to read as the same
+ * plain italic text — no border, no button — that only reveals it's a field
+ * on hover/focus (a quiet background wash), matching the status line's model
+ * picker (status-line.tsx). Callers that omit it (fixtures, demo pages) get
+ * the old static span, unchanged.
  */
+import { useRef } from "react";
 import { ThemeToggle } from "./theme-toggle";
 
 export interface MastheadData {
 	repo: string;
 	/** `null` = unknown (repo connected unverified); the segment is omitted. */
 	branch: string | null;
+	/** The session's current best title, possibly `""` (no title yet). */
 	title: string;
 	agentName: string;
 	/** e.g. "sandbox active"; `live` adds the green halo dot. */
@@ -16,11 +27,35 @@ export interface MastheadData {
 	live?: boolean;
 }
 
+/** Shown wherever a title has none yet — never "Untitled": the tab a user is
+ * actually in reads as a fresh session, not a broken one. */
+export const UNTITLED_MASTHEAD_TITLE = "New session";
+
 function Separator() {
 	return <span className="mx-[7px] text-faint">·</span>;
 }
 
-export function SessionMasthead({ session }: { session: MastheadData }) {
+export function SessionMasthead({
+	session,
+	onTitleChange,
+}: {
+	session: MastheadData;
+	/** Wired by the live session view; omitted on fixtures/demo pages. */
+	onTitleChange?: (title: string) => void;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const commit = () => {
+		const input = inputRef.current;
+		if (!input) return;
+		const next = input.value.trim();
+		if (next && next !== session.title) {
+			onTitleChange?.(next);
+		} else {
+			input.value = session.title;
+		}
+	};
+
 	return (
 		<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between gap-3 border-b border-line bg-mast-bg px-5 font-mono text-masthead tracking-[.02em] text-muted backdrop-blur-[10px] backdrop-saturate-[1.1] sm:px-8">
 			<span className="min-w-0 truncate whitespace-nowrap">
@@ -32,9 +67,32 @@ export function SessionMasthead({ session }: { session: MastheadData }) {
 					</>
 				)}
 			</span>
-			<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint md:block">
-				{session.title}
-			</span>
+			{onTitleChange ? (
+				<input
+					key={session.title}
+					ref={inputRef}
+					type="text"
+					data-testid="session-title"
+					aria-label="Session title"
+					defaultValue={session.title}
+					placeholder={UNTITLED_MASTHEAD_TITLE}
+					size={1}
+					onBlur={commit}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") {
+							event.currentTarget.blur();
+						} else if (event.key === "Escape") {
+							event.currentTarget.value = session.title;
+							event.currentTarget.blur();
+						}
+					}}
+					className="absolute left-1/2 hidden w-[46%] max-w-[420px] -translate-x-1/2 truncate rounded-[6px] border-none bg-transparent px-1.5 py-0.5 text-center font-serif text-title text-faint italic tracking-[.01em] outline-none transition-colors duration-150 placeholder:text-faint hover:bg-hover-bg hover:text-ink focus:bg-hover-bg focus:text-ink focus:shadow-[0_0_0_3px_var(--focus-ring)] md:block"
+				/>
+			) : (
+				<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint md:block">
+					{session.title || UNTITLED_MASTHEAD_TITLE}
+				</span>
+			)}
 			<span className="flex shrink-0 items-center whitespace-nowrap">
 				{session.agentName}
 				<Separator />

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -79,6 +79,9 @@ export interface SessionViewProps {
 	/** Model picker handler (client wrappers wire this; fixtures omit it, which
 	 * leaves the status line's model as static text — see status-line.tsx). */
 	onModelChange?: (id: string) => void;
+	/** Inline title-edit handler (client wrappers wire this; fixtures omit it,
+	 * which leaves the masthead title as static text — see session-masthead.tsx). */
+	onTitleChange?: (title: string) => void;
 }
 
 export function SessionView({
@@ -86,11 +89,12 @@ export function SessionView({
 	onSend,
 	composeDisabled,
 	onModelChange,
+	onTitleChange,
 }: SessionViewProps) {
 	const isEmpty = session.messages.length === 0 && !session.activeTurn;
 	return (
 		<>
-			<SessionMasthead session={session.masthead} />
+			<SessionMasthead session={session.masthead} onTitleChange={onTitleChange} />
 			<main className="mx-auto max-w-[680px] px-5 pt-[76px] pb-6">
 				{isEmpty && session.empty && (
 					<div

--- a/web-next/src/lib/agent-runtime/run-turn.test.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.test.ts
@@ -280,6 +280,53 @@ describe("runSessionTurn", () => {
 		).toHaveLength(2);
 	});
 
+	test("titles the session from the first turn's message, before the tab could close (#823)", async () => {
+		const handle = freshDb();
+		const session = await makeSession(handle);
+		const turn = await runSessionTurn(handle, session, "  Fix   the   login   bug  ", stubProvider());
+		// The title is set as soon as runSessionTurn returns — synchronously with
+		// the durable user-event append, not waiting on the detached ingest.
+		expect((await getSession(handle, "s1"))?.title).toBe("Fix the login bug");
+		await turn.ingest;
+	});
+
+	test("a second turn never overwrites the title from the first (#823)", async () => {
+		const handle = freshDb();
+		const session = await makeSession(handle);
+		const first = await runSessionTurn(handle, session, "Fix the login bug", stubProvider());
+		await first.ingest;
+
+		const resessioned = (await getSession(handle, "s1")) as Session;
+		const second = await runSessionTurn(handle, resessioned, "Now add a test", stubProvider());
+		await second.ingest;
+
+		expect((await getSession(handle, "s1"))?.title).toBe("Fix the login bug");
+	});
+
+	test("an empty first message leaves the session untitled for a later turn to name (#823)", async () => {
+		const handle = freshDb();
+		const session = await makeSession(handle);
+		const first = await runSessionTurn(handle, session, "   ", stubProvider());
+		await first.ingest;
+		expect((await getSession(handle, "s1"))?.title).toBe("");
+
+		const resessioned = (await getSession(handle, "s1")) as Session;
+		const second = await runSessionTurn(handle, resessioned, "Fix the real bug", stubProvider());
+		await second.ingest;
+		expect((await getSession(handle, "s1"))?.title).toBe("Fix the real bug");
+	});
+
+	test("a user-edited title survives a later turn (#823)", async () => {
+		const handle = freshDb();
+		await makeSession(handle);
+		await updateSession(handle, "s1", { title: "My own title" });
+		const resessioned = (await getSession(handle, "s1")) as Session;
+
+		const turn = await runSessionTurn(handle, resessioned, "Fix the login bug", stubProvider());
+		await turn.ingest;
+		expect((await getSession(handle, "s1"))?.title).toBe("My own title");
+	});
+
 	test("a stale unfinished predecessor is closed durably before a new send (#811)", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);

--- a/web-next/src/lib/agent-runtime/turn-ingest.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Auto-title failure isolation (#823, found in review): `titleSessionIfEmpty`
+ * is mocked to throw, proving startTurn's try/catch keeps a title-write
+ * hiccup from losing the user event that's already durably committed by the
+ * time it runs, or from failing the turn-start itself.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../db/client";
+import { createSession, getSession, readEvents } from "../db/sessions";
+import type { ComputeProvider } from "./provider";
+import type { StreamChunk } from "./stream-chunk";
+import { startTurn } from "./turn-ingest";
+
+vi.mock("../db/sessions", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../db/sessions")>();
+	return {
+		...actual,
+		titleSessionIfEmpty: vi.fn(async () => {
+			throw new Error("simulated DB hiccup");
+		}),
+	};
+});
+
+let open: DatabaseHandle | undefined;
+let dir: string | undefined;
+
+function freshDb(): DatabaseHandle {
+	dir = mkdtempSync(join(tmpdir(), "web-next-turn-ingest-"));
+	open = openDatabase(`file:${join(dir, "test.db")}`);
+	return open;
+}
+
+afterEach(async () => {
+	await open?.db.destroy();
+	open = undefined;
+	if (dir) rmSync(dir, { recursive: true, force: true });
+	dir = undefined;
+});
+
+function stubProvider(): ComputeProvider {
+	return {
+		id: "stub",
+		runTurn: async function* () {
+			yield { type: "done", content: "" } as StreamChunk;
+		},
+	};
+}
+
+describe("startTurn — auto-title failure isolation", () => {
+	test("a title-write failure doesn't lose the already-durable user event or fail turn-start", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, { id: "s1", provider: "mock" });
+
+		const started = await startTurn(handle, session, "Fix the login bug", stubProvider());
+		expect(started.fromSeq).toBe(2);
+		await started.ingest;
+
+		const events = await readEvents(handle, "s1");
+		expect(events[0]).toMatchObject({
+			role: "user",
+			chunk: { type: "text", content: "Fix the login bug" },
+		});
+		// The (mocked) title write failed — the session stays untitled, but
+		// nothing else about the turn was lost or blocked.
+		expect((await getSession(handle, "s1"))?.title).toBe("");
+	});
+});

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -17,10 +17,19 @@
  * This is the seam #750 replaces with a sandbox-side detached runner: the
  * contract is exactly "append the turn's chunks to the log under (sessionId,
  * seq), notify, and terminate the run with a `done`".
+ *
+ * startTurn also carries the auto-title write (#823): same durability
+ * argument applies — it has to land before a tab close can lose it.
  */
 import { EventEmitter } from "node:events";
 import type { DatabaseHandle } from "../db/client";
-import { appendEvents, type Session, updateSession } from "../db/sessions";
+import {
+	appendEvents,
+	type Session,
+	titleSessionIfEmpty,
+	updateSession,
+} from "../db/sessions";
+import { deriveSessionTitle } from "../session-title";
 import {
 	type ComputeProvider,
 	getProvider,
@@ -88,6 +97,15 @@ export async function startTurn(
 	const userSeq = await appendEvents(handle, session.id, [
 		{ role: "user", chunk: { type: "text", content: userText } },
 	]);
+	// Auto-title (#823): runs on every turn, not just conditionally "the
+	// first" — `titleSessionIfEmpty`'s atomic `WHERE title = ''` is what
+	// actually enforces "only once", so a first message that derives no
+	// usable title (blank/whitespace) correctly leaves the session open for
+	// a later turn to name it, and a user-edited title is never touched
+	// (its row no longer matches the empty-title guard). This sits before
+	// the detached ingest starts, on the same durable path as the user
+	// event itself, so a closed tab can't lose the title.
+	await titleSessionIfEmpty(handle, session.id, deriveSessionTitle(userText));
 	const fromSeq = userSeq + 1;
 	const ingest = ingestTurn(handle, session, userText, provider);
 	activeTurns.set(session.id, { fromSeq, startedAt: Date.now() });

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -104,8 +104,16 @@ export async function startTurn(
 	// a later turn to name it, and a user-edited title is never touched
 	// (its row no longer matches the empty-title guard). This sits before
 	// the detached ingest starts, on the same durable path as the user
-	// event itself, so a closed tab can't lose the title.
-	await titleSessionIfEmpty(handle, session.id, deriveSessionTitle(userText));
+	// event itself, so a closed tab can't lose the title. Best-effort: the
+	// user event above is already durably committed by this point, so a
+	// title-write failure (a DB hiccup) must not fail the whole turn-start
+	// and strand that committed message — it just leaves the session
+	// untitled for the next turn to retry.
+	try {
+		await titleSessionIfEmpty(handle, session.id, deriveSessionTitle(userText));
+	} catch (error) {
+		console.error(`[turn-ingest] auto-title write failed for ${session.id}`, error);
+	}
 	const fromSeq = userSeq + 1;
 	const ingest = ingestTurn(handle, session, userText, provider);
 	activeTurns.set(session.id, { fromSeq, startedAt: Date.now() });

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -12,6 +12,7 @@ import {
 	getSession,
 	readEvents,
 	readTranscript,
+	titleSessionIfEmpty,
 	updateSession,
 } from "./sessions";
 
@@ -94,6 +95,46 @@ describe("session store", () => {
 		await createSession(handle, { id: "s1", provider: "mock" });
 		await updateSession(handle, "s1", { model: "claude-opus-4-8" });
 		expect((await getSession(handle, "s1"))?.model).toBe("claude-opus-4-8");
+	});
+
+	test("updateSession persists a user-edited title (#823)", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+		await updateSession(handle, "s1", { title: "My title" });
+		expect((await getSession(handle, "s1"))?.title).toBe("My title");
+	});
+
+	test("titleSessionIfEmpty sets the title only while it is empty (#823)", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+
+		expect(await titleSessionIfEmpty(handle, "s1", "Fix the bug")).toBe(true);
+		expect((await getSession(handle, "s1"))?.title).toBe("Fix the bug");
+
+		// A second call — e.g. a later turn, or the #811 concurrent-first-send
+		// race — never overwrites the title once it is set.
+		expect(await titleSessionIfEmpty(handle, "s1", "Something else entirely")).toBe(
+			false,
+		);
+		expect((await getSession(handle, "s1"))?.title).toBe("Fix the bug");
+	});
+
+	test("titleSessionIfEmpty never overwrites a user-edited title", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+		await updateSession(handle, "s1", { title: "My own title" });
+
+		expect(await titleSessionIfEmpty(handle, "s1", "Derived from a message")).toBe(
+			false,
+		);
+		expect((await getSession(handle, "s1"))?.title).toBe("My own title");
+	});
+
+	test("titleSessionIfEmpty is a no-op for a blank derived title", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+		expect(await titleSessionIfEmpty(handle, "s1", "")).toBe(false);
+		expect((await getSession(handle, "s1"))?.title).toBe("");
 	});
 
 	test("updateSession persists and clears the harness resume handle", async () => {

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -125,6 +125,17 @@ export async function updateSession(
  * A blank `title` (the deriver's empty-message fallback) is also a no-op —
  * the session stays untitled for a later turn to name. Returns whether this
  * call was the one that set it.
+ *
+ * Known gap (codex review, #823): the guard makes the write race-safe (no
+ * exception, no double-title, no lost update) but not race-*correct* in the
+ * sense of always reflecting the log's true first user event — under the
+ * same #811 double-first-send race, whichever caller's transaction commits
+ * first wins the title, which is not guaranteed to be the caller holding the
+ * lower `seq`. This is the same out-of-scope boundary #811 already draws
+ * ("full serialization would need a DB reservation"); closing it fully means
+ * deriving from a `SELECT ... ORDER BY seq LIMIT 1` read of the log rather
+ * than the caller's local text, which folds into #811's eventual fix rather
+ * than #823's.
  */
 export async function titleSessionIfEmpty(
 	handle: DatabaseHandle,

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -90,8 +90,10 @@ export async function createSession(
 
 /**
  * Persists the harness handle a turn parked with `detach()` (claude session id
- * + JSON resume payload; `resumeState` of `null` clears a stale handle) and/or
- * the session's selected model (#824's picker).
+ * + JSON resume payload; `resumeState` of `null` clears a stale handle),
+ * the session's selected model (#824's picker), and/or a user-edited title
+ * (#823 — unconditional, unlike `titleSessionIfEmpty` below: an explicit edit
+ * always wins).
  */
 export async function updateSession(
 	handle: DatabaseHandle,
@@ -100,6 +102,7 @@ export async function updateSession(
 		claudeSessionId?: string | null;
 		resumeState?: string | null;
 		model?: string;
+		title?: string;
 	},
 ): Promise<void> {
 	await ensureSchema(handle);
@@ -107,8 +110,36 @@ export async function updateSession(
 	if ("claudeSessionId" in fields) set.claude_session_id = fields.claudeSessionId ?? null;
 	if ("resumeState" in fields) set.resume_state = fields.resumeState ?? null;
 	if ("model" in fields && fields.model) set.model = fields.model;
+	if ("title" in fields && fields.title) set.title = fields.title;
 	if (Object.keys(set).length === 0) return;
 	await handle.db.updateTable("sessions").set(set).where("id", "=", id).execute();
+}
+
+/**
+ * Titles a session ONLY if it has no title yet — the auto-titler's write
+ * (#823). The empty-title check and the write share one atomic UPDATE
+ * (`WHERE title = ''`), not a separate read-then-write, so two concurrent
+ * first turns on the same session (the #811 race a `TurnConflictError` can't
+ * always catch) can't both "win": SQLite serializes the two UPDATEs, the
+ * first to commit clears the `title = ''` match, and the second is a no-op.
+ * A blank `title` (the deriver's empty-message fallback) is also a no-op —
+ * the session stays untitled for a later turn to name. Returns whether this
+ * call was the one that set it.
+ */
+export async function titleSessionIfEmpty(
+	handle: DatabaseHandle,
+	id: string,
+	title: string,
+): Promise<boolean> {
+	await ensureSchema(handle);
+	if (!title) return false;
+	const result = await handle.db
+		.updateTable("sessions")
+		.set({ title })
+		.where("id", "=", id)
+		.where("title", "=", "")
+		.execute();
+	return Number(result[0]?.numUpdatedRows ?? 0) > 0;
 }
 
 /** A sessions-home row: the session plus its repo's display name. */

--- a/web-next/src/lib/session-title.test.ts
+++ b/web-next/src/lib/session-title.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { cleanTitleText, deriveSessionTitle, MAX_TITLE_LENGTH } from "./session-title";
+
+describe("deriveSessionTitle", () => {
+	test("cleans and returns the first line", () => {
+		expect(deriveSessionTitle("Fix the login bug")).toBe("Fix the login bug");
+	});
+
+	test("trims and collapses internal whitespace", () => {
+		expect(deriveSessionTitle("  Fix   the   login   bug  \nmore detail")).toBe(
+			"Fix the login bug",
+		);
+	});
+
+	test("caps at MAX_TITLE_LENGTH with an ellipsis", () => {
+		const long = "x".repeat(MAX_TITLE_LENGTH + 40);
+		const title = deriveSessionTitle(long);
+		expect(title.length).toBe(MAX_TITLE_LENGTH);
+		expect(title.endsWith("…")).toBe(true);
+		expect(title.startsWith("x".repeat(MAX_TITLE_LENGTH - 1))).toBe(true);
+	});
+
+	test("does not cap a message exactly at the limit", () => {
+		const exact = "x".repeat(MAX_TITLE_LENGTH);
+		expect(deriveSessionTitle(exact)).toBe(exact);
+	});
+
+	test("returns empty for an empty or whitespace-only message", () => {
+		expect(deriveSessionTitle("")).toBe("");
+		expect(deriveSessionTitle("   \t  ")).toBe("");
+		expect(deriveSessionTitle("\n\nsecond line has content")).toBe("");
+	});
+});
+
+describe("cleanTitleText", () => {
+	test("trims edges and collapses interior whitespace", () => {
+		expect(cleanTitleText("  hello   world  ")).toBe("hello world");
+	});
+
+	test("collapses newlines and tabs into single spaces", () => {
+		expect(cleanTitleText("hello\n\tworld")).toBe("hello world");
+	});
+});

--- a/web-next/src/lib/session-title.test.ts
+++ b/web-next/src/lib/session-title.test.ts
@@ -30,6 +30,22 @@ describe("deriveSessionTitle", () => {
 		expect(deriveSessionTitle("   \t  ")).toBe("");
 		expect(deriveSessionTitle("\n\nsecond line has content")).toBe("");
 	});
+
+	test("truncates by code point, never splitting a surrogate pair (review finding)", () => {
+		// An astral emoji sits right at the truncation boundary.
+		const emoji = "\u{1F600}"; // one code point, two UTF-16 units
+		const long = "x".repeat(MAX_TITLE_LENGTH - 1) + emoji + "tail";
+		const title = deriveSessionTitle(long);
+		expect(title.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+		// No lone surrogate (U+D800-U+DFFF) anywhere in the result.
+		expect(/[\uD800-\uDFFF]/.test(title)).toBe(false);
+		expect(title.endsWith("…")).toBe(true);
+	});
+
+	test("a title of only zero-width characters is treated as empty (review finding)", () => {
+		const zeroWidthOnly = "\u200B\u200C\u200D\uFEFF";
+		expect(deriveSessionTitle(zeroWidthOnly)).toBe("");
+	});
 });
 
 describe("cleanTitleText", () => {

--- a/web-next/src/lib/session-title.ts
+++ b/web-next/src/lib/session-title.ts
@@ -12,10 +12,16 @@ export const MAX_TITLE_LENGTH = 72;
 
 const ELLIPSIS = "…";
 
+// Zero-width formatting characters (ZWSP/ZWNJ/ZWJ/BOM) render as nothing, so
+// a title made of only these would look blank while passing a naive
+// non-empty check — strip them alongside whitespace, not just trim around them.
+const ZERO_WIDTH = /[\u200B-\u200D\uFEFF]/g;
+
 /** Trims and collapses internal whitespace runs (including newlines) to a
- * single space — the shared cleanup for both a derived and a user-typed title. */
+ * single space, and drops zero-width formatting characters — the shared
+ * cleanup for both a derived and a user-typed title. */
 export function cleanTitleText(raw: string): string {
-	return raw.trim().replace(/\s+/g, " ");
+	return raw.replace(ZERO_WIDTH, "").trim().replace(/\s+/g, " ");
 }
 
 /**
@@ -29,6 +35,11 @@ export function deriveSessionTitle(firstUserMessage: string): string {
 	const firstLine = firstUserMessage.split(/\r?\n/, 1)[0] ?? "";
 	const cleaned = cleanTitleText(firstLine);
 	if (!cleaned) return "";
-	if (cleaned.length <= MAX_TITLE_LENGTH) return cleaned;
-	return `${cleaned.slice(0, MAX_TITLE_LENGTH - ELLIPSIS.length).trimEnd()}${ELLIPSIS}`;
+	// Split by code point (Array.from), not UTF-16 unit (slice/length) — a
+	// raw slice can cut a surrogate pair in half and leave a mangled glyph
+	// right before the ellipsis.
+	const codePoints = Array.from(cleaned);
+	if (codePoints.length <= MAX_TITLE_LENGTH) return cleaned;
+	const truncated = codePoints.slice(0, MAX_TITLE_LENGTH - ELLIPSIS.length).join("");
+	return `${truncated.trimEnd()}${ELLIPSIS}`;
 }

--- a/web-next/src/lib/session-title.ts
+++ b/web-next/src/lib/session-title.ts
@@ -1,0 +1,34 @@
+/*
+ * Session title text rules — the single source of truth for both the
+ * auto-titler (turn-ingest.ts, derives from the first user message) and the
+ * inline-edit PATCH route (validates a user-typed title). Deterministic by
+ * design (#823): a model-generated upgrade can swap `deriveSessionTitle`'s
+ * body later without touching either call site or the shared cap/cleaning
+ * rules.
+ */
+
+/** Titles never exceed this many characters (ellipsis included). */
+export const MAX_TITLE_LENGTH = 72;
+
+const ELLIPSIS = "…";
+
+/** Trims and collapses internal whitespace runs (including newlines) to a
+ * single space — the shared cleanup for both a derived and a user-typed title. */
+export function cleanTitleText(raw: string): string {
+	return raw.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Derives a title from a session's first user message: its first line,
+ * cleaned and capped. Returns `""` when the message has no usable first
+ * line (empty/whitespace, or a leading blank line) — callers treat that as
+ * "no title yet", not an error; the session stays untitled until a message
+ * that actually has one.
+ */
+export function deriveSessionTitle(firstUserMessage: string): string {
+	const firstLine = firstUserMessage.split(/\r?\n/, 1)[0] ?? "";
+	const cleaned = cleanTitleText(firstLine);
+	if (!cleaned) return "";
+	if (cleaned.length <= MAX_TITLE_LENGTH) return cleaned;
+	return `${cleaned.slice(0, MAX_TITLE_LENGTH - ELLIPSIS.length).trimEnd()}${ELLIPSIS}`;
+}

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -60,7 +60,13 @@ test("typing an owner/name creates the repo + session and routes to it", async (
 	await expect(page).toHaveURL(SESSION_URL);
 	// The empty Folio session: masthead repo, calm note, autofocused compose.
 	await expect(page.locator("header")).toContainText("fairchild/workspaces");
-	await expect(page.locator("header")).toContainText("New session");
+	// No title yet: the inline field is empty, showing the "New session"
+	// placeholder rather than persisted text (#823).
+	await expect(page.getByTestId("session-title")).toHaveValue("");
+	await expect(page.getByTestId("session-title")).toHaveAttribute(
+		"placeholder",
+		"New session",
+	);
 	await expect(page.getByTestId("empty-transcript")).toContainText(
 		"No turns yet.",
 	);
@@ -165,6 +171,39 @@ test("sending a message streams a mock coding turn into the Folio transcript", a
 	// Turn over: compose re-enables, the activity line is gone.
 	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+
+	// The session titled itself from the turn just sent — masthead + tab (#823).
+	await expect(page.getByTestId("session-title")).toHaveValue(
+		"Fix the failing session test",
+	);
+	await expect(page).toHaveTitle("Fix the failing session test — Spaces");
+});
+
+test("the derived title shows on home and is inline-editable from the masthead, persisting across reload (#823)", async ({
+	page,
+}) => {
+	await page.goto("/");
+	await expect(
+		page.getByRole("link", { name: /Fix the failing session test/ }),
+	).toBeVisible();
+
+	await page.goto(turnSessionUrl);
+	const titleField = page.getByTestId("session-title");
+	await expect(titleField).toHaveValue("Fix the failing session test");
+
+	await titleField.fill("Renamed by hand");
+	await titleField.press("Enter");
+	await expect(page).toHaveTitle("Renamed by hand — Spaces");
+
+	await page.reload();
+	await expect(page.getByTestId("session-title")).toHaveValue("Renamed by hand");
+	await expect(page).toHaveTitle("Renamed by hand — Spaces");
+
+	await page.goto("/");
+	await expect(page.getByRole("link", { name: /Renamed by hand/ })).toBeVisible();
+	// A later turn on this session must not clobber the hand-edited title.
+	await page.getByRole("link", { name: /Renamed by hand/ }).click();
+	await expect(page).toHaveURL(SESSION_URL);
 });
 
 test("a reload renders the same turn from the persisted event log", async ({


### PR DESCRIPTION
## Summary

- Sessions now title themselves from the first turn's user message: a deterministic first-line derivation (`src/lib/session-title.ts`), persisted via an atomic `WHERE title = ''` update at turn-start (`titleSessionIfEmpty`, `src/lib/db/sessions.ts`, called from `startTurn` in `src/lib/agent-runtime/turn-ingest.ts`) — durable (lands before a tab close could lose it) and idempotent (a later turn only titles an untitled session).
- Titles are inline-editable from the masthead (calm Folio treatment: a bare `<input>` styled as plain italic text, a quiet hover/focus background wash, no visible chrome) via `PATCH /api/sessions/[id]`, extended to accept `title` alongside the existing `model` field — trim + whitespace-collapse, non-empty, length-capped, unknown fields rejected with a 400.
- A user-edited title is never overwritten by the auto-titler (the guard only fires while `title` is still empty).
- Home list, masthead, and the document `<title>` (`generateMetadata` + a client-side `document.title` effect) all reflect the title once a session has one; before that, the masthead shows a placeholder ("New session") — never "Untitled" in a session with content.
- Follow-up noted in code: the deriver (`deriveSessionTitle`) is a small pure module specifically so a later model-generated titling upgrade can swap its body in without touching either call site.

Closes #823

## Mergeability

- Surface: web (web-next/ — sessions API, DB store, agent-runtime turn seam, Folio masthead/session-view components)
- User-facing behavior changed: Yes — sessions now auto-acquire a readable title from their first message instead of staying "Untitled session" forever; the masthead title is now click-to-edit.
- Non-happy paths considered: empty/whitespace-only first message (stays untitled, retried on the next turn); a title-write DB failure (fails soft — try/catch — so it can't strand the already-committed user event or fail turn-start); concurrent first-sends on the same session (atomic `WHERE title = ''` update prevents corruption/double-write; see the documented residual-risk note below); PATCH with unknown fields, non-string title, empty/oversized title, unauthenticated/forbidden caller; a user's inline edit racing the client's optimistic state.
- Residual risk or follow-up: under the pre-existing #811 double-first-send race (two truly-simultaneous first sends bypass the `TurnConflictError` check), the atomic guard prevents corruption but doesn't guarantee the title reflects the log's literal first-appended message — whichever transaction commits first wins. This is the same out-of-scope boundary #811 already documents ("full serialization would need a DB reservation"); closing it fully means deriving the title from a `SELECT ... ORDER BY seq LIMIT 1` read rather than the caller's local text, which folds into #811's eventual fix. Documented in `src/lib/db/sessions.ts`.

## Validation

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 247 tests passed, 24 files
- [x] `pnpm run test:e2e` — 26 tests passed (extends `tests/e2e/sessions.spec.ts`: derived title on home + masthead after a streamed turn, inline edit + reload persistence, empty-state placeholder)
- [x] `pnpm run evidence` — screenshots captured, see Evidence below

## Evidence

tests passed: `pnpm run test` — 247 passed (24 files); `pnpm run test:e2e` — 26 passed (0 failed).

- CI: green quality lane on 753dafc: https://github.com/fairchild/workspaces/actions/runs/28884852373/job/85682286763
- Gate note: orchestrator read the sensitive hunks (atomic WHERE title='' guard at the turn-ingest seam, PATCH whole-body validation incl. unknown-field 400 with no partial write, auth-gating tests both failure modes); codex loop ran (3 fixed, 1 declined with documented #811 boundary, XSS non-finding); evidence hosted on evidence.cloudcompute.com; merged on delegated authority.

Screenshots (`pnpm run evidence`, light + dark):

![session-titles-home](https://evidence.cloudcompute.com/workspaces/pr-908/20260707-171342-session-titles-home.png)
Home list — a real UI-created session shows its derived title instead of "Untitled session".

![session-titles-home-dark](https://evidence.cloudcompute.com/workspaces/pr-908/20260707-171348-session-titles-home-dark.png)
Same, dark theme.

![session-titles-empty-placeholder](https://evidence.cloudcompute.com/workspaces/pr-908/20260707-171347-session-titles-empty-placeholder.png)
A fresh, turn-less session: the masthead's inline field shows the "New session" placeholder, not persisted text.

![session-titles-turn-final](https://evidence.cloudcompute.com/workspaces/pr-908/20260707-171348-session-titles-turn-final.png)
Masthead after the first turn completes — titled from that turn's message.

## Review loop

Ran the `codex-review-loop` skill (reflect → directed codex `gpt-5.5`/xhigh → attributed reactions) before opening this PR.

**Self-reflection (before codex)** — found and fixed: `titleSessionIfEmpty` ran unguarded in `startTurn`, after the user event was already durably appended; a transient DB error there would fail the whole turn-start (500) despite the message already being committed. Wrapped in try/catch (commit "fix(web-next): keep an auto-title write failure from stranding a committed turn") so titling degrades gracefully instead of stranding a committed turn. Also added a PATCH empty-body test found while re-reading the route.

**Codex findings** (directed at: auto-title idempotence under concurrent turn starts, PATCH validation completeness, XSS/escaping in title rendering):

1. `turn-ingest.ts` unguarded `titleSessionIfEmpty` call — **blocking**. Already fixed in the self-reflection pass above; codex independently flagged the same gap in the (then-uncommitted) working tree.
2. Atomic guard is race-*safe* but not race-*"true first message"*-correct under #811's double-first-send scenario — **moderate**. **Declined as a fix, documented instead**: this is the same out-of-scope boundary #811's own docstring already draws; a full fix needs a log read (`ORDER BY seq LIMIT 1`) and belongs with #811's eventual DB-reservation fix, not this issue's scope. Documented in `sessions.ts`'s `titleSessionIfEmpty` docstring.
3. `deriveSessionTitle`'s truncation used UTF-16 `slice`, which can split a surrogate pair — **minor**. **Fixed**: truncates by code point (`Array.from`) instead.
4. `cleanTitleText` didn't strip zero-width formatting characters (ZWSP/ZWNJ/ZWJ/BOM), so a title made only of these passed the non-empty check while rendering blank — **minor**. **Fixed**: stripped alongside whitespace.
5. The masthead's title PATCH ignored the response body on success, so a raw-vs-server-cleaned mismatch (e.g. collapsed internal whitespace) stayed displayed until reload — **minor**. **Fixed**: client reconciles to the server's cleaned value, guarded against being superseded by a newer edit.
6. No XSS/escaping path found in the title render sinks (React-escaped `<input>`/`<span>` text, `document.title` property assignment, Next `generateMetadata`) — **non-finding**, confirmed.

Fix commits: "fix(web-next): keep an auto-title write failure from stranding a committed turn" (self-reflection) and "fix(web-next): react to codex findings — truncation, whitespace, PATCH reconcile" (codex-attributed).

## Mutation check

Removed the `WHERE title = ''` guard in `titleSessionIfEmpty` (`sessions.ts`) so it would unconditionally overwrite any title. Re-ran the affected suites: 5 tests failed across 3 files — `sessions.test.ts` (`titleSessionIfEmpty sets the title only while it is empty`, `titleSessionIfEmpty never overwrites a user-edited title`), `run-turn.test.ts` (`a second turn never overwrites the title from the first`, `a user-edited title survives a later turn`), `route.test.ts` (`a title edit is never overwritten by a later auto-title write`) — confirming the "only-titles-empty" contract is actually covered. Reverted; suite back to green (247/247).


