### PR TITLE
docs(adr): record #915 capture-spike outcome (own-window TCC + IOSurface readback)

### DIFF
--- a/docs/decisions/automation-operator-scope.md
+++ b/docs/decisions/automation-operator-scope.md
@@ -116,6 +116,28 @@ CAMetalLayer surface can be read back (framebufferOnly, IOSurface, drawable
 capture). The `WindowSnapshotService` interface stays stable regardless of
 which mechanism wins.
 
+**Resolved (2026-07-07, spike [#915](https://github.com/fairchild/workspaces/issues/915)).**
+Both questions came back good, so the VM lane stays a fallback, not the
+primary path. The [decision memo](https://github.com/fairchild/workspaces/issues/915#issuecomment-4907509271)
+records the evidence; the short version:
+
+- **(a) TCC:** capturing the app's *own* windows needs **no** Screen Recording
+  TCC via `CGWindowList` — proven in-process with
+  `CGPreflightScreenCaptureAccess() == false` while the capture still returned
+  full real pixels.
+- **(b) Metal readback:** the GhosttyKit surface reads back with real pixels
+  through the composited path *and* through in-process layer readback, because
+  Ghostty presents via an `IOSurfaceLayer` (readable contents), not an opaque
+  `CAMetalLayer` drawable.
+
+Chosen mechanism: `CGWindowListCreateImage` scoped to own window IDs —
+TCC-free, full composited fidelity, single call (deprecated in macOS 14.0 but
+functional; ScreenCaptureKit is the eventual migration target behind the
+stable `WindowSnapshotService` interface). Composited paths (`CGWindowList`
+and ScreenCaptureKit) fail on a locked screen, so locked-screen evidence keeps
+the VM / `tart-ui` fallback; unlocked background/occluded windows capture fine
+with zero focus stealing.
+
 ## Consequences
 
 - The V1 non-goal "global cross-workspace control" is partially superseded:


### PR DESCRIPTION
Docs-only. Records the outcome of the `[A1]` capture research spike (#915) in the `automation-operator-scope` ADR's **Facts before mechanism** section, cross-linking the [decision memo](https://github.com/fairchild/workspaces/issues/915#issuecomment-4907509271) on the issue.

Both spike questions came back good, so the VM lane stays a fallback, not the primary path:

- **(a) Own-window TCC:** capturing the app's own windows needs **no** Screen Recording TCC via `CGWindowList` — proven in-process (`CGPreflightScreenCaptureAccess() == false` while capture still returned full real pixels).
- **(b) Metal readback:** the GhosttyKit surface reads back with real pixels through the composited path *and* in-process, because Ghostty presents via an `IOSurfaceLayer` (readable contents), not an opaque `CAMetalLayer` drawable.

Chosen mechanism for `WindowSnapshotService`: `CGWindowListCreateImage` scoped to own window IDs — TCC-free, full composited fidelity, single call. Evidence (throwaway in-process probe, since deleted) is captured in the memo; no probe code is merged in this PR.

## Mergeability

- Surface: docs — `docs/decisions/automation-operator-scope.md` (ADR facts-before-mechanism resolution note only)
- User-facing behavior changed: No — documentation only; no product code touched
- Non-happy paths considered: n/a — docs-only diff; `git diff --check` clean (no whitespace errors)
- Residual risk or follow-up: None for this PR. Follow-up is the `WindowSnapshotService` implementation itself (separate issue), which the memo scopes; locked-screen evidence keeps the VM/`tart-ui` fallback

## Evidence

Docs-only change — `git diff --check` reports clean (no whitespace/conflict errors). No runtime surface to screenshot.

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
