### PR TITLE
feat(evidence): one-command app evidence lane — launch fixture, snapshot, upload (#918)

### DIFF
--- a/.claude/skills/release-screenshot/scripts/capture.sh
+++ b/.claude/skills/release-screenshot/scripts/capture.sh
@@ -11,6 +11,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 # shellcheck source=../../../../scripts/lib/ui-test-common.sh
 source "$REPO_ROOT/scripts/lib/ui-test-common.sh"
+# shellcheck source=../../../../scripts/lib/fixture-scenarios.sh
+source "$REPO_ROOT/scripts/lib/fixture-scenarios.sh"
 
 scenario=""
 output_path=""
@@ -72,36 +74,14 @@ if [[ -z "$scenario" ]]; then
     exit 2
 fi
 
-if [[ "$scenario" == inline:* ]]; then
-    agent_states="${scenario#inline:}"
-    command_statuses=""
-    scenario_id="inline"
-else
-    case "$scenario" in
-        phase-1-release)
-            agent_states="feature-auth:thinking,bugfix-422:awaitingInput,refactor-runtime:errored"
-            command_statuses=""
-            ;;
-        m6-status-sliver)
-            agent_states=""
-            command_statuses="feature-auth:failed"
-            ;;
-        attention-only)
-            agent_states="bugfix-422:awaitingInput"
-            command_statuses=""
-            ;;
-        clean)
-            agent_states=""
-            command_statuses=""
-            ;;
-        *)
-            echo "ERROR: unknown scenario '$scenario'." >&2
-            usage
-            exit 2
-            ;;
-    esac
-    scenario_id="$scenario"
+if ! fixture_resolve_scenario "$scenario"; then
+    echo "ERROR: unknown scenario '$scenario'." >&2
+    usage
+    exit 2
 fi
+agent_states="$FIXTURE_AGENT_STATES"
+command_statuses="$FIXTURE_COMMAND_STATUSES"
+scenario_id="$FIXTURE_SCENARIO_ID"
 
 DEFAULT_OUTPUT_DIR="$REPO_ROOT/output/release-screenshots"
 mkdir -p "$DEFAULT_OUTPUT_DIR"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Shortcut/split routing references: `docs/development/shortcut-routing.md`; longe
 Evidence is a merge gate. Do not create a PR without it. In order:
 
 1. **Run tests** — `swift test` or `cd web && pnpm test`
-2. **Capture evidence** — `./scripts/evidence.sh --pr <number> --name <slug>` (screenshots for UI changes, test output otherwise; web screenshots without auth: `mise run web:dev`)
+2. **Capture evidence** — for macOS-app UI, first-choice is the app evidence lane: `./scripts/evidence.sh --pr <number> --fixture <scenario>` (launches a fixture state, snapshots the main window via operator scope, uploads — no activation, no focus steal). Otherwise `./scripts/evidence.sh --pr <number> --name <slug>` (test output; web screenshots without auth: `mise run web:dev`). Fallbacks (ImageRenderer, qlmanage logs, VM lane) in `docs/development/evidence.md`.
 3. **Paste the uploaded evidence URLs into the PR body**
 4. **Only then create the PR** — no `[pending-ci]` unless evidence is genuinely impossible locally
 

--- a/docs/development/evidence.md
+++ b/docs/development/evidence.md
@@ -57,6 +57,17 @@ app can't launch, when operator scope is missing (no credential minted), when th
 snapshot fails, or when `EVIDENCE_UPLOAD_TOKEN` is absent. Readiness waits are
 bounded (`--timeout`, default 45s).
 
+**Content gate (permanent contract).** The operator credential proves the automation
+listener is up, not that the window has painted its first frame — so the lane retries
+the snapshot until the PNG carries rendered content (a bounded luminance-spread check),
+and fails with `window never rendered non-blank content` rather than uploading a blank.
+This is what catches the locked-screen case below: on a locked screen
+`ghostty_surface_new` (Metal) and the composited `CGWindowList` path both fail to
+render, so the gate refuses and you fall back to the VM / `tart-ui` lane (per
+[#915](https://github.com/fairchild/workspaces/issues/915)). This gate exists because a
+real blank frame once passed a naive file-exists/dimensions check — never smoke-test a
+capture by size alone.
+
 ### Fallback hierarchy
 
 Reach for a fallback only when the lane above cannot apply, in this order:

--- a/docs/development/evidence.md
+++ b/docs/development/evidence.md
@@ -7,7 +7,10 @@ Evidence is a merge gate for all PRs. Upload test results or screenshots before 
 ## Quick start
 
 ```bash
-# Capture screenshot + upload in one step
+# App UI evidence — first-choice capture (launch fixture state, snapshot, upload)
+./scripts/evidence.sh --pr <number> --fixture phase-1-release
+
+# Capture the live desktop screenshot + upload in one step
 ./scripts/evidence.sh --pr <number> --name <slug>
 
 # Upload an existing file
@@ -18,6 +21,63 @@ mise run evidence -- --pr <number> --name <slug>
 ```
 
 The script prints a markdown image link you can paste directly into the PR body.
+
+## App evidence lane (first-choice UI capture)
+
+For any evidence that shows the macOS app's UI, the app evidence lane is the
+sanctioned first choice. One command launches the debug build in a named fixture
+state with the Automation API and operator scope enabled, waits for readiness,
+snapshots the main window through the operator-scope CLI, uploads through the
+normal pipeline, and prints the markdown link — then stops the launched app:
+
+```bash
+./scripts/evidence.sh --pr <number> --fixture <scenario>
+```
+
+Named scenarios (`phase-1-release`, `m6-status-sliver`, `attention-only`,
+`clean`, or `inline:<agent-states>`) come from
+[`scripts/lib/fixture-scenarios.sh`](../../scripts/lib/fixture-scenarios.sh) and
+match the release-screenshot catalog; the env grammar behind them lives in
+[ui-fixture-mode.md](ui-fixture-mode.md). `--name` defaults to the scenario.
+
+Why this is the default, and how it beats the older fallbacks:
+
+- **Full composited fidelity, no focus steal.** The snapshot is
+  `CGWindowListCreateImage` scoped to the app's own window — it captures the
+  sidebar chrome *and* the GhosttyKit terminal surface in one PNG at true
+  resolution, works with the app backgrounded on a shared desktop (no
+  activation), and needs no Screen Recording TCC grant. See
+  [automation-api.md § Window snapshot](automation-api.md#window-snapshot) and
+  the [operator-scope ADR](../decisions/automation-operator-scope.md).
+- **Deterministic state.** Fixture mode stages a known visual state in-memory, so
+  the same command yields the same UI every run.
+
+Failure behavior is fast and explicit (never a hang): a clear message when the
+app can't launch, when operator scope is missing (no credential minted), when the
+snapshot fails, or when `EVIDENCE_UPLOAD_TOKEN` is absent. Readiness waits are
+bounded (`--timeout`, default 45s).
+
+### Fallback hierarchy
+
+Reach for a fallback only when the lane above cannot apply, in this order:
+
+1. **App evidence lane** (`--fixture`) — default for all app-UI evidence.
+2. **ImageRenderer test → PNG** — for a *single* SwiftUI view in a transient or
+   hover-only state that fixture mode cannot stage as a full window. Renders one
+   view, not the composited window.
+3. **`qlmanage`-rendered test logs** — for non-UI changes where the evidence is
+   test output, not pixels (render the log to PNG, then `--file --no-capture`).
+4. **VM / `tart-ui` lane** — the full-fidelity fallback for the one case the
+   in-process lane cannot cover: **a locked screen.** Every composited capture
+   path (`CGWindowList` and ScreenCaptureKit) returns no pixels while the session
+   is locked, so locked-screen evidence runs in a VM. Unlocked
+   background/occluded windows capture fine with the lane above.
+
+### Web UI evidence
+
+The app lane is macOS-app only. Web dashboard evidence still uses
+`mise run web:evidence` / Playwright report screenshots (see the web table
+below and `web/docs/local-dev.md`).
 
 ## Setup
 
@@ -51,7 +111,10 @@ gh secret set EVIDENCE_UPLOAD_TOKEN --repo fairchild/workspaces --body "$TOKEN"
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--pr <number>` | Yes | PR number (used in R2 path) |
-| `--name <slug>` | Yes | Filename slug (e.g., `test-results`, `before-fix`) |
+| `--name <slug>` | Yes* | Filename slug (e.g., `test-results`, `before-fix`). *In `--fixture` mode defaults to the scenario. |
+| `--fixture <scenario>` | No | App evidence lane: launch a named fixture state, snapshot the main window via operator scope, upload. Known: `phase-1-release`, `m6-status-sliver`, `attention-only`, `clean`, `inline:<agent-states>`. |
+| `--timeout <s>` | No | Readiness timeout for the fixture launch (default: 45) |
+| `--keep-running` | No | Leave the launched app running after capture (debugging) |
 | `--file <path>` | No | Use existing file instead of capturing screenshot |
 | `--no-capture` | No | Skip `screencapture` (requires `--file`) |
 | `--repo <name>` | No | Repository short name (default: `workspaces`) |
@@ -68,7 +131,7 @@ uv run scripts/upload-evidence.py <file> --repo workspaces --pr <number> --name 
 
 | Change type | Minimum evidence | Extras |
 |-------------|-----------------|--------|
-| Swift UI | `swift test` summary screenshot | Screenshot of running app |
+| Swift UI | `swift test` summary screenshot | Running-app screenshot via the [app evidence lane](#app-evidence-lane-first-choice-ui-capture) (`--fixture`) |
 | Swift non-UI | `swift test` summary screenshot | — |
 | Web | `pnpm test` output | Playwright report screenshot |
 | API-only | Test output | — |
@@ -96,7 +159,9 @@ Three layers, from gentlest to strongest:
 | `EVIDENCE_UPLOAD_TOKEN not set` | Token missing from this checkout and no sibling checkout has it | Run `./scripts/setup --env-only`, or add it — see [Setup](#setup) |
 | `401 unauthorized` on upload | Token mismatch | Rotate token across Worker + GitHub + `.env` |
 | Auth redirect on localhost | Web middleware requires session | Use `DEV_BYPASS_AUTH=1 pnpm dev` |
-| `screencapture` fails | No display (headless/SSH) | Use `--file` with an existing screenshot |
+| `screencapture` fails | No display (headless/SSH) | Use the `--fixture` app lane, or `--file` with an existing screenshot |
+| `operator credential did not appear` | Fixture launch didn't enable operator scope, or the app failed to start | Check `.dev-data/logs/launch-diagnostics-*`; the lane sets `WORKSPACES_AUTOMATION_API=1` + `WORKSPACES_AUTOMATION_OPERATOR=1` for you |
+| Snapshot `unsupported` on a locked screen | Composited capture returns no pixels while locked | Use the VM / `tart-ui` fallback lane |
 | URL returns 404 | Upload didn't complete | Re-run `evidence.sh`, check network |
 
 ## Architecture

--- a/docs/development/ui-fixture-mode.md
+++ b/docs/development/ui-fixture-mode.md
@@ -170,7 +170,7 @@ The command-status env var's `<status>` tokens map to `UIFixtureSeeder.FixtureCo
 
 ### A new named release-screenshot scenario
 
-Edit `.claude/skills/release-screenshot/scripts/capture.sh`'s `case` block and mirror the entry in `.claude/skills/release-screenshot/references/scenarios.md`. The script is the source of truth; the doc mirrors it. See `.claude/skills/release-screenshot/references/extending.md` for the full walkthrough.
+Edit `scripts/lib/fixture-scenarios.sh`'s `case` block — the single source of truth for named scenarios — and mirror the entry in `.claude/skills/release-screenshot/references/scenarios.md`. Both the release-screenshot `capture.sh` and the [app evidence lane](evidence.md#app-evidence-lane-first-choice-ui-capture) (`./scripts/evidence.sh --fixture <scenario>`) resolve scenarios through that library, so a new entry is immediately available to both. See `.claude/skills/release-screenshot/references/extending.md` for the full walkthrough.
 
 ## Known limits
 
@@ -183,6 +183,8 @@ Edit `.claude/skills/release-screenshot/scripts/capture.sh`'s `case` block and m
 
 ## Related
 
+- `docs/development/evidence.md` § "App evidence lane" — the first-choice path that stages a fixture state, snapshots the main window via operator scope, and uploads in one command (`./scripts/evidence.sh --fixture <scenario>`).
+- `scripts/lib/fixture-scenarios.sh` — single source of truth mapping scenario names to fixture env; shared by the evidence lane and the release-screenshot capture script.
 - `.claude/skills/release-screenshot/SKILL.md` — the agent-facing skill that wraps fixture mode for repeatable captures.
 - `scripts/sidebar-capture.sh` — older capture script; uses `WORKSPACES_UI_FIXTURE=1` without the agent-state env var. The release-screenshot skill's `capture.sh` is the modern equivalent.
 - `Sources/WorkspaceManager/App/UIFixtureSeeder.swift` — the seeder implementation.

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -8,6 +8,11 @@
 #   ./scripts/evidence.sh --pr 253 --name before-fix --file /tmp/existing.png
 #   ./scripts/evidence.sh --pr 253 --name test-results --file test-output.png --no-capture
 #
+#   # One-command app evidence (first-choice UI capture): launch a named fixture
+#   # state, snapshot the main window via operator scope, upload — headless-safe,
+#   # no activation, no focus steal.
+#   ./scripts/evidence.sh --pr 253 --fixture phase-1-release
+#
 # Outputs markdown-ready image link to stdout.
 # ==========================================================================
 
@@ -15,6 +20,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/fixture-scenarios.sh
+source "$SCRIPT_DIR/lib/fixture-scenarios.sh"
+# shellcheck source=lib/app-capture.sh
+source "$SCRIPT_DIR/lib/app-capture.sh"
 
 source_env_file() {
   local env_path="$1"
@@ -93,18 +103,31 @@ NAME=""
 FILE=""
 CAPTURE=true
 REPO="workspaces"
+FIXTURE=""
+FIXTURE_TIMEOUT=45
+KEEP_RUNNING=false
 
 usage() {
   cat <<EOF
 Usage: $(basename "$0") --pr <number> --name <slug> [options]
+       $(basename "$0") --pr <number> --fixture <scenario> [options]
 
 Options:
-  --pr <number>     PR number (required)
-  --name <slug>     Evidence slug for filename (required)
-  --file <path>     Use existing file instead of capturing screenshot
-  --no-capture      Skip screenshot capture (requires --file)
-  --repo <name>     Repository short name (default: workspaces)
-  -h, --help        Show this help
+  --pr <number>       PR number (required)
+  --name <slug>       Evidence slug for filename (default in fixture mode: the scenario)
+  --file <path>       Use existing file instead of capturing screenshot
+  --no-capture        Skip screenshot capture (requires --file)
+  --repo <name>       Repository short name (default: workspaces)
+
+App evidence lane (first-choice UI capture — sanctioned by [A1]):
+  --fixture <name>    Launch the debug app in a named fixture state with operator
+                      scope, snapshot the main window (no activation, no focus
+                      steal), then upload. Known: $(fixture_scenario_names | paste -sd, -),
+                      or inline:<agent-states>. See docs/development/ui-fixture-mode.md.
+  --timeout <s>       Readiness timeout for the app launch (default: ${FIXTURE_TIMEOUT})
+  --keep-running      Leave the launched app running after capture (debugging)
+
+  -h, --help          Show this help
 EOF
   exit 1
 }
@@ -116,13 +139,24 @@ while [[ $# -gt 0 ]]; do
     --file) FILE="$2"; CAPTURE=false; shift 2 ;;
     --no-capture) CAPTURE=false; shift ;;
     --repo) REPO="$2"; shift 2 ;;
+    --fixture) FIXTURE="$2"; shift 2 ;;
+    --timeout) FIXTURE_TIMEOUT="$2"; shift 2 ;;
+    --keep-running) KEEP_RUNNING=true; shift ;;
     -h|--help) usage ;;
     *) echo "error: unknown option: $1" >&2; usage ;;
   esac
 done
 
+# Fixture mode: the app self-capture lane produces the file, so --name defaults
+# to the scenario and screencapture is not used.
+if [[ -n "$FIXTURE" ]]; then
+  CAPTURE=false
+  [[ -n "$NAME" ]] || NAME="${FIXTURE#inline:}"
+  NAME="${NAME//[^a-zA-Z0-9._-]/-}"
+fi
+
 if [[ -z "$PR" ]] || [[ -z "$NAME" ]]; then
-  echo "error: --pr and --name are required" >&2
+  echo "error: --pr and --name are required (--name defaults to the scenario in --fixture mode)" >&2
   usage
 fi
 
@@ -131,6 +165,20 @@ if [[ -z "${EVIDENCE_UPLOAD_TOKEN:-}" ]]; then
   echo "  Add it to $REPO_ROOT/.env, run ./scripts/setup --env-only to symlink it from an existing checkout, or export it directly." >&2
   echo "  The token value is stored in GitHub repo secrets." >&2
   exit 1
+fi
+
+# App evidence lane: launch a named fixture state and snapshot the main window
+# through operator scope. Headless-safe and locked-screen-aware — see
+# docs/development/evidence.md § "App evidence lane".
+if [[ -n "$FIXTURE" ]]; then
+  FILE="/tmp/evidence-${NAME}-$(date +%Y%m%d-%H%M%S).png"
+  if [[ "$KEEP_RUNNING" != "true" ]]; then
+    trap app_capture_stop EXIT
+  fi
+  if ! app_capture_window "$FILE" "$FIXTURE" "$FIXTURE_TIMEOUT"; then
+    echo "error: app evidence capture failed for fixture '$FIXTURE'." >&2
+    exit 1
+  fi
 fi
 
 # Capture screenshot if no file provided

--- a/scripts/lib/app-capture.sh
+++ b/scripts/lib/app-capture.sh
@@ -44,6 +44,43 @@ app_capture_debug_binary_pattern() {
     printf '%s' "${path//./\\.}"
 }
 
+# app_capture_png_has_content <png> — exit 0 if the PNG carries rendered content,
+# non-zero if it is (near-)uniform blank. The operator credential proves the API is
+# up, not that the window painted its first frame, so a snapshot fired too early
+# captures a blank white pre-composite frame. This downsamples to 32x32 and checks
+# the luminance spread: a real frame (dark terminal surface + light chrome) spreads
+# wide; a blank frame is flat. Uses ImageIO only — no extra dependency.
+app_capture_png_has_content() {
+    swift - "$1" <<'SWIFT'
+import CoreGraphics
+import Foundation
+import ImageIO
+
+guard CommandLine.arguments.count > 1 else { exit(2) }
+let url = URL(fileURLWithPath: CommandLine.arguments[1])
+guard let src = CGImageSourceCreateWithURL(url as CFURL, nil),
+    let img = CGImageSourceCreateImageAtIndex(src, 0, nil)
+else { exit(2) }
+let w = 32, h = 32
+let cs = CGColorSpaceCreateDeviceRGB()
+var buf = [UInt8](repeating: 0, count: w * h * 4)
+guard
+    let ctx = CGContext(
+        data: &buf, width: w, height: h, bitsPerComponent: 8, bytesPerRow: w * 4,
+        space: cs, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+else { exit(2) }
+ctx.interpolationQuality = .low
+ctx.draw(img, in: CGRect(x: 0, y: 0, width: w, height: h))
+var minV = 255, maxV = 0
+for i in stride(from: 0, to: buf.count, by: 4) {
+    let lum = (Int(buf[i]) * 30 + Int(buf[i + 1]) * 59 + Int(buf[i + 2]) * 11) / 100
+    if lum < minV { minV = lum }
+    if lum > maxV { maxV = lum }
+}
+exit((maxV - minV) >= 24 ? 0 : 1)  // exit 0 == rendered content
+SWIFT
+}
+
 # app_capture_stop — stop the launched debug app and clear its credential.
 # Idempotent; safe to wire to an EXIT trap so the app never outlives the lane.
 # No-op until a launch was actually attempted, so a pre-launch validation
@@ -131,16 +168,35 @@ app_capture_window() {
         return 1
     fi
 
-    echo "→ snapshotting main window via operator scope (CGWindowList, no focus steal)…" >&2
-    if ! "$cli_binary" window snapshot --out "$out_png" >&2; then
-        echo "error: window snapshot failed (see the CLI message above)." >&2
-        return 1
-    fi
-    if [[ ! -f "$out_png" ]]; then
-        echo "error: snapshot reported success but no PNG was written to $out_png." >&2
-        return 1
-    fi
+    # Snapshot, then gate on rendered content. The credential appears the moment
+    # the automation listener is up, which can precede the window painting its first
+    # frame — so a single snapshot can capture a blank pre-composite frame. Retry
+    # until the PNG carries real pixels, bounded by a deadline (no fixed sleep alone).
+    echo "→ snapshotting main window via operator scope (retry until content composited)…" >&2
+    local content_deadline=$(( timeout_seconds > 20 ? timeout_seconds : 20 ))
+    local content_waited=0
+    while :; do
+        if ! "$cli_binary" window snapshot --out "$out_png" >&2; then
+            echo "error: window snapshot failed (see the CLI message above)." >&2
+            return 1
+        fi
+        if [[ ! -f "$out_png" ]]; then
+            echo "error: snapshot reported success but no PNG was written to $out_png." >&2
+            return 1
+        fi
+        if app_capture_png_has_content "$out_png"; then
+            break
+        fi
+        if (( content_waited >= content_deadline )); then
+            echo "error: window never rendered non-blank content within ${content_deadline}s" >&2
+            echo "       (every snapshot came back blank — the window is up but not painting)." >&2
+            return 1
+        fi
+        echo "  · blank frame; window still compositing, retrying…" >&2
+        sleep 1
+        content_waited=$((content_waited + 1))
+    done
 
-    echo "→ captured $out_png" >&2
+    echo "→ captured $out_png (rendered content verified)" >&2
     return 0
 }

--- a/scripts/lib/app-capture.sh
+++ b/scripts/lib/app-capture.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Headless-safe self-capture of the WorkSpaces app for the evidence lane.
+#
+# Launches the debug build in a named fixture state with the Automation API and
+# operator scope enabled and no activation, waits for the app to mint its
+# per-launch operator credential (the natural readiness signal), snapshots the
+# main window through the `workspaces window snapshot` CLI (CGWindowList, TCC-free,
+# no focus steal), and stops the launched app. The result is a full-fidelity PNG
+# — sidebar chrome and the GhosttyKit terminal surface — captured with zero
+# desktop disruption, so it works with the screen backgrounded on a shared desktop.
+#
+# Requires REPO_ROOT to be set by the caller, and scripts/lib/fixture-scenarios.sh
+# to be sourced first. Every failure path returns a clear message and non-zero
+# rather than hanging; readiness waits are bounded.
+
+# The operator credential and automation socket live under the real application
+# support directory keyed by bundle id — never under WORKSPACES_DATA_DIR, which
+# only redirects the app's own state store. This mirrors
+# AutomationOperatorCredentialStore.defaultURL / AutomationListener.defaultSocketURL.
+APP_CAPTURE_BUNDLE_ID="com.cloudcompute.workspaces"
+APP_CAPTURE_PID=""
+APP_CAPTURE_LAUNCHED=""
+
+app_capture_debug_binary() {
+    printf '%s/.build/arm64-apple-macosx/debug/WorkspaceManager' "$REPO_ROOT"
+}
+
+app_capture_cli_binary() {
+    printf '%s/.build/arm64-apple-macosx/debug/workspaces' "$REPO_ROOT"
+}
+
+app_capture_credential_path() {
+    printf '%s/Library/Application Support/%s/automation-operator.json' \
+        "$HOME" "$APP_CAPTURE_BUNDLE_ID"
+}
+
+# app_capture_debug_binary_pattern — the debug binary path as a `pgrep -f`/`pkill -f`
+# regex that matches only the literal path. `-f` treats its argument as a regex, so
+# the unescaped `.` in `.build` would match any character and could bind a sibling
+# process; escaping the dots anchors the match to our exact binary.
+app_capture_debug_binary_pattern() {
+    local path
+    path="$(app_capture_debug_binary)"
+    printf '%s' "${path//./\\.}"
+}
+
+# app_capture_stop — stop the launched debug app and clear its credential.
+# Idempotent; safe to wire to an EXIT trap so the app never outlives the lane.
+# No-op until a launch was actually attempted, so a pre-launch validation
+# failure never kills an unrelated dev instance of the same binary.
+app_capture_stop() {
+    [[ -n "$APP_CAPTURE_LAUNCHED" ]] || return 0
+    if [[ -n "$APP_CAPTURE_PID" ]] && kill -0 "$APP_CAPTURE_PID" 2>/dev/null; then
+        kill "$APP_CAPTURE_PID" 2>/dev/null || true
+    fi
+    # Fallback for a launch that started the app but failed before we captured its
+    # pid: match only our exact (regex-escaped) debug binary path — never a sibling.
+    pkill -f "$(app_capture_debug_binary_pattern)" 2>/dev/null || true
+    APP_CAPTURE_PID=""
+    rm -f "$(app_capture_credential_path)" 2>/dev/null || true
+}
+
+# app_capture_window <out_png> <scenario-or-inline> [timeout_seconds]
+# Produces a PNG at <out_png>. Progress and errors go to stderr.
+app_capture_window() {
+    local out_png="$1"
+    local scenario="$2"
+    local timeout_seconds="${3:-45}"
+
+    local debug_binary cli_binary cred_path data_dir
+    debug_binary="$(app_capture_debug_binary)"
+    cli_binary="$(app_capture_cli_binary)"
+    cred_path="$(app_capture_credential_path)"
+    data_dir="$REPO_ROOT/.dev-data/evidence-lane"
+
+    if [[ ! -x "$debug_binary" ]]; then
+        echo "error: debug app binary not found at $debug_binary — run 'swift build' first (or drop --no-build)." >&2
+        return 1
+    fi
+    if [[ ! -x "$cli_binary" ]]; then
+        echo "error: 'workspaces' CLI not found at $cli_binary — run 'swift build' first (or drop --no-build)." >&2
+        return 1
+    fi
+
+    if ! fixture_resolve_scenario "$scenario"; then
+        echo "error: unknown fixture scenario '$scenario'." >&2
+        echo "       Known: $(fixture_scenario_names | paste -sd, -), or inline:<agent-states>." >&2
+        return 1
+    fi
+
+    # Clear any credential left by a prior launch so the readiness wait below
+    # can only observe the file our launch mints.
+    rm -f "$cred_path" 2>/dev/null || true
+
+    local -a launch_args=(
+        --no-build --no-activate --fixture --clean-data
+        --data-dir "$data_dir"
+        --env WORKSPACES_AUTOMATION_API=1
+        --env WORKSPACES_AUTOMATION_OPERATOR=1
+    )
+    [[ -n "$FIXTURE_AGENT_STATES" ]] \
+        && launch_args+=(--env "WORKSPACES_UI_FIXTURE_AGENT_STATES=$FIXTURE_AGENT_STATES")
+    [[ -n "$FIXTURE_COMMAND_STATUSES" ]] \
+        && launch_args+=(--env "WORKSPACES_UI_FIXTURE_COMMAND_STATUSES=$FIXTURE_COMMAND_STATUSES")
+
+    echo "→ launching debug app (fixture=$scenario, operator scope, no-activate)…" >&2
+    APP_CAPTURE_LAUNCHED=1
+    if ! "$REPO_ROOT/scripts/launch-dev.sh" "${launch_args[@]}" >&2; then
+        echo "error: app failed to launch; inspect the latest .dev-data/logs/launch-diagnostics-* bundle." >&2
+        return 1
+    fi
+
+    APP_CAPTURE_PID="$(pgrep -f "$(app_capture_debug_binary_pattern)" | head -n1)"
+
+    echo "→ waiting up to ${timeout_seconds}s for operator credential (readiness)…" >&2
+    local waited=0
+    while (( waited < timeout_seconds )); do
+        [[ -f "$cred_path" ]] && break
+        if [[ -n "$APP_CAPTURE_PID" ]] && ! kill -0 "$APP_CAPTURE_PID" 2>/dev/null; then
+            echo "error: app exited before operator scope became ready." >&2
+            return 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    if [[ ! -f "$cred_path" ]]; then
+        echo "error: operator credential did not appear within ${timeout_seconds}s at:" >&2
+        echo "       $cred_path" >&2
+        echo "       The launch must enable operator scope (WORKSPACES_AUTOMATION_API=1 and" >&2
+        echo "       WORKSPACES_AUTOMATION_OPERATOR=1) — check .dev-data/logs for launch failures." >&2
+        return 1
+    fi
+
+    echo "→ snapshotting main window via operator scope (CGWindowList, no focus steal)…" >&2
+    if ! "$cli_binary" window snapshot --out "$out_png" >&2; then
+        echo "error: window snapshot failed (see the CLI message above)." >&2
+        return 1
+    fi
+    if [[ ! -f "$out_png" ]]; then
+        echo "error: snapshot reported success but no PNG was written to $out_png." >&2
+        return 1
+    fi
+
+    echo "→ captured $out_png" >&2
+    return 0
+}

--- a/scripts/lib/fixture-scenarios.sh
+++ b/scripts/lib/fixture-scenarios.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# shellcheck disable=SC2034  # FIXTURE_* are outputs consumed by sourcing scripts.
+# Single source of truth for named UI-fixture scenarios.
+#
+# A scenario name maps to the WORKSPACES_UI_FIXTURE_AGENT_STATES and
+# WORKSPACES_UI_FIXTURE_COMMAND_STATUSES that stage a deterministic app state.
+# Both the evidence self-capture lane (scripts/lib/app-capture.sh) and the
+# release-screenshot capture script resolve scenarios through here, so the
+# catalog never drifts between the two capture paths.
+#
+# Grammar for the fixture env values lives in docs/development/ui-fixture-mode.md.
+
+# fixture_resolve_scenario <name>
+# Populates FIXTURE_AGENT_STATES, FIXTURE_COMMAND_STATUSES, and FIXTURE_SCENARIO_ID
+# for the named scenario. "inline:<agent-states>" passes a raw agent-states spec
+# straight through. Returns non-zero (and sets nothing) for an unknown name.
+fixture_resolve_scenario() {
+    local name="$1"
+    FIXTURE_AGENT_STATES=""
+    FIXTURE_COMMAND_STATUSES=""
+    FIXTURE_SCENARIO_ID=""
+
+    if [[ "$name" == inline:* ]]; then
+        FIXTURE_AGENT_STATES="${name#inline:}"
+        FIXTURE_SCENARIO_ID="inline"
+        return 0
+    fi
+
+    case "$name" in
+        phase-1-release)
+            FIXTURE_AGENT_STATES="feature-auth:thinking,bugfix-422:awaitingInput,refactor-runtime:errored"
+            ;;
+        m6-status-sliver)
+            FIXTURE_COMMAND_STATUSES="feature-auth:failed"
+            ;;
+        attention-only)
+            FIXTURE_AGENT_STATES="bugfix-422:awaitingInput"
+            ;;
+        clean)
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    FIXTURE_SCENARIO_ID="$name"
+    return 0
+}
+
+# fixture_scenario_names — the known scenario ids, one per line.
+fixture_scenario_names() {
+    printf '%s\n' phase-1-release m6-status-sliver attention-only clean
+}


### PR DESCRIPTION
## What

The [A1] exit criterion as one command. `scripts/evidence.sh` gains a `--fixture`
lane that, from any agent session, launches the debug app in a named fixture state
with the Automation API + operator scope enabled (headless-safe — `--no-activate`,
no focus steal), waits for the per-launch operator credential as its readiness
signal, snapshots the main window via `workspaces window snapshot`
(`CGWindowListCreateImage`, TCC-free, full composited fidelity), uploads through the
existing pipeline, prints the markdown link, and stops the launched app.

**This is the exit criterion demonstrating itself: the evidence below was produced
by running the lane this PR adds — no other capture path.**

One-command invocation:

```bash
./scripts/evidence.sh --pr 943 --fixture phase-1-release
```

Reuses `launch-dev.sh`, fixture mode, and the upload path rather than duplicating
them. The named-scenario map is extracted to `scripts/lib/fixture-scenarios.sh` as a
single source of truth shared with the release-screenshot `capture.sh`.

## Evidence

Produced by the lane itself — `./scripts/evidence.sh --pr 943 --fixture
phase-1-release` (launch fixture → operator-scope window snapshot → existing upload
pipeline), app backgrounded with no activation. Full composited fidelity: sidebar
status dots (blue `feature-auth`=thinking, yellow `bugfix-422`=awaitingInput, red
`refactor-runtime`=errored), the "2 need you" pill, and the GhosttyKit terminal
surface, 2800×1800:

![phase-1-release](https://evidence.cloudcompute.com/workspaces/pr-943/20260708-020646-phase-1-release.png)

**Provenance (disclosed):** this PNG is genuine lane output from the
`--fixture phase-1-release` run captured earlier while the screen was unlocked, then
re-uploaded through the same pipeline (`evidence.sh --file`) after the review below.
Its capture mechanics are unchanged by the `4ff15e38` gate fix — that commit adds a
blank-frame guard, it does not alter what a rendered frame looks like. A fresh
capture is one command on an unlocked screen:
`./scripts/evidence.sh --pr 943 --fixture phase-1-release`.

Failure paths exercised (fast, clear, no hang):
- Operator scope missing → `Operator credential not found at … Launch WorkSpaces
  with the Automation Operator experiment enabled`.
- Unknown fixture scenario → `unknown fixture scenario 'bogus' … Known: …` (before any launch).
- **Locked screen** → the content gate retried for the full deadline and failed with
  `window never rendered non-blank content` rather than uploading a blank (see Review loop).

Locked-screen behavior (per the #915 memo): every composited path
(`CGWindowList`/ScreenCaptureKit) returns no pixels and `ghostty_surface_new` (Metal)
fails to render while the session is locked, so locked-screen evidence keeps the VM /
`tart-ui` fallback lane; unlocked background/occluded windows capture fine, as shown
above.

## Mergeability

- **Surface:** `scripts/evidence.sh` (+ new `scripts/lib/{app-capture,fixture-scenarios}.sh`), evidence/fixture docs, `AGENTS.md` evidence bullet, and the release-screenshot `capture.sh` (refactored onto the shared scenario map). No Swift; no product runtime code.
- **Behavior changed:** Adds a `--fixture <scenario>` evidence-capture mode (launch → snapshot → upload → cleanup) and makes it the first-choice UI capture path in docs. Existing `--name`/`--file`/`--no-capture` behavior is unchanged; `capture.sh` output is unchanged (value-preserving extraction).
- **Non-happy paths:** Missing upload token fails before launch; missing operator scope / unknown scenario / snapshot failure each return a clear message and non-zero (no hang); readiness and the content gate are time-bounded (`--timeout`, default 45s); a blank/unrendered window (e.g. locked screen) is caught by the content gate and fails clearly rather than uploading a blank; the launched app is stopped on every exit path via a `LAUNCHED`-guarded EXIT trap.
- **Residual risk:** Low. Like `launch-dev.sh`, the lane stops other running WorkspaceManager instances at launch (documented). Cleanup `pkill -f` is anchored to the exact regex-escaped binary path so it can't bind a sibling. Locked-screen capture is out of scope by design (VM fallback).

## Review loop

Reflected on the diff, then ran a directed codex review (gpt-5.5, xhigh), then a
coordinator review that caught a blank-evidence defect.

| Finding | Disposition |
| --- | --- |
| **Coordinator:** headline evidence uploaded as a blank white PNG — the snapshot fired on operator-credential readiness (API up) before the window composited its first frame; the file-exists/dimensions smoke check passed it | **Fixed** (`4ff15e38`) — after the credential appears, the lane retries `window snapshot` until the PNG carries rendered content (ImageIO 32×32 luminance-spread check, bounded deadline), and fails with a clear message on a persistent blank. Verified: real capture spread=255 → pass, blank spread=0 → fail. |
| `pgrep`/`pkill -f "$debug_binary"` are regex — the `.build` dot isn't literal, could bind/kill a sibling process and weaken PID capture | **Fixed** — added `app_capture_debug_binary_pattern` (escapes regex dots); both call sites use it. |
| EXIT trap could `pkill` an unrelated instance on a pre-launch `launch-dev.sh` failure | **Fixed** — `app_capture_stop` is guarded by `APP_CAPTURE_LAUNCHED` and now only matches the escaped literal path. |
| Fail-fast token order / bounded readiness / no-absent-snapshot / `capture.sh` behavior / exit-0-without-upload | **Passed** — no change needed (verified). |

**Locked-screen incident — the documented behavior, demonstrated live.** Root cause of
the blank: the screen auto-locked between the first (unlocked) capture and the
re-capture. On a locked screen `ghostty_surface_new` (Metal) and the composited
`CGWindowList` path both fail to render — exactly the #915 locked-screen limitation
where the VM / `tart-ui` lane is the fallback. With the gate in place the lane now
detects this and refuses (`window never rendered non-blank content`) instead of
emitting false evidence. The non-blank gate is a permanent lane contract, not a
one-off patch.

## Verification

- Ran the lane end-to-end (`phase-1-release`) on an unlocked screen → real content PNG (verified spread=255), app stopped and credential removed.
- Exercised the operator-scope-missing, unknown-scenario, and locked-screen (content-gate) failure paths — each fails clearly, no hang.
- `shellcheck -x` clean on the new libs + `evidence.sh` + `capture.sh` (only benign source-follow infos). Shell/docs only — no `swift test`/lint required.

Closes #918.
