### PR TITLE
feat(automation): window.snapshot — WindowSnapshotService + route + CLI, terminal surface included (#917)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -89,6 +89,9 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         let windows: @MainActor () -> [AutomationWindowDescriptor] = {
             AutomationWindowEnumerator.descriptors()
         }
+        let windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome = { windowID in
+            WindowSnapshotService.snapshot(windowID: windowID)
+        }
 
         if let startTask {
             let socketPath = try await startTask.value
@@ -98,7 +101,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 requestCloseTerminal: requestCloseTerminal,
                 webSurfaces: webSurfaces,
                 webSnapshot: webSnapshot,
-                windows: windows
+                windows: windows,
+                windowSnapshot: windowSnapshot
             )
             return socketPath
         }
@@ -110,7 +114,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 requestCloseTerminal: requestCloseTerminal,
                 webSurfaces: webSurfaces,
                 webSnapshot: webSnapshot,
-                windows: windows
+                windows: windows,
+                windowSnapshot: windowSnapshot
             )
             guard let socketPath else {
                 throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
@@ -125,7 +130,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             requestCloseTerminal: requestCloseTerminal,
             webSurfaces: webSurfaces,
             webSnapshot: webSnapshot,
-            windows: windows
+            windows: windows,
+            windowSnapshot: windowSnapshot
         )
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -11,6 +11,7 @@ final class AutomationController: AutomationControlling {
     private var webSurfaces: @MainActor () -> [AutomationWebSurfaceDescriptor]
     private var webSnapshot: @MainActor (UUID) async -> WebSnapshotOutcome
     private var windows: @MainActor () -> [AutomationWindowDescriptor]
+    private var windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome
 
     init(
         handleRegistry: AutomationHandleRegistry,
@@ -20,6 +21,7 @@ final class AutomationController: AutomationControlling {
         webSurfaces: @escaping @MainActor () -> [AutomationWebSurfaceDescriptor] = { [] },
         webSnapshot: @escaping @MainActor (UUID) async -> WebSnapshotOutcome = { _ in .unknownSource },
         windows: @escaping @MainActor () -> [AutomationWindowDescriptor] = { [] },
+        windowSnapshot: @escaping @MainActor (String) async -> WindowSnapshotOutcome = { _ in .unknownWindow },
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
         }
@@ -31,6 +33,7 @@ final class AutomationController: AutomationControlling {
         self.webSurfaces = webSurfaces
         self.webSnapshot = webSnapshot
         self.windows = windows
+        self.windowSnapshot = windowSnapshot
         self.isInputWriteEnabled = isInputWriteEnabled
     }
 
@@ -40,7 +43,8 @@ final class AutomationController: AutomationControlling {
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
         webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil,
         webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil,
-        windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil
+        windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil,
+        windowSnapshot: (@MainActor (String) async -> WindowSnapshotOutcome)? = nil
     ) {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
@@ -53,6 +57,9 @@ final class AutomationController: AutomationControlling {
         }
         if let windows {
             self.windows = windows
+        }
+        if let windowSnapshot {
+            self.windowSnapshot = windowSnapshot
         }
     }
 
@@ -78,6 +85,22 @@ final class AutomationController: AutomationControlling {
         return AutomationWindowsResult(
             windows: windows(),
             system: AutomationSystemDescriptor(capabilities: entry.capabilities)
+        )
+    }
+
+    func automationWindowSnapshot(
+        for handle: String,
+        windowID: String
+    ) async throws -> AutomationWindowSnapshotResult {
+        // Operator scope, capture-only: like the window list, this resolves without the tile-liveness
+        // check — the caller need not own a terminal tile. window.snapshot is gated here; a tile
+        // handle lacks it and fails capability_denied before any capture runs.
+        let entry = try resolveOperator(handle, requiring: .windowSnapshot)
+        let outcome = await windowSnapshot(windowID)
+        return try WindowSnapshotEncoder.result(
+            from: outcome,
+            windowID: windowID,
+            capabilities: entry.capabilities
         )
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/WindowSnapshotService.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/WindowSnapshotService.swift
@@ -1,0 +1,87 @@
+//
+//  WindowSnapshotService.swift
+//  WorkspaceManager
+//
+//  Captures a composited PNG of one of the app's own windows for the operator-scope
+//  `POST /v1/window/snapshot` route. The mechanism is `CGWindowListCreateImage` scoped to the
+//  window's own AppKit window number — chosen by the #915 spike: TCC-free for own windows, full
+//  composited fidelity (sidebar chrome *and* the GhosttyKit IOSurface terminal surface), captured
+//  with the app backgrounded and no activation. The pixel work stops here; the outcome is handed to
+//  the pure Core `WindowSnapshotEncoder`.
+//
+//  `CGWindowListCreateImage` is deprecated in macOS 14 but fully functional; ScreenCaptureKit is the
+//  eventual migration target (it needs a Screen Recording grant even for own windows, so there is no
+//  reason to pay that cost while this path works). The swap stays behind this service's interface.
+//
+
+import AppKit
+import CoreGraphics
+import UniformTypeIdentifiers
+import WorkspaceManagerCore
+
+@MainActor
+enum WindowSnapshotService {
+    /// Snapshot the app-owned window named by `windowID` (the AppKit window number a caller listed
+    /// via `window.read`). Resolving against `NSApp.windows` is the security boundary: the operator
+    /// can only capture windows the app owns, never an arbitrary system window. Never activates the
+    /// app or reorders the window — a backgrounded, occluded window still yields its real
+    /// last-composited content because WindowServer retains each window's IOSurface regardless of
+    /// z-order.
+    static func snapshot(windowID: String, windows: [NSWindow]? = nil) -> WindowSnapshotOutcome {
+        guard let windowNumber = Int(windowID), windowNumber > 0 else {
+            return .unknownWindow
+        }
+        // Own-window only: the requested id must belong to one of the app's visible, addressable
+        // windows — the same set `window.read` lists. A window we don't own is `unknownWindow`, not
+        // a capture we quietly attempt against a stranger's surface.
+        guard
+            (windows ?? NSApp.windows).contains(where: {
+                $0.windowNumber == windowNumber && $0.isVisible
+            })
+        else {
+            return .unknownWindow
+        }
+
+        guard let image = capture(windowNumber: CGWindowID(windowNumber)) else {
+            // A nil image from a window we *do* own means it is not compositing right now:
+            // off the active Space, minimized after listing, or a locked screen.
+            return .notCapturable
+        }
+        guard image.width > 0, image.height > 0 else {
+            return .notCapturable
+        }
+        guard let pngData = pngData(from: image) else {
+            return .captureFailed("PNG encoding failed")
+        }
+        return .captured(pngData: pngData, width: image.width, height: image.height)
+    }
+
+    /// The single deprecated call, isolated so the ScreenCaptureKit migration touches one function.
+    /// `boundsIgnoreFraming` trims the window's drop shadow to the real content bounds;
+    /// `bestResolution` captures at the backing (Retina) scale rather than down-sampling.
+    private static func capture(windowNumber: CGWindowID) -> CGImage? {
+        CGWindowListCreateImage(
+            .null,
+            .optionIncludingWindow,
+            windowNumber,
+            [.boundsIgnoreFraming, .bestResolution]
+        )
+    }
+
+    private static func pngData(from image: CGImage) -> Data? {
+        let data = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                data as CFMutableData,
+                UTType.png.identifier as CFString,
+                1,
+                nil
+            )
+        else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
+}

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -840,18 +840,25 @@ private final class CLIApp {
         return 0
     }
 
-    /// `workspaces window list [--json]` — the operator-scope command. Unlike the tile-scoped
-    /// commands, it reads the per-launch operator credential file (minted next to the socket by an
-    /// opted-in launch) rather than the `WORKSPACES_AUTOMATION_HANDLE` env, so it works from any
-    /// same-user shell outside a WorkSpaces tile. Absent the credential it fails closed with guidance.
+    /// `workspaces window <list|snapshot>` — the operator-scope commands. Unlike the tile-scoped
+    /// commands, they read the per-launch operator credential file (minted next to the socket by an
+    /// opted-in launch) rather than the `WORKSPACES_AUTOMATION_HANDLE` env, so they work from any
+    /// same-user shell outside a WorkSpaces tile. Absent the credential they fail closed with guidance.
     private func runWindow(arguments: [String]) throws -> Int32 {
-        let usage = "workspaces window list [--json]"
-        guard arguments.first == "list" else {
-            throw CLIError("Usage: \(usage)")
+        switch arguments.first {
+        case "list":
+            return try runWindowList(arguments: Array(arguments.dropFirst()))
+        case "snapshot":
+            return try runWindowSnapshot(arguments: Array(arguments.dropFirst()))
+        default:
+            throw CLIError("Usage: workspaces window list [--json] | window snapshot --out <path> [--window <id>]")
         }
+    }
 
+    private func runWindowList(arguments: [String]) throws -> Int32 {
+        let usage = "workspaces window list [--json]"
         var json = false
-        for argument in arguments.dropFirst() {
+        for argument in arguments {
             switch argument {
             case "--json":
                 json = true
@@ -861,21 +868,13 @@ private final class CLIApp {
         }
 
         let credential = try loadOperatorCredential()
-        let client = AutomationSocketClient(socketPath: credential.socketPath)
-        let response = try client.request(
+        let result = try operatorRequest(
+            AutomationWindowsResult.self,
+            credential: credential,
             method: "GET",
             path: "/v1/windows",
-            handle: credential.handle,
             body: Data()
         )
-        let result: AutomationWindowsResult
-        do {
-            result = try AutomationCLIResultPrinter.decodeEnvelope(AutomationWindowsResult.self, from: response)
-        } catch let error as AutomationServiceError {
-            throw CLIError(
-                "automation request failed: \(error.response.code.rawValue): \(error.response.message)"
-            )
-        }
 
         if json {
             print(try AutomationCLIResultPrinter.resultJSON(result))
@@ -892,6 +891,100 @@ private final class CLIApp {
             print("\(window.windowID)\t\(size)\t\(title)")
         }
         return 0
+    }
+
+    /// `workspaces window snapshot --out <path> [--window <id>]` — writes a composited PNG of an app
+    /// window (operator scope). With no `--window`, it targets the main window (falling back to the
+    /// first listed), so the common "snapshot the app" case needs no id lookup. Works with the app
+    /// backgrounded — no activation, no focus steal.
+    private func runWindowSnapshot(arguments: [String]) throws -> Int32 {
+        let usage = "workspaces window snapshot --out <path> [--window <id>]"
+        var outPath: String?
+        var windowID: String?
+
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--out":
+                index += 1
+                guard index < arguments.count else { throw CLIError("Missing value for --out") }
+                outPath = arguments[index]
+            case "--window":
+                index += 1
+                guard index < arguments.count else { throw CLIError("Missing value for --window") }
+                windowID = arguments[index]
+            default:
+                throw CLIError("Usage: \(usage)")
+            }
+            index += 1
+        }
+
+        guard let outPath, !outPath.isEmpty else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        let credential = try loadOperatorCredential()
+
+        let targetWindowID: String
+        if let windowID {
+            targetWindowID = windowID
+        } else {
+            let windows = try operatorRequest(
+                AutomationWindowsResult.self,
+                credential: credential,
+                method: "GET",
+                path: "/v1/windows",
+                body: Data()
+            )
+            guard
+                let target = windows.windows.first(where: { $0.isMain }) ?? windows.windows.first
+            else {
+                throw CLIError("No capturable WorkSpaces window is open.")
+            }
+            targetWindowID = target.windowID
+        }
+
+        let body = try JSONSerialization.data(
+            withJSONObject: ["windowID": targetWindowID],
+            options: [.sortedKeys]
+        )
+        let result = try operatorRequest(
+            AutomationWindowSnapshotResult.self,
+            credential: credential,
+            method: "POST",
+            path: "/v1/window/snapshot",
+            body: body
+        )
+        guard let pngData = Data(base64Encoded: result.data) else {
+            throw CLIError("Snapshot response was not decodable PNG data.")
+        }
+        let outURL = normalizePath(outPath)
+        try pngData.write(to: outURL, options: [.atomic])
+        print("Wrote \(result.width)x\(result.height) PNG (\(result.byteCount) bytes) to \(outURL.path)")
+        return 0
+    }
+
+    private func operatorRequest<Result>(
+        _ type: Result.Type = Result.self,
+        credential: AutomationOperatorCredential,
+        method: String,
+        path: String,
+        body: Data
+    ) throws -> Result where Result: Codable & Sendable & Equatable {
+        let client = AutomationSocketClient(socketPath: credential.socketPath)
+        let response = try client.request(
+            method: method,
+            path: path,
+            handle: credential.handle,
+            body: body
+        )
+        do {
+            return try AutomationCLIResultPrinter.decodeEnvelope(type, from: response)
+        } catch let error as AutomationServiceError {
+            throw CLIError(
+                "automation request failed: \(error.response.code.rawValue): \(error.response.message)"
+            )
+        }
     }
 
     private func loadOperatorCredential() throws -> AutomationOperatorCredential {
@@ -1438,6 +1531,7 @@ private func printHelp() {
           workspaces tile close
           workspaces input write <text> [--submit]
           workspaces window list [--json]
+          workspaces window snapshot --out <path> [--window <id>]
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -19,10 +19,10 @@ public enum AutomationAPI {
     /// Kept separate from `v1Capabilities` so default handles never widen.
     public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
 
-    /// Capabilities granted to an opt-in operator handle (`[A1]`). Capture-only at first:
-    /// `window.read` lists the app's windows. `window.snapshot` is a follow-on slice and is
-    /// deliberately absent here. Operator handles never carry tile mutation capabilities.
-    public static let operatorCapabilities = [AutomationCapability.windowRead]
+    /// Capabilities granted to an opt-in operator handle (`[A1]`). Capture-only: `window.read`
+    /// lists the app's windows and `window.snapshot` returns a composited PNG of one of them.
+    /// Operator handles never carry tile mutation or `input.write` capabilities.
+    public static let operatorCapabilities = [AutomationCapability.windowRead, .windowSnapshot]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
 
@@ -35,6 +35,13 @@ public enum AutomationAPI {
     public static let webSnapshotMaxWidth = 1600
     public static let webSnapshotMaxRawBytes = 8 * 1_024 * 1_024
     public static let webSnapshotTimeoutSeconds = 5.0
+
+    /// Upper bound for `POST /v1/window/snapshot` (`window.snapshot`, operator scope). A full
+    /// composited window at Retina scale is many times a web viewport's pixel count, so the cap is
+    /// generous; an encoded PNG past it is rejected (`unsupported`) rather than truncated. There is
+    /// no width bound — the snapshot is the window at its true composited resolution, since
+    /// full-fidelity evidence is the whole point of the operator capture lane.
+    public static let windowSnapshotMaxRawBytes = 64 * 1_024 * 1_024
 }
 
 public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equatable {
@@ -46,6 +53,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case inputWrite = "input.write"
     case browserRead = "browser.read"
     case windowRead = "window.read"
+    case windowSnapshot = "window.snapshot"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -319,6 +327,44 @@ public struct AutomationWindowsResult: Codable, Sendable, Equatable {
     }
 }
 
+/// A composited PNG snapshot of one of the app's on-screen windows (`window.snapshot`, operator
+/// scope). `windowID` is the AppKit window number the caller listed via `window.read`; `data` is the
+/// base64-encoded PNG and `byteCount` its raw (pre-base64) size, bounded by
+/// `AutomationAPI.windowSnapshotMaxRawBytes`. `width`/`height` are the PNG's true pixel dimensions
+/// (Retina-scaled, not down-sampled). Produced only for a window the app owns and that is realized
+/// on the active Space; an unknown or non-capturable window fails with a structured error rather
+/// than a fabricated image. The capture is composited (sidebar chrome + the GhosttyKit terminal
+/// surface) and needs no app activation.
+public struct AutomationWindowSnapshotResult: Codable, Sendable, Equatable {
+    public let windowID: String
+    public let encoding: String
+    public let width: Int
+    public let height: Int
+    public let byteCount: Int
+    public let data: String
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        windowID: String,
+        encoding: String = "png",
+        width: Int,
+        height: Int,
+        byteCount: Int,
+        data: String,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.windowID = windowID
+        self.encoding = encoding
+        self.width = width
+        self.height = height
+        self.byteCount = byteCount
+        self.data = data
+        self.system = system
+    }
+}
+
 public struct AutomationMutationResult: Codable, Sendable, Equatable {
     public let changed: Bool
     public let focusedSurfaceID: String?
@@ -489,6 +535,10 @@ public protocol AutomationControlling: AnyObject, Sendable {
     func automationContext(for handle: String) throws -> AutomationContextResult
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
     func automationWindows(for handle: String) throws -> AutomationWindowsResult
+    func automationWindowSnapshot(
+        for handle: String,
+        windowID: String
+    ) async throws -> AutomationWindowSnapshotResult
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult
     func automationWebSurfaceSnapshot(
         for handle: String,

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -77,6 +77,10 @@ enum AutomationHTTPRouter {
         case ("GET", "/v1/windows"):
             return try await controller.automationWindows(for: handle)
 
+        case ("POST", "/v1/window/snapshot"):
+            let windowID = try decodeWindowID(from: request.body)
+            return try await controller.automationWindowSnapshot(for: handle, windowID: windowID)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -113,6 +117,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/web-surfaces.")
         case (_, "/v1/windows"):
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/windows.")
+        case (_, "/v1/window/snapshot"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/window/snapshot.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -178,6 +184,28 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.invalidRequest, "Unsupported direction: \(rawDirection).")
         }
         return direction
+    }
+
+    /// The `windowID` from a snapshot request body. Unlike the tile routes, a window id is not a
+    /// caller-supplied *tile* id to reject — it is a global window identity the caller obtained from
+    /// `window.read`, the same way the web-surface snapshot names a source id in its path. So this
+    /// route accepts it directly; the controller still confirms the id names a window the app owns.
+    private static func decodeWindowID(from body: Data) throws -> String {
+        guard !body.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request body must include a windowID.")
+        }
+        guard
+            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else {
+            throw AutomationServiceError(.malformedJSON, "Request body is not valid JSON.")
+        }
+        guard
+            let windowID = object["windowID"] as? String,
+            !windowID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw AutomationServiceError(.invalidRequest, "Request body must be JSON with a non-empty string windowID.")
+        }
+        return windowID
     }
 
     private static func decodeInputWrite(from body: Data) throws -> AutomationInputWriteRequest {
@@ -295,6 +323,7 @@ extension AutomationHealthResult: CodableSendableEquatable {}
 extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
 extension AutomationWindowsResult: CodableSendableEquatable {}
+extension AutomationWindowSnapshotResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}
 extension AutomationMutationResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -194,10 +194,14 @@ enum AutomationHTTPRouter {
         guard !body.isEmpty else {
             throw AutomationServiceError(.invalidRequest, "Request body must include a windowID.")
         }
-        guard
-            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
-        else {
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: body)
+        } catch {
             throw AutomationServiceError(.malformedJSON, "Request body is not valid JSON.")
+        }
+        guard let object = parsed as? [String: Any] else {
+            throw AutomationServiceError(.invalidRequest, "Request body must be a JSON object.")
         }
         guard
             let windowID = object["windowID"] as? String,

--- a/Sources/WorkspaceManagerCore/Services/Automation/WindowSnapshotEncoder.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/WindowSnapshotEncoder.swift
@@ -1,0 +1,73 @@
+//
+//  WindowSnapshotEncoder.swift
+//  WorkspaceManagerCore
+//
+//  Maps a window-snapshot attempt into the Automation API's `AutomationWindowSnapshotResult`
+//  or a structured `AutomationServiceError`. Pure and AppKit-free: the MainActor capture
+//  (a deprecated-but-functional `CGWindowList` call today, ScreenCaptureKit tomorrow) reduces
+//  to a `WindowSnapshotOutcome`, and this type owns the byte-cap enforcement, base64 encoding,
+//  and error mapping — so the failure contract (unknown window, not capturable, oversize) is
+//  unit-testable without a live window or capture mechanism.
+//
+
+import Foundation
+
+/// Result of trying to snapshot one of the app's windows. Failure is encoded as a case (rather
+/// than thrown) so the MainActor capture stays non-throwing and the mapping to error codes lives
+/// in one pure place — the same shape `WebSnapshotOutcome` uses for the browser-read lane.
+public enum WindowSnapshotOutcome: Sendable, Equatable {
+    /// No window the app owns has this id (unparseable id, or not one of `NSApp`'s windows).
+    case unknownWindow
+    /// The window exists but produced no capturable image — minimized, off the active Space, or
+    /// a locked screen where WindowServer stops compositing a capturable framebuffer.
+    case notCapturable
+    /// The capture ran but produced no usable image (nil `CGImage`, encode failure, etc.).
+    case captureFailed(String)
+    /// A PNG capture with its pixel dimensions.
+    case captured(pngData: Data, width: Int, height: Int)
+}
+
+public enum WindowSnapshotEncoder {
+    /// Produces the success envelope payload, or throws the mapped automation error. `capabilities`
+    /// are echoed into the system descriptor for discovery, matching the other operator routes.
+    public static func result(
+        from outcome: WindowSnapshotOutcome,
+        windowID: String,
+        maxRawBytes: Int = AutomationAPI.windowSnapshotMaxRawBytes,
+        capabilities: [AutomationCapability]
+    ) throws -> AutomationWindowSnapshotResult {
+        switch outcome {
+        case .unknownWindow:
+            throw AutomationServiceError(
+                .invalidRequest,
+                "No WorkSpaces window has id \(windowID). List capturable windows with `window.read` first."
+            )
+        case .notCapturable:
+            throw AutomationServiceError(
+                .unsupported,
+                "Window \(windowID) is not capturable right now; it must be realized on the active Space "
+                    + "(minimized, hidden, or locked-screen windows do not composite)."
+            )
+        case .captureFailed(let reason):
+            throw AutomationServiceError(
+                .internalError,
+                "Snapshot of window \(windowID) failed: \(reason)."
+            )
+        case .captured(let pngData, let width, let height):
+            guard pngData.count <= maxRawBytes else {
+                throw AutomationServiceError(
+                    .unsupported,
+                    "Snapshot of window \(windowID) is \(pngData.count) bytes, over the \(maxRawBytes)-byte cap."
+                )
+            }
+            return AutomationWindowSnapshotResult(
+                windowID: windowID,
+                width: width,
+                height: height,
+                byteCount: pngData.count,
+                data: pngData.base64EncodedString(),
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        }
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -509,7 +509,7 @@ struct AutomationControllerTests {
 
         let result = try controller.automationWindows(for: operatorEntry.handle)
         #expect(result.windows == [descriptor])
-        #expect(result.system.capabilities == [.windowRead])
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
 
@@ -554,6 +554,123 @@ struct AutomationControllerTests {
             Issue.record("Expected an unknown handle to be stale")
         } catch let error as AutomationServiceError {
             #expect(error.response.code == .staleHandle)
+        }
+    }
+
+    @Test("Operator handle snapshots a window via the provider; capabilities echo operator scope")
+    func operatorWindowSnapshotReturnsCapture() async throws {
+        let store = TileTreeStore()
+        let registry = AutomationHandleRegistry()
+        let operatorEntry = registry.registerOperator(appScopeID: "workspaces.local")
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+        var requestedWindowIDs: [String] = []
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            windowSnapshot: { windowID in
+                requestedWindowIDs.append(windowID)
+                return .captured(pngData: png, width: 2800, height: 1800)
+            }
+        )
+
+        let result = try await controller.automationWindowSnapshot(for: operatorEntry.handle, windowID: "42")
+        #expect(result.windowID == "42")
+        #expect(result.width == 2800)
+        #expect(result.height == 1800)
+        #expect(Data(base64Encoded: result.data) == png)
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot])
+        #expect(requestedWindowIDs == ["42"])
+    }
+
+    @Test("Window snapshot denies a tile handle before invoking the capture provider")
+    func operatorWindowSnapshotDeniesTileHandle() async throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "tile" })
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        var captureCalls = 0
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            windowSnapshot: { _ in
+                captureCalls += 1
+                return .captured(pngData: Data([0x89]), width: 1, height: 1)
+            }
+        )
+
+        do {
+            _ = try await controller.automationWindowSnapshot(for: "tile", windowID: "42")
+            Issue.record("Expected a tile handle to be denied window.snapshot")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+        // The capability gate runs before the capture provider, so nothing was captured.
+        #expect(captureCalls == 0)
+    }
+
+    @Test("WindowSnapshotService rejects ids it does not own without capturing")
+    func windowSnapshotServiceRejectsUnownedWindows() {
+        // Deterministic, headless-safe: the own-window guard resolves against the supplied window
+        // list, so a non-numeric, non-positive, or non-app-owned id is unknownWindow before any
+        // WindowServer capture is attempted.
+        #expect(WindowSnapshotService.snapshot(windowID: "not-a-number", windows: []) == .unknownWindow)
+        #expect(WindowSnapshotService.snapshot(windowID: "0", windows: []) == .unknownWindow)
+        #expect(WindowSnapshotService.snapshot(windowID: "999999999", windows: []) == .unknownWindow)
+    }
+
+    @Test("Live window capture produces a bounded, non-empty composited PNG")
+    func liveWindowCaptureProducesPNG() async throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let content = NSView(frame: NSRect(x: 0, y: 0, width: 480, height: 320))
+        content.wantsLayer = true
+        content.layer?.backgroundColor = NSColor.systemBlue.cgColor
+        window.contentView = content
+        // orderFront realizes and composites the window without activating the app (no focus steal),
+        // mirroring the backgrounded-capture contract. Off-screen placement keeps it invisible.
+        window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+        window.orderFront(nil)
+        try? await Task.sleep(for: .milliseconds(400))
+
+        let outcome = WindowSnapshotService.snapshot(windowID: String(window.windowNumber))
+        window.orderOut(nil)
+
+        // WindowServer compositing is required to capture; a headless CI host may not provide it, so
+        // a non-capturable outcome is tolerated. When capture does succeed (local GUI session, the
+        // evidence lane), assert the PNG is non-empty and dimensionally sane, and drop the evidence.
+        switch outcome {
+        case .captured(let pngData, let width, let height):
+            #expect(!pngData.isEmpty)
+            #expect(width >= 480)  // >= point size; Retina backing may 2x it
+            #expect(height >= 320)
+            #expect(pngData.count <= AutomationAPI.windowSnapshotMaxRawBytes)
+            #expect(pngData.prefix(4) == Data([0x89, 0x50, 0x4E, 0x47]))  // PNG magic
+            if let dir = ProcessInfo.processInfo.environment["WINDOW_SNAPSHOT_EVIDENCE_DIR"] {
+                let url = URL(fileURLWithPath: dir).appendingPathComponent("window-snapshot.png")
+                try? pngData.write(to: url)
+            }
+        default:
+            // No compositing available in this host — mechanism fidelity is proven by the evidence lane.
+            break
         }
     }
 

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -78,6 +78,30 @@ private final class FakeAutomationController: AutomationControlling {
         )
     }
 
+    var windowSnapshotCalls: [String] = []
+
+    func automationWindowSnapshot(
+        for handle: String,
+        windowID: String
+    ) async throws -> AutomationWindowSnapshotResult {
+        // Mirrors the operator-scope projection: only an operator handle carries window.snapshot; a
+        // tile handle ("live") is capability_denied and any other handle is stale.
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include window.snapshot.")
+        }
+        windowSnapshotCalls.append(windowID)
+        return AutomationWindowSnapshotResult(
+            windowID: windowID,
+            width: 2,
+            height: 1,
+            byteCount: 4,
+            data: "AQID"
+        )
+    }
+
     func automationHandleIsOperator(_ handle: String) -> Bool {
         handle == "operator"
     }
@@ -685,7 +709,7 @@ struct AutomationAPITests {
         #expect(entry.handle == "op-1")
         #expect(entry.isOperator)
         #expect(entry.tileID == nil)
-        #expect(entry.capabilities == [.windowRead])
+        #expect(entry.capabilities == [.windowRead, .windowSnapshot])
         // Capture-only: an operator handle never carries tile mutation or input.write.
         #expect(!entry.capabilities.contains(.tileClose))
         #expect(!entry.capabilities.contains(.inputWrite))
@@ -719,7 +743,7 @@ struct AutomationAPITests {
         #expect(ok.status == 200)
         #expect(okEnvelope.result?.windows.count == 1)
         #expect(okEnvelope.result?.windows.first?.windowID == "42")
-        #expect(okEnvelope.result?.system.capabilities == [.windowRead])
+        #expect(okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot])
         #expect(controller.windowCalls == ["operator"])
 
         // A tile handle holds the v1 tile capabilities but not window.read → capability_denied.
@@ -770,6 +794,143 @@ struct AutomationAPITests {
         #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
     }
 
+    @Test("Window-snapshot encoder base64-encodes a captured PNG and reports raw byte count")
+    func windowSnapshotEncoderCaptured() throws {
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A])
+        let result = try WindowSnapshotEncoder.result(
+            from: .captured(pngData: png, width: 2800, height: 1800),
+            windowID: "42",
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+        #expect(result.windowID == "42")
+        #expect(result.encoding == "png")
+        #expect(result.width == 2800)
+        #expect(result.height == 1800)
+        #expect(result.byteCount == png.count)
+        #expect(Data(base64Encoded: result.data) == png)
+        #expect(result.system.capabilities.contains(.windowSnapshot))
+    }
+
+    @Test("Window-snapshot encoder rejects a capture over the raw byte cap as unsupported")
+    func windowSnapshotEncoderOverCap() throws {
+        let png = Data(repeating: 0xAB, count: 64)
+        do {
+            _ = try WindowSnapshotEncoder.result(
+                from: .captured(pngData: png, width: 10, height: 10),
+                windowID: "42",
+                maxRawBytes: 32,
+                capabilities: AutomationAPI.operatorCapabilities
+            )
+            Issue.record("Expected an over-cap capture to be rejected")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .unsupported)
+            #expect(error.response.message.contains("cap"))
+        }
+    }
+
+    @Test("Window-snapshot encoder maps each failure outcome to its structured error code")
+    func windowSnapshotEncoderFailureMapping() throws {
+        func code(_ outcome: WindowSnapshotOutcome) -> AutomationErrorCode? {
+            do {
+                _ = try WindowSnapshotEncoder.result(
+                    from: outcome,
+                    windowID: "42",
+                    capabilities: AutomationAPI.operatorCapabilities
+                )
+                return nil
+            } catch let error as AutomationServiceError {
+                return error.response.code
+            } catch {
+                return nil
+            }
+        }
+        #expect(code(.unknownWindow) == .invalidRequest)
+        #expect(code(.notCapturable) == .unsupported)
+        #expect(code(.captureFailed("boom")) == .internalError)
+    }
+
+    @Test("POST /v1/window/snapshot captures for an operator handle and fails closed otherwise")
+    @MainActor
+    func routerWindowSnapshot() async throws {
+        let controller = FakeAutomationController()
+        let body = try JSONSerialization.data(withJSONObject: ["windowID": "42"], options: [.sortedKeys])
+
+        let ok = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/window/snapshot",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: body
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWindowSnapshotResult>.self,
+            from: ok.body
+        )
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.windowID == "42")
+        #expect(okEnvelope.result?.encoding == "png")
+        #expect(controller.windowSnapshotCalls == ["42"])
+
+        // A tile handle holds tile capabilities but not window.snapshot → capability_denied.
+        let denied = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/window/snapshot",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: body
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: denied.body
+        )
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        // Missing body → invalid_request, before any capture is attempted.
+        let noBody = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/window/snapshot",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let noBodyEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: noBody.body
+        )
+        #expect(noBody.status == 400)
+        #expect(noBodyEnvelope.error?.code == .invalidRequest)
+
+        // Wrong method on the snapshot path → method_not_allowed.
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/window/snapshot",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+        // The capture provider was never reached on the denied/malformed/wrong-method attempts.
+        #expect(controller.windowSnapshotCalls == ["42"])
+    }
+
     @Test("Operator credential round-trips through the store and is written user-only (0600)")
     func operatorCredentialStoreRoundTrip() throws {
         let url = FileManager.default.temporaryDirectory
@@ -781,7 +942,7 @@ struct AutomationAPITests {
 
         let loaded = AutomationOperatorCredentialStore.load(from: url)
         #expect(loaded == credential)
-        #expect(loaded?.capabilities == [.windowRead])
+        #expect(loaded?.capabilities == [.windowRead, .windowSnapshot])
 
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
@@ -810,7 +971,7 @@ struct AutomationAPITests {
         )
         let mintedCredential = try #require(minted)
         #expect(AutomationOperatorCredentialStore.load(from: url) == mintedCredential)
-        #expect(registry.resolve(mintedCredential.handle)?.capabilities == [.windowRead])
+        #expect(registry.resolve(mintedCredential.handle)?.capabilities == [.windowRead, .windowSnapshot])
         #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)
 
         // A non-opt-in launch mints nothing and clears any stale credential left on disk.

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -910,6 +910,25 @@ struct AutomationAPITests {
         #expect(noBody.status == 400)
         #expect(noBodyEnvelope.error?.code == .invalidRequest)
 
+        // Valid JSON of the wrong top-level shape (an array) → invalid_request, not malformed_json:
+        // it parsed fine, it is just not the object the route expects.
+        let wrongShape = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/window/snapshot",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data("[1,2]".utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongShapeEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongShape.body
+        )
+        #expect(wrongShape.status == 400)
+        #expect(wrongShapeEnvelope.error?.code == .invalidRequest)
+
         // Wrong method on the snapshot path → method_not_allowed.
         let wrongMethod = await AutomationHTTPRouter.route(
             HTTPRequest(

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -64,9 +64,9 @@ WorkSpaces terminal tile. See
   exits, and the credential file is removed on a clean exit. A credential left
   behind by a crashed launch fails closed — its handle no longer resolves
   against the fresh registry (`stale_handle`).
-- **Capture-only.** The initial operator capability set is `window.read`
-  (list windows). `window.snapshot` arrives with the follow-on slice. Operator
-  handles never carry tile mutation or `input.write`.
+- **Capture-only.** The operator capability set is `window.read` (list windows)
+  and `window.snapshot` (composited PNG of a listed window). Operator handles
+  never carry tile mutation or `input.write`.
 
 ## Invariants
 
@@ -114,6 +114,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/context` | Returns the caller's resolved context and capabilities. |
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
 | `GET /v1/windows` | **Operator scope.** Returns the app's on-screen windows with stable identifiers (`window.read`). Keyed by the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address. Requires an operator handle; a tile handle lacks `window.read` and fails `capability_denied`. |
+| `POST /v1/window/snapshot` | **Operator scope.** Returns a composited PNG of the app window named by the body's `windowID` (a `window.read` id). The capture includes the full window — sidebar chrome *and* the GhosttyKit terminal surface — and works with the app backgrounded (no activation). Requires `window.snapshot`; own-window only, so an id the app does not own fails `invalid_request`. See [Window snapshot](#window-snapshot). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -143,6 +144,7 @@ handle.
 | `surfaces.read` | `GET /v1/surfaces` |
 | `browser.read` | `GET /v1/web-surfaces` (read-only listing) and `GET /v1/web-surfaces/{id}/snapshot` (bounded PNG of a live surface); granted to default handles under the Automation API experiment |
 | `window.read` | `GET /v1/windows` (list the app's windows); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
+| `window.snapshot` | `POST /v1/window/snapshot` (composited PNG of a listed window); granted only to operator handles, never to tile handles |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -177,6 +179,55 @@ Failure mapping (reusing the stable error codes): an id matching no web source �
 timeout or over-cap PNG → `unsupported` (distinct messages); an internal capture
 error → `internal_error`. Snapshotting a source whose view is not instantiated
 never creates one — the request fails closed.
+
+## Window snapshot
+
+`POST /v1/window/snapshot` (operator scope, `window.snapshot`) returns a
+composited PNG of one of the app's windows. The body names the target by the
+`windowID` a caller obtained from `GET /v1/windows`:
+
+```json
+{ "windowID": "42" }
+```
+
+The success envelope carries the same base64-PNG shape as the web-surface
+snapshot, keyed by `windowID`:
+
+```json
+{ "windowID": "42", "encoding": "png", "width": 2800, "height": 1800,
+  "byteCount": 481203, "data": "<base64 png>" }
+```
+
+`byteCount` is the raw (pre-base64) PNG size; `width`/`height` are its true pixel
+dimensions (Retina-scaled, never down-sampled). Decode with
+`jq -r .result.data | base64 -d > window.png`.
+
+Mechanism and properties (chosen by spike
+[#915](https://github.com/fairchild/workspaces/issues/915), recorded in the
+[operator-scope ADR](../decisions/automation-operator-scope.md)):
+
+- **`CGWindowListCreateImage` scoped to the app's own window number.** TCC-free
+  for own windows (no Screen Recording grant, no prompt) and full composited
+  fidelity — sidebar chrome *and* the GhosttyKit `IOSurfaceLayer` terminal
+  surface in one call. Deprecated in macOS 14 but functional; ScreenCaptureKit is
+  the migration target behind the stable `WindowSnapshotService` interface.
+- **Backgrounded, no focus steal.** WindowServer retains each window's IOSurface
+  regardless of z-order, so a non-frontmost or occluded window still yields its
+  real last-composited content. The route never activates the app or reorders the
+  window.
+- **Own-window only.** The `windowID` must belong to a window the app owns (the
+  set `window.read` lists); any other id fails `invalid_request`. This is the
+  security boundary — an operator cannot capture a stranger's window.
+- **Bound.** A PNG over 64 MiB is rejected (`unsupported`), never truncated.
+  There is no width bound: the capture is the window at its true composited
+  resolution, since full-fidelity evidence is the point of this lane.
+
+Failure mapping: an id naming no app-owned window → `invalid_request`; a window
+that is not compositing (minimized, off the active Space, or locked screen) →
+`unsupported`; an over-cap PNG → `unsupported`; an internal capture/encode error
+→ `internal_error`. Locked-screen full-window capture is not achievable in-process
+(every composited path fails when the session is locked); that evidence keeps the
+VM / `tart-ui` fallback lane.
 
 ## Error Codes
 
@@ -218,16 +269,23 @@ workspaces input write 'echo hi'
 workspaces input write 'echo hi' --submit
 ```
 
-`workspaces window list` is the operator-scope command. Unlike the tile-scoped
-commands, it reads the per-launch operator credential file (minted next to the
-socket by an opt-in launch) rather than the injected terminal environment, so it
-works from any same-user shell outside a WorkSpaces tile. Absent the credential
-it fails closed with guidance.
+`workspaces window list` and `workspaces window snapshot` are the operator-scope
+commands. Unlike the tile-scoped commands, they read the per-launch operator
+credential file (minted next to the socket by an opt-in launch) rather than the
+injected terminal environment, so they work from any same-user shell outside a
+WorkSpaces tile. Absent the credential they fail closed with guidance.
 
 ```bash
 workspaces window list
 workspaces window list --json
+workspaces window snapshot --out shot.png            # main window, or first if none is main
+workspaces window snapshot --out shot.png --window 42 # a specific window.read id
 ```
+
+`window snapshot` writes the PNG to `--out` and, with no `--window`, targets the
+main window (falling back to the first listed) so the common "snapshot the app"
+case needs no id lookup. It works with the app backgrounded — no activation, no
+focus steal.
 
 ## Implementation Map
 
@@ -237,8 +295,10 @@ workspaces window list --json
 | Socket listener and lock | `Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift` |
 | HTTP route projection | `Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift` |
 | Web-surface snapshot encoding (pure) | `Sources/WorkspaceManagerCore/Services/Automation/WebSurfaceSnapshotEncoder.swift` |
+| Window snapshot encoding (pure) | `Sources/WorkspaceManagerCore/Services/Automation/WindowSnapshotEncoder.swift` |
 | Operator credential store + provisioner | `Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift` |
 | Window enumeration (AppKit → descriptors) | `Sources/WorkspaceManager/Views/MainWindow/AutomationWindowEnumerator.swift` |
+| Window snapshot capture (`CGWindowList`, MainActor) | `Sources/WorkspaceManager/Views/MainWindow/WindowSnapshotService.swift` |
 | Web-surface snapshot capture (MainActor) | `Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift` |
 | CLI socket client | `Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift` |
 | CLI formatting | `Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift` |
@@ -268,9 +328,10 @@ V1 does not support browser mutation (navigating, clicking, filling, or
 evaluating JavaScript in a web surface), opening web URLs, tab title or metadata
 changes, writing into other tiles, resize/equalize, or global cross-workspace
 *mutation*. Those capabilities require separate product and safety review before
-they can be added. Read-only global window listing is the one reviewed
-exception, and it is gated behind the opt-in operator scope above
-(`window.read`), not granted to tile handles. Two reviewed exceptions widen the read/write surface
+they can be added. Read-only global window capture is the one reviewed
+exception — listing (`window.read`) and composited snapshots
+(`window.snapshot`) — gated behind the opt-in operator scope above, never
+granted to tile handles. Two reviewed exceptions widen the read/write surface
 deliberately: caller-scoped input injection ships as the experimental,
 double-gated `input.write` capability (see
 [Automation Input Write Decision](../decisions/automation-input-write.md)), and


### PR DESCRIPTION
Closes #917

## Summary

Completes the `[A1]` window-snapshot slice on the merged operator scope (#941): a composited PNG of an app window — **including the GhosttyKit terminal surface** — captured with the app **backgrounded and no focus steal**.

Building on the operator-scope machinery, this adds:

- **`WindowSnapshotService`** (App) — the capture mechanism behind a stable interface. Uses `CGWindowListCreateImage` scoped to the app's **own window number**, the mechanism the #915 spike chose: TCC-free for own windows (no Screen Recording grant, no prompt), full composited fidelity (sidebar chrome *and* the Metal-backed terminal surface). The deprecated call is isolated so the eventual ScreenCaptureKit swap stays internal to the service.
- **`window.snapshot` capability** added to the operator capability set (`[.windowRead, .windowSnapshot]`). Operator handles only — tile handles never carry it.
- **`POST /v1/window/snapshot`** — own-window-only, base64-PNG envelope keyed by `windowID`, 64 MiB cap, enforced with the existing error vocabulary (`capability_denied` / `invalid_request` / `unsupported` / `method_not_allowed`).
- **`WindowSnapshotEncoder`** (Core) — pure outcome→result/error mapping, unit-testable without AppKit; mirrors `WebSurfaceSnapshotEncoder`.
- **CLI** `workspaces window snapshot --out <path> [--window <id>]` — reads the per-launch operator credential; targets the main window by default; fails closed with guidance when operator scope is absent.
- Operator-tagged audit events ride the existing listener classification (the snapshot route goes through the same `respond()` path, so operator calls are already distinguishable in `automation-audit.jsonl`).
- Docs: routes table, capability table, a **Window snapshot** section, CLI, non-goals.

## Evidence

**Headline — composited window PNG, captured backgrounded via the new CLI verb from a host shell** (fixture-state app launched with `--no-activate`; `workspaces window snapshot` wrote a 2800×1800 PNG). Shows the SwiftUI sidebar, the "Workspace cleanup available" banner, **and the live GhosttyKit terminal surface** with real shell output (`Last login…`, the actual prompt):

![window snapshot](https://evidence.cloudcompute.com/workspaces/pr-942/20260708-002727-window-snapshot-live.png)

**Tests** — `swift test`: 1226 passed; the window/snapshot + operator suites green:

![test output](https://evidence.cloudcompute.com/workspaces/pr-942/20260708-002728-test-output.png)

Reproduce:
```bash
./scripts/launch-dev.sh --no-build --no-activate --fixture \
  --env WORKSPACES_AUTOMATION_API=1 --env WORKSPACES_AUTOMATION_OPERATOR=1
workspaces window snapshot --out shot.png   # app stays backgrounded, no focus steal
```

## Review loop

Reflect → codex (gpt-5.5, xhigh) → react. Codex confirmed **one** finding; the rest NOT-A-BUG, completeness verified.

| Finding | Disposition |
| --- | --- |
| #3 wrong-shape body (valid JSON, non-object like `[1,2]`) mapped to `malformed_json` instead of `invalid_request` | **Fixed** (also caught in reflect pass) — split parse from cast in `decodeWindowID`; added a router test for the array-body case. Commit `da30ab9`. |
| #1 capability leak (tile handle reaching capture) | NOT-A-BUG — `resolveOperator` checks `window.snapshot` then `isOperator` before any capture. |
| #2 own-window bypass (capturing an unowned window) | NOT-A-BUG — `windowID` is resolved against `NSApp.windows` by `windowNumber` before `CGWindowListCreateImage`. |
| #4 route collision / wrong-method code | NOT-A-BUG — exact static case; wrong method → `method_not_allowed`. |
| #5 byte-cap / pixel dims | NOT-A-BUG — 64 MiB cap enforced on raw PNG bytes pre-base64; dims from `CGImage.width/height`. |
| Completeness: all `[.windowRead]` projections updated to `[.windowRead, .windowSnapshot]`? | Verified yes — no stale assertion remains. |

## Mergeability

- **Surface:** Automation API (operator scope) — new `window.snapshot` capability, `POST /v1/window/snapshot` route, `WindowSnapshotService`/`WindowSnapshotEncoder`, `workspaces window snapshot` CLI verb, automation-api doc.
- **Behavior changed:** Adds a new operator-only route and CLI verb that return a composited PNG of an app window. Widens the operator capability set from `[window.read]` to `[window.read, window.snapshot]`; no existing route or default (tile) handle behavior changes.
- **Non-happy paths:** Non-operator/tile handle → `capability_denied` before capture; unknown/unowned/unparseable `windowID` → `invalid_request`; window not compositing (minimized/off-Space/locked) → `unsupported`; over-cap PNG → `unsupported`; missing body → `invalid_request`; non-JSON → `malformed_json`; wrong-shape body → `invalid_request`; wrong method → `method_not_allowed`; CLI without operator credential → clean error with guidance.
- **Residual risk:** `CGWindowListCreateImage` is deprecated in macOS 14 (functional; ScreenCaptureKit is the migration target behind the stable service interface — accepted per the #915 spike/ADR). Locked-screen full-window capture is not achievable in-process (every composited path fails when locked); that evidence keeps the VM/`tart-ui` fallback lane, as the ADR records. The live-capture unit test tolerates a non-compositing headless host (the mechanism is proven by the evidence lane, not unit asserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
