### PR TITLE
fix(ci): trim GhosttyKit's repair sweep to a thin, host-arch-only archive

### DIFF
--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -285,12 +285,15 @@ repair_ghostty_archive_if_needed() {
   # on an arm64 host), not just the target slice — sweeping every *.o
   # unfiltered produces a needlessly fat archive (both arches present, though
   # harmless since the linker only pulls the matching slice). Keep only
-  # objects matching the host arch, using the same `file`-output convention
-  # as zig_binary_matches_host_arch.
+  # objects matching the host arch: `file -b` drops the path prefix (an
+  # unanchored match against the full `file` line, path included, could keep
+  # or drop an object based on its filename rather than its actual
+  # architecture), and `-w` requires a whole-word match so "arm64" doesn't
+  # also match "arm64e".
   local host_arch object
   host_arch="$(uname -m)"
   while IFS= read -r object; do
-    if ! file "$object" 2>/dev/null | grep -q "$host_arch"; then
+    if ! file -b "$object" 2>/dev/null | grep -qw "$host_arch"; then
       rm -f "$object"
     fi
   done < <(find "$tmp_dir/objects" -type f -name "*.o")

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -279,6 +279,26 @@ repair_ghostty_archive_if_needed() {
   rm -f "$archives_file"
 
   chmod -R u+rwX "$tmp_dir"
+
+  # The zig cache also holds build-time helper objects compiled for the
+  # compiler host's own arch (e.g. x86_64 on a Rosetta-translated zig running
+  # on an arm64 host), not just the target slice — sweeping every *.o
+  # unfiltered produces a needlessly fat archive (both arches present, though
+  # harmless since the linker only pulls the matching slice). Keep only
+  # objects matching the host arch, using the same `file`-output convention
+  # as zig_binary_matches_host_arch.
+  local host_arch object
+  host_arch="$(uname -m)"
+  while IFS= read -r object; do
+    if ! file "$object" 2>/dev/null | grep -q "$host_arch"; then
+      rm -f "$object"
+    fi
+  done < <(find "$tmp_dir/objects" -type f -name "*.o")
+
+  if ! find "$tmp_dir/objects" -type f -name "*.o" -print -quit | grep -q .; then
+    die "no $host_arch objects found in the Zig cache to repair the GhosttyKit archive"
+  fi
+
   find "$tmp_dir/objects" -type f -name "*.o" -print0 \
     | xargs -0 libtool -static -o "$tmp_dir/libghostty-fat.a"
   mv "$tmp_dir/libghostty-fat.a" "$archive"


### PR DESCRIPTION
Closes #939.

## Problem

The successful Xcode Cloud builds (594/595, see #925) ship a shipped `libghostty-fat.a` that's a Mach-O universal binary `[x86_64 + arm64]`, even though the app only ever links the arm64 slice — confirmed via that build's arch diagnostics. The zig cache also accumulates build-time helper objects compiled for the compiler host's own arch (x86_64 on the Rosetta-translated zig), not just the target slice. `repair_ghostty_archive_if_needed()` (runs whenever the built archive doesn't already export `ghostty_init` — the common case on a cross-compiled slice) swept every `*.o` in the cache unfiltered before merging with `libtool`, so both arches ended up in the final archive.

## Fix

Filter extracted objects to the host arch before the `libtool` merge, die loudly if filtering leaves nothing to merge.

## Evidence

Local forced-mismatch build (same technique used for #925 — `file` stubbed to report the zig binary as wrong-arch, exercising the same repair path Xcode Cloud hits):

- Before: `lipo -info` → `Architectures in the fat file: ... x86_64 arm64`
- After: `lipo -info` → `Non-fat file: ... architecture: arm64`

`scripts/tests/test_security_hardening.py`: 29 passed, 0 failed.

## Review loop

Reflected, then codex (gpt-5.5, xhigh) reviewed 868423ab (two earlier codex invocations hung/errored on "model at capacity" before this one completed — noted here since it delayed the loop, not a code issue). One finding, accepted and fixed in 62cd5467: the arch filter's `file "$object" | grep -q "$host_arch"` matched against `file`'s full output line, which includes the path — an object's filename containing an arch-like substring could cause a false keep/drop independent of its actual architecture, and `"arm64"` would also substring-match `"arm64e"`. Fixed with `file -b` (drops the path) + `grep -qw` (whole-word match); re-verified with the same forced-mismatch build.

## Mergeability

- **Surface**: `scripts/build-ghosttykit.sh` only; no product code.
- **User-facing behavior changed**: None — output archive is smaller and single-arch; build behavior and linked symbols unchanged.
- **Non-happy paths considered**: filtering leaving nothing to merge (dies loudly, tested indirectly via the die path); x86_64-host case (uses `uname -m`, no arm64 assumption, per review question); pre-existing gap noted by review (a thin archive containing a fat/universal `.o` member is not handled — same limitation as the archive-level fat skip just above it, out of scope here).
- **Residual risk or follow-up**: none beyond the pre-existing thin-archive-with-fat-member edge case noted above, which has never been observed in this pinned Ghostty commit's cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋

