### PR TITLE
feat(web-next): terminal drawer — a real shell into the session's sandbox (#752)

### DIFF
--- a/web-next/.env.local.example
+++ b/web-next/.env.local.example
@@ -31,3 +31,8 @@ GITHUB_APP_PRIVATE_KEY=
 # GITHUB_OAUTH_CLIENT_SECRET=
 # BETTER_AUTH_SECRET=            # openssl rand -hex 32
 # BETTER_AUTH_URL=              # e.g. https://spaces.example.com
+
+# --- Terminal drawer (#752) ---
+# HMAC secret for the in-sandbox ttyd path token; optional — falls back to
+# BETTER_AUTH_SECRET (see docs/terminal-access.md):
+# TTYD_TOKEN_SECRET=

--- a/web-next/docs/perf-floor.md
+++ b/web-next/docs/perf-floor.md
@@ -7,7 +7,7 @@ to catch a slowdown, not to define where the app should land.
 
 ## Scenario set
 
-Eight scenarios, defined in `perf/contract.json`:
+Nine scenarios, defined in `perf/contract.json`:
 
 | Scenario | What it measures |
 |---|---|
@@ -16,6 +16,7 @@ Eight scenarios, defined in `perf/contract.json`:
 | `transcript_render_200` | Cold load of a 200-message session to full paint |
 | `projection_200` | In-process cost of projecting a 200-event log into `UIMessage[]` (the tail/resume read path) |
 | `route_home` / `route_session_empty` / `route_sessions_demo` | LCP, total blocking time, and gzipped first-load JS for the three primary routes |
+| `terminal_drawer_interactive` | Drawer toggle → shell painted interactive (lazy ghostty-web init + ticket exchange), over the mock PTY seam |
 | `resume_latency_100` | Reconnect-and-backfill latency for an interrupted 100-event turn |
 
 `perf/projection-bench.mjs` runs `projection_200` in-process (no browser);

--- a/web-next/docs/terminal-access.md
+++ b/web-next/docs/terminal-access.md
@@ -1,0 +1,62 @@
+# Terminal access model (#752)
+
+The terminal drawer on `/sessions/[id]` puts a real shell into the **same
+Vercel sandbox the session's turns run in** — the shared-sandbox pattern. This
+doc is the security-relevant contract; the code lives in
+`src/lib/terminal/` and `src/app/api/sessions/[id]/terminal/`.
+
+## The three gates
+
+A terminal connection passes three independent gates, in order:
+
+1. **App auth.** Both terminal routes run the same `getAuthState()` allowlist
+   verdict as the chat routes (middleware freshness alone is not enough for a
+   sandbox-touching route). Signed out → 401/redirect at the edge; signed in
+   but not allowlisted → 403.
+2. **A single-use ticket.** `POST /api/sessions/[id]/terminal` mints 32
+   random bytes (base64url) with a 30s TTL, stored as a SHA-256 digest
+   (`terminal_tickets`) bound to the login, the session, and the sandbox name
+   it was resolved against. `POST .../terminal/redeem` consumes it exactly
+   once — an atomic UPDATE guard settles concurrent redeems to one winner —
+   and re-checks all three bindings plus expiry. The ticket travels only in
+   POST bodies; no URL (page, API, or asset) ever carries it.
+3. **The ttyd path token.** The sandbox's shell is served by ttyd behind
+   `--base-path /<token>`, where the token is 24 hex chars of
+   HMAC-SHA256(secret, sandbox VM session id). Browsers can't attach headers
+   to a WebSocket, so a path segment is the strongest gate ttyd offers; the
+   token is derived (never stored), scoped to one VM (a new VM session under
+   the same sandbox name gets a new token), and dies with the sandbox
+   (≤ 30 min). Guessing a sandbox name reveals nothing connectable without
+   the server-side secret.
+
+Secret resolution: `TTYD_TOKEN_SECRET`, falling back to `BETTER_AUTH_SECRET`
+(prod always has the latter — the #857 lesson), with a dev-only constant
+outside production and a hard refusal in production when neither is set.
+
+## Sandbox attachment
+
+`resolveLiveSandbox` derives the sandbox name from the session's **own**
+parked harness handle (`sessions.claude_session_id` →
+`ai-sdk-harness-session-<id>`, the exact derivation the turn resume path
+uses) — there is no request parameter that can point it at another session's
+sandbox. The lookup is attach-only (`resume: false`): opening the drawer
+never boots or resumes a VM. Sessions with no live sandbox (never ran a
+turn, sandbox expired/stopped, or a sandbox from before `TERMINAL_PORT` was
+declared) get a calm `no-sandbox` state; the honest affordance is starting a
+turn, which boots the sandbox the terminal then attaches to.
+
+The shell is `tmux new-session -A -s shell` in the session's workspace
+clone, so disconnect/reconnect within one sandbox lands back in the same
+shell state. ttyd + tmux are static binaries baked into the sandbox
+template's bootstrap (best-effort, so a fetch failure never blocks the chat
+path); the mint route re-runs the same idempotent install as a fallback for
+sandboxes built from older templates.
+
+## The mock PTY seam
+
+Under `AUTH_BYPASS` (e2e, perf) the mint resolves mode `"mock"`: the full
+ticket exchange still runs, but the client attaches a deterministic
+in-browser PTY sim (`src/components/terminal/mock-pty.ts`) instead of a
+WebSocket. Playwright and the `terminal_drawer_interactive` perf scenario
+stay hermetic — no sandbox, no credentials — while exercising the real
+drawer, terminal rendering, and both auth gates.

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -5,8 +5,8 @@
 	"scripts": {
 		"dev": "next dev --port 3100",
 		"build": "NODE_ENV=production next build",
-		"start": "next start --port 3100",
-		"e2e:server": "rm -f .data/e2e.db* && { test -f .next/BUILD_ID || NODE_ENV=production next build; } && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port 3100",
+		"start": "next start --port ${E2E_PORT:-3100}",
+		"e2e:server": "rm -f .data/e2e.db* && { test -f .next/BUILD_ID || NODE_ENV=production next build; } && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port ${E2E_PORT:-3100}",
 		"test": "vitest run",
 		"test:e2e": "playwright test",
 		"typecheck": "tsc --noEmit",
@@ -27,6 +27,7 @@
 		"@vercel/sandbox": "2.4.0",
 		"ai": "7.0.15",
 		"better-auth": "1.6.20",
+		"ghostty-web": "^0.4.0",
 		"kysely": "^0.28.17",
 		"next": "^15.5.19",
 		"react": "^19.0.0",

--- a/web-next/perf/BASELINE.md
+++ b/web-next/perf/BASELINE.md
@@ -32,6 +32,7 @@ tightening any budget.
 | route_sessions_demo | lcp_ms | median | 78 | 190 | pass |
 | route_sessions_demo | tbt_ms | median | 0 | 0 | pass |
 | route_sessions_demo | first_load_js_kb | exact | 118.5 | 135 | pass |
+| terminal_drawer_interactive | drawer_interactive_ms | median | 120 / 181.5 | 480 | pass |
 | resume_latency_100 | resume_ms | median | 203.8 | 450 | pass |
 
 Raw samples from the 2026-07-07 (#856) refresh — 10 full `pnpm run perf`
@@ -62,6 +63,17 @@ resume_ms 197.3/800 (all pass).
 
 Reading notes:
 
+- **2026-07-07 (#752):** `terminal_drawer_interactive` added (measured) — on
+  a fresh empty session, Ctrl+` to the drawer's shell painted interactive
+  against the mock PTY seam: lazy ghostty-web WASM load + init, the ticket
+  mint/redeem exchange, first PTY bytes in a painted frame. Two 10-run
+  batches on the same commit: samples 258, 339, 287, 131, 77, 106, 90, 86,
+  109, 188 (median 120) and 158, 197, 267, 361, 362, 176, 134, 187, 157, 150
+  (median 181.5); max observed 362 → budget ceil(362 × 1.3) ≈ 471, rounded
+  to 480. `route_session_empty` first-load JS moved 183.8 → 187.3 kB gz (the
+  drawer shell + transport seam in the session route's first load; ghostty-web
+  itself is a lazily-loaded chunk and stays out of first load). All other
+  scenarios re-verified inside budget on the same runs.
 - **2026-07-07 (#856):** Re-baselined budgets from the loose initial values
   (set once, generously, when each scenario first went from pending to
   measured) to the measured floor: a real regression guard instead of a

--- a/web-next/perf/contract.json
+++ b/web-next/perf/contract.json
@@ -1,14 +1,14 @@
 {
 	"version": 1,
-	"note": "Canonical web-next performance scenarios + budgets (mirrors config/performance/contract.json culture). Budgets gate local + CI runs of perf/run.mjs against a production build (`next start` on localhost, headless Chromium). Baselines live in BASELINE.md; refresh them before tightening a budget. Pending scenarios are declared here so the runner and budgets exist before their surfaces land — the runner reports them as pending and never fails on them.",
+	"note": "Canonical web-next performance scenarios + budgets (mirrors config/performance/contract.json culture). Budgets gate local + CI runs of perf/run.mjs against a production build (`next start` on localhost, headless Chromium). Baselines live in BASELINE.md; refresh them before tightening a budget. Pending scenarios are declared here so the runner and budgets exist before their surfaces land \u2014 the runner reports them as pending and never fails on them.",
 	"ratchet_policy": "Budgets are a regression guard against the measured floor, not a target. Build-artifact-size metrics (first_load_js_kb) are deterministic across runs on a given commit: budget = ceil(median * 1.10), rounded to the nearest 5kb. Wall-clock browser timing metrics (ttft_ms, initial_render_ms, projection_ms, lcp_ms, tbt_ms, resume_ms) are exposed to host CPU scheduling noise: budget = ceil(max-observed-across-runs * 1.3), rounded to a sensible figure (10-50ms), over at least 10 runs so the max reflects real tail noise rather than one sample's jitter. Budgets only ever tighten: a formula result above the current budget keeps the current budget unchanged. Derivation rationale and refresh procedure: docs/perf-floor.md; measured baselines: BASELINE.md.",
 	"methodology": {
-		"paint_timing": "waitForFunction polls on requestAnimationFrame, so 'painted' means the frame after the DOM change — within one frame of true paint.",
+		"paint_timing": "waitForFunction polls on requestAnimationFrame, so 'painted' means the frame after the DOM change \u2014 within one frame of true paint.",
 		"long_tasks": "PerformanceObserver longtask entries, observed in-page. The longtask API only reports tasks >= 50ms, so longest_task_ms reads 0 in a clean run and any nonzero value is a budget violation.",
 		"tbt": "Sum of (longtask duration - 50ms) for buffered long tasks within the settle window after navigation.",
-		"first_load_js": "Gzipped size of the route's client JS chunks from the .next build manifests — same basis as the `next build` First Load JS column.",
-		"projection": "In-process (no browser): perf/projection-bench.mjs, run under tsx, builds a deterministic 200-event log and times projectSessionEvents over N runs after one warmup, printing JSON samples run.mjs aggregates. Measures the pure events→UIMessage[] projection (adapter + readUIMessageStream reduction) that #749's tail/resume path replays through.",
-		"auth": "Routes are behind auth (#747). The server runs in test-bypass mode (AUTH_BYPASS=1, throwaway database seeded with one repo + one empty session) and every browser context carries the signed-in test cookie, so route metrics include the middleware + server auth gate — same work production requests do."
+		"first_load_js": "Gzipped size of the route's client JS chunks from the .next build manifests \u2014 same basis as the `next build` First Load JS column.",
+		"projection": "In-process (no browser): perf/projection-bench.mjs, run under tsx, builds a deterministic 200-event log and times projectSessionEvents over N runs after one warmup, printing JSON samples run.mjs aggregates. Measures the pure events\u2192UIMessage[] projection (adapter + readUIMessageStream reduction) that #749's tail/resume path replays through.",
+		"auth": "Routes are behind auth (#747). The server runs in test-bypass mode (AUTH_BYPASS=1, throwaway database seeded with one repo + one empty session) and every browser context carries the signed-in test cookie, so route metrics include the middleware + server auth gate \u2014 same work production requests do."
 	},
 	"scenarios": [
 		{
@@ -17,7 +17,10 @@
 			"description": "On a real empty session at /sessions/[id], submit a message (the full send path: chat route auth gate, user-event append, mock provider); time from submit to the first assistant token painted in the Folio transcript. One fresh seeded session per run.",
 			"runs": 3,
 			"metrics": {
-				"ttft_ms": { "stat": "median", "budget": 1050 }
+				"ttft_ms": {
+					"stat": "median",
+					"budget": 1050
+				}
 			}
 		},
 		{
@@ -26,7 +29,10 @@
 			"description": "While a full mock turn streams into the Folio transcript on /sessions/[id] (prose, ledger rows, diff card, receipt), no main-thread long task may exceed 50ms. One fresh seeded session per run.",
 			"runs": 3,
 			"metrics": {
-				"longest_task_ms": { "stat": "max", "budget": 0 }
+				"longest_task_ms": {
+					"stat": "max",
+					"budget": 0
+				}
 			}
 		},
 		{
@@ -36,7 +42,10 @@
 			"route": "/sessions/demo?seed=200",
 			"runs": 3,
 			"metrics": {
-				"initial_render_ms": { "stat": "median", "budget": 450 }
+				"initial_render_ms": {
+					"stat": "median",
+					"budget": 450
+				}
 			}
 		},
 		{
@@ -46,7 +55,10 @@
 			"description": "Project a 200-event session log (20 interleaved user+assistant turns with status/text/tool events) into UIMessage[] in-process; median wall-clock over the runs. This is the read path #749's tail/resume replays; it must stay cheap enough to project a full transcript on reconnect without blocking.",
 			"runs": 3,
 			"metrics": {
-				"projection_ms": { "stat": "median", "budget": 30 }
+				"projection_ms": {
+					"stat": "median",
+					"budget": 30
+				}
 			}
 		},
 		{
@@ -56,9 +68,18 @@
 			"route": "/",
 			"runs": 3,
 			"metrics": {
-				"lcp_ms": { "stat": "median", "budget": 120 },
-				"tbt_ms": { "stat": "median", "budget": 0 },
-				"first_load_js_kb": { "stat": "exact", "budget": 130 }
+				"lcp_ms": {
+					"stat": "median",
+					"budget": 120
+				},
+				"tbt_ms": {
+					"stat": "median",
+					"budget": 0
+				},
+				"first_load_js_kb": {
+					"stat": "exact",
+					"budget": 130
+				}
 			}
 		},
 		{
@@ -69,9 +90,18 @@
 			"manifest_route": "/sessions/[id]",
 			"runs": 3,
 			"metrics": {
-				"lcp_ms": { "stat": "median", "budget": 140 },
-				"tbt_ms": { "stat": "median", "budget": 0 },
-				"first_load_js_kb": { "stat": "exact", "budget": 200 }
+				"lcp_ms": {
+					"stat": "median",
+					"budget": 140
+				},
+				"tbt_ms": {
+					"stat": "median",
+					"budget": 0
+				},
+				"first_load_js_kb": {
+					"stat": "exact",
+					"budget": 200
+				}
 			}
 		},
 		{
@@ -81,9 +111,30 @@
 			"route": "/sessions/demo",
 			"runs": 3,
 			"metrics": {
-				"lcp_ms": { "stat": "median", "budget": 190 },
-				"tbt_ms": { "stat": "median", "budget": 0 },
-				"first_load_js_kb": { "stat": "exact", "budget": 135 }
+				"lcp_ms": {
+					"stat": "median",
+					"budget": 190
+				},
+				"tbt_ms": {
+					"stat": "median",
+					"budget": 0
+				},
+				"first_load_js_kb": {
+					"stat": "exact",
+					"budget": 135
+				}
+			}
+		},
+		{
+			"id": "terminal_drawer_interactive",
+			"status": "measured",
+			"description": "On a real empty session at /sessions/[id], toggle the terminal drawer (Ctrl+`): time from the toggle keypress to the drawer's shell painted interactive - lazy ghostty-web WASM load + init, the ticket mint/redeem exchange, and the first PTY bytes in a painted frame (data-ready). Runs against the mock PTY seam (AUTH_BYPASS), so it needs no sandbox credentials in CI; the real ttyd path adds sandbox + network time on top. One fresh seeded session per run, cold context each run.",
+			"runs": 10,
+			"metrics": {
+				"drawer_interactive_ms": {
+					"stat": "median",
+					"budget": 480
+				}
 			}
 		},
 		{
@@ -92,7 +143,10 @@
 			"description": "Load a session whose ~100-event assistant turn was left in flight (seeded stale, no `done`): the client resumes it, the tail route closes the abandoned turn and backfills the whole log. Median time from navigation start to the turn's last event (a marker) painted. One fresh interrupted session per run.",
 			"runs": 3,
 			"metrics": {
-				"resume_ms": { "stat": "median", "budget": 450 }
+				"resume_ms": {
+					"stat": "median",
+					"budget": 450
+				}
 			}
 		}
 	]

--- a/web-next/perf/run.mjs
+++ b/web-next/perf/run.mjs
@@ -247,7 +247,8 @@ async function runResumeLatency(browser, baseUrl, scenario) {
 			waitUntil: "commit",
 		});
 		await page.waitForFunction(
-			(marker) => document.body.innerText.includes(marker),
+			// body can be briefly null right after "commit" — poll past it.
+			(marker) => Boolean(document.body?.innerText.includes(marker)),
 			RESUME_MARKER,
 			{ timeout: TURN_TIMEOUT_MS },
 		);
@@ -255,6 +256,34 @@ async function runResumeLatency(browser, baseUrl, scenario) {
 		await context.close();
 	}
 	return { resume_ms: samples };
+}
+
+// Drawer-open → interactive (#752): on a fresh seeded session, press Ctrl+`
+// and time until the drawer reports data-ready — the lazy ghostty-web WASM
+// load + init, the ticket mint/redeem exchange, and the first PTY bytes of
+// the mock seam in a painted frame (data-ready flips on a rAF after the
+// first onData). Cold context per run, so every run pays the full cost.
+async function runTerminalDrawer(browser, baseUrl, scenario) {
+	const samples = [];
+	for (let i = 0; i < scenario.runs; i++) {
+		const { context, page } = await openSession(
+			browser,
+			baseUrl,
+			`perf-drawer-${i}`,
+		);
+		const start = Date.now();
+		await page.keyboard.press("Control+Backquote");
+		await page.waitForFunction(
+			() =>
+				document.querySelector('[data-testid="terminal-drawer"]')?.dataset
+					.ready === "true",
+			undefined,
+			{ timeout: TURN_TIMEOUT_MS },
+		);
+		samples.push(Date.now() - start);
+		await context.close();
+	}
+	return { drawer_interactive_ms: samples };
 }
 
 // Time from navigation start until every seeded message is present in a
@@ -299,6 +328,7 @@ const SCENARIO_RUNNERS = {
 	streaming_cadence: (browser, baseUrl, scenario) =>
 		runStreamingCadence(browser, baseUrl, scenario.runs),
 	resume_latency_100: runResumeLatency,
+	terminal_drawer_interactive: runTerminalDrawer,
 	transcript_render_200: (browser, baseUrl, scenario) =>
 		runTranscriptRender(browser, baseUrl, scenario.route, scenario.runs),
 	projection_200: (browser, baseUrl, scenario) => runProjectionBench(scenario),
@@ -478,6 +508,9 @@ async function runLocalSuite() {
 	}
 	for (let i = 0; i < runsOf("streaming_cadence"); i++) {
 		await seedSession(`perf-cadence-${i}`);
+	}
+	for (let i = 0; i < runsOf("terminal_drawer_interactive"); i++) {
+		await seedSession(`perf-drawer-${i}`);
 	}
 	// resume_latency_100: one interrupted turn per run. Each is a ~100-event
 	// assistant turn with NO `done` and a backdated clock, so resolveTurn reads

--- a/web-next/playwright.config.ts
+++ b/web-next/playwright.config.ts
@@ -7,7 +7,11 @@
  */
 import { defineConfig, devices } from "@playwright/test";
 
-const BASE_URL = "http://localhost:3100";
+// E2E_PORT lets concurrent checkouts (sibling worktrees) run their own e2e
+// servers without colliding on one port — parity with the perf runner's
+// PERF_PORT. Default stays 3100 (CI and the common case).
+const PORT = Number(process.env.E2E_PORT ?? 3100);
+const BASE_URL = `http://localhost:${PORT}`;
 
 /** Must match ALLOWED_LOGINS in the e2e:server script. */
 export const E2E_LOGIN = "fairchild";
@@ -56,6 +60,15 @@ export default defineConfig({
 		{
 			name: "chromium",
 			use: { ...devices["Desktop Chrome"] },
+			// sessions.spec owns the sessions table (wipes + counts rows), so
+			// specs that create sessions of their own run in a later project.
+			testIgnore: /terminal\.spec\.ts/,
+		},
+		{
+			name: "terminal",
+			use: { ...devices["Desktop Chrome"] },
+			testMatch: /terminal\.spec\.ts/,
+			dependencies: ["chromium"],
 		},
 	],
 	webServer: {

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       better-auth:
         specifier: 1.6.20
         version: 1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)))
+      ghostty-web:
+        specifier: ^0.4.0
+        version: 0.4.0
       kysely:
         specifier: ^0.28.17
         version: 0.28.17
@@ -1909,6 +1912,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  ghostty-web@0.4.0:
+    resolution: {integrity: sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4651,6 +4657,8 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  ghostty-web@0.4.0: {}
 
   glob-parent@5.1.2:
     dependencies:

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -130,6 +130,31 @@ async function captureSessionTurn(page, shot) {
 }
 
 /**
+ * The terminal drawer (#752), on the session the turn just ran in: Ctrl+`
+ * opens it (lazy ghostty-web init + the ticket mint/redeem exchange over the
+ * mock PTY seam), a command runs in the shell, and the drawer is captured
+ * over the transcript.
+ */
+async function captureTerminalDrawer(page, file) {
+	await page.keyboard.press("Control+Backquote");
+	await page.waitForFunction(
+		() =>
+			document.querySelector('[data-testid="terminal-drawer"]')?.dataset
+				.ready === "true",
+		undefined,
+		{ timeout: TURN_TIMEOUT_MS },
+	);
+	await page.keyboard.type("echo hello from the session sandbox");
+	await page.keyboard.press("Enter");
+	await page.keyboard.type("pwd");
+	await page.keyboard.press("Enter");
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: file });
+	// Leave the page as we found it for the captures that follow.
+	await page.keyboard.press("Control+Backquote");
+}
+
+/**
  * The durable-turn story: start a turn, close the tab mid-stream, reopen the
  * session in a fresh tab and watch it catch up and complete. Manages its own
  * pages (the starter tab is closed on purpose) so the caller's page is left
@@ -257,6 +282,7 @@ async function main() {
 			await captureSettled(page, "/", shot("home-empty"));
 			await captureNewSessionFlow(page, shot("session-empty"));
 			await captureSessionTurn(page, shot);
+			await captureTerminalDrawer(page, shot("session-terminal-drawer"));
 			await captureDisconnectResume(context, shot);
 			await seedPopulatedHome(db);
 			await captureSettled(page, "/", shot("home-populated"));

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -267,5 +267,3 @@ export function LiveSessionView({
 		</>
 	);
 }
-	);
-}

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -34,6 +34,7 @@ import {
 	type SessionViewData,
 } from "@/components/folio/session-view";
 import type { FolioDataParts, FolioMessage } from "@/components/folio/types";
+import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 
@@ -242,23 +243,29 @@ export function LiveSessionView({
 	}, [displayTitle]);
 
 	return (
-		<SessionView
-			session={{
-				...session,
-				messages: visibleMessages,
-				activeTurn,
-				masthead: { ...session.masthead, title: displayTitle },
-				statusLine: {
-					...session.statusLine,
-					model,
-					modelLabel: modelLabel(model),
-					contextLabel: deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
-				},
-			}}
-			onSend={send}
-			composeDisabled={busy}
-			onModelChange={handleModelChange}
-			onTitleChange={handleTitleChange}
-		/>
+		<>
+			<TerminalDrawer sessionId={sessionId} />
+			<SessionView
+				session={{
+					...session,
+					messages: visibleMessages,
+					activeTurn,
+					masthead: { ...session.masthead, title: displayTitle },
+					statusLine: {
+						...session.statusLine,
+						model,
+						modelLabel: modelLabel(model),
+						contextLabel:
+							deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
+					},
+				}}
+				onSend={send}
+				composeDisabled={busy}
+				onModelChange={handleModelChange}
+				onTitleChange={handleTitleChange}
+			/>
+		</>
+	);
+}
 	);
 }

--- a/web-next/src/app/api/sessions/[id]/terminal/redeem/route.ts
+++ b/web-next/src/app/api/sessions/[id]/terminal/redeem/route.ts
@@ -1,0 +1,86 @@
+/*
+ * POST /api/sessions/[id]/terminal/redeem — exchange a single-use ticket for
+ * the terminal transport (#752). Auth-gated again (a ticket alone is never
+ * enough), ticket in the POST body (never a URL), bound to this session and
+ * the login it was minted for. "ttyd" tickets re-resolve the live sandbox and
+ * verify it is still the one the ticket was pinned to before revealing the
+ * WebSocket URL; "mock" tickets (AUTH_BYPASS) just confirm the mode.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { getSession } from "@/lib/db/sessions";
+import {
+	ensureTerminal,
+	resolveLiveSandbox,
+	TerminalUnsupportedError,
+} from "@/lib/terminal/sandbox-terminal";
+import { redeemTerminalTicket } from "@/lib/terminal/tickets";
+
+export const runtime = "nodejs";
+
+function redeemFailure(reason: string): Response {
+	const gone = reason === "expired" || reason === "redeemed";
+	return Response.json(
+		{ error: gone ? `terminal ticket ${reason}` : "terminal ticket denied" },
+		{ status: gone ? 410 : 403 },
+	);
+}
+
+export async function POST(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	const body: unknown = await request.json().catch(() => undefined);
+	const ticket =
+		typeof body === "object" && body !== null && "ticket" in body
+			? String((body as { ticket: unknown }).ticket)
+			: "";
+	if (ticket.length === 0) {
+		return Response.json({ error: "ticket is required" }, { status: 400 });
+	}
+
+	const redeemed = await redeemTerminalTicket(handle, ticket, {
+		login: auth.user.login,
+		sessionId: id,
+	});
+	if (!redeemed.ok) return redeemFailure(redeemed.reason);
+
+	if (redeemed.record.mode === "mock") {
+		return Response.json({ mode: "mock" });
+	}
+
+	const live = await resolveLiveSandbox(session);
+	if (live.state === "none" || live.sandbox.name !== redeemed.record.sandboxName) {
+		return Response.json(
+			{ error: "the session's sandbox is no longer running" },
+			{ status: 409 },
+		);
+	}
+	try {
+		const { wsUrl } = await ensureTerminal(live.sandbox);
+		return Response.json({ mode: "ttyd", wsUrl });
+	} catch (error) {
+		const message =
+			error instanceof TerminalUnsupportedError
+				? error.message
+				: error instanceof Error
+					? error.message
+					: "terminal setup failed";
+		return Response.json({ error: message }, { status: 502 });
+	}
+}

--- a/web-next/src/app/api/sessions/[id]/terminal/route.ts
+++ b/web-next/src/app/api/sessions/[id]/terminal/route.ts
@@ -1,0 +1,75 @@
+/*
+ * POST /api/sessions/[id]/terminal — mint a terminal access ticket (#752).
+ * Auth-gated like the chat route (same allowlist verdict), then resolves the
+ * session's LIVE sandbox: live → ensure ttyd + issue a single-use 30s ticket
+ * (redeemed at ./redeem for the WebSocket URL — the ticket travels only in
+ * POST bodies, never a URL); no live sandbox → a calm `no-sandbox` state the
+ * drawer renders honestly (the fix is to start a turn, not to fake a shell).
+ * Under AUTH_BYPASS (e2e/perf) the ticket is minted in "mock" mode: the full
+ * exchange runs hermetically and the client attaches its deterministic PTY.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+import { authBypassEnabled } from "@/lib/auth/config";
+import { getDatabase } from "@/lib/db/client";
+import { getSession } from "@/lib/db/sessions";
+import {
+	ensureTerminal,
+	resolveLiveSandbox,
+	TerminalUnsupportedError,
+} from "@/lib/terminal/sandbox-terminal";
+import { issueTerminalTicket } from "@/lib/terminal/tickets";
+
+export const runtime = "nodejs";
+
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	if (authBypassEnabled()) {
+		const ticket = await issueTerminalTicket(handle, {
+			login: auth.user.login,
+			sessionId: id,
+			mode: "mock",
+		});
+		return Response.json({ state: "ready", mode: "mock", ...ticket });
+	}
+
+	const live = await resolveLiveSandbox(session);
+	if (live.state === "none") {
+		return Response.json({ state: "no-sandbox", reason: live.reason });
+	}
+	try {
+		// Start ttyd now (idempotent) so redeem + connect stays fast and a
+		// broken sandbox surfaces here, before a ticket is spent on it.
+		await ensureTerminal(live.sandbox);
+	} catch (error) {
+		if (error instanceof TerminalUnsupportedError) {
+			return Response.json({ state: "no-sandbox", reason: error.message });
+		}
+		const message =
+			error instanceof Error ? error.message : "terminal setup failed";
+		return Response.json({ error: message }, { status: 502 });
+	}
+	const ticket = await issueTerminalTicket(handle, {
+		login: auth.user.login,
+		sessionId: id,
+		mode: "ttyd",
+		sandboxName: live.sandbox.name,
+	});
+	return Response.json({ state: "ready", mode: "ttyd", ...ticket });
+}

--- a/web-next/src/components/terminal/mock-pty.test.ts
+++ b/web-next/src/components/terminal/mock-pty.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { evalMockCommand, MOCK_PROMPT, openMockPty } from "./mock-pty";
+
+describe("evalMockCommand", () => {
+	test("is deterministic over the fixed command set", () => {
+		expect(evalMockCommand("echo hello world")).toEqual(["hello world"]);
+		expect(evalMockCommand("pwd")).toEqual(["/vercel/sandbox/workspace"]);
+		expect(evalMockCommand("whoami")).toEqual(["sandbox"]);
+		expect(evalMockCommand("")).toEqual([]);
+		expect(evalMockCommand("   ")).toEqual([]);
+		expect(evalMockCommand("nope --flag")).toEqual([
+			"sh: nope: command not found",
+		]);
+	});
+});
+
+describe("openMockPty", () => {
+	function attach() {
+		const chunks: string[] = [];
+		const conn = openMockPty({
+			onData: (text) => chunks.push(text),
+			onClose: () => {},
+		});
+		return { conn, output: () => chunks.join("") };
+	}
+
+	test("paints a banner and prompt synchronously on open", () => {
+		const { output } = attach();
+		expect(output()).toContain("mock sandbox shell");
+		expect(output()).toContain(MOCK_PROMPT);
+	});
+
+	test("echoes keystrokes and runs the line on Enter", () => {
+		const { conn, output } = attach();
+		conn.send("echo hi");
+		conn.send("\r");
+		expect(output()).toContain("echo hi\r\nhi\r\n");
+		expect(output().endsWith(MOCK_PROMPT)).toBe(true);
+	});
+
+	test("backspace edits the line", () => {
+		const { conn, output } = attach();
+		conn.send("pwdd");
+		conn.send("\x7f");
+		conn.send("\r");
+		expect(output()).toContain("/vercel/sandbox/workspace");
+	});
+
+	test("a closed connection emits nothing further", () => {
+		const { conn, output } = attach();
+		const before = output();
+		conn.close();
+		conn.send("echo after\r");
+		expect(output()).toBe(before);
+	});
+});

--- a/web-next/src/components/terminal/mock-pty.ts
+++ b/web-next/src/components/terminal/mock-pty.ts
@@ -1,0 +1,93 @@
+/*
+ * Deterministic in-browser PTY sim (#752): the transport behind the drawer
+ * under AUTH_BYPASS, so Playwright e2e and the perf gate exercise the real
+ * drawer + terminal rendering with no sandbox. Local echo, line editing
+ * (backspace), and a tiny fixed command set — no clock, no randomness, so
+ * every run paints identical bytes. `evalMockCommand` is pure and exported
+ * for unit tests.
+ */
+import type {
+	TerminalConnection,
+	TerminalTransportHandlers,
+} from "./transport";
+
+export const MOCK_PROMPT = "sandbox:workspace$ ";
+const MOCK_BANNER = "mock sandbox shell — deterministic PTY (AUTH_BYPASS)";
+
+const MOCK_LS = [
+	"README.md   package.json   src   tests",
+];
+
+/** The output lines for one entered command line. Pure and deterministic. */
+export function evalMockCommand(line: string): string[] {
+	const trimmed = line.trim();
+	if (trimmed.length === 0) return [];
+	const [cmd, ...args] = trimmed.split(/\s+/);
+	switch (cmd) {
+		case "echo":
+			return [args.join(" ")];
+		case "pwd":
+			return ["/vercel/sandbox/workspace"];
+		case "ls":
+			return MOCK_LS;
+		case "whoami":
+			return ["sandbox"];
+		case "help":
+			return ["mock shell commands: echo, pwd, ls, whoami, help, clear"];
+		default:
+			return [`sh: ${cmd}: command not found`];
+	}
+}
+
+export function openMockPty(
+	handlers: TerminalTransportHandlers,
+): TerminalConnection {
+	let line = "";
+	let closed = false;
+	const write = (text: string) => {
+		if (!closed) handlers.onData(text);
+	};
+
+	// The first paint: banner + prompt, synchronously on open.
+	write(`\x1b[2m${MOCK_BANNER}\x1b[0m\r\n${MOCK_PROMPT}`);
+
+	const run = () => {
+		const entered = line;
+		line = "";
+		if (entered.trim() === "clear") {
+			write(`\x1b[2J\x1b[H${MOCK_PROMPT}`);
+			return;
+		}
+		const output = evalMockCommand(entered);
+		const body = output.length > 0 ? `${output.join("\r\n")}\r\n` : "";
+		write(`\r\n${body}${MOCK_PROMPT}`);
+	};
+
+	return {
+		send(data: string) {
+			for (const ch of data) {
+				if (ch === "\r" || ch === "\n") {
+					run();
+				} else if (ch === "\x7f" || ch === "\b") {
+					if (line.length > 0) {
+						line = line.slice(0, -1);
+						write("\b \b");
+					}
+				} else if (ch === "\x03") {
+					// Ctrl-C: drop the line, fresh prompt.
+					line = "";
+					write(`^C\r\n${MOCK_PROMPT}`);
+				} else if (ch >= " ") {
+					line += ch;
+					write(ch);
+				}
+			}
+		},
+		resize() {
+			// The sim has no PTY to resize; deterministic output ignores size.
+		},
+		close() {
+			closed = true;
+		},
+	};
+}

--- a/web-next/src/components/terminal/terminal-drawer.tsx
+++ b/web-next/src/components/terminal/terminal-drawer.tsx
@@ -74,6 +74,8 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 	const [phase, setPhase] = useState<Phase>("idle");
 	const [note, setNote] = useState("");
 	const [ready, setReady] = useState(false);
+	/** Transport the exchange resolved — shown honestly in the status bar. */
+	const [mode, setMode] = useState<"ttyd" | "mock" | null>(null);
 
 	const hostRef = useRef<HTMLDivElement>(null);
 	const transcriptRef = useRef<HTMLDivElement>(null);
@@ -128,7 +130,14 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 		try {
 			const term = await ensureTerminal();
 			if (!term) return;
-			const access = await requestTerminalAccess(sessionId);
+			let access: Awaited<ReturnType<typeof requestTerminalAccess>>;
+			try {
+				access = await requestTerminalAccess(sessionId);
+			} catch (error) {
+				setNote(error instanceof Error ? error.message : "connection failed");
+				setPhase("denied");
+				return;
+			}
 			if (access.kind === "no-sandbox") {
 				setNote(access.reason);
 				setPhase("no-sandbox");
@@ -170,6 +179,7 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 							cols: term.cols,
 							rows: term.rows,
 						});
+			setMode(access.kind);
 			setPhase("ready");
 			term.focus();
 		} finally {
@@ -226,7 +236,10 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 	const statusLabel: Record<Phase, string> = {
 		idle: "",
 		connecting: "connecting…",
-		ready: "attached to the session's sandbox",
+		ready:
+			mode === "mock"
+				? "mock PTY (AUTH_BYPASS)"
+				: "attached to the session's sandbox",
 		"no-sandbox": "no live sandbox",
 		denied: "access denied",
 		disconnected: "disconnected",

--- a/web-next/src/components/terminal/terminal-drawer.tsx
+++ b/web-next/src/components/terminal/terminal-drawer.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+/*
+ * The terminal drawer (#752): a collapsible bottom drawer on /sessions/[id]
+ * holding a real shell into the session's live sandbox. Quiet affordances —
+ * Ctrl+` and a small `>_` control above the status line — not persistent
+ * chrome. ghostty-web renders the PTY; the transport behind it is the ticket
+ * exchange's verdict (ttyd WebSocket, or the deterministic mock under
+ * AUTH_BYPASS). The terminal mounts once and survives open/close and
+ * reconnects, so scrollback and the tmux session read as one continuous
+ * shell. A session with no live sandbox gets a calm note, not a fake shell.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { openMockPty } from "./mock-pty";
+import {
+	requestTerminalAccess,
+	type TerminalConnection,
+} from "./transport";
+import { openTtydSocket } from "./ttyd-transport";
+
+type GhosttyTerminal = import("ghostty-web").Terminal;
+type GhosttyFitAddon = import("ghostty-web").FitAddon;
+
+type Phase =
+	| "idle"
+	| "connecting"
+	| "ready"
+	| "no-sandbox"
+	| "denied"
+	| "disconnected";
+
+/** Folio-toned ANSI palettes, chosen from globals.css's token values. */
+const TERMINAL_THEMES = {
+	light: {
+		background: "#f1ede0",
+		foreground: "#26221a",
+		cursor: "#a15c31",
+		selectionBackground: "#ebdfc8",
+		black: "#26221a",
+		red: "#9a4b33",
+		green: "#3e6b36",
+		yellow: "#8a6d1f",
+		blue: "#4a6b8a",
+		magenta: "#7d5a8a",
+		cyan: "#3e7373",
+		white: "#7a7261",
+	},
+	dark: {
+		background: "#1b1913",
+		foreground: "#eae4d6",
+		cursor: "#d89a62",
+		selectionBackground: "rgba(216, 154, 98, 0.3)",
+		black: "#2a261e",
+		red: "#ce9480",
+		green: "#a9c896",
+		yellow: "#d8c07a",
+		blue: "#8fb0cc",
+		magenta: "#c0a0cc",
+		cyan: "#8fc0b8",
+		white: "#a79e8c",
+	},
+} as const;
+
+/** Cap on the hidden plain-text mirror of PTY output (tests + screen readers). */
+const TRANSCRIPT_CAP = 8_000;
+
+const stripControl = (text: string) =>
+	text
+		.replace(/\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*\x07/g, "")
+		.replace(/[\r\x07]/g, "");
+
+export function TerminalDrawer({ sessionId }: { sessionId: string }) {
+	const [open, setOpen] = useState(false);
+	const [phase, setPhase] = useState<Phase>("idle");
+	const [note, setNote] = useState("");
+	const [ready, setReady] = useState(false);
+
+	const hostRef = useRef<HTMLDivElement>(null);
+	const transcriptRef = useRef<HTMLDivElement>(null);
+	const termRef = useRef<GhosttyTerminal | null>(null);
+	const fitRef = useRef<GhosttyFitAddon | null>(null);
+	const connRef = useRef<TerminalConnection | null>(null);
+	const connectingRef = useRef(false);
+	const sawDataRef = useRef(false);
+
+	/** Create the ghostty-web terminal once, on first open. */
+	const ensureTerminal = useCallback(async (): Promise<GhosttyTerminal | null> => {
+		if (termRef.current) return termRef.current;
+		const host = hostRef.current;
+		if (!host) return null;
+		const { init, Terminal, FitAddon } = await import("ghostty-web");
+		await init();
+		if (termRef.current || !hostRef.current) return termRef.current;
+		const theme =
+			document.documentElement.dataset.theme === "dark"
+				? TERMINAL_THEMES.dark
+				: TERMINAL_THEMES.light;
+		const term = new Terminal({
+			cursorBlink: true,
+			fontSize: 13,
+			// A concrete stack: the canvas renderer can't resolve CSS variables,
+			// so the next/font-registered Plex Mono is out of reach here.
+			fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
+			theme,
+		});
+		const fit = new FitAddon();
+		term.loadAddon(fit);
+		term.onData((data) => connRef.current?.send(data));
+		term.onResize(({ cols, rows }) => connRef.current?.resize(cols, rows));
+		term.open(host);
+		termRef.current = term;
+		fitRef.current = fit;
+		requestAnimationFrame(() => {
+			try {
+				fit.fit();
+				fit.observeResize();
+			} catch {
+				// host not laid out yet; observeResize catches the next pass
+			}
+		});
+		return term;
+	}, []);
+
+	const connect = useCallback(async () => {
+		if (connRef.current || connectingRef.current) return;
+		connectingRef.current = true;
+		setPhase("connecting");
+		try {
+			const term = await ensureTerminal();
+			if (!term) return;
+			const access = await requestTerminalAccess(sessionId);
+			if (access.kind === "no-sandbox") {
+				setNote(access.reason);
+				setPhase("no-sandbox");
+				return;
+			}
+			if (access.kind === "denied") {
+				setNote(access.message);
+				setPhase("denied");
+				return;
+			}
+			const handlers = {
+				onData: (text: string) => {
+					term.write(text);
+					const mirror = transcriptRef.current;
+					if (mirror) {
+						mirror.textContent = (
+							(mirror.textContent ?? "") + stripControl(text)
+						).slice(-TRANSCRIPT_CAP);
+					}
+					if (!sawDataRef.current) {
+						sawDataRef.current = true;
+						// "Interactive" = the first PTY bytes are in a painted frame.
+						requestAnimationFrame(() => setReady(true));
+					}
+				},
+				onClose: (reason: string) => {
+					connRef.current = null;
+					sawDataRef.current = false;
+					setReady(false);
+					setNote(reason);
+					setPhase("disconnected");
+					term.write(`\r\n\x1b[2m[${reason}]\x1b[0m\r\n`);
+				},
+			};
+			connRef.current =
+				access.kind === "mock"
+					? openMockPty(handlers)
+					: openTtydSocket(access.wsUrl, handlers, {
+							cols: term.cols,
+							rows: term.rows,
+						});
+			setPhase("ready");
+			term.focus();
+		} finally {
+			connectingRef.current = false;
+		}
+	}, [ensureTerminal, sessionId]);
+
+	const toggle = useCallback(() => {
+		setOpen((wasOpen) => {
+			const next = !wasOpen;
+			if (next) {
+				void connect();
+				requestAnimationFrame(() => {
+					try {
+						fitRef.current?.fit();
+					} catch {
+						// not laid out yet
+					}
+					termRef.current?.focus();
+				});
+			} else {
+				termRef.current?.blur();
+			}
+			return next;
+		});
+	}, [connect]);
+
+	// Ctrl+` — the conventional terminal toggle. Capture phase, so it works
+	// even while the terminal itself has focus (ghostty's key handler would
+	// otherwise consume the event before a bubbling listener saw it), and
+	// stopPropagation keeps the chord out of the shell.
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.ctrlKey && (event.key === "`" || event.code === "Backquote")) {
+				event.preventDefault();
+				event.stopPropagation();
+				toggle();
+			}
+		};
+		window.addEventListener("keydown", onKeyDown, true);
+		return () => window.removeEventListener("keydown", onKeyDown, true);
+	}, [toggle]);
+
+	// Dispose the terminal + transport with the session surface.
+	useEffect(() => {
+		return () => {
+			connRef.current?.close();
+			connRef.current = null;
+			termRef.current?.dispose();
+			termRef.current = null;
+		};
+	}, []);
+
+	const statusLabel: Record<Phase, string> = {
+		idle: "",
+		connecting: "connecting…",
+		ready: "attached to the session's sandbox",
+		"no-sandbox": "no live sandbox",
+		denied: "access denied",
+		disconnected: "disconnected",
+	};
+
+	return (
+		<>
+			<button
+				type="button"
+				data-testid="terminal-toggle"
+				aria-label="Toggle terminal"
+				title="Terminal (Ctrl+`)"
+				onClick={toggle}
+				className="fixed right-[16px] bottom-[42px] z-[16] rounded-[5px] px-1.5 py-1 font-mono text-stat leading-none text-faint opacity-70 transition-[opacity,color] duration-200 hover:text-ink hover:opacity-100"
+			>
+				&gt;_
+			</button>
+			<section
+				data-testid="terminal-drawer"
+				data-open={open ? "true" : "false"}
+				data-ready={ready ? "true" : "false"}
+				aria-label="Terminal"
+				aria-hidden={!open}
+				className={`fixed inset-x-0 bottom-0 z-30 border-t border-line-strong bg-status-bg shadow-palette transition-transform duration-200 ${
+					open ? "translate-y-0" : "pointer-events-none translate-y-full"
+				}`}
+			>
+				{/* A div, not <header>: the drawer bar is chrome, not a landmark —
+				    and the page's one banner stays the masthead. */}
+				<div className="flex h-[30px] items-center gap-2 border-b border-line px-3 font-mono text-stat tracking-[.03em] text-faint">
+					<span className="text-muted">terminal</span>
+					{phase !== "idle" && (
+						<span data-testid="terminal-status">— {statusLabel[phase]}</span>
+					)}
+					{(phase === "disconnected" || phase === "no-sandbox") && (
+						<button
+							type="button"
+							onClick={() => void connect()}
+							className="rounded-[5px] px-1.5 py-0.5 text-faint underline decoration-dotted underline-offset-2 hover:text-ink"
+						>
+							{phase === "disconnected" ? "reconnect" : "check again"}
+						</button>
+					)}
+					<button
+						type="button"
+						aria-label="Close terminal"
+						title="Close terminal (Ctrl+`)"
+						onClick={toggle}
+						className="ml-auto rounded-[5px] px-1.5 py-1 leading-none text-faint opacity-70 hover:text-ink hover:opacity-100"
+					>
+						✕
+					</button>
+				</div>
+				<div className="relative h-[38vh] min-h-[220px]">
+					<div ref={hostRef} className="h-full w-full px-2 py-1" />
+					{(phase === "no-sandbox" || phase === "denied") && (
+						<div
+							data-testid="terminal-empty"
+							className="absolute inset-0 flex flex-col items-center justify-center gap-2.5 bg-status-bg text-center"
+						>
+							<p className="font-serif text-body text-muted italic">
+								{phase === "no-sandbox" ? "No live sandbox." : "Terminal unavailable."}
+							</p>
+							<p className="max-w-[52ch] font-mono text-caption text-faint">
+								{note}
+								{phase === "no-sandbox" &&
+									" — start a turn and the terminal attaches to the same sandbox it runs in."}
+							</p>
+						</div>
+					)}
+				</div>
+				{/* Plain-text mirror of PTY output: assertable by tests, readable by
+				    screen readers; the canvas above is neither. */}
+				<div
+					ref={transcriptRef}
+					data-testid="terminal-transcript"
+					aria-live="off"
+					className="sr-only"
+				/>
+			</section>
+		</>
+	);
+}

--- a/web-next/src/components/terminal/transport.ts
+++ b/web-next/src/components/terminal/transport.ts
@@ -1,0 +1,84 @@
+/*
+ * The terminal transport seam (#752): one interface the drawer speaks, two
+ * implementations behind it — the real ttyd WebSocket and the deterministic
+ * mock PTY (AUTH_BYPASS e2e/perf). requestTerminalAccess runs the ticket
+ * exchange: mint and redeem are both authenticated POSTs with the ticket in
+ * the body, so no token ever rides in a URL the browser records.
+ */
+
+export interface TerminalTransportHandlers {
+	/** Bytes/text from the PTY, ready to write to the terminal. */
+	onData(text: string): void;
+	/** The transport ended (socket closed, sandbox gone). */
+	onClose(reason: string): void;
+}
+
+export interface TerminalConnection {
+	/** Keystrokes from the terminal to the PTY. */
+	send(data: string): void;
+	resize(cols: number, rows: number): void;
+	close(): void;
+}
+
+export type TerminalAccess =
+	| { kind: "mock" }
+	| { kind: "ttyd"; wsUrl: string }
+	| { kind: "no-sandbox"; reason: string }
+	| { kind: "denied"; message: string };
+
+interface MintResponse {
+	state?: string;
+	mode?: string;
+	ticket?: string;
+	reason?: string;
+	error?: string;
+}
+
+interface RedeemResponse {
+	mode?: string;
+	wsUrl?: string;
+	error?: string;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+	return response.json().catch(() => ({}) as T);
+}
+
+export async function requestTerminalAccess(
+	sessionId: string,
+): Promise<TerminalAccess> {
+	const mint = await fetch(`/api/sessions/${sessionId}/terminal`, {
+		method: "POST",
+	});
+	const minted = await readJson<MintResponse>(mint);
+	if (!mint.ok) {
+		return {
+			kind: "denied",
+			message: minted.error ?? `terminal access denied (HTTP ${mint.status})`,
+		};
+	}
+	if (minted.state === "no-sandbox") {
+		return { kind: "no-sandbox", reason: minted.reason ?? "no live sandbox" };
+	}
+	if (!minted.ticket) {
+		return { kind: "denied", message: "terminal mint returned no ticket" };
+	}
+
+	const redeem = await fetch(`/api/sessions/${sessionId}/terminal/redeem`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ ticket: minted.ticket }),
+	});
+	const redeemed = await readJson<RedeemResponse>(redeem);
+	if (!redeem.ok) {
+		return {
+			kind: "denied",
+			message: redeemed.error ?? `ticket redemption failed (HTTP ${redeem.status})`,
+		};
+	}
+	if (redeemed.mode === "mock") return { kind: "mock" };
+	if (redeemed.mode === "ttyd" && redeemed.wsUrl) {
+		return { kind: "ttyd", wsUrl: redeemed.wsUrl };
+	}
+	return { kind: "denied", message: "ticket redemption returned no transport" };
+}

--- a/web-next/src/components/terminal/ttyd-transport.ts
+++ b/web-next/src/components/terminal/ttyd-transport.ts
@@ -1,0 +1,62 @@
+/*
+ * The real terminal transport (#752): a WebSocket speaking ttyd's protocol to
+ * the shell in the session's sandbox. Binary frames, first byte the command:
+ * server→client '0' = output; client→server '0' = input, '1' = resize JSON.
+ * The opening message is ttyd's JSON handshake ({AuthToken, columns, rows} —
+ * auth is the HMAC base-path in the URL, so the token field stays empty).
+ * Ported from web/'s terminal-canvas wiring.
+ */
+import type {
+	TerminalConnection,
+	TerminalTransportHandlers,
+} from "./transport";
+
+export function openTtydSocket(
+	wsUrl: string,
+	handlers: TerminalTransportHandlers,
+	size: { cols: number; rows: number },
+): TerminalConnection {
+	const ws = new WebSocket(wsUrl, ["tty"]);
+	ws.binaryType = "arraybuffer";
+	const encoder = new TextEncoder();
+	const decoder = new TextDecoder();
+
+	const frame = (command: string, payload: string): Uint8Array => {
+		const bytes = encoder.encode(payload);
+		const out = new Uint8Array(bytes.length + 1);
+		out[0] = command.charCodeAt(0);
+		out.set(bytes, 1);
+		return out;
+	};
+
+	ws.onopen = () => {
+		ws.send(
+			JSON.stringify({ AuthToken: "", columns: size.cols, rows: size.rows }),
+		);
+	};
+	ws.onmessage = (event) => {
+		if (!(event.data instanceof ArrayBuffer)) return;
+		const data = new Uint8Array(event.data);
+		if (data.length === 0) return;
+		if (String.fromCharCode(data[0]) === "0") {
+			handlers.onData(decoder.decode(data.subarray(1)));
+		}
+	};
+	ws.onclose = () => handlers.onClose("disconnected");
+	ws.onerror = () => handlers.onClose("connection error");
+
+	return {
+		send(data: string) {
+			if (ws.readyState === WebSocket.OPEN) ws.send(frame("0", data));
+		},
+		resize(cols: number, rows: number) {
+			if (ws.readyState === WebSocket.OPEN)
+				ws.send(frame("1", JSON.stringify({ columns: cols, rows })));
+		},
+		close() {
+			ws.onclose = null;
+			ws.onerror = null;
+			ws.close();
+		},
+	};
+}

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -17,6 +17,7 @@
  */
 import type { HarnessAgentSandboxConfig } from "@ai-sdk/harness/agent";
 import { mintInstallationToken } from "../diag/github-app";
+import { TERMINAL_INSTALL_SCRIPT } from "../terminal/install";
 import type {
 	ComputeProvider,
 	SessionResumeHandle,
@@ -36,6 +37,14 @@ const TARGET_REPO = process.env.AGENT_TARGET_REPO ?? "fairchild/workspaces";
 /** Port the in-sandbox harness bridge binds; must be declared on the sandbox. */
 const BRIDGE_PORT = 4000;
 /**
+ * Port the in-sandbox ttyd terminal binds (#752) — declared on the sandbox so
+ * `sandbox.domain(TERMINAL_PORT)` publishes it; the terminal routes attach a
+ * shell to the SAME sandbox the session's turns run in (the shared-sandbox
+ * pattern). Sandboxes created before this port was declared have no terminal;
+ * the drawer reports that calmly rather than booting anything.
+ */
+export const TERMINAL_PORT = 7681;
+/**
  * Max sandbox lifetime. Also the resume window: a parked (detached) session
  * reconnects only while its sandbox is still alive, so this bounds how long a
  * conversation can idle between turns before the next turn re-clones fresh.
@@ -43,8 +52,9 @@ const BRIDGE_PORT = 4000;
 const SANDBOX_TIMEOUT_MS = 30 * 60 * 1000;
 /** The persistent per-session working copy: name under the sandbox default cwd. */
 const WORKSPACE_DIR_NAME = "workspace";
-/** Absolute path to that working copy (sandbox default cwd is /vercel/sandbox). */
-const WORKSPACE_DIR = `/vercel/sandbox/${WORKSPACE_DIR_NAME}`;
+/** Absolute path to that working copy (sandbox default cwd is /vercel/sandbox).
+ * Exported so the terminal (#752) opens its shell in the same working copy. */
+export const WORKSPACE_DIR = `/vercel/sandbox/${WORKSPACE_DIR_NAME}`;
 /**
  * Stable template name so `runTurn` and `prewarmVercelTemplate` target the same
  * named snapshot; the harness reuses a template only when the sandbox identity
@@ -54,8 +64,10 @@ const TEMPLATE_NAME = "web-next-claude-code";
 /**
  * Bump whenever the `onBootstrap` side effects change — it invalidates the
  * reusable snapshot so the next prewarm (or first turn) rebuilds the template.
+ * v2: + ttyd/tmux static binaries for the terminal drawer (#752), and the
+ * sandbox now declares TERMINAL_PORT (a fresh template picks that up too).
  */
-const BOOTSTRAP_HASH = "claude-code-cli-v1";
+const BOOTSTRAP_HASH = "claude-code-cli-v2-terminal";
 
 /** A stable per-session branch the agent commits and opens its PR from. */
 function sessionBranch(sessionId: string): string {
@@ -310,6 +322,15 @@ export function createHarness(
 const SESSION_SANDBOX_PREFIX = "ai-sdk-harness-session";
 
 /**
+ * The Vercel sandbox name a parked harness session lives under — the same
+ * derivation the adapter's resume path uses, exported so the terminal routes
+ * (#752) can attach to the LIVE sandbox of a session and nothing else.
+ */
+export function sessionSandboxName(harnessSessionId: string): string {
+	return `${SESSION_SANDBOX_PREFIX}-${harnessSessionId}`;
+}
+
+/**
  * The Vercel sandbox provider, built via the factory path with a stable `name`
  * so `runTurn` and prewarm target the same named template snapshot.
  *
@@ -326,7 +347,7 @@ function createSandboxProvider(createVercelSandbox: CreateVercelSandbox) {
 	const projectId = process.env.VERCEL_PROJECT_ID;
 	const provider = createVercelSandbox({
 		runtime: "node22",
-		ports: [BRIDGE_PORT],
+		ports: [BRIDGE_PORT, TERMINAL_PORT],
 		resources: { vcpus: 4 },
 		timeout: SANDBOX_TIMEOUT_MS,
 		token,
@@ -348,7 +369,7 @@ function createSandboxProvider(createVercelSandbox: CreateVercelSandbox) {
 		}) => {
 			const { Sandbox } = await import("@vercel/sandbox");
 			const sandbox = await Sandbox.get({
-				name: `${SESSION_SANDBOX_PREFIX}-${sessionId}`,
+				name: sessionSandboxName(sessionId),
 				token,
 				teamId,
 				projectId,
@@ -379,6 +400,19 @@ const SANDBOX_BOOTSTRAP: Omit<HarnessAgentSandboxConfig, "onSession"> = {
 			throw new Error(
 				`claude CLI install failed (exit ${r.exitCode}): ${r.stderr.slice(0, 400)}`,
 			);
+		// Bake the terminal binaries (ttyd + tmux, #752) into the snapshot so
+		// drawer-open doesn't pay the download. Best-effort: a transient fetch
+		// failure must never block the chat path — the terminal mint route
+		// re-runs the same idempotent script as a fallback.
+		try {
+			const res = await session.run({ command: TERMINAL_INSTALL_SCRIPT });
+			if (res.exitCode !== 0 && process.env.HARNESS_DEBUG === "1")
+				console.error(
+					`[dbg onBootstrap] terminal install failed (exit ${res.exitCode}): ${res.stderr.slice(0, 200)}`,
+				);
+		} catch {
+			// best-effort — the mint route re-runs the same idempotent script
+		}
 		if (process.env.HARNESS_DEBUG === "1") {
 			const v = await session.run({ command: "claude --version" });
 			console.error(`[dbg onBootstrap] claude installed: ${v.stdout.trim()}`);

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -75,10 +75,33 @@ export interface SessionEventsTable {
 	created_at: string;
 }
 
+/**
+ * Single-use, short-TTL terminal access tickets (#752): issued by the
+ * authenticated mint route and redeemed exactly once, binding a login +
+ * session to one sandbox attach. Only the SHA-256 of the ticket is stored;
+ * the ticket itself exists solely in the mint response and the redeem body.
+ */
+export interface TerminalTicketsTable {
+	/** SHA-256 hex of the ticket string — the lookup key; never the ticket. */
+	ticket_hash: string;
+	/** GitHub login the ticket was issued to (web-next identity is the login). */
+	login: string;
+	/** sessions.id the ticket authorizes a terminal for. */
+	session_id: string;
+	/** Transport the mint resolved — "ttyd" (live sandbox) | "mock" (bypass). */
+	mode: string;
+	/** Vercel sandbox name the ticket is pinned to; null in mock mode. */
+	sandbox_name: string | null;
+	created_at: string;
+	expires_at: string;
+	redeemed_at: string | null;
+}
+
 export interface Database {
 	repos: ReposTable;
 	sessions: SessionsTable;
 	session_events: SessionEventsTable;
+	terminal_tickets: TerminalTicketsTable;
 }
 
 /** A connected database: the raw client (for PRAGMA/DDL) and the typed builder. */

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -191,9 +191,34 @@ const sessionModel: Migration = {
 	},
 };
 
+/**
+ * Adds `terminal_tickets` — single-use, short-TTL terminal access tickets
+ * (#752, the ticket/HMAC model ported from web/'s terminal_access_tickets).
+ * Rows are pruned opportunistically on issue; no index beyond the PK is
+ * needed at this volume (one user, seconds-long TTLs).
+ */
+const terminalTickets: Migration = {
+	id: "0005_terminal_tickets",
+	async up(db) {
+		await db.schema
+			.createTable("terminal_tickets")
+			.ifNotExists()
+			.addColumn("ticket_hash", "text", (c) => c.primaryKey())
+			.addColumn("login", "text", (c) => c.notNull())
+			.addColumn("session_id", "text", (c) => c.notNull())
+			.addColumn("mode", "text", (c) => c.notNull())
+			.addColumn("sandbox_name", "text")
+			.addColumn("created_at", "text", (c) => c.notNull())
+			.addColumn("expires_at", "text", (c) => c.notNull())
+			.addColumn("redeemed_at", "text")
+			.execute();
+	},
+};
+
 export const MIGRATIONS: Migration[] = [
 	baseline,
 	authTables,
 	sessionResumeState,
 	sessionModel,
+	terminalTickets,
 ];

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -53,6 +53,7 @@ describe("session store", () => {
 			"0002_auth_tables",
 			"0003_session_resume_state",
 			"0004_session_model",
+			"0005_terminal_tickets",
 		]);
 	});
 

--- a/web-next/src/lib/terminal/install.ts
+++ b/web-next/src/lib/terminal/install.ts
@@ -1,0 +1,36 @@
+/*
+ * The ttyd + tmux installation contract for session sandboxes (#752): static
+ * binaries into a user-writable dir (no sudo — the harness bootstrap seam runs
+ * plain commands), idempotent so it can run both at template-bootstrap time
+ * (baked into the reusable snapshot, the fast path) and lazily from the mint
+ * route (the fallback for sandboxes built from a pre-terminal template).
+ * The Vercel node22 runtime is Amazon Linux 2023 on amd64; neither tool is in
+ * its repos, and the static builds have zero runtime deps (ported from web/).
+ */
+
+/** Where the terminal binaries live inside the sandbox. */
+export const TERMINAL_BIN_DIR = "/vercel/sandbox/.terminal-bin";
+export const TTYD_BIN = `${TERMINAL_BIN_DIR}/ttyd`;
+export const TMUX_BIN = `${TERMINAL_BIN_DIR}/tmux`;
+
+const TTYD_STATIC_URL =
+	"https://github.com/tsl0922/ttyd/releases/latest/download/ttyd.x86_64";
+/** If this URL ever breaks, pythops/tmux-linux-binary is a known-good alternative. */
+const TMUX_STATIC_URL =
+	"https://github.com/mjakob-gh/build-static-tmux/releases/latest/download/tmux.linux-amd64.stripped.gz";
+
+/** Idempotent install: a no-op when both binaries are already present. */
+export const TERMINAL_INSTALL_SCRIPT = [
+	"set -e",
+	`mkdir -p ${TERMINAL_BIN_DIR}`,
+	`if [ ! -x ${TTYD_BIN} ]; then`,
+	`  curl -sfL ${TTYD_STATIC_URL} -o ${TTYD_BIN}`,
+	`  chmod +x ${TTYD_BIN}`,
+	"fi",
+	`if [ ! -x ${TMUX_BIN} ]; then`,
+	`  curl -sfL ${TMUX_STATIC_URL} -o ${TMUX_BIN}.gz`,
+	`  gunzip -f ${TMUX_BIN}.gz`,
+	`  chmod +x ${TMUX_BIN}`,
+	"fi",
+	"",
+].join("\n");

--- a/web-next/src/lib/terminal/path-token.test.ts
+++ b/web-next/src/lib/terminal/path-token.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { terminalPathToken, terminalTokenSecret } from "./path-token";
+
+describe("terminalPathToken", () => {
+	test("is deterministic for a sandbox session id under one secret", () => {
+		const env = { TTYD_TOKEN_SECRET: "s3cret" };
+		expect(terminalPathToken("vm-1", env)).toBe(terminalPathToken("vm-1", env));
+		expect(terminalPathToken("vm-1", env)).toMatch(/^[0-9a-f]{24}$/);
+	});
+
+	test("differs across sandbox sessions and across secrets", () => {
+		const env = { TTYD_TOKEN_SECRET: "s3cret" };
+		expect(terminalPathToken("vm-1", env)).not.toBe(
+			terminalPathToken("vm-2", env),
+		);
+		expect(terminalPathToken("vm-1", env)).not.toBe(
+			terminalPathToken("vm-1", { TTYD_TOKEN_SECRET: "other" }),
+		);
+	});
+
+	test("secret resolution prefers TTYD_TOKEN_SECRET, falls back to BETTER_AUTH_SECRET", () => {
+		expect(
+			terminalTokenSecret({ TTYD_TOKEN_SECRET: "a", BETTER_AUTH_SECRET: "b" }),
+		).toBe("a");
+		expect(terminalTokenSecret({ BETTER_AUTH_SECRET: "b" })).toBe("b");
+	});
+
+	test("production with no secret refuses; non-production gets the dev fallback", () => {
+		expect(() => terminalTokenSecret({ NODE_ENV: "production" })).toThrow(
+			/TTYD_TOKEN_SECRET or BETTER_AUTH_SECRET/,
+		);
+		expect(terminalTokenSecret({ NODE_ENV: "test" })).toBeTruthy();
+	});
+});

--- a/web-next/src/lib/terminal/path-token.ts
+++ b/web-next/src/lib/terminal/path-token.ts
@@ -1,0 +1,37 @@
+/*
+ * The per-sandbox HMAC path token gating the in-sandbox ttyd endpoint (#752).
+ * ttyd serves its WebSocket under `--base-path /<token>`; the token is an HMAC
+ * of the sandbox VM's unique session id under a server-side secret, so knowing
+ * (or guessing) a sandbox name reveals nothing connectable. Stateless — both
+ * the ttyd launch and the redeem route recompute it — and scoped to one VM:
+ * a new VM session under the same sandbox name derives a different token.
+ * Ported from web/'s ttydPathToken; secret resolution is identical
+ * (TTYD_TOKEN_SECRET, falling back to BETTER_AUTH_SECRET — the #857 lesson).
+ */
+import crypto from "node:crypto";
+
+type Env = Record<string, string | undefined>;
+
+const DEV_FALLBACK_SECRET = "web-next-dev-terminal-secret-not-for-prod";
+
+/** The HMAC secret; a stable throwaway outside production, required inside. */
+export function terminalTokenSecret(env: Env = process.env): string {
+	const secret = env.TTYD_TOKEN_SECRET ?? env.BETTER_AUTH_SECRET;
+	if (secret) return secret;
+	if (env.NODE_ENV !== "production") return DEV_FALLBACK_SECRET;
+	throw new Error(
+		"TTYD_TOKEN_SECRET or BETTER_AUTH_SECRET is required for terminal access in production",
+	);
+}
+
+/** 24 hex chars of HMAC-SHA256(secret, sandbox VM session id). */
+export function terminalPathToken(
+	sandboxSessionId: string,
+	env: Env = process.env,
+): string {
+	return crypto
+		.createHmac("sha256", terminalTokenSecret(env))
+		.update(sandboxSessionId)
+		.digest("hex")
+		.slice(0, 24);
+}

--- a/web-next/src/lib/terminal/sandbox-terminal.test.ts
+++ b/web-next/src/lib/terminal/sandbox-terminal.test.ts
@@ -19,13 +19,14 @@ function finished(exitCode: number, stdout = "", stderr = ""): FinishedCommand {
 
 interface FakeOptions {
 	status?: string;
-	ttydRunning?: boolean;
+	/** The running ttyd's command line, or null when none is running. */
+	ttydCmdline?: string | null;
 	hasTerminalPort?: boolean;
 }
 
 function fakeSandbox(options: FakeOptions = {}) {
 	const commands: { cmd: string; args?: string[]; detached?: boolean }[] = [];
-	let ttydRunning = options.ttydRunning ?? false;
+	let ttydCmdline = options.ttydCmdline ?? null;
 	const sandbox: TerminalSandbox = {
 		name: "ai-sdk-harness-session-abc",
 		status: options.status ?? "running",
@@ -37,14 +38,30 @@ function fakeSandbox(options: FakeOptions = {}) {
 		currentSession: () => ({ sessionId: "vm-session-1" }),
 		async runCommand(params) {
 			commands.push(params);
-			if (params.args?.[1]?.includes("pgrep")) {
-				return finished(0, ttydRunning ? "running" : "stopped");
+			const script = params.args?.[1] ?? "";
+			if (script.includes("pgrep")) {
+				// Model the attestation probe: a running ttyd counts only when
+				// its command line carries the greps' -b and -p patterns; a
+				// non-matching one is killed by the probe.
+				const patterns = [...script.matchAll(/grep -qF -- "([^"]+)"/g)].map(
+					(m) => m[1],
+				);
+				if (
+					ttydCmdline !== null &&
+					patterns.every((p) => ttydCmdline?.includes(p))
+				) {
+					return finished(0, "attested");
+				}
+				ttydCmdline = null; // probe killed the impostor (if any)
+				return finished(0, "absent");
 			}
-			if (params.cmd.endsWith("/ttyd")) ttydRunning = true;
+			if (params.cmd.endsWith("/ttyd")) {
+				ttydCmdline = `ttyd ${(params.args ?? []).join(" ")}`;
+			}
 			return finished(0);
 		},
 	};
-	return { sandbox, commands };
+	return { sandbox, commands, currentTtyd: () => ttydCmdline };
 }
 
 const parked = { claudeSessionId: "abc", resumeState: "{}" };
@@ -111,10 +128,24 @@ describe("ensureTerminal", () => {
 		expect(start?.args?.join(" ")).toContain("new-session -A -s shell");
 	});
 
-	test("a running ttyd is left alone (idempotent reconnect)", async () => {
-		const { sandbox, commands } = fakeSandbox({ ttydRunning: true });
+	test("a ttyd attesting the current token is left alone (idempotent reconnect)", async () => {
+		const token = terminalPathToken("vm-session-1");
+		const { sandbox, commands } = fakeSandbox({
+			ttydCmdline: `ttyd -W -p ${TERMINAL_PORT} -b /${token} tmux new-session -A -s shell`,
+		});
 		await ensureTerminal(sandbox);
 		expect(commands.filter((c) => c.cmd.endsWith("/ttyd"))).toHaveLength(0);
+	});
+
+	test("a ttyd serving a stale token is replaced, not blessed", async () => {
+		const { sandbox, currentTtyd } = fakeSandbox({
+			ttydCmdline: `ttyd -W -p ${TERMINAL_PORT} -b /0000stale0000 tmux new-session -A -s shell`,
+		});
+		const { wsUrl } = await ensureTerminal(sandbox);
+		const token = terminalPathToken("vm-session-1");
+		expect(wsUrl).toContain(`/${token}/ws`);
+		expect(currentTtyd()).toContain(`-b /${token}`);
+		expect(currentTtyd()).not.toContain("stale");
 	});
 
 	test("a sandbox that never exposed the terminal port is unsupported", async () => {

--- a/web-next/src/lib/terminal/sandbox-terminal.test.ts
+++ b/web-next/src/lib/terminal/sandbox-terminal.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+import { sessionSandboxName, TERMINAL_PORT } from "../agent-runtime/vercel-provider";
+import { terminalPathToken } from "./path-token";
+import {
+	ensureTerminal,
+	type FinishedCommand,
+	resolveLiveSandbox,
+	type TerminalSandbox,
+	TerminalUnsupportedError,
+} from "./sandbox-terminal";
+
+function finished(exitCode: number, stdout = "", stderr = ""): FinishedCommand {
+	return {
+		exitCode,
+		stdout: async () => stdout,
+		stderr: async () => stderr,
+	};
+}
+
+interface FakeOptions {
+	status?: string;
+	ttydRunning?: boolean;
+	hasTerminalPort?: boolean;
+}
+
+function fakeSandbox(options: FakeOptions = {}) {
+	const commands: { cmd: string; args?: string[]; detached?: boolean }[] = [];
+	let ttydRunning = options.ttydRunning ?? false;
+	const sandbox: TerminalSandbox = {
+		name: "ai-sdk-harness-session-abc",
+		status: options.status ?? "running",
+		domain(port: number) {
+			if (options.hasTerminalPort === false)
+				throw new Error(`port ${port} is not exposed`);
+			return `https://sb-abc-${port}.vercel.run`;
+		},
+		currentSession: () => ({ sessionId: "vm-session-1" }),
+		async runCommand(params) {
+			commands.push(params);
+			if (params.args?.[1]?.includes("pgrep")) {
+				return finished(0, ttydRunning ? "running" : "stopped");
+			}
+			if (params.cmd.endsWith("/ttyd")) ttydRunning = true;
+			return finished(0);
+		},
+	};
+	return { sandbox, commands };
+}
+
+const parked = { claudeSessionId: "abc", resumeState: "{}" };
+
+describe("resolveLiveSandbox", () => {
+	test("a session with no parked handle has no sandbox to attach to", async () => {
+		const result = await resolveLiveSandbox(
+			{ claudeSessionId: null, resumeState: null },
+			async () => {
+				throw new Error("must not be called");
+			},
+		);
+		expect(result).toEqual({
+			state: "none",
+			reason: "no turn has started a sandbox yet",
+		});
+	});
+
+	test("looks up exactly the session's own sandbox name", async () => {
+		const requested: string[] = [];
+		await resolveLiveSandbox(parked, async (name) => {
+			requested.push(name);
+			return fakeSandbox().sandbox;
+		});
+		expect(requested).toEqual([sessionSandboxName("abc")]);
+	});
+
+	test("an expired (missing) sandbox resolves to none, not an error", async () => {
+		const result = await resolveLiveSandbox(parked, async () => {
+			throw new Error("not_found");
+		});
+		expect(result).toEqual({
+			state: "none",
+			reason: "the session's sandbox has expired",
+		});
+	});
+
+	test("a stopped sandbox is not live", async () => {
+		const { sandbox } = fakeSandbox({ status: "stopped" });
+		const result = await resolveLiveSandbox(parked, async () => sandbox);
+		expect(result).toEqual({
+			state: "none",
+			reason: "the session's sandbox is stopped",
+		});
+	});
+
+	test("a running sandbox resolves live", async () => {
+		const { sandbox } = fakeSandbox();
+		const result = await resolveLiveSandbox(parked, async () => sandbox);
+		expect(result).toEqual({ state: "live", sandbox });
+	});
+});
+
+describe("ensureTerminal", () => {
+	test("starts ttyd behind the HMAC base-path and returns the wss URL", async () => {
+		const { sandbox, commands } = fakeSandbox();
+		const { wsUrl } = await ensureTerminal(sandbox);
+		const token = terminalPathToken("vm-session-1");
+		expect(wsUrl).toBe(`wss://sb-abc-${TERMINAL_PORT}.vercel.run/${token}/ws`);
+		const start = commands.find((c) => c.cmd.endsWith("/ttyd"));
+		expect(start?.detached).toBe(true);
+		expect(start?.args).toContain(`/${token}`);
+		// tmux keeps the shell state across reconnects within a sandbox.
+		expect(start?.args?.join(" ")).toContain("new-session -A -s shell");
+	});
+
+	test("a running ttyd is left alone (idempotent reconnect)", async () => {
+		const { sandbox, commands } = fakeSandbox({ ttydRunning: true });
+		await ensureTerminal(sandbox);
+		expect(commands.filter((c) => c.cmd.endsWith("/ttyd"))).toHaveLength(0);
+	});
+
+	test("a sandbox that never exposed the terminal port is unsupported", async () => {
+		const { sandbox } = fakeSandbox({ hasTerminalPort: false });
+		await expect(ensureTerminal(sandbox)).rejects.toBeInstanceOf(
+			TerminalUnsupportedError,
+		);
+	});
+});

--- a/web-next/src/lib/terminal/sandbox-terminal.ts
+++ b/web-next/src/lib/terminal/sandbox-terminal.ts
@@ -154,6 +154,7 @@ export async function ensureTerminal(
 			detached: true,
 		});
 	}
-	const wss = domain.replace(/^https:/, "wss:").replace(/\/$/, "");
+	// http → ws, https → wss (the shared prefix makes one replace cover both).
+	const wss = domain.replace(/^http/, "ws").replace(/\/$/, "");
 	return { wsUrl: `${wss}/${token}/ws` };
 }

--- a/web-next/src/lib/terminal/sandbox-terminal.ts
+++ b/web-next/src/lib/terminal/sandbox-terminal.ts
@@ -1,0 +1,159 @@
+/*
+ * Attaches a terminal to a session's LIVE sandbox (#752): resolves the Vercel
+ * sandbox the session's last turn parked (by the same name derivation the
+ * harness resume path uses), verifies it is actually running, ensures ttyd is
+ * serving behind its HMAC base-path, and composes the WebSocket URL.
+ *
+ * Attach-only by design: `resume: false` on the lookup, so opening the drawer
+ * never boots or resumes a VM. A parked/expired session honestly reports
+ * "none" — the sandbox is the product of a turn, and the drawer attaches to
+ * it; it doesn't manufacture one. The Vercel dependency is injected
+ * (GetSandbox) so the resolution and ttyd logic are unit-testable.
+ */
+import {
+	sessionSandboxName,
+	TERMINAL_PORT,
+	WORKSPACE_DIR,
+} from "../agent-runtime/vercel-provider";
+import type { Session } from "../db/sessions";
+import { TERMINAL_INSTALL_SCRIPT, TMUX_BIN, TTYD_BIN } from "./install";
+import { terminalPathToken } from "./path-token";
+
+/** @vercel/sandbox v2 command handle: exit code property, output as methods. */
+export interface FinishedCommand {
+	exitCode: number;
+	stdout(): Promise<string>;
+	stderr(): Promise<string>;
+}
+
+/** The slice of @vercel/sandbox's Sandbox the terminal path touches. */
+export interface TerminalSandbox {
+	name: string;
+	status: string;
+	domain(port: number): string;
+	currentSession(): { sessionId: string };
+	runCommand(params: {
+		cmd: string;
+		args?: string[];
+		cwd?: string;
+		detached?: boolean;
+	}): Promise<FinishedCommand>;
+}
+
+/** Fetch-by-name, throwing when the sandbox is gone. Injected for tests. */
+export type GetSandbox = (name: string) => Promise<TerminalSandbox>;
+
+export type LiveSandboxResolution =
+	| { state: "live"; sandbox: TerminalSandbox }
+	| { state: "none"; reason: string };
+
+/** `Sandbox.get` succeeds for stopped/failed sandboxes too — check status. */
+const ALIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
+
+async function defaultGetSandbox(name: string): Promise<TerminalSandbox> {
+	const { Sandbox } = await import("@vercel/sandbox");
+	const token = process.env.VERCEL_TOKEN;
+	const teamId = process.env.VERCEL_TEAM_ID;
+	const projectId = process.env.VERCEL_PROJECT_ID;
+	return (await Sandbox.get({
+		name,
+		// Attach-only: looking at a stopped sandbox must not resurrect it.
+		resume: false,
+		...(token && teamId && projectId ? { token, teamId, projectId } : {}),
+	})) as unknown as TerminalSandbox;
+}
+
+/**
+ * The session's live sandbox, or a calm "none" with the honest reason. Bound
+ * to the session's own parked handle — there is no path to another session's
+ * sandbox from here.
+ */
+export async function resolveLiveSandbox(
+	session: Pick<Session, "claudeSessionId" | "resumeState">,
+	getSandbox: GetSandbox = defaultGetSandbox,
+): Promise<LiveSandboxResolution> {
+	if (!session.claudeSessionId || !session.resumeState) {
+		return { state: "none", reason: "no turn has started a sandbox yet" };
+	}
+	let sandbox: TerminalSandbox;
+	try {
+		sandbox = await getSandbox(sessionSandboxName(session.claudeSessionId));
+	} catch {
+		return { state: "none", reason: "the session's sandbox has expired" };
+	}
+	if (!ALIVE_STATUSES.has(sandbox.status)) {
+		return {
+			state: "none",
+			reason: `the session's sandbox is ${sandbox.status}`,
+		};
+	}
+	return { state: "live", sandbox };
+}
+
+/** Sandboxes created before TERMINAL_PORT was declared can't publish a shell. */
+export class TerminalUnsupportedError extends Error {
+	constructor() {
+		super(
+			"this sandbox predates terminal support — the next fresh turn will boot one that has it",
+		);
+		this.name = "TerminalUnsupportedError";
+	}
+}
+
+/**
+ * Ensures ttyd serves the sandbox's shell behind its HMAC base-path and
+ * returns the WebSocket URL. Idempotent: a running ttyd is left alone (its
+ * token is stable — it's derived from the VM session id). The shell is
+ * `tmux new-session -A -s shell`, so disconnect/reconnect within a sandbox
+ * lands back in the same shell state (the tmux acceptance criterion).
+ */
+export async function ensureTerminal(
+	sandbox: TerminalSandbox,
+): Promise<{ wsUrl: string }> {
+	let domain: string;
+	try {
+		domain = sandbox.domain(TERMINAL_PORT);
+	} catch {
+		throw new TerminalUnsupportedError();
+	}
+	const token = terminalPathToken(sandbox.currentSession().sessionId);
+	const probe = await sandbox.runCommand({
+		cmd: "bash",
+		args: ["-c", "pgrep -x ttyd >/dev/null && echo running || echo stopped"],
+	});
+	if (!(await probe.stdout()).includes("running")) {
+		// Fallback install for sandboxes built from a pre-terminal template
+		// snapshot; a no-op when the bootstrap already baked the binaries in.
+		const install = await sandbox.runCommand({
+			cmd: "bash",
+			args: ["-c", TERMINAL_INSTALL_SCRIPT],
+		});
+		if (install.exitCode !== 0) {
+			const stderr = await install.stderr();
+			throw new Error(
+				`terminal install failed (exit ${install.exitCode}): ${stderr.slice(0, 300)}`,
+			);
+		}
+		await sandbox.runCommand({
+			cmd: TTYD_BIN,
+			// -W: writable; base-path is the HMAC gate — ttyd serves its
+			// WebSocket only under /<token>/ws.
+			args: [
+				"-W",
+				"-p",
+				String(TERMINAL_PORT),
+				"-b",
+				`/${token}`,
+				TMUX_BIN,
+				"new-session",
+				"-A",
+				"-s",
+				"shell",
+			],
+			cwd: WORKSPACE_DIR,
+			detached: true,
+		});
+	}
+	const wss = domain.replace(/^https:/, "wss:").replace(/\/$/, "");
+	return { wsUrl: `${wss}/${token}/ws` };
+}

--- a/web-next/src/lib/terminal/sandbox-terminal.ts
+++ b/web-next/src/lib/terminal/sandbox-terminal.ts
@@ -101,9 +101,33 @@ export class TerminalUnsupportedError extends Error {
 }
 
 /**
+ * The reuse probe: a running ttyd counts only if its command line attests the
+ * expected `-b /<token>` and `-p <port>` — a process that merely shares the
+ * name (stale token after secret rotation, or something else that bound the
+ * port) is killed and replaced, so the published port is never served outside
+ * the current HMAC gate (codex review finding, gpt-5.5 xhigh). Token is hex
+ * and port digits, so both embed safely in the grep -F patterns.
+ */
+function ttydProbeScript(token: string, port: number): string {
+	return [
+		`pid=$(pgrep -x ttyd | head -n1 || true)`,
+		`if [ -n "$pid" ] && tr '\\0' ' ' < /proc/$pid/cmdline | grep -qF -- "-b /${token}" && tr '\\0' ' ' < /proc/$pid/cmdline | grep -qF -- "-p ${port}"; then`,
+		`  echo attested`,
+		`else`,
+		`  if [ -n "$pid" ]; then`,
+		`    kill "$pid" 2>/dev/null || true`,
+		`    for i in 1 2 3 4 5 6 7 8; do pgrep -x ttyd >/dev/null 2>&1 || break; sleep 0.25; done`,
+		`  fi`,
+		`  echo absent`,
+		`fi`,
+	].join("\n");
+}
+
+/**
  * Ensures ttyd serves the sandbox's shell behind its HMAC base-path and
- * returns the WebSocket URL. Idempotent: a running ttyd is left alone (its
- * token is stable — it's derived from the VM session id). The shell is
+ * returns the WebSocket URL. Idempotent: a ttyd whose command line attests
+ * the current token and port is left alone (the token is stable — it's
+ * derived from the VM session id); anything else is replaced. The shell is
  * `tmux new-session -A -s shell`, so disconnect/reconnect within a sandbox
  * lands back in the same shell state (the tmux acceptance criterion).
  */
@@ -119,9 +143,9 @@ export async function ensureTerminal(
 	const token = terminalPathToken(sandbox.currentSession().sessionId);
 	const probe = await sandbox.runCommand({
 		cmd: "bash",
-		args: ["-c", "pgrep -x ttyd >/dev/null && echo running || echo stopped"],
+		args: ["-c", ttydProbeScript(token, TERMINAL_PORT)],
 	});
-	if (!(await probe.stdout()).includes("running")) {
+	if (!(await probe.stdout()).includes("attested")) {
 		// Fallback install for sandboxes built from a pre-terminal template
 		// snapshot; a no-op when the bootstrap already baked the binaries in.
 		const install = await sandbox.runCommand({

--- a/web-next/src/lib/terminal/tickets.test.ts
+++ b/web-next/src/lib/terminal/tickets.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../db/client";
+import {
+	issueTerminalTicket,
+	redeemTerminalTicket,
+	TERMINAL_TICKET_TTL_MS,
+} from "./tickets";
+
+let open: DatabaseHandle | undefined;
+let dir: string | undefined;
+
+function freshDb(): DatabaseHandle {
+	dir = mkdtempSync(join(tmpdir(), "web-next-tickets-"));
+	open = openDatabase(`file:${join(dir, "test.db")}`);
+	return open;
+}
+
+afterEach(async () => {
+	await open?.db.destroy();
+	open = undefined;
+	if (dir) rmSync(dir, { recursive: true, force: true });
+	dir = undefined;
+});
+
+const MINT = {
+	login: "fairchild",
+	sessionId: "session-1",
+	mode: "ttyd" as const,
+	sandboxName: "ai-sdk-harness-session-session-1",
+};
+
+describe("terminal tickets", () => {
+	test("mint → redeem roundtrip returns the bound record exactly once", async () => {
+		const db = freshDb();
+		const { ticket, expiresAt } = await issueTerminalTicket(db, MINT);
+		expect(new Date(expiresAt).getTime()).toBeGreaterThan(Date.now());
+
+		const first = await redeemTerminalTicket(db, ticket, {
+			login: "fairchild",
+			sessionId: "session-1",
+		});
+		expect(first).toEqual({
+			ok: true,
+			record: {
+				login: "fairchild",
+				sessionId: "session-1",
+				mode: "ttyd",
+				sandboxName: MINT.sandboxName,
+			},
+		});
+
+		// Replay: the same ticket never redeems twice.
+		const replay = await redeemTerminalTicket(db, ticket, {
+			login: "fairchild",
+			sessionId: "session-1",
+		});
+		expect(replay).toEqual({ ok: false, reason: "redeemed" });
+	});
+
+	test("a tampered or unknown ticket is invalid", async () => {
+		const db = freshDb();
+		const { ticket } = await issueTerminalTicket(db, MINT);
+		const tampered = ticket.slice(0, -2) + (ticket.endsWith("AA") ? "BB" : "AA");
+		expect(
+			await redeemTerminalTicket(db, tampered, {
+				login: "fairchild",
+				sessionId: "session-1",
+			}),
+		).toEqual({ ok: false, reason: "invalid" });
+	});
+
+	test("a ticket is bound to the login and session it was minted for", async () => {
+		const db = freshDb();
+		const { ticket } = await issueTerminalTicket(db, MINT);
+		expect(
+			await redeemTerminalTicket(db, ticket, {
+				login: "mallory",
+				sessionId: "session-1",
+			}),
+		).toEqual({ ok: false, reason: "wrong-user" });
+		expect(
+			await redeemTerminalTicket(db, ticket, {
+				login: "fairchild",
+				sessionId: "session-2",
+			}),
+		).toEqual({ ok: false, reason: "wrong-session" });
+		// The failed attempts spent nothing: the rightful redeem still works.
+		const rightful = await redeemTerminalTicket(db, ticket, {
+			login: "fairchild",
+			sessionId: "session-1",
+		});
+		expect(rightful.ok).toBe(true);
+	});
+
+	test("a ticket expires after its TTL", async () => {
+		const db = freshDb();
+		const minted = new Date("2026-07-07T00:00:00.000Z");
+		const { ticket } = await issueTerminalTicket(db, MINT, minted);
+		const justAfter = new Date(minted.getTime() + TERMINAL_TICKET_TTL_MS + 1);
+		expect(
+			await redeemTerminalTicket(
+				db,
+				ticket,
+				{ login: "fairchild", sessionId: "session-1" },
+				justAfter,
+			),
+		).toEqual({ ok: false, reason: "expired" });
+	});
+
+	test("issuing prunes rows that have already expired", async () => {
+		const db = freshDb();
+		const past = new Date(Date.now() - 2 * TERMINAL_TICKET_TTL_MS);
+		await issueTerminalTicket(db, MINT, past);
+		await issueTerminalTicket(db, MINT);
+		const rows = await db.db
+			.selectFrom("terminal_tickets")
+			.selectAll()
+			.execute();
+		expect(rows).toHaveLength(1);
+	});
+});

--- a/web-next/src/lib/terminal/tickets.ts
+++ b/web-next/src/lib/terminal/tickets.ts
@@ -1,0 +1,120 @@
+/*
+ * Single-use, short-TTL terminal access tickets (#752) — the authenticated
+ * exchange in front of every terminal attach, ported from web/'s
+ * terminal-tickets. Mint issues 32 random bytes and stores only their SHA-256
+ * (a stolen table row is not a ticket; a lookup by digest also blunts timing
+ * probes on the comparison); redeem consumes exactly once via an atomic
+ * UPDATE guard and checks the login + session binding and the expiry clock.
+ */
+import crypto from "node:crypto";
+import type { DatabaseHandle } from "../db/client";
+import { ensureSchema } from "../db/schema";
+
+export const TERMINAL_TICKET_TTL_MS = 30_000;
+
+/** Transport the mint resolved: a live sandbox's ttyd, or the bypass mock. */
+export type TerminalMode = "ttyd" | "mock";
+
+export interface IssuedTerminalTicket {
+	ticket: string;
+	expiresAt: string;
+}
+
+export interface TerminalTicketRecord {
+	login: string;
+	sessionId: string;
+	mode: TerminalMode;
+	/** Sandbox the ticket is pinned to (redeem re-verifies it); null for mock. */
+	sandboxName: string | null;
+}
+
+export type RedeemTicketResult =
+	| { ok: true; record: TerminalTicketRecord }
+	| {
+			ok: false;
+			reason: "invalid" | "wrong-user" | "wrong-session" | "expired" | "redeemed";
+	  };
+
+function ticketHash(ticket: string): string {
+	return crypto.createHash("sha256").update(ticket, "utf8").digest("hex");
+}
+
+export async function issueTerminalTicket(
+	handle: DatabaseHandle,
+	params: {
+		login: string;
+		sessionId: string;
+		mode: TerminalMode;
+		sandboxName?: string | null;
+	},
+	now = new Date(),
+): Promise<IssuedTerminalTicket> {
+	await ensureSchema(handle);
+	const ticket = crypto.randomBytes(32).toString("base64url");
+	const createdAt = now.toISOString();
+	const expiresAt = new Date(now.getTime() + TERMINAL_TICKET_TTL_MS).toISOString();
+	// Opportunistic hygiene: expired rows are dead weight, never redeemable.
+	await handle.db
+		.deleteFrom("terminal_tickets")
+		.where("expires_at", "<=", createdAt)
+		.execute();
+	await handle.db
+		.insertInto("terminal_tickets")
+		.values({
+			ticket_hash: ticketHash(ticket),
+			login: params.login,
+			session_id: params.sessionId,
+			mode: params.mode,
+			sandbox_name: params.sandboxName ?? null,
+			created_at: createdAt,
+			expires_at: expiresAt,
+			redeemed_at: null,
+		})
+		.execute();
+	return { ticket, expiresAt };
+}
+
+export async function redeemTerminalTicket(
+	handle: DatabaseHandle,
+	ticket: string,
+	params: { login: string; sessionId: string },
+	now = new Date(),
+): Promise<RedeemTicketResult> {
+	await ensureSchema(handle);
+	const nowIso = now.toISOString();
+	const hash = ticketHash(ticket);
+	const row = await handle.db
+		.selectFrom("terminal_tickets")
+		.selectAll()
+		.where("ticket_hash", "=", hash)
+		.executeTakeFirst();
+	if (!row) return { ok: false, reason: "invalid" };
+	if (row.login !== params.login) return { ok: false, reason: "wrong-user" };
+	if (row.session_id !== params.sessionId)
+		return { ok: false, reason: "wrong-session" };
+	if (row.redeemed_at !== null) return { ok: false, reason: "redeemed" };
+	if (row.expires_at <= nowIso) return { ok: false, reason: "expired" };
+
+	// Exactly-once: the guard re-checks under the write, so two concurrent
+	// redeems of one ticket produce one winner and one "redeemed".
+	const updated = await handle.db
+		.updateTable("terminal_tickets")
+		.set({ redeemed_at: nowIso })
+		.where("ticket_hash", "=", hash)
+		.where("login", "=", params.login)
+		.where("redeemed_at", "is", null)
+		.where("expires_at", ">", nowIso)
+		.executeTakeFirst();
+	if (Number(updated.numUpdatedRows ?? 0) !== 1) {
+		return { ok: false, reason: "redeemed" };
+	}
+	return {
+		ok: true,
+		record: {
+			login: row.login,
+			sessionId: row.session_id,
+			mode: row.mode as TerminalMode,
+			sandboxName: row.sandbox_name,
+		},
+	};
+}

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -23,7 +23,7 @@ test.beforeAll(async () => {
 	// request, and in auth-bypass mode the unauthenticated readiness probe
 	// never touches the session tables — so without this the DELETEs below can
 	// hit tables that don't exist yet on a cold server.
-	await fetch("http://localhost:3100/", {
+	await fetch(`http://localhost:${process.env.E2E_PORT ?? 3100}/`, {
 		headers: { cookie: "test-auth-login=fairchild" },
 	});
 	// Same file the e2e server opened (see e2e:server); libSQL file handles

--- a/web-next/tests/e2e/terminal.spec.ts
+++ b/web-next/tests/e2e/terminal.spec.ts
@@ -66,9 +66,8 @@ test("Ctrl+` opens a live shell and a typed command runs in it", async ({
 	await expect(page.getByTestId("terminal-transcript")).toContainText(
 		"drawer-proof-42",
 	);
-	await expect(page.getByTestId("terminal-status")).toContainText(
-		"attached to the session's sandbox",
-	);
+	// The status bar names the transport honestly: this is the mock seam.
+	await expect(page.getByTestId("terminal-status")).toContainText("mock PTY");
 
 	// The exchange really ran (a ticket was minted)…
 	expect(mintedTicket).not.toBe("");

--- a/web-next/tests/e2e/terminal.spec.ts
+++ b/web-next/tests/e2e/terminal.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Terminal drawer e2e (#752), hermetic over the mock PTY seam: the drawer
+ * opens from its quiet affordances (Ctrl+` and the `>_` control), runs the
+ * full ticket mint→redeem exchange, paints a shell, and runs a command.
+ * Network-level assertion: the ticket travels only in POST bodies — no
+ * request URL ever carries it. Videos are recorded as the PR's evidence.
+ */
+import { expect, type Page, test } from "@playwright/test";
+
+test.use({ video: "on" });
+
+// The drawer + ghostty-web WASM load lazily on first open.
+const DRAWER_TIMEOUT = 15_000;
+
+async function createSession(page: Page): Promise<void> {
+	await page.goto("/");
+	const picker = page.getByTestId("new-session-picker");
+	if (!(await picker.isVisible())) {
+		await page.getByRole("button", { name: "+ new session" }).click();
+	}
+	await page
+		.getByRole("textbox", { name: "Repository (owner/name)" })
+		.fill("fairchild/workspaces");
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(/\/sessions\/[0-9a-f-]{36}$/);
+}
+
+function drawer(page: Page) {
+	return page.getByTestId("terminal-drawer");
+}
+
+async function openDrawerAndAwaitShell(page: Page): Promise<void> {
+	await page.keyboard.press("Control+Backquote");
+	await expect(drawer(page)).toHaveAttribute("data-open", "true");
+	await expect(drawer(page)).toHaveAttribute("data-ready", "true", {
+		timeout: DRAWER_TIMEOUT,
+	});
+	await expect(page.getByTestId("terminal-transcript")).toContainText(
+		"mock sandbox shell",
+	);
+}
+
+test("Ctrl+` opens a live shell and a typed command runs in it", async ({
+	page,
+}) => {
+	// Collect every request URL and the minted ticket, to prove the token
+	// never rides in a URL (only in POST bodies).
+	const requestUrls: string[] = [];
+	page.on("request", (request) => requestUrls.push(request.url()));
+	let mintedTicket = "";
+	page.on("response", async (response) => {
+		if (response.url().endsWith("/terminal") && response.ok()) {
+			const body = (await response.json().catch(() => ({}))) as {
+				ticket?: string;
+			};
+			if (body.ticket) mintedTicket = body.ticket;
+		}
+	});
+
+	await createSession(page);
+	await openDrawerAndAwaitShell(page);
+
+	// Type a command into the terminal and see its output land.
+	await page.keyboard.type("echo drawer-proof-42");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("terminal-transcript")).toContainText(
+		"drawer-proof-42",
+	);
+	await expect(page.getByTestId("terminal-status")).toContainText(
+		"attached to the session's sandbox",
+	);
+
+	// The exchange really ran (a ticket was minted)…
+	expect(mintedTicket).not.toBe("");
+	// …and no URL — page, API, or asset — ever carried it, nor any ticket=
+	// query parameter at all.
+	for (const url of requestUrls) {
+		expect(url).not.toContain(mintedTicket);
+		expect(url).not.toContain("ticket=");
+	}
+});
+
+test("the drawer closes and reopens from the quiet control, keeping its shell", async ({
+	page,
+}) => {
+	await createSession(page);
+	await openDrawerAndAwaitShell(page);
+	await page.keyboard.type("echo still-here");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("terminal-transcript")).toContainText(
+		"still-here",
+	);
+
+	// Close via Ctrl+`; the drawer hides but is not torn down.
+	await page.keyboard.press("Control+Backquote");
+	await expect(drawer(page)).toHaveAttribute("data-open", "false");
+
+	// Reopen from the `>_` control: same shell, scrollback intact, no
+	// second banner (the transport connected exactly once).
+	await page.getByTestId("terminal-toggle").click();
+	await expect(drawer(page)).toHaveAttribute("data-open", "true");
+	await expect(page.getByTestId("terminal-transcript")).toContainText(
+		"still-here",
+	);
+	const transcript = await page
+		.getByTestId("terminal-transcript")
+		.textContent();
+	expect(transcript?.match(/mock sandbox shell/g)).toHaveLength(1);
+});
+
+test.describe("signed out", () => {
+	test.use({ storageState: { cookies: [], origins: [] } });
+
+	test("the terminal routes are bounced before any sandbox work", async ({
+		request,
+	}) => {
+		for (const path of [
+			"/api/sessions/any/terminal",
+			"/api/sessions/any/terminal/redeem",
+		]) {
+			const response = await request.post(path, {
+				data: {},
+				maxRedirects: 0,
+			});
+			// The middleware turns unauthenticated API posts away at the edge.
+			expect([307, 401]).toContain(response.status());
+		}
+	});
+});


### PR DESCRIPTION
A collapsible terminal drawer on `/sessions/[id]`: a real shell into the **same Vercel sandbox the session's turns run in**, one keystroke away (Ctrl+`` ` `` or the quiet `>_` control above the status line). Closes #752.

## What shipped

- **Access model** (ported from web/'s ticket/HMAC design, contract in `web-next/docs/terminal-access.md`): three independent gates — the `getAuthState` allowlist verdict on both routes, a single-use 30s ticket (32 random bytes, stored as SHA-256, bound to login + session + sandbox name, consumed exactly once via an atomic UPDATE guard), and ttyd behind an HMAC base-path (24 hex of HMAC-SHA256(secret, sandbox VM session id); `TTYD_TOKEN_SECRET` → `BETTER_AUTH_SECRET` fallback, hard refusal in prod without either). The ticket travels only in POST bodies — the e2e asserts at the network layer that no request URL ever carries it. The only URL-borne secret is the per-VM path token inside the `wss://` upgrade URL, which is the strongest gate browser WebSockets admit (no headers); it is derived (never stored), single-VM-scoped, and dies with the sandbox.
- **Sandbox attachment**: `resolveLiveSandbox` derives the sandbox name from the session's own parked harness handle — the exact derivation the turn-resume path uses (`sessionSandboxName`, now shared) — so no request parameter can point at another session's sandbox. Attach-only (`resume: false`): the drawer never boots a VM. The running ttyd is **attested** (command line must carry the current `-b /<token>` and `-p <port>`) before reuse; a stale or foreign ttyd is replaced. Shell is `tmux new-session -A -s shell` in the workspace clone, so reconnects within a sandbox land in the same shell state.
- **No live sandbox** → a calm note ("No live sandbox … start a turn and the terminal attaches to the same sandbox it runs in") with a quiet "check again". Defended choice: the sandbox is the product of a turn — a boot affordance here would manufacture an empty sandbox with no harness session and no working state, which lies about "the session's sandbox". The honest affordance is starting a turn.
- **Drawer UI**: ghostty-web (lazy import + WASM init on first open, out of first-load JS), Folio-toned palettes for both themes, reduced-motion honored by the global media rule, terminal mounted once across open/close (scrollback persists), capture-phase Ctrl+`` ` `` so the chord also closes from inside the shell, and a hidden plain-text transcript mirror (capped 8k) that makes canvas output assertable by tests and readable by screen readers. Integration surface: one mount in `live-session-view.tsx` (#823/#908 masthead churn safety — rebased over #908 cleanly).
- **Mock PTY seam**: under `AUTH_BYPASS` the mint resolves mode `mock` — the full ticket exchange runs, the client attaches a deterministic in-browser PTY (pure `evalMockCommand`, unit-tested), and the status bar names the transport honestly ("mock PTY (AUTH_BYPASS)"). e2e and perf stay hermetic; the real path is unit-tested with the Vercel dependency injected (`GetSandbox` seam).
- **Provider changes** (small): sandbox declares `TERMINAL_PORT`; bootstrap bakes ttyd+tmux static binaries into the template snapshot (best-effort — a fetch failure never blocks the chat path; the mint route re-runs the same idempotent install as fallback); `BOOTSTRAP_HASH` bumped, so the next prewarm rebuilds the template once.
- **Perf**: `terminal_drawer_interactive` scenario added per the ratchet policy — toggle → first PTY bytes in a painted frame, over the mock seam so CI needs no creds. Two 10-run batches: medians 120 / 181.5 ms, max 362 ms → budget ceil(362×1.3) ≈ 471, rounded to **480 ms** (samples in `perf/BASELINE.md`). Full suite passes; `route_session_empty` first-load JS 183.8 → 187.9 kB gz (drawer shell; ghostty-web stays a lazy chunk).
- **Tooling**: `E2E_PORT` override so sibling worktrees don't collide on :3100 (parity with `PERF_PORT`); terminal e2e runs as a dependent Playwright project because `sessions.spec` owns (wipes + counts) the sessions table.

## Real-path proof status

**Blocked on creds, explicitly.** `web-next/.env.local` on this machine carries only `VERCEL_TOKEN` — no model key, no `VERCEL_TEAM_ID`/`PROJECT_ID`, no GitHub App key — so a real session turn (and therefore a live-sandbox drawer attach) cannot run locally. The real-path proof (one `WEB_NEXT_COMPUTE_PROVIDER=vercel` turn, drawer open against that live sandbox, `ls`, video) is a follow-up under #818. Not faked here: all evidence below is the mock-PTY seam, and the UI says so on screen.

## Review loop

Self-reflection fixes (committed before codex): a thrown ticket exchange left the drawer stuck on "connecting…" (now lands in `denied` with the reason); the `wss` rewrite only matched `https:`; the ready label claimed "attached to the session's sandbox" even over the mock seam (now transport-honest).

codex (gpt-5.5, xhigh), directed at ticket/HMAC parity, token-in-URL, auth-gate ordering, and sandbox-attachment correctness:

1. **Blocker (adjudicated pre-existing → #910):** `AUTH_BYPASS=1` + missing OAuth config in a production deploy would trust the unsigned test cookie. `src/lib/auth/config.ts` is untouched by this diff (the #747 double-lock design); filed as #910 with a proposed third lock rather than scope-creeping shared auth config here.
2. **Important (adjudicated pre-existing → #910):** no per-session owner scoping among allowlisted logins — pre-existing schema shape (single-user product); terminals raise its stakes, named in #910.
3. **Important (mine, fixed):** ttyd reuse wasn't attested — any process named `ttyd` was blessed, so a stale base-path after secret rotation (or a foreign ttyd) would be served the published port outside the HMAC gate. Fixed in `fix(web-next): attest the running ttyd's base path before reuse` with a stale-token replacement unit test.

Codex's sound-list: ticket primitive, auth-first route ordering, ticket-never-in-URL, non-parameter-controlled sandbox lookup, capped transcript mirror. Completeness verdict: in real-auth mode it found no path for an unauthenticated/unallowlisted caller to reach any sandbox, nor for the terminal routes to attach anything but the session's own parked sandbox.

## Evidence

Unit: **270 tests passed** (28 files) — includes ticket mint/redeem/expiry/tamper/replay/binding, path-token secret resolution, sandbox resolution + ttyd attestation, mock-PTY determinism. E2E: **29 tests passed** — drawer open/type/output, close/reopen keeping the shell, network-level token-absent-from-URLs assertion, signed-out bounce. Perf: all 15 metrics within budget (`terminal_drawer_interactive` median 86 ms vs 480 budget on the final tip).

- Drawer over a completed turn, dark: https://evidence.cloudcompute.com/workspaces/pr-912/20260707-173702-terminal-drawer-dark.png
- Drawer over a completed turn, light: https://evidence.cloudcompute.com/workspaces/pr-912/20260707-173703-terminal-drawer-light.png
- Video (open → run commands → close, mock seam): https://evidence.cloudcompute.com/workspaces/pr-912/20260707-173703-terminal-drawer-demo.gif
- CI: [Lint, Test, Build, E2E & Perf passed](https://github.com/fairchild/workspaces/actions/runs/28886258055)

## Mergeability

- Surface: web (web-next session surface + terminal API routes; small agent-runtime provider config change)
- User-facing behavior changed: Yes — a terminal drawer on `/sessions/[id]` (Ctrl+`` ` `` / `>_` control); no change to chat, home, or demo surfaces.
- Non-happy paths considered: no live sandbox (calm state, no boot), expired/stopped sandbox at mint and at redeem (409), pre-terminal-port sandboxes (graceful "unsupported" → no-sandbox), ticket expiry/replay/tamper/wrong-user/wrong-session, concurrent redeem (single winner), ttyd stale-token replacement, transport drop (disconnected state + reconnect via fresh exchange), connect exception (denied state, no stuck spinner), signed-out/forbidden on both routes, bootstrap install failure (never blocks chat).
- Residual risk or follow-up: real-path (live sandbox) proof blocked on creds → follow-up under #818; pre-existing auth hardening items → #910; template rebuild on next prewarm (one-time ~1–4 min) from the `BOOTSTRAP_HASH` bump; ghostty theme is fixed at first drawer open (doesn't follow a mid-session theme toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Gate
- CI: green quality lane (incl. the new terminal_drawer_interactive perf scenario) on 0373c30: https://github.com/fairchild/workspaces/actions/runs/28886258055/job/85687093114
- Gate note (security-tier): orchestrator read both new routes (auth-first, no pre-auth leaks, ticket only in POST bodies) and the redemption compare-and-set (single winner under concurrency, login/session/expiry bound in the WHERE); codex xhigh directed at ticket/HMAC parity ran, 1 finding fixed, 2 pre-existing adjudicated out to #910; real-sandbox proof explicitly deferred to #818 (local runtime creds absent) — labeled, not faked. Merged on delegated authority.