### PR TITLE
fix(ci): cross-compile the GhosttyKit slice when Xcode Cloud's zig is wrong-arch

### DIFF
--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -226,22 +226,28 @@ carries the Darwin linker patch needed on Tahoe hosts, so
 - `GHOSTTY_ZIG_BIN`, if set
 - `/opt/homebrew/opt/zig@0.15/bin/zig`, if installed and its architecture
   matches the host (`uname -m`)
-- `$(brew --prefix zig@0.15)/bin/zig`, if installed and matching — covers
-  Xcode Cloud macOS images that run Homebrew from `/usr/local` instead of the
-  standard Apple Silicon `/opt/homebrew` prefix
-- otherwise, on an arm64 host with any `brew` on `PATH`: bootstrap (or reuse)
-  a native Homebrew at `/opt/homebrew` and install `zig@0.15` there. Confirmed
-  on one Xcode Cloud macOS image whose only available `zig@0.15` bottle was
-  itself Rosetta-translated x86_64 even though the host reports arm64 —
-  Ghostty's `build.zig` resolves `-Dxcframework-target=native` via the zig
-  compiler binary's own baked-in architecture, not the actual host CPU, so a
-  wrong-arch zig here silently produces a GhosttyKit slice that doesn't match
-  the app's arm64 build target. That doesn't fail the framework build; it
-  surfaces later as `error: no such module 'GhosttyKit'` during `swift build`,
-  which is a confusing place to debug an architecture mismatch. Vanilla
-  upstream zig is not a viable substitute for this fallback (see the linker
-  bug above), so this is a real Homebrew bootstrap, not a tarball download.
+- `$(brew --prefix zig@0.15)/bin/zig`, matching or not — covers Xcode Cloud
+  macOS images that run Homebrew from `/usr/local` instead of the standard
+  Apple Silicon `/opt/homebrew` prefix
 - `mise exec zig@0.15.2` as a final fallback
+
+A wrong-arch Homebrew zig (or `GHOSTTY_ZIG_BIN`) is accepted and asked to
+cross-compile. Confirmed on one Xcode Cloud macOS image whose only available
+`zig@0.15` bottle was itself Rosetta-translated x86_64 even though the host
+reports arm64 — Ghostty's `build.zig` resolves `-Dxcframework-target=native`
+via the zig compiler binary's own baked-in architecture, not the actual host
+CPU, so a wrong-arch zig silently produces a GhosttyKit slice that doesn't
+match the app's arm64 build target. That doesn't fail the framework build; it
+surfaces later as `error: no such module 'GhosttyKit'` during `swift build`,
+which is a confusing place to debug an architecture mismatch. When the script
+detects the mismatch it patches the pinned checkout's
+`src/build/GhosttyXCFramework.zig` (one token: the native slice's
+`Config.genericMacOSTarget(b, null)` becomes `.aarch64`/`.x86_64` for the real
+host arch) so zig cross-compiles the correct slice, and a post-build assertion
+fails loudly if the produced slice still doesn't contain the host arch. The
+two tempting alternatives are both dead on that image: vanilla upstream zig
+hits the linker bug above, and bootstrapping a native `/opt/homebrew` needs
+sudo the Xcode Cloud user does not have (confirmed via build 574's log).
 
 `GHOSTTY_ARCH_DIAGNOSTICS` (default on) reports the resolved zig binary's
 `file` output and the built xcframework's `Info.plist` slice list, so a

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -28,8 +28,8 @@ set -euo pipefail
 #                     info). Defaults to 1. Added to chase down a "no such
 #                     module 'GhosttyKit'" failure that turned out to be a
 #                     Rosetta/x86_64 zig producing a slice that doesn't match
-#                     an arm64 build target; see resolve_zig_runner() below
-#                     for the fix, kept on to catch a regression.
+#                     an arm64 build target; see prepare_slice_arch_patch()
+#                     below for the fix, kept on to catch a regression.
 # -----------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -81,34 +81,60 @@ zig_binary_matches_host_arch() {
 
 # Confirmed on an Xcode Cloud macOS image: its only available zig@0.15 bottle
 # was Rosetta-translated x86_64 even though the host (and its own `uname -m`)
-# is arm64. Upstream ziglang.org's official arm64 build is not a substitute —
-# it fails to link its own build runner against this repo's supported Xcode
-# SDKs with "undefined symbol: __availability_version_check" and a long list
-# of missing libSystem symbols (confirmed locally against Xcode 26.4.1); only
-# Homebrew's zig@0.15 formula carries the Darwin linker patch this needs. So
-# when the available zig is wrong-arch, bootstrap a real native Homebrew at
-# the standard Apple Silicon prefix instead, and get a correctly-arched
-# zig@0.15 bottle from it.
-bootstrap_arm64_homebrew_zig() {
-  echo "warning: resolved zig@0.15 does not match host arch ($(uname -m)); bootstrapping a native Homebrew at $ARM64_HOMEBREW_PREFIX to get a correctly-arched build" >&2
+# is arm64. Neither replacement compiler works there: upstream ziglang.org's
+# arm64 build fails to link its own build runner against this repo's supported
+# Xcode SDKs ("undefined symbol: __availability_version_check" plus missing
+# libSystem symbols; only Homebrew's zig@0.15 formula carries the needed
+# Darwin linker patch), and bootstrapping a native /opt/homebrew needs sudo
+# the Xcode Cloud user does not have (confirmed via build 574's log). So a
+# wrong-arch Homebrew zig is accepted and asked to CROSS-COMPILE the host-arch
+# slice: Ghostty's native xcframework slice hardcodes the zig compiler
+# binary's own arch (`Config.genericMacOSTarget(b, null)`), so the pinned
+# checkout gets a one-token patch replacing that `null` with the real host
+# arch. zig is a native cross-compiler; the compiler binary's arch stops
+# mattering once the slice target is explicit.
+NEEDS_SLICE_ARCH_PATCH=0
+SLICE_ARCH_PATCH_FILE="src/build/GhosttyXCFramework.zig"
 
-  if [[ ! -x "$ARM64_HOMEBREW_PREFIX/bin/brew" ]]; then
-    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+host_zig_cpu_arch() {
+  case "$(uname -m)" in
+    arm64 | aarch64) echo "aarch64" ;;
+    x86_64) echo "x86_64" ;;
+    *) die "unsupported host architecture for GhosttyKit: $(uname -m)" ;;
+  esac
+}
+
+prepare_slice_arch_patch() {
+  if [[ -n "$EXPLICIT_GHOSTTY_DIR" ]]; then
+    if [[ "$NEEDS_SLICE_ARCH_PATCH" == "1" ]]; then
+      die "resolved zig does not match host arch and GHOSTTY_DIR is set; refusing to patch a user-managed checkout. Provide a host-arch zig via GHOSTTY_ZIG_BIN or unset GHOSTTY_DIR."
+    fi
+    return
   fi
 
-  if [[ ! -x "$ARM64_HOMEBREW_PREFIX/bin/brew" ]]; then
-    die "expected a native Homebrew at $ARM64_HOMEBREW_PREFIX/bin/brew after bootstrap but it is missing"
+  # Reset unconditionally so a patch from a previous run never leaks into an
+  # arch-matched build via the cached checkout.
+  git -C "$GHOSTTY_DIR" checkout -- "$SLICE_ARCH_PATCH_FILE"
+
+  if [[ "$NEEDS_SLICE_ARCH_PATCH" != "1" ]]; then
+    return
   fi
 
-  "$ARM64_HOMEBREW_PREFIX/bin/brew" install zig@0.15
+  local arch
+  arch="$(host_zig_cpu_arch)"
+  local patch_path="$GHOSTTY_DIR/$SLICE_ARCH_PATCH_FILE"
 
-  if [[ ! -x "$HOMEBREW_ZIG_BIN" ]]; then
-    die "bootstrapped Homebrew at $ARM64_HOMEBREW_PREFIX but zig@0.15 is still missing at $HOMEBREW_ZIG_BIN"
+  if ! grep -q 'Config\.genericMacOSTarget(b, null)' "$patch_path"; then
+    die "expected 'Config.genericMacOSTarget(b, null)' in $SLICE_ARCH_PATCH_FILE at pinned commit $GHOSTTY_COMMIT; the pin changed — re-verify the slice-arch patch"
   fi
 
-  if ! zig_binary_matches_host_arch "$HOMEBREW_ZIG_BIN"; then
-    die "bootstrapped a native Homebrew at $ARM64_HOMEBREW_PREFIX but its zig@0.15 still does not match host arch ($(uname -m))"
+  sed -i '' "s/Config\.genericMacOSTarget(b, null)/Config.genericMacOSTarget(b, .$arch)/" "$patch_path"
+
+  if ! grep -q "Config\.genericMacOSTarget(b, \.$arch)" "$patch_path"; then
+    die "failed to patch $SLICE_ARCH_PATCH_FILE for host arch .$arch"
   fi
+
+  echo "warning: resolved zig does not match host arch ($(uname -m)); patched $SLICE_ARCH_PATCH_FILE to cross-compile the native slice for .$arch" >&2
 }
 
 resolve_zig_runner() {
@@ -117,6 +143,9 @@ resolve_zig_runner() {
       die "GHOSTTY_ZIG_BIN is set but is not executable: $EXPLICIT_ZIG_BIN"
     fi
 
+    if ! zig_binary_matches_host_arch "$EXPLICIT_ZIG_BIN"; then
+      NEEDS_SLICE_ARCH_PATCH=1
+    fi
     ZIG_RUNNER=("$EXPLICIT_ZIG_BIN")
     return
   fi
@@ -130,19 +159,18 @@ resolve_zig_runner() {
   # standard Apple Silicon /opt/homebrew prefix. Only used as a fallback here
   # so a host with a real /opt/homebrew zig@0.15 (checked above) never gets
   # overridden by a different-prefix (and potentially different-arch) one.
+  # A wrong-arch brew zig is still usable — it cross-compiles the host-arch
+  # slice via the pinned-source patch (see prepare_slice_arch_patch).
   if command -v brew >/dev/null 2>&1; then
     local brew_zig_prefix
     brew_zig_prefix="$(brew --prefix zig@0.15 2>/dev/null || true)"
-    if [[ -n "$brew_zig_prefix" && -x "$brew_zig_prefix/bin/zig" ]] && zig_binary_matches_host_arch "$brew_zig_prefix/bin/zig"; then
+    if [[ -n "$brew_zig_prefix" && -x "$brew_zig_prefix/bin/zig" ]]; then
+      if ! zig_binary_matches_host_arch "$brew_zig_prefix/bin/zig"; then
+        NEEDS_SLICE_ARCH_PATCH=1
+      fi
       ZIG_RUNNER=("$brew_zig_prefix/bin/zig")
       return
     fi
-  fi
-
-  if [[ "$(uname -m)" == "arm64" ]] && command -v brew >/dev/null 2>&1; then
-    bootstrap_arm64_homebrew_zig
-    ZIG_RUNNER=("$HOMEBREW_ZIG_BIN")
-    return
   fi
 
   if command -v mise >/dev/null 2>&1; then
@@ -228,6 +256,11 @@ repair_ghostty_archive_if_needed() {
   local index=0
   local source_archive
   while IFS= read -r source_archive; do
+    # Fat archives (lipo products, e.g. from a universal-mode build sharing
+    # this cache) are not ar-extractable; only thin archives carry objects.
+    if lipo -info "$source_archive" 2>/dev/null | grep -q '^Architectures in the fat file'; then
+      continue
+    fi
     local archive_dir="$tmp_dir/objects/$index"
     mkdir -p "$archive_dir"
     (
@@ -261,6 +294,27 @@ postprocess_xcframework() {
     repair_ghostty_archive_if_needed "$archive"
     xcrun strip -S -x "$archive"
   done < <(find "$framework_dir" -type f -name "libghostty-fat.a")
+}
+
+# The failure mode this whole arch dance guards against is a silently
+# wrong-arch slice that only surfaces later as "no such module 'GhosttyKit'"
+# at Swift compile time. Fail here, loudly, instead.
+assert_host_arch_slice() {
+  local framework_dir="$1"
+  local host_arch
+  host_arch="$(uname -m)"
+
+  local archive found=0
+  while IFS= read -r archive; do
+    found=1
+    if ! lipo -info "$archive" 2>/dev/null | grep -q "$host_arch"; then
+      die "built GhosttyKit slice does not contain host arch $host_arch: $(lipo -info "$archive" 2>&1)"
+    fi
+  done < <(find "$framework_dir" -type f -name "libghostty-fat.a" 2>/dev/null)
+
+  if [[ "$found" == "0" ]]; then
+    die "no libghostty-fat.a found in $framework_dir to verify architecture"
+  fi
 }
 
 log_arch_diagnostics() {
@@ -387,6 +441,7 @@ main() {
   resolve_ghostty_dir
   ensure_ghostty_checkout
   ensure_pinned_commit
+  prepare_slice_arch_patch
   build_ghostty_xcframework
 
   local xcframework_src
@@ -397,6 +452,7 @@ main() {
   install_xcframework "$xcframework_src"
   postprocess_xcframework "$OUT_DIR/GhosttyKit.xcframework"
   log_arch_diagnostics "$OUT_DIR/GhosttyKit.xcframework"
+  assert_host_arch_slice "$OUT_DIR/GhosttyKit.xcframework"
   echo "Built GhosttyKit.xcframework -> $OUT_DIR/GhosttyKit.xcframework"
 }
 

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -109,6 +109,13 @@ prepare_slice_arch_patch() {
     if [[ "$NEEDS_SLICE_ARCH_PATCH" == "1" ]]; then
       die "resolved zig does not match host arch and GHOSTTY_DIR is set; refusing to patch a user-managed checkout. Provide a host-arch zig via GHOSTTY_ZIG_BIN or unset GHOSTTY_DIR."
     fi
+
+    # A user-managed checkout is never mutated, so a leftover slice-arch patch
+    # (e.g. GHOSTTY_DIR pointing at this script's own cache dir after a killed
+    # patched run) must fail loudly instead of silently retargeting the slice.
+    if [[ -n "$(git -C "$GHOSTTY_DIR" status --porcelain -- "$SLICE_ARCH_PATCH_FILE")" ]]; then
+      die "GHOSTTY_DIR has local modifications to $SLICE_ARCH_PATCH_FILE; reset it (git -C \"$GHOSTTY_DIR\" checkout -- $SLICE_ARCH_PATCH_FILE) or unset GHOSTTY_DIR"
+    fi
     return
   fi
 
@@ -315,6 +322,15 @@ assert_host_arch_slice() {
   if [[ "$found" == "0" ]]; then
     die "no libghostty-fat.a found in $framework_dir to verify architecture"
   fi
+
+  # SwiftPM selects the slice from Info.plist metadata, not the archive, so a
+  # repaired archive with the right objects can still hide a wrong-arch slice
+  # declaration. The exact-quoted match ("arm64") does not false-positive on
+  # LibraryIdentifier values like "macos-arm64".
+  local info_plist="$framework_dir/Info.plist"
+  if ! plutil -p "$info_plist" 2>/dev/null | grep -q "\"$host_arch\""; then
+    die "xcframework Info.plist does not declare a slice supporting host arch $host_arch: $info_plist"
+  fi
 }
 
 log_arch_diagnostics() {
@@ -387,6 +403,10 @@ ensure_pinned_commit() {
   fi
 
   if [[ "$current_commit" != "$GHOSTTY_COMMIT" ]]; then
+    # A slice-arch patch left behind by a killed run would make the detach
+    # below refuse to overwrite local changes; drop it first (best-effort —
+    # the file may not exist at the old commit).
+    git -C "$GHOSTTY_DIR" checkout -- "$SLICE_ARCH_PATCH_FILE" 2>/dev/null || true
     # Ghostty's `tip` tag moves; force tag updates so it does not block pinned commits.
     git -C "$GHOSTTY_DIR" fetch --force --tags origin
     git -C "$GHOSTTY_DIR" checkout --detach "$GHOSTTY_COMMIT"


### PR DESCRIPTION
## Problem

Xcode Cloud build 574 (commit 9b57a02a, first build with #907's Homebrew bootstrap) failed in `ci_post_clone.sh`. The real log — fetched via the App Store Connect API — shows the bootstrap is a dead end on this VM image:

```
==> Checking for `sudo` access (which may request your password)...
Need sudo access on macOS (e.g. the user local needs to be an Administrator)!
```

The CI user has no sudo, so a native `/opt/homebrew` can never exist there. The underlying problem is unchanged: the image's only `zig@0.15` is a Rosetta-translated x86_64 bottle, and Ghostty's `-Dxcframework-target=native` resolves the slice arch from the zig **compiler binary's** baked-in arch, silently producing an x86_64-only GhosttyKit on an arm64 host.

## Fix

Accept the wrong-arch zig and make it **cross-compile**:

- When the resolved zig doesn't match `uname -m`, patch the pinned checkout's `src/build/GhosttyXCFramework.zig` (one token: the native slice's `Config.genericMacOSTarget(b, null)` → `.aarch64`/`.x86_64` for the real host arch). zig is a native cross-compiler; the compiler binary's arch stops mattering once the slice target is explicit.
- Reset the patch file unconditionally before each auto-clone build (no stale-patch leakage), and refuse to mutate a user-managed `GHOSTTY_DIR`.
- Add `assert_host_arch_slice`: post-build, both the archive (`lipo`) and the xcframework `Info.plist` must declare a host-arch slice — the original sin of this saga was a wrong slice surfacing three stages later as `no such module 'GhosttyKit'`; now it fails loudly at the build step.
- Skip fat archives in the `ghostty_init` repair sweep — a stale universal-mode lipo product in the shared zig cache is not `ar`-extractable and killed the script mid-repair.

The two shortcut alternatives remain ruled out with evidence: `-Dxcframework-target=universal` hits a real `ar`-on-fat-file packaging bug at this pin, and vanilla upstream zig can't link its own build runner against Xcode 26.4+ SDKs (only Homebrew's formula carries the Darwin linker patch).

## Evidence

![zig-cross-compile-proof](https://evidence.cloudcompute.com/workspaces/pr-925/20260707-181349-zig-cross-compile-proof.png)

1. Build 574 log excerpt (root cause: sudo).
2. Cross-arch proof: local arm64 zig + `.x86_64` patch → pure `macos-x86_64` slice at the pinned commit (mirror direction of what the VM will do).
3. Forced-mismatch end-to-end: full script with `file` stubbed to report the zig binary as x86_64 → patches to `.aarch64`, builds, repairs, asserts, exit 0.
4. `scripts/tests/test_security_hardening.py`: 29/29 OK.

Residual risk: the exact CI direction (x86_64 zig under Rosetta emitting an arm64 slice) can't be reproduced locally; the mirror direction is verified. If it fails, the new assertion makes it fail loudly in `ci_post_clone` with arch diagnostics in the log, and the ASC log-fetch workflow (branch `ci/xcode-cloud-logs`) retrieves the evidence without a manual round-trip.

## Review loop

Reflected, then codex (gpt-5.5, xhigh) reviewed commit 6c73f5bc. Three findings, all accepted and fixed in 20c64a71:

1. Pin-bump vs dirty checkout: a killed patched run would wedge `ensure_pinned_commit`'s detach → reset the patch file before the detach.
2. Explicit `GHOSTTY_DIR` skipped stale-patch validation → die loudly when the slice-arch file has local modifications.
3. `assert_host_arch_slice` only checked the archive, but SwiftPM selects slices from `Info.plist` → assert the plist too.

## Mergeability

- **User-facing behavior changed**: None — CI build script + doc only; no product code or UI.
- **Non-happy paths considered**: no-sudo VM (removes the installer path entirely); stale patch across pin bumps and killed runs (reset before detach + before each build); user-managed GHOSTTY_DIR (never mutated, dies loudly if dirty); wrong slice still produced (lipo + Info.plist assertions fail the build at ci_post_clone with diagnostics on); fat archives polluting the repair sweep (skipped).
- **Residual risk or follow-up**: the exact CI direction (x86_64 zig under Rosetta → arm64 slice) is only verifiable on Xcode Cloud itself; mirror direction proven locally. If the post-merge build fails, the assertion fails loudly and the ci/xcode-cloud-logs workflow fetches the real log without a manual round-trip.

- Scope: `scripts/build-ghosttykit.sh` + its doc section only; no product code.
- Tests: hardening suite 29/29; end-to-end script runs above.
- Ops: failure modes now die loudly at the earliest stage with diagnostics on; no new network or privileged operations (removes the sudo-requiring installer path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


