### PR TITLE
feat(web-next): turn-completion webhook notifications (#971)

### DIFF
--- a/web-next/src/lib/agent-runtime/turn-ingest.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.test.ts
@@ -7,12 +7,13 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { type DatabaseHandle, openDatabase } from "../db/client";
 import { createSession, getSession, readEvents } from "../db/sessions";
+import { notifyTurnCompleted } from "../notify/turn-notification";
 import type { ComputeProvider } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
-import { startTurn } from "./turn-ingest";
+import { startTurn, stopActiveTurn } from "./turn-ingest";
 
 vi.mock("../db/sessions", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../db/sessions")>();
@@ -24,14 +25,24 @@ vi.mock("../db/sessions", async (importOriginal) => {
 	};
 });
 
+vi.mock("../notify/turn-notification", () => ({
+	notifyTurnCompleted: vi.fn(async () => {}),
+}));
+
 let open: DatabaseHandle | undefined;
 let dir: string | undefined;
+const notifyTurnCompletedMock = vi.mocked(notifyTurnCompleted);
 
 function freshDb(): DatabaseHandle {
 	dir = mkdtempSync(join(tmpdir(), "web-next-turn-ingest-"));
 	open = openDatabase(`file:${join(dir, "test.db")}`);
 	return open;
 }
+
+beforeEach(() => {
+	notifyTurnCompletedMock.mockReset();
+	notifyTurnCompletedMock.mockResolvedValue(undefined);
+});
 
 afterEach(async () => {
 	await open?.db.destroy();
@@ -40,10 +51,30 @@ afterEach(async () => {
 	dir = undefined;
 });
 
-function stubProvider(): ComputeProvider {
+function stubProvider(chunks: StreamChunk[] = [{ type: "done", content: "" }]): ComputeProvider {
 	return {
 		id: "stub",
 		runTurn: async function* () {
+			for (const chunk of chunks) yield chunk;
+		},
+	};
+}
+
+function throwingProvider(error: Error): ComputeProvider {
+	return {
+		id: "throwing",
+		runTurn: async function* () {
+			throw error;
+			yield { type: "done", content: "" } as StreamChunk;
+		},
+	};
+}
+
+function hangingProvider(): ComputeProvider {
+	return {
+		id: "hanging",
+		runTurn: async function* () {
+			await new Promise(() => {});
 			yield { type: "done", content: "" } as StreamChunk;
 		},
 	};
@@ -66,5 +97,116 @@ describe("startTurn — auto-title failure isolation", () => {
 		// The (mocked) title write failed — the session stays untitled, but
 		// nothing else about the turn was lost or blocked.
 		expect((await getSession(handle, "s1"))?.title).toBe("");
+	});
+});
+
+describe("startTurn — completion notification", () => {
+	test("fires with a completed payload after the terminal done is durable", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "complete-session",
+			provider: "mock",
+			repoId: "fairchild/workspaces",
+			title: "Fix notifications",
+		});
+
+		const started = await startTurn(handle, session, "Ship it", stubProvider());
+		await started.ingest;
+
+		const events = await readEvents(handle, "complete-session");
+		expect(events.at(-1)?.chunk).toMatchObject({ type: "done" });
+		await vi.waitFor(() => {
+			expect(notifyTurnCompletedMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					durationMs: expect.any(Number),
+					outcome: "completed",
+					session: expect.objectContaining({
+						id: "complete-session",
+						repoId: "fairchild/workspaces",
+						title: "Fix notifications",
+					}),
+				}),
+			);
+		});
+	});
+
+	test("fires with a failed payload after error and aborted done are durable", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "failed-session",
+			provider: "mock",
+			repoId: "fairchild/workspaces",
+			title: "Broken turn",
+		});
+
+		const started = await startTurn(
+			handle,
+			session,
+			"Fail",
+			throwingProvider(new Error("sandbox died")),
+		);
+		await started.ingest;
+
+		const events = await readEvents(handle, "failed-session");
+		expect(events.slice(-2).map((event) => event.chunk)).toEqual([
+			{ type: "error", content: "sandbox died" },
+			{ type: "done", content: "", metadata: { aborted: true } },
+		]);
+		await vi.waitFor(() => {
+			expect(notifyTurnCompletedMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					outcome: "failed",
+					session: expect.objectContaining({ id: "failed-session" }),
+				}),
+			);
+		});
+	});
+
+	test("fires with a stopped payload for the stop path", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "stopped-session",
+			provider: "mock",
+			repoId: "fairchild/workspaces",
+			title: "Stopped turn",
+		});
+
+		const started = await startTurn(handle, session, "Stop me", hangingProvider());
+		expect(stopActiveTurn("stopped-session")).toBe(true);
+		await started.ingest;
+
+		const events = await readEvents(handle, "stopped-session");
+		expect(events.slice(-2).map((event) => event.chunk)).toEqual([
+			{ type: "error", content: "Turn stopped." },
+			{ type: "done", content: "", metadata: { aborted: true } },
+		]);
+		await vi.waitFor(() => {
+			expect(notifyTurnCompletedMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					outcome: "stopped",
+					session: expect.objectContaining({ id: "stopped-session" }),
+				}),
+			);
+		});
+	});
+
+	test("a synchronously throwing notifier does not reject the ingest path", async () => {
+		notifyTurnCompletedMock.mockImplementationOnce(() => {
+			throw new Error("notify blew up");
+		});
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "notify-throws-session",
+			provider: "mock",
+		});
+
+		const started = await startTurn(handle, session, "Survive", stubProvider());
+		await expect(started.ingest).resolves.toBeUndefined();
+
+		const events = await readEvents(handle, "notify-throws-session");
+		expect(events.at(-1)?.chunk).toMatchObject({ type: "done" });
+		await vi.waitFor(() => {
+			expect(notifyTurnCompletedMock).toHaveBeenCalledOnce();
+		});
 	});
 });

--- a/web-next/src/lib/agent-runtime/turn-ingest.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { type DatabaseHandle, openDatabase } from "../db/client";
+import { ensureRepo } from "../db/repos";
 import { createSession, getSession, readEvents } from "../db/sessions";
 import { notifyTurnCompleted } from "../notify/turn-notification";
 import type { ComputeProvider } from "./provider";
@@ -103,10 +104,11 @@ describe("startTurn — auto-title failure isolation", () => {
 describe("startTurn — completion notification", () => {
 	test("fires with a completed payload after the terminal done is durable", async () => {
 		const handle = freshDb();
+		const repo = await ensureRepo(handle, "fairchild/workspaces", "main");
 		const session = await createSession(handle, {
 			id: "complete-session",
 			provider: "mock",
-			repoId: "fairchild/workspaces",
+			repoId: repo.id,
 			title: "Fix notifications",
 		});
 
@@ -120,12 +122,39 @@ describe("startTurn — completion notification", () => {
 				expect.objectContaining({
 					durationMs: expect.any(Number),
 					outcome: "completed",
+					// The payload carries the repo's owner/name, resolved from the
+					// repos row — sessions store only the opaque repo row id.
+					repoFullName: "fairchild/workspaces",
 					session: expect.objectContaining({
 						id: "complete-session",
-						repoId: "fairchild/workspaces",
 						title: "Fix notifications",
 					}),
 				}),
+			);
+		});
+	});
+
+	test("a turn that streams an error chunk but closes normally notifies failed", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "errored-session",
+			provider: "mock",
+		});
+
+		const started = await startTurn(
+			handle,
+			session,
+			"Try anyway",
+			stubProvider([
+				{ type: "error", content: "provider hiccup" },
+				{ type: "done", content: "" },
+			]),
+		);
+		await started.ingest;
+
+		await vi.waitFor(() => {
+			expect(notifyTurnCompletedMock).toHaveBeenCalledWith(
+				expect.objectContaining({ outcome: "failed" }),
 			);
 		});
 	});

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -25,10 +25,15 @@ import { EventEmitter } from "node:events";
 import type { DatabaseHandle } from "../db/client";
 import {
 	appendEvents,
+	getSession,
 	type Session,
 	titleSessionIfEmpty,
 	updateSession,
 } from "../db/sessions";
+import {
+	notifyTurnCompleted,
+	type TurnNotificationOutcome,
+} from "../notify/turn-notification";
 import { deriveSessionTitle } from "../session-title";
 import {
 	type ComputeProvider,
@@ -145,16 +150,56 @@ export async function startTurn(
 	}
 	const fromSeq = userSeq + 1;
 	const controller = new AbortController();
-	const ingest = ingestTurn(handle, session, userText, provider, controller.signal);
-	activeTurns.set(session.id, { fromSeq, startedAt: Date.now(), controller });
-	// Deregister once this turn settles — but only if a newer turn hasn't
-	// already taken the slot (guards a fast resend replacing the entry).
-	void ingest.finally(() => {
-		if (activeTurns.get(session.id)?.fromSeq === fromSeq) {
-			activeTurns.delete(session.id);
-		}
-	});
+	const startedAt = Date.now();
+	const ingest = ingestTurn(handle, session, userText, provider, controller.signal).then(
+		(outcome) => {
+			// Deregister once this turn settles — but only if a newer turn hasn't
+			// already taken the slot (guards a fast resend replacing the entry).
+			if (activeTurns.get(session.id)?.fromSeq === fromSeq) {
+				activeTurns.delete(session.id);
+			}
+			// Fire after durability and active-turn cleanup; never let delivery
+			// affect the turn's own promise or persisted transcript.
+			try {
+				void emitTurnCompletionNotification(
+					handle,
+					session,
+					outcome,
+					Date.now() - startedAt,
+				);
+			} catch (error) {
+				console.error(
+					`[turn-ingest] turn completion notification failed for ${session.id}`,
+					error,
+				);
+			}
+		},
+		(error) => {
+			if (activeTurns.get(session.id)?.fromSeq === fromSeq) {
+				activeTurns.delete(session.id);
+			}
+			throw error;
+		},
+	);
+	activeTurns.set(session.id, { fromSeq, startedAt, controller });
 	return { fromSeq, ingest };
+}
+
+async function emitTurnCompletionNotification(
+	handle: DatabaseHandle,
+	session: Session,
+	outcome: TurnNotificationOutcome,
+	durationMs: number,
+): Promise<void> {
+	try {
+		const currentSession = (await getSession(handle, session.id)) ?? session;
+		await notifyTurnCompleted({ session: currentSession, outcome, durationMs });
+	} catch (error) {
+		console.error(
+			`[turn-ingest] turn completion notification failed for ${session.id}`,
+			error,
+		);
+	}
 }
 
 /** The abort-race verdict: the source yielded (or finished), or the stop won. */
@@ -208,7 +253,7 @@ async function ingestTurn(
 	userText: string,
 	provider: ComputeProvider,
 	signal: AbortSignal,
-): Promise<void> {
+): Promise<TurnNotificationOutcome> {
 	let closed = false;
 	try {
 		const iterator = provider
@@ -241,14 +286,16 @@ async function ingestTurn(
 			]);
 			notify(session.id);
 		}
+		return "completed";
 	} catch (error) {
-		if (closed) return; // the run already has its terminal `done` — never a second
+		if (closed) return "completed"; // the run already has its terminal `done` — never a second
 		const message = error instanceof Error ? error.message : "the turn failed";
 		await appendEvents(handle, session.id, [
 			{ role: "assistant", chunk: { type: "error", content: message } },
 			{ role: "assistant", chunk: { type: "done", content: "", metadata: { aborted: true } } },
 		]);
 		notify(session.id);
+		return error instanceof TurnStoppedError ? "stopped" : "failed";
 	}
 }
 

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -23,6 +23,7 @@
  */
 import { EventEmitter } from "node:events";
 import type { DatabaseHandle } from "../db/client";
+import { getRepo } from "../db/repos";
 import {
 	appendEvents,
 	getSession,
@@ -193,7 +194,15 @@ async function emitTurnCompletionNotification(
 ): Promise<void> {
 	try {
 		const currentSession = (await getSession(handle, session.id)) ?? session;
-		await notifyTurnCompleted({ session: currentSession, outcome, durationMs });
+		const repo = currentSession.repoId
+			? await getRepo(handle, currentSession.repoId)
+			: undefined;
+		await notifyTurnCompleted({
+			session: currentSession,
+			repoFullName: repo?.fullName ?? "",
+			outcome,
+			durationMs,
+		});
 	} catch (error) {
 		console.error(
 			`[turn-ingest] turn completion notification failed for ${session.id}`,
@@ -255,6 +264,11 @@ async function ingestTurn(
 	signal: AbortSignal,
 ): Promise<TurnNotificationOutcome> {
 	let closed = false;
+	// An `error` chunk anywhere in the stream marks the turn failed for the
+	// completion notice, even when the provider still closes with its own
+	// `done` — the owner is being told whether the turn needs their attention,
+	// not whether the stream terminated cleanly.
+	let sawError = false;
 	try {
 		const iterator = provider
 			.runTurn({
@@ -278,6 +292,7 @@ async function ingestTurn(
 					: chunk;
 			await appendEvents(handle, session.id, [{ role: "assistant", chunk: stored }]);
 			if (chunk.type === "done") closed = true;
+			if (chunk.type === "error") sawError = true;
 			notify(session.id);
 		}
 		if (!closed) {
@@ -286,9 +301,10 @@ async function ingestTurn(
 			]);
 			notify(session.id);
 		}
-		return "completed";
+		return sawError ? "failed" : "completed";
 	} catch (error) {
-		if (closed) return "completed"; // the run already has its terminal `done` — never a second
+		// The run already has its terminal `done` — never append a second.
+		if (closed) return sawError ? "failed" : "completed";
 		const message = error instanceof Error ? error.message : "the turn failed";
 		await appendEvents(handle, session.id, [
 			{ role: "assistant", chunk: { type: "error", content: message } },

--- a/web-next/src/lib/notify/turn-notification.test.ts
+++ b/web-next/src/lib/notify/turn-notification.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+	buildTurnNotificationPayload,
+	notifyTurnCompleted,
+	type TurnNotificationInput,
+} from "./turn-notification";
+
+const input: TurnNotificationInput = {
+	session: {
+		id: "session-1",
+		repoId: "fairchild/workspaces",
+		title: "Fix notifications",
+	},
+	outcome: "completed",
+	durationMs: 42,
+};
+
+describe("buildTurnNotificationPayload", () => {
+	test("includes the configured session URL when BETTER_AUTH_URL is set", () => {
+		expect(
+			buildTurnNotificationPayload(input, {
+				BETTER_AUTH_URL: "https://spaces.example/",
+			}),
+		).toEqual({
+			event: "turn_completed",
+			sessionId: "session-1",
+			title: "Fix notifications",
+			repo: "fairchild/workspaces",
+			outcome: "completed",
+			durationMs: 42,
+			url: "https://spaces.example/sessions/session-1",
+		});
+	});
+
+	test("omits url and uses an empty repo when those fields are absent", () => {
+		expect(
+			buildTurnNotificationPayload({
+				...input,
+				session: { id: "session-2", repoId: null, title: "" },
+			}),
+		).toEqual({
+			event: "turn_completed",
+			sessionId: "session-2",
+			title: "",
+			repo: "",
+			outcome: "completed",
+			durationMs: 42,
+		});
+	});
+});
+
+describe("notifyTurnCompleted", () => {
+	test("does nothing when WEB_NEXT_NOTIFY_URL is absent", async () => {
+		const fetchImpl = vi.fn<typeof fetch>();
+		await notifyTurnCompleted(input, { env: {}, fetch: fetchImpl });
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	test("posts the payload and optional bearer token", async () => {
+		const fetchImpl = vi.fn<typeof fetch>(async () => new Response("", { status: 204 }));
+
+		await notifyTurnCompleted(input, {
+			env: {
+				BETTER_AUTH_URL: "https://spaces.example",
+				WEB_NEXT_NOTIFY_TOKEN: "secret",
+				WEB_NEXT_NOTIFY_URL: "https://hooks.example/turns",
+			},
+			fetch: fetchImpl,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://hooks.example/turns",
+			expect.objectContaining({
+				body: JSON.stringify({
+					event: "turn_completed",
+					sessionId: "session-1",
+					title: "Fix notifications",
+					repo: "fairchild/workspaces",
+					outcome: "completed",
+					durationMs: 42,
+					url: "https://spaces.example/sessions/session-1",
+				}),
+				headers: {
+					authorization: "Bearer secret",
+					"content-type": "application/json",
+				},
+				method: "POST",
+			}),
+		);
+	});
+
+	test("swallows a throwing endpoint", async () => {
+		const error = new Error("network down");
+		const logger = { error: vi.fn() };
+		const fetchImpl = vi.fn<typeof fetch>(async () => {
+			throw error;
+		});
+
+		await expect(
+			notifyTurnCompleted(input, {
+				env: { WEB_NEXT_NOTIFY_URL: "https://hooks.example/turns" },
+				fetch: fetchImpl,
+				logger,
+			}),
+		).resolves.toBeUndefined();
+		expect(logger.error).toHaveBeenCalledWith(
+			"[turn-notification] webhook delivery failed",
+			error,
+		);
+	});
+
+	test("bounds a hanging endpoint with the abort timeout", async () => {
+		const logger = { error: vi.fn() };
+		const fetchImpl = vi.fn<typeof fetch>(
+			(_url, init) =>
+				new Promise((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => {
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				}),
+		);
+
+		await expect(
+			notifyTurnCompleted(input, {
+				env: { WEB_NEXT_NOTIFY_URL: "https://hooks.example/turns" },
+				fetch: fetchImpl,
+				logger,
+				timeoutMs: 1,
+			}),
+		).resolves.toBeUndefined();
+		expect(logger.error).toHaveBeenCalledOnce();
+	});
+});

--- a/web-next/src/lib/notify/turn-notification.test.ts
+++ b/web-next/src/lib/notify/turn-notification.test.ts
@@ -8,9 +8,9 @@ import {
 const input: TurnNotificationInput = {
 	session: {
 		id: "session-1",
-		repoId: "fairchild/workspaces",
 		title: "Fix notifications",
 	},
+	repoFullName: "fairchild/workspaces",
 	outcome: "completed",
 	durationMs: 42,
 };
@@ -36,7 +36,8 @@ describe("buildTurnNotificationPayload", () => {
 		expect(
 			buildTurnNotificationPayload({
 				...input,
-				session: { id: "session-2", repoId: null, title: "" },
+				session: { id: "session-2", title: "" },
+				repoFullName: null,
 			}),
 		).toEqual({
 			event: "turn_completed",

--- a/web-next/src/lib/notify/turn-notification.ts
+++ b/web-next/src/lib/notify/turn-notification.ts
@@ -1,0 +1,113 @@
+/*
+ * Sends detached-turn completion notices to the owner-configured webhook.
+ * The ingest loop calls this after the terminal events are durable so a
+ * finished, failed, or stopped background turn can find the owner even when no
+ * browser is attached.
+ */
+import type { Session } from "../db/sessions";
+
+export type TurnNotificationOutcome = "completed" | "failed" | "stopped";
+
+export interface TurnNotificationPayload {
+	event: "turn_completed";
+	sessionId: string;
+	title: string;
+	repo: string;
+	outcome: TurnNotificationOutcome;
+	durationMs: number;
+	url?: string;
+}
+
+type TurnNotificationFetch = typeof fetch;
+interface TurnNotificationEnv {
+	[key: string]: string | undefined;
+	BETTER_AUTH_URL?: string;
+	WEB_NEXT_NOTIFY_TOKEN?: string;
+	WEB_NEXT_NOTIFY_URL?: string;
+}
+
+export interface TurnNotificationInput {
+	session: Pick<Session, "id" | "repoId" | "title">;
+	outcome: TurnNotificationOutcome;
+	durationMs: number;
+}
+
+export interface TurnNotificationOptions {
+	env?: TurnNotificationEnv;
+	fetch?: TurnNotificationFetch;
+	logger?: Pick<Console, "error">;
+	timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 3_000;
+
+export async function notifyTurnCompleted(
+	input: TurnNotificationInput,
+	options: TurnNotificationOptions = {},
+): Promise<void> {
+	const env = options.env ?? runtimeEnv();
+	const notifyUrl = env.WEB_NEXT_NOTIFY_URL;
+	if (!notifyUrl) return;
+
+	const logger = options.logger ?? console;
+	const fetchImpl = options.fetch ?? globalThis.fetch;
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(),
+		options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+	);
+
+	try {
+		const response = await fetchImpl(notifyUrl, {
+			body: JSON.stringify(buildTurnNotificationPayload(input, env)),
+			headers: headers(env),
+			method: "POST",
+			signal: controller.signal,
+		});
+		if (!response.ok) {
+			logger.error(
+				`[turn-notification] webhook returned ${response.status} ${response.statusText}`,
+			);
+		}
+	} catch (error) {
+		logger.error("[turn-notification] webhook delivery failed", error);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export function buildTurnNotificationPayload(
+	input: TurnNotificationInput,
+	env: Pick<TurnNotificationEnv, "BETTER_AUTH_URL"> = runtimeEnv(),
+): TurnNotificationPayload {
+	return {
+		event: "turn_completed",
+		sessionId: input.session.id,
+		title: input.session.title,
+		repo: input.session.repoId ?? "",
+		outcome: input.outcome,
+		durationMs: input.durationMs,
+		...(env.BETTER_AUTH_URL ? { url: sessionUrl(env.BETTER_AUTH_URL, input.session.id) } : {}),
+	};
+}
+
+function headers(env: Pick<TurnNotificationEnv, "WEB_NEXT_NOTIFY_TOKEN">): HeadersInit {
+	return {
+		"content-type": "application/json",
+		...(env.WEB_NEXT_NOTIFY_TOKEN
+			? { authorization: `Bearer ${env.WEB_NEXT_NOTIFY_TOKEN}` }
+			: {}),
+	};
+}
+
+function sessionUrl(baseUrl: string, sessionId: string): string {
+	return `${baseUrl.replace(/\/+$/, "")}/sessions/${encodeURIComponent(sessionId)}`;
+}
+
+function runtimeEnv(): TurnNotificationEnv {
+	return {
+		BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+		WEB_NEXT_NOTIFY_TOKEN: process.env.WEB_NEXT_NOTIFY_TOKEN,
+		WEB_NEXT_NOTIFY_URL: process.env.WEB_NEXT_NOTIFY_URL,
+	};
+}

--- a/web-next/src/lib/notify/turn-notification.ts
+++ b/web-next/src/lib/notify/turn-notification.ts
@@ -27,7 +27,10 @@ interface TurnNotificationEnv {
 }
 
 export interface TurnNotificationInput {
-	session: Pick<Session, "id" | "repoId" | "title">;
+	session: Pick<Session, "id" | "title">;
+	/** The repo's `owner/name` — resolved by the caller; sessions store only
+	 * the repo row id, which means nothing in a phone notification. */
+	repoFullName?: string | null;
 	outcome: TurnNotificationOutcome;
 	durationMs: number;
 }
@@ -84,7 +87,7 @@ export function buildTurnNotificationPayload(
 		event: "turn_completed",
 		sessionId: input.session.id,
 		title: input.session.title,
-		repo: input.session.repoId ?? "",
+		repo: input.repoFullName ?? "",
 		outcome: input.outcome,
 		durationMs: input.durationMs,
 		...(env.BETTER_AUTH_URL ? { url: sessionUrl(env.BETTER_AUTH_URL, input.session.id) } : {}),


### PR DESCRIPTION
Closes #971 (milestone W5, Lane B).

A detached turn now finds the owner when it ends: after the terminal events
are durable and the active-turn slot is cleared, the ingest loop fires one
env-gated webhook — `WEB_NEXT_NOTIFY_URL` absent means silent no-op, so local
dev and every existing deployment are unchanged.

**What to look at:** nothing visual — this is the ingest seam
(`turn-ingest.ts`) plus a new `src/lib/notify/turn-notification.ts`. Payload:
`{event, sessionId, title, repo (owner/name), outcome: completed|failed|stopped, durationMs, url}`,
optional `WEB_NEXT_NOTIFY_TOKEN` as a Bearer header, 3s abort timeout, all
failures swallowed and logged — delivery can never affect the turn or its log.

Implementation by codex CLI (gpt-5.5, high) from a coordinator brief;
coordinator review added two fixes in the follow-up commit: the payload's
`repo` resolves the owner/name (sessions store only the repo row id), and a
turn that streams an `error` chunk but closes with a normal `done` notifies
`failed` — the notice reports whether the turn needs attention, not whether
the stream terminated cleanly.

## Mergeability

- **Surface:** web-next agent runtime (ingest seam) + new notify module; no UI, no schema, no API routes.
- **Behavior changed:** on turn end (completed/failed/stopped), one POST to `WEB_NEXT_NOTIFY_URL` when configured; nothing otherwise.
- **Non-happy paths:** notifier throwing/hanging/non-2xx is swallowed + logged (unit-tested, incl. sync-throw mutation check); missing env is a no-op; repo row absent → empty `repo` field.
- **Residual risk:** outcome labeling for exotic streams (error chunk after the provider's own `done`) rides the `sawError` flag — acceptable; notification is advisory, transcript stays the source of truth.

## Evidence

![turn-notification-tests](https://evidence.cloudcompute.com/workspaces/pr-974/20260708-091007-turn-notification-tests.png)

Unit gates on the rebased tree: 441/441 tests, typecheck, lint, clean production build.

