### PR TITLE
web-next validation: folio default target, reasoning-model probe headroom, crash-proof model checks

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -146,7 +146,7 @@ env vars) — per the matrix in [`docs/deploy.md`](docs/deploy.md).
 ## Deploying
 
 The app is linked to Vercel project **`cloudcompute/web-next`**
-(https://web-next-ivory-six.vercel.app):
+(https://folio.cloudcompute.com):
 
 ```bash
 npx vercel login            # device flow

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -7,7 +7,7 @@
  */
 
 /** The deployed production origin; override with WEB_NEXT_PROD_URL. */
-export const DEFAULT_PROD_URL = "https://web-next-ivory-six.vercel.app";
+export const DEFAULT_PROD_URL = "https://folio.cloudcompute.com";
 
 export const LOCAL_PORT = 3101;
 
@@ -274,7 +274,7 @@ export function evaluateModelChecks(results) {
 			status: ok ? "pass" : "fail",
 			detail: ok
 				? `${id} → routed via ${body.gatewayModel ?? "?"} in ${body.latencyMs ?? "?"}ms: ${JSON.stringify(body.reply)}`
-				: `${id} → HTTP ${status} ${JSON.stringify(body).slice(0, 200)}`,
+				: `${id} → HTTP ${status} ${JSON.stringify(body ?? null).slice(0, 200)}`,
 		};
 	});
 }

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -235,6 +235,19 @@ describe("evaluateModelChecks (#816)", () => {
 		expect(byId["model:claude-opus-4-8"]).toBe("fail");
 		expect(byId["model:claude-sonnet-5"]).toBe("fail");
 	});
+
+	test("an unreachable probe (no body at all) is a failed check, not a crash", () => {
+		const checks = evaluateModelChecks([
+			{ id: "claude-fable-5", status: 0, body: undefined },
+		]);
+		expect(checks).toEqual([
+			{
+				id: "model:claude-fable-5",
+				status: "fail",
+				detail: "claude-fable-5 → HTTP 0 null",
+			},
+		]);
+	});
 });
 
 describe("evaluateE2eResults (#817)", () => {

--- a/web-next/src/app/api/diag/gateway/route.ts
+++ b/web-next/src/app/api/diag/gateway/route.ts
@@ -49,7 +49,9 @@ export async function GET(request: Request) {
 			body: JSON.stringify({
 				model: resolved.gatewayModel,
 				messages: [{ role: "user", content: "Reply with exactly: gateway live" }],
-				max_tokens: 10,
+				// Reasoning models (fable-5) spend completion budget on thinking
+				// before any text — 10 tokens yields an empty reply and a false red.
+				max_tokens: 400,
 			}),
 		});
 	} catch (error) {


### PR DESCRIPTION
## What

Three validation-surface fixes shipping the folio decision (#754):

1. **`DEFAULT_PROD_URL` → `https://folio.cloudcompute.com`** — owner decision: no cutover; web-next ships at folio while the old dashboard stays in maintenance mode. Folio is DNS-live with TLS and validated end-to-end (posture 7/7, authed 2/2, deployed-safe e2e 11/11, real agentic turn 9/9 on 2026-07-07).
2. **`/api/diag/gateway` `max_tokens` 10 → 400** — reasoning models (fable-5) spend completion budget on thinking before emitting text; with 10 tokens the probe returns HTTP 200 with an empty reply, a false red in the model sweep (observed tonight: 3/4 with fable-5 the only failure, `ok:true, reply:""`).
3. **`evaluateModelChecks` crash-proofing** — an unreachable target gives `body: undefined`, and `JSON.stringify(undefined).slice` threw, killing the whole suite instead of recording one failed check (crash observed tonight; unit test added).

Also flips the CONTRIBUTING.md production URL. `config/vercel/web-next.json`'s `BETTER_AUTH_URL` is deliberately **not** flipped: it reflects live state, and the auth-origin switch is gated on the GitHub OAuth App callback edit (owner action pending).

## Evidence

Tests passed: 430/430 unit (`pnpm run test`), lint + typecheck green.

![unit-tests-430](https://evidence.cloudcompute.com/workspaces/pr-949/20260708-050607-unit-tests-430.png)

## Review loop

Small diff (2 behavior lines + test + docs); codex review skipped per the metadata/small-diff convention — self-reviewed.

## Mergeability

- Surface: web (`web-next/` — validation scripts, gateway diag probe, contributor docs)
- User-facing behavior changed: No end-user UI change. Operational: validation defaults to folio; the gateway probe returns a real reply for reasoning models (slightly higher per-probe token spend, ≤400 completion tokens × 4 models × 1/day).
- Non-happy paths considered: unreachable target now records a failed check instead of crashing the suite; `WEB_NEXT_PROD_URL` still overrides the default for ad-hoc targets; probe cost stays bounded by max_tokens.
- Residual risk or follow-up: interactive sign-in on folio still pends the OAuth App callback edit + `BETTER_AUTH_URL` flip (tracked in #754); `config/vercel/web-next.json` flips with that.

Closes nothing yet — #754 closes after the auth-origin switch.

