### PR TITLE
feat(automation): bounded web-surface snapshot route (#679)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -68,6 +68,10 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             tileTreeStore: tileTreeStore,
             webSurfaceRecords: webSurfaceRecords
         )
+        let webSnapshot = Self.makeWebSnapshot(
+            tileTreeStore: tileTreeStore,
+            webSurfaceRecords: webSurfaceRecords
+        )
 
         if let startTask {
             let socketPath = try await startTask.value
@@ -75,7 +79,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 tileTreeStore: tileTreeStore,
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal,
-                webSurfaces: webSurfaces
+                webSurfaces: webSurfaces,
+                webSnapshot: webSnapshot
             )
             return socketPath
         }
@@ -85,7 +90,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 tileTreeStore: tileTreeStore,
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal,
-                webSurfaces: webSurfaces
+                webSurfaces: webSurfaces,
+                webSnapshot: webSnapshot
             )
             guard let socketPath else {
                 throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
@@ -98,7 +104,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             tileTreeStore: tileTreeStore,
             focusTerminal: focusTerminal,
             requestCloseTerminal: requestCloseTerminal,
-            webSurfaces: webSurfaces
+            webSurfaces: webSurfaces,
+            webSnapshot: webSnapshot
         )
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
@@ -154,6 +161,24 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                     tileTreeStore?.surfaceStore.liveWebState(forSourceID: sourceID)
                 }
             )
+        }
+    }
+
+    /// Resolves a snapshot request against the caller's live source records and the surface
+    /// store's live `WKWebView` (both non-creating), then captures on the MainActor. Fails
+    /// closed: an unknown id or a source without an instantiated view never spins up a page.
+    private static func makeWebSnapshot(
+        tileTreeStore: TileTreeStore,
+        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord]
+    ) -> @MainActor (UUID) async -> WebSnapshotOutcome {
+        { [weak tileTreeStore] sourceID in
+            guard webSurfaceRecords().contains(where: { $0.sourceID == sourceID }) else {
+                return .unknownSource
+            }
+            guard let webView = tileTreeStore?.surfaceStore.liveWebView(forSourceID: sourceID) else {
+                return .notLive
+            }
+            return await WebSurfaceSnapshotCapture.capture(webView)
         }
     }
 

--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -1,4 +1,5 @@
 import AppKit
+import WebKit
 import WorkspaceManagerCore
 
 /// Owns the live `Surface` for each `TileID` in a tile tree: a `[TileID: any Surface]` map plus a
@@ -205,6 +206,14 @@ final class SurfaceStore {
     /// instantiates a store, so listing web surfaces can't spin up hidden WKWebViews.
     func liveWebState(forSourceID sourceID: UUID) -> WebSurfaceLiveState? {
         webStoresBySourceID[sourceID]?.liveState
+    }
+
+    /// The live `WKWebView` backing `sourceID`, or `nil` when none is instantiated. The
+    /// non-creating peek the Automation API's browser-read snapshot resolves through: like
+    /// `liveWebState(forSourceID:)` it never spins up a store, so snapshotting a released
+    /// surface fails closed instead of loading a hidden page.
+    func liveWebView(forSourceID sourceID: UUID) -> WKWebView? {
+        webStoresBySourceID[sourceID]?.liveWebView
     }
 
     /// Get-or-create the shared per-source store backing `sourceID`'s web views.

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -9,6 +9,7 @@ final class AutomationController: AutomationControlling {
     private var requestCloseTerminal: @MainActor (UUID) -> Void
     private let isInputWriteEnabled: @MainActor () -> Bool
     private var webSurfaces: @MainActor () -> [AutomationWebSurfaceDescriptor]
+    private var webSnapshot: @MainActor (UUID) async -> WebSnapshotOutcome
 
     init(
         handleRegistry: AutomationHandleRegistry,
@@ -16,6 +17,7 @@ final class AutomationController: AutomationControlling {
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
         webSurfaces: @escaping @MainActor () -> [AutomationWebSurfaceDescriptor] = { [] },
+        webSnapshot: @escaping @MainActor (UUID) async -> WebSnapshotOutcome = { _ in .unknownSource },
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
         }
@@ -25,6 +27,7 @@ final class AutomationController: AutomationControlling {
         self.focusTerminal = focusTerminal
         self.requestCloseTerminal = requestCloseTerminal
         self.webSurfaces = webSurfaces
+        self.webSnapshot = webSnapshot
         self.isInputWriteEnabled = isInputWriteEnabled
     }
 
@@ -32,13 +35,17 @@ final class AutomationController: AutomationControlling {
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
-        webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil
+        webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil,
+        webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil
     ) {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
         self.requestCloseTerminal = requestCloseTerminal
         if let webSurfaces {
             self.webSurfaces = webSurfaces
+        }
+        if let webSnapshot {
+            self.webSnapshot = webSnapshot
         }
     }
 
@@ -63,6 +70,22 @@ final class AutomationController: AutomationControlling {
         return AutomationWebSurfacesResult(
             webSurfaces: webSurfaces(),
             system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
+        )
+    }
+
+    func automationWebSurfaceSnapshot(
+        for handle: String,
+        sourceID: UUID
+    ) async throws -> AutomationWebSurfaceSnapshotResult {
+        // Same trust level as the web-surface list: read-only pixels of an already-visible
+        // surface, gated on browser.read. The caller is a terminal tile; the snapshot targets
+        // an app-owned web surface addressed by stable WebSource id, never the caller's tile.
+        let resolved = try resolve(handle, requiring: .browserRead)
+        let outcome = await webSnapshot(sourceID)
+        return try WebSurfaceSnapshotEncoder.result(
+            from: outcome,
+            sourceID: sourceID,
+            capabilities: resolved.entry.capabilities
         )
     }
 

--- a/Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift
+++ b/Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift
@@ -1,0 +1,95 @@
+//
+//  WebSurfaceSnapshotCapture.swift
+//  WorkspaceManager
+//
+//  Captures a bounded PNG of a live `WKWebView` for the Automation API's browser-read
+//  snapshot. Runs on the MainActor (WebKit requirement), scales output to a max width,
+//  and races `takeSnapshot` against a deadline so a hung page cannot wedge the automation
+//  server. The pixel work stops here; the outcome is handed to the pure Core encoder.
+//
+
+import AppKit
+import WebKit
+import WorkspaceManagerCore
+
+@MainActor
+enum WebSurfaceSnapshotCapture {
+    /// Snapshot `webView`'s currently-rendered viewport as PNG, scaled to at most
+    /// `maxWidth` points. Returns `.timedOut` if `takeSnapshot` does not complete within
+    /// `timeoutSeconds`, `.captureFailed` on an encode/WebKit error, else `.captured`.
+    ///
+    /// The timeout is a hard return, not a structured race: a single-resume settler wins
+    /// on whichever of the deadline or the snapshot completion fires first, so a snapshot
+    /// callback that never arrives cannot keep this call (or the automation server) blocked.
+    static func capture(
+        _ webView: WKWebView,
+        maxWidth: Int = AutomationAPI.webSnapshotMaxWidth,
+        timeoutSeconds: Double = AutomationAPI.webSnapshotTimeoutSeconds
+    ) async -> WebSnapshotOutcome {
+        let config = WKSnapshotConfiguration()
+        // rect stays .null → the view's visible bounds (viewport), not the full scroll height.
+        let boundsWidth = webView.bounds.width
+        let targetWidth = boundsWidth > 0 ? min(boundsWidth, CGFloat(maxWidth)) : CGFloat(maxWidth)
+        config.snapshotWidth = NSNumber(value: Double(targetWidth))
+
+        let settler = SnapshotSettler()
+        return await withCheckedContinuation { continuation in
+            settler.attach(continuation)
+
+            let deadline = DispatchWorkItem {
+                // asyncAfter on .main runs on the main thread, so the MainActor is active.
+                MainActor.assumeIsolated { settler.settle(.timedOut) }
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + timeoutSeconds, execute: deadline)
+
+            webView.takeSnapshot(with: config) { image, error in
+                // WebKit delivers this completion on the main thread.
+                MainActor.assumeIsolated {
+                    deadline.cancel()
+                    settler.settle(outcome(image: image, error: error))
+                }
+            }
+        }
+    }
+
+    private static func outcome(image: NSImage?, error: Error?) -> WebSnapshotOutcome {
+        if let error {
+            return .captureFailed("\(error)")
+        }
+        guard let image, let (png, width, height) = pngData(from: image) else {
+            return .captureFailed("no image produced")
+        }
+        return .captured(pngData: png, width: width, height: height)
+    }
+
+    /// PNG bytes plus the bitmap's pixel dimensions, or `nil` when the image has no
+    /// rasterizable representation.
+    private static func pngData(from image: NSImage) -> (Data, Int, Int)? {
+        guard
+            let tiff = image.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff),
+            let png = rep.representation(using: .png, properties: [:])
+        else {
+            return nil
+        }
+        return (png, rep.pixelsWide, rep.pixelsHigh)
+    }
+}
+
+/// Single-resume guard around the snapshot continuation. MainActor-isolated so the
+/// deadline and the WebKit completion (both on the main thread) settle it without a
+/// data race; the loser's `settle` is a no-op.
+@MainActor
+private final class SnapshotSettler {
+    private var continuation: CheckedContinuation<WebSnapshotOutcome, Never>?
+
+    func attach(_ continuation: CheckedContinuation<WebSnapshotOutcome, Never>) {
+        self.continuation = continuation
+    }
+
+    func settle(_ outcome: WebSnapshotOutcome) {
+        guard let continuation else { return }
+        self.continuation = nil
+        continuation.resume(returning: outcome)
+    }
+}

--- a/Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift
+++ b/Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift
@@ -37,22 +37,28 @@ enum WebSurfaceSnapshotCapture {
             settler.attach(continuation)
 
             let deadline = DispatchWorkItem {
-                // asyncAfter on .main runs on the main thread, so the MainActor is active.
-                MainActor.assumeIsolated { settler.settle(.timedOut) }
+                Task { @MainActor in settler.settle(.timedOut) }
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + timeoutSeconds, execute: deadline)
 
             webView.takeSnapshot(with: config) { image, error in
-                // WebKit delivers this completion on the main thread.
-                MainActor.assumeIsolated {
+                // Hop to the MainActor explicitly rather than assuming this completion is
+                // already main-isolated: WebKit delivers it on the main thread, but the
+                // single-resume settler serializes the deadline and this callback either way,
+                // and the hop cannot crash the way `assumeIsolated` would off-thread.
+                let result = outcome(image: image, error: error)
+                Task { @MainActor in
                     deadline.cancel()
-                    settler.settle(outcome(image: image, error: error))
+                    settler.settle(result)
                 }
             }
         }
     }
 
-    private static func outcome(image: NSImage?, error: Error?) -> WebSnapshotOutcome {
+    /// Reduces `takeSnapshot`'s result to an outcome. `nonisolated` so it can run inside the
+    /// WebKit completion (which is not statically main-isolated) without an actor hop; it only
+    /// touches its arguments and produces `Sendable` `Data`.
+    private nonisolated static func outcome(image: NSImage?, error: Error?) -> WebSnapshotOutcome {
         if let error {
             return .captureFailed("\(error)")
         }
@@ -63,8 +69,9 @@ enum WebSurfaceSnapshotCapture {
     }
 
     /// PNG bytes plus the bitmap's pixel dimensions, or `nil` when the image has no
-    /// rasterizable representation.
-    private static func pngData(from image: NSImage) -> (Data, Int, Int)? {
+    /// rasterizable representation. `nonisolated`: a pure image→bytes conversion callable
+    /// from the (not statically isolated) WebKit completion.
+    private nonisolated static func pngData(from image: NSImage) -> (Data, Int, Int)? {
         guard
             let tiff = image.tiffRepresentation,
             let rep = NSBitmapImageRep(data: tiff),

--- a/Sources/WorkspaceManager/Web/WebSurfaceStore.swift
+++ b/Sources/WorkspaceManager/Web/WebSurfaceStore.swift
@@ -44,6 +44,14 @@ final class WebSurfaceStore: ObservableObject {
         )
     }
 
+    /// The live `WKWebView` for the Automation API's browser-read snapshot, or `nil`
+    /// when no surface is instantiated. A non-creating peek (like `liveState`): it never
+    /// instantiates a view, so snapshotting a released surface fails closed rather than
+    /// spinning up a hidden page.
+    var liveWebView: WKWebView? {
+        activeSurface?.webView
+    }
+
     func ensureSurface(
         for source: WebSource,
         onBlockedNavigation: ((URL) -> Void)? = nil

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -20,6 +20,16 @@ public enum AutomationAPI {
     public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
+
+    /// Bounds for `GET /v1/web-surfaces/{id}/snapshot` (`browser.read`). The snapshot
+    /// captures the live view's currently-rendered viewport (WKWebView bounds), scaled
+    /// to at most `webSnapshotMaxWidth`; a page taller than the viewport is not captured
+    /// in full. The encoded PNG is rejected past `webSnapshotMaxRawBytes` rather than
+    /// truncated, and the capture is abandoned past `webSnapshotTimeoutSeconds` so a hung
+    /// page cannot wedge the automation server.
+    public static let webSnapshotMaxWidth = 1600
+    public static let webSnapshotMaxRawBytes = 8 * 1_024 * 1_024
+    public static let webSnapshotTimeoutSeconds = 5.0
 }
 
 public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equatable {
@@ -181,6 +191,39 @@ public struct AutomationWebSurfacesResult: Codable, Sendable, Equatable {
         system: AutomationSystemDescriptor = AutomationSystemDescriptor()
     ) {
         self.webSurfaces = webSurfaces
+        self.system = system
+    }
+}
+
+/// Bounded PNG snapshot of a live WorkSpaces-owned web surface (`browser.read`).
+/// `data` is the base64-encoded PNG; `byteCount` is the raw (pre-base64) PNG size,
+/// bounded by `AutomationAPI.webSnapshotMaxRawBytes`. `width`/`height` are the PNG's
+/// pixel dimensions. Produced only when a `WKWebView` is live for the source — a
+/// non-live source fails with `unsupported` rather than returning a fabricated image.
+public struct AutomationWebSurfaceSnapshotResult: Codable, Sendable, Equatable {
+    public let sourceID: UUID
+    public let encoding: String
+    public let width: Int
+    public let height: Int
+    public let byteCount: Int
+    public let data: String
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        sourceID: UUID,
+        encoding: String = "png",
+        width: Int,
+        height: Int,
+        byteCount: Int,
+        data: String,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor()
+    ) {
+        self.sourceID = sourceID
+        self.encoding = encoding
+        self.width = width
+        self.height = height
+        self.byteCount = byteCount
+        self.data = data
         self.system = system
     }
 }
@@ -360,6 +403,10 @@ public protocol AutomationControlling: AnyObject, Sendable {
     func automationContext(for handle: String) throws -> AutomationContextResult
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult
+    func automationWebSurfaceSnapshot(
+        for handle: String,
+        sourceID: UUID
+    ) async throws -> AutomationWebSurfaceSnapshotResult
     func automationFocusTile(
         for handle: String,
         direction: AutomationTileFocusDirection

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -130,7 +130,11 @@ enum AutomationHTTPRouter {
         guard path.hasPrefix(prefix), path.hasSuffix(suffix) else { return nil }
         let start = path.index(path.startIndex, offsetBy: prefix.count)
         let end = path.index(path.endIndex, offsetBy: -suffix.count)
-        guard start < end else { return nil }
+        // start == end is the empty-id path (`/v1/web-surfaces//snapshot`): a well-shaped
+        // snapshot route with a bad id, so surface it (UUID validation returns invalid_request)
+        // rather than letting it fall through to route_not_found. start > end is the overlapping
+        // case (`/v1/web-surfaces/snapshot`), which is genuinely not this route.
+        guard start <= end else { return nil }
         let segment = String(path[start..<end])
         guard !segment.contains("/") else { return nil }
         return segment

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -52,6 +52,18 @@ enum AutomationHTTPRouter {
 
         let handle = try scopedHandle(from: request)
 
+        // Dynamic route: /v1/web-surfaces/{id}/snapshot. Checked before the static switch
+        // since it shares the /v1/web-surfaces prefix but never collides with the exact path.
+        if let segment = webSurfaceSnapshotSegment(inPath: request.path) {
+            guard method == "GET" else {
+                throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/web-surfaces/{id}/snapshot.")
+            }
+            guard let sourceID = UUID(uuidString: segment) else {
+                throw AutomationServiceError(.invalidRequest, "Web surface id must be a UUID.")
+            }
+            return try await controller.automationWebSurfaceSnapshot(for: handle, sourceID: sourceID)
+        }
+
         switch (method, request.path) {
         case ("GET", "/v1/context"):
             return try await controller.automationContext(for: handle)
@@ -107,6 +119,21 @@ enum AutomationHTTPRouter {
         default:
             throw AutomationServiceError(.routeNotFound, "Unsupported automation route: \(method) \(request.path)")
         }
+    }
+
+    /// The raw id segment of `/v1/web-surfaces/{segment}/snapshot`, or `nil` when `path`
+    /// is not that shape. UUID validation is the caller's job so a well-shaped path with a
+    /// bad id reports `invalid_request` rather than falling through to `route_not_found`.
+    private static func webSurfaceSnapshotSegment(inPath path: String) -> String? {
+        let prefix = "/v1/web-surfaces/"
+        let suffix = "/snapshot"
+        guard path.hasPrefix(prefix), path.hasSuffix(suffix) else { return nil }
+        let start = path.index(path.startIndex, offsetBy: prefix.count)
+        let end = path.index(path.endIndex, offsetBy: -suffix.count)
+        guard start < end else { return nil }
+        let segment = String(path[start..<end])
+        guard !segment.contains("/") else { return nil }
+        return segment
     }
 
     private static func scopedHandle(from request: HTTPRequest) throws -> String {
@@ -259,6 +286,7 @@ extension AutomationHealthResult: CodableSendableEquatable {}
 extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
+extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}
 extension AutomationMutationResult: CodableSendableEquatable {}
 extension AutomationInputWriteResult: CodableSendableEquatable {}
 extension AutomationEmptyResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/WebSurfaceSnapshotEncoder.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/WebSurfaceSnapshotEncoder.swift
@@ -1,0 +1,79 @@
+//
+//  WebSurfaceSnapshotEncoder.swift
+//  WorkspaceManagerCore
+//
+//  Maps a web-surface snapshot attempt into the Automation API's
+//  `AutomationWebSurfaceSnapshotResult` or a structured `AutomationServiceError`.
+//  Pure and WKWebView-free: the MainActor capture reduces to a `WebSnapshotOutcome`,
+//  and this type owns the byte-cap enforcement, base64 encoding, and error mapping —
+//  so the failure contract (unknown source, not live, timeout, oversize) is
+//  unit-testable without a live view.
+//
+
+import Foundation
+
+/// Result of trying to snapshot one web source's live surface. Failure is encoded as
+/// a case (rather than thrown) so the MainActor capture stays non-throwing and the
+/// mapping to error codes lives in one pure place.
+public enum WebSnapshotOutcome: Sendable, Equatable {
+    /// No WorkSpaces web source has this id.
+    case unknownSource
+    /// The source exists but has no instantiated `WKWebView` to snapshot.
+    case notLive
+    /// The capture did not complete within the deadline.
+    case timedOut
+    /// The capture completed but produced no usable image (encode failure, etc.).
+    case captureFailed(String)
+    /// A PNG capture with its pixel dimensions.
+    case captured(pngData: Data, width: Int, height: Int)
+}
+
+public enum WebSurfaceSnapshotEncoder {
+    /// Produces the success envelope payload, or throws the mapped automation error.
+    /// `capabilities` are echoed into the system descriptor for discovery, matching the
+    /// other browser-read routes.
+    public static func result(
+        from outcome: WebSnapshotOutcome,
+        sourceID: UUID,
+        maxRawBytes: Int = AutomationAPI.webSnapshotMaxRawBytes,
+        capabilities: [AutomationCapability]
+    ) throws -> AutomationWebSurfaceSnapshotResult {
+        switch outcome {
+        case .unknownSource:
+            throw AutomationServiceError(
+                .invalidRequest,
+                "No WorkSpaces web surface has id \(sourceID.uuidString)."
+            )
+        case .notLive:
+            throw AutomationServiceError(
+                .unsupported,
+                "Web surface \(sourceID.uuidString) has no live view to snapshot; open it in WorkSpaces first."
+            )
+        case .timedOut:
+            throw AutomationServiceError(
+                .unsupported,
+                "Snapshot of web surface \(sourceID.uuidString) timed out after \(AutomationAPI.webSnapshotTimeoutSeconds)s."
+            )
+        case .captureFailed(let reason):
+            throw AutomationServiceError(
+                .internalError,
+                "Snapshot of web surface \(sourceID.uuidString) failed: \(reason)."
+            )
+        case .captured(let pngData, let width, let height):
+            guard pngData.count <= maxRawBytes else {
+                throw AutomationServiceError(
+                    .unsupported,
+                    "Snapshot of web surface \(sourceID.uuidString) is \(pngData.count) bytes, over the \(maxRawBytes)-byte cap."
+                )
+            }
+            return AutomationWebSurfaceSnapshotResult(
+                sourceID: sourceID,
+                width: width,
+                height: height,
+                byteCount: pngData.count,
+                data: pngData.base64EncodedString(),
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Foundation
 import Testing
+import WebKit
 
 @testable import WorkspaceManager
 @testable import WorkspaceManagerCore
@@ -281,6 +283,150 @@ struct AutomationControllerTests {
             Issue.record("Expected browser.read to be required for web-surface listing")
         } catch let error as AutomationServiceError {
             #expect(error.response.code == .capabilityDenied)
+        }
+    }
+
+    @Test("Web-surface snapshot returns the provider's captured PNG for a browser.read handle")
+    func webSurfaceSnapshotReturnsCapture() async throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "browser" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        let sourceID = UUID()
+        let png = Data([0x89, 0x50, 0x4E, 0x47])
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            webSnapshot: { requested in
+                requested == sourceID ? .captured(pngData: png, width: 8, height: 4) : .unknownSource
+            }
+        )
+
+        let result = try await controller.automationWebSurfaceSnapshot(for: "browser", sourceID: sourceID)
+        #expect(result.sourceID == sourceID)
+        #expect(result.width == 8)
+        #expect(result.byteCount == png.count)
+        #expect(Data(base64Encoded: result.data) == png)
+        #expect(result.system.capabilities.contains(.browserRead))
+    }
+
+    @Test("Web-surface snapshot maps a not-live source to unsupported")
+    func webSurfaceSnapshotNotLive() async throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "browser" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            webSnapshot: { _ in .notLive }
+        )
+
+        do {
+            _ = try await controller.automationWebSurfaceSnapshot(for: "browser", sourceID: UUID())
+            Issue.record("Expected a not-live source to fail as unsupported")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .unsupported)
+        }
+    }
+
+    @Test("Web-surface snapshot denies handles without browser.read before capturing")
+    func webSurfaceSnapshotDeniesWithoutBrowserRead() async throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "limited" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: [.contextRead]
+        )
+        var captureCalls = 0
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            webSnapshot: { _ in
+                captureCalls += 1
+                return .notLive
+            }
+        )
+
+        do {
+            _ = try await controller.automationWebSurfaceSnapshot(for: "limited", sourceID: UUID())
+            Issue.record("Expected browser.read to be required for snapshotting")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+        // The capability gate runs before the capture provider, so no snapshot was attempted.
+        #expect(captureCalls == 0)
+    }
+
+    @Test("Live WKWebView capture produces a bounded, non-empty PNG")
+    func liveWebViewCaptureProducesPNG() async throws {
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(webView)
+        webView.loadHTMLString(
+            "<html><body style=\"margin:0;background:#2266cc;\"><h1 style=\"color:white\">snapshot</h1></body></html>",
+            baseURL: nil
+        )
+        // Let the page paint before capturing; takeSnapshot of a blank view is a valid but empty PNG.
+        try? await Task.sleep(for: .milliseconds(800))
+
+        let outcome = await WebSurfaceSnapshotCapture.capture(webView, maxWidth: 320, timeoutSeconds: 5)
+        guard case .captured(let pngData, let width, let height) = outcome else {
+            Issue.record("Expected a captured PNG, got \(outcome)")
+            return
+        }
+        #expect(!pngData.isEmpty)
+        #expect(width > 0)
+        #expect(height > 0)
+        // Bounded: scaled to at most maxWidth (backing-store scale may 2x on Retina).
+        #expect(width <= 320 * 2)
+        #expect(pngData.count <= AutomationAPI.webSnapshotMaxRawBytes)
+
+        if let dir = ProcessInfo.processInfo.environment["WEB_SNAPSHOT_EVIDENCE_DIR"] {
+            let url = URL(fileURLWithPath: dir).appendingPathComponent("web-surface-snapshot.png")
+            try? pngData.write(to: url)
         }
     }
 

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -73,6 +73,26 @@ private final class FakeAutomationController: AutomationControlling {
         )
     }
 
+    var snapshotCalls: [UUID] = []
+
+    func automationWebSurfaceSnapshot(
+        for handle: String,
+        sourceID: UUID
+    ) async throws -> AutomationWebSurfaceSnapshotResult {
+        guard handle != "nobrowser" else {
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include browser.read.")
+        }
+        _ = try automationContext(for: handle)
+        snapshotCalls.append(sourceID)
+        return AutomationWebSurfaceSnapshotResult(
+            sourceID: sourceID,
+            width: 2,
+            height: 1,
+            byteCount: 4,
+            data: "AQID"
+        )
+    }
+
     func automationFocusTile(
         for handle: String,
         direction: AutomationTileFocusDirection
@@ -466,6 +486,141 @@ struct AutomationAPITests {
         )
         #expect(wrongMethod.status == 405)
         #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("Snapshot encoder base64-encodes a captured PNG and reports raw byte count")
+    func snapshotEncoderCaptured() throws {
+        let sourceID = UUID()
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+        let result = try WebSurfaceSnapshotEncoder.result(
+            from: .captured(pngData: png, width: 320, height: 200),
+            sourceID: sourceID,
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        #expect(result.sourceID == sourceID)
+        #expect(result.encoding == "png")
+        #expect(result.width == 320)
+        #expect(result.height == 200)
+        #expect(result.byteCount == png.count)
+        #expect(Data(base64Encoded: result.data) == png)
+        #expect(result.system.capabilities.contains(.browserRead))
+    }
+
+    @Test("Snapshot encoder rejects a capture over the raw byte cap as unsupported")
+    func snapshotEncoderOverCap() throws {
+        let png = Data(repeating: 0xAB, count: 64)
+        do {
+            _ = try WebSurfaceSnapshotEncoder.result(
+                from: .captured(pngData: png, width: 10, height: 10),
+                sourceID: UUID(),
+                maxRawBytes: 32,
+                capabilities: AutomationAPI.v1Capabilities
+            )
+            Issue.record("Expected an over-cap capture to be rejected")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .unsupported)
+            #expect(error.response.message.contains("cap"))
+        }
+    }
+
+    @Test("Snapshot encoder maps each failure outcome to its structured error code")
+    func snapshotEncoderFailureMapping() throws {
+        let sourceID = UUID()
+        func code(_ outcome: WebSnapshotOutcome) -> AutomationErrorCode? {
+            do {
+                _ = try WebSurfaceSnapshotEncoder.result(
+                    from: outcome,
+                    sourceID: sourceID,
+                    capabilities: AutomationAPI.v1Capabilities
+                )
+                return nil
+            } catch let error as AutomationServiceError {
+                return error.response.code
+            } catch {
+                return nil
+            }
+        }
+        #expect(code(.unknownSource) == .invalidRequest)
+        #expect(code(.notLive) == .unsupported)
+        #expect(code(.timedOut) == .unsupported)
+        #expect(code(.captureFailed("boom")) == .internalError)
+    }
+
+    @Test("Router captures a web-surface snapshot, rejects a bad id, wrong method, and under-capable handle")
+    @MainActor
+    func routerWebSurfaceSnapshot() async throws {
+        let controller = FakeAutomationController()
+        let sourceID = UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
+
+        let ok = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/web-surfaces/\(sourceID.uuidString)/snapshot",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWebSurfaceSnapshotResult>.self,
+            from: ok.body
+        )
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.sourceID == sourceID)
+        #expect(okEnvelope.result?.encoding == "png")
+        #expect(controller.snapshotCalls == [sourceID])
+
+        let badID = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/web-surfaces/not-a-uuid/snapshot",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let badIDEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: badID.body
+        )
+        #expect(badID.status == 400)
+        #expect(badIDEnvelope.error?.code == .invalidRequest)
+
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/web-surfaces/\(sourceID.uuidString)/snapshot",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+
+        let denied = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/web-surfaces/\(sourceID.uuidString)/snapshot",
+                headers: [AutomationAPI.handleHeader: "nobrowser"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: denied.body
+        )
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
     }
 
     @Test("CLI formatter emits result JSON and surfaces envelope errors")

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -588,6 +588,25 @@ struct AutomationAPITests {
         #expect(badID.status == 400)
         #expect(badIDEnvelope.error?.code == .invalidRequest)
 
+        // An empty id (`/v1/web-surfaces//snapshot`) is a well-shaped snapshot path with a
+        // bad id, so it reports invalid_request rather than falling through to route_not_found.
+        let emptyID = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/web-surfaces//snapshot",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let emptyIDEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: emptyID.body
+        )
+        #expect(emptyID.status == 400)
+        #expect(emptyIDEnvelope.error?.code == .invalidRequest)
+
         let wrongMethod = await AutomationHTTPRouter.route(
             HTTPRequest(
                 method: "POST",

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -89,6 +89,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/context` | Returns the caller's resolved context and capabilities. |
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
+| `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
 | `POST /v1/tile/split` | Splits `left`, `right`, `up`, or `down` from a primary tile. Each successful split creates a new terminal surface in the caller's tab. Secondary split-tile callers return `unsupported` in V1. |
 | `POST /v1/tile/close` | Requests close for the caller tile through the normal close-confirmation path. |
@@ -114,13 +115,41 @@ handle.
 | --- | --- |
 | `context.read` | `GET /v1/context` |
 | `surfaces.read` | `GET /v1/surfaces` |
-| `browser.read` | `GET /v1/web-surfaces` (read-only web-surface listing; granted to default handles under the Automation API experiment) |
+| `browser.read` | `GET /v1/web-surfaces` (read-only listing) and `GET /v1/web-surfaces/{id}/snapshot` (bounded PNG of a live surface); granted to default handles under the Automation API experiment |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
 | `input.write` | `POST /v1/input/write` (experimental; granted per-handle only while the Automation Input Write experiment is enabled, and re-checked per request) |
 
 Under-capable handles fail with `capability_denied`.
+
+## Web-surface snapshot bounds
+
+`GET /v1/web-surfaces/{id}/snapshot` returns the standard success envelope with a
+base64 PNG, not raw image bytes:
+
+```json
+{ "sourceID": "…", "encoding": "png", "width": 640, "height": 480,
+  "byteCount": 12497, "data": "<base64 png>" }
+```
+
+`byteCount` is the raw (pre-base64) PNG size; `width`/`height` are its pixel
+dimensions. Decode with `jq -r .result.data | base64 -d > snapshot.png`.
+
+The snapshot is bounded three ways so a caller cannot pull an unbounded image or
+wedge the server:
+
+| Bound | Value | Behavior |
+| --- | --- | --- |
+| Max width | 1600 px (`WKSnapshotConfiguration.snapshotWidth`) | Output is scaled to at most this width. Capture uses the live view's visible bounds (viewport), never the full scroll height, so a long page is not captured in full. Backing-store scale (Retina) may 2× the pixel width. |
+| Max raw bytes | 8 MiB | A PNG over the cap is rejected (`unsupported`), never truncated. |
+| Timeout | 5 s | `takeSnapshot` is raced against a deadline; a capture that does not complete returns `unsupported` rather than blocking the automation server. |
+
+Failure mapping (reusing the stable error codes): an id matching no web source →
+`invalid_request`; a source with no live `WKWebView` → `unsupported`; a capture
+timeout or over-cap PNG → `unsupported` (distinct messages); an internal capture
+error → `internal_error`. Snapshotting a source whose view is not instantiated
+never creates one — the request fails closed.
 
 ## Error Codes
 
@@ -169,6 +198,8 @@ workspaces input write 'echo hi' --submit
 | Wire models and envelopes | `Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift` |
 | Socket listener and lock | `Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift` |
 | HTTP route projection | `Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift` |
+| Web-surface snapshot encoding (pure) | `Sources/WorkspaceManagerCore/Services/Automation/WebSurfaceSnapshotEncoder.swift` |
+| Web-surface snapshot capture (MainActor) | `Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift` |
 | CLI socket client | `Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift` |
 | CLI formatting | `Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift` |
 | App-side controller | `Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift` |
@@ -201,7 +232,9 @@ they can be added. Two reviewed exceptions widen the read/write surface
 deliberately: caller-scoped input injection ships as the experimental,
 double-gated `input.write` capability (see
 [Automation Input Write Decision](../decisions/automation-input-write.md)), and
-read-only web-surface listing ships as `browser.read` (`GET /v1/web-surfaces`),
-granted to default handles under the Automation API experiment. Web-surface
-snapshotting and any browser interaction remain out of scope pending the
+read-only web-surface reads ship as `browser.read` — both listing
+(`GET /v1/web-surfaces`) and bounded snapshots
+(`GET /v1/web-surfaces/{id}/snapshot`), granted to default handles under the
+Automation API experiment. Browser *mutation* (navigating, clicking, filling, or
+evaluating JavaScript in a web surface) remains out of scope pending the
 JavaScript-evaluation trust-boundary review.


### PR DESCRIPTION
## What this ships

Slice 2 of #679: `GET /v1/web-surfaces/{id}/snapshot` on the local Automation API — a **bounded PNG of a live** WorkSpaces-owned web surface, base64-encoded inside the standard JSON envelope, gated on the existing **`browser.read`** capability.

Read-only pixels of an already-visible surface sit at the same trust level as the URL/title the slice-1 list already returns, so this reuses `browser.read` rather than adding a capability. Decode with `jq -r .result.data | base64 -d > snapshot.png`.

**Contract honored — fails closed, never creates a view.** Snapshotting a source whose `WKWebView` is not instantiated returns a structured automation error and never spins one up (non-creating peek `SurfaceStore.liveWebView(forSourceID:)` → `WebSurfaceStore.liveWebView`, mirroring slice 1's `liveWebState`).

**Bounded three ways** (documented in `docs/development/automation-api.md` § "Web-surface snapshot bounds"):
- max width **1600px** via `WKSnapshotConfiguration.snapshotWidth` — captures the live view's viewport (visible bounds), never the full scroll height;
- max raw PNG **8 MiB** — an over-cap PNG is rejected (`unsupported`), never truncated;
- **5s** capture timeout — `takeSnapshot` is raced against a deadline by a single-resume MainActor settler, so a hung page cannot wedge the automation server.

**Structured failures** (reusing stable error codes, no enum widening): unknown id → `invalid_request`; no live view / timeout / over-cap → `unsupported` (distinct messages); capture error → `internal_error`.

**Architecture.** Pure `WebSurfaceSnapshotEncoder` (Core) maps a `WebSnapshotOutcome` to result/error — unit-testable with no WKWebView; MainActor `WebSurfaceSnapshotCapture` (App) produces that outcome from `takeSnapshot`. The automation server is off-main; the router `await`s the `@MainActor` controller and the new protocol method is `async throws`.

## Deferred (out of scope, unchanged)

Slice 3 (interact: navigate/click/fill/JS-eval) and slice 4 (status ingestion) remain out of scope behind the JavaScript-evaluation trust-boundary review. This PR narrows the API's V1 Non-Goals to browser *mutation* only; read-only snapshots now ship under `browser.read`.

## Review loop

Reflection (pre-codex) caught a real defect: the first cut raced `takeSnapshot` vs the deadline in a `withTaskGroup`, but structured concurrency implicitly drains the still-pending snapshot child when the closure returns — so a genuinely hung `takeSnapshot` would still block despite the "timeout." Rewrote to the unstructured single-resume settler before committing.

Directed codex (gpt-5.5, xhigh) review — findings and disposition:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | Concurrency: task-group timeout not a hard return | Already fixed in the implementation commit (single-resume settler). Codex's additional point — `MainActor.assumeIsolated` could crash if a WebKit completion ever fired off-main — **addressed** in the follow-up commit: explicit `Task { @MainActor in }` hop instead. |
| 2 | Non-creating contract | Confirmed **clean** (records check → `liveWebView` peek only). |
| 3 | Route parsing: `/v1/web-surfaces//snapshot` (empty id) returned `route_not_found` | **Fixed** in the follow-up commit → `invalid_request`, with a test. |
| 4 | Byte-cap enforcement | Confirmed **clean** (raw PNG capped before base64; dims from the same bitmap rep). |
| 5 | Completeness: released-view path never reloads | Confirmed **clean** (peek returns nil → `.notLive` → `unsupported`; reload path not reached). |

## Tests

`swift test --filter Automation` — 51/51 pass. New:
- Core `WebSurfaceSnapshotEncoder`: base64 roundtrip, raw byte-cap rejection, each outcome → error-code mapping.
- Core router: snapshot path parse, bad-UUID → `invalid_request`, empty-id → `invalid_request`, wrong-method → `method_not_allowed`, `browser.read` gate.
- App `AutomationController`: `browser.read` required (capability gate runs before the capture provider), not-live → `unsupported`, provider capture → success envelope.
- App **live e2e**: a real `WKWebView` loads inline HTML in an offscreen window; `WebSurfaceSnapshotCapture` produces a bounded, non-empty PNG. Runs headless in ~1.2s, not flaky.

## Live end-to-end validation (at-keyboard)

**This is a post-merge spot-check, not a merge gate.** The live `@MainActor` `WKWebView` capture already runs green headless and non-flaky in CI, and this route is read-only (no destructive path — the at-keyboard merge-gating that applies to in-app editing like #704 does not apply here). The curl below is for Michael to confirm the real app + socket wiring end to end whenever convenient; it does not block ready/merge.

To run it, from a WorkSpaces terminal tile with the Automation API experiment on and a web surface open:

```bash
SOCK="$WORKSPACES_AUTOMATION_SOCKET"; H="x-workspaces-automation-handle: $WORKSPACES_AUTOMATION_HANDLE"
curl -s --unix-socket "$SOCK" -H "$H" http://localhost/v1/web-surfaces | jq '.result.webSurfaces[] | {sourceID, isLive, liveURL}'
# pick a sourceID with isLive:true, then:
ID=<sourceID>
curl -s --unix-socket "$SOCK" -H "$H" "http://localhost/v1/web-surfaces/$ID/snapshot" \
  | jq -r '.result.data' | base64 -d > /tmp/snap.png && open /tmp/snap.png
```

## Mergeability

- **Surface:** Local Automation API (`automation.sock`) — new `GET /v1/web-surfaces/{id}/snapshot` route; new Core wire type + pure encoder; new MainActor capture helper; two non-creating live-view accessors; lifecycle wiring; docs. Off-by-default (Automation API experiment).
- **User-facing behavior changed:** None for users who do not invoke the automation path. No UI change; WKWebView user behavior is untouched (read-only snapshot, no focus/navigation side effects).
- **Non-happy paths considered:** Unknown source id, no live view (released ~30s after inactive), capture timeout (hard-returns via settler — verified no structured-concurrency drain), over-byte-cap PNG, empty/malformed id in path, wrong HTTP method, under-capable handle, off-main WebKit completion (hardened against crash).
- **Release/ops preconditions:** None. Gated behind the existing Automation API experiment; no migration, no new capability, no new env/secret. Base64 PNG (≤ ~11 MiB post-encode at the 8 MiB raw cap) travels the local unix socket only.
- **Residual risk or follow-up:** (1) The capture-timeout path is covered by construction + the encoder's `.timedOut` mapping test, not a deterministic hang test (can't hang `takeSnapshot` without a flaky sleep race). (2) Not-live/timeout/over-cap all map to `unsupported` with distinct messages; a dedicated `timeout` error code is a reasonable follow-up but widening the stable error enum wants its own review. (3) No CLI wrapper this slice (slice 1 shipped none either); curl-over-socket is the caller path.

Refs #679

## Evidence

Real PNG captured end-to-end by the live e2e test (a `WKWebView` rendering inline HTML, snapshotted through `WebSurfaceSnapshotCapture`) — 640×480, bounded under the 1600px width cap (Retina 2× of the 320px test cap):

![live snapshot](https://evidence.cloudcompute.com/workspaces/pr-926/20260707-181406-679-web-snapshot.png)

Automation test suite (51/51), snapshot-relevant lines + build/lint clean:

![tests](https://evidence.cloudcompute.com/workspaces/pr-926/20260707-181514-679-web-snapshot-tests.png)
