### PR TITLE
docs(xcode-cloud): debugging runbook — real log access, SHA-pinned watching, VM quirks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ New standalone Python utilities are single-file UV scripts: `#!/usr/bin/env -S u
 | Lume integration / daemon reliability | docs/development/lume-integration.md | - |
 | Lume validation lanes | docs/development/lume-validation.md | - |
 | Lume runner setup | docs/development/lume-runner-setup.md | - |
+| Xcode Cloud harness + debugging (real logs, VM quirks) | docs/development/xcode-cloud.md | - |
 | Web local dev (mise tasks, auth bypass) | web/docs/local-dev.md | - |
 | Web architecture | web/docs/architecture.md | - |
 | PR reviewer agent | docs/pr-review/pr-reviewer.md | - |

--- a/docs/development/xcode-cloud.md
+++ b/docs/development/xcode-cloud.md
@@ -55,6 +55,64 @@ Homebrew's `gettext` may be keg-only, so the script prepends
 
 Keep release signing/notarization on the existing GitHub Actions signing-host lane until the Xcode Cloud validation lane has proven stable.
 
+## Debugging Builds (read this before guessing)
+
+First green builds: 594/595 on `4058f0fc` (2026-07-07), after five distinct
+failure generations (license → xtrace-in-trap noise #795 → `/usr/local` brew
+prefix #854 → silent x86_64 zig slice, diagnosed via probe #869 →
+bootstrap-needs-sudo #907, refuted by build 574's log → cross-compile fix #925
++ ASC log access #928).
+
+### Getting real logs
+
+GitHub check-runs only ever carry Xcode Cloud's one-line summary
+(`Running ci_post_clone.sh script failed (exited with code 1)`). Full script
+stdout/stderr lives in App Store Connect LOG_BUNDLE artifacts, and the ASC API
+credentials exist only as repo secrets — so the fetch runs inside Actions:
+
+```sh
+gh workflow run xcode-cloud-logs.yml -f sha=<full-commit-sha>
+```
+
+The job log prints structured `ciIssues` plus filtered log excerpts (usually
+enough on its own); full bundles upload as a 5-day artifact. Implementation:
+`scripts/fetch-xcode-cloud-logs.py`. The key must be a **Team** API key with
+App Manager role — an individual key 401s.
+
+### Watching builds
+
+Pin to a commit SHA, never to `main`'s moving head:
+
+```sh
+gh api repos/fairchild/workspaces/commits/<SHA>/check-runs \
+  --jq '.check_runs[] | select(.app.slug|test("xcode";"i")) | [.name, .status, .conclusion] | @tsv'
+```
+
+Cancellation on supersede is normal: when a newer commit lands on `main`
+mid-build, Xcode Cloud cancels the in-flight build. A `cancelled` conclusion on
+an older SHA is not a failure signal; check the newest head instead.
+
+Two ASC-side workflows ("Default" and "Untitled Workflow") currently both build
+every push, so each commit produces two identical build runs. Deleting one
+requires the App Store Connect web UI.
+
+### VM image quirks (all confirmed via real build logs)
+
+- Host is arm64, but Homebrew runs from `/usr/local` and pours **x86_64**
+  bottles — including zig. Ghostty resolves `-Dxcframework-target=native` from
+  the zig **compiler binary's** baked-in arch, so an unpatched build silently
+  produces an x86_64-only GhosttyKit that surfaces three stages later as
+  `no such module 'GhosttyKit'`. `build-ghosttykit.sh` detects the mismatch,
+  patches the pinned checkout to cross-compile the host-arch slice, and
+  hard-asserts the result (lipo + Info.plist). Details and ruled-out
+  alternatives: `docs/development/libghostty-integration.md` § "Zig 0.15.2
+  with newer macOS SDKs".
+- **The CI user has no sudo** (build 574): anything needing `/opt/homebrew`
+  creation, installer scripts, or privileged paths fails. Do not reintroduce a
+  bootstrap.
+- VMs are fresh per build — no zig cache reuse; the GhosttyKit build costs a
+  few minutes every run.
+
 ## Local Harness Verification
 
 The Xcode project can be checked without running the expensive SwiftPM validation scripts:


### PR DESCRIPTION
Docs-only. Extends `docs/development/xcode-cloud.md` (harness setup) with the operational knowledge from the 2026-07-07 debugging arc, so the next agent facing an Xcode Cloud failure starts from the runbook instead of re-deriving it:

- **Real log access**: check-runs carry only the one-line summary; `gh workflow run xcode-cloud-logs.yml -f sha=<SHA>` fetches structured issues + full LOG_BUNDLEs (shipped in #928).
- **Watching builds**: pin to a commit SHA; cancellation-on-supersede is normal, not a failure.
- **VM image quirks** (all log-confirmed): `/usr/local` x86_64 Homebrew on an arm64 host, no sudo, fresh VMs per build — the constraints behind `build-ghosttykit.sh`'s cross-compile path (#925).
- Failure-generation history with PR pointers; adds the AGENTS.md doc-navigation row.

Follow-ups filed: #938 (delete duplicate ASC workflow — human/ASC-UI), #939 (fat-archive trim in the repair sweep — cosmetic).

## Mergeability

- **Surface**: docs (`docs/development/xcode-cloud.md`) + one AGENTS.md nav-table row; no code.
- **User-facing behavior changed**: None.
- **Non-happy paths considered**: N/A — reference content; claims are backed by fetched build logs (594/595 diagnostics).
- **Residual risk or follow-up**: none beyond the two filed issues; content goes stale only if Apple changes the VM image, in which case the runbook's own log-fetch instructions are the recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
