### PR TITLE
docs: document D-lane feature additions (#679, #680, #894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,11 @@ Tester prerelease. Headline: the Tile Tree + Surface abstraction epic (#627) is 
 
 ## [Unreleased]
 
+### Added
+- Native diff review: open a changed file's diff in-app (add/remove/context coloring, old|new gutters) from the Changes tab or the code editor (#704).
+- Session cards show live activity: a status-derived snippet on session switcher rows (running tool + detail, "waiting for permission," or the error), and the sidebar hover card surfaces the last assistant message from a Claude Code session's transcript (#680).
+- Automation API: read-only `browser.read` capability exposes embedded web surfaces to local scripting — `GET /v1/web-surfaces` lists them (live URL/title only when a view is open) and `GET /v1/web-surfaces/{id}/snapshot` returns a bounded PNG of a live surface (#679).
+
 ### Fixed
 - Write machine-agnostic Claude Code hook and status-line commands: both forwarders extract to a stable, space-free dir (`~/.local/share/workspaces/hook-forwarders/`) and `settings.json` carries a tilde-relative, unquoted path identical on every machine. This keeps the committed dotclaude config matching runtime so `~/.claude` stops going dirty and the auto-deploy no longer silently skips. Opted-in users migrate off the older `Application Support` / `.build` bundle paths on next launch. See `docs/decisions/hook-forwarder-command-shape.md`.
 

--- a/docs/product_overview.md
+++ b/docs/product_overview.md
@@ -29,6 +29,9 @@ Think of it as **a terminal session manager for your code portfolio, with worksp
 - **Two-Pane Split Control**: Ghostty split actions can create, focus, resize, and equalize the current two-pane stack
 - **Ghostty-First Shortcut Routing**: Terminal keybindings should default to Ghostty behavior; app-level shortcuts are for non-overlapping chrome actions
 - **File/Changes Pane**: Collapsible right pane showing file tree and git status
+- **Native Diff Review**: Open a changed file's diff in-app — colored add/remove/context rows with old|new line-number gutters — from the Changes tab or the code editor
+- **Session Activity at a Glance**: The session switcher shows a live status snippet per session (running tool and detail, waiting-for-permission, or the error); hovering a Claude Code session in the sidebar shows its last assistant message
+- **Local Automation API**: An opt-in local socket (`automation.sock`) exposes capability-gated read routes for scripting against the running app — context, visible terminal surfaces, and (`browser.read`) embedded web surfaces including a bounded snapshot of a live one
 - **Configurable Location**: Choose where workspaces are stored (default: `~/workspaces`)
 
 ## Sidebar Structure


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` `[Unreleased]` entries for what shipped in tonight's D-lane arc: read-only native diff review (#894/#704 slice 1), session activity snippets + transcript tail (#680), and the `browser.read` automation routes (#679).
- Extends `docs/product_overview.md`'s Core Capabilities list with the same three additions, matching the existing bullet style.
- Deliberately does **not** document #704's stage/unstage/discard actions (PR #924) — that PR is still pending Michael's live click-through validation before merge, so documenting it now would describe a feature that isn't shipped yet. Follow-up entry once #924 merges.
- Docs-only diff; no code changes, no test impact.

## Mergeability
- **Surface:** Documentation only — `CHANGELOG.md` and `docs/product_overview.md` (the latter is synced to the public docs site via `web/scripts/docs-sync-manifest.json`).
- **User-facing behavior changed:** None — this only documents behavior that already shipped in prior merged PRs (#896, #897, #898, #926, #930, #894).
- **Non-happy paths considered:** N/A — text-only change, no runtime paths affected.
- **Release/ops preconditions:** None.
- **Residual risk or follow-up:** Add a CHANGELOG/product_overview entry for #704's destructive diff actions once PR #924 merges. Separately noted to Michael: `docs/user-guide/index.html` (linked from `docs/README.md`) contains stale Daytona-era content unrelated to the current app and may be worth retiring or rewriting in a future pass — out of scope here.

Skipping the codex-review-loop per repo convention (docs/metadata-only diff).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>