### PR TITLE
feat(web-next): validation stages — per-model gateway sweep (#816) + deployed-safe e2e vs deployed envs (#817)

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -50,7 +50,17 @@ pnpm validate    # env-targetable validation (--env local|prod, --url <origin>)
 `pnpm validate` also runs against real deployments — `pnpm validate --env prod`
 probes reachability and auth/security posture with zero credentials, and
 credential-gated stages report themselves skipped rather than passing silently
-(see `docs/roadmap.md` Phase 2 / milestone #13).
+(see `docs/roadmap.md` Phase 2 / milestone #13). Two more stages gate on the
+same `WEB_NEXT_VALIDATION_SESSION` (the pre-minted validation identity —
+`docs/decisions/web-next-validation-identity.md`): a model sweep (#816) that
+calls `/api/diag/gateway?model=<id>` once per selectable model
+(`agent-runtime/models.ts`) to prove selection actually routes in the target,
+and an e2e stage (#817) that replays the `@deployed-safe`-tagged specs in
+`tests/e2e/` against the target through `playwright.config.ts`'s
+`VALIDATE_TARGET_URL` seam — set by `validate.mjs` itself, not meant to be
+set by hand. Both report `skipped: validation session expired — re-seed`
+when the session cookie doesn't authenticate, matching the decision doc's
+expiry wording, rather than failing.
 
 ## Cleaning up
 

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -14,7 +14,7 @@
 		"clean": "node scripts/clean.mjs",
 		"evidence": "node scripts/evidence.mjs",
 		"perf": "node perf/run.mjs",
-		"validate": "node scripts/validate.mjs"
+		"validate": "tsx scripts/validate.mjs"
 	},
 	"dependencies": {
 		"@ai-sdk/harness": "1.0.18",

--- a/web-next/playwright.config.ts
+++ b/web-next/playwright.config.ts
@@ -1,10 +1,21 @@
 /*
- * Playwright e2e config for web-next: runs specs in tests/e2e against a
- * production build served on port 3100 (webServer builds only when needed).
- * The server runs in auth-bypass mode (see e2e:server) and every test starts
- * signed in as the allowlisted user via the seeded test cookie; auth specs
- * override storageState to exercise signed-out / wrong-user requests.
+ * Playwright e2e config for web-next. Default (unset VALIDATE_TARGET_URL):
+ * runs specs in tests/e2e against a production build served on port 3100
+ * (webServer builds only when needed), auth-bypass mode (see e2e:server),
+ * every test starting signed in as the allowlisted user via the seeded test
+ * cookie — byte-identical to before #817. Deployed seam (VALIDATE_TARGET_URL
+ * set — scripts/validate.mjs's e2eDeployedSafeStage is the only caller):
+ * points baseURL at a real deployment, swaps the storage state for a real
+ * Better Auth session cookie (WEB_NEXT_VALIDATION_SESSION, the pre-minted
+ * validation identity — see docs/decisions/web-next-validation-identity.md),
+ * carries the Vercel protection-bypass header for SSO-walled previews, turns
+ * on screenshots, and redirects reporter/output under output/validate/. Spec
+ * curation for that seam is per-test: only `@deployed-safe`-tagged specs are
+ * read-mostly enough to run against a real environment (validate.mjs greps
+ * for the tag; nothing here filters by tag, so `pnpm test:e2e` locally still
+ * runs everything).
  */
+import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
 // E2E_PORT lets concurrent checkouts (sibling worktrees) run their own e2e
@@ -12,6 +23,11 @@ import { defineConfig, devices } from "@playwright/test";
 // PERF_PORT. Default stays 3100 (CI and the common case).
 const PORT = Number(process.env.E2E_PORT ?? 3100);
 const BASE_URL = `http://localhost:${PORT}`;
+
+// Playwright transpiles this config to CJS regardless of package.json's
+// module type, so `import.meta.url` (used elsewhere in this repo's ESM
+// scripts) isn't available here — __dirname is what actually works.
+const WEB_NEXT_ROOT = __dirname;
 
 /** Must match ALLOWED_LOGINS in the e2e:server script. */
 export const E2E_LOGIN = "fairchild";
@@ -32,6 +48,52 @@ export const signedInAs = (login: string) => ({
 	origins: [],
 });
 
+/**
+ * Better Auth's session-token cookie is `__Secure-` prefixed over https (see
+ * src/lib/auth/session-cookie.ts's SESSION_TOKEN_COOKIES) — a deployed
+ * target is always https, so this always picks the secure name in practice.
+ */
+function validationSessionStorageState(baseUrl: string, sessionToken: string) {
+	const url = new URL(baseUrl);
+	const secure = url.protocol === "https:";
+	return {
+		cookies: [
+			{
+				name: secure ? "__Secure-better-auth.session_token" : "better-auth.session_token",
+				value: sessionToken,
+				domain: url.hostname,
+				path: "/",
+				expires: -1,
+				httpOnly: true,
+				secure,
+				sameSite: "Lax" as const,
+			},
+		],
+		origins: [],
+	};
+}
+
+/** Resolves the deployed-target seam, or undefined for the untouched local default. */
+function resolveDeployedTarget(): { baseUrl: string; sessionToken: string } | undefined {
+	const targetUrl = process.env.VALIDATE_TARGET_URL;
+	if (!targetUrl) return undefined;
+	const sessionToken = process.env.WEB_NEXT_VALIDATION_SESSION;
+	if (!sessionToken) {
+		// The e2eDeployedSafeStage gates on this before it ever spawns Playwright
+		// — reaching here without it means the config was invoked some other
+		// way, and failing loudly beats silently running unauthenticated.
+		throw new Error(
+			"VALIDATE_TARGET_URL is set but WEB_NEXT_VALIDATION_SESSION is not — set both, or neither.",
+		);
+	}
+	return { baseUrl: targetUrl.replace(/\/$/, ""), sessionToken };
+}
+
+const deployedTarget = resolveDeployedTarget();
+const isDeployed = !!deployedTarget;
+const envName = process.env.VALIDATE_ENV_NAME ?? "deployed";
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
 // Remote sandboxes (claude.ai sessions) preinstall a Chromium whose revision
 // may trail the @playwright/test pin, and their proxy blocks Playwright's CDN,
 // so the pinned browser can't be downloaded. Point this at the preinstalled
@@ -45,13 +107,38 @@ export default defineConfig({
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
-	reporter: process.env.CI
-		? [["list"], ["html", { open: "never" }]]
-		: [["list"]],
+	reporter: isDeployed
+		? [
+				["list"],
+				[
+					"json",
+					{
+						outputFile:
+							process.env.VALIDATE_E2E_JSON_OUTPUT ??
+							path.join(WEB_NEXT_ROOT, "output", "validate", envName, "e2e-results.json"),
+					},
+				],
+			]
+		: process.env.CI
+			? [["list"], ["html", { open: "never" }]]
+			: [["list"]],
 	use: {
-		baseURL: BASE_URL,
-		storageState: signedInAs(E2E_LOGIN),
-		trace: "on-first-retry",
+		baseURL: deployedTarget ? deployedTarget.baseUrl : BASE_URL,
+		storageState: deployedTarget
+			? validationSessionStorageState(deployedTarget.baseUrl, deployedTarget.sessionToken)
+			: signedInAs(E2E_LOGIN),
+		// Deployed runs turn trace off (screenshots are the deployed evidence
+		// instead): Playwright traces capture request/response headers, which
+		// would embed the validation session cookie and the bypass header in an
+		// artifact — a credential-in-report risk the local path doesn't have
+		// (its cookie is a throwaway test-bypass value, not a real session).
+		trace: isDeployed ? "off" : "on-first-retry",
+		...(isDeployed
+			? {
+					screenshot: "on" as const,
+					...(bypassSecret ? { extraHTTPHeaders: { "x-vercel-protection-bypass": bypassSecret } } : {}),
+				}
+			: {}),
 		...(CHROMIUM_EXECUTABLE
 			? { launchOptions: { executablePath: CHROMIUM_EXECUTABLE } }
 			: {}),
@@ -71,10 +158,14 @@ export default defineConfig({
 			dependencies: ["chromium"],
 		},
 	],
-	webServer: {
-		command: "pnpm run e2e:server",
-		url: BASE_URL,
-		reuseExistingServer: !process.env.CI,
-		timeout: 180_000,
-	},
+	...(isDeployed
+		? { outputDir: path.join(WEB_NEXT_ROOT, "output", "validate", envName, "test-results") }
+		: {
+				webServer: {
+					command: "pnpm run e2e:server",
+					url: BASE_URL,
+					reuseExistingServer: !process.env.CI,
+					timeout: 180_000,
+				},
+			}),
 });

--- a/web-next/scripts/deployed-safe-specs.test.mjs
+++ b/web-next/scripts/deployed-safe-specs.test.mjs
@@ -1,0 +1,43 @@
+/*
+ * Regression guard for the #817 spec curation: every test carrying the
+ * `@deployed-safe` grep tag (what `pnpm validate`'s e2e stage replays
+ * against real deployments) must live in a file that is genuinely
+ * read-mostly — sessions-demo.spec.ts renders fixture data, no backend (see
+ * its top-of-file doc block). sessions.spec.ts and auth.spec.ts drive real
+ * session/turn creation and sign-out; tagging anything there would send
+ * validate's deployed run to mutate state or trigger a real (costly)
+ * agent-runtime turn. This test reads the actual spec files, so a future
+ * `@deployed-safe` added to the wrong file fails CI instead of only being
+ * caught by a careful reviewer.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const E2E_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "tests", "e2e");
+
+function taggedTestTitles(file) {
+	const text = readFileSync(path.join(E2E_DIR, file), "utf8");
+	const titles = [...text.matchAll(/^test\(\s*"([^"]*)"/gm)].map((m) => m[1]);
+	return titles.filter((title) => title.includes("@deployed-safe"));
+}
+
+describe("@deployed-safe spec curation (#817)", () => {
+	test("sessions-demo.spec.ts (fixture-rendered, no backend) is fully tagged", () => {
+		const tagged = taggedTestTitles("sessions-demo.spec.ts");
+		expect(tagged.length).toBeGreaterThanOrEqual(7);
+	});
+
+	test("sessions.spec.ts (real session/turn creation) carries no deployed-safe tag", () => {
+		expect(taggedTestTitles("sessions.spec.ts")).toEqual([]);
+	});
+
+	test("auth.spec.ts (sign-out, bypass-only forged cookies) carries no deployed-safe tag", () => {
+		expect(taggedTestTitles("auth.spec.ts")).toEqual([]);
+	});
+
+	test("terminal.spec.ts (session creation + a live sandbox shell) carries no deployed-safe tag", () => {
+		expect(taggedTestTitles("terminal.spec.ts")).toEqual([]);
+	});
+});

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -1,8 +1,9 @@
 /*
  * Pure logic for the environment-targetable validation runner (validate.mjs):
  * target resolution (--env/--url), auth-mode detection, the posture checks
- * evaluated over probe results, and the summary/exit semantics. No I/O here —
- * everything is unit-testable (scripts/validate-core.test.mjs).
+ * evaluated over probe results, the #816 model-sweep and #817 e2e result
+ * interpreters, and the summary/exit semantics. No I/O here — everything is
+ * unit-testable (scripts/validate-core.test.mjs).
  */
 
 /** The deployed production origin; override with WEB_NEXT_PROD_URL. */
@@ -70,7 +71,13 @@ function check(id, pass, detail) {
 	return { id, status: pass ? "pass" : "fail", detail };
 }
 
-const isRedirectToSignIn = (probe) =>
+/**
+ * A redirect to /sign-in: the middleware's verdict for no-or-stale session,
+ * whichever auth mode is active. Exported for the #817 e2e stage's own
+ * pre-check (a deployed-target page load with a bounced validation session
+ * redirects the same way, before any browser ever opens).
+ */
+export const isRedirectToSignIn = (probe) =>
 	probe.status >= 300 && probe.status < 400 && /\/sign-in/.test(probe.location ?? "");
 
 /**
@@ -141,6 +148,95 @@ export function gateStage(requirements) {
 	return missing.length === 0
 		? { runnable: true }
 		: { runnable: false, reason: `missing ${missing.join(", ")}` };
+}
+
+/**
+ * The Better Auth session-token cookie name is protocol-dependent (Better
+ * Auth applies the `__Secure-` prefix over https — see
+ * `src/lib/auth/session-cookie.ts`'s SESSION_TOKEN_COOKIES). A deployed
+ * target is always https; `http://localhost` never is, so this only ever
+ * picks the plain name in that case (unused there in practice — local runs
+ * use the AUTH_BYPASS cookie instead).
+ */
+export function validationSessionCookieName(baseUrl) {
+	return baseUrl.startsWith("https://")
+		? "__Secure-better-auth.session_token"
+		: "better-auth.session_token";
+}
+
+/**
+ * Interprets the first probe of the #816 model sweep to decide whether the
+ * stage is even runnable in this target — distinct from any individual
+ * model's pass/fail. Two gates, both reported as skips (never a fail):
+ * a bounced validation session (the decision doc's "expired — re-seed"
+ * state) and a target deployment with no gateway credential at all.
+ */
+export function classifyModelSweepGate(firstProbe) {
+	if (firstProbe.status === 401 || firstProbe.status === 403) {
+		return { skip: true, reason: "validation session expired — re-seed" };
+	}
+	if (firstProbe.status === 500) {
+		const error = firstProbe.body && typeof firstProbe.body === "object" ? firstProbe.body.error : undefined;
+		if (typeof error === "string" && /AI_GATEWAY_API_KEY/.test(error)) {
+			return { skip: true, reason: "missing AI_GATEWAY_API_KEY in target deployment" };
+		}
+	}
+	return { skip: false };
+}
+
+/**
+ * Turns raw `/api/diag/gateway?model=<id>` probe results into per-model pass/
+ * fail checks. `results`: `[{ id, status, body }]`, `body` already JSON-
+ * parsed (or `undefined` if the probe returned unparseable/empty text).
+ */
+export function evaluateModelChecks(results) {
+	return results.map(({ id, status, body }) => {
+		const ok = status === 200 && !!body && body.ok === true && typeof body.reply === "string" && body.reply.length > 0;
+		return {
+			id: `model:${id}`,
+			status: ok ? "pass" : "fail",
+			detail: ok
+				? `${id} → routed via ${body.gatewayModel ?? "?"} in ${body.latencyMs ?? "?"}ms: ${JSON.stringify(body.reply)}`
+				: `${id} → HTTP ${status} ${JSON.stringify(body).slice(0, 200)}`,
+		};
+	});
+}
+
+/**
+ * Flattens a Playwright JSON-reporter report (any nesting of `suites`) into
+ * one entry per spec — a spec's `ok` is Playwright's own verdict across its
+ * (possibly retried) test runs, so it already accounts for flake/retries.
+ */
+function flattenSpecs(suites, out = []) {
+	for (const suite of suites) {
+		for (const spec of suite.specs ?? []) {
+			out.push(spec);
+		}
+		if (suite.suites?.length) flattenSpecs(suite.suites, out);
+	}
+	return out;
+}
+
+/**
+ * Interprets a Playwright JSON-reporter report (the #817 deployed-safe e2e
+ * run) into validate.mjs checks, one per spec. A report with zero matched
+ * specs (an empty `--grep` match — e.g. the deployed-safe tag was removed or
+ * misspelled) is reported as its own failing check rather than silently
+ * "0/0 passed", since that would otherwise read as a clean run.
+ */
+export function evaluateE2eResults(report) {
+	const specs = flattenSpecs(report.suites ?? []);
+	if (specs.length === 0) {
+		return [{ id: "e2e:no_specs_matched", status: "fail", detail: "no deployed-safe specs matched — check the @deployed-safe grep tag" }];
+	}
+	return specs.map((spec) => {
+		const statuses = spec.tests.map((t) => t.status);
+		return {
+			id: `e2e:${spec.title}`,
+			status: spec.ok ? "pass" : "fail",
+			detail: `${spec.title} → ${statuses.join(", ")}`,
+		};
+	});
 }
 
 /** Collapses stage results into the exit verdict and the human summary lines. */

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -165,11 +165,32 @@ export function validationSessionCookieName(baseUrl) {
 }
 
 /**
+ * Replaces every occurrence of the given secret values in a string with a
+ * placeholder. Probe/report text can otherwise carry a secret verbatim: a
+ * malformed credential (say, a trailing newline from a sloppy copy-paste)
+ * makes Node's fetch throw an invalid-header error whose message *echoes the
+ * header value* — and that error string flows into check details and the
+ * persisted JSON report (codex review finding).
+ */
+export function redactSecrets(text, secrets) {
+	let out = text;
+	for (const secret of secrets) {
+		if (secret) out = out.split(secret).join("[redacted]");
+	}
+	return out;
+}
+
+/** The exact error the diag route reports when the target has no gateway key. */
+export const MISSING_GATEWAY_KEY_ERROR = "AI_GATEWAY_API_KEY is not set in this deployment";
+
+/**
  * Interprets the first probe of the #816 model sweep to decide whether the
  * stage is even runnable in this target — distinct from any individual
  * model's pass/fail. Two gates, both reported as skips (never a fail):
  * a bounced validation session (the decision doc's "expired — re-seed"
- * state) and a target deployment with no gateway credential at all.
+ * state) and a target deployment with no gateway credential at all (matched
+ * against the route's exact message, so an unrelated 500 that merely
+ * mentions the variable name can't masquerade as a credential gate).
  */
 export function classifyModelSweepGate(firstProbe) {
 	if (firstProbe.status === 401 || firstProbe.status === 403) {
@@ -177,7 +198,7 @@ export function classifyModelSweepGate(firstProbe) {
 	}
 	if (firstProbe.status === 500) {
 		const error = firstProbe.body && typeof firstProbe.body === "object" ? firstProbe.body.error : undefined;
-		if (typeof error === "string" && /AI_GATEWAY_API_KEY/.test(error)) {
+		if (error === MISSING_GATEWAY_KEY_ERROR) {
 			return { skip: true, reason: "missing AI_GATEWAY_API_KEY in target deployment" };
 		}
 	}

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -9,6 +9,7 @@ import {
 	evaluatePosture,
 	gateStage,
 	isRedirectToSignIn,
+	redactSecrets,
 	resolveTarget,
 	summarize,
 	validationSessionCookieName,
@@ -163,8 +164,33 @@ describe("classifyModelSweepGate (#816)", () => {
 		});
 	});
 
+	test("a 500 merely mentioning the variable name is not a credential gate — exact message only (codex finding)", () => {
+		expect(
+			classifyModelSweepGate({
+				status: 500,
+				body: { error: "failed while reading AI_GATEWAY_API_KEY from config" },
+			}),
+		).toEqual({ skip: false });
+	});
+
+	test("a transient network blip (status 0) is a fail path, never a credential skip (codex-verified)", () => {
+		expect(classifyModelSweepGate({ status: 0, body: undefined })).toEqual({ skip: false });
+	});
+
 	test("a clean 200 first probe runs the sweep", () => {
 		expect(classifyModelSweepGate({ status: 200, body: { ok: true } })).toEqual({ skip: false });
+	});
+});
+
+describe("redactSecrets (codex finding: fetch header errors echo credential values)", () => {
+	test("replaces every occurrence of each secret", () => {
+		expect(
+			redactSecrets("TypeError: invalid header value: 'sekret\\n' (from sekret)", ["sekret"]),
+		).toBe("TypeError: invalid header value: '[redacted]\\n' (from [redacted])");
+	});
+
+	test("unset/empty secrets are inert and non-matching text passes through", () => {
+		expect(redactSecrets("plain error", [undefined, ""])).toBe("plain error");
 	});
 });
 

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "vitest";
 import {
+	classifyModelSweepGate,
 	DEFAULT_PROD_URL,
 	detectAuthMode,
 	detectSsoWall,
+	evaluateE2eResults,
+	evaluateModelChecks,
 	evaluatePosture,
 	gateStage,
+	isRedirectToSignIn,
 	resolveTarget,
 	summarize,
+	validationSessionCookieName,
 } from "./validate-core.mjs";
 
 describe("resolveTarget", () => {
@@ -114,4 +119,130 @@ test("detectSsoWall spots Vercel deployment protection, not app redirects", () =
 	).toBe(true);
 	expect(detectSsoWall({ status: 307, location: "/sign-in" })).toBe(false);
 	expect(detectSsoWall({ status: 200 })).toBe(false);
+});
+
+test("isRedirectToSignIn (shared by posture and the #817 session pre-check)", () => {
+	expect(isRedirectToSignIn({ status: 307, location: "/sign-in" })).toBe(true);
+	expect(isRedirectToSignIn({ status: 200, location: "/sign-in" })).toBe(false);
+	expect(isRedirectToSignIn({ status: 307, location: "/" })).toBe(false);
+});
+
+test("validationSessionCookieName picks the __Secure- prefix over https, plain over http", () => {
+	expect(validationSessionCookieName("https://preview.example.vercel.app")).toBe(
+		"__Secure-better-auth.session_token",
+	);
+	expect(validationSessionCookieName("http://localhost:3101")).toBe(
+		"better-auth.session_token",
+	);
+});
+
+describe("classifyModelSweepGate (#816)", () => {
+	test("a 401/403 first probe means the validation session bounced — re-seed, not a failure", () => {
+		expect(classifyModelSweepGate({ status: 401 })).toEqual({
+			skip: true,
+			reason: "validation session expired — re-seed",
+		});
+		expect(classifyModelSweepGate({ status: 403 })).toEqual({
+			skip: true,
+			reason: "validation session expired — re-seed",
+		});
+	});
+
+	test("the route's exact missing-AI_GATEWAY_API_KEY message gates the whole stage as skipped", () => {
+		expect(
+			classifyModelSweepGate({
+				status: 500,
+				body: { ok: false, error: "AI_GATEWAY_API_KEY is not set in this deployment" },
+			}),
+		).toEqual({ skip: true, reason: "missing AI_GATEWAY_API_KEY in target deployment" });
+	});
+
+	test("an unrelated 500 is not swallowed as a credential gate", () => {
+		expect(classifyModelSweepGate({ status: 500, body: { error: "boom" } })).toEqual({
+			skip: false,
+		});
+	});
+
+	test("a clean 200 first probe runs the sweep", () => {
+		expect(classifyModelSweepGate({ status: 200, body: { ok: true } })).toEqual({ skip: false });
+	});
+});
+
+describe("evaluateModelChecks (#816)", () => {
+	test("a routed, replying model passes with the gateway id and latency in the detail", () => {
+		const checks = evaluateModelChecks([
+			{
+				id: "claude-haiku-4-5",
+				status: 200,
+				body: { ok: true, gatewayModel: "anthropic/claude-haiku-4.5", reply: "gateway live", latencyMs: 812 },
+			},
+		]);
+		expect(checks).toEqual([
+			{
+				id: "model:claude-haiku-4-5",
+				status: "pass",
+				detail: 'claude-haiku-4-5 → routed via anthropic/claude-haiku-4.5 in 812ms: "gateway live"',
+			},
+		]);
+	});
+
+	test("a non-200 or empty-reply model fails, one check per model, independent of the others", () => {
+		const checks = evaluateModelChecks([
+			{ id: "claude-fable-5", status: 200, body: { ok: true, reply: "gateway live" } },
+			{ id: "claude-opus-4-8", status: 502, body: { ok: false, status: 429, upstream: { error: "rate limited" } } },
+			{ id: "claude-sonnet-5", status: 200, body: { ok: true, reply: "" } },
+		]);
+		const byId = Object.fromEntries(checks.map((c) => [c.id, c.status]));
+		expect(byId["model:claude-fable-5"]).toBe("pass");
+		expect(byId["model:claude-opus-4-8"]).toBe("fail");
+		expect(byId["model:claude-sonnet-5"]).toBe("fail");
+	});
+});
+
+describe("evaluateE2eResults (#817)", () => {
+	function report(specs, extraSuites = []) {
+		return { suites: [{ title: "sample.spec.ts", specs }, ...extraSuites] };
+	}
+
+	test("one check per spec, pass/fail from Playwright's own ok verdict", () => {
+		const checks = evaluateE2eResults(
+			report([
+				{ title: "theme toggles @deployed-safe", ok: true, tests: [{ status: "expected" }] },
+				{ title: "compose autofocuses @deployed-safe", ok: false, tests: [{ status: "unexpected" }] },
+			]),
+		);
+		expect(checks).toEqual([
+			{ id: "e2e:theme toggles @deployed-safe", status: "pass", detail: "theme toggles @deployed-safe → expected" },
+			{
+				id: "e2e:compose autofocuses @deployed-safe",
+				status: "fail",
+				detail: "compose autofocuses @deployed-safe → unexpected",
+			},
+		]);
+	});
+
+	test("walks nested suites (describe blocks) too", () => {
+		const nested = evaluateE2eResults({
+			suites: [
+				{
+					title: "outer",
+					specs: [],
+					suites: [{ title: "inner", specs: [{ title: "a @deployed-safe", ok: true, tests: [{ status: "expected" }] }] }],
+				},
+			],
+		});
+		expect(nested).toHaveLength(1);
+		expect(nested[0].id).toBe("e2e:a @deployed-safe");
+	});
+
+	test("zero matched specs is a failing check, not a silent 0/0 pass", () => {
+		const checks = evaluateE2eResults({ suites: [] });
+		expect(checks).toEqual([
+			{
+				id: "e2e:no_specs_matched",
+				status: "fail",
+				detail: "no deployed-safe specs matched — check the @deployed-safe grep tag",
+			},
+		]);
+	});
 });

--- a/web-next/scripts/validate.mjs
+++ b/web-next/scripts/validate.mjs
@@ -1,22 +1,30 @@
 /*
  * Environment-targetable validation: `pnpm validate [--env local|prod | --url
  * <origin>]` runs the credential-free stages — reachability, then the
- * auth/security posture suite — against a local spawn or a real deployment,
- * and reports pass/fail/skip per check (JSON to output/validate/, exit 1 on
- * any failure). Stages needing credentials gate themselves and report
- * `skipped: missing <name>` rather than silently passing. #813/#815; the
- * authenticated, model, and agentic stages (#814/#816–#818) extend this.
+ * auth/security posture suite — plus the credentialed model-sweep (#816) and
+ * deployed-safe e2e (#817) stages, against a local spawn or a real
+ * deployment, and reports pass/fail/skip per check (JSON to output/validate/,
+ * exit 1 on any failure). Stages needing credentials gate themselves and
+ * report `skipped: missing <name>` rather than silently passing. #813/#815;
+ * the authenticated and agentic stages (#814/#818) still extend this.
  */
-import { mkdirSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { MODEL_OPTIONS } from "../src/lib/agent-runtime/models.ts";
 import {
+	classifyModelSweepGate,
 	detectAuthMode,
 	detectSsoWall,
+	evaluateE2eResults,
+	evaluateModelChecks,
 	evaluatePosture,
 	gateStage,
+	isRedirectToSignIn,
 	LOCAL_PORT,
 	resolveTarget,
 	summarize,
+	validationSessionCookieName,
 } from "./validate-core.mjs";
 import { bypassServerEnv, startProductionServer, WEB_NEXT_ROOT } from "./harness.mjs";
 
@@ -104,6 +112,102 @@ function authenticatedStage(env) {
 	return { id: "authenticated flows (#814)", status: "skip", reason: gate.runnable ? "not implemented" : gate.reason };
 }
 
+function safeJson(text) {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * #816: iterates every selectable model (agent-runtime/models.ts — the same
+ * set the picker offers) through the auth-gated `/api/diag/gateway`, proving
+ * selection actually routes per-model, not just a hardcoded default. Gates
+ * on the validation session (needed to call the auth-gated route at all) and
+ * — via the first probe's response — on the target actually having
+ * AI_GATEWAY_API_KEY, since that can only be observed by asking the
+ * deployment itself.
+ */
+async function modelSweepStage(baseUrl, env) {
+	const id = "model sweep (#816)";
+	const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION });
+	if (!gate.runnable) return { id, status: "skip", reason: gate.reason };
+
+	const cookie = `${validationSessionCookieName(baseUrl)}=${env.WEB_NEXT_VALIDATION_SESSION}`;
+	const probeModel = (modelId) =>
+		probe(baseUrl, `/api/diag/gateway?model=${encodeURIComponent(modelId)}`, { headers: { cookie } });
+
+	const [first, ...rest] = MODEL_OPTIONS;
+	const firstProbe = await probeModel(first.id);
+	const firstBody = safeJson(firstProbe.body);
+	const modelGate = classifyModelSweepGate({ status: firstProbe.status, body: firstBody });
+	if (modelGate.skip) return { id, status: "skip", reason: modelGate.reason };
+
+	const restProbes = await Promise.all(rest.map((m) => probeModel(m.id)));
+	const results = [
+		{ id: first.id, status: firstProbe.status, body: firstBody },
+		...rest.map((m, i) => ({ id: m.id, status: restProbes[i].status, body: safeJson(restProbes[i].body) })),
+	];
+	return { id, status: "run", checks: evaluateModelChecks(results) };
+}
+
+/**
+ * #817: replays the deployed-safe (`@deployed-safe`-tagged) Playwright specs
+ * against the target through `playwright.config.ts`'s deployed project seam
+ * (VALIDATE_TARGET_URL / VALIDATE_ENV_NAME), then interprets its JSON report.
+ * Gates on the validation session; a redirect-to-sign-in on a plain page
+ * fetch with that session's cookie — cheaper than launching a browser to find
+ * out — means the session bounced, matching the decision doc's expired-
+ * session skip wording.
+ */
+async function e2eDeployedSafeStage(target, env) {
+	const id = "e2e deployed-safe flows (#817)";
+	const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION });
+	if (!gate.runnable) return { id, status: "skip", reason: gate.reason };
+
+	const cookie = `${validationSessionCookieName(target.baseUrl)}=${env.WEB_NEXT_VALIDATION_SESSION}`;
+	const authCheck = await probe(target.baseUrl, "/", { headers: { cookie } });
+	if (isRedirectToSignIn(authCheck)) {
+		return { id, status: "skip", reason: "validation session expired — re-seed" };
+	}
+
+	const jsonOut = path.join(WEB_NEXT_ROOT, "output", "validate", target.envName, "e2e-results.json");
+	mkdirSync(path.dirname(jsonOut), { recursive: true });
+
+	const exitCode = await new Promise((resolve) => {
+		const child = spawn("pnpm", ["exec", "playwright", "test", "--grep", "@deployed-safe"], {
+			cwd: WEB_NEXT_ROOT,
+			stdio: "inherit",
+			env: {
+				...process.env,
+				VALIDATE_TARGET_URL: target.baseUrl,
+				VALIDATE_ENV_NAME: target.envName,
+				WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION,
+				VALIDATE_E2E_JSON_OUTPUT: jsonOut,
+			},
+		});
+		child.on("exit", (code) => resolve(code ?? 1));
+		child.on("error", () => resolve(1));
+	});
+
+	if (!existsSync(jsonOut)) {
+		return {
+			id,
+			status: "run",
+			checks: [
+				{
+					id: "e2e:report_missing",
+					status: "fail",
+					detail: `playwright exited ${exitCode} without writing a JSON report at ${path.relative(WEB_NEXT_ROOT, jsonOut)}`,
+				},
+			],
+		};
+	}
+	const report = JSON.parse(readFileSync(jsonOut, "utf8"));
+	return { id, status: "run", checks: evaluateE2eResults(report) };
+}
+
 async function main() {
 	const target = resolveTarget(process.argv.slice(2), process.env);
 	let server;
@@ -120,6 +224,8 @@ async function main() {
 			stages.push(await postureStage(target.baseUrl, reach.signIn));
 		}
 		stages.push(authenticatedStage(process.env));
+		stages.push(await modelSweepStage(target.baseUrl, process.env));
+		stages.push(await e2eDeployedSafeStage(target, process.env));
 
 		const summary = summarize(stages);
 		console.log(summary.lines.join("\n"));

--- a/web-next/scripts/validate.mjs
+++ b/web-next/scripts/validate.mjs
@@ -22,6 +22,7 @@ import {
 	gateStage,
 	isRedirectToSignIn,
 	LOCAL_PORT,
+	redactSecrets,
 	resolveTarget,
 	summarize,
 	validationSessionCookieName,
@@ -29,6 +30,9 @@ import {
 import { bypassServerEnv, startProductionServer, WEB_NEXT_ROOT } from "./harness.mjs";
 
 const PROBE_TIMEOUT_MS = 15_000;
+
+const MODEL_SWEEP_STAGE_ID = "model sweep (#816)";
+const E2E_STAGE_ID = "e2e deployed-safe flows (#817)";
 
 /** A fetch that never follows redirects and never throws on HTTP errors.
  * When VERCEL_AUTOMATION_BYPASS_SECRET is set, every probe carries the
@@ -55,7 +59,14 @@ async function probe(baseUrl, pathname, init = {}) {
 			body: await res.text().catch(() => ""),
 		};
 	} catch (error) {
-		return { path: pathname, method, status: 0, body: String(error) };
+		// A malformed credential can make fetch throw an invalid-header error
+		// that echoes the header VALUE — redact both secrets before the message
+		// can reach a check detail or the persisted report (codex finding).
+		const secrets = [
+			process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+			process.env.WEB_NEXT_VALIDATION_SESSION,
+		];
+		return { path: pathname, method, status: 0, body: redactSecrets(String(error), secrets) };
 	}
 }
 
@@ -130,7 +141,7 @@ function safeJson(text) {
  * deployment itself.
  */
 async function modelSweepStage(baseUrl, env) {
-	const id = "model sweep (#816)";
+	const id = MODEL_SWEEP_STAGE_ID;
 	const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION });
 	if (!gate.runnable) return { id, status: "skip", reason: gate.reason };
 
@@ -162,7 +173,7 @@ async function modelSweepStage(baseUrl, env) {
  * session skip wording.
  */
 async function e2eDeployedSafeStage(target, env) {
-	const id = "e2e deployed-safe flows (#817)";
+	const id = E2E_STAGE_ID;
 	const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION });
 	if (!gate.runnable) return { id, status: "skip", reason: gate.reason };
 
@@ -219,13 +230,24 @@ async function main() {
 		console.log(`validating ${target.envName}: ${target.baseUrl}\n`);
 		const reach = await reachabilityStage(target.baseUrl);
 		const stages = [reach];
-		// No point probing posture on a target that isn't serving (or is walled).
-		if (reach.status === "run" && reach.checks.every((c) => c.status === "pass")) {
+		// No point probing posture — or running the credentialed stages — on a
+		// target that isn't serving (or is SSO-walled). Running the model sweep /
+		// e2e against a wall would report app failures for what is a missing
+		// bypass credential (codex finding); they inherit reachability's verdict
+		// as their own skip reason instead.
+		const reachable = reach.status === "run" && reach.checks.every((c) => c.status === "pass");
+		if (reachable) {
 			stages.push(await postureStage(target.baseUrl, reach.signIn));
 		}
 		stages.push(authenticatedStage(process.env));
-		stages.push(await modelSweepStage(target.baseUrl, process.env));
-		stages.push(await e2eDeployedSafeStage(target, process.env));
+		if (reachable) {
+			stages.push(await modelSweepStage(target.baseUrl, process.env));
+			stages.push(await e2eDeployedSafeStage(target, process.env));
+		} else {
+			const reason = reach.status === "skip" ? reach.reason : "target unreachable — see reachability stage";
+			stages.push({ id: MODEL_SWEEP_STAGE_ID, status: "skip", reason });
+			stages.push({ id: E2E_STAGE_ID, status: "skip", reason });
+		}
 
 		const summary = summarize(stages);
 		console.log(summary.lines.join("\n"));

--- a/web-next/src/app/api/diag/gateway/route.test.ts
+++ b/web-next/src/app/api/diag/gateway/route.test.ts
@@ -1,0 +1,109 @@
+/*
+ * GET /api/diag/gateway — auth gating (unchanged), model-id validation
+ * against agent-runtime/models.ts, and the gateway-model translation used in
+ * the outgoing AI Gateway call. `getAuthState` and `fetch` are mocked; no
+ * real network call or credential is involved.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getAuthState } from "@/lib/auth/auth-state";
+
+vi.mock("@/lib/auth/auth-state", () => ({
+	getAuthState: vi.fn(),
+}));
+
+const AUTHORIZED = {
+	kind: "authorized" as const,
+	user: { login: "fairchild", name: "Fairchild" },
+};
+
+const originalFetch = global.fetch;
+const originalKey = process.env.AI_GATEWAY_API_KEY;
+
+beforeEach(() => {
+	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+	process.env.AI_GATEWAY_API_KEY = "test-key";
+});
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	process.env.AI_GATEWAY_API_KEY = originalKey;
+	vi.clearAllMocks();
+});
+
+async function get(url: string) {
+	const { GET } = await import("./route");
+	return GET(new Request(url));
+}
+
+describe("GET /api/diag/gateway", () => {
+	test("401s when unauthenticated (auth gate unchanged)", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "unauthenticated" });
+		const res = await get("http://test/api/diag/gateway");
+		expect(res.status).toBe(401);
+	});
+
+	test("403s when signed in but not allowlisted", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "forbidden", login: "nope" });
+		const res = await get("http://test/api/diag/gateway");
+		expect(res.status).toBe(403);
+	});
+
+	test("rejects an unknown model id with 400, never reaching the gateway", async () => {
+		const fetchSpy = vi.fn();
+		global.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await get("http://test/api/diag/gateway?model=gpt-5");
+		expect(res.status).toBe(400);
+		expect((await res.json()).error).toMatch(/unknown model/);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	test("defaults to DEFAULT_MODEL when no model param is given (#815 posture probe unaffected)", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ model: "anthropic/claude-fable-5", choices: [{ message: { content: "gateway live" } }] }), {
+				status: 200,
+			}),
+		);
+		global.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await get("http://test/api/diag/gateway");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.model).toBe("claude-fable-5");
+		expect(body.gatewayModel).toBe("anthropic/claude-fable-5");
+	});
+
+	test("translates a selected model id to its gateway string in the outgoing call", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ choices: [{ message: { content: "gateway live" } }] }), { status: 200 }),
+		);
+		global.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await get("http://test/api/diag/gateway?model=claude-haiku-4-5");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.model).toBe("claude-haiku-4-5");
+		expect(body.gatewayModel).toBe("anthropic/claude-haiku-4.5");
+
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const sentBody = JSON.parse(init.body as string);
+		expect(sentBody.model).toBe("anthropic/claude-haiku-4.5");
+	});
+
+	test("missing AI_GATEWAY_API_KEY reports 500 with the exact message the validation stage gates on", async () => {
+		delete process.env.AI_GATEWAY_API_KEY;
+		const res = await get("http://test/api/diag/gateway?model=claude-sonnet-5");
+		expect(res.status).toBe(500);
+		expect((await res.json()).error).toBe("AI_GATEWAY_API_KEY is not set in this deployment");
+	});
+
+	test("an upstream gateway error is returned verbatim with the requested model", async () => {
+		const fetchSpy = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ error: "rate limited" }), { status: 429 }),
+		);
+		global.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await get("http://test/api/diag/gateway?model=claude-opus-4-8");
+		expect(res.status).toBe(502);
+		const body = await res.json();
+		expect(body.ok).toBe(false);
+		expect(body.model).toBe("claude-opus-4-8");
+		expect(body.status).toBe(429);
+	});
+});

--- a/web-next/src/app/api/diag/gateway/route.test.ts
+++ b/web-next/src/app/api/diag/gateway/route.test.ts
@@ -106,4 +106,17 @@ describe("GET /api/diag/gateway", () => {
 		expect(body.model).toBe("claude-opus-4-8");
 		expect(body.status).toBe(429);
 	});
+
+	test("a throwing fetch (malformed key → invalid-header error) yields 502 with no key material (codex finding)", async () => {
+		process.env.AI_GATEWAY_API_KEY = "sekret-key-value\n";
+		const fetchSpy = vi
+			.fn()
+			.mockRejectedValue(new TypeError("invalid header value: 'Bearer sekret-key-value\n'"));
+		global.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await get("http://test/api/diag/gateway?model=claude-haiku-4-5");
+		expect(res.status).toBe(502);
+		const text = JSON.stringify(await res.json());
+		expect(text).not.toContain("sekret-key-value");
+		expect(text).toContain("TypeError");
+	});
 });

--- a/web-next/src/app/api/diag/gateway/route.ts
+++ b/web-next/src/app/api/diag/gateway/route.ts
@@ -1,18 +1,32 @@
 /*
- * GET /api/diag/gateway — auth-gated diagnostic probe: makes one tiny real
- * model call through the AI Gateway to prove the credential, billing, and
- * model routing work in this deployment, before the real runtime (#750)
- * depends on them. Returns the model's reply or the upstream error verbatim.
+ * GET /api/diag/gateway[?model=<id>] — auth-gated diagnostic probe: makes one
+ * tiny real model call through the AI Gateway to prove the credential,
+ * billing, and model routing work in this deployment, before the real
+ * runtime (#750) depends on them. `model` must be one of the selectable ids
+ * in `agent-runtime/models.ts` (the single source of truth the picker and
+ * session creation also read) — defaults to `DEFAULT_MODEL` when omitted, so
+ * the #815 posture stage's existing bare `GET /api/diag/gateway` probe is
+ * unaffected. #816's validation stage calls this once per selectable model to
+ * prove selection actually routes, not just a hardcoded default. Returns the
+ * model's reply or the upstream error verbatim.
  */
+import { DEFAULT_MODEL } from "@/lib/agent-runtime/models";
 import { getAuthState } from "@/lib/auth/auth-state";
+import { resolveGatewayModel } from "@/lib/diag/gateway-model";
 
-export async function GET() {
+export async function GET(request: Request) {
 	const auth = await getAuthState();
 	if (auth.kind !== "authorized") {
 		return Response.json(
 			{ error: "not signed in as the allowed user" },
 			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
 		);
+	}
+
+	const requestedModel = new URL(request.url).searchParams.get("model") ?? DEFAULT_MODEL;
+	const resolved = resolveGatewayModel(requestedModel);
+	if (!resolved.ok) {
+		return Response.json({ ok: false, error: resolved.error }, { status: 400 });
 	}
 
 	const key = process.env.AI_GATEWAY_API_KEY;
@@ -31,7 +45,7 @@ export async function GET() {
 			"Content-Type": "application/json",
 		},
 		body: JSON.stringify({
-			model: "anthropic/claude-haiku-4.5",
+			model: resolved.gatewayModel,
 			messages: [{ role: "user", content: "Reply with exactly: gateway live" }],
 			max_tokens: 10,
 		}),
@@ -40,14 +54,15 @@ export async function GET() {
 	const body = await response.json().catch(() => null);
 	if (!response.ok) {
 		return Response.json(
-			{ ok: false, status: response.status, upstream: body },
+			{ ok: false, model: requestedModel, status: response.status, upstream: body },
 			{ status: 502 },
 		);
 	}
 
 	return Response.json({
 		ok: true,
-		model: body?.model,
+		model: requestedModel,
+		gatewayModel: resolved.gatewayModel,
 		reply: body?.choices?.[0]?.message?.content,
 		usage: body?.usage,
 		latencyMs: Date.now() - startedAt,

--- a/web-next/src/app/api/diag/gateway/route.ts
+++ b/web-next/src/app/api/diag/gateway/route.ts
@@ -38,18 +38,30 @@ export async function GET(request: Request) {
 	}
 
 	const startedAt = Date.now();
-	const response = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${key}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			model: resolved.gatewayModel,
-			messages: [{ role: "user", content: "Reply with exactly: gateway live" }],
-			max_tokens: 10,
-		}),
-	});
+	let response: Response;
+	try {
+		response = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${key}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				model: resolved.gatewayModel,
+				messages: [{ role: "user", content: "Reply with exactly: gateway live" }],
+				max_tokens: 10,
+			}),
+		});
+	} catch (error) {
+		// A malformed key value makes fetch throw an invalid-header error whose
+		// message echoes `Bearer <value>` — report the error CLASS only, never
+		// the message, so the credential can't leak into logs or the response.
+		const name = error instanceof Error ? error.name : "Error";
+		return Response.json(
+			{ ok: false, model: requestedModel, error: `gateway request failed before a response (${name})` },
+			{ status: 502 },
+		);
+	}
 
 	const body = await response.json().catch(() => null);
 	if (!response.ok) {

--- a/web-next/src/lib/diag/gateway-model.test.ts
+++ b/web-next/src/lib/diag/gateway-model.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { MODEL_OPTIONS } from "@/lib/agent-runtime/models";
+import { resolveGatewayModel, toGatewayModelId } from "./gateway-model";
+
+describe("toGatewayModelId", () => {
+	test("translates every current selectable model id (grounded against the pre-existing hardcoded call)", () => {
+		expect(toGatewayModelId("claude-fable-5")).toBe("anthropic/claude-fable-5");
+		expect(toGatewayModelId("claude-opus-4-8")).toBe("anthropic/claude-opus-4.8");
+		expect(toGatewayModelId("claude-sonnet-5")).toBe("anthropic/claude-sonnet-5");
+		expect(toGatewayModelId("claude-haiku-4-5")).toBe("anthropic/claude-haiku-4.5");
+	});
+
+	test("every MODEL_OPTIONS id translates to a distinct gateway id", () => {
+		const translated = MODEL_OPTIONS.map((option) => toGatewayModelId(option.id));
+		expect(new Set(translated).size).toBe(MODEL_OPTIONS.length);
+	});
+});
+
+describe("resolveGatewayModel", () => {
+	test("accepts a known id and returns its gateway translation", () => {
+		expect(resolveGatewayModel("claude-haiku-4-5")).toEqual({
+			ok: true,
+			gatewayModel: "anthropic/claude-haiku-4.5",
+		});
+	});
+
+	test("rejects an id outside the selectable set", () => {
+		expect(resolveGatewayModel("gpt-5")).toEqual({
+			ok: false,
+			error: "unknown model: gpt-5",
+		});
+	});
+
+	test("rejects the empty string", () => {
+		expect(resolveGatewayModel("").ok).toBe(false);
+	});
+});

--- a/web-next/src/lib/diag/gateway-model.ts
+++ b/web-next/src/lib/diag/gateway-model.ts
@@ -1,0 +1,30 @@
+/*
+ * Translates a selectable Claude Code model id (`agent-runtime/models.ts` —
+ * the CLI's own id shape, e.g. `claude-haiku-4-5`) into the AI Gateway's
+ * OpenAI-compatible model string (e.g. `anthropic/claude-haiku-4.5`) for
+ * `/api/diag/gateway`. These are two different id namespaces for the same
+ * models: the CLI harness forwards its id straight to `claude --model`,
+ * while the gateway's chat/completions endpoint wants a provider-prefixed,
+ * dot-versioned string. The only structural difference between the two
+ * shapes is the trailing `-<major>-<minor>` version suffix becoming
+ * `-<major>.<minor>` — verified against all four current ids, including the
+ * pre-existing hardcoded gateway call this replaces (`claude-haiku-4-5` →
+ * `anthropic/claude-haiku-4.5`).
+ */
+import { isSelectableModel } from "@/lib/agent-runtime/models";
+
+const TRAILING_TWO_PART_VERSION = /-(\d+)-(\d+)$/;
+
+export function toGatewayModelId(id: string): string {
+	return `anthropic/${id.replace(TRAILING_TWO_PART_VERSION, "-$1.$2")}`;
+}
+
+/** Validates against the single source of truth before translating. */
+export function resolveGatewayModel(
+	id: string,
+): { ok: true; gatewayModel: string } | { ok: false; error: string } {
+	if (!isSelectableModel(id)) {
+		return { ok: false, error: `unknown model: ${id}` };
+	}
+	return { ok: true, gatewayModel: toGatewayModelId(id) };
+}

--- a/web-next/tests/e2e/sessions-demo.spec.ts
+++ b/web-next/tests/e2e/sessions-demo.spec.ts
@@ -4,13 +4,24 @@
  * compose, ledger row disclosure (including a landed edit's diff, which
  * lives inside its own Edit row — #790), status line dismiss-to-dot, and
  * the focus cue / receipt furniture.
+ *
+ * Every test here is tagged `@deployed-safe` (#817): /sessions/demo renders
+ * entirely from fixture data (see page.tsx — "no backend"), so the whole
+ * file is read-mostly and safe to replay against a real deployment through
+ * `pnpm validate`'s e2e stage — no session is created, no DB row is
+ * written, and no real agent-runtime turn is ever triggered. Contrast
+ * sessions.spec.ts and terminal.spec.ts, which drive real session creation,
+ * a scripted mock turn, and a live shell, and are deliberately left
+ * untagged: against a deployed target the mock provider is gone and those
+ * flows would run a real, costly Claude Code sandbox — out of scope until
+ * #818's spend-gated real-agentic-turn stage.
  */
 import { expect, test } from "@playwright/test";
 
 const theme = (page: import("@playwright/test").Page) =>
 	page.locator("html").getAttribute("data-theme");
 
-test("theme: system preference by default, toggle overrides and persists", async ({
+test("theme: system preference by default, toggle overrides and persists @deployed-safe", async ({
 	page,
 }) => {
 	await page.emulateMedia({ colorScheme: "dark" });
@@ -26,7 +37,7 @@ test("theme: system preference by default, toggle overrides and persists", async
 	expect(await theme(page)).toBe("light");
 });
 
-test("theme: #light/#dark hash forces the theme like the prototype", async ({
+test("theme: #light/#dark hash forces the theme like the prototype @deployed-safe", async ({
 	page,
 }) => {
 	await page.emulateMedia({ colorScheme: "light" });
@@ -45,7 +56,7 @@ test("theme: #light/#dark hash forces the theme like the prototype", async ({
 	expect(await theme(page)).toBe("light");
 });
 
-test("compose autofocuses with no placeholder or hint chips", async ({
+test("compose autofocuses with no placeholder or hint chips @deployed-safe", async ({
 	page,
 }) => {
 	await page.goto("/sessions/demo");
@@ -58,7 +69,7 @@ test("compose autofocuses with no placeholder or hint chips", async ({
 	).toBeLessThanOrEqual(2);
 });
 
-test("tool ledger rows disclose and collapse their bodies", async ({
+test("tool ledger rows disclose and collapse their bodies @deployed-safe", async ({
 	page,
 }) => {
 	await page.goto("/sessions/demo");
@@ -82,7 +93,7 @@ test("tool ledger rows disclose and collapse their bodies", async ({
 	await expect(readBody).toBeHidden();
 });
 
-test("expanding the Edit row reveals its diff — no separate floating diff card", async ({
+test("expanding the Edit row reveals its diff — no separate floating diff card @deployed-safe", async ({
 	page,
 }) => {
 	await page.goto("/sessions/demo");
@@ -109,7 +120,7 @@ test("expanding the Edit row reveals its diff — no separate floating diff card
 	await expect(body).toBeHidden();
 });
 
-test("status line dismisses to a dot and comes back", async ({ page }) => {
+test("status line dismisses to a dot and comes back @deployed-safe", async ({ page }) => {
 	await page.goto("/sessions/demo");
 	const statusLine = page.getByTestId("status-line");
 	await expect(statusLine).toContainText("opus-4.8");
@@ -123,7 +134,7 @@ test("status line dismisses to a dot and comes back", async ({ page }) => {
 	await expect(page.getByTestId("status-line")).toContainText("2.1k ctx");
 });
 
-test("turn frame focus cue and end-of-turn receipt are present", async ({
+test("turn frame focus cue and end-of-turn receipt are present @deployed-safe", async ({
 	page,
 }) => {
 	await page.goto("/sessions/demo");
@@ -141,7 +152,7 @@ test("turn frame focus cue and end-of-turn receipt are present", async ({
 	).toContainText("Editing");
 });
 
-test("seeded transcript renders the requested message count", async ({
+test("seeded transcript renders the requested message count @deployed-safe", async ({
 	page,
 }) => {
 	await page.goto("/sessions/demo?seed=20");


### PR DESCRIPTION
Closes #816
Closes #817

## Summary

Two more self-gating stages for `pnpm validate` (milestone #13's W3 arc), both consuming the pre-minted `WEB_NEXT_VALIDATION_SESSION` identity from `docs/decisions/web-next-validation-identity.md`:

- **#816 — model sweep.** `/api/diag/gateway` now accepts `?model=<id>`, validated against `agent-runtime/models.ts` (the same source of truth the picker reads), and translates it to the AI Gateway's provider-prefixed string via a new pure `toGatewayModelId`. A new `modelSweepStage` in `validate.mjs` calls the route once per selectable model against the target, reporting per-model routed/replied + latency.
- **#817 — deployed-safe e2e.** `playwright.config.ts` gets an additive, env-gated seam (`VALIDATE_TARGET_URL` + `WEB_NEXT_VALIDATION_SESSION`) that points the *same* spec files at a real deployment instead of the local bypass server — default local behavior is unchanged when that var is unset. Eight `sessions-demo.spec.ts` tests are tagged `@deployed-safe` (fixture-rendered, no backend — theme, compose, ledger disclosure, diff card, status line, focus cue, seeded transcript); `sessions.spec.ts`/`auth.spec.ts` are deliberately untagged. A new `e2eDeployedSafeStage` greps for the tag, spawns Playwright, and interprets its JSON report.

## Stage designs + skip semantics

Both stages gate on `WEB_NEXT_VALIDATION_SESSION` first (`skipped: missing WEB_NEXT_VALIDATION_SESSION`), then probe once to distinguish a genuinely broken target from a credential problem:

- **Bounced session** (401/403 from `/api/diag/gateway`, or a redirect-to-`/sign-in` on a plain page load) → `skipped: validation session expired — re-seed`, the exact wording the decision doc specifies.
- **Model sweep only:** the target's own `AI_GATEWAY_API_KEY is not set in this deployment` message (already the route's exact error string) → `skipped: missing AI_GATEWAY_API_KEY in target deployment`. This can only be observed by asking the deployment itself — there's no way to know from outside whether that key is set.
- Anything else runs for real, and a broken model call or a failing e2e assertion is `fail`, never silently absorbed into a skip. Verified with a mutation check (see Evidence).

## Deliberate scope call — session/turn flows are NOT deployed-safe

Issue #817's acceptance text mentions "new session, a streamed turn, resume/persistence" — I deliberately did **not** tag `sessions.spec.ts` for deployed runs. Against a real deployment the mock provider is gone; sending a message there would trigger a real, costly Claude Code sandbox turn (and potentially open a real PR) from an automated validation run. That's out of scope until #818's spend-gated real-agentic-turn stage, per the decision doc's spend posture. `sessions-demo.spec.ts` (fixture-rendered, `?seed=`/`?scenario=` driven, zero backend) covers the same UI surface — theme, compose, ledger, diff card, status line, turn-frame receipt — without ever mutating state or spending money, which is what "deployed-safe" means here.

## Preview-500 diagnosis (read-only investigation — no Vercel settings changed)

Investigated why preview deployments 500 when hit with the bypass header. Via the Vercel API (project `prj_ucOY3JKR5BCrbtbfz8DTSFJe5U9m`), **all 12 project env vars are scoped to `target: ["production"]` only** — zero vars have `preview` in their target list (`AI_GATEWAY_API_KEY`, `ALLOWED_LOGINS`, `ANTHROPIC_API_KEY`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `GITHUB_WEB_WORKSPACES_APP_ID`, `SESSIONS_DATABASE_AUTH_TOKEN`, `SESSIONS_DATABASE_URL`, `WEB_NEXT_COMPUTE_PROVIDER`). Probed two live `READY` preview deployments directly with the bypass header: `/` redirects cleanly (307 → `/sign-in` — middleware never touches the DB), but `/sign-in` itself 500s on both (generic Next.js error shell, no stack — expected for a prod build).

**Root cause (verified in code, consistent with the probes):** with no env vars, preview has neither `GITHUB_OAUTH_CLIENT_ID` (so real auth is unconfigured) nor `AUTH_BYPASS` (so the bypass is inert). `/sign-in`'s server component calls `getAuthState()`, whose real-auth branch calls `getDatabase()`; `SESSIONS_DATABASE_URL` unset falls back to `file:.data/sessions.db`, and `createDatabase` runs `mkdirSync(dirname(...))` (`src/lib/db/client.ts:94`) — on Vercel's read-only serverless filesystem that throws, uncaught, → 500.

**Recommended fix (not applied):** add to the `preview` target — `SESSIONS_DATABASE_URL` + `SESSIONS_DATABASE_AUTH_TOKEN` (same remote DB as production, so a validation-session row is visible there), `BETTER_AUTH_SECRET` (same value as production — cookie-cache verification needs the identical signing secret), `ALLOWED_LOGINS`, `GITHUB_WEB_WORKSPACES_APP_ID` + `GITHUB_APP_PRIVATE_KEY`, `AI_GATEWAY_API_KEY`.

Two things that need an explicit owner decision, not a mechanical copy-paste:
1. `BETTER_AUTH_URL`/`GITHUB_OAUTH_CLIENT_ID`/`GITHUB_OAUTH_CLIENT_SECRET` — GitHub OAuth apps have a fixed callback URL, but preview URLs are per-deployment. Real interactive OAuth can't work on preview regardless of env vars; if the intent is only to *replay* the pre-minted validation session cookie (this PR's design), `GITHUB_OAUTH_CLIENT_ID` can stay production-only. But then `realAuthConfigured()` is false on preview, which makes `AUTH_BYPASS` non-inert there if it's ever set — worth being deliberate about.
2. If `BETTER_AUTH_URL` is scoped to preview, it can't be the static production value — Vercel supports interpolating `https://$VERCEL_URL` per-deployment for this.

## Quality gates

- `pnpm test` — 273/273 passing (up from 260; +13 new: `gateway-model.test.ts`, `route.test.ts`, `deployed-safe-specs.test.mjs`, plus additions to `validate-core.test.mjs`).
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- `pnpm build` — clean.
- `pnpm test:e2e` — 29/29 passing locally after rebasing onto #909/#912 (confirms the default `VALIDATE_TARGET_URL`-unset path is unchanged, including main's new terminal project).
- Mutation check: flipped `evaluateModelChecks`'s pass condition to `const ok = true`; the "non-200 or empty-reply model fails" test caught it immediately; reverted.
- `pnpm validate --env prod` (real production, uncredentialed): reachability + posture green (8/8 checks), all three credentialed stages correctly `skipped: missing WEB_NEXT_VALIDATION_SESSION`.
- Same run with a deliberately garbage `WEB_NEXT_VALIDATION_SESSION` value against real production: model sweep and e2e stages both correctly reported `skipped: validation session expired — re-seed` — proves the gate logic against the real deployment, not just mocks (the session hasn't been minted yet, so this is the closest available live proof of the credentialed path).
- `pnpm validate --url http://localhost:9` with a session set: reachability fails, and the model/e2e stages report `skipped: target unreachable — see reachability stage` (the codex blocker-1 fix, proven live).

## Review loop

Self-reflection pass (pre-codex): caught that Playwright traces capture request headers — a deployed-run trace would embed the validation session cookie and bypass header in an artifact. Fixed before review (`trace: isDeployed ? "off" : "on-first-retry"`); codex independently confirmed the fix sound and found no other artifact path for a well-formed token.

codex (gpt-5.5, xhigh) directed review — findings and dispositions (reaction commit: `In response to codex (gpt-5.5, xhigh): …`):

1. **Blocker — SSO/unreachable target turned credential absence into stage failures** (validate.mjs ran the model sweep + e2e even when reachability skipped/failed; against an SSO wall they'd report app failures). **Accepted + fixed**: both stages now inherit reachability's verdict as their own skip reason; proven live (see Evidence).
2. **Blocker — malformed secret values could echo into logs/reports** (Node fetch's invalid-header error message embeds the header *value*; `String(error)` flowed into check details and the persisted JSON; same class in the diag route's outbound call, which could log `Bearer <key>`). **Accepted + fixed**: `probe()` redacts both harness secrets from error text (`redactSecrets`, unit-tested); the route catches the outbound fetch throw and reports the error class only, with a test asserting no key material in the 502 body.
3. **Minor — `.mjs` importing `.ts` is fragile under raw `node`** (works on Node 26 with a warning; CI pins Node 22, and the repo precedent — `perf/run.mjs` → `projection-bench.mjs` — runs such imports through `tsx`). **Accepted + fixed**: `pnpm validate` now runs via `tsx`.
4. codex also suggested tightening the missing-key gate to the exact message — **accepted** in the same commit (`MISSING_GATEWAY_KEY_ERROR` exact match, with a test that a 500 merely mentioning the variable name doesn't gate).

codex confirmations (negative results worth citing): transient network blips (status 0) are a fail path, not a credential skip; upstream gateway 5xx isn't swallowed by the key gate; the local Playwright path with `VALIDATE_TARGET_URL` unset matches the pre-diff behavior for webServer, storageState, reporter, and trace. codex's own verification run: 38 targeted tests passed.

Process note: codex reviewed the pre-rebase diff; the subsequent rebase onto #909/#912 only reconciled `playwright.config.ts` (E2E_PORT + terminal project), re-tagged the renamed Edit-row spec, and extended the curation guard to `terminal.spec.ts` — all gates re-run green after the rebase.

## Mergeability

- Surface: web — `web-next/` validation harness (`scripts/validate.mjs`, `playwright.config.ts`, `/api/diag/gateway`), plus 8 e2e spec titles tagged.
- User-facing behavior changed: No — `/api/diag/gateway` is an internal auth-gated diagnostic route with no UI caller; its default (`?model` omitted) behavior is unchanged. `playwright.config.ts`'s default (local) behavior is unchanged when `VALIDATE_TARGET_URL` is unset — verified by a full local `pnpm test:e2e` pass (29/29 incl. the new terminal project).
- Non-happy paths considered: missing/expired validation session; missing target gateway credential (exact-message gate); SSO-walled or unreachable target (stages skip with reachability's reason, never fail); malformed `?model` id (400, never reaches the gateway); a malformed credential making fetch throw (secret-redacted error text, route reports error class only); a Playwright run that crashes without producing a JSON report; zero specs matching the deployed-safe grep tag (failing check, not a silent 0/0 pass).
- Residual risk or follow-up: `WEB_NEXT_VALIDATION_SESSION` isn't minted yet, so the live credentialed sweep/e2e paths are proven against a deliberately-invalid token (the gate fires correctly) rather than a real successful run — the natural follow-up once the orchestrator seeds the session. The preview-500 env var gaps found above are a separate follow-up for the orchestrator to apply (no Vercel settings touched by this PR).

## Evidence

tests passed: `pnpm test` 314/314 (31 files), `pnpm typecheck` clean, `pnpm lint` clean, `pnpm build` clean, `pnpm test:e2e` 29/29 — all on the rebased head.

`pnpm validate --env prod` output (real production run, uncredentialed):
```
validating prod: https://web-next-ivory-six.vercel.app

✓ reachability — 1/1 checks
   ✓ signin_reachable: GET https://web-next-ivory-six.vercel.app/sign-in → 200
✓ posture (real auth) — 7/7 checks
   ✓ home_gated / signin_serves / no_bypass_button / forged_bypass_cookie_inert / api_no_data×3
○ authenticated flows (#814) — skipped: missing WEB_NEXT_VALIDATION_SESSION
○ model sweep (#816) — skipped: missing WEB_NEXT_VALIDATION_SESSION
○ e2e deployed-safe flows (#817) — skipped: missing WEB_NEXT_VALIDATION_SESSION
```

Same target with a deliberately invalid session token (gate proof against real prod):
```
○ model sweep (#816) — skipped: validation session expired — re-seed
○ e2e deployed-safe flows (#817) — skipped: validation session expired — re-seed
```

- CI: green quality lane on bb71f9e: https://github.com/fairchild/workspaces/actions/runs/28888445223/job/85694560249
- Gate note: orchestrator ran the LIVE authed validation against production with the freshly-minted WEB_NEXT_VALIDATION_SESSION (the credential the agent lacked): reachability 1/1, posture 7/7, model sweep #816 **4/4 live** (fable-5 1488ms, opus-4-8 558ms, sonnet-5 624ms, haiku-4-5 1010ms — all routed and replied through prod's gateway), deployed-safe e2e #817 **8/8 in a real browser against prod**. Preview env posture fix applied per this PR's diagnosis (7 vars now target production+preview). Codex ran foreground (2 blockers + 1 minor fixed, attributed). Merged on delegated authority.

