### PR TITLE
feat(web-next): surface streaming turn failures — inline error + retry

### DIFF
--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -2,10 +2,11 @@
  * Evidence capture, light + dark: the sessions home (empty and populated),
  * an empty session reached through the real new-session flow, a real mock
  * turn streamed into that session (mid-stream, final, and reloaded from the
- * event log), the durable disconnect→resume story (tab closed mid-turn, a
- * fresh tab catching up, then completed), the Folio session demo, and the
- * refine-folio prototype beside it for pixel comparison. Runs against a
- * production build in auth-bypass
+ * event log), the terminal drawer (#752), a failing turn's inline failure
+ * card + retry-to-success (#808), the durable disconnect→resume story (tab
+ * closed mid-turn, a fresh tab catching up, then completed), the Folio
+ * session demo, and the refine-folio prototype beside it for pixel
+ * comparison. Runs against a production build in auth-bypass
  * mode over a throwaway database. Output goes to output/evidence/
  * (gitignored); CI uploads it as an artifact — the sanctioned publish path
  * per docs/development/remote-sessions.md.
@@ -158,6 +159,38 @@ async function captureTerminalDrawer(page, file) {
 }
 
 /**
+ * A failing turn (#808): sends a message carrying mock-provider.ts's
+ * MOCK_TURN_ERROR_TRIGGER, captures the inline failure card + retry action,
+ * then clicks Retry (the mock spends its one guaranteed failure per session,
+ * so this succeeds) and captures the completed retry turn beneath it — proof
+ * the failed turn's own record survives, it isn't erased.
+ */
+async function captureFailedTurn(page, shot) {
+	await page.goto("/", { waitUntil: "networkidle" });
+	await page.getByRole("button", { name: "+ new session" }).click();
+	await page
+		.getByTestId("new-session-picker")
+		.getByRole("button", { name: "fairchild/workspaces" })
+		.click();
+	await page.waitForURL(/\/sessions\//, { timeout: TURN_TIMEOUT_MS });
+
+	await page
+		.getByRole("textbox", { name: "Reply to Claude" })
+		.fill("Fix the bug __mock_turn_error__");
+	await page.keyboard.press("Enter");
+
+	await page.getByTestId("turn-failure").waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: shot("session-turn-failed") });
+
+	await page.getByRole("button", { name: "Retry" }).click();
+	await page.getByTestId("turn-stats").waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: shot("session-turn-failed-retried") });
+}
+
+/**
  * The durable-turn story: start a turn, close the tab mid-stream, reopen the
  * session in a fresh tab and watch it catch up and complete. Manages its own
  * pages (the starter tab is closed on purpose) so the caller's page is left
@@ -286,6 +319,7 @@ async function main() {
 			await captureNewSessionFlow(page, shot("session-empty"));
 			await captureSessionTurn(page, shot);
 			await captureTerminalDrawer(page, shot("session-terminal-drawer"));
+			await captureFailedTurn(page, shot);
 			await captureDisconnectResume(context, shot);
 			await seedPopulatedHome(db);
 			await captureSettled(page, "/", shot("home-populated"));
@@ -294,7 +328,7 @@ async function main() {
 			await capturePrototype(page, colorScheme, shot("prototype-folio"));
 			await context.close();
 			console.log(
-				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
+				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + terminal drawer + failed turn (failure, retried) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
 			);
 		}
 	} finally {

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -24,15 +24,21 @@
  * same text; a user edit (or the eventual server write) replaces the preview
  * with the real persisted string.
  *
- * A turn that errors (#808) surfaces the same way live and after a reload:
- * `status === "error"` here tags the trailing assistant message with
- * `metadata.error` (see live-turn-error.ts — the SDK's error throw cuts the
- * stream before the adapter's `finish` chunk, which would normally carry that
- * tag, ever arrives), and project-events.ts tags it server-side from the
- * persisted `error`/aborted-`done` chunks on reload. Either way the message
- * flows into `visibleMessages` and renders through Message's failure card;
- * its Retry button (session-view.tsx) re-sends the turn's original text,
- * which `send` already exists to do.
+ * A turn that errors (#808) surfaces the same way live and after a reload.
+ * Live: `status === "error"` records the trailing assistant message's id
+ * against the error text (see live-turn-error.ts's `recordLiveTurnError` —
+ * the SDK's error throw cuts the stream before the adapter's `finish` chunk,
+ * which would normally carry `metadata.error`, ever arrives) in a *sticky*
+ * `liveFailures` map, not a value re-derived from the hook's current status —
+ * a status-gated patch would un-tag an earlier failed turn the instant a
+ * later turn's Retry moves `status` off "error", making its card vanish
+ * until the next reload. Reload: project-events.ts tags it server-side from
+ * the persisted `error`/aborted-`done` chunks — independently durable, so a
+ * turn's failure card survives even if the live map above were somehow lost
+ * (e.g. this component remounting). Either way the message flows into
+ * `visibleMessages` and renders through Message's failure card; its Retry
+ * button (session-view.tsx) re-sends the turn's original text, which `send`
+ * already exists to do.
  */
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
@@ -46,7 +52,12 @@ import {
 import type { FolioDataParts, FolioMessage } from "@/components/folio/types";
 import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
-import { isVisibleMessage, withLiveTurnError } from "@/lib/transcript/live-turn-error";
+import {
+	applyLiveTurnErrors,
+	isVisibleMessage,
+	type LiveTurnErrors,
+	recordLiveTurnError,
+} from "@/lib/transcript/live-turn-error";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
@@ -220,12 +231,19 @@ export function LiveSessionView({
 
 	// A live failure (#808): the trailing assistant message useChat pushed at
 	// the turn's `start` never gets `metadata.error` from the stream itself
-	// (see live-turn-error.ts), so tag it here from the hook's own error
-	// state — idempotent, so this is safe to recompute every render.
-	const displayMessages =
-		status === "error" && error
-			? withLiveTurnError(messages, error.message, session.masthead.agentName)
-			: messages;
+	// (see live-turn-error.ts), so record it here from the hook's own error
+	// state the moment it appears. Sticky by message id (real state, not a
+	// value re-derived from the current `status`) — a later turn's own
+	// status transitions must not erase an earlier turn's recorded failure.
+	const [liveFailures, setLiveFailures] = useState<LiveTurnErrors>({});
+	useEffect(() => {
+		if (status !== "error" || !error) return;
+		setLiveFailures((current) => recordLiveTurnError(current, messages, error.message));
+	}, [status, error, messages]);
+	const displayMessages = useMemo(
+		() => applyLiveTurnErrors(messages, liveFailures, session.masthead.agentName),
+		[messages, liveFailures, session.masthead.agentName],
+	);
 
 	// The reply message exists (empty) as soon as the stream starts; keep it
 	// out of the transcript until it has content or has failed — the activity

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -23,6 +23,16 @@
  * reload always agrees because both sides compute the same function over the
  * same text; a user edit (or the eventual server write) replaces the preview
  * with the real persisted string.
+ *
+ * A turn that errors (#808) surfaces the same way live and after a reload:
+ * `status === "error"` here tags the trailing assistant message with
+ * `metadata.error` (see live-turn-error.ts — the SDK's error throw cuts the
+ * stream before the adapter's `finish` chunk, which would normally carry that
+ * tag, ever arrives), and project-events.ts tags it server-side from the
+ * persisted `error`/aborted-`done` chunks on reload. Either way the message
+ * flows into `visibleMessages` and renders through Message's failure card;
+ * its Retry button (session-view.tsx) re-sends the turn's original text,
+ * which `send` already exists to do.
  */
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
@@ -36,6 +46,7 @@ import {
 import type { FolioDataParts, FolioMessage } from "@/components/folio/types";
 import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
+import { isVisibleMessage, withLiveTurnError } from "@/lib/transcript/live-turn-error";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
@@ -181,7 +192,7 @@ export function LiveSessionView({
 		[sessionId],
 	);
 
-	const { messages, sendMessage, status } = useChat<FolioMessage>({
+	const { messages, sendMessage, status, error } = useChat<FolioMessage>({
 		id: sessionId,
 		transport,
 		messages: initialMessages,
@@ -207,16 +218,25 @@ export function LiveSessionView({
 		);
 	};
 
+	// A live failure (#808): the trailing assistant message useChat pushed at
+	// the turn's `start` never gets `metadata.error` from the stream itself
+	// (see live-turn-error.ts), so tag it here from the hook's own error
+	// state — idempotent, so this is safe to recompute every render.
+	const displayMessages =
+		status === "error" && error
+			? withLiveTurnError(messages, error.message, session.masthead.agentName)
+			: messages;
+
 	// The reply message exists (empty) as soon as the stream starts; keep it
-	// out of the transcript until it has content — the activity article
-	// stands in for it.
-	const visibleMessages = messages.filter((message) => message.parts.length > 0);
+	// out of the transcript until it has content or has failed — the activity
+	// article stands in for an in-progress, contentless reply.
+	const visibleMessages = displayMessages.filter(isVisibleMessage);
 
 	// The standalone activity article covers the gap before the streamed
 	// reply renders content (provisioning statuses); once parts land, the
 	// growing message itself — running ledger rows, prose — is the live
 	// indicator, and a second "Claude" article would just double the label.
-	const last = messages.at(-1);
+	const last = displayMessages.at(-1);
 	const replyStarted = last?.role === "assistant" && last.parts.length > 0;
 	const activeTurn: ActiveTurnData | undefined =
 		busy && !replyStarted

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -19,6 +19,7 @@ import {
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "./reasoning";
 import { TestOutputPanel } from "./test-output-panel";
 import { ToolLedgerRow } from "./tool-ledger-row";
+import { TurnFailure } from "./turn-failure";
 import { TurnStatsReceipt } from "./turn-stats";
 import type { FolioMessage } from "./types";
 
@@ -175,12 +176,18 @@ export interface MessageProps {
 	/** Tool calls whose ledger rows start expanded (e.g. the landed test run). */
 	openToolCallIds?: string[];
 	animationDelay?: number;
+	/** Re-sends this turn's original text (present on failed turns only). */
+	onRetry?: () => void;
+	/** Holds retry while another turn on this session is already running. */
+	retryDisabled?: boolean;
 }
 
 export function Message({
 	message,
 	openToolCallIds,
 	animationDelay,
+	onRetry,
+	retryDisabled,
 }: MessageProps) {
 	const isUser = message.role === "user";
 	const meta = message.metadata;
@@ -244,6 +251,9 @@ export function Message({
 					</p>
 				));
 			})}
+			{meta?.error && (
+				<TurnFailure message={meta.error} onRetry={onRetry} retryDisabled={retryDisabled} />
+			)}
 			{meta?.turnStats && <TurnStatsReceipt stats={meta.turnStats} />}
 		</MessageArticle>
 	);

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -58,6 +58,16 @@ function groupIntoTurns(messages: FolioMessage[]): Turn[] {
 	return turns;
 }
 
+/** The turn's original user text — what a failed reply's Retry re-sends. */
+function turnUserText(turn: Turn): string {
+	return turn.messages
+		.filter((message) => message.role === "user")
+		.flatMap((message) => message.parts)
+		.filter((part) => part.type === "text")
+		.map((part) => part.text)
+		.join("");
+}
+
 /**
  * The frame draws the turn's presence, so the per-message focal tick and the
  * older-context fade are cleared — otherwise a turn would signal focus twice.
@@ -125,6 +135,7 @@ export function SessionView({
 						const frame = recent
 							? "border-line-strong bg-raised shadow-card"
 							: "border-line";
+						const retryText = turnUserText(turn);
 						return (
 							<section
 								key={turn.key}
@@ -137,6 +148,12 @@ export function SessionView({
 										message={withoutMessagePresence(message)}
 										openToolCallIds={session.openToolCallIds}
 										animationDelay={riseDelay(orderIndex.get(message.id) ?? 0)}
+										onRetry={
+											message.metadata?.error && onSend && retryText
+												? () => onSend(retryText)
+												: undefined
+										}
+										retryDisabled={composeDisabled}
 									/>
 								))}
 								{recent && session.activeTurn && (

--- a/web-next/src/components/folio/turn-failure.tsx
+++ b/web-next/src/components/folio/turn-failure.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/*
+ * Inline failure affordance for a turn that errored or was interrupted before
+ * completion — quiet, typography-first, in the same faint-caption register as
+ * TurnStatsReceipt (the receipt it replaces on a failed turn), no toast/alert
+ * chrome. Guards against a double-fired retry itself (a click while the
+ * request is still in flight): `retryDisabled` from the caller covers the
+ * turn-level "another turn is already running" state, but there's a gap
+ * between the click and that flag flipping true, so a local latch closes it.
+ */
+import { useState } from "react";
+
+export interface TurnFailureProps {
+	/** The stream's error text, or the interrupted-turn fallback message. */
+	message: string;
+	/** Omitted when the turn's original text can't be recovered (rare). */
+	onRetry?: () => void;
+	/** Holds retry while another turn on this session is already running. */
+	retryDisabled?: boolean;
+}
+
+export function TurnFailure({ message, onRetry, retryDisabled }: TurnFailureProps) {
+	const [pending, setPending] = useState(false);
+	const disabled = retryDisabled || pending;
+
+	const handleRetry = () => {
+		if (disabled || !onRetry) return;
+		setPending(true);
+		onRetry();
+	};
+
+	return (
+		<div
+			data-testid="turn-failure"
+			className="mt-5 flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-stat tracking-[.04em] text-del-ink"
+		>
+			<span>{message}</span>
+			{onRetry && (
+				<button
+					type="button"
+					onClick={handleRetry}
+					disabled={disabled}
+					className="border-b border-transparent pb-px text-del-ink transition-colors duration-200 hover:border-del-ink disabled:cursor-default disabled:opacity-50 disabled:hover:border-transparent"
+				>
+					Retry
+				</button>
+			)}
+		</div>
+	);
+}

--- a/web-next/src/components/folio/turn-failure.tsx
+++ b/web-next/src/components/folio/turn-failure.tsx
@@ -8,8 +8,16 @@
  * request is still in flight): `retryDisabled` from the caller covers the
  * turn-level "another turn is already running" state, but there's a gap
  * between the click and that flag flipping true, so a local latch closes it.
+ *
+ * The latch is a ref, not state: two `handleRetry` calls from the same click
+ * burst (e.g. a fast double-click, or React batching two events before a
+ * re-render) both read `pendingRef.current` synchronously, so the second call
+ * sees the first's write immediately — a `useState` flag would still show its
+ * pre-click value to both, since neither call observes the other's `setState`
+ * until the next render, and one render can't happen between two events fired
+ * before it.
  */
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export interface TurnFailureProps {
 	/** The stream's error text, or the interrupted-turn fallback message. */
@@ -21,11 +29,14 @@ export interface TurnFailureProps {
 }
 
 export function TurnFailure({ message, onRetry, retryDisabled }: TurnFailureProps) {
+	const pendingRef = useRef(false);
+	// Mirrors pendingRef into render output (refs alone don't trigger one).
 	const [pending, setPending] = useState(false);
 	const disabled = retryDisabled || pending;
 
 	const handleRetry = () => {
-		if (disabled || !onRetry) return;
+		if (retryDisabled || pendingRef.current || !onRetry) return;
+		pendingRef.current = true;
 		setPending(true);
 		onRetry();
 	};

--- a/web-next/src/components/folio/types.ts
+++ b/web-next/src/components/folio/types.ts
@@ -43,6 +43,13 @@ export interface FolioMetadata {
 	recede?: boolean;
 	/** Present on completed agent turns only. */
 	turnStats?: TurnStatsData;
+	/**
+	 * Present when the turn ended in a stream error or was interrupted before
+	 * completion (see lib/transcript/turn-stats.ts's `deriveTurnError`) —
+	 * mutually exclusive with `turnStats`. The message this renders holds
+	 * whatever content streamed before the failure (possibly none).
+	 */
+	error?: string;
 }
 
 export interface DiffLine {

--- a/web-next/src/lib/agent-runtime/mock-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { deriveTurnStats } from "../transcript/turn-stats";
-import { mockCodingTurn, mockProvider } from "./mock-provider";
+import { MOCK_TURN_ERROR_TRIGGER, mockCodingTurn, mockProvider } from "./mock-provider";
 import { DEFAULT_MODEL } from "./models";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -118,5 +118,71 @@ describe("mockCodingTurn", () => {
 		const chunks = await fullTurn("go");
 		const done = chunks.find((chunk) => chunk.type === "done");
 		expect(done?.metadata?.contextTokens).toBeGreaterThan(0);
+	});
+
+	describe("MOCK_TURN_ERROR_TRIGGER (#808)", () => {
+		test("throws instead of running the script when the trigger is present", async () => {
+			const iterator = mockCodingTurn(
+				`please fix it ${MOCK_TURN_ERROR_TRIGGER}`,
+				() => Promise.resolve(),
+			)[Symbol.asyncIterator]();
+			// One status chunk (realistic provisioning) precedes the failure.
+			const first = await iterator.next();
+			expect(first.value).toEqual({ type: "status", content: "Starting sandbox" });
+			await expect(iterator.next()).rejects.toThrow(
+				"Simulated turn failure (mock provider)",
+			);
+		});
+
+		test("a message without the trigger runs the normal script unaffected", async () => {
+			const chunks = await fullTurn(`no trigger here`);
+			expect(chunks.some((chunk) => chunk.type === "error")).toBe(false);
+			expect(chunks.at(-1)).toMatchObject({ type: "done" });
+		});
+
+		test("mockProvider.runTurn fails once per session, then succeeds on retry", async () => {
+			// mockProvider.runTurn (unlike fullTurn's injectable sleep) paces with
+			// the real scripted delays, so this only reads the first couple of
+			// chunks of each run — enough to prove which path it took — rather
+			// than draining the whole ~9s script.
+			const sessionId = `s-${crypto.randomUUID()}`;
+			const text = `Fix it ${MOCK_TURN_ERROR_TRIGGER}`;
+
+			// First turn against this session: the trigger fires.
+			const first = mockProvider
+				.runTurn({ sessionId, userMessage: text })
+				[Symbol.asyncIterator]();
+			await expect(first.next()).resolves.toEqual({
+				value: { type: "status", content: "Starting sandbox" },
+				done: false,
+			});
+			await expect(first.next()).rejects.toThrow(
+				"Simulated turn failure (mock provider)",
+			);
+
+			// A retry re-sending the identical text against the SAME session
+			// succeeds — the trigger is spent (#808's e2e "retry succeeds" case):
+			// the second status chunk (only reachable past the would-be throw)
+			// proves the normal script ran instead of failing again.
+			const retry = mockProvider
+				.runTurn({ sessionId, userMessage: text })
+				[Symbol.asyncIterator]();
+			await retry.next();
+			await expect(retry.next()).resolves.toEqual({
+				value: { type: "status", content: "Cloning repo" },
+				done: false,
+			});
+			await retry.return?.(undefined);
+
+			// A DIFFERENT session with the same text still gets its own guaranteed
+			// failure — the gate is per-session, not global.
+			const other = mockProvider
+				.runTurn({ sessionId: `s-${crypto.randomUUID()}`, userMessage: text })
+				[Symbol.asyncIterator]();
+			await other.next();
+			await expect(other.next()).rejects.toThrow(
+				"Simulated turn failure (mock provider)",
+			);
+		});
 	});
 });

--- a/web-next/src/lib/agent-runtime/mock-provider.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.ts
@@ -7,6 +7,21 @@
  * The requested model is recorded (not used — there's no real model call
  * here) on the terminal `done` chunk, so #824's routing is unit-testable
  * against this provider without a sandbox.
+ *
+ * A user message containing `MOCK_TURN_ERROR_TRIGGER` (#808) throws instead of
+ * running the script — a deterministic, hermetic way to exercise a whole-turn
+ * failure (turn-ingest.ts's catch appends the `error` + aborted `done` a real
+ * provider fault or dead sandbox would) without depending on timing or a real
+ * provider outage. Test-only by convention: nothing in the product surface
+ * sends this text on purpose.
+ *
+ * `mockCodingTurn` itself always fails when the trigger is present — that's
+ * what makes it hermetically unit-testable. `mockProvider.runTurn` (the seam
+ * sessions actually call) spends the trigger once per session: the first turn
+ * against a session whose text carries it fails, and a later turn against
+ * that same session — e.g. a UI Retry re-sending the identical failed text —
+ * runs the normal script instead of failing forever. This is what lets #808's
+ * e2e spec drive a real "retry succeeds" turn without a second magic string.
  */
 import { DEFAULT_MODEL } from "./models";
 import type { ComputeProvider, TurnRequest } from "./provider";
@@ -17,6 +32,9 @@ type Sleep = (ms: number) => Promise<void>;
 const defaultSleep: Sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const EDITED_FILE = "src/lib/session.ts";
+
+/** A user message containing this text makes the mock turn fail (#808). */
+export const MOCK_TURN_ERROR_TRIGGER = "__mock_turn_error__";
 
 const REASONING_TRACE = [
 	"The repro says `resumeSession` comes back with undefined for an unknown id, and the test expects a thrown `SessionNotFoundError`.",
@@ -84,6 +102,11 @@ export async function* mockCodingTurn(
 
 	yield { type: "status", content: "Starting sandbox" };
 	await sleep(300);
+
+	if (userMessage.includes(MOCK_TURN_ERROR_TRIGGER)) {
+		throw new Error("Simulated turn failure (mock provider)");
+	}
+
 	yield { type: "status", content: "Cloning repo" };
 	await sleep(300);
 
@@ -196,8 +219,26 @@ export async function* mockCodingTurn(
 	};
 }
 
+/** Sessions whose one guaranteed `MOCK_TURN_ERROR_TRIGGER` failure has already
+ * fired — dev/e2e-only in-memory state, same lifetime as turn-ingest.ts's
+ * `activeTurns`; never pruned. */
+const spentErrorTrigger = new Set<string>();
+
 export const mockProvider: ComputeProvider = {
 	id: "mock",
-	runTurn: (request: TurnRequest) =>
-		mockCodingTurn(request.userMessage, undefined, request.model),
+	runTurn: (request: TurnRequest) => {
+		let userMessage = request.userMessage;
+		if (userMessage.includes(MOCK_TURN_ERROR_TRIGGER)) {
+			if (spentErrorTrigger.has(request.sessionId)) {
+				// Already spent on this session — strip the trigger so the script
+				// runs normally instead of failing forever (the persisted user
+				// event, appended before the provider ever runs, keeps the original
+				// text regardless of what's passed here).
+				userMessage = userMessage.split(MOCK_TURN_ERROR_TRIGGER).join("").trim();
+			} else {
+				spentErrorTrigger.add(request.sessionId);
+			}
+		}
+		return mockCodingTurn(userMessage, undefined, request.model);
+	},
 };

--- a/web-next/src/lib/transcript/live-turn-error.test.ts
+++ b/web-next/src/lib/transcript/live-turn-error.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 import type { FolioMessage } from "@/components/folio/types";
-import { isVisibleMessage, withLiveTurnError } from "./live-turn-error";
+import {
+	applyLiveTurnErrors,
+	isVisibleMessage,
+	type LiveTurnErrors,
+	recordLiveTurnError,
+} from "./live-turn-error";
 
 function userMessage(id: string, text: string): FolioMessage {
 	return { id, role: "user", parts: [{ type: "text", text, state: "done" }] };
@@ -14,61 +19,127 @@ function assistantMessage(
 	return { id, role: "assistant", parts, metadata };
 }
 
-describe("withLiveTurnError (#808)", () => {
-	test("tags the trailing empty assistant placeholder with the failure", () => {
+describe("recordLiveTurnError (#808)", () => {
+	test("records the trailing assistant message's id against the error text", () => {
 		const messages = [
 			userMessage("u1", "fix the bug"),
 			assistantMessage("a1", [], { author: "Claude" }),
 		];
-		const patched = withLiveTurnError(messages, "sandbox died", "Claude");
-		expect(patched[1]).toMatchObject({
-			id: "a1",
-			role: "assistant",
-			metadata: { author: "Claude", error: "sandbox died" },
+		expect(recordLiveTurnError({}, messages, "sandbox died")).toEqual({
+			a1: "sandbox died",
 		});
-		// The user's turn text is untouched — it was never at risk (already
-		// durably persisted before the assistant turn even starts).
-		expect(patched[0]).toEqual(messages[0]);
 	});
 
-	test("preserves whatever partial content the trailing message already has", () => {
+	test("normalizes an empty error chunk the same way turn-stats.ts's deriveTurnError does", () => {
+		const messages = [assistantMessage("a1")];
+		expect(recordLiveTurnError({}, messages, "")).toEqual({
+			a1: "The turn failed.",
+		});
+	});
+
+	test("is idempotent — a message already recorded is returned as the SAME object", () => {
+		const current: LiveTurnErrors = { a1: "already recorded" };
+		const messages = [assistantMessage("a1")];
+		expect(recordLiveTurnError(current, messages, "a different message")).toBe(current);
+	});
+
+	test("a no-op when the trailing message isn't an assistant reply", () => {
+		const current: LiveTurnErrors = {};
+		const messages = [userMessage("u1", "go")];
+		expect(recordLiveTurnError(current, messages, "boom")).toBe(current);
+	});
+
+	test("a no-op on an empty transcript", () => {
+		const current: LiveTurnErrors = {};
+		expect(recordLiveTurnError(current, [], "boom")).toBe(current);
+	});
+
+	test("accumulates a second, later failure alongside an earlier recorded one", () => {
+		const first = recordLiveTurnError({}, [assistantMessage("a1")], "first failure");
+		const messages = [
+			assistantMessage("a1"),
+			userMessage("u2", "try again"),
+			assistantMessage("a2"),
+		];
+		expect(recordLiveTurnError(first, messages, "second failure")).toEqual({
+			a1: "first failure",
+			a2: "second failure",
+		});
+	});
+});
+
+describe("applyLiveTurnErrors (#808)", () => {
+	test("tags every message with a recorded failure, not just the trailing one", () => {
 		const messages = [
 			userMessage("u1", "fix the bug"),
+			assistantMessage("a1", [], { author: "Claude" }),
+			userMessage("u2", "try again"),
+			assistantMessage("a2", [], { author: "Claude" }),
+		];
+		const patched = applyLiveTurnErrors(
+			messages,
+			{ a1: "first failure" },
+			"Claude",
+		);
+		expect(patched[1].metadata?.error).toBe("first failure");
+		// a2 — the later, unfailed turn — is untouched.
+		expect(patched[3].metadata?.error).toBeUndefined();
+		// Messages with no recorded failure are returned as the SAME object.
+		expect(patched[0]).toBe(messages[0]);
+		expect(patched[3]).toBe(messages[3]);
+	});
+
+	test("survives status moving on to a later turn — the earlier card stays tagged (#808 regression)", () => {
+		// The scenario codex flagged: turn 1 fails live (no reload), the user
+		// retries, and turn 2 succeeds. A status-gated ("only while status ===
+		// 'error'") patch would un-tag turn 1's message the instant status
+		// leaves "error" for turn 2. The sticky record must not.
+		const failures = recordLiveTurnError({}, [assistantMessage("a1")], "sandbox died");
+		const messagesAfterRetry = [
+			assistantMessage("a1"),
+			userMessage("u2", "fix the bug"),
+			assistantMessage("a2", [{ type: "text", text: "Fixed it.", state: "done" }], {
+				author: "Claude",
+			}),
+		];
+		// status is now "streaming"/"ready" for turn 2, not "error" — a
+		// status-gated approach would pass `failures` as empty here.
+		const patched = applyLiveTurnErrors(messagesAfterRetry, failures, "Claude");
+		expect(patched[0].metadata?.error).toBe("sandbox died");
+		expect(patched[2].metadata?.error).toBeUndefined();
+	});
+
+	test("preserves whatever partial content the failed message already has", () => {
+		const messages = [
 			assistantMessage(
 				"a1",
 				[{ type: "text", text: "Let me check", state: "done" }],
 				{ author: "Claude" },
 			),
 		];
-		const patched = withLiveTurnError(messages, "sandbox died", "Claude");
-		expect(patched[1].parts).toEqual([
+		const patched = applyLiveTurnErrors(messages, { a1: "sandbox died" }, "Claude");
+		expect(patched[0].parts).toEqual([
 			{ type: "text", text: "Let me check", state: "done" },
 		]);
-		expect(patched[1].metadata?.error).toBe("sandbox died");
 	});
 
 	test("falls back to the given author when the message has no metadata yet", () => {
-		const messages = [userMessage("u1", "go"), assistantMessage("a1")];
-		const patched = withLiveTurnError(messages, "boom", "Claude");
-		expect(patched[1].metadata).toEqual({ author: "Claude", error: "boom" });
+		const messages = [assistantMessage("a1")];
+		const patched = applyLiveTurnErrors(messages, { a1: "boom" }, "Claude");
+		expect(patched[0].metadata).toEqual({ author: "Claude", error: "boom" });
 	});
 
-	test("is idempotent — a message that already carries an error is returned unchanged", () => {
+	test("does not re-tag a message that already carries an error (e.g. from a reload's projection)", () => {
 		const messages = [
-			userMessage("u1", "go"),
 			assistantMessage("a1", [], { author: "Claude", error: "already tagged" }),
 		];
-		const patched = withLiveTurnError(messages, "a different message", "Claude");
-		expect(patched).toBe(messages);
+		const patched = applyLiveTurnErrors(messages, { a1: "a different message" }, "Claude");
+		expect(patched[0]).toBe(messages[0]);
 	});
 
-	test("a no-op when the trailing message isn't an assistant reply", () => {
+	test("returns the SAME array reference when there are no failures recorded", () => {
 		const messages = [userMessage("u1", "go")];
-		expect(withLiveTurnError(messages, "boom", "Claude")).toBe(messages);
-	});
-
-	test("a no-op on an empty transcript", () => {
-		expect(withLiveTurnError([], "boom", "Claude")).toEqual([]);
+		expect(applyLiveTurnErrors(messages, {}, "Claude")).toBe(messages);
 	});
 });
 

--- a/web-next/src/lib/transcript/live-turn-error.test.ts
+++ b/web-next/src/lib/transcript/live-turn-error.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import type { FolioMessage } from "@/components/folio/types";
+import { isVisibleMessage, withLiveTurnError } from "./live-turn-error";
+
+function userMessage(id: string, text: string): FolioMessage {
+	return { id, role: "user", parts: [{ type: "text", text, state: "done" }] };
+}
+
+function assistantMessage(
+	id: string,
+	parts: FolioMessage["parts"] = [],
+	metadata?: FolioMessage["metadata"],
+): FolioMessage {
+	return { id, role: "assistant", parts, metadata };
+}
+
+describe("withLiveTurnError (#808)", () => {
+	test("tags the trailing empty assistant placeholder with the failure", () => {
+		const messages = [
+			userMessage("u1", "fix the bug"),
+			assistantMessage("a1", [], { author: "Claude" }),
+		];
+		const patched = withLiveTurnError(messages, "sandbox died", "Claude");
+		expect(patched[1]).toMatchObject({
+			id: "a1",
+			role: "assistant",
+			metadata: { author: "Claude", error: "sandbox died" },
+		});
+		// The user's turn text is untouched — it was never at risk (already
+		// durably persisted before the assistant turn even starts).
+		expect(patched[0]).toEqual(messages[0]);
+	});
+
+	test("preserves whatever partial content the trailing message already has", () => {
+		const messages = [
+			userMessage("u1", "fix the bug"),
+			assistantMessage(
+				"a1",
+				[{ type: "text", text: "Let me check", state: "done" }],
+				{ author: "Claude" },
+			),
+		];
+		const patched = withLiveTurnError(messages, "sandbox died", "Claude");
+		expect(patched[1].parts).toEqual([
+			{ type: "text", text: "Let me check", state: "done" },
+		]);
+		expect(patched[1].metadata?.error).toBe("sandbox died");
+	});
+
+	test("falls back to the given author when the message has no metadata yet", () => {
+		const messages = [userMessage("u1", "go"), assistantMessage("a1")];
+		const patched = withLiveTurnError(messages, "boom", "Claude");
+		expect(patched[1].metadata).toEqual({ author: "Claude", error: "boom" });
+	});
+
+	test("is idempotent — a message that already carries an error is returned unchanged", () => {
+		const messages = [
+			userMessage("u1", "go"),
+			assistantMessage("a1", [], { author: "Claude", error: "already tagged" }),
+		];
+		const patched = withLiveTurnError(messages, "a different message", "Claude");
+		expect(patched).toBe(messages);
+	});
+
+	test("a no-op when the trailing message isn't an assistant reply", () => {
+		const messages = [userMessage("u1", "go")];
+		expect(withLiveTurnError(messages, "boom", "Claude")).toBe(messages);
+	});
+
+	test("a no-op on an empty transcript", () => {
+		expect(withLiveTurnError([], "boom", "Claude")).toEqual([]);
+	});
+});
+
+describe("isVisibleMessage (#808)", () => {
+	test("a message with parts is visible", () => {
+		expect(
+			isVisibleMessage(
+				assistantMessage("a1", [{ type: "text", text: "hi", state: "done" }]),
+			),
+		).toBe(true);
+	});
+
+	test("a failed turn with no parts is still visible", () => {
+		expect(
+			isVisibleMessage(assistantMessage("a1", [], { author: "Claude", error: "boom" })),
+		).toBe(true);
+	});
+
+	test("an empty in-progress placeholder (no parts, no error) is hidden", () => {
+		expect(isVisibleMessage(assistantMessage("a1", [], { author: "Claude" }))).toBe(
+			false,
+		);
+	});
+});

--- a/web-next/src/lib/transcript/live-turn-error.ts
+++ b/web-next/src/lib/transcript/live-turn-error.ts
@@ -1,0 +1,49 @@
+/*
+ * Client-only patch for a turn that errors while streaming live. The SDK's
+ * chunk pipeline throws on the stream's `error` chunk (@ai-sdk/react's
+ * `processUIMessageStream` rethrows it) before the adapter's `finish` chunk —
+ * which is what would normally carry `metadata.error` — ever arrives, so the
+ * assistant message useChat already pushed at `start` never gets tagged.
+ * `withLiveTurnError` reproduces that tag locally from the hook's
+ * `status`/`error` state, so the live and reloaded failure states render
+ * through the exact same Message component (see chunk-adapter.ts's
+ * `case "error"` and turn-stats.ts's `deriveTurnError` for the server-side
+ * half of this contract, which projection relies on directly).
+ */
+import type { FolioMessage } from "@/components/folio/types";
+
+/**
+ * Tags the trailing assistant message with the live failure, if one hasn't
+ * already been recorded. A no-op when the trailing message isn't an
+ * assistant reply (nothing to tag) or already carries `metadata.error`
+ * (idempotent — safe to call on every render while `status === "error"`).
+ */
+export function withLiveTurnError(
+	messages: FolioMessage[],
+	errorText: string,
+	fallbackAuthor: string,
+): FolioMessage[] {
+	const last = messages.at(-1);
+	if (!last || last.role !== "assistant" || last.metadata?.error) return messages;
+	const patched: FolioMessage = {
+		...last,
+		metadata: {
+			...last.metadata,
+			author: last.metadata?.author ?? fallbackAuthor,
+			error: errorText,
+		},
+	};
+	return [...messages.slice(0, -1), patched];
+}
+
+/**
+ * A message worth rendering in the transcript: it has content, or it's a
+ * failed turn's card (`metadata.error` set, however few parts it produced).
+ * The one case still hidden is the empty in-progress placeholder useChat
+ * pushes at a turn's `start` — no parts, no failure (yet) — which the
+ * standalone activity article stands in for instead (see
+ * live-session-view.tsx).
+ */
+export function isVisibleMessage(message: FolioMessage): boolean {
+	return message.parts.length > 0 || message.metadata?.error != null;
+}

--- a/web-next/src/lib/transcript/live-turn-error.ts
+++ b/web-next/src/lib/transcript/live-turn-error.ts
@@ -4,36 +4,70 @@
  * `processUIMessageStream` rethrows it) before the adapter's `finish` chunk —
  * which is what would normally carry `metadata.error` — ever arrives, so the
  * assistant message useChat already pushed at `start` never gets tagged.
- * `withLiveTurnError` reproduces that tag locally from the hook's
- * `status`/`error` state, so the live and reloaded failure states render
- * through the exact same Message component (see chunk-adapter.ts's
+ * `applyLiveTurnErrors` reproduces that tag locally from a *sticky* record of
+ * failures keyed by message id (live-session-view.tsx populates it from the
+ * hook's `status`/`error` state), so the live and reloaded failure states
+ * render through the exact same Message component (see chunk-adapter.ts's
  * `case "error"` and turn-stats.ts's `deriveTurnError` for the server-side
  * half of this contract, which projection relies on directly).
+ *
+ * Sticky, not derived-from-current-status: a naive "patch the trailing
+ * message while status === 'error'" only holds while that message stays both
+ * trailing AND the hook's status hasn't moved on. The moment a later turn
+ * starts (e.g. its own Retry), status leaves "error" and a new message
+ * becomes trailing — a status-gated patch would silently un-tag the earlier
+ * failure, making its card vanish from the live view (only a reload would
+ * bring it back, via project-events.ts's independent persisted tagging).
+ * Recording each failure once, by the id it was caught on, keeps it tagged
+ * for the rest of the session regardless of what happens afterward.
  */
 import type { FolioMessage } from "@/components/folio/types";
 
+/** Matches turn-stats.ts's deriveTurnError fallback for an empty error chunk
+ * — keeps the live and projected text identical in that edge case too. */
+const EMPTY_ERROR_FALLBACK = "The turn failed.";
+
+/** messageId -> error text, accumulated for the life of the session view. */
+export type LiveTurnErrors = Readonly<Record<string, string>>;
+
 /**
- * Tags the trailing assistant message with the live failure, if one hasn't
- * already been recorded. A no-op when the trailing message isn't an
- * assistant reply (nothing to tag) or already carries `metadata.error`
- * (idempotent — safe to call on every render while `status === "error"`).
+ * Records the trailing assistant message's failure, if the hook just entered
+ * `status === "error"` and that message isn't already recorded — a no-op
+ * otherwise (including on every later re-render, since the id is already a
+ * key). Returns the SAME object when nothing changed, so callers can use it
+ * as a `setState` updater without triggering an extra render.
  */
-export function withLiveTurnError(
-	messages: FolioMessage[],
+export function recordLiveTurnError(
+	current: LiveTurnErrors,
+	messages: readonly FolioMessage[],
 	errorText: string,
+): LiveTurnErrors {
+	const last = messages.at(-1);
+	if (!last || last.role !== "assistant" || current[last.id] !== undefined) {
+		return current;
+	}
+	return { ...current, [last.id]: errorText.length > 0 ? errorText : EMPTY_ERROR_FALLBACK };
+}
+
+/** Tags every message with a recorded failure, leaving the rest untouched. */
+export function applyLiveTurnErrors(
+	messages: FolioMessage[],
+	failures: LiveTurnErrors,
 	fallbackAuthor: string,
 ): FolioMessage[] {
-	const last = messages.at(-1);
-	if (!last || last.role !== "assistant" || last.metadata?.error) return messages;
-	const patched: FolioMessage = {
-		...last,
-		metadata: {
-			...last.metadata,
-			author: last.metadata?.author ?? fallbackAuthor,
-			error: errorText,
-		},
-	};
-	return [...messages.slice(0, -1), patched];
+	if (Object.keys(failures).length === 0) return messages;
+	return messages.map((message) => {
+		const errorText = failures[message.id];
+		if (errorText === undefined || message.metadata?.error !== undefined) return message;
+		return {
+			...message,
+			metadata: {
+				...message.metadata,
+				author: message.metadata?.author ?? fallbackAuthor,
+				error: errorText,
+			},
+		};
+	});
 }
 
 /**

--- a/web-next/src/lib/transcript/project-events.test.ts
+++ b/web-next/src/lib/transcript/project-events.test.ts
@@ -237,6 +237,49 @@ describe("projectSessionEvents", () => {
 		expect(messages.map((m) => m.role)).toEqual(["user"]);
 	});
 
+	test("a failed turn with no content still projects, as a visible failure (#808)", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "go"),
+			a(2, "status", "Starting sandbox"),
+			a(3, "error", "Simulated turn failure (mock provider)"),
+			a(4, "done", "", { aborted: true }),
+		]);
+		expect(messages).toHaveLength(2);
+		expect(messages[1]).toEqual({
+			id: "s:2",
+			role: "assistant",
+			metadata: { author: "Claude", error: "Simulated turn failure (mock provider)" },
+			parts: [],
+		});
+	});
+
+	test("a failed turn keeps whatever content streamed before the failure (#808)", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "go"),
+			a(2, "text", "Let me check "),
+			a(3, "error", "sandbox died"),
+			a(4, "done", "", { aborted: true }),
+		]);
+		expect(messages[1]).toMatchObject({
+			role: "assistant",
+			metadata: { author: "Claude", error: "sandbox died" },
+			parts: [{ type: "text", text: "Let me check " }],
+		});
+	});
+
+	test("an interrupted turn (closeAbandonedTurn's synthesized terminal) also projects as a failure (#808)", async () => {
+		const messages = await projectSessionEvents("s", [
+			u(1, "go"),
+			a(2, "error", "Turn interrupted before completion."),
+			a(3, "done", "", { aborted: true }),
+		]);
+		expect(messages[1]).toMatchObject({
+			role: "assistant",
+			metadata: { error: "Turn interrupted before completion." },
+			parts: [],
+		});
+	});
+
 	test("concatenates consecutive user events into one message", async () => {
 		const messages = await projectSessionEvents("s", [
 			u(1, "part one "),

--- a/web-next/src/lib/transcript/project-events.ts
+++ b/web-next/src/lib/transcript/project-events.ts
@@ -13,7 +13,7 @@
 import { type UIMessage, readUIMessageStream } from "ai";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
 import { toUIMessageChunkStream } from "./chunk-adapter";
-import { folioTurnMetadata } from "./turn-stats";
+import { deriveTurnError, folioTurnMetadata } from "./turn-stats";
 
 export type SessionEventRole = "user" | "assistant";
 
@@ -39,8 +39,12 @@ export interface ProjectedEvent {
  * - Assistant runs replay through the adapter + `readUIMessageStream`; transient
  *   `status` chunks and stream `error`s never break projection (they are
  *   dropped / surfaced out-of-band, matching the adapter contract).
- * - An assistant run that yields no renderable parts (e.g. only status/error) is
- *   omitted rather than emitting an empty bubble.
+ * - An assistant run that yields no renderable parts is omitted rather than
+ *   emitting an empty bubble — UNLESS it failed (an `error` chunk, or a `done`
+ *   chunk with `metadata.aborted`; see turn-stats.ts's `deriveTurnError`), in
+ *   which case it still projects (with `metadata.error` set and possibly zero
+ *   parts) so an interrupted turn renders as a visible failure instead of
+ *   vanishing (#808) — whatever content streamed before the failure is kept.
  */
 export async function projectSessionEvents(
 	sessionId: string,
@@ -92,8 +96,9 @@ function buildUserMessage(id: string, chunks: StreamChunk[]): UIMessage {
  * Replays assistant events through the shared adapter and reduces the resulting
  * UIMessageChunk stream to a single message. Part ids are seeded from the
  * message id so the projection is byte-for-byte reproducible. Metadata (author
- * + turn stats) is derived by the same folioTurnMetadata the live stream uses,
- * so a completed turn projects with its receipt and an unfinished one without.
+ * + turn stats, or author + error) is derived by the same folioTurnMetadata the
+ * live stream uses, so a completed turn projects with its receipt, a failed one
+ * with its failure, and an unfinished one with neither.
  */
 async function buildAssistantMessage(
 	id: string,
@@ -112,6 +117,10 @@ async function buildAssistantMessage(
 	for await (const message of readUIMessageStream({ stream, onError: () => {} })) {
 		last = message;
 	}
-	if (!last || last.parts.length === 0) return undefined;
+	if (!last) return undefined;
+	// A run that failed always projects — even with zero parts (the common
+	// case: the failure lands before any content streams) — so the turn
+	// renders as a visible failure card instead of disappearing (#808).
+	if (last.parts.length === 0 && deriveTurnError(chunks) === undefined) return undefined;
 	return last;
 }

--- a/web-next/src/lib/transcript/turn-stats.test.ts
+++ b/web-next/src/lib/transcript/turn-stats.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "vitest";
 import type { FolioMessage } from "@/components/folio/types";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
-import { deriveContextLabel, deriveTurnStats, folioTurnMetadata } from "./turn-stats";
+import {
+	deriveContextLabel,
+	deriveTurnError,
+	deriveTurnStats,
+	folioTurnMetadata,
+} from "./turn-stats";
 
 const done = (metadata?: Record<string, unknown>): StreamChunk => ({
 	type: "done",
@@ -120,5 +125,50 @@ describe("folioTurnMetadata", () => {
 			author: "Claude",
 			turnStats: { toolCount: 0, durationMs: 10 },
 		});
+	});
+
+	test("carries the failure instead of a receipt on a failed turn (#808)", () => {
+		expect(
+			folioTurnMetadata([
+				{ type: "error", content: "sandbox died" },
+				done({ aborted: true }),
+			]),
+		).toEqual({ author: "Claude", error: "sandbox died" });
+	});
+});
+
+describe("deriveTurnError (#808)", () => {
+	test("undefined for a normal, still-open turn", () => {
+		expect(deriveTurnError([{ type: "text", content: "working…" }])).toBeUndefined();
+	});
+
+	test("undefined for a cleanly completed turn", () => {
+		expect(deriveTurnError([done({ durationMs: 10 })])).toBeUndefined();
+	});
+
+	test("the error chunk's text, when one is present", () => {
+		expect(
+			deriveTurnError([
+				{ type: "text", content: "partial answer" },
+				{ type: "error", content: "sandbox died" },
+				done({ aborted: true }),
+			]),
+		).toBe("sandbox died");
+	});
+
+	test("a generic message for an aborted done with no explicit error chunk", () => {
+		expect(deriveTurnError([done({ aborted: true })])).toBe(
+			"Turn interrupted before completion.",
+		);
+	});
+
+	test("a generic message when the error chunk carries no content", () => {
+		expect(
+			deriveTurnError([{ type: "error", content: "" }, done({ aborted: true })]),
+		).toBe("The turn failed.");
+	});
+
+	test("a done chunk without aborted metadata is not a failure", () => {
+		expect(deriveTurnError([done()])).toBeUndefined();
 	});
 });

--- a/web-next/src/lib/transcript/turn-stats.ts
+++ b/web-next/src/lib/transcript/turn-stats.ts
@@ -29,6 +29,23 @@ function parseTestsPassed(output: string): number | undefined {
 }
 
 /**
+ * The turn's failure text, or undefined if it hasn't failed. An `error`
+ * chunk (a live provider fault, or the synthesized message
+ * `closeAbandonedTurn`/turn-ingest's catch write for an interrupted run) wins
+ * outright; a `done` chunk carrying `metadata.aborted` with no explicit error
+ * chunk (defensive — the two are always paired in practice) falls back to a
+ * generic message. Undefined for a normal, still-open, or cleanly completed
+ * turn (see `folioTurnMetadata`, which this feeds).
+ */
+export function deriveTurnError(chunks: readonly StreamChunk[]): string | undefined {
+	const errorChunk = chunks.find((chunk) => chunk.type === "error");
+	if (errorChunk) return errorChunk.content.length > 0 ? errorChunk.content : "The turn failed.";
+	const doneChunk = chunks.find((chunk) => chunk.type === "done");
+	if (doneChunk?.metadata?.aborted === true) return "Turn interrupted before completion.";
+	return undefined;
+}
+
+/**
  * Stats for a completed turn, or undefined while the turn is still open
  * (no `done` chunk yet) — an unfinished turn gets no receipt.
  *
@@ -90,11 +107,15 @@ export function deriveTurnStats(
 
 /**
  * The assistant-message metadata for a turn: author immediately (fed to the
- * adapter's `start`), turn stats once the turn completed (fed to `finish`).
+ * adapter's `start`), then either the turn's failure or its stats once the
+ * turn completed (fed to `finish`) — a failed turn gets `error` instead of a
+ * `turnStats` receipt, never both.
  */
 export function folioTurnMetadata(
 	chunks: readonly StreamChunk[],
 ): FolioMetadata {
+	const error = deriveTurnError(chunks);
+	if (error) return { author: AGENT_AUTHOR, error };
 	const turnStats = deriveTurnStats(chunks);
 	return turnStats ? { author: AGENT_AUTHOR, turnStats } : { author: AGENT_AUTHOR };
 }

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -357,20 +357,16 @@ test("a failing turn surfaces an inline failure + retry, live and after reload (
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
 
-	// A reload projects the identical failure from the persisted log — same
-	// card, same message, same turn — proving live and reloaded agree.
-	await page.reload();
-	await expect(page.getByTestId("turn-failure")).toContainText(
-		"Simulated turn failure (mock provider)",
-	);
-	await expect(page.locator('[data-message-role="user"]')).toContainText(
-		"Fix the bug",
-	);
-
 	// Retry re-sends the turn's original text — recoverable, not lost, even
-	// though the compose field itself cleared on the original submit. The mock
-	// has already spent its one guaranteed failure on this session, so this
-	// attempt runs the normal script through to completion.
+	// though the compose field itself cleared on the original submit — WITHOUT
+	// a reload in between: this is the live-only path, where the failed
+	// turn's card is tagged by a sticky client-side record (live-turn-error.ts)
+	// rather than the server projection. A status-gated version of that record
+	// would un-tag the card the instant this retry's turn leaves the "error"
+	// status, making it vanish here even though the log still has it — so this
+	// ordering (retry BEFORE reload) is the one that actually exercises that.
+	// The mock has already spent its one guaranteed failure on this session,
+	// so this attempt runs the normal script through to completion.
 	await page.getByRole("button", { name: "Retry" }).click();
 	await expect(page.locator('[data-message-role="user"]')).toHaveCount(2);
 	await expect(
@@ -381,9 +377,19 @@ test("a failing turn surfaces an inline failure + retry, live and after reload (
 	});
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
 
-	// The failed turn's own card is untouched — retry started a new turn, it
-	// didn't erase the record of the failure.
+	// The failed turn's own card is still there, live — retry started a new
+	// turn, it didn't erase the record of the failure.
 	await expect(page.getByTestId("turn-failure")).toBeVisible();
+
+	// A reload projects the identical story from the persisted log — both the
+	// failure card and the successful retry turn survive it, proving live and
+	// reloaded agree throughout, not just in the moment right after failing.
+	await page.reload();
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"Simulated turn failure (mock provider)",
+	);
+	await expect(page.locator('[data-message-role="user"]')).toHaveCount(2);
+	await expect(page.getByTestId("turn-stats")).toBeVisible();
 });
 
 // GitHub-backed repo picker (#825): the /api/repos fixture list under

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -319,6 +319,73 @@ test("closing the tab mid-turn does not kill it — a fresh tab catches up", asy
 	await expect(reopened.getByTestId("activity-line")).toHaveCount(0);
 });
 
+// A failing turn (#808): mock-provider.ts's MOCK_TURN_ERROR_TRIGGER
+// ("__mock_turn_error__" in the sent text) fails the turn deterministically
+// instead of running the script — the hermetic seam for driving this without
+// a real provider outage. The same provider spends that trigger once per
+// session, so a retry re-sending the identical text succeeds.
+test("a failing turn surfaces an inline failure + retry, live and after reload (#808)", async ({
+	page,
+}) => {
+	// A brand-new session, isolated from the shared turn session above.
+	await page.goto("/");
+	await page.getByRole("button", { name: "+ new session" }).click();
+	await page
+		.getByTestId("new-session-picker")
+		.getByRole("button", { name: "fairchild/workspaces" })
+		.click();
+	await expect(page).toHaveURL(SESSION_URL);
+
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await compose.fill("Fix the bug __mock_turn_error__");
+	await page.keyboard.press("Enter");
+
+	// The user's message lands at once — it is never at risk, durably
+	// persisted before the turn even starts — and the activity line breathes
+	// briefly while the mock "provisions".
+	await expect(page.locator('[data-message-role="user"]')).toContainText(
+		"Fix the bug",
+	);
+	await expect(page.getByTestId("activity-line")).toBeVisible();
+
+	// The turn fails: a calm inline failure card (no toast/alert chrome) with
+	// the stream's error text and a Retry action; compose re-enables.
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"Simulated turn failure (mock provider)",
+		{ timeout: TURN_TIMEOUT },
+	);
+	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
+
+	// A reload projects the identical failure from the persisted log — same
+	// card, same message, same turn — proving live and reloaded agree.
+	await page.reload();
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"Simulated turn failure (mock provider)",
+	);
+	await expect(page.locator('[data-message-role="user"]')).toContainText(
+		"Fix the bug",
+	);
+
+	// Retry re-sends the turn's original text — recoverable, not lost, even
+	// though the compose field itself cleared on the original submit. The mock
+	// has already spent its one guaranteed failure on this session, so this
+	// attempt runs the normal script through to completion.
+	await page.getByRole("button", { name: "Retry" }).click();
+	await expect(page.locator('[data-message-role="user"]')).toHaveCount(2);
+	await expect(
+		page.locator('[data-message-role="user"]').nth(1),
+	).toContainText("Fix the bug");
+	await expect(page.getByTestId("turn-stats")).toBeVisible({
+		timeout: TURN_TIMEOUT,
+	});
+	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+
+	// The failed turn's own card is untouched — retry started a new turn, it
+	// didn't erase the record of the failure.
+	await expect(page.getByTestId("turn-failure")).toBeVisible();
+});
+
 // GitHub-backed repo picker (#825): the /api/repos fixture list under
 // AUTH_BYPASS covers both a real (non-"main") default branch landing in the
 // masthead and a calm inline error for a repo the fixture directory doesn't


### PR DESCRIPTION
## Summary

- A turn that errored or was interrupted before completion used to vanish from the transcript entirely — live, because the zero-part reply useChat pushes at `start` got filtered out of `visibleMessages`; after a reload, because `projectSessionEvents` dropped an assistant run with no renderable parts. Now it renders as a calm, typography-first inline failure card (no toast/alert chrome) with a Retry action, identically live and after reload.
- The user's submitted text was never actually at risk — it's durably persisted as a user event before the assistant turn even starts — but it was effectively unrecoverable without retyping. Retry re-sends the turn's original text (read straight from the transcript, not the compose field, which does clear on submit).
- `mock-provider.ts` gains a deterministic, hermetic failure seam (`MOCK_TURN_ERROR_TRIGGER`) that spends itself once per session, so a UI retry of the identical failed text succeeds instead of failing forever.

Closes #808

## Mergeability

- Surface: web-next/ — Folio session transcript (`live-session-view.tsx`, `session-view.tsx`, `message.tsx`), the transcript projection (`project-events.ts`, `turn-stats.ts`), and the mock compute provider.
- User-facing behavior changed: Yes. A failed/interrupted turn now renders an inline failure card + Retry button instead of silently disappearing from the transcript, live and after reload.
- Non-happy paths considered: An immediate failure (no content streamed yet), a failure after partial content, an interrupted/abandoned turn (`closeAbandonedTurn`'s synthesized `error`+aborted-`done`), an empty error-chunk edge case (normalized to "The turn failed." on both live and projected paths), a double-clicked Retry (ref-latched, not state-latched — see review loop below), and a later turn's own status transitions no longer erasing an earlier turn's live failure card (see review loop).
- Residual risk or follow-up: Retry always starts a genuinely new turn (a new durable user event), same as any other send — two rapid, *simultaneous* sends (whether an ordinary compose send or two different failed turns' Retry buttons clicked near-simultaneously) can still race the server's single-active-turn check; this is the same pre-existing limitation `run-turn.ts` documents and tracks as #811, not something this PR introduces or resolves.

## Evidence

tests passed: `pnpm run lint && pnpm run typecheck` clean; `pnpm run test` — 310/310 passed; `pnpm run test:e2e` — 30/30 passed (includes the new `#808` spec in `tests/e2e/sessions.spec.ts`).

Mutation checks (two, both confirmed the covered behavior is actually exercised — mutated, watched the relevant test(s) fail, reverted, watched them pass again):
- `turn-stats.ts`'s `deriveTurnError`: flipped `aborted === true` to `aborted === false` → `turn-stats.test.ts`'s "a generic message for an aborted done with no explicit error chunk" failed as expected.
- `live-turn-error.ts`'s `applyLiveTurnErrors`: restricted it to only ever tag the trailing message (reproducing the exact bug codex's review found) → both `live-turn-error.test.ts`'s "tags every message with a recorded failure, not just the trailing one" and "survives status moving on to a later turn — the earlier card stays tagged (#808 regression)" failed as expected.

Screenshots (light + dark), captured via `pnpm run evidence`:
- The inline failure card, live: [light](https://evidence.cloudcompute.com/workspaces/pr-929/20260707-182317-turn-failed-live-light.png) / [dark](https://evidence.cloudcompute.com/workspaces/pr-929/20260707-182334-turn-failed-live-dark.png)
- After Retry succeeds (scrolled to the new turn's receipt): [light](https://evidence.cloudcompute.com/workspaces/pr-929/20260707-182338-turn-failed-retried-light.png) / [dark](https://evidence.cloudcompute.com/workspaces/pr-929/20260707-182342-turn-failed-retried-dark.png)

- CI: green quality lane on 15e4d22: https://github.com/fairchild/workspaces/actions/runs/28888917188/job/85696169713
- Gate note: orchestrator reviewed the design (sticky messageId→errorText record in React state — fixes the codex-found regression where a later retry cleared an earlier turn's failure card; consistent live/projected rendering through one Message path; one-shot error trigger makes retry-succeeds e2e-drivable); 2 mutation checks ran; 310/310 unit + 30/30 e2e; evidence hosted. Merged on delegated authority.

## Review loop

Ran `codex-review-loop` (gpt-5.5, xhigh), directed at retry idempotence, live/projected consistency, and whether the `visibleMessages` filter change leaks other empty messages. Findings and disposition:

1. **Retry idempotence — real gap, fixed.** `TurnFailure`'s double-click guard was a `useState` flag: two `handleRetry` invocations fired before a re-render both read the same stale `false`. Fixed with a `useRef` latch checked/set synchronously in the same call (commit `fix(web-next): make the live failure card sticky, not status-gated`). Codex separately called the resend-creates-a-new-user-turn behavior itself working-as-intended given the durable turn-log architecture — declined as scope, tracked under the pre-existing #811 simultaneous-send caveat noted above.
2. **Live/projected consistency — two findings, both fixed.** (a) An empty error chunk rendered as blank text live but normalized to "The turn failed." after a reload; the live path now applies the same fallback. (b) The more serious one: the live failure tag was derived fresh every render from `status === "error"`, patching only the trailing message — the moment a later turn's own status left `"error"` (e.g. a successful Retry), an *earlier* failed turn's card would silently vanish from the live view until the next reload. Rewrote `live-turn-error.ts` around a sticky `messageId -> errorText` record (`recordLiveTurnError` / `applyLiveTurnErrors`) kept in real React state instead of a per-render derivation, so a turn's failure card survives whatever happens afterward. The e2e spec now clicks Retry *before* reloading specifically to exercise this path (it was previously masked by reloading first).
3. **`visibleMessages` filter leak — working as intended, no change.** The widened filter (`parts.length > 0 || metadata.error != null`) only ever admits messages the app itself tags with `metadata.error` (assistant-only, either from the live sticky record or the server projection); it doesn't newly expose user messages or empty in-progress placeholders.

## Deviations from the brief

- Evidence upload via `scripts/evidence.sh` requires a real PR number, so screenshots were captured locally before PR creation (per the evidence-before-PR convention) and are uploaded immediately after this draft is opened, with the resulting links added here — not literally uploaded *before* `gh pr create`, since that's not orderable with a tool that's keyed on the PR number.

