### PR TITLE
fix(carl): capped retry with backoff on transient 429/5xx

### DIFF
--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -11,6 +11,8 @@ on:
       - "scripts/tests/test_run_contributor.py"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
+      - "scripts/carl-community.py"
+      - "scripts/tests/test_carl_community.py"
   pull_request:
     branches: [main]
     paths:
@@ -21,6 +23,8 @@ on:
       - "scripts/tests/test_run_contributor.py"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
+      - "scripts/carl-community.py"
+      - "scripts/tests/test_carl_community.py"
   workflow_dispatch:
 
 permissions:
@@ -57,3 +61,6 @@ jobs:
 
       - name: Run Fable orchestrator tests
         run: uv run --script scripts/tests/test_fable_orchestrator.py
+
+      - name: Run Carl community tests
+        run: uv run --script scripts/tests/test_carl_community.py

--- a/scripts/carl-community.py
+++ b/scripts/carl-community.py
@@ -21,13 +21,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import re
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 
@@ -566,15 +569,24 @@ Write your commentary post now. Output only the markdown body, no preamble."""
 # ---------------------------------------------------------------------------
 
 
+# The fleet (April, Plat, Carl) shares one CLAUDE_CODE_OAUTH_TOKEN, so a Carl
+# run that overlaps a contributor run can get a transient 429. Retry those (and
+# transient 5xx) a few times with capped backoff rather than failing the day.
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 529})
+MAX_RETRY_DELAY_SECONDS = 30.0
+
+
 def call_claude(
     system: str, user: str, *, model: str, oauth_token: str = "", api_key: str = "",
+    max_attempts: int = 4,
 ) -> str:
     """Call the Anthropic Messages API via urllib (no SDK dependency).
 
     Prefers a Claude Code OAuth token (Authorization: Bearer + the oauth beta
     header) so Carl can reuse the CLAUDE_CODE_OAUTH_TOKEN the rest of the fleet
     already has; falls back to a raw ANTHROPIC_API_KEY via x-api-key. Never
-    sends both — the API rejects that.
+    sends both — the API rejects that. Retries transient rate-limit/5xx
+    responses with capped exponential backoff (honoring Retry-After).
     """
     # Sonnet 5 (and the 4.7+ family) reject sampling params like temperature.
     payload = json.dumps({
@@ -601,17 +613,45 @@ def call_claude(
         method="POST",
     )
 
-    try:
-        with urlopen(req, timeout=60) as resp:
-            data = json.loads(resp.read())
-    except Exception as e:
-        raise CarlError(f"Claude API call failed: {e}") from e
+    data = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with urlopen(req, timeout=60) as resp:
+                data = json.loads(resp.read())
+            break
+        except HTTPError as e:
+            if e.code in RETRYABLE_STATUS and attempt < max_attempts:
+                delay = _retry_delay(e, attempt)
+                log(
+                    f"Claude API returned HTTP {e.code}; retrying in {delay:.0f}s "
+                    f"(attempt {attempt}/{max_attempts})"
+                )
+                time.sleep(delay)
+                continue
+            raise CarlError(f"Claude API call failed: HTTP Error {e.code}: {e.reason}") from e
+        except Exception as e:
+            raise CarlError(f"Claude API call failed: {e}") from e
+
+    if data is None:
+        raise CarlError(
+            f"Claude API still rate-limited after {max_attempts} attempts "
+            "(the fleet shares one OAuth token)."
+        )
 
     for block in data.get("content", []):
         if block.get("type") == "text":
             return block["text"]
 
     raise CarlError(f"No text content in API response: {data}")
+
+
+def _retry_delay(error: HTTPError, attempt: int) -> float:
+    """Honor a numeric Retry-After header, else exponential backoff with jitter,
+    both capped so a rate-limited run fails cleanly instead of hanging the job."""
+    retry_after = error.headers.get("retry-after") if error.headers else None
+    if retry_after and retry_after.strip().isdigit():
+        return min(float(retry_after), MAX_RETRY_DELAY_SECONDS)
+    return min(2.0**attempt + random.uniform(0, 1), MAX_RETRY_DELAY_SECONDS)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_carl_community.py
+++ b/scripts/tests/test_carl_community.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Guard tests for Carl's Claude API call: transient errors retry with capped
+backoff (the fleet shares one OAuth token, so 429s happen), the happy path is
+untouched, and exhaustion fails cleanly. No network — urlopen and sleep mocked."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from urllib.error import HTTPError
+
+SCRIPT = Path(__file__).resolve().parents[1] / "carl-community.py"
+spec = importlib.util.spec_from_file_location("carl_community", SCRIPT)
+assert spec and spec.loader
+carl = importlib.util.module_from_spec(spec)
+sys.modules["carl_community"] = carl
+spec.loader.exec_module(carl)
+
+
+def _ok_response(text: str = "hi"):
+    class R:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"content":[{"type":"text","text":"%s"}]}' % text.encode()
+
+    return R()
+
+
+def _http_error(code: int, headers: dict | None = None) -> HTTPError:
+    return HTTPError("https://api", code, "err", headers or {}, io.BytesIO(b""))
+
+
+class CallClaudeRetryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_urlopen = carl.urlopen
+        self._orig_sleep = carl.time.sleep
+        carl.time.sleep = lambda _s: None  # instant
+
+    def tearDown(self) -> None:
+        carl.urlopen = self._orig_urlopen
+        carl.time.sleep = self._orig_sleep
+
+    def test_retries_transient_429_then_succeeds(self) -> None:
+        calls = {"n": 0}
+
+        def flaky(_req, timeout=60):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _http_error(429)
+            return _ok_response("hello")
+
+        carl.urlopen = flaky
+        out = carl.call_claude("s", "u", model="claude-sonnet-5", oauth_token="t")
+        self.assertEqual(out, "hello")
+        self.assertEqual(calls["n"], 3)
+
+    def test_exhausts_cleanly_when_always_rate_limited(self) -> None:
+        calls = {"n": 0}
+
+        def always(_req, timeout=60):
+            calls["n"] += 1
+            raise _http_error(429)
+
+        carl.urlopen = always
+        with self.assertRaises(carl.CarlError):
+            carl.call_claude("s", "u", model="m", oauth_token="t", max_attempts=3)
+        self.assertEqual(calls["n"], 3)
+
+    def test_non_retryable_status_fails_immediately(self) -> None:
+        calls = {"n": 0}
+
+        def unauthorized(_req, timeout=60):
+            calls["n"] += 1
+            raise _http_error(401)
+
+        carl.urlopen = unauthorized
+        with self.assertRaises(carl.CarlError):
+            carl.call_claude("s", "u", model="m", oauth_token="t")
+        self.assertEqual(calls["n"], 1)  # no retry on a non-transient error
+
+    def test_happy_path_makes_one_call(self) -> None:
+        calls = {"n": 0}
+
+        def ok(_req, timeout=60):
+            calls["n"] += 1
+            return _ok_response("done")
+
+        carl.urlopen = ok
+        self.assertEqual(carl.call_claude("s", "u", model="m", oauth_token="t"), "done")
+        self.assertEqual(calls["n"], 1)
+
+    def test_retry_after_header_is_honored_and_capped(self) -> None:
+        self.assertEqual(carl._retry_delay(_http_error(429, {"retry-after": "5"}), 1), 5.0)
+        # A huge Retry-After is capped so a run fails cleanly, not hangs.
+        capped = carl._retry_delay(_http_error(429, {"retry-after": "9999"}), 1)
+        self.assertEqual(capped, carl.MAX_RETRY_DELAY_SECONDS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Carl's daily run has been failing on **HTTP 429** every day since the OAuth fix landed (07-03 → 07-07). Root cause: the fleet — April, Plat, Carl — all draw on the **one shared `CLAUDE_CODE_OAUTH_TOKEN`**, so a Carl run that overlaps a contributor run gets rate-limited. The OAuth auth itself works (the custom system prompt is accepted — that earlier unknown is resolved); the only problem is contention.

`call_claude` now retries transient statuses (**429/500/502/503/529**) up to **4 attempts** with exponential backoff + jitter, honoring a numeric `Retry-After` header — both **capped at 30s** so a genuinely rate-limited run fails cleanly instead of hanging the job. Non-transient errors (401/400) still fail immediately; the happy path is one call, unchanged.

## Verification
**5 unit tests** (`urlopen` + `sleep` mocked, wired into `ci-agents.yml`):
- retry-then-succeed (429, 429, 200 → 3 calls)
- clean exhaustion (always 429 → `CarlError` after N attempts)
- no retry on a non-transient 401 (1 call)
- happy path is a single call
- `Retry-After` honored and capped

## Mergeability
- Surface: agent-runtime (scripts/carl-community.py)
- User-facing behavior changed: No — internal agent; makes Carl survive the shared-token 429 contention that's been failing it daily.
- Non-happy paths considered: transient 429/5xx retried with capped backoff; non-transient 401/400 fail immediately; exhaustion raises a clear CarlError; happy path is one call. All unit-tested.
- Residual risk or follow-up: if the token is hard-limited for a full window, retries won't help and Carl fails cleanly (by design); giving Carl its own ANTHROPIC_API_KEY to fully de-contend is an optional future change.

## Evidence

![carl-retry](https://evidence.cloudcompute.com/workspaces/pr-956/20260708-063720-carl-retry.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
