### PR TITLE
chore: encode no-ad-hoc-rm-rf cleanup convention (AGENTS.md + allowlist)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,29 +1,32 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(mise run web:*)"
+ "permissions": {
+  "allow": [
+   "Bash(mise run web:*)",
+   "Bash(pnpm run clean:*)",
+   "Bash(pnpm -C web-next run clean:*)",
+   "Bash(cd web-next && pnpm run clean:*)"
+  ]
+ },
+ "hooks": {
+  "PreToolUse": [
+   {
+    "matcher": "Bash(gh pr create*)",
+    "hooks": [
+     {
+      "type": "command",
+      "command": "echo '⚠️  Evidence check: Have you uploaded evidence with ./scripts/evidence.sh before creating this PR? Evidence is a merge gate — see AGENTS.md § Evidence-Driven Development.'"
+     }
     ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash(gh pr create*)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '⚠️  Evidence check: Have you uploaded evidence with ./scripts/evidence.sh before creating this PR? Evidence is a merge gate — see AGENTS.md § Evidence-Driven Development.'"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash(mise run *)",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cd \"$(git rev-parse --show-toplevel)\" && { git diff --name-only HEAD -- .mise.toml web/.mise.toml 2>/dev/null; git ls-files --others --exclude-standard -- .mise.toml web/.mise.toml 2>/dev/null; } | grep -q . && echo 'BLOCKED: .mise.toml has uncommitted changes. Commit the task definitions first so the user can review them.' && exit 1 || true"
-          }
-        ]
-      }
+   },
+   {
+    "matcher": "Bash(mise run *)",
+    "hooks": [
+     {
+      "type": "command",
+      "command": "cd \"$(git rev-parse --show-toplevel)\" && { git diff --name-only HEAD -- .mise.toml web/.mise.toml 2>/dev/null; git ls-files --others --exclude-standard -- .mise.toml web/.mise.toml 2>/dev/null; } | grep -q . && echo 'BLOCKED: .mise.toml has uncommitted changes. Commit the task definitions first so the user can review them.' && exit 1 || true"
+     }
     ]
-  }
+   }
+  ]
+ }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ PR summary style: prefer concise Markdown links for completed checks/artifacts (
 ## Commit Hygiene
 
 - Do not include screenshot artifacts in commits unless explicitly requested (`output/`).
+- Never delete build/test state with ad-hoc `rm -rf` — it trips shell-permission prompts that stall unattended sessions. In `web-next/`, use `pnpm run clean [build|data|artifacts|deps|all] [--dry-run]` (allowlisted; see `web-next/CONTRIBUTING.md` § "Cleaning up"). Elsewhere, prefer an existing script/mise task, and file the gap if none covers your case.
 
 ## Quick Commands
 


### PR DESCRIPTION
The clean script (PR #904) only helps if agents reliably reach for it. This encodes the convention at the two surfaces that fire for every session, not just in orchestrator briefs: an AGENTS.md Commit Hygiene line naming `pnpm run clean` as the deletion path, and project-allowlist entries for the clean-command shapes so routine cleanup never prompts.

Lesson source: agents whose worktrees predated #904 fell back to `rm -rf` and stalled on approval prompts while the owner was away.

## Mergeability
Surface: repo instruction/config surfaces only — AGENTS.md (one bullet) and .claude/settings.json (three allow entries). No code.
User-facing behavior changed: none for the product; agent sessions gain prompt-free `pnpm run clean`.
Non-happy paths considered: the allow shapes are exact-prefix (`pnpm run clean:*`) so only the fixed-map script gains prompt-free deletion — arbitrary rm stays gated; a worktree predating #904 still lacks the script, and the AGENTS.md line tells agents to file the gap rather than fall back.
Residual risk or follow-up: none beyond the target map maintenance already noted in #904.

## Evidence
Docs/config-only change — no testable surface; readiness evidence exemption applies (AGENTS.md is docs; settings.json is harness config validated by JSON parse before commit).
<!-- check-refire 174033 -->
<!-- check-refire 180354 -->

- [x] Not a testable change (instruction + permission-config surfaces only; settings.json validated by JSON parse before commit)