### PR TITLE
feat(automation): add workspace.create gesture verb

### DIFF
--- a/Sources/WorkspaceManager/App/DesktopUISmokeAutomation.swift
+++ b/Sources/WorkspaceManager/App/DesktopUISmokeAutomation.swift
@@ -23,18 +23,27 @@ enum DesktopUISmokeSelectDriver: String, Sendable {
     case api
 }
 
+/// Who drives the workspace creation step. `ui` preserves the daily-driver lane; `api` imports the
+/// repo, emits an `awaiting_api_create` milestone, and leaves creation to the operator route.
+enum DesktopUISmokeCreateDriver: String, Sendable {
+    case ui
+    case api
+}
+
 struct DesktopUISmokeAutomationConfiguration: Equatable, Sendable {
     static let modeEnvironmentKey = "WORKSPACES_AUTOMATION_MODE"
     static let repoPathEnvironmentKey = "WORKSPACES_AUTOMATION_REPO_PATH"
     static let workspaceNameEnvironmentKey = "WORKSPACES_AUTOMATION_WORKSPACE_NAME"
     static let eventsPathEnvironmentKey = "WORKSPACES_AUTOMATION_EVENTS_PATH"
     static let selectDriverEnvironmentKey = "WORKSPACES_AUTOMATION_SELECT_DRIVER"
+    static let createDriverEnvironmentKey = "WORKSPACES_AUTOMATION_CREATE_DRIVER"
     static let modeValue = "desktop-ui-smoke"
 
     let repoURL: URL
     let workspaceName: String
     let eventsURL: URL
     let selectDriver: DesktopUISmokeSelectDriver
+    let createDriver: DesktopUISmokeCreateDriver
 
     static func from(environment: [String: String]) -> DesktopUISmokeAutomationConfiguration? {
         guard
@@ -63,12 +72,18 @@ struct DesktopUISmokeAutomationConfiguration: Equatable, Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         let selectDriver = selectDriverRaw.flatMap(DesktopUISmokeSelectDriver.init(rawValue:)) ?? .ui
+        let createDriverRaw =
+            environment[createDriverEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let createDriver = createDriverRaw.flatMap(DesktopUISmokeCreateDriver.init(rawValue:)) ?? .ui
 
         return DesktopUISmokeAutomationConfiguration(
             repoURL: URL(fileURLWithPath: (repoPath as NSString).expandingTildeInPath),
             workspaceName: workspaceName,
             eventsURL: URL(fileURLWithPath: (eventsPath as NSString).expandingTildeInPath),
-            selectDriver: selectDriver
+            selectDriver: selectDriver,
+            createDriver: createDriver
         )
     }
 }
@@ -89,6 +104,7 @@ private struct DesktopUISmokeEvent: Codable, Sendable {
         case workspaceCreated = "workspace_created"
         case sidebarUpdated = "sidebar_updated"
         case terminalSessionAttached = "terminal_session_attached"
+        case awaitingApiCreate = "awaiting_api_create"
         case awaitingApiSelect = "awaiting_api_select"
         case webSurfaceAttached = "web_surface_attached"
         case surfaceFocused = "surface_focused"
@@ -100,6 +116,7 @@ private struct DesktopUISmokeEvent: Codable, Sendable {
     let type: Kind
     let timestamp: String
     let repoName: String?
+    let repoID: String?
     let repoPath: String?
     let workspaceName: String?
     let workspacePath: String?
@@ -196,6 +213,10 @@ final class DesktopUISmokeAutomationController: ObservableObject {
         configuration?.selectDriver == .api
     }
 
+    var usesAPICreateDriver: Bool {
+        configuration?.createDriver == .api
+    }
+
     /// Signals the scenario has created the workspace, parked the active surface on the repo terminal,
     /// and is now waiting for an external API-driven select to switch back to the workspace. The
     /// api-select smoke script keys its `workspaces workspace select` on this milestone.
@@ -207,6 +228,18 @@ final class DesktopUISmokeAutomationController: ObservableObject {
                 workspaceName: workspace.name,
                 workspacePath: workspace.path,
                 workspaceID: workspace.id.uuidString
+            )
+        )
+    }
+
+    func noteAwaitingAPICreate(repo: Repo) async {
+        guard isEnabled else { return }
+        await emit(
+            makeEvent(
+                type: .awaitingApiCreate,
+                repoName: repo.name,
+                repoID: repo.id.uuidString,
+                repoPath: repo.localURL.standardizedFileURL.resolvingSymlinksInPath().path
             )
         )
     }
@@ -234,7 +267,14 @@ final class DesktopUISmokeAutomationController: ObservableObject {
         let normalizedPath = repo.localURL.standardizedFileURL.resolvingSymlinksInPath().path
         guard emittedRepoPath != normalizedPath else { return }
         emittedRepoPath = normalizedPath
-        await emit(makeEvent(type: .repoReady, repoName: repo.name, repoPath: normalizedPath))
+        await emit(
+            makeEvent(
+                type: .repoReady,
+                repoName: repo.name,
+                repoID: repo.id.uuidString,
+                repoPath: normalizedPath
+            )
+        )
     }
 
     func noteWorkspaceCreationStarted(repo: Repo) async {
@@ -243,6 +283,7 @@ final class DesktopUISmokeAutomationController: ObservableObject {
             makeEvent(
                 type: .workspaceCreationStarted,
                 repoName: repo.name,
+                repoID: repo.id.uuidString,
                 repoPath: repo.localURL.standardizedFileURL.resolvingSymlinksInPath().path
             )
         )
@@ -354,6 +395,7 @@ final class DesktopUISmokeAutomationController: ObservableObject {
     private func makeEvent(
         type: DesktopUISmokeEvent.Kind,
         repoName: String? = nil,
+        repoID: String? = nil,
         repoPath: String? = nil,
         workspaceName: String? = nil,
         workspacePath: String? = nil,
@@ -369,6 +411,7 @@ final class DesktopUISmokeAutomationController: ObservableObject {
             type: type,
             timestamp: Date().ISO8601Format(),
             repoName: repoName,
+            repoID: repoID,
             repoPath: repoPath ?? targetRepoURL?.path,
             workspaceName: workspaceName ?? targetWorkspaceName,
             workspacePath: workspacePath,

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -13,7 +13,7 @@ final class AutomationController: AutomationControlling {
     private var windows: @MainActor () -> [AutomationWindowDescriptor]
     private var windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome
     private var workspaceInventory: @MainActor () -> AutomationWorkspaceInventory
-    /// The gesture-verb layer — the single place `workspace.select` (and later mutation verbs) enter
+    /// The gesture-verb layer — the single place workspace mutation verbs enter
     /// the real UI path. `nil` when no window is attached, which is exactly the `unsupported`
     /// condition: a mutation verb cannot run without a live window, and never falls back.
     private var gestureVerbs: AutomationGestureVerbs?
@@ -131,7 +131,7 @@ final class AutomationController: AutomationControlling {
         for handle: String,
         workspaceID: String
     ) async throws -> AutomationWorkspaceSelectResult {
-        // Operator scope, the first operator *mutation*: gated on workspace.select (distinct from the
+        // Operator scope mutation: gated on workspace.select (distinct from the
         // read-only workspace.read), and — like the other operator routes — resolved without the
         // tile-liveness check. A tile handle lacks workspace.select and fails capability_denied.
         let entry = try resolveOperator(handle, requiring: .workspaceSelect)
@@ -172,6 +172,74 @@ final class AutomationController: AutomationControlling {
         case .notFound:
             throw AutomationServiceError(
                 .invalidRequest, "No workspace with id \(workspaceID) is tracked by the app.")
+        }
+    }
+
+    func automationCreateWorkspace(
+        for handle: String,
+        request: AutomationWorkspaceCreateRequest
+    ) async throws -> AutomationWorkspaceCreateResult {
+        let entry = try resolveOperator(handle, requiring: .workspaceCreate)
+        let repoIDText = request.repoID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let repoID = UUID(uuidString: repoIDText) else {
+            throw AutomationServiceError(.invalidRequest, "repoID must be a UUID.")
+        }
+        let name = request.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Workspace name must be non-empty.")
+        }
+        let providerID =
+            request.providerID?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? LocalWorkspaceProvider.identifier
+        guard !providerID.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "providerID must be non-empty when provided.")
+        }
+
+        guard let gestureVerbs else {
+            throw AutomationServiceError(
+                .unsupported,
+                "No WorkSpaces window is attached; workspace.create requires a live window."
+            )
+        }
+
+        let command = AutomationWorkspaceCreateCommand(
+            repoID: repoID,
+            name: name,
+            providerID: providerID,
+            guestOS: request.guestOS
+        )
+        let capabilities = entry.capabilities
+        switch await gestureVerbs.createWorkspace(command) {
+        case .completed(let effect):
+            return AutomationWorkspaceCreateResult(
+                repoID: repoIDText,
+                workspaceID: effect.workspaceID,
+                workspaceName: effect.workspaceName,
+                workspacePath: effect.workspacePath,
+                outcome: .completed,
+                changed: true,
+                selectedWorkspaceID: effect.selectedWorkspaceID,
+                attachedTerminal: effect.attachedTerminal,
+                attachedSurfaceID: effect.attachedSurfaceID?.uuidString,
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        case .confirmationRequired(let confirmation):
+            return AutomationWorkspaceCreateResult(
+                repoID: repoIDText,
+                workspaceName: name,
+                outcome: .confirmationRequired,
+                changed: false,
+                confirmation: confirmation,
+                message: confirmation.message,
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        case .unsupported(let message):
+            throw AutomationServiceError(.unsupported, message)
+        case .notFound:
+            throw AutomationServiceError(
+                .invalidRequest, "No repo with id \(repoIDText) is tracked by the app.")
+        case .invalidRequest(let message):
+            throw AutomationServiceError(.invalidRequest, message)
         }
     }
 

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceCreateGestureBridge.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceCreateGestureBridge.swift
@@ -1,0 +1,27 @@
+import Foundation
+import WorkspaceManagerCore
+
+/// Main-actor handoff between ContentView's automation controller wiring and SidebarView's real
+/// workspace-create helper. The bridge holds only a UI gesture closure and clears it on teardown,
+/// so `workspace.create` fails closed when the sidebar/window is gone.
+@MainActor
+final class AutomationWorkspaceCreateGestureBridge: ObservableObject {
+    typealias Handler = @MainActor (AutomationWorkspaceCreateCommand) async -> AutomationWorkspaceCreateOutcome
+
+    private var handler: Handler?
+
+    func install(_ handler: @escaping Handler) {
+        self.handler = handler
+    }
+
+    func clear() {
+        handler = nil
+    }
+
+    func createWorkspace(_ command: AutomationWorkspaceCreateCommand) async -> AutomationWorkspaceCreateOutcome {
+        guard let handler else {
+            return .unsupported("No WorkSpaces sidebar is attached; workspace.create requires a live window.")
+        }
+        return await handler(command)
+    }
+}

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceEnumerator.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceEnumerator.swift
@@ -4,7 +4,7 @@
 //
 //  Projects the app's live SwiftData repos and workspaces into the read-only descriptors the
 //  operator-scope `GET /v1/workspaces` route returns. Keyed by the stable SwiftData model ids so
-//  later `[A2]` orchestration verbs can target the same repo/workspace an operator listed here.
+//  mutation verbs can target the same repo/workspace an operator listed here.
 //
 
 import Foundation

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -72,6 +72,7 @@ struct ContentView: View {
     @State private var accessRecorder = MainWindowAccessRecorder()
     @State private var presentedSessionSwitcherSnapshot: SessionSwitcherSnapshot?
     @StateObject private var rightPaneStateStore = RightPaneStateStore()
+    @StateObject private var automationWorkspaceCreateBridge = AutomationWorkspaceCreateGestureBridge()
     /// Seam store for the web main-content pane: a one-tile `SurfaceStore` domain. Source switches
     /// rebind `webDetailTileID` to a new `WebSurface` (identity-guarded); per-source `WebSurfaceStore`s
     /// inside keep each source's page alive through the deferred-release window.
@@ -619,7 +620,8 @@ struct ContentView: View {
                 },
                 workspaceProviderSetupCoordinator: workspaceProviderSetupCoordinator,
                 hostLumeSmokeAutomation: hostLumeSmokeAutomation,
-                desktopUISmokeAutomation: desktopUISmokeAutomation
+                desktopUISmokeAutomation: desktopUISmokeAutomation,
+                automationWorkspaceCreateBridge: automationWorkspaceCreateBridge
             )
             .navigationSplitViewColumnWidth(min: 200, ideal: 260, max: 350)
         } detail: {
@@ -2096,6 +2098,36 @@ struct ContentView: View {
                     selectedWorkspaceID: selectedID,
                     attachedSurfaceID: attached ? activeSessionID : nil,
                     attachedTerminal: attached
+                )
+            },
+            resolveRepo: { repoID in
+                guard let repo = repos.first(where: { $0.id == repoID }) else {
+                    return nil
+                }
+                return AutomationGestureVerbs.RepoTarget(
+                    repoID: repo.id,
+                    name: repo.name,
+                    path: repo.localPath
+                )
+            },
+            performCreation: { _, command in
+                let outcome = await automationWorkspaceCreateBridge.createWorkspace(command)
+                guard case .completed(let effect) = outcome else {
+                    return outcome
+                }
+                let selectedID = currentSelectedWorkspace?.id
+                let activeSessionID = tileTreeStore.activeSessionID
+                let attached = selectedID == effect.workspaceID && activeSessionID != nil
+                return .completed(
+                    AutomationWorkspaceCreateEffect(
+                        repoID: effect.repoID,
+                        workspaceID: effect.workspaceID,
+                        workspaceName: effect.workspaceName,
+                        workspacePath: effect.workspacePath,
+                        selectedWorkspaceID: selectedID,
+                        attachedSurfaceID: attached ? activeSessionID : nil,
+                        attachedTerminal: attached
+                    )
                 )
             }
         )

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -24,6 +24,13 @@ struct WorkspaceCreationStatus {
     let message: String
 }
 
+private enum SidebarWorkspaceCreationResult {
+    case created(Workspace)
+    case confirmationRequired(AutomationConfirmationRequirement)
+    case invalidRequest(String)
+    case failed(String)
+}
+
 private struct NewWorkspaceSheetContext: Identifiable {
     let repo: Repo
 
@@ -61,6 +68,7 @@ struct SidebarView: View {
     let workspaceProviderSetupCoordinator: WorkspaceProviderSetupCoordinator
     let hostLumeSmokeAutomation: HostLumeSmokeAutomationController
     let desktopUISmokeAutomation: DesktopUISmokeAutomationController
+    let automationWorkspaceCreateBridge: AutomationWorkspaceCreateGestureBridge
 
     @AppStorage(SidebarRepoSortMode.storageKey)
     private var repoSortModeRawValue: String = SidebarRepoSortMode.alphabetical.rawValue
@@ -237,6 +245,10 @@ struct SidebarView: View {
         }
         .onDisappear {
             clearAppCommands()
+            automationWorkspaceCreateBridge.clear()
+        }
+        .onAppear {
+            installAutomationWorkspaceCreateGesture()
         }
         .onChange(of: selectedWorkspace?.id) { _, _ in
             expandRepoForSelectedWorkspace()
@@ -253,11 +265,13 @@ struct SidebarView: View {
             Task { @MainActor in
                 await maybeDriveDesktopUISmokeAutomation()
             }
+            installAutomationWorkspaceCreateGesture()
         }
         .onChange(of: repoSortModeRawValue) { _, _ in
             syncRepoSortSnapshot(forceRefresh: true)
         }
         .onAppear {
+            installAutomationWorkspaceCreateGesture()
             initializeExpandedReposIfNeeded()
             expandContainersForSelectedWebSource()
             syncRepoSortSnapshot(forceRefresh: false)
@@ -809,25 +823,116 @@ struct SidebarView: View {
     }
 
     @MainActor
+    private func installAutomationWorkspaceCreateGesture() {
+        automationWorkspaceCreateBridge.install { command in
+            await performAutomationWorkspaceCreate(command)
+        }
+    }
+
+    @MainActor
+    private func performAutomationWorkspaceCreate(
+        _ command: AutomationWorkspaceCreateCommand
+    ) async -> AutomationWorkspaceCreateOutcome {
+        guard newWorkspaceSheetContext == nil else {
+            return .confirmationRequired(
+                AutomationConfirmationRequirement(
+                    action: "workspace.create",
+                    title: "New Workspace",
+                    message:
+                        "A New Workspace sheet is already open; confirm or dismiss it before creating another workspace."
+                )
+            )
+        }
+        if let confirmation = workspaceProviderSetupCoordinator.confirmationRequest {
+            return .confirmationRequired(automationConfirmation(from: confirmation))
+        }
+        if let progress = workspaceProviderSetupCoordinator.progressPresentation {
+            return .confirmationRequired(
+                AutomationConfirmationRequirement(
+                    action: "workspace.create",
+                    title: progress.title,
+                    message:
+                        "\(progress.providerDisplayName) setup is already in progress for \(progress.action.summary).",
+                    providerID: progress.providerID,
+                    providerDisplayName: progress.providerDisplayName
+                )
+            )
+        }
+
+        guard let repo = repos.first(where: { $0.id == command.repoID }) else {
+            return .notFound
+        }
+
+        let result = await createWorkspace(
+            from: repo,
+            name: command.name,
+            nameSource: .manual,
+            providerID: command.providerID,
+            guestOS: command.guestOS
+        )
+
+        switch result {
+        case .created(let workspace):
+            await desktopUISmokeAutomation.noteWorkspaceCreated(workspace)
+            await emitDesktopUISmokeSidebarUpdate(for: workspace)
+            return .completed(
+                AutomationWorkspaceCreateEffect(
+                    repoID: repo.id,
+                    workspaceID: workspace.id,
+                    workspaceName: workspace.name,
+                    workspacePath: workspace.path,
+                    selectedWorkspaceID: workspace.id,
+                    attachedSurfaceID: nil,
+                    attachedTerminal: false
+                )
+            )
+        case .confirmationRequired(let confirmation):
+            workspaceProviderSetupCoordinator.cancelPendingAction()
+            return .confirmationRequired(confirmation)
+        case .invalidRequest(let message):
+            return .invalidRequest(message)
+        case .failed(let message):
+            return .unsupported(message)
+        }
+    }
+
+    private func automationConfirmation(
+        from request: WorkspaceProviderSetupConfirmationRequest
+    ) -> AutomationConfirmationRequirement {
+        let message = "\(request.action.summary) requires \(request.providerDisplayName) setup confirmation."
+        return AutomationConfirmationRequirement(
+            action: "workspace.create",
+            title: request.title,
+            message: message,
+            providerID: request.providerID,
+            providerDisplayName: request.providerDisplayName,
+            primaryButtonTitle: request.primaryButtonTitle
+        )
+    }
+
+    @MainActor
+    @discardableResult
     private func createWorkspace(
         from repo: Repo,
         name: String,
         nameSource: WorkspaceNameSource,
         providerID: String,
         guestOS: WorkspaceGuestOS? = nil
-    ) async {
+    ) async -> SidebarWorkspaceCreationResult {
         guard let provider = workspaceProviderRegistry.provider(for: providerID) else {
-            presentSidebarError("Workspace provider '\(providerID)' is not registered.")
-            return
+            let message = "Workspace provider '\(providerID)' is not registered."
+            presentSidebarError(message)
+            return .invalidRequest(message)
         }
 
         do {
-            try await workspaceProviderSetupActionRunner.run(
+            var createdWorkspace: Workspace?
+            let intercepted = try await workspaceProviderSetupActionRunner.run(
                 provider: provider,
                 action: .createWorkspace(name: name, guestOS: guestOS)
             ) {
                 await refreshWorkspaceEnvironmentState(trigger: "workspace_create_after_setup")
-                await createWorkspaceAfterSetup(
+                createdWorkspace = await createWorkspaceAfterSetup(
                     from: repo,
                     name: name,
                     nameSource: nameSource,
@@ -835,7 +940,7 @@ struct SidebarView: View {
                     guestOS: guestOS
                 )
             } perform: {
-                await createWorkspaceAfterSetup(
+                createdWorkspace = await createWorkspaceAfterSetup(
                     from: repo,
                     name: name,
                     nameSource: nameSource,
@@ -843,21 +948,44 @@ struct SidebarView: View {
                     guestOS: guestOS
                 )
             }
+            if intercepted {
+                if let confirmation = workspaceProviderSetupCoordinator.confirmationRequest {
+                    return .confirmationRequired(automationConfirmation(from: confirmation))
+                }
+                let message = "Workspace provider setup is already in progress."
+                return .confirmationRequired(
+                    AutomationConfirmationRequirement(
+                        action: "workspace.create",
+                        title: "Workspace Provider Setup",
+                        message: message,
+                        providerID: providerID,
+                        providerDisplayName: provider.descriptor.displayName
+                    )
+                )
+            }
+            guard let createdWorkspace else {
+                let message = "Workspace creation did not produce a workspace."
+                return .failed(message)
+            }
+            return .created(createdWorkspace)
         } catch {
-            presentSidebarError(error.localizedDescription)
+            let message = error.localizedDescription
+            presentSidebarError(message)
+            return .failed(message)
         }
     }
 
     @MainActor
+    @discardableResult
     private func createWorkspaceAfterSetup(
         from repo: Repo,
         name: String,
         nameSource: WorkspaceNameSource,
         providerID: String,
         guestOS: WorkspaceGuestOS? = nil
-    ) async {
+    ) async -> Workspace? {
         let repoID = repo.id
-        guard !isCreatingWorkspace(for: repoID) else { return }
+        guard !isCreatingWorkspace(for: repoID) else { return nil }
         expansionController.expandRepo(repoID)
         workspaceCreationStatusByRepoID[repoID] = WorkspaceCreationStatus(
             message: initialCreationMessage(for: providerID)
@@ -908,6 +1036,7 @@ struct SidebarView: View {
             await hostLumeSmokeAutomation.noteWorkspaceActive(
                 HostLumeSmokeWorkspaceRecord(workspace: workspace)
             )
+            return workspace
         } catch {
             creationLog.error(
                 "createWorkspaceAfterSetup: failed: \(error.localizedDescription)"
@@ -915,6 +1044,7 @@ struct SidebarView: View {
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             let providerName = providerDisplayName(for: providerID)
             presentSidebarError("Failed to create \(providerName) workspace: \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -1263,6 +1393,16 @@ struct SidebarView: View {
 
         await desktopUISmokeAutomation.noteRepoReady(repo)
         guard desktopUISmokeAutomation.shouldStartScenario() else { return }
+        if desktopUISmokeAutomation.usesAPICreateDriver {
+            let focusBaselineBeforeRepoPark = desktopUISmokeAutomation.surfaceFocusCount
+            onRepoTerminalSelected(repo)
+            _ = await desktopUISmokeAutomation.waitForSurfaceFocus(
+                after: focusBaselineBeforeRepoPark,
+                timeout: .seconds(15)
+            )
+            await desktopUISmokeAutomation.noteAwaitingAPICreate(repo: repo)
+            return
+        }
         await runDesktopUISmokeScenario(repo: repo)
     }
 

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -979,8 +979,12 @@ private final class CLIApp {
             return try runWorkspaceList(arguments: arguments)
         case "select":
             return try runWorkspaceSelect(arguments: Array(arguments.dropFirst()))
+        case "create":
+            return try runWorkspaceCreate(arguments: Array(arguments.dropFirst()))
         default:
-            throw CLIError("Usage: workspaces workspace list [--json] | workspace select <id> [--json]")
+            throw CLIError(
+                "Usage: workspaces workspace list [--json] | workspace select <id> [--json] | workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json]"
+            )
         }
     }
 
@@ -1039,7 +1043,90 @@ private final class CLIApp {
         return 0
     }
 
-    /// `workspaces workspace select <id> [--json]` — the first operator mutation verb. Drives the
+    /// `workspaces workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json]`
+    /// drives the running app's real sidebar create helper via the operator socket. A completed
+    /// response means the app created the workspace, selected it, and attached its terminal; setup
+    /// sheets return `confirmation_required` with the confirmation payload instead of blocking.
+    private func runWorkspaceCreate(arguments: [String]) throws -> Int32 {
+        let usage =
+            "workspaces workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json]"
+        var json = false
+        var repoID: String?
+        var name: String?
+        var providerID: String?
+        var guestOS: WorkspaceGuestOS?
+
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--json":
+                json = true
+                index += 1
+            case "--provider":
+                guard index + 1 < arguments.count else { throw CLIError("Usage: \(usage)") }
+                providerID = arguments[index + 1]
+                index += 2
+            case "--guest-os":
+                guard index + 1 < arguments.count else { throw CLIError("Usage: \(usage)") }
+                guard let parsed = WorkspaceGuestOS(rawValue: arguments[index + 1]) else {
+                    throw CLIError("Unsupported guest OS '\(arguments[index + 1])'. Use linux or macos.")
+                }
+                guestOS = parsed
+                index += 2
+            default:
+                if repoID == nil {
+                    repoID = argument
+                } else if name == nil {
+                    name = argument
+                } else {
+                    throw CLIError("Usage: \(usage)")
+                }
+                index += 1
+            }
+        }
+
+        guard let repoID, !repoID.isEmpty, let name, !name.isEmpty else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        let credential = try loadOperatorCredential()
+        let request = AutomationWorkspaceCreateRequest(
+            repoID: repoID,
+            name: name,
+            providerID: providerID,
+            guestOS: guestOS
+        )
+        let body = try JSONEncoder().encode(request)
+        let result = try operatorRequest(
+            AutomationWorkspaceCreateResult.self,
+            credential: credential,
+            method: "POST",
+            path: "/v1/workspace/create",
+            body: body
+        )
+
+        if json {
+            print(try AutomationCLIResultPrinter.resultJSON(result))
+            return 0
+        }
+
+        switch result.outcome {
+        case .completed:
+            let id = result.workspaceID?.uuidString ?? "-"
+            if result.attachedTerminal {
+                let surface = result.attachedSurfaceID ?? "-"
+                print("Created \(result.workspaceName) (\(id)) — terminal attached (surface \(surface)).")
+            } else {
+                print("Created \(result.workspaceName) (\(id)) — no terminal attached.")
+            }
+        case .confirmationRequired:
+            print("Confirmation required: \(result.message ?? "the app needs confirmation to proceed.")")
+        }
+        return 0
+    }
+
+    /// `workspaces workspace select <id> [--json]` — an operator mutation verb. Drives the
     /// running app's real selection gesture (the same path a sidebar click takes) via the socket, so
     /// the app highlights the workspace, attaches its terminal, and requests focus. `<id>` is a stable
     /// workspace id from `workspace list`. Operator scope: reads the per-launch credential, so it works
@@ -1659,6 +1746,8 @@ private func printHelp() {
           workspaces window list [--json]
           workspaces window snapshot --out <path> [--window <id>]
           workspaces workspace list [--json]
+          workspaces workspace select <workspace-id> [--json]
+          workspaces workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json]
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -21,11 +21,11 @@ public enum AutomationAPI {
 
     /// Capabilities granted to an opt-in operator handle. Capture and read (`window.read`,
     /// `window.snapshot` — composited PNGs; `workspace.read` — the repo/workspace inventory)
-    /// plus the first operator *mutation* capability, `workspace.select`: a reviewed
-    /// exception that drives the real selection gesture, never a data-layer write. Operator handles
-    /// still never carry tile mutation or `input.write`.
+    /// plus operator mutation capabilities that drive real UI gestures, never data-layer writes.
+    /// Operator handles still never carry tile mutation or `input.write`.
     public static let operatorCapabilities = [
         AutomationCapability.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect,
+        .workspaceCreate,
     ]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
@@ -60,6 +60,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case windowSnapshot = "window.snapshot"
     case workspaceRead = "workspace.read"
     case workspaceSelect = "workspace.select"
+    case workspaceCreate = "workspace.create"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -446,8 +447,8 @@ public struct AutomationWorkspaceInventory: Sendable, Equatable {
 }
 
 /// Response for `GET /v1/workspaces` (`workspace.read`, operator scope): the app's repos and
-/// workspaces with stable model ids, names, and enough state to target. Read-only — no mutation
-/// rides this route; orchestration verbs arrive in later `[A2]` slices.
+/// workspaces with stable model ids, names, and enough state to target. Read-only — mutation verbs
+/// use these stable ids when they enter the real UI path.
 public struct AutomationWorkspacesResult: Codable, Sendable, Equatable {
     public let repos: [AutomationRepoDescriptor]
     public let workspaces: [AutomationWorkspaceDescriptor]
@@ -476,6 +477,34 @@ public struct AutomationWorkspacesResult: Codable, Sendable, Equatable {
 public enum AutomationGestureOutcomeKind: String, Codable, Sendable, Equatable {
     case completed
     case confirmationRequired = "confirmation_required"
+}
+
+/// Structured payload for a gesture that reached UI requiring explicit user confirmation. The
+/// payload names the action and the visible confirmation surface so automation callers can report
+/// or retry intentionally instead of hanging on a modal.
+public struct AutomationConfirmationRequirement: Codable, Sendable, Equatable {
+    public let action: String
+    public let title: String
+    public let message: String
+    public let providerID: String?
+    public let providerDisplayName: String?
+    public let primaryButtonTitle: String?
+
+    public init(
+        action: String,
+        title: String,
+        message: String,
+        providerID: String? = nil,
+        providerDisplayName: String? = nil,
+        primaryButtonTitle: String? = nil
+    ) {
+        self.action = action
+        self.title = title
+        self.message = message
+        self.providerID = providerID
+        self.providerDisplayName = providerDisplayName
+        self.primaryButtonTitle = primaryButtonTitle
+    }
 }
 
 /// What driving the real selection gesture produced. `attachedTerminal` is the observable proof the
@@ -532,6 +561,124 @@ public struct AutomationWorkspaceSelectResult: Codable, Sendable, Equatable {
         self.selectedWorkspaceID = selectedWorkspaceID
         self.attachedTerminal = attachedTerminal
         self.attachedSurfaceID = attachedSurfaceID
+        self.message = message
+        self.system = system
+    }
+}
+
+public struct AutomationWorkspaceCreateRequest: Codable, Sendable, Equatable {
+    public let repoID: String
+    public let name: String
+    public let providerID: String?
+    public let guestOS: WorkspaceGuestOS?
+
+    public init(
+        repoID: String,
+        name: String,
+        providerID: String? = nil,
+        guestOS: WorkspaceGuestOS? = nil
+    ) {
+        self.repoID = repoID
+        self.name = name
+        self.providerID = providerID
+        self.guestOS = guestOS
+    }
+}
+
+public struct AutomationWorkspaceCreateCommand: Sendable, Equatable {
+    public let repoID: UUID
+    public let name: String
+    public let providerID: String
+    public let guestOS: WorkspaceGuestOS?
+
+    public init(
+        repoID: UUID,
+        name: String,
+        providerID: String,
+        guestOS: WorkspaceGuestOS? = nil
+    ) {
+        self.repoID = repoID
+        self.name = name
+        self.providerID = providerID
+        self.guestOS = guestOS
+    }
+}
+
+/// What driving the real workspace-create gesture produced. A completed create must report the
+/// created workspace, the selected workspace, and the attached terminal surface so callers can prove
+/// the next input will land in the newly created PTY.
+public struct AutomationWorkspaceCreateEffect: Sendable, Equatable {
+    public let repoID: UUID
+    public let workspaceID: UUID
+    public let workspaceName: String
+    public let workspacePath: String
+    public let selectedWorkspaceID: UUID?
+    public let attachedSurfaceID: UUID?
+    public let attachedTerminal: Bool
+
+    public init(
+        repoID: UUID,
+        workspaceID: UUID,
+        workspaceName: String,
+        workspacePath: String,
+        selectedWorkspaceID: UUID?,
+        attachedSurfaceID: UUID?,
+        attachedTerminal: Bool
+    ) {
+        self.repoID = repoID
+        self.workspaceID = workspaceID
+        self.workspaceName = workspaceName
+        self.workspacePath = workspacePath
+        self.selectedWorkspaceID = selectedWorkspaceID
+        self.attachedSurfaceID = attachedSurfaceID
+        self.attachedTerminal = attachedTerminal
+    }
+}
+
+/// Response for `POST /v1/workspace/create` (`workspace.create`, operator scope). On completion the
+/// result mirrors the sidebar create path: the new workspace is selected and its terminal is attached.
+/// If the path reaches a setup sheet or other modal UI, the success envelope reports
+/// `confirmation_required` with a structured payload naming what needs user confirmation.
+public struct AutomationWorkspaceCreateResult: Codable, Sendable, Equatable {
+    public let repoID: String
+    public let workspaceID: UUID?
+    public let workspaceName: String
+    public let workspacePath: String?
+    public let outcome: AutomationGestureOutcomeKind
+    public let changed: Bool
+    public let selectedWorkspaceID: UUID?
+    public let attachedTerminal: Bool
+    public let attachedSurfaceID: String?
+    public let confirmation: AutomationConfirmationRequirement?
+    public let message: String?
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        repoID: String,
+        workspaceID: UUID? = nil,
+        workspaceName: String,
+        workspacePath: String? = nil,
+        outcome: AutomationGestureOutcomeKind,
+        changed: Bool,
+        selectedWorkspaceID: UUID? = nil,
+        attachedTerminal: Bool = false,
+        attachedSurfaceID: String? = nil,
+        confirmation: AutomationConfirmationRequirement? = nil,
+        message: String? = nil,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.repoID = repoID
+        self.workspaceID = workspaceID
+        self.workspaceName = workspaceName
+        self.workspacePath = workspacePath
+        self.outcome = outcome
+        self.changed = changed
+        self.selectedWorkspaceID = selectedWorkspaceID
+        self.attachedTerminal = attachedTerminal
+        self.attachedSurfaceID = attachedSurfaceID
+        self.confirmation = confirmation
         self.message = message
         self.system = system
     }
@@ -712,6 +859,10 @@ public protocol AutomationControlling: AnyObject, Sendable {
         for handle: String,
         workspaceID: String
     ) async throws -> AutomationWorkspaceSelectResult
+    func automationCreateWorkspace(
+        for handle: String,
+        request: AutomationWorkspaceCreateRequest
+    ) async throws -> AutomationWorkspaceCreateResult
     func automationWindowSnapshot(
         for handle: String,
         windowID: String

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
@@ -33,6 +33,20 @@ public enum AutomationWorkspaceSelectOutcome: Sendable, Equatable {
     case notFound
 }
 
+public enum AutomationWorkspaceCreateOutcome: Sendable, Equatable {
+    /// The create gesture ran through the real UI path and produced a selected, attached workspace.
+    case completed(AutomationWorkspaceCreateEffect)
+    /// The gesture reached a modal or setup confirmation. The caller gets the confirmation details
+    /// as data instead of waiting on UI it cannot answer.
+    case confirmationRequired(AutomationConfirmationRequirement)
+    /// The verb cannot run in the current context, most often because no live window/sidebar is bound.
+    case unsupported(String)
+    /// The repo id resolves to nothing the app tracks. Mapped to `invalid_request` at the wire.
+    case notFound
+    /// The request named something the UI path cannot create, such as an unknown provider.
+    case invalidRequest(String)
+}
+
 @MainActor
 public final class AutomationGestureVerbs {
     /// The minimum a verb needs to target and describe a workspace, projected out of the live
@@ -51,21 +65,46 @@ public final class AutomationGestureVerbs {
         }
     }
 
+    /// The minimum the create verb needs to target a repo after `workspace.read` projects it.
+    /// The app resolves this from live SwiftData models before the gesture runs.
+    public struct RepoTarget: Sendable, Equatable {
+        public let repoID: UUID
+        public let name: String
+        public let path: String
+
+        public init(repoID: UUID, name: String, path: String) {
+            self.repoID = repoID
+            self.name = name
+            self.path = path
+        }
+    }
+
     /// Resolve a stable workspace id (a `workspace.read` id) to a target, or `nil` if the app tracks
     /// no such workspace. Read-only — it never mutates selection.
     private let resolveWorkspace: @MainActor (UUID) -> WorkspaceTarget?
+    /// Resolve a stable repo id (a `workspace.read` repo id) to a target. Read-only.
+    private let resolveRepo: (@MainActor (UUID) -> RepoTarget?)?
 
     /// Drive the real selection gesture for `target` — write the selection binding whose setter
     /// attaches the terminal and requests focus — and report back what the UI did. This closure is
     /// the app's actual click path; the layer holds nothing else.
     private let performSelection: @MainActor (WorkspaceTarget) -> AutomationWorkspaceSelectEffect
+    /// Drive the real sidebar create gesture for `command` and report what the UI did.
+    private let performCreation:
+        (@MainActor (RepoTarget, AutomationWorkspaceCreateCommand) async -> AutomationWorkspaceCreateOutcome)?
 
     public init(
         resolveWorkspace: @escaping @MainActor (UUID) -> WorkspaceTarget?,
-        performSelection: @escaping @MainActor (WorkspaceTarget) -> AutomationWorkspaceSelectEffect
+        performSelection: @escaping @MainActor (WorkspaceTarget) -> AutomationWorkspaceSelectEffect,
+        resolveRepo: (@MainActor (UUID) -> RepoTarget?)? = nil,
+        performCreation: (
+            @MainActor (RepoTarget, AutomationWorkspaceCreateCommand) async -> AutomationWorkspaceCreateOutcome
+        )? = nil
     ) {
         self.resolveWorkspace = resolveWorkspace
         self.performSelection = performSelection
+        self.resolveRepo = resolveRepo
+        self.performCreation = performCreation
     }
 
     /// `workspace.select`: enter the same selection path a sidebar click takes. Resolves the id, then
@@ -78,5 +117,20 @@ public final class AutomationGestureVerbs {
         }
         let effect = performSelection(target)
         return .completed(effect)
+    }
+
+    /// `workspace.create`: enter the same sidebar helper the New Workspace sheet and smoke driver
+    /// use. Resolves the repo id, then drives only the supplied gesture closure. A missing create
+    /// closure means the live window did not install a create path, so the verb fails closed.
+    public func createWorkspace(
+        _ command: AutomationWorkspaceCreateCommand
+    ) async -> AutomationWorkspaceCreateOutcome {
+        guard let resolveRepo, let performCreation else {
+            return .unsupported("No WorkSpaces sidebar is attached; workspace.create requires a live window.")
+        }
+        guard let target = resolveRepo(command.repoID) else {
+            return .notFound
+        }
+        return await performCreation(target, command)
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -88,6 +88,10 @@ enum AutomationHTTPRouter {
             let workspaceID = try decodeWorkspaceID(from: request.body)
             return try await controller.automationSelectWorkspace(for: handle, workspaceID: workspaceID)
 
+        case ("POST", "/v1/workspace/create"):
+            let create = try decodeWorkspaceCreate(from: request.body)
+            return try await controller.automationCreateWorkspace(for: handle, request: create)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -130,6 +134,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/window/snapshot.")
         case (_, "/v1/workspace/select"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/select.")
+        case (_, "/v1/workspace/create"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/create.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -251,6 +257,31 @@ enum AutomationHTTPRouter {
         return workspaceID
     }
 
+    private static func decodeWorkspaceCreate(from body: Data) throws -> AutomationWorkspaceCreateRequest {
+        try rejectCallerSuppliedTargetIDs(in: body, allowEmptyBody: false)
+        let request: AutomationWorkspaceCreateRequest
+        do {
+            request = try AutomationJSON.decoder.decode(AutomationWorkspaceCreateRequest.self, from: body)
+        } catch {
+            throw AutomationServiceError(
+                .invalidRequest,
+                "Request body must be JSON with string 'repoID', string 'name', optional string 'providerID', and optional 'guestOS'."
+            )
+        }
+        guard !request.repoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request 'repoID' must be a non-empty string.")
+        }
+        guard !request.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request 'name' must be a non-empty string.")
+        }
+        if let providerID = request.providerID,
+            providerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            throw AutomationServiceError(.invalidRequest, "Request 'providerID' must be non-empty when provided.")
+        }
+        return request
+    }
+
     private static func decodeInputWrite(from body: Data) throws -> AutomationInputWriteRequest {
         try rejectCallerSuppliedTargetIDs(in: body, allowEmptyBody: false)
         let request: AutomationInputWriteRequest
@@ -368,6 +399,7 @@ extension AutomationSurfacesResult: CodableSendableEquatable {}
 extension AutomationWindowsResult: CodableSendableEquatable {}
 extension AutomationWorkspacesResult: CodableSendableEquatable {}
 extension AutomationWorkspaceSelectResult: CodableSendableEquatable {}
+extension AutomationWorkspaceCreateResult: CodableSendableEquatable {}
 extension AutomationWindowSnapshotResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
@@ -73,7 +73,7 @@ public final class AutomationHandleRegistry {
     }
 
     /// Registers a per-launch operator handle carrying the operator capabilities (read/capture plus
-    /// the one reviewed mutation, workspace.select). Unlike `upsert`,
+    /// reviewed workspace mutation verbs). Unlike `upsert`,
     /// this is not keyed by a live terminal session — the entry stands alone under a synthetic host
     /// session id so `remove(hostSessionID:)`/`removeAll` still evict it when the launch ends. Each
     /// call mints a fresh handle; a launch mints exactly one.

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -509,7 +509,10 @@ struct AutomationControllerTests {
 
         let result = try controller.automationWindows(for: operatorEntry.handle)
         #expect(result.windows == [descriptor])
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+        #expect(
+            result.system.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+            ])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
 
@@ -600,7 +603,10 @@ struct AutomationControllerTests {
         #expect(result.workspaces == inventory.workspaces)
         #expect(result.workspaces.first?.isArchived == true)
         #expect(result.workspaces.first?.backend == "lume")
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+        #expect(
+            result.system.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+            ])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
 
@@ -671,7 +677,10 @@ struct AutomationControllerTests {
         #expect(result.width == 2800)
         #expect(result.height == 1800)
         #expect(Data(base64Encoded: result.data) == png)
-        #expect(result.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+        #expect(
+            result.system.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+            ])
         #expect(requestedWindowIDs == ["42"])
     }
 

--- a/Tests/WorkspaceManagerAppTests/AutomationCreateVerbTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationCreateVerbTests.swift
@@ -1,0 +1,252 @@
+//
+//  AutomationCreateVerbTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Exercises the real AutomationController.automationCreateWorkspace against a real handle registry
+//  and TileTreeStore: operator-scope capability enforcement, completed/confirmation/unsupported
+//  outcome mapping, and the wrong-PTY guard for a newly created workspace.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("AutomationController workspace.create")
+struct AutomationCreateVerbTests {
+    private func expectFailure(
+        _ code: AutomationErrorCode,
+        _ body: () async throws -> some Any
+    ) async {
+        do {
+            _ = try await body()
+            Issue.record("Expected \(code.rawValue) but the call succeeded.")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == code)
+        } catch {
+            Issue.record("Expected AutomationServiceError but got \(error).")
+        }
+    }
+
+    private func operatorController(
+        gestureVerbs: AutomationGestureVerbs?
+    ) -> (AutomationController, registry: AutomationHandleRegistry, operatorHandle: String) {
+        let registry = AutomationHandleRegistry(makeHandle: { UUID().uuidString })
+        let entry = registry.registerOperator(appScopeID: "workspaces.local")
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: TileTreeStore(),
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            gestureVerbs: gestureVerbs
+        )
+        return (controller, registry, entry.handle)
+    }
+
+    @Test("operator handle with a live create layer completes and reports the attach")
+    func operatorCompletes() async throws {
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in
+                $0 == repoID
+                    ? AutomationGestureVerbs.RepoTarget(repoID: repoID, name: "repo", path: "/tmp/repo")
+                    : nil
+            },
+            performCreation: { _, command in
+                .completed(
+                    AutomationWorkspaceCreateEffect(
+                        repoID: repoID,
+                        workspaceID: workspaceID,
+                        workspaceName: command.name,
+                        workspacePath: "/tmp/repo/\(command.name)",
+                        selectedWorkspaceID: workspaceID,
+                        attachedSurfaceID: surfaceID,
+                        attachedTerminal: true
+                    )
+                )
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        let result = try await controller.automationCreateWorkspace(
+            for: handle,
+            request: AutomationWorkspaceCreateRequest(repoID: repoID.uuidString, name: "created")
+        )
+
+        #expect(result.outcome == .completed)
+        #expect(result.changed)
+        #expect(result.workspaceID == workspaceID)
+        #expect(result.attachedTerminal)
+        #expect(result.attachedSurfaceID == surfaceID.uuidString)
+        #expect(result.selectedWorkspaceID == workspaceID)
+        #expect(result.system.capabilities.contains(.workspaceCreate))
+    }
+
+    @Test("a tile handle lacks workspace.create and is denied")
+    func tileHandleDenied() async throws {
+        let (controller, registry, _) = operatorController(gestureVerbs: nil)
+        let tile = registry.upsert(
+            hostSessionID: UUID(),
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "workspaces.local"
+        )
+
+        await expectFailure(.capabilityDenied) {
+            try await controller.automationCreateWorkspace(
+                for: tile.handle,
+                request: AutomationWorkspaceCreateRequest(repoID: UUID().uuidString, name: "created")
+            )
+        }
+    }
+
+    @Test("no live gesture layer is unsupported")
+    func noWindowUnsupported() async throws {
+        let (controller, _, handle) = operatorController(gestureVerbs: nil)
+
+        await expectFailure(.unsupported) {
+            try await controller.automationCreateWorkspace(
+                for: handle,
+                request: AutomationWorkspaceCreateRequest(repoID: UUID().uuidString, name: "created")
+            )
+        }
+    }
+
+    @Test("detaching the gesture layer makes create unsupported")
+    func detachedGestureLayerIsUnsupported() async throws {
+        var drove = false
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: {
+                AutomationGestureVerbs.RepoTarget(repoID: $0, name: "repo", path: "/tmp/repo")
+            },
+            performCreation: { _, _ in
+                drove = true
+                return .unsupported("should not run")
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        controller.detachGestureVerbs()
+
+        await expectFailure(.unsupported) {
+            try await controller.automationCreateWorkspace(
+                for: handle,
+                request: AutomationWorkspaceCreateRequest(repoID: UUID().uuidString, name: "created")
+            )
+        }
+        #expect(!drove)
+    }
+
+    @Test("confirmation requirements return a structured success outcome")
+    func confirmationRequired() async throws {
+        let repoID = UUID()
+        let confirmation = AutomationConfirmationRequirement(
+            action: "workspace.create",
+            title: "Set Up Provider",
+            message: "Create workspace requires setup confirmation.",
+            providerID: "provider",
+            providerDisplayName: "Provider",
+            primaryButtonTitle: "Set Up"
+        )
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in
+                $0 == repoID
+                    ? AutomationGestureVerbs.RepoTarget(repoID: repoID, name: "repo", path: "/tmp/repo")
+                    : nil
+            },
+            performCreation: { _, _ in .confirmationRequired(confirmation) }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        let result = try await controller.automationCreateWorkspace(
+            for: handle,
+            request: AutomationWorkspaceCreateRequest(repoID: repoID.uuidString, name: "created")
+        )
+
+        #expect(result.outcome == .confirmationRequired)
+        #expect(!result.changed)
+        #expect(result.confirmation == confirmation)
+        #expect(result.message == confirmation.message)
+    }
+
+    @Test("input after create targets the newly created workspace surface")
+    func createThenInputTargetsCreatedWorkspacePTY() async throws {
+        let store = TileTreeStore()
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let staleSession = store.activateSession(
+            key: .repoPath("/tmp/repo"),
+            directory: URL(fileURLWithPath: "/tmp/repo")
+        ).session
+        let workspacePath = "/tmp/repo/workspaces/created"
+
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in
+                $0 == repoID
+                    ? AutomationGestureVerbs.RepoTarget(repoID: repoID, name: "repo", path: "/tmp/repo")
+                    : nil
+            },
+            performCreation: { _, command in
+                let session = store.activateSession(
+                    key: .hostPath(workspacePath),
+                    directory: URL(fileURLWithPath: workspacePath)
+                ).session
+                return .completed(
+                    AutomationWorkspaceCreateEffect(
+                        repoID: repoID,
+                        workspaceID: workspaceID,
+                        workspaceName: command.name,
+                        workspacePath: workspacePath,
+                        selectedWorkspaceID: workspaceID,
+                        attachedSurfaceID: session.id,
+                        attachedTerminal: true
+                    )
+                )
+            }
+        )
+        let registry = AutomationHandleRegistry(makeHandle: { UUID().uuidString })
+        let entry = registry.registerOperator(appScopeID: "workspaces.local")
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            gestureVerbs: verbs
+        )
+
+        let result = try await controller.automationCreateWorkspace(
+            for: entry.handle,
+            request: AutomationWorkspaceCreateRequest(repoID: repoID.uuidString, name: "created")
+        )
+        let activeSessionID = try #require(store.activeSessionID)
+
+        #expect(result.attachedSurfaceID == activeSessionID.uuidString)
+        #expect(activeSessionID != staleSession.id)
+        #expect(store.sessions.first(where: { $0.id == activeSessionID })?.directoryPath == workspacePath)
+    }
+}

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -116,6 +116,7 @@ private final class FakeAutomationController: AutomationControlling {
     }
 
     var selectCalls: [String] = []
+    var createCalls: [AutomationWorkspaceCreateRequest] = []
 
     /// Named ids the fake maps to each projected outcome, so router tests can drive the wire mapping
     /// without a live app. A well-shaped-but-unknown id and a non-UUID id both project to
@@ -123,6 +124,11 @@ private final class FakeAutomationController: AutomationControlling {
     static let selectUnknownID = "00000000-0000-0000-0000-000000000000"
     static let selectNoWindowID = "11111111-1111-1111-1111-111111111111"
     static let selectAttachedSurfaceID = "22222222-2222-2222-2222-222222222222"
+    static let createUnknownRepoID = "33333333-3333-3333-3333-333333333333"
+    static let createNoWindowRepoID = "44444444-4444-4444-4444-444444444444"
+    static let createConfirmationRepoID = "55555555-5555-5555-5555-555555555555"
+    static let createWorkspaceID = "88888888-8888-8888-8888-888888888888"
+    static let createAttachedSurfaceID = "99999999-9999-9999-9999-999999999999"
 
     func automationSelectWorkspace(
         for handle: String,
@@ -156,6 +162,59 @@ private final class FakeAutomationController: AutomationControlling {
             selectedWorkspaceID: UUID(uuidString: workspaceID),
             attachedTerminal: true,
             attachedSurfaceID: Self.selectAttachedSurfaceID
+        )
+    }
+
+    func automationCreateWorkspace(
+        for handle: String,
+        request: AutomationWorkspaceCreateRequest
+    ) async throws -> AutomationWorkspaceCreateResult {
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(
+                .capabilityDenied, "The automation handle does not include workspace.create.")
+        }
+        guard UUID(uuidString: request.repoID) != nil else {
+            throw AutomationServiceError(.invalidRequest, "repoID must be a UUID.")
+        }
+        if request.repoID == Self.createUnknownRepoID {
+            throw AutomationServiceError(
+                .invalidRequest, "No repo with id \(request.repoID) is tracked by the app.")
+        }
+        if request.repoID == Self.createNoWindowRepoID {
+            throw AutomationServiceError(
+                .unsupported, "No WorkSpaces window is attached; workspace.create requires a live window.")
+        }
+        if request.repoID == Self.createConfirmationRepoID {
+            return AutomationWorkspaceCreateResult(
+                repoID: request.repoID,
+                workspaceName: request.name,
+                outcome: .confirmationRequired,
+                changed: false,
+                confirmation: AutomationConfirmationRequirement(
+                    action: "workspace.create",
+                    title: "Set Up Lume",
+                    message: "Create workspace '\(request.name)' requires Lume setup confirmation.",
+                    providerID: "lume",
+                    providerDisplayName: "Lume",
+                    primaryButtonTitle: "Set Up Lume"
+                ),
+                message: "Create workspace '\(request.name)' requires Lume setup confirmation."
+            )
+        }
+        createCalls.append(request)
+        return AutomationWorkspaceCreateResult(
+            repoID: request.repoID,
+            workspaceID: UUID(uuidString: Self.createWorkspaceID),
+            workspaceName: request.name,
+            workspacePath: "/Users/test/workspaces/\(request.name)",
+            outcome: .completed,
+            changed: true,
+            selectedWorkspaceID: UUID(uuidString: Self.createWorkspaceID),
+            attachedTerminal: true,
+            attachedSurfaceID: Self.createAttachedSurfaceID
         )
     }
 
@@ -781,7 +840,7 @@ struct AutomationAPITests {
         #expect(deniedEnvelope.error?.code == .capabilityDenied)
     }
 
-    @Test("Registry mints an operator handle carrying read/capture plus workspace.select")
+    @Test("Registry mints an operator handle carrying read/capture plus workspace gesture verbs")
     @MainActor
     func registryRegistersOperatorHandle() {
         let registry = AutomationHandleRegistry(makeHandle: { "op-1" })
@@ -790,9 +849,10 @@ struct AutomationAPITests {
         #expect(entry.handle == "op-1")
         #expect(entry.isOperator)
         #expect(entry.tileID == nil)
-        #expect(entry.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
-        // The one operator mutation is workspace.select (a reviewed exception that drives the real
-        // gesture); an operator handle still never carries tile mutation or input.write.
+        #expect(
+            entry.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate])
+        // Operator mutation capabilities are reviewed gesture verbs; an operator handle still never
+        // carries tile mutation or input.write.
         #expect(!entry.capabilities.contains(.tileClose))
         #expect(!entry.capabilities.contains(.inputWrite))
         #expect(registry.resolve("op-1")?.isOperator == true)
@@ -826,7 +886,9 @@ struct AutomationAPITests {
         #expect(okEnvelope.result?.windows.count == 1)
         #expect(okEnvelope.result?.windows.first?.windowID == "42")
         #expect(
-            okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+            okEnvelope.result?.system.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+            ])
         #expect(controller.windowCalls == ["operator"])
 
         // A tile handle holds the v1 tile capabilities but not window.read → capability_denied.
@@ -906,7 +968,9 @@ struct AutomationAPITests {
         #expect(okEnvelope.result?.workspaces.first?.backend == "local")
         #expect(okEnvelope.result?.workspaces.first?.isSelected == true)
         #expect(
-            okEnvelope.result?.system.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+            okEnvelope.result?.system.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+            ])
         #expect(controller.workspaceCalls == ["operator"])
 
         // A tile handle holds the v1 tile capabilities but not workspace.read → capability_denied.
@@ -1109,6 +1173,113 @@ struct AutomationAPITests {
         #expect(completedJSON.contains("\"outcome\":\"completed\""))
     }
 
+    @Test("POST /v1/workspace/create projects completed and confirmation outcomes")
+    @MainActor
+    func routerWorkspaceCreate() async throws {
+        let controller = FakeAutomationController()
+        let validRepoID = "77777777-7777-7777-7777-777777777777"
+
+        func post(_ handle: String?, body: Data) async -> AutomationHTTPResult {
+            var headers: [String: String] = [:]
+            if let handle { headers[AutomationAPI.handleHeader] = handle }
+            return await AutomationHTTPRouter.route(
+                HTTPRequest(method: "POST", path: "/v1/workspace/create", headers: headers, body: body),
+                controller: controller,
+                enabled: true
+            )
+        }
+
+        func body(repoID: String, name: String = "created") throws -> Data {
+            try AutomationJSON.encoder.encode(
+                AutomationWorkspaceCreateRequest(repoID: repoID, name: name)
+            )
+        }
+
+        let ok = await post("operator", body: try body(repoID: validRepoID))
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWorkspaceCreateResult>.self, from: ok.body)
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.outcome == .completed)
+        #expect(okEnvelope.result?.changed == true)
+        #expect(okEnvelope.result?.workspaceID?.uuidString == FakeAutomationController.createWorkspaceID)
+        #expect(okEnvelope.result?.attachedTerminal == true)
+        #expect(okEnvelope.result?.attachedSurfaceID == FakeAutomationController.createAttachedSurfaceID)
+        #expect(okEnvelope.result?.system.capabilities.contains(.workspaceCreate) == true)
+        #expect(controller.createCalls == [AutomationWorkspaceCreateRequest(repoID: validRepoID, name: "created")])
+
+        let confirmation = await post(
+            "operator",
+            body: try body(repoID: FakeAutomationController.createConfirmationRepoID, name: "needs-lume")
+        )
+        let confirmationEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWorkspaceCreateResult>.self, from: confirmation.body)
+        #expect(confirmation.status == 200)
+        #expect(confirmationEnvelope.result?.outcome == .confirmationRequired)
+        #expect(confirmationEnvelope.result?.changed == false)
+        #expect(confirmationEnvelope.result?.confirmation?.action == "workspace.create")
+        #expect(confirmationEnvelope.result?.confirmation?.providerID == "lume")
+        #expect(confirmationEnvelope.result?.message?.contains("Lume setup confirmation") == true)
+
+        let denied = await post("live", body: try body(repoID: validRepoID))
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: denied.body)
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        let unknown = await post("operator", body: try body(repoID: FakeAutomationController.createUnknownRepoID))
+        #expect(unknown.status == 400)
+        let badUUID = await post("operator", body: try body(repoID: "not-a-uuid"))
+        let badUUIDEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: badUUID.body)
+        #expect(badUUID.status == 400)
+        #expect(badUUIDEnvelope.error?.code == .invalidRequest)
+
+        let noWindow = await post("operator", body: try body(repoID: FakeAutomationController.createNoWindowRepoID))
+        let noWindowEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: noWindow.body)
+        #expect(noWindow.status == 409)
+        #expect(noWindowEnvelope.error?.code == .unsupported)
+
+        let empty = await post("operator", body: Data())
+        #expect(empty.status == 400)
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET", path: "/v1/workspace/create",
+                headers: [AutomationAPI.handleHeader: "operator"], body: Data()),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: wrongMethod.body)
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("workspace-create result encodes the structured confirmation payload")
+    func workspaceCreateResultEncoding() throws {
+        let confirmation = AutomationWorkspaceCreateResult(
+            repoID: "repo",
+            workspaceName: "ws",
+            outcome: .confirmationRequired,
+            changed: false,
+            confirmation: AutomationConfirmationRequirement(
+                action: "workspace.create",
+                title: "Set Up Lume",
+                message: "Create workspace requires setup.",
+                providerID: "lume",
+                providerDisplayName: "Lume",
+                primaryButtonTitle: "Set Up"
+            ),
+            message: "Create workspace requires setup."
+        )
+        let data = try AutomationJSON.encoder.encode(AutomationResponseEnvelope(result: confirmation))
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("\"outcome\":\"confirmation_required\""))
+        #expect(json.contains("\"confirmation\""))
+        #expect(json.contains("\"action\":\"workspace.create\""))
+        #expect(json.contains("\"providerID\":\"lume\""))
+    }
+
     @Test("POST /v1/window/snapshot captures for an operator handle and fails closed otherwise")
     @MainActor
     func routerWindowSnapshot() async throws {
@@ -1221,7 +1392,8 @@ struct AutomationAPITests {
 
         let loaded = AutomationOperatorCredentialStore.load(from: url)
         #expect(loaded == credential)
-        #expect(loaded?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect])
+        #expect(
+            loaded?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate])
 
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
@@ -1252,7 +1424,7 @@ struct AutomationAPITests {
         #expect(AutomationOperatorCredentialStore.load(from: url) == mintedCredential)
         #expect(
             registry.resolve(mintedCredential.handle)?.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
             ]
         )
         #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)

--- a/Tests/WorkspaceManagerTests/AutomationGestureVerbsTests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationGestureVerbsTests.swift
@@ -18,6 +18,10 @@ struct AutomationGestureVerbsTests {
         AutomationGestureVerbs.WorkspaceTarget(workspaceID: id, name: name, isArchived: isArchived)
     }
 
+    private func repoTarget(_ id: UUID, name: String = "repo") -> AutomationGestureVerbs.RepoTarget {
+        AutomationGestureVerbs.RepoTarget(repoID: id, name: name, path: "/tmp/\(name)")
+    }
+
     @Test("select resolves and drives the gesture, returning the completed effect")
     func selectCompleted() {
         let id = UUID()
@@ -136,5 +140,104 @@ struct AutomationGestureVerbsTests {
         #expect(effectB.attachedSurfaceID == surfaceB)
         #expect(activeSurface == surfaceB)
         #expect(activeSurface != surfaceA)
+    }
+
+    @Test("create resolves the repo and drives the create gesture")
+    func createCompleted() async {
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        var performed: [AutomationWorkspaceCreateCommand] = []
+        let command = AutomationWorkspaceCreateCommand(
+            repoID: repoID,
+            name: "created",
+            providerID: "local"
+        )
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in $0 == repoID ? self.repoTarget(repoID) : nil },
+            performCreation: { _, command in
+                performed.append(command)
+                return .completed(
+                    AutomationWorkspaceCreateEffect(
+                        repoID: command.repoID,
+                        workspaceID: workspaceID,
+                        workspaceName: command.name,
+                        workspacePath: "/tmp/repo/\(command.name)",
+                        selectedWorkspaceID: workspaceID,
+                        attachedSurfaceID: surfaceID,
+                        attachedTerminal: true
+                    )
+                )
+            }
+        )
+
+        let outcome = await verbs.createWorkspace(command)
+
+        #expect(performed == [command])
+        guard case .completed(let effect) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(effect.workspaceID == workspaceID)
+        #expect(effect.workspaceName == "created")
+        #expect(effect.attachedTerminal)
+        #expect(effect.attachedSurfaceID == surfaceID)
+    }
+
+    @Test("create of an unknown repo is notFound and never drives the gesture")
+    func createNotFound() async {
+        var performCount = 0
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { _ in nil },
+            performCreation: { _, _ in
+                performCount += 1
+                return .unsupported("should not run")
+            }
+        )
+
+        let outcome = await verbs.createWorkspace(
+            AutomationWorkspaceCreateCommand(repoID: UUID(), name: "ws", providerID: "local")
+        )
+
+        #expect(outcome == .notFound)
+        #expect(performCount == 0)
+    }
+
+    @Test("create reports confirmation requirements as structured data")
+    func createConfirmationRequired() async {
+        let repoID = UUID()
+        let confirmation = AutomationConfirmationRequirement(
+            action: "workspace.create",
+            title: "Set Up Provider",
+            message: "Create workspace requires provider setup.",
+            providerID: "provider",
+            providerDisplayName: "Provider",
+            primaryButtonTitle: "Set Up"
+        )
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in $0 == repoID ? self.repoTarget(repoID) : nil },
+            performCreation: { _, _ in .confirmationRequired(confirmation) }
+        )
+
+        let outcome = await verbs.createWorkspace(
+            AutomationWorkspaceCreateCommand(repoID: repoID, name: "ws", providerID: "provider")
+        )
+
+        #expect(outcome == .confirmationRequired(confirmation))
     }
 }

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -64,11 +64,11 @@ WorkSpaces terminal tile. See
   exits, and the credential file is removed on a clean exit. A credential left
   behind by a crashed launch fails closed — its handle no longer resolves
   against the fresh registry (`stale_handle`).
-- **Capture, read, and the first mutation.** The operator capability set is
+- **Capture, read, and operator mutations.** The operator capability set is
   `window.read` (list windows), `window.snapshot` (composited PNG of a listed
-  window), and `workspace.read` (list repos and workspaces), plus — the one
-  operator *mutation* — `workspace.select`, a reviewed exception that drives
-  the real selection gesture rather than a data-layer write
+  window), and `workspace.read` (list repos and workspaces), plus
+  `workspace.select` and `workspace.create`, reviewed exceptions that drive real
+  UI gestures rather than data-layer writes
   (see [Verb contract](#verb-contract-verbs--clicks)). Operator handles still
   never carry tile mutation or `input.write`.
 
@@ -102,12 +102,13 @@ is enforced is the internal gesture-verb layer
 app's real UI entry points — and holds no backend handle, so a verb structurally
 cannot bypass the UI.
 
-`workspace.select` is the exemplar. Selecting a workspace via the API writes the
+`workspace.select` is the exemplar: selecting a workspace via the API writes the
 *same selection binding* a sidebar click writes — the binding whose setter attaches
 the terminal session and requests focus — so an API-driven select produces the
-identical user-visible reactions a click does: the sidebar highlights, the
-workspace's terminal attaches, and focus is requested. Concretely, this is why the
-rule matters:
+identical user-visible reactions a click does. `workspace.create` follows the
+same rule for creation: it enters the sidebar create helper used by the New
+Workspace sheet and desktop UI smoke driver, so the created workspace arrives
+selected with its terminal attached. Concretely, this is why the rule matters:
 
 - **A snapshot taken after a verb shows what actually happened.** A data-layer
   `workspace.select` would flip selection state without attaching the terminal, so a
@@ -128,12 +129,13 @@ hang or a fallback:
 | Outcome | Meaning | Wire |
 | --- | --- | --- |
 | `completed` | The gesture ran through the real UI path; the result reports what it did (e.g. `attachedTerminal`, `attachedSurfaceID`). | Success envelope, `outcome: "completed"`. |
-| `confirmation_required` | The gesture would surface a modal; the message is what the user would confirm. Surfaced as data so a verb never blocks on modal UI. `workspace.select` has no confirmation dialog, so it never raises this — the shared contract models it for sibling verbs. | Success envelope, `outcome: "confirmation_required"`. |
+| `confirmation_required` | The gesture would surface a modal; the payload names what the user would confirm. Surfaced as data so a verb never blocks on modal UI. `workspace.create` uses this for provider setup confirmations. | Success envelope, `outcome: "confirmation_required"`, with `confirmation`. |
 | `unsupported` | The verb cannot run in the current context — most often no live window. It fails closed rather than falling back to a data-layer write. | Error envelope, code `unsupported`. |
 
-An id that resolves to no tracked workspace fails `invalid_request` (it is not a
-gesture outcome — nothing was driven). App Intents and any companion app call the
-same verb layer, so "Siri said done" and "the sidebar updated" are the same event.
+An id that resolves to no tracked repo or workspace fails `invalid_request` (it is
+not a gesture outcome — nothing was driven). App Intents and any companion app call
+the same verb layer, so "Siri said done" and "the sidebar updated" are the same
+event.
 
 ## Envelope
 
@@ -164,8 +166,9 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/surfaces` | Returns visible terminal surfaces in the caller's window/app scope. |
 | `GET /v1/windows` | **Operator scope.** Returns the app's on-screen windows with stable identifiers (`window.read`). Keyed by the AppKit window number — the same identity `CGWindowList`/ScreenCaptureKit address. Requires an operator handle; a tile handle lacks `window.read` and fails `capability_denied`. |
 | `POST /v1/window/snapshot` | **Operator scope.** Returns a composited PNG of the app window named by the body's `windowID` (a `window.read` id). The capture includes the full window — sidebar chrome *and* the GhosttyKit terminal surface — and works with the app backgrounded (no activation). Requires `window.snapshot`; own-window only, so an id the app does not own fails `invalid_request`. See [Window snapshot](#window-snapshot). |
-| `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — the stable-target list later `[A2]` orchestration verbs act on. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
+| `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — mutation verbs use these stable targets. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
 | `POST /v1/workspace/select` | **Operator scope, mutation.** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
+| `POST /v1/workspace/create` | **Operator scope, mutation.** Creates a workspace in the repo named by `repoID` (from `workspace.read`) by driving the sidebar's real create helper. Body is `{"repoID":"…","name":"…","providerID":"local","guestOS":null}`; `providerID` defaults to `local`. Returns `completed` with the created workspace and attached terminal, or `confirmation_required` with provider setup confirmation details. Requires `workspace.create`; tile handles fail `capability_denied`. See [Workspace create](#workspace-create). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -197,7 +200,8 @@ handle.
 | `window.read` | `GET /v1/windows` (list the app's windows); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `window.snapshot` | `POST /v1/window/snapshot` (composited PNG of a listed window); granted only to operator handles, never to tile handles |
 | `workspace.read` | `GET /v1/workspaces` (list the app's repos and workspaces); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
-| `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); the first operator *mutation* capability, granted only to operator handles, never to tile handles — distinct from `workspace.read` so the read/write split stays legible |
+| `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); granted only to operator handles, never to tile handles |
+| `workspace.create` | `POST /v1/workspace/create` (drive the real sidebar create helper for a repo); granted only to operator handles, never to tile handles — distinct from `workspace.read` and `workspace.select` so the read/write split stays legible |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -285,8 +289,8 @@ VM / `tart-ui` fallback lane.
 ## Workspace list
 
 `GET /v1/workspaces` (operator scope, `workspace.read`) returns the app's tracked
-repos and workspaces so later `[A2]` orchestration verbs have stable targets. It is
-read-only: no mutation rides this route.
+repos and workspaces so mutation verbs have stable targets. It is read-only: no
+mutation rides this route.
 
 ```json
 {
@@ -298,7 +302,12 @@ read-only: no mutation rides this route.
       "path": "/Users/me/.workspaces/workspaces/feature-a", "branch": "feature-a",
       "status": "active", "isArchived": false, "backend": "local", "isSelected": true }
   ],
-  "system": { "capabilities": ["window.read", "window.snapshot", "workspace.read"] }
+  "system": {
+    "capabilities": [
+      "window.read", "window.snapshot", "workspace.read",
+      "workspace.select", "workspace.create"
+    ]
+  }
 }
 ```
 
@@ -313,6 +322,74 @@ read-only: no mutation rides this route.
 - **Live app state.** The listing reflects what the *running app* currently has,
   read from the live SwiftData models and selection state — distinct from the
   CLI's own local-state store (`workspaces ws list`).
+
+## Workspace create
+
+`POST /v1/workspace/create` (operator scope, `workspace.create`) creates a
+workspace by driving the sidebar create helper used by the New Workspace sheet
+and desktop UI smoke driver. The body names a repo from `workspace.read`; `name`
+is the workspace name; `providerID` defaults to `local`; `guestOS` is optional
+and used by providers that support guest OS variants:
+
+```json
+{ "repoID": "…", "name": "feature-a", "providerID": "local", "guestOS": null }
+```
+
+The success envelope reports the structured gesture outcome and, on completion,
+the selected and attached workspace terminal:
+
+```json
+{
+  "repoID": "…",
+  "workspaceID": "…",
+  "workspaceName": "feature-a",
+  "workspacePath": "/Users/me/.workspaces/workspaces/feature-a",
+  "outcome": "completed",
+  "changed": true,
+  "selectedWorkspaceID": "…",
+  "attachedTerminal": true,
+  "attachedSurfaceID": "…",
+  "system": { "capabilities": [ … ] }
+}
+```
+
+If the UI path reaches provider setup or another modal surface, the verb returns
+success with `outcome: "confirmation_required"` and a payload naming what the
+user must confirm:
+
+```json
+{
+  "repoID": "…",
+  "workspaceName": "feature-a",
+  "outcome": "confirmation_required",
+  "changed": false,
+  "confirmation": {
+    "action": "workspace.create",
+    "title": "Set Up Lume",
+    "message": "Create macOS workspace 'feature-a' requires Lume setup confirmation.",
+    "providerID": "lume",
+    "providerDisplayName": "Lume",
+    "primaryButtonTitle": "Set Up Lume"
+  },
+  "message": "Create macOS workspace 'feature-a' requires Lume setup confirmation.",
+  "system": { "capabilities": [ … ] }
+}
+```
+
+- **Same path as the UI.** The verb enters the sidebar create helper, not
+  `WorkspaceService` or SwiftData directly. On completion, the helper selects the
+  created workspace through the same binding the UI uses, which attaches and
+  activates the workspace terminal.
+- **Wrong-PTY guard.** `attachedSurfaceID` is the active terminal session after
+  create. A following caller-scoped input write targets that PTY, not the repo
+  terminal or a previously selected workspace.
+- **Structured outcome.** `outcome` is `completed` or `confirmation_required`.
+  A live-window-less app fails `unsupported` (never a data-layer fallback), an
+  unknown/non-UUID `repoID` fails `invalid_request`, and unknown providers fail
+  `invalid_request`.
+- **Operator mutation.** Requires `workspace.create`, distinct from
+  `workspace.read` and `workspace.select`. A tile handle lacks it and fails
+  `capability_denied`.
 
 ## Workspace select
 
@@ -344,9 +421,8 @@ did:
   `workspace.select` only ever `completed`s today. A live-window-less app fails
   `unsupported` (never a data-layer fallback), and an unknown or non-UUID
   `workspaceID` fails `invalid_request`.
-- **Operator mutation.** Requires `workspace.select` — the first operator mutation
-  capability, distinct from the read-only `workspace.read`. A tile handle lacks it
-  and fails `capability_denied`. The call is operator-tagged in
+- **Operator mutation.** Requires `workspace.select`, distinct from the read-only
+  `workspace.read`. A tile handle lacks it and fails `capability_denied`. The call is operator-tagged in
   `automation-audit.jsonl` like every operator route.
 
 ## Error Codes
@@ -405,6 +481,9 @@ workspaces workspace list                            # repos + workspaces, human
 workspaces workspace list --json                     # same, as the raw result envelope
 workspaces workspace select <id>                     # drive the real selection gesture for <id>
 workspaces workspace select <id> --json              # same, as the raw result envelope
+workspaces workspace create <repo-id> feature-a      # create local workspace through the UI path
+workspaces workspace create <repo-id> feature-a --json
+workspaces workspace create <repo-id> feature-a --provider lume --guest-os macos
 ```
 
 `workspace list` reads the running app's repos and workspaces (`workspace.read`),
@@ -423,6 +502,15 @@ attaches its terminal, and requests focus, exactly as a sidebar click would. It
 prints whether a terminal attached; `--json` emits the raw result envelope. Absent a
 live window it fails `unsupported` — it never falls back to a data-layer write.
 
+`workspace create <repo-id> <name>` drives the sidebar's real create helper for
+the repo with stable `<repo-id>` (from `workspace list`). It defaults to the local
+provider; `--provider` and `--guest-os` mirror the New Workspace sheet's provider
+choice. On success, the app creates the workspace, selects it, and attaches its
+terminal. If provider setup needs user confirmation, the command prints the
+confirmation message; `--json` includes the structured confirmation payload.
+Absent a live window it fails `unsupported` — it never falls back to a data-layer
+write.
+
 ## Implementation Map
 
 | Concern | File |
@@ -437,6 +525,7 @@ live window it fails `unsupported` — it never falls back to a data-layer write
 | Window enumeration (AppKit → descriptors) | `Sources/WorkspaceManager/Views/MainWindow/AutomationWindowEnumerator.swift` |
 | Workspace inventory (SwiftData → descriptors) | `Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceEnumerator.swift` |
 | Window snapshot capture (`CGWindowList`, MainActor) | `Sources/WorkspaceManager/Views/MainWindow/WindowSnapshotService.swift` |
+| Sidebar create gesture bridge | `Sources/WorkspaceManager/Views/MainWindow/AutomationWorkspaceCreateGestureBridge.swift` |
 | Web-surface snapshot capture (MainActor) | `Sources/WorkspaceManager/Web/WebSurfaceSnapshotCapture.swift` |
 | CLI socket client | `Sources/WorkspaceManagerCore/Services/Automation/AutomationSocketClient.swift` |
 | CLI formatting | `Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift` |
@@ -457,12 +546,13 @@ swift-format lint --strict --recursive Sources/ Tests/
 ./scripts/dev-smoke.sh --no-build
 ```
 
-For a change touching a mutation verb, also verify it against the real app — an
-API-driven `workspace.select` through the socket must attach the workspace's
-terminal, proving the verb entered the real binding:
+For a change touching a mutation verb, also verify it against the real app. The
+API-driven smoke lanes go through the socket and assert the terminal attach
+milestones that prove the verb entered the real UI path:
 
 ```bash
 ./scripts/api-select-smoke.sh --no-build   # asserts terminal_session_attached after the CLI select
+./scripts/api-create-smoke.sh --no-build   # asserts create, selection, and new workspace attach
 ```
 
 If docs or public examples changed, also run the docs checks listed in
@@ -478,10 +568,10 @@ review before they can be added. Read-only global reads are the reviewed
 operator-scope exceptions — window capture (`window.read` listing and
 `window.snapshot` composited snapshots) and the repo/workspace inventory
 (`workspace.read`) — gated behind the opt-in operator scope above, never granted to
-tile handles. The one operator *mutation* is `workspace.select`, a
-reviewed exception that drives the real selection gesture under the verbs-=-clicks
-contract, never a data-layer write. Two reviewed exceptions widen the read/write surface
-deliberately: caller-scoped input injection ships as the experimental,
+tile handles. Operator mutations are limited to reviewed gesture verbs such as
+`workspace.select` and `workspace.create`, which drive real UI paths under the
+verbs-=-clicks contract, never data-layer writes. Reviewed exceptions widen the
+read/write surface deliberately: caller-scoped input injection ships as the experimental,
 double-gated `input.write` capability (see
 [Automation Input Write Decision](../decisions/automation-input-write.md)), and
 read-only web-surface reads ship as `browser.read` — both listing

--- a/scripts/api-create-smoke.sh
+++ b/scripts/api-create-smoke.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+# ==========================================================================
+# api-create-smoke.sh - API-driven workspace.create smoke for the debug app
+# ==========================================================================
+#
+# Proves the create verb through the real app socket:
+#
+#   1. The app imports a disposable repo in desktop-ui-smoke mode, parks the
+#      active surface on that repo terminal, and emits `awaiting_api_create`.
+#   2. This script runs `workspaces workspace create <repo-id> <name>`.
+#   3. The verb enters the sidebar create helper, creating the workspace,
+#      selecting it, and attaching the new workspace terminal. The JSONL must
+#      show workspace/sidebar milestones and a workspace terminal attach after
+#      `awaiting_api_create`; the create result's attached surface must match
+#      that milestone and differ from the parked repo terminal.
+#
+# Headless-safe (--no-activate). Artifacts land under output/api-create-smoke/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LAUNCH_SCRIPT="$REPO_ROOT/scripts/launch-dev.sh"
+CLI_BIN="$REPO_ROOT/.build/arm64-apple-macosx/debug/workspaces"
+OUTPUT_ROOT="$REPO_ROOT/output/api-create-smoke"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="$OUTPUT_ROOT/$TIMESTAMP"
+RUN_LINK="$OUTPUT_ROOT/latest"
+DEFAULT_TIMEOUT_SECONDS=$((4 * 60))
+
+SKIP_BUILD=false
+KEEP_ARTIFACTS=false
+TOTAL_TIMEOUT_SECONDS="$DEFAULT_TIMEOUT_SECONDS"
+APP_PID=""
+SMOKE_REPO_PATH=""
+WORKSPACE_NAME="api-create-smoke-$TIMESTAMP"
+EVENTS_PATH=""
+RUN_STATUS="failed"
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/api-create-smoke.sh [options]
+
+Options:
+  --no-build              Reuse the current debug binary
+  --keep-artifacts        Keep the disposable smoke repo after a passing run
+  --timeout-seconds <n>   Total timeout (default: 240)
+  --help, -h              Show this help
+USAGE
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-build) SKIP_BUILD=true; shift ;;
+            --keep-artifacts) KEEP_ARTIFACTS=true; shift ;;
+            --timeout-seconds) [[ $# -ge 2 ]] || fail "--timeout-seconds requires a value"; TOTAL_TIMEOUT_SECONDS="$2"; shift 2 ;;
+            --help|-h) usage; exit 0 ;;
+            *) fail "Unknown argument: $1" ;;
+        esac
+    done
+}
+
+cleanup_app() {
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" >/dev/null 2>&1; then
+        kill "$APP_PID" >/dev/null 2>&1 || true
+        sleep 1
+    fi
+    pkill -f "$REPO_ROOT/.build/arm64-apple-macosx/debug/WorkspaceManager" >/dev/null 2>&1 || true
+}
+
+cleanup_repo() {
+    [[ "$KEEP_ARTIFACTS" == true ]] && return 0
+    if [[ -n "$SMOKE_REPO_PATH" && -d "$SMOKE_REPO_PATH" ]]; then
+        chmod -R u+w "$SMOKE_REPO_PATH" >/dev/null 2>&1 || true
+        rm -rf "$SMOKE_REPO_PATH" >/dev/null 2>&1 || true
+    fi
+    cleanup_created_worktree
+}
+
+cleanup_created_worktree() {
+    [[ -f "$EVENTS_PATH" ]] || return 0
+    local workspace_path
+    workspace_path="$(read_event_field workspacePath workspace_created)"
+    [[ -n "$workspace_path" && -d "$workspace_path" ]] || return 0
+    chmod -R u+w "$workspace_path" >/dev/null 2>&1 || true
+    rm -rf "$workspace_path" >/dev/null 2>&1 || true
+    local repo_container
+    repo_container="$(dirname "$workspace_path")"
+    if [[ -d "$repo_container" && -z "$(ls -A "$repo_container" 2>/dev/null)" ]]; then
+        rmdir "$repo_container" >/dev/null 2>&1 || true
+    fi
+}
+
+on_exit() {
+    local code="$?"
+    trap - EXIT
+    cleanup_app
+    [[ "$RUN_STATUS" == "passed" ]] && cleanup_repo
+    log "Run directory: $RUN_DIR"
+    exit "$code"
+}
+
+setup_run_dir() {
+    mkdir -p "$RUN_DIR"
+    ln -sfn "$RUN_DIR" "$RUN_LINK"
+    EVENTS_PATH="$RUN_DIR/events.jsonl"
+}
+
+create_disposable_repo() {
+    SMOKE_REPO_PATH="$(mktemp -d "${TMPDIR:-/tmp}/workspaces-api-create-XXXXXX")"
+    (
+        cd "$SMOKE_REPO_PATH"
+        git init >/dev/null
+        git config user.name "WorkspaceManager Smoke" >/dev/null
+        git config user.email "smoke@local.invalid" >/dev/null
+        printf "# API create smoke\n\nCreated %s\n" "$TIMESTAMP" >README.md
+        git add README.md
+        git commit -m "Initial smoke fixture" >/dev/null
+    )
+}
+
+launch_automated_app() {
+    local app_data_dir="$RUN_DIR/app-data"
+    local -a args=(
+        "--no-activate"
+        "--data-dir" "$app_data_dir"
+        "--clean-data"
+        "--window-timeout" "20"
+        "--env" "WORKSPACES_DISABLE_AUTO_IMPORT=1"
+        "--env" "WORKSPACES_AUTOMATION_API=1"
+        "--env" "WORKSPACES_AUTOMATION_OPERATOR=1"
+        "--env" "WORKSPACES_AUTOMATION_MODE=desktop-ui-smoke"
+        "--env" "WORKSPACES_AUTOMATION_CREATE_DRIVER=api"
+        "--env" "WORKSPACES_AUTOMATION_REPO_PATH=$SMOKE_REPO_PATH"
+        "--env" "WORKSPACES_AUTOMATION_WORKSPACE_NAME=$WORKSPACE_NAME"
+        "--env" "WORKSPACES_AUTOMATION_EVENTS_PATH=$EVENTS_PATH"
+    )
+    [[ "$SKIP_BUILD" == true ]] && args+=("--no-build")
+
+    local launch_output
+    launch_output="$(
+        cd "$REPO_ROOT"
+        "$LAUNCH_SCRIPT" "${args[@]}" 2>&1 | tee "$RUN_DIR/launch-command.log"
+    )"
+    APP_PID="$(printf '%s\n' "$launch_output" | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | tail -n 1)"
+    [[ -n "$APP_PID" ]] || fail "Could not determine WorkspaceManager pid from launch output."
+}
+
+read_event_field() {
+    local field="$1" event_type="$2"
+    python3 - "$EVENTS_PATH" "$field" "$event_type" <<'PY'
+import json, sys
+from pathlib import Path
+path, field, event_type = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+value = ""
+if path.exists():
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        event = json.loads(line)
+        if event.get("type") == event_type and event.get(field):
+            value = event[field]
+print(value)
+PY
+}
+
+event_index() {
+    python3 - "$EVENTS_PATH" "$1" <<'PY'
+import json, sys
+from pathlib import Path
+path, target = Path(sys.argv[1]), sys.argv[2]
+idx = -1
+if path.exists():
+    for i, line in enumerate(l.strip() for l in path.read_text().splitlines() if l.strip()):
+        if json.loads(line).get("type") == target:
+            idx = i
+            break
+print(idx)
+PY
+}
+
+wait_for_event() {
+    local event_type="$1" deadline=$(( $(date +%s) + TOTAL_TIMEOUT_SECONDS ))
+    while (( $(date +%s) < deadline )); do
+        if [[ "$(event_index "$event_type")" != "-1" ]]; then
+            return 0
+        fi
+        if [[ "$(event_index failure)" != "-1" ]]; then
+            fail "App reported a failure milestone: $(read_event_field message failure)"
+        fi
+        sleep 1
+    done
+    fail "Timed out waiting for milestone: $event_type"
+}
+
+assert_create_result_and_events() {
+    local await_idx="$1"
+    python3 - "$EVENTS_PATH" "$RUN_DIR/create-result.json" "$await_idx" <<'PY'
+import json, sys
+from pathlib import Path
+events_path, result_path, await_idx = Path(sys.argv[1]), Path(sys.argv[2]), int(sys.argv[3])
+events = [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+result = json.loads(result_path.read_text())
+
+before = events[:await_idx]
+after = events[await_idx + 1:]
+repo_attach = next(
+    (event for event in reversed(before)
+     if event.get("type") == "terminal_session_attached" and event.get("selectionKind") == "repo"),
+    None,
+)
+workspace_attach = next(
+    (event for event in after
+     if event.get("type") == "terminal_session_attached" and event.get("selectionKind") == "workspace"),
+    None,
+)
+workspace_created = next((event for event in after if event.get("type") == "workspace_created"), None)
+sidebar_updated = next((event for event in after if event.get("type") == "sidebar_updated"), None)
+
+failures = []
+if repo_attach is None:
+    failures.append("no repo terminal attach before awaiting_api_create")
+if workspace_attach is None:
+    failures.append("no workspace terminal attach after awaiting_api_create")
+if workspace_created is None:
+    failures.append("no workspace_created after awaiting_api_create")
+if sidebar_updated is None:
+    failures.append("no sidebar_updated after awaiting_api_create")
+
+if result.get("outcome") != "completed":
+    failures.append(f"create outcome was {result.get('outcome')!r}, not completed")
+if result.get("attachedTerminal") is not True:
+    failures.append("create result did not report attachedTerminal=true")
+
+if workspace_attach is not None:
+    if result.get("attachedSurfaceID") != workspace_attach.get("sessionID"):
+        failures.append("create result attachedSurfaceID did not match workspace attach milestone")
+    if repo_attach is not None and workspace_attach.get("sessionID") == repo_attach.get("sessionID"):
+        failures.append("workspace attach reused the parked repo terminal session")
+    workspace_path = workspace_created.get("workspacePath") if workspace_created else None
+    if workspace_path and workspace_attach.get("sessionScope") != workspace_path:
+        failures.append("workspace attach scope did not match created workspace path")
+
+if workspace_created is not None:
+    if result.get("workspaceID") != workspace_created.get("workspaceID"):
+        failures.append("create result workspaceID did not match workspace_created")
+    if result.get("workspacePath") != workspace_created.get("workspacePath"):
+        failures.append("create result workspacePath did not match workspace_created")
+
+if failures:
+    print("ASSERTION FAILED:", file=sys.stderr)
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    print("Events after awaiting_api_create:", file=sys.stderr)
+    for event in after:
+        print(
+            f"  - {event.get('type')} kind={event.get('selectionKind')} "
+            f"session={event.get('sessionID')} scope={event.get('sessionScope')}",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+print(
+    "OK: API create attached workspace terminal "
+    f"{workspace_attach.get('sessionID')} scope={workspace_attach.get('sessionScope')}"
+)
+PY
+}
+
+main() {
+    parse_args "$@"
+    trap on_exit EXIT
+    setup_run_dir
+    create_disposable_repo
+
+    if [[ "$SKIP_BUILD" != true ]]; then
+        log "Building debug binaries..."
+        ( cd "$REPO_ROOT" && swift build >/dev/null )
+    fi
+    [[ -x "$CLI_BIN" ]] || fail "CLI binary not found at $CLI_BIN (run swift build)."
+
+    log "Launching app (api create driver)..."
+    launch_automated_app
+
+    log "Waiting for repo terminal park before API create..."
+    wait_for_event awaiting_api_create
+
+    local repo_id
+    repo_id="$(read_event_field repoID awaiting_api_create)"
+    [[ -n "$repo_id" ]] || fail "Could not read repoID from awaiting_api_create."
+    log "Repo id: $repo_id"
+
+    local await_idx
+    await_idx="$(event_index awaiting_api_create)"
+
+    log "Driving API create: workspaces workspace create $repo_id $WORKSPACE_NAME"
+    "$CLI_BIN" workspace create "$repo_id" "$WORKSPACE_NAME" --json | tee "$RUN_DIR/create-result.json"
+
+    log "Waiting for create milestones..."
+    wait_for_event workspace_created
+    wait_for_event sidebar_updated
+    wait_for_event terminal_session_attached
+    assert_create_result_and_events "$await_idx"
+
+    if "$CLI_BIN" window snapshot --out "$RUN_DIR/after-create.png" >/dev/null 2>&1; then
+        log "Captured post-create window snapshot: $RUN_DIR/after-create.png"
+    else
+        log "Window snapshot unavailable (likely a locked screen) — JSONL + create result stand as evidence."
+    fi
+
+    RUN_STATUS="passed"
+    log "PASS — API-driven workspace.create created, selected, and attached the new workspace terminal."
+    {
+        echo "# API Create Smoke"
+        echo
+        echo "- Outcome: passed"
+        echo "- Repo id: $repo_id"
+        echo "- Workspace name: $WORKSPACE_NAME"
+        echo "- Events: $EVENTS_PATH"
+        echo "- Create result: $RUN_DIR/create-result.json"
+    } >"$RUN_DIR/summary.md"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements #921.

- Add `workspace.create` as an operator-only gesture verb and CLI command, routed through the live sidebar create helper rather than a service/data fallback.
- Add structured `confirmation_required` results with confirmation payloads for modal/provider-setup paths.
- Add API/router/app tests plus a real-app `scripts/api-create-smoke.sh` lane proving API create creates, selects, and attaches the new workspace terminal.

## Verification

- `swift build`
- `swift test` (1253 tests in 191 suites)
- `mise run lint`
- `./scripts/api-create-smoke.sh --no-build` (passed; artifacts from `output/api-create-smoke/20260707-223333`)

## Evidence

- ![api-create-final-summary](https://evidence.cloudcompute.com/workspaces/pr-952/20260708-053429-api-create-final-summary.svg)
- ![api-create-final-window](https://evidence.cloudcompute.com/workspaces/pr-952/20260708-053433-api-create-final-window.png)

## Review loop

- ADR contract reflection: `workspace.create` enters `AutomationGestureVerbs` only through UI closures installed by `ContentView` and cleared on teardown; no core/service-layer fallback was added.
- UI path disposition: the create closure calls the same `SidebarView.createWorkspace` helper used by the New Workspace UI and desktop smoke driver, then reports the selected workspace and active terminal surface from the live UI state.
- Modal disposition: existing provider setup/sheet/progress states return `confirmation_required` with a structured payload instead of waiting on UI.
- Residual concern: the external smoke proves the active PTY switched via terminal attach milestones because caller-scoped `input.write` intentionally requires a tile handle and is not granted to operator credentials.

## Mergeability

- Surface: macOS automation API, operator capabilities, CLI, sidebar create path, smoke automation, docs.
- User-facing behavior changed: `workspaces workspace create <repo-id> <name>` creates through the running app and selects/attaches the new workspace terminal when completed.
- Non-happy paths considered: no live window/sidebar returns `unsupported`; tile handles are denied; unknown repos/providers are invalid; modal/provider setup returns `confirmation_required` payloads.
- Residual risk or follow-up: provider confirmation is reported but not remotely acted on; future work can add an explicit confirm verb if product policy allows it.
