### PR TITLE
fix(web-next): give a landed edit one home — its Edit ledger row (#790)

### DIFF
--- a/web-next/docs/architecture.html
+++ b/web-next/docs/architecture.html
@@ -82,7 +82,7 @@
     <div class="layer">
       <span class="tag live">live</span>
       <div class="name">Browser — the Folio transcript</div>
-      <div class="role">useChat renders streamed message parts: prose, thinking block, tool ledger, diff cards, receipt</div>
+      <div class="role">useChat renders streamed message parts: prose, thinking block, tool ledger (diffs expand inline in their Edit row), receipt</div>
     </div>
     <div class="layer">
       <span class="tag live">live</span>

--- a/web-next/docs/design.md
+++ b/web-next/docs/design.md
@@ -77,8 +77,13 @@ Each is a specific call and the reason for it.
 - **The tool ledger is one line per step, expandable.** Read / Edit / Run as
   quiet rows that open on demand. No decorative left rule — the turn frame now
   carries the grouping, so the rule was chrome without meaning.
-- **Diffs and test output are contextual panels**, surfaced when the work
-  produces them, not persistent regions.
+- **A landed edit has one home: its Edit ledger row.** Expanding the row reveals
+  its diff inline, reusing the same add/del hunk everywhere — there is no
+  separate floating diff card in the transcript. The just-landed edit's row
+  auto-expands (the contextual moment the edit itself triggers) and collapses
+  again once a newer step arrives, so the reveal earns its beat without
+  becoming a second persistent thing to manage. Test output works the same
+  way, inside its Bash row.
 
 ## Identity
 

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -112,12 +112,15 @@ async function captureSessionTurn(page, shot) {
 	);
 	await page.screenshot({ path: shot("session-turn-midstream") });
 
-	// Final: receipt rendered; disclose the passing re-run's output panel
+	// Final: receipt rendered; disclose the passing re-run's output panel and
+	// the landed edit's diff — its one home is the Edit row itself (#790)
 	// (the mock turn is: failed run, Read, Edit, passing run).
 	await page.getByTestId("turn-stats").waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.getByTestId("tool-row").nth(2).locator("button").first().click();
+	await page.getByTestId("diff-lines").waitFor();
 	await page.getByTestId("tool-row").nth(3).locator("button").first().click();
 	await page.getByTestId("test-output").waitFor();
-	// Scroll to the end of the turn so diff card + receipt are in frame.
+	// Scroll to the end of the turn so the diff + receipt are in frame.
 	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
 	await page.waitForTimeout(ANIMATION_SETTLE_MS);
 	await page.screenshot({ path: shot("session-turn-final") });

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -133,10 +133,10 @@
 	--text-body--line-height: 1.72;
 	--text-compose: 17px;
 	--text-title: 13.5px; /* masthead center title, serif italic */
-	--text-tool: 13px; /* ledger rows, diff body */
+	--text-tool: 13px; /* ledger rows, diff hunk */
 	--text-code: 12.5px; /* expanded step bodies */
 	--text-code--line-height: 1.75;
-	--text-caption: 12px; /* diff-card caption, ledger meta */
+	--text-caption: 12px; /* ledger meta */
 	--text-masthead: 11.5px;
 	--text-stat: 11px; /* turn stats, status line */
 	--text-label: 10.5px; /* message author labels */

--- a/web-next/src/components/folio/diff-card.tsx
+++ b/web-next/src/components/folio/diff-card.tsx
@@ -1,16 +1,14 @@
-"use client";
-
 /*
- * Contextual diff card: a landed edit surfaces as a raised, dismissible
- * figure — file + delta caption, then the hunk with add/del washes.
- * Takes structured DiffCardData; #748 maps real Edit results onto it.
- * A long refactor stays a bounded figure: past ~28 lines the hunk scrolls
- * inside the card instead of stretching the turn into a wall.
+ * The diff hunk: add/del/context lines for a landed edit. A code edit has
+ * one home — its Edit tool-ledger row (#790) — so this renders inside that
+ * row's expanded body (see message.tsx's LedgerBodyView), not as a separate
+ * floating card; the row's own header already carries the file + delta.
+ * A long refactor stays a bounded block: past ~28 lines the hunk scrolls
+ * inside its own box instead of stretching the row (and the turn) into a wall.
  */
-import { useState } from "react";
-import type { DiffCardData, DiffLine } from "./types";
+import type { DiffLine } from "./types";
 
-/** Beyond this many lines the hunk gets its own scroll rather than growing the turn. */
+/** Beyond this many lines the hunk gets its own scroll rather than growing the row. */
 const TALL_DIFF_LINES = 28;
 
 const LINE_CLASS: Record<DiffLine["kind"], string> = {
@@ -19,47 +17,20 @@ const LINE_CLASS: Record<DiffLine["kind"], string> = {
 	del: "bg-del-bg text-del-ink line-through [text-decoration-color:var(--del-strike)]",
 };
 
-export function DiffCard({ diff }: { diff: DiffCardData }) {
-	const [dismissed, setDismissed] = useState(false);
-	if (dismissed) return null;
+export function DiffHunk({ lines }: { lines: DiffLine[] }) {
 	return (
-		<figure
-			data-testid="diff-card"
-			className="group/landed animate-settle my-[30px] overflow-hidden rounded-xl border border-line bg-raised shadow-card"
+		<pre
+			data-testid="diff-lines"
+			className={`overflow-x-auto rounded-lg border border-line bg-raised py-3 font-mono text-tool leading-[1.7] ${lines.length > TALL_DIFF_LINES ? "max-h-[460px] overflow-y-auto" : ""}`}
 		>
-			<figcaption className="flex items-baseline gap-3 border-b border-line px-[18px] py-[11px] font-mono text-caption text-muted">
-				<span className="font-medium text-ink">{diff.file}</span>
-				<span>
-					<span className="text-add-ink">+{diff.additions}</span>
-					<span className="ml-1.5 text-del-ink">−{diff.deletions}</span>
-				</span>
-				{diff.note !== undefined && (
-					<span className="ml-auto font-serif text-[12.5px] italic text-faint">
-						{diff.note}
-					</span>
-				)}
-				<button
-					type="button"
-					title="Dismiss"
-					aria-label="Dismiss diff card"
-					onClick={() => setDismissed(true)}
-					className={`pl-2.5 text-[13px] leading-none text-faint opacity-0 transition-opacity duration-200 group-hover/landed:opacity-100 hover:text-ink ${diff.note === undefined ? "ml-auto" : ""}`}
+			{lines.map((line, i) => (
+				<span
+					key={i}
+					className={`block px-[18px] py-px whitespace-pre text-muted ${LINE_CLASS[line.kind]}`}
 				>
-					✕
-				</button>
-			</figcaption>
-			<pre
-				className={`overflow-x-auto py-3 font-mono text-tool leading-[1.7] ${diff.lines.length > TALL_DIFF_LINES ? "max-h-[460px] overflow-y-auto" : ""}`}
-			>
-				{diff.lines.map((line, i) => (
-					<span
-						key={i}
-						className={`block px-[18px] py-px whitespace-pre text-muted ${LINE_CLASS[line.kind]}`}
-					>
-						{line.text}
-					</span>
-				))}
-			</pre>
-		</figure>
+					{line.text}
+				</span>
+			))}
+		</pre>
 	);
 }

--- a/web-next/src/components/folio/ledger.test.ts
+++ b/web-next/src/components/folio/ledger.test.ts
@@ -1,11 +1,13 @@
 import type { DynamicToolUIPart } from "ai";
 import { describe, expect, it } from "vitest";
 import {
+	contextualOpenToolCallId,
 	describeToolPart,
 	formatTurnStats,
 	highlightTestOutput,
 	parseTestSummary,
 } from "./ledger";
+import type { FolioMessage } from "./types";
 
 function toolPart(overrides: Partial<DynamicToolUIPart>): DynamicToolUIPart {
 	return {
@@ -97,6 +99,82 @@ describe("describeToolPart", () => {
 			} as Partial<DynamicToolUIPart>),
 		);
 		expect(row).toEqual({ verb: "Ran", subject: "pnpm test" });
+	});
+
+	it("renders a landed edit's diff as the body, with counts from the diff itself", () => {
+		const diff = {
+			file: "src/session/resume.ts",
+			additions: 4,
+			deletions: 1,
+			lines: [{ kind: "add" as const, text: "+ throw new SessionNotFoundError(id);" }],
+		};
+		const row = describeToolPart(
+			toolPart({
+				toolName: "Edit",
+				input: {
+					file_path: "src/session/resume.ts",
+					old_string: "return hydrate(record);",
+					new_string: "if (!record) throw e;\nreturn hydrate(record);",
+				},
+				output: { content: "guard added", diff },
+			}),
+		);
+		expect(row.body).toEqual({ kind: "diff", diff });
+		// The diff's real counts win over the old/new-string line-count estimate.
+		expect(row.meta).toEqual({ kind: "delta", additions: 4, deletions: 1 });
+	});
+});
+
+describe("contextualOpenToolCallId", () => {
+	function editPart(toolCallId: string, hasDiff: boolean): DynamicToolUIPart {
+		return toolPart({
+			toolCallId,
+			toolName: "Edit",
+			state: "output-available",
+			output: hasDiff
+				? {
+						content: "landed",
+						diff: { file: "a.ts", additions: 1, deletions: 0, lines: [] },
+					}
+				: "landed",
+		});
+	}
+
+	function parts(...items: DynamicToolUIPart[]): FolioMessage["parts"] {
+		return items as unknown as FolioMessage["parts"];
+	}
+
+	it("is the last part's toolCallId when it's a completed edit with a diff", () => {
+		expect(contextualOpenToolCallId(parts(editPart("tool-3", true)))).toBe("tool-3");
+	});
+
+	it("is undefined once a newer part has landed after the edit", () => {
+		const withTrailingText = [
+			editPart("tool-3", true),
+			{ type: "text", text: "Done." },
+		] as unknown as FolioMessage["parts"];
+		expect(contextualOpenToolCallId(withTrailingText)).toBeUndefined();
+
+		const withTrailingTool = parts(editPart("tool-3", true), editPart("tool-4", false));
+		expect(contextualOpenToolCallId(withTrailingTool)).toBeUndefined();
+	});
+
+	it("is undefined when the last tool call has no diff", () => {
+		expect(contextualOpenToolCallId(parts(editPart("tool-3", false)))).toBeUndefined();
+	});
+
+	it("is undefined when the last tool call is still running", () => {
+		const running = toolPart({
+			toolCallId: "tool-3",
+			toolName: "Edit",
+			state: "input-available",
+			output: undefined,
+		} as Partial<DynamicToolUIPart>);
+		expect(contextualOpenToolCallId(parts(running))).toBeUndefined();
+	});
+
+	it("is undefined for an empty parts list", () => {
+		expect(contextualOpenToolCallId(parts())).toBeUndefined();
 	});
 });
 

--- a/web-next/src/components/folio/ledger.test.ts
+++ b/web-next/src/components/folio/ledger.test.ts
@@ -123,6 +123,43 @@ describe("describeToolPart", () => {
 		// The diff's real counts win over the old/new-string line-count estimate.
 		expect(row.meta).toEqual({ kind: "delta", additions: 4, deletions: 1 });
 	});
+
+	it("sanitizes a malformed persisted diff instead of rendering it broken", () => {
+		const row = describeToolPart(
+			toolPart({
+				toolName: "Edit",
+				output: {
+					content: "guard added",
+					diff: {
+						file: "a.ts",
+						additions: "not-a-number",
+						deletions: null,
+						lines: [
+							{ kind: "add", text: "+ ok" },
+							{ kind: "add", text: 42 }, // non-string text: dropped
+							{ kind: "explode", text: "+ bogus kind" }, // bad kind: dropped
+							"not even an object", // dropped
+							{ kind: "del", text: "- also ok" },
+						],
+					},
+				},
+			}),
+		);
+		expect(row.body).toEqual({
+			kind: "diff",
+			diff: {
+				file: "a.ts",
+				// Falls back to counting the sanitized lines, not "NaN"/"+undefined".
+				additions: 1,
+				deletions: 1,
+				lines: [
+					{ kind: "add", text: "+ ok" },
+					{ kind: "del", text: "- also ok" },
+				],
+			},
+		});
+		expect(row.meta).toEqual({ kind: "delta", additions: 1, deletions: 1 });
+	});
 });
 
 describe("contextualOpenToolCallId", () => {

--- a/web-next/src/components/folio/ledger.ts
+++ b/web-next/src/components/folio/ledger.ts
@@ -7,7 +7,7 @@
  * is no separate free-floating diff card in the transcript (#790).
  */
 import { isDynamicToolUIPart, type DynamicToolUIPart } from "ai";
-import type { DiffCardData, FolioMessage, TurnStatsData } from "./types";
+import type { DiffCardData, DiffLine, FolioMessage, TurnStatsData } from "./types";
 
 export type LedgerMeta =
 	| { kind: "text"; text: string }
@@ -50,10 +50,43 @@ function asOptionalString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
-/** Duck-types a diff payload: an object with a `lines` array is close enough. */
+const DIFF_LINE_KINDS = new Set<DiffLine["kind"]>(["context", "add", "del"]);
+
+function asDiffLine(value: unknown): DiffLine | undefined {
+	const record = asRecord(value);
+	const kind = record.kind;
+	if (typeof kind !== "string" || !DIFF_LINE_KINDS.has(kind as DiffLine["kind"]))
+		return undefined;
+	const text = asOptionalString(record.text);
+	if (text === undefined) return undefined;
+	return { kind: kind as DiffLine["kind"], text };
+}
+
+/**
+ * Duck-types a diff payload defensively — this can be an old/malformed
+ * persisted event, not just a fresh one this version produced. A line that
+ * doesn't match the expected shape is dropped rather than rendered broken,
+ * and additions/deletions fall back to counting the (sanitized) lines, so a
+ * corrupted row can't surface as a literal "+undefined −undefined".
+ */
 function asDiff(value: unknown): DiffCardData | undefined {
 	const record = asRecord(value);
-	return Array.isArray(record.lines) ? (value as DiffCardData) : undefined;
+	if (!Array.isArray(record.lines)) return undefined;
+	const lines = record.lines
+		.map(asDiffLine)
+		.filter((line): line is DiffLine => line !== undefined);
+	return {
+		file: asOptionalString(record.file) ?? "",
+		additions:
+			typeof record.additions === "number"
+				? record.additions
+				: lines.filter((line) => line.kind === "add").length,
+		deletions:
+			typeof record.deletions === "number"
+				? record.deletions
+				: lines.filter((line) => line.kind === "del").length,
+		lines,
+	};
 }
 
 function normalizeOutput(output: unknown): StructuredToolOutput | undefined {

--- a/web-next/src/components/folio/ledger.ts
+++ b/web-next/src/components/folio/ledger.ts
@@ -2,9 +2,12 @@
  * Maps AI SDK dynamic-tool parts onto tool-ledger row content: a verb, a
  * subject, a right-aligned meta summary, and an expandable body. Pure logic
  * so #748 can point real tool outputs at the same rows without UI changes.
+ * A landed edit's diff (when its structured output carries one) is a body
+ * kind like any other — the Edit ledger row is the diff's one home; there
+ * is no separate free-floating diff card in the transcript (#790).
  */
-import type { DynamicToolUIPart } from "ai";
-import type { TurnStatsData } from "./types";
+import { isDynamicToolUIPart, type DynamicToolUIPart } from "ai";
+import type { DiffCardData, FolioMessage, TurnStatsData } from "./types";
 
 export type LedgerMeta =
 	| { kind: "text"; text: string }
@@ -12,7 +15,8 @@ export type LedgerMeta =
 
 export type LedgerBody =
 	| { kind: "code"; content: string }
-	| { kind: "test-output"; content: string; passed: boolean };
+	| { kind: "test-output"; content: string; passed: boolean }
+	| { kind: "diff"; diff: DiffCardData };
 
 export interface LedgerRowModel {
 	verb: string;
@@ -29,10 +33,11 @@ const TOOL_VERBS: Record<string, string> = {
 	Bash: "Ran",
 };
 
-/** Tool outputs may carry a display summary next to their content. */
+/** Tool outputs may carry a display summary and/or the edit's landed diff. */
 interface StructuredToolOutput {
 	content: string;
 	summary?: string;
+	diff?: DiffCardData;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -45,12 +50,22 @@ function asOptionalString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
 
+/** Duck-types a diff payload: an object with a `lines` array is close enough. */
+function asDiff(value: unknown): DiffCardData | undefined {
+	const record = asRecord(value);
+	return Array.isArray(record.lines) ? (value as DiffCardData) : undefined;
+}
+
 function normalizeOutput(output: unknown): StructuredToolOutput | undefined {
 	if (typeof output === "string") return { content: output };
 	const record = asRecord(output);
 	const content = asOptionalString(record.content);
 	if (content === undefined) return undefined;
-	return { content, summary: asOptionalString(record.summary) };
+	return {
+		content,
+		summary: asOptionalString(record.summary),
+		diff: asDiff(record.diff),
+	};
 }
 
 function countLines(text: string): number {
@@ -90,13 +105,16 @@ export function describeToolPart(part: DynamicToolUIPart): LedgerRowModel {
 		part.state === "output-available" ? normalizeOutput(part.output) : undefined;
 	if (output === undefined) return { verb, subject };
 
-	const body: LedgerBody = looksLikeTestOutput(output.content)
-		? {
-				kind: "test-output",
-				content: output.content,
-				passed: !/\d+\s+failed|[✗×]/.test(output.content),
-			}
-		: { kind: "code", content: output.content };
+	const body: LedgerBody =
+		output.diff !== undefined
+			? { kind: "diff", diff: output.diff }
+			: looksLikeTestOutput(output.content)
+				? {
+						kind: "test-output",
+						content: output.content,
+						passed: !/\d+\s+failed|[✗×]/.test(output.content),
+					}
+				: { kind: "code", content: output.content };
 
 	return { verb, subject, meta: deriveMeta(part, input, output), body };
 }
@@ -106,6 +124,14 @@ function deriveMeta(
 	input: Record<string, unknown>,
 	output: StructuredToolOutput,
 ): LedgerMeta | undefined {
+	// The diff's own counts are exact (derived from the real hunk); prefer
+	// them over a summary string or an old/new-string line count estimate.
+	if (output.diff !== undefined)
+		return {
+			kind: "delta",
+			additions: output.diff.additions,
+			deletions: output.diff.deletions,
+		};
 	if (output.summary !== undefined)
 		return { kind: "text", text: output.summary };
 	const oldString = asOptionalString(input.old_string);
@@ -122,6 +148,26 @@ function deriveMeta(
 	if (part.toolName === "Read")
 		return { kind: "text", text: `${countLines(output.content)} lines` };
 	return undefined;
+}
+
+// --- the contextual moment ---------------------------------------------------
+
+/**
+ * The toolCallId of the "just landed" contextual moment: the message's very
+ * last part, if it's a completed tool call whose body is a diff. Its ledger
+ * row starts open — the diff surfacing because the edit landed, per Folio's
+ * "contextual moments are the star" principle. Any later part (more prose,
+ * another tool call) supersedes it, so this reports nothing once something
+ * newer has arrived; the row's caller re-keys on this id and remounts
+ * collapsed when it changes, which is the auto-collapse.
+ */
+export function contextualOpenToolCallId(
+	parts: FolioMessage["parts"],
+): string | undefined {
+	const last = parts.at(-1);
+	if (last === undefined || !isDynamicToolUIPart(last)) return undefined;
+	if (last.state !== "output-available") return undefined;
+	return describeToolPart(last).body?.kind === "diff" ? last.toolCallId : undefined;
 }
 
 // --- test-output highlighting -----------------------------------------------

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -1,20 +1,26 @@
 /*
  * The manuscript message: serif prose paragraphs with contiguous tool
- * parts grouped into a quiet "workings" apparatus, landed edits surfacing
- * as diff cards, and an end-of-turn receipt. Consumes AI SDK UIMessages
- * (text / dynamic-tool / data-diff parts) so live streaming (#748) renders
- * through the same component.
+ * parts grouped into a quiet "workings" apparatus and an end-of-turn
+ * receipt. A landed edit has one home — its Edit ledger row expands to
+ * reveal its diff inline (#790); there is no separate floating diff card.
+ * Consumes AI SDK UIMessages (text / dynamic-tool parts) so live streaming
+ * (#748) renders through the same component.
  */
 import { isDynamicToolUIPart, type DynamicToolUIPart } from "ai";
 import type { CSSProperties, ReactNode } from "react";
-import { DiffCard } from "./diff-card";
+import { DiffHunk } from "./diff-card";
 import { InlineMarkdown } from "./inline-markdown";
-import { describeToolPart, type LedgerBody, type LedgerMeta } from "./ledger";
+import {
+	contextualOpenToolCallId,
+	describeToolPart,
+	type LedgerBody,
+	type LedgerMeta,
+} from "./ledger";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
 import { TestOutputPanel } from "./test-output-panel";
 import { ToolLedgerRow } from "./tool-ledger-row";
 import { TurnStatsReceipt } from "./turn-stats";
-import type { DiffCardData, FolioMessage } from "./types";
+import type { FolioMessage } from "./types";
 
 // --- shell -------------------------------------------------------------------
 
@@ -76,8 +82,7 @@ export function MessageArticle({
 type Segment =
 	| { kind: "text"; key: string; text: string }
 	| { kind: "reasoning"; key: string; text: string; streaming: boolean }
-	| { kind: "tools"; key: string; parts: DynamicToolUIPart[] }
-	| { kind: "diff"; key: string; data: DiffCardData };
+	| { kind: "tools"; key: string; parts: DynamicToolUIPart[] };
 
 /** Contiguous tool parts collapse into one workings block. */
 function groupParts(parts: FolioMessage["parts"]): Segment[] {
@@ -96,8 +101,6 @@ function groupParts(parts: FolioMessage["parts"]): Segment[] {
 			const last = segments.at(-1);
 			if (last?.kind === "tools") last.parts.push(part);
 			else segments.push({ kind: "tools", key: `part-${index}`, parts: [part] });
-		} else if (part.type === "data-diff") {
-			segments.push({ kind: "diff", key: `part-${index}`, data: part.data });
 		}
 	});
 	return segments;
@@ -120,6 +123,7 @@ function LedgerMetaView({ meta }: { meta: LedgerMeta }) {
 function LedgerBodyView({ body }: { body: LedgerBody }) {
 	if (body.kind === "test-output")
 		return <TestOutputPanel output={body.content} passed={body.passed} />;
+	if (body.kind === "diff") return <DiffHunk lines={body.diff.lines} />;
 	return (
 		<pre className="overflow-x-auto rounded-lg border border-line bg-raised px-4 py-3 font-mono text-code whitespace-pre text-muted">
 			{body.content}
@@ -130,21 +134,31 @@ function LedgerBodyView({ body }: { body: LedgerBody }) {
 function Workings({
 	parts,
 	openToolCallIds,
+	contextualToolCallId,
 }: {
 	parts: DynamicToolUIPart[];
 	openToolCallIds?: string[];
+	/**
+	 * The just-landed edit's toolCallId (see ledger.ts's contextualOpenToolCallId).
+	 * Folded into the row's key, not just `defaultOpen`: once a newer part makes
+	 * this call no longer contextual, the key changes and the row remounts
+	 * collapsed — `defaultOpen` alone only applies on a row's first mount, so it
+	 * can't express "open now, auto-collapse later" on its own.
+	 */
+	contextualToolCallId?: string;
 }) {
 	return (
 		<div className="my-[26px] space-y-[2px] py-1">
 			{parts.map((part) => {
 				const row = describeToolPart(part);
+				const isContextual = part.toolCallId === contextualToolCallId;
 				return (
 					<ToolLedgerRow
-						key={part.toolCallId}
+						key={`${part.toolCallId}-${isContextual}`}
 						verb={row.verb}
 						subject={row.subject}
 						meta={row.meta && <LedgerMetaView meta={row.meta} />}
-						defaultOpen={openToolCallIds?.includes(part.toolCallId)}
+						defaultOpen={isContextual || openToolCallIds?.includes(part.toolCallId)}
 					>
 						{row.body && <LedgerBodyView body={row.body} />}
 					</ToolLedgerRow>
@@ -197,6 +211,7 @@ export function Message({
 			</MessageArticle>
 		);
 	}
+	const contextualToolCallId = contextualOpenToolCallId(message.parts);
 	return (
 		<MessageArticle
 			role="assistant"
@@ -220,10 +235,9 @@ export function Message({
 							key={segment.key}
 							parts={segment.parts}
 							openToolCallIds={openToolCallIds}
+							contextualToolCallId={contextualToolCallId}
 						/>
 					);
-				if (segment.kind === "diff")
-					return <DiffCard key={segment.key} diff={segment.data} />;
 				return segment.text.split(/\n{2,}/).map((paragraph, i) => (
 					<p key={`${segment.key}-${i}`} className={isUser ? "text-user-ink" : ""}>
 						<InlineMarkdown text={paragraph} />

--- a/web-next/src/components/folio/types.ts
+++ b/web-next/src/components/folio/types.ts
@@ -2,6 +2,9 @@
  * Shared Folio data shapes: the message metadata + custom data parts the
  * components consume. Messages are AI SDK UIMessages so #748 can stream
  * into the same components; everything visual rides in metadata/data parts.
+ * A landed edit has one home — its Edit tool part's own structured output
+ * (see ledger.ts's LedgerBody "diff" kind) — so there is no separate diff
+ * data part here.
  */
 import type { UIMessage } from "ai";
 
@@ -47,18 +50,17 @@ export interface DiffLine {
 	text: string;
 }
 
-/** A landed edit surfaced as a contextual card. */
+/** A landed edit's diff, rendered inside its Edit ledger row's body. */
 export interface DiffCardData {
 	file: string;
 	additions: number;
 	deletions: number;
-	/** Italic caption on the right (e.g. "edit landed · just now"). */
+	/** Unused by rendering; kept on the wire for provenance/debugging. */
 	note?: string;
 	lines: DiffLine[];
 }
 
 export type FolioDataParts = {
-	diff: DiffCardData;
 	/** Transient provider status ("Cloning repo") — surfaced via onData, never a part. */
 	status: { message: string };
 };

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -6,6 +6,7 @@ import {
 	mapFullStream,
 	parseGitDiff,
 	toolResultContent,
+	uniqueDiffToolCallId,
 } from "./vercel-provider";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -259,5 +260,23 @@ describe("parseGitDiff", () => {
 
 	test("returns no cards for an empty diff", () => {
 		expect(parseGitDiff("")).toEqual([]);
+	});
+});
+
+describe("uniqueDiffToolCallId", () => {
+	test("is diff:<file> when nothing has claimed that id yet", () => {
+		expect(uniqueDiffToolCallId("a.ts", new Set())).toBe("diff:a.ts");
+	});
+
+	// A real tool call id is never diff:<path>-shaped, but the id space is
+	// shared, so a synthetic Diff row must not silently overwrite one that is.
+	test("disambiguates against a real toolCallId already used this turn", () => {
+		const seen = new Set(["diff:a.ts"]);
+		expect(uniqueDiffToolCallId("a.ts", seen)).toBe("diff:a.ts#1");
+	});
+
+	test("keeps disambiguating past a single collision", () => {
+		const seen = new Set(["diff:a.ts", "diff:a.ts#1", "diff:a.ts#2"]);
+		expect(uniqueDiffToolCallId("a.ts", seen)).toBe("diff:a.ts#3");
 	});
 });

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -540,11 +540,16 @@ export const vercelProvider: ComputeProvider = {
 				}
 				yield chunk;
 			}
-			// Synthesize a diff card per changed file from the working tree (the
-			// Edit/Write results carry no patch; the real diff lives in git). Emit
-			// each as a tool_use + tool_result pair — the Folio adapter renders the
-			// DiffCard from a tool_result's metadata.diff, and the AI SDK only keeps
-			// a tool result that has a matching opened call.
+			// Synthesize one Diff ledger row per changed file from the working tree
+			// (the Edit/Write results carry no patch; the real diff lives in git).
+			// Emitted as a tool_use + tool_result pair — the Folio adapter merges
+			// metadata.diff into that same call's own output (#790: a diff's home
+			// is its own expandable ledger row, never a separate floating card),
+			// and the AI SDK only keeps a tool result that has a matching opened
+			// call. This is a per-file summary, not per Edit invocation — git diff
+			// can't attribute hunks back to individual tool calls when a file is
+			// edited more than once in a turn, so multiple edits to one file land
+			// as a single Diff row rather than each Edit call carrying its own.
 			for (const diff of await changedFileDiffs(sandbox)) {
 				const toolUseId = `diff:${diff.file}`;
 				yield {
@@ -597,8 +602,8 @@ interface RunnableSandbox {
 	}) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>;
 }
 
-/** A rendered diff card: file, line counts, and the hunk lines. */
-interface DiffCard {
+/** One changed file's diff: file, line counts, and the hunk lines. */
+interface FileDiff {
 	file: string;
 	additions: number;
 	deletions: number;
@@ -606,15 +611,15 @@ interface DiffCard {
 	lines: { kind: "add" | "del" | "context"; text: string }[];
 }
 
-/** Beyond this many hunk lines a single file's card is truncated. */
+/** Beyond this many hunk lines a single file's diff is truncated. */
 const DIFF_LINE_CAP = 200;
 
 /**
  * Runs `git diff` over the workspace (untracked files marked intent-to-add so
- * new files show) and parses it into one diff card per changed file. Best-effort
- * — any failure yields no cards, never breaking the turn.
+ * new files show) and parses it into one diff per changed file. Best-effort —
+ * any failure yields no diffs, never breaking the turn.
  */
-async function changedFileDiffs(sandbox: RunnableSandbox | undefined): Promise<DiffCard[]> {
+async function changedFileDiffs(sandbox: RunnableSandbox | undefined): Promise<FileDiff[]> {
 	if (!sandbox) return [];
 	try {
 		const res = await sandbox.run({
@@ -626,14 +631,14 @@ async function changedFileDiffs(sandbox: RunnableSandbox | undefined): Promise<D
 	}
 }
 
-/** Splits a multi-file unified diff into per-file cards. */
-export function parseGitDiff(raw: string): DiffCard[] {
-	const cards: DiffCard[] = [];
-	let current: DiffCard | undefined;
+/** Splits a multi-file unified diff into per-file diffs. */
+export function parseGitDiff(raw: string): FileDiff[] {
+	const diffs: FileDiff[] = [];
+	let current: FileDiff | undefined;
 	let inHunk = false;
 	for (const line of raw.split("\n")) {
 		if (line.startsWith("diff --git")) {
-			if (current && current.lines.length > 0) cards.push(current);
+			if (current && current.lines.length > 0) diffs.push(current);
 			const file = line.match(/ b\/(.+)$/)?.[1] ?? "(file)";
 			current = { file, additions: 0, deletions: 0, note: "edit landed", lines: [] };
 			inHunk = false;
@@ -657,8 +662,8 @@ export function parseGitDiff(raw: string): DiffCard[] {
 			current.lines.push({ kind: "context", text: line });
 		}
 	}
-	if (current && current.lines.length > 0) cards.push(current);
-	return cards;
+	if (current && current.lines.length > 0) diffs.push(current);
+	return diffs;
 }
 
 /**

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -429,9 +429,9 @@ export const vercelProvider: ComputeProvider = {
 		const debugHarness = process.env.HARNESS_DEBUG === "1";
 
 		// The sandbox session is captured here so the turn can run `git diff` after
-		// streaming to synthesize diff cards (the harness session drives turns, not
-		// arbitrary commands). The sandbox stays alive until detach, so it is valid
-		// through the end of the turn.
+		// streaming to synthesize Diff ledger rows (the harness session drives
+		// turns, not arbitrary commands). The sandbox stays alive until detach, so
+		// it is valid through the end of the turn.
 		let sandbox: RunnableSandbox | undefined;
 
 		const agent = new HarnessAgent({
@@ -530,14 +530,21 @@ export const vercelProvider: ComputeProvider = {
 				prompt: buildPrompt(request.userMessage, request.sessionId, !resumed),
 			});
 			let doneChunk: StreamChunk | undefined;
+			// Tracks every real toolCallId this turn so the synthetic Diff rows
+			// below can't collide with one — the AI SDK upserts dynamic-tool parts
+			// by toolCallId, so a collision would silently overwrite a real tool's
+			// result instead of adding a second row.
+			const seenToolCallIds = new Set<string>();
 			for await (const chunk of mapFullStream(
 				result.fullStream as AsyncIterable<{ type: string; [k: string]: unknown }>,
 				startedAt,
 			)) {
 				if (chunk.type === "done") {
 					doneChunk = chunk;
-					break; // the terminal chunk — emit diff cards, then park, then it
+					break; // the terminal chunk — emit Diff rows, then park, then it
 				}
+				const id = chunk.metadata?.toolUseId;
+				if (typeof id === "string") seenToolCallIds.add(id);
 				yield chunk;
 			}
 			// Synthesize one Diff ledger row per changed file from the working tree
@@ -551,7 +558,8 @@ export const vercelProvider: ComputeProvider = {
 			// edited more than once in a turn, so multiple edits to one file land
 			// as a single Diff row rather than each Edit call carrying its own.
 			for (const diff of await changedFileDiffs(sandbox)) {
-				const toolUseId = `diff:${diff.file}`;
+				const toolUseId = uniqueDiffToolCallId(diff.file, seenToolCallIds);
+				seenToolCallIds.add(toolUseId);
 				yield {
 					type: "tool_use",
 					content: "Diff",
@@ -593,6 +601,19 @@ function isNameCollision(error: unknown): boolean {
 	const e = error as { message?: unknown; text?: unknown; json?: unknown };
 	const haystack = [asText(e?.message), asText(e?.text), asText(e?.json)].join(" ");
 	return /already exists/i.test(haystack);
+}
+
+/**
+ * A synthetic diff row's id, disambiguated against any real toolCallId
+ * already seen this turn. In practice a real id (the model provider's own
+ * tool-use id) never looks like `diff:<path>`, but the id space is shared
+ * with real tool calls, so this guards the collision explicitly rather than
+ * assuming it can't happen.
+ */
+export function uniqueDiffToolCallId(file: string, seen: ReadonlySet<string>): string {
+	let id = `diff:${file}`;
+	for (let suffix = 1; seen.has(id); suffix += 1) id = `diff:${file}#${suffix}`;
+	return id;
 }
 
 /** A sandbox session that can run shell commands (the onSession surface). */

--- a/web-next/src/lib/fixtures/demo-session.ts
+++ b/web-next/src/lib/fixtures/demo-session.ts
@@ -1,11 +1,13 @@
 /*
  * Fixture data for /sessions/demo: the refine-folio prototype's session —
- * one completed coding turn (a thinking block, workings, landed diff, receipt),
- * a follow-up, and an in-progress turn — expressed as AI SDK UIMessages. Also:
+ * one completed coding turn (a thinking block, workings, a landed edit whose
+ * diff lives in its own Edit ledger row, receipt), a follow-up, and an
+ * in-progress turn — expressed as AI SDK UIMessages. Also:
  *   - seededDemoSession: arbitrary-length transcripts for transcript_render_200.
  *   - adversarialSession (?scenario=adversarial): one worst-case turn — a long
  *     reasoning trace, 16 tool calls (one failed), a 100+ line diff, long prose —
- *     the stress test the turn frame, workings, diff card, and receipt must hold.
+ *     the stress test the turn frame, workings, diff-carrying ledger row, and
+ *     receipt must hold.
  *   - longTranscriptSession (?scenario=long): 15+ stacked turns to check the
  *     card-in-card framing (recent turn lifted, older ones quiet) at scale.
  */
@@ -21,7 +23,7 @@ function completedTool(
 	toolCallId: string,
 	toolName: string,
 	input: Record<string, unknown>,
-	output: string | { content: string; summary?: string },
+	output: string | { content: string; summary?: string; diff?: DiffCardData },
 ): DynamicToolUIPart {
 	return {
 		type: "dynamic-tool",
@@ -120,7 +122,27 @@ export function demoSession(): SessionViewData {
 						new_string:
 							"  if (!record) {\n    throw new SessionNotFoundError(id);\n  }\n  return hydrate(record);",
 					},
-					"guard added before hydrate() — see the change below",
+					{
+						content: "guard added before hydrate() — see the change below",
+						diff: {
+							file: "src/session/resume.ts",
+							additions: 4,
+							deletions: 1,
+							lines: [
+								{
+									kind: "context",
+									text: "  export async function resumeSession(id: SessionId): Promise<Session> {",
+								},
+								{ kind: "context", text: "    const record = await store.get(id);" },
+								{ kind: "del", text: "-   return hydrate(record);" },
+								{ kind: "add", text: "+   if (!record) {" },
+								{ kind: "add", text: "+     throw new SessionNotFoundError(id);" },
+								{ kind: "add", text: "+   }" },
+								{ kind: "add", text: "+   return hydrate(record);" },
+								{ kind: "context", text: "  }" },
+							],
+						},
+					},
 				),
 				completedTool(
 					"tool-4",
@@ -128,28 +150,6 @@ export function demoSession(): SessionViewData {
 					{ command: "pnpm test" },
 					TEST_RUN_OUTPUT,
 				),
-				{
-					type: "data-diff",
-					data: {
-						file: "src/session/resume.ts",
-						additions: 4,
-						deletions: 1,
-						note: "edit landed · just now",
-						lines: [
-							{
-								kind: "context",
-								text: "  export async function resumeSession(id: SessionId): Promise<Session> {",
-							},
-							{ kind: "context", text: "    const record = await store.get(id);" },
-							{ kind: "del", text: "-   return hydrate(record);" },
-							{ kind: "add", text: "+   if (!record) {" },
-							{ kind: "add", text: "+     throw new SessionNotFoundError(id);" },
-							{ kind: "add", text: "+   }" },
-							{ kind: "add", text: "+   return hydrate(record);" },
-							{ kind: "context", text: "  }" },
-						],
-					},
-				},
 				{
 					type: "text",
 					text: "The guard now rejects at the boundary, before hydration is ever attempted. Full suite is green — 28 tests across three files, including the two that were red.",
@@ -358,8 +358,10 @@ function bigRefactorDiff(): DiffCardData {
 }
 
 /** 16 tool calls — a grep, a spread of reads, four edits, a failed typecheck,
- * its green re-run, and the suite. One `output-error` row exercises failure. */
-function adversarialWorkings(): DynamicToolUIPart[] {
+ * its green re-run, and the suite. One `output-error` row exercises failure.
+ * The turn's aggregate diff (a git-diff-style summary spanning all 13 files)
+ * lands on the last Edit call — its ledger row is the diff's one home. */
+function adversarialWorkings(diff: DiffCardData): DynamicToolUIPart[] {
 	const tools: DynamicToolUIPart[] = [
 		completedTool(
 			"adv-1",
@@ -407,6 +409,7 @@ function adversarialWorkings(): DynamicToolUIPart[] {
 			"switch replaced by a registry lookup",
 		),
 	);
+	const lastEditIndex = 2;
 	ADVERSARIAL_MODULES.slice(0, 3).forEach((name, i) => {
 		tools.push(
 			completedTool(
@@ -417,7 +420,7 @@ function adversarialWorkings(): DynamicToolUIPart[] {
 					old_string: `registerLegacy("${name}", ${name}Provider);`,
 					new_string: `registerProvider(${name}Provider);`,
 				},
-				"self-registration",
+				i === lastEditIndex ? { content: "self-registration", diff } : "self-registration",
 			),
 		);
 	});
@@ -463,7 +466,8 @@ const ADVERSARIAL_CONCLUSION =
 /**
  * One worst-case turn: a long thinking block, 16 tool calls (one failed), a
  * 100+ line diff, and long prose on both sides — the stress test the turn
- * frame, workings apparatus, diff card, reasoning block, and receipt must hold.
+ * frame, workings apparatus, a diff-carrying ledger row, reasoning block, and
+ * receipt must hold.
  */
 export function adversarialSession(): SessionViewData {
 	const diff = bigRefactorDiff();
@@ -493,8 +497,7 @@ export function adversarialSession(): SessionViewData {
 			parts: [
 				{ type: "reasoning", state: "done", text: ADVERSARIAL_REASONING },
 				{ type: "text", text: ADVERSARIAL_INTRO },
-				...adversarialWorkings(),
-				{ type: "data-diff", data: diff },
+				...adversarialWorkings(diff),
 				{ type: "text", text: ADVERSARIAL_CONCLUSION },
 			],
 		},

--- a/web-next/src/lib/fixtures/demo-session.ts
+++ b/web-next/src/lib/fixtures/demo-session.ts
@@ -294,7 +294,8 @@ const ADVERSARIAL_TEST_OUTPUT = [
 /**
  * A 100+ line refactor: a hand-wired provider `switch` replaced by a
  * self-registering map, rippling across a dozen backend modules. Deliberately
- * tall — the stress the diff card (and the frame around it) has to survive.
+ * tall — the stress the diff-carrying ledger row (and the frame around it)
+ * has to survive.
  */
 function bigRefactorDiff(): DiffCardData {
 	const lines: DiffLine[] = [

--- a/web-next/src/lib/transcript/chunk-adapter.test.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.test.ts
@@ -186,6 +186,25 @@ describe("toUIMessageChunks", () => {
 		});
 	});
 
+	test("a diff on an object output with no content of its own falls back to the chunk's content, never dropping the diff", async () => {
+		const diff = { file: "a.ts", additions: 1, deletions: 0, lines: [] };
+		const out = await collect([
+			{ type: "tool_use", content: "Edit", metadata: { toolUseId: "t-1" } },
+			{
+				type: "tool_result",
+				content: "fallback text",
+				metadata: { toolUseId: "t-1", output: { summary: "landed" }, diff },
+			},
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({
+			type: "tool-output-available",
+			toolCallId: "t-1",
+			output: { summary: "landed", content: "fallback text", diff },
+			dynamic: true,
+		});
+	});
+
 	test("messageMetadata is emitted on start (no chunks) and finish (all chunks)", async () => {
 		const seen: number[] = [];
 		const out = [];

--- a/web-next/src/lib/transcript/chunk-adapter.test.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.test.ts
@@ -147,18 +147,42 @@ describe("toUIMessageChunks", () => {
 		expect(out.at(-1)).toEqual({ type: "finish" });
 	});
 
-	test("a tool_result carrying a diff also emits a data-diff part", async () => {
+	test("a tool_result carrying a diff merges it into that call's own output, not a separate part", async () => {
 		const diff = { file: "a.ts", additions: 3, deletions: 1, lines: [] };
 		const out = await collect([
 			{ type: "tool_use", content: "Edit", metadata: { toolUseId: "t-1" } },
 			{ type: "tool_result", content: "ok", metadata: { toolUseId: "t-1", diff } },
 			{ type: "done", content: "" },
 		]);
-		const outputIndex = out.findIndex((c) => c.type === "tool-output-available");
-		expect(out[outputIndex + 1]).toEqual({
-			type: "data-diff",
-			id: "id-0",
-			data: diff,
+		expect(out).toContainEqual({
+			type: "tool-output-available",
+			toolCallId: "t-1",
+			output: { content: "ok", diff },
+			dynamic: true,
+		});
+		expect(out.some((c) => c.type === "data-diff")).toBe(false);
+	});
+
+	test("a diff on a structured output object is folded in alongside its other fields", async () => {
+		const diff = { file: "a.ts", additions: 1, deletions: 0, lines: [] };
+		const out = await collect([
+			{ type: "tool_use", content: "Edit", metadata: { toolUseId: "t-1" } },
+			{
+				type: "tool_result",
+				content: "ok",
+				metadata: {
+					toolUseId: "t-1",
+					output: { content: "ok", summary: "landed" },
+					diff,
+				},
+			},
+			{ type: "done", content: "" },
+		]);
+		expect(out).toContainEqual({
+			type: "tool-output-available",
+			toolCallId: "t-1",
+			output: { content: "ok", summary: "landed", diff },
+			dynamic: true,
 		});
 	});
 

--- a/web-next/src/lib/transcript/chunk-adapter.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.ts
@@ -25,11 +25,20 @@ function asString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-/** Folds a diff onto a tool's output, coercing a bare string into `{ content }` first. */
-function withDiff(output: unknown, diff: unknown): unknown {
+/**
+ * Folds a diff onto a tool's output, guaranteeing a string `content` so the
+ * ledger's normalizeOutput never drops the diff for want of one — `fallback`
+ * is the tool_result chunk's own `content` (always a string on StreamChunk),
+ * used when `output` is an object that doesn't already carry its own.
+ */
+function withDiff(output: unknown, diff: unknown, fallback: string): unknown {
 	if (typeof output === "string") return { content: output, diff };
-	if (typeof output === "object" && output !== null) return { ...output, diff };
-	return { content: "", diff };
+	if (typeof output === "object" && output !== null) {
+		const record = output as Record<string, unknown>;
+		const content = typeof record.content === "string" ? record.content : fallback;
+		return { ...record, content, diff };
+	}
+	return { content: fallback, diff };
 }
 
 /**
@@ -139,7 +148,7 @@ export async function* toUIMessageChunks(
 				const baseOutput = chunk.metadata?.output ?? chunk.content;
 				const output =
 					chunk.metadata?.diff !== undefined
-						? withDiff(baseOutput, chunk.metadata.diff)
+						? withDiff(baseOutput, chunk.metadata.diff, chunk.content)
 						: baseOutput;
 				yield {
 					type: chunk.metadata?.isError

--- a/web-next/src/lib/transcript/chunk-adapter.ts
+++ b/web-next/src/lib/transcript/chunk-adapter.ts
@@ -25,6 +25,13 @@ function asString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+/** Folds a diff onto a tool's output, coercing a bare string into `{ content }` first. */
+function withDiff(output: unknown, diff: unknown): unknown {
+	if (typeof output === "string") return { content: output, diff };
+	if (typeof output === "object" && output !== null) return { ...output, diff };
+	return { content: "", diff };
+}
+
 /**
  * Converts a provider StreamChunk sequence into UIMessageChunks.
  *
@@ -34,8 +41,9 @@ function asString(value: unknown): string | undefined {
  *   it and an open text part close each other, so the two never overlap.
  * - `tool_use`/`tool_result` become dynamic tool parts. Results pair by
  *   `metadata.toolUseId` when present, otherwise FIFO against unresolved calls.
- * - A `tool_result` carrying `metadata.diff` additionally surfaces it as a
- *   persistent `data-diff` part (the Folio contextual diff card).
+ * - A `tool_result` carrying `metadata.diff` merges it into that same call's
+ *   structured output (`{ content, summary?, diff }`) rather than emitting a
+ *   separate part — the Edit ledger row is the diff's one home (#790).
  * - `status` becomes a transient `data-status` chunk (delivered via onData,
  *   never persisted into the message).
  * - `done` — or the source ending — closes open parts and emits `finish`.
@@ -128,23 +136,19 @@ export async function* toUIMessageChunks(
 				if (toolCallId === undefined) break; // result with no known call
 				const index = unresolvedToolIds.indexOf(toolCallId);
 				if (index !== -1) unresolvedToolIds.splice(index, 1);
+				const baseOutput = chunk.metadata?.output ?? chunk.content;
+				const output =
+					chunk.metadata?.diff !== undefined
+						? withDiff(baseOutput, chunk.metadata.diff)
+						: baseOutput;
 				yield {
 					type: chunk.metadata?.isError
 						? "tool-output-error"
 						: "tool-output-available",
 					toolCallId,
-					...(chunk.metadata?.isError
-						? { errorText: chunk.content }
-						: { output: chunk.metadata?.output ?? chunk.content }),
+					...(chunk.metadata?.isError ? { errorText: chunk.content } : { output }),
 					dynamic: true,
 				} as UIMessageChunk;
-				if (chunk.metadata?.diff !== undefined) {
-					yield {
-						type: "data-diff",
-						id: generateId(),
-						data: chunk.metadata.diff,
-					};
-				}
 				break;
 			}
 			case "status": {

--- a/web-next/src/lib/transcript/project-events.test.ts
+++ b/web-next/src/lib/transcript/project-events.test.ts
@@ -150,18 +150,21 @@ describe("projectSessionEvents", () => {
 		});
 	});
 
-	test("a diff-carrying tool result projects to a persistent data-diff part", async () => {
+	test("a diff-carrying tool result projects into that call's own dynamic-tool part", async () => {
 		const diff = { file: "a.ts", additions: 3, deletions: 1, lines: [] };
 		const messages = await projectSessionEvents("s", [
 			a(1, "tool_use", "Edit", { toolUseId: "t-1", toolName: "Edit" }),
 			a(2, "tool_result", "ok", { toolUseId: "t-1", diff }),
 			a(3, "done", ""),
 		]);
-		expect(messages[0].parts).toContainEqual({
-			type: "data-diff",
-			id: "s:1:p0",
-			data: diff,
-		});
+		expect(messages[0].parts).toContainEqual(
+			expect.objectContaining({
+				type: "dynamic-tool",
+				toolCallId: "t-1",
+				output: { content: "ok", diff },
+			}),
+		);
+		expect(messages[0].parts.some((part) => part.type === "data-diff")).toBe(false);
 	});
 
 	test("projects a reasoning event into a reasoning part before the answer", async () => {

--- a/web-next/tests/e2e/sessions-demo.spec.ts
+++ b/web-next/tests/e2e/sessions-demo.spec.ts
@@ -1,8 +1,9 @@
 /*
  * E2E for the Folio session demo (/sessions/demo): theme resolution
  * (toggle, persistence, #light/#dark hash parity), autofocused bare
- * compose, ledger row disclosure, diff card dismissal, status line
- * dismiss-to-dot, and the focus cue / receipt furniture.
+ * compose, ledger row disclosure (including a landed edit's diff, which
+ * lives inside its own Edit row — #790), status line dismiss-to-dot, and
+ * the focus cue / receipt furniture.
  */
 import { expect, test } from "@playwright/test";
 
@@ -81,14 +82,31 @@ test("tool ledger rows disclose and collapse their bodies", async ({
 	await expect(readBody).toBeHidden();
 });
 
-test("diff card renders the landed edit and dismisses", async ({ page }) => {
+test("expanding the Edit row reveals its diff — no separate floating diff card", async ({
+	page,
+}) => {
 	await page.goto("/sessions/demo");
-	const card = page.getByTestId("diff-card");
-	await expect(card).toContainText("src/session/resume.ts");
-	await expect(card).toContainText("throw new SessionNotFoundError(id);");
-	await card.hover();
-	await card.getByRole("button", { name: /dismiss/i }).click();
-	await expect(card).toHaveCount(0);
+	// A landed edit has one home: its own Edit ledger row. There is never a
+	// standalone diff card in the transcript.
+	await expect(page.getByTestId("diff-card")).toHaveCount(0);
+
+	const editRow = page
+		.getByRole("button", { name: /Edit src\/session\/resume\.ts/ })
+		.first();
+	const body = page
+		.getByTestId("tool-row")
+		.filter({ has: editRow })
+		.getByTestId("tool-row-body");
+	await expect(body).toBeHidden();
+
+	await editRow.click();
+	await expect(body).toBeVisible();
+	await expect(body.getByTestId("diff-lines")).toContainText(
+		"throw new SessionNotFoundError(id);",
+	);
+
+	await editRow.click();
+	await expect(body).toBeHidden();
 });
 
 test("status line dismisses to a dot and comes back", async ({ page }) => {

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -140,11 +140,14 @@ test("sending a message streams a mock coding turn into the Folio transcript", a
 	await expect(rows.nth(2)).toContainText("+3 −1");
 	await expect(rows.nth(3)).toContainText("Ran");
 	await expect(rows.nth(3)).toContainText("pnpm test session");
-	// …the landed diff card…
-	await expect(page.getByTestId("diff-card")).toContainText(
+	// …the landed edit's diff — its one home is the Edit row itself, never a
+	// separate floating card.
+	await expect(page.getByTestId("diff-card")).toHaveCount(0);
+	await rows.nth(2).locator("button").first().click();
+	await expect(rows.nth(2).getByTestId("diff-lines")).toContainText(
 		"SessionNotFoundError",
-		{ timeout: TURN_TIMEOUT },
 	);
+	await rows.nth(2).locator("button").first().click(); // collapse it back
 	// …and the end-of-turn receipt derived from the stream.
 	await expect(page.getByTestId("turn-stats")).toContainText(
 		"4 tools · 1 file · +3 −1 · 4 tests",
@@ -174,8 +177,15 @@ test("a reload renders the same turn from the persisted event log", async ({
 	await expect(page.locator('[data-message-role="user"]')).toContainText(
 		"Fix the failing session test",
 	);
-	await expect(page.getByTestId("tool-row")).toHaveCount(4);
-	await expect(page.getByTestId("diff-card")).toContainText("src/lib/session.ts");
+	const reloadedRows = page.getByTestId("tool-row");
+	await expect(reloadedRows).toHaveCount(4);
+	await expect(page.getByTestId("diff-card")).toHaveCount(0);
+	// The Edit row's own subject carries the file; expanding it reveals the diff.
+	await expect(reloadedRows.nth(2)).toContainText("src/lib/session.ts");
+	await reloadedRows.nth(2).locator("button").first().click();
+	await expect(reloadedRows.nth(2).getByTestId("diff-lines")).toContainText(
+		"SessionNotFoundError",
+	);
 	await expect(page.getByTestId("turn-stats")).toContainText(
 		"4 tools · 1 file · +3 −1 · 4 tests",
 	);


### PR DESCRIPTION
## Summary

Closes #790. A landed code edit now has one representation: its Edit tool-ledger row. Expanding the row reveals its diff inline (reusing the add/del hunk rendering); there is no longer a separate free-floating diff card anywhere in the transcript.

**Verification found the acceptance criteria were NOT already met** (issue said "being implemented in PR #787", merged 2026-07-04) — the free-floating `DiffCard` still existed alongside the Edit row, both in the mock/live path (`chunk-adapter.ts` emitted a separate `data-diff` part) and the fixtures (`demo-session.ts`). This PR closes the gap.

### What changed
- `src/lib/transcript/chunk-adapter.ts`: a `tool_result` carrying `metadata.diff` now merges the diff into that *same* tool call's own structured output (`{content, summary?, diff}`) instead of emitting a separate `data-diff` part.
- `src/components/folio/ledger.ts`: `LedgerBody` gained a `diff` kind; `describeToolPart` prefers the diff's own (exact) counts over the old `old_string`/`new_string` line-count estimate. New pure function `contextualOpenToolCallId(parts)` — the toolCallId of the message's *last* part iff it's a completed tool call whose body is a diff, used to drive the "just landed" auto-expand.
- `src/components/folio/message.tsx`: removed the free-floating `DiffCard` rendering entirely. `LedgerBodyView` renders the diff hunk inline when `body.kind === "diff"`. `Workings` folds `isContextual` into each row's React `key`, so once a row stops being the contextual (last-part) row, React remounts it with `defaultOpen=false` — that's the auto-collapse (`ToolLedgerRow`'s open state is uncontrolled, driven by `defaultOpen` at mount).
- `src/components/folio/diff-card.tsx`: `DiffCard` (figure + caption + dismiss button) → `DiffHunk` (just the add/del/context lines) — the row's own header already carries the file + delta, so the standalone caption/dismiss chrome is gone.
- `src/lib/agent-runtime/vercel-provider.ts` (real provider): its per-changed-file `git diff` synthesis now goes through the same merged-output path (no separate part). Documented residual limitation: this is a per-*file* summary, not per-Edit-invocation, since `git diff` can't attribute hunks back to a specific tool call.
- `src/lib/fixtures/demo-session.ts` + mock provider: every mock Edit's diff now rides on that same Edit call's own output.
- `web-next/docs/design.md`: replaced the stale "Diffs and test output are contextual panels" decision with the one-representation model.

### Codex review response (see `## Review loop` below)
Hardened the diff plumbing against two real gaps codex found: a synthetic diff row's `toolCallId` could collide with a real tool's id (the AI SDK upserts by id, so a collision would silently overwrite a real result — now disambiguated), and a diff would silently vanish if its paired tool_result's structured output was an object without its own `content` field (now falls back to the chunk's own content). Also added defensive sanitization for malformed/legacy persisted diff payloads and fixed four stale "diff card" comments.

## Acceptance criteria (from #790)

- [x] Expanding any Edit shows its diff — one consistent interaction, everywhere. (`ledger.test.ts`, e2e in both `sessions-demo.spec.ts` and `sessions.spec.ts`)
- [x] No separate free-floating diff card in the transcript. (removed `data-diff` part + `DiffCard` component; e2e asserts `getByTestId("diff-card")` has count 0)
- [x] Most-recent edit expanded by default; older edits collapsed. (`contextualOpenToolCallId` + key-remount; unit-tested in `ledger.test.ts`)
- [x] Both themes; calm Folio aesthetic. (evidence below, light + dark)
- [x] `web-next/docs/design.md` updated to describe the one-representation model.

## Mergeability

- Surface: web (web-next/ — Folio transcript rendering, chunk adapter, real + mock providers, fixtures)
- User-facing behavior changed: Yes — expanding a landed Edit's ledger row now shows its diff inline; there is no longer a separate diff card below the ledger. The just-landed edit's row auto-expands and auto-collapses as the turn continues.
- Non-happy paths considered: malformed/legacy persisted diff payloads (sanitized, not crashed — see `ledger.test.ts`'s sanitization test); a diff's paired tool_result with an object output lacking `content` (falls back to the chunk's own content); synthetic per-file diff row toolCallId colliding with a real tool's id (disambiguated via `uniqueDiffToolCallId`, unit-tested).
- Residual risk or follow-up: the real (vercel) provider's diff-per-changed-file synthesis stays decoupled from individual Edit/Write tool calls (a `git diff`-derived per-file summary, not per-invocation) — multiple edits to the same file in one turn still land as a single Diff row rather than each Edit call carrying its own; this is a pre-existing architectural limitation of that provider, documented in code, not solved by this PR.

## Evidence

Unit + component-logic tests passed: `pnpm run test` — 228 tests, 21 files, all passed. `pnpm run lint` and `pnpm run typecheck` clean. `pnpm run test:e2e` — 25 tests, all passed (including the two updated specs: `sessions-demo.spec.ts` "expanding the Edit row reveals its diff — no separate floating diff card", `sessions.spec.ts`'s live mock-turn diff assertions).

Mutation-checked: `contextualOpenToolCallId`, the diff-body branch in `describeToolPart`, `chunk-adapter.ts`'s diff merge (including the object-output fallback), `asDiff`'s sanitization, and `uniqueDiffToolCallId` — each mutated to a broken variant and confirmed the relevant test(s) failed, then reverted.

Screenshots (light + dark) — `session-turn-final` shows the Edit row expanded with its diff visible inline, no floating card:

![session-turn-final-light](https://evidence.cloudcompute.com/workspaces/pr-909/20260707-171904-session-turn-final-light.png)
![session-turn-final-dark](https://evidence.cloudcompute.com/workspaces/pr-909/20260707-171910-session-turn-final-dark.png)
![sessions-demo-light](https://evidence.cloudcompute.com/workspaces/pr-909/20260707-171910-sessions-demo-light.png)
![sessions-demo-dark](https://evidence.cloudcompute.com/workspaces/pr-909/20260707-171911-sessions-demo-dark.png)

Test run output (228 unit/component tests + 25 e2e tests, all passed):

![test-results](https://evidence.cloudcompute.com/workspaces/pr-909/20260707-172019-test-results.png)

- CI: green quality lane on 668e52e: https://github.com/fairchild/workspaces/actions/runs/28885171865/job/85683394311
- Gate note: orchestrator verified the four acceptance gaps were real (issue's 'already implemented in #787' claim was wrong), read the contextualOpenToolCallId auto-expand core and the chunk-adapter merge; codex loop ran (1 High id-collision + 2 Medium fixed, 6 mutation checks); merged on delegated authority.

## Review loop

Ran the codex-review-loop skill (reflect → directed codex gpt-5.5 xhigh → attributed reactions).

Reflection pass (before codex): re-walked the diff for lifecycle/eviction issues; no additional findings beyond what shipped in the first commit.

Codex findings and disposition:

| Severity | Finding | Disposition |
|---|---|---|
| High | Synthetic per-file Diff row's `toolCallId` (`diff:<file>`) has no collision guard against a real tool's id; AI SDK upserts by id, so a collision silently overwrites a real result (reproduced with a script). | **Fixed** — `uniqueDiffToolCallId` tracks every real toolCallId seen this turn and disambiguates (`diff:<file>#1`, `#2`, ...). Unit-tested. |
| Medium | `withDiff()` drops the diff entirely when the paired tool_result's structured output is an object without its own `content` — `normalizeOutput` requires a string `content` to render anything. | **Fixed** — falls back to the tool_result chunk's own `content` (always a string on `StreamChunk`). Unit-tested. |
| Medium | `asDiff()` trusted a persisted diff payload structurally; a malformed/legacy row could render `+undefined −undefined` or an invalid line `kind`. | **Fixed** — sanitizes lines (drops malformed entries) and falls back to counting sanitized lines when `additions`/`deletions` aren't numbers. Unit-tested. |
| Nit | Stale "diff card"/"diff cards" wording in 4 comments (`globals.css`, `demo-session.ts`, `vercel-provider.ts` ×2, `docs/architecture.html`) left over from the `DiffCard` → `DiffHunk` refactor. | **Fixed**. |

Codex's completeness check ("is there any code path where a diff could still reach the UI outside a ToolLedgerRow's body") returned no findings after searching `data-diff`, `DiffCard`, `diff-card`, `DiffHunk`, `metadata.diff` — confirmed no regression toward the banned floating-card pattern.

Fix commit: `668e52e9` ("fix(web-next): harden diff plumbing against id collisions and malformed data").
<!-- check-refire 174031 -->
