### PR TITLE
fix(web-next): API routes answer 401 JSON at the edge; reconcile design.md fonts

### DIFF
--- a/web-next/docs/design.md
+++ b/web-next/docs/design.md
@@ -87,8 +87,8 @@ Each is a specific call and the reason for it.
 
 ## Identity
 
-- **Type:** Instrument Serif (display / session title, italic) with JetBrains
-  Mono (UI, code, metadata). The serif carries the personality; the mono carries
+- **Type:** Newsreader (display / session title, italic) with IBM Plex Mono
+  (UI, code, metadata). The serif carries the personality; the mono carries
   the machinery.
 - **Color:** warm paper in light, warm charcoal in dark, a single restrained
   accent. Semantic color (diff add/remove, live/error) is desaturated — it

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -81,6 +81,21 @@ export const isRedirectToSignIn = (probe) =>
 	probe.status >= 300 && probe.status < 400 && /\/sign-in/.test(probe.location ?? "");
 
 /**
+ * The #828 contract: an unauthenticated API call answers 401 with the same
+ * `{ error }` JSON shape every route's own getAuthState gate returns —
+ * never an HTML redirect, never a bare 401 with no body.
+ */
+function isUnauthenticatedApiJson(probe) {
+	if (probe.status !== 401) return false;
+	try {
+		const parsed = JSON.parse(probe.body ?? "");
+		return typeof parsed === "object" && parsed !== null && typeof parsed.error === "string";
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Evaluates the posture checks over the probe results gathered by the runner.
  * `probes`: { home, signIn, forgedCookieHome, api: [{path, method, status, body}] }.
  * Every check is mode-aware: in bypass mode the forged cookie *working* is the
@@ -124,13 +139,14 @@ export function evaluatePosture(mode, probes) {
 		);
 	}
 	for (const api of probes.api) {
-		// The floor is "no data": never 2xx for an unauthenticated API call.
-		// 401/403 is the route-level answer; 307 is the middleware wart (#828).
+		// The contract (#828): an unauthenticated API call gets the route-level
+		// 401 JSON answer straight from the edge — never an HTML redirect and
+		// never a 2xx leak.
 		checks.push(
 			check(
-				`api_no_data:${api.path}`,
-				api.status >= 300,
-				`${api.method} ${api.path} → ${api.status}${api.status >= 300 && api.status < 400 ? " (redirect, not 401 JSON — #828)" : ""}`,
+				`api_unauthenticated_json:${api.path}`,
+				isUnauthenticatedApiJson(api),
+				`${api.method} ${api.path} → ${api.status}${api.status === 401 ? "" : " (expected 401 JSON)"}`,
 			),
 		);
 	}

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -51,12 +51,14 @@ describe("evaluatePosture", () => {
 	const signIn = { status: 200, body: "Continue with GitHub" };
 	const redirect = { status: 307, location: "/sign-in" };
 
-	test("real mode: gated home, inert forged cookie, no-data APIs all pass", () => {
+	const unauthJson = JSON.stringify({ error: "not signed in as the allowed user" });
+
+	test("real mode: gated home, inert forged cookie, unauthenticated APIs answer 401 JSON", () => {
 		const checks = evaluatePosture("real", {
 			home: redirect,
 			signIn,
 			forgedCookieHome: redirect,
-			api: [{ path: "/api/x", method: "GET", status: 401 }],
+			api: [{ path: "/api/x", method: "GET", status: 401, body: unauthJson }],
 		});
 		expect(checks.every((c) => c.status === "pass")).toBe(true);
 	});
@@ -66,11 +68,11 @@ describe("evaluatePosture", () => {
 			home: redirect,
 			signIn,
 			forgedCookieHome: { status: 200 },
-			api: [{ path: "/api/x", method: "GET", status: 200 }],
+			api: [{ path: "/api/x", method: "GET", status: 200, body: "" }],
 		});
 		const byId = Object.fromEntries(checks.map((c) => [c.id, c.status]));
 		expect(byId["forged_bypass_cookie_inert"]).toBe("fail");
-		expect(byId["api_no_data:/api/x"]).toBe("fail");
+		expect(byId["api_unauthenticated_json:/api/x"]).toBe("fail");
 	});
 
 	test("bypass mode: the cookie signing in is the designed pass", () => {
@@ -78,20 +80,27 @@ describe("evaluatePosture", () => {
 			home: redirect,
 			signIn: { status: 200, body: "test bypass" },
 			forgedCookieHome: { status: 200 },
-			api: [{ path: "/api/x", method: "POST", status: 307 }],
+			api: [{ path: "/api/x", method: "POST", status: 401, body: unauthJson }],
 		});
 		expect(checks.every((c) => c.status === "pass")).toBe(true);
 	});
 
-	test("redirected API is a pass with the #828 wart named", () => {
-		const [apiCheck] = evaluatePosture("real", {
+	test("a redirect or a bodiless 401 both fail the #828 contract", () => {
+		const [redirectCheck] = evaluatePosture("real", {
 			home: redirect,
 			signIn,
 			forgedCookieHome: redirect,
-			api: [{ path: "/api/x", method: "GET", status: 307 }],
-		}).filter((c) => c.id.startsWith("api_no_data"));
-		expect(apiCheck.status).toBe("pass");
-		expect(apiCheck.detail).toContain("#828");
+			api: [{ path: "/api/x", method: "GET", status: 307, location: "/sign-in" }],
+		}).filter((c) => c.id.startsWith("api_unauthenticated_json"));
+		expect(redirectCheck.status).toBe("fail");
+
+		const [bareCheck] = evaluatePosture("real", {
+			home: redirect,
+			signIn,
+			forgedCookieHome: redirect,
+			api: [{ path: "/api/x", method: "GET", status: 401, body: "" }],
+		}).filter((c) => c.id.startsWith("api_unauthenticated_json"));
+		expect(bareCheck.status).toBe("fail");
 	});
 });
 

--- a/web-next/src/middleware.test.ts
+++ b/web-next/src/middleware.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Unit coverage for the edge auth gate's API-vs-page response shape (#828):
+ * unauthenticated `/api/*` requests get 401 JSON straight from the edge,
+ * never an HTML sign-in redirect, while page requests are unaffected.
+ * Exercises the real `middleware` export directly against a NextRequest in
+ * the deterministic bypass mode (env-stubbed, restored after each test).
+ */
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { middleware } from "./middleware";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function requestFor(path: string, cookie?: string): NextRequest {
+	return new NextRequest(`https://spaces.example${path}`, {
+		headers: cookie ? { cookie } : {},
+	});
+}
+
+describe("middleware", () => {
+	beforeEach(() => {
+		process.env.AUTH_BYPASS = "1";
+		delete process.env.GITHUB_OAUTH_CLIENT_ID;
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("answers an unauthenticated /api/* request with 401 JSON, not a redirect", async () => {
+		const response = await middleware(requestFor("/api/sessions/any/chat"));
+		expect(response.status).toBe(401);
+		expect(response.headers.get("location")).toBeNull();
+		expect(response.headers.get("content-type")).toContain("application/json");
+		await expect(response.json()).resolves.toEqual({
+			error: "not signed in as the allowed user",
+		});
+	});
+
+	it("still redirects an unauthenticated page request to /sign-in", async () => {
+		const response = await middleware(requestFor("/"));
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toContain("/sign-in");
+	});
+
+	it("lets a valid bypass cookie through for both /api and page paths", async () => {
+		const cookie = "test-auth-login=fairchild";
+		const apiResponse = await middleware(requestFor("/api/repos", cookie));
+		expect(apiResponse.headers.get("x-middleware-next")).toBe("1");
+		const pageResponse = await middleware(requestFor("/", cookie));
+		expect(pageResponse.headers.get("x-middleware-next")).toBe("1");
+	});
+
+	it("passes /api/auth/* through unauthenticated — already public", async () => {
+		const response = await middleware(requestFor("/api/auth/session"));
+		expect(response.headers.get("x-middleware-next")).toBe("1");
+	});
+});

--- a/web-next/src/middleware.ts
+++ b/web-next/src/middleware.ts
@@ -1,9 +1,13 @@
 /*
  * Edge gate: everything except sign-in, the auth API, and static assets
  * requires a session. Freshness is verified at the edge (signed cookie
- * cache — see lib/auth/session-cookie.ts) so stale/tampered sessions
- * redirect without rendering the shell; the allowlist verdict itself is
- * server-side in getAuthState (it needs the user record).
+ * cache — see lib/auth/session-cookie.ts) so stale/tampered sessions are
+ * refused without rendering the shell or reaching a route handler; the
+ * allowlist verdict itself is server-side in getAuthState (it needs the
+ * user record). Pages get an HTML redirect to /sign-in; `/api/*` callers
+ * get the same JSON shape (`{ error }`, 401) the routes themselves return
+ * for an unauthenticated caller, so API clients never have to parse a
+ * sign-in page as an error response (#828).
  */
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
@@ -24,9 +28,33 @@ function isPublic(pathname: string): boolean {
 	return false;
 }
 
+function isApiPath(pathname: string): boolean {
+	return pathname === "/api" || pathname.startsWith("/api/");
+}
+
+// Same error shape every route handler's own getAuthState gate returns for
+// an unauthenticated caller (see e.g. sessions/[id]/chat/route.ts) — the
+// edge and the route stay indistinguishable to API clients.
+function unauthorizedJson(): NextResponse {
+	return NextResponse.json(
+		{ error: "not signed in as the allowed user" },
+		{ status: 401 },
+	);
+}
+
 function redirectToSignIn(request: NextRequest): NextResponse {
 	const signInUrl = new URL("/sign-in", request.url);
 	return NextResponse.redirect(signInUrl);
+}
+
+// The edge only ever refuses on a missing/stale/tampered session (`stale`
+// freshness, or bypass mode's absent test cookie) — it never returns 403;
+// the allowlist verdict that can produce "forbidden" is server-side and
+// left to getAuthState in the route handler or layout.
+function unauthenticatedResponse(request: NextRequest): NextResponse {
+	return isApiPath(request.nextUrl.pathname)
+		? unauthorizedJson()
+		: redirectToSignIn(request);
 }
 
 export async function middleware(request: NextRequest) {
@@ -35,15 +63,15 @@ export async function middleware(request: NextRequest) {
 
 	// Test bypass (inert in production — see authBypassEnabled): the test
 	// cookie is the session. Absent cookie still means signed out, so the
-	// unauth redirect stays testable.
+	// unauth response stays testable.
 	if (authBypassEnabled()) {
 		return request.cookies.has(TEST_AUTH_COOKIE)
 			? NextResponse.next()
-			: redirectToSignIn(request);
+			: unauthenticatedResponse(request);
 	}
 
 	// If the secret can't be resolved (misconfig) fall through so middleware
-	// never hard-fails the app; the layout gate still refuses access.
+	// never hard-fails the app; the layout/route gate still refuses access.
 	let secret: string;
 	try {
 		secret = resolveAuthSecret();
@@ -52,10 +80,10 @@ export async function middleware(request: NextRequest) {
 	}
 
 	const freshness = await evaluateSessionFreshness(request, { secret });
-	if (freshness === "stale") return redirectToSignIn(request);
+	if (freshness === "stale") return unauthenticatedResponse(request);
 
-	// "fresh" proceeds; "indeterminate" also proceeds and defers to the layout
-	// gate rather than logging out a possibly-valid idle session.
+	// "fresh" proceeds; "indeterminate" also proceeds and defers to the
+	// layout/route gate rather than logging out a possibly-valid idle session.
 	return NextResponse.next();
 }
 

--- a/web-next/tests/e2e/auth.spec.ts
+++ b/web-next/tests/e2e/auth.spec.ts
@@ -1,10 +1,12 @@
 /*
- * Auth gate e2e: signed-out requests redirect to sign-in, the test-bypass
- * button signs in as the allowlisted user, a signed-in-but-not-allowlisted
- * user gets the polite refusal (and no data), and sign-in bounces users who
- * are already in. The server runs in bypass mode (e2e:server) where the
- * test cookie is the session — absence of it is a real signed-out request
- * through the same middleware as production.
+ * Auth gate e2e: signed-out page requests redirect to sign-in, signed-out
+ * /api/* requests get the route-level 401 JSON straight from the edge (no
+ * HTML redirect — #828), the test-bypass button signs in as the allowlisted
+ * user, a signed-in-but-not-allowlisted user gets the polite refusal (and
+ * no data), and sign-in bounces users who are already in. The server runs
+ * in bypass mode (e2e:server) where the test cookie is the session —
+ * absence of it is a real signed-out request through the same middleware
+ * as production.
  */
 import { expect, test } from "@playwright/test";
 import { E2E_LOGIN, signedInAs } from "../../playwright.config";
@@ -24,15 +26,42 @@ test.describe("signed out", () => {
 		).toBeVisible();
 	});
 
-	test("the chat API is bounced at the edge, not served", async ({
+	test("the chat API is refused at the edge with 401 JSON, not an HTML redirect", async ({
 		request,
 	}) => {
 		const response = await request.post("/api/sessions/any/chat", {
 			data: { text: "hi" },
 			maxRedirects: 0,
 		});
-		expect(response.status()).toBe(307);
-		expect(response.headers()["location"]).toContain("/sign-in");
+		expect(response.status()).toBe(401);
+		expect(response.headers()["location"]).toBeUndefined();
+		expect(response.headers()["content-type"]).toContain("application/json");
+		await expect(response.json()).resolves.toEqual({
+			error: "not signed in as the allowed user",
+		});
+	});
+
+	test("every unauthenticated /api/* route answers 401 JSON, no data leak (#828)", async ({
+		request,
+	}) => {
+		const probes: Array<{ method: "GET" | "PATCH"; path: string }> = [
+			{ method: "PATCH", path: "/api/sessions/any" },
+			{ method: "GET", path: "/api/sessions/any/stream" },
+			{ method: "GET", path: "/api/diag/gateway" },
+			{ method: "GET", path: "/api/repos" },
+		];
+		for (const { method, path } of probes) {
+			const response = await request.fetch(path, { method, maxRedirects: 0 });
+			expect(response.status(), `${method} ${path}`).toBe(401);
+			expect(
+				response.headers()["content-type"],
+				`${method} ${path} content-type`,
+			).toContain("application/json");
+			const body: unknown = await response.json();
+			expect(body, `${method} ${path} body`).toEqual({
+				error: "not signed in as the allowed user",
+			});
+		}
 	});
 
 	test("the bypass button signs in as the allowlisted user", async ({

--- a/web-next/tests/e2e/auth.spec.ts
+++ b/web-next/tests/e2e/auth.spec.ts
@@ -48,6 +48,8 @@ test.describe("signed out", () => {
 			{ method: "PATCH", path: "/api/sessions/any" },
 			{ method: "GET", path: "/api/sessions/any/stream" },
 			{ method: "GET", path: "/api/diag/gateway" },
+			{ method: "GET", path: "/api/diag/preflight" },
+			{ method: "GET", path: "/api/diag/prewarm" },
 			{ method: "GET", path: "/api/repos" },
 		];
 		for (const { method, path } of probes) {

--- a/web-next/tests/e2e/terminal.spec.ts
+++ b/web-next/tests/e2e/terminal.spec.ts
@@ -121,8 +121,11 @@ test.describe("signed out", () => {
 				data: {},
 				maxRedirects: 0,
 			});
-			// The middleware turns unauthenticated API posts away at the edge.
-			expect([307, 401]).toContain(response.status());
+			// The edge answers 401 JSON directly, same shape as the route gate (#828).
+			expect(response.status()).toBe(401);
+			await expect(response.json()).resolves.toEqual({
+				error: "not signed in as the allowed user",
+			});
 		}
 	});
 });


### PR DESCRIPTION
Closes #828
Closes #812

## Summary

**#828** — `src/middleware.ts` redirected *every* unauthenticated request to `/sign-in`, including `/api/*`, before a route handler ever ran — so the route's own `getAuthState()` 401/403 JSON gate was unreachable for a signed-out caller. Verified all nine non-auth `/api/*/route.ts` handlers already call `getAuthState()` as the first statement and return the same `{ error }` JSON on failure, so the edge only needed to change *what it answers with*, not defer entirely to the route. The middleware still evaluates session freshness at the edge exactly as before (same `evaluateSessionFreshness` call, same `fresh`/`stale`/`indeterminate` semantics — this preserves the cheap edge check that avoids a DB round-trip for a stale/tampered cookie); the only change is that a `stale` verdict on an `/api/*` path now returns `NextResponse.json({ error: "not signed in as the allowed user" }, { status: 401 })` instead of a redirect. Page paths are unaffected. The middleware still never decides 403 — the allowlist verdict stays server-side in `getAuthState`.

**#812** — `docs/design.md`'s Identity section named Instrument Serif / JetBrains Mono; the app actually ships Newsreader / IBM Plex Mono (`src/app/layout.tsx`, `src/app/globals.css`). Updated the doc to match; the italic display-title usage still holds for Newsreader (`--text-title` in `globals.css`, used in `session-masthead.tsx`).

## Review loop

Ran `codex-review-loop` (gpt-5.5, xhigh) directed at the middleware branch logic, test coverage, the tightened `validate-core.mjs` posture check, and the design.md fact-check. **No blocker/major/minor findings** — codex independently re-verified the shipped fonts, confirmed `middleware.test.ts` exercises the real code path (would catch a revert of the `isApiPath` branch), and confirmed `evaluatePosture`'s new check isn't over-strict. One completeness gap flagged (non-blocking): the e2e "every unauthenticated /api/* route" loop didn't cover `/api/diag/preflight` / `/api/diag/prewarm`. Closed it — commit `test(web-next): cover diag/preflight and diag/prewarm in the #828 e2e loop`.

## Mergeability

- Surface: web (web-next/) — edge middleware auth response shape, validation harness posture check, e2e coverage, design doc
- User-facing behavior changed: Yes, for API clients only — an unauthenticated `/api/*` request now gets a 401 JSON body instead of a 307 redirect to `/sign-in`. Page navigation (browser requests) is unchanged: still redirects to `/sign-in`. No change to signed-in behavior or the allowlist verdict.
- Non-happy paths considered: forged/tampered/expired session cookies on `/api/*` still resolve to 401 (freshness check unchanged, just the response shape branches on path); `authBypassEnabled()` mode's absent test cookie on `/api/*` also 401s; `/api/auth/*` stays public and unaffected; the secret-misconfiguration fallback (`resolveAuthSecret` throws) still falls through to `NextResponse.next()` for both page and API paths, deferring to the route/layout gate exactly as before.
- Residual risk or follow-up: none from this change. Unrelated: `tests/e2e/sessions.spec.ts`'s new `#929` test ("a failing turn surfaces an inline failure + retry") is flaky/failing on a clean checkout of `origin/main` post-rebase (reproduced identically pre- and post- this diff, isolated and in-suite) — pre-existing, not touched or caused by this PR, called out here rather than silently masked.

## Evidence

tests passed:
- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm run test` — 346/346 passed (33 files)
- `pnpm run test:e2e` — 30/31 passed, 1 pre-existing failure unrelated to this diff skipped for a clean run (`sessions.spec.ts` `#929` "a failing turn surfaces..." — reproduces identically on unmodified `origin/main`)
- Mutation check: reverted the `isApiPath` branch in `middleware.ts` locally (always redirect) — `src/middleware.test.ts` caught it (`expected 307 to be 401`); reverted the mutation, tests green again.

`node scripts/validate.mjs --env local` posture stage:
```
✓ posture (bypass auth) — 6/6 checks
   ✓ home_gated: GET / (unauthenticated) → 307 /sign-in
   ✓ signin_serves: GET /sign-in → 200
   ✓ bypass_cookie_signs_in: GET / with test-auth-login cookie → 200 (bypass mode)
   ✓ api_unauthenticated_json:/api/sessions/validation-probe/chat: POST /api/sessions/validation-probe/chat → 401
   ✓ api_unauthenticated_json:/api/sessions/validation-probe/stream: GET /api/sessions/validation-probe/stream → 401
   ✓ api_unauthenticated_json:/api/diag/gateway: GET /api/diag/gateway → 401
```

- CI: green quality lane on 025fd39: https://github.com/fairchild/workspaces/actions/runs/28890742462/job/85702511384
- Gate note: orchestrator reviewed the design (edge answers 401 JSON for /api/* while keeping freshness semantics; 403 verdict stays server-side; nine-route auth audit confirmed gate-first handlers); codex foreground ran clean with one completeness gap closed (diag preflight/prewarm probes); posture stage tightened to exact-401 assertions; the unrelated #929-spec flake is isolated on clean main and filed as its own W4 issue. Base is fresh (rebased over #929). Merged on delegated authority.

