### PR TITLE
fix(web-next): thread the session repo into the compute provider (#967)

### DIFF
--- a/web-next/src/app/api/sessions/route.ts
+++ b/web-next/src/app/api/sessions/route.ts
@@ -3,9 +3,10 @@
  * the UI's server action (actions.ts). Exists for API clients that need a
  * throwaway session with an explicit title and provider — the #818 real-turn
  * validation probe is the first — so it skips the action's GitHub repo
- * resolution (repoId stays null; the vercel provider clones its configured
- * AGENT_TARGET_REPO regardless). Auth-gated like every session route; model
- * always starts at the DEFAULT_MODEL, same as the UI path.
+ * resolution (repoId stays null; the vercel provider falls back to its
+ * configured AGENT_TARGET_REPO only for these repo-less sessions). Auth-gated
+ * like every session route; model always starts at the DEFAULT_MODEL, same as
+ * the UI path.
  */
 import { getProvider } from "@/lib/agent-runtime/provider";
 import { getAuthState } from "@/lib/auth/auth-state";

--- a/web-next/src/lib/agent-runtime/mock-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.test.ts
@@ -12,15 +12,21 @@ import {
 	mockProvider,
 } from "./mock-provider";
 import { DEFAULT_MODEL } from "./models";
+import type { TurnRepo } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
 /** The whole scripted turn, without waiting out the streaming pace. */
-async function fullTurn(userMessage: string, model?: string): Promise<StreamChunk[]> {
+async function fullTurn(
+	userMessage: string,
+	model?: string,
+	repo?: TurnRepo | null,
+): Promise<StreamChunk[]> {
 	const chunks: StreamChunk[] = [];
 	for await (const chunk of mockCodingTurn(
 		userMessage,
 		() => Promise.resolve(),
 		model,
+		repo,
 	)) {
 		chunks.push(chunk);
 	}
@@ -122,6 +128,16 @@ describe("mockCodingTurn", () => {
 		const chunks = await fullTurn("go", "claude-haiku-4-5");
 		const done = chunks.find((chunk) => chunk.type === "done");
 		expect(done?.metadata?.model).toBe("claude-haiku-4-5");
+	});
+
+	test("records the requested repo on the terminal done chunk (#967)", async () => {
+		const repo = {
+			fullName: "fairchild/web-next-fixtures",
+			defaultBranch: "trunk",
+		};
+		const chunks = await fullTurn("go", undefined, repo);
+		const done = chunks.find((chunk) => chunk.type === "done");
+		expect(done?.metadata?.repo).toEqual(repo);
 	});
 
 	test("also records a plausible contextTokens figure alongside tokenCount", async () => {

--- a/web-next/src/lib/agent-runtime/mock-provider.ts
+++ b/web-next/src/lib/agent-runtime/mock-provider.ts
@@ -4,9 +4,9 @@
  * diff → done with usage figures) that exercises the whole Folio apparatus —
  * including the thinking block and the error tool path — without a sandbox.
  * Paced with small delays so streaming behavior is observable and measurable.
- * The requested model is recorded (not used — there's no real model call
- * here) on the terminal `done` chunk, so #824's routing is unit-testable
- * against this provider without a sandbox.
+ * The requested model and repo are recorded (not used — there's no real model
+ * call or clone here) on the terminal `done` chunk, so routing is
+ * unit-testable against this provider without a sandbox.
  *
  * A user message containing `MOCK_TURN_ERROR_TRIGGER` (#808) throws instead of
  * running the script — a deterministic, hermetic way to exercise a whole-turn
@@ -27,7 +27,7 @@
  * e2e spec drive a real "retry succeeds" turn without a second magic string.
  */
 import { DEFAULT_MODEL } from "./models";
-import type { ComputeProvider, TurnRequest } from "./provider";
+import type { ComputeProvider, TurnRepo, TurnRequest } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
 type Sleep = (ms: number) => Promise<void>;
@@ -119,6 +119,7 @@ export async function* mockCodingTurn(
 	userMessage: string,
 	sleep: Sleep = defaultSleep,
 	model: string = DEFAULT_MODEL,
+	repo?: TurnRepo | null,
 ): AsyncGenerator<StreamChunk> {
 	const startedAt = Date.now();
 	let proseChars = 0;
@@ -272,6 +273,7 @@ export async function* mockCodingTurn(
 			// is testable without a sandbox call.
 			contextTokens: Math.ceil((userMessage.length + proseChars) / 3.2),
 			model,
+			...(repo !== undefined ? { repo } : {}),
 		},
 	};
 }
@@ -299,6 +301,6 @@ export const mockProvider: ComputeProvider = {
 				spentErrorTriggers.add(spendKey);
 			}
 		}
-		return mockCodingTurn(userMessage, undefined, request.model);
+		return mockCodingTurn(userMessage, undefined, request.model, request.repo);
 	},
 };

--- a/web-next/src/lib/agent-runtime/provider.ts
+++ b/web-next/src/lib/agent-runtime/provider.ts
@@ -20,9 +20,20 @@ export interface SessionResumeHandle {
 	resumeState: string;
 }
 
+export interface TurnRepo {
+	fullName: string;
+	defaultBranch: string | null;
+}
+
 export interface TurnRequest {
 	sessionId: string;
 	userMessage: string;
+	/**
+	 * The repo selected when the session was created. Repo-less sessions (for
+	 * example POST /api/sessions probes) leave this null/undefined and let the
+	 * provider use its configured fallback.
+	 */
+	repo?: TurnRepo | null;
 	/** Prior parked session to resume, or null/undefined for a fresh turn. */
 	resume?: SessionResumeHandle | null;
 	/**

--- a/web-next/src/lib/agent-runtime/turn-ingest.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.test.ts
@@ -50,6 +50,7 @@ afterEach(async () => {
 	open = undefined;
 	if (dir) rmSync(dir, { recursive: true, force: true });
 	dir = undefined;
+	vi.unstubAllEnvs();
 });
 
 function stubProvider(chunks: StreamChunk[] = [{ type: "done", content: "" }]): ComputeProvider {
@@ -98,6 +99,37 @@ describe("startTurn — auto-title failure isolation", () => {
 		// The (mocked) title write failed — the session stays untitled, but
 		// nothing else about the turn was lost or blocked.
 		expect((await getSession(handle, "s1"))?.title).toBe("");
+	});
+
+	test("threads the session repo into the provider request instead of the global fallback", async () => {
+		vi.stubEnv("AGENT_TARGET_REPO", "fairchild/workspaces");
+		const handle = freshDb();
+		const repo = await ensureRepo(handle, "fairchild/web-next-fixtures", "trunk");
+		const session = await createSession(handle, {
+			id: "s-repo",
+			provider: "mock",
+			repoId: repo.id,
+		});
+		let seenRequest: unknown;
+		const provider: ComputeProvider = {
+			id: "stub",
+			runTurn: async function* (request) {
+				seenRequest = request;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+
+		const started = await startTurn(handle, session, "Fix the failing test", provider);
+		await started.ingest;
+
+		expect(
+			(seenRequest as {
+				repo?: { fullName: string; defaultBranch: string | null } | null;
+			}).repo,
+		).toEqual({
+			fullName: "fairchild/web-next-fixtures",
+			defaultBranch: "trunk",
+		});
 	});
 });
 

--- a/web-next/src/lib/agent-runtime/turn-ingest.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.test.ts
@@ -196,7 +196,6 @@ describe("startTurn — completion notification", () => {
 		const session = await createSession(handle, {
 			id: "failed-session",
 			provider: "mock",
-			repoId: "fairchild/workspaces",
 			title: "Broken turn",
 		});
 
@@ -228,7 +227,6 @@ describe("startTurn — completion notification", () => {
 		const session = await createSession(handle, {
 			id: "stopped-session",
 			provider: "mock",
-			repoId: "fairchild/workspaces",
 			title: "Stopped turn",
 		});
 

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -40,6 +40,7 @@ import {
 	type ComputeProvider,
 	getProvider,
 	type SessionResumeHandle,
+	type TurnRepo,
 } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -129,6 +130,7 @@ export async function startTurn(
 	userText: string,
 	provider: ComputeProvider = getProvider(session.provider),
 ): Promise<StartedTurn> {
+	const repo = await resolveTurnRepo(handle, session);
 	const userSeq = await appendEvents(handle, session.id, [
 		{ role: "user", chunk: { type: "text", content: userText } },
 	]);
@@ -152,7 +154,7 @@ export async function startTurn(
 	const fromSeq = userSeq + 1;
 	const controller = new AbortController();
 	const startedAt = Date.now();
-	const ingest = ingestTurn(handle, session, userText, provider, controller.signal).then(
+	const ingest = ingestTurn(handle, session, userText, provider, controller.signal, repo).then(
 		(outcome) => {
 			// Deregister once this turn settles — but only if a newer turn hasn't
 			// already taken the slot (guards a fast resend replacing the entry).
@@ -211,6 +213,16 @@ async function emitTurnCompletionNotification(
 	}
 }
 
+async function resolveTurnRepo(
+	handle: DatabaseHandle,
+	session: Session,
+): Promise<TurnRepo | null> {
+	if (!session.repoId) return null;
+	const repo = await getRepo(handle, session.repoId);
+	if (!repo) throw new Error(`session repo not found: ${session.repoId}`);
+	return { fullName: repo.fullName, defaultBranch: repo.defaultBranch };
+}
+
 /** The abort-race verdict: the source yielded (or finished), or the stop won. */
 type NextOrAborted<T> = { aborted: true } | { aborted: false; result: IteratorResult<T> };
 
@@ -262,6 +274,7 @@ async function ingestTurn(
 	userText: string,
 	provider: ComputeProvider,
 	signal: AbortSignal,
+	repo: TurnRepo | null,
 ): Promise<TurnNotificationOutcome> {
 	let closed = false;
 	// An `error` chunk anywhere in the stream marks the turn failed for the
@@ -274,6 +287,7 @@ async function ingestTurn(
 			.runTurn({
 				sessionId: session.id,
 				userMessage: userText,
+				repo,
 				resume: resumeHandle(session),
 				model: session.model,
 			})

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "vitest";
 import {
+	buildPrompt,
+	buildSessionSetupScript,
 	canonicalToolName,
 	createHarness,
 	errorText,
 	mapFullStream,
 	parseGitDiff,
+	resolveTargetRepo,
 	toolResultContent,
 	uniqueDiffToolCallId,
+	vercelProvider,
 } from "./vercel-provider";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -20,6 +24,95 @@ async function collect(parts: Part[]): Promise<StreamChunk[]> {
 	for await (const chunk of mapFullStream(source(), 0)) out.push(chunk);
 	return out;
 }
+
+describe("repo targeting", () => {
+	test("resolves the repo carried on the turn request", () => {
+		expect(
+			resolveTargetRepo({
+				repo: {
+					fullName: "fairchild/web-next-fixtures",
+					defaultBranch: "trunk",
+				},
+			}),
+		).toEqual({
+			ok: true,
+			repo: {
+				fullName: "fairchild/web-next-fixtures",
+				defaultBranch: "trunk",
+			},
+		});
+	});
+
+	test("builds setup and first-turn prompt from the request repo", () => {
+		const repo = {
+			fullName: "fairchild/web-next-fixtures",
+			defaultBranch: "trunk",
+		};
+
+		const script = buildSessionSetupScript("abcdef123456", repo);
+		expect(script).toContain(
+			"git clone --depth 50 --branch \"$DEFAULT_BRANCH\" https://github.com/fairchild/web-next-fixtures.git",
+		);
+		expect(script).toContain(
+			'printf "%s" "$DEFAULT_BRANCH" > /tmp/default_branch',
+		);
+
+		const prompt = buildPrompt("Fix the failing test", "abcdef123456", true, repo);
+		expect(prompt).toContain(
+			"persistent clone of the GitHub repository fairchild/web-next-fixtures",
+		);
+		expect(prompt).toContain(
+			"https://api.github.com/repos/fairchild/web-next-fixtures/pulls",
+		);
+		expect(prompt).toContain("BASE_BRANCH='trunk'");
+		expect(prompt).toContain('\\"base\\":\\"$BASE_BRANCH\\"');
+		expect(prompt).not.toContain("fairchild/workspaces");
+		expect(prompt).not.toContain('"base":"main"');
+	});
+
+	test("uses the clone default HEAD fallback when the repo row has no default branch", () => {
+		const repo = {
+			fullName: "fairchild/web-next-fixtures",
+			defaultBranch: null,
+		};
+
+		const script = buildSessionSetupScript("abcdef123456", repo);
+		expect(script).toContain(
+			"git clone --depth 50 https://github.com/fairchild/web-next-fixtures.git",
+		);
+		expect(script).toContain("symbolic-ref --quiet --short refs/remotes/origin/HEAD");
+
+		const prompt = buildPrompt("Fix the failing test", "abcdef123456", true, repo);
+		expect(prompt).toContain("the clone's default HEAD");
+		expect(prompt).toContain('BASE_BRANCH="$(cat /tmp/default_branch)"');
+	});
+
+	test("rejects invalid repo full names with structured chunks before setup", async () => {
+		const chunks: StreamChunk[] = [];
+		for await (const chunk of vercelProvider.runTurn({
+			sessionId: "s-bad-repo",
+			userMessage: "go",
+			repo: {
+				fullName: "fairchild/workspaces;rm -rf /",
+				defaultBranch: null,
+			},
+		})) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks.map((chunk) => chunk.type)).toEqual(["error", "done"]);
+		expect(chunks[0]).toMatchObject({
+			type: "error",
+			content:
+				'invalid repository full name for agent runtime: "fairchild/workspaces;rm -rf /"',
+			metadata: { code: "invalid_repo" },
+		});
+		expect(chunks[1]).toMatchObject({
+			type: "done",
+			metadata: { aborted: true },
+		});
+	});
+});
 
 describe("mapFullStream", () => {
 	test("maps deltas and tool parts onto StreamChunks", async () => {

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -21,6 +21,7 @@ import { TERMINAL_INSTALL_SCRIPT } from "../terminal/install";
 import type {
 	ComputeProvider,
 	SessionResumeHandle,
+	TurnRepo,
 	TurnRequest,
 } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
@@ -32,8 +33,9 @@ type CreateClaudeCode =
 type CreateVercelSandbox =
 	typeof import("@ai-sdk/sandbox-vercel")["createVercelSandbox"];
 
-/** Repo the agent clones into its workspace and opens its PR against. */
-const TARGET_REPO = process.env.AGENT_TARGET_REPO ?? "fairchild/workspaces";
+/** Fallback repo for repo-less API-created sessions. */
+const FALLBACK_TARGET_REPO =
+	process.env.AGENT_TARGET_REPO ?? "fairchild/workspaces";
 /** Port the in-sandbox harness bridge binds; must be declared on the sandbox. */
 const BRIDGE_PORT = 4000;
 /**
@@ -69,6 +71,43 @@ const TEMPLATE_NAME = "web-next-claude-code";
  */
 const BOOTSTRAP_HASH = "claude-code-cli-v2-terminal";
 
+// GitHub owner/name shape only. Session creation performs existence/access
+// validation; the provider repeats this cheap shape guard before interpolating
+// into the setup script.
+const REPO_FULL_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9_.-]+$/;
+
+type TargetRepoResolution =
+	| { ok: true; repo: TurnRepo }
+	| { ok: false; error: string };
+
+export function resolveTargetRepo(
+	request: Pick<TurnRequest, "repo">,
+): TargetRepoResolution {
+	const candidate = request.repo ?? {
+		fullName: FALLBACK_TARGET_REPO,
+		defaultBranch: null,
+	};
+	if (
+		typeof candidate.fullName !== "string" ||
+		!REPO_FULL_NAME.test(candidate.fullName)
+	) {
+		return {
+			ok: false,
+			error: `invalid repository full name for agent runtime: ${JSON.stringify(candidate.fullName)}`,
+		};
+	}
+	return {
+		ok: true,
+		repo: {
+			fullName: candidate.fullName,
+			defaultBranch:
+				typeof candidate.defaultBranch === "string"
+					? candidate.defaultBranch
+					: null,
+		},
+	};
+}
+
 /** A stable per-session branch the agent commits and opens its PR from. */
 function sessionBranch(sessionId: string): string {
 	return `agent/session-${sessionId.slice(0, 8)}`;
@@ -82,7 +121,10 @@ function sessionBranch(sessionId: string): string {
  * creates the session branch — all idempotent, so a resumed sandbox with the
  * clone already present is a no-op and a fresh fallback sandbox re-clones.
  */
-function buildSessionSetupScript(sessionId: string): string {
+export function buildSessionSetupScript(
+	sessionId: string,
+	repo: TurnRepo,
+): string {
 	const branch = sessionBranch(sessionId);
 	return [
 		"set -e",
@@ -93,9 +135,17 @@ function buildSessionSetupScript(sessionId: string): string {
 		"git config --global user.email 'agent@users.noreply.github.com'",
 		'printf "%s" "$GH_TOKEN" > /tmp/gh_token',
 		`if [ ! -d ${WORKSPACE_DIR}/.git ]; then`,
-		`  git clone --depth 50 https://github.com/${TARGET_REPO}.git ${WORKSPACE_DIR}`,
+		`  if [ -n "$DEFAULT_BRANCH" ]; then`,
+		`    git clone --depth 50 --branch "$DEFAULT_BRANCH" https://github.com/${repo.fullName}.git ${WORKSPACE_DIR}`,
+		"  else",
+		`    git clone --depth 50 https://github.com/${repo.fullName}.git ${WORKSPACE_DIR}`,
+		"  fi",
 		`  git -C ${WORKSPACE_DIR} checkout -b ${branch}`,
 		"fi",
+		`if [ -z "$DEFAULT_BRANCH" ]; then`,
+		`  DEFAULT_BRANCH="$(git -C ${WORKSPACE_DIR} symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##' || true)"`,
+		"fi",
+		'printf "%s" "$DEFAULT_BRANCH" > /tmp/default_branch',
 		"",
 	].join("\n");
 }
@@ -263,19 +313,39 @@ export async function* mapFullStream(
  * session already carries that context in its harness conversation, so it
  * receives the user's message alone.
  */
-function buildPrompt(
+function baseBranchLabel(repo: TurnRepo): string {
+	return repo.defaultBranch
+		? `\`${repo.defaultBranch}\``
+		: "the clone's default HEAD (`cat /tmp/default_branch`)";
+}
+
+function promptCurlBase(repo: TurnRepo): string {
+	return repo.defaultBranch ?? "$(cat /tmp/default_branch)";
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildPrompt(
 	userMessage: string,
 	sessionId: string,
 	firstTurn: boolean,
+	repo: TurnRepo,
 ): string {
 	if (!firstTurn) return userMessage;
 	const branch = sessionBranch(sessionId);
+	const base = promptCurlBase(repo);
+	const baseLabel = baseBranchLabel(repo);
+	const baseAssignment = repo.defaultBranch
+		? `BASE_BRANCH=${shellQuote(base)}`
+		: `BASE_BRANCH="${base}"`;
 	return [
-		`You are working inside a persistent clone of the GitHub repository ${TARGET_REPO}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
+		`You are working inside a persistent clone of the GitHub repository ${repo.fullName}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`, created from ${baseLabel}. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
 		``,
 		`Working notes:`,
 		`- Relative paths and git commands resolve against the repo (you are inside it) — edit and \`git status\`/\`git diff\` normally.`,
-		`- To open or update a pull request: commit, \`git push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token, e.g. \`curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${TARGET_REPO}/pulls -d '{"title":"…","head":"${branch}","base":"main","body":"…"}'\`. Report the \`html_url\`.`,
+		`- To open or update a pull request: commit, \`git push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token against base ${baseLabel}, e.g. \`${baseAssignment}; curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${repo.fullName}/pulls -d "{\\"title\\":\\"…\\",\\"head\\":\\"${branch}\\",\\"base\\":\\"$BASE_BRANCH\\",\\"body\\":\\"…\\"}"\`. Report the \`html_url\`.`,
 		`- Only open a PR when the request calls for one; otherwise just do the work and summarize it.`,
 		``,
 		`The user's request:`,
@@ -448,9 +518,24 @@ export const vercelProvider: ComputeProvider = {
 	id: "vercel",
 	async *runTurn(request: TurnRequest): AsyncIterable<StreamChunk> {
 		const startedAt = Date.now();
+		const targetRepo = resolveTargetRepo(request);
+		if (!targetRepo.ok) {
+			yield {
+				type: "error",
+				content: targetRepo.error,
+				metadata: { code: "invalid_repo" },
+			};
+			yield {
+				type: "done",
+				content: "",
+				metadata: { durationMs: Date.now() - startedAt, aborted: true },
+			};
+			return;
+		}
+		const repo = targetRepo.repo;
 
 		yield { type: "status", content: "Minting GitHub credential" };
-		const { token } = await mintInstallationToken(TARGET_REPO);
+		const { token } = await mintInstallationToken(repo.fullName);
 
 		yield { type: "status", content: "Preparing sandbox runtime" };
 		const [{ HarnessAgent }, { createClaudeCode }, { createVercelSandbox }] =
@@ -485,11 +570,14 @@ export const vercelProvider: ComputeProvider = {
 					sandbox = session as RunnableSandbox;
 					await session.writeTextFile({
 						path: "/tmp/session-setup.sh",
-						content: buildSessionSetupScript(request.sessionId),
+						content: buildSessionSetupScript(request.sessionId, repo),
 					});
 					const res = await session.run({
 						command: "bash /tmp/session-setup.sh",
-						env: { GH_TOKEN: token },
+						env: {
+							GH_TOKEN: token,
+							DEFAULT_BRANCH: repo.defaultBranch ?? "",
+						},
 					});
 					if (res.exitCode !== 0)
 						throw new Error(
@@ -561,7 +649,7 @@ export const vercelProvider: ComputeProvider = {
 		try {
 			const result = await agent.stream({
 				session,
-				prompt: buildPrompt(request.userMessage, request.sessionId, !resumed),
+				prompt: buildPrompt(request.userMessage, request.sessionId, !resumed, repo),
 			});
 			let doneChunk: StreamChunk | undefined;
 			// Tracks every real toolCallId this turn so the synthetic Diff rows


### PR DESCRIPTION
Closes #967 (milestone W5, Lane A — the bug the owner hit in daily use).

The repo picked at session creation now reaches the runtime. Previously the
picker validated and stored the repo but every turn minted its token, cloned,
and prompted against the global `AGENT_TARGET_REPO` — a session labeled
`fairchild/ipxe` edited `fairchild/workspaces`.

**What to look at:** start a session on any non-workspaces repo (with
`WEB_NEXT_COMPUTE_PROVIDER=vercel`) and watch the first turn clone and edit
that repo. The daily folio validation lane (#818's real-turn probe) exercises
this after deploy.

`TurnRequest` gains the session's repo (resolved in `startTurn`, one query);
the vercel provider uses it for installation-token minting, clone URL, and
the first-turn PR instructions, cloning `--branch` the recorded default
branch and discovering it in-sandbox when unrecorded. `AGENT_TARGET_REPO`
remains only the fallback for repo-less sessions (the #818 probe's
`POST /api/sessions` path). Defense in depth: the provider re-asserts the
`owner/name` shape before shell interpolation and rejects with a structured
`invalid_repo` error chunk. Sandbox template identity is untouched — repo
state lives in `onSession`, exactly like the GitHub credential.

Implementation by codex CLI (gpt-5.5, xhigh) from a coordinator brief; codex's
mutation check reverted the provider to the fallback repo and got real
assertion failures. Coordinator follow-up commit fixes two notification-test
fixtures (from #971, merged mid-flight) that stamped a fake repoId with no
repos row — strict resolution now rightly rejects dangling repo ids.

## Mergeability

- **Surface:** web-next agent runtime (TurnRequest seam, vercel provider, ingest threading) + mock provider metadata; no UI, no schema.
- **Behavior changed:** vercel-provider turns target the session's repo (token, clone, prompt); repo-less sessions keep today's fallback behavior.
- **Non-happy paths:** invalid repo shape → structured error chunk + aborted done (no sandbox boot); missing repos row → turn-start rejects before the provider runs; null default branch → clone default HEAD, discovered branch recorded at /tmp/default_branch.
- **Residual risk:** a parked sandbox from before this change resumes with its existing clone (always the fallback repo, matching its session's stored repo anyway); cross-repo confusion can't occur because the sandbox is per-session.

## Evidence

![repo-threading-tests](https://evidence.cloudcompute.com/workspaces/pr-975/20260708-092758-repo-threading-tests.png)

Gates on the rebased tree (over #974): 447/447 tests, typecheck, lint, clean production build. Codex mutation check: provider reverted to fallback repo → 2 real assertion failures → restored.

