### PR TITLE
ci: fetch Xcode Cloud build logs via the App Store Connect API

### DIFF
--- a/.github/workflows/xcode-cloud-logs.yml
+++ b/.github/workflows/xcode-cloud-logs.yml
@@ -1,0 +1,44 @@
+# Fetches Xcode Cloud build logs for a commit via the App Store Connect API.
+# GitHub check-runs only carry Xcode Cloud's one-line failure summary; the full
+# script stdout/stderr lives in ASC LOG_BUNDLE artifacts, and the ASC API
+# credentials exist only as repo secrets — so the fetch runs inside Actions.
+name: Xcode Cloud Logs
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Commit SHA whose Xcode Cloud build logs to fetch
+        required: true
+  push:
+    branches:
+      - ci/xcode-cloud-logs
+
+permissions:
+  contents: read
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
+      - name: Fetch logs
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          TARGET_SHA: ${{ inputs.sha || '9b57a02a714fdb218b3db6cb8fc673510c84081b' }}
+        run: uv run --script scripts/fetch-xcode-cloud-logs.py --sha "$TARGET_SHA" --out "$RUNNER_TEMP/xcode-cloud-logs"
+
+      - name: Upload log bundles
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: xcode-cloud-logs
+          path: ${{ runner.temp }}/xcode-cloud-logs
+          retention-days: 5
+          if-no-files-found: ignore

--- a/scripts/fetch-xcode-cloud-logs.py
+++ b/scripts/fetch-xcode-cloud-logs.py
@@ -35,6 +35,7 @@ API_BASE = "https://api.appstoreconnect.apple.com"
 INTERESTING_LOG = re.compile(r"post[_-]?clone|pre[_-]?xcodebuild|RunScript|ghosttykit", re.I)
 FAILURE_LINE = re.compile(r"error|failed|fatal|No such file|command not found|sudo", re.I)
 TAIL_LINES = 200
+MAX_LINE_CHARS = 400
 
 
 def require_env(name: str) -> str:
@@ -69,7 +70,10 @@ def api_get(token: str, url: str) -> dict[str, Any]:
             return json.load(resp)
     except HTTPError as err:
         body = err.read().decode("utf-8", "replace")[:2000]
-        sys.exit(f"error: GET {url} -> HTTP {err.code}\n{body}")
+        hint = ""
+        if err.code == 401:
+            hint = "\nhint: Xcode Cloud endpoints need a Team API key with the App Manager role (ASC > Users and Access > Integrations > Team Keys, issuer ID from that page)"
+        sys.exit(f"error: GET {url} -> HTTP {err.code}\n{body}{hint}")
 
 
 def paged(token: str, path: str, max_pages: int = 5, **params: str) -> Iterator[dict[str, Any]]:
@@ -82,6 +86,7 @@ def paged(token: str, path: str, max_pages: int = 5, **params: str) -> Iterator[
         url = page.get("links", {}).get("next")
         if not url:
             return
+    print(f"note: stopped after {max_pages} pages of {path}; older entries were not searched", file=sys.stderr)
 
 
 def commit_sha(run: dict[str, Any]) -> str:
@@ -111,21 +116,29 @@ def print_issues(token: str, action_id: str) -> None:
         print(f"    issue [{attrs.get('issueType')}/{attrs.get('category')}]{location}: {attrs.get('message')}")
 
 
+def clip(line: str) -> str:
+    return line if len(line) <= MAX_LINE_CHARS else line[:MAX_LINE_CHARS] + " …[truncated]"
+
+
 def excerpt(path: Path) -> None:
     try:
-        lines = path.read_text(errors="replace").splitlines()
+        raw = path.read_bytes()
     except OSError as err:
         print(f"    (unreadable: {err})")
         return
+    if b"\x00" in raw[:8192]:
+        print(f"    (binary file skipped: {path.name})")
+        return
+    lines = raw.decode("utf-8", "replace").splitlines()
     interesting = path.name and INTERESTING_LOG.search(str(path))
     if interesting:
         print(f"    ---- tail -{TAIL_LINES} {path.name} ----")
         for line in lines[-TAIL_LINES:]:
-            print(f"    {line}")
+            print(f"    {clip(line)}")
     else:
         hits = [line for line in lines if FAILURE_LINE.search(line)][:40]
         for line in hits:
-            print(f"    {path.name}: {line}")
+            print(f"    {path.name}: {clip(line)}")
 
 
 def download_artifacts(token: str, action_id: str, dest: Path) -> None:
@@ -144,7 +157,9 @@ def download_artifacts(token: str, action_id: str, dest: Path) -> None:
         with urlopen(Request(url)) as resp:
             target.write_bytes(resp.read())
         if zipfile.is_zipfile(target):
-            extract_dir = target.with_suffix("")
+            # A distinct suffix, not with_suffix(""): a suffixless fileName
+            # would otherwise collide with the downloaded archive itself.
+            extract_dir = target.with_name(target.name + ".extracted")
             with zipfile.ZipFile(target) as bundle:
                 bundle.extractall(extract_dir)
             for member in sorted(extract_dir.rglob("*")):

--- a/scripts/fetch-xcode-cloud-logs.py
+++ b/scripts/fetch-xcode-cloud-logs.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pyjwt[crypto]>=2.8",
+# ]
+# ///
+"""Fetch Xcode Cloud build logs and issues for a commit via the App Store Connect API.
+
+GitHub check-runs only carry Xcode Cloud's one-line failure summary; the real
+script stdout/stderr lives in ASC LOG_BUNDLE artifacts. Requires a Team API key
+with App Manager role: APPLE_API_KEY_ID, APPLE_API_ISSUER_ID, and
+APPLE_API_KEY_BASE64 (or APPLE_API_KEY_PATH).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import zipfile
+from pathlib import Path
+from typing import Any, Iterator
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import jwt
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+INTERESTING_LOG = re.compile(r"post[_-]?clone|pre[_-]?xcodebuild|RunScript|ghosttykit", re.I)
+FAILURE_LINE = re.compile(r"error|failed|fatal|No such file|command not found|sudo", re.I)
+TAIL_LINES = 200
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        sys.exit(f"error: {name} environment variable is required")
+    return value
+
+
+def mint_token() -> str:
+    key_id = require_env("APPLE_API_KEY_ID")
+    issuer = require_env("APPLE_API_ISSUER_ID")
+    if key_b64 := os.environ.get("APPLE_API_KEY_BASE64"):
+        key = base64.b64decode(key_b64)
+    elif key_path := os.environ.get("APPLE_API_KEY_PATH"):
+        key = Path(key_path).read_bytes()
+    else:
+        sys.exit("error: set APPLE_API_KEY_BASE64 or APPLE_API_KEY_PATH")
+    now = int(time.time())
+    return jwt.encode(
+        {"iss": issuer, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"},
+        key,
+        algorithm="ES256",
+        headers={"kid": key_id, "typ": "JWT"},
+    )
+
+
+def api_get(token: str, url: str) -> dict[str, Any]:
+    req = Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urlopen(req) as resp:
+            return json.load(resp)
+    except HTTPError as err:
+        body = err.read().decode("utf-8", "replace")[:2000]
+        sys.exit(f"error: GET {url} -> HTTP {err.code}\n{body}")
+
+
+def paged(token: str, path: str, max_pages: int = 5, **params: str) -> Iterator[dict[str, Any]]:
+    url = f"{API_BASE}{path}"
+    if params:
+        url += "?" + urlencode(params)
+    for _ in range(max_pages):
+        page = api_get(token, url)
+        yield from page.get("data", [])
+        url = page.get("links", {}).get("next")
+        if not url:
+            return
+
+
+def commit_sha(run: dict[str, Any]) -> str:
+    source = run.get("attributes", {}).get("sourceCommit") or {}
+    return source.get("commitSha") or source.get("sha") or ""
+
+
+def find_build_runs(token: str, sha: str) -> list[dict[str, Any]]:
+    sha = sha.lower()
+    matches = []
+    for product in paged(token, "/v1/ciProducts"):
+        for run in paged(token, f"/v1/ciProducts/{product['id']}/buildRuns", limit="200"):
+            if commit_sha(run).lower().startswith(sha) or sha in json.dumps(run).lower():
+                matches.append(run)
+    return matches
+
+
+def slug(text: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", text).strip("-") or "unnamed"
+
+
+def print_issues(token: str, action_id: str) -> None:
+    for issue in paged(token, f"/v1/ciBuildActions/{action_id}/issues"):
+        attrs = issue.get("attributes", {})
+        source = attrs.get("fileSource") or {}
+        location = f" [{source.get('path')}:{source.get('lineNumber')}]" if source.get("path") else ""
+        print(f"    issue [{attrs.get('issueType')}/{attrs.get('category')}]{location}: {attrs.get('message')}")
+
+
+def excerpt(path: Path) -> None:
+    try:
+        lines = path.read_text(errors="replace").splitlines()
+    except OSError as err:
+        print(f"    (unreadable: {err})")
+        return
+    interesting = path.name and INTERESTING_LOG.search(str(path))
+    if interesting:
+        print(f"    ---- tail -{TAIL_LINES} {path.name} ----")
+        for line in lines[-TAIL_LINES:]:
+            print(f"    {line}")
+    else:
+        hits = [line for line in lines if FAILURE_LINE.search(line)][:40]
+        for line in hits:
+            print(f"    {path.name}: {line}")
+
+
+def download_artifacts(token: str, action_id: str, dest: Path) -> None:
+    for artifact in paged(token, f"/v1/ciBuildActions/{action_id}/artifacts"):
+        attrs = artifact.get("attributes", {})
+        file_type, file_name = attrs.get("fileType", ""), attrs.get("fileName", "artifact")
+        print(f"    artifact: {file_type} {file_name} ({attrs.get('fileSize')} bytes)")
+        if "LOG" not in file_type.upper():
+            continue
+        url = attrs.get("downloadUrl")
+        if not url:
+            print("      (no downloadUrl)")
+            continue
+        dest.mkdir(parents=True, exist_ok=True)
+        target = dest / slug(file_name)
+        with urlopen(Request(url)) as resp:
+            target.write_bytes(resp.read())
+        if zipfile.is_zipfile(target):
+            extract_dir = target.with_suffix("")
+            with zipfile.ZipFile(target) as bundle:
+                bundle.extractall(extract_dir)
+            for member in sorted(extract_dir.rglob("*")):
+                if member.is_file():
+                    print(f"      extracted: {member.relative_to(dest)}")
+                    excerpt(member)
+        else:
+            excerpt(target)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch Xcode Cloud logs for a commit")
+    parser.add_argument("--sha", required=True, help="Commit SHA (prefix ok) to look up")
+    parser.add_argument("--out", type=Path, default=Path("xcode-cloud-logs"), help="Download directory")
+    args = parser.parse_args()
+
+    token = mint_token()
+    runs = find_build_runs(token, args.sha)
+    if not runs:
+        print(f"no Xcode Cloud build runs found for {args.sha}", file=sys.stderr)
+        return 2
+
+    for run in runs:
+        attrs = run.get("attributes", {})
+        print(
+            f"build run #{attrs.get('number')} ({run['id']}): "
+            f"{attrs.get('executionProgress')}/{attrs.get('completionStatus')} "
+            f"commit={commit_sha(run)[:12]} started={attrs.get('startedDate')}"
+        )
+        for action in paged(token, f"/v1/ciBuildRuns/{run['id']}/actions"):
+            a_attrs = action.get("attributes", {})
+            name = a_attrs.get("name", "action")
+            print(f"  action {name} [{a_attrs.get('actionType')}]: {a_attrs.get('completionStatus')}")
+            print_issues(token, action["id"])
+            download_artifacts(token, action["id"], args.out / f"run-{attrs.get('number')}" / slug(name))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Xcode Cloud has been undebuggable from this repo: GitHub check-runs only carry the one-line summary (`Running ci_post_clone.sh script failed (exited with code 1)`), and every diagnosis round-trip required a human to paste the log from Xcode's Report Navigator. The full script stdout/stderr lives in App Store Connect `ciArtifacts` (LOG_BUNDLE), and the ASC API credentials exist only as repo secrets — readable inside Actions, not locally.

## What this adds

- `scripts/fetch-xcode-cloud-logs.py` (uv single-file): mints the ASC ES256 JWT, finds `ciBuildRuns` matching a commit SHA across products, prints structured `ciIssues` plus filtered log excerpts (binary-sniffed, line-clipped), downloads LOG_BUNDLE artifacts.
- `.github/workflows/xcode-cloud-logs.yml`: runs it with the `APPLE_API_*` secrets on push to this branch or `workflow_dispatch` with an explicit SHA; bundles upload as a 5-day artifact.

## Evidence

Tests passed: two green end-to-end workflow runs, both retrieving real Xcode Cloud logs for commit `9b57a02a`:

- [Run 28887088371](https://github.com/fairchild/workspaces/actions/runs/28887088371) — first version; its output diagnosed the actual CI failure (Homebrew bootstrap needs sudo; CI user has none), unblocking the fix in #925.
- [Run 28888725521](https://github.com/fairchild/workspaces/actions/runs/28888725521) — hardened version after the review loop, same result.

## Review loop

Reflected, then codex (gpt-5.5, xhigh) reviewed 1f538359. Three findings, all accepted and fixed in 22a32c38 (codex live-repro'd the second one):

1. `excerpt()` printed unbounded/binary content into the public job log → NUL-sniff skip + 400-char line clip.
2. Suffixless artifact `fileName` made the zip extraction dir collide with the archive path (`NotADirectoryError`) → distinct `.extracted` suffix.
3. Pagination silently stopped at the page cap, making "no build runs found" untrustworthy → stderr note; 401s now carry the Team-Key/App-Manager hint.

## Mergeability

- **Surface**: repo CI tooling (`scripts/fetch-xcode-cloud-logs.py`, `.github/workflows/xcode-cloud-logs.yml`); no product code.
- **User-facing behavior changed**: None — repo tooling only; no product code.
- **Non-happy paths considered**: missing/insufficient key role (loud 401 with actionable hint); run not found (exit 2 + page-cap note); in-progress runs (no artifacts yet → issues/actions still print); binary or oversized log content (skipped/clipped, public-repo safe); artifact name collisions (fixed per review).
- **Residual risk or follow-up**: job logs and artifacts are public on this repo — content is limited to build-script output that already appears in public check-run annotations, and full bundles age out in 5 days. The two "Default"/"Untitled Workflow" duplicate Xcode Cloud workflows still both build every push; deleting one needs the ASC UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋

