### PR TITLE
feat(web-next): lifecycle controls + first-class error surfaces + mobile 375px

### DIFF
--- a/web-next/playwright.config.ts
+++ b/web-next/playwright.config.ts
@@ -149,12 +149,21 @@ export default defineConfig({
 			use: { ...devices["Desktop Chrome"] },
 			// sessions.spec owns the sessions table (wipes + counts rows), so
 			// specs that create sessions of their own run in a later project.
-			testIgnore: /terminal\.spec\.ts/,
+			testIgnore: /(terminal|errors|mobile)\.spec\.ts/,
 		},
 		{
 			name: "terminal",
 			use: { ...devices["Desktop Chrome"] },
 			testMatch: /terminal\.spec\.ts/,
+			dependencies: ["chromium"],
+		},
+		{
+			// Error surfaces + lifecycle controls + the 375px walk (#753): these
+			// create their own sessions, so they run after sessions.spec's wipe.
+			// mobile.spec narrows its own viewport via test.use.
+			name: "lifecycle",
+			use: { ...devices["Desktop Chrome"] },
+			testMatch: /(errors|mobile)\.spec\.ts/,
 			dependencies: ["chromium"],
 		},
 	],

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -3,10 +3,11 @@
  * an empty session reached through the real new-session flow, a real mock
  * turn streamed into that session (mid-stream, final, and reloaded from the
  * event log), the terminal drawer (#752), a failing turn's inline failure
- * card + retry-to-success (#808), the durable disconnect→resume story (tab
- * closed mid-turn, a fresh tab catching up, then completed), the Folio
- * session demo, and the refine-folio prototype beside it for pixel
- * comparison. Runs against a production build in auth-bypass
+ * card + retry-to-success (#808), the three first-class error surfaces +
+ * the stop control + the 375px mobile walk (#753), the durable
+ * disconnect→resume story (tab closed mid-turn, a fresh tab catching up,
+ * then completed), the Folio session demo, and the refine-folio prototype
+ * beside it for pixel comparison. Runs against a production build in auth-bypass
  * mode over a throwaway database. Output goes to output/evidence/
  * (gitignored); CI uploads it as an artifact — the sanctioned publish path
  * per docs/development/remote-sessions.md.
@@ -190,6 +191,90 @@ async function captureFailedTurn(page, shot) {
 	await page.screenshot({ path: shot("session-turn-failed-retried") });
 }
 
+/** A fresh session via the picker (the connected repo, one click). */
+async function newSession(page) {
+	await page.goto("/", { waitUntil: "networkidle" });
+	await page.getByRole("button", { name: "+ new session" }).click();
+	await page
+		.getByTestId("new-session-picker")
+		.getByRole("button", { name: "fairchild/workspaces" })
+		.click();
+	await page.waitForURL(/\/sessions\//, { timeout: TURN_TIMEOUT_MS });
+}
+
+/**
+ * The three first-class error surfaces (#753), one capture per class via the
+ * mock provider's deterministic triggers: provisioning failure (the card is
+ * the whole reply), sandbox died mid-turn (streamed work survives above the
+ * card), stream error (the provider's own structured error text).
+ */
+async function captureErrorSurfaces(page, shot) {
+	const cases = [
+		["session-error-provisioning", "Build the importer __mock_provision_error__"],
+		["session-error-sandbox-died", "Fix the flaky test __mock_sandbox_died__"],
+		["session-error-stream", "Refactor the adapter __mock_stream_error__"],
+	];
+	for (const [name, text] of cases) {
+		await newSession(page);
+		await page.getByRole("textbox", { name: "Reply to Claude" }).fill(text);
+		await page.keyboard.press("Enter");
+		await page.getByTestId("turn-failure").waitFor({ timeout: TURN_TIMEOUT_MS });
+		await page.getByTestId("turn-failure").scrollIntoViewIfNeeded();
+		await page.waitForTimeout(ANIMATION_SETTLE_MS);
+		await page.screenshot({ path: shot(name) });
+	}
+}
+
+/**
+ * The stop control (#753): mid-stream the send affordance is the stop; the
+ * first capture holds that moment, the second the stopped turn's honest
+ * record ("Turn stopped.") with compose handed back.
+ */
+async function captureStoppedTurn(page, shot) {
+	await newSession(page);
+	await page
+		.getByRole("textbox", { name: "Reply to Claude" })
+		.fill("Fix the failing session test");
+	await page.keyboard.press("Enter");
+	const stop = page.getByRole("button", { name: "Stop" });
+	await stop.waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.getByTestId("activity-line").waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.waitForTimeout(350);
+	await page.screenshot({ path: shot("session-turn-stopping") });
+	await stop.click();
+	await page
+		.getByTestId("turn-failure")
+		.waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: shot("session-turn-stopped") });
+}
+
+/**
+ * The 375px surface (#753): a full streamed turn on a phone-width viewport —
+ * transcript mid-scroll with the receipt, then the expanded diff (the widest
+ * content) — proving the page never scrolls sideways. Uses its own page so
+ * the shared 1280px page is untouched.
+ */
+async function captureMobile(context, shot) {
+	const page = await context.newPage();
+	await page.setViewportSize({ width: 375, height: 812 });
+	await newSession(page);
+	await page
+		.getByRole("textbox", { name: "Reply to Claude" })
+		.fill("Fix the failing session test");
+	await page.keyboard.press("Enter");
+	await page.getByTestId("turn-stats").waitFor({ timeout: TURN_TIMEOUT_MS });
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: shot("session-mobile-turn") });
+	const rows = page.getByTestId("tool-row");
+	await rows.nth(2).locator("button").first().click();
+	await page.getByTestId("diff-lines").waitFor();
+	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: shot("session-mobile-diff") });
+	await page.close();
+}
+
 /**
  * The durable-turn story: start a turn, close the tab mid-stream, reopen the
  * session in a fresh tab and watch it catch up and complete. Manages its own
@@ -320,6 +405,9 @@ async function main() {
 			await captureSessionTurn(page, shot);
 			await captureTerminalDrawer(page, shot("session-terminal-drawer"));
 			await captureFailedTurn(page, shot);
+			await captureErrorSurfaces(page, shot);
+			await captureStoppedTurn(page, shot);
+			await captureMobile(context, shot);
 			await captureDisconnectResume(context, shot);
 			await seedPopulatedHome(db);
 			await captureSettled(page, "/", shot("home-populated"));
@@ -328,7 +416,7 @@ async function main() {
 			await capturePrototype(page, colorScheme, shot("prototype-folio"));
 			await context.close();
 			console.log(
-				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + terminal drawer + failed turn (failure, retried) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
+				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + terminal drawer + failed turn (failure, retried) + error surfaces (provisioning, sandbox-died, stream) + stop control (stopping, stopped) + mobile 375px (turn, diff) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
 			);
 		}
 	} finally {

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -59,6 +59,7 @@ import {
 	recordLiveTurnError,
 } from "@/lib/transcript/live-turn-error";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
+import { sandboxStateLabel, useSandboxState } from "./use-sandbox-state";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
 const TOKEN_THROTTLE_MS = 50;
@@ -220,6 +221,20 @@ export function LiveSessionView({
 	});
 
 	const busy = status === "submitted" || status === "streaming";
+
+	// The sandbox lifecycle surface (#753): a verified state in the masthead,
+	// and two honest controls — stop the in-flight turn (the compose's send
+	// affordance while busy), stop the live VM (a quiet masthead action).
+	const { sandbox, stopSandbox } = useSandboxState(sessionId, busy);
+	const stopTurn = () => {
+		// Fire-and-forget: the server closes the turn's log, the live stream
+		// surfaces the stop as this turn's failure card ("Turn stopped."), and
+		// the hook's own status transition re-enables compose — the UI follows
+		// the stream, not this request. A 409 (the turn just finished on its
+		// own) needs no handling: there is nothing left to stop.
+		void fetch(`/api/sessions/${sessionId}/stop`, { method: "POST" });
+	};
+
 	const send = (text: string) => {
 		setSteps([]);
 		// Await any in-flight model PATCH first, so the turn the server starts
@@ -288,7 +303,12 @@ export function LiveSessionView({
 					...session,
 					messages: visibleMessages,
 					activeTurn,
-					masthead: { ...session.masthead, title: displayTitle },
+					masthead: {
+						...session.masthead,
+						title: displayTitle,
+						stateLabel: sandboxStateLabel(sandbox),
+						live: sandbox?.state === "live",
+					},
 					statusLine: {
 						...session.statusLine,
 						model,
@@ -301,6 +321,10 @@ export function LiveSessionView({
 				composeDisabled={busy}
 				onModelChange={handleModelChange}
 				onTitleChange={handleTitleChange}
+				onStopTurn={busy ? stopTurn : undefined}
+				onSandboxStop={
+					sandbox?.state === "live" && !busy ? () => void stopSandbox() : undefined
+				}
 			/>
 		</>
 	);

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -227,12 +227,32 @@ export function LiveSessionView({
 	// affordance while busy), stop the live VM (a quiet masthead action).
 	const { sandbox, stopSandbox } = useSandboxState(sessionId, busy);
 	const stopTurn = () => {
-		// Fire-and-forget: the server closes the turn's log, the live stream
-		// surfaces the stop as this turn's failure card ("Turn stopped."), and
-		// the hook's own status transition re-enables compose — the UI follows
-		// the stream, not this request. A 409 (the turn just finished on its
-		// own) needs no handling: there is nothing left to stop.
-		void fetch(`/api/sessions/${sessionId}/stop`, { method: "POST" });
+		// On success the UI follows the stream, not this request: the server
+		// closes the turn's log, the tail surfaces the stop as this turn's
+		// failure card ("Turn stopped."), and the hook's status transition
+		// re-enables compose. A refusal is surfaced as an activity step — the
+		// one case a shown control can't act (the turn's runner lives on
+		// another server instance) must not be a silent click (codex finding,
+		// gpt-5.5 xhigh). The benign 409 right after the turn finished on its
+		// own adds a step nothing renders: the activity line is already gone.
+		void (async () => {
+			try {
+				const res = await fetch(`/api/sessions/${sessionId}/stop`, {
+					method: "POST",
+				});
+				if (!res.ok) {
+					const data = (await res.json().catch(() => null)) as {
+						error?: string;
+					} | null;
+					setSteps((current) => [
+						...current,
+						`Stop unavailable — ${data?.error ?? `HTTP ${res.status}`}`,
+					]);
+				}
+			} catch {
+				setSteps((current) => [...current, "Stop unavailable — network error"]);
+			}
+		})();
 	};
 
 	const send = (text: string) => {

--- a/web-next/src/app/(app)/sessions/[id]/page.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/page.tsx
@@ -85,7 +85,9 @@ export default async function SessionPage({
 					// masthead itself falls back to "New session" display text.
 					title: session.title,
 					agentName: "Claude",
-					stateLabel: "idle",
+					// The client fills this in from the verified sandbox state (#753);
+					// "" renders as absence — the masthead never guesses.
+					stateLabel: "",
 				},
 				statusLine: {
 					model: session.model,

--- a/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
@@ -17,11 +17,18 @@ const REFRESH_INTERVAL_MS = 60_000;
 export function useSandboxState(sessionId: string, turnInFlight: boolean) {
 	const [sandbox, setSandbox] = useState<SandboxState | null>(null);
 
+	// Monotonic fetch ordering: only the NEWEST in-flight check may write the
+	// state. Without this, a slow earlier GET resolving after a fast later one
+	// would overwrite the fresher verdict with a stale one — exactly the lie
+	// this surface exists to avoid.
+	const fetchSeq = useRef(0);
 	const refresh = useCallback(async () => {
+		const seq = ++fetchSeq.current;
 		try {
 			const res = await fetch(`/api/sessions/${sessionId}/sandbox`);
-			if (!res.ok) return;
+			if (!res.ok || seq !== fetchSeq.current) return;
 			const data = (await res.json()) as SandboxState;
+			if (seq !== fetchSeq.current) return;
 			if (data && typeof data.state === "string") setSandbox(data);
 		} catch {
 			// Network hiccup: keep the last verified state rather than flapping.

--- a/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
@@ -3,16 +3,25 @@
 /*
  * Client view of the session's sandbox state (#753): fetches the truthful
  * verdict from GET /api/sessions/[id]/sandbox and keeps it honest over time —
- * re-checked when a turn settles (the moment a sandbox is born or parked),
- * on window focus, and on a slow interval while a VM exists (sandboxes
- * expire on their own; a "live" label must not outlive the VM). `null`
- * means not-yet-known, which the masthead renders as absence, not a guess.
+ * re-checked on window focus, on a short cadence WHILE a turn runs (the turn
+ * is what births the VM, so "no sandbox" must not persist across a running
+ * turn), at the settle edge (detach parks it), and on a slow interval while
+ * a VM exists (sandboxes expire on their own; a "live" label must not
+ * outlive the VM). A verdict that can no longer be re-verified degrades to
+ * `null` — not-yet-known — which the masthead renders as absence, not a
+ * guess kept on display.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SandboxState } from "@/lib/agent-runtime/sandbox-state";
 
 /** How often a known live/parked state is re-verified against the platform. */
 const REFRESH_INTERVAL_MS = 60_000;
+
+/** Re-check cadence while a turn is in flight (the VM's birth window). */
+const IN_TURN_REFRESH_MS = 10_000;
+
+/** Consecutive failed checks after which the last verdict stops being shown. */
+const MAX_STALE_CHECKS = 2;
 
 export function useSandboxState(sessionId: string, turnInFlight: boolean) {
 	const [sandbox, setSandbox] = useState<SandboxState | null>(null);
@@ -22,16 +31,33 @@ export function useSandboxState(sessionId: string, turnInFlight: boolean) {
 	// would overwrite the fresher verdict with a stale one — exactly the lie
 	// this surface exists to avoid.
 	const fetchSeq = useRef(0);
+	// Consecutive checks that couldn't produce a verdict. One blip keeps the
+	// last verified state (no flapping); past MAX_STALE_CHECKS the verdict is
+	// no longer trustworthy and recedes to absence rather than staying up as
+	// a claim nothing can back (codex finding, gpt-5.5 xhigh).
+	const staleChecks = useRef(0);
 	const refresh = useCallback(async () => {
 		const seq = ++fetchSeq.current;
+		const failed = () => {
+			if (seq !== fetchSeq.current) return;
+			staleChecks.current += 1;
+			if (staleChecks.current >= MAX_STALE_CHECKS) setSandbox(null);
+		};
 		try {
 			const res = await fetch(`/api/sessions/${sessionId}/sandbox`);
-			if (!res.ok || seq !== fetchSeq.current) return;
+			if (seq !== fetchSeq.current) return;
+			if (!res.ok) {
+				failed();
+				return;
+			}
 			const data = (await res.json()) as SandboxState;
 			if (seq !== fetchSeq.current) return;
-			if (data && typeof data.state === "string") setSandbox(data);
+			if (data && typeof data.state === "string") {
+				staleChecks.current = 0;
+				setSandbox(data);
+			}
 		} catch {
-			// Network hiccup: keep the last verified state rather than flapping.
+			failed();
 		}
 	}, [sessionId]);
 
@@ -43,12 +69,18 @@ export function useSandboxState(sessionId: string, turnInFlight: boolean) {
 		return () => window.removeEventListener("focus", onFocus);
 	}, [refresh]);
 
-	// A turn settling is exactly when the sandbox changes hands (born on the
-	// first vercel turn, parked by detach) — re-check at that edge.
+	// A running turn is what births the VM (the first vercel turn boots it
+	// seconds in, minutes before it settles), so the label must follow DURING
+	// the turn, not only at its edges: re-check on entry, on a short cadence
+	// while in flight, and once more at the settle edge (detach parks it).
 	const wasInFlight = useRef(turnInFlight);
 	useEffect(() => {
 		if (wasInFlight.current && !turnInFlight) void refresh();
 		wasInFlight.current = turnInFlight;
+		if (!turnInFlight) return;
+		void refresh();
+		const timer = setInterval(() => void refresh(), IN_TURN_REFRESH_MS);
+		return () => clearInterval(timer);
 	}, [turnInFlight, refresh]);
 
 	// While a VM exists, its 30-minute lifetime can lapse under an idle tab.

--- a/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
@@ -1,0 +1,76 @@
+"use client";
+
+/*
+ * Client view of the session's sandbox state (#753): fetches the truthful
+ * verdict from GET /api/sessions/[id]/sandbox and keeps it honest over time —
+ * re-checked when a turn settles (the moment a sandbox is born or parked),
+ * on window focus, and on a slow interval while a VM exists (sandboxes
+ * expire on their own; a "live" label must not outlive the VM). `null`
+ * means not-yet-known, which the masthead renders as absence, not a guess.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SandboxState } from "@/lib/agent-runtime/sandbox-state";
+
+/** How often a known live/parked state is re-verified against the platform. */
+const REFRESH_INTERVAL_MS = 60_000;
+
+export function useSandboxState(sessionId: string, turnInFlight: boolean) {
+	const [sandbox, setSandbox] = useState<SandboxState | null>(null);
+
+	const refresh = useCallback(async () => {
+		try {
+			const res = await fetch(`/api/sessions/${sessionId}/sandbox`);
+			if (!res.ok) return;
+			const data = (await res.json()) as SandboxState;
+			if (data && typeof data.state === "string") setSandbox(data);
+		} catch {
+			// Network hiccup: keep the last verified state rather than flapping.
+		}
+	}, [sessionId]);
+
+	// Known on arrival, re-verified whenever the tab comes back into focus.
+	useEffect(() => {
+		void refresh();
+		const onFocus = () => void refresh();
+		window.addEventListener("focus", onFocus);
+		return () => window.removeEventListener("focus", onFocus);
+	}, [refresh]);
+
+	// A turn settling is exactly when the sandbox changes hands (born on the
+	// first vercel turn, parked by detach) — re-check at that edge.
+	const wasInFlight = useRef(turnInFlight);
+	useEffect(() => {
+		if (wasInFlight.current && !turnInFlight) void refresh();
+		wasInFlight.current = turnInFlight;
+	}, [turnInFlight, refresh]);
+
+	// While a VM exists, its 30-minute lifetime can lapse under an idle tab.
+	useEffect(() => {
+		if (sandbox?.state !== "live" && sandbox?.state !== "parked") return;
+		const timer = setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
+		return () => clearInterval(timer);
+	}, [sandbox?.state, refresh]);
+
+	const stopSandbox = useCallback(async () => {
+		try {
+			const res = await fetch(`/api/sessions/${sessionId}/sandbox`, {
+				method: "DELETE",
+			});
+			if (!res.ok) return;
+			const data = (await res.json()) as SandboxState;
+			if (data && typeof data.state === "string") setSandbox(data);
+		} catch {
+			// The next refresh re-verifies; the label never claims the stop worked.
+		}
+	}, [sessionId]);
+
+	return { sandbox, stopSandbox };
+}
+
+/** The masthead's quiet phrasing for each verified state ("" = not yet known). */
+export function sandboxStateLabel(sandbox: SandboxState | null): string {
+	if (!sandbox) return "";
+	if (sandbox.state === "live") return "sandbox live";
+	if (sandbox.state === "parked") return "sandbox parked";
+	return "no sandbox";
+}

--- a/web-next/src/app/api/sessions/[id]/sandbox/route.ts
+++ b/web-next/src/app/api/sessions/[id]/sandbox/route.ts
@@ -1,0 +1,62 @@
+/*
+ * The session's sandbox lifecycle surface (#753). GET reports the sandbox's
+ * real state (live / parked / none — checked against the platform, never
+ * inferred); DELETE stops a live VM and reports the state that's actually
+ * left. Auth-gated same as the chat route; both verbs are safe to repeat —
+ * a re-GET re-checks, a re-DELETE of an already-parked sandbox is a no-op
+ * that returns the honest current state.
+ */
+import {
+	resolveSandboxState,
+	stopSessionSandbox,
+} from "@/lib/agent-runtime/sandbox-state";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { getSession } from "@/lib/db/sessions";
+
+export const runtime = "nodejs";
+
+async function gate(id: string) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return {
+			response: Response.json(
+				{ error: "not signed in as the allowed user" },
+				{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+			),
+		};
+	}
+	const session = await getSession(getDatabase(), id);
+	if (!session) {
+		return {
+			response: Response.json({ error: "unknown session" }, { status: 404 }),
+		};
+	}
+	return { session };
+}
+
+export async function GET(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const { id } = await params;
+	const gated = await gate(id);
+	if (gated.response) return gated.response;
+	return Response.json(await resolveSandboxState(gated.session));
+}
+
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const { id } = await params;
+	const gated = await gate(id);
+	if (gated.response) return gated.response;
+	try {
+		return Response.json(await stopSessionSandbox(gated.session));
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "failed to stop the sandbox";
+		return Response.json({ error: message }, { status: 502 });
+	}
+}

--- a/web-next/src/app/api/sessions/[id]/stop/route.ts
+++ b/web-next/src/app/api/sessions/[id]/stop/route.ts
@@ -1,0 +1,59 @@
+/*
+ * POST /api/sessions/[id]/stop — stop the session's in-flight turn (#753).
+ * Auth-gated same as the chat route. Aborts the ingest loop when it runs in
+ * this process (the loop closes the turn durably with `error` + aborted
+ * `done`, so live tails and reloads agree it was stopped); a turn whose
+ * runner already died (stale) is closed the same way. A turn running on
+ * another server instance is reported honestly as unreachable rather than
+ * having its log closed under a still-appending writer — process-local
+ * abort is the only stop the runtime actually supports (see turn-ingest.ts).
+ */
+import { stopActiveTurn, TURN_STOPPED_MESSAGE } from "@/lib/agent-runtime/turn-ingest";
+import { closeAbandonedTurn, resolveTurn } from "@/lib/agent-runtime/turn-tail";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { getSession } from "@/lib/db/sessions";
+
+export const runtime = "nodejs";
+
+export async function POST(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	if (stopActiveTurn(id)) {
+		return Response.json({ stopped: true, message: TURN_STOPPED_MESSAGE });
+	}
+
+	const turn = await resolveTurn(handle, id);
+	if (turn.status === "stale" && turn.fromSeq !== null) {
+		// The runner died without closing its turn — stopping it means closing
+		// the log durably, which is safe precisely because nothing is appending.
+		await closeAbandonedTurn(handle, id, turn.fromSeq);
+		return Response.json({ stopped: true, message: TURN_STOPPED_MESSAGE });
+	}
+	if (turn.status === "running") {
+		return Response.json(
+			{
+				error:
+					"the turn is running on another server instance and can't be stopped from here",
+			},
+			{ status: 409 },
+		);
+	}
+	return Response.json({ error: "no turn is running" }, { status: 409 });
+}

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -14,9 +14,13 @@ export interface ComposeFieldProps {
 	onSend?: (text: string) => void;
 	/** While true, submits are held and the draft kept (turn in flight). */
 	disabled?: boolean;
+	/** Stops the in-flight turn (#753). While `disabled` (a turn is running)
+	 * the send affordance becomes this stop — same footprint, honest verb —
+	 * rather than a dead button beside new chrome. */
+	onStop?: () => void;
 }
 
-export function ComposeField({ agentName, onSend, disabled }: ComposeFieldProps) {
+export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFieldProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [text, setText] = useState("");
 
@@ -57,16 +61,28 @@ export function ComposeField({ agentName, onSend, disabled }: ComposeFieldProps)
 					}}
 					className="min-w-0 flex-1 border-none bg-transparent font-serif text-compose text-ink outline-none"
 				/>
-				<button
-					type="button"
-					title="Send"
-					aria-label="Send"
-					disabled={disabled}
-					onClick={submit}
-					className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent disabled:opacity-40 disabled:group-focus-within:border-line-strong disabled:group-focus-within:bg-transparent disabled:group-focus-within:text-muted disabled:hover:border-line-strong disabled:hover:text-muted"
-				>
-					↑
-				</button>
+				{disabled && onStop ? (
+					<button
+						type="button"
+						title="Stop the turn"
+						aria-label="Stop"
+						onClick={onStop}
+						className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[11px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
+					>
+						■
+					</button>
+				) : (
+					<button
+						type="button"
+						title="Send"
+						aria-label="Send"
+						disabled={disabled}
+						onClick={submit}
+						className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent disabled:opacity-40 disabled:group-focus-within:border-line-strong disabled:group-focus-within:bg-transparent disabled:group-focus-within:text-muted disabled:hover:border-line-strong disabled:hover:text-muted"
+					>
+						↑
+					</button>
+				)}
 			</div>
 		</div>
 	);

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -22,7 +22,8 @@ export interface MastheadData {
 	/** The session's current best title, possibly `""` (no title yet). */
 	title: string;
 	agentName: string;
-	/** e.g. "sandbox active"; `live` adds the green halo dot. */
+	/** e.g. "sandbox live"; `""` (state not yet known) omits the segment —
+	 * absence over a guess, per #753's truthful-state rule. */
 	stateLabel: string;
 	live?: boolean;
 }
@@ -38,10 +39,15 @@ function Separator() {
 export function SessionMasthead({
 	session,
 	onTitleChange,
+	onSandboxStop,
 }: {
 	session: MastheadData;
 	/** Wired by the live session view; omitted on fixtures/demo pages. */
 	onTitleChange?: (title: string) => void;
+	/** Stops the session's live sandbox (#753). Supplied only when there is
+	 * actually something running to stop; a quiet hover-revealed action beside
+	 * the state label, never persistent chrome. */
+	onSandboxStop?: () => void;
 }) {
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -94,12 +100,35 @@ export function SessionMasthead({
 				</span>
 			)}
 			<span className="flex shrink-0 items-center whitespace-nowrap">
-				{session.agentName}
-				<Separator />
-				{session.live && (
-					<span className="mr-2 inline-block h-[7px] w-[7px] rounded-full bg-live align-[1px] shadow-[0_0_0_3px_var(--live-halo)]" />
+				{/* The agent name yields first at phone widths — the sandbox state is
+				    the load-bearing fact on the right (#753). */}
+				<span className="hidden items-center sm:flex">
+					{session.agentName}
+					{session.stateLabel && <Separator />}
+				</span>
+				{session.stateLabel && (
+					<span
+						data-testid="sandbox-state"
+						className="group/sandbox flex items-center"
+					>
+						{session.live && (
+							<span className="mr-2 inline-block h-[7px] w-[7px] rounded-full bg-live align-[1px] shadow-[0_0_0_3px_var(--live-halo)]" />
+						)}
+						{session.stateLabel}
+						{onSandboxStop && (
+							<button
+								type="button"
+								data-testid="sandbox-stop"
+								title="Stop the sandbox"
+								aria-label="Stop sandbox"
+								onClick={onSandboxStop}
+								className="ml-2 rounded-[5px] border-b border-transparent px-1 py-0.5 leading-none text-faint opacity-0 transition-opacity duration-200 group-hover/sandbox:opacity-100 hover:text-del-ink focus-visible:opacity-100"
+							>
+								stop
+							</button>
+						)}
+					</span>
 				)}
-				{session.stateLabel}
 				<ThemeToggle />
 			</span>
 		</header>

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -92,6 +92,12 @@ export interface SessionViewProps {
 	/** Inline title-edit handler (client wrappers wire this; fixtures omit it,
 	 * which leaves the masthead title as static text — see session-masthead.tsx). */
 	onTitleChange?: (title: string) => void;
+	/** Stops the in-flight turn (#753); the compose's send affordance becomes
+	 * the stop while a turn runs. Fixtures omit it. */
+	onStopTurn?: () => void;
+	/** Stops the session's live sandbox (#753); a quiet masthead action beside
+	 * the state label. Fixtures omit it. */
+	onSandboxStop?: () => void;
 }
 
 export function SessionView({
@@ -100,12 +106,21 @@ export function SessionView({
 	composeDisabled,
 	onModelChange,
 	onTitleChange,
+	onStopTurn,
+	onSandboxStop,
 }: SessionViewProps) {
 	const isEmpty = session.messages.length === 0 && !session.activeTurn;
 	return (
 		<>
-			<SessionMasthead session={session.masthead} onTitleChange={onTitleChange} />
-			<main className="mx-auto max-w-[680px] px-5 pt-[76px] pb-6">
+			<SessionMasthead
+				session={session.masthead}
+				onTitleChange={onTitleChange}
+				onSandboxStop={onSandboxStop}
+			/>
+			{/* break-words inherits into the prose, so an unbroken token (a long
+			    path, a URL) wraps instead of forcing 375px pages sideways (#753);
+			    pre/diff bodies keep their own inner overflow-x scrolling. */}
+			<main className="mx-auto max-w-[680px] px-4 pt-[76px] pb-6 break-words sm:px-5">
 				{isEmpty && session.empty && (
 					<div
 						data-testid="empty-transcript"
@@ -140,7 +155,7 @@ export function SessionView({
 							<section
 								key={turn.key}
 								data-turn={recent ? "recent" : "past"}
-								className={`animate-rise mb-9 rounded-[18px] border ${frame} px-8 py-7`}
+								className={`animate-rise mb-9 rounded-[18px] border ${frame} px-4 py-5 sm:px-8 sm:py-7`}
 							>
 								{turn.messages.map((message) => (
 									<Message
@@ -178,6 +193,7 @@ export function SessionView({
 					agentName={session.masthead.agentName}
 					onSend={onSend}
 					disabled={composeDisabled}
+					onStop={onStopTurn}
 				/>
 				<StatusLine status={session.statusLine} onModelChange={onModelChange} />
 			</footer>

--- a/web-next/src/components/folio/tool-ledger-row.tsx
+++ b/web-next/src/components/folio/tool-ledger-row.tsx
@@ -40,7 +40,7 @@ export function ToolLedgerRow({
 					▸
 				</span>
 				<span className="min-w-[3.6em] text-faint">{verb}</span>
-				<span>{subject}</span>
+				<span className="min-w-0 flex-1 truncate">{subject}</span>
 				{meta !== undefined && (
 					<span className="ml-auto pl-4 text-caption whitespace-nowrap text-faint">
 						{meta}

--- a/web-next/src/lib/agent-runtime/mock-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "vitest";
-import { deriveTurnStats } from "../transcript/turn-stats";
-import { MOCK_TURN_ERROR_TRIGGER, mockCodingTurn, mockProvider } from "./mock-provider";
+import { deriveTurnError, deriveTurnStats } from "../transcript/turn-stats";
+import {
+	MOCK_PROVISION_ERROR_TEXT,
+	MOCK_PROVISION_ERROR_TRIGGER,
+	MOCK_SANDBOX_DIED_TEXT,
+	MOCK_SANDBOX_DIED_TRIGGER,
+	MOCK_STREAM_ERROR_TEXT,
+	MOCK_STREAM_ERROR_TRIGGER,
+	MOCK_TURN_ERROR_TRIGGER,
+	mockCodingTurn,
+	mockProvider,
+} from "./mock-provider";
 import { DEFAULT_MODEL } from "./models";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -183,6 +193,90 @@ describe("mockCodingTurn", () => {
 			await expect(other.next()).rejects.toThrow(
 				"Simulated turn failure (mock provider)",
 			);
+		});
+	});
+
+	describe("error-class triggers (#753)", () => {
+		test("provisioning failure: throws before ANY content chunk streams", async () => {
+			const iterator = mockCodingTurn(
+				`build it ${MOCK_PROVISION_ERROR_TRIGGER}`,
+				() => Promise.resolve(),
+			)[Symbol.asyncIterator]();
+			const first = await iterator.next();
+			expect(first.value).toEqual({ type: "status", content: "Starting sandbox" });
+			await expect(iterator.next()).rejects.toThrow(MOCK_PROVISION_ERROR_TEXT);
+		});
+
+		test("sandbox died: fails mid-turn, AFTER prose and a tool call landed", async () => {
+			const chunks: StreamChunk[] = [];
+			const turn = mockCodingTurn(
+				`build it ${MOCK_SANDBOX_DIED_TRIGGER}`,
+				() => Promise.resolve(),
+			);
+			await expect(async () => {
+				for await (const chunk of turn) chunks.push(chunk);
+			}).rejects.toThrow(MOCK_SANDBOX_DIED_TEXT);
+			// The work streamed before the VM died is real and precedes the failure.
+			expect(chunks.some((chunk) => chunk.type === "text")).toBe(true);
+			expect(chunks.some((chunk) => chunk.type === "tool_result")).toBe(true);
+		});
+
+		test("stream error: an `error` CHUNK mid-stream, ending without `done`", async () => {
+			const chunks: StreamChunk[] = [];
+			for await (const chunk of mockCodingTurn(
+				`build it ${MOCK_STREAM_ERROR_TRIGGER}`,
+				() => Promise.resolve(),
+			)) {
+				chunks.push(chunk);
+			}
+			// Prose streamed first; the structured error chunk closes the stream.
+			expect(chunks.some((chunk) => chunk.type === "text")).toBe(true);
+			expect(chunks.at(-1)).toEqual({
+				type: "error",
+				content: MOCK_STREAM_ERROR_TEXT,
+			});
+			expect(chunks.some((chunk) => chunk.type === "done")).toBe(false);
+			// deriveTurnError tags the turn from the chunk — the same read both the
+			// projection and the live receipt path use.
+			expect(deriveTurnError(chunks)).toBe(MOCK_STREAM_ERROR_TEXT);
+		});
+
+		test("each trigger spends independently on the same session", async () => {
+			const sessionId = `s-${crypto.randomUUID()}`;
+
+			// Spend the provisioning trigger…
+			const provision = mockProvider
+				.runTurn({
+					sessionId,
+					userMessage: `go ${MOCK_PROVISION_ERROR_TRIGGER}`,
+				})
+				[Symbol.asyncIterator]();
+			await provision.next();
+			await expect(provision.next()).rejects.toThrow(MOCK_PROVISION_ERROR_TEXT);
+
+			// …the generic trigger (also unspent, also failing at the same early
+			// point) still gets ITS guaranteed failure on this session.
+			const generic = mockProvider
+				.runTurn({ sessionId, userMessage: `go ${MOCK_TURN_ERROR_TRIGGER}` })
+				[Symbol.asyncIterator]();
+			await generic.next();
+			await expect(generic.next()).rejects.toThrow(
+				"Simulated turn failure (mock provider)",
+			);
+
+			// And a provisioning retry (that trigger already spent) runs the script.
+			const retry = mockProvider
+				.runTurn({
+					sessionId,
+					userMessage: `go ${MOCK_PROVISION_ERROR_TRIGGER}`,
+				})
+				[Symbol.asyncIterator]();
+			await retry.next();
+			await expect(retry.next()).resolves.toEqual({
+				value: { type: "status", content: "Cloning repo" },
+				done: false,
+			});
+			await retry.return?.(undefined);
 		});
 	});
 });

--- a/web-next/src/lib/agent-runtime/mock-provider.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.ts
@@ -12,8 +12,11 @@
  * running the script — a deterministic, hermetic way to exercise a whole-turn
  * failure (turn-ingest.ts's catch appends the `error` + aborted `done` a real
  * provider fault or dead sandbox would) without depending on timing or a real
- * provider outage. Test-only by convention: nothing in the product surface
- * sends this text on purpose.
+ * provider outage. #753 adds one trigger per first-class error surface —
+ * provisioning failure, sandbox died mid-turn, stream error — each failing at
+ * the point and through the mechanism its real counterpart would (see the
+ * trigger constants below). Test-only by convention: nothing in the product
+ * surface sends this text on purpose.
  *
  * `mockCodingTurn` itself always fails when the trigger is present — that's
  * what makes it hermetically unit-testable. `mockProvider.runTurn` (the seam
@@ -35,6 +38,41 @@ const EDITED_FILE = "src/lib/session.ts";
 
 /** A user message containing this text makes the mock turn fail (#808). */
 export const MOCK_TURN_ERROR_TRIGGER = "__mock_turn_error__";
+
+/**
+ * The #753 error-class seams, one per first-class failure surface. Same
+ * contract as MOCK_TURN_ERROR_TRIGGER (deterministic, hermetic, spent once
+ * per session so a Retry succeeds), but each fails at the point — and through
+ * the mechanism — its real counterpart would:
+ *
+ * - provisioning: throws before any content streams, while the turn is still
+ *   "Starting sandbox" — a sandbox that never came up (turn-ingest's catch
+ *   closes it, exactly like a real create failure).
+ * - sandbox died: throws mid-turn, after prose and a tool call already
+ *   landed — a VM lost under a running agent; the streamed work survives in
+ *   the log, the failure is recorded after it.
+ * - stream error: emits an `error` CHUNK mid-stream and ends without `done`
+ *   — the provider's own structured error path (#811), exercising the
+ *   adapter's error case rather than the ingest catch.
+ */
+export const MOCK_PROVISION_ERROR_TRIGGER = "__mock_provision_error__";
+export const MOCK_SANDBOX_DIED_TRIGGER = "__mock_sandbox_died__";
+export const MOCK_STREAM_ERROR_TRIGGER = "__mock_stream_error__";
+
+export const MOCK_PROVISION_ERROR_TEXT =
+	"Sandbox provisioning failed — the sandbox never started (mock).";
+export const MOCK_SANDBOX_DIED_TEXT =
+	"The sandbox died mid-turn — connection to the running agent was lost (mock).";
+export const MOCK_STREAM_ERROR_TEXT =
+	"The stream broke before the turn finished (mock).";
+
+/** Every failure seam the mock honors; runTurn spends each once per session. */
+const ERROR_TRIGGERS = [
+	MOCK_TURN_ERROR_TRIGGER,
+	MOCK_PROVISION_ERROR_TRIGGER,
+	MOCK_SANDBOX_DIED_TRIGGER,
+	MOCK_STREAM_ERROR_TRIGGER,
+] as const;
 
 const REASONING_TRACE = [
 	"The repro says `resumeSession` comes back with undefined for an unknown id, and the test expects a thrown `SessionNotFoundError`.",
@@ -106,6 +144,11 @@ export async function* mockCodingTurn(
 	if (userMessage.includes(MOCK_TURN_ERROR_TRIGGER)) {
 		throw new Error("Simulated turn failure (mock provider)");
 	}
+	// Provisioning failure (#753): the sandbox never comes up — the turn dies
+	// before a single content chunk, so the failure card is the whole reply.
+	if (userMessage.includes(MOCK_PROVISION_ERROR_TRIGGER)) {
+		throw new Error(MOCK_PROVISION_ERROR_TEXT);
+	}
 
 	yield { type: "status", content: "Cloning repo" };
 	await sleep(300);
@@ -115,6 +158,14 @@ export async function* mockCodingTurn(
 	yield* prose(
 		`You asked: "${userMessage}". Let me reproduce the failure first.`,
 	);
+
+	// Stream error (#753): the provider's own structured `error` chunk lands
+	// mid-stream and the turn ends without a `done` — ingest synthesizes the
+	// terminal, and deriveTurnError picks the chunk's text up on both paths.
+	if (userMessage.includes(MOCK_STREAM_ERROR_TRIGGER)) {
+		yield { type: "error", content: MOCK_STREAM_ERROR_TEXT };
+		return;
+	}
 
 	yield { type: "status", content: "Running `pnpm test session`" };
 	yield {
@@ -132,6 +183,12 @@ export async function* mockCodingTurn(
 		content: FAILING_TEST_OUTPUT,
 		metadata: { toolUseId: "tool-1", isError: true },
 	};
+
+	// Sandbox died (#753): the VM vanishes under a running agent — prose and a
+	// tool call already landed, so the log keeps that work ahead of the failure.
+	if (userMessage.includes(MOCK_SANDBOX_DIED_TRIGGER)) {
+		throw new Error(MOCK_SANDBOX_DIED_TEXT);
+	}
 
 	yield* prose(
 		"Confirmed — it throws a `TypeError` inside `hydrate` instead of rejecting. Reading the source.",
@@ -219,24 +276,27 @@ export async function* mockCodingTurn(
 	};
 }
 
-/** Sessions whose one guaranteed `MOCK_TURN_ERROR_TRIGGER` failure has already
- * fired — dev/e2e-only in-memory state, same lifetime as turn-ingest.ts's
- * `activeTurns`; never pruned. */
-const spentErrorTrigger = new Set<string>();
+/** `sessionId:trigger` pairs whose one guaranteed failure has already fired —
+ * dev/e2e-only in-memory state, same lifetime as turn-ingest.ts's
+ * `activeTurns`; never pruned. Keyed per trigger so each error class gets its
+ * own spend on a session. */
+const spentErrorTriggers = new Set<string>();
 
 export const mockProvider: ComputeProvider = {
 	id: "mock",
 	runTurn: (request: TurnRequest) => {
 		let userMessage = request.userMessage;
-		if (userMessage.includes(MOCK_TURN_ERROR_TRIGGER)) {
-			if (spentErrorTrigger.has(request.sessionId)) {
+		for (const trigger of ERROR_TRIGGERS) {
+			if (!userMessage.includes(trigger)) continue;
+			const spendKey = `${request.sessionId}:${trigger}`;
+			if (spentErrorTriggers.has(spendKey)) {
 				// Already spent on this session — strip the trigger so the script
 				// runs normally instead of failing forever (the persisted user
 				// event, appended before the provider ever runs, keeps the original
 				// text regardless of what's passed here).
-				userMessage = userMessage.split(MOCK_TURN_ERROR_TRIGGER).join("").trim();
+				userMessage = userMessage.split(trigger).join("").trim();
 			} else {
-				spentErrorTrigger.add(request.sessionId);
+				spentErrorTriggers.add(spendKey);
 			}
 		}
 		return mockCodingTurn(userMessage, undefined, request.model);

--- a/web-next/src/lib/agent-runtime/sandbox-state.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-state.test.ts
@@ -1,0 +1,121 @@
+/*
+ * The truthfulness contract of the sandbox lifecycle (#753): every platform
+ * status maps to exactly one of live/parked/none, an absent or unreachable
+ * sandbox reads calmly as none, and stop only ever calls the platform when a
+ * VM is actually up — an already-parked or gone sandbox is reported, not
+ * "stopped" again.
+ */
+import { describe, expect, test, vi } from "vitest";
+import {
+	type LifecycleSandbox,
+	resolveSandboxState,
+	stopSessionSandbox,
+} from "./sandbox-state";
+import { sessionSandboxName } from "./vercel-provider";
+
+const PARKED_SESSION = {
+	claudeSessionId: "harness-1",
+	resumeState: '{"parked":true}',
+};
+
+function sandboxWith(status: string): LifecycleSandbox & { stop: ReturnType<typeof vi.fn> } {
+	return {
+		name: sessionSandboxName("harness-1"),
+		status,
+		stop: vi.fn(async () => ({})),
+	};
+}
+
+describe("resolveSandboxState", () => {
+	test("a session that never started a sandbox is none", async () => {
+		const state = await resolveSandboxState(
+			{ claudeSessionId: null, resumeState: null },
+			async () => {
+				throw new Error("must not be called");
+			},
+		);
+		expect(state).toEqual({
+			state: "none",
+			detail: "no turn has started a sandbox yet",
+		});
+	});
+
+	test("an unreachable (expired) sandbox is none, calmly", async () => {
+		const state = await resolveSandboxState(PARKED_SESSION, async () => {
+			throw new Error("sandbox_not_found");
+		});
+		expect(state).toEqual({
+			state: "none",
+			detail: "the session's sandbox has expired",
+		});
+	});
+
+	test.each(["running", "pending"])("%s reads as live", async (status) => {
+		const state = await resolveSandboxState(PARKED_SESSION, async () =>
+			sandboxWith(status),
+		);
+		expect(state).toEqual({ state: "live" });
+	});
+
+	test.each(["stopping", "stopped", "snapshotting"])(
+		"%s reads as parked",
+		async (status) => {
+			const state = await resolveSandboxState(PARKED_SESSION, async () =>
+				sandboxWith(status),
+			);
+			expect(state).toEqual({ state: "parked", detail: status });
+		},
+	);
+
+	test.each(["failed", "aborted"])("%s reads as none with the reason", async (status) => {
+		const state = await resolveSandboxState(PARKED_SESSION, async () =>
+			sandboxWith(status),
+		);
+		expect(state).toEqual({
+			state: "none",
+			detail: `the session's sandbox is ${status}`,
+		});
+	});
+
+	test("looks the sandbox up by the session's own parked name", async () => {
+		const getSandbox = vi.fn(async () => sandboxWith("running"));
+		await resolveSandboxState(PARKED_SESSION, getSandbox);
+		expect(getSandbox).toHaveBeenCalledWith(sessionSandboxName("harness-1"));
+	});
+});
+
+describe("stopSessionSandbox", () => {
+	test("stops a running VM and reports it parked", async () => {
+		const sandbox = sandboxWith("running");
+		const state = await stopSessionSandbox(PARKED_SESSION, async () => sandbox);
+		expect(sandbox.stop).toHaveBeenCalledTimes(1);
+		expect(state).toEqual({ state: "parked", detail: "stopped" });
+	});
+
+	test("an already-parked sandbox is reported, never stop()ed again", async () => {
+		const sandbox = sandboxWith("stopped");
+		const state = await stopSessionSandbox(PARKED_SESSION, async () => sandbox);
+		expect(sandbox.stop).not.toHaveBeenCalled();
+		expect(state).toEqual({ state: "parked", detail: "stopped" });
+	});
+
+	test("a gone sandbox is none; nothing is called", async () => {
+		const state = await stopSessionSandbox(PARKED_SESSION, async () => {
+			throw new Error("sandbox_not_found");
+		});
+		expect(state).toEqual({
+			state: "none",
+			detail: "the session's sandbox has expired",
+		});
+	});
+
+	test("a session with no sandbox handle is none; the platform is never asked", async () => {
+		const getSandbox = vi.fn();
+		const state = await stopSessionSandbox(
+			{ claudeSessionId: null, resumeState: null },
+			getSandbox,
+		);
+		expect(getSandbox).not.toHaveBeenCalled();
+		expect(state.state).toBe("none");
+	});
+});

--- a/web-next/src/lib/agent-runtime/sandbox-state.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-state.ts
@@ -1,0 +1,111 @@
+/*
+ * The session's sandbox lifecycle, truthfully (#753): resolve the parked
+ * Vercel sandbox's real status into the three states the masthead surfaces
+ * (live / parked / none), and stop a live one on request. Point-in-time
+ * facts checked against the platform, never inferred from what the UI hopes
+ * is true — the same honesty contract as the terminal drawer's
+ * `resolveLiveSandbox` (#752), with which this shares the name derivation
+ * and the "a stale/absent handle reads as none, calmly" behavior.
+ *
+ * Why stop is the only control: the Vercel sandbox API has no pause/freeze —
+ * `Sandbox.stop()` ends the VM (optionally snapshotting), and resumption
+ * happens implicitly on the next `Sandbox.get`/turn, not as a user verb. A
+ * pause button would be a fake; stop is real, so stop is what ships.
+ */
+import { sessionSandboxName } from "./vercel-provider";
+import type { Session } from "../db/sessions";
+
+/** The slice of @vercel/sandbox's Sandbox the lifecycle path touches. */
+export interface LifecycleSandbox {
+	name: string;
+	/** "failed" | "aborted" | "pending" | "running" | "stopping" | "stopped" | "snapshotting" */
+	status: string;
+	stop(): Promise<unknown>;
+}
+
+/** Fetch-by-name, throwing when the sandbox is gone. Injected for tests. */
+export type GetLifecycleSandbox = (name: string) => Promise<LifecycleSandbox>;
+
+/**
+ * live: a VM is up (or coming up) — the terminal can attach, the next turn
+ * resumes warm. parked: the VM is stopped/snapshotting; nothing is running,
+ * but the platform may restore it on the next turn. none: no sandbox exists
+ * for this session (never started, expired, or failed) — `detail` says why.
+ */
+export type SandboxState =
+	| { state: "live" }
+	| { state: "parked"; detail: string }
+	| { state: "none"; detail: string };
+
+const LIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
+const PARKED_STATUSES: ReadonlySet<string> = new Set([
+	"stopping",
+	"stopped",
+	"snapshotting",
+]);
+
+async function defaultGetSandbox(name: string): Promise<LifecycleSandbox> {
+	const { Sandbox } = await import("@vercel/sandbox");
+	const token = process.env.VERCEL_TOKEN;
+	const teamId = process.env.VERCEL_TEAM_ID;
+	const projectId = process.env.VERCEL_PROJECT_ID;
+	return (await Sandbox.get({
+		name,
+		// A status check must never resurrect a parked sandbox.
+		resume: false,
+		...(token && teamId && projectId ? { token, teamId, projectId } : {}),
+	})) as unknown as LifecycleSandbox;
+}
+
+/** The session's sandbox state, checked against the platform right now. */
+export async function resolveSandboxState(
+	session: Pick<Session, "claudeSessionId" | "resumeState">,
+	getSandbox: GetLifecycleSandbox = defaultGetSandbox,
+): Promise<SandboxState> {
+	if (!session.claudeSessionId || !session.resumeState) {
+		return { state: "none", detail: "no turn has started a sandbox yet" };
+	}
+	let sandbox: LifecycleSandbox;
+	try {
+		sandbox = await getSandbox(sessionSandboxName(session.claudeSessionId));
+	} catch {
+		return { state: "none", detail: "the session's sandbox has expired" };
+	}
+	if (LIVE_STATUSES.has(sandbox.status)) return { state: "live" };
+	if (PARKED_STATUSES.has(sandbox.status)) {
+		return { state: "parked", detail: sandbox.status };
+	}
+	return { state: "none", detail: `the session's sandbox is ${sandbox.status}` };
+}
+
+/**
+ * Stops the session's sandbox if a VM is actually up, then reports the
+ * post-stop state. Idempotent from the caller's view: stopping a session
+ * whose sandbox is already parked or gone changes nothing and returns the
+ * honest current state — no error for asking twice. The parked resume
+ * handle stays on the session row: the next turn's resume path already
+ * treats an unresumable handle as "boot fresh", so a stale handle is
+ * self-healing, and clearing it here would discard a restorable snapshot.
+ */
+export async function stopSessionSandbox(
+	session: Pick<Session, "claudeSessionId" | "resumeState">,
+	getSandbox: GetLifecycleSandbox = defaultGetSandbox,
+): Promise<SandboxState> {
+	if (!session.claudeSessionId || !session.resumeState) {
+		return { state: "none", detail: "no turn has started a sandbox yet" };
+	}
+	let sandbox: LifecycleSandbox;
+	try {
+		sandbox = await getSandbox(sessionSandboxName(session.claudeSessionId));
+	} catch {
+		return { state: "none", detail: "the session's sandbox has expired" };
+	}
+	if (!LIVE_STATUSES.has(sandbox.status)) {
+		// Nothing running to stop — report what is actually there.
+		return PARKED_STATUSES.has(sandbox.status)
+			? { state: "parked", detail: sandbox.status }
+			: { state: "none", detail: `the session's sandbox is ${sandbox.status}` };
+	}
+	await sandbox.stop();
+	return { state: "parked", detail: "stopped" };
+}

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -37,10 +37,12 @@ import {
 } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
-/** One in-flight turn: where its assistant message starts, and when it began. */
+/** One in-flight turn: where its assistant message starts, when it began, and
+ * the handle a user-initiated stop (#753) aborts it through. */
 interface ActiveTurn {
 	fromSeq: number;
 	startedAt: number;
+	controller: AbortController;
 }
 
 /** Turns whose ingest loop is running in THIS process, keyed by session id. */
@@ -70,6 +72,33 @@ export function isTurnActive(sessionId: string): boolean {
 /** The started-at of an in-process turn, or undefined if none is running. */
 export function activeTurnStartedAt(sessionId: string): number | undefined {
 	return activeTurns.get(sessionId)?.startedAt;
+}
+
+/** The calm terminal text a stopped turn's failure card shows. */
+export const TURN_STOPPED_MESSAGE = "Turn stopped.";
+
+/** Thrown inside the ingest loop when a stop aborts the turn — the existing
+ * catch then records it like any other turn failure, so a stopped turn closes
+ * with the same durable error + aborted-`done` pair an interrupted one does. */
+class TurnStoppedError extends Error {
+	constructor() {
+		super(TURN_STOPPED_MESSAGE);
+		this.name = "TurnStoppedError";
+	}
+}
+
+/**
+ * Stops the session's in-flight turn, if its ingest loop runs in THIS process:
+ * aborts the loop (which closes the turn durably with `error` + aborted
+ * `done`) and returns true. Returns false when no in-process turn exists —
+ * the caller distinguishes "nothing to stop" from "running on another
+ * instance" via resolveTurn, since this map is process-local by design.
+ */
+export function stopActiveTurn(sessionId: string): boolean {
+	const active = activeTurns.get(sessionId);
+	if (!active) return false;
+	active.controller.abort();
+	return true;
 }
 
 export interface StartedTurn {
@@ -115,8 +144,9 @@ export async function startTurn(
 		console.error(`[turn-ingest] auto-title write failed for ${session.id}`, error);
 	}
 	const fromSeq = userSeq + 1;
-	const ingest = ingestTurn(handle, session, userText, provider);
-	activeTurns.set(session.id, { fromSeq, startedAt: Date.now() });
+	const controller = new AbortController();
+	const ingest = ingestTurn(handle, session, userText, provider, controller.signal);
+	activeTurns.set(session.id, { fromSeq, startedAt: Date.now(), controller });
 	// Deregister once this turn settles — but only if a newer turn hasn't
 	// already taken the slot (guards a fast resend replacing the entry).
 	void ingest.finally(() => {
@@ -127,27 +157,73 @@ export async function startTurn(
 	return { fromSeq, ingest };
 }
 
+/** The abort-race verdict: the source yielded (or finished), or the stop won. */
+type NextOrAborted<T> = { aborted: true } | { aborted: false; result: IteratorResult<T> };
+
+/**
+ * Races the iterator's next value against the stop signal, so a stop takes
+ * effect between chunks without waiting out a slow provider step. On abort
+ * the underlying generator's `return()` is fired (not awaited — its cleanup,
+ * e.g. the vercel provider's sandbox teardown, proceeds in the background and
+ * can only touch the sandbox, never this session's log) and any still-pending
+ * `next` is defused so it can't surface as an unhandled rejection.
+ */
+async function nextOrAborted<T>(
+	iterator: AsyncIterator<T>,
+	signal: AbortSignal,
+): Promise<NextOrAborted<T>> {
+	if (signal.aborted) return { aborted: true };
+	let onAbort: () => void = () => {};
+	const aborted = new Promise<{ aborted: true }>((resolve) => {
+		onAbort = () => resolve({ aborted: true });
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
+	const next = iterator
+		.next()
+		.then((result) => ({ aborted: false as const, result }));
+	try {
+		return await Promise.race([next, aborted]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+		if (signal.aborted) {
+			next.catch(() => {});
+			void iterator.return?.()?.catch?.(() => {});
+		}
+	}
+}
+
 /**
  * Consumes the provider turn, appending each chunk to the log and notifying
  * tail readers. Guarantees the run is closed by exactly one terminal `done`:
  * providers that emit their own `done` (the norm) close themselves; a provider
- * that ends without one, or throws, gets a synthesized terminal so the turn is
- * never left open in the log. Never rejects — failures are recorded as events.
+ * that ends without one, throws, or is stopped mid-turn (#753) gets a
+ * synthesized terminal so the turn is never left open in the log — and a
+ * failure arriving AFTER the provider's own `done` (including a stop racing
+ * the turn's natural finish) appends nothing, so the log never carries a
+ * second terminal. Never rejects — failures are recorded as events.
  */
 async function ingestTurn(
 	handle: DatabaseHandle,
 	session: Session,
 	userText: string,
 	provider: ComputeProvider,
+	signal: AbortSignal,
 ): Promise<void> {
 	let closed = false;
 	try {
-		for await (const chunk of provider.runTurn({
-			sessionId: session.id,
-			userMessage: userText,
-			resume: resumeHandle(session),
-			model: session.model,
-		})) {
+		const iterator = provider
+			.runTurn({
+				sessionId: session.id,
+				userMessage: userText,
+				resume: resumeHandle(session),
+				model: session.model,
+			})
+			[Symbol.asyncIterator]();
+		while (true) {
+			const verdict = await nextOrAborted(iterator, signal);
+			if (verdict.aborted) throw new TurnStoppedError();
+			if (verdict.result.done) break;
+			const chunk = verdict.result.value;
 			// A terminal `done` may carry the harness handle the turn parked with
 			// detach(); persist it to the session row (not the transcript) so the
 			// next turn reconnects, and store the chunk without that private blob.
@@ -166,6 +242,7 @@ async function ingestTurn(
 			notify(session.id);
 		}
 	} catch (error) {
+		if (closed) return; // the run already has its terminal `done` — never a second
 		const message = error instanceof Error ? error.message : "the turn failed";
 		await appendEvents(handle, session.id, [
 			{ role: "assistant", chunk: { type: "error", content: message } },

--- a/web-next/src/lib/agent-runtime/turn-stop.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-stop.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Stopping an in-flight turn (#753): the abort must close the turn's log with
+ * exactly one durable `error` + aborted-`done` pair, release the session for
+ * the next send, tear the provider down, and — the race codex is pointed at —
+ * never append a second terminal when the stop lands after the turn's own
+ * `done` (or after a provider fault already closed it).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { type DatabaseHandle, openDatabase } from "../db/client";
+import { createSession, readEvents } from "../db/sessions";
+import type { ComputeProvider } from "./provider";
+import type { StreamChunk } from "./stream-chunk";
+import {
+	isTurnActive,
+	startTurn,
+	stopActiveTurn,
+	TURN_STOPPED_MESSAGE,
+} from "./turn-ingest";
+import { resolveTurn } from "./turn-tail";
+
+let open: DatabaseHandle | undefined;
+let dir: string | undefined;
+
+function freshDb(): DatabaseHandle {
+	dir = mkdtempSync(join(tmpdir(), "web-next-turn-stop-"));
+	open = openDatabase(`file:${join(dir, "test.db")}`);
+	return open;
+}
+
+afterEach(async () => {
+	await open?.db.destroy();
+	open = undefined;
+	if (dir) rmSync(dir, { recursive: true, force: true });
+	dir = undefined;
+});
+
+/** A provider whose chunks the test hand-feeds, with cleanup observability. */
+function controlledProvider() {
+	let feed: (chunk: StreamChunk | null) => void = () => {};
+	let queue: Promise<StreamChunk | null> = new Promise((resolve) => {
+		feed = resolve;
+	});
+	const state = { cleanedUp: false };
+	const provider: ComputeProvider = {
+		id: "controlled",
+		runTurn: async function* () {
+			try {
+				while (true) {
+					const chunk = await queue;
+					if (chunk === null) return;
+					queue = new Promise((resolve) => {
+						feed = resolve;
+					});
+					yield chunk;
+				}
+			} finally {
+				state.cleanedUp = true;
+			}
+		},
+	};
+	return { provider, next: (chunk: StreamChunk | null) => feed(chunk), state };
+}
+
+async function until(predicate: () => boolean, ms = 2000): Promise<void> {
+	const deadline = Date.now() + ms;
+	while (!predicate()) {
+		if (Date.now() > deadline) throw new Error("condition never held");
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+/** Polls the log until it holds at least `count` events. */
+async function untilEvents(
+	handle: DatabaseHandle,
+	sessionId: string,
+	count: number,
+): Promise<void> {
+	const deadline = Date.now() + 2000;
+	while ((await readEvents(handle, sessionId)).length < count) {
+		if (Date.now() > deadline) throw new Error("events never appended");
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+describe("stopActiveTurn", () => {
+	test("stops a streaming turn: one error + aborted done, session released, provider torn down", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, { id: "s1", provider: "mock" });
+		const { provider, next, state } = controlledProvider();
+
+		const started = await startTurn(handle, session, "long job", provider);
+		next({ type: "text", content: "working…" });
+		// The first chunk must be durably appended before the stop, so the log
+		// proves streamed work survives ahead of the stop record.
+		await untilEvents(handle, "s1", 2);
+
+		expect(stopActiveTurn("s1")).toBe(true);
+		await started.ingest;
+
+		const events = await readEvents(handle, "s1");
+		const kinds = events.map((event) => event.chunk.type);
+		expect(kinds).toEqual(["text", "text", "error", "done"]);
+		expect(events[2].chunk.content).toBe(TURN_STOPPED_MESSAGE);
+		expect(events[3].chunk.metadata?.aborted).toBe(true);
+
+		// The turn reads as closed — a follow-up send is not a conflict.
+		expect(isTurnActive("s1")).toBe(false);
+		expect((await resolveTurn(handle, "s1")).status).toBe("done");
+
+		// The provider generator's cleanup runs once its in-flight await settles
+		// (the queued return() takes effect then) — and, critically, the chunk it
+		// was producing never reaches the closed log above.
+		next({ type: "text", content: "too late" });
+		await until(() => state.cleanedUp);
+		expect((await readEvents(handle, "s1")).map((e) => e.chunk.type)).toEqual([
+			"text",
+			"text",
+			"error",
+			"done",
+		]);
+	});
+
+	test("returns false when nothing is running", () => {
+		expect(stopActiveTurn("nope")).toBe(false);
+	});
+
+	test("a stop racing the turn's natural finish appends no second terminal", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, { id: "s2", provider: "mock" });
+		const { provider, next } = controlledProvider();
+
+		const started = await startTurn(handle, session, "quick job", provider);
+		next({ type: "done", content: "" });
+		await untilEvents(handle, "s2", 2); // the done chunk is in the log
+		// Now the stop lands — after `done`, before the loop observes the
+		// generator's end. It must not add a second terminal pair.
+		stopActiveTurn("s2");
+		await started.ingest;
+
+		const events = await readEvents(handle, "s2");
+		expect(events.map((event) => event.chunk.type)).toEqual(["text", "done"]);
+	});
+
+	test("a provider fault after its own done appends no second terminal", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, { id: "s3", provider: "mock" });
+		const provider: ComputeProvider = {
+			id: "faulty",
+			runTurn: async function* () {
+				yield { type: "done", content: "" } as StreamChunk;
+				throw new Error("post-done fault");
+			},
+		};
+		const started = await startTurn(handle, session, "job", provider);
+		await started.ingest;
+		const events = await readEvents(handle, "s3");
+		expect(events.map((event) => event.chunk.type)).toEqual(["text", "done"]);
+	});
+});

--- a/web-next/tests/e2e/errors.spec.ts
+++ b/web-next/tests/e2e/errors.spec.ts
@@ -1,0 +1,147 @@
+/*
+ * First-class error surfaces + lifecycle controls (#753), hermetic over the
+ * mock provider's injection seams: each failure class — provisioning, sandbox
+ * died mid-turn, stream error — renders its own calm inline card (no toast
+ * chrome), the stop control ends a streaming turn and releases the session
+ * for the next send, and the masthead reports the sandbox state truthfully
+ * (a mock session never has one: "no sandbox", and no stop-sandbox control).
+ */
+import { expect, type Page, test } from "@playwright/test";
+
+// The mock turn takes ~9s of scripted delays end to end.
+const TURN_TIMEOUT = 20_000;
+
+async function createSession(page: Page): Promise<void> {
+	await page.goto("/");
+	const picker = page.getByTestId("new-session-picker");
+	if (!(await picker.isVisible())) {
+		await page.getByRole("button", { name: "+ new session" }).click();
+	}
+	await page
+		.getByRole("textbox", { name: "Repository (owner/name)" })
+		.fill("fairchild/workspaces");
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(/\/sessions\/[0-9a-f-]{36}$/);
+}
+
+async function send(page: Page, text: string): Promise<void> {
+	await page.getByRole("textbox", { name: "Reply to Claude" }).fill(text);
+	await page.keyboard.press("Enter");
+}
+
+test("a provisioning failure renders its calm card — the failure is the whole reply", async ({
+	page,
+}) => {
+	await createSession(page);
+	await send(page, "Build the thing __mock_provision_error__");
+
+	// The user's message is never at risk; the activity line breathes while
+	// the mock "provisions"…
+	await expect(page.locator('[data-message-role="user"]')).toContainText(
+		"Build the thing",
+	);
+
+	// …then the sandbox never comes up: the failure card is the entire
+	// assistant reply (no content ever streamed), with Retry on offer.
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"Sandbox provisioning failed",
+		{ timeout: TURN_TIMEOUT },
+	);
+	await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
+});
+
+test("a sandbox that dies mid-turn keeps the streamed work above its failure card", async ({
+	page,
+}) => {
+	await createSession(page);
+	await send(page, "Fix the flaky test __mock_sandbox_died__");
+
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"The sandbox died mid-turn",
+		{ timeout: TURN_TIMEOUT },
+	);
+	// The prose and the tool call that landed before the VM died are still
+	// there — the failure is recorded after the work, not instead of it.
+	await expect(page.locator('[data-message-role="assistant"]')).toContainText(
+		"Let me reproduce the failure first",
+	);
+	await expect(page.getByTestId("tool-row")).toHaveCount(1);
+	await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
+});
+
+test("a stream error surfaces the provider's own error text, live and after reload", async ({
+	page,
+}) => {
+	await createSession(page);
+	await send(page, "Refactor the adapter __mock_stream_error__");
+
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"The stream broke before the turn finished",
+		{ timeout: TURN_TIMEOUT },
+	);
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
+
+	// The projection tags the same failure from the persisted error chunk —
+	// live and reloaded agree.
+	await page.reload();
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"The stream broke before the turn finished",
+	);
+	await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+});
+
+test("stop ends a streaming turn, records it honestly, and releases the session", async ({
+	page,
+}) => {
+	await createSession(page);
+	await send(page, "Fix the failing session test");
+
+	// While the turn runs, the send affordance is the stop control.
+	const stop = page.getByRole("button", { name: "Stop" });
+	await expect(stop).toBeVisible();
+	await expect(page.getByTestId("activity-line")).toBeVisible();
+	await stop.click();
+
+	// The turn closes as a calm failure card — "Turn stopped." — and compose
+	// hands back the send affordance.
+	await expect(page.getByTestId("turn-failure")).toContainText("Turn stopped.", {
+		timeout: TURN_TIMEOUT,
+	});
+	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
+
+	// The session is genuinely released (#811's one-turn-at-a-time guard sees
+	// the stopped turn as closed): a follow-up send streams to completion.
+	await send(page, "Carry on from where you stopped");
+	await expect(page.locator('[data-message-role="user"]')).toHaveCount(2);
+	await expect(page.getByTestId("turn-stats")).toBeVisible({
+		timeout: TURN_TIMEOUT,
+	});
+
+	// The stopped turn's own record survives the later turn, and a reload
+	// projects the same story from the log.
+	await expect(page.getByTestId("turn-failure")).toContainText("Turn stopped.");
+	await page.reload();
+	await expect(page.getByTestId("turn-failure")).toContainText("Turn stopped.");
+	await expect(page.getByTestId("turn-stats")).toBeVisible();
+});
+
+test("the masthead reports the sandbox state truthfully: a mock session has none", async ({
+	page,
+}) => {
+	await createSession(page);
+	// The verdict is fetched, not guessed: "no sandbox", with no stop control
+	// (there is nothing to stop — a fake button would be dishonest chrome).
+	await expect(page.getByTestId("sandbox-state")).toContainText("no sandbox");
+	await expect(page.getByTestId("sandbox-stop")).toHaveCount(0);
+
+	// Still true after a turn: the mock provider parks no sandbox.
+	await send(page, "Fix the failing session test");
+	await expect(page.getByTestId("turn-stats")).toBeVisible({
+		timeout: TURN_TIMEOUT,
+	});
+	await expect(page.getByTestId("sandbox-state")).toContainText("no sandbox");
+});

--- a/web-next/tests/e2e/mobile.spec.ts
+++ b/web-next/tests/e2e/mobile.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * The phone-width contract (#753): at 375px the whole session surface —
+ * home, transcript with a real streamed turn (prose, reasoning, ledger
+ * rows, an expanded diff and test output — the widest content the app
+ * renders), compose, and the failure card — works with NO horizontal
+ * scroll at the page level. Wide content scrolls inside its own panel,
+ * never by dragging the page sideways.
+ */
+import { expect, type Page, test } from "@playwright/test";
+
+test.use({ viewport: { width: 375, height: 812 } });
+
+const TURN_TIMEOUT = 20_000;
+
+/** Page-level horizontal overflow in px (0 = none). */
+function horizontalOverflow(page: Page): Promise<number> {
+	return page.evaluate(() => {
+		const root = document.documentElement;
+		return Math.max(
+			root.scrollWidth - root.clientWidth,
+			document.body.scrollWidth - root.clientWidth,
+		);
+	});
+}
+
+async function expectNoHorizontalScroll(page: Page, where: string): Promise<void> {
+	expect(await horizontalOverflow(page), `horizontal overflow ${where}`).toBe(0);
+}
+
+async function createSession(page: Page): Promise<void> {
+	await page.goto("/");
+	const picker = page.getByTestId("new-session-picker");
+	if (!(await picker.isVisible())) {
+		await page.getByRole("button", { name: "+ new session" }).click();
+	}
+	await page
+		.getByRole("textbox", { name: "Repository (owner/name)" })
+		.fill("fairchild/workspaces");
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(/\/sessions\/[0-9a-f-]{36}$/);
+}
+
+test("transcript + compose hold up at 375px through a full turn, with no horizontal scroll", async ({
+	page,
+}) => {
+	await createSession(page);
+	await expectNoHorizontalScroll(page, "on the empty session");
+
+	// Compose is usable: autofocused, and the send affordance is in reach.
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await expect(compose).toBeFocused();
+	await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+
+	// Stream a full mock turn — prose, reasoning, four ledger rows, receipt.
+	await compose.fill("Fix the failing session test");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("turn-stats")).toContainText("4 tools", {
+		timeout: TURN_TIMEOUT,
+	});
+	await expectNoHorizontalScroll(page, "after the streamed turn");
+
+	// Open the widest content the transcript renders: the landed edit's diff
+	// and the highlighted test output. Each scrolls inside its own panel.
+	const rows = page.getByTestId("tool-row");
+	await rows.nth(2).locator("button").first().click();
+	await expect(rows.nth(2).getByTestId("diff-lines")).toBeVisible();
+	await rows.nth(3).locator("button").first().click();
+	await expect(page.getByTestId("test-output")).toBeVisible();
+	await expectNoHorizontalScroll(page, "with diff + test output expanded");
+
+	// The thinking block expands and reads within the frame too.
+	await page.getByTestId("reasoning").locator("button").first().click();
+	await expectNoHorizontalScroll(page, "with the reasoning block open");
+
+	// Compose still works after the turn: a draft types cleanly at 375px.
+	await compose.click();
+	await compose.fill("And now add a regression test for it");
+	await expect(compose).toHaveValue("And now add a regression test for it");
+	await expectNoHorizontalScroll(page, "with a draft in compose");
+});
+
+test("the failure card fits and stays actionable at 375px", async ({ page }) => {
+	await createSession(page);
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await compose.fill("Build it __mock_provision_error__");
+	await page.keyboard.press("Enter");
+
+	await expect(page.getByTestId("turn-failure")).toContainText(
+		"Sandbox provisioning failed",
+		{ timeout: TURN_TIMEOUT },
+	);
+	await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+	await expectNoHorizontalScroll(page, "with the failure card shown");
+});
+
+test("home renders within 375px", async ({ page }) => {
+	await page.goto("/");
+	await expectNoHorizontalScroll(page, "on the sessions home");
+});

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -116,13 +116,15 @@ test("sending a message streams a mock coding turn into the Folio transcript", a
 	await compose.fill("Fix the failing session test");
 	await page.keyboard.press("Enter");
 
-	// The user message lands at once; compose clears and holds while busy.
+	// The user message lands at once; compose clears and holds while busy —
+	// the send affordance becomes the stop control for the in-flight turn (#753).
 	await expect(page.locator('[data-message-role="user"]')).toContainText(
 		"Fix the failing session test",
 	);
 	await expect(page.getByTestId("empty-transcript")).toHaveCount(0);
 	await expect(compose).toHaveValue("");
-	await expect(page.getByRole("button", { name: "Send" })).toBeDisabled();
+	await expect(page.getByRole("button", { name: "Send" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
 
 	// The activity line breathes while the provider provisions.
 	await expect(page.getByTestId("activity-line")).toBeVisible();


### PR DESCRIPTION
Closes #753

## What this does

**Sandbox state, truthfully.** The session masthead now reports the sandbox's verified state — `sandbox live` (green halo dot) / `sandbox parked` / `no sandbox` — from a new `GET /api/sessions/[id]/sandbox` that checks the platform (`Sandbox.get` with `resume: false`, so looking never resurrects anything). The label is a checked fact, not a guess: re-verified on arrival, on focus, on a 10s cadence while a turn runs (the turn is what births the VM), at the settle edge, and every 60s while a VM exists. A verdict that can't be re-verified for two consecutive checks recedes to absence rather than staying up as a claim nothing can back. SSR renders no state at all until the first verdict.

**Honest controls only — and why pause is omitted.** The platform truth (`@vercel/sandbox` 2.4.0, verified against the installed `sandbox.d.ts`): a Sandbox has `stop()` (ends the VM, optionally snapshotting) and implicit resume via `Sandbox.get`/`withResume` on next use. There is **no pause/freeze API** — session statuses are `failed | aborted | pending | running | stopping | stopped | snapshotting`, with nothing between running and stopped. A pause button would be fake, so it doesn't exist here; the issue's own bar is "controls reflect reality". What ships:

- **Stop the in-flight turn** — while a turn streams, the compose's send affordance becomes the stop (same footprint, honest verb). `POST /api/sessions/[id]/stop` aborts the ingest loop via an `AbortController` raced against the provider iterator (`nextOrAborted`), which closes the turn durably with `error "Turn stopped." + aborted done` — the same failure shape live tails, reloads, and #929's card already render. A stale turn (dead runner) is closed through the existing transactional `appendEventsIfTurnOpen` path; a turn running on **another server instance** is refused with an honest 409 rather than closing a log a foreign writer is still appending to, and the client surfaces the refusal as an activity step.
- **Stop the live VM** — a quiet hover-revealed `stop` beside the masthead state label (only when live and no turn is running); `DELETE /api/sessions/[id]/sandbox` calls `sandbox.stop()` and reports the state that's actually left. Idempotent: stopping a parked/gone sandbox changes nothing and says so.

**First-class error surfaces.** Three deterministic injection seams in the mock provider, each failing at the point and through the mechanism its real counterpart would, all rendering through #929's TurnFailure card with Retry (each trigger spends once per session, so Retry succeeds):

| Class | Trigger | Mechanism |
|---|---|---|
| Provisioning failure | `__mock_provision_error__` | throws before any content — the card is the whole reply |
| Sandbox died mid-turn | `__mock_sandbox_died__` | throws after prose + a tool call — streamed work survives above the card |
| Stream error | `__mock_stream_error__` | emits a structured `error` **chunk** and ends without `done` — exercises the adapter's error path, not the ingest catch |

**Mobile 375px.** Turn frames tighten below `sm`, prose word-breaks (long tokens wrap instead of forcing the page sideways), ledger subjects truncate in place, the agent name yields to the sandbox state in the masthead. Desktop (≥640px) is pixel-unchanged. A Playwright 375px spec walks home → compose → a full streamed turn → expanded diff/test-output/reasoning and asserts **zero page-level horizontal overflow** at every step.

## Review loop

Self-reflection fix (pre-codex): out-of-order sandbox-state responses could let a stale verdict overwrite a fresher one — monotonic fetch sequencing added (a2f67d0d).

codex (gpt-5.5, xhigh), directed at state truthfulness, stop races, and desktop regression:

1. **blocker — "no sandbox" persists across a running vercel turn.** Accepted; fixed in 95f5d779 (10s in-turn refresh cadence + entry-edge check).
2. **major — failed refreshes keep "live" up indefinitely.** Accepted; fixed in 95f5d779 (verdict recedes to absence after 2 consecutive failed checks).
3. **blocker — stale-close can race a quiet-but-alive foreign runner.** Declined as this PR's scope: the stop route reuses the pre-existing `closeAbandonedTurn`/`STALE_TURN_MS` machinery (turn-tail.ts, untouched here) that the resume GET and next-send paths already invoke; the append-after-close hazard is the documented #811 serialization boundary ("full serialization would need a DB reservation"). This diff adds a caller, not the boundary.
4. **major — stop leaves a stale resume handle while the sandbox is being destroyed.** Declined: the provider's resume path is self-healing by design (`createSession(resumeFrom)` failure → "Previous sandbox expired — starting fresh", plus the name-collision fallback), so the worst case is one fresh boot; clearing the handle on stop would instead orphan a live sandbox when the abort lands before the provider's try/finally is entered.
5. **major — a shown stop control can be refused (foreign runner) as a silent click.** Accepted; fixed in 95f5d779 (refusal lands as an activity step "Stop unavailable — …", no new chrome). Known residual: if the resumed reply already streams content, the activity line isn't rendered and the step stays invisible — noted below.

codex found no defect in the same-process abort/terminal-event path and no desktop regression from the mobile CSS.

## Evidence

Tests passed:
- `pnpm run lint` + `pnpm run typecheck` — clean
- `pnpm run test` — **368 passed (368)**, 34 files (adds turn-stop, sandbox-state, and mock-provider trigger suites)
- `pnpm run test:e2e` — **38 passed** (adds `errors.spec.ts` — one test per injected error class + the stop flow + the truthful-state surface — and `mobile.spec.ts`, in a new `lifecycle` project sequenced after the table-wiping sessions suite)
- `pnpm run perf` — all budgets pass, no regression (ttft 693/1050ms · session first-load 188.8/200kB · lcp 44/140ms · tbt 0/0 · resume 144/450ms)
- Mutation check (2 behaviors): deleting the `closed` guard in `ingestTurn` fails 2 turn-stop tests; inverting the live-status check in `stopSessionSandbox` fails 2 sandbox-state tests. Both restored, suite green.

Screenshots (both themes):

| State | Light | Dark |
|---|---|---|
| Provisioning failure | ![provisioning-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232427-session-error-provisioning-light.png) | ![provisioning-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232428-session-error-provisioning-dark.png) |
| Sandbox died mid-turn | ![died-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232429-session-error-sandbox-died-light.png) | ![died-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232429-session-error-sandbox-died-dark.png) |
| Stream error | ![stream-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232430-session-error-stream-light.png) | ![stream-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232431-session-error-stream-dark.png) |
| Stop control mid-stream | ![stopping-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232431-session-turn-stopping-light.png) | ![stopping-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232432-session-turn-stopping-dark.png) |
| Stopped turn ("Turn stopped." + Retry) | ![stopped-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232432-session-turn-stopped-light.png) | ![stopped-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232433-session-turn-stopped-dark.png) |
| 375px — full turn | ![mobile-turn-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232433-session-mobile-turn-light.png) | ![mobile-turn-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232434-session-mobile-turn-dark.png) |
| 375px — expanded diff | ![mobile-diff-light](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232434-session-mobile-diff-light.png) | ![mobile-diff-dark](https://evidence.cloudcompute.com/workspaces/pr-935/20260707-232435-session-mobile-diff-dark.png) |

- CI: green quality lane on 95f5d77: https://github.com/fairchild/workspaces/actions/runs/28905762148/job/85752384012
- Gate note: orchestrator spot-read both new routes (gate-first auth, honest 409 for cross-instance stops, idempotent sandbox DELETE) and the platform-truth call (no fake pause verbs — @vercel/sandbox 2.4.0 exposes stop()+implicit resume only, verified against installed types); codex foreground 3 fixed/2 declined-with-rationale; 2 mutation checks; 368/368 unit + 38/38 e2e + perf under ratcheted budgets; 14 evidence screenshots hosted. Fresh base. Merged on delegated authority.

## Mergeability

- Surface: web (web-next/ only — session masthead, compose, mock provider, turn ingest, three new API route surfaces, e2e + evidence harnesses)
- User-facing behavior changed: Yes — masthead shows verified sandbox state with a stop-VM action; the compose send affordance becomes Stop while a turn streams; failed turns of three distinct classes render calm inline cards with Retry; 375px layouts tighten (desktop unchanged)
- Non-happy paths considered: stop racing the turn's natural finish (exactly-once terminal, unit-gated); provider fault after its own `done` (no second terminal); foreign-instance stop refused honestly (409 + activity step); sandbox-state fetch failures (verdict recedes to unknown, never flaps or lies); out-of-order state responses (monotonic seq); stopping an already-parked/gone sandbox (idempotent, reports reality); abort before the first chunk (failure card is the whole reply); each error trigger spends once so Retry succeeds
- Residual risk or follow-up: the "Stop unavailable" refusal step is invisible when the resumed reply already streams content (activity line not rendered) — acceptable for the rare serverless cross-instance case, candidate follow-up; sandbox state is a polled fact with up-to-10s/60s staleness windows by design; live/parked states aren't e2e-drivable without real Vercel credentials (unit-gated instead); codex finding 3 tracks the pre-existing #811 serialization boundary, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
