### PR TITLE
web-next: keyboard-reachable reveals + AA contrast + multiline compose (#805, #806, #807)

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -47,6 +47,12 @@ pnpm perf        # perf harness vs perf/contract.json budgets
 pnpm validate    # env-targetable validation (--env local|prod, --url <origin>)
 ```
 
+`pnpm evidence` only writes local files — the repo's evidence gate needs
+uploaded URLs in the PR body (`docs/development/evidence.md`). Upload the
+whole walk in one shot with `pnpm evidence:upload -- --pr <N>` (wraps
+repo-root `scripts/evidence.sh` once per PNG, needs `EVIDENCE_UPLOAD_TOKEN`)
+and paste the printed markdown summary into the PR.
+
 `pnpm validate` also runs against real deployments — `pnpm validate --env prod`
 probes reachability and auth/security posture with zero credentials, and
 credential-gated stages report themselves skipped rather than passing silently

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -13,6 +13,7 @@
 		"lint": "eslint .",
 		"clean": "node scripts/clean.mjs",
 		"evidence": "node scripts/evidence.mjs",
+		"evidence:upload": "bash scripts/upload-evidence.sh",
 		"perf": "node perf/run.mjs",
 		"validate": "tsx scripts/validate.mjs"
 	},

--- a/web-next/perf/run.mjs
+++ b/web-next/perf/run.mjs
@@ -118,7 +118,8 @@ async function openSession(browser, baseUrl, sessionId) {
 }
 
 async function sendSessionMessage(page, text) {
-	const compose = 'input[aria-label="Reply to Claude"]';
+	// A textarea since #807 (auto-growing multiline compose) — was <input>.
+	const compose = 'textarea[aria-label="Reply to Claude"]';
 	await page.fill(compose, text);
 	await page.press(compose, "Enter");
 }

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -1,16 +1,17 @@
 /*
  * Evidence capture, light + dark: the sessions home (empty and populated),
- * an empty session reached through the real new-session flow, a real mock
- * turn streamed into that session (mid-stream, final, and reloaded from the
- * event log), the terminal drawer (#752), a failing turn's inline failure
- * card + retry-to-success (#808), the three first-class error surfaces +
- * the stop control + the 375px mobile walk (#753), the durable
- * disconnect→resume story (tab closed mid-turn, a fresh tab catching up,
- * then completed), the Folio session demo, and the refine-folio prototype
- * beside it for pixel comparison. Runs against a production build in auth-bypass
- * mode over a throwaway database. Output goes to output/evidence/
- * (gitignored); CI uploads it as an artifact — the sanctioned publish path
- * per docs/development/remote-sessions.md.
+ * an empty session reached through the real new-session flow, the compose
+ * field's states (#807 — empty, a grown multiline draft, disabled-with-Stop
+ * mid-turn), a real mock turn streamed into that session (mid-stream, final,
+ * and reloaded from the event log), the terminal drawer (#752), a failing
+ * turn's inline failure card + retry-to-success (#808), the three
+ * first-class error surfaces + the stop control + the 375px mobile walk
+ * (#753), the durable disconnect→resume story (tab closed mid-turn, a fresh
+ * tab catching up, then completed), the Folio session demo, and the
+ * refine-folio prototype beside it for pixel comparison. Runs against a
+ * production build in auth-bypass mode over a throwaway database. Output
+ * goes to output/evidence/ (gitignored); CI uploads it as an artifact — the
+ * sanctioned publish path per docs/development/remote-sessions.md.
  */
 import { execFileSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
@@ -86,6 +87,29 @@ async function captureNewSessionFlow(page, file) {
 }
 
 /**
+ * The compose field's states (#807), on the empty session the new-session
+ * flow just made: the resting single-line field (autofocused, no
+ * placeholder), then a multi-line draft (two Shift+Enter newlines) grown to
+ * its taller auto-height — cleared before captureSessionTurn sends the real
+ * turn that follows.
+ */
+async function captureComposeStates(page, shot) {
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await page.screenshot({ path: shot("compose-empty") });
+
+	await compose.fill("Here's the stack trace:");
+	await compose.press("Shift+Enter");
+	await compose.type("  at Object.<anonymous> (session.test.ts:42:11)");
+	await compose.press("Shift+Enter");
+	await compose.type("Can you fix the underlying bug?");
+	await page.waitForTimeout(200);
+	await page.screenshot({ path: shot("compose-multiline") });
+
+	await compose.fill("");
+}
+
+/**
  * Streams a real mock turn in the session the new-session flow just made
  * (the page is already on it): mid-stream while the activity line breathes,
  * mid-stream as ledger rows land, final with the receipt + disclosed test
@@ -99,10 +123,13 @@ async function captureSessionTurn(page, shot) {
 
 	// Mid-stream, early: the provisioning activity line. The provisioning
 	// window is ~650ms, so give the 0.55s rise animation most of its run
-	// without letting the first prose token close the window.
+	// without letting the first prose token close the window. Also the
+	// compose's disabled-while-busy state (#807): draft held, Stop affordance
+	// live (#935).
 	await page.getByTestId("activity-line").waitFor({ timeout: TURN_TIMEOUT_MS });
 	await page.waitForTimeout(350);
 	await page.screenshot({ path: shot("session-turn-streaming") });
+	await page.screenshot({ path: shot("compose-disabled") });
 
 	// Mid-stream, later: two ledger rows landed, the turn still open.
 	await page.waitForFunction(
@@ -402,6 +429,7 @@ async function main() {
 			await wipeRows(db);
 			await captureSettled(page, "/", shot("home-empty"));
 			await captureNewSessionFlow(page, shot("session-empty"));
+			await captureComposeStates(page, shot);
 			await captureSessionTurn(page, shot);
 			await captureTerminalDrawer(page, shot("session-terminal-drawer"));
 			await captureFailedTurn(page, shot);
@@ -416,7 +444,7 @@ async function main() {
 			await capturePrototype(page, colorScheme, shot("prototype-folio"));
 			await context.close();
 			console.log(
-				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + terminal drawer + failed turn (failure, retried) + error surfaces (provisioning, sandbox-died, stream) + stop control (stopping, stopped) + mobile 375px (turn, diff) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
+				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + compose (empty, multiline, disabled) + terminal drawer + failed turn (failure, retried) + error surfaces (provisioning, sandbox-died, stream) + stop control (stopping, stopped) + mobile 375px (turn, diff) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
 			);
 		}
 	} finally {

--- a/web-next/scripts/upload-evidence.sh
+++ b/web-next/scripts/upload-evidence.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ==========================================================================
+# upload-evidence.sh — batch-upload a web-next evidence walk to the R2 store
+# ==========================================================================
+#
+# `pnpm run evidence` writes a light+dark screenshot walk to output/evidence/
+# (gitignored) but doesn't upload it — the repo's evidence gate requires
+# uploaded URLs in the PR body, not local-only files (docs/development/
+# evidence.md). This wraps the repo-root scripts/evidence.sh once per PNG so
+# a full walk (~40 files) becomes one command instead of forty, and prints
+# ready-to-paste markdown for the PR's Evidence section.
+#
+# Usage:
+#   ./scripts/upload-evidence.sh --pr 936
+#   ./scripts/upload-evidence.sh --pr 936 --dir output/evidence --prefix a11y-
+#   pnpm run evidence && ./scripts/upload-evidence.sh --pr 936
+#
+# Requires EVIDENCE_UPLOAD_TOKEN (see repo-root scripts/evidence.sh, which
+# this delegates every upload to — same .env resolution, same failure mode).
+# ==========================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WEB_NEXT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$WEB_NEXT_ROOT/.." && pwd)"
+ROOT_EVIDENCE_SH="$REPO_ROOT/scripts/evidence.sh"
+
+PR=""
+DIR="$WEB_NEXT_ROOT/output/evidence"
+PREFIX=""
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") --pr <number> [options]
+
+Options:
+  --pr <number>    PR number (required)
+  --dir <path>     Directory of PNGs to upload (default: output/evidence)
+  --prefix <str>   Prepended to each upload's --name slug (e.g. "a11y-")
+  -h, --help       Show this help
+
+Uploads every *.png in --dir via the repo-root evidence.sh (one call per
+file, --no-capture), then prints a markdown summary — pipe or redirect it
+straight into the PR body's Evidence section.
+EOF
+	exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--pr)
+		PR="$2"
+		shift 2
+		;;
+	--dir)
+		DIR="$2"
+		shift 2
+		;;
+	--prefix)
+		PREFIX="$2"
+		shift 2
+		;;
+	-h | --help) usage ;;
+	*)
+		echo "error: unknown option: $1" >&2
+		usage
+		;;
+	esac
+done
+
+[[ -z "$PR" ]] && {
+	echo "error: --pr is required" >&2
+	usage
+}
+
+[[ -d "$DIR" ]] || {
+	echo "error: no such directory: $DIR (run 'pnpm run evidence' first)" >&2
+	exit 1
+}
+
+shopt -s nullglob
+FILES=("$DIR"/*.png)
+shopt -u nullglob
+
+[[ ${#FILES[@]} -eq 0 ]] && {
+	echo "error: no .png files in $DIR" >&2
+	exit 1
+}
+
+echo "Uploading ${#FILES[@]} screenshot(s) from $DIR for PR #$PR..." >&2
+
+SUMMARY="$DIR/UPLOADED.md"
+: >"$SUMMARY"
+
+for file in "${FILES[@]}"; do
+	base="$(basename "$file" .png)"
+	name="${PREFIX}${base}"
+	url="$("$ROOT_EVIDENCE_SH" --pr "$PR" --name "$name" --file "$file" --no-capture)"
+	echo "  $name -> $url" >&2
+	{
+		echo "### $base"
+		echo "![${name}](${url})"
+		echo ""
+	} >>"$SUMMARY"
+done
+
+echo "" >&2
+echo "Wrote markdown summary: $SUMMARY" >&2
+cat "$SUMMARY"

--- a/web-next/src/app/(app)/new-session.tsx
+++ b/web-next/src/app/(app)/new-session.tsx
@@ -62,7 +62,7 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 			<button
 				type="button"
 				onClick={() => setOpen(true)}
-				className="font-mono text-[13px] text-faint transition-colors hover:text-accent"
+				className="font-mono text-[13px] text-hint transition-colors hover:text-accent"
 			>
 				+ new session
 			</button>
@@ -125,19 +125,19 @@ export function NewSession({ startOpen = false }: { startOpen?: boolean }) {
 					placeholder="owner/repository — search or connect"
 					autoComplete="off"
 					spellCheck={false}
-					className="min-w-0 flex-1 border-b border-line bg-transparent pb-1 font-mono text-[13px] text-ink transition-colors outline-none placeholder:text-faint focus:border-focus-line"
+					className="min-w-0 flex-1 border-b border-line bg-transparent pb-1 font-mono text-[13px] text-ink transition-colors outline-none placeholder:text-hint focus:border-focus-line"
 				/>
 			</form>
 			{state?.error && !isPending && (
 				<p
 					data-testid="new-session-error"
-					className="px-2.5 pt-1 font-mono text-caption text-faint italic"
+					className="px-2.5 pt-1 font-mono text-caption text-hint italic"
 				>
 					{state.error}
 				</p>
 			)}
 			{degraded && !state?.error && (
-				<p className="px-2.5 pt-1 font-mono text-caption text-faint italic">
+				<p className="px-2.5 pt-1 font-mono text-caption text-hint italic">
 					Repositories aren&apos;t verified against GitHub right now — entries
 					are accepted unverified.
 				</p>

--- a/web-next/src/app/(app)/page.tsx
+++ b/web-next/src/app/(app)/page.tsx
@@ -25,7 +25,7 @@ function SessionRow({ session, index }: { session: SessionListItem; index: numbe
 						{session.title}
 					</span>
 				) : (
-					<span className="font-serif text-body text-faint italic transition-colors group-hover:text-accent">
+					<span className="font-serif text-body text-hint italic transition-colors group-hover:text-accent">
 						Untitled session
 					</span>
 				)}
@@ -36,7 +36,7 @@ function SessionRow({ session, index }: { session: SessionListItem; index: numbe
 					{session.status !== "active" && (
 						<>
 							<span className="text-faint">·</span>
-							<span className="text-faint">{session.status}</span>
+							<span className="text-hint">{session.status}</span>
 						</>
 					)}
 				</span>
@@ -65,7 +65,7 @@ export default async function SessionsHome() {
 						<p className="font-serif text-body text-muted italic">
 							No sessions yet.
 						</p>
-						<p className="mt-2 mb-10 font-mono text-caption text-faint">
+						<p className="mt-2 mb-10 font-mono text-caption text-hint">
 							Start one on a repository.
 						</p>
 						<div className="w-full max-w-[380px]">
@@ -74,7 +74,7 @@ export default async function SessionsHome() {
 					</div>
 				) : (
 					<>
-						<h1 className="mb-2 px-2.5 font-mono text-label font-medium tracking-[.16em] text-faint uppercase">
+						<h1 className="mb-2 px-2.5 font-mono text-label font-medium tracking-[.16em] text-hint uppercase">
 							Sessions
 						</h1>
 						<ul>

--- a/web-next/src/app/(app)/sign-out-button.tsx
+++ b/web-next/src/app/(app)/sign-out-button.tsx
@@ -21,7 +21,7 @@ export function SignOutButton() {
 		<button
 			type="button"
 			onClick={handleSignOut}
-			className="mt-3 font-mono text-[13px] text-faint underline decoration-line-strong underline-offset-4 transition-colors hover:text-accent"
+			className="mt-3 font-mono text-[13px] text-hint underline decoration-line-strong underline-offset-4 transition-colors hover:text-accent"
 		>
 			sign out
 		</button>

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -15,8 +15,16 @@
 	--paper: #f7f4ed;
 	--raised: #fdfbf6;
 	--ink: #26221a;
-	--muted: #7a7261;
-	--faint: #aca492;
+	--muted: #736b5b;
+	/* Decorative-only: hairlines, separators, icon-glyph buttons. Needs only
+	   the 3:1 WCAG floor for graphical objects (1.4.11), never carries
+	   readable words — see --hint below for that (#806). */
+	--faint: #908a7b;
+	/* Readable small text that used to ride on --faint (captions, hints,
+	   timestamps, placeholders, ledger verbs/meta): #806 split this out so it
+	   can hit the 4.5:1 AA floor for text without flattening the decorative
+	   marks that shared the old --faint value. */
+	--hint: #726c60;
 	--line: #e7e1d2;
 	--line-strong: #dcd3bf;
 	--accent: #a15c31;
@@ -55,6 +63,11 @@
 	--ink: #eae4d6;
 	--muted: #a79e8c;
 	--faint: #837a69;
+	/* Text token (#806): dark --faint was already ~4.3:1 (close but not
+	   quite AA for small text) — --hint lightens further so readable text
+	   clears 4.5:1 while --faint stays put for hairlines/marks (unchanged,
+	   still comfortably ≥3:1). */
+	--hint: #8f8778;
 	--line: rgba(234, 222, 196, 0.1);
 	--line-strong: rgba(234, 222, 196, 0.2);
 	--accent: #d89a62;
@@ -92,6 +105,7 @@
 	--color-ink: var(--ink);
 	--color-muted: var(--muted);
 	--color-faint: var(--faint);
+	--color-hint: var(--hint);
 	--color-line: var(--line);
 	--color-line-strong: var(--line-strong);
 	--color-accent: var(--accent);

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -15,7 +15,7 @@
 	--paper: #f7f4ed;
 	--raised: #fdfbf6;
 	--ink: #26221a;
-	--muted: #736b5b;
+	--muted: #6e6757;
 	/* Decorative-only: hairlines, separators, icon-glyph buttons. Needs only
 	   the 3:1 WCAG floor for graphical objects (1.4.11), never carries
 	   readable words — see --hint below for that (#806). */
@@ -23,8 +23,10 @@
 	/* Readable small text that used to ride on --faint (captions, hints,
 	   timestamps, placeholders, ledger verbs/meta): #806 split this out so it
 	   can hit the 4.5:1 AA floor for text without flattening the decorative
-	   marks that shared the old --faint value. */
-	--hint: #726c60;
+	   marks that shared the old --faint value. Both --hint and --muted are
+	   set to clear 4.5:1 on --status-bg (#f1ede0), the darkest surface small
+	   text sits on — paper and raised are lighter, so they only gain. */
+	--hint: #6d685c;
 	--line: #e7e1d2;
 	--line-strong: #dcd3bf;
 	--accent: #a15c31;

--- a/web-next/src/app/sign-in/page.tsx
+++ b/web-next/src/app/sign-in/page.tsx
@@ -22,7 +22,7 @@ export default async function SignInPage() {
 		<main className="animate-rise flex min-h-screen flex-col items-center justify-center gap-8 px-5">
 			<div className="flex flex-col items-center gap-2 text-center">
 				<h1 className="font-serif text-5xl text-ink italic">Spaces</h1>
-				<p className="font-mono text-[12px] tracking-[.04em] text-faint">
+				<p className="font-mono text-[12px] tracking-[.04em] text-hint">
 					coding sessions in the browser
 				</p>
 			</div>
@@ -32,7 +32,7 @@ export default async function SignInPage() {
 					<form action={testSignInAction}>
 						<button
 							type="submit"
-							className="font-mono text-[12px] text-faint underline decoration-line-strong underline-offset-4 transition-colors hover:text-accent"
+							className="font-mono text-[12px] text-hint underline decoration-line-strong underline-offset-4 transition-colors hover:text-accent"
 						>
 							continue as {bypassLogin} (test bypass)
 						</button>

--- a/web-next/src/components/folio/activity-line.tsx
+++ b/web-next/src/components/folio/activity-line.tsx
@@ -33,7 +33,7 @@ export function ActivityLine({ action, details }: ActivityLineProps) {
 					<button
 						type="button"
 						onClick={() => setShowDetails((current) => !current)}
-						className="ml-auto border-b border-transparent pb-px font-mono text-masthead tracking-[.06em] text-faint opacity-0 transition-opacity duration-[.25s] group-hover:opacity-100 hover:border-accent hover:text-accent"
+						className="ml-auto border-b border-transparent pb-px font-mono text-masthead tracking-[.06em] text-hint opacity-0 transition-opacity duration-[.25s] group-hover:opacity-100 hover:border-accent hover:text-accent focus-visible:opacity-100"
 					>
 						details
 					</button>
@@ -44,7 +44,7 @@ export function ActivityLine({ action, details }: ActivityLineProps) {
 					{details.map((row, i) => (
 						<div
 							key={i}
-							className={`flex gap-2.5 py-[3px] font-mono text-code ${row.state === "current" ? "text-muted" : "text-faint"}`}
+							className={`flex gap-2.5 py-[3px] font-mono text-code ${row.state === "current" ? "text-muted" : "text-hint"}`}
 						>
 							{row.state === "current" ? (
 								<span className="animate-breathe-fast text-accent">▍</span>

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -14,6 +14,13 @@
  */
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
+/** Collapse-then-grow: height tracks content, capped by the CSS max-height. */
+function autoGrow(el: HTMLTextAreaElement | null) {
+	if (!el) return;
+	el.style.height = "auto";
+	el.style.height = `${el.scrollHeight}px`;
+}
+
 export interface ComposeFieldProps {
 	/** Names the reply target for assistive tech ("Reply to Claude"). */
 	agentName: string;
@@ -46,11 +53,26 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 	// past the bound. Layout-effect so the resize lands before paint (no
 	// visible jump on the growing keystroke).
 	useLayoutEffect(() => {
+		autoGrow(textareaRef.current);
+	}, [text]);
+
+	// Wrapping also changes when the field gets narrower or wider (viewport
+	// resize, mobile rotation) with no text change, so a keystroke-only
+	// re-measure would leave a stale height. Width is what drives rewrapping;
+	// gating on it also keeps the observer loop-safe (autoGrow writes height,
+	// never width). Codex finding (gpt-5.5, xhigh).
+	useEffect(() => {
 		const el = textareaRef.current;
 		if (!el) return;
-		el.style.height = "auto";
-		el.style.height = `${el.scrollHeight}px`;
-	}, [text]);
+		let lastWidth = el.clientWidth;
+		const observer = new ResizeObserver(() => {
+			if (el.clientWidth === lastWidth) return;
+			lastWidth = el.clientWidth;
+			autoGrow(el);
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, []);
 
 	const submit = () => {
 		const trimmed = text.trim();

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -5,8 +5,14 @@
  * hint chips, the whole field a click target, the send affordance warming
  * up only while focused. Sits over a paper gradient so the transcript
  * fades out beneath it.
+ *
+ * The field is an auto-growing textarea (#807): it starts at one line and
+ * grows with the draft up to a bounded max height, then scrolls internally
+ * rather than pushing the page around. Enter sends, Shift+Enter inserts a
+ * newline — the peer-tool convention (Slack, Discord, ChatGPT) — so pasting
+ * a stack trace or writing a multi-paragraph instruction doesn't truncate.
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 export interface ComposeFieldProps {
 	/** Names the reply target for assistive tech ("Reply to Claude"). */
@@ -21,7 +27,7 @@ export interface ComposeFieldProps {
 }
 
 export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFieldProps) {
-	const inputRef = useRef<HTMLInputElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const [text, setText] = useState("");
 
 	// Focus after mount rather than via the `autoFocus` attribute: an
@@ -30,8 +36,21 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 	// trip a hydration mismatch. This covers initial mount and client-nav
 	// remounts alike.
 	useEffect(() => {
-		inputRef.current?.focus();
+		textareaRef.current?.focus();
 	}, []);
+
+	// Re-measure on every keystroke (and on mount, e.g. a draft restored from
+	// elsewhere): collapse to one line first so a deleted line shrinks the
+	// field back down, then grow to the content's natural height, capped by
+	// the CSS max-height — which is what makes it scroll instead of growing
+	// past the bound. Layout-effect so the resize lands before paint (no
+	// visible jump on the growing keystroke).
+	useLayoutEffect(() => {
+		const el = textareaRef.current;
+		if (!el) return;
+		el.style.height = "auto";
+		el.style.height = `${el.scrollHeight}px`;
+	}, [text]);
 
 	const submit = () => {
 		const trimmed = text.trim();
@@ -43,23 +62,34 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 	return (
 		<div className="bg-[linear-gradient(to_top,var(--paper)_66%,var(--paper-0))] px-5 pt-11 pb-5">
 			<div
-				className="group mx-auto flex min-h-[54px] max-w-[680px] cursor-text items-center gap-[13px] rounded-[13px] border border-line-strong bg-raised py-2 pr-2 pl-[19px] shadow-field transition-[border-color,box-shadow] duration-200 hover:border-focus-line focus-within:border-focus-line focus-within:shadow-[0_0_0_3px_var(--focus-ring),var(--field-shadow)]"
+				className="group mx-auto flex min-h-[54px] max-w-[680px] cursor-text items-end gap-[13px] rounded-[13px] border border-line-strong bg-raised py-2 pr-2 pl-[19px] shadow-field transition-[border-color,box-shadow] duration-200 hover:border-focus-line focus-within:border-focus-line focus-within:shadow-[0_0_0_3px_var(--focus-ring),var(--field-shadow)]"
 				onClick={(event) => {
 					if (!(event.target as HTMLElement).closest("button"))
-						inputRef.current?.focus();
+						textareaRef.current?.focus();
 				}}
 			>
-				<span className="font-mono text-[15px] text-accent">›</span>
-				<input
-					ref={inputRef}
-					type="text"
+				<span aria-hidden className="mb-[7px] font-mono text-[15px] text-accent">
+					›
+				</span>
+				<textarea
+					ref={textareaRef}
+					rows={1}
 					aria-label={`Reply to ${agentName}`}
 					value={text}
 					onChange={(event) => setText(event.target.value)}
 					onKeyDown={(event) => {
-						if (event.key === "Enter") submit();
+						if (
+							event.key === "Enter" &&
+							!event.shiftKey &&
+							!event.nativeEvent.isComposing
+						) {
+							event.preventDefault();
+							submit();
+						}
 					}}
-					className="min-w-0 flex-1 border-none bg-transparent font-serif text-compose text-ink outline-none"
+					// Bounded growth (#807): past this height the draft scrolls inside
+					// the field instead of growing the field (and the page) forever.
+					className="my-[7px] max-h-[168px] min-w-0 flex-1 resize-none overflow-y-auto border-none bg-transparent font-serif text-compose text-ink outline-none"
 				/>
 				{disabled && onStop ? (
 					<button

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -67,8 +67,11 @@ export function MessageArticle({
 					<span aria-hidden className="h-px w-3.5 self-center bg-faint" />
 				)}
 				{author}
+				{/* The stamp reveals at full opacity: it inherits text-hint, and a
+				    partial-opacity reveal would blend the readable time back below
+				    AA (#806) — the hover gating is the quietness. */}
 				{stamp !== undefined && (
-					<span className="font-normal tracking-[.04em] opacity-0 transition-opacity duration-[.25s] group-hover:opacity-80">
+					<span className="font-normal tracking-[.04em] opacity-0 transition-opacity duration-[.25s] group-hover:opacity-100">
 						{stamp}
 					</span>
 				)}

--- a/web-next/src/components/folio/message.tsx
+++ b/web-next/src/components/folio/message.tsx
@@ -62,7 +62,7 @@ export function MessageArticle({
 					: undefined
 			}
 		>
-			<div className="mb-3.5 flex items-baseline gap-3 font-mono text-label font-medium tracking-[.16em] uppercase text-faint">
+			<div className="mb-3.5 flex items-baseline gap-3 font-mono text-label font-medium tracking-[.16em] uppercase text-hint">
 				{role === "user" && (
 					<span aria-hidden className="h-px w-3.5 self-center bg-faint" />
 				)}

--- a/web-next/src/components/folio/reasoning.tsx
+++ b/web-next/src/components/folio/reasoning.tsx
@@ -154,7 +154,7 @@ export const ReasoningTrigger = memo(function ReasoningTrigger({
 	const { isStreaming, isOpen, duration } = useReasoning();
 	return (
 		<Collapsible.Trigger
-			className={`group/reasoning flex w-full items-center gap-2.5 rounded-md py-[5px] pr-2 text-left font-mono text-tool text-faint transition-colors hover:text-muted ${className ?? ""}`}
+			className={`group/reasoning flex w-full items-center gap-2.5 rounded-md py-[5px] pr-2 text-left font-mono text-tool text-hint transition-colors hover:text-muted ${className ?? ""}`}
 			{...props}
 		>
 			{children ?? (

--- a/web-next/src/components/folio/session-masthead.tsx
+++ b/web-next/src/components/folio/session-masthead.tsx
@@ -11,6 +11,11 @@
  * on hover/focus (a quiet background wash), matching the status line's model
  * picker (status-line.tsx). Callers that omit it (fixtures, demo pages) get
  * the old static span, unchanged.
+ *
+ * The decorative centered title (input or span) is `md:block` — hidden below
+ * md, same as before. A real, unconditional `sr-only` `<h1>` (#805) carries
+ * the session's semantic heading and gives screen readers a title at every
+ * viewport width, since the decorative copy alone is invisible on phones.
  */
 import { useRef } from "react";
 import { ThemeToggle } from "./theme-toggle";
@@ -73,6 +78,9 @@ export function SessionMasthead({
 					</>
 				)}
 			</span>
+			{/* Real heading (#805): present at every width regardless of the
+			    decorative copy's md:block gating, visually unchanged. */}
+			<h1 className="sr-only">{session.title || UNTITLED_MASTHEAD_TITLE}</h1>
 			{onTitleChange ? (
 				<input
 					key={session.title}
@@ -92,10 +100,10 @@ export function SessionMasthead({
 							event.currentTarget.blur();
 						}
 					}}
-					className="absolute left-1/2 hidden w-[46%] max-w-[420px] -translate-x-1/2 truncate rounded-[6px] border-none bg-transparent px-1.5 py-0.5 text-center font-serif text-title text-faint italic tracking-[.01em] outline-none transition-colors duration-150 placeholder:text-faint hover:bg-hover-bg hover:text-ink focus:bg-hover-bg focus:text-ink focus:shadow-[0_0_0_3px_var(--focus-ring)] md:block"
+					className="absolute left-1/2 hidden w-[46%] max-w-[420px] -translate-x-1/2 truncate rounded-[6px] border-none bg-transparent px-1.5 py-0.5 text-center font-serif text-title text-hint italic tracking-[.01em] outline-none transition-colors duration-150 placeholder:text-hint hover:bg-hover-bg hover:text-ink focus:bg-hover-bg focus:text-ink focus:shadow-[0_0_0_3px_var(--focus-ring)] md:block"
 				/>
 			) : (
-				<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-faint md:block">
+				<span className="absolute left-1/2 hidden -translate-x-1/2 font-serif text-title italic tracking-[.01em] text-hint md:block">
 					{session.title || UNTITLED_MASTHEAD_TITLE}
 				</span>
 			)}
@@ -122,7 +130,7 @@ export function SessionMasthead({
 								title="Stop the sandbox"
 								aria-label="Stop sandbox"
 								onClick={onSandboxStop}
-								className="ml-2 rounded-[5px] border-b border-transparent px-1 py-0.5 leading-none text-faint opacity-0 transition-opacity duration-200 group-hover/sandbox:opacity-100 hover:text-del-ink focus-visible:opacity-100"
+								className="ml-2 rounded-[5px] border-b border-transparent px-1 py-0.5 leading-none text-hint opacity-0 transition-opacity duration-200 group-hover/sandbox:opacity-100 hover:text-del-ink focus-visible:opacity-100"
 							>
 								stop
 							</button>

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -129,7 +129,7 @@ export function SessionView({
 						<p className="font-serif text-body text-muted italic">
 							{session.empty.title}
 						</p>
-						<p className="font-mono text-caption text-faint">
+						<p className="font-mono text-caption text-hint">
 							{session.empty.hint}
 						</p>
 					</div>

--- a/web-next/src/components/folio/status-line.tsx
+++ b/web-next/src/components/folio/status-line.tsx
@@ -59,7 +59,7 @@ export function StatusLine({
 	return (
 		<div
 			data-testid="status-line"
-			className="h-[30px] border-t border-line bg-status-bg font-mono text-stat tracking-[.03em] text-faint"
+			className="h-[30px] border-t border-line bg-status-bg font-mono text-stat tracking-[.03em] text-hint"
 		>
 			<div className="mx-auto flex h-full max-w-[680px] items-center px-0.5">
 				<span className="font-medium text-muted before:mr-2 before:inline-block before:h-[5px] before:w-[5px] before:rounded-full before:bg-accent before:align-[2px] before:opacity-75 before:content-['']">
@@ -84,7 +84,7 @@ export function StatusLine({
 				</span>
 				{status.contextLabel && (
 					<>
-						<span className="mx-[9px] opacity-55">·</span>
+						<span className="mx-[9px] text-faint opacity-55">·</span>
 						{status.contextLabel}
 					</>
 				)}

--- a/web-next/src/components/folio/tool-ledger-row.tsx
+++ b/web-next/src/components/folio/tool-ledger-row.tsx
@@ -39,10 +39,10 @@ export function ToolLedgerRow({
 				>
 					▸
 				</span>
-				<span className="min-w-[3.6em] text-faint">{verb}</span>
+				<span className="min-w-[3.6em] text-hint">{verb}</span>
 				<span className="min-w-0 flex-1 truncate">{subject}</span>
 				{meta !== undefined && (
-					<span className="ml-auto pl-4 text-caption whitespace-nowrap text-faint">
+					<span className="ml-auto pl-4 text-caption whitespace-nowrap text-hint">
 						{meta}
 					</span>
 				)}

--- a/web-next/src/components/folio/turn-stats.tsx
+++ b/web-next/src/components/folio/turn-stats.tsx
@@ -1,5 +1,5 @@
 /*
- * End-of-turn receipt: a faint one-line tally under completed agent turns.
+ * End-of-turn receipt: a quiet one-line tally under completed agent turns.
  */
 import { formatTurnStats } from "./ledger";
 import type { TurnStatsData } from "./types";
@@ -8,7 +8,11 @@ export function TurnStatsReceipt({ stats }: { stats: TurnStatsData }) {
 	return (
 		<div
 			data-testid="turn-stats"
-			className="mt-5 font-mono text-stat tracking-[.04em] text-faint opacity-[.82]"
+			// text-hint carries the "quiet" weight on its own (#806) — an extra
+			// opacity multiply on top of it would blend the readable tally back
+			// below AA, so the token replaces the opacity rather than layering
+			// under it.
+			className="mt-5 font-mono text-stat tracking-[.04em] text-hint"
 		>
 			{formatTurnStats(stats)}
 		</div>

--- a/web-next/src/components/terminal/terminal-drawer.tsx
+++ b/web-next/src/components/terminal/terminal-drawer.tsx
@@ -269,7 +269,7 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 			>
 				{/* A div, not <header>: the drawer bar is chrome, not a landmark —
 				    and the page's one banner stays the masthead. */}
-				<div className="flex h-[30px] items-center gap-2 border-b border-line px-3 font-mono text-stat tracking-[.03em] text-faint">
+				<div className="flex h-[30px] items-center gap-2 border-b border-line px-3 font-mono text-stat tracking-[.03em] text-hint">
 					<span className="text-muted">terminal</span>
 					{phase !== "idle" && (
 						<span data-testid="terminal-status">— {statusLabel[phase]}</span>
@@ -278,7 +278,7 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 						<button
 							type="button"
 							onClick={() => void connect()}
-							className="rounded-[5px] px-1.5 py-0.5 text-faint underline decoration-dotted underline-offset-2 hover:text-ink"
+							className="rounded-[5px] px-1.5 py-0.5 text-hint underline decoration-dotted underline-offset-2 hover:text-ink"
 						>
 							{phase === "disconnected" ? "reconnect" : "check again"}
 						</button>
@@ -303,7 +303,7 @@ export function TerminalDrawer({ sessionId }: { sessionId: string }) {
 							<p className="font-serif text-body text-muted italic">
 								{phase === "no-sandbox" ? "No live sandbox." : "Terminal unavailable."}
 							</p>
-							<p className="max-w-[52ch] font-mono text-caption text-faint">
+							<p className="max-w-[52ch] font-mono text-caption text-hint">
 								{note}
 								{phase === "no-sandbox" &&
 									" — start a turn and the terminal attaches to the same sandbox it runs in."}

--- a/web-next/tests/e2e/sessions-demo.spec.ts
+++ b/web-next/tests/e2e/sessions-demo.spec.ts
@@ -158,3 +158,47 @@ test("seeded transcript renders the requested message count @deployed-safe", asy
 	await page.goto("/sessions/demo?seed=20");
 	await expect(page.locator("[data-message-role]")).toHaveCount(20);
 });
+
+test("session page renders a real h1 carrying the title @deployed-safe", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+	// #805: a real <h1>, present regardless of the decorative centered
+	// title's md:block gating — visually sr-only, not the masthead copy.
+	await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+		"Fix the failing session-resume test",
+	);
+});
+
+test("keyboard-tab reveals the hover-only activity-line details toggle @deployed-safe", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+	// #805: reveal-on-hover controls must also reveal on keyboard focus. A
+	// real Tab walk (not .focus()) — script-focus doesn't reliably engage
+	// :focus-visible, which is what the CSS keys off.
+	const detailsToggle = page.getByRole("button", { name: "details" });
+	await expect(detailsToggle).toHaveCSS("opacity", "0");
+	for (let i = 0; i < 60; i++) {
+		if (await detailsToggle.evaluate((el) => el === document.activeElement)) break;
+		await page.keyboard.press("Tab");
+	}
+	await expect(detailsToggle).toBeFocused();
+	await expect(detailsToggle).toHaveCSS("opacity", "1");
+});
+
+test("compose: Shift+Enter inserts a newline, bare Enter sends the multiline draft @deployed-safe", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await compose.fill("line one");
+	await compose.press("Shift+Enter");
+	await compose.type("line two");
+	await expect(compose).toHaveValue("line one\nline two");
+
+	// Bare Enter sends (and clears the draft) even mid-multiline-edit — the
+	// newline above did NOT submit.
+	await compose.press("Enter");
+	await expect(compose).toHaveValue("");
+});


### PR DESCRIPTION
Three small polish fixes in `web-next/`, found in the first-release review: keyboard-reachable reveal controls + a semantic session heading + hidden decorative glyphs (#805), WCAG-AA light-mode text contrast (#806), and a multiline compose field (#807).

## What changed

**#805 — a11y**
- `activity-line.tsx`: the "details" toggle now also reveals on `focus-visible`, not just `group-hover` — a keyboard user no longer tabs onto a fully transparent control.
- `session-masthead.tsx`: adds a real, unconditional `sr-only` `<h1>` carrying the session title, present at every viewport width — the decorative centered copy (input/span) it sits beside stays `md:block`-gated exactly as before.
- `compose-field.tsx`: the `›` prompt gets `aria-hidden`, matching the identical glyph in `new-session.tsx`.
- The diff-card dismiss ✕ named in the issue is **already gone** — #909's `DiffCard`→`DiffHunk` rework dropped it. Nothing to fix there.
- #935's hover-revealed sandbox-stop control (landed after the issue was filed) **already** carries `focus-visible:opacity-100` — verified, no change needed.

**#806 — contrast**
`globals.css` splits `--faint` into a decorative token (hairlines, separators, icon-glyph buttons — WCAG's 3:1 non-text floor) and a new `--hint` text token (captions, hints, timestamps, the status-line context figure, placeholders, ledger verbs/meta, the session title — needs 4.5:1). `--muted` is darkened to clear 4.5:1 too. Every component using `text-faint` for content that's actually *read* (not just decoration) swaps to `text-hint`; icon-only buttons, separators, and hairline marks keep `text-faint`. Both text tokens are set to clear AA on `--status-bg` (`#f1ede0`), the darkest surface small text sits on — paper and raised are lighter, so they only gain (codex finding; see Review loop).

**#807 — multiline compose**
`compose-field.tsx`'s single-line `<input>` becomes an auto-growing `<textarea>` (bounded at 168px, then scrolls internally; a width-gated `ResizeObserver` re-measures on viewport resize/rotation so a rewrapped draft never keeps a stale height). Enter sends, Shift+Enter inserts a newline (Slack/Discord/ChatGPT convention). Preserved exactly: autofocus on mount, no placeholder or hint chips, whole-field click-to-focus, disabled-while-busy holding the draft, the send affordance warming on focus, and #935's Stop morph while busy.

**Tooling**: `scripts/evidence.mjs` now captures the compose field's empty / multiline-draft / disabled states. Added `scripts/upload-evidence.sh` (+ `pnpm run evidence:upload`) so a full ~50-screenshot walk uploads in one command instead of one `evidence.sh` call per file — CONTRIBUTING.md documents it next to the other gates.

## Contrast ratios (WCAG AA: 4.5:1 text, 3:1 non-text/decorative)

Ratios shown for `--paper` and `--status-bg` — status-bg (`#f1ede0` light / `#1b1913` dark) is the darkest light-mode surface small text sits on; `--raised` is lighter than paper and only improves the numbers.

| Token | Mode | Old value | Old ratio (paper) | New value | New ratio (paper) | New ratio (status-bg) | Role |
|---|---|---|---|---|---|---|---|
| `--muted` | light | `#7a7261` | 4.34:1 (fail) | `#6e6757` | **5.11:1** | **4.79:1** | small text |
| `--faint` | light | `#aca492` | 2.25:1 (fail) | `#908a7b` | **3.13:1** | 2.94:1 † | decorative (3:1 floor) |
| `--hint` (new) | light | — | — | `#6d685c` | **5.05:1** | **4.74:1** | small text (split from old `--faint`) |
| `--muted` | dark | `#a79e8c` | 6.93:1 | unchanged | 6.93:1 | 6.62:1 | small text (already AA) |
| `--faint` | dark | `#837a69` | 4.34:1 | unchanged | 4.34:1 | 4.05:1 | decorative (well over 3:1) |
| `--hint` (new) | dark | — | — | `#8f8778` | **5.17:1** | **4.94:1** | small text |

† the only `--faint` items on status-bg are the `·` separator and icon-dimmed controls covered by the notes below — no readable text.

Opacity-blended cases (CSS `opacity` blends toward the background and can pull an AA-passing color back under the floor):
- `turn-stats.tsx`'s end-of-turn tally carried `text-faint opacity-[.82]` — removed the opacity; `--hint` alone carries the "quiet" weight, fully opaque.
- `message.tsx`'s hover-revealed timestamp revealed at `opacity-80` — blended ~3.25:1 with the inherited `text-hint`. Now reveals at full opacity; the hover gating is the quietness (codex finding).
- The status-line's `·` separator (`opacity-55`) stays on the decorative `--faint` token deliberately under 3:1 when blended (~1.77:1) — ornamental punctuation between two already-readable text runs, not content; WCAG's floors target text and meaningful graphics. Noted rather than silently left.
- Terminal-drawer's `>_` / ✕ icon buttons and the status-line ✕/dot keep `text-faint`/`bg-faint` at `opacity-70`/`opacity-40` — pre-existing dimming unrelated to the token split (icon-only controls, not the `--faint` text usages #806 named). Blended, they land under 3:1. Out of scope (a separate icon-opacity audit) — flagged as residual risk below rather than fixing unrequested.

## Compose keybinding

**Enter sends, Shift+Enter inserts a newline** — matches Slack/Discord/ChatGPT, and matches what `sessions.spec.ts`/`mobile.spec.ts` already assumed (`page.keyboard.press("Enter")` after `.fill()`), so no existing test needed to change. IME composition is guarded (`!event.nativeEvent.isComposing`) so committing an IME candidate with Enter doesn't fire a spurious submit. Discoverability is intentionally not surfaced in UI chrome (no hint chip) per the issue's "preserve current behavior" list — noting it here per the issue's ask.

## Review loop

Self-reflection pass, then a directed codex (gpt-5.5, xhigh) review of the full diff. Codex findings and dispositions (reaction commit: `fix(web-next): react to codex review — status-bg contrast, timestamp opacity, resize re-measure`):

1. **Blocking — accepted.** Light `--hint`/`--muted` cleared AA on paper/raised but not on `--status-bg` (4.45:1 / 4.50:1), which the status line and terminal-drawer chrome sit on. Darkened both (`#6d685c` / `#6e6757` → 4.74:1 / 4.79:1 on status-bg).
2. **Blocking — accepted.** `message.tsx`'s timestamp revealed at `opacity-80` while inheriting the new `text-hint` — blended ~3.25:1, the same defect class the turn-stats fix addressed. Reveals at `opacity-100` now.
3. **Observation — declined.** Icon glyphs at `text-faint opacity-70` under the 3:1 graphical-object floor: pre-existing dimming, unchanged by this diff, already declared out of scope in the residual-risk section. Codex concurred these are not hover/focus-reveal regressions (they stay visible without hover).
4. **Nit — accepted.** The auto-grow effect re-measured only on `[text]`, leaving a stale height when a width change rewraps the draft (mobile rotation, viewport resize). Added a width-gated `ResizeObserver` (loop-safe: autoGrow writes only height).
5. Codex explicitly found **no** pointer-hover regression from the `focus-visible` additions, no stale dark-mode token, no strict-mode/lifecycle issue in the auto-grow effect, and no Stop/Send alignment or hit-target change from `items-center` → `items-end`.

## Mergeability

- Surface: web (`web-next/` — Folio session UI: compose, masthead, activity line, design tokens)
- User-facing behavior changed: Yes — compose is now a multiline textarea (Shift+Enter for newline, Enter still sends); several caption/hint/label text colors are darker in light mode (still reads as Folio, not muddy — see evidence); keyboard-focus now reveals the activity-line "details" control; hover-revealed timestamps show at full opacity; the session page has a screen-reader-only `<h1>` (no visual change).
- Non-happy paths considered: IME composition during Enter (guarded), a deleted multiline draft collapsing the textarea back to one line, very long pasted text hitting the 168px scroll cap, viewport resize/rotation rewrapping a held draft (ResizeObserver re-measure), disabled-while-busy still never sets the HTML `disabled` attribute on the textarea (matches prior `<input>` behavior — draft holds, submit is gated in `submit()`).
- Residual risk or follow-up: the pre-existing icon-button opacity dimming (terminal toggle, drawer/status-line ✕, status-line dot) still lands under WCAG's 3:1 non-text floor when blended — flagged above and by codex, out of scope for this PR's `--faint`/`--muted` text-contrast split; the decorative `·` separator is intentionally left under 3:1 as ornamental punctuation. Neither was named in #806's acceptance criteria.

## Evidence

- Tests passed: `pnpm run typecheck` clean; `pnpm run lint` clean; `pnpm run test` — 429/429 unit tests passed; `pnpm run test:e2e` — 42/42 Playwright tests passed (fresh production build, no stale-`.next` reuse), including 3 new specs (keyboard-tab reveal, session `<h1>`, Shift+Enter/Enter multiline); `pnpm run perf` — all 9 scenarios under budget. All gates re-run green after the codex reaction commit.
- Mutation check: removed the `!event.shiftKey` guard in `compose-field.tsx` — the new "Shift+Enter inserts a newline" e2e test failed as expected (`toHaveValue` mismatch: Shift+Enter submitted instead of inserting a newline). Reverted; test passes again on a rebuilt tree.
- Contrast ratio table: above (recomputed after the codex reaction).
- Screenshots (full ~50-shot light+dark walk re-captured on the final token values and uploaded via `pnpm run evidence:upload`; curated set below):
  - Compose, empty: [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043733-compose-empty-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043732-compose-empty-dark.png)
  - Compose, multiline draft (#807): [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043734-compose-multiline-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043733-compose-multiline-dark.png)
  - Compose, disabled + Stop (#807, #935): [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043732-compose-disabled-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043730-compose-disabled-dark.png)
  - Home, populated — caption/hint/meta contrast (#806): [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043736-home-populated-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043736-home-populated-dark.png)
  - Home, empty — "+ new session" hint contrast (#806): [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043735-home-empty-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043735-home-empty-dark.png)
  - `/sessions/demo` — activity-line details toggle, ledger verbs/meta, turn-stats receipt (#805, #806): [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043805-sessions-demo-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043804-sessions-demo-dark.png)
  - Mobile 375px, streamed turn — compose + contrast hold up narrow (#753 regression check): [light](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043752-session-mobile-turn-light.png) · [dark](https://evidence.cloudcompute.com/workspaces/pr-948/20260708-043752-session-mobile-turn-dark.png)
- CI: <green run link to be added at ready-flip>

Closes #805
Closes #806
Closes #807
