### PR TITLE
Add App Intents for workspace verbs

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -24,6 +24,8 @@ final class AutomationIntegrationLifecycle: ObservableObject {
     private var didStart = false
     private var startTask: Task<String, Error>?
     private var operatorCredentialURL: URL?
+    private var appIntentOperatorHandle: String?
+    private let appIntentOperatorHostSessionID = UUID()
 
     /// The app scope id operator handles carry — matched to the value `TileTreeStore` stamps on tile
     /// handles so audit and context read consistently across both handle classes.
@@ -52,6 +54,33 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         },
         gestureVerbs: AutomationGestureVerbs? = nil
     ) async {
+        let webSurfaces = Self.makeWebSurfaces(
+            tileTreeStore: tileTreeStore,
+            webSurfaceRecords: webSurfaceRecords
+        )
+        let webSnapshot = Self.makeWebSnapshot(
+            tileTreeStore: tileTreeStore,
+            webSurfaceRecords: webSurfaceRecords
+        )
+        let windows: @MainActor () -> [AutomationWindowDescriptor] = {
+            AutomationWindowEnumerator.descriptors()
+        }
+        let windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome = { windowID in
+            WindowSnapshotService.snapshot(windowID: windowID)
+        }
+
+        configureController(
+            tileTreeStore: tileTreeStore,
+            focusTerminal: focusTerminal,
+            requestCloseTerminal: requestCloseTerminal,
+            webSurfaces: webSurfaces,
+            webSnapshot: webSnapshot,
+            windows: windows,
+            windowSnapshot: windowSnapshot,
+            workspaceInventory: workspaceInventory,
+            gestureVerbs: gestureVerbs
+        )
+
         guard isEnabled else {
             tileTreeStore.configureAutomation(handleRegistry: nil, socketPath: nil)
             // Fail closed: an app without the Automation API leaves no operator credential behind.
@@ -66,7 +95,11 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 requestCloseTerminal: requestCloseTerminal,
                 webSurfaceRecords: webSurfaceRecords,
                 workspaceInventory: workspaceInventory,
-                gestureVerbs: gestureVerbs
+                gestureVerbs: gestureVerbs,
+                webSurfaces: webSurfaces,
+                webSnapshot: webSnapshot,
+                windows: windows,
+                windowSnapshot: windowSnapshot
             )
             tileTreeStore.configureAutomation(handleRegistry: handleRegistry, socketPath: socketPath)
         } catch {
@@ -84,24 +117,28 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
             AutomationWorkspaceInventory()
         },
-        gestureVerbs: AutomationGestureVerbs? = nil
+        gestureVerbs: AutomationGestureVerbs? = nil,
+        webSurfaces: (@MainActor () -> [AutomationWebSurfaceDescriptor])? = nil,
+        webSnapshot: (@MainActor (UUID) async -> WebSnapshotOutcome)? = nil,
+        windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil,
+        windowSnapshot: (@MainActor (String) async -> WindowSnapshotOutcome)? = nil
     ) async throws -> String {
         // Compose the read-only web-surface list from the caller's live source records
         // joined with the surface store's live WKWebView state (non-creating peek).
-        let webSurfaces = Self.makeWebSurfaces(
-            tileTreeStore: tileTreeStore,
-            webSurfaceRecords: webSurfaceRecords
-        )
-        let webSnapshot = Self.makeWebSnapshot(
-            tileTreeStore: tileTreeStore,
-            webSurfaceRecords: webSurfaceRecords
-        )
-        let windows: @MainActor () -> [AutomationWindowDescriptor] = {
-            AutomationWindowEnumerator.descriptors()
-        }
-        let windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome = { windowID in
-            WindowSnapshotService.snapshot(windowID: windowID)
-        }
+        let webSurfaces =
+            webSurfaces
+            ?? Self.makeWebSurfaces(tileTreeStore: tileTreeStore, webSurfaceRecords: webSurfaceRecords)
+        let webSnapshot =
+            webSnapshot
+            ?? Self.makeWebSnapshot(tileTreeStore: tileTreeStore, webSurfaceRecords: webSurfaceRecords)
+        let windows =
+            windows ?? {
+                AutomationWindowEnumerator.descriptors()
+            }
+        let windowSnapshot =
+            windowSnapshot ?? { windowID in
+                WindowSnapshotService.snapshot(windowID: windowID)
+            }
 
         if let startTask {
             let socketPath = try await startTask.value
@@ -137,8 +174,7 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             return socketPath
         }
 
-        let controller = AutomationController(
-            handleRegistry: handleRegistry,
+        let controller = configureController(
             tileTreeStore: tileTreeStore,
             focusTerminal: focusTerminal,
             requestCloseTerminal: requestCloseTerminal,
@@ -216,6 +252,49 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         return listener.socketPath
     }
 
+    @discardableResult
+    private func configureController(
+        tileTreeStore: TileTreeStore,
+        focusTerminal: @escaping @MainActor (UUID) -> Void,
+        requestCloseTerminal: @escaping @MainActor (UUID) -> Void,
+        webSurfaces: @escaping @MainActor () -> [AutomationWebSurfaceDescriptor],
+        webSnapshot: @escaping @MainActor (UUID) async -> WebSnapshotOutcome,
+        windows: @escaping @MainActor () -> [AutomationWindowDescriptor],
+        windowSnapshot: @escaping @MainActor (String) async -> WindowSnapshotOutcome,
+        workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory,
+        gestureVerbs: AutomationGestureVerbs?
+    ) -> AutomationController {
+        if let controller {
+            controller.update(
+                tileTreeStore: tileTreeStore,
+                focusTerminal: focusTerminal,
+                requestCloseTerminal: requestCloseTerminal,
+                webSurfaces: webSurfaces,
+                webSnapshot: webSnapshot,
+                windows: windows,
+                windowSnapshot: windowSnapshot,
+                workspaceInventory: workspaceInventory,
+                gestureVerbs: gestureVerbs
+            )
+            return controller
+        }
+
+        let controller = AutomationController(
+            handleRegistry: handleRegistry,
+            tileTreeStore: tileTreeStore,
+            focusTerminal: focusTerminal,
+            requestCloseTerminal: requestCloseTerminal,
+            webSurfaces: webSurfaces,
+            webSnapshot: webSnapshot,
+            windows: windows,
+            windowSnapshot: windowSnapshot,
+            workspaceInventory: workspaceInventory,
+            gestureVerbs: gestureVerbs
+        )
+        self.controller = controller
+        return controller
+    }
+
     private static func makeWebSurfaces(
         tileTreeStore: TileTreeStore,
         webSurfaceRecords: @escaping @MainActor () -> [WebSurfaceRecord]
@@ -256,6 +335,27 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         controller?.detachGestureVerbs()
     }
 
+    func appIntentControllerAndHandle() throws -> (controller: AutomationController, handle: String) {
+        guard let controller else {
+            throw AutomationServiceError(
+                .unsupported,
+                "No WorkSpaces window is attached; open a WorkSpaces window and try again."
+            )
+        }
+        if let appIntentOperatorHandle,
+            handleRegistry.resolve(appIntentOperatorHandle)?.isOperator == true
+        {
+            return (controller, appIntentOperatorHandle)
+        }
+
+        let entry = handleRegistry.registerOperator(
+            appScopeID: Self.appScopeID,
+            hostSessionID: appIntentOperatorHostSessionID
+        )
+        appIntentOperatorHandle = entry.handle
+        return (controller, entry.handle)
+    }
+
     func stop() async {
         startTask?.cancel()
         startTask = nil
@@ -264,6 +364,7 @@ final class AutomationIntegrationLifecycle: ObservableObject {
         controller = nil
         socketPath = nil
         didStart = false
+        appIntentOperatorHandle = nil
         handleRegistry.removeAll()
         // The operator handle dies with the launch; remove its credential file on the way out so a
         // clean exit leaves nothing readable (a crash can't, which is why stale credentials fail

--- a/Sources/WorkspaceManager/App/WorkspacesAppIntents.swift
+++ b/Sources/WorkspaceManager/App/WorkspacesAppIntents.swift
@@ -1,0 +1,413 @@
+//
+//  WorkspacesAppIntents.swift
+//  WorkspaceManager
+//
+//  Shortcuts/Siri/Spotlight actions for the workspace automation verbs. These intents are a veneer:
+//  they resolve App Intents entities, then call the same AutomationController methods used by the
+//  local socket routes so the gesture-verb layer remains the only mutation semantics path.
+//
+
+import AppIntents
+import Foundation
+import WorkspaceManagerCore
+
+@MainActor
+struct WorkspacesAppIntentAutomationClient: Sendable {
+    enum CreateOutcome: Equatable {
+        case completed(AutomationWorkspaceCreateResult)
+        case confirmationRequired(AutomationConfirmationRequirement)
+    }
+
+    typealias ControllerProvider =
+        @MainActor @Sendable () throws -> (
+            controller: any AutomationControlling, handle: String
+        )
+
+    static let live = WorkspacesAppIntentAutomationClient {
+        try AutomationIntegrationLifecycle.shared.appIntentControllerAndHandle()
+    }
+
+    private let controllerProvider: ControllerProvider
+
+    init(controllerProvider: @escaping ControllerProvider) {
+        self.controllerProvider = controllerProvider
+    }
+
+    func inventory() throws -> AutomationWorkspaceInventory {
+        do {
+            let (controller, handle) = try controllerAndHandle()
+            let result = try controller.automationWorkspaces(for: handle)
+            return AutomationWorkspaceInventory(repos: result.repos, workspaces: result.workspaces)
+        } catch let error as WorkspacesAppIntentError {
+            throw error
+        } catch let error as AutomationServiceError {
+            throw WorkspacesAppIntentError.automation(error.response)
+        }
+    }
+
+    func select(workspaceID: String) async throws -> AutomationWorkspaceSelectResult {
+        do {
+            let (controller, handle) = try controllerAndHandle()
+            return try await controller.automationSelectWorkspace(for: handle, workspaceID: workspaceID)
+        } catch let error as WorkspacesAppIntentError {
+            throw error
+        } catch let error as AutomationServiceError {
+            throw WorkspacesAppIntentError.automation(error.response)
+        }
+    }
+
+    func create(
+        repoID: String,
+        name: String,
+        providerID: String?,
+        guestOS: WorkspaceGuestOS?
+    ) async throws -> CreateOutcome {
+        do {
+            let (controller, handle) = try controllerAndHandle()
+            let result = try await controller.automationCreateWorkspace(
+                for: handle,
+                request: AutomationWorkspaceCreateRequest(
+                    repoID: repoID,
+                    name: name,
+                    providerID: providerID,
+                    guestOS: guestOS
+                )
+            )
+            if let confirmation = result.confirmation, result.outcome == .confirmationRequired {
+                return .confirmationRequired(confirmation)
+            }
+            return .completed(result)
+        } catch let error as WorkspacesAppIntentError {
+            throw error
+        } catch let error as AutomationServiceError {
+            throw WorkspacesAppIntentError.automation(error.response)
+        }
+    }
+
+    private func controllerAndHandle() throws -> (
+        controller: any AutomationControlling, handle: String
+    ) {
+        do {
+            return try controllerProvider()
+        } catch let error as AutomationServiceError {
+            throw WorkspacesAppIntentError.automation(error.response)
+        }
+    }
+}
+
+enum WorkspacesAppIntentError: LocalizedError, Equatable {
+    case automation(AutomationErrorResponse)
+    case confirmationRequired(String)
+    case cancelled(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .automation(let response):
+            return response.message
+        case .confirmationRequired(let message):
+            return message
+        case .cancelled(let message):
+            return message
+        }
+    }
+}
+
+struct WorkspaceIntentEntity: AppEntity, Equatable, Hashable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Workspace"
+    static let defaultQuery = WorkspaceIntentWorkspaceQuery()
+
+    let id: String
+    let repoID: String?
+    let repoName: String?
+    let name: String
+    let path: String
+    let branch: String?
+    let status: String
+    let isSelected: Bool
+
+    var displayRepresentation: DisplayRepresentation {
+        let subtitle = [repoName, branch, isSelected ? "selected" : status]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " - ")
+        return DisplayRepresentation(title: "\(name)", subtitle: "\(subtitle)")
+    }
+
+    init(
+        id: String,
+        repoID: String?,
+        repoName: String?,
+        name: String,
+        path: String,
+        branch: String?,
+        status: String,
+        isSelected: Bool
+    ) {
+        self.id = id
+        self.repoID = repoID
+        self.repoName = repoName
+        self.name = name
+        self.path = path
+        self.branch = branch
+        self.status = status
+        self.isSelected = isSelected
+    }
+
+    init(descriptor: AutomationWorkspaceDescriptor, repoNameByID: [UUID: String]) {
+        self.init(
+            id: descriptor.workspaceID.uuidString,
+            repoID: descriptor.repoID?.uuidString,
+            repoName: descriptor.repoID.flatMap { repoNameByID[$0] },
+            name: descriptor.name,
+            path: descriptor.path,
+            branch: descriptor.branch,
+            status: descriptor.status,
+            isSelected: descriptor.isSelected
+        )
+    }
+}
+
+struct WorkspaceIntentRepoEntity: AppEntity, Equatable, Hashable {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Repository"
+    static let defaultQuery = WorkspaceIntentRepoQuery()
+
+    let id: String
+    let name: String
+    let path: String
+    let isSelected: Bool
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(name)",
+            subtitle: "\(isSelected ? "selected - " : "")\(path)"
+        )
+    }
+
+    init(id: String, name: String, path: String, isSelected: Bool) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.isSelected = isSelected
+    }
+
+    init(descriptor: AutomationRepoDescriptor) {
+        self.init(
+            id: descriptor.repoID.uuidString,
+            name: descriptor.name,
+            path: descriptor.path,
+            isSelected: descriptor.isSelected
+        )
+    }
+}
+
+struct WorkspaceIntentWorkspaceQuery: EntityStringQuery, EnumerableEntityQuery {
+    func entities(for identifiers: [WorkspaceIntentEntity.ID]) async throws -> [WorkspaceIntentEntity] {
+        let wanted = Set(identifiers)
+        return try await allEntities().filter { wanted.contains($0.id) }
+    }
+
+    func allEntities() async throws -> [WorkspaceIntentEntity] {
+        let inventory = try await Self.inventory()
+        let repoNameByID = Dictionary(uniqueKeysWithValues: inventory.repos.map { ($0.repoID, $0.name) })
+        return inventory.workspaces.map {
+            WorkspaceIntentEntity(descriptor: $0, repoNameByID: repoNameByID)
+        }
+    }
+
+    func entities(matching string: String) async throws -> [WorkspaceIntentEntity] {
+        let query = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return try await allEntities() }
+        return try await allEntities().filter { entity in
+            [entity.name, entity.repoName, entity.branch, entity.path]
+                .compactMap { $0?.lowercased() }
+                .contains { $0.contains(query) }
+        }
+    }
+
+    private static func inventory() async throws -> AutomationWorkspaceInventory {
+        try await MainActor.run {
+            try WorkspacesAppIntentAutomationClient.live.inventory()
+        }
+    }
+}
+
+struct WorkspaceIntentRepoQuery: EntityStringQuery, EnumerableEntityQuery {
+    func entities(for identifiers: [WorkspaceIntentRepoEntity.ID]) async throws -> [WorkspaceIntentRepoEntity] {
+        let wanted = Set(identifiers)
+        return try await allEntities().filter { wanted.contains($0.id) }
+    }
+
+    func allEntities() async throws -> [WorkspaceIntentRepoEntity] {
+        let inventory = try await Self.inventory()
+        return inventory.repos.map(WorkspaceIntentRepoEntity.init(descriptor:))
+    }
+
+    func entities(matching string: String) async throws -> [WorkspaceIntentRepoEntity] {
+        let query = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return try await allEntities() }
+        return try await allEntities().filter { entity in
+            [entity.name, entity.path]
+                .map { $0.lowercased() }
+                .contains { $0.contains(query) }
+        }
+    }
+
+    private static func inventory() async throws -> AutomationWorkspaceInventory {
+        try await MainActor.run {
+            try WorkspacesAppIntentAutomationClient.live.inventory()
+        }
+    }
+}
+
+enum WorkspaceIntentGuestOS: String, AppEnum {
+    case linux
+    case macOS = "macos"
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Guest OS"
+    static let caseDisplayRepresentations: [WorkspaceIntentGuestOS: DisplayRepresentation] = [
+        .linux: "Linux",
+        .macOS: "macOS",
+    ]
+
+    var workspaceGuestOS: WorkspaceGuestOS {
+        switch self {
+        case .linux:
+            return .linux
+        case .macOS:
+            return .macOS
+        }
+    }
+}
+
+struct ListWorkspacesIntent: AppIntent {
+    static let title: LocalizedStringResource = "List Workspaces"
+    static let description = IntentDescription(
+        "Lists the WorkSpaces repositories and workspaces visible to automation.")
+    static let openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[WorkspaceIntentEntity]> & ProvidesDialog {
+        let workspaces = try await WorkspaceIntentWorkspaceQuery().allEntities()
+        return .result(
+            value: workspaces,
+            dialog: "Found \(workspaces.count) workspace\(workspaces.count == 1 ? "" : "s")."
+        )
+    }
+}
+
+struct SelectWorkspaceIntent: AppIntent {
+    static let title: LocalizedStringResource = "Select Workspace"
+    static let description = IntentDescription(
+        "Selects a WorkSpaces workspace by driving the same gesture as the sidebar.")
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Workspace")
+    var workspace: WorkspaceIntentEntity
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Select \(\.$workspace)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        do {
+            let result = try await WorkspacesAppIntentAutomationClient.live.select(workspaceID: workspace.id)
+            if result.outcome == .confirmationRequired {
+                let confirmed = try await $workspace.requestConfirmation(
+                    for: workspace,
+                    dialog: "\(result.message ?? "WorkSpaces needs confirmation before selecting this workspace.")"
+                )
+                guard confirmed else {
+                    throw WorkspacesAppIntentError.cancelled("Workspace selection was cancelled.")
+                }
+            }
+            return .result(dialog: "Selected \(workspace.name).")
+        } catch let error as AutomationServiceError {
+            throw WorkspacesAppIntentError.automation(error.response)
+        }
+    }
+}
+
+struct CreateWorkspaceIntent: AppIntent {
+    static let title: LocalizedStringResource = "Create Workspace"
+    static let description = IntentDescription(
+        "Creates a workspace through the same WorkSpaces gesture path as the app UI.")
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Repository")
+    var repo: WorkspaceIntentRepoEntity
+
+    @Parameter(title: "Name")
+    var name: String
+
+    @Parameter(title: "Provider")
+    var providerID: String?
+
+    @Parameter(title: "Guest OS")
+    var guestOS: WorkspaceIntentGuestOS?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Create \(\.$name) in \(\.$repo)")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        do {
+            let outcome = try await WorkspacesAppIntentAutomationClient.live.create(
+                repoID: repo.id,
+                name: name,
+                providerID: providerID,
+                guestOS: guestOS?.workspaceGuestOS
+            )
+            switch outcome {
+            case .completed(let result):
+                return .result(dialog: "Created \(result.workspaceName).")
+            case .confirmationRequired(let confirmation):
+                let confirmed = try await $repo.requestConfirmation(
+                    for: repo,
+                    dialog: IntentDialog(
+                        full: "\(confirmation.title)",
+                        supporting: "\(confirmation.message)"
+                    )
+                )
+                guard confirmed else {
+                    throw WorkspacesAppIntentError.cancelled("Workspace creation was cancelled.")
+                }
+                return .result(dialog: "\(confirmation.message)")
+            }
+        } catch let error as AutomationServiceError {
+            throw WorkspacesAppIntentError.automation(error.response)
+        }
+    }
+}
+
+struct WorkspacesAppShortcutsProvider: AppShortcutsProvider {
+    static var shortcutTileColor: ShortcutTileColor = .teal
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ListWorkspacesIntent(),
+            phrases: [
+                "List workspaces in \(.applicationName)",
+                "Show my \(.applicationName) workspaces",
+            ],
+            shortTitle: "List Workspaces",
+            systemImageName: "list.bullet"
+        )
+        AppShortcut(
+            intent: SelectWorkspaceIntent(),
+            phrases: [
+                "Select workspace in \(.applicationName)",
+                "Switch \(.applicationName) workspace",
+            ],
+            shortTitle: "Select Workspace",
+            systemImageName: "rectangle.stack"
+        )
+        AppShortcut(
+            intent: CreateWorkspaceIntent(),
+            phrases: [
+                "Create workspace in \(.applicationName)",
+                "New \(.applicationName) workspace",
+            ],
+            shortTitle: "Create Workspace",
+            systemImageName: "plus.rectangle"
+        )
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/WorkspacesAppIntentsTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspacesAppIntentsTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+private final class FakeWorkspacesAppIntentController: AutomationControlling {
+    var inventoryHandles: [String] = []
+    var selectCalls: [(handle: String, workspaceID: String)] = []
+    var createCalls: [(handle: String, request: AutomationWorkspaceCreateRequest)] = []
+    var createResult: AutomationWorkspaceCreateResult?
+    var createError: AutomationServiceError?
+
+    let repoID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+    let workspaceID = UUID(uuidString: "66666666-6666-6666-6666-666666666666")!
+    let surfaceID = UUID(uuidString: "77777777-7777-7777-7777-777777777777")!
+
+    func automationContext(for handle: String) throws -> AutomationContextResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationSurfaces(for handle: String) throws -> AutomationSurfacesResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationWindows(for handle: String) throws -> AutomationWindowsResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationWorkspaces(for handle: String) throws -> AutomationWorkspacesResult {
+        guard handle == "operator" else {
+            throw AutomationServiceError(.capabilityDenied, "Missing workspace.read.")
+        }
+        inventoryHandles.append(handle)
+        return AutomationWorkspacesResult(
+            repos: [
+                AutomationRepoDescriptor(
+                    repoID: repoID,
+                    name: "workspaces",
+                    path: "/Users/test/workspaces",
+                    isSelected: true
+                )
+            ],
+            workspaces: [
+                AutomationWorkspaceDescriptor(
+                    workspaceID: workspaceID,
+                    repoID: repoID,
+                    name: "feature-a",
+                    path: "/Users/test/workspaces/feature-a",
+                    branch: "feature-a",
+                    status: "active",
+                    isArchived: false,
+                    backend: "local",
+                    isSelected: true
+                )
+            ]
+        )
+    }
+
+    func automationSelectWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceSelectResult {
+        guard handle == "operator" else {
+            throw AutomationServiceError(.capabilityDenied, "Missing workspace.select.")
+        }
+        selectCalls.append((handle, workspaceID))
+        return AutomationWorkspaceSelectResult(
+            workspaceID: workspaceID,
+            outcome: .completed,
+            changed: true,
+            selectedWorkspaceID: UUID(uuidString: workspaceID),
+            attachedTerminal: true,
+            attachedSurfaceID: surfaceID.uuidString
+        )
+    }
+
+    func automationCreateWorkspace(
+        for handle: String,
+        request: AutomationWorkspaceCreateRequest
+    ) async throws -> AutomationWorkspaceCreateResult {
+        guard handle == "operator" else {
+            throw AutomationServiceError(.capabilityDenied, "Missing workspace.create.")
+        }
+        if let createError {
+            throw createError
+        }
+        createCalls.append((handle, request))
+        return createResult
+            ?? AutomationWorkspaceCreateResult(
+                repoID: request.repoID,
+                workspaceID: UUID(uuidString: "88888888-8888-8888-8888-888888888888"),
+                workspaceName: request.name,
+                workspacePath: "/Users/test/workspaces/\(request.name)",
+                outcome: .completed,
+                changed: true,
+                selectedWorkspaceID: UUID(uuidString: "88888888-8888-8888-8888-888888888888"),
+                attachedTerminal: true,
+                attachedSurfaceID: surfaceID.uuidString
+            )
+    }
+
+    func automationWindowSnapshot(
+        for handle: String,
+        windowID: String
+    ) async throws -> AutomationWindowSnapshotResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationWebSurfaceSnapshot(
+        for handle: String,
+        sourceID: UUID
+    ) async throws -> AutomationWebSurfaceSnapshotResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationFocusTile(
+        for handle: String,
+        direction: AutomationTileFocusDirection
+    ) throws -> AutomationMutationResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationSplitTile(
+        for handle: String,
+        direction: AutomationTileSplitDirection
+    ) throws -> AutomationMutationResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationCloseTile(for handle: String) throws -> AutomationMutationResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationWriteInput(
+        for handle: String,
+        text: String,
+        submit: Bool
+    ) throws -> AutomationInputWriteResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
+    func automationHandleIsOperator(_ handle: String) -> Bool {
+        handle == "operator"
+    }
+}
+
+@MainActor
+@Suite("Workspaces App Intents")
+struct WorkspacesAppIntentsTests {
+    @Test("shortcuts provider registers list select and create")
+    func shortcutsProviderRegistersAllShippedVerbs() {
+        #expect(WorkspacesAppShortcutsProvider.appShortcuts.count == 3)
+    }
+
+    @Test("list inventory calls the shared automation workspace route")
+    func listUsesAutomationWorkspaceRoute() throws {
+        let controller = FakeWorkspacesAppIntentController()
+        let client = WorkspacesAppIntentAutomationClient {
+            (controller, "operator")
+        }
+
+        let inventory = try client.inventory()
+
+        #expect(controller.inventoryHandles == ["operator"])
+        #expect(inventory.repos.map(\.repoID) == [controller.repoID])
+        #expect(inventory.workspaces.map(\.workspaceID) == [controller.workspaceID])
+    }
+
+    @Test("select calls the shared automation select route")
+    func selectUsesAutomationSelectRoute() async throws {
+        let controller = FakeWorkspacesAppIntentController()
+        let client = WorkspacesAppIntentAutomationClient {
+            (controller, "operator")
+        }
+
+        let result = try await client.select(workspaceID: controller.workspaceID.uuidString)
+
+        #expect(controller.selectCalls.map(\.handle) == ["operator"])
+        #expect(controller.selectCalls.map(\.workspaceID) == [controller.workspaceID.uuidString])
+        #expect(result.outcome == .completed)
+        #expect(result.attachedTerminal)
+        #expect(result.attachedSurfaceID == controller.surfaceID.uuidString)
+    }
+
+    @Test("create confirmation stays structured for the intent confirmation prompt")
+    func createConfirmationSurfacesAsIntentOutcome() async throws {
+        let controller = FakeWorkspacesAppIntentController()
+        let confirmation = AutomationConfirmationRequirement(
+            action: "workspace.create",
+            title: "Set Up Provider",
+            message: "Create workspace requires provider setup.",
+            providerID: "lume",
+            providerDisplayName: "Lume",
+            primaryButtonTitle: "Set Up"
+        )
+        controller.createResult = AutomationWorkspaceCreateResult(
+            repoID: controller.repoID.uuidString,
+            workspaceName: "vm-workspace",
+            outcome: .confirmationRequired,
+            changed: false,
+            confirmation: confirmation,
+            message: confirmation.message
+        )
+        let client = WorkspacesAppIntentAutomationClient {
+            (controller, "operator")
+        }
+
+        let outcome = try await client.create(
+            repoID: controller.repoID.uuidString,
+            name: "vm-workspace",
+            providerID: "lume",
+            guestOS: .macOS
+        )
+
+        #expect(controller.createCalls.count == 1)
+        #expect(controller.createCalls.first?.request.providerID == "lume")
+        #expect(controller.createCalls.first?.request.guestOS == .macOS)
+        guard case .confirmationRequired(let requirement) = outcome else {
+            Issue.record("Expected confirmationRequired, got \(outcome).")
+            return
+        }
+        #expect(requirement == confirmation)
+    }
+
+    @Test("unsupported automation errors become clear intent errors")
+    func unsupportedMapsToIntentError() async throws {
+        let controller = FakeWorkspacesAppIntentController()
+        controller.createError = AutomationServiceError(
+            .unsupported,
+            "No WorkSpaces window is attached; workspace.create requires a live window."
+        )
+        let client = WorkspacesAppIntentAutomationClient {
+            (controller, "operator")
+        }
+
+        do {
+            _ = try await client.create(
+                repoID: controller.repoID.uuidString,
+                name: "blocked",
+                providerID: nil,
+                guestOS: nil
+            )
+            Issue.record("Expected unsupported to map to a WorkspacesAppIntentError.")
+        } catch let error as WorkspacesAppIntentError {
+            guard case .automation(let response) = error else {
+                Issue.record("Expected automation error, got \(error).")
+                return
+            }
+            #expect(response.code == .unsupported)
+            #expect(response.message.contains("workspace.create requires a live window"))
+        }
+    }
+}

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -85,6 +85,9 @@ WorkSpaces terminal tile. See
 - Mutation routes are stable product verbs, not raw `TileTreeAction` exposure.
 - Mutation verbs enter the same UI gesture the equivalent user action does — they
   never write the data layer directly. See [Verb contract](#verb-contract-verbs--clicks).
+- App Intents are in-process, user-initiated, OS-mediated veneers; they do not
+  require the Automation API or Operator Scope experiments and do not expose a
+  socket or process-readable operator credential.
 - Browser **read** (listing WorkSpaces-owned web surfaces) is supported; browser
   **mutation** (navigating, clicking, evaluating JS), resize/equalize, and global
   control remain out of V1.
@@ -149,6 +152,12 @@ carry their own fallback semantics. If the controller reports `unsupported`
 because no live window is attached, the intent surfaces that error; if the verb
 returns `confirmation_required`, the intent maps it to the native App Intents
 confirmation prompt before reporting the outcome.
+
+App Intents intentionally work independently of the Automation API and Operator
+Scope experiments. They are user-initiated by Shortcuts/Siri/Spotlight and run
+in process, so their handle is registered only in memory and never leaves the
+app or exposes a socket. The experiments continue to gate the external socket
+surface and the process-readable operator credential used by CLI/dev/CI callers.
 
 ## Envelope
 

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -137,6 +137,19 @@ not a gesture outcome — nothing was driven). App Intents and any companion app
 the same verb layer, so "Siri said done" and "the sidebar updated" are the same
 event.
 
+### App Intents veneer
+
+The Shortcuts/Siri/Spotlight surface exposes `workspace.list`, `workspace.select`,
+and `workspace.create` only as an App Intents veneer over this automation spine.
+Entity queries list repos and workspaces through `automationWorkspaces`, and
+mutation intents call `automationSelectWorkspace` / `automationCreateWorkspace`
+on the app-side controller with an in-process operator handle. They do not read
+or write SwiftData directly, do not call workspace services directly, and do not
+carry their own fallback semantics. If the controller reports `unsupported`
+because no live window is attached, the intent surfaces that error; if the verb
+returns `confirmation_required`, the intent maps it to the native App Intents
+confirmation prompt before reporting the outcome.
+
 ## Envelope
 
 Every route returns a versioned JSON envelope:


### PR DESCRIPTION
Closes #922

## Summary

- Adds Shortcuts/Siri/Spotlight App Intents for `workspace.list`, `workspace.select`, and `workspace.create`.
- Routes the intents through the live `AutomationController` methods used by socket routes, with an in-process operator handle from the same registry.
- Documents the App Intents veneer rule and adds tests for shortcut registration, shared route calls, confirmation mapping, and unsupported errors.

## Tests

- `swift build`
- `swift test` — 1271 tests in 193 suites passed
- `mise run lint`
- `./scripts/api-select-smoke.sh --no-build` — API-driven `workspace.select` attached terminal session `247401DD-7F1A-41F2-9CC4-6A8640974F09`

## Evidence

- Headless select parity smoke snapshot: ![app-intents-api-select](https://evidence.cloudcompute.com/workspaces/pr-954/20260708-061717-app-intents-api-select.png)
- Limitation: I did not drive the macOS Shortcuts UI directly in this shared desktop lane because that would require foreground Shortcuts automation. Coverage here is AppShortcut metadata/unit tests plus the API select smoke through the same controller and gesture-verb layer that the intents call.

## Review Loop

- Self-reviewed against `docs/decisions/automation-operator-scope.md` § "One spine, veneers on top" and § "Verb contract: verbs = clicks".
- Disposition: list/select/create intents are adapters over `automationWorkspaces`, `automationSelectWorkspace`, and `automationCreateWorkspace`; no intent reads/writes SwiftData directly, calls workspace services directly, or carries fallback mutation semantics.
- The local `codex-review-loop` skill referenced by `AGENTS.md` is not present in this checkout or available skill list, so this PR records the ADR self-review and the verification evidence instead of an attributed skill run.

## Mergeability

- Surface: desktop app — App Intents veneer over workspace automation verbs
- User-facing behavior changed: Adds Shortcuts/Siri/Spotlight actions to list, select, and create WorkSpaces workspaces through the shared automation controller.
- Non-happy paths considered: No live window maps to unsupported; confirmation_required maps to App Intents confirmation; invalid ids and under-capable handles stay on controller error mapping.
- Residual risk or follow-up: Headless validation could not drive the macOS Shortcuts UI directly; covered by AppShortcut metadata/tests plus API select smoke through the shared verb layer.
