### PR TITLE
feat(sidebar): latest-activity snippets on session cards (#680 slice 3)

### DIFF
--- a/Sources/WorkspaceManager/Views/CommandPalette/SessionSwitcherView.swift
+++ b/Sources/WorkspaceManager/Views/CommandPalette/SessionSwitcherView.swift
@@ -106,7 +106,7 @@ struct SessionSwitcherView: View {
                                 highlightedIndex = index
                                 activate(row)
                             } label: {
-                                rowView(row, isHighlighted: index == highlightedIndex)
+                                SessionSwitcherRowView(row: row, isHighlighted: index == highlightedIndex)
                             }
                             .buttonStyle(.plain)
                             .id(row.id)
@@ -137,10 +137,55 @@ struct SessionSwitcherView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func rowView(_ row: SessionSwitcherRow, isHighlighted: Bool) -> some View {
+    private func rowBackground(isHighlighted: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(isHighlighted ? Color.accentColor.opacity(0.18) : Color.clear)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+    }
+
+    private func moveHighlight(by delta: Int) {
+        let rows = rows
+        guard !rows.isEmpty else { return }
+        highlightedIndex = max(0, min(rows.count - 1, highlightedIndex + delta))
+    }
+
+    private func activateHighlightedRow() {
+        let rows = rows
+        guard highlightedIndex >= 0, highlightedIndex < rows.count else { return }
+        activate(rows[highlightedIndex])
+    }
+
+    private func activate(_ row: SessionSwitcherRow) {
+        switch row.target {
+        case .hostSession(let id):
+            onSelectHostSession(id)
+        case .workspace(let id):
+            guard let workspace = workspacesByID[id] else { return }
+            onSelectWorkspace(workspace)
+        case .repo(let id):
+            guard let repo = reposByID[id] else { return }
+            onSelectRepo(repo)
+        case .webSource(let id):
+            guard let source = webSourcesByID[id] else { return }
+            onSelectWebSource(source)
+        case .command(.changeTerminalTheme):
+            onOpenThemeSwitcher()
+        }
+    }
+}
+
+/// One switcher card: icon + live-activity dot, title/kind, subtitle, the status-derived
+/// activity snippet (`row.preview`), and the metadata chip row. Extracted from the List so it
+/// renders standalone (SwiftUI `List` does not draw its rows under `ImageRenderer`).
+struct SessionSwitcherRowView: View {
+    let row: SessionSwitcherRow
+    var isHighlighted: Bool = false
+
+    var body: some View {
         HStack(alignment: .top, spacing: 11) {
             ZStack(alignment: .bottomTrailing) {
-                Image(systemName: iconName(for: row))
+                Image(systemName: iconName)
                     .font(.system(size: 16, weight: .medium))
                     .foregroundStyle(isHighlighted ? .primary : .secondary)
                     .frame(width: 24, height: 24)
@@ -169,7 +214,7 @@ struct SessionSwitcherView: View {
                     .lineLimit(1)
                 Text(row.preview)
                     .font(.caption)
-                    .foregroundStyle(row.activity == .awaitingInput ? .primary : .secondary)
+                    .foregroundStyle(row.activity.emphasizesPreview ? .primary : .secondary)
                     .lineLimit(1)
                 chipRow(row.chips)
             }
@@ -206,50 +251,13 @@ struct SessionSwitcherView: View {
         .frame(height: 20)
     }
 
-    private func rowBackground(isHighlighted: Bool) -> some View {
-        RoundedRectangle(cornerRadius: 6)
-            .fill(isHighlighted ? Color.accentColor.opacity(0.18) : Color.clear)
-            .padding(.horizontal, 4)
-            .padding(.vertical, 1)
-    }
-
-    private func iconName(for row: SessionSwitcherRow) -> String {
+    private var iconName: String {
         switch row.kind {
         case .workspace: return "terminal"
         case .repo: return "folder"
         case .terminal: return "rectangle.terminal"
         case .web: return "globe"
         case .command: return "command"
-        }
-    }
-
-    private func moveHighlight(by delta: Int) {
-        let rows = rows
-        guard !rows.isEmpty else { return }
-        highlightedIndex = max(0, min(rows.count - 1, highlightedIndex + delta))
-    }
-
-    private func activateHighlightedRow() {
-        let rows = rows
-        guard highlightedIndex >= 0, highlightedIndex < rows.count else { return }
-        activate(rows[highlightedIndex])
-    }
-
-    private func activate(_ row: SessionSwitcherRow) {
-        switch row.target {
-        case .hostSession(let id):
-            onSelectHostSession(id)
-        case .workspace(let id):
-            guard let workspace = workspacesByID[id] else { return }
-            onSelectWorkspace(workspace)
-        case .repo(let id):
-            guard let repo = reposByID[id] else { return }
-            onSelectRepo(repo)
-        case .webSource(let id):
-            guard let source = webSourcesByID[id] else { return }
-            onSelectWebSource(source)
-        case .command(.changeTerminalTheme):
-            onOpenThemeSwitcher()
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
+++ b/Sources/WorkspaceManager/Views/Components/SidebarInfoCard.swift
@@ -19,6 +19,9 @@ struct SidebarTabSummary: Identifiable, Equatable {
     let id: UUID
     let title: String
     var agentStatus: AgentSessionStatus? = nil
+    /// Last assistant message from the agent's transcript, resolved lazily when the hover
+    /// card opens (Claude Code only; `nil` for every non-happy path). See #680.
+    var transcriptTail: String? = nil
 }
 
 struct SidebarInfoCard: View {
@@ -42,11 +45,11 @@ struct SidebarInfoCard: View {
         return branch
     }
 
-    /// The single running agent, if exactly one tab has one — used to surface its
-    /// telemetry without crowding the card when several agents are running.
-    private var soleAgent: AgentSessionStatus? {
-        let agents = tabs.compactMap(\.agentStatus)
-        return agents.count == 1 ? agents.first : nil
+    /// The single tab running an agent, if exactly one does — used to surface its telemetry
+    /// (and latest transcript message) without crowding the card when several agents run.
+    private var soleAgentTab: SidebarTabSummary? {
+        let agentTabs = tabs.filter { $0.agentStatus != nil }
+        return agentTabs.count == 1 ? agentTabs.first : nil
     }
 
     var body: some View {
@@ -69,9 +72,17 @@ struct SidebarInfoCard: View {
                 }
             }
 
-            if let soleAgent {
+            if let soleAgentTab, let agent = soleAgentTab.agentStatus {
                 Divider()
-                agentDetails(soleAgent)
+                agentDetails(agent)
+                if let tail = soleAgentTab.transcriptTail, !tail.isEmpty {
+                    Text(tail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityLabel("Latest message: \(tail)")
+                }
             }
         }
         .padding(14)

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -1499,11 +1499,16 @@ struct SidebarView: View {
                         foregroundName: foregroundNameBySessionID[session.id],
                         terminalTitle: title)
                     : title
+                // Only Claude Code tabs carry a transcript tail. Gating on the current kind (not
+                // just presence of a cached entry) keeps a stale tail from a prior Claude session
+                // from leaking onto a non-Claude agent that later reuses the same host session id.
+                let transcriptTail =
+                    agentStatus?.kind == .claudeCode ? transcriptTailBySessionID[session.id] : nil
                 return SidebarTabSummary(
                     id: session.id,
                     title: displayTitle,
                     agentStatus: agentStatus,
-                    transcriptTail: transcriptTailBySessionID[session.id]
+                    transcriptTail: transcriptTail
                 )
             }
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -96,6 +96,12 @@ struct SidebarView: View {
     @State private var foregroundNameBySessionID: [UUID: String] = [:]
     private let foregroundResolver = TerminalForegroundProcessResolver()
 
+    /// Last assistant message per Claude Code agent tab, resolved lazily when a hover card
+    /// opens and shown on the card. Populated by `refreshTranscriptTails`; fails closed to
+    /// absent for every non-happy path (see #680).
+    @State private var transcriptTailBySessionID: [UUID: String] = [:]
+    private let transcriptTailResolver = ClaudeTranscriptTailResolver()
+
     private var isUIFixtureMode: Bool {
         ProcessInfo.processInfo.environment["WORKSPACES_UI_FIXTURE"] == "1"
     }
@@ -479,6 +485,7 @@ struct SidebarView: View {
             },
             tabsProvider: {
                 refreshForegroundProcessNames(for: repoSessionKey)
+                refreshTranscriptTails(for: repoSessionKey)
                 return tabSummaries(for: repoSessionKey)
             }
         )
@@ -571,6 +578,7 @@ struct SidebarView: View {
             showsDisclosure: !workspace.webSources.isEmpty,
             tabsProvider: {
                 refreshForegroundProcessNames(for: sessionKey(for: workspace))
+                refreshTranscriptTails(for: sessionKey(for: workspace))
                 return tabSummaries(for: workspace)
             },
             onToggleExpansion: {
@@ -1494,7 +1502,8 @@ struct SidebarView: View {
                 return SidebarTabSummary(
                     id: session.id,
                     title: displayTitle,
-                    agentStatus: agentStatus
+                    agentStatus: agentStatus,
+                    transcriptTail: transcriptTailBySessionID[session.id]
                 )
             }
     }
@@ -1523,6 +1532,32 @@ struct SidebarView: View {
                     foregroundNameBySessionID[session.id] = name
                 } else if name == nil, foregroundNameBySessionID[session.id] != nil {
                     foregroundNameBySessionID.removeValue(forKey: session.id)
+                }
+            }
+        }
+    }
+
+    /// Kicks off async transcript-tail resolution for the Claude Code agent tabs under `key`,
+    /// updating `transcriptTailBySessionID` when a message resolves. Fire-and-forget and
+    /// idempotent — the resolver caches per file for a short TTL and this writes only on change —
+    /// so it is safe to call from the hover card's lazy `tabsProvider`. Non-Claude tabs and every
+    /// read/parse failure resolve to absent (#680).
+    private func refreshTranscriptTails(for key: HostTerminalSessionKey) {
+        let normalizedKey = key.normalized()
+        let agentSessions = hostSessions.filter {
+            $0.key == normalizedKey && agentStatusBySessionID[$0.id]?.kind == .claudeCode
+        }
+        guard !agentSessions.isEmpty else { return }
+        let resolver = transcriptTailResolver
+        Task { @MainActor in
+            for session in agentSessions {
+                guard let status = agentStatusBySessionID[session.id] else { continue }
+                let tail = await resolver.tail(
+                    cwd: status.cwd, agentSessionID: status.agentSessionID, kind: status.kind)
+                if let tail, transcriptTailBySessionID[session.id] != tail {
+                    transcriptTailBySessionID[session.id] = tail
+                } else if tail == nil, transcriptTailBySessionID[session.id] != nil {
+                    transcriptTailBySessionID.removeValue(forKey: session.id)
                 }
             }
         }

--- a/Sources/WorkspaceManagerCore/Models/SessionActivity.swift
+++ b/Sources/WorkspaceManagerCore/Models/SessionActivity.swift
@@ -101,6 +101,17 @@ public enum SessionActivity: Equatable, Sendable {
         paneCount > 1
     }
 
+    /// Whether a card's activity snippet should render with primary (not secondary) emphasis:
+    /// the attention states a glance should land on first (#680).
+    public var emphasizesPreview: Bool {
+        switch self {
+        case .awaitingInput, .errored:
+            return true
+        case .inactive, .live, .active, .thinking, .runningTool:
+            return false
+        }
+    }
+
     /// Severity ranking used to merge a baseline (own-session) activity with a bubbled
     /// activity derived from child workspaces, and to order the session switcher. Higher wins.
     public var severity: Int {

--- a/Sources/WorkspaceManagerCore/Models/SessionActivitySnippet.swift
+++ b/Sources/WorkspaceManagerCore/Models/SessionActivitySnippet.swift
@@ -1,0 +1,63 @@
+//
+//  SessionActivitySnippet.swift
+//  WorkspaceManagerCore
+//
+//  The latest-activity line shown on a session card, formatted purely from an agent's
+//  run state (#680). Surfaces the states worth glancing at — a running tool and its
+//  detail, a per-reason "awaiting input", an error — and stays silent for idle/complete
+//  so the card carries no filler. UI-free and unit-tested; the switcher row feeds it into
+//  its existing preview slot and falls back to a neutral descriptor when this is nil.
+//
+
+import Foundation
+
+public enum SessionActivitySnippet {
+    /// Default single-line character budget for a card snippet.
+    public static let defaultMaxLength = 120
+
+    /// A one-line activity snippet for `run`, or `nil` when the state warrants no line
+    /// (idle/complete). Output is always collapsed to a single line and truncated.
+    public static func text(for run: AgentRunState, maxLength: Int = defaultMaxLength) -> String? {
+        switch run {
+        case .idle, .complete:
+            return nil
+        case .thinking:
+            return "Thinking…"
+        case .runningTool(let name, let detail):
+            let base = "Running \(name)"
+            if let detail = detail?.singleLineTruncated(maxLength: maxLength), !detail.isEmpty {
+                return "\(base): \(detail)".singleLineTruncated(maxLength: maxLength)
+            }
+            return base.singleLineTruncated(maxLength: maxLength)
+        case .awaitingInput(let reason):
+            return awaitingPhrase(reason)
+        case .errored(let category, let message):
+            if let message = message?.singleLineTruncated(maxLength: maxLength), !message.isEmpty {
+                return message
+            }
+            // Reuse the one error-category vocabulary ("Rate limited", "Auth error", …).
+            return AgentChromeProjection.runState(.errored(category: category, message: nil)).summaryText
+        }
+    }
+
+    private static func awaitingPhrase(_ reason: AwaitingReason) -> String {
+        switch reason {
+        case .permissionPrompt: return "Waiting for permission"
+        case .idlePrompt: return "Waiting for your reply"
+        case .custom: return "Awaiting input"
+        }
+    }
+}
+
+extension String {
+    /// Collapse all whitespace (including newlines) to single spaces, trim, and truncate to
+    /// `maxLength` with a trailing ellipsis. Returns an empty string when nothing remains.
+    func singleLineTruncated(maxLength: Int) -> String {
+        let collapsed =
+            split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .joined(separator: " ")
+        guard collapsed.count > maxLength else { return collapsed }
+        let end = collapsed.index(collapsed.startIndex, offsetBy: max(0, maxLength - 1))
+        return String(collapsed[collapsed.startIndex..<end]) + "…"
+    }
+}

--- a/Sources/WorkspaceManagerCore/Models/SessionSwitcherSnapshot.swift
+++ b/Sources/WorkspaceManagerCore/Models/SessionSwitcherSnapshot.swift
@@ -417,22 +417,12 @@ public struct SessionSwitcherSnapshot: Sendable {
         return chips
     }
 
+    /// The card's latest-activity line: the pure `SessionActivitySnippet` for the agent's
+    /// run state, or a neutral descriptor when the state warrants no snippet (idle/complete,
+    /// or no registered agent). Keeps run-state phrasing in one place (#680).
     private static func preview(for status: AgentSessionStatus?, fallback: String) -> String {
         guard let status else { return fallback }
-        switch status.run {
-        case .idle:
-            return "Idle"
-        case .thinking:
-            return "Thinking"
-        case .runningTool(let name, let detail):
-            return subtitle(parts: ["Running \(name)", detail])
-        case .awaitingInput(let reason):
-            return "Awaiting input: \(reason.displayName)"
-        case .complete:
-            return "Complete"
-        case .errored(_, let message):
-            return message ?? "Errored"
-        }
+        return SessionActivitySnippet.text(for: status.run) ?? fallback
     }
 
     private static func activityForRow(activity: SessionActivity, isActive: Bool) -> SessionActivity {

--- a/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptTail.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptTail.swift
@@ -51,10 +51,13 @@ public enum ClaudeTranscriptTail {
         inTailChunk chunk: String,
         maxLength: Int = SessionActivitySnippet.defaultMaxLength
     ) -> String? {
-        let lines = chunk.split(separator: "\n", omittingEmptySubsequences: true)
+        let lines = chunk.split(whereSeparator: \.isNewline)
         for line in lines.reversed() {
+            // Trim so a stray CR (CRLF transcripts) or surrounding whitespace doesn't defeat the
+            // JSON parse; a partial leading line from the tail boundary simply fails to parse.
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
             guard
-                let data = String(line).data(using: .utf8),
+                let data = trimmed.data(using: .utf8),
                 let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                 object["type"] as? String == "assistant",
                 let message = object["message"] as? [String: Any],

--- a/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptTail.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptTail.swift
@@ -13,9 +13,11 @@
 import Foundation
 
 public enum ClaudeTranscriptTail {
-    /// Default number of bytes read from the end of a transcript. Comfortably larger than a
-    /// single assistant turn's JSONL line, so the last message is present without loading the file.
-    public static let defaultTailByteCount = 16_384
+    /// Default number of bytes read from the end of a transcript. Comfortably larger than a single
+    /// assistant turn's JSONL line, so the last message is present without loading the file. A final
+    /// record larger than this still fails closed to nil (a valid last message is missed, never a
+    /// wrong or older one), which is why the budget is generous rather than minimal.
+    public static let defaultTailByteCount = 65_536
 
     /// The on-disk transcript for a Claude Code session, or `nil` when it can't apply (non-Claude
     /// agent, missing session id, or empty cwd). Existence is not checked here — callers read lazily.
@@ -113,7 +115,15 @@ public actor ClaudeTranscriptTailResolver {
         else { return nil }
 
         let path = url.path
-        let modificationDate = (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+        // Only ever read a plain file. `attributesOfItem` does not follow symlinks, so a symlink,
+        // FIFO, or device at the transcript path is rejected here — never opened — which keeps a
+        // pathological path from blocking the resolver's actor in `FileHandle(forReadingFrom:)`.
+        guard attributes?[.type] as? FileAttributeType == .typeRegular else {
+            cache[path] = CacheEntry(value: nil, modificationDate: nil, expiresAt: now.addingTimeInterval(ttl))
+            return nil
+        }
+        let modificationDate = attributes?[.modificationDate] as? Date
         if let cached = cache[path],
             cached.expiresAt > now,
             cached.modificationDate == modificationDate

--- a/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptTail.swift
+++ b/Sources/WorkspaceManagerCore/Services/ClaudeTranscriptTail.swift
@@ -1,0 +1,139 @@
+//
+//  ClaudeTranscriptTail.swift
+//  WorkspaceManagerCore
+//
+//  Resolves the last assistant message from a Claude Code session's JSONL transcript, for the
+//  sidebar hover card's latest-activity line (#680). Claude Code stores transcripts at
+//  ~/.claude/projects/<slug>/<agentSessionID>.jsonl, where <slug> is the session cwd with every
+//  '/' and '.' turned into '-'. The pure pieces (path + last-assistant parse) are unit-tested;
+//  the actor reads only the file's tail (no whole-file loads) with a short TTL cache. Every
+//  failure mode — wrong agent kind, missing id, unreadable or unparseable file — resolves to nil.
+//
+
+import Foundation
+
+public enum ClaudeTranscriptTail {
+    /// Default number of bytes read from the end of a transcript. Comfortably larger than a
+    /// single assistant turn's JSONL line, so the last message is present without loading the file.
+    public static let defaultTailByteCount = 16_384
+
+    /// The on-disk transcript for a Claude Code session, or `nil` when it can't apply (non-Claude
+    /// agent, missing session id, or empty cwd). Existence is not checked here — callers read lazily.
+    public static func transcriptURL(
+        cwd: String,
+        agentSessionID: String?,
+        kind: AgentKind,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL? {
+        guard kind == .claudeCode else { return nil }
+        guard let agentSessionID, !agentSessionID.isEmpty else { return nil }
+        let trimmedCWD = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCWD.isEmpty else { return nil }
+        return
+            homeDirectory
+            .appendingPathComponent(".claude", isDirectory: true)
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(projectSlug(forCWD: trimmedCWD), isDirectory: true)
+            .appendingPathComponent("\(agentSessionID).jsonl", isDirectory: false)
+    }
+
+    /// Claude Code's project-directory slug: the cwd with every '/' and '.' replaced by '-'
+    /// (so `/a/b/.hidden` becomes `-a-b--hidden`). Verified against on-disk transcript dirs.
+    public static func projectSlug(forCWD cwd: String) -> String {
+        String(cwd.map { ($0 == "/" || $0 == ".") ? "-" : $0 })
+    }
+
+    /// The last assistant text block found in a JSONL tail chunk, collapsed to one line and
+    /// truncated. The chunk may begin mid-line (a partial leading line simply fails to parse and
+    /// is skipped). Lines are scanned newest-first; `thinking`/`tool_use` blocks and non-assistant
+    /// rows are ignored. Returns `nil` when no assistant text is present.
+    public static func lastAssistantText(
+        inTailChunk chunk: String,
+        maxLength: Int = SessionActivitySnippet.defaultMaxLength
+    ) -> String? {
+        let lines = chunk.split(separator: "\n", omittingEmptySubsequences: true)
+        for line in lines.reversed() {
+            guard
+                let data = String(line).data(using: .utf8),
+                let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                object["type"] as? String == "assistant",
+                let message = object["message"] as? [String: Any],
+                let content = message["content"] as? [[String: Any]]
+            else { continue }
+            for block in content.reversed()
+            where block["type"] as? String == "text" {
+                if let text = block["text"] as? String {
+                    let single = text.singleLineTruncated(maxLength: maxLength)
+                    if !single.isEmpty { return single }
+                }
+            }
+        }
+        return nil
+    }
+}
+
+/// Reads the last assistant message from a Claude Code transcript, caching by path + mtime for a
+/// short TTL so the hover card's repeated re-renders don't re-read the file. Reads only the tail.
+public actor ClaudeTranscriptTailResolver {
+    private struct CacheEntry {
+        let value: String?
+        let modificationDate: Date?
+        let expiresAt: Date
+    }
+
+    private let ttl: TimeInterval
+    private let tailByteCount: Int
+    private let maxLength: Int
+    private var cache: [String: CacheEntry] = [:]
+
+    public init(
+        ttl: TimeInterval = 2,
+        tailByteCount: Int = ClaudeTranscriptTail.defaultTailByteCount,
+        maxLength: Int = SessionActivitySnippet.defaultMaxLength
+    ) {
+        self.ttl = ttl
+        self.tailByteCount = tailByteCount
+        self.maxLength = maxLength
+    }
+
+    /// The latest assistant message for a Claude Code session, or `nil` for any non-happy path.
+    public func tail(
+        cwd: String,
+        agentSessionID: String?,
+        kind: AgentKind,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        now: Date = Date()
+    ) -> String? {
+        guard
+            let url = ClaudeTranscriptTail.transcriptURL(
+                cwd: cwd, agentSessionID: agentSessionID, kind: kind, homeDirectory: homeDirectory)
+        else { return nil }
+
+        let path = url.path
+        let modificationDate = (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+        if let cached = cache[path],
+            cached.expiresAt > now,
+            cached.modificationDate == modificationDate
+        {
+            return cached.value
+        }
+
+        let value = Self.readTail(at: url, tailByteCount: tailByteCount, maxLength: maxLength)
+        cache[path] = CacheEntry(
+            value: value, modificationDate: modificationDate, expiresAt: now.addingTimeInterval(ttl))
+        return value
+    }
+
+    private static func readTail(at url: URL, tailByteCount: Int, maxLength: Int) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let end = try? handle.seekToEnd() else { return nil }
+        let offset = end > UInt64(tailByteCount) ? end - UInt64(tailByteCount) : 0
+        guard (try? handle.seek(toOffset: offset)) != nil,
+            let data = try? handle.readToEnd(),
+            !data.isEmpty
+        else { return nil }
+        let chunk = String(decoding: data, as: UTF8.self)
+        return ClaudeTranscriptTail.lastAssistantText(inTailChunk: chunk, maxLength: maxLength)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SessionSwitcherSnippetRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SessionSwitcherSnippetRenderTests.swift
@@ -1,0 +1,114 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("SessionSwitcher snippet render")
+struct SessionSwitcherSnippetRenderTests {
+    /// Renders the switcher rows (via the extracted `SessionSwitcherRowView`, not the List, which
+    /// SwiftUI does not draw under `ImageRenderer`) over a snapshot whose live rows carry
+    /// status-derived activity snippets — a running tool with its detail and an awaiting-input row
+    /// with primary emphasis (#680). Asserts a non-empty image and, when `WORKSPACES_EVIDENCE_DIR`
+    /// is set, writes a PNG for PR evidence without launching the app.
+    @Test("Switcher rows render status-derived activity snippets")
+    func rendersActivitySnippets() throws {
+        let repo = Repo(name: "workspaces", localPath: URL(fileURLWithPath: "/tmp/workspaces"))
+        let running = Workspace(
+            name: "feature-mux",
+            path: URL(fileURLWithPath: "/tmp/ws-running"),
+            sourceRepo: repo,
+            gitBranch: "claude/680-snippets"
+        )
+        let awaiting = Workspace(
+            name: "review-pane",
+            path: URL(fileURLWithPath: "/tmp/ws-awaiting"),
+            sourceRepo: repo,
+            gitBranch: "claude/review"
+        )
+        repo.workspaces = [running, awaiting]
+
+        let runningSession = hostSession(at: "/tmp/ws-running")
+        let awaitingSession = hostSession(at: "/tmp/ws-awaiting")
+
+        let snapshot = SessionSwitcherSnapshot.make(
+            repos: [repo],
+            webSources: [],
+            sessions: [runningSession, awaitingSession],
+            activeSessionID: runningSession.id,
+            agentStatuses: [
+                runningSession.id: status(
+                    for: runningSession, cwd: "/tmp/ws-running",
+                    run: .runningTool(name: "Bash", detail: "swift test")),
+                awaitingSession.id: status(
+                    for: awaitingSession, cwd: "/tmp/ws-awaiting",
+                    run: .awaitingInput(reason: .permissionPrompt)),
+            ],
+            paneCountBySessionKey: [:],
+            workspaceSessionKeys: [
+                running.id: runningSession.key,
+                awaiting.id: awaitingSession.key,
+            ],
+            workspaceActivities: [:],
+            repoActivities: [:]
+        )
+
+        // The two live workspace rows, in the snapshot's attention-first order.
+        let rows = snapshot.rows.filter {
+            if case .hostSession = $0.target { return true }
+            return false
+        }
+
+        let view = VStack(alignment: .leading, spacing: 4) {
+            ForEach(rows) { row in
+                SessionSwitcherRowView(row: row, isHighlighted: row.id == rows.first?.id)
+            }
+        }
+        .frame(width: 720, alignment: .leading)
+        .padding(12)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("session-switcher-snippets.png")
+        try png.write(to: url)
+    }
+
+    private func hostSession(at path: String) -> HostTerminalSession {
+        HostTerminalSession(
+            id: UUID(),
+            key: .hostPath(path),
+            directory: URL(fileURLWithPath: path)
+        )
+    }
+
+    private func status(
+        for session: HostTerminalSession, cwd: String, run: AgentRunState
+    )
+        -> AgentSessionStatus
+    {
+        AgentSessionStatus(
+            hostSessionID: session.id,
+            kind: .claudeCode,
+            cwd: cwd,
+            run: run,
+            contextUsedPercent: 48,
+            costUSD: 0.42,
+            modelDisplayName: "Claude Opus"
+        )
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/SidebarTranscriptTailRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarTranscriptTailRenderTests.swift
@@ -1,0 +1,60 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("SidebarInfoCard transcript-tail render")
+struct SidebarTranscriptTailRenderTests {
+    /// Renders the hover card for a single Claude Code agent tab carrying a resolved transcript
+    /// tail (the last assistant message, #680). Asserts a non-empty image (layout smoke) and,
+    /// when `WORKSPACES_EVIDENCE_DIR` is set, writes a PNG for PR evidence without launching the app.
+    @Test("Hover card renders the latest assistant message for a sole Claude Code agent")
+    func rendersTranscriptTail() throws {
+        let status = AgentSessionStatus(
+            hostSessionID: UUID(),
+            agentSessionID: "abc-123",
+            kind: .claudeCode,
+            cwd: "/Users/me/code",
+            run: .runningTool(name: "Bash", detail: "swift test"),
+            contextUsedPercent: 42,
+            costUSD: 0.37,
+            modelDisplayName: "Claude Opus"
+        )
+        let card = SidebarInfoCard(
+            name: "feature-mux",
+            branch: "claude/680-snippets",
+            tabs: [
+                SidebarTabSummary(
+                    id: UUID(),
+                    title: "Claude Code",
+                    agentStatus: status,
+                    transcriptTail:
+                        "Wired the transcript tail into the hover card and added fixture-backed parse tests."
+                )
+            ]
+        )
+        .padding(16)
+        .frame(width: 260, alignment: .leading)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: card)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        let url = URL(fileURLWithPath: dir).appendingPathComponent("sidebar-transcript-tail.png")
+        try png.write(to: url)
+    }
+}

--- a/Tests/WorkspaceManagerTests/ClaudeTranscriptTailTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeTranscriptTailTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("ClaudeTranscriptTail")
+struct ClaudeTranscriptTailTests {
+    // MARK: - Project slug
+
+    @Test("Slug replaces every slash and dot with a dash")
+    func slugRule() {
+        #expect(ClaudeTranscriptTail.projectSlug(forCWD: "/Users/me/code") == "-Users-me-code")
+        // A leading dot on a path segment (e.g. `/.chat`) yields a double dash, matching disk.
+        #expect(
+            ClaudeTranscriptTail.projectSlug(forCWD: "/Users/me/proj/.chat-worktrees/session-1")
+                == "-Users-me-proj--chat-worktrees-session-1")
+    }
+
+    // MARK: - Transcript URL
+
+    @Test("URL resolves under ~/.claude/projects for a Claude Code session")
+    func urlHappyPath() throws {
+        let home = URL(fileURLWithPath: "/Users/me")
+        let url = try #require(
+            ClaudeTranscriptTail.transcriptURL(
+                cwd: "/Users/me/code", agentSessionID: "abc-123", kind: .claudeCode,
+                homeDirectory: home))
+        #expect(url.path == "/Users/me/.claude/projects/-Users-me-code/abc-123.jsonl")
+    }
+
+    @Test("URL is nil for non-happy inputs")
+    func urlNilCases() {
+        let home = URL(fileURLWithPath: "/Users/me")
+        // Wrong agent kind.
+        #expect(
+            ClaudeTranscriptTail.transcriptURL(
+                cwd: "/Users/me/code", agentSessionID: "abc", kind: .opencode, homeDirectory: home)
+                == nil)
+        // Missing / empty session id.
+        #expect(
+            ClaudeTranscriptTail.transcriptURL(
+                cwd: "/Users/me/code", agentSessionID: nil, kind: .claudeCode, homeDirectory: home)
+                == nil)
+        #expect(
+            ClaudeTranscriptTail.transcriptURL(
+                cwd: "/Users/me/code", agentSessionID: "", kind: .claudeCode, homeDirectory: home)
+                == nil)
+        // Empty cwd.
+        #expect(
+            ClaudeTranscriptTail.transcriptURL(
+                cwd: "   ", agentSessionID: "abc", kind: .claudeCode, homeDirectory: home) == nil)
+    }
+
+    // MARK: - Last assistant text parsing
+
+    private let sampleTranscript = """
+        {"type":"user","message":{"role":"user","content":"review the code"}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"An earlier reply."}]}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"hmm"}]}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"}]}}
+        {"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ok"}]}}
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"more"},{"type":"text","text":"The final answer."}]}}
+        {"type":"system"}
+        """
+
+    @Test("Picks the last assistant text block, skipping thinking, tool_use, and user rows")
+    func picksLastAssistantText() {
+        #expect(ClaudeTranscriptTail.lastAssistantText(inTailChunk: sampleTranscript) == "The final answer.")
+    }
+
+    @Test("A partial leading line fails to parse and is ignored")
+    func ignoresPartialLeadingLine() {
+        let partial = "type\":\"assistant\",\"garbage\n" + sampleTranscript
+        #expect(ClaudeTranscriptTail.lastAssistantText(inTailChunk: partial) == "The final answer.")
+    }
+
+    @Test("No assistant text yields nil")
+    func noAssistantText() {
+        let chunk = """
+            {"type":"user","message":{"role":"user","content":"hello"}}
+            {"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"}]}}
+            """
+        #expect(ClaudeTranscriptTail.lastAssistantText(inTailChunk: chunk) == nil)
+        #expect(ClaudeTranscriptTail.lastAssistantText(inTailChunk: "") == nil)
+    }
+
+    @Test("Assistant text is collapsed to one line and truncated")
+    func collapsesAndTruncates() {
+        let long = String(repeating: "y", count: 300)
+        let chunk =
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"line one\\nline two\"}]}}"
+        #expect(ClaudeTranscriptTail.lastAssistantText(inTailChunk: chunk) == "line one line two")
+
+        let longChunk =
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"\(long)\"}]}}"
+        let snippet = ClaudeTranscriptTail.lastAssistantText(inTailChunk: longChunk, maxLength: 50)
+        #expect(snippet?.count == 50)
+        #expect(snippet?.hasSuffix("…") == true)
+    }
+
+    // MARK: - Resolver (reads the file tail)
+
+    @Test("Resolver reads the last assistant message from a transcript on disk")
+    func resolverReadsTail() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cc-home-\(UUID().uuidString)", isDirectory: true)
+        let cwd = "/Users/tester/project"
+        let sessionID = "session-\(UUID().uuidString)"
+        let dir =
+            home
+            .appendingPathComponent(
+                ".claude/projects/\(ClaudeTranscriptTail.projectSlug(forCWD: cwd))", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("\(sessionID).jsonl")
+        try sampleTranscript.write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = ClaudeTranscriptTailResolver()
+
+        // End-to-end: the resolver seeks the file tail, parses, and returns the last message.
+        let resolved = await resolver.tail(
+            cwd: cwd, agentSessionID: sessionID, kind: .claudeCode, homeDirectory: home)
+        #expect(resolved == "The final answer.")
+
+        // A missing file resolves to nil (fail-closed).
+        let missing = await resolver.tail(
+            cwd: "/nope/does/not/exist", agentSessionID: "missing", kind: .claudeCode,
+            homeDirectory: home)
+        #expect(missing == nil)
+
+        // A non-Claude kind never resolves.
+        let wrongKind = await resolver.tail(
+            cwd: cwd, agentSessionID: sessionID, kind: .opencode, homeDirectory: home)
+        #expect(wrongKind == nil)
+    }
+}

--- a/Tests/WorkspaceManagerTests/ClaudeTranscriptTailTests.swift
+++ b/Tests/WorkspaceManagerTests/ClaudeTranscriptTailTests.swift
@@ -133,4 +133,55 @@ struct ClaudeTranscriptTailTests {
             cwd: cwd, agentSessionID: sessionID, kind: .opencode, homeDirectory: home)
         #expect(wrongKind == nil)
     }
+
+    @Test("Resolver rejects a non-regular file at the transcript path")
+    func resolverRejectsNonRegularFile() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cc-home-\(UUID().uuidString)", isDirectory: true)
+        let cwd = "/Users/tester/project"
+        let sessionID = "session-\(UUID().uuidString)"
+        let dir =
+            home
+            .appendingPathComponent(
+                ".claude/projects/\(ClaudeTranscriptTail.projectSlug(forCWD: cwd))", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Put a *directory* where the "<id>.jsonl" file would be — a stand-in for any non-regular
+        // path (symlink/FIFO/device). The resolver must reject it, not open it.
+        let nonRegular = dir.appendingPathComponent("\(sessionID).jsonl")
+        try FileManager.default.createDirectory(at: nonRegular, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolver = ClaudeTranscriptTailResolver()
+        let resolved = await resolver.tail(
+            cwd: cwd, agentSessionID: sessionID, kind: .claudeCode, homeDirectory: home)
+        #expect(resolved == nil)
+    }
+
+    @Test("A final record larger than the tail budget fails closed to nil, never an older message")
+    func oversizedFinalRecordFailsClosed() async throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cc-home-\(UUID().uuidString)", isDirectory: true)
+        let cwd = "/Users/tester/project"
+        let sessionID = "session-\(UUID().uuidString)"
+        let dir =
+            home
+            .appendingPathComponent(
+                ".claude/projects/\(ClaudeTranscriptTail.projectSlug(forCWD: cwd))", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("\(sessionID).jsonl")
+        // An earlier valid assistant message, then a final record far larger than the tail budget.
+        let huge = String(repeating: "z", count: 4096)
+        let transcript =
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Older answer.\"}]}}\n"
+            + "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"\(huge)\"}]}}"
+        try transcript.write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        // A tiny tail budget starts the read inside the final record: it fails closed to nil rather
+        // than surfacing the *older* "Older answer." message.
+        let resolver = ClaudeTranscriptTailResolver(tailByteCount: 256)
+        let resolved = await resolver.tail(
+            cwd: cwd, agentSessionID: sessionID, kind: .claudeCode, homeDirectory: home)
+        #expect(resolved == nil)
+    }
 }

--- a/Tests/WorkspaceManagerTests/SessionActivitySnippetTests.swift
+++ b/Tests/WorkspaceManagerTests/SessionActivitySnippetTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("SessionActivitySnippet")
+struct SessionActivitySnippetTests {
+    @Test("Idle and complete produce no snippet")
+    func silentStates() {
+        #expect(SessionActivitySnippet.text(for: .idle) == nil)
+        #expect(SessionActivitySnippet.text(for: .complete) == nil)
+    }
+
+    @Test("Thinking is surfaced")
+    func thinking() {
+        #expect(SessionActivitySnippet.text(for: .thinking) == "Thinking…")
+    }
+
+    @Test("Running tool includes name and detail")
+    func runningToolWithDetail() {
+        #expect(
+            SessionActivitySnippet.text(for: .runningTool(name: "Bash", detail: "swift test"))
+                == "Running Bash: swift test")
+    }
+
+    @Test("Running tool without detail omits the colon")
+    func runningToolWithoutDetail() {
+        #expect(SessionActivitySnippet.text(for: .runningTool(name: "Bash", detail: nil)) == "Running Bash")
+        #expect(
+            SessionActivitySnippet.text(for: .runningTool(name: "Bash", detail: "   ")) == "Running Bash")
+    }
+
+    @Test("Awaiting input uses per-reason human phrasing")
+    func awaitingPhrasing() {
+        #expect(
+            SessionActivitySnippet.text(for: .awaitingInput(reason: .permissionPrompt))
+                == "Waiting for permission")
+        #expect(
+            SessionActivitySnippet.text(for: .awaitingInput(reason: .idlePrompt))
+                == "Waiting for your reply")
+        #expect(SessionActivitySnippet.text(for: .awaitingInput(reason: .custom)) == "Awaiting input")
+    }
+
+    @Test("Errored prefers the message, falling back to the category vocabulary")
+    func erroredPhrasing() {
+        #expect(
+            SessionActivitySnippet.text(for: .errored(category: .toolFailure, message: "Tests failed"))
+                == "Tests failed")
+        #expect(
+            SessionActivitySnippet.text(for: .errored(category: .rateLimit, message: nil))
+                == "Rate limited")
+        // Blank message falls through to the category vocabulary rather than an empty line.
+        #expect(
+            SessionActivitySnippet.text(for: .errored(category: .authentication, message: "  "))
+                == "Auth error")
+    }
+
+    @Test("Snippets collapse whitespace to a single line")
+    func singleLine() {
+        #expect(
+            SessionActivitySnippet.text(for: .runningTool(name: "Edit", detail: "a\n\tb   c"))
+                == "Running Edit: a b c")
+    }
+
+    @Test("Long snippets are truncated with an ellipsis")
+    func truncation() {
+        let detail = String(repeating: "x", count: 300)
+        let snippet = try? #require(
+            SessionActivitySnippet.text(for: .runningTool(name: "Bash", detail: detail), maxLength: 40))
+        #expect(snippet?.count == 40)
+        #expect(snippet?.hasSuffix("…") == true)
+    }
+}

--- a/Tests/WorkspaceManagerTests/SessionSwitcherSnapshotTests.swift
+++ b/Tests/WorkspaceManagerTests/SessionSwitcherSnapshotTests.swift
@@ -51,7 +51,7 @@ struct SessionSwitcherSnapshotTests {
         #expect(row.target == .hostSession(sessionID))
         #expect(row.kind == .workspace)
         #expect(row.title == "feature-mux")
-        #expect(row.preview == "Awaiting input: permission")
+        #expect(row.preview == "Waiting for permission")
         #expect(row.isActive)
         #expect(row.activity == .awaitingInput)
         #expect(row.chips.map(\.title).contains("codex/session-switcher"))


### PR DESCRIPTION
Slice 3 of #680 — latest-activity snippets on session cards (A+B layered, ratified by Michael). Refs #680.

## What shipped

**A) Status-derived activity snippet on the ⌘P switcher row.** A pure, unit-tested Core formatter (`SessionActivitySnippet.text(for:)`) turns an agent's `AgentRunState` into the card's one-line activity string: a running tool with its detail ("Running Bash: swift test"), per-reason awaiting phrasing ("Waiting for permission"), an error message (or its category fallback), and "Thinking…". Idle/complete produce no snippet, so the row falls back to its neutral descriptor instead of "Idle"/"Complete" filler. The switcher row is extracted to a standalone `SessionSwitcherRowView` and surfaces the snippet via its `preview` slot; attention states (awaiting, errored) render with primary emphasis.

**B) Transcript tail on the sidebar hover card.** When a hover card opens over a single Claude Code agent, its last assistant message is resolved lazily from the JSONL transcript and shown under the agent telemetry — mirroring #893's foreground-process resolver (lazy provider in `tabsProvider`, short-TTL cache, fire-and-forget `@State` write). Transcripts resolve from `cwd` + `agentSessionID` at `~/.claude/projects/<slug>/<id>.jsonl` (slug = cwd with every `/` and `.` → `-`, verified against on-disk dirs). Only the file's tail (~16KB) is read. claudeCode only; every failure mode (no file, unparseable, non-Claude, missing id) fails closed to nil — never an error surface.

## Review loop

Reflect pass hardened the JSONL line parse against CRLF / stray whitespace (commit `e206338`).

Directed codex review (gpt-5.5, xhigh) — verified both filtered suites green itself; **no blocker**. Findings and dispositions (all agent-introduced in this branch, fixed in `73be0d2`):

- **Important — stale tail could leak onto a non-Claude agent.** A tail cached while a host session ran Claude Code was attached unconditionally in `SidebarView.tabSummaries`, so if the same session id later became `.opencode`/`.aider` the old Claude tail would render under it. **Fixed:** the attach is now gated on the tab's current `kind == .claudeCode`.
- **Minor — symlink/FIFO could block the resolver actor.** `FileHandle(forReadingFrom:)` on a special file could wedge. **Fixed:** reject any non-regular file up front (reusing the stat already taken for mtime); never opened.
- **Minor — a final assistant record larger than the tail budget is missed.** **Mitigated:** raised the default budget 16KB → 64KB; a still-larger final record fails closed to nil (never a wrong or older message), covered by a new test. Grow-on-miss deferred as the failure is already fail-closed.

codex confirmed sound: CRLF, split UTF-8 at the tail boundary, final line without a trailing newline, unreadable/missing/empty/garbage files, nil/empty `agentSessionID`, empty `cwd`, non-Claude calls — all fail closed or parse correctly; the cache is not poisoned; the snippet path does no I/O and cannot block the MainActor.

## Mergeability

- **Surface:** ⌘P session switcher rows (Core read model + view) and the sidebar repo/workspace hover card. No schema, persistence, or network surface.
- **User-facing behavior changed:** Routing the switcher row's activity line through the shared formatter changes these preview strings for existing agent states (before → after): idle `Idle` → neutral descriptor (e.g. "Live terminal session"); complete `Complete` → neutral descriptor; thinking `Thinking` → `Thinking…`; running-tool `Running <name> - <detail>` → `Running <name>: <detail>`; awaiting-input `Awaiting input: permission` → `Waiting for permission` (and `Waiting for your reply` / `Awaiting input` for the idle/custom reasons); errored `<message>` (or bare `Errored`) → `<message>`, else the category vocabulary ("Rate limited", "Auth error", …). Attention rows (awaiting, errored) now render their line with primary emphasis. Separately, hover cards over a lone Claude Code agent gain a last-assistant-message line. No change to ordering, selection, or any other card metadata.
- **Non-happy paths considered:** transcript missing/unreadable/unparseable, non-Claude agents, missing `agentSessionID`, empty cwd, partial leading JSONL line, blank tool detail / error message, multiple agents on one row (tail suppressed unless exactly one) — all resolve to nil / neutral fallback. Long strings collapse to one line and truncate with an ellipsis.
- **Release/ops preconditions:** none. Pure-formatting + read-only lazy file tail; no flags, migrations, or config.
- **Residual risk or follow-up:** transcript read is best-effort and cache-TTL'd (a just-finished turn can lag one hover); the parser tracks Claude Code's current JSONL shape (assistant `message.content[].text`) and would need a touch if that format changes. The render tests prove the card draws a tail when given one, but the lazy resolve-then-repaint cycle on hover is only fully exercised in the running app — it reuses #893's proven foreground-resolver mechanism, so this is a **post-merge spot-check, not a merge gate**: hover a live Claude Code session in the sidebar and expect its last assistant message under the telemetry within ~1s.

## Evidence

`swift build` + `swift test` green (1200 tests, 188 suites); `mise run lint` (swift-format --strict) clean. New coverage: `SessionActivitySnippetTests`, `ClaudeTranscriptTailTests` (slug incl. the `/.`→`--` case, URL nil-cases, fixture-JSONL parse, temp-file resolver end-to-end), and two ImageRenderer render suites (below) that double as these screenshots.

**A — switcher rows with status-derived snippets** (awaiting row emphasized, running row shows tool detail):

![680-switcher-snippets](https://evidence.cloudcompute.com/workspaces/pr-930/20260707-182451-680-switcher-snippets.png)

**B — hover card with the last assistant message** under the agent telemetry:

![680-transcript-tail](https://evidence.cloudcompute.com/workspaces/pr-930/20260707-182451-680-transcript-tail.png)
