### PR TITLE
Add API-driven desktop UI smoke parity lane

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -58,6 +58,16 @@ description = "Drive the daily-driver desktop flows (create workspace, terminal 
 run = "./scripts/desktop-ui-smoke.sh"
 usage = "[--no-build] [--keep-artifacts] [--timeout-seconds <n>] [--inactivity-seconds <n>]"
 
+[tasks."dev-api-ui-smoke"]
+description = "Drive the daily-driver desktop flows through operator workspace create/select verbs."
+run = "./scripts/api-desktop-ui-smoke.sh"
+usage = "[--no-build] [--keep-artifacts] [--timeout-seconds <n>]"
+
+[tasks."dev-ui-smoke-parity"]
+description = "Run UI and API desktop smoke lanes repeatedly and write a milestone parity report."
+run = "uv run --script scripts/desktop-ui-smoke-parity.py"
+usage = "[--runs <n>] [--no-build] [--timeout-seconds <n>]"
+
 [tasks."claude-integration-smoke"]
 description = "Run the interactive Claude Code integration smoke and evidence capture harness."
 run = "./scripts/claude-integration-smoke.sh"

--- a/Sources/WorkspaceManager/App/DesktopUISmokeAutomation.swift
+++ b/Sources/WorkspaceManager/App/DesktopUISmokeAutomation.swift
@@ -179,6 +179,9 @@ final class DesktopUISmokeAutomationController: ObservableObject {
     private var emittedRepoPath: String?
     private var hasStartedScenario = false
     private var lastFailureSignature: String?
+    private var pendingAPISelectWorkspacePath: String?
+    private var apiSelectCompletionTask: Task<Void, Never>?
+    private var emittedScenarioComplete = false
 
     /// Monotonic counter bumped each time a terminal surface reports focus.
     /// The scenario captures it before a selection action and waits for it to
@@ -222,6 +225,8 @@ final class DesktopUISmokeAutomationController: ObservableObject {
     /// api-select smoke script keys its `workspaces workspace select` on this milestone.
     func noteAwaitingAPISelect(workspace: Workspace) async {
         guard isEnabled else { return }
+        pendingAPISelectWorkspacePath = normalizedPath(workspace.path)
+        apiSelectCompletionTask?.cancel()
         await emit(
             makeEvent(
                 type: .awaitingApiSelect,
@@ -330,6 +335,23 @@ final class DesktopUISmokeAutomationController: ObservableObject {
                 sessionScope: scopePath
             )
         )
+
+        guard
+            configuration?.selectDriver == .api,
+            kind == .workspace,
+            pendingAPISelectWorkspacePath == normalizedPath(scopePath)
+        else {
+            return
+        }
+
+        pendingAPISelectWorkspacePath = nil
+        let focusBaseline = surfaceFocusCount
+        apiSelectCompletionTask?.cancel()
+        apiSelectCompletionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            _ = await self.waitForSurfaceFocus(after: focusBaseline, timeout: .seconds(15))
+            await self.noteScenarioComplete()
+        }
     }
 
     func noteSurfaceFocused(sessionID: UUID) async {
@@ -346,7 +368,8 @@ final class DesktopUISmokeAutomationController: ObservableObject {
     }
 
     func noteScenarioComplete() async {
-        guard isEnabled else { return }
+        guard isEnabled, !emittedScenarioComplete else { return }
+        emittedScenarioComplete = true
         await emit(makeEvent(type: .scenarioComplete))
     }
 
@@ -390,6 +413,10 @@ final class DesktopUISmokeAutomationController: ObservableObject {
     private func emit(_ event: DesktopUISmokeEvent) async {
         guard let writer else { return }
         await writer.emit(event)
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
     }
 
     private func makeEvent(

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2152,6 +2152,21 @@ struct ContentView: View {
                 let selectedID = currentSelectedWorkspace?.id
                 let activeSessionID = tileTreeStore.activeSessionID
                 let attached = selectedID == effect.workspaceID && activeSessionID != nil
+                if desktopUISmokeAutomation.usesAPICreateDriver,
+                    desktopUISmokeAutomation.usesAPISelectDriver,
+                    let repo = repos.first(where: { $0.id == effect.repoID }),
+                    let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == effect.workspaceID })
+                {
+                    Task { @MainActor in
+                        let focusBaselineBeforeRepoPark = desktopUISmokeAutomation.surfaceFocusCount
+                        handleRepoTerminalSelection(repo)
+                        _ = await desktopUISmokeAutomation.waitForSurfaceFocus(
+                            after: focusBaselineBeforeRepoPark,
+                            timeout: .seconds(15)
+                        )
+                        await desktopUISmokeAutomation.noteAwaitingAPISelect(workspace: workspace)
+                    }
+                }
                 return .completed(
                     AutomationWorkspaceCreateEffect(
                         repoID: effect.repoID,

--- a/Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift
+++ b/Tests/WorkspaceManagerAppTests/DesktopUISmokeAutomationTests.swift
@@ -13,6 +13,8 @@ struct DesktopUISmokeAutomationTests {
             DesktopUISmokeAutomationConfiguration.repoPathEnvironmentKey: "/tmp/repo",
             DesktopUISmokeAutomationConfiguration.workspaceNameEnvironmentKey: "ui-smoke-v1",
             DesktopUISmokeAutomationConfiguration.eventsPathEnvironmentKey: "/tmp/events.jsonl",
+            DesktopUISmokeAutomationConfiguration.selectDriverEnvironmentKey: "api",
+            DesktopUISmokeAutomationConfiguration.createDriverEnvironmentKey: "api",
         ]
 
         let configuration = DesktopUISmokeAutomationConfiguration.from(environment: environment)
@@ -20,6 +22,8 @@ struct DesktopUISmokeAutomationTests {
         #expect(configuration?.repoURL.path == "/tmp/repo")
         #expect(configuration?.workspaceName == "ui-smoke-v1")
         #expect(configuration?.eventsURL.path == "/tmp/events.jsonl")
+        #expect(configuration?.selectDriver == .api)
+        #expect(configuration?.createDriver == .api)
     }
 
     @Test("Configuration ignores other automation modes")
@@ -150,13 +154,50 @@ struct DesktopUISmokeAutomationTests {
         #expect(events.filter { $0 == "launch_ready" }.count == 1)
     }
 
-    private static func environment(eventsURL: URL) -> [String: String] {
-        [
+    @Test("API select handoff completes scenario after selected workspace focuses")
+    @MainActor
+    func apiSelectHandoffCompletesScenarioAfterFocus() async throws {
+        let eventsURL = Self.temporaryEventsURL()
+        defer { try? FileManager.default.removeItem(at: eventsURL) }
+
+        let controller = DesktopUISmokeAutomationController(
+            environment: Self.environment(
+                eventsURL: eventsURL,
+                extra: [DesktopUISmokeAutomationConfiguration.selectDriverEnvironmentKey: "api"]
+            )
+        )
+        let repo = Repo(name: "repo", localPath: URL(fileURLWithPath: "/tmp/repo"))
+        let workspace = Workspace(
+            name: "ui-smoke-v1",
+            path: URL(fileURLWithPath: "/tmp/repo-workspace"),
+            sourceRepo: repo
+        )
+
+        await controller.noteAwaitingAPISelect(workspace: workspace)
+        let sessionID = UUID()
+        await controller.noteTerminalSessionAttached(
+            kind: .workspace,
+            sessionID: sessionID,
+            scopePath: "/tmp/repo-workspace"
+        )
+        await controller.noteSurfaceFocused(sessionID: sessionID)
+
+        let events = try Self.readEventTypes(at: eventsURL, waitingFor: "scenario_complete")
+        #expect(events.contains("awaiting_api_select"))
+        #expect(events.contains("terminal_session_attached"))
+        #expect(events.contains("surface_focused"))
+        #expect(events.last == "scenario_complete")
+    }
+
+    private static func environment(eventsURL: URL, extra: [String: String] = [:]) -> [String: String] {
+        var environment = [
             DesktopUISmokeAutomationConfiguration.modeEnvironmentKey: "desktop-ui-smoke",
             DesktopUISmokeAutomationConfiguration.repoPathEnvironmentKey: "/tmp/repo",
             DesktopUISmokeAutomationConfiguration.workspaceNameEnvironmentKey: "ui-smoke-v1",
             DesktopUISmokeAutomationConfiguration.eventsPathEnvironmentKey: eventsURL.path,
         ]
+        environment.merge(extra) { _, new in new }
+        return environment
     }
 
     private static func temporaryEventsURL() -> URL {
@@ -164,16 +205,24 @@ struct DesktopUISmokeAutomationTests {
             .appendingPathComponent("desktop-ui-smoke-\(UUID().uuidString).jsonl")
     }
 
-    private static func readEvents(at url: URL) throws -> [[String: Any]] {
+    private static func readEvents(at url: URL, waitingFor eventType: String? = nil) throws -> [[String: Any]] {
         // Events are written by a background actor; allow a brief settle.
         let deadline = Date().addingTimeInterval(2)
         while Date() < deadline {
-            if let data = try? Data(contentsOf: url), !data.isEmpty {
+            if let events = try? parseEvents(at: url), !events.isEmpty {
+                if let eventType, !events.contains(where: { $0["type"] as? String == eventType }) {
+                    Thread.sleep(forTimeInterval: 0.02)
+                    continue
+                }
                 break
             }
             Thread.sleep(forTimeInterval: 0.02)
         }
 
+        return try parseEvents(at: url)
+    }
+
+    private static func parseEvents(at url: URL) throws -> [[String: Any]] {
         let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
         return
             contents
@@ -184,7 +233,7 @@ struct DesktopUISmokeAutomationTests {
             }
     }
 
-    private static func readEventTypes(at url: URL) throws -> [String] {
-        try readEvents(at: url).compactMap { $0["type"] as? String }
+    private static func readEventTypes(at url: URL, waitingFor eventType: String? = nil) throws -> [String] {
+        try readEvents(at: url, waitingFor: eventType).compactMap { $0["type"] as? String }
     }
 }

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -553,6 +553,8 @@ milestones that prove the verb entered the real UI path:
 ```bash
 ./scripts/api-select-smoke.sh --no-build   # asserts terminal_session_attached after the CLI select
 ./scripts/api-create-smoke.sh --no-build   # asserts create, selection, and new workspace attach
+./scripts/api-desktop-ui-smoke.sh --no-build
+uv run --script scripts/desktop-ui-smoke-parity.py --runs 3 --no-build
 ```
 
 If docs or public examples changed, also run the docs checks listed in

--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -313,18 +313,23 @@ Use this exact loop in future sessions to avoid stale-build confusion:
    - if you launched with `--no-activate`, pause your own keyboard/mouse input
    - run `./scripts/capture-window.sh`
    - resume input after the capture finishes
-6. Exercise shortcuts when activation is allowed:
+6. Verify the daily-driver smoke lanes:
+   - authoritative UI lane: `./scripts/desktop-ui-smoke.sh --no-build`
+   - API parity lane: `./scripts/api-desktop-ui-smoke.sh --no-build`
+   - repeated comparison report: `uv run --script scripts/desktop-ui-smoke-parity.py --runs 3 --no-build`
+   - the API lane drives `workspace.create` and `workspace.select` through the operator socket; repo selection remains app-side until a reviewed repo-select verb exists
+7. Exercise shortcuts when activation is allowed:
    - `Cmd+B` collapse/restore sidebar
    - `Cmd+D` create split pane
    - optional: trigger configured resize/equalize bindings and confirm divider movement / 50:50 reset
    - `./scripts/shortcut-pass-through-smoke.sh` is intentionally not shared-desktop-safe and requires `Ghostty Splits` mode
    - Optional scripted smoke: `mask verify-shortcuts`
-7. Verify split runtime path in logs:
+8. Verify split runtime path in logs:
    - `tail -n 80 .dev-data/logs/launch-dev-*.log`
    - Expect `"[GhosttyAppManager] action=new_split direction="`
    - Optional resize/equalize traces:
      - `"[GhosttyAppManager] action=resize_split direction="`
      - `"[GhosttyAppManager] action=equalize_splits"`
-8. If you need input-driving automation without foreground activation on a shared desktop, escalate to Tart/Lume or a separate macOS user/session instead of forcing local focus.
+9. If you need input-driving automation without foreground activation on a shared desktop, escalate to Tart/Lume or a separate macOS user/session instead of forcing local focus.
 
 If shortcut behavior regresses, first confirm step 4 before changing code.

--- a/scripts/api-desktop-ui-smoke.sh
+++ b/scripts/api-desktop-ui-smoke.sh
@@ -1,0 +1,482 @@
+#!/bin/bash
+# ==========================================================================
+# api-desktop-ui-smoke.sh - API-driven daily-driver smoke for the debug app
+# ==========================================================================
+#
+# Runs the desktop daily-driver scenario beside the authoritative UI lane while
+# driving the reviewed operator verbs from outside the app:
+#
+#   1. Launch the debug app headless-safe with operator scope enabled.
+#   2. Read the repo target with `workspaces workspace list`, then create a
+#      local workspace with `workspaces workspace create`.
+#   3. Read the workspace target with `workspaces workspace list`, then reselect
+#      the workspace with `workspaces workspace select` after the app parks on
+#      the repo terminal. Repo selection is app-side because no reviewed
+#      repo-select operator verb exists.
+#
+# Artifacts land under output/api-desktop-ui-smoke/<timestamp>/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LAUNCH_SCRIPT="$REPO_ROOT/scripts/launch-dev.sh"
+CLI_BIN="$REPO_ROOT/.build/arm64-apple-macosx/debug/workspaces"
+OUTPUT_ROOT="$REPO_ROOT/output/api-desktop-ui-smoke"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="$OUTPUT_ROOT/$TIMESTAMP"
+RUN_LINK="$OUTPUT_ROOT/latest"
+DEFAULT_TIMEOUT_SECONDS=$((5 * 60))
+
+SKIP_BUILD=false
+KEEP_ARTIFACTS=false
+TOTAL_TIMEOUT_SECONDS="$DEFAULT_TIMEOUT_SECONDS"
+APP_PID=""
+LAUNCH_LOG_PATH=""
+SMOKE_REPO_PATH=""
+WORKSPACE_NAME="api-desktop-ui-smoke-$TIMESTAMP"
+EVENTS_PATH=""
+RUN_STATUS="failed"
+STARTED_AT=0
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/api-desktop-ui-smoke.sh [options]
+
+Options:
+  --no-build              Reuse the current debug binary
+  --keep-artifacts        Keep the disposable smoke repo after a passing run
+  --timeout-seconds <n>   Total timeout (default: 300)
+  --help, -h              Show this help
+USAGE
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-build) SKIP_BUILD=true; shift ;;
+            --keep-artifacts) KEEP_ARTIFACTS=true; shift ;;
+            --timeout-seconds)
+                [[ $# -ge 2 ]] || fail "--timeout-seconds requires a value"
+                TOTAL_TIMEOUT_SECONDS="$2"
+                shift 2
+                ;;
+            --help|-h) usage; exit 0 ;;
+            *) fail "Unknown argument: $1" ;;
+        esac
+    done
+}
+
+setup_run_dir() {
+    mkdir -p "$RUN_DIR"
+    ln -sfn "$RUN_DIR" "$RUN_LINK"
+    EVENTS_PATH="$RUN_DIR/events.jsonl"
+}
+
+cleanup_app() {
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" >/dev/null 2>&1; then
+        kill "$APP_PID" >/dev/null 2>&1 || true
+        sleep 1
+    fi
+    pkill -f "$REPO_ROOT/.build/arm64-apple-macosx/debug/WorkspaceManager" >/dev/null 2>&1 || true
+}
+
+read_event_field() {
+    local field="$1" event_type="$2"
+    python3 - "$EVENTS_PATH" "$field" "$event_type" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, field, event_type = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+value = ""
+if path.exists():
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        event = json.loads(line)
+        if event.get("type") == event_type and event.get(field):
+            value = event[field]
+print(value)
+PY
+}
+
+cleanup_created_worktree() {
+    [[ -f "$EVENTS_PATH" ]] || return 0
+    local workspace_path
+    workspace_path="$(read_event_field workspacePath workspace_created)"
+    [[ -n "$workspace_path" && -d "$workspace_path" ]] || return 0
+    chmod -R u+w "$workspace_path" >/dev/null 2>&1 || true
+    rm -rf "$workspace_path" >/dev/null 2>&1 || true
+    local repo_container
+    repo_container="$(dirname "$workspace_path")"
+    if [[ -d "$repo_container" && -z "$(ls -A "$repo_container" 2>/dev/null)" ]]; then
+        rmdir "$repo_container" >/dev/null 2>&1 || true
+    fi
+}
+
+cleanup_repo() {
+    [[ "$KEEP_ARTIFACTS" == true ]] && return 0
+    if [[ -n "$SMOKE_REPO_PATH" && -d "$SMOKE_REPO_PATH" ]]; then
+        chmod -R u+w "$SMOKE_REPO_PATH" >/dev/null 2>&1 || true
+        rm -rf "$SMOKE_REPO_PATH" >/dev/null 2>&1 || true
+    fi
+    cleanup_created_worktree
+}
+
+on_exit() {
+    local code="$?"
+    trap - EXIT
+    cleanup_app
+    [[ "$RUN_STATUS" == "passed" ]] && cleanup_repo
+    write_summary "$code"
+    log "Run directory: $RUN_DIR"
+    exit "$code"
+}
+
+write_summary() {
+    local exit_code="$1"
+    local elapsed_seconds
+    elapsed_seconds=$(( $(date +%s) - STARTED_AT ))
+    cat >"$RUN_DIR/summary.md" <<EOF
+# API Desktop UI Smoke
+
+- Outcome: $RUN_STATUS
+- Exit code: $exit_code
+- Repo path: ${SMOKE_REPO_PATH:-unknown}
+- Workspace name: $WORKSPACE_NAME
+- Elapsed seconds: $elapsed_seconds
+- Events: $EVENTS_PATH
+- Create result: $RUN_DIR/create-result.json
+- Select result: $RUN_DIR/select-result.json
+- Repo selection driver: app-side handoff; no reviewed repo-select operator verb exists yet
+EOF
+    if [[ -n "$LAUNCH_LOG_PATH" && -f "$LAUNCH_LOG_PATH" ]]; then
+        cp "$LAUNCH_LOG_PATH" "$RUN_DIR/launch.log" 2>/dev/null || true
+    fi
+}
+
+create_disposable_repo() {
+    SMOKE_REPO_PATH="$(mktemp -d "${TMPDIR:-/tmp}/workspaces-api-desktop-ui-XXXXXX")"
+    (
+        cd "$SMOKE_REPO_PATH"
+        git init >/dev/null
+        git config user.name "WorkspaceManager Smoke" >/dev/null
+        git config user.email "smoke@local.invalid" >/dev/null
+        printf "# API desktop UI smoke\n\nCreated %s\n" "$TIMESTAMP" >README.md
+        git add README.md
+        git commit -m "Initial smoke fixture" >/dev/null
+    )
+}
+
+launch_automated_app() {
+    local app_data_dir="$RUN_DIR/app-data"
+    local -a args=(
+        "--no-activate"
+        "--data-dir" "$app_data_dir"
+        "--clean-data"
+        "--window-timeout" "20"
+        "--env" "WORKSPACES_DISABLE_AUTO_IMPORT=1"
+        "--env" "WORKSPACES_AUTOMATION_API=1"
+        "--env" "WORKSPACES_AUTOMATION_OPERATOR=1"
+        "--env" "WORKSPACES_AUTOMATION_MODE=desktop-ui-smoke"
+        "--env" "WORKSPACES_AUTOMATION_CREATE_DRIVER=api"
+        "--env" "WORKSPACES_AUTOMATION_SELECT_DRIVER=api"
+        "--env" "WORKSPACES_AUTOMATION_REPO_PATH=$SMOKE_REPO_PATH"
+        "--env" "WORKSPACES_AUTOMATION_WORKSPACE_NAME=$WORKSPACE_NAME"
+        "--env" "WORKSPACES_AUTOMATION_EVENTS_PATH=$EVENTS_PATH"
+    )
+    [[ "$SKIP_BUILD" == true ]] && args+=("--no-build")
+
+    local launch_output
+    launch_output="$(
+        cd "$REPO_ROOT"
+        "$LAUNCH_SCRIPT" "${args[@]}" 2>&1 | tee "$RUN_DIR/launch-command.log"
+    )"
+    APP_PID="$(printf '%s\n' "$launch_output" | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' | tail -n 1)"
+    LAUNCH_LOG_PATH="$(printf '%s\n' "$launch_output" | sed -n 's/.*Log file: \(.*\)$/\1/p' | tail -n 1)"
+    [[ -n "$APP_PID" ]] || fail "Could not determine WorkspaceManager pid from launch output."
+}
+
+event_index() {
+    python3 - "$EVENTS_PATH" "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, target = Path(sys.argv[1]), sys.argv[2]
+idx = -1
+if path.exists():
+    for index, line in enumerate(l.strip() for l in path.read_text().splitlines() if l.strip()):
+        if json.loads(line).get("type") == target:
+            idx = index
+            break
+print(idx)
+PY
+}
+
+wait_for_event() {
+    local event_type="$1" deadline=$(( $(date +%s) + TOTAL_TIMEOUT_SECONDS ))
+    while (( $(date +%s) < deadline )); do
+        if [[ "$(event_index "$event_type")" != "-1" ]]; then
+            return 0
+        fi
+        if [[ "$(event_index failure)" != "-1" ]]; then
+            fail "App reported a failure milestone: $(read_event_field message failure)"
+        fi
+        sleep 1
+    done
+    fail "Timed out waiting for milestone: $event_type"
+}
+
+workspace_list_json() {
+    local output_path="$1"
+    "$CLI_BIN" workspace list --json | tee "$output_path" >/dev/null
+}
+
+extract_repo_id() {
+    python3 - "$1" "$SMOKE_REPO_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+target = Path(sys.argv[2]).resolve()
+for repo in data.get("repos", []):
+    if Path(repo.get("path", "")).resolve() == target:
+        print(repo["repoID"])
+        sys.exit(0)
+print(f"No repo from workspace list matched {target}", file=sys.stderr)
+sys.exit(1)
+PY
+}
+
+extract_workspace_id() {
+    python3 - "$1" "$2" "$WORKSPACE_NAME" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+repo_id, workspace_name = sys.argv[2], sys.argv[3]
+for workspace in data.get("workspaces", []):
+    if workspace.get("repoID") == repo_id and workspace.get("name") == workspace_name:
+        print(workspace["workspaceID"])
+        sys.exit(0)
+print(
+    f"No workspace from workspace list matched repoID={repo_id} name={workspace_name}",
+    file=sys.stderr,
+)
+sys.exit(1)
+PY
+}
+
+assert_create_result() {
+    python3 - "$RUN_DIR/create-result.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(Path(sys.argv[1]).read_text())
+failures = []
+if result.get("outcome") != "completed":
+    failures.append(f"outcome was {result.get('outcome')!r}")
+if result.get("attachedTerminal") is not True:
+    failures.append("attachedTerminal was not true")
+if not result.get("workspaceID"):
+    failures.append("workspaceID was missing")
+if failures:
+    print("ASSERTION FAILED: create result", file=sys.stderr)
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+assert_select_result() {
+    python3 - "$RUN_DIR/select-result.json" "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = json.loads(Path(sys.argv[1]).read_text())
+workspace_id = sys.argv[2]
+failures = []
+if result.get("outcome") != "completed":
+    failures.append(f"outcome was {result.get('outcome')!r}")
+if result.get("workspaceID") != workspace_id:
+    failures.append("workspaceID did not match target")
+if result.get("attachedTerminal") is not True:
+    failures.append("attachedTerminal was not true")
+if failures:
+    print("ASSERTION FAILED: select result", file=sys.stderr)
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+assert_api_milestone_sequence() {
+    python3 - "$EVENTS_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+events = [json.loads(line) for line in Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+types = [event.get("type") for event in events]
+
+
+def fail(message):
+    print(f"ASSERTION FAILED: {message}", file=sys.stderr)
+    print("Observed milestone order:", file=sys.stderr)
+    for event in events:
+        print(
+            f"  - {event.get('type')} kind={event.get('selectionKind')} "
+            f"session={event.get('sessionID')}",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+
+
+if "failure" in types:
+    failure = next(event for event in events if event.get("type") == "failure")
+    fail(f"app reported failure: {failure.get('message')}")
+
+
+def index_of(kind):
+    return types.index(kind) if kind in types else None
+
+
+required = [
+    "launch_ready",
+    "repo_ready",
+    "awaiting_api_create",
+    "workspace_created",
+    "sidebar_updated",
+    "awaiting_api_select",
+    "scenario_complete",
+]
+for kind in required:
+    if kind not in types:
+        fail(f"missing required milestone: {kind}")
+
+if not (
+    index_of("launch_ready")
+    < index_of("repo_ready")
+    < index_of("awaiting_api_create")
+    < index_of("workspace_created")
+    < index_of("sidebar_updated")
+    < index_of("awaiting_api_select")
+    < index_of("scenario_complete")
+):
+    fail("API handoff milestones are out of order")
+
+if types[-1] != "scenario_complete":
+    fail("scenario_complete was not the final milestone")
+
+await_create = index_of("awaiting_api_create")
+await_select = index_of("awaiting_api_select")
+attaches = [
+    (index, event)
+    for index, event in enumerate(events)
+    if event.get("type") == "terminal_session_attached"
+]
+repo_before_create = [
+    event for index, event in attaches
+    if index < await_create and event.get("selectionKind") == "repo"
+]
+workspace_after_create = [
+    event for index, event in attaches
+    if await_create < index < await_select and event.get("selectionKind") == "workspace"
+]
+repo_before_select = [
+    event for index, event in attaches
+    if await_create < index < await_select and event.get("selectionKind") == "repo"
+]
+workspace_after_select = [
+    event for index, event in attaches
+    if index > await_select and event.get("selectionKind") == "workspace"
+]
+
+if not repo_before_create:
+    fail("repo terminal did not attach before API create handoff")
+if not workspace_after_create:
+    fail("workspace terminal did not attach after API create")
+if not repo_before_select:
+    fail("repo terminal did not attach before API select handoff")
+if not workspace_after_select:
+    fail("workspace terminal did not attach after API select")
+
+created_workspace = next(event for event in events if event.get("type") == "workspace_created")
+if workspace_after_select[0].get("sessionScope") != created_workspace.get("workspacePath"):
+    fail("API select workspace attach scope did not match created workspace path")
+
+focus_events = [event for event in events if event.get("type") == "surface_focused"]
+focus_timeouts = [event for event in events if event.get("type") == "surface_focus_timed_out"]
+print(
+    "OK: API lane emitted create/sidebar/select milestones, "
+    f"{len(attaches)} terminal attaches, {len(focus_events)} focuses, "
+    f"{len(focus_timeouts)} focus timeouts"
+)
+PY
+}
+
+main() {
+    parse_args "$@"
+    STARTED_AT="$(date +%s)"
+    trap on_exit EXIT
+    setup_run_dir
+    create_disposable_repo
+
+    if [[ "$SKIP_BUILD" != true ]]; then
+        log "Building debug binaries..."
+        ( cd "$REPO_ROOT" && swift build >/dev/null )
+    fi
+    [[ -x "$CLI_BIN" ]] || fail "CLI binary not found at $CLI_BIN (run swift build)."
+
+    log "Launching app (API create + API select drivers)..."
+    launch_automated_app
+
+    log "Waiting for API create handoff..."
+    wait_for_event awaiting_api_create
+
+    workspace_list_json "$RUN_DIR/workspace-list-before-create.json"
+    local repo_id
+    repo_id="$(extract_repo_id "$RUN_DIR/workspace-list-before-create.json")"
+    log "Repo id from workspace list: $repo_id"
+
+    log "Driving API create: workspaces workspace create $repo_id $WORKSPACE_NAME"
+    "$CLI_BIN" workspace create "$repo_id" "$WORKSPACE_NAME" --json | tee "$RUN_DIR/create-result.json"
+    assert_create_result
+
+    log "Waiting for API select handoff..."
+    wait_for_event awaiting_api_select
+
+    workspace_list_json "$RUN_DIR/workspace-list-before-select.json"
+    local workspace_id
+    workspace_id="$(extract_workspace_id "$RUN_DIR/workspace-list-before-select.json" "$repo_id")"
+    log "Workspace id from workspace list: $workspace_id"
+
+    log "Driving API select: workspaces workspace select $workspace_id"
+    "$CLI_BIN" workspace select "$workspace_id" --json | tee "$RUN_DIR/select-result.json"
+    assert_select_result "$workspace_id"
+
+    log "Waiting for scenario completion..."
+    wait_for_event scenario_complete
+    assert_api_milestone_sequence | tee "$RUN_DIR/assertions.log"
+
+    if "$CLI_BIN" window snapshot --out "$RUN_DIR/final.png" >/dev/null 2>&1; then
+        log "Captured final window snapshot: $RUN_DIR/final.png"
+    else
+        log "Window snapshot unavailable (likely a locked screen) — JSONL + API results stand as evidence."
+    fi
+
+    RUN_STATUS="passed"
+    log "PASS — API-driven lane created and reselected the workspace through operator verbs."
+}
+
+main "$@"

--- a/scripts/desktop-ui-smoke-parity.py
+++ b/scripts/desktop-ui-smoke-parity.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Run and compare UI-driven and API-driven desktop smoke lanes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_ROOT = REPO_ROOT / "output" / "desktop-ui-smoke-parity"
+LANES = {
+    "ui": {
+        "script": REPO_ROOT / "scripts" / "desktop-ui-smoke.sh",
+        "output": REPO_ROOT / "output" / "desktop-ui-smoke",
+    },
+    "api": {
+        "script": REPO_ROOT / "scripts" / "api-desktop-ui-smoke.sh",
+        "output": REPO_ROOT / "output" / "api-desktop-ui-smoke",
+    },
+}
+
+
+@dataclass
+class LaneRun:
+    lane: str
+    index: int
+    run_dir: Path
+    events_path: Path
+    events: list[dict[str, Any]]
+    command: list[str]
+
+    @property
+    def tokens(self) -> list[str]:
+        return [event_token(event) for event in self.events]
+
+    @property
+    def comparable_walk(self) -> list[str]:
+        return comparable_walk(self.events)
+
+    @property
+    def focus_count(self) -> int:
+        return sum(1 for event in self.events if event.get("type") == "surface_focused")
+
+    @property
+    def focus_timeout_count(self) -> int:
+        return sum(1 for event in self.events if event.get("type") == "surface_focus_timed_out")
+
+
+def event_token(event: dict[str, Any]) -> str:
+    kind = event.get("type", "")
+    if kind == "terminal_session_attached":
+        return f"{kind}:{event.get('selectionKind', 'unknown')}"
+    return kind
+
+
+def comparable_walk(events: list[dict[str, Any]]) -> list[str]:
+    """Project a lane to the shared create + workspace-repo-workspace contract."""
+
+    tokens: list[str] = []
+    types = [event.get("type") for event in events]
+    if "workspace_created" in types:
+        tokens.append("workspace_created")
+    if "sidebar_updated" in types:
+        tokens.append("sidebar_updated")
+
+    attaches = [
+        event
+        for event in events
+        if event.get("type") == "terminal_session_attached"
+        and event.get("selectionKind") in {"workspace", "repo"}
+    ]
+
+    first_workspace_index = next(
+        (index for index, event in enumerate(attaches) if event.get("selectionKind") == "workspace"),
+        None,
+    )
+    if first_workspace_index is not None:
+        first_workspace = attaches[first_workspace_index]
+        tokens.append(f"terminal_session_attached:{first_workspace.get('selectionKind')}")
+        repo_index = next(
+            (
+                index
+                for index, event in enumerate(attaches[first_workspace_index + 1 :], first_workspace_index + 1)
+                if event.get("selectionKind") == "repo"
+            ),
+            None,
+        )
+        if repo_index is not None:
+            repo_attach = attaches[repo_index]
+            tokens.append(f"terminal_session_attached:{repo_attach.get('selectionKind')}")
+            later_workspace = next(
+                (
+                    event
+                    for event in attaches[repo_index + 1 :]
+                    if event.get("selectionKind") == "workspace"
+                ),
+                None,
+            )
+            if later_workspace is not None:
+                tokens.append(f"terminal_session_attached:{later_workspace.get('selectionKind')}")
+
+    if "scenario_complete" in types:
+        tokens.append("scenario_complete")
+    return tokens
+
+
+def load_events(run_dir: Path) -> list[dict[str, Any]]:
+    events_path = run_dir / "events.jsonl"
+    if not events_path.exists():
+        raise RuntimeError(f"events file missing: {events_path}")
+    events: list[dict[str, Any]] = []
+    for line in events_path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    if not events:
+        raise RuntimeError(f"events file was empty: {events_path}")
+    return events
+
+
+def resolve_latest(output_root: Path) -> Path:
+    latest = output_root / "latest"
+    if latest.exists():
+        return latest.resolve()
+    candidates = sorted([path for path in output_root.iterdir() if path.is_dir()])
+    if not candidates:
+        raise RuntimeError(f"no run directories found under {output_root}")
+    return candidates[-1]
+
+
+def run_command(command: list[str], timeout_seconds: int) -> None:
+    print("$ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=REPO_ROOT, check=True, timeout=timeout_seconds)
+
+
+def run_lane(lane: str, index: int, no_build: bool, timeout_seconds: int) -> LaneRun:
+    lane_info = LANES[lane]
+    command = [str(lane_info["script"])]
+    if no_build:
+        command.append("--no-build")
+    command.extend(["--timeout-seconds", str(timeout_seconds)])
+    run_command(command, timeout_seconds + 30)
+    run_dir = resolve_latest(lane_info["output"])
+    return LaneRun(
+        lane=lane,
+        index=index,
+        run_dir=run_dir,
+        events_path=run_dir / "events.jsonl",
+        events=load_events(run_dir),
+        command=command,
+    )
+
+
+def build_once() -> None:
+    run_command(["swift", "build"], timeout_seconds=300)
+
+
+def analyze_divergences(runs: list[LaneRun]) -> list[str]:
+    divergences: list[str] = []
+    expected_walk = [
+        "workspace_created",
+        "sidebar_updated",
+        "terminal_session_attached:workspace",
+        "terminal_session_attached:repo",
+        "terminal_session_attached:workspace",
+        "scenario_complete",
+    ]
+
+    for run in runs:
+        if run.comparable_walk != expected_walk:
+            divergences.append(
+                f"{run.lane} run {run.index}: comparable walk was {run.comparable_walk}, "
+                f"expected {expected_walk}."
+            )
+        if run.tokens[-1] != "scenario_complete":
+            divergences.append(
+                f"{run.lane} run {run.index}: final milestone was {run.tokens[-1]!r}, "
+                "not scenario_complete."
+            )
+
+    api_runs = [run for run in runs if run.lane == "api"]
+    if api_runs:
+        divergences.append(
+            "Expected API-lane-only handoffs: awaiting_api_create and awaiting_api_select mark where "
+            "the host script calls operator verbs."
+        )
+        divergences.append(
+            "Expected residual gap: repo selection is still app-side because the shipped operator API "
+            "has workspace.select but no reviewed repo-select verb."
+        )
+
+    ui_has_web = any("web_surface_attached" in run.tokens for run in runs if run.lane == "ui")
+    api_has_web = any("web_surface_attached" in run.tokens for run in api_runs)
+    if ui_has_web and not api_has_web:
+        divergences.append(
+            "Expected scope difference: the authoritative UI lane still includes the web-surface seam "
+            "check; the API parity lane covers the create and workspace-repo-workspace daily-driver walk."
+        )
+
+    return divergences
+
+
+def write_report(report_dir: Path, runs: list[LaneRun], started_at: str) -> Path:
+    report_path = report_dir / "parity-report.md"
+    divergences = analyze_divergences(runs)
+    expected_walk = [
+        "workspace_created",
+        "sidebar_updated",
+        "terminal_session_attached:workspace",
+        "terminal_session_attached:repo",
+        "terminal_session_attached:workspace",
+        "scenario_complete",
+    ]
+    lines = [
+        "# Desktop UI Smoke Parity Report",
+        "",
+        f"- Started: {started_at}",
+        f"- UI runs: {sum(1 for run in runs if run.lane == 'ui')}",
+        f"- API runs: {sum(1 for run in runs if run.lane == 'api')}",
+        f"- Comparable contract: `{' -> '.join(expected_walk)}`",
+        "- `surface_focused` is best-effort; focus timeout counts are reported but do not fail parity.",
+        "",
+        "## Runs",
+        "",
+        "| Lane | Run | Directory | Comparable walk | Focus | Focus timeouts |",
+        "| --- | ---: | --- | --- | ---: | ---: |",
+    ]
+    for run in runs:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    run.lane,
+                    str(run.index),
+                    f"`{run.run_dir.relative_to(REPO_ROOT)}`",
+                    f"`{' -> '.join(run.comparable_walk)}`",
+                    str(run.focus_count),
+                    str(run.focus_timeout_count),
+                ]
+            )
+            + " |"
+        )
+
+    lines.extend(["", "## Full Milestone Streams", ""])
+    for run in runs:
+        lines.extend(
+            [
+                f"### {run.lane.upper()} run {run.index}",
+                "",
+                f"- Events: `{run.events_path.relative_to(REPO_ROOT)}`",
+                "",
+                "```text",
+                " -> ".join(run.tokens),
+                "```",
+                "",
+            ]
+        )
+
+    lines.extend(["## Divergences", ""])
+    if divergences:
+        for divergence in divergences:
+            lines.append(f"- {divergence}")
+    else:
+        lines.append("- None.")
+
+    lines.extend(
+        [
+            "",
+            "## Result",
+            "",
+        ]
+    )
+    failed = [
+        run
+        for run in runs
+        if run.comparable_walk != expected_walk or run.tokens[-1] != "scenario_complete"
+    ]
+    if failed:
+        lines.append("Parity failed for the comparable daily-driver milestone contract.")
+    else:
+        lines.append(
+            "Parity passed for the comparable daily-driver milestone contract across all runs."
+        )
+
+    report_path.write_text("\n".join(lines) + "\n")
+    return report_path
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=3, help="runs per lane (default: 3)")
+    parser.add_argument(
+        "--no-build",
+        action="store_true",
+        help="reuse the current debug binaries; otherwise build once before all runs",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=300,
+        help="timeout passed to each smoke lane (default: 300)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.runs < 1:
+        raise SystemExit("--runs must be at least 1")
+
+    started_at = datetime.now().astimezone().isoformat(timespec="seconds")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    report_dir = OUTPUT_ROOT / timestamp
+    report_dir.mkdir(parents=True, exist_ok=True)
+    latest = OUTPUT_ROOT / "latest"
+    latest.unlink(missing_ok=True)
+    latest.symlink_to(report_dir, target_is_directory=True)
+
+    if not args.no_build:
+        build_once()
+    lane_no_build = True
+
+    runs: list[LaneRun] = []
+    for index in range(1, args.runs + 1):
+        runs.append(run_lane("ui", index, lane_no_build, args.timeout_seconds))
+        runs.append(run_lane("api", index, lane_no_build, args.timeout_seconds))
+
+    report_path = write_report(report_dir, runs, started_at)
+    print(f"Parity report: {report_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/desktop-ui-smoke.sh
+++ b/scripts/desktop-ui-smoke.sh
@@ -349,9 +349,13 @@ if not (
 ):
     fail("creation milestones are out of order")
 
-attaches = [e for e in events if e.get("type") == "terminal_session_attached"]
-workspace_attaches = [a for a in attaches if a.get("selectionKind") == "workspace"]
-repo_attaches = [a for a in attaches if a.get("selectionKind") == "repo"]
+attaches = [
+    (i, e)
+    for i, e in enumerate(events)
+    if e.get("type") == "terminal_session_attached"
+]
+workspace_attaches = [(i, a) for i, a in attaches if a.get("selectionKind") == "workspace"]
+repo_attaches = [(i, a) for i, a in attaches if a.get("selectionKind") == "repo"]
 
 if not workspace_attaches:
     fail("no workspace terminal session was attached")
@@ -361,16 +365,16 @@ if not repo_attaches:
 # Flow 2: prove the surface follows selection. The first workspace attach, a
 # repo attach, then a workspace attach again, with the repo session distinct
 # from the workspace session and the workspace session reused on return.
-first_workspace = workspace_attaches[0]
-first_repo = repo_attaches[0]
+_, first_workspace = workspace_attaches[0]
+first_repo_index, first_repo = repo_attaches[0]
 
 if first_repo.get("sessionID") == first_workspace.get("sessionID"):
     fail("repo terminal reused the workspace session — selection did not switch")
 
 later_workspace = [
     a
-    for a in workspace_attaches
-    if events.index(a) > events.index(first_repo)
+    for i, a in workspace_attaches
+    if i > first_repo_index
 ]
 if not later_workspace:
     fail("workspace terminal did not re-attach after switching back")
@@ -384,10 +388,11 @@ if restored.get("sessionScope") != first_workspace.get("sessionScope"):
 # routing after the web swap; surface remount/focus stays best-effort
 # (surface_focused), matching Flows 1-2.
 web_attaches = [e for e in events if e.get("type") == "web_surface_attached"]
+web_attach_index = next(i for i, e in enumerate(events) if e.get("type") == "web_surface_attached")
 post_web_workspace = [
     a
-    for a in workspace_attaches
-    if events.index(a) > events.index(web_attaches[0])
+    for i, a in workspace_attaches
+    if i > web_attach_index
 ]
 if not post_web_workspace:
     fail("no workspace terminal session attached after the web pane")


### PR DESCRIPTION
## Summary

- Adds an API-driven desktop UI smoke lane that composes the shipped operator `workspace.create`, `workspace.list`, and `workspace.select` verbs into the daily-driver create + workspace/repo/workspace selection scenario.
- Adds a parity-report runner for repeated UI/API lane comparison and wires both scripts into `mise`.
- Updates the automation runbook/docs and fixes the existing UI smoke assertion to compare duplicate workspace reattach milestones by event position.

Closes #923

## Evidence

- [Parity report rendering](https://evidence.cloudcompute.com/workspaces/pr-955/20260708-063500-api-desktop-ui-smoke-parity.svg)

## Parity Report

Post-rebase report: `output/desktop-ui-smoke-parity/20260707-232704/parity-report.md`

Comparable contract:

`workspace_created -> sidebar_updated -> terminal_session_attached:workspace -> terminal_session_attached:repo -> terminal_session_attached:workspace -> scenario_complete`

| Lane | Run | Directory | Comparable walk | Focus | Focus timeouts |
| --- | ---: | --- | --- | ---: | ---: |
| ui | 1 | `output/desktop-ui-smoke/20260707-232705` | pass | 0 | 4 |
| api | 1 | `output/api-desktop-ui-smoke/20260707-232820` | pass | 0 | 3 |
| ui | 2 | `output/desktop-ui-smoke/20260707-232912` | pass | 4 | 0 |
| api | 2 | `output/api-desktop-ui-smoke/20260707-232936` | pass | 0 | 3 |
| ui | 3 | `output/desktop-ui-smoke/20260707-233031` | pass | 0 | 4 |
| api | 3 | `output/api-desktop-ui-smoke/20260707-233142` | pass | 0 | 3 |

Divergences explained:

- API-only `awaiting_api_create` and `awaiting_api_select` milestones mark host-script handoffs to the operator verbs.
- Repo selection remains app-side because the shipped operator API has `workspace.select` but no reviewed repo-select verb.
- The authoritative UI lane still includes the web-surface seam check; the API parity lane covers the issue's create + workspace/repo/workspace daily-driver walk.
- `surface_focused` remains best-effort in no-activation runs; timeout milestones are reported but not parity failures.

## Verification

- `swift build`
- `swift test`
- `mise run lint`
- `bash -n scripts/desktop-ui-smoke.sh scripts/api-desktop-ui-smoke.sh`
- `env PYTHONPYCACHEPREFIX=/tmp/workspaces-pycache python3 -m py_compile scripts/desktop-ui-smoke-parity.py`
- `uv run --script scripts/desktop-ui-smoke-parity.py --runs 3 --no-build`

## Review loop

- ADR self-review: checked `docs/decisions/automation-operator-scope.md`; the API lane runs alongside the UI lane, keeps `desktop-ui-smoke` authoritative, uses shipped operator verbs, and documents the repo-select residual gap instead of inventing a verb.
- Mergeability self-review: checked `docs/development/mergeability-standard.md`; the change is scoped to smoke automation, docs, and tests, with no product default behavior change.
- `codex-review-loop` skill: not available in this checkout or exposed skill list, so I could not run the named skill; disposition is this documented self-review plus passing local gates and parity evidence.

## Mergeability

- Surface: desktop automation smoke lane, operator API verification scripts, and runbook docs
- User-facing behavior changed: No product UI change; developer-facing smoke lanes and `mise` tasks are added
- Non-happy paths considered: no-activation focus timeouts remain best-effort and reported; missing repo-select operator verb is documented as a residual gap; duplicate terminal attach milestones are asserted by event position
- Residual risk or follow-up: API lane still cannot prove event-level hit-testing or API-driven repo selection until a reviewed repo-select verb exists
