### PR TITLE
feat(automation): workspace.read — operator read route + CLI (#919)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -46,7 +46,10 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
-        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] }
+        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] },
+        workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
+            AutomationWorkspaceInventory()
+        }
     ) async {
         guard isEnabled else {
             tileTreeStore.configureAutomation(handleRegistry: nil, socketPath: nil)
@@ -60,7 +63,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 tileTreeStore: tileTreeStore,
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal,
-                webSurfaceRecords: webSurfaceRecords
+                webSurfaceRecords: webSurfaceRecords,
+                workspaceInventory: workspaceInventory
             )
             tileTreeStore.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
         } catch {
@@ -74,7 +78,10 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         tileTreeStore: TileTreeStore,
         focusTerminal: @escaping @MainActor (UUID) -> Void,
         requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
-        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] }
+        webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] },
+        workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
+            AutomationWorkspaceInventory()
+        }
     ) async throws -> String {
         // Compose the read-only web-surface list from the caller's live source records
         // joined with the surface store's live WKWebView state (non-creating peek).
@@ -102,7 +109,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 webSurfaces: webSurfaces,
                 webSnapshot: webSnapshot,
                 windows: windows,
-                windowSnapshot: windowSnapshot
+                windowSnapshot: windowSnapshot,
+                workspaceInventory: workspaceInventory
             )
             return socketPath
         }
@@ -115,7 +123,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 webSurfaces: webSurfaces,
                 webSnapshot: webSnapshot,
                 windows: windows,
-                windowSnapshot: windowSnapshot
+                windowSnapshot: windowSnapshot,
+                workspaceInventory: workspaceInventory
             )
             guard let socketPath else {
                 throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
@@ -131,7 +140,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             webSurfaces: webSurfaces,
             webSnapshot: webSnapshot,
             windows: windows,
-            windowSnapshot: windowSnapshot
+            windowSnapshot: windowSnapshot,
+            workspaceInventory: workspaceInventory
         )
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -12,6 +12,7 @@ final class AutomationController: AutomationControlling {
     private var webSnapshot: @MainActor (UUID) async -> WebSnapshotOutcome
     private var windows: @MainActor () -> [AutomationWindowDescriptor]
     private var windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome
+    private var workspaceInventory: @MainActor () -> AutomationWorkspaceInventory
 
     init(
         handleRegistry: AutomationHandleRegistry,
@@ -22,6 +23,9 @@ final class AutomationController: AutomationControlling {
         webSnapshot: @escaping @MainActor (UUID) async -> WebSnapshotOutcome = { _ in .unknownSource },
         windows: @escaping @MainActor () -> [AutomationWindowDescriptor] = { [] },
         windowSnapshot: @escaping @MainActor (String) async -> WindowSnapshotOutcome = { _ in .unknownWindow },
+        workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
+            AutomationWorkspaceInventory()
+        },
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
         }
@@ -34,6 +38,7 @@ final class AutomationController: AutomationControlling {
         self.webSnapshot = webSnapshot
         self.windows = windows
         self.windowSnapshot = windowSnapshot
+        self.workspaceInventory = workspaceInventory
         self.isInputWriteEnabled = isInputWriteEnabled
     }
 
@@ -44,7 +49,8 @@ final class AutomationController: AutomationControlling {
         webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil,
         webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil,
         windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil,
-        windowSnapshot: (@MainActor (String) async -> WindowSnapshotOutcome)? = nil
+        windowSnapshot: (@MainActor (String) async -> WindowSnapshotOutcome)? = nil,
+        workspaceInventory: (@MainActor () -> AutomationWorkspaceInventory)? = nil
     ) {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
@@ -60,6 +66,9 @@ final class AutomationController: AutomationControlling {
         }
         if let windowSnapshot {
             self.windowSnapshot = windowSnapshot
+        }
+        if let workspaceInventory {
+            self.workspaceInventory = workspaceInventory
         }
     }
 
@@ -84,6 +93,19 @@ final class AutomationController: AutomationControlling {
         let entry = try resolveOperator(handle, requiring: .windowRead)
         return AutomationWindowsResult(
             windows: windows(),
+            system: AutomationSystemDescriptor(capabilities: entry.capabilities)
+        )
+    }
+
+    func automationWorkspaces(for handle: String) throws -> AutomationWorkspacesResult {
+        // Operator scope, read-only: like the window list, the caller need not own a terminal tile,
+        // so this resolves without the tile-liveness check — only the workspace.read capability and
+        // operator-scope guard apply. A tile handle lacks workspace.read and fails capability_denied.
+        let entry = try resolveOperator(handle, requiring: .workspaceRead)
+        let inventory = workspaceInventory()
+        return AutomationWorkspacesResult(
+            repos: inventory.repos,
+            workspaces: inventory.workspaces,
             system: AutomationSystemDescriptor(capabilities: entry.capabilities)
         )
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceEnumerator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceEnumerator.swift
@@ -1,0 +1,45 @@
+//
+//  AutomationWorkspaceEnumerator.swift
+//  WorkspaceManager
+//
+//  Projects the app's live SwiftData repos and workspaces into the read-only descriptors the
+//  operator-scope `GET /v1/workspaces` route returns. Keyed by the stable SwiftData model ids so
+//  later `[A2]` orchestration verbs can target the same repo/workspace an operator listed here.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+enum AutomationWorkspaceEnumerator {
+    @MainActor
+    static func inventory(
+        repos: [Repo],
+        selectedWorkspaceID: UUID?,
+        selectedRepoID: UUID?
+    ) -> AutomationWorkspaceInventory {
+        let repoDescriptors = repos.map { repo in
+            AutomationRepoDescriptor(
+                repoID: repo.id,
+                name: repo.name,
+                path: repo.localPath,
+                isSelected: repo.id == selectedRepoID
+            )
+        }
+
+        let workspaceDescriptors = repos.flatMap(\.workspaces).map { workspace in
+            AutomationWorkspaceDescriptor(
+                workspaceID: workspace.id,
+                repoID: workspace.sourceRepo?.id,
+                name: workspace.name,
+                path: workspace.path,
+                branch: workspace.gitBranch,
+                status: workspace.status.rawValue,
+                isArchived: workspace.status == .archived,
+                backend: workspace.backendIdentifier,
+                isSelected: workspace.id == selectedWorkspaceID
+            )
+        }
+
+        return AutomationWorkspaceInventory(repos: repoDescriptors, workspaces: workspaceDescriptors)
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2036,7 +2036,14 @@ struct ContentView: View {
             requestCloseTerminal: { sessionID in
                 requestCloseTerminalTabs([sessionID])
             },
-            webSurfaceRecords: { webSources.map(WebSurfaceRecord.init(from:)) }
+            webSurfaceRecords: { webSources.map(WebSurfaceRecord.init(from:)) },
+            workspaceInventory: {
+                AutomationWorkspaceEnumerator.inventory(
+                    repos: repos,
+                    selectedWorkspaceID: viewState.selectedWorkspace?.workspaceID,
+                    selectedRepoID: viewState.selectedRepoForLandingID
+                )
+            }
         )
     }
 

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -41,6 +41,7 @@ private final class CLIApp {
         "tile",
         "input",
         "window",
+        "workspace",
     ]
 
     private let stateStore = CLIStateStore()
@@ -89,6 +90,8 @@ private final class CLIApp {
             return try runInput(arguments: tail)
         case "window":
             return try runWindow(arguments: tail)
+        case "workspace":
+            return try runWorkspaceOperator(arguments: tail)
         default:
             throw CLIError("Unknown command '\(command)'. Run 'workspaces help'.")
         }
@@ -964,6 +967,70 @@ private final class CLIApp {
         return 0
     }
 
+    /// `workspaces workspace list [--json]` — the operator-scope read of the app's repos and
+    /// workspaces (`workspace.read`). Like `window list`, it reads the per-launch operator credential
+    /// file (minted next to the socket by an opted-in launch) rather than the injected terminal
+    /// environment, so it works from any same-user shell outside a WorkSpaces tile. Absent the
+    /// credential it fails closed with guidance. Distinct from `ws list`, which lists the CLI's own
+    /// local-state workspaces; this reflects what the running app currently has.
+    private func runWorkspaceOperator(arguments: [String]) throws -> Int32 {
+        guard arguments.first == "list" else {
+            throw CLIError("Usage: workspaces workspace list [--json]")
+        }
+        let usage = "workspaces workspace list [--json]"
+        var json = false
+        for argument in arguments.dropFirst() {
+            switch argument {
+            case "--json":
+                json = true
+            default:
+                throw CLIError("Usage: \(usage)")
+            }
+        }
+
+        let credential = try loadOperatorCredential()
+        let result = try operatorRequest(
+            AutomationWorkspacesResult.self,
+            credential: credential,
+            method: "GET",
+            path: "/v1/workspaces",
+            body: Data()
+        )
+
+        if json {
+            print(try AutomationCLIResultPrinter.resultJSON(result))
+            return 0
+        }
+
+        if result.repos.isEmpty && result.workspaces.isEmpty {
+            print("No repos or workspaces.")
+            return 0
+        }
+
+        if !result.repos.isEmpty {
+            print("Repos:")
+            for repo in result.repos {
+                let marker = repo.isSelected ? "*" : " "
+                print("\(marker) \(repo.repoID)\t\(repo.name)\t\(repo.path)")
+            }
+        }
+        if !result.workspaces.isEmpty {
+            if !result.repos.isEmpty {
+                print("")
+            }
+            print("Workspaces:")
+            for workspace in result.workspaces {
+                let marker = workspace.isSelected ? "*" : " "
+                let branch = workspace.branch ?? "-"
+                print(
+                    "\(marker) \(workspace.workspaceID)\t\(workspace.name)\t"
+                        + "\(workspace.status)\t\(workspace.backend)\t\(branch)"
+                )
+            }
+        }
+        return 0
+    }
+
     private func operatorRequest<Result>(
         _ type: Result.Type = Result.self,
         credential: AutomationOperatorCredential,
@@ -1532,6 +1599,7 @@ private func printHelp() {
           workspaces input write <text> [--submit]
           workspaces window list [--json]
           workspaces window snapshot --out <path> [--window <id>]
+          workspaces workspace list [--json]
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -19,10 +19,12 @@ public enum AutomationAPI {
     /// Kept separate from `v1Capabilities` so default handles never widen.
     public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
 
-    /// Capabilities granted to an opt-in operator handle (`[A1]`). Capture-only: `window.read`
-    /// lists the app's windows and `window.snapshot` returns a composited PNG of one of them.
-    /// Operator handles never carry tile mutation or `input.write` capabilities.
-    public static let operatorCapabilities = [AutomationCapability.windowRead, .windowSnapshot]
+    /// Capabilities granted to an opt-in operator handle. Capture-only plus read-only inventory:
+    /// `window.read` lists the app's windows, `window.snapshot` returns a composited PNG of one of
+    /// them (`[A1]`), and `workspace.read` lists the app's repos and workspaces so later
+    /// orchestration verbs have stable targets (`[A2]`). Operator handles never carry tile mutation
+    /// or `input.write` capabilities.
+    public static let operatorCapabilities = [AutomationCapability.windowRead, .windowSnapshot, .workspaceRead]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
 
@@ -54,6 +56,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case browserRead = "browser.read"
     case windowRead = "window.read"
     case windowSnapshot = "window.snapshot"
+    case workspaceRead = "workspace.read"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -365,6 +368,101 @@ public struct AutomationWindowSnapshotResult: Codable, Sendable, Equatable {
     }
 }
 
+/// Read-only descriptor for one of the app's tracked repos (`workspace.read`, operator scope).
+/// `repoID` is the SwiftData model id — stable across launches, the identity later orchestration
+/// verbs target. `isSelected` reflects whether the repo is the one currently selected for its
+/// landing view in the sidebar.
+public struct AutomationRepoDescriptor: Codable, Sendable, Equatable {
+    public let repoID: UUID
+    public let name: String
+    public let path: String
+    public let isSelected: Bool
+
+    public init(repoID: UUID, name: String, path: String, isSelected: Bool) {
+        self.repoID = repoID
+        self.name = name
+        self.path = path
+        self.isSelected = isSelected
+    }
+}
+
+/// Read-only descriptor for one of the app's workspaces (`workspace.read`, operator scope).
+/// `workspaceID` is the SwiftData model id — the stable identity later verbs target. `repoID` ties
+/// it back to its source repo. Enough state rides along to target it: `status` (raw
+/// `WorkspaceStatus`), `isArchived`, and `backend` (the backend identifier, e.g. `local`/`lume`).
+/// `isSelected` reflects whether this is the workspace currently selected in the app.
+public struct AutomationWorkspaceDescriptor: Codable, Sendable, Equatable {
+    public let workspaceID: UUID
+    public let repoID: UUID?
+    public let name: String
+    public let path: String
+    public let branch: String?
+    public let status: String
+    public let isArchived: Bool
+    public let backend: String
+    public let isSelected: Bool
+
+    public init(
+        workspaceID: UUID,
+        repoID: UUID?,
+        name: String,
+        path: String,
+        branch: String?,
+        status: String,
+        isArchived: Bool,
+        backend: String,
+        isSelected: Bool
+    ) {
+        self.workspaceID = workspaceID
+        self.repoID = repoID
+        self.name = name
+        self.path = path
+        self.branch = branch
+        self.status = status
+        self.isArchived = isArchived
+        self.backend = backend
+        self.isSelected = isSelected
+    }
+}
+
+/// The projected repo + workspace lists an operator handle reads via `GET /v1/workspaces`. A plain
+/// value the app produces on the MainActor (reading the live SwiftData models and selection state)
+/// and the controller wraps into `AutomationWorkspacesResult` with the resolved handle's
+/// capabilities — the same split the window list uses between its enumerator and result.
+public struct AutomationWorkspaceInventory: Sendable, Equatable {
+    public let repos: [AutomationRepoDescriptor]
+    public let workspaces: [AutomationWorkspaceDescriptor]
+
+    public init(
+        repos: [AutomationRepoDescriptor] = [],
+        workspaces: [AutomationWorkspaceDescriptor] = []
+    ) {
+        self.repos = repos
+        self.workspaces = workspaces
+    }
+}
+
+/// Response for `GET /v1/workspaces` (`workspace.read`, operator scope): the app's repos and
+/// workspaces with stable model ids, names, and enough state to target. Read-only — no mutation
+/// rides this route; orchestration verbs arrive in later `[A2]` slices.
+public struct AutomationWorkspacesResult: Codable, Sendable, Equatable {
+    public let repos: [AutomationRepoDescriptor]
+    public let workspaces: [AutomationWorkspaceDescriptor]
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        repos: [AutomationRepoDescriptor],
+        workspaces: [AutomationWorkspaceDescriptor],
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.repos = repos
+        self.workspaces = workspaces
+        self.system = system
+    }
+}
+
 public struct AutomationMutationResult: Codable, Sendable, Equatable {
     public let changed: Bool
     public let focusedSurfaceID: String?
@@ -535,6 +633,7 @@ public protocol AutomationControlling: AnyObject, Sendable {
     func automationContext(for handle: String) throws -> AutomationContextResult
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
     func automationWindows(for handle: String) throws -> AutomationWindowsResult
+    func automationWorkspaces(for handle: String) throws -> AutomationWorkspacesResult
     func automationWindowSnapshot(
         for handle: String,
         windowID: String

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -77,6 +77,9 @@ enum AutomationHTTPRouter {
         case ("GET", "/v1/windows"):
             return try await controller.automationWindows(for: handle)
 
+        case ("GET", "/v1/workspaces"):
+            return try await controller.automationWorkspaces(for: handle)
+
         case ("POST", "/v1/window/snapshot"):
             let windowID = try decodeWindowID(from: request.body)
             return try await controller.automationWindowSnapshot(for: handle, windowID: windowID)
@@ -117,6 +120,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/web-surfaces.")
         case (_, "/v1/windows"):
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/windows.")
+        case (_, "/v1/workspaces"):
+            throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/workspaces.")
         case (_, "/v1/window/snapshot"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/window/snapshot.")
         case (_, "/v1/tile/focus"):
@@ -327,6 +332,7 @@ extension AutomationHealthResult: CodableSendableEquatable {}
 extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
 extension AutomationWindowsResult: CodableSendableEquatable {}
+extension AutomationWorkspacesResult: CodableSendableEquatable {}
 extension AutomationWindowSnapshotResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -509,7 +509,7 @@ struct AutomationControllerTests {
 
         let result = try controller.automationWindows(for: operatorEntry.handle)
         #expect(result.windows == [descriptor])
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot])
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
 
@@ -557,6 +557,97 @@ struct AutomationControllerTests {
         }
     }
 
+    @Test("Operator handle lists workspaces without owning a tile; tile handle is denied")
+    func operatorWorkspacesProjection() throws {
+        // A store with no live session at all — operator scope must not depend on a caller tile.
+        let store = TileTreeStore()
+        let registry = AutomationHandleRegistry()
+        let operatorEntry = registry.registerOperator(appScopeID: "workspaces.local")
+        let repoID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+        let inventory = AutomationWorkspaceInventory(
+            repos: [
+                AutomationRepoDescriptor(
+                    repoID: repoID,
+                    name: "workspaces",
+                    path: "/Users/test/workspaces",
+                    isSelected: true
+                )
+            ],
+            workspaces: [
+                AutomationWorkspaceDescriptor(
+                    workspaceID: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!,
+                    repoID: repoID,
+                    name: "feature-a",
+                    path: "/Users/test/workspaces/feature-a",
+                    branch: "feature-a",
+                    status: "archived",
+                    isArchived: true,
+                    backend: "lume",
+                    isSelected: false
+                )
+            ]
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            workspaceInventory: { inventory }
+        )
+
+        let result = try controller.automationWorkspaces(for: operatorEntry.handle)
+        #expect(result.repos == inventory.repos)
+        #expect(result.workspaces == inventory.workspaces)
+        #expect(result.workspaces.first?.isArchived == true)
+        #expect(result.workspaces.first?.backend == "lume")
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(controller.automationHandleIsOperator(operatorEntry.handle))
+    }
+
+    @Test("Workspaces route fails closed for tile, under-capable, and stale handles")
+    func operatorWorkspacesFailClosed() throws {
+        let store = TileTreeStore()
+        let primary =
+            store.activateSession(
+                key: .repoPath("/Users/test/repo"),
+                directory: URL(fileURLWithPath: "/Users/test/repo")
+            ).session
+        let registry = AutomationHandleRegistry(makeHandle: { "tile" })
+        // A tile handle carrying the full v1 tile capabilities — but not workspace.read.
+        _ = registry.upsert(
+            hostSessionID: primary.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "app",
+            capabilities: AutomationAPI.v1Capabilities
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            workspaceInventory: { AutomationWorkspaceInventory() }
+        )
+
+        // Tile handle: has tile capabilities but not workspace.read → capability_denied.
+        do {
+            _ = try controller.automationWorkspaces(for: "tile")
+            Issue.record("Expected a tile handle to be denied workspace.read")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .capabilityDenied)
+        }
+        #expect(!controller.automationHandleIsOperator("tile"))
+
+        // Unknown/stale handle → stale_handle.
+        do {
+            _ = try controller.automationWorkspaces(for: "not-live")
+            Issue.record("Expected an unknown handle to be stale")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == .staleHandle)
+        }
+    }
+
     @Test("Operator handle snapshots a window via the provider; capabilities echo operator scope")
     func operatorWindowSnapshotReturnsCapture() async throws {
         let store = TileTreeStore()
@@ -580,7 +671,7 @@ struct AutomationControllerTests {
         #expect(result.width == 2800)
         #expect(result.height == 1800)
         #expect(Data(base64Encoded: result.data) == png)
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot])
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
         #expect(requestedWindowIDs == ["42"])
     }
 

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -78,6 +78,43 @@ private final class FakeAutomationController: AutomationControlling {
         )
     }
 
+    var workspaceCalls: [String] = []
+
+    func automationWorkspaces(for handle: String) throws -> AutomationWorkspacesResult {
+        // Only an operator handle carries workspace.read; a tile handle ("live") fails closed, and an
+        // unknown handle is stale — mirrors the real controller's operator-scope projection.
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include workspace.read.")
+        }
+        workspaceCalls.append(handle)
+        return AutomationWorkspacesResult(
+            repos: [
+                AutomationRepoDescriptor(
+                    repoID: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+                    name: "workspaces",
+                    path: "/Users/test/workspaces",
+                    isSelected: true
+                )
+            ],
+            workspaces: [
+                AutomationWorkspaceDescriptor(
+                    workspaceID: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!,
+                    repoID: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+                    name: "feature-a",
+                    path: "/Users/test/workspaces/feature-a",
+                    branch: "feature-a",
+                    status: "active",
+                    isArchived: false,
+                    backend: "local",
+                    isSelected: true
+                )
+            ]
+        )
+    }
+
     var windowSnapshotCalls: [String] = []
 
     func automationWindowSnapshot(
@@ -709,7 +746,7 @@ struct AutomationAPITests {
         #expect(entry.handle == "op-1")
         #expect(entry.isOperator)
         #expect(entry.tileID == nil)
-        #expect(entry.capabilities == [.windowRead, .windowSnapshot])
+        #expect(entry.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
         // Capture-only: an operator handle never carries tile mutation or input.write.
         #expect(!entry.capabilities.contains(.tileClose))
         #expect(!entry.capabilities.contains(.inputWrite))
@@ -743,7 +780,7 @@ struct AutomationAPITests {
         #expect(ok.status == 200)
         #expect(okEnvelope.result?.windows.count == 1)
         #expect(okEnvelope.result?.windows.first?.windowID == "42")
-        #expect(okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot])
+        #expect(okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
         #expect(controller.windowCalls == ["operator"])
 
         // A tile handle holds the v1 tile capabilities but not window.read → capability_denied.
@@ -780,6 +817,85 @@ struct AutomationAPITests {
             HTTPRequest(
                 method: "POST",
                 path: "/v1/windows",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("GET /v1/workspaces succeeds for an operator handle and denies a tile handle")
+    @MainActor
+    func routerWorkspaces() async throws {
+        let controller = FakeAutomationController()
+
+        let ok = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/workspaces",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWorkspacesResult>.self,
+            from: ok.body
+        )
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.repos.count == 1)
+        #expect(okEnvelope.result?.repos.first?.name == "workspaces")
+        #expect(okEnvelope.result?.repos.first?.isSelected == true)
+        #expect(okEnvelope.result?.workspaces.count == 1)
+        #expect(okEnvelope.result?.workspaces.first?.name == "feature-a")
+        #expect(okEnvelope.result?.workspaces.first?.status == "active")
+        #expect(okEnvelope.result?.workspaces.first?.backend == "local")
+        #expect(okEnvelope.result?.workspaces.first?.isSelected == true)
+        #expect(okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(controller.workspaceCalls == ["operator"])
+
+        // A tile handle holds the v1 tile capabilities but not workspace.read → capability_denied.
+        let denied = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/workspaces",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: denied.body
+        )
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        let missing = await AutomationHTTPRouter.route(
+            HTTPRequest(method: "GET", path: "/v1/workspaces", headers: [:], body: Data()),
+            controller: controller,
+            enabled: true
+        )
+        let missingEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: missing.body
+        )
+        #expect(missing.status == 401)
+        #expect(missingEnvelope.error?.code == .missingHandle)
+
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/workspaces",
                 headers: [AutomationAPI.handleHeader: "operator"],
                 body: Data()
             ),
@@ -961,7 +1077,7 @@ struct AutomationAPITests {
 
         let loaded = AutomationOperatorCredentialStore.load(from: url)
         #expect(loaded == credential)
-        #expect(loaded?.capabilities == [.windowRead, .windowSnapshot])
+        #expect(loaded?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
 
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
@@ -990,7 +1106,9 @@ struct AutomationAPITests {
         )
         let mintedCredential = try #require(minted)
         #expect(AutomationOperatorCredentialStore.load(from: url) == mintedCredential)
-        #expect(registry.resolve(mintedCredential.handle)?.capabilities == [.windowRead, .windowSnapshot])
+        #expect(
+            registry.resolve(mintedCredential.handle)?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead]
+        )
         #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)
 
         // A non-opt-in launch mints nothing and clears any stale credential left on disk.

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -64,9 +64,10 @@ WorkSpaces terminal tile. See
   exits, and the credential file is removed on a clean exit. A credential left
   behind by a crashed launch fails closed — its handle no longer resolves
   against the fresh registry (`stale_handle`).
-- **Capture-only.** The operator capability set is `window.read` (list windows)
-  and `window.snapshot` (composited PNG of a listed window). Operator handles
-  never carry tile mutation or `input.write`.
+- **Capture-plus-read.** The operator capability set is `window.read` (list
+  windows) and `window.snapshot` (composited PNG of a listed window) from `[A1]`,
+  plus `workspace.read` (list repos and workspaces) from `[A2]`. All read-only —
+  operator handles never carry tile mutation or `input.write`.
 
 ## Invariants
 
@@ -115,6 +116,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
 | `GET /v1/windows` | **Operator scope.** Returns the app's on-screen windows with stable identifiers (`window.read`). Keyed by the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address. Requires an operator handle; a tile handle lacks `window.read` and fails `capability_denied`. |
 | `POST /v1/window/snapshot` | **Operator scope.** Returns a composited PNG of the app window named by the body's `windowID` (a `window.read` id). The capture includes the full window — sidebar chrome *and* the GhosttyKit terminal surface — and works with the app backgrounded (no activation). Requires `window.snapshot`; own-window only, so an id the app does not own fails `invalid_request`. See [Window snapshot](#window-snapshot). |
+| `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — the stable-target list later `[A2]` orchestration verbs act on. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -145,6 +147,7 @@ handle.
 | `browser.read` | `GET /v1/web-surfaces` (read-only listing) and `GET /v1/web-surfaces/{id}/snapshot` (bounded PNG of a live surface); granted to default handles under the Automation API experiment |
 | `window.read` | `GET /v1/windows` (list the app's windows); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `window.snapshot` | `POST /v1/window/snapshot` (composited PNG of a listed window); granted only to operator handles, never to tile handles |
+| `workspace.read` | `GET /v1/workspaces` (list the app's repos and workspaces); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -229,6 +232,38 @@ that is not compositing (minimized, off the active Space, or locked screen) →
 (every composited path fails when the session is locked); that evidence keeps the
 VM / `tart-ui` fallback lane.
 
+## Workspace list
+
+`GET /v1/workspaces` (operator scope, `workspace.read`) returns the app's tracked
+repos and workspaces so later `[A2]` orchestration verbs have stable targets. It is
+read-only: no mutation rides this route.
+
+```json
+{
+  "repos": [
+    { "repoID": "…", "name": "workspaces", "path": "/Users/me/code/workspaces", "isSelected": true }
+  ],
+  "workspaces": [
+    { "workspaceID": "…", "repoID": "…", "name": "feature-a",
+      "path": "/Users/me/.workspaces/workspaces/feature-a", "branch": "feature-a",
+      "status": "active", "isArchived": false, "backend": "local", "isSelected": true }
+  ],
+  "system": { "capabilities": ["window.read", "window.snapshot", "workspace.read"] }
+}
+```
+
+- **Stable identity.** `repoID` and `workspaceID` are the SwiftData model ids —
+  stable across launches, the identity later verbs target. `workspaces[].repoID`
+  ties a workspace back to its source repo.
+- **Enough state to target.** Each workspace carries `status` (raw
+  `WorkspaceStatus`: `provisioning`/`active`/`stopped`/`archived`), `isArchived`,
+  `backend` (the backend identifier, e.g. `local`/`lume`), and `isSelected`
+  (whether it is the workspace currently selected in the app). Each repo carries
+  `isSelected` (whether it is the repo selected for its landing view).
+- **Live app state.** The listing reflects what the *running app* currently has,
+  read from the live SwiftData models and selection state — distinct from the
+  CLI's own local-state store (`workspaces ws list`).
+
 ## Error Codes
 
 | Code | Meaning |
@@ -269,18 +304,26 @@ workspaces input write 'echo hi'
 workspaces input write 'echo hi' --submit
 ```
 
-`workspaces window list` and `workspaces window snapshot` are the operator-scope
-commands. Unlike the tile-scoped commands, they read the per-launch operator
-credential file (minted next to the socket by an opt-in launch) rather than the
-injected terminal environment, so they work from any same-user shell outside a
-WorkSpaces tile. Absent the credential they fail closed with guidance.
+`workspaces window list`, `workspaces window snapshot`, and `workspaces workspace
+list` are the operator-scope commands. Unlike the tile-scoped commands, they read
+the per-launch operator credential file (minted next to the socket by an opt-in
+launch) rather than the injected terminal environment, so they work from any
+same-user shell outside a WorkSpaces tile. Absent the credential they fail closed
+with guidance.
 
 ```bash
 workspaces window list
 workspaces window list --json
 workspaces window snapshot --out shot.png            # main window, or first if none is main
 workspaces window snapshot --out shot.png --window 42 # a specific window.read id
+workspaces workspace list                            # repos + workspaces, human-readable
+workspaces workspace list --json                     # same, as the raw result envelope
 ```
+
+`workspace list` reads the running app's repos and workspaces (`workspace.read`),
+marking the currently-selected repo and workspace with a leading `*`. It is
+distinct from `workspaces ws list`, which lists the CLI's own local-state
+workspaces rather than what the app currently has.
 
 `window snapshot` writes the PNG to `--out` and, with no `--window`, targets the
 main window (falling back to the first listed) so the common "snapshot the app"
@@ -298,6 +341,7 @@ focus steal.
 | Window snapshot encoding (pure) | `Sources/WorkspaceManagerCore/Services/Automation/WindowSnapshotEncoder.swift` |
 | Operator credential store + provisioner | `Sources/WorkspaceManagerCore/Services/Automation/AutomationOperatorCredentialStore.swift` |
 | Window enumeration (AppKit → descriptors) | `Sources/WorkspaceManager/Views/MainWindow/AutomationWindowEnumerator.swift` |
+| Workspace inventory (SwiftData → descriptors) | `Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceEnumerator.swift` |
 | Window snapshot capture (`CGWindowList`, MainActor) | `Sources/WorkspaceManager/Views/MainWindow/WindowSnapshotService.swift` |
 | Web-surface snapshot capture (MainActor) | `Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift` |
 | CLI socket client | `Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift` |
@@ -328,10 +372,10 @@ V1 does not support browser mutation (navigating, clicking, filling, or
 evaluating JavaScript in a web surface), opening web URLs, tab title or metadata
 changes, writing into other tiles, resize/equalize, or global cross-workspace
 *mutation*. Those capabilities require separate product and safety review before
-they can be added. Read-only global window capture is the one reviewed
-exception — listing (`window.read`) and composited snapshots
-(`window.snapshot`) — gated behind the opt-in operator scope above, never
-granted to tile handles. Two reviewed exceptions widen the read/write surface
+they can be added. Read-only global reads are the reviewed operator-scope
+exceptions — window capture (`window.read` listing and `window.snapshot`
+composited snapshots) and the repo/workspace inventory (`workspace.read`) — gated
+behind the opt-in operator scope above, never granted to tile handles. Two reviewed exceptions widen the read/write surface
 deliberately: caller-scoped input injection ships as the experimental,
 double-gated `input.write` capability (see
 [Automation Input Write Decision](../decisions/automation-input-write.md)), and


### PR DESCRIPTION
## Summary

First [A2] slice (milestone #17): a **read-only** operator-scope listing of the app's repos and workspaces, so later orchestration verbs (#920+) have stable targets. Deliberately small — no mutation, no verb layer.

- **`workspace.read` capability** added to the operator handle set (`window.read`, `window.snapshot`, `workspace.read`). Read-only; tile handles never carry it and fail `capability_denied`, mirroring the `window.read` route from #941.
- **`GET /v1/workspaces`** returns repos + workspaces with stable **SwiftData model ids**, names, and enough state to target: per workspace `status`, `isArchived`, `backend`, `isSelected`; per repo `isSelected`. Reflects the running app's live models + selection state, not the CLI's local-state store.
- **`workspaces workspace list [--json]`** reads the per-launch operator credential like `window list` does; human output marks the selected repo/workspace with `*`. Distinct from `ws list` (CLI local state).
- **Operator-tagged audit** rides the existing route-agnostic classification (`automationHandleIsOperator`) — no new audit code. Verified `GET /v1/workspaces operator=True`.

Closes #919

## Review loop

Reflected on the diff (capability projection, selection wiring, ordering impact of the new capability on existing assertions), then a directed `codex` (gpt-5.5, xhigh) pass over the named failure modes: capability leak to a tile handle, selection correctness, exact-count capability assertions, route/method/audit wiring, CLI credential loading.

**Codex verdict: no findings.** Completeness question ("any reachable path where the route returns data to a handle lacking `workspace.read`?") answered **No**, tracing `AutomationHTTPRouter` → `automationWorkspaces` → `resolveOperator(requiring: .workspaceRead)` (capability check + `isOperator` guard) before any inventory read. No fix commits needed.

## Evidence

- [Live CLI transcript — `workspace list` (human + JSON) against a headless opted-in launch](https://evidence.cloudcompute.com/workspaces/pr-946/20260708-023817-cli-transcript.svg) — real repos with stable ids, `isSelected` flags, `workspace.read` in the capability set, operator audit tag, fail-closed message.
- [Automation test suite — 70 tests pass incl. 3 new](https://evidence.cloudcompute.com/workspaces/pr-946/20260708-023818-test-output.svg) — route projection (operator ok / tile denied / missing-handle / wrong-method), controller projection + fail-closed, payload shape.

`swift test` (1229 pass), `mise run lint` clean. App-fixture snapshot lane not used: this slice is a CLI/route change with no new pixels; the live CLI transcript against a real app is the stronger proof.

## Mergeability

- **Surface:** Automation API operator scope — `AutomationAPI` wire models + capability, `AutomationHTTPRouter` route, `AutomationController` projection, app-side `AutomationWorkspaceEnumerator`, lifecycle wiring, `workspaces workspace list` CLI, `automation-api.md`.
- **Behavior changed:** Adds a read-only `GET /v1/workspaces` + `workspace.read` operator capability + CLI verb. No existing behavior changes; `operatorCapabilities` gains one read-only entry (tile handles unaffected).
- **Non-happy paths:** tile/under-capable handle → `capability_denied`; missing handle → `missing_handle`; non-GET → `method_not_allowed`; missing operator credential → CLI fails closed with guidance. All covered by tests.
- **Residual risk:** Low. Read-only, operator-gated (opt-in launch only), no mutation. Inventory reads live SwiftData on MainActor via the same closure pattern as the web-surface/window lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
