### PR TITLE
feat(editor): diff-review stage/unstage/discard + dirty-nav veto (#704)

### DIFF
--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -829,10 +829,14 @@ enum MainWindowCommand {
 final class AppCommandState: ObservableObject {
     @Published private(set) var canCreateWorkspace = false
     @Published private(set) var canSaveDocument = false
+    /// True while the open editor document has unsaved edits, so navigation intents can pause for
+    /// a Save / Discard / Cancel prompt (#704 Phase 4).
+    @Published private(set) var hasUnsavedDocumentEdits = false
     @Published private(set) var mainWindowAvailability = MainWindowCommandAvailability.empty
 
     private var newWorkspaceAction: (@MainActor () -> Void)?
     private var saveDocumentAction: (@MainActor () -> Void)?
+    private var saveDocumentAsyncAction: (@MainActor () async -> Bool)?
     private var mainWindowActions = MainWindowFocusedActions.empty
 
     func setNewWorkspaceAction(_ action: (@MainActor () -> Void)?) {
@@ -851,6 +855,28 @@ final class AppCommandState: ObservableObject {
 
     func clearSaveDocumentAction() {
         setSaveDocumentAction(nil, isEnabled: false)
+    }
+
+    /// Register the open document's dirty state and the awaiting-Save hook the navigation guard
+    /// uses. (Discarding needs no hook: navigating away replaces the buffer, abandoning edits.)
+    func setDocumentEditsState(isDirty: Bool, save: (@MainActor () async -> Bool)?) {
+        saveDocumentAsyncAction = save
+        guard hasUnsavedDocumentEdits != isDirty else { return }
+        hasUnsavedDocumentEdits = isDirty
+    }
+
+    func clearDocumentEditsState() {
+        saveDocumentAsyncAction = nil
+        guard hasUnsavedDocumentEdits else { return }
+        hasUnsavedDocumentEdits = false
+    }
+
+    /// Save the dirty document, returning whether the save succeeded. No registered hook (or no
+    /// unsaved edits) counts as success so navigation proceeds.
+    @discardableResult
+    func saveDirtyDocument() async -> Bool {
+        guard let saveDocumentAsyncAction else { return true }
+        return await saveDocumentAsyncAction()
     }
 
     func setMainWindowActions(

--- a/Sources/WorkspaceManager/Views/Components/DiffReviewSheet.swift
+++ b/Sources/WorkspaceManager/Views/Components/DiffReviewSheet.swift
@@ -3,9 +3,11 @@
 //  WorkspaceManager
 //
 //  Presents the native `DiffReviewView` for one changed file: loads the working-tree diff
-//  via `GitService`, provides the scroll container the render view expects, and shows quiet
-//  loading / empty / error states. Reused from the Changes tab and the just-saved edit path
-//  (see #704 Phase 3). Staging/discard controls are a later slice.
+//  via `GitService`, provides the scroll container the render view expects, and hosts the
+//  native stage / unstage / discard controls beside the review (see #704 Phase 3). Reused from
+//  the Changes tab and the just-saved edit path. Discard is confirm-gated and routes tracked
+//  files to `git checkout --` and untracked files to a single-path delete, so a "discard" of a
+//  new file is never silent.
 //
 
 import SwiftUI
@@ -14,15 +16,28 @@ import WorkspaceManagerCore
 struct DiffReviewSheet: View {
     let filePath: String
     let directoryURL: URL
+    /// Known git status for `filePath`, if the caller has it (the Changes tab does). When nil the
+    /// sheet resolves it so discard can word itself and route correctly for untracked files.
+    var status: GitStatus? = nil
+    /// Invoked after a stage / unstage / discard mutates the working tree so callers can refresh.
+    var onChanged: () -> Void = {}
     let onClose: () -> Void
 
     @Environment(\.gitService) private var gitService
     @State private var phase: Phase = .loading
+    @State private var resolvedStatus: GitStatus?
+    @State private var isBusy = false
+    @State private var actionError: String?
+    @State private var isConfirmingDiscard = false
 
     private enum Phase {
         case loading
         case loaded(UnifiedDiff)
         case failed(String)
+    }
+
+    private var isUntracked: Bool {
+        resolvedStatus == .untracked
     }
 
     var body: some View {
@@ -54,18 +69,151 @@ struct DiffReviewSheet: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+
+            if case .loading = phase {
+                EmptyView()
+            } else {
+                DiffReviewActionBar(
+                    isUntracked: isUntracked,
+                    isBusy: isBusy,
+                    errorMessage: actionError,
+                    onStage: {
+                        Task {
+                            await performAction {
+                                try await gitService.stage(file: filePath, at: directoryURL)
+                            }
+                        }
+                    },
+                    onUnstage: {
+                        Task {
+                            await performAction {
+                                try await gitService.unstage(file: filePath, at: directoryURL)
+                            }
+                        }
+                    },
+                    onDiscardRequested: { isConfirmingDiscard = true }
+                )
+            }
         }
         .frame(minWidth: 480, minHeight: 360)
         .task(id: filePath) { await load() }
+        .confirmationDialog(
+            discardConfirmationTitle,
+            isPresented: $isConfirmingDiscard,
+            titleVisibility: .visible
+        ) {
+            Button(isUntracked ? "Delete File" : "Discard Changes", role: .destructive) {
+                Task { await performDiscard() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(discardConfirmationMessage)
+        }
+    }
+
+    private var discardConfirmationTitle: String {
+        isUntracked ? "Delete “\(filePath)”?" : "Discard changes to “\(filePath)”?"
+    }
+
+    private var discardConfirmationMessage: String {
+        isUntracked
+            ? "This permanently deletes the untracked file. It is not tracked by git and cannot be recovered."
+            : "This restores the file to its last staged or committed contents. Unsaved working-tree changes are lost and cannot be recovered."
     }
 
     private func load() async {
         phase = .loading
+        actionError = nil
+        resolvedStatus = status
         do {
-            let diff = try await gitService.diff(file: filePath, at: directoryURL)
-            phase = .loaded(diff)
+            async let diffTask = gitService.diff(file: filePath, at: directoryURL)
+            if resolvedStatus == nil {
+                resolvedStatus =
+                    try? await gitService.getStatus(at: directoryURL)
+                    .first(where: { $0.path == filePath })?.status
+            }
+            phase = .loaded(try await diffTask)
         } catch {
             phase = .failed(error.localizedDescription)
+        }
+    }
+
+    private func performDiscard() async {
+        await performAction {
+            if isUntracked {
+                try await gitService.discardUntracked(file: filePath, at: directoryURL)
+            } else {
+                try await gitService.discard(file: filePath, at: directoryURL)
+            }
+        }
+    }
+
+    private func performAction(_ operation: @escaping () async throws -> Void) async {
+        guard !isBusy else { return }
+        isBusy = true
+        actionError = nil
+        do {
+            try await operation()
+            onChanged()
+            await load()
+        } catch {
+            actionError = error.localizedDescription
+        }
+        isBusy = false
+    }
+}
+
+/// Presentational stage / unstage / discard controls for the diff review surface. Pulled out of
+/// `DiffReviewSheet` so the exact control set — including the untracked "Delete" wording and the
+/// inline action-error banner — renders deterministically under `ImageRenderer` for PR evidence.
+struct DiffReviewActionBar: View {
+    let isUntracked: Bool
+    let isBusy: Bool
+    let errorMessage: String?
+    let onStage: () -> Void
+    let onUnstage: () -> Void
+    let onDiscardRequested: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let errorMessage {
+                HStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.red.opacity(0.08))
+            }
+
+            Divider()
+
+            HStack(spacing: 8) {
+                Spacer()
+
+                Button("Stage", action: onStage)
+                    .disabled(isBusy)
+                    .help("Stage this file (git add)")
+
+                Button("Unstage", action: onUnstage)
+                    .disabled(isBusy)
+                    .help("Unstage this file (git reset HEAD)")
+
+                Button(isUntracked ? "Delete" : "Discard", role: .destructive, action: onDiscardRequested)
+                    .disabled(isBusy)
+                    .help(
+                        isUntracked
+                            ? "Delete this untracked file (permanent)"
+                            : "Discard working-tree changes to this file"
+                    )
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/Components/DiffReviewSheet.swift
+++ b/Sources/WorkspaceManager/Views/Components/DiffReviewSheet.swift
@@ -124,14 +124,14 @@ struct DiffReviewSheet: View {
     private func load() async {
         phase = .loading
         actionError = nil
+        // Optimistic initial value avoids a flash, but always re-resolve from git so a reload after
+        // Stage/Unstage routes discard correctly instead of trusting the now-stale passed-in status.
         resolvedStatus = status
         do {
             async let diffTask = gitService.diff(file: filePath, at: directoryURL)
-            if resolvedStatus == nil {
-                resolvedStatus =
-                    try? await gitService.getStatus(at: directoryURL)
-                    .first(where: { $0.path == filePath })?.status
-            }
+            resolvedStatus =
+                try? await gitService.getStatus(at: directoryURL)
+                .first(where: { $0.path == filePath })?.status
             phase = .loaded(try await diffTask)
         } catch {
             phase = .failed(error.localizedDescription)

--- a/Sources/WorkspaceManager/Views/Components/DiffReviewView.swift
+++ b/Sources/WorkspaceManager/Views/Components/DiffReviewView.swift
@@ -2,10 +2,10 @@
 //  DiffReviewView.swift
 //  WorkspaceManager
 //
-//  Native, read-only diff review surface: renders a parsed `UnifiedDiff` as coloured
-//  addition / removal / context rows with old|new line-number gutters. Staging, unstaging,
-//  and discard controls are intentionally absent in this slice — they land beside the review
-//  in a later slice (see #704 Phase 3).
+//  Native, read-only diff render: turns a parsed `UnifiedDiff` into coloured addition /
+//  removal / context rows with old|new line-number gutters. This view stays a pure renderer;
+//  the stage / unstage / discard controls live in the presenting `DiffReviewSheet` beside the
+//  review, not in the diff body (see #704 Phase 3).
 //
 //  The view lays out header + all rows in a plain stack; the presenting container provides
 //  scrolling (a `ScrollView`), which keeps this renderable under `ImageRenderer` for evidence.

--- a/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/CodeFilePreviewView.swift
@@ -214,10 +214,12 @@ struct CodeFilePreviewView: View {
         }
         .onDisappear {
             appCommandState.clearSaveDocumentAction()
+            appCommandState.clearDocumentEditsState()
         }
         .onChange(of: selection.id) { _, _ in
             saveErrorMessage = nil
             appCommandState.clearSaveDocumentAction()
+            appCommandState.clearDocumentEditsState()
         }
         .onChange(of: isDirty) { _, _ in
             syncSaveCommand()
@@ -229,6 +231,7 @@ struct CodeFilePreviewView: View {
             DiffReviewSheet(
                 filePath: selection.relativePath,
                 directoryURL: selection.rootURL,
+                onChanged: { onSaved() },
                 onClose: { isShowingDiffReview = false }
             )
         }
@@ -318,8 +321,9 @@ struct CodeFilePreviewView: View {
     }
 
     @MainActor
-    private func saveCurrentDocument() async {
-        guard canSaveDocument, case .loaded(let document) = state else { return }
+    @discardableResult
+    private func saveCurrentDocument() async -> Bool {
+        guard canSaveDocument, case .loaded(let document) = state else { return false }
         let savedText = document.currentText
 
         isSaving = true
@@ -352,6 +356,7 @@ struct CodeFilePreviewView: View {
         if didSave {
             onSaved()
         }
+        return didSave
     }
 
     @MainActor
@@ -361,6 +366,21 @@ struct CodeFilePreviewView: View {
         } else {
             appCommandState.setSaveDocumentAction(nil, isEnabled: false)
         }
+        syncDocumentEditsState()
+    }
+
+    /// Publish the document's dirty state and the Save / Discard hooks the navigation guard uses
+    /// so a dirty file switch or preview close can veto the loss (#704 Phase 4).
+    @MainActor
+    private func syncDocumentEditsState() {
+        guard isDirty else {
+            appCommandState.clearDocumentEditsState()
+            return
+        }
+        appCommandState.setDocumentEditsState(
+            isDirty: true,
+            save: { await saveCurrentDocument() }
+        )
     }
 }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2660,10 +2660,11 @@ struct ContentView: View {
             pendingCodePreviewNavigation = nil
             commitPendingCodePreviewNavigation(pending)
         case .saveThenProceed:
+            // The dialog dismissal already cleared `pendingCodePreviewNavigation`; the captured
+            // `pending` drives the commit. Deliberately do not touch that state again here — a
+            // second navigation raised during the await owns it now.
             Task { @MainActor in
-                let didSave = await appCommandState.saveDirtyDocument()
-                pendingCodePreviewNavigation = nil
-                if didSave {
+                if await appCommandState.saveDirtyDocument() {
                     commitPendingCodePreviewNavigation(pending)
                 }
             }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -80,6 +80,9 @@ struct ContentView: View {
     /// A code-preview navigation (open another file / close the preview) held back because the
     /// open editor has unsaved edits, pending the Save / Discard / Cancel prompt (#704 Phase 4).
     @State private var pendingCodePreviewNavigation: PendingCodePreviewNavigation?
+    /// Monotonic token bumped each time a new pending navigation is raised, so a Save that awaits
+    /// across a newer navigation can detect it was superseded and decline to commit its stale target.
+    @State private var codePreviewNavigationGeneration = 0
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
     /// Seam store for the web main-content pane: a one-tile `SurfaceStore` domain. Source switches
     /// rebind `webDetailTileID` to a new `WebSurface` (identity-guarded); per-source `WebSurfaceStore`s
@@ -2586,10 +2589,17 @@ struct ContentView: View {
             let current = viewState.selectedCodePreview,
             current.id != selection.id
         {
-            pendingCodePreviewNavigation = .open(selection)
+            raisePendingCodePreviewNavigation(.open(selection))
             return
         }
         commitCodePreviewSelection(selection)
+    }
+
+    /// Set a new pending navigation and bump the generation token so an in-flight Save resolving an
+    /// older intent can see it was superseded.
+    private func raisePendingCodePreviewNavigation(_ pending: PendingCodePreviewNavigation) {
+        codePreviewNavigationGeneration &+= 1
+        pendingCodePreviewNavigation = pending
     }
 
     private func commitCodePreviewSelection(_ selection: CodePreviewSelection) {
@@ -2639,7 +2649,7 @@ struct ContentView: View {
         if DirtyNavigationGuard.requiresPrompt(isDirty: appCommandState.hasUnsavedDocumentEdits),
             viewState.selectedCodePreview != nil
         {
-            pendingCodePreviewNavigation = .close
+            raisePendingCodePreviewNavigation(.close)
             return
         }
         commitClearCodePreview()
@@ -2660,15 +2670,18 @@ struct ContentView: View {
             pendingCodePreviewNavigation = nil
             commitPendingCodePreviewNavigation(pending)
         case .saveThenProceed:
-            // The dialog dismissal already cleared `pendingCodePreviewNavigation`; the captured
-            // `pending` drives the commit. Deliberately do not touch that state again here — a
-            // second navigation raised during the await owns it now. Re-check the live dirty flag
-            // after the await rather than trusting the save's return value: if the user typed more
-            // while the write was in flight the document is dirty again, and navigating would drop
-            // those newer edits.
+            // Capture the generation now; a newer navigation raised during the await bumps it and
+            // must win. After the save, only commit this (captured) target if nothing superseded it
+            // and the document is genuinely clean — the user may have typed more while the write was
+            // in flight, which would leave it dirty again.
+            let capturedGeneration = codePreviewNavigationGeneration
             Task { @MainActor in
                 await appCommandState.saveDirtyDocument()
-                if !appCommandState.hasUnsavedDocumentEdits {
+                if DirtyNavigationGuard.shouldCommitDeferredNavigation(
+                    capturedGeneration: capturedGeneration,
+                    currentGeneration: codePreviewNavigationGeneration,
+                    hasUnsavedEdits: appCommandState.hasUnsavedDocumentEdits
+                ) {
                     commitPendingCodePreviewNavigation(pending)
                 }
             }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2662,9 +2662,13 @@ struct ContentView: View {
         case .saveThenProceed:
             // The dialog dismissal already cleared `pendingCodePreviewNavigation`; the captured
             // `pending` drives the commit. Deliberately do not touch that state again here — a
-            // second navigation raised during the await owns it now.
+            // second navigation raised during the await owns it now. Re-check the live dirty flag
+            // after the await rather than trusting the save's return value: if the user typed more
+            // while the write was in flight the document is dirty again, and navigating would drop
+            // those newer edits.
             Task { @MainActor in
-                if await appCommandState.saveDirtyDocument() {
+                await appCommandState.saveDirtyDocument()
+                if !appCommandState.hasUnsavedDocumentEdits {
                     commitPendingCodePreviewNavigation(pending)
                 }
             }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -22,6 +22,12 @@ private struct ModelSnapshot: Equatable {
     let webSourceIDs: [UUID]
 }
 
+/// A code-preview navigation intent deferred behind the dirty-editor prompt.
+enum PendingCodePreviewNavigation: Equatable {
+    case open(CodePreviewSelection)
+    case close
+}
+
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.localStateStore) private var localStateStore
@@ -71,6 +77,9 @@ struct ContentView: View {
     @State private var isShowingFeedbackSheet = false
     @State private var accessRecorder = MainWindowAccessRecorder()
     @State private var presentedSessionSwitcherSnapshot: SessionSwitcherSnapshot?
+    /// A code-preview navigation (open another file / close the preview) held back because the
+    /// open editor has unsaved edits, pending the Save / Discard / Cancel prompt (#704 Phase 4).
+    @State private var pendingCodePreviewNavigation: PendingCodePreviewNavigation?
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
     /// Seam store for the web main-content pane: a one-tile `SurfaceStore` domain. Source switches
     /// rebind `webDetailTileID` to a new `WebSurface` (identity-guarded); per-source `WebSurfaceStore`s
@@ -535,6 +544,7 @@ struct ContentView: View {
             onOpenInDefaultEditor: openInDefaultEditor,
             onOpenInEditor: openInSelectedEditor,
             onCodePreviewSaved: requestRightPaneRefreshAfterCodeSave,
+            onCloseCodePreview: requestCloseCodePreview,
             rightPaneStateStore: rightPaneStateStore,
             isRightPaneVisible: $viewState.isRightPaneVisible
         )
@@ -1086,6 +1096,27 @@ struct ContentView: View {
                     onDismiss: { isShowingFeedbackSheet = false }
                 )
             }
+            .confirmationDialog(
+                "Unsaved changes",
+                isPresented: pendingCodePreviewNavigationBinding,
+                titleVisibility: .visible,
+                presenting: pendingCodePreviewNavigation
+            ) { _ in
+                Button("Save") { resolvePendingCodePreviewNavigation(.save) }
+                Button("Discard", role: .destructive) { resolvePendingCodePreviewNavigation(.discard) }
+                Button("Cancel", role: .cancel) { resolvePendingCodePreviewNavigation(.cancel) }
+            } message: { _ in
+                Text("This file has unsaved edits. Save them before leaving, or discard them?")
+            }
+    }
+
+    private var pendingCodePreviewNavigationBinding: Binding<Bool> {
+        Binding(
+            get: { pendingCodePreviewNavigation != nil },
+            set: { isPresented in
+                if !isPresented { pendingCodePreviewNavigation = nil }
+            }
+        )
     }
 
     @MainActor
@@ -2550,6 +2581,18 @@ struct ContentView: View {
     }
 
     private func handleCodePreviewSelection(_ selection: CodePreviewSelection) {
+        // Opening a different file while the current one is dirty pauses for Save / Discard / Cancel.
+        if DirtyNavigationGuard.requiresPrompt(isDirty: appCommandState.hasUnsavedDocumentEdits),
+            let current = viewState.selectedCodePreview,
+            current.id != selection.id
+        {
+            pendingCodePreviewNavigation = .open(selection)
+            return
+        }
+        commitCodePreviewSelection(selection)
+    }
+
+    private func commitCodePreviewSelection(_ selection: CodePreviewSelection) {
         viewState.selectedCodePreview = selection
         viewState.isTerminalPanelVisible = true
     }
@@ -2582,9 +2625,58 @@ struct ContentView: View {
         }
     }
 
+    /// Unguarded preview teardown used by repo/workspace removal and surface switches, where the
+    /// surrounding selection has already changed. The dirty-edit veto deliberately does not fire
+    /// here — a full repo/workspace-switch prompt is deferred (#704 Phase 4 follow-up); this path
+    /// only tears the preview down alongside its context.
     private func clearCodePreview() {
+        commitClearCodePreview()
+    }
+
+    /// Guarded close for the editor's own Close button / terminal toggle: when the open file is
+    /// dirty this pauses for Save / Discard / Cancel instead of dropping edits.
+    private func requestCloseCodePreview() {
+        if DirtyNavigationGuard.requiresPrompt(isDirty: appCommandState.hasUnsavedDocumentEdits),
+            viewState.selectedCodePreview != nil
+        {
+            pendingCodePreviewNavigation = .close
+            return
+        }
+        commitClearCodePreview()
+    }
+
+    private func commitClearCodePreview() {
         viewState.selectedCodePreview = nil
         viewState.isTerminalPanelVisible = true
+    }
+
+    /// Resolve a deferred code-preview navigation once the user answers the unsaved-changes prompt.
+    private func resolvePendingCodePreviewNavigation(_ choice: DirtyNavigationChoice) {
+        guard let pending = pendingCodePreviewNavigation else { return }
+        switch DirtyNavigationGuard.outcome(for: choice) {
+        case .veto:
+            pendingCodePreviewNavigation = nil
+        case .proceed:
+            pendingCodePreviewNavigation = nil
+            commitPendingCodePreviewNavigation(pending)
+        case .saveThenProceed:
+            Task { @MainActor in
+                let didSave = await appCommandState.saveDirtyDocument()
+                pendingCodePreviewNavigation = nil
+                if didSave {
+                    commitPendingCodePreviewNavigation(pending)
+                }
+            }
+        }
+    }
+
+    private func commitPendingCodePreviewNavigation(_ pending: PendingCodePreviewNavigation) {
+        switch pending {
+        case .open(let selection):
+            commitCodePreviewSelection(selection)
+        case .close:
+            commitClearCodePreview()
+        }
     }
 
     @MainActor
@@ -3190,6 +3282,8 @@ struct MainTerminalDetailView: View {
     let onOpenInDefaultEditor: () -> Void
     let onOpenInEditor: (ExternalEditorID) -> Void
     let onCodePreviewSaved: () -> Void
+    /// Close the preview, routed through the dirty-navigation guard so unsaved edits prompt first.
+    let onCloseCodePreview: () -> Void
     let rightPaneStateStore: RightPaneStateStore
     @Binding var isRightPaneVisible: Bool
 
@@ -3297,11 +3391,9 @@ struct MainTerminalDetailView: View {
                         defaultEditor: defaultEditor,
                         onOpenInDefaultEditor: onOpenInDefaultEditor,
                         onOpenInEditor: onOpenInEditor,
-                        onSaved: onCodePreviewSaved
-                    ) {
-                        self.selectedCodePreview = nil
-                        self.isTerminalPanelVisible = true
-                    }
+                        onSaved: onCodePreviewSaved,
+                        onClose: onCloseCodePreview
+                    )
                     .frame(minHeight: 220)
 
                     hostTerminalPanel
@@ -3315,11 +3407,9 @@ struct MainTerminalDetailView: View {
                     defaultEditor: defaultEditor,
                     onOpenInDefaultEditor: onOpenInDefaultEditor,
                     onOpenInEditor: onOpenInEditor,
-                    onSaved: onCodePreviewSaved
-                ) {
-                    self.selectedCodePreview = nil
-                    self.isTerminalPanelVisible = true
-                }
+                    onSaved: onCodePreviewSaved,
+                    onClose: onCloseCodePreview
+                )
             }
         } else {
             hostTerminalPanel

--- a/Sources/WorkspaceManager/Views/MainWindow/DirtyNavigationGuard.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DirtyNavigationGuard.swift
@@ -41,4 +41,17 @@ enum DirtyNavigationGuard {
             return .veto
         }
     }
+
+    /// Whether a Save-then-navigate deferred across an async save may still commit its captured
+    /// navigation. It must not if (a) a newer navigation superseded it while the save was in
+    /// flight — detected by the generation token changing — or (b) the document is dirty again
+    /// because the user typed more during the save. Either case would strand the user on the
+    /// wrong file or drop the newer edits.
+    static func shouldCommitDeferredNavigation(
+        capturedGeneration: Int,
+        currentGeneration: Int,
+        hasUnsavedEdits: Bool
+    ) -> Bool {
+        capturedGeneration == currentGeneration && !hasUnsavedEdits
+    }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/DirtyNavigationGuard.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/DirtyNavigationGuard.swift
@@ -1,0 +1,44 @@
+//
+//  DirtyNavigationGuard.swift
+//  WorkspaceManager
+//
+//  Pure decision for the editor's dirty-navigation veto (#704 Phase 4): given whether the open
+//  document has unsaved edits and, when it does, the user's Save / Discard / Cancel choice, it
+//  says whether a navigation intent (opening another file, closing the preview) proceeds, saves
+//  first, or is vetoed. Keeping the decision here — separate from the SwiftUI wiring — makes the
+//  contract testable without a running window.
+//
+
+enum DirtyNavigationChoice: Equatable {
+    case save
+    case discard
+    case cancel
+}
+
+enum DirtyNavigationOutcome: Equatable {
+    /// Perform the navigation now (nothing needed saving, or the user chose Discard).
+    case proceed
+    /// Save the document first; only navigate if the save succeeds.
+    case saveThenProceed
+    /// Veto: leave the current file and selection untouched.
+    case veto
+}
+
+enum DirtyNavigationGuard {
+    /// Whether a navigation intent must pause for a Save / Discard / Cancel prompt.
+    static func requiresPrompt(isDirty: Bool) -> Bool {
+        isDirty
+    }
+
+    /// Outcome once the user has answered the prompt (only meaningful when `requiresPrompt`).
+    static func outcome(for choice: DirtyNavigationChoice) -> DirtyNavigationOutcome {
+        switch choice {
+        case .save:
+            return .saveThenProceed
+        case .discard:
+            return .proceed
+        case .cancel:
+            return .veto
+        }
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/RightPaneView.swift
@@ -353,6 +353,8 @@ struct RightPaneView: View {
                 DiffReviewSheet(
                     filePath: change.path,
                     directoryURL: directoryURL,
+                    status: change.status,
+                    onChanged: { state.refreshRequestID = UUID() },
                     onClose: { reviewDiffTarget = nil }
                 )
             }

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -142,10 +142,64 @@ public actor GitService: GitServiceProtocol {
         _ = try await runGit(["reset", "HEAD", "--", file], at: path)
     }
 
-    /// Discard working-tree changes for `file`, restoring HEAD contents.
-    /// Destructive: unstaged edits are lost without recovery.
+    /// Discard working-tree changes for a tracked `file`, restoring its index/HEAD contents.
+    /// Destructive: unstaged edits are lost without recovery. Untracked files are inert here
+    /// (`git checkout --` ignores them) — use `discardUntracked` for those so a "discard" of a
+    /// new file is never a silent no-op.
     public func discard(file: String, at path: URL) async throws {
         _ = try await runGit(["checkout", "--", file], at: path)
+    }
+
+    /// Remove a single untracked `file`. Destructive and unrecoverable: untracked files are not
+    /// in git history, so this is the only "discard" path that deletes real content. Kept as
+    /// narrow as possible — it deletes exactly the one resolved path via the filesystem (never
+    /// `git clean`, which could sweep siblings), and only after confirming the path stays inside
+    /// `path` and is a regular file rather than a symlink. Callers must confirm-gate it in the UI.
+    public func discardUntracked(file: String, at path: URL) async throws {
+        let lexicalTarget = try Self.lexicalFileURL(rootURL: path, relativePath: file)
+
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: lexicalTarget.path)) == nil
+        else {
+            throw GitError.symlinkRefused
+        }
+
+        // Containment is checked on the symlink-resolved path so an intermediate symlink cannot
+        // escape the root; deletion targets the lexical path git reported.
+        _ = try Self.containedFileURL(rootURL: path, relativePath: file)
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: lexicalTarget.path, isDirectory: &isDirectory),
+            !isDirectory.boolValue
+        else {
+            throw GitError.untrackedTargetMissing(relativePath: file)
+        }
+
+        try FileManager.default.removeItem(at: lexicalTarget)
+    }
+
+    /// Lexical (non-symlink-resolved) URL for `relativePath` under `rootURL`, rejecting absolute
+    /// paths and `.`/`..` traversal components before any filesystem touch.
+    static func lexicalFileURL(rootURL: URL, relativePath: String) throws -> URL {
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        guard !relativePath.isEmpty,
+            !relativePath.hasPrefix("/"),
+            components.allSatisfy({ !$0.isEmpty && $0 != ".." && $0 != "." })
+        else {
+            throw GitError.invalidRelativePath(relativePath)
+        }
+        return rootURL.appendingPathComponent(relativePath).standardizedFileURL
+    }
+
+    /// Symlink-resolved URL for `relativePath`, throwing `pathEscapesRoot` if it lands outside
+    /// the resolved `rootURL`.
+    static func containedFileURL(rootURL: URL, relativePath: String) throws -> URL {
+        let lexicalTarget = try lexicalFileURL(rootURL: rootURL, relativePath: relativePath)
+        let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+        let target = lexicalTarget.resolvingSymlinksInPath()
+        guard target.path == root.path || target.path.hasPrefix(root.path + "/") else {
+            throw GitError.pathEscapesRoot
+        }
+        return target
     }
 
     // MARK: - File Tree
@@ -336,10 +390,14 @@ extension String {
 
 // MARK: - Errors
 
-public enum GitError: LocalizedError {
+public enum GitError: LocalizedError, Equatable {
     case commandFailed(args: [String], stderr: String)
     case notARepository
     case branchAlreadyExists(name: String)
+    case invalidRelativePath(String)
+    case pathEscapesRoot
+    case symlinkRefused
+    case untrackedTargetMissing(relativePath: String)
 
     public var errorDescription: String? {
         switch self {
@@ -349,6 +407,14 @@ public enum GitError: LocalizedError {
             return "Not a git repository"
         case .branchAlreadyExists(let name):
             return "A branch named '\(name)' already exists"
+        case .invalidRelativePath(let path):
+            return "Refused because '\(path)' is not a valid relative file path."
+        case .pathEscapesRoot:
+            return "Refused because the selected path resolves outside the repository root."
+        case .symlinkRefused:
+            return "Refused because the selected file is a symbolic link."
+        case .untrackedTargetMissing(let path):
+            return "There is no untracked file at '\(path)' to delete."
         }
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -5,6 +5,7 @@
 //  Git operations: status, file tree, branch management
 //
 
+import Darwin
 import Foundation
 
 public actor GitService: GitServiceProtocol {
@@ -182,7 +183,57 @@ public actor GitService: GitServiceProtocol {
             throw GitError.discardUntrackedOnTrackedFile(relativePath: file)
         }
 
-        try FileManager.default.removeItem(at: lexicalTarget)
+        // The lexical checks above race a concurrent swap of an intermediate directory to a
+        // symlink (TOCTOU). Delete via an O_NOFOLLOW descriptor walk so the unlink cannot follow a
+        // symlink that appeared after the containment check and escape the root.
+        try Self.raceSafeUnlink(root: path, relativePath: file)
+    }
+
+    /// Unlink `relativePath` under `rootURL` without following a symlink in any path component:
+    /// walks the directories with `O_NOFOLLOW` and unlinks relative to the parent descriptor. A
+    /// concurrent swap of an intermediate directory to a symlink fails the walk instead of
+    /// escaping the root, and the leaf must still be a regular file at unlink time.
+    static func raceSafeUnlink(root: URL, relativePath: String) throws {
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: true).map(
+            String.init)
+        guard let leaf = components.last,
+            components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." })
+        else {
+            throw GitError.invalidRelativePath(relativePath)
+        }
+
+        var directoryFD = root.path.withCString { open($0, O_RDONLY | O_DIRECTORY) }
+        guard directoryFD >= 0 else {
+            throw GitError.untrackedTargetMissing(relativePath: relativePath)
+        }
+        var openFDs = [directoryFD]
+        defer {
+            for fd in openFDs { close(fd) }
+        }
+
+        for component in components.dropLast() {
+            let childFD = component.withCString {
+                openat(directoryFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            }
+            guard childFD >= 0 else {
+                throw GitError.pathEscapesRoot
+            }
+            openFDs.append(childFD)
+            directoryFD = childFD
+        }
+
+        var info = stat()
+        let statResult = leaf.withCString { fstatat(directoryFD, $0, &info, AT_SYMLINK_NOFOLLOW) }
+        guard statResult == 0 else {
+            throw GitError.untrackedTargetMissing(relativePath: relativePath)
+        }
+        guard (info.st_mode & S_IFMT) == S_IFREG else {
+            throw GitError.symlinkRefused
+        }
+
+        guard leaf.withCString({ unlinkat(directoryFD, $0, 0) }) == 0 else {
+            throw GitError.untrackedDeleteFailed(relativePath: relativePath)
+        }
     }
 
     /// Lexical (non-symlink-resolved) URL for `relativePath` under `rootURL`, rejecting absolute
@@ -407,6 +458,7 @@ public enum GitError: LocalizedError, Equatable {
     case symlinkRefused
     case untrackedTargetMissing(relativePath: String)
     case discardUntrackedOnTrackedFile(relativePath: String)
+    case untrackedDeleteFailed(relativePath: String)
 
     public var errorDescription: String? {
         switch self {
@@ -426,6 +478,8 @@ public enum GitError: LocalizedError, Equatable {
             return "There is no untracked file at '\(path)' to delete."
         case .discardUntrackedOnTrackedFile(let path):
             return "Refused to delete '\(path)' because git tracks it; discard its changes instead."
+        case .untrackedDeleteFailed(let path):
+            return "Could not delete the untracked file '\(path)'."
         }
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -174,6 +174,14 @@ public actor GitService: GitServiceProtocol {
             throw GitError.untrackedTargetMissing(relativePath: file)
         }
 
+        // Defense in depth against a stale caller status: confirm git does not track this path
+        // before deleting it. `ls-files --error-unmatch` exits 0 only for a tracked path; a tracked
+        // file must go through `discard` (recoverable) rather than an unrecoverable delete.
+        let tracked = try await runGitResult(["ls-files", "--error-unmatch", "--", file], at: path)
+        guard tracked.exitCode != 0 else {
+            throw GitError.discardUntrackedOnTrackedFile(relativePath: file)
+        }
+
         try FileManager.default.removeItem(at: lexicalTarget)
     }
 
@@ -398,6 +406,7 @@ public enum GitError: LocalizedError, Equatable {
     case pathEscapesRoot
     case symlinkRefused
     case untrackedTargetMissing(relativePath: String)
+    case discardUntrackedOnTrackedFile(relativePath: String)
 
     public var errorDescription: String? {
         switch self {
@@ -415,6 +424,8 @@ public enum GitError: LocalizedError, Equatable {
             return "Refused because the selected file is a symbolic link."
         case .untrackedTargetMissing(let path):
             return "There is no untracked file at '\(path)' to delete."
+        case .discardUntrackedOnTrackedFile(let path):
+            return "Refused to delete '\(path)' because git tracks it; discard its changes instead."
         }
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -94,6 +94,7 @@ public protocol GitServiceProtocol: Sendable {
     func stage(file: String, at path: URL) async throws
     func unstage(file: String, at path: URL) async throws
     func discard(file: String, at path: URL) async throws
+    func discardUntracked(file: String, at path: URL) async throws
     func branches(at path: URL) async throws -> [BranchName]
 }
 

--- a/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
@@ -57,6 +57,52 @@ struct AppCommandStateTests {
         #expect(emissions == 2)
     }
 
+    @Test("document edits state publishes dirty transitions and forwards the save hook")
+    func documentEditsStatePublishesAndSaves() async {
+        let state = AppCommandState()
+        var emissions = 0
+        let cancellable = state.objectWillChange.sink { _ in
+            emissions += 1
+        }
+        defer { cancellable.cancel() }
+
+        #expect(!state.hasUnsavedDocumentEdits)
+
+        var saveCount = 0
+        state.setDocumentEditsState(
+            isDirty: true,
+            save: {
+                saveCount += 1
+                return true
+            })
+        #expect(state.hasUnsavedDocumentEdits)
+        #expect(emissions == 1)
+
+        // Re-registering with the same dirty value re-binds the hook without a redundant emission.
+        state.setDocumentEditsState(
+            isDirty: true,
+            save: {
+                saveCount += 1
+                return true
+            })
+        #expect(emissions == 1)
+
+        let didSave = await state.saveDirtyDocument()
+        #expect(didSave)
+        #expect(saveCount == 1)
+
+        state.clearDocumentEditsState()
+        #expect(!state.hasUnsavedDocumentEdits)
+        #expect(emissions == 2)
+    }
+
+    @Test("saveDirtyDocument reports success when no hook is registered")
+    func saveDirtyDocumentDefaultsToSuccess() async {
+        let state = AppCommandState()
+        let didSave = await state.saveDirtyDocument()
+        #expect(didSave)
+    }
+
     @Test("main window actions only publish when availability changes")
     func mainWindowActionsOnlyPublishWhenAvailabilityChanges() {
         let state = AppCommandState()

--- a/Tests/WorkspaceManagerAppTests/DiffReviewRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DiffReviewRenderTests.swift
@@ -51,4 +51,48 @@ struct DiffReviewRenderTests {
         let url = URL(fileURLWithPath: dir).appendingPathComponent("diff-review.png")
         try png.write(to: url)
     }
+
+    /// Renders the stage / unstage / discard action bar in its tracked and untracked variants
+    /// (the untracked one reads "Delete") to a non-empty image, writing a PNG for PR evidence when
+    /// `WORKSPACES_EVIDENCE_DIR` is set.
+    @Test("Diff review action bar renders tracked and untracked control sets")
+    func rendersActionBar() throws {
+        let view = VStack(spacing: 12) {
+            DiffReviewActionBar(
+                isUntracked: false,
+                isBusy: false,
+                errorMessage: nil,
+                onStage: {},
+                onUnstage: {},
+                onDiscardRequested: {}
+            )
+            DiffReviewActionBar(
+                isUntracked: true,
+                isBusy: false,
+                errorMessage: "Refused because the selected file is a symbolic link.",
+                onStage: {},
+                onUnstage: {},
+                onDiscardRequested: {}
+            )
+        }
+        .frame(width: 460)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("diff-review-action-bar.png")
+        try png.write(to: url)
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/DirtyNavigationGuardTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DirtyNavigationGuardTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+@testable import WorkspaceManager
+
+@Suite("DirtyNavigationGuard")
+struct DirtyNavigationGuardTests {
+    @Test("a clean editor never prompts")
+    func cleanEditorNeverPrompts() {
+        #expect(!DirtyNavigationGuard.requiresPrompt(isDirty: false))
+    }
+
+    @Test("a dirty editor prompts before navigating")
+    func dirtyEditorPrompts() {
+        #expect(DirtyNavigationGuard.requiresPrompt(isDirty: true))
+    }
+
+    @Test("Save saves before proceeding, Discard proceeds, Cancel vetoes")
+    func choiceMapsToOutcome() {
+        #expect(DirtyNavigationGuard.outcome(for: .save) == .saveThenProceed)
+        #expect(DirtyNavigationGuard.outcome(for: .discard) == .proceed)
+        #expect(DirtyNavigationGuard.outcome(for: .cancel) == .veto)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/DirtyNavigationGuardTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DirtyNavigationGuardTests.swift
@@ -20,4 +20,29 @@ struct DirtyNavigationGuardTests {
         #expect(DirtyNavigationGuard.outcome(for: .discard) == .proceed)
         #expect(DirtyNavigationGuard.outcome(for: .cancel) == .veto)
     }
+
+    @Test("a deferred save-then-navigate commits only when nothing superseded it and the doc is clean")
+    func deferredNavigationCommitRules() {
+        // Nothing changed during the save and the document saved clean: commit.
+        #expect(
+            DirtyNavigationGuard.shouldCommitDeferredNavigation(
+                capturedGeneration: 3, currentGeneration: 3, hasUnsavedEdits: false))
+
+        // A newer navigation arrived during the await (generation bumped): do not commit the stale
+        // target — the newer navigation owns the outcome now.
+        #expect(
+            !DirtyNavigationGuard.shouldCommitDeferredNavigation(
+                capturedGeneration: 3, currentGeneration: 4, hasUnsavedEdits: false))
+
+        // The user typed more while the write was in flight, so the document is dirty again: do not
+        // navigate away and drop those edits.
+        #expect(
+            !DirtyNavigationGuard.shouldCommitDeferredNavigation(
+                capturedGeneration: 3, currentGeneration: 3, hasUnsavedEdits: true))
+
+        // Both conditions bad: still no commit.
+        #expect(
+            !DirtyNavigationGuard.shouldCommitDeferredNavigation(
+                capturedGeneration: 3, currentGeneration: 5, hasUnsavedEdits: true))
+    }
 }

--- a/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
+++ b/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
@@ -95,4 +95,68 @@ struct GitServiceDiffTests {
         let diff = try await GitService.shared.diff(file: "a.txt", at: repo.url)
         #expect(diff.hunks.isEmpty)
     }
+
+    @Test("discardUntracked deletes exactly the one untracked file")
+    func discardUntrackedDeletesTargetOnly() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("keep.txt", content: "keep\n")
+        try repo.commit(message: "init")
+        try repo.createFile("scratch.txt", content: "temporary\n")
+        try repo.createFile("sibling.txt", content: "also new\n")
+
+        try await GitService.shared.discardUntracked(file: "scratch.txt", at: repo.url)
+
+        #expect(!FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("scratch.txt").path))
+        #expect(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("sibling.txt").path))
+        #expect(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("keep.txt").path))
+    }
+
+    @Test("discardUntracked refuses a path escaping the root")
+    func discardUntrackedRefusesEscape() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        await #expect(throws: GitError.invalidRelativePath("../outside.txt")) {
+            try await GitService.shared.discardUntracked(file: "../outside.txt", at: repo.url)
+        }
+        await #expect(throws: GitError.invalidRelativePath("/etc/hosts")) {
+            try await GitService.shared.discardUntracked(file: "/etc/hosts", at: repo.url)
+        }
+    }
+
+    @Test("discardUntracked refuses a symlink target")
+    func discardUntrackedRefusesSymlink() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("real-secret.txt", content: "secret\n")
+        try repo.commit(message: "init")
+        let linkURL = repo.url.appendingPathComponent("link.txt")
+        try FileManager.default.createSymbolicLink(
+            at: linkURL,
+            withDestinationURL: repo.url.appendingPathComponent("real-secret.txt")
+        )
+
+        await #expect(throws: GitError.symlinkRefused) {
+            try await GitService.shared.discardUntracked(file: "link.txt", at: repo.url)
+        }
+        // The symlink and its target both survive the refusal.
+        #expect(FileManager.default.fileExists(atPath: linkURL.path))
+        #expect(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("real-secret.txt").path))
+    }
+
+    @Test("discardUntracked reports a missing target instead of failing silently")
+    func discardUntrackedReportsMissingTarget() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("a.txt", content: "x\n")
+        try repo.commit(message: "init")
+
+        await #expect(throws: GitError.untrackedTargetMissing(relativePath: "ghost.txt")) {
+            try await GitService.shared.discardUntracked(file: "ghost.txt", at: repo.url)
+        }
+    }
 }

--- a/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
+++ b/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
@@ -147,6 +147,21 @@ struct GitServiceDiffTests {
         #expect(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("real-secret.txt").path))
     }
 
+    @Test("discardUntracked refuses to delete a tracked file even if asked")
+    func discardUntrackedRefusesTrackedFile() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+
+        try repo.createFile("tracked.txt", content: "committed\n")
+        try repo.commit(message: "init")
+
+        await #expect(throws: GitError.discardUntrackedOnTrackedFile(relativePath: "tracked.txt")) {
+            try await GitService.shared.discardUntracked(file: "tracked.txt", at: repo.url)
+        }
+        // The tracked file is untouched — the delete is refused at the service layer.
+        #expect(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("tracked.txt").path))
+    }
+
     @Test("discardUntracked reports a missing target instead of failing silently")
     func discardUntrackedReportsMissingTarget() async throws {
         let repo = try TestGitRepository.create()

--- a/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
+++ b/Tests/WorkspaceManagerTests/GitServiceDiffTests.swift
@@ -147,6 +147,29 @@ struct GitServiceDiffTests {
         #expect(FileManager.default.fileExists(atPath: repo.url.appendingPathComponent("real-secret.txt").path))
     }
 
+    @Test("discardUntracked refuses a path reaching outside the root through a symlinked directory")
+    func discardUntrackedRefusesSymlinkedParentEscape() async throws {
+        let repo = try TestGitRepository.create()
+        defer { repo.cleanup() }
+        try repo.createFile("keep.txt", content: "keep\n")
+        try repo.commit(message: "init")
+
+        // A victim file living outside the repo, reachable only through an in-repo directory symlink.
+        let outsideDir = repo.url.deletingLastPathComponent()
+            .appendingPathComponent("outside-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outsideDir) }
+        let victim = outsideDir.appendingPathComponent("victim.txt")
+        try "precious\n".write(to: victim, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: repo.url.appendingPathComponent("link-dir"), withDestinationURL: outsideDir)
+
+        await #expect(throws: GitError.pathEscapesRoot) {
+            try await GitService.shared.discardUntracked(file: "link-dir/victim.txt", at: repo.url)
+        }
+        #expect(FileManager.default.fileExists(atPath: victim.path), "the outside file must survive")
+    }
+
     @Test("discardUntracked refuses to delete a tracked file even if asked")
     func discardUntrackedRefusesTrackedFile() async throws {
         let repo = try TestGitRepository.create()

--- a/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
@@ -68,6 +68,8 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     var stageCalls: [(file: String, path: URL)] = []
     var unstageCalls: [(file: String, path: URL)] = []
     var discardCalls: [(file: String, path: URL)] = []
+    var discardUntrackedCalls: [(file: String, path: URL)] = []
+    var discardUntrackedError: Error? = nil
 
     func diff(file: String, at path: URL) async throws -> UnifiedDiff {
         diffResult
@@ -83,6 +85,13 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
 
     func discard(file: String, at path: URL) async throws {
         discardCalls.append((file: file, path: path))
+    }
+
+    func discardUntracked(file: String, at path: URL) async throws {
+        discardUntrackedCalls.append((file: file, path: path))
+        if let error = discardUntrackedError {
+            throw error
+        }
     }
 
     // MARK: - Branches (M8 prep)


### PR DESCRIPTION
Native diff-review actions and the editor's dirty-navigation veto — the open half of #704 (Phase 3 slice 2 + Phase 4 slice 3). Builds on the merged native diff render (PR #894, slice 1). Refs #704 (issue stays open for the deferred repo/workspace-switch veto).

## What shipped

**Stage / unstage / discard on the diff review surface (slice 2).** `DiffReviewSheet` — the shared review surface used from both the Changes tab and a just-saved editor buffer — now hosts a `DiffReviewActionBar` with Stage, Unstage, and Discard. Each calls the existing `GitService` primitives and then reloads the diff and refreshes the caller's Changes list (the Changes tab bumps its refresh token; the editor routes through its existing post-save refresh).

Discard is confirm-gated with a native dialog naming the file, and its wording and routing branch on tracked vs untracked:
- **Tracked** files route to the existing `git checkout -- <file>` (restores index/HEAD contents).
- **Untracked** files route to a new, narrowly-scoped `GitService.discardUntracked(file:at:)` that deletes **exactly one** resolved path via the filesystem — never `git clean` — and only after confirming the path stays inside the repo root and is a regular file, not a symlink. The confirmation reads "Delete file … — permanent, not recoverable." A discard of a new file is therefore never a silent no-op (the old behavior, since `git checkout --` ignores untracked paths) and never a broad sweep.

**Dirty-navigation veto for the editor (slice 3).** Navigating away from a file with unsaved edits now pauses for a native Save / Discard / Cancel prompt; **Cancel truly vetoes** (selection untouched), and Save awaits the write and only proceeds if it succeeds. Wired at the two navigation intents the editor owns cleanly:
- **File switch** (opening a different file from Files/Changes).
- **Explicit preview close** (the editor's Close button / terminal-only toggle).

The decision itself is a pure `DirtyNavigationGuard`; dirty state and the awaiting-save hook flow up through `AppCommandState` (`hasUnsavedDocumentEdits` + `saveDirtyDocument()`), which already bridged the editor and the window chrome for the Save command.

## Explicitly deferred

- **Veto on destination switches (repo / workspace / web source).** Two families clear the preview without the prompt: the removal flows (`handleSelectedWorkspaceRemoval`, `handleSelectedRepoRemoval`, `clearSelectionForHostTerminalSurface`) that mutate sibling selection before tearing down the preview, and every `applyNavigationDestination` switch (repo overview/terminal, workspace terminal, web-source selection) whose callers run side effects before the transition applies. Guarding them cleanly needs those callers reordered so Cancel can veto without stranding half-applied state — a focused follow-up now that the pure guard + `AppCommandState` channel exist. Left unguarded and documented in code; noted on the issue.
- **Per-hunk staging.** Out of scope; file-level only, as briefed.

## Review loop

Self-reflection then a directed codex pass (gpt-5.5, xhigh) over the full diff, aimed at the destructive delete, the discard routing, and the async save-then-navigate flow.

Reflection fixes (commit `83ab4cf6`): hardened `discardUntracked` to refuse a tracked path at the service layer (`ls-files --error-unmatch`) so a stale UI status can't route a tracked file into delete; removed a redundant pending-navigation clear that could clobber a second dialog raised mid-await.

Codex findings and disposition (commit `e8fdcf27`):
- **Blocker — TOCTOU in `discardUntracked`.** Containment was checked on the resolved path but the unlink used the lexical path; a concurrent swap of an intermediate directory to a symlink could delete outside the repo (codex proved the primitive). **Fixed:** race-free `O_NOFOLLOW` descriptor walk (`raceSafeUnlink`) that unlinks relative to the parent fd and rejects a symlink in any component or a non-regular leaf; added a symlinked-parent escape test.
- **Blocker — concurrent-edit loss in save-then-navigate.** Committing on the save's `true` return dropped edits typed while the async write was in flight. **Fixed:** the resolver re-checks the live `hasUnsavedDocumentEdits` after the await and only proceeds when the document is actually clean.
- **Blocker — web-source selection bypasses the veto.** **Adjudicated as deferred (not fixed).** It clears the preview through `applyNavigationDestination`, the same chokepoint all destination switches share and whose callers run side effects before teardown — exactly the already-approved repo/workspace-switch deferral class. Broadened the deferral scope below rather than expand this PR into the full navigation-veto refactor.
- **Minor — stale `resolvedStatus` after Stage.** **Fixed:** `DiffReviewSheet.load()` now always re-resolves status from git.

"What looks sound" per codex: the `ls-files` tracked-delete guard, lexical `..`/absolute + final-symlink refusal, save-failure-does-not-navigate, `GitError: Equatable`, and the `confirmationDialog` binding pair.

Second codex pass (team-lead's independent gpt-5.5/xhigh run) reconfirmed the same three areas. Its blocker (discardUntracked TOCTOU) and stale-status major were already closed above (the `O_NOFOLLOW` walk is the full-correctness approach it recommended; the `ls-files` guard is the currently-untracked verification it asked for). Its remaining major sharpened the save-then-navigate fix (commit `7d49c7e5`): the live-dirty re-check alone didn't cover a *second navigation* arriving during the await, which would commit a stale target. Added a monotonic generation token bumped on every new pending navigation; the deferred Save commits only when the token is unchanged and the document is clean, extracted as the pure `DirtyNavigationGuard.shouldCommitDeferredNavigation` with test coverage.

## Evidence

- [Build + lint + 1194 tests passing (post codex-review)](https://evidence.cloudcompute.com/workspaces/pr-924/20260708-041455-704-test-summary-v2.png)
- Diff-review action bar, tracked + untracked states (ImageRenderer):

![action bar](https://evidence.cloudcompute.com/workspaces/pr-924/20260707-180825-704-action-bar.png)

## Merge gate — destructive-path live validation (Michael)

The destructive discard/untracked-delete and the dirty-nav veto are UI-interaction surfaces; they carry `GitService` integration tests, a pure guard-model test, and a render test, but the click-through is merge-gated on live validation. Checklist to run in the debug app:

1. Changes tab → open a modified file's diff → **Stage**; confirm it leaves the unstaged diff and the Changes list refreshes.
2. **Unstage** the same file; confirm the diff/entry returns.
3. **Discard** a tracked modified file → confirm dialog → confirm; file restored to committed contents, no unrelated diff noise.
4. Create a new (untracked) file → open its diff → **Delete** → confirm dialog reads "permanent, not recoverable" → confirm; only that file is gone, siblings untouched.
5. Edit a file (dirty), then trigger each navigation with each choice:
   - File switch → **Cancel** vetoes (stays on the file); **Save** writes then switches; **Discard** switches abandoning edits.
   - Close preview → same three outcomes.
6. Confirm `Cmd+B` / `Cmd+D` / terminal input still route correctly after the editor and dialog have had focus.

## Mergeability

- **Surface:** macOS app — native diff review surface (`DiffReviewSheet`) and the code editor (`CodeFilePreviewView` / `ContentView` navigation), plus `GitService` in Core.
- **User-facing behavior changed:** Stage/Unstage/Discard controls appear on the diff review surface; discarding a file now confirms first and, for untracked files, deletes the file (previously a silent no-op). Leaving a file with unsaved edits now prompts Save/Discard/Cancel instead of dropping edits silently.
- **Non-happy paths considered:** untracked discard refuses paths escaping the repo root, refuses symlink targets, and reports a missing target instead of failing silently (all tested); dirty-nav Cancel vetoes without changing selection; Save proceeds only when the write succeeds; action errors surface inline in the sheet without dismissing it.
- **Release/ops preconditions:** none — no new entitlements, config, or migrations. Existing `GitService` primitives; one additive protocol method.
- **Residual risk or follow-up:** the veto covers file-switch and explicit preview-close; **all destination switches routed through `applyNavigationDestination`** — repo overview/terminal, workspace terminal, and web-source selection — still abandon unsaved edits without a prompt (codex escalated the web-source case; it shares the chokepoint with the already-approved repo/workspace deferral, whose callers run side effects before teardown). Deferred to a follow-up that guards that single chokepoint after reordering its callers. The destructive discard/delete and the veto interaction are merge-gated on the live-validation checklist above; automated coverage is at the `GitService`/model/render layer, not the click-through.
