### PR TITLE
feat(automation): operator scope end-to-end — opt-in launch, minted credential, window.read, CLI window list (#916)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -23,11 +23,23 @@ final class AutomationIntegrationLifecycle: ObservableObject {
     private var teardownObserver: Any?
     private var didStart = false
     private var startTask: Task<String, Error>?
+    private var operatorCredentialURL: URL?
+
+    /// The app scope id operator handles carry — matched to the value `TileTreeStore` stamps on tile
+    /// handles so audit and context read consistently across both handle classes.
+    private static let appScopeID = "workspaces.local"
 
     private init() {}
 
     var isEnabled: Bool {
         ExperimentalFeatures.isEnabled(.automationAPI)
+    }
+
+    /// Whether this launch opted into operator scope. Operator scope rides on the automation listener,
+    /// so it requires the Automation API experiment as well; the caller only reaches minting when the
+    /// listener is enabled.
+    private var isOperatorEnabled: Bool {
+        ExperimentalFeatures.isEnabled(.automationOperator)
     }
 
     func configure(
@@ -38,6 +50,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
     ) async {
         guard isEnabled else {
             tileTreeStore.configureAutomation(handleRegistry: nil, socketPath: nil)
+            // Fail closed: an app without the Automation API leaves no operator credential behind.
+            clearOperatorCredential()
             return
         }
 
@@ -72,6 +86,9 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             tileTreeStore: tileTreeStore,
             webSurfaceRecords: webSurfaceRecords
         )
+        let windows: @MainActor () -> [AutomationWindowDescriptor] = {
+            AutomationWindowEnumerator.descriptors()
+        }
 
         if let startTask {
             let socketPath = try await startTask.value
@@ -80,7 +97,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal,
                 webSurfaces: webSurfaces,
-                webSnapshot: webSnapshot
+                webSnapshot: webSnapshot,
+                windows: windows
             )
             return socketPath
         }
@@ -91,7 +109,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal,
                 webSurfaces: webSurfaces,
-                webSnapshot: webSnapshot
+                webSnapshot: webSnapshot,
+                windows: windows
             )
             guard let socketPath else {
                 throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
@@ -105,7 +124,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             focusTerminal: focusTerminal,
             requestCloseTerminal: requestCloseTerminal,
             webSurfaces: webSurfaces,
-            webSnapshot: webSnapshot
+            webSnapshot: webSnapshot,
+            windows: windows
         )
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
@@ -140,11 +160,35 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         self.startTask = nil
         NSLog("[AutomationIntegration] listener started at %@", listener.socketPath)
 
+        // Mint the per-launch operator credential exactly once, on first start. Opted-in launches
+        // register an operator handle and write the credential next to the socket; every other
+        // launch clears any stale credential so a non-opted-in app never leaves one behind.
+        let credentialURL = AutomationOperatorCredentialStore.defaultURL(bundleIdentifier: bundleID)
+        operatorCredentialURL = credentialURL
+        let credential = AutomationOperatorProvisioner.provision(
+            optedIn: isOperatorEnabled,
+            registry: handleRegistry,
+            socketPath: startedSocketPath,
+            appScopeID: Self.appScopeID,
+            credentialURL: credentialURL
+        )
+        if credential != nil {
+            NSLog("[AutomationIntegration] operator credential minted at %@", credentialURL.path)
+        }
+
         teardownObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            // Remove the credential synchronously here: the async stop() Task below may not run
+            // before the process exits, and "dies with the launch" should hold on a clean quit.
+            // (A crash can't clean up, which is why a stale credential also fails closed against the
+            // fresh registry — see AutomationOperatorCredentialStore.)
+            let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
+            AutomationOperatorCredentialStore.remove(
+                at: AutomationOperatorCredentialStore.defaultURL(bundleIdentifier: bundleID)
+            )
             Task { @MainActor [weak self] in await self?.stop() }
         }
         return listener.socketPath
@@ -191,9 +235,20 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         socketPath = nil
         didStart = false
         handleRegistry.removeAll()
+        // The operator handle dies with the launch; remove its credential file on the way out so a
+        // clean exit leaves nothing readable (a crash can't, which is why stale credentials fail
+        // closed against the fresh registry — see AutomationOperatorCredentialStore).
+        clearOperatorCredential()
         if let teardownObserver {
             NotificationCenter.default.removeObserver(teardownObserver)
             self.teardownObserver = nil
         }
+    }
+
+    private func clearOperatorCredential() {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"
+        let url = operatorCredentialURL ?? AutomationOperatorCredentialStore.defaultURL(bundleIdentifier: bundleID)
+        AutomationOperatorCredentialStore.remove(at: url)
+        operatorCredentialURL = nil
     }
 }

--- a/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
+++ b/Sources/WorkspaceManager/App/ExperimentalFeatures.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum ExperimentalFeature: String, CaseIterable, Identifiable {
     case automationAPI = "automationAPI"
     case automationInputWrite = "automationInputWrite"
+    case automationOperator = "automationOperator"
     case minimalToolbar = "minimalToolbar"
     case restoreSessionsOnLaunch = "restoreSessionsOnLaunch"
 
@@ -20,6 +21,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
             return "Automation API"
         case .automationInputWrite:
             return "Automation Input Write"
+        case .automationOperator:
+            return "Automation Operator Scope"
         case .minimalToolbar:
             return "Minimal Toolbar"
         case .restoreSessionsOnLaunch:
@@ -33,6 +36,10 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
             return "Expose a local same-user socket so terminal tiles can inspect and arrange their WorkSpaces shell."
         case .automationInputWrite:
             return "Let automation clients type into their own terminal tile. Requires the Automation API experiment."
+        case .automationOperator:
+            return "Mint a per-launch operator credential next to the automation socket so trusted "
+                + "same-user tools outside any tile can list the app's windows. Requires the "
+                + "Automation API experiment."
         case .minimalToolbar:
             return "Hide secondary toolbar controls so terminal surfaces stay closer to the canvas."
         case .restoreSessionsOnLaunch:
@@ -54,6 +61,8 @@ enum ExperimentalFeature: String, CaseIterable, Identifiable {
             return "WORKSPACES_AUTOMATION_API"
         case .automationInputWrite:
             return "WORKSPACES_AUTOMATION_INPUT_WRITE"
+        case .automationOperator:
+            return "WORKSPACES_AUTOMATION_OPERATOR"
         case .minimalToolbar:
             return "WORKSPACES_PERF_MINIMAL_TOOLBAR"
         case .restoreSessionsOnLaunch:

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -10,6 +10,7 @@ final class AutomationController: AutomationControlling {
     private let isInputWriteEnabled: @MainActor () -> Bool
     private var webSurfaces: @MainActor () -> [AutomationWebSurfaceDescriptor]
     private var webSnapshot: @MainActor (UUID) async -> WebSnapshotOutcome
+    private var windows: @MainActor () -> [AutomationWindowDescriptor]
 
     init(
         handleRegistry: AutomationHandleRegistry,
@@ -18,6 +19,7 @@ final class AutomationController: AutomationControlling {
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
         webSurfaces: @escaping @MainActor () -> [AutomationWebSurfaceDescriptor] = { [] },
         webSnapshot: @escaping @MainActor (UUID) async -> WebSnapshotOutcome = { _ in .unknownSource },
+        windows: @escaping @MainActor () -> [AutomationWindowDescriptor] = { [] },
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
         }
@@ -28,6 +30,7 @@ final class AutomationController: AutomationControlling {
         self.requestCloseTerminal = requestCloseTerminal
         self.webSurfaces = webSurfaces
         self.webSnapshot = webSnapshot
+        self.windows = windows
         self.isInputWriteEnabled = isInputWriteEnabled
     }
 
@@ -36,7 +39,8 @@ final class AutomationController: AutomationControlling {
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
         webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil,
-        webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil
+        webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil,
+        windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil
     ) {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
@@ -46,6 +50,9 @@ final class AutomationController: AutomationControlling {
         }
         if let webSnapshot {
             self.webSnapshot = webSnapshot
+        }
+        if let windows {
+            self.windows = windows
         }
     }
 
@@ -60,6 +67,22 @@ final class AutomationController: AutomationControlling {
             surfaces: surfaceDescriptors(for: resolved),
             system: AutomationSystemDescriptor(capabilities: resolved.entry.capabilities)
         )
+    }
+
+    func automationWindows(for handle: String) throws -> AutomationWindowsResult {
+        // Operator scope: capture-only listing of the app's windows. The caller need not own a
+        // terminal tile, so this resolves the handle without the tile-liveness check — only the
+        // window.read capability and operator-scope guard apply. A tile handle lacks window.read
+        // and fails capability_denied.
+        let entry = try resolveOperator(handle, requiring: .windowRead)
+        return AutomationWindowsResult(
+            windows: windows(),
+            system: AutomationSystemDescriptor(capabilities: entry.capabilities)
+        )
+    }
+
+    func automationHandleIsOperator(_ handle: String) -> Bool {
+        handleRegistry.resolve(handle)?.isOperator ?? false
     }
 
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult {
@@ -201,6 +224,33 @@ final class AutomationController: AutomationControlling {
     private struct ResolvedHandle {
         let entry: AutomationHandleRegistry.Entry
         let tileTreeStore: TileTreeStore
+    }
+
+    /// Resolves an operator handle for a capture-only route. Unlike `resolve`, it does not require a
+    /// live terminal tile — operator scope exists outside any tile. It still fails closed: a
+    /// missing/stale handle is `stale_handle`, an under-capable handle is `capability_denied`, and a
+    /// tile handle that somehow reaches here (it lacks the operator capabilities by construction) is
+    /// `capability_denied` on the operator-scope guard.
+    private func resolveOperator(
+        _ handle: String,
+        requiring capability: AutomationCapability
+    ) throws -> AutomationHandleRegistry.Entry {
+        guard let entry = handleRegistry.resolve(handle) else {
+            throw AutomationServiceError(.staleHandle, "The automation handle is missing or stale.")
+        }
+        guard entry.capabilities.contains(capability) else {
+            throw AutomationServiceError(
+                .capabilityDenied,
+                "The automation handle does not include \(capability.rawValue)."
+            )
+        }
+        guard entry.isOperator else {
+            throw AutomationServiceError(
+                .capabilityDenied,
+                "This route requires an operator handle."
+            )
+        }
+        return entry
     }
 
     private func resolve(

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationWindowEnumerator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationWindowEnumerator.swift
@@ -1,0 +1,36 @@
+//
+//  AutomationWindowEnumerator.swift
+//  WorkspaceManager
+//
+//  Projects the app's live AppKit windows into the read-only descriptors the operator-scope
+//  `GET /v1/windows` route returns. Lists on-screen, addressable windows only, keyed by the AppKit
+//  window number — the stable identity `CGWindowList`/ScreenCaptureKit share, so the follow-on
+//  `window.snapshot` slice can target the same window a caller listed here.
+//
+
+import AppKit
+import WorkspaceManagerCore
+
+enum AutomationWindowEnumerator {
+    @MainActor
+    static func descriptors(windows: [NSWindow]? = nil) -> [AutomationWindowDescriptor] {
+        (windows ?? NSApp.windows).compactMap { window in
+            // On-screen, real windows only. `windowNumber <= 0` is an off-screen/deferred window
+            // with no capturable identity; an invisible window is not a listable surface.
+            guard window.isVisible, window.windowNumber > 0 else { return nil }
+            let frame = window.frame
+            return AutomationWindowDescriptor(
+                windowID: String(window.windowNumber),
+                title: window.title,
+                subtitle: window.subtitle.isEmpty ? nil : window.subtitle,
+                isMain: window.isMainWindow,
+                isKey: window.isKeyWindow,
+                isVisible: window.isVisible,
+                x: frame.origin.x,
+                y: frame.origin.y,
+                width: frame.size.width,
+                height: frame.size.height
+            )
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -40,6 +40,7 @@ private final class CLIApp {
         "surface",
         "tile",
         "input",
+        "window",
     ]
 
     private let stateStore = CLIStateStore()
@@ -86,6 +87,8 @@ private final class CLIApp {
             return try runTile(arguments: tail)
         case "input":
             return try runInput(arguments: tail)
+        case "window":
+            return try runWindow(arguments: tail)
         default:
             throw CLIError("Unknown command '\(command)'. Run 'workspaces help'.")
         }
@@ -837,6 +840,71 @@ private final class CLIApp {
         return 0
     }
 
+    /// `workspaces window list [--json]` — the operator-scope command. Unlike the tile-scoped
+    /// commands, it reads the per-launch operator credential file (minted next to the socket by an
+    /// opted-in launch) rather than the `WORKSPACES_AUTOMATION_HANDLE` env, so it works from any
+    /// same-user shell outside a WorkSpaces tile. Absent the credential it fails closed with guidance.
+    private func runWindow(arguments: [String]) throws -> Int32 {
+        let usage = "workspaces window list [--json]"
+        guard arguments.first == "list" else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        var json = false
+        for argument in arguments.dropFirst() {
+            switch argument {
+            case "--json":
+                json = true
+            default:
+                throw CLIError("Usage: \(usage)")
+            }
+        }
+
+        let credential = try loadOperatorCredential()
+        let client = AutomationSocketClient(socketPath: credential.socketPath)
+        let response = try client.request(
+            method: "GET",
+            path: "/v1/windows",
+            handle: credential.handle,
+            body: Data()
+        )
+        let result: AutomationWindowsResult
+        do {
+            result = try AutomationCLIResultPrinter.decodeEnvelope(AutomationWindowsResult.self, from: response)
+        } catch let error as AutomationServiceError {
+            throw CLIError(
+                "automation request failed: \(error.response.code.rawValue): \(error.response.message)"
+            )
+        }
+
+        if json {
+            print(try AutomationCLIResultPrinter.resultJSON(result))
+            return 0
+        }
+
+        if result.windows.isEmpty {
+            print("No windows.")
+            return 0
+        }
+        for window in result.windows {
+            let title = window.title.isEmpty ? "(untitled)" : window.title
+            let size = "\(Int(window.width))x\(Int(window.height))"
+            print("\(window.windowID)\t\(size)\t\(title)")
+        }
+        return 0
+    }
+
+    private func loadOperatorCredential() throws -> AutomationOperatorCredential {
+        let url = AutomationOperatorCredentialStore.defaultURL(bundleIdentifier: Self.appBundleIdentifier)
+        guard let credential = AutomationOperatorCredentialStore.load(from: url) else {
+            throw CLIError(
+                "Operator credential not found at \(url.path). Launch WorkSpaces with the Automation "
+                    + "Operator experiment enabled (or WORKSPACES_AUTOMATION_OPERATOR=1) and try again."
+            )
+        }
+        return credential
+    }
+
     private func performAutomationRequest<Result>(
         _ type: Result.Type = Result.self,
         method: String,
@@ -1369,6 +1437,7 @@ private func printHelp() {
           workspaces tile split --left|--right|--up|--down
           workspaces tile close
           workspaces input write <text> [--submit]
+          workspaces window list [--json]
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -19,6 +19,11 @@ public enum AutomationAPI {
     /// Kept separate from `v1Capabilities` so default handles never widen.
     public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
 
+    /// Capabilities granted to an opt-in operator handle (`[A1]`). Capture-only at first:
+    /// `window.read` lists the app's windows. `window.snapshot` is a follow-on slice and is
+    /// deliberately absent here. Operator handles never carry tile mutation capabilities.
+    public static let operatorCapabilities = [AutomationCapability.windowRead]
+
     public static let inputWriteMaxUTF8Bytes = 32_768
 
     /// Bounds for `GET /v1/web-surfaces/{id}/snapshot` (`browser.read`). The snapshot
@@ -40,6 +45,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case tileClose = "tile.close"
     case inputWrite = "input.write"
     case browserRead = "browser.read"
+    case windowRead = "window.read"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -257,6 +263,62 @@ public struct AutomationSurfacesResult: Codable, Sendable, Equatable {
     }
 }
 
+/// Read-only descriptor for one of the app's on-screen windows (`window.read`, operator scope).
+/// `windowID` is the AppKit window number as a string — stable for the window's lifetime and the
+/// same identity `CGWindowList`/ScreenCaptureKit address, so the follow-on `window.snapshot` slice
+/// can target it. Geometry is in AppKit points (bottom-left origin, the global display space).
+public struct AutomationWindowDescriptor: Codable, Sendable, Equatable {
+    public let windowID: String
+    public let title: String
+    public let subtitle: String?
+    public let isMain: Bool
+    public let isKey: Bool
+    public let isVisible: Bool
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(
+        windowID: String,
+        title: String,
+        subtitle: String?,
+        isMain: Bool,
+        isKey: Bool,
+        isVisible: Bool,
+        x: Double,
+        y: Double,
+        width: Double,
+        height: Double
+    ) {
+        self.windowID = windowID
+        self.title = title
+        self.subtitle = subtitle
+        self.isMain = isMain
+        self.isKey = isKey
+        self.isVisible = isVisible
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+}
+
+public struct AutomationWindowsResult: Codable, Sendable, Equatable {
+    public let windows: [AutomationWindowDescriptor]
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        windows: [AutomationWindowDescriptor],
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.windows = windows
+        self.system = system
+    }
+}
+
 public struct AutomationMutationResult: Codable, Sendable, Equatable {
     public let changed: Bool
     public let focusedSurfaceID: String?
@@ -318,6 +380,30 @@ public struct AutomationTerminalEnvironment: Sendable, Equatable {
     public init(socketPath: String, handle: String) {
         self.socketPath = socketPath
         self.handle = handle
+    }
+}
+
+/// The per-launch operator credential (`[A1]`). An opt-in launch mints this and writes it to a
+/// user-private file next to `automation.sock`; any same-user process (a dev shell, `evidence.sh`,
+/// CI) reads it to call operator-scoped routes without living inside a terminal tile. The `handle`
+/// registers in the live handle registry and dies with the launch, so a credential left behind by a
+/// crashed launch fails closed (`stale_handle`) against the fresh registry. Normal launches mint no
+/// credential; the file's absence is the fail-closed signal.
+public struct AutomationOperatorCredential: Codable, Sendable, Equatable {
+    public let v: Int
+    public let socketPath: String
+    public let handle: String
+    public let capabilities: [AutomationCapability]
+
+    public init(
+        socketPath: String,
+        handle: String,
+        capabilities: [AutomationCapability] = AutomationAPI.operatorCapabilities
+    ) {
+        self.v = AutomationAPI.version
+        self.socketPath = socketPath
+        self.handle = handle
+        self.capabilities = capabilities
     }
 }
 
@@ -402,6 +488,7 @@ public struct AutomationServiceError: Error, Sendable, Equatable {
 public protocol AutomationControlling: AnyObject, Sendable {
     func automationContext(for handle: String) throws -> AutomationContextResult
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
+    func automationWindows(for handle: String) throws -> AutomationWindowsResult
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult
     func automationWebSurfaceSnapshot(
         for handle: String,
@@ -421,4 +508,9 @@ public protocol AutomationControlling: AnyObject, Sendable {
         text: String,
         submit: Bool
     ) throws -> AutomationInputWriteResult
+
+    /// Whether `handle` resolves to a live operator entry. The listener consults this to tag audit
+    /// events, so operator calls are distinguishable in `automation-audit.jsonl` without the audit
+    /// logger seeing the opaque handle's scope. A missing/stale handle is not an operator handle.
+    func automationHandleIsOperator(_ handle: String) -> Bool
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
@@ -6,6 +6,9 @@ public actor AutomationAuditLogger {
         public let method: String
         public let path: String
         public let handlePresent: Bool
+        /// True when the request's handle resolved to a live operator entry, so operator calls are
+        /// distinguishable from tile calls in the audit log (`[A1]`).
+        public let operatorHandle: Bool
         public let allowed: Bool
         public let errorCode: AutomationErrorCode?
 
@@ -14,6 +17,7 @@ public actor AutomationAuditLogger {
             method: String,
             path: String,
             handlePresent: Bool,
+            operatorHandle: Bool = false,
             allowed: Bool,
             errorCode: AutomationErrorCode?
         ) {
@@ -21,6 +25,7 @@ public actor AutomationAuditLogger {
             self.method = method
             self.path = path
             self.handlePresent = handlePresent
+            self.operatorHandle = operatorHandle
             self.allowed = allowed
             self.errorCode = errorCode
         }
@@ -45,13 +50,20 @@ public actor AutomationAuditLogger {
         return dir.appendingPathComponent("automation-audit.jsonl", isDirectory: false)
     }
 
-    public func record(method: String, path: String, headers: [String: String], responseBody: Data) {
+    public func record(
+        method: String,
+        path: String,
+        headers: [String: String],
+        responseBody: Data,
+        operatorHandle: Bool = false
+    ) {
         let summary = (try? AutomationJSON.decoder.decode(AuditEnvelopeSummary.self, from: responseBody))
         let event = Event(
             timestamp: timestampFormatter.string(from: Date()),
             method: method,
             path: path,
             handlePresent: headers[AutomationAPI.handleHeader]?.isEmpty == false,
+            operatorHandle: operatorHandle,
             allowed: summary?.ok == true,
             errorCode: summary?.error?.code
         )

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -74,6 +74,9 @@ enum AutomationHTTPRouter {
         case ("GET", "/v1/web-surfaces"):
             return try await controller.automationWebSurfaces(for: handle)
 
+        case ("GET", "/v1/windows"):
+            return try await controller.automationWindows(for: handle)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -108,6 +111,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/surfaces.")
         case (_, "/v1/web-surfaces"):
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/web-surfaces.")
+        case (_, "/v1/windows"):
+            throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/windows.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -289,6 +294,7 @@ extension CodableSendableEquatable {
 extension AutomationHealthResult: CodableSendableEquatable {}
 extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
+extension AutomationWindowsResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}
 extension AutomationMutationResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
@@ -2,6 +2,10 @@ import Foundation
 
 @MainActor
 public final class AutomationHandleRegistry {
+    /// The synthetic window scope carried by operator entries. Operator scope is not window-bound
+    /// (it lists every app window), so this is a marker, not a live SwiftUI window identity.
+    public static let operatorWindowScopeID = "operator"
+
     public struct Entry: Sendable, Equatable {
         public let handle: String
         public let hostSessionID: UUID
@@ -10,6 +14,9 @@ public final class AutomationHandleRegistry {
         public let windowScopeID: String
         public let appScopeID: String
         public let capabilities: [AutomationCapability]
+        /// True for an opt-in operator handle (trusted caller outside any tile). Operator entries do
+        /// not resolve to a terminal tile, so callers must skip tile-liveness checks for them.
+        public let isOperator: Bool
 
         public init(
             handle: String,
@@ -18,7 +25,8 @@ public final class AutomationHandleRegistry {
             surfaceKind: AutomationSurfaceKind,
             windowScopeID: String,
             appScopeID: String,
-            capabilities: [AutomationCapability] = AutomationAPI.v1Capabilities
+            capabilities: [AutomationCapability] = AutomationAPI.v1Capabilities,
+            isOperator: Bool = false
         ) {
             self.handle = handle
             self.hostSessionID = hostSessionID
@@ -27,6 +35,7 @@ public final class AutomationHandleRegistry {
             self.windowScopeID = windowScopeID
             self.appScopeID = appScopeID
             self.capabilities = capabilities
+            self.isOperator = isOperator
         }
     }
 
@@ -58,6 +67,32 @@ public final class AutomationHandleRegistry {
             windowScopeID: windowScopeID,
             appScopeID: appScopeID,
             capabilities: capabilities
+        )
+        entriesByHandle[handle] = entry
+        return entry
+    }
+
+    /// Registers a per-launch operator handle carrying capture-only capabilities. Unlike `upsert`,
+    /// this is not keyed by a live terminal session — the entry stands alone under a synthetic host
+    /// session id so `remove(hostSessionID:)`/`removeAll` still evict it when the launch ends. Each
+    /// call mints a fresh handle; a launch mints exactly one.
+    @discardableResult
+    public func registerOperator(
+        appScopeID: String,
+        capabilities: [AutomationCapability] = AutomationAPI.operatorCapabilities,
+        hostSessionID: UUID = UUID()
+    ) -> Entry {
+        let handle = makeUniqueHandle()
+        handleByHostSessionID[hostSessionID] = handle
+        let entry = Entry(
+            handle: handle,
+            hostSessionID: hostSessionID,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: Self.operatorWindowScopeID,
+            appScopeID: appScopeID,
+            capabilities: capabilities,
+            isOperator: true
         )
         entriesByHandle[handle] = entry
         return entry

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
@@ -175,11 +175,20 @@ public actor AutomationListener {
         }
 
         let response = Self.httpResponse(status: result.status, body: result.body)
+        // Classify the caller's handle against the live registry so the audit event can tell an
+        // operator call from a tile call; a missing/unresolvable handle is not an operator handle.
+        let operatorHandle: Bool
+        if let handleValue = request.headers[AutomationAPI.handleHeader], !handleValue.isEmpty {
+            operatorHandle = await controller.automationHandleIsOperator(handleValue)
+        } else {
+            operatorHandle = false
+        }
         await auditLogger?.record(
             method: request.method,
             path: request.path,
             headers: request.headers,
-            responseBody: result.body
+            responseBody: result.body,
+            operatorHandle: operatorHandle
         )
         connection.send(
             content: response,

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift
@@ -73,7 +73,17 @@ public enum AutomationOperatorProvisioner {
             handle: entry.handle,
             capabilities: entry.capabilities
         )
-        try? AutomationOperatorCredentialStore.write(credential, to: credentialURL)
+        do {
+            try AutomationOperatorCredentialStore.write(credential, to: credentialURL)
+        } catch {
+            // Keep state consistent: if the credential can't be written, roll back the handle
+            // registration and report failure rather than leaving a handle nobody can reach a
+            // credential for. Returning nil lets the caller log an honest "not minted".
+            registry.remove(hostSessionID: entry.hostSessionID)
+            AutomationOperatorCredentialStore.remove(at: credentialURL)
+            NSLog("[AutomationOperator] credential write failed, minting aborted: %@", "\(error)")
+            return nil
+        }
         return credential
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift
@@ -1,0 +1,79 @@
+//
+//  AutomationOperatorCredentialStore.swift
+//  WorkspaceManagerCore
+//
+//  Reads and writes the per-launch operator credential file (`[A1]`). The file lives next to
+//  `automation.sock` under the user-private application-support directory, is user-only (0600),
+//  and is removed when the launch ends. Provisioning ties minting to the opt-in gate: opted-in
+//  launches mint a handle and write the file; every other launch clears any stale file so a
+//  non-opted-in app never leaves an operator credential behind.
+//
+
+import Foundation
+
+public enum AutomationOperatorCredentialStore {
+    public static let fileName = "automation-operator.json"
+
+    /// The credential file's default location — next to `automation.sock`, so its directory
+    /// inherits the same user-private (0700) parent the listener already hardens.
+    public static func defaultURL(bundleIdentifier: String) -> URL {
+        AutomationListener.defaultSocketURL(bundleIdentifier: bundleIdentifier)
+            .deletingLastPathComponent()
+            .appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    /// Writes the credential atomically and clamps it to owner-only read/write (0600). The parent
+    /// directory is created 0700 if missing (mirrors the listener), so the credential is never
+    /// group- or world-readable.
+    public static func write(_ credential: AutomationOperatorCredential, to url: URL) throws {
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(credential)
+        try data.write(to: url, options: [.atomic])
+        // `atomic` writes via a temp file + rename, so set the mode after the rename lands.
+        chmod(url.path, 0o600)
+    }
+
+    public static func load(from url: URL) -> AutomationOperatorCredential? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(AutomationOperatorCredential.self, from: data)
+    }
+
+    public static func remove(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+/// Ties operator minting to the opt-in gate. This is the single decision point so the same rule is
+/// testable in isolation and reused by the app lifecycle: opted-in ⇒ mint a handle in the registry
+/// and write the credential; not opted-in ⇒ clear any stale credential and mint nothing.
+public enum AutomationOperatorProvisioner {
+    @MainActor
+    @discardableResult
+    public static func provision(
+        optedIn: Bool,
+        registry: AutomationHandleRegistry,
+        socketPath: String,
+        appScopeID: String,
+        credentialURL: URL
+    ) -> AutomationOperatorCredential? {
+        guard optedIn else {
+            AutomationOperatorCredentialStore.remove(at: credentialURL)
+            return nil
+        }
+        let entry = registry.registerOperator(appScopeID: appScopeID)
+        let credential = AutomationOperatorCredential(
+            socketPath: socketPath,
+            handle: entry.handle,
+            capabilities: entry.capabilities
+        )
+        try? AutomationOperatorCredentialStore.write(credential, to: credentialURL)
+        return credential
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -481,6 +481,82 @@ struct AutomationControllerTests {
         #expect(fixture.closedSessionIDs == [fixture.primary.id])
     }
 
+    @Test("Operator handle lists windows without owning a tile; tile handle is denied")
+    func operatorWindowsProjection() throws {
+        // A store with no live session at all — operator scope must not depend on a caller tile.
+        let store = TileTreeStore()
+        let registry = AutomationHandleRegistry()
+        let operatorEntry = registry.registerOperator(appScopeID: "workspaces.local")
+        let descriptor = AutomationWindowDescriptor(
+            windowID: "7",
+            title: "WorkSpaces",
+            subtitle: nil,
+            isMain: true,
+            isKey: false,
+            isVisible: true,
+            x: 0,
+            y: 0,
+            width: 1200,
+            height: 800
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            windows: { [descriptor] }
+        )
+
+        let result = try controller.automationWindows(for: operatorEntry.handle)
+        #expect(result.windows == [descriptor])
+        #expect(result.system.capabilities == [.windowRead])
+        #expect(controller.automationHandleIsOperator(operatorEntry.handle))
+    }
+
+    @Test("Windows route fails closed for tile, under-capable, and stale handles")
+    func operatorWindowsFailClosed() throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "tile" })
+        // A tile handle carrying the full v1 tile capabilities — but not window.read.
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            windows: { [] }
+        )
+
+        // Tile handle: has tile capabilities but not window.read → capability_denied.
+        do {
+            _ = try controller.automationWindows(for: "tile")
+            Issue.record("Expected a tile handle to be denied window.read")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+        #expect(!controller.automationHandleIsOperator("tile"))
+
+        // Unknown/stale handle → stale_handle.
+        do {
+            _ = try controller.automationWindows(for: "not-live")
+            Issue.record("Expected an unknown handle to be stale")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .staleHandle)
+        }
+    }
+
     @MainActor
     private final class Fixture {
         let store: TileTreeStore

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -48,6 +48,40 @@ private final class FakeAutomationController: AutomationControlling {
         return AutomationSurfacesResult(surfaces: [])
     }
 
+    var windowCalls: [String] = []
+
+    func automationWindows(for handle: String) throws -> AutomationWindowsResult {
+        // Only an operator handle carries window.read; a tile handle ("live") fails closed, and an
+        // unknown handle is stale — mirrors the real controller's operator-scope projection.
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include window.read.")
+        }
+        windowCalls.append(handle)
+        return AutomationWindowsResult(
+            windows: [
+                AutomationWindowDescriptor(
+                    windowID: "42",
+                    title: "WorkSpaces",
+                    subtitle: "Development Build",
+                    isMain: true,
+                    isKey: true,
+                    isVisible: true,
+                    x: 0,
+                    y: 0,
+                    width: 1400,
+                    height: 900
+                )
+            ]
+        )
+    }
+
+    func automationHandleIsOperator(_ handle: String) -> Bool {
+        handle == "operator"
+    }
+
     var webSurfaceCalls: [String] = []
 
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult {
@@ -640,6 +674,193 @@ struct AutomationAPITests {
         )
         #expect(denied.status == 403)
         #expect(deniedEnvelope.error?.code == .capabilityDenied)
+    }
+
+    @Test("Registry mints an operator handle carrying only capture-only capabilities")
+    @MainActor
+    func registryRegistersOperatorHandle() {
+        let registry = AutomationHandleRegistry(makeHandle: { "op-1" })
+        let entry = registry.registerOperator(appScopeID: "workspaces.local")
+
+        #expect(entry.handle == "op-1")
+        #expect(entry.isOperator)
+        #expect(entry.tileID == nil)
+        #expect(entry.capabilities == [.windowRead])
+        // Capture-only: an operator handle never carries tile mutation or input.write.
+        #expect(!entry.capabilities.contains(.tileClose))
+        #expect(!entry.capabilities.contains(.inputWrite))
+        #expect(registry.resolve("op-1")?.isOperator == true)
+
+        // The handle dies with the launch: once the registry is cleared it no longer resolves,
+        // so a credential left behind by a crashed launch fails closed against a fresh registry.
+        registry.removeAll()
+        #expect(registry.resolve("op-1") == nil)
+    }
+
+    @Test("GET /v1/windows succeeds for an operator handle and denies a tile handle")
+    @MainActor
+    func routerWindows() async throws {
+        let controller = FakeAutomationController()
+
+        let ok = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/windows",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWindowsResult>.self,
+            from: ok.body
+        )
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.windows.count == 1)
+        #expect(okEnvelope.result?.windows.first?.windowID == "42")
+        #expect(okEnvelope.result?.system.capabilities == [.windowRead])
+        #expect(controller.windowCalls == ["operator"])
+
+        // A tile handle holds the v1 tile capabilities but not window.read → capability_denied.
+        let denied = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/windows",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: denied.body
+        )
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        let missing = await AutomationHTTPRouter.route(
+            HTTPRequest(method: "GET", path: "/v1/windows", headers: [:], body: Data()),
+            controller: controller,
+            enabled: true
+        )
+        let missingEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: missing.body
+        )
+        #expect(missing.status == 401)
+        #expect(missingEnvelope.error?.code == .missingHandle)
+
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/windows",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("Operator credential round-trips through the store and is written user-only (0600)")
+    func operatorCredentialStoreRoundTrip() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wm-op-cred-\(UUID().uuidString.prefix(8)).json")
+        defer { AutomationOperatorCredentialStore.remove(at: url) }
+
+        let credential = AutomationOperatorCredential(socketPath: "/tmp/automation.sock", handle: "op-xyz")
+        try AutomationOperatorCredentialStore.write(credential, to: url)
+
+        let loaded = AutomationOperatorCredentialStore.load(from: url)
+        #expect(loaded == credential)
+        #expect(loaded?.capabilities == [.windowRead])
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
+        #expect(permissions == 0o600)
+
+        AutomationOperatorCredentialStore.remove(at: url)
+        #expect(AutomationOperatorCredentialStore.load(from: url) == nil)
+    }
+
+    @Test("Provisioner mints only when opted in and clears a stale credential otherwise")
+    @MainActor
+    func operatorProvisionerGate() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wm-op-prov-\(UUID().uuidString.prefix(8)).json")
+        defer { AutomationOperatorCredentialStore.remove(at: url) }
+
+        // Opt-in launch mints: the credential file exists and its handle resolves as an operator
+        // entry carrying window.read.
+        let registry = AutomationHandleRegistry()
+        let minted = AutomationOperatorProvisioner.provision(
+            optedIn: true,
+            registry: registry,
+            socketPath: "/tmp/automation.sock",
+            appScopeID: "workspaces.local",
+            credentialURL: url
+        )
+        let mintedCredential = try #require(minted)
+        #expect(AutomationOperatorCredentialStore.load(from: url) == mintedCredential)
+        #expect(registry.resolve(mintedCredential.handle)?.capabilities == [.windowRead])
+        #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)
+
+        // A non-opt-in launch mints nothing and clears any stale credential left on disk.
+        let freshRegistry = AutomationHandleRegistry()
+        let notMinted = AutomationOperatorProvisioner.provision(
+            optedIn: false,
+            registry: freshRegistry,
+            socketPath: "/tmp/automation.sock",
+            appScopeID: "workspaces.local",
+            credentialURL: url
+        )
+        #expect(notMinted == nil)
+        #expect(AutomationOperatorCredentialStore.load(from: url) == nil)
+    }
+
+    @Test("Audit log records the operator flag so operator calls are distinguishable")
+    func auditLogTagsOperatorCalls() async throws {
+        let auditURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wm-op-audit-\(UUID().uuidString.prefix(8)).jsonl")
+        defer { try? FileManager.default.removeItem(at: auditURL) }
+        let logger = AutomationAuditLogger(auditURL: auditURL)
+
+        let okBody = try AutomationJSON.encoder.encode(
+            AutomationResponseEnvelope(result: AutomationWindowsResult(windows: []))
+        )
+        await logger.record(
+            method: "GET",
+            path: "/v1/windows",
+            headers: [AutomationAPI.handleHeader: "op"],
+            responseBody: okBody,
+            operatorHandle: true
+        )
+        await logger.record(
+            method: "GET",
+            path: "/v1/context",
+            headers: [AutomationAPI.handleHeader: "tile"],
+            responseBody: okBody,
+            operatorHandle: false
+        )
+
+        let contents = try String(contentsOf: auditURL, encoding: .utf8)
+        let lines = contents.split(separator: "\n").map(String.init)
+        #expect(lines.count == 2)
+        let events = try lines.map { line in
+            try AutomationJSON.decoder.decode(AutomationAuditLogger.Event.self, from: Data(line.utf8))
+        }
+        let windowsEvent = try #require(events.first { $0.path == "/v1/windows" })
+        #expect(windowsEvent.operatorHandle)
+        let contextEvent = try #require(events.first { $0.path == "/v1/context" })
+        #expect(!contextEvent.operatorHandle)
     }
 
     @Test("CLI formatter emits result JSON and surfaces envelope errors")

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -826,6 +826,34 @@ struct AutomationAPITests {
         #expect(AutomationOperatorCredentialStore.load(from: url) == nil)
     }
 
+    @Test("Provisioner rolls back the handle when the credential write fails")
+    @MainActor
+    func operatorProvisionerRollsBackOnWriteFailure() throws {
+        // Force a write failure by making the credential's parent path a regular file, so
+        // createDirectory (and the write) throw. The provisioner must then leave no dangling handle.
+        let parentFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wm-op-blocker-\(UUID().uuidString.prefix(8))")
+        try Data("not a directory".utf8).write(to: parentFile)
+        defer { try? FileManager.default.removeItem(at: parentFile) }
+        let unwritableURL = parentFile.appendingPathComponent("automation-operator.json")
+
+        // Deterministic handle so the rollback is observable: registerOperator mints "op-fixed",
+        // and a successful rollback must leave it unresolvable.
+        let registry = AutomationHandleRegistry(makeHandle: { "op-fixed" })
+        let result = AutomationOperatorProvisioner.provision(
+            optedIn: true,
+            registry: registry,
+            socketPath: "/tmp/automation.sock",
+            appScopeID: "workspaces.local",
+            credentialURL: unwritableURL
+        )
+
+        #expect(result == nil)
+        #expect(AutomationOperatorCredentialStore.load(from: unwritableURL) == nil)
+        // The handle registered during the aborted mint must have been rolled back.
+        #expect(registry.resolve("op-fixed") == nil)
+    }
+
     @Test("Audit log records the operator flag so operator calls are distinguishable")
     func auditLogTagsOperatorCalls() async throws {
         let auditURL = FileManager.default.temporaryDirectory

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -41,7 +41,32 @@ processes only receive automation environment when their surface is created.
 
 Allowed and denied requests are appended to `automation-audit.jsonl` next to
 the socket state. The audit log stores route-level metadata and error codes,
-not terminal input or output.
+not terminal input or output. Each event carries an `operatorHandle` boolean so
+operator calls are distinguishable from tile calls (`[A1]`).
+
+### Operator scope (`[A1]`)
+
+A second handle class for trusted callers *outside* any tile — dev sessions,
+`evidence.sh`, CI — enabling capture-only global reads without living inside a
+WorkSpaces terminal tile. See
+[Automation Operator Scope Decision](../decisions/automation-operator-scope.md).
+
+- **Opt-in launch.** Operator scope exists only when the launch enables it:
+  the `Automation Operator Scope` experiment, or `WORKSPACES_AUTOMATION_OPERATOR=1`.
+  It rides on the automation listener, so the Automation API experiment must
+  also be on. Normal launches mint no operator credential and fail closed.
+- **Minted credential.** An opt-in launch registers a per-launch operator
+  handle in the live handle registry and writes it to a user-private file,
+  `automation-operator.json`, next to `automation.sock`. The file is owner-only
+  (0600) JSON: `{ "v", "socketPath", "handle", "capabilities" }`. Any same-user
+  process reads it to call operator-scoped routes.
+- **Dies with the launch.** The handle is in-memory; it is gone once the app
+  exits, and the credential file is removed on a clean exit. A credential left
+  behind by a crashed launch fails closed — its handle no longer resolves
+  against the fresh registry (`stale_handle`).
+- **Capture-only.** The initial operator capability set is `window.read`
+  (list windows). `window.snapshot` arrives with the follow-on slice. Operator
+  handles never carry tile mutation or `input.write`.
 
 ## Invariants
 
@@ -88,6 +113,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | --- | --- |
 | `GET /v1/context` | Returns the caller's resolved context and capabilities. |
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
+| `GET /v1/windows` | **Operator scope.** Returns the app's on-screen windows with stable identifiers (`window.read`). Keyed by the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address. Requires an operator handle; a tile handle lacks `window.read` and fails `capability_denied`. |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -116,6 +142,7 @@ handle.
 | `context.read` | `GET /v1/context` |
 | `surfaces.read` | `GET /v1/surfaces` |
 | `browser.read` | `GET /v1/web-surfaces` (read-only listing) and `GET /v1/web-surfaces/{id}/snapshot` (bounded PNG of a live surface); granted to default handles under the Automation API experiment |
+| `window.read` | `GET /v1/windows` (list the app's windows); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -191,6 +218,17 @@ workspaces input write 'echo hi'
 workspaces input write 'echo hi' --submit
 ```
 
+`workspaces window list` is the operator-scope command. Unlike the tile-scoped
+commands, it reads the per-launch operator credential file (minted next to the
+socket by an opt-in launch) rather than the injected terminal environment, so it
+works from any same-user shell outside a WorkSpaces tile. Absent the credential
+it fails closed with guidance.
+
+```bash
+workspaces window list
+workspaces window list --json
+```
+
 ## Implementation Map
 
 | Concern | File |
@@ -199,6 +237,8 @@ workspaces input write 'echo hi' --submit
 | Socket listener and lock | `Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift` |
 | HTTP route projection | `Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift` |
 | Web-surface snapshot encoding (pure) | `Sources/WorkspaceManagerCore/Services/Automation/WebSurfaceSnapshotEncoder.swift` |
+| Operator credential store + provisioner | `Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift` |
+| Window enumeration (AppKit → descriptors) | `Sources/WorkspaceManager/Views/MainWindow/AutomationWindowEnumerator.swift` |
 | Web-surface snapshot capture (MainActor) | `Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift` |
 | CLI socket client | `Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift` |
 | CLI formatting | `Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift` |
@@ -227,8 +267,10 @@ If docs or public examples changed, also run the docs checks listed in
 V1 does not support browser mutation (navigating, clicking, filling, or
 evaluating JavaScript in a web surface), opening web URLs, tab title or metadata
 changes, writing into other tiles, resize/equalize, or global cross-workspace
-control. Those capabilities require separate product and safety review before
-they can be added. Two reviewed exceptions widen the read/write surface
+*mutation*. Those capabilities require separate product and safety review before
+they can be added. Read-only global window listing is the one reviewed
+exception, and it is gated behind the opt-in operator scope above
+(`window.read`), not granted to tile handles. Two reviewed exceptions widen the read/write surface
 deliberately: caller-scoped input injection ships as the experimental,
 double-gated `input.write` capability (see
 [Automation Input Write Decision](../decisions/automation-input-write.md)), and


### PR DESCRIPTION
## Summary

Implements the operator trust model as a complete thin path (`[A1]`, milestone #16), using window listing as the tracer route. Per `docs/decisions/automation-operator-scope.md`, an **opt-in launch** mints a per-launch operator handle into the live handle registry carrying capture-only `window.read`, and writes a **user-private (0600) credential file** next to `automation.sock`. Any same-user process — a dev shell, `evidence.sh`, CI — reads it to call `GET /v1/windows` and list the app's windows with stable identifiers, without living inside a WorkSpaces tile. Normal launches mint nothing and fail closed with the existing error vocabulary.

`window.snapshot` is a deliberate follow-on slice and is **not** built here.

Closes #916.

## Acceptance criteria → where

| Criterion | Where |
| --- | --- |
| Opt-in mints the credential; normal launch does not; handle invalid after exit | `AutomationOperatorProvisioner` + `AutomationIntegrationLifecycle` (mint on first start, clear on non-opt-in / terminate); registry drops the handle with the launch |
| `GET /v1/windows` succeeds with operator handle, `capability_denied` with tile handle | `AutomationHTTPRouter` route + `AutomationController.resolveOperator` (`window.read` gate; tile handles lack it) |
| Missing/stale/under-capable handles fail closed | `resolveOperator` → `stale_handle` / `capability_denied`; CLI reports absent credential |
| `workspaces window list` works from a shell outside any tile | `WorkspaceManagerCLI` `window list` reads the credential file, not the tile env |
| Audit log distinguishes operator calls | `AutomationAuditLogger.Event.operatorHandle`, derived by the listener via `automationHandleIsOperator` |
| Tests: credential lifecycle, fail-closed, route projection | `AutomationAPITests` (registry/store/provisioner/router/audit) + `AutomationControllerTests` (real controller operator resolution) |
| Automation API doc updated | `docs/development/automation-api.md` (operator scope, routes, capabilities, trust boundary, credential location) |

## Design notes

- **Fail-closed rests on the registry, not the file.** The operator handle is in-memory; a credential left behind by a crashed launch fails closed because its handle no longer resolves against the fresh registry (`stale_handle`). Clean-exit file removal is best-effort hygiene on top of that.
- **Capability projection is by the capability set.** Operator handles carry only `[window.read]`; tile handles carry the v1 tile set and never `window.read`, so a tile handle on `/v1/windows` is denied without any special-casing. `resolveOperator` also skips the tile-liveness check — operator scope exists outside any tile.
- **Stable window identity.** `windowID` is the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address — so the follow-on `window.snapshot` slice can target a window a caller listed.

## Evidence

**Tests** — 59 automation tests (incl. new operator coverage), full suite 1218 passing, `swift-format --strict` clean:

![test-output](https://evidence.cloudcompute.com/workspaces/pr-941/20260707-235257-test-output.png)

**`workspaces window list` end-to-end** against an opted-in dev launch, from a host shell with no tile handle — mint (0600, `window.read`), list (default + `--json`), operator-tagged audit event, and fail-closed when the credential is absent:

![window-list-transcript](https://evidence.cloudcompute.com/workspaces/pr-941/20260707-235258-window-list-transcript.png)

Additional live verification (not pictured): after an unclean exit + opted-in restart, the handle rotates and the **old** handle returns `stale_handle`; a non-opt-in relaunch (API on, operator off) removes the stale credential file at startup.

## Review loop

Ran `codex-review-loop` (reflect → codex `gpt-5.5` xhigh → react).

- **`try?` swallowed a credential write failure while still returning a credential (important) — FIXED** in `11d22c88`. The provisioner now rolls back the registry registration on write failure, removes any partial file, logs, and returns `nil` so the mint is honestly reported as not-minted. New test forces the write to fail and asserts the handle is unresolvable.
- **`git diff --check` whitespace "blocker" — DECLINED.** Codex ran `git diff --check origin/main...HEAD` (a ref-diff), which flags this repo's deliberate 4-space Swift indentation. CI runs `git diff --check` against the **working tree** (passes on a clean committed tree), and the real style gate is `swift-format lint --strict`, which passes. A ref-diff whitespace check would flag every Swift PR in this repo.

## Mergeability

- **Surface:** Automation API (`Sources/WorkspaceManagerCore/Services/Automation/`), the app-side controller + lifecycle (`Sources/WorkspaceManager/`), and the `workspaces` CLI. New experiment `Automation Operator Scope` (`WORKSPACES_AUTOMATION_OPERATOR=1`).
- **Behavior changed:** Adds an opt-in operator handle class + `GET /v1/windows` + `workspaces window list` + a per-launch 0600 credential file next to the socket + an `operatorHandle` field in `automation-audit.jsonl`. No change to any existing tile-scoped route, capability, or handle; `window.read` is granted only to operator handles, never to tile handles. Audit `Event.operatorHandle` defaults false so old JSONL lines still decode.
- **Non-happy paths:** Missing credential → CLI fail-closed error; missing/stale/under-capable handle → `stale_handle`/`capability_denied`; tile handle on `/v1/windows` → `capability_denied`; credential write failure → mint rolled back, `nil` returned; non-opt-in launch → any stale credential removed at startup; unclean exit → stale handle invalidated by the fresh registry.
- **Residual risk:** Clean-exit credential removal runs in the `willTerminate` handler and is best-effort (a `SIGKILL` can't clean up) — mitigated because the trust boundary is the in-memory registry, not the file, and the next launch overwrites or clears it. Window enumeration lists `isVisible && windowNumber > 0` AppKit windows; the exact filter may want tuning when `window.snapshot` lands, but the descriptor shape is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
