### PR TITLE
feat(web-next): validation W3 — real agentic turn probe (#818), reporting + scheduled lane (#819), authed flows close-out (#814)

### DIFF
--- a/.github/workflows/web-next-validate.yml
+++ b/.github/workflows/web-next-validate.yml
@@ -1,0 +1,122 @@
+name: Web Next Validate
+
+# Scheduled deployed-environment validation for web-next (#819): runs the full
+# staged suite (scripts/validate.mjs — reachability, posture, authenticated
+# flows, model sweep, deployed-safe e2e, and one real agentic coding turn)
+# against production daily, uploading the per-env JSON + Markdown report and
+# evidence screenshots as one artifact. Stage *failures* turn the run red;
+# credential/deployment-gap *skips* do not — the report names each skip.
+#
+# Preview validation has no stable origin to resolve without Vercel API access
+# (deploys are manual/label-driven — see web-next-preview.yml), so the
+# scheduled run targets prod only; a preview run is a workflow_dispatch with
+# its URL pasted into `target_url`.
+#
+# Spend note: each run includes one small real coding turn in a sandbox
+# (cents). The cadence lever is the cron below.
+
+on:
+  schedule:
+    - cron: "23 9 * * *"
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "Optional explicit target origin (e.g. a preview URL); defaults to production"
+        required: false
+        type: string
+      env_name:
+        description: "Environment label for the report/artifact when target_url is set"
+        required: false
+        default: "preview"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: web-next-validate
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate deployed web-next
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: web-next
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: pnpm/action-setup@02f6c237bd2518259fed6c71566509edfb3f2b74 # v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web-next/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm exec playwright --version | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-web-next-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Install Playwright system deps
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      # Secrets ride only in env vars: validate.mjs redacts them from any
+      # error text before it can reach the console, the JSON record, or the
+      # report (see redactSecrets in scripts/validate-core.mjs), and the
+      # deployed e2e seam turns Playwright traces off so no artifact embeds
+      # the session cookie or bypass header.
+      - name: Validate
+        id: run
+        env:
+          WEB_NEXT_VALIDATION_SESSION: ${{ secrets.WEB_NEXT_VALIDATION_SESSION }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          TARGET_URL: ${{ inputs.target_url }}
+          ENV_NAME: ${{ inputs.env_name }}
+        run: |
+          if [ -n "$TARGET_URL" ]; then
+            echo "env_name=${ENV_NAME:-preview}" >> "$GITHUB_OUTPUT"
+            pnpm validate --url "$TARGET_URL" --env "${ENV_NAME:-preview}"
+          else
+            echo "env_name=prod" >> "$GITHUB_OUTPUT"
+            pnpm validate --env prod
+          fi
+
+      - name: Report to job summary
+        if: always()
+        env:
+          ENV_NAME: ${{ steps.run.outputs.env_name || 'prod' }}
+        run: |
+          report="output/validate/$ENV_NAME/report.md"
+          if [ -f "$report" ]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report was written (the run failed before the reporter)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload validation artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: web-next-validate
+          path: web-next/output/validate/
+          if-no-files-found: warn

--- a/web-next/.env.local.example
+++ b/web-next/.env.local.example
@@ -36,3 +36,10 @@ GITHUB_APP_PRIVATE_KEY=
 # HMAC secret for the in-sandbox ttyd path token; optional — falls back to
 # BETTER_AUTH_SECRET (see docs/terminal-access.md):
 # TTYD_TOKEN_SECRET=
+
+# --- Validation identity (#814) — driving DEPLOYED envs with scripts/validate.mjs ---
+# Pre-minted Better Auth session token for the allowlisted validation identity
+# (replayed as the session cookie; see docs/decisions/web-next-validation-identity.md):
+# WEB_NEXT_VALIDATION_SESSION=
+# Vercel Protection Bypass for Automation — clears deployment-protection SSO on previews:
+# VERCEL_AUTOMATION_BYPASS_SECRET=

--- a/web-next/docs/deploy.md
+++ b/web-next/docs/deploy.md
@@ -66,3 +66,18 @@ Notes:
   list must include `<BETTER_AUTH_URL>/api/auth/callback/github`.
 - Exact runtime var names are finalized when #750 lands; this is the canonical set
   to provision against.
+
+## Validation identity (#814)
+
+`scripts/validate.mjs` drives *deployed* environments with two credentials —
+never committed, present in GitHub Actions secrets (for
+`.github/workflows/web-next-validate.yml`) and the local `.env`. Full
+rationale: `docs/decisions/web-next-validation-identity.md` (repo root).
+
+| Variable | Purpose |
+|---|---|
+| `WEB_NEXT_VALIDATION_SESSION` | Pre-minted Better Auth session token for the allowlisted validation identity; replayed as the session cookie (`__Secure-better-auth.session_token` on https targets). Expiry degrades authed stages to `skipped: validation session expired — re-seed`. |
+| `VERCEL_AUTOMATION_BYPASS_SECRET` | Vercel Protection Bypass for Automation (`x-vercel-protection-bypass` header) — clears deployment-protection SSO on previews; production is publicly reachable without it. |
+
+A run missing either reports the affected stages as explicit skips — validation
+never silently passes an environment it couldn't actually reach or sign into.

--- a/web-next/scripts/real-turn-core.mjs
+++ b/web-next/scripts/real-turn-core.mjs
@@ -1,0 +1,315 @@
+/*
+ * Pure logic for the #818 real-agentic-turn validation stage: the probe
+ * prompt/title, the gate classifiers (preflight, create), the event-log
+ * assertions, the teardown/leak semantics, and the orchestrating
+ * `runRealTurnProbe` — which takes an injected API client so the teardown
+ * guarantee (delete the probe session even when an assertion throws) is
+ * unit-testable without a network. I/O lives in real-turn.mjs.
+ */
+
+/** One probe file the scripted turn writes; nonce makes each run verifiable. */
+export const PROBE_FILE = "VALIDATION-PROBE.md";
+
+export function buildProbeTitle(nowIso) {
+	return `validation: real-turn probe ${nowIso}`;
+}
+
+/**
+ * The scripted coding change, kept tiny (one file write + one cat) so a
+ * scheduled run costs cents: the nonce in the file content is what the log
+ * assertions later look for in tool output/diffs, proving the change actually
+ * landed in the sandbox workspace rather than being narrated.
+ */
+export function buildProbePrompt(nonce) {
+	return [
+		`Create a file named ${PROBE_FILE} at the repository root containing exactly one line:`,
+		"",
+		`real-turn probe ${nonce}`,
+		"",
+		`Then run \`cat ${PROBE_FILE}\` to show its content. Do not commit, push, or open a pull request. Do not do anything else.`,
+	].join("\n");
+}
+
+/**
+ * Interprets `/api/diag/preflight` (cheap, no sandbox spin-up) as the stage's
+ * runtime-credential gate. Only a failing env-presence check is a *skip* — a
+ * target that was never provisioned for the real runtime. Any other failing
+ * check (model inference, GitHub App, Vercel access) means the target claims
+ * the credentials but they don't work: a real finding, reported as `fail`.
+ */
+export function classifyPreflightGate(probe) {
+	if (probe.status === 401 || probe.status === 403) {
+		return { skip: true, reason: "validation session expired — re-seed" };
+	}
+	if (probe.status === 404) {
+		return {
+			skip: true,
+			reason: "target has no /api/diag/preflight — deployment predates the real runtime",
+		};
+	}
+	if (probe.status === 200) return { ok: true };
+	const checks = Array.isArray(probe.body?.checks) ? probe.body.checks : [];
+	const failing = checks.filter((c) => c.ok === false);
+	const envCheck = failing.find((c) => /env/i.test(String(c.name)));
+	if (probe.status === 503 && envCheck) {
+		// Missing credentials cascade into the dependent checks; the env check
+		// is the root cause worth naming.
+		return {
+			skip: true,
+			reason: `target runtime not provisioned: ${envCheck.error ?? JSON.stringify(envCheck.detail ?? {})}`,
+		};
+	}
+	return {
+		fail: true,
+		detail:
+			failing.length > 0
+				? `preflight failing checks: ${failing.map((c) => `${c.name}: ${c.error ?? "failed"}`).join("; ")}`
+				: `preflight → HTTP ${probe.status}`,
+	};
+}
+
+/**
+ * Interprets the create-session response as a gate. A 404/405 means the
+ * target deployment predates these routes (web-next deploys are manual, so
+ * prod can lag main) — a deployment-gap skip, not an app failure. Auth
+ * bounces skip with the shared expired-session wording.
+ */
+export function classifyCreateGate(probe) {
+	if (probe.status === 404 || probe.status === 405) {
+		return {
+			skip: true,
+			reason: "target has no POST /api/sessions — deploy a revision with the #818 probe routes",
+		};
+	}
+	if (probe.status === 401 || probe.status === 403) {
+		return { skip: true, reason: "validation session expired — re-seed" };
+	}
+	return { ok: true };
+}
+
+function check(id, pass, detail) {
+	return { id, status: pass ? "pass" : "fail", detail };
+}
+
+/** The created session must start on the app's DEFAULT model (assertion 1). */
+export function checkDefaultModel(created, defaultModel) {
+	return check(
+		"session_default_model",
+		created?.model === defaultModel,
+		`created session model ${JSON.stringify(created?.model)} (default: ${defaultModel})`,
+	);
+}
+
+const isAssistant = (e) => e.role === "assistant";
+
+/**
+ * The event-log assertions over the durable projection (GET
+ * /api/sessions/[id] events, StreamChunk-shaped). `events` may be a partial
+ * log when the poll deadline passed — every assertion then reports what it
+ * saw, so a hung turn fails with detail instead of a bare timeout.
+ */
+export function evaluateRealTurnEvents(events, nonce, { deadlineMs } = {}) {
+	const checks = [];
+	const assistant = events.filter(isAssistant);
+
+	const statuses = assistant.filter((e) => e.kind === "status");
+	const bootStatus = statuses.find((e) =>
+		/booting claude code in sandbox|resuming session/i.test(e.content ?? ""),
+	);
+	checks.push(
+		check(
+			"sandbox_created",
+			!!bootStatus,
+			bootStatus
+				? `sandbox lifecycle observed: ${JSON.stringify(bootStatus.content)}`
+				: `no sandbox boot/resume status event (saw: ${statuses.map((e) => JSON.stringify(e.content)).join(", ") || "none"})`,
+		),
+	);
+
+	const streamed = assistant.filter(
+		(e) => (e.kind === "text" || e.kind === "reasoning") && (e.content ?? "").length > 0,
+	);
+	checks.push(
+		check(
+			"streamed_output",
+			streamed.length > 0,
+			`${streamed.length} text/reasoning event(s) in the durable log`,
+		),
+	);
+
+	const toolUses = assistant.filter((e) => e.kind === "tool_use");
+	const resultWithNonce = assistant.find(
+		(e) => e.kind === "tool_result" && (e.content ?? "").includes(nonce),
+	);
+	const diffWithNonce = assistant.find(
+		(e) =>
+			e.kind === "tool_result" &&
+			e.metadata?.diff &&
+			JSON.stringify(e.metadata.diff).includes(nonce),
+	);
+	const inputWithFile = toolUses.find((e) =>
+		JSON.stringify(e.metadata?.input ?? {}).includes(PROBE_FILE),
+	);
+	checks.push(
+		check(
+			"coding_change_landed",
+			!!(resultWithNonce || diffWithNonce),
+			resultWithNonce
+				? `tool output carries the nonce (via ${toolUses.length} tool call(s))`
+				: diffWithNonce
+					? "workspace diff carries the nonce"
+					: `no tool output or diff contains the nonce (${toolUses.length} tool call(s)${inputWithFile ? `, an input names ${PROBE_FILE}` : ""})`,
+		),
+	);
+
+	const errors = assistant.filter((e) => e.kind === "error");
+	checks.push(
+		check(
+			"no_turn_errors",
+			errors.length === 0,
+			errors.length === 0
+				? "no error events"
+				: `error event(s): ${errors.map((e) => JSON.stringify((e.content ?? "").slice(0, 200))).join("; ")}`,
+		),
+	);
+
+	const done = assistant.find((e) => e.kind === "done");
+	const aborted = done?.metadata?.aborted === true;
+	checks.push(
+		check(
+			"turn_done",
+			!!done && !aborted,
+			done
+				? aborted
+					? "turn closed as aborted (synthesized terminal after a failure)"
+					: `terminal done arrived (durationMs=${done.metadata?.durationMs ?? "?"})`
+				: `no terminal done${deadlineMs ? ` within ${Math.round(deadlineMs / 1000)}s — the in-flight sandbox will expire at its own lifetime cap` : ""}`,
+		),
+	);
+
+	return checks;
+}
+
+/**
+ * The no-leak verdict from the DELETE response (assertion 6). `parked` is the
+ * session's post-turn resume state: a parked session must yield a stopped (or
+ * already-expired) sandbox; an unparked one has nothing to stop. A 502
+ * `stop-failed` is the leak — a live sandbox we could neither stop nor
+ * disprove — and any other non-2xx leaves the probe session behind, which is
+ * litter and equally a failure.
+ */
+export function classifyTeardown(parked, del) {
+	if (del.status === 200 && del.body?.deleted === true) {
+		const sandbox = del.body.sandbox;
+		const ok = parked
+			? sandbox === "stopped" || sandbox === "expired"
+			: sandbox === "none" || sandbox === "stopped" || sandbox === "expired";
+		return check(
+			"no_leaked_sandbox",
+			ok,
+			`session deleted; sandbox disposition: ${sandbox}${parked ? " (session was parked)" : ""}`,
+		);
+	}
+	if (del.status === 502 && del.body?.sandbox === "stop-failed") {
+		return check(
+			"no_leaked_sandbox",
+			false,
+			`LEAK: live sandbox could not be stopped — ${del.body.error ?? "no detail"} (session retained for retry)`,
+		);
+	}
+	return check(
+		"no_leaked_sandbox",
+		false,
+		`probe session not deleted: DELETE → HTTP ${del.status} ${JSON.stringify(del.body ?? {}).slice(0, 200)}`,
+	);
+}
+
+const hasDone = (events) =>
+	events.some((e) => e.role === "assistant" && e.kind === "done");
+
+/**
+ * Orchestrates one probe: create (default model) → send the scripted turn →
+ * poll the durable log until its terminal `done` (or the deadline) → assert →
+ * ALWAYS tear down. The client is injected:
+ *   createSession({title, provider}) / sendChat(id, text) /
+ *   getSession(id) / deleteSession(id)
+ * each resolving `{ status, body }` (body JSON-parsed or undefined) and never
+ * throwing for HTTP errors. Teardown runs in a `finally`, so a thrown
+ * assertion or client fault can't leak the probe session; the teardown check
+ * is appended even on that path so the report shows what happened to it.
+ */
+export async function runRealTurnProbe(client, options) {
+	const {
+		nonce,
+		defaultModel,
+		nowIso = new Date().toISOString(),
+		deadlineMs = 480_000,
+		pollMs = 3_000,
+		sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+		now = Date.now,
+	} = options;
+
+	const created = await client.createSession({
+		title: buildProbeTitle(nowIso),
+		provider: "vercel",
+	});
+	const gate = classifyCreateGate(created);
+	if (gate.skip) return { status: "skip", reason: gate.reason };
+
+	const checks = [];
+	if (created.status !== 201 || !created.body?.id) {
+		return {
+			status: "run",
+			checks: [
+				check(
+					"session_created",
+					false,
+					`POST /api/sessions → HTTP ${created.status} ${JSON.stringify(created.body ?? {}).slice(0, 200)}`,
+				),
+			],
+		};
+	}
+	const sessionId = created.body.id;
+	checks.push(check("session_created", true, `probe session ${sessionId}`));
+	checks.push(checkDefaultModel(created.body, defaultModel));
+
+	let parked = false;
+	try {
+		const chat = await client.sendChat(sessionId, buildProbePrompt(nonce));
+		if (chat.status !== 200) {
+			checks.push(
+				check(
+					"turn_started",
+					false,
+					`POST chat → HTTP ${chat.status} ${JSON.stringify(chat.body ?? {}).slice(0, 200)}`,
+				),
+			);
+			return { status: "run", checks };
+		}
+		checks.push(check("turn_started", true, "chat accepted, turn streaming"));
+
+		let events = [];
+		const deadline = now() + deadlineMs;
+		while (now() < deadline) {
+			const res = await client.getSession(sessionId);
+			if (res.status === 200 && Array.isArray(res.body?.events)) {
+				events = res.body.events;
+				if (hasDone(events)) {
+					parked = res.body.session?.parked === true;
+					break;
+				}
+			}
+			await sleep(pollMs);
+		}
+		checks.push(...evaluateRealTurnEvents(events, nonce, { deadlineMs }));
+	} finally {
+		let del;
+		try {
+			del = await client.deleteSession(sessionId);
+		} catch (error) {
+			del = { status: 0, body: { error: String(error) } };
+		}
+		checks.push(classifyTeardown(parked, del));
+	}
+	return { status: "run", checks };
+}

--- a/web-next/scripts/real-turn-core.mjs
+++ b/web-next/scripts/real-turn-core.mjs
@@ -191,16 +191,28 @@ export function evaluateRealTurnEvents(events, nonce, { deadlineMs } = {}) {
 }
 
 /**
- * The no-leak verdict from the DELETE response (assertion 6). `parked` is the
- * session's post-turn resume state: a parked session must yield a stopped (or
- * already-expired) sandbox; an unparked one has nothing to stop. A 502
- * `stop-failed` is the leak — a live sandbox we could neither stop nor
- * disprove — and any other non-2xx leaves the probe session behind, which is
- * litter and equally a failure.
+ * The no-leak verdict from the DELETE response (assertion 6). `state` is what
+ * the probe observed: `turnCompleted` (a terminal done landed) and `parked`
+ * (the session held a resume handle afterward). A turn that never closed can
+ * have a live UNPARKED sandbox no disposition can vouch for (nothing was
+ * persisted to find it by — codex finding, gpt-5.5 xhigh), so only a
+ * completed turn can pass; then a parked session must yield a stopped (or
+ * already-expired) sandbox and an unparked one has nothing to stop. A 502
+ * (`stop-failed`/`unreachable`) is the leak — a live sandbox we could neither
+ * stop nor disprove — and any other non-2xx leaves the probe session behind,
+ * which is litter and equally a failure.
  */
-export function classifyTeardown(parked, del) {
+export function classifyTeardown(state, del) {
+	const { parked, turnCompleted } = state;
 	if (del.status === 200 && del.body?.deleted === true) {
 		const sandbox = del.body.sandbox;
+		if (!turnCompleted) {
+			return check(
+				"no_leaked_sandbox",
+				false,
+				`session deleted but the turn never closed — an unparked live sandbox may persist until its lifetime cap (disposition: ${sandbox})`,
+			);
+		}
 		const ok = parked
 			? sandbox === "stopped" || sandbox === "expired"
 			: sandbox === "none" || sandbox === "stopped" || sandbox === "expired";
@@ -210,11 +222,11 @@ export function classifyTeardown(parked, del) {
 			`session deleted; sandbox disposition: ${sandbox}${parked ? " (session was parked)" : ""}`,
 		);
 	}
-	if (del.status === 502 && del.body?.sandbox === "stop-failed") {
+	if (del.status === 502 && (del.body?.sandbox === "stop-failed" || del.body?.sandbox === "unreachable")) {
 		return check(
 			"no_leaked_sandbox",
 			false,
-			`LEAK: live sandbox could not be stopped — ${del.body.error ?? "no detail"} (session retained for retry)`,
+			`LEAK: live sandbox could not be released — ${del.body.error ?? "no detail"} (session retained for retry)`,
 		);
 	}
 	return check(
@@ -258,13 +270,20 @@ export async function runRealTurnProbe(client, options) {
 
 	const checks = [];
 	if (created.status !== 201 || !created.body?.id) {
+		// A status-0 create is a client-side fault; the create may still have
+		// landed server-side, so name the possible litter instead of implying
+		// there is nothing to clean (codex finding, gpt-5.5 xhigh).
+		const litterNote =
+			created.status === 0
+				? " (request failed client-side — if the create landed anyway, a probe-titled session may remain)"
+				: "";
 		return {
 			status: "run",
 			checks: [
 				check(
 					"session_created",
 					false,
-					`POST /api/sessions → HTTP ${created.status} ${JSON.stringify(created.body ?? {}).slice(0, 200)}`,
+					`POST /api/sessions → HTTP ${created.status} ${JSON.stringify(created.body ?? {}).slice(0, 200)}${litterNote}`,
 				),
 			],
 		};
@@ -274,6 +293,8 @@ export async function runRealTurnProbe(client, options) {
 	checks.push(checkDefaultModel(created.body, defaultModel));
 
 	let parked = false;
+	let turnCompleted = false;
+	let aborted = false;
 	try {
 		const chat = await client.sendChat(sessionId, buildProbePrompt(nonce));
 		if (chat.status !== 200) {
@@ -284,6 +305,7 @@ export async function runRealTurnProbe(client, options) {
 					`POST chat → HTTP ${chat.status} ${JSON.stringify(chat.body ?? {}).slice(0, 200)}`,
 				),
 			);
+			aborted = true;
 			return { status: "run", checks };
 		}
 		checks.push(check("turn_started", true, "chat accepted, turn streaming"));
@@ -295,6 +317,7 @@ export async function runRealTurnProbe(client, options) {
 			if (res.status === 200 && Array.isArray(res.body?.events)) {
 				events = res.body.events;
 				if (hasDone(events)) {
+					turnCompleted = true;
 					parked = res.body.session?.parked === true;
 					break;
 				}
@@ -302,6 +325,13 @@ export async function runRealTurnProbe(client, options) {
 			await sleep(pollMs);
 		}
 		checks.push(...evaluateRealTurnEvents(events, nonce, { deadlineMs }));
+	} catch (error) {
+		// Never rethrow: an escaped client fault would otherwise discard every
+		// accumulated check — including the teardown verdict below — from the
+		// stage report (codex finding, gpt-5.5 xhigh).
+		checks.push(
+			check("probe_error", false, error instanceof Error ? error.message : String(error)),
+		);
 	} finally {
 		let del;
 		try {
@@ -309,7 +339,9 @@ export async function runRealTurnProbe(client, options) {
 		} catch (error) {
 			del = { status: 0, body: { error: String(error) } };
 		}
-		checks.push(classifyTeardown(parked, del));
+		// A probe aborted before its turn ever started has no turn to hold
+		// against the teardown — only the delete itself is asserted.
+		checks.push(classifyTeardown({ parked, turnCompleted: turnCompleted || aborted }, del));
 	}
 	return { status: "run", checks };
 }

--- a/web-next/scripts/real-turn-core.test.mjs
+++ b/web-next/scripts/real-turn-core.test.mjs
@@ -183,38 +183,51 @@ describe("checkDefaultModel", () => {
 });
 
 describe("classifyTeardown (leak semantics)", () => {
+	const done = (parked) => ({ parked, turnCompleted: true });
+
 	test("a parked session must yield a stopped or expired sandbox", () => {
 		expect(
-			classifyTeardown(true, { status: 200, body: { deleted: true, sandbox: "stopped" } }).status,
+			classifyTeardown(done(true), { status: 200, body: { deleted: true, sandbox: "stopped" } }).status,
 		).toBe("pass");
 		expect(
-			classifyTeardown(true, { status: 200, body: { deleted: true, sandbox: "expired" } }).status,
+			classifyTeardown(done(true), { status: 200, body: { deleted: true, sandbox: "expired" } }).status,
 		).toBe("pass");
 	});
 
 	test("an unparked session yields none", () => {
 		expect(
-			classifyTeardown(false, { status: 200, body: { deleted: true, sandbox: "none" } }).status,
+			classifyTeardown(done(false), { status: 200, body: { deleted: true, sandbox: "none" } }).status,
 		).toBe("pass");
 	});
 
 	test("a parked session whose sandbox reports none is suspicious — fail", () => {
 		expect(
-			classifyTeardown(true, { status: 200, body: { deleted: true, sandbox: "none" } }).status,
+			classifyTeardown(done(true), { status: 200, body: { deleted: true, sandbox: "none" } }).status,
 		).toBe("fail");
 	});
 
-	test("stop-failed is the leak — a live sandbox we could not stop", () => {
-		const verdict = classifyTeardown(true, {
-			status: 502,
-			body: { sandbox: "stop-failed", error: "api timeout" },
-		});
+	test("a turn that never closed cannot pass, even when the delete succeeds", () => {
+		const verdict = classifyTeardown(
+			{ parked: false, turnCompleted: false },
+			{ status: 200, body: { deleted: true, sandbox: "none" } },
+		);
 		expect(verdict.status).toBe("fail");
-		expect(verdict.detail).toMatch(/LEAK/);
+		expect(verdict.detail).toMatch(/never closed/);
+	});
+
+	test("stop-failed and unreachable are the leak — a live sandbox we could not release", () => {
+		for (const sandbox of ["stop-failed", "unreachable"]) {
+			const verdict = classifyTeardown(done(true), {
+				status: 502,
+				body: { sandbox, error: "api timeout" },
+			});
+			expect(verdict.status).toBe("fail");
+			expect(verdict.detail).toMatch(/LEAK/);
+		}
 	});
 
 	test("an undeleted probe session is litter and fails too", () => {
-		expect(classifyTeardown(false, { status: 500, body: {} }).status).toBe("fail");
+		expect(classifyTeardown(done(false), { status: 500, body: {} }).status).toBe("fail");
 	});
 });
 
@@ -288,7 +301,7 @@ describe("runRealTurnProbe", () => {
 		expect(log.some(([op]) => op === "delete")).toBe(true);
 	});
 
-	test("a client fault mid-poll still tears the session down, then rethrows", async () => {
+	test("a client fault mid-poll still tears down AND keeps every check in the report", async () => {
 		const log = [];
 		const client = {
 			...happyClient(log),
@@ -296,8 +309,13 @@ describe("runRealTurnProbe", () => {
 				throw new Error("network died");
 			},
 		};
-		await expect(runRealTurnProbe(client, options())).rejects.toThrow("network died");
+		const result = await runRealTurnProbe(client, options());
 		expect(log.some(([op]) => op === "delete")).toBe(true);
+		const byId = Object.fromEntries(result.checks.map((c) => [c.id, c]));
+		expect(byId.probe_error.status).toBe("fail");
+		expect(byId.probe_error.detail).toMatch(/network died/);
+		// The teardown verdict survives the fault instead of being replaced by it.
+		expect(byId.no_leaked_sandbox).toBeDefined();
 	});
 
 	test("a failed teardown is reported as the leak check, not thrown", async () => {
@@ -330,5 +348,8 @@ describe("runRealTurnProbe", () => {
 		const done = result.checks.find((c) => c.id === "turn_done");
 		expect(done.status).toBe("fail");
 		expect(log.some(([op]) => op === "delete")).toBe(true);
+		// An unclosed turn can hide a live unparked sandbox — the leak check
+		// must not read the delete's "none" as proof of cleanliness.
+		expect(result.checks.find((c) => c.id === "no_leaked_sandbox").status).toBe("fail");
 	});
 });

--- a/web-next/scripts/real-turn-core.test.mjs
+++ b/web-next/scripts/real-turn-core.test.mjs
@@ -1,0 +1,334 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildProbePrompt,
+	buildProbeTitle,
+	classifyCreateGate,
+	classifyPreflightGate,
+	classifyTeardown,
+	checkDefaultModel,
+	evaluateRealTurnEvents,
+	PROBE_FILE,
+	runRealTurnProbe,
+} from "./real-turn-core.mjs";
+
+const NONCE = "abc123deadbeef00";
+
+const ev = (role, kind, content = "", metadata = undefined) => ({
+	seq: 0,
+	role,
+	kind,
+	content,
+	metadata,
+});
+
+/** A complete, healthy turn as it lands in the durable log. */
+function happyEvents() {
+	return [
+		ev("user", "text", buildProbePrompt(NONCE)),
+		ev("assistant", "status", "Minting GitHub credential"),
+		ev("assistant", "status", "Booting Claude Code in sandbox"),
+		ev("assistant", "text", "Creating the probe file."),
+		ev("assistant", "tool_use", "Write", { input: { file_path: PROBE_FILE } }),
+		ev("assistant", "tool_result", `Wrote ${PROBE_FILE}`),
+		ev("assistant", "tool_use", "Bash", { input: { command: `cat ${PROBE_FILE}` } }),
+		ev("assistant", "tool_result", `real-turn probe ${NONCE}`),
+		ev("assistant", "done", "", { durationMs: 42000 }),
+	];
+}
+
+describe("probe prompt/title", () => {
+	test("prompt embeds the nonce and forbids PRs", () => {
+		const prompt = buildProbePrompt(NONCE);
+		expect(prompt).toContain(NONCE);
+		expect(prompt).toContain(PROBE_FILE);
+		expect(prompt).toMatch(/do not commit, push, or open a pull request/i);
+	});
+
+	test("title marks the session as a validation probe (the no-litter rule)", () => {
+		expect(buildProbeTitle("2026-07-07T00:00:00Z")).toBe(
+			"validation: real-turn probe 2026-07-07T00:00:00Z",
+		);
+	});
+});
+
+describe("classifyPreflightGate", () => {
+	test("auth bounce and missing route are skips", () => {
+		expect(classifyPreflightGate({ status: 401 })).toMatchObject({ skip: true });
+		expect(classifyPreflightGate({ status: 404 }).reason).toMatch(/predates/);
+	});
+
+	test("a 503 rooted in the env-presence check is a not-provisioned skip", () => {
+		const gate = classifyPreflightGate({
+			status: 503,
+			body: {
+				checks: [
+					{ name: "env", ok: false, error: "missing AI_GATEWAY_API_KEY" },
+					{ name: "model_inference", ok: false, error: "no key" },
+				],
+			},
+		});
+		expect(gate).toMatchObject({ skip: true });
+		expect(gate.reason).toMatch(/AI_GATEWAY_API_KEY/);
+	});
+
+	test("a 503 with env present is a real finding, not a skip", () => {
+		const gate = classifyPreflightGate({
+			status: 503,
+			body: {
+				checks: [
+					{ name: "env", ok: true },
+					{ name: "model_inference", ok: false, error: "gateway 500" },
+				],
+			},
+		});
+		expect(gate).toMatchObject({ fail: true });
+		expect(gate.detail).toMatch(/model_inference/);
+	});
+
+	test("200 runs the stage", () => {
+		expect(classifyPreflightGate({ status: 200 })).toEqual({ ok: true });
+	});
+});
+
+describe("classifyCreateGate", () => {
+	test("routes not deployed on the target is a skip, not a failure", () => {
+		expect(classifyCreateGate({ status: 404 }).skip).toBe(true);
+		expect(classifyCreateGate({ status: 405 }).skip).toBe(true);
+	});
+
+	test("auth bounce is the shared expired-session skip", () => {
+		expect(classifyCreateGate({ status: 401 }).reason).toMatch(/re-seed/);
+	});
+
+	test("anything else proceeds to hard assertions", () => {
+		expect(classifyCreateGate({ status: 201 })).toEqual({ ok: true });
+		expect(classifyCreateGate({ status: 500 })).toEqual({ ok: true });
+	});
+});
+
+describe("evaluateRealTurnEvents", () => {
+	test("a healthy turn passes all five assertions", () => {
+		const checks = evaluateRealTurnEvents(happyEvents(), NONCE);
+		expect(checks.map((c) => [c.id, c.status])).toEqual([
+			["sandbox_created", "pass"],
+			["streamed_output", "pass"],
+			["coding_change_landed", "pass"],
+			["no_turn_errors", "pass"],
+			["turn_done", "pass"],
+		]);
+	});
+
+	test("the nonce in a synthesized workspace diff also proves the change", () => {
+		const events = happyEvents().filter((e) => !(e.content ?? "").includes(NONCE));
+		events.splice(events.length - 1, 0, {
+			...ev("assistant", "tool_result", "", {
+				diff: { file: PROBE_FILE, lines: [{ kind: "add", text: `+real-turn probe ${NONCE}` }] },
+			}),
+		});
+		const change = evaluateRealTurnEvents(events, NONCE).find(
+			(c) => c.id === "coding_change_landed",
+		);
+		expect(change.status).toBe("pass");
+		expect(change.detail).toMatch(/diff/);
+	});
+
+	test("narration without tool output containing the nonce fails the change assertion", () => {
+		const events = happyEvents().map((e) =>
+			e.kind === "tool_result" ? { ...e, content: "done!" } : e,
+		);
+		const change = evaluateRealTurnEvents(events, NONCE).find(
+			(c) => c.id === "coding_change_landed",
+		);
+		expect(change.status).toBe("fail");
+	});
+
+	test("a user event containing the nonce (the prompt itself) is never evidence", () => {
+		const events = [ev("user", "text", `please write real-turn probe ${NONCE}`)];
+		const change = evaluateRealTurnEvents(events, NONCE).find(
+			(c) => c.id === "coding_change_landed",
+		);
+		expect(change.status).toBe("fail");
+	});
+
+	test("an errored turn fails no_turn_errors and an aborted done fails turn_done", () => {
+		const events = [
+			ev("assistant", "status", "Booting Claude Code in sandbox"),
+			ev("assistant", "error", "sandbox exploded"),
+			ev("assistant", "done", "", { aborted: true }),
+		];
+		const byId = Object.fromEntries(
+			evaluateRealTurnEvents(events, NONCE).map((c) => [c.id, c]),
+		);
+		expect(byId.no_turn_errors.status).toBe("fail");
+		expect(byId.no_turn_errors.detail).toMatch(/sandbox exploded/);
+		expect(byId.turn_done.status).toBe("fail");
+	});
+
+	test("a missing done reports the deadline and the sandbox lifetime cap", () => {
+		const done = evaluateRealTurnEvents([], NONCE, { deadlineMs: 480_000 }).find(
+			(c) => c.id === "turn_done",
+		);
+		expect(done.status).toBe("fail");
+		expect(done.detail).toMatch(/480s/);
+		expect(done.detail).toMatch(/lifetime cap/);
+	});
+});
+
+describe("checkDefaultModel", () => {
+	test("passes only when the created session carries the default", () => {
+		expect(checkDefaultModel({ model: "m1" }, "m1").status).toBe("pass");
+		expect(checkDefaultModel({ model: "m2" }, "m1").status).toBe("fail");
+		expect(checkDefaultModel(undefined, "m1").status).toBe("fail");
+	});
+});
+
+describe("classifyTeardown (leak semantics)", () => {
+	test("a parked session must yield a stopped or expired sandbox", () => {
+		expect(
+			classifyTeardown(true, { status: 200, body: { deleted: true, sandbox: "stopped" } }).status,
+		).toBe("pass");
+		expect(
+			classifyTeardown(true, { status: 200, body: { deleted: true, sandbox: "expired" } }).status,
+		).toBe("pass");
+	});
+
+	test("an unparked session yields none", () => {
+		expect(
+			classifyTeardown(false, { status: 200, body: { deleted: true, sandbox: "none" } }).status,
+		).toBe("pass");
+	});
+
+	test("a parked session whose sandbox reports none is suspicious — fail", () => {
+		expect(
+			classifyTeardown(true, { status: 200, body: { deleted: true, sandbox: "none" } }).status,
+		).toBe("fail");
+	});
+
+	test("stop-failed is the leak — a live sandbox we could not stop", () => {
+		const verdict = classifyTeardown(true, {
+			status: 502,
+			body: { sandbox: "stop-failed", error: "api timeout" },
+		});
+		expect(verdict.status).toBe("fail");
+		expect(verdict.detail).toMatch(/LEAK/);
+	});
+
+	test("an undeleted probe session is litter and fails too", () => {
+		expect(classifyTeardown(false, { status: 500, body: {} }).status).toBe("fail");
+	});
+});
+
+describe("runRealTurnProbe", () => {
+	const options = (over = {}) => ({
+		nonce: NONCE,
+		defaultModel: "model-default",
+		nowIso: "2026-07-07T00:00:00Z",
+		deadlineMs: 10,
+		pollMs: 1,
+		sleep: () => Promise.resolve(),
+		...over,
+	});
+
+	function happyClient(log = []) {
+		return {
+			createSession: async (body) => {
+				log.push(["create", body]);
+				return { status: 201, body: { id: "probe-1", model: "model-default" } };
+			},
+			sendChat: async (id, text) => {
+				log.push(["chat", id, text]);
+				return { status: 200 };
+			},
+			getSession: async (id) => {
+				log.push(["get", id]);
+				return {
+					status: 200,
+					body: { session: { parked: true }, events: happyEvents() },
+				};
+			},
+			deleteSession: async (id) => {
+				log.push(["delete", id]);
+				return { status: 200, body: { deleted: true, sandbox: "stopped" } };
+			},
+		};
+	}
+
+	test("happy path: every assertion passes and the probe session is deleted", async () => {
+		const log = [];
+		const result = await runRealTurnProbe(happyClient(log), options());
+		expect(result.status).toBe("run");
+		expect(result.checks.every((c) => c.status === "pass")).toBe(true);
+		expect(result.checks.map((c) => c.id)).toContain("no_leaked_sandbox");
+		expect(log.at(-1)[0]).toBe("delete");
+		// The probe session is titled as validation litter and runs on vercel.
+		expect(log[0][1]).toMatchObject({
+			title: "validation: real-turn probe 2026-07-07T00:00:00Z",
+			provider: "vercel",
+		});
+	});
+
+	test("routes missing on the target is a stage skip and creates nothing to clean", async () => {
+		const result = await runRealTurnProbe(
+			{ createSession: async () => ({ status: 404 }) },
+			options(),
+		);
+		expect(result).toMatchObject({ status: "skip" });
+	});
+
+	test("a rejected chat still tears the session down", async () => {
+		const log = [];
+		const client = {
+			...happyClient(log),
+			sendChat: async () => ({ status: 500, body: { error: "boom" } }),
+		};
+		const result = await runRealTurnProbe(client, options());
+		const ids = result.checks.map((c) => c.id);
+		expect(ids).toContain("turn_started");
+		expect(result.checks.find((c) => c.id === "turn_started").status).toBe("fail");
+		expect(log.some(([op]) => op === "delete")).toBe(true);
+	});
+
+	test("a client fault mid-poll still tears the session down, then rethrows", async () => {
+		const log = [];
+		const client = {
+			...happyClient(log),
+			getSession: async () => {
+				throw new Error("network died");
+			},
+		};
+		await expect(runRealTurnProbe(client, options())).rejects.toThrow("network died");
+		expect(log.some(([op]) => op === "delete")).toBe(true);
+	});
+
+	test("a failed teardown is reported as the leak check, not thrown", async () => {
+		const client = {
+			...happyClient(),
+			deleteSession: async () => {
+				throw new Error("delete route down");
+			},
+		};
+		const result = await runRealTurnProbe(client, options());
+		const leak = result.checks.find((c) => c.id === "no_leaked_sandbox");
+		expect(leak.status).toBe("fail");
+		expect(leak.detail).toMatch(/delete route down/);
+	});
+
+	test("a turn that never closes fails turn_done after the deadline (and still deletes)", async () => {
+		const log = [];
+		let t = 0;
+		const client = {
+			...happyClient(log),
+			getSession: async () => ({
+				status: 200,
+				body: { session: { parked: false }, events: [ev("assistant", "status", "Booting Claude Code in sandbox")] },
+			}),
+		};
+		const result = await runRealTurnProbe(
+			client,
+			options({ now: () => (t += 6), deadlineMs: 20 }),
+		);
+		const done = result.checks.find((c) => c.id === "turn_done");
+		expect(done.status).toBe("fail");
+		expect(log.some(([op]) => op === "delete")).toBe(true);
+	});
+});

--- a/web-next/scripts/real-turn.mjs
+++ b/web-next/scripts/real-turn.mjs
@@ -136,6 +136,14 @@ export async function realTurnStage(baseUrl, cookie, env, options = {}) {
 			defaultModel: DEFAULT_MODEL,
 			...options,
 		});
+		// Belt over the client's own redaction: no check detail reaches the
+		// console/JSON/report carrying a credential, whatever produced it.
+		if (result.checks) {
+			result.checks = result.checks.map((c) => ({
+				...c,
+				detail: redactSecrets(String(c.detail ?? ""), secretsToRedact(env)),
+			}));
+		}
 		return { id, ...result };
 	} catch (error) {
 		// The probe's own teardown already ran (its `finally`); an escaped error

--- a/web-next/scripts/real-turn.mjs
+++ b/web-next/scripts/real-turn.mjs
@@ -1,0 +1,155 @@
+/*
+ * I/O for the #818 real-agentic-turn validation stage: an HTTP client over
+ * the session APIs (create → chat → poll the durable log → delete) plus the
+ * stage wrapper validate.mjs calls. All verdict logic lives in
+ * real-turn-core.mjs; this file only moves bytes — every request carries the
+ * Vercel protection-bypass header when present, redacts secrets from any
+ * error text, and never throws on HTTP errors.
+ */
+import crypto from "node:crypto";
+import { DEFAULT_MODEL } from "../src/lib/agent-runtime/models.ts";
+import {
+	classifyPreflightGate,
+	runRealTurnProbe,
+} from "./real-turn-core.mjs";
+import { redactSecrets } from "./validate-core.mjs";
+
+/** Ordinary API calls; generous, but not the turn itself. */
+const REQUEST_TIMEOUT_MS = 30_000;
+/** The chat POST — the route's own maxDuration is 300s. */
+const CHAT_TIMEOUT_MS = 330_000;
+
+function secretsToRedact(env) {
+	return [env.VERCEL_AUTOMATION_BYPASS_SECRET, env.WEB_NEXT_VALIDATION_SESSION];
+}
+
+async function request(baseUrl, pathname, { cookie, env, timeoutMs = REQUEST_TIMEOUT_MS, ...init } = {}) {
+	const bypass = env.VERCEL_AUTOMATION_BYPASS_SECRET;
+	try {
+		const res = await fetch(`${baseUrl}${pathname}`, {
+			...init,
+			headers: {
+				...(bypass ? { "x-vercel-protection-bypass": bypass } : {}),
+				...(cookie ? { cookie } : {}),
+				...init.headers,
+			},
+			redirect: "manual",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		const text = await res.text().catch(() => "");
+		let body;
+		try {
+			body = JSON.parse(text);
+		} catch {
+			body = undefined;
+		}
+		return { status: res.status, body };
+	} catch (error) {
+		return {
+			status: 0,
+			body: { error: redactSecrets(String(error), secretsToRedact(env)) },
+		};
+	}
+}
+
+/** The injected client runRealTurnProbe drives (see real-turn-core.mjs). */
+export function createRealTurnClient(baseUrl, cookie, env) {
+	return {
+		createSession: (body) =>
+			request(baseUrl, "/api/sessions", {
+				cookie,
+				env,
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			}),
+		sendChat: async (id, text) => {
+			// The chat response streams the turn; the durable log is what the
+			// probe asserts on, so the body is consumed and discarded — reading
+			// it keeps the connection (and a serverless invocation) alive while
+			// the poll below follows the log.
+			const bypass = env.VERCEL_AUTOMATION_BYPASS_SECRET;
+			try {
+				const res = await fetch(`${baseUrl}/api/sessions/${id}/chat`, {
+					method: "POST",
+					headers: {
+						...(bypass ? { "x-vercel-protection-bypass": bypass } : {}),
+						...(cookie ? { cookie } : {}),
+						"content-type": "application/json",
+					},
+					body: JSON.stringify({ text }),
+					redirect: "manual",
+					signal: AbortSignal.timeout(CHAT_TIMEOUT_MS),
+				});
+				if (res.status !== 200) {
+					const text = await res.text().catch(() => "");
+					let body;
+					try {
+						body = JSON.parse(text);
+					} catch {
+						body = undefined;
+					}
+					return { status: res.status, body };
+				}
+				// Drain in the background; failures here are the stream ending.
+				res.text().catch(() => {});
+				return { status: 200, body: undefined };
+			} catch (error) {
+				return {
+					status: 0,
+					body: { error: redactSecrets(String(error), secretsToRedact(env)) },
+				};
+			}
+		},
+		getSession: (id) => request(baseUrl, `/api/sessions/${id}`, { cookie, env }),
+		deleteSession: (id) =>
+			request(baseUrl, `/api/sessions/${id}`, { cookie, env, method: "DELETE" }),
+	};
+}
+
+/**
+ * The stage: preflight-gate the target's runtime credentials (cheap, no
+ * sandbox), then run exactly one scripted coding turn and assert the six #818
+ * contract points from the durable log. Spend: one small real turn per run —
+ * the sanctioned cadence is the scheduled daily lane plus on-demand runs.
+ */
+export async function realTurnStage(baseUrl, cookie, env, options = {}) {
+	const id = "real agentic turn (#818)";
+	const preflight = await request(baseUrl, "/api/diag/preflight", {
+		cookie,
+		env,
+		timeoutMs: 120_000,
+	});
+	const gate = classifyPreflightGate(preflight);
+	if (gate.skip) return { id, status: "skip", reason: gate.reason };
+	if (gate.fail) {
+		return {
+			id,
+			status: "run",
+			checks: [{ id: "runtime_preflight", status: "fail", detail: gate.detail }],
+		};
+	}
+
+	try {
+		const result = await runRealTurnProbe(createRealTurnClient(baseUrl, cookie, env), {
+			nonce: crypto.randomBytes(8).toString("hex"),
+			defaultModel: DEFAULT_MODEL,
+			...options,
+		});
+		return { id, ...result };
+	} catch (error) {
+		// The probe's own teardown already ran (its `finally`); an escaped error
+		// becomes a failing check rather than crashing the whole run.
+		return {
+			id,
+			status: "run",
+			checks: [
+				{
+					id: "probe_crashed",
+					status: "fail",
+					detail: redactSecrets(String(error), secretsToRedact(env)),
+				},
+			],
+		};
+	}
+}

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -181,6 +181,46 @@ export function validationSessionCookieName(baseUrl) {
 }
 
 /**
+ * The cookie an authenticated stage sends, chosen by the target's observed
+ * auth mode: a bypass-mode target (local spawn / e2e server) accepts the test
+ * cookie with no credential at all, while a real-auth target needs the
+ * pre-minted validation session (#814). `null` means the stage can't
+ * authenticate and should gate itself with `gateStage`.
+ */
+export function authedCookie(mode, baseUrl, env) {
+	if (mode === "bypass") return "test-auth-login=fairchild";
+	if (!env.WEB_NEXT_VALIDATION_SESSION) return null;
+	return `${validationSessionCookieName(baseUrl)}=${env.WEB_NEXT_VALIDATION_SESSION}`;
+}
+
+/**
+ * #814's authenticated-flows check: an authenticated GET of an auth-gated,
+ * data-reading API (`/api/repos`) must answer 200 with the shape the client
+ * is built against. This proves the validation identity clears the full auth
+ * stack (middleware freshness + allowlist verdict) end to end.
+ */
+export function evaluateAuthedProbe(probe) {
+	const ok200 = probe.status === 200;
+	const body = probe.body;
+	const shapeOk =
+		!!body && Array.isArray(body.repos) && typeof body.degraded === "boolean";
+	return [
+		{
+			id: "authed_api_200",
+			status: ok200 ? "pass" : "fail",
+			detail: `GET /api/repos (authenticated) → ${probe.status}`,
+		},
+		{
+			id: "authed_api_shape",
+			status: ok200 && shapeOk ? "pass" : "fail",
+			detail: shapeOk
+				? `repos: ${body.repos.length}, degraded: ${body.degraded}`
+				: "response is not { repos: [...], degraded: boolean }",
+		},
+	];
+}
+
+/**
  * Replaces every occurrence of the given secret values in a string with a
  * placeholder. Probe/report text can otherwise carry a secret verbatim: a
  * malformed credential (say, a trailing newline from a sloppy copy-paste)
@@ -274,6 +314,80 @@ export function evaluateE2eResults(report) {
 			detail: `${spec.title} → ${statuses.join(", ")}`,
 		};
 	});
+}
+
+const STATUS_LABEL = {
+	pass: "✅ pass",
+	fail: "❌ FAIL",
+	skip: "⏭️ skipped",
+};
+
+function stageVerdict(stage) {
+	if (stage.status === "skip") return "skip";
+	return stage.checks.some((c) => c.status === "fail") ? "fail" : "pass";
+}
+
+const formatSeconds = (ms) =>
+	typeof ms === "number" ? `${(ms / 1000).toFixed(1)}s` : "—";
+
+/**
+ * The #819 human report: one Markdown document per run — stage table with
+ * timings, failing-check detail, skip reasons, and evidence paths — written
+ * alongside the JSON record and suitable verbatim as a PR/handoff note or a
+ * CI job summary. Pure renderer: callers gather the evidence file list.
+ */
+export function renderMarkdownReport(run) {
+	const { target, ranAt, stages, evidence = [] } = run;
+	const lines = [
+		`# web-next validation — ${target.envName}`,
+		"",
+		`Target: ${target.baseUrl} · ran ${ranAt} · total ${formatSeconds(
+			stages.reduce((sum, s) => sum + (s.tookMs ?? 0), 0),
+		)}`,
+		"",
+		"| Stage | Result | Checks | Took |",
+		"|---|---|---|---|",
+	];
+	for (const stage of stages) {
+		const verdict = stageVerdict(stage);
+		const checks =
+			stage.status === "skip"
+				? "—"
+				: `${stage.checks.filter((c) => c.status === "pass").length}/${stage.checks.length}`;
+		lines.push(
+			`| ${stage.id} | ${STATUS_LABEL[verdict]} | ${checks} | ${formatSeconds(stage.tookMs)} |`,
+		);
+	}
+
+	const skipped = stages.filter((s) => s.status === "skip");
+	if (skipped.length > 0) {
+		lines.push("", "## Skipped");
+		for (const stage of skipped) {
+			lines.push(`- **${stage.id}** — ${stage.reason}`);
+		}
+	}
+
+	const failing = stages.flatMap((stage) =>
+		(stage.checks ?? [])
+			.filter((c) => c.status === "fail")
+			.map((c) => ({ stage: stage.id, ...c })),
+	);
+	if (failing.length > 0) {
+		lines.push("", "## Failing checks");
+		for (const f of failing) {
+			lines.push(`- **${f.stage}** / \`${f.id}\`: ${f.detail}`);
+		}
+	}
+
+	if (evidence.length > 0) {
+		lines.push("", "## Evidence");
+		for (const file of evidence) {
+			lines.push(`- \`${file}\``);
+		}
+	}
+
+	lines.push("");
+	return lines.join("\n");
 }
 
 /** Collapses stage results into the exit verdict and the human summary lines. */

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -1,15 +1,18 @@
 import { describe, expect, test } from "vitest";
 import {
+	authedCookie,
 	classifyModelSweepGate,
 	DEFAULT_PROD_URL,
 	detectAuthMode,
 	detectSsoWall,
+	evaluateAuthedProbe,
 	evaluateE2eResults,
 	evaluateModelChecks,
 	evaluatePosture,
 	gateStage,
 	isRedirectToSignIn,
 	redactSecrets,
+	renderMarkdownReport,
 	resolveTarget,
 	summarize,
 	validationSessionCookieName,
@@ -279,5 +282,91 @@ describe("evaluateE2eResults (#817)", () => {
 				detail: "no deployed-safe specs matched — check the @deployed-safe grep tag",
 			},
 		]);
+	});
+});
+
+describe("authedCookie", () => {
+	test("bypass mode uses the test cookie with no credential gate", () => {
+		expect(authedCookie("bypass", "http://localhost:3101", {})).toBe(
+			"test-auth-login=fairchild",
+		);
+	});
+
+	test("real mode replays the validation session under the https cookie name", () => {
+		expect(
+			authedCookie("real", "https://x.vercel.app", { WEB_NEXT_VALIDATION_SESSION: "tok" }),
+		).toBe("__Secure-better-auth.session_token=tok");
+	});
+
+	test("real mode without the credential yields null (stage gates itself)", () => {
+		expect(authedCookie("real", "https://x.vercel.app", {})).toBeNull();
+	});
+});
+
+describe("evaluateAuthedProbe (#814)", () => {
+	test("200 with the client's shape passes both checks", () => {
+		const checks = evaluateAuthedProbe({ status: 200, body: { repos: [], degraded: false } });
+		expect(checks.map((c) => c.status)).toEqual(["pass", "pass"]);
+	});
+
+	test("200 with a foreign shape fails the shape check", () => {
+		const checks = evaluateAuthedProbe({ status: 200, body: { html: "<!doctype html>" } });
+		expect(checks.map((c) => c.status)).toEqual(["pass", "fail"]);
+	});
+
+	test("a non-200 fails both", () => {
+		const checks = evaluateAuthedProbe({ status: 500, body: undefined });
+		expect(checks.every((c) => c.status === "fail")).toBe(true);
+	});
+});
+
+describe("renderMarkdownReport (#819)", () => {
+	const run = {
+		target: { envName: "prod", baseUrl: "https://x.vercel.app" },
+		ranAt: "2026-07-07T00:00:00Z",
+		stages: [
+			{
+				id: "reachability",
+				status: "run",
+				tookMs: 400,
+				checks: [{ id: "signin_reachable", status: "pass", detail: "→ 200" }],
+			},
+			{ id: "authenticated flows (#814)", status: "skip", reason: "missing WEB_NEXT_VALIDATION_SESSION" },
+			{
+				id: "real agentic turn (#818)",
+				status: "run",
+				tookMs: 61_000,
+				checks: [
+					{ id: "session_created", status: "pass", detail: "probe session p1" },
+					{ id: "no_leaked_sandbox", status: "fail", detail: "LEAK: could not stop" },
+				],
+			},
+		],
+		evidence: ["output/validate/prod/test-results/home.png"],
+	};
+
+	test("renders the stage table with verdicts, counts, and timings", () => {
+		const md = renderMarkdownReport(run);
+		expect(md).toContain("# web-next validation — prod");
+		expect(md).toContain("| reachability | ✅ pass | 1/1 | 0.4s |");
+		expect(md).toContain("| authenticated flows (#814) | ⏭️ skipped | — | — |");
+		expect(md).toContain("| real agentic turn (#818) | ❌ FAIL | 1/2 | 61.0s |");
+	});
+
+	test("skips carry their reasons and failures their detail", () => {
+		const md = renderMarkdownReport(run);
+		expect(md).toContain("- **authenticated flows (#814)** — missing WEB_NEXT_VALIDATION_SESSION");
+		expect(md).toContain("- **real agentic turn (#818)** / `no_leaked_sandbox`: LEAK: could not stop");
+	});
+
+	test("evidence paths are listed", () => {
+		expect(renderMarkdownReport(run)).toContain("output/validate/prod/test-results/home.png");
+	});
+
+	test("an all-green run has no failing-checks section", () => {
+		const md = renderMarkdownReport({ ...run, stages: [run.stages[0]], evidence: [] });
+		expect(md).not.toContain("## Failing checks");
+		expect(md).not.toContain("## Skipped");
+		expect(md).not.toContain("## Evidence");
 	});
 });

--- a/web-next/scripts/validate.mjs
+++ b/web-next/scripts/validate.mjs
@@ -1,21 +1,25 @@
 /*
  * Environment-targetable validation: `pnpm validate [--env local|prod | --url
- * <origin>]` runs the credential-free stages — reachability, then the
- * auth/security posture suite — plus the credentialed model-sweep (#816) and
- * deployed-safe e2e (#817) stages, against a local spawn or a real
- * deployment, and reports pass/fail/skip per check (JSON to output/validate/,
- * exit 1 on any failure). Stages needing credentials gate themselves and
- * report `skipped: missing <name>` rather than silently passing. #813/#815;
- * the authenticated and agentic stages (#814/#818) still extend this.
+ * <origin>]` runs the full staged suite — reachability, the auth/security
+ * posture checks, authenticated flows (#814), the per-model gateway sweep
+ * (#816), deployed-safe e2e (#817), and one real agentic coding turn (#818,
+ * deployed targets; `--skip-real-turn` to opt out of the spend) — against a
+ * local spawn or a real deployment, and reports pass/fail/skip per check
+ * (JSON + a Markdown report under output/validate/, exit 1 on any failure).
+ * Stages needing credentials gate themselves and report `skipped: missing
+ * <name>` rather than silently passing.
  */
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { MODEL_OPTIONS } from "../src/lib/agent-runtime/models.ts";
+import { realTurnStage } from "./real-turn.mjs";
 import {
+	authedCookie,
 	classifyModelSweepGate,
 	detectAuthMode,
 	detectSsoWall,
+	evaluateAuthedProbe,
 	evaluateE2eResults,
 	evaluateModelChecks,
 	evaluatePosture,
@@ -23,6 +27,7 @@ import {
 	isRedirectToSignIn,
 	LOCAL_PORT,
 	redactSecrets,
+	renderMarkdownReport,
 	resolveTarget,
 	summarize,
 	validationSessionCookieName,
@@ -31,8 +36,10 @@ import { bypassServerEnv, startProductionServer, WEB_NEXT_ROOT } from "./harness
 
 const PROBE_TIMEOUT_MS = 15_000;
 
+const AUTHED_STAGE_ID = "authenticated flows (#814)";
 const MODEL_SWEEP_STAGE_ID = "model sweep (#816)";
 const E2E_STAGE_ID = "e2e deployed-safe flows (#817)";
+const REAL_TURN_STAGE_ID = "real agentic turn (#818)";
 
 /** A fetch that never follows redirects and never throws on HTTP errors.
  * When VERCEL_AUTOMATION_BYPASS_SECRET is set, every probe carries the
@@ -117,10 +124,24 @@ async function postureStage(baseUrl, signIn) {
 	};
 }
 
-/** Placeholder for the authenticated stages: demonstrates explicit skip. */
-function authenticatedStage(env) {
-	const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION });
-	return { id: "authenticated flows (#814)", status: "skip", reason: gate.runnable ? "not implemented" : gate.reason };
+/**
+ * #814's authenticated flows: prove the validation identity can call an
+ * auth-gated, data-reading API end to end. Mode-aware — a bypass-mode target
+ * authenticates with the test cookie (no credential to gate on); a real-auth
+ * target replays the pre-minted validation session and gates on its absence.
+ */
+async function authenticatedStage(baseUrl, mode, env) {
+	const id = AUTHED_STAGE_ID;
+	const cookie = authedCookie(mode, baseUrl, env);
+	if (!cookie) {
+		const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: env.WEB_NEXT_VALIDATION_SESSION });
+		return { id, status: "skip", reason: gate.reason };
+	}
+	const res = await probe(baseUrl, "/api/repos", { headers: { cookie } });
+	if (res.status === 401 || res.status === 403 || isRedirectToSignIn(res)) {
+		return { id, status: "skip", reason: "validation session expired — re-seed" };
+	}
+	return { id, status: "run", checks: evaluateAuthedProbe({ status: res.status, body: safeJson(res.body) }) };
 }
 
 function safeJson(text) {
@@ -219,8 +240,28 @@ async function e2eDeployedSafeStage(target, env) {
 	return { id, status: "run", checks: evaluateE2eResults(report) };
 }
 
+/** Runs a stage and stamps how long it took (the #819 report's timings). */
+async function timed(run) {
+	const started = Date.now();
+	const stage = await run();
+	return { ...stage, tookMs: Date.now() - started };
+}
+
+/** Every file under `dir`, repo-relative — the report's evidence links. */
+function collectEvidenceFiles(dir) {
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir, { recursive: true, withFileTypes: true })
+		.filter((entry) => entry.isFile() && /\.(png|webm|zip)$/.test(entry.name))
+		.map((entry) =>
+			path.relative(WEB_NEXT_ROOT, path.join(entry.parentPath ?? entry.path, entry.name)),
+		)
+		.sort();
+}
+
 async function main() {
-	const target = resolveTarget(process.argv.slice(2), process.env);
+	const args = process.argv.slice(2);
+	const target = resolveTarget(args, process.env);
+	const skipRealTurn = args.includes("--skip-real-turn");
 	let server;
 	if (target.spawnLocal) {
 		const { env } = bypassServerEnv("validate-db");
@@ -228,7 +269,7 @@ async function main() {
 	}
 	try {
 		console.log(`validating ${target.envName}: ${target.baseUrl}\n`);
-		const reach = await reachabilityStage(target.baseUrl);
+		const reach = await timed(() => reachabilityStage(target.baseUrl));
 		const stages = [reach];
 		// No point probing posture — or running the credentialed stages — on a
 		// target that isn't serving (or is SSO-walled). Running the model sweep /
@@ -236,40 +277,70 @@ async function main() {
 		// bypass credential (codex finding); they inherit reachability's verdict
 		// as their own skip reason instead.
 		const reachable = reach.status === "run" && reach.checks.every((c) => c.status === "pass");
+		const mode = detectAuthMode(reach.signIn?.body ?? "");
 		if (reachable) {
-			stages.push(await postureStage(target.baseUrl, reach.signIn));
-		}
-		stages.push(authenticatedStage(process.env));
-		if (reachable) {
-			stages.push(await modelSweepStage(target.baseUrl, process.env));
-			stages.push(await e2eDeployedSafeStage(target, process.env));
+			stages.push(await timed(() => postureStage(target.baseUrl, reach.signIn)));
+			stages.push(await timed(() => authenticatedStage(target.baseUrl, mode, process.env)));
+			stages.push(await timed(() => modelSweepStage(target.baseUrl, process.env)));
+			stages.push(await timed(() => e2eDeployedSafeStage(target, process.env)));
+			// The real turn runs LAST: it is the only stage that spends real money
+			// (one small coding turn) and boots a sandbox, so everything cheaper
+			// gets its verdict in first. Local spawns skip it — the throwaway
+			// bypass server has no deployed runtime posture worth probing, and
+			// `pnpm validate` with no args must never surprise-spend.
+			if (skipRealTurn) {
+				stages.push({ id: REAL_TURN_STAGE_ID, status: "skip", reason: "skipped by flag (--skip-real-turn)" });
+			} else if (target.spawnLocal) {
+				stages.push({
+					id: REAL_TURN_STAGE_ID,
+					status: "skip",
+					reason: "local spawn — probe a deployed target (or --url a server provisioned with runtime credentials)",
+				});
+			} else {
+				const cookie = authedCookie(mode, target.baseUrl, process.env);
+				if (!cookie) {
+					const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: process.env.WEB_NEXT_VALIDATION_SESSION });
+					stages.push({ id: REAL_TURN_STAGE_ID, status: "skip", reason: gate.reason });
+				} else {
+					stages.push(await timed(() => realTurnStage(target.baseUrl, cookie, process.env)));
+				}
+			}
 		} else {
 			const reason = reach.status === "skip" ? reach.reason : "target unreachable — see reachability stage";
+			stages.push({ id: AUTHED_STAGE_ID, status: "skip", reason });
 			stages.push({ id: MODEL_SWEEP_STAGE_ID, status: "skip", reason });
 			stages.push({ id: E2E_STAGE_ID, status: "skip", reason });
+			stages.push({ id: REAL_TURN_STAGE_ID, status: "skip", reason });
 		}
 
 		const summary = summarize(stages);
 		console.log(summary.lines.join("\n"));
 
+		const ranAt = new Date().toISOString();
+		// The raw sign-in response rides on the reachability stage for the
+		// posture probe; drop it from the persisted records.
+		const persistedStages = stages.map((stage) => ({ ...stage, signIn: undefined }));
+
 		const outDir = path.join(WEB_NEXT_ROOT, "output", "validate");
 		mkdirSync(outDir, { recursive: true });
 		const outFile = path.join(outDir, `${Date.now()}-${target.envName}.json`);
-		writeFileSync(
-			outFile,
-			JSON.stringify(
-				{
-					target,
-					ranAt: new Date().toISOString(),
-					// The raw sign-in response rides on the reachability stage for the
-					// posture probe; drop it from the persisted record.
-					stages: stages.map((stage) => ({ ...stage, signIn: undefined })),
-				},
-				null,
-				2,
-			),
-		);
+		writeFileSync(outFile, JSON.stringify({ target, ranAt, stages: persistedStages }, null, 2));
+
+		// The #819 per-env report: same verdicts as the console summary, plus
+		// timings and evidence paths, at a stable path the scheduled workflow
+		// can pour into its job summary and upload as an artifact.
+		const envDir = path.join(outDir, target.envName);
+		mkdirSync(envDir, { recursive: true });
+		const report = renderMarkdownReport({
+			target,
+			ranAt,
+			stages: persistedStages,
+			evidence: collectEvidenceFiles(envDir),
+		});
+		const reportFile = path.join(envDir, "report.md");
+		writeFileSync(reportFile, report);
 		console.log(`\nresults: ${path.relative(WEB_NEXT_ROOT, outFile)}`);
+		console.log(`report:  ${path.relative(WEB_NEXT_ROOT, reportFile)}`);
 		if (!summary.ok) {
 			console.error(`\n${summary.failed} check(s) failed`);
 			process.exitCode = 1;

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -283,4 +283,16 @@ describe("DELETE /api/sessions/[id]", () => {
 		// The resume handle (the only pointer to the live machine) survives.
 		expect(await getSession(getDatabase(), id)).toBeDefined();
 	});
+
+	test("an unreachable sandbox lookup also keeps the session (502)", async () => {
+		vi.mocked(releaseParkedSandbox).mockResolvedValue({
+			disposition: "unreachable",
+			detail: "rate limited",
+		});
+		const id = await freshSession();
+		const res = await del(id);
+		expect(res.status).toBe(502);
+		expect((await res.json()).sandbox).toBe("unreachable");
+		expect(await getSession(getDatabase(), id)).toBeDefined();
+	});
 });

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -239,12 +239,26 @@ describe("DELETE /api/sessions/[id]", () => {
 		const id = await freshSession();
 		await appendEvents(getDatabase(), id, [
 			{ role: "user", chunk: { type: "text", content: "hi" } },
+			{ role: "assistant", chunk: { type: "done", content: "" } },
 		]);
 		const res = await del(id);
 		expect(res.status).toBe(200);
 		expect(await res.json()).toEqual({ deleted: true, sandbox: "none" });
 		expect(await getSession(getDatabase(), id)).toBeUndefined();
 		expect((await get(id)).status).toBe(404);
+	});
+
+	test("refuses (409) while a turn is still running — no orphaned ingest writes", async () => {
+		const id = await freshSession();
+		// A fresh user event with no terminal done classifies as a running turn
+		// (resolveTurn's cross-instance log-freshness rule).
+		await appendEvents(getDatabase(), id, [
+			{ role: "user", chunk: { type: "text", content: "do the thing" } },
+		]);
+		const res = await del(id);
+		expect(res.status).toBe(409);
+		expect((await res.json()).error).toMatch(/still running/);
+		expect(await getSession(getDatabase(), id)).toBeDefined();
 	});
 
 	test("stops a live parked sandbox before deleting", async () => {

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -1,8 +1,10 @@
 /*
- * PATCH /api/sessions/[id] — auth gating, per-field validation (model,
- * title), and the "unknown field is a 400" contract. `getAuthState` is
- * mocked (it reaches into next/headers, which needs a real request scope);
- * the DB is real, pointed at a throwaway file via SESSIONS_DATABASE_URL so
+ * /api/sessions/[id] — GET (session + durable log), PATCH (auth gating,
+ * per-field validation, the "unknown field is a 400" contract), and DELETE
+ * (sandbox release before cascade, a stop failure keeping the session).
+ * `getAuthState` is mocked (it reaches into next/headers, which needs a real
+ * request scope), as is the sandbox release (no Vercel in tests); the DB is
+ * real, pointed at a throwaway file via SESSIONS_DATABASE_URL so
  * `getDatabase()`'s module singleton (shared with the route under test)
  * resolves to it.
  */
@@ -10,13 +12,18 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { releaseParkedSandbox } from "@/lib/agent-runtime/sandbox-release";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
-import { createSession, getSession } from "@/lib/db/sessions";
+import { appendEvents, createSession, getSession, updateSession } from "@/lib/db/sessions";
 import { MAX_TITLE_LENGTH } from "@/lib/session-title";
 
 vi.mock("@/lib/auth/auth-state", () => ({
 	getAuthState: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime/sandbox-release", () => ({
+	releaseParkedSandbox: vi.fn(),
 }));
 
 const dir = mkdtempSync(join(tmpdir(), "web-next-route-"));
@@ -33,6 +40,7 @@ const AUTHORIZED = {
 
 beforeEach(() => {
 	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+	vi.mocked(releaseParkedSandbox).mockResolvedValue({ disposition: "none" });
 });
 
 async function patch(id: string, body: unknown) {
@@ -150,5 +158,115 @@ describe("PATCH /api/sessions/[id]", () => {
 		const session = await getSession(getDatabase(), id);
 		expect(session?.model).toBe("claude-opus-4-8");
 		expect(session?.title).toBe("Both at once");
+	});
+});
+
+async function get(id: string, query = "") {
+	const { GET } = await import("./route");
+	return GET(new Request(`http://test/api/sessions/${id}${query}`), {
+		params: Promise.resolve({ id }),
+	});
+}
+
+async function del(id: string) {
+	const { DELETE } = await import("./route");
+	return DELETE(
+		new Request(`http://test/api/sessions/${id}`, { method: "DELETE" }),
+		{ params: Promise.resolve({ id }) },
+	);
+}
+
+describe("GET /api/sessions/[id]", () => {
+	test("401s when unauthenticated, 404s for an unknown session", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "unauthenticated" });
+		expect((await get("whatever")).status).toBe(401);
+		vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+		expect((await get("does-not-exist")).status).toBe(404);
+	});
+
+	test("returns the session with its durable event log", async () => {
+		const id = await freshSession();
+		await appendEvents(getDatabase(), id, [
+			{ role: "user", chunk: { type: "text", content: "hi" } },
+			{ role: "assistant", chunk: { type: "status", content: "Booting Claude Code in sandbox" } },
+			{ role: "assistant", chunk: { type: "done", content: "", metadata: { durationMs: 5 } } },
+		]);
+		const res = await get(id);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.session).toMatchObject({ id, provider: "mock", parked: false });
+		expect(body.events).toEqual([
+			{ seq: 1, role: "user", kind: "text", content: "hi" },
+			{ seq: 2, role: "assistant", kind: "status", content: "Booting Claude Code in sandbox" },
+			{ seq: 3, role: "assistant", kind: "done", content: "", metadata: { durationMs: 5 } },
+		]);
+	});
+
+	test("parked reflects a persisted resume handle without exposing it", async () => {
+		const id = await freshSession();
+		await updateSession(getDatabase(), id, {
+			claudeSessionId: "harness-1",
+			resumeState: '{"secret":"blob"}',
+		});
+		const body = await (await get(id)).json();
+		expect(body.session.parked).toBe(true);
+		expect(JSON.stringify(body)).not.toContain("blob");
+	});
+
+	test("sinceSeq tails the log; a bad value is a 400", async () => {
+		const id = await freshSession();
+		await appendEvents(getDatabase(), id, [
+			{ role: "user", chunk: { type: "text", content: "one" } },
+			{ role: "assistant", chunk: { type: "text", content: "two" } },
+		]);
+		const body = await (await get(id, "?sinceSeq=1")).json();
+		expect(body.events).toHaveLength(1);
+		expect(body.events[0].content).toBe("two");
+		expect((await get(id, "?sinceSeq=-1")).status).toBe(400);
+		expect((await get(id, "?sinceSeq=nope")).status).toBe(400);
+	});
+});
+
+describe("DELETE /api/sessions/[id]", () => {
+	test("401s when unauthenticated, 404s for an unknown session", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "unauthenticated" });
+		expect((await del("whatever")).status).toBe(401);
+		vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+		expect((await del("does-not-exist")).status).toBe(404);
+	});
+
+	test("deletes the session and its log, reporting the sandbox disposition", async () => {
+		const id = await freshSession();
+		await appendEvents(getDatabase(), id, [
+			{ role: "user", chunk: { type: "text", content: "hi" } },
+		]);
+		const res = await del(id);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ deleted: true, sandbox: "none" });
+		expect(await getSession(getDatabase(), id)).toBeUndefined();
+		expect((await get(id)).status).toBe(404);
+	});
+
+	test("stops a live parked sandbox before deleting", async () => {
+		vi.mocked(releaseParkedSandbox).mockResolvedValue({ disposition: "stopped" });
+		const id = await freshSession();
+		const res = await del(id);
+		expect(await res.json()).toEqual({ deleted: true, sandbox: "stopped" });
+		expect(await getSession(getDatabase(), id)).toBeUndefined();
+	});
+
+	test("a sandbox that can't be stopped keeps the session for a retry (502)", async () => {
+		vi.mocked(releaseParkedSandbox).mockResolvedValue({
+			disposition: "stop-failed",
+			detail: "api timeout",
+		});
+		const id = await freshSession();
+		const res = await del(id);
+		expect(res.status).toBe(502);
+		const body = await res.json();
+		expect(body.sandbox).toBe("stop-failed");
+		expect(body.error).toMatch(/api timeout/);
+		// The resume handle (the only pointer to the live machine) survives.
+		expect(await getSession(getDatabase(), id)).toBeDefined();
 	});
 });

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -1,17 +1,115 @@
 /*
- * PATCH /api/sessions/[id] — update a session's mutable settings: `model`
- * (#824's picker) and/or `title` (#823's inline edit). Auth-gated same as the
- * chat route. Each field validates against its own source of truth —
- * `isSelectableModel` (agent-runtime/models.ts) and the title cap/cleaning in
- * session-title.ts, shared with the auto-titler so both paths agree on what a
- * valid title is. Any key outside {model, title} is a 400, not a silent
- * no-op, so a typo'd field fails loudly instead of patching nothing.
+ * /api/sessions/[id] — the session resource. GET reads the session plus its
+ * durable event log (the projection the transcript is built from — what the
+ * #818 validation probe polls as the source of truth). PATCH updates the
+ * mutable settings: `model` (#824's picker) and/or `title` (#823's inline
+ * edit), each validated against its own source of truth, any unknown key a
+ * 400. DELETE removes the session and its log — but first stops any live
+ * parked sandbox (sandbox-release.ts); a sandbox that can't be stopped keeps
+ * the session, so the only pointer to a still-billing machine is never lost.
+ * Every method carries the same auth gate as the chat route.
  */
 import { isSelectableModel } from "@/lib/agent-runtime/models";
+import { releaseParkedSandbox } from "@/lib/agent-runtime/sandbox-release";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
-import { getSession, updateSession } from "@/lib/db/sessions";
+import {
+	deleteSession,
+	getSession,
+	readEvents,
+	updateSession,
+} from "@/lib/db/sessions";
 import { cleanTitleText, MAX_TITLE_LENGTH } from "@/lib/session-title";
+
+export const runtime = "nodejs";
+
+export async function GET(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	const sinceParam = new URL(request.url).searchParams.get("sinceSeq");
+	const sinceSeq = sinceParam ? Number(sinceParam) : 0;
+	if (!Number.isFinite(sinceSeq) || sinceSeq < 0) {
+		return Response.json(
+			{ error: "sinceSeq must be a non-negative number" },
+			{ status: 400 },
+		);
+	}
+	const events = await readEvents(handle, id, sinceSeq);
+	return Response.json({
+		session: {
+			id: session.id,
+			title: session.title,
+			provider: session.provider,
+			status: session.status,
+			model: session.model,
+			// Whether a turn parked a resumable sandbox handle; the handle itself
+			// is private server state and never leaves the row.
+			parked: !!(session.claudeSessionId && session.resumeState),
+			createdAt: session.createdAt,
+			lastActivityAt: session.lastActivityAt,
+		},
+		events: events.map((event) => ({
+			seq: event.seq,
+			role: event.role,
+			kind: event.chunk.type,
+			content: event.chunk.content,
+			metadata: event.chunk.metadata,
+		})),
+	});
+}
+
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	const release = await releaseParkedSandbox(session);
+	if (release.disposition === "stop-failed") {
+		// The sandbox is (as far as we can tell) still running and we could not
+		// stop it. Deleting the session now would drop the resume handle — the
+		// only pointer to a machine that keeps billing — so keep everything and
+		// report the failure for a retry.
+		return Response.json(
+			{
+				error: `the session's sandbox could not be stopped: ${release.detail}`,
+				sandbox: release.disposition,
+			},
+			{ status: 502 },
+		);
+	}
+	await deleteSession(handle, id);
+	return Response.json({ deleted: true, sandbox: release.disposition });
+}
 
 const ALLOWED_FIELDS = new Set(["model", "title"]);
 

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -108,14 +108,15 @@ export async function DELETE(
 	}
 
 	const release = await releaseParkedSandbox(session);
-	if (release.disposition === "stop-failed") {
-		// The sandbox is (as far as we can tell) still running and we could not
-		// stop it. Deleting the session now would drop the resume handle — the
-		// only pointer to a machine that keeps billing — so keep everything and
+	if (release.disposition === "stop-failed" || release.disposition === "unreachable") {
+		// The sandbox may still be running (stop failed, or the lookup itself
+		// did — a transient API fault is indistinguishable from a live machine).
+		// Deleting the session now would drop the resume handle — the only
+		// pointer to a machine that keeps billing — so keep everything and
 		// report the failure for a retry.
 		return Response.json(
 			{
-				error: `the session's sandbox could not be stopped: ${release.detail}`,
+				error: `the session's sandbox could not be released: ${release.detail}`,
 				sandbox: release.disposition,
 			},
 			{ status: 502 },

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -11,6 +11,7 @@
  */
 import { isSelectableModel } from "@/lib/agent-runtime/models";
 import { releaseParkedSandbox } from "@/lib/agent-runtime/sandbox-release";
+import { resolveTurn } from "@/lib/agent-runtime/turn-tail";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
 import {
@@ -91,6 +92,19 @@ export async function DELETE(
 	const session = await getSession(handle, id);
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+
+	// A running turn's detached ingest keeps appending to this session;
+	// deleting now would orphan those writes and lose the resume handle the
+	// turn is about to park (a sandbox leak until its lifetime cap). Refuse
+	// until it settles — a *stale* turn (dead runner) has no live writer and
+	// deletes fine.
+	const turn = await resolveTurn(handle, id);
+	if (turn.status === "running") {
+		return Response.json(
+			{ error: "a turn is still running on this session — retry once it completes" },
+			{ status: 409 },
+		);
 	}
 
 	const release = await releaseParkedSandbox(session);

--- a/web-next/src/app/api/sessions/route.test.ts
+++ b/web-next/src/app/api/sessions/route.test.ts
@@ -1,0 +1,90 @@
+/*
+ * POST /api/sessions — auth gating, field validation, and the created row's
+ * defaults (DEFAULT_MODEL, empty repo). Same harness pattern as the [id]
+ * route's tests: mocked auth state, real DB behind SESSIONS_DATABASE_URL.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { DEFAULT_MODEL } from "@/lib/agent-runtime/models";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { getSession } from "@/lib/db/sessions";
+
+vi.mock("@/lib/auth/auth-state", () => ({
+	getAuthState: vi.fn(),
+}));
+
+const dir = mkdtempSync(join(tmpdir(), "web-next-sessions-route-"));
+process.env.SESSIONS_DATABASE_URL = `file:${join(dir, "test.db")}`;
+
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const AUTHORIZED = {
+	kind: "authorized" as const,
+	user: { login: "fairchild", name: "Fairchild" },
+};
+
+beforeEach(() => {
+	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+});
+
+async function post(body: unknown) {
+	const { POST } = await import("./route");
+	return POST(
+		new Request("http://test/api/sessions", {
+			method: "POST",
+			body: JSON.stringify(body),
+		}),
+	);
+}
+
+describe("POST /api/sessions", () => {
+	test("401s when unauthenticated, 403s when not allowlisted", async () => {
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "unauthenticated" });
+		expect((await post({ title: "x" })).status).toBe(401);
+		vi.mocked(getAuthState).mockResolvedValue({ kind: "forbidden", login: "nope" });
+		expect((await post({ title: "x" })).status).toBe(403);
+	});
+
+	test("creates a session on the DEFAULT model with the given title/provider", async () => {
+		const res = await post({ title: "validation: real-turn probe t0", provider: "vercel" });
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body).toMatchObject({
+			title: "validation: real-turn probe t0",
+			provider: "vercel",
+			model: DEFAULT_MODEL,
+			status: "active",
+		});
+		const row = await getSession(getDatabase(), body.id);
+		expect(row?.model).toBe(DEFAULT_MODEL);
+		expect(row?.repoId).toBeNull();
+	});
+
+	test("defaults: empty title, the configured default provider", async () => {
+		const res = await post({});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.title).toBe("");
+		expect(body.provider).toBe("mock");
+	});
+
+	test("rejects an unknown provider and an unknown field", async () => {
+		expect((await post({ provider: "skynet" })).status).toBe(400);
+		expect((await post({ repo: "o/r" })).status).toBe(400);
+	});
+
+	test("rejects a non-string or over-long title, and a non-JSON body", async () => {
+		expect((await post({ title: 42 })).status).toBe(400);
+		expect((await post({ title: "x".repeat(500) })).status).toBe(400);
+		const { POST } = await import("./route");
+		const res = await POST(
+			new Request("http://test/api/sessions", { method: "POST", body: "not json" }),
+		);
+		expect(res.status).toBe(400);
+	});
+});

--- a/web-next/src/app/api/sessions/route.ts
+++ b/web-next/src/app/api/sessions/route.ts
@@ -1,0 +1,87 @@
+/*
+ * POST /api/sessions — programmatic session creation, the API complement to
+ * the UI's server action (actions.ts). Exists for API clients that need a
+ * throwaway session with an explicit title and provider — the #818 real-turn
+ * validation probe is the first — so it skips the action's GitHub repo
+ * resolution (repoId stays null; the vercel provider clones its configured
+ * AGENT_TARGET_REPO regardless). Auth-gated like every session route; model
+ * always starts at the DEFAULT_MODEL, same as the UI path.
+ */
+import { getProvider } from "@/lib/agent-runtime/provider";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import { createSession } from "@/lib/db/sessions";
+import { defaultComputeProvider } from "@/lib/db/start-session";
+import { cleanTitleText, MAX_TITLE_LENGTH } from "@/lib/session-title";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const body: unknown = await request.json().catch(() => undefined);
+	if (typeof body !== "object" || body === null) {
+		return Response.json({ error: "a JSON body is required" }, { status: 400 });
+	}
+	const { title: rawTitle, provider: rawProvider, ...rest } = body as {
+		title?: unknown;
+		provider?: unknown;
+	};
+	const unknownFields = Object.keys(rest);
+	if (unknownFields.length > 0) {
+		return Response.json(
+			{ error: `unknown field(s): ${unknownFields.join(", ")}` },
+			{ status: 400 },
+		);
+	}
+
+	let title = "";
+	if (rawTitle !== undefined) {
+		if (typeof rawTitle !== "string") {
+			return Response.json({ error: "title must be a string" }, { status: 400 });
+		}
+		title = cleanTitleText(rawTitle);
+		if (title.length > MAX_TITLE_LENGTH) {
+			return Response.json(
+				{ error: `title must be at most ${MAX_TITLE_LENGTH} characters` },
+				{ status: 400 },
+			);
+		}
+	}
+
+	let provider = defaultComputeProvider();
+	if (rawProvider !== undefined) {
+		provider = String(rawProvider);
+		try {
+			getProvider(provider);
+		} catch {
+			return Response.json(
+				{ error: `unknown provider: ${provider}` },
+				{ status: 400 },
+			);
+		}
+	}
+
+	const session = await createSession(getDatabase(), {
+		id: crypto.randomUUID(),
+		title,
+		provider,
+	});
+	return Response.json(
+		{
+			id: session.id,
+			title: session.title,
+			provider: session.provider,
+			model: session.model,
+			status: session.status,
+			createdAt: session.createdAt,
+		},
+		{ status: 201 },
+	);
+}

--- a/web-next/src/lib/agent-runtime/sandbox-release.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { releaseParkedSandbox, type StoppableSandbox } from "./sandbox-release";
+import { sessionSandboxName } from "./vercel-provider";
+
+const parked = { claudeSessionId: "harness-1", resumeState: "{}" };
+
+function sandbox(status: string, stop: () => Promise<unknown> = async () => {}) {
+	return { status, stop } satisfies StoppableSandbox;
+}
+
+describe("releaseParkedSandbox", () => {
+	test("a session that never parked has nothing to release", async () => {
+		expect(
+			await releaseParkedSandbox({ claudeSessionId: null, resumeState: null }),
+		).toEqual({ disposition: "none" });
+		expect(
+			await releaseParkedSandbox({ claudeSessionId: "h", resumeState: null }),
+		).toEqual({ disposition: "none" });
+	});
+
+	test("looks up the sandbox by the resume path's own name derivation", async () => {
+		let requested: string | undefined;
+		await releaseParkedSandbox(parked, async (name) => {
+			requested = name;
+			return sandbox("running");
+		});
+		expect(requested).toBe(sessionSandboxName("harness-1"));
+	});
+
+	test("a live sandbox is stopped", async () => {
+		let stopped = false;
+		const release = await releaseParkedSandbox(parked, async () =>
+			sandbox("running", async () => {
+				stopped = true;
+			}),
+		);
+		expect(release).toEqual({ disposition: "stopped" });
+		expect(stopped).toBe(true);
+	});
+
+	test("a gone or non-running sandbox is expired, never a throw", async () => {
+		expect(
+			await releaseParkedSandbox(parked, async () => {
+				throw new Error("not found");
+			}),
+		).toEqual({ disposition: "expired", detail: "not found" });
+		expect(
+			await releaseParkedSandbox(parked, async () => sandbox("stopped")),
+		).toEqual({ disposition: "expired", detail: "sandbox is stopped" });
+	});
+
+	test("a stop failure is reported, not swallowed — the caller decides", async () => {
+		const release = await releaseParkedSandbox(parked, async () =>
+			sandbox("running", async () => {
+				throw new Error("api timeout");
+			}),
+		);
+		expect(release).toEqual({ disposition: "stop-failed", detail: "api timeout" });
+	});
+});

--- a/web-next/src/lib/agent-runtime/sandbox-release.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.test.ts
@@ -49,6 +49,22 @@ describe("releaseParkedSandbox", () => {
 		).toEqual({ disposition: "expired", detail: "sandbox is stopped" });
 	});
 
+	test("a non-404 lookup failure is unreachable, not expired — the sandbox may be alive", async () => {
+		expect(
+			await releaseParkedSandbox(parked, async () => {
+				throw new Error("ETIMEDOUT: request timed out");
+			}),
+		).toEqual({ disposition: "unreachable", detail: "ETIMEDOUT: request timed out" });
+		// A structured 404 still reads as gone.
+		expect(
+			await releaseParkedSandbox(parked, async () => {
+				const err = new Error("Status code 404") as Error & { status: number };
+				err.status = 404;
+				throw err;
+			}),
+		).toEqual({ disposition: "expired", detail: "Status code 404" });
+	});
+
 	test("a stop failure is reported, not swallowed — the caller decides", async () => {
 		const release = await releaseParkedSandbox(parked, async () =>
 			sandbox("running", async () => {

--- a/web-next/src/lib/agent-runtime/sandbox-release.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.ts
@@ -1,0 +1,77 @@
+/*
+ * Tears down the LIVE sandbox a session's last turn parked (#818's no-leak
+ * contract): resolve the parked sandbox by the same name derivation the
+ * resume path uses, stop it if it is still running, and report an honest
+ * disposition. Session deletion (the DELETE route) calls this BEFORE removing
+ * rows — a stop failure keeps the session (and its resume handle) so a retry
+ * can still reach the sandbox, rather than deleting the only pointer to a
+ * machine that is still billing. The Vercel dependency is injected for tests.
+ */
+import type { Session } from "../db/sessions";
+import { sessionSandboxName } from "./vercel-provider";
+
+/** The slice of @vercel/sandbox's Sandbox the release path touches. */
+export interface StoppableSandbox {
+	status: string;
+	stop(): Promise<unknown>;
+}
+
+/** Fetch-by-name, throwing when the sandbox is gone. Injected for tests. */
+export type GetStoppableSandbox = (name: string) => Promise<StoppableSandbox>;
+
+export type SandboxRelease =
+	/** The session never parked a sandbox — nothing to release. */
+	| { disposition: "none" }
+	/** A handle existed but the sandbox is already gone or not running. */
+	| { disposition: "expired"; detail: string }
+	/** A live sandbox was found and stopped. */
+	| { disposition: "stopped" }
+	/** A live sandbox was found but could not be stopped — it may still bill. */
+	| { disposition: "stop-failed"; detail: string };
+
+/** Mirrors sandbox-terminal.ts: `Sandbox.get` succeeds for dead sandboxes too. */
+const ALIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
+
+async function defaultGetSandbox(name: string): Promise<StoppableSandbox> {
+	const { Sandbox } = await import("@vercel/sandbox");
+	const token = process.env.VERCEL_TOKEN;
+	const teamId = process.env.VERCEL_TEAM_ID;
+	const projectId = process.env.VERCEL_PROJECT_ID;
+	return (await Sandbox.get({
+		name,
+		// Looking for the sandbox must not resurrect a stopped one.
+		resume: false,
+		...(token && teamId && projectId ? { token, teamId, projectId } : {}),
+	})) as unknown as StoppableSandbox;
+}
+
+/**
+ * Stops the session's parked sandbox, if any. Every outcome is a disposition,
+ * never a throw — the caller decides what each one means (the DELETE route
+ * treats `stop-failed` as a reason not to delete; everything else is clear).
+ */
+export async function releaseParkedSandbox(
+	session: Pick<Session, "claudeSessionId" | "resumeState">,
+	getSandbox: GetStoppableSandbox = defaultGetSandbox,
+): Promise<SandboxRelease> {
+	if (!session.claudeSessionId || !session.resumeState) {
+		return { disposition: "none" };
+	}
+	let sandbox: StoppableSandbox;
+	try {
+		sandbox = await getSandbox(sessionSandboxName(session.claudeSessionId));
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		return { disposition: "expired", detail };
+	}
+	if (!ALIVE_STATUSES.has(sandbox.status)) {
+		return { disposition: "expired", detail: `sandbox is ${sandbox.status}` };
+	}
+	try {
+		await sandbox.stop();
+		return { disposition: "stopped" };
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		return { disposition: "stop-failed", detail };
+	}
+}

--- a/web-next/src/lib/agent-runtime/sandbox-release.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.ts
@@ -27,7 +27,36 @@ export type SandboxRelease =
 	/** A live sandbox was found and stopped. */
 	| { disposition: "stopped" }
 	/** A live sandbox was found but could not be stopped — it may still bill. */
-	| { disposition: "stop-failed"; detail: string };
+	| { disposition: "stop-failed"; detail: string }
+	/** The lookup itself failed for a non-404 reason (API timeout/auth/rate
+	 * limit) — the sandbox may well be alive, we just can't tell. */
+	| { disposition: "unreachable"; detail: string };
+
+function asText(value: unknown): string {
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function errorDetail(error: unknown): string {
+	return error instanceof Error ? error.message : asText(error);
+}
+
+/**
+ * Whether a `Sandbox.get` failure means "no such sandbox" (vs a transient API
+ * fault). The Vercel APIError's `message` is only the status line; the reason
+ * can live in `json`/`text` — same matching posture as the provider's
+ * isNameCollision.
+ */
+function isNotFound(error: unknown): boolean {
+	const e = error as { status?: unknown; message?: unknown; text?: unknown; json?: unknown };
+	if (e?.status === 404) return true;
+	const haystack = [asText(e?.message ?? ""), asText(e?.text ?? ""), asText(e?.json ?? "")].join(" ");
+	return /not[ _-]?found|status code 404|\b404\b/i.test(haystack);
+}
 
 /** Mirrors sandbox-terminal.ts: `Sandbox.get` succeeds for dead sandboxes too. */
 const ALIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
@@ -61,8 +90,14 @@ export async function releaseParkedSandbox(
 	try {
 		sandbox = await getSandbox(sessionSandboxName(session.claudeSessionId));
 	} catch (error) {
-		const detail = error instanceof Error ? error.message : String(error);
-		return { disposition: "expired", detail };
+		const detail = errorDetail(error);
+		// Only a definite not-found means the sandbox is gone; any other lookup
+		// failure (timeout, auth, rate limit) could be hiding a live machine —
+		// report it as such so the caller doesn't drop the resume pointer
+		// (codex review finding, gpt-5.5 xhigh).
+		return isNotFound(error)
+			? { disposition: "expired", detail }
+			: { disposition: "unreachable", detail };
 	}
 	if (!ALIVE_STATUSES.has(sandbox.status)) {
 		return { disposition: "expired", detail: `sandbox is ${sandbox.status}` };

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -9,6 +9,7 @@ import {
 	type AppendEvent,
 	appendEvents,
 	createSession,
+	deleteSession,
 	getSession,
 	readEvents,
 	readTranscript,
@@ -245,5 +246,41 @@ describe("session store", () => {
 				],
 			},
 		]);
+	});
+});
+
+describe("deleteSession", () => {
+	test("removes the session, its event log, and its terminal tickets together", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "goner", provider: "vercel" });
+		await createSession(handle, { id: "keeper", provider: "mock" });
+		await appendEvents(handle, "goner", [
+			evt("user", { type: "text", content: "hello" }),
+			evt("assistant", { type: "done", content: "" }),
+		]);
+		await appendEvents(handle, "keeper", [evt("user", { type: "text", content: "stay" })]);
+		await handle.client.execute({
+			sql: "INSERT INTO terminal_tickets (ticket_hash, login, session_id, mode, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)",
+			args: ["h1", "fairchild", "goner", "mock", "2026-01-01", "2026-01-01"],
+		});
+
+		expect(await deleteSession(handle, "goner")).toBe(true);
+		expect(await getSession(handle, "goner")).toBeUndefined();
+		expect(await readEvents(handle, "goner")).toEqual([]);
+		const tickets = await handle.client.execute(
+			"SELECT ticket_hash FROM terminal_tickets WHERE session_id = 'goner'",
+		);
+		expect(tickets.rows).toHaveLength(0);
+
+		// The cascade is scoped: the other session and its log are untouched.
+		expect(await getSession(handle, "keeper")).toBeDefined();
+		expect(await readEvents(handle, "keeper")).toHaveLength(1);
+	});
+
+	test("deleting an unknown session reports false and touches nothing", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "only", provider: "mock" });
+		expect(await deleteSession(handle, "ghost")).toBe(false);
+		expect(await getSession(handle, "only")).toBeDefined();
 	});
 });

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -153,6 +153,26 @@ export async function titleSessionIfEmpty(
 	return Number(result[0]?.numUpdatedRows ?? 0) > 0;
 }
 
+/**
+ * Deletes a session and everything that hangs off it — its event log and any
+ * terminal tickets — in one transaction, so a partial delete can't leave
+ * orphaned events behind (the cascade the schema's PKs don't encode). Returns
+ * whether a session row was actually removed. Sandbox teardown is the API
+ * route's job (agent-runtime/sandbox-release.ts) — this is storage only.
+ */
+export async function deleteSession(
+	handle: DatabaseHandle,
+	id: string,
+): Promise<boolean> {
+	await ensureSchema(handle);
+	return handle.db.transaction().execute(async (trx) => {
+		await trx.deleteFrom("session_events").where("session_id", "=", id).execute();
+		await trx.deleteFrom("terminal_tickets").where("session_id", "=", id).execute();
+		const result = await trx.deleteFrom("sessions").where("id", "=", id).execute();
+		return Number(result[0]?.numDeletedRows ?? 0) > 0;
+	});
+}
+
 /** A sessions-home row: the session plus its repo's display name. */
 export interface SessionListItem extends Session {
 	repoFullName: string | null;


### PR DESCRIPTION
Closes #818
Closes #819
Closes #814

The final W3 validation stages: `pnpm validate` now carries a real authenticated-flows check, a real-agentic-turn probe, and a per-env report, and a scheduled lane runs the whole suite against production daily.

## #814 close-out — authenticated flows

The placeholder stage becomes a real check: an authenticated `GET /api/repos` must answer 200 with the client's shape (`{ repos: [...], degraded: boolean }`), proving the validation identity clears middleware freshness + the allowlist verdict end to end. Mode-aware — bypass-mode targets use the test cookie (no credential gate), real-auth targets replay `WEB_NEXT_VALIDATION_SESSION` and gate on its absence. Both credentials are now documented in `docs/deploy.md`'s env matrix and `.env.local.example` (names + purpose only). The heavy mechanics (#927) had already landed; this completes #814's acceptance — it ran live against prod (2/2, see Evidence).

## #818 — real agentic turn probe

A last-in-line stage (the only one that spends money) that runs ONE scripted coding turn against the target and asserts the six contract points from the durable log:

1. **session created** on the DEFAULT model, titled `validation: real-turn probe <ts>` (no-litter rule)
2. **sandbox created** — boot/resume status event observed in the log
3. **streams real output** — polls `GET /api/sessions/[id]` (the durable projection, the source of truth), not the SSE side-channel
4. **coding change lands** — a nonce written to `VALIDATION-PROBE.md` must reappear in tool output or the synthesized workspace diff; narration doesn't count
5. **terminal `done`** arrives (aborted/error events fail)
6. **no leaked sandbox** — teardown deletes the probe session and the DELETE response's sandbox disposition must prove closure; `stop-failed`/`unreachable` or an undeleted session is a stage failure

Because session creation/read/delete had no API surface (creation is a server action; the transcript is SSR + a resume-tail stream), the probe rides on three new auth-gated routes following the existing PATCH pattern: `POST /api/sessions` (programmatic create; repoId stays null — the provider clones its configured `AGENT_TARGET_REPO`), `GET /api/sessions/[id]` (session + event log; the resume handle itself never leaves the row, only a `parked` boolean), and `DELETE /api/sessions/[id]` (stops any live parked sandbox via `sandbox-release.ts` **before** cascading `session_events` + `terminal_tickets` + the row in one transaction; a stop failure or unreachable lookup keeps the session — never drop the only pointer to a machine that may still bill; a running turn is a 409).

Teardown is guaranteed by construction: the probe's `finally` deletes the session on every exit path, an escaped client fault becomes a `probe_error` check instead of discarding the report, and a turn that never closed can never pass the leak check. Skip ladder (reused #927 conventions): missing/expired session credential, unprovisioned target runtime (preflight env check), and target deployments predating the probe routes are explicit skips; anything else red.

**#753 note:** no stop control existed to adopt at implementation time, so DELETE-with-sandbox-release is the honest teardown path; if #753 lands a first-class stop, the release module is the seam to swap.

**Spend:** one tiny prompt, one small turn per run (cents). Local spawns skip the stage by default (`pnpm validate` never surprise-spends); `--skip-real-turn` opts a deployed run out.

## #819 — reporting + scheduled lane

- `renderMarkdownReport` writes `output/validate/<env>/report.md` beside the JSON record: stage table with per-stage timings, skip reasons, failing-check detail, and evidence file paths (deployed e2e screenshots fold in automatically).
- `.github/workflows/web-next-validate.yml`: daily cron + `workflow_dispatch` (optional `target_url` for previews — no stable preview origin is resolvable without Vercel API access, so scheduled runs target prod only, documented in the workflow). Secrets ride only in env; `redactSecrets` covers error paths, deployed e2e keeps traces off. Uploads `output/validate/**` as the `web-next-validate` artifact and pours the report into `$GITHUB_STEP_SUMMARY`. Stage failures fail the job; skips don't.

## Real finding from the live run → #936

The sanctioned prod run surfaced that **prod cannot run a real agentic turn today**: its own preflight reports no Vercel Sandbox credentials (`VERCEL_OIDC_TOKEN` not injected, no `VERCEL_TOKEN`/`VERCEL_TEAM_ID`). The stage reports the honest skip rather than a green pass — filed as #936 with the fix options (enable OIDC on the project, or set the token trio). A full end-to-end pass of assertions 1–6 against a deployed env is therefore blocked on #936; the probe's verdict logic is covered by 27 unit tests including the leak/teardown matrix, and every gate rung was exercised live (see Evidence).

## Mergeability

- Surface: web (web-next validation harness + session API routes) / infra (one new scheduled workflow, `web-next-validate.yml` — dedicated lane, touches nothing the desktop lanes own)
- User-facing behavior changed: No UI changes. New auth-gated API surface: POST /api/sessions, GET+DELETE /api/sessions/[id] (DELETE is destructive but allowlist-gated, refuses mid-turn, and preserves sessions whose sandbox can't be proven stopped).
- Non-happy paths considered: teardown on thrown assertions/client faults (finally + probe_error, unit-tested); DELETE during a running turn (409); sandbox stop failure and unreachable lookups (502, session kept); turn deadline overrun (leak check fails, sandbox lifetime cap named); create-timeout litter named in the check detail; expired credential vs missing credential vs unprovisioned runtime vs undeployed routes each get distinct explicit skips; zero-spec e2e and report-missing already covered by #927.
- Residual risk or follow-up: (1) prod redeploy needed before the daily lane is meaningful — it picks up both the probe routes and #931's tightened 401-JSON posture (the lane will show posture failures + a routes-not-deployed skip against the current stale deployment); (2) #936 blocks the full live real-turn pass; (3) `resolveTurn`'s 120s-quiet stale window means DELETE can proceed on a genuinely-running-but-silent turn — same liveness contract the stream route already uses, and the probe's leak check now fails closed in that scenario; (4) auth bounces collapse to `expired — re-seed` skips per the decision doc — a route-specific 401 regression would surface as a *new skip* in the daily report rather than a red run (declined codex finding, see Review loop).

## Evidence

**Tests passed:** unit 407/407 (36 files, includes 27 probe-core + 7 sandbox-release + 12 new route tests), e2e 31/31, lint + typecheck clean. Mutation check: inverting the leak verdict in `classifyTeardown` failed 1 test (caught), restored → green.

- [gates + mutation check](https://evidence.cloudcompute.com/workspaces/pr-937/20260707-233029-gates.png)
- [live prod run — full stage output](https://evidence.cloudcompute.com/workspaces/pr-937/20260707-233027-prod-validate.png): reachability 1/1, posture 7/7, **authenticated flows (#814) 2/2**, model sweep 4/4, deployed-safe e2e 8/8, real turn → `skipped: target runtime not provisioned` (#936). Captured pre-rebase; post-#931 posture tightens to 401-JSON and needs the prod redeploy above.
- [live local-live run — skip-ladder rung](https://evidence.cloudcompute.com/workspaces/pr-937/20260707-233028-local-live-validate.png): production build + partial runtime creds → same honest preflight skip naming exactly the missing names.
- [reporter sample (report.md)](https://evidence.cloudcompute.com/workspaces/pr-937/20260707-233030-prod-report-md.png)
- CI: [Web Next CI green (lint, typecheck, unit, build, e2e, evidence, perf)](https://github.com/fairchild/workspaces/actions/runs/28905920101)

## Gate
- CI: green quality lane on 40eb38d: https://github.com/fairchild/workspaces/actions/runs/28905920101/job/85752878423
- Gate note: orchestrator verified zero file overlap with #935 (disjoint despite adjacent turn-lifecycle domain); live prod run: posture 7/7, authed #814 flows 2/2, model sweep 4/4, e2e 8/8, real-turn stage correctly skip-reported the missing prod sandbox creds (real finding -> #936, orchestrator provisioning next); codex 4 fixed / 1 declined with decision-doc rationale; 407/407 unit + 31/31 e2e. Merged on delegated authority.

## Review loop

Reflect pass: found + fixed DELETE-during-running-turn (orphaned ingest writes / lost resume handle) before codex — 409 guard, own commit.

codex (gpt-5.5, xhigh), directed at teardown guarantees, DELETE auth+cascade, workflow secret handling, skip-vs-fail semantics:

1. **High — teardown verdict lost when the probe rethrows** → fixed: core never rethrows; escaped faults become a `probe_error` check beside the teardown verdict.
2. **High — quiet-turn stale delete reads as "no leak"** → fixed: `classifyTeardown` takes `turnCompleted`; an unclosed turn fails the leak check even when the delete succeeds.
3. **High — transient `Sandbox.get` faults classified as `expired`, deleting the resume pointer** → fixed: non-404 lookup failures are `unreachable`; the route keeps the session (502).
4. **Medium — create-timeout litter unreported** → fixed: status-0 create names the possible server-side litter in its check detail.
5. **Medium — auth bounces over-classified as skips could mask a route-specific 401 regression** → declined, documented: distinguishing an expired credential from a route regression isn't reliably possible with one credential; the decision doc chose the `expired — re-seed` skip wording and the daily report lists every skip loudly (a new skip on prod is a visible signal, not green-wash).

codex also verified: no field mismatches between the routes' response shapes and what the probe consumes, and no concrete secret-leak path into logs/JSON/report/summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

