### PR TITLE
feat(automation): gesture-verb layer + workspace.select through the real selection binding (#920)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -49,7 +49,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] },
         workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
             AutomationWorkspaceInventory()
-        }
+        },
+        gestureVerbs: AutomationGestureVerbs? = nil
     ) async {
         guard isEnabled else {
             tileTreeStore.configureAutomation(handleRegistry: nil, socketPath: nil)
@@ -64,7 +65,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 focusTerminal: focusTerminal,
                 requestCloseTerminal: requestCloseTerminal,
                 webSurfaceRecords: webSurfaceRecords,
-                workspaceInventory: workspaceInventory
+                workspaceInventory: workspaceInventory,
+                gestureVerbs: gestureVerbs
             )
             tileTreeStore.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
         } catch {
@@ -81,7 +83,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord] = { [] },
         workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
             AutomationWorkspaceInventory()
-        }
+        },
+        gestureVerbs: AutomationGestureVerbs? = nil
     ) async throws -> String {
         // Compose the read-only web-surface list from the caller's live source records
         // joined with the surface store's live WKWebView state (non-creating peek).
@@ -110,7 +113,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 webSnapshot: webSnapshot,
                 windows: windows,
                 windowSnapshot: windowSnapshot,
-                workspaceInventory: workspaceInventory
+                workspaceInventory: workspaceInventory,
+                gestureVerbs: gestureVerbs
             )
             return socketPath
         }
@@ -124,7 +128,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 webSnapshot: webSnapshot,
                 windows: windows,
                 windowSnapshot: windowSnapshot,
-                workspaceInventory: workspaceInventory
+                workspaceInventory: workspaceInventory,
+                gestureVerbs: gestureVerbs
             )
             guard let socketPath else {
                 throw AutomationListener.ListenerError.socketBindFailed("listener started without a socket path")
@@ -141,7 +146,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             webSnapshot: webSnapshot,
             windows: windows,
             windowSnapshot: windowSnapshot,
-            workspaceInventory: workspaceInventory
+            workspaceInventory: workspaceInventory,
+            gestureVerbs: gestureVerbs
         )
 
         let bundleID = Bundle.main.bundleIdentifier ?? "com.cloudcompute.workspaces"

--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -248,6 +248,14 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         }
     }
 
+    /// Detaches the gesture-verb layer when the installing window disappears, so a mutation verb
+    /// fails closed (`unsupported`) rather than driving a stale gesture while the app lingers as an
+    /// accessory. The listener and operator credential stay up — only the window-bound gesture layer
+    /// drops; a reappearing window reinstalls it via `configure`.
+    func detachGestureVerbs() {
+        controller?.detachGestureVerbs()
+    }
+
     func stop() async {
         startTask?.cancel()
         startTask = nil

--- a/Sources/WorkspaceManager/App/DesktopUISmokeAutomation.swift
+++ b/Sources/WorkspaceManager/App/DesktopUISmokeAutomation.swift
@@ -12,16 +12,29 @@
 import Foundation
 import WorkspaceManagerCore
 
+/// Who drives the "switch selection back to the workspace" step of the smoke. `ui` (default) drives
+/// the real selection binding directly, as a sidebar click does. `api` parks after creating the
+/// workspace and selecting the repo terminal, leaving an external `workspace.select` verb (the operator
+/// route) to drive the reselect — the same binding, entered through the API instead. `api` mode is how
+/// the smoke proves an API-driven select produces the identical `terminal_session_attached` milestone a
+/// click does, and that it switches the active PTY off the repo terminal (the wrong-PTY guard).
+enum DesktopUISmokeSelectDriver: String, Sendable {
+    case ui
+    case api
+}
+
 struct DesktopUISmokeAutomationConfiguration: Equatable, Sendable {
     static let modeEnvironmentKey = "WORKSPACES_AUTOMATION_MODE"
     static let repoPathEnvironmentKey = "WORKSPACES_AUTOMATION_REPO_PATH"
     static let workspaceNameEnvironmentKey = "WORKSPACES_AUTOMATION_WORKSPACE_NAME"
     static let eventsPathEnvironmentKey = "WORKSPACES_AUTOMATION_EVENTS_PATH"
+    static let selectDriverEnvironmentKey = "WORKSPACES_AUTOMATION_SELECT_DRIVER"
     static let modeValue = "desktop-ui-smoke"
 
     let repoURL: URL
     let workspaceName: String
     let eventsURL: URL
+    let selectDriver: DesktopUISmokeSelectDriver
 
     static func from(environment: [String: String]) -> DesktopUISmokeAutomationConfiguration? {
         guard
@@ -45,10 +58,17 @@ struct DesktopUISmokeAutomationConfiguration: Equatable, Sendable {
             return nil
         }
 
+        let selectDriverRaw =
+            environment[selectDriverEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let selectDriver = selectDriverRaw.flatMap(DesktopUISmokeSelectDriver.init(rawValue:)) ?? .ui
+
         return DesktopUISmokeAutomationConfiguration(
             repoURL: URL(fileURLWithPath: (repoPath as NSString).expandingTildeInPath),
             workspaceName: workspaceName,
-            eventsURL: URL(fileURLWithPath: (eventsPath as NSString).expandingTildeInPath)
+            eventsURL: URL(fileURLWithPath: (eventsPath as NSString).expandingTildeInPath),
+            selectDriver: selectDriver
         )
     }
 }
@@ -69,6 +89,7 @@ private struct DesktopUISmokeEvent: Codable, Sendable {
         case workspaceCreated = "workspace_created"
         case sidebarUpdated = "sidebar_updated"
         case terminalSessionAttached = "terminal_session_attached"
+        case awaitingApiSelect = "awaiting_api_select"
         case webSurfaceAttached = "web_surface_attached"
         case surfaceFocused = "surface_focused"
         case surfaceFocusTimedOut = "surface_focus_timed_out"
@@ -167,6 +188,27 @@ final class DesktopUISmokeAutomationController: ObservableObject {
 
     var targetWorkspaceName: String? {
         configuration?.workspaceName
+    }
+
+    /// Whether the reselect step is left to an external `workspace.select` verb rather than driven
+    /// in-process. See `DesktopUISmokeSelectDriver`.
+    var usesAPISelectDriver: Bool {
+        configuration?.selectDriver == .api
+    }
+
+    /// Signals the scenario has created the workspace, parked the active surface on the repo terminal,
+    /// and is now waiting for an external API-driven select to switch back to the workspace. The
+    /// api-select smoke script keys its `workspaces workspace select` on this milestone.
+    func noteAwaitingAPISelect(workspace: Workspace) async {
+        guard isEnabled else { return }
+        await emit(
+            makeEvent(
+                type: .awaitingApiSelect,
+                workspaceName: workspace.name,
+                workspacePath: workspace.path,
+                workspaceID: workspace.id.uuidString
+            )
+        )
     }
 
     func matchingRepo(in repos: [Repo], normalizePath: (URL) -> String) -> Repo? {

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -13,6 +13,10 @@ final class AutomationController: AutomationControlling {
     private var windows: @MainActor () -> [AutomationWindowDescriptor]
     private var windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome
     private var workspaceInventory: @MainActor () -> AutomationWorkspaceInventory
+    /// The gesture-verb layer — the single place `workspace.select` (and later mutation verbs) enter
+    /// the real UI path. `nil` when no window is attached, which is exactly the `unsupported`
+    /// condition: a mutation verb cannot run without a live window, and never falls back.
+    private var gestureVerbs: AutomationGestureVerbs?
 
     init(
         handleRegistry: AutomationHandleRegistry,
@@ -26,6 +30,7 @@ final class AutomationController: AutomationControlling {
         workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
             AutomationWorkspaceInventory()
         },
+        gestureVerbs: AutomationGestureVerbs? = nil,
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
         }
@@ -39,6 +44,7 @@ final class AutomationController: AutomationControlling {
         self.windows = windows
         self.windowSnapshot = windowSnapshot
         self.workspaceInventory = workspaceInventory
+        self.gestureVerbs = gestureVerbs
         self.isInputWriteEnabled = isInputWriteEnabled
     }
 
@@ -50,11 +56,13 @@ final class AutomationController: AutomationControlling {
         webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil,
         windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil,
         windowSnapshot: (@MainActor (String) async -> WindowSnapshotOutcome)? = nil,
-        workspaceInventory: (@MainActor () -> AutomationWorkspaceInventory)? = nil
+        workspaceInventory: (@MainActor () -> AutomationWorkspaceInventory)? = nil,
+        gestureVerbs: AutomationGestureVerbs? = nil
     ) {
         self.tileTreeStore = tileTreeStore
         self.focusTerminal = focusTerminal
         self.requestCloseTerminal = requestCloseTerminal
+        self.gestureVerbs = gestureVerbs
         if let webSurfaces {
             self.webSurfaces = webSurfaces
         }
@@ -108,6 +116,54 @@ final class AutomationController: AutomationControlling {
             workspaces: inventory.workspaces,
             system: AutomationSystemDescriptor(capabilities: entry.capabilities)
         )
+    }
+
+    func automationSelectWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceSelectResult {
+        // Operator scope, the first operator *mutation*: gated on workspace.select (distinct from the
+        // read-only workspace.read), and — like the other operator routes — resolved without the
+        // tile-liveness check. A tile handle lacks workspace.select and fails capability_denied.
+        let entry = try resolveOperator(handle, requiring: .workspaceSelect)
+        guard let uuid = UUID(uuidString: workspaceID) else {
+            throw AutomationServiceError(.invalidRequest, "workspaceID must be a UUID.")
+        }
+        // No gesture layer means no live window is bound to the API. That is precisely the
+        // `unsupported` case: the verb cannot run without a window, and never falls back to a
+        // data-layer write.
+        guard let gestureVerbs else {
+            throw AutomationServiceError(
+                .unsupported,
+                "No WorkSpaces window is attached; workspace.select requires a live window."
+            )
+        }
+        let capabilities = entry.capabilities
+        switch gestureVerbs.selectWorkspace(uuid) {
+        case .completed(let effect):
+            return AutomationWorkspaceSelectResult(
+                workspaceID: workspaceID,
+                outcome: .completed,
+                changed: true,
+                selectedWorkspaceID: effect.selectedWorkspaceID,
+                attachedTerminal: effect.attachedTerminal,
+                attachedSurfaceID: effect.attachedSurfaceID?.uuidString,
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        case .confirmationRequired(let message):
+            return AutomationWorkspaceSelectResult(
+                workspaceID: workspaceID,
+                outcome: .confirmationRequired,
+                changed: false,
+                message: message,
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        case .unsupported(let message):
+            throw AutomationServiceError(.unsupported, message)
+        case .notFound:
+            throw AutomationServiceError(
+                .invalidRequest, "No workspace with id \(workspaceID) is tracked by the app.")
+        }
     }
 
     func automationWindowSnapshot(

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -80,6 +80,15 @@ final class AutomationController: AutomationControlling {
         }
     }
 
+    /// Drops the gesture-verb layer when the window that installed it goes away. The app stays alive
+    /// as an accessory after its last window closes, so without this an escaped `performSelection`
+    /// closure would keep `workspace.select` "working" against a window that no longer exists. Clearing
+    /// it here is what makes a post-teardown select correctly return `unsupported` (no live window)
+    /// rather than driving a stale gesture. A window reappearing reinstalls it via `configure`.
+    func detachGestureVerbs() {
+        gestureVerbs = nil
+    }
+
     func automationContext(for handle: String) throws -> AutomationContextResult {
         let resolved = try resolve(handle, requiring: .contextRead)
         return try context(for: resolved)

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2043,6 +2043,56 @@ struct ContentView: View {
                     selectedWorkspaceID: viewState.selectedWorkspace?.workspaceID,
                     selectedRepoID: viewState.selectedRepoForLandingID
                 )
+            },
+            gestureVerbs: makeAutomationGestureVerbs()
+        )
+    }
+
+    /// The gesture-verb layer backing `workspace.select`. Its `performSelection` writes the exact same
+    /// `selectedWorkspaceBinding` a sidebar click writes — the setter runs `handleWorkspaceSelection`,
+    /// which attaches the terminal and requests focus. Because the verb enters this binding (not a
+    /// service or SwiftData write), an API-driven select produces the identical user-visible reactions
+    /// a click does: sidebar highlight, terminal attach, focus request. The layer holds only these two
+    /// closures — no backend handle — so a verb cannot silently bypass the UI.
+    @MainActor
+    private func makeAutomationGestureVerbs() -> AutomationGestureVerbs {
+        AutomationGestureVerbs(
+            resolveWorkspace: { workspaceID in
+                guard
+                    let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == workspaceID })
+                else {
+                    return nil
+                }
+                return AutomationGestureVerbs.WorkspaceTarget(
+                    workspaceID: workspace.id,
+                    name: workspace.name,
+                    isArchived: workspace.status == .archived
+                )
+            },
+            performSelection: { target in
+                guard
+                    let workspace = repos.flatMap(\.workspaces).first(where: {
+                        $0.id == target.workspaceID
+                    })
+                else {
+                    return AutomationWorkspaceSelectEffect(
+                        selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+                }
+                // Enter the real selection path: write the binding whose setter runs
+                // handleWorkspaceSelection (terminal attach + focus request), exactly as a click does.
+                selectedWorkspaceBinding.wrappedValue = workspace
+                // Read back what the gesture did. Selection landing on the target workspace (not the
+                // archived → repo-overview branch) with a live active session is the terminal attach;
+                // that active session is the surface a following input would land in — the wrong-PTY
+                // guard, observable rather than assumed.
+                let selectedID = currentSelectedWorkspace?.id
+                let activeSessionID = tileTreeStore.activeSessionID
+                let attached = selectedID == workspace.id && activeSessionID != nil
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: selectedID,
+                    attachedSurfaceID: attached ? activeSessionID : nil,
+                    attachedTerminal: attached
+                )
             }
         )
     }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -773,6 +773,10 @@ struct ContentView: View {
             .onDisappear {
                 ShortcutRoutingPolicy.shared.setOverride(nil, for: AppChromeShortcut.openInEditor.chord)
                 statusAggregationCoalescer.cancel()
+                // The window that installed the gesture-verb layer is gone; drop it so an operator
+                // mutation verb fails closed (unsupported) instead of driving a stale selection
+                // gesture while the app lingers as an accessory. Reappearing reinstalls it via onAppear.
+                AutomationIntegrationLifecycle.shared.detachGestureVerbs()
             }
             .onChange(of: deepLinkState.pendingRequest) { _, _ in
                 resolveSurfaceLifecycle()

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -1296,6 +1296,22 @@ struct SidebarView: View {
             timeout: .seconds(15)
         )
 
+        // API-driven select variant: park the active surface on the repo terminal, then hand the
+        // reselect to an external `workspace.select` verb. The verb enters the same selection binding
+        // this scenario's `selectWorkspace` writes, so it must produce the identical
+        // `terminal_session_attached` milestone — and switch the active PTY off the repo terminal,
+        // which is the wrong-PTY guard proven end to end.
+        if desktopUISmokeAutomation.usesAPISelectDriver {
+            let focusBaselineBeforeRepoPark = desktopUISmokeAutomation.surfaceFocusCount
+            onRepoTerminalSelected(repo)
+            _ = await desktopUISmokeAutomation.waitForSurfaceFocus(
+                after: focusBaselineBeforeRepoPark,
+                timeout: .seconds(15)
+            )
+            await desktopUISmokeAutomation.noteAwaitingAPISelect(workspace: workspace)
+            return
+        }
+
         // Flow 2: switch selection to the repo terminal, then back to the
         // workspace. Distinct attached session IDs prove the surface follows
         // selection rather than stranding a stale session.

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -974,9 +974,17 @@ private final class CLIApp {
     /// credential it fails closed with guidance. Distinct from `ws list`, which lists the CLI's own
     /// local-state workspaces; this reflects what the running app currently has.
     private func runWorkspaceOperator(arguments: [String]) throws -> Int32 {
-        guard arguments.first == "list" else {
-            throw CLIError("Usage: workspaces workspace list [--json]")
+        switch arguments.first {
+        case "list":
+            return try runWorkspaceList(arguments: arguments)
+        case "select":
+            return try runWorkspaceSelect(arguments: Array(arguments.dropFirst()))
+        default:
+            throw CLIError("Usage: workspaces workspace list [--json] | workspace select <id> [--json]")
         }
+    }
+
+    private func runWorkspaceList(arguments: [String]) throws -> Int32 {
         let usage = "workspaces workspace list [--json]"
         var json = false
         for argument in arguments.dropFirst() {
@@ -1027,6 +1035,57 @@ private final class CLIApp {
                         + "\(workspace.status)\t\(workspace.backend)\t\(branch)"
                 )
             }
+        }
+        return 0
+    }
+
+    /// `workspaces workspace select <id> [--json]` — the first operator mutation verb. Drives the
+    /// running app's real selection gesture (the same path a sidebar click takes) via the socket, so
+    /// the app highlights the workspace, attaches its terminal, and requests focus. `<id>` is a stable
+    /// workspace id from `workspace list`. Operator scope: reads the per-launch credential, so it works
+    /// from any same-user shell outside a tile.
+    private func runWorkspaceSelect(arguments: [String]) throws -> Int32 {
+        let usage = "workspaces workspace select <id> [--json]"
+        var json = false
+        var workspaceID: String?
+        for argument in arguments {
+            switch argument {
+            case "--json":
+                json = true
+            default:
+                guard workspaceID == nil else { throw CLIError("Usage: \(usage)") }
+                workspaceID = argument
+            }
+        }
+        guard let workspaceID, !workspaceID.isEmpty else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        let credential = try loadOperatorCredential()
+        let body = try JSONSerialization.data(withJSONObject: ["workspaceID": workspaceID])
+        let result = try operatorRequest(
+            AutomationWorkspaceSelectResult.self,
+            credential: credential,
+            method: "POST",
+            path: "/v1/workspace/select",
+            body: body
+        )
+
+        if json {
+            print(try AutomationCLIResultPrinter.resultJSON(result))
+            return 0
+        }
+
+        switch result.outcome {
+        case .completed:
+            if result.attachedTerminal {
+                let surface = result.attachedSurfaceID ?? "-"
+                print("Selected \(result.workspaceID) — terminal attached (surface \(surface)).")
+            } else {
+                print("Selected \(result.workspaceID) — no terminal attached.")
+            }
+        case .confirmationRequired:
+            print("Confirmation required: \(result.message ?? "the app needs confirmation to proceed.")")
         }
         return 0
     }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -19,12 +19,14 @@ public enum AutomationAPI {
     /// Kept separate from `v1Capabilities` so default handles never widen.
     public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
 
-    /// Capabilities granted to an opt-in operator handle. Capture-only plus read-only inventory:
-    /// `window.read` lists the app's windows, `window.snapshot` returns a composited PNG of one of
-    /// them (`[A1]`), and `workspace.read` lists the app's repos and workspaces so later
-    /// orchestration verbs have stable targets (`[A2]`). Operator handles never carry tile mutation
-    /// or `input.write` capabilities.
-    public static let operatorCapabilities = [AutomationCapability.windowRead, .windowSnapshot, .workspaceRead]
+    /// Capabilities granted to an opt-in operator handle. Capture and read (`window.read`,
+    /// `window.snapshot` — composited PNGs, `[A1]`; `workspace.read` — the repo/workspace inventory,
+    /// `[A2]`) plus the first operator *mutation* capability, `workspace.select` (`[A2]`): a reviewed
+    /// exception that drives the real selection gesture, never a data-layer write. Operator handles
+    /// still never carry tile mutation or `input.write`.
+    public static let operatorCapabilities = [
+        AutomationCapability.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect,
+    ]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
 
@@ -57,6 +59,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case windowRead = "window.read"
     case windowSnapshot = "window.snapshot"
     case workspaceRead = "workspace.read"
+    case workspaceSelect = "workspace.select"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -463,6 +466,77 @@ public struct AutomationWorkspacesResult: Codable, Sendable, Equatable {
     }
 }
 
+/// The structured outcome shared by every gesture verb (`[A2]`). A verb either `completed` (the
+/// gesture ran through the real UI path), needs `confirmationRequired` (a modal the user would see,
+/// surfaced as data instead of blocking on UI), or is `unsupported` (it cannot run — most often no
+/// live window). `notFound` is the id-does-not-resolve case, mapped to `invalid_request` at the wire.
+/// The gesture-verb layer (`AutomationGestureVerbs`) is the single place that produces these, so the
+/// verbs-=-clicks rule has one enforcement point. See the layer's doc for why a verb never falls back
+/// to a data-layer write.
+public enum AutomationGestureOutcomeKind: String, Codable, Sendable, Equatable {
+    case completed
+    case confirmationRequired = "confirmation_required"
+}
+
+/// What driving the real selection gesture produced. `attachedTerminal` is the observable proof the
+/// verb behaved like a click: selecting a live local workspace attaches (and focuses) its terminal
+/// surface, so `attachedSurfaceID` is the session a subsequent input would land in — the wrong-PTY
+/// guard. Selecting an archived workspace navigates to its repo overview instead, so it completes
+/// with `attachedTerminal == false` and no surface.
+public struct AutomationWorkspaceSelectEffect: Sendable, Equatable {
+    public let selectedWorkspaceID: UUID?
+    public let attachedSurfaceID: UUID?
+    public let attachedTerminal: Bool
+
+    public init(
+        selectedWorkspaceID: UUID?,
+        attachedSurfaceID: UUID?,
+        attachedTerminal: Bool
+    ) {
+        self.selectedWorkspaceID = selectedWorkspaceID
+        self.attachedSurfaceID = attachedSurfaceID
+        self.attachedTerminal = attachedTerminal
+    }
+}
+
+/// Response for `POST /v1/workspace/select` (`workspace.select`, operator scope). `outcome` is the
+/// structured gesture outcome (`completed` or `confirmation_required`); the `unsupported` and bad-id
+/// cases fail closed with the stable error codes instead. On `completed`, `attachedTerminal` and
+/// `attachedSurfaceID` report what the real selection gesture did — the same terminal attach a
+/// sidebar click produces.
+public struct AutomationWorkspaceSelectResult: Codable, Sendable, Equatable {
+    public let workspaceID: String
+    public let outcome: AutomationGestureOutcomeKind
+    public let changed: Bool
+    public let selectedWorkspaceID: UUID?
+    public let attachedTerminal: Bool
+    public let attachedSurfaceID: String?
+    public let message: String?
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        workspaceID: String,
+        outcome: AutomationGestureOutcomeKind,
+        changed: Bool,
+        selectedWorkspaceID: UUID? = nil,
+        attachedTerminal: Bool = false,
+        attachedSurfaceID: String? = nil,
+        message: String? = nil,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.workspaceID = workspaceID
+        self.outcome = outcome
+        self.changed = changed
+        self.selectedWorkspaceID = selectedWorkspaceID
+        self.attachedTerminal = attachedTerminal
+        self.attachedSurfaceID = attachedSurfaceID
+        self.message = message
+        self.system = system
+    }
+}
+
 public struct AutomationMutationResult: Codable, Sendable, Equatable {
     public let changed: Bool
     public let focusedSurfaceID: String?
@@ -634,6 +708,10 @@ public protocol AutomationControlling: AnyObject, Sendable {
     func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult
     func automationWindows(for handle: String) throws -> AutomationWindowsResult
     func automationWorkspaces(for handle: String) throws -> AutomationWorkspacesResult
+    func automationSelectWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceSelectResult
     func automationWindowSnapshot(
         for handle: String,
         windowID: String

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -20,8 +20,8 @@ public enum AutomationAPI {
     public static let inputWriteCapabilities = v1Capabilities + [AutomationCapability.inputWrite]
 
     /// Capabilities granted to an opt-in operator handle. Capture and read (`window.read`,
-    /// `window.snapshot` — composited PNGs, `[A1]`; `workspace.read` — the repo/workspace inventory,
-    /// `[A2]`) plus the first operator *mutation* capability, `workspace.select` (`[A2]`): a reviewed
+    /// `window.snapshot` — composited PNGs; `workspace.read` — the repo/workspace inventory)
+    /// plus the first operator *mutation* capability, `workspace.select`: a reviewed
     /// exception that drives the real selection gesture, never a data-layer write. Operator handles
     /// still never carry tile mutation or `input.write`.
     public static let operatorCapabilities = [
@@ -466,7 +466,7 @@ public struct AutomationWorkspacesResult: Codable, Sendable, Equatable {
     }
 }
 
-/// The structured outcome shared by every gesture verb (`[A2]`). A verb either `completed` (the
+/// The structured outcome shared by every gesture verb. A verb either `completed` (the
 /// gesture ran through the real UI path), needs `confirmationRequired` (a modal the user would see,
 /// surfaced as data instead of blocking on UI), or is `unsupported` (it cannot run — most often no
 /// live window). `notFound` is the id-does-not-resolve case, mapped to `invalid_request` at the wire.

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
@@ -1,0 +1,82 @@
+//
+//  AutomationGestureVerbs.swift
+//  WorkspaceManagerCore
+//
+//  The gesture-verb layer — the single place the "verbs = clicks" rule is enforced (`[A2]`).
+//
+//  Every mutation verb enters the same UI gesture the equivalent user action does. This layer is
+//  constructed with *only* gesture closures — the app's real UI entry points (for `workspace.select`,
+//  the selection binding whose setter attaches the terminal and requests focus) — and holds no
+//  service, backend, or SwiftData handle. That absence is the guarantee: a verb here structurally
+//  cannot reach a data-layer write, so it cannot produce a snapshot that lies or misroute the next
+//  input into a stale PTY. When no window is live the app installs no gesture layer at all and the
+//  controller reports `unsupported`, never a fallback.
+//
+
+import Foundation
+
+/// The structured outcome of a gesture verb. `AutomationGestureOutcomeKind` is the wire-facing subset
+/// (`completed`/`confirmation_required`); `unsupported` and `notFound` fail closed with stable error
+/// codes instead of riding the success envelope. Every verb the layer grows returns this same enum,
+/// so the outcome contract has one definition.
+public enum AutomationWorkspaceSelectOutcome: Sendable, Equatable {
+    /// The gesture ran through the real selection path; `effect` reports what the UI did.
+    case completed(AutomationWorkspaceSelectEffect)
+    /// The gesture would surface a modal; the message is what the user would confirm. `workspace.select`
+    /// never raises this today (selection has no confirmation dialog), but the shared verb contract
+    /// models it for sibling verbs (e.g. a destructive close) so dialogs become data, never a hang.
+    case confirmationRequired(String)
+    /// The verb cannot run in the current context. For selection the dominant cause is "no live
+    /// window," which the controller detects by the absence of the gesture layer.
+    case unsupported(String)
+    /// The workspace id resolves to nothing the app tracks. Mapped to `invalid_request` at the wire.
+    case notFound
+}
+
+@MainActor
+public final class AutomationGestureVerbs {
+    /// The minimum a verb needs to target and describe a workspace, projected out of the live
+    /// SwiftData model by the app so this layer never touches the model directly. `isArchived`
+    /// lets the layer stay honest about the archived branch (selection navigates to the repo
+    /// overview rather than attaching a terminal).
+    public struct WorkspaceTarget: Sendable, Equatable {
+        public let workspaceID: UUID
+        public let name: String
+        public let isArchived: Bool
+
+        public init(workspaceID: UUID, name: String, isArchived: Bool) {
+            self.workspaceID = workspaceID
+            self.name = name
+            self.isArchived = isArchived
+        }
+    }
+
+    /// Resolve a stable workspace id (a `workspace.read` id) to a target, or `nil` if the app tracks
+    /// no such workspace. Read-only — it never mutates selection.
+    private let resolveWorkspace: @MainActor (UUID) -> WorkspaceTarget?
+
+    /// Drive the real selection gesture for `target` — write the selection binding whose setter
+    /// attaches the terminal and requests focus — and report back what the UI did. This closure is
+    /// the app's actual click path; the layer holds nothing else.
+    private let performSelection: @MainActor (WorkspaceTarget) -> AutomationWorkspaceSelectEffect
+
+    public init(
+        resolveWorkspace: @escaping @MainActor (UUID) -> WorkspaceTarget?,
+        performSelection: @escaping @MainActor (WorkspaceTarget) -> AutomationWorkspaceSelectEffect
+    ) {
+        self.resolveWorkspace = resolveWorkspace
+        self.performSelection = performSelection
+    }
+
+    /// `workspace.select`: enter the same selection path a sidebar click takes. Resolves the id, then
+    /// drives the real binding gesture — no service call, no data-layer flip. A completed selection of
+    /// a live local workspace attaches (and focuses) its terminal exactly as the click would; that
+    /// attach is what keeps a following input from landing in the previously selected PTY.
+    public func selectWorkspace(_ workspaceID: UUID) -> AutomationWorkspaceSelectOutcome {
+        guard let target = resolveWorkspace(workspaceID) else {
+            return .notFound
+        }
+        let effect = performSelection(target)
+        return .completed(effect)
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
@@ -2,7 +2,7 @@
 //  AutomationGestureVerbs.swift
 //  WorkspaceManagerCore
 //
-//  The gesture-verb layer — the single place the "verbs = clicks" rule is enforced (`[A2]`).
+//  The gesture-verb layer — the single place the "verbs = clicks" rule is enforced.
 //
 //  Every mutation verb enters the same UI gesture the equivalent user action does. This layer is
 //  constructed with *only* gesture closures — the app's real UI entry points (for `workspace.select`,

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -84,6 +84,10 @@ enum AutomationHTTPRouter {
             let windowID = try decodeWindowID(from: request.body)
             return try await controller.automationWindowSnapshot(for: handle, windowID: windowID)
 
+        case ("POST", "/v1/workspace/select"):
+            let workspaceID = try decodeWorkspaceID(from: request.body)
+            return try await controller.automationSelectWorkspace(for: handle, workspaceID: workspaceID)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -124,6 +128,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/workspaces.")
         case (_, "/v1/window/snapshot"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/window/snapshot.")
+        case (_, "/v1/workspace/select"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/select.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -215,6 +221,34 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.invalidRequest, "Request body must be JSON with a non-empty string windowID.")
         }
         return windowID
+    }
+
+    /// The `workspaceID` from a `workspace.select` body. Like the window id, this is a global stable
+    /// identity the caller obtained from `workspace.read` (a SwiftData model id), not a caller-supplied
+    /// *tile* id to reject — so the route accepts it directly and the controller confirms it names a
+    /// workspace the app tracks. UUID-shape validation is the controller's job so a well-shaped body
+    /// with a non-UUID id reports `invalid_request` rather than a decode failure.
+    private static func decodeWorkspaceID(from body: Data) throws -> String {
+        guard !body.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request body must include a workspaceID.")
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: body)
+        } catch {
+            throw AutomationServiceError(.malformedJSON, "Request body is not valid JSON.")
+        }
+        guard let object = parsed as? [String: Any] else {
+            throw AutomationServiceError(.invalidRequest, "Request body must be a JSON object.")
+        }
+        guard
+            let workspaceID = object["workspaceID"] as? String,
+            !workspaceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw AutomationServiceError(
+                .invalidRequest, "Request body must be JSON with a non-empty string workspaceID.")
+        }
+        return workspaceID
     }
 
     private static func decodeInputWrite(from body: Data) throws -> AutomationInputWriteRequest {
@@ -333,6 +367,7 @@ extension AutomationContextResult: CodableSendableEquatable {}
 extension AutomationSurfacesResult: CodableSendableEquatable {}
 extension AutomationWindowsResult: CodableSendableEquatable {}
 extension AutomationWorkspacesResult: CodableSendableEquatable {}
+extension AutomationWorkspaceSelectResult: CodableSendableEquatable {}
 extension AutomationWindowSnapshotResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
@@ -72,7 +72,8 @@ public final class AutomationHandleRegistry {
         return entry
     }
 
-    /// Registers a per-launch operator handle carrying capture-only capabilities. Unlike `upsert`,
+    /// Registers a per-launch operator handle carrying the operator capabilities (read/capture plus
+    /// the one reviewed mutation, workspace.select). Unlike `upsert`,
     /// this is not keyed by a live terminal session — the entry stands alone under a synthetic host
     /// session id so `remove(hostSessionID:)`/`removeAll` still evict it when the launch ends. Each
     /// call mints a fresh handle; a launch mints exactly one.

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -509,7 +509,7 @@ struct AutomationControllerTests {
 
         let result = try controller.automationWindows(for: operatorEntry.handle)
         #expect(result.windows == [descriptor])
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
 
@@ -600,7 +600,7 @@ struct AutomationControllerTests {
         #expect(result.workspaces == inventory.workspaces)
         #expect(result.workspaces.first?.isArchived == true)
         #expect(result.workspaces.first?.backend == "lume")
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
 
@@ -671,7 +671,7 @@ struct AutomationControllerTests {
         #expect(result.width == 2800)
         #expect(result.height == 1800)
         #expect(Data(base64Encoded: result.data) == png)
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
         #expect(requestedWindowIDs == ["42"])
     }
 

--- a/Tests/WorkspaceManagerAppTests/AutomationSelectVerbTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationSelectVerbTests.swift
@@ -104,6 +104,32 @@ struct AutomationSelectVerbTests {
         }
     }
 
+    @Test("detaching the gesture layer (window gone) makes select unsupported, not a stale drive")
+    func detachedGestureLayerIsUnsupported() async throws {
+        var drove = false
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: {
+                AutomationGestureVerbs.WorkspaceTarget(workspaceID: $0, name: "ws", isArchived: false)
+            },
+            performSelection: { _ in
+                drove = true
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        // The window that installed the gesture layer disappears (the app lingers as an accessory).
+        controller.detachGestureVerbs()
+
+        await expectFailure(.unsupported) {
+            try await controller.automationSelectWorkspace(
+                for: handle, workspaceID: UUID().uuidString)
+        }
+        // Fail closed: the stale gesture is never driven after detach.
+        #expect(!drove)
+    }
+
     @Test("a non-UUID id is invalid_request")
     func badUUIDInvalid() async throws {
         let verbs = AutomationGestureVerbs(

--- a/Tests/WorkspaceManagerAppTests/AutomationSelectVerbTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationSelectVerbTests.swift
@@ -1,0 +1,192 @@
+//
+//  AutomationSelectVerbTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Exercises the real AutomationController.automationSelectWorkspace against a real handle registry
+//  and a real TileTreeStore: operator-scope capability enforcement, the completed/unsupported/
+//  invalid_request outcome mapping, and the named wrong-PTY regression — selecting workspace A then B
+//  makes each workspace's own terminal the active surface a following input would land in.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("AutomationController workspace.select")
+struct AutomationSelectVerbTests {
+    /// Runs `body` expecting it to throw an `AutomationServiceError` with `code`, matching the
+    /// do/catch assertion style used elsewhere in the automation tests.
+    private func expectFailure(
+        _ code: AutomationErrorCode,
+        _ body: () async throws -> some Any
+    ) async {
+        do {
+            _ = try await body()
+            Issue.record("Expected \(code.rawValue) but the call succeeded.")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == code)
+        } catch {
+            Issue.record("Expected AutomationServiceError but got \(error).")
+        }
+    }
+
+    private func operatorController(
+        gestureVerbs: AutomationGestureVerbs?
+    ) -> (AutomationController, registry: AutomationHandleRegistry, operatorHandle: String) {
+        let registry = AutomationHandleRegistry(makeHandle: { UUID().uuidString })
+        let entry = registry.registerOperator(appScopeID: "workspaces.local")
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: TileTreeStore(),
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            gestureVerbs: gestureVerbs
+        )
+        return (controller, registry, entry.handle)
+    }
+
+    @Test("operator handle with a live gesture layer completes and reports the attach")
+    func operatorCompletes() async throws {
+        let id = UUID()
+        let surface = UUID()
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { [id] in
+                $0 == id
+                    ? AutomationGestureVerbs.WorkspaceTarget(workspaceID: id, name: "ws", isArchived: false)
+                    : nil
+            },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: id, attachedSurfaceID: surface, attachedTerminal: true)
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        let result = try await controller.automationSelectWorkspace(
+            for: handle, workspaceID: id.uuidString)
+
+        #expect(result.outcome == .completed)
+        #expect(result.changed)
+        #expect(result.attachedTerminal)
+        #expect(result.attachedSurfaceID == surface.uuidString)
+        #expect(result.selectedWorkspaceID == id)
+        #expect(result.system.capabilities.contains(.workspaceSelect))
+    }
+
+    @Test("a tile handle lacks workspace.select and is denied")
+    func tileHandleDenied() async throws {
+        let (controller, registry, _) = operatorController(gestureVerbs: nil)
+        // A tile handle carries the v1 tile capabilities but not workspace.select.
+        let tile = registry.upsert(
+            hostSessionID: UUID(),
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "workspaces.local"
+        )
+
+        await expectFailure(.capabilityDenied) {
+            try await controller.automationSelectWorkspace(
+                for: tile.handle, workspaceID: UUID().uuidString)
+        }
+    }
+
+    @Test("no live gesture layer is unsupported, never a data-layer fallback")
+    func noWindowUnsupported() async throws {
+        let (controller, _, handle) = operatorController(gestureVerbs: nil)
+
+        await expectFailure(.unsupported) {
+            try await controller.automationSelectWorkspace(
+                for: handle, workspaceID: UUID().uuidString)
+        }
+    }
+
+    @Test("a non-UUID id is invalid_request")
+    func badUUIDInvalid() async throws {
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        await expectFailure(.invalidRequest) {
+            try await controller.automationSelectWorkspace(for: handle, workspaceID: "not-a-uuid")
+        }
+    }
+
+    @Test("a well-shaped but unknown id is invalid_request and never drives the gesture")
+    func unknownIDInvalid() async throws {
+        var performed = false
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                performed = true
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        await expectFailure(.invalidRequest) {
+            try await controller.automationSelectWorkspace(
+                for: handle, workspaceID: UUID().uuidString)
+        }
+        #expect(!performed)
+    }
+
+    /// Wrong-PTY regression against a real TileTreeStore: the gesture activates the selected
+    /// workspace's own host session, so the store's active session — where a following input lands —
+    /// follows the select. Selecting A makes A's session active; selecting B switches it to B, leaving
+    /// no stale A surface to misroute the next write.
+    @Test("selecting workspace A then workspace B routes input to each workspace's own PTY")
+    func selectingWorkspaceAThenInputLandsInASPTY() async throws {
+        let store = TileTreeStore()
+        let workspaceA = UUID()
+        let workspaceB = UUID()
+        let pathA = "/tmp/wrong-pty-smoke/workspace-a"
+        let pathB = "/tmp/wrong-pty-smoke/workspace-b"
+        let pathByID = [workspaceA: pathA, workspaceB: pathB]
+
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { id in
+                pathByID[id].map {
+                    _ in AutomationGestureVerbs.WorkspaceTarget(workspaceID: id, name: "ws", isArchived: false)
+                }
+            },
+            performSelection: { target in
+                let path = pathByID[target.workspaceID]!
+                // The real selection gesture attaches (and activates) the workspace's terminal.
+                let session = store.activateSession(
+                    key: .hostPath(path), directory: URL(fileURLWithPath: path)
+                ).session
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: target.workspaceID,
+                    attachedSurfaceID: store.activeSessionID,
+                    attachedTerminal: session.id == store.activeSessionID
+                )
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        let selectA = try await controller.automationSelectWorkspace(
+            for: handle, workspaceID: workspaceA.uuidString)
+        let sessionA = try #require(store.activeSessionID)
+        #expect(selectA.attachedSurfaceID == sessionA.uuidString)
+        // Input now targets the active surface, which is A's session.
+        #expect(store.sessions.first(where: { $0.id == sessionA })?.directoryPath == pathA)
+
+        let selectB = try await controller.automationSelectWorkspace(
+            for: handle, workspaceID: workspaceB.uuidString)
+        let sessionB = try #require(store.activeSessionID)
+        #expect(selectB.attachedSurfaceID == sessionB.uuidString)
+        #expect(sessionB != sessionA)
+        // The active surface switched to B — a following input lands in B's PTY, not A's stale one.
+        #expect(store.sessions.first(where: { $0.id == sessionB })?.directoryPath == pathB)
+    }
+}

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -115,6 +115,50 @@ private final class FakeAutomationController: AutomationControlling {
         )
     }
 
+    var selectCalls: [String] = []
+
+    /// Named ids the fake maps to each projected outcome, so router tests can drive the wire mapping
+    /// without a live app. A well-shaped-but-unknown id and a non-UUID id both project to
+    /// `invalid_request`; the no-window id projects to `unsupported`.
+    static let selectUnknownID = "00000000-0000-0000-0000-000000000000"
+    static let selectNoWindowID = "11111111-1111-1111-1111-111111111111"
+    static let selectAttachedSurfaceID = "22222222-2222-2222-2222-222222222222"
+
+    func automationSelectWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceSelectResult {
+        // Mirrors the operator-scope projection: only an operator handle carries workspace.select; a
+        // tile handle ("live") is capability_denied and any other handle is stale.
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(
+                .capabilityDenied, "The automation handle does not include workspace.select.")
+        }
+        guard UUID(uuidString: workspaceID) != nil else {
+            throw AutomationServiceError(.invalidRequest, "workspaceID must be a UUID.")
+        }
+        if workspaceID == Self.selectUnknownID {
+            throw AutomationServiceError(
+                .invalidRequest, "No workspace with id \(workspaceID) is tracked by the app.")
+        }
+        if workspaceID == Self.selectNoWindowID {
+            throw AutomationServiceError(
+                .unsupported, "No WorkSpaces window is attached; workspace.select requires a live window.")
+        }
+        selectCalls.append(workspaceID)
+        return AutomationWorkspaceSelectResult(
+            workspaceID: workspaceID,
+            outcome: .completed,
+            changed: true,
+            selectedWorkspaceID: UUID(uuidString: workspaceID),
+            attachedTerminal: true,
+            attachedSurfaceID: Self.selectAttachedSurfaceID
+        )
+    }
+
     var windowSnapshotCalls: [String] = []
 
     func automationWindowSnapshot(
@@ -737,7 +781,7 @@ struct AutomationAPITests {
         #expect(deniedEnvelope.error?.code == .capabilityDenied)
     }
 
-    @Test("Registry mints an operator handle carrying only capture-only capabilities")
+    @Test("Registry mints an operator handle carrying read/capture plus workspace.select")
     @MainActor
     func registryRegistersOperatorHandle() {
         let registry = AutomationHandleRegistry(makeHandle: { "op-1" })
@@ -746,8 +790,9 @@ struct AutomationAPITests {
         #expect(entry.handle == "op-1")
         #expect(entry.isOperator)
         #expect(entry.tileID == nil)
-        #expect(entry.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
-        // Capture-only: an operator handle never carries tile mutation or input.write.
+        #expect(entry.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+        // The one operator mutation is workspace.select (a reviewed exception that drives the real
+        // gesture); an operator handle still never carries tile mutation or input.write.
         #expect(!entry.capabilities.contains(.tileClose))
         #expect(!entry.capabilities.contains(.inputWrite))
         #expect(registry.resolve("op-1")?.isOperator == true)
@@ -780,7 +825,8 @@ struct AutomationAPITests {
         #expect(ok.status == 200)
         #expect(okEnvelope.result?.windows.count == 1)
         #expect(okEnvelope.result?.windows.first?.windowID == "42")
-        #expect(okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(
+            okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
         #expect(controller.windowCalls == ["operator"])
 
         // A tile handle holds the v1 tile capabilities but not window.read → capability_denied.
@@ -859,7 +905,8 @@ struct AutomationAPITests {
         #expect(okEnvelope.result?.workspaces.first?.status == "active")
         #expect(okEnvelope.result?.workspaces.first?.backend == "local")
         #expect(okEnvelope.result?.workspaces.first?.isSelected == true)
-        #expect(okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(
+            okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
         #expect(controller.workspaceCalls == ["operator"])
 
         // A tile handle holds the v1 tile capabilities but not workspace.read → capability_denied.
@@ -963,6 +1010,103 @@ struct AutomationAPITests {
         #expect(code(.unknownWindow) == .invalidRequest)
         #expect(code(.notCapturable) == .unsupported)
         #expect(code(.captureFailed("boom")) == .internalError)
+    }
+
+    @Test("POST /v1/workspace/select projects the gesture outcome and enforces the capability")
+    @MainActor
+    func routerWorkspaceSelect() async throws {
+        let controller = FakeAutomationController()
+        let validID = "77777777-7777-7777-7777-777777777777"
+
+        func post(_ handle: String?, body: Data) async -> AutomationHTTPResult {
+            var headers: [String: String] = [:]
+            if let handle { headers[AutomationAPI.handleHeader] = handle }
+            return await AutomationHTTPRouter.route(
+                HTTPRequest(method: "POST", path: "/v1/workspace/select", headers: headers, body: body),
+                controller: controller,
+                enabled: true
+            )
+        }
+
+        func body(_ id: String) -> Data {
+            Data("{\"workspaceID\":\"\(id)\"}".utf8)
+        }
+
+        // Operator handle + valid id → completed, attached, and the controller was actually driven.
+        let ok = await post("operator", body: body(validID))
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWorkspaceSelectResult>.self, from: ok.body)
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.outcome == .completed)
+        #expect(okEnvelope.result?.changed == true)
+        #expect(okEnvelope.result?.attachedTerminal == true)
+        #expect(okEnvelope.result?.attachedSurfaceID == FakeAutomationController.selectAttachedSurfaceID)
+        #expect(okEnvelope.result?.system.capabilities.contains(.workspaceSelect) == true)
+        #expect(controller.selectCalls == [validID])
+
+        // A tile handle holds tile mutation but not workspace.select → capability_denied.
+        let denied = await post("live", body: body(validID))
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: denied.body)
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        // Unknown handle is stale; missing handle is missing.
+        let stale = await post("ghost", body: body(validID))
+        #expect(stale.status == 401)
+        let missing = await post(nil, body: body(validID))
+        #expect(missing.status == 401)
+        let missingEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: missing.body)
+        #expect(missingEnvelope.error?.code == .missingHandle)
+
+        // A well-shaped-but-unknown id and a non-UUID id both project to invalid_request.
+        let unknown = await post("operator", body: body(FakeAutomationController.selectUnknownID))
+        #expect(unknown.status == 400)
+        let badUUID = await post("operator", body: body("not-a-uuid"))
+        let badUUIDEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: badUUID.body)
+        #expect(badUUID.status == 400)
+        #expect(badUUIDEnvelope.error?.code == .invalidRequest)
+
+        // No live window → unsupported (the verb never falls back to a data-layer write).
+        let noWindow = await post("operator", body: body(FakeAutomationController.selectNoWindowID))
+        let noWindowEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: noWindow.body)
+        #expect(noWindow.status == 409)
+        #expect(noWindowEnvelope.error?.code == .unsupported)
+
+        // An empty body is invalid_request; GET is method_not_allowed.
+        let empty = await post("operator", body: Data())
+        #expect(empty.status == 400)
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET", path: "/v1/workspace/select",
+                headers: [AutomationAPI.handleHeader: "operator"], body: Data()),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: wrongMethod.body)
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("workspace-select result encodes the structured outcome kind on the wire")
+    func workspaceSelectResultEncoding() throws {
+        let confirmation = AutomationWorkspaceSelectResult(
+            workspaceID: "abc", outcome: .confirmationRequired, changed: false,
+            message: "Confirm?")
+        let data = try AutomationJSON.encoder.encode(AutomationResponseEnvelope(result: confirmation))
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("\"outcome\":\"confirmation_required\""))
+        #expect(json.contains("\"message\":\"Confirm?\""))
+
+        let completed = AutomationWorkspaceSelectResult(
+            workspaceID: "abc", outcome: .completed, changed: true, attachedTerminal: true)
+        let completedJSON = try #require(
+            String(data: try AutomationJSON.encoder.encode(completed), encoding: .utf8))
+        #expect(completedJSON.contains("\"outcome\":\"completed\""))
     }
 
     @Test("POST /v1/window/snapshot captures for an operator handle and fails closed otherwise")
@@ -1077,7 +1221,7 @@ struct AutomationAPITests {
 
         let loaded = AutomationOperatorCredentialStore.load(from: url)
         #expect(loaded == credential)
-        #expect(loaded?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead])
+        #expect(loaded?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
 
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
@@ -1107,7 +1251,9 @@ struct AutomationAPITests {
         let mintedCredential = try #require(minted)
         #expect(AutomationOperatorCredentialStore.load(from: url) == mintedCredential)
         #expect(
-            registry.resolve(mintedCredential.handle)?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead]
+            registry.resolve(mintedCredential.handle)?.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect,
+            ]
         )
         #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)
 

--- a/Tests/WorkspaceManagerTests/AutomationGestureVerbsTests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationGestureVerbsTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+/// The gesture-verb layer is where the verbs-=-clicks rule lives. These tests pin the outcome
+/// contract and the wrong-PTY guard at the layer boundary using fake gesture closures — no live app
+/// — so the enforcement point has its own fast, deterministic coverage. The real-app behavior is
+/// verified separately by the api-select smoke (JSONL milestones).
+@Suite("AutomationGestureVerbs")
+@MainActor
+struct AutomationGestureVerbsTests {
+    private func target(
+        _ id: UUID, name: String = "ws", isArchived: Bool = false
+    )
+        -> AutomationGestureVerbs.WorkspaceTarget
+    {
+        AutomationGestureVerbs.WorkspaceTarget(workspaceID: id, name: name, isArchived: isArchived)
+    }
+
+    @Test("select resolves and drives the gesture, returning the completed effect")
+    func selectCompleted() {
+        let id = UUID()
+        let surface = UUID()
+        var performed: [UUID] = []
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { [id] in $0 == id ? self.target(id) : nil },
+            performSelection: { t in
+                performed.append(t.workspaceID)
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: t.workspaceID,
+                    attachedSurfaceID: surface,
+                    attachedTerminal: true
+                )
+            }
+        )
+
+        let outcome = verbs.selectWorkspace(id)
+
+        // The gesture ran exactly once, for the resolved workspace.
+        #expect(performed == [id])
+        guard case .completed(let effect) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(effect.selectedWorkspaceID == id)
+        #expect(effect.attachedTerminal)
+        #expect(effect.attachedSurfaceID == surface)
+    }
+
+    @Test("select of an unknown id is notFound and never drives the gesture")
+    func selectNotFound() {
+        var performCount = 0
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                performCount += 1
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            }
+        )
+
+        let outcome = verbs.selectWorkspace(UUID())
+
+        #expect(outcome == .notFound)
+        // Fail closed: an unresolvable id never touches the selection gesture.
+        #expect(performCount == 0)
+    }
+
+    @Test("selecting an archived workspace completes without a terminal attach")
+    func selectArchivedCompletesWithoutTerminal() {
+        let id = UUID()
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { [id] in $0 == id ? self.target(id, isArchived: true) : nil },
+            performSelection: { _ in
+                // The real archived path navigates to the repo overview: selection does not land on
+                // the workspace and no terminal attaches.
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            }
+        )
+
+        guard case .completed(let effect) = verbs.selectWorkspace(id) else {
+            Issue.record("expected .completed for an archived selection")
+            return
+        }
+        #expect(!effect.attachedTerminal)
+        #expect(effect.attachedSurfaceID == nil)
+    }
+
+    /// Wrong-PTY regression: selecting workspace A then writing input must land in A's PTY. At this
+    /// layer that reduces to: each select drives the gesture for the *requested* workspace, and the
+    /// effect reports that workspace's own attached surface — never a stale one cached from a prior
+    /// select. The fake gesture models a tile tree by making the selected workspace's surface the
+    /// active one; the active surface is where a following input goes.
+    @Test("selecting workspace A then workspace B routes input to each workspace's own PTY")
+    func selectingWorkspaceAThenInputLandsInASPTY() {
+        let workspaceA = UUID()
+        let workspaceB = UUID()
+        let surfaceA = UUID()
+        let surfaceB = UUID()
+        let surfaceForWorkspace = [workspaceA: surfaceA, workspaceB: surfaceB]
+
+        // The single mutable "active PTY" the next input would target.
+        var activeSurface: UUID?
+
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { id in
+                surfaceForWorkspace[id] != nil ? self.target(id) : nil
+            },
+            performSelection: { t in
+                // Driving the real selection gesture activates the workspace's own surface.
+                let surface = surfaceForWorkspace[t.workspaceID]
+                activeSurface = surface
+                return AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: t.workspaceID,
+                    attachedSurfaceID: surface,
+                    attachedTerminal: surface != nil
+                )
+            }
+        )
+
+        // Select A: A's surface is now the active PTY, so input lands in A.
+        guard case .completed(let effectA) = verbs.selectWorkspace(workspaceA) else {
+            Issue.record("expected .completed selecting A")
+            return
+        }
+        #expect(effectA.attachedSurfaceID == surfaceA)
+        #expect(activeSurface == surfaceA)
+
+        // Select B: the active PTY switches to B — no stale A surface left live to misroute input.
+        guard case .completed(let effectB) = verbs.selectWorkspace(workspaceB) else {
+            Issue.record("expected .completed selecting B")
+            return
+        }
+        #expect(effectB.attachedSurfaceID == surfaceB)
+        #expect(activeSurface == surfaceB)
+        #expect(activeSurface != surfaceA)
+    }
+}

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -65,10 +65,10 @@ WorkSpaces terminal tile. See
   behind by a crashed launch fails closed — its handle no longer resolves
   against the fresh registry (`stale_handle`).
 - **Capture, read, and the first mutation.** The operator capability set is
-  `window.read` (list windows) and `window.snapshot` (composited PNG of a listed
-  window) from `[A1]`, `workspace.read` (list repos and workspaces) from `[A2]`,
-  and — the one operator *mutation* — `workspace.select` (`[A2]`), a reviewed
-  exception that drives the real selection gesture rather than a data-layer write
+  `window.read` (list windows), `window.snapshot` (composited PNG of a listed
+  window), and `workspace.read` (list repos and workspaces), plus — the one
+  operator *mutation* — `workspace.select`, a reviewed exception that drives
+  the real selection gesture rather than a data-layer write
   (see [Verb contract](#verb-contract-verbs--clicks)). Operator handles still
   never carry tile mutation or `input.write`.
 
@@ -165,7 +165,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/windows` | **Operator scope.** Returns the app's on-screen windows with stable identifiers (`window.read`). Keyed by the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address. Requires an operator handle; a tile handle lacks `window.read` and fails `capability_denied`. |
 | `POST /v1/window/snapshot` | **Operator scope.** Returns a composited PNG of the app window named by the body's `windowID` (a `window.read` id). The capture includes the full window — sidebar chrome *and* the GhosttyKit terminal surface — and works with the app backgrounded (no activation). Requires `window.snapshot`; own-window only, so an id the app does not own fails `invalid_request`. See [Window snapshot](#window-snapshot). |
 | `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — the stable-target list later `[A2]` orchestration verbs act on. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
-| `POST /v1/workspace/select` | **Operator scope, mutation (`[A2]`).** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
+| `POST /v1/workspace/select` | **Operator scope, mutation.** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -197,7 +197,7 @@ handle.
 | `window.read` | `GET /v1/windows` (list the app's windows); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `window.snapshot` | `POST /v1/window/snapshot` (composited PNG of a listed window); granted only to operator handles, never to tile handles |
 | `workspace.read` | `GET /v1/workspaces` (list the app's repos and workspaces); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
-| `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); the first operator *mutation* capability (`[A2]`), granted only to operator handles, never to tile handles — distinct from `workspace.read` so the read/write split stays legible |
+| `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); the first operator *mutation* capability, granted only to operator handles, never to tile handles — distinct from `workspace.read` so the read/write split stays legible |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -478,7 +478,7 @@ review before they can be added. Read-only global reads are the reviewed
 operator-scope exceptions — window capture (`window.read` listing and
 `window.snapshot` composited snapshots) and the repo/workspace inventory
 (`workspace.read`) — gated behind the opt-in operator scope above, never granted to
-tile handles. The one operator *mutation* is `workspace.select` (`[A2]`), a
+tile handles. The one operator *mutation* is `workspace.select`, a
 reviewed exception that drives the real selection gesture under the verbs-=-clicks
 contract, never a data-layer write. Two reviewed exceptions widen the read/write surface
 deliberately: caller-scoped input injection ships as the experimental,

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -64,10 +64,13 @@ WorkSpaces terminal tile. See
   exits, and the credential file is removed on a clean exit. A credential left
   behind by a crashed launch fails closed — its handle no longer resolves
   against the fresh registry (`stale_handle`).
-- **Capture-plus-read.** The operator capability set is `window.read` (list
-  windows) and `window.snapshot` (composited PNG of a listed window) from `[A1]`,
-  plus `workspace.read` (list repos and workspaces) from `[A2]`. All read-only —
-  operator handles never carry tile mutation or `input.write`.
+- **Capture, read, and the first mutation.** The operator capability set is
+  `window.read` (list windows) and `window.snapshot` (composited PNG of a listed
+  window) from `[A1]`, `workspace.read` (list repos and workspaces) from `[A2]`,
+  and — the one operator *mutation* — `workspace.select` (`[A2]`), a reviewed
+  exception that drives the real selection gesture rather than a data-layer write
+  (see [Verb contract](#verb-contract-verbs--clicks)). Operator handles still
+  never carry tile mutation or `input.write`.
 
 ## Invariants
 
@@ -80,12 +83,57 @@ WorkSpaces terminal tile. See
   `hostSessionID`.
 - Capabilities are enforced before each scoped operation.
 - Mutation routes are stable product verbs, not raw `TileTreeAction` exposure.
+- Mutation verbs enter the same UI gesture the equivalent user action does — they
+  never write the data layer directly. See [Verb contract](#verb-contract-verbs--clicks).
 - Browser **read** (listing WorkSpaces-owned web surfaces) is supported; browser
   **mutation** (navigating, clicking, evaluating JS), resize/equalize, and global
   control remain out of V1.
 - Input injection is caller-scoped only and double-gated behind the
   `Automation Input Write` experiment; see
   [Automation Input Write Decision](../decisions/automation-input-write.md).
+
+## Verb contract: verbs = clicks
+
+Every mutation verb enters the same UI path the equivalent user gesture does. A
+verb never writes the service or SwiftData layer directly; it drives the real UI
+entry point and inherits exactly what a click produces. The single place this rule
+is enforced is the internal gesture-verb layer
+(`AutomationGestureVerbs`): it is constructed with *only* gesture closures — the
+app's real UI entry points — and holds no backend handle, so a verb structurally
+cannot bypass the UI.
+
+`workspace.select` is the exemplar. Selecting a workspace via the API writes the
+*same selection binding* a sidebar click writes — the binding whose setter attaches
+the terminal session and requests focus — so an API-driven select produces the
+identical user-visible reactions a click does: the sidebar highlights, the
+workspace's terminal attaches, and focus is requested. Concretely, this is why the
+rule matters:
+
+- **A snapshot taken after a verb shows what actually happened.** A data-layer
+  `workspace.select` would flip selection state without attaching the terminal, so a
+  follow-up `window.snapshot` would show stale UI — evidence that lies. Entering the
+  binding makes the snapshot honest.
+- **The next input lands in the right PTY.** Selecting workspace A attaches (and
+  activates) A's terminal surface, so a subsequent write targets A. A data-layer
+  select would leave the previously focused terminal live and misroute the write —
+  the wrong-PTY bug the regression test `selecting workspace A then workspace B routes
+  input to each workspace's own PTY` guards against.
+- **Refactors that disconnect UI wiring stay visible.** A verb entering the real
+  binding fails exactly when a user click would, so a broken selection path is caught
+  by the verb, not hidden behind a service call that still "succeeds."
+
+Verbs return a structured outcome so dialogs and dead-ends become data, never a
+hang or a fallback:
+
+| Outcome | Meaning | Wire |
+| --- | --- | --- |
+| `completed` | The gesture ran through the real UI path; the result reports what it did (e.g. `attachedTerminal`, `attachedSurfaceID`). | Success envelope, `outcome: "completed"`. |
+| `confirmation_required` | The gesture would surface a modal; the message is what the user would confirm. Surfaced as data so a verb never blocks on modal UI. `workspace.select` has no confirmation dialog, so it never raises this — the shared contract models it for sibling verbs. | Success envelope, `outcome: "confirmation_required"`. |
+| `unsupported` | The verb cannot run in the current context — most often no live window. It fails closed rather than falling back to a data-layer write. | Error envelope, code `unsupported`. |
+
+An id that resolves to no tracked workspace fails `invalid_request` (it is not a
+gesture outcome — nothing was driven). App Intents and any companion app call the
+same verb layer, so "Siri said done" and "the sidebar updated" are the same event.
 
 ## Envelope
 
@@ -117,6 +165,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/windows` | **Operator scope.** Returns the app's on-screen windows with stable identifiers (`window.read`). Keyed by the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address. Requires an operator handle; a tile handle lacks `window.read` and fails `capability_denied`. |
 | `POST /v1/window/snapshot` | **Operator scope.** Returns a composited PNG of the app window named by the body's `windowID` (a `window.read` id). The capture includes the full window — sidebar chrome *and* the GhosttyKit terminal surface — and works with the app backgrounded (no activation). Requires `window.snapshot`; own-window only, so an id the app does not own fails `invalid_request`. See [Window snapshot](#window-snapshot). |
 | `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — the stable-target list later `[A2]` orchestration verbs act on. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
+| `POST /v1/workspace/select` | **Operator scope, mutation (`[A2]`).** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -148,6 +197,7 @@ handle.
 | `window.read` | `GET /v1/windows` (list the app's windows); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `window.snapshot` | `POST /v1/window/snapshot` (composited PNG of a listed window); granted only to operator handles, never to tile handles |
 | `workspace.read` | `GET /v1/workspaces` (list the app's repos and workspaces); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
+| `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); the first operator *mutation* capability (`[A2]`), granted only to operator handles, never to tile handles — distinct from `workspace.read` so the read/write split stays legible |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -264,6 +314,41 @@ read-only: no mutation rides this route.
   read from the live SwiftData models and selection state — distinct from the
   CLI's own local-state store (`workspaces ws list`).
 
+## Workspace select
+
+`POST /v1/workspace/select` (operator scope, `workspace.select`) selects a workspace
+by driving the real selection gesture — the verbs-=-clicks exemplar (see
+[Verb contract](#verb-contract-verbs--clicks)). The body names the target by a
+`workspaceID` obtained from `workspace.read`:
+
+```json
+{ "workspaceID": "…" }
+```
+
+The success envelope reports the structured gesture outcome and what the selection
+did:
+
+```json
+{ "workspaceID": "…", "outcome": "completed", "changed": true,
+  "selectedWorkspaceID": "…", "attachedTerminal": true,
+  "attachedSurfaceID": "…", "system": { "capabilities": [ … ] } }
+```
+
+- **Same path as a click.** The verb writes the selection binding whose setter runs
+  the workspace-selection handler — terminal attach + focus request. So the sidebar
+  highlights the workspace, its terminal attaches, and focus is requested, identical
+  to a sidebar click. `attachedSurfaceID` is the session a following input would land
+  in; `attachedTerminal` is `false` for an archived workspace (selection navigates to
+  its repo overview instead of attaching a terminal, so it completes without one).
+- **Structured outcome.** `outcome` is `completed` or `confirmation_required`;
+  `workspace.select` only ever `completed`s today. A live-window-less app fails
+  `unsupported` (never a data-layer fallback), and an unknown or non-UUID
+  `workspaceID` fails `invalid_request`.
+- **Operator mutation.** Requires `workspace.select` — the first operator mutation
+  capability, distinct from the read-only `workspace.read`. A tile handle lacks it
+  and fails `capability_denied`. The call is operator-tagged in
+  `automation-audit.jsonl` like every operator route.
+
 ## Error Codes
 
 | Code | Meaning |
@@ -318,6 +403,8 @@ workspaces window snapshot --out shot.png            # main window, or first if 
 workspaces window snapshot --out shot.png --window 42 # a specific window.read id
 workspaces workspace list                            # repos + workspaces, human-readable
 workspaces workspace list --json                     # same, as the raw result envelope
+workspaces workspace select <id>                     # drive the real selection gesture for <id>
+workspaces workspace select <id> --json              # same, as the raw result envelope
 ```
 
 `workspace list` reads the running app's repos and workspaces (`workspace.read`),
@@ -330,11 +417,18 @@ main window (falling back to the first listed) so the common "snapshot the app"
 case needs no id lookup. It works with the app backgrounded — no activation, no
 focus steal.
 
+`workspace select <id>` drives the running app's real selection gesture for the
+workspace with stable `<id>` (from `workspace list`): the app highlights it,
+attaches its terminal, and requests focus, exactly as a sidebar click would. It
+prints whether a terminal attached; `--json` emits the raw result envelope. Absent a
+live window it fails `unsupported` — it never falls back to a data-layer write.
+
 ## Implementation Map
 
 | Concern | File |
 | --- | --- |
 | Wire models and envelopes | `Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift` |
+| Gesture-verb layer (verbs = clicks) | `Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift` |
 | Socket listener and lock | `Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift` |
 | HTTP route projection | `Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift` |
 | Web-surface snapshot encoding (pure) | `Sources/WorkspaceManagerCore/Services/Automation/WebSurfaceSnapshotEncoder.swift` |
@@ -363,6 +457,14 @@ swift-format lint --strict --recursive Sources/ Tests/
 ./scripts/dev-smoke.sh --no-build
 ```
 
+For a change touching a mutation verb, also verify it against the real app — an
+API-driven `workspace.select` through the socket must attach the workspace's
+terminal, proving the verb entered the real binding:
+
+```bash
+./scripts/api-select-smoke.sh --no-build   # asserts terminal_session_attached after the CLI select
+```
+
 If docs or public examples changed, also run the docs checks listed in
 [Docs Site Runbook](../README.md).
 
@@ -370,12 +472,15 @@ If docs or public examples changed, also run the docs checks listed in
 
 V1 does not support browser mutation (navigating, clicking, filling, or
 evaluating JavaScript in a web surface), opening web URLs, tab title or metadata
-changes, writing into other tiles, resize/equalize, or global cross-workspace
-*mutation*. Those capabilities require separate product and safety review before
-they can be added. Read-only global reads are the reviewed operator-scope
-exceptions — window capture (`window.read` listing and `window.snapshot`
-composited snapshots) and the repo/workspace inventory (`workspace.read`) — gated
-behind the opt-in operator scope above, never granted to tile handles. Two reviewed exceptions widen the read/write surface
+changes, writing into other tiles, resize/equalize, or *arbitrary* global
+cross-workspace mutation. Those capabilities require separate product and safety
+review before they can be added. Read-only global reads are the reviewed
+operator-scope exceptions — window capture (`window.read` listing and
+`window.snapshot` composited snapshots) and the repo/workspace inventory
+(`workspace.read`) — gated behind the opt-in operator scope above, never granted to
+tile handles. The one operator *mutation* is `workspace.select` (`[A2]`), a
+reviewed exception that drives the real selection gesture under the verbs-=-clicks
+contract, never a data-layer write. Two reviewed exceptions widen the read/write surface
 deliberately: caller-scoped input injection ships as the experimental,
 double-gated `input.write` capability (see
 [Automation Input Write Decision](../decisions/automation-input-write.md)), and

--- a/scripts/api-select-smoke.sh
+++ b/scripts/api-select-smoke.sh
@@ -260,6 +260,15 @@ if attach is None:
 print(f"OK: API select attached workspace terminal session {attach.get('sessionID')} scope={attach.get('sessionScope')}")
 PY
 
+    # Best-effort visual: snapshot the app window (operator scope) in the post-select state, showing
+    # the workspace's terminal attached. Composited capture fails on a locked screen (unsupported) —
+    # that is fine, the JSONL above is the load-bearing evidence; the snapshot is a bonus when unlocked.
+    if "$CLI_BIN" window snapshot --out "$RUN_DIR/after-select.png" >/dev/null 2>&1; then
+        log "Captured post-select window snapshot: $RUN_DIR/after-select.png"
+    else
+        log "Window snapshot unavailable (likely a locked screen) — JSONL + select result stand as evidence."
+    fi
+
     RUN_STATUS="passed"
     log "PASS — API-driven workspace.select attached the workspace terminal via the real binding."
     {

--- a/scripts/api-select-smoke.sh
+++ b/scripts/api-select-smoke.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+# ==========================================================================
+# api-select-smoke.sh - API-driven workspace.select smoke for the debug app
+# ==========================================================================
+#
+# Proves the [A2] verbs-=-clicks contract end to end, through the real socket:
+#
+#   1. The app (desktop-ui-smoke mode, WORKSPACES_AUTOMATION_SELECT_DRIVER=api)
+#      creates a local workspace, then parks the active surface on the repo
+#      terminal and emits `awaiting_api_select`.
+#   2. This script reads the created workspace id from the JSONL, then runs
+#      `workspaces workspace select <id>` against the operator socket.
+#   3. The verb enters the SAME selection binding a sidebar click writes, so the
+#      app emits `terminal_session_attached` (selectionKind=workspace) — proving
+#      the API select attached the workspace's terminal and switched the active
+#      PTY off the repo terminal (the wrong-PTY guard).
+#
+# Headless-safe (--no-activate). Artifacts land under output/api-select-smoke/.
+# The socket + operator credential resolve under the standard app-support path
+# keyed by bundle id (com.cloudcompute.workspaces), same as `workspaces window
+# list`, so the CLI finds them regardless of --data-dir.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LAUNCH_SCRIPT="$REPO_ROOT/scripts/launch-dev.sh"
+CLI_BIN="$REPO_ROOT/.build/arm64-apple-macosx/debug/workspaces"
+OUTPUT_ROOT="$REPO_ROOT/output/api-select-smoke"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="$OUTPUT_ROOT/$TIMESTAMP"
+RUN_LINK="$OUTPUT_ROOT/latest"
+DEFAULT_TIMEOUT_SECONDS=$((4 * 60))
+
+SKIP_BUILD=false
+KEEP_ARTIFACTS=false
+TOTAL_TIMEOUT_SECONDS="$DEFAULT_TIMEOUT_SECONDS"
+APP_PID=""
+LAUNCH_LOG_PATH=""
+SMOKE_REPO_PATH=""
+WORKSPACE_NAME="api-select-smoke-$TIMESTAMP"
+EVENTS_PATH=""
+RUN_STATUS="failed"
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/api-select-smoke.sh [options]
+
+Options:
+  --no-build         Reuse the current debug binary
+  --keep-artifacts   Keep the disposable smoke repo after a passing run
+  --timeout-seconds <n>  Total timeout (default: 240)
+  --help, -h         Show this help
+USAGE
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-build) SKIP_BUILD=true; shift ;;
+            --keep-artifacts) KEEP_ARTIFACTS=true; shift ;;
+            --timeout-seconds) [[ $# -ge 2 ]] || fail "--timeout-seconds requires a value"; TOTAL_TIMEOUT_SECONDS="$2"; shift 2 ;;
+            --help|-h) usage; exit 0 ;;
+            *) fail "Unknown argument: $1" ;;
+        esac
+    done
+}
+
+cleanup_app() {
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" >/dev/null 2>&1; then
+        kill "$APP_PID" >/dev/null 2>&1 || true
+        sleep 1
+    fi
+    pkill -f "$REPO_ROOT/.build/arm64-apple-macosx/debug/WorkspaceManager" >/dev/null 2>&1 || true
+}
+
+cleanup_repo() {
+    [[ "$KEEP_ARTIFACTS" == true ]] && return 0
+    if [[ -n "$SMOKE_REPO_PATH" && -d "$SMOKE_REPO_PATH" ]]; then
+        chmod -R u+w "$SMOKE_REPO_PATH" >/dev/null 2>&1 || true
+        rm -rf "$SMOKE_REPO_PATH" >/dev/null 2>&1 || true
+    fi
+    cleanup_created_worktree
+}
+
+cleanup_created_worktree() {
+    [[ -f "$EVENTS_PATH" ]] || return 0
+    local workspace_path
+    workspace_path="$(read_workspace_field workspacePath workspace_created)"
+    [[ -n "$workspace_path" && -d "$workspace_path" ]] || return 0
+    chmod -R u+w "$workspace_path" >/dev/null 2>&1 || true
+    rm -rf "$workspace_path" >/dev/null 2>&1 || true
+    local repo_container
+    repo_container="$(dirname "$workspace_path")"
+    if [[ -d "$repo_container" && -z "$(ls -A "$repo_container" 2>/dev/null)" ]]; then
+        rmdir "$repo_container" >/dev/null 2>&1 || true
+    fi
+}
+
+on_exit() {
+    local code="$?"
+    trap - EXIT
+    cleanup_app
+    [[ "$RUN_STATUS" == "passed" ]] && cleanup_repo
+    log "Run directory: $RUN_DIR"
+    exit "$code"
+}
+
+setup_run_dir() {
+    mkdir -p "$RUN_DIR"
+    ln -sfn "$RUN_DIR" "$RUN_LINK"
+    EVENTS_PATH="$RUN_DIR/events.jsonl"
+}
+
+create_disposable_repo() {
+    SMOKE_REPO_PATH="$(mktemp -d "${TMPDIR:-/tmp}/workspaces-api-select-XXXXXX")"
+    (
+        cd "$SMOKE_REPO_PATH"
+        git init >/dev/null
+        git config user.name "WorkspaceManager Smoke" >/dev/null
+        git config user.email "smoke@local.invalid" >/dev/null
+        printf "# API select smoke\n\nCreated %s\n" "$TIMESTAMP" >README.md
+        git add README.md
+        git commit -m "Initial smoke fixture" >/dev/null
+    )
+}
+
+launch_automated_app() {
+    local app_data_dir="$RUN_DIR/app-data"
+    local -a args=(
+        "--no-activate"
+        "--data-dir" "$app_data_dir"
+        "--clean-data"
+        "--window-timeout" "20"
+        "--env" "WORKSPACES_DISABLE_AUTO_IMPORT=1"
+        "--env" "WORKSPACES_AUTOMATION_API=1"
+        "--env" "WORKSPACES_AUTOMATION_OPERATOR=1"
+        "--env" "WORKSPACES_AUTOMATION_MODE=desktop-ui-smoke"
+        "--env" "WORKSPACES_AUTOMATION_SELECT_DRIVER=api"
+        "--env" "WORKSPACES_AUTOMATION_REPO_PATH=$SMOKE_REPO_PATH"
+        "--env" "WORKSPACES_AUTOMATION_WORKSPACE_NAME=$WORKSPACE_NAME"
+        "--env" "WORKSPACES_AUTOMATION_EVENTS_PATH=$EVENTS_PATH"
+    )
+    [[ "$SKIP_BUILD" == true ]] && args+=("--no-build")
+
+    local launch_output
+    launch_output="$(
+        cd "$REPO_ROOT"
+        "$LAUNCH_SCRIPT" "${args[@]}" 2>&1 | tee "$RUN_DIR/launch-command.log"
+    )"
+    APP_PID="$(printf '%s\n' "$launch_output" | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | tail -n 1)"
+    LAUNCH_LOG_PATH="$(printf '%s\n' "$launch_output" | sed -n 's/.*Log file: \(.*\)$/\1/p' | tail -n 1)"
+    [[ -n "$APP_PID" ]] || fail "Could not determine WorkspaceManager pid from launch output."
+}
+
+# Reads the value of $1 from the last JSONL event whose type == $2.
+read_workspace_field() {
+    local field="$1" event_type="$2"
+    python3 - "$EVENTS_PATH" "$field" "$event_type" <<'PY'
+import json, sys
+from pathlib import Path
+path, field, event_type = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+value = ""
+if path.exists():
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        e = json.loads(line)
+        if e.get("type") == event_type and e.get(field):
+            value = e[field]
+print(value)
+PY
+}
+
+# Prints the 0-based index of the first event of type $1, or -1.
+event_index() {
+    python3 - "$EVENTS_PATH" "$1" <<'PY'
+import json, sys
+from pathlib import Path
+path, target = Path(sys.argv[1]), sys.argv[2]
+idx = -1
+if path.exists():
+    for i, line in enumerate(l.strip() for l in path.read_text().splitlines() if l.strip()):
+        if json.loads(line).get("type") == target:
+            idx = i
+            break
+print(idx)
+PY
+}
+
+wait_for_event() {
+    local event_type="$1" deadline=$(( $(date +%s) + TOTAL_TIMEOUT_SECONDS ))
+    while (( $(date +%s) < deadline )); do
+        if [[ "$(event_index "$event_type")" != "-1" ]]; then
+            return 0
+        fi
+        # Surface an app-side failure milestone immediately rather than waiting out the timeout.
+        if [[ "$(event_index failure)" != "-1" ]]; then
+            fail "App reported a failure milestone: $(read_workspace_field message failure)"
+        fi
+        sleep 1
+    done
+    fail "Timed out waiting for milestone: $event_type"
+}
+
+main() {
+    parse_args "$@"
+    trap on_exit EXIT
+    setup_run_dir
+    create_disposable_repo
+
+    if [[ "$SKIP_BUILD" != true ]]; then
+        log "Building debug binaries…"
+        ( cd "$REPO_ROOT" && swift build >/dev/null )
+    fi
+    [[ -x "$CLI_BIN" ]] || fail "CLI binary not found at $CLI_BIN (run swift build)."
+
+    log "Launching app (api select driver)…"
+    launch_automated_app
+
+    log "Waiting for the app to create the workspace and park on the repo terminal…"
+    wait_for_event awaiting_api_select
+
+    local workspace_id
+    workspace_id="$(read_workspace_field workspaceID awaiting_api_select)"
+    [[ -n "$workspace_id" ]] || fail "Could not read workspaceID from awaiting_api_select."
+    log "Workspace id: $workspace_id"
+
+    local await_idx
+    await_idx="$(event_index awaiting_api_select)"
+
+    log "Driving API select: workspaces workspace select $workspace_id"
+    "$CLI_BIN" workspace select "$workspace_id" --json | tee "$RUN_DIR/select-result.json"
+
+    log "Waiting for terminal_session_attached from the API-driven select…"
+    wait_for_event terminal_session_attached
+
+    # Assert a workspace-scoped terminal attach occurred AFTER the handoff — i.e. the API verb, not
+    # the app's own scenario, drove it.
+    python3 - "$EVENTS_PATH" "$await_idx" <<'PY'
+import json, sys
+from pathlib import Path
+events = [json.loads(l) for l in Path(sys.argv[1]).read_text().splitlines() if l.strip()]
+await_idx = int(sys.argv[2])
+after = events[await_idx + 1:]
+attach = next(
+    (e for e in after
+     if e.get("type") == "terminal_session_attached" and e.get("selectionKind") == "workspace"),
+    None,
+)
+if attach is None:
+    print("ASSERTION FAILED: no workspace-scoped terminal_session_attached after awaiting_api_select", file=sys.stderr)
+    for e in after:
+        print(f"  - {e.get('type')} kind={e.get('selectionKind')} session={e.get('sessionID')}", file=sys.stderr)
+    sys.exit(1)
+print(f"OK: API select attached workspace terminal session {attach.get('sessionID')} scope={attach.get('sessionScope')}")
+PY
+
+    RUN_STATUS="passed"
+    log "PASS — API-driven workspace.select attached the workspace terminal via the real binding."
+    {
+        echo "# API Select Smoke"
+        echo
+        echo "- Outcome: passed"
+        echo "- Workspace id: $workspace_id"
+        echo "- Events: $EVENTS_PATH"
+        echo "- Select result: $RUN_DIR/select-result.json"
+    } >"$RUN_DIR/summary.md"
+}
+
+main "$@"

--- a/scripts/api-select-smoke.sh
+++ b/scripts/api-select-smoke.sh
@@ -3,7 +3,7 @@
 # api-select-smoke.sh - API-driven workspace.select smoke for the debug app
 # ==========================================================================
 #
-# Proves the [A2] verbs-=-clicks contract end to end, through the real socket:
+# Proves the verbs-=-clicks contract end to end, through the real socket:
 #
 #   1. The app (desktop-ui-smoke mode, WORKSPACES_AUTOMATION_SELECT_DRIVER=api)
 #      creates a local workspace, then parks the active surface on the repo


### PR DESCRIPTION
## What & why

The contract-bearing slice of the automation ADR: an internal **gesture-verb layer** — the single place the **verbs = clicks** rule is enforced — plus `workspace.select` as its first verb, exposed as an operator route (`POST /v1/workspace/select`) and CLI verb (`workspaces workspace select <id>`).

Every mutation verb enters the *same* UI path the equivalent user gesture does — no service-layer shortcut, no data-layer fallback, ever. `workspace.select` drives the exact selection binding a sidebar click writes; selecting via the API produces the identical user-visible reactions: sidebar highlight, terminal attach, focus request. A verb that cannot run without a live window returns `unsupported`, never a fallback.

Closes #920. Spec: `docs/decisions/automation-operator-scope.md` § "Verb contract: verbs = clicks".

## Contract walkthrough (route → verb layer → selection binding → terminal attach)

The load-bearing invariant, traced line by line so the enforcement is reviewable:

1. **Route** — `AutomationHTTPRouter` maps `POST /v1/workspace/select` to `controller.automationSelectWorkspace(for:workspaceID:)` (`AutomationHTTPRouter.swift`). The `workspaceID` is a global `workspace.read` id (like `windowID`), accepted directly; a non-UUID / unknown id fails `invalid_request`.
2. **Capability + operator gate** — `AutomationController.automationSelectWorkspace` calls `resolveOperator(handle, requiring: .workspaceSelect)`. A tile handle lacks `workspace.select` → `capability_denied`; a non-operator handle → `capability_denied`. `workspace.select` is distinct from the read-only `workspace.read`.
3. **No-window guard** — `guard let gestureVerbs else { throw .unsupported }`. When no window is attached the gesture layer is absent, so the verb fails closed rather than driving a data-layer write.
4. **Gesture-verb layer** — `AutomationGestureVerbs.selectWorkspace(_:)` (`AutomationGestureVerbs.swift`) is constructed with **only** gesture closures — no backend handle — so it structurally cannot bypass the UI. It resolves the id, then calls `performSelection`.
5. **Selection binding** — `performSelection` (built in `ContentView.makeAutomationGestureVerbs`) writes `selectedWorkspaceBinding.wrappedValue = workspace` — the *same* binding a sidebar row click writes.
6. **Binding setter → handler** — the setter runs `handleWorkspaceSelection(workspace)` (`ContentView.swift:239`).
7. **Terminal attach + focus** — `handleWorkspaceSelection` calls `activateHostSession(key: .hostPath(...))` (terminal attach, sets the active session synchronously) then `terminalFocusCoordinator.requestMainTerminalFocus(...)` (focus request). The effect readback (`attachedSurfaceID` = `tileTreeStore.activeSessionID`) is the session a following input lands in — the wrong-PTY guard, observed not assumed.

## Verification

- `swift test` — **1242 tests pass** (`swift build`, `swift-format lint --strict` clean).
- **Verb outcome contract** — `AutomationGestureVerbsTests` (completed / notFound / archived-no-attach) + wire encoding of `outcome`.
- **Route capability projection** — `AutomationAPITests.routerWorkspaceSelect` (capability_denied for tile handle, invalid_request for bad/unknown id, unsupported→409, method_not_allowed, missing_handle).
- **Real controller + capability** — `AutomationSelectVerbTests` against a real `AutomationController` + `TileTreeStore`.
- **Wrong-PTY regression (named)** — `selecting workspace A then workspace B routes input to each workspace's own PTY`, at both the layer and the real store.
- **Real app via smoke** — `scripts/api-select-smoke.sh`: an external `workspaces workspace select` over the socket emits `terminal_session_attached` on the workspace's session, switching the active PTY off the repo terminal (`surface_focused` best-effort per existing smoke policy).

### Evidence (API-driven select against the real app)

**Milestone JSONL + CLI verb result** — socket → `AutomationController` → `AutomationGestureVerbs` → selection binding:

![api-select milestones](https://evidence.cloudcompute.com/workspaces/pr-947/20260708-035104-api-select-milestones.png)

The sequence shows `terminal_session_attached selectionKind=repo` (app parked on the repo PTY) → `awaiting_api_select` (handoff) → the external `workspaces workspace select` over the socket → `terminal_session_attached selectionKind=workspace` on the workspace's session. The active terminal switched off the repo terminal onto the workspace — the wrong-PTY guard, end to end. The CLI verb returned `outcome: completed`, `attachedTerminal: true`, capabilities including `workspace.select`.

**Post-select window snapshot** (operator `window.snapshot`, screen unlocked) — the sidebar highlights the workspace and its terminal is attached and live, the identical reaction a sidebar click produces:

![after select window](https://evidence.cloudcompute.com/workspaces/pr-947/20260708-035017-api-select-after-window.png)

`surface_focused` timed out (best-effort per existing smoke policy when backgrounded); `terminal_session_attached` is the hard gate and is asserted.

## Review loop

Ran `codex-review-loop` (reflect → codex gpt-5.5 xhigh → attributed reaction) before opening.

| Finding | Disposition |
| --- | --- |
| Stale-window contract leak: the app lingers as an accessory after its last window closes, but `AutomationController.gestureVerbs` was never cleared on teardown, so `workspace.select` would drive a stale captured closure instead of returning `unsupported`. | **Fixed** in `918d4e2c` — `ContentView` `.onDisappear` → `AutomationIntegrationLifecycle.detachGestureVerbs` → `AutomationController.detachGestureVerbs`, with a regression test. |
| Contract leak (live window), capture/propagation, capability gating, outcome mapping, smoke-driver default gate | Codex confirmed each sound; cited in the walkthrough above. |

## Mergeability

- **Surface:** macOS app automation control plane (operator scope) — new gesture-verb layer, `workspace.select` route + CLI, `workspace.select` capability, docs, and an api-select smoke lane. No change to default handles or the read-only operator routes.
- **Behavior changed:** Adds one operator mutation verb that drives the real selection gesture. Operator capability set gains `workspace.select` (first mutation; distinct from `workspace.read`). No tile-handle or default-handle surface changes; no change to the default `desktop-ui-smoke` gate (the api driver is opt-in via `WORKSPACES_AUTOMATION_SELECT_DRIVER=api`).
- **Non-happy paths:** no live window → `unsupported` (fails closed, incl. after window teardown); tile/non-operator handle → `capability_denied`; bad/unknown id → `invalid_request`; empty body → `invalid_request`; wrong method → `method_not_allowed`. Archived workspace completes without a terminal attach (navigates to repo overview, matching a click). All covered by tests.
- **Residual risk:** `surface_focused` stays best-effort when backgrounded (existing smoke policy). The verb inherits `handleWorkspaceSelection`'s provider-backed (remote) branch behavior unchanged — a stopped remote workspace completes without an immediate terminal attach, exactly as a click does. NSEvent-level hit-testing is not exercised (accepted per the ADR smoke-lane policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
