### PR TITLE
fix(web-next): auth hardening — third bypass lock + per-session owner scoping (#910)

### DIFF
--- a/web-next/src/app/(app)/actions.ts
+++ b/web-next/src/app/(app)/actions.ts
@@ -27,7 +27,7 @@ export async function createSessionAction(
 	_prevState: CreateSessionState | null,
 	formData: FormData,
 ): Promise<CreateSessionState> {
-	await requireAuthorizedUser();
+	const user = await requireAuthorizedUser();
 	const repo = String(formData.get("repo") ?? "").trim();
 	// The input's pattern blocks this in the UI; a direct POST gets the same
 	// calm state instead of an unhandled server-action throw.
@@ -36,7 +36,7 @@ export async function createSessionAction(
 	}
 	let session: Awaited<ReturnType<typeof startSession>>;
 	try {
-		session = await startSession(getDatabase(), repo);
+		session = await startSession(getDatabase(), repo, user.login);
 	} catch (error) {
 		if (error instanceof RepoUnavailableError) {
 			return {

--- a/web-next/src/app/api/sessions/[id]/chat/route.ts
+++ b/web-next/src/app/api/sessions/[id]/chat/route.ts
@@ -9,6 +9,7 @@ import { createUIMessageStreamResponse } from "ai";
 import { after } from "next/server";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { runSessionTurn, TurnConflictError } from "@/lib/agent-runtime/run-turn";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
 import { getSession } from "@/lib/db/sessions";
 
@@ -35,6 +36,8 @@ export async function POST(
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
 	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
 
 	const body: unknown = await request.json().catch(() => undefined);
 	const text =

--- a/web-next/src/app/api/sessions/[id]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/route.test.ts
@@ -56,9 +56,9 @@ async function patch(id: string, body: unknown) {
 
 let seq = 0;
 /** A fresh session id per test — one shared DB, no cross-test collisions. */
-async function freshSession(): Promise<string> {
+async function freshSession(ownerLogin?: string | null): Promise<string> {
 	const id = `s-${++seq}`;
-	await createSession(getDatabase(), { id, provider: "mock" });
+	await createSession(getDatabase(), { id, ownerLogin, provider: "mock" });
 	return id;
 }
 
@@ -80,6 +80,18 @@ describe("PATCH /api/sessions/[id]", () => {
 	test("404s for an unknown session", async () => {
 		const res = await patch("does-not-exist", { title: "New title" });
 		expect(res.status).toBe(404);
+	});
+
+	test("403s for a foreign owner and allows a legacy null owner", async () => {
+		const foreign = await freshSession("octocat");
+		const denied = await patch(foreign, { title: "Nope" });
+		expect(denied.status).toBe(403);
+		expect((await getSession(getDatabase(), foreign))?.title).toBe("");
+
+		const legacy = await freshSession(null);
+		const allowed = await patch(legacy, { title: "Grandfathered" });
+		expect(allowed.status).toBe(200);
+		expect((await getSession(getDatabase(), legacy))?.title).toBe("Grandfathered");
 	});
 
 	test("rejects a field outside {model, title}", async () => {

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -13,6 +13,7 @@ import { isSelectableModel } from "@/lib/agent-runtime/models";
 import { releaseParkedSandbox } from "@/lib/agent-runtime/sandbox-release";
 import { resolveTurn } from "@/lib/agent-runtime/turn-tail";
 import { getAuthState } from "@/lib/auth/auth-state";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
 import {
 	deleteSession,
@@ -93,6 +94,8 @@ export async function DELETE(
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
 	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
 
 	// A running turn's detached ingest keeps appending to this session;
 	// deleting now would orphan those writes and lose the resume handle the
@@ -146,6 +149,8 @@ export async function PATCH(
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
 	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
 
 	const body: unknown = await request.json().catch(() => undefined);
 	if (typeof body !== "object" || body === null) {

--- a/web-next/src/app/api/sessions/[id]/sandbox/route.ts
+++ b/web-next/src/app/api/sessions/[id]/sandbox/route.ts
@@ -11,12 +11,13 @@ import {
 	stopSessionSandbox,
 } from "@/lib/agent-runtime/sandbox-state";
 import { getAuthState } from "@/lib/auth/auth-state";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
 import { getSession } from "@/lib/db/sessions";
 
 export const runtime = "nodejs";
 
-async function gate(id: string) {
+async function gate(id: string, options: { ownerScoped?: boolean } = {}) {
 	const auth = await getAuthState();
 	if (auth.kind !== "authorized") {
 		return {
@@ -31,6 +32,10 @@ async function gate(id: string) {
 		return {
 			response: Response.json({ error: "unknown session" }, { status: 404 }),
 		};
+	}
+	if (options.ownerScoped) {
+		const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+		if (ownerScope) return { response: ownerScope };
 	}
 	return { session };
 }
@@ -50,7 +55,7 @@ export async function DELETE(
 	{ params }: { params: Promise<{ id: string }> },
 ) {
 	const { id } = await params;
-	const gated = await gate(id);
+	const gated = await gate(id, { ownerScoped: true });
 	if (gated.response) return gated.response;
 	try {
 		return Response.json(await stopSessionSandbox(gated.session));

--- a/web-next/src/app/api/sessions/[id]/stop/route.ts
+++ b/web-next/src/app/api/sessions/[id]/stop/route.ts
@@ -11,6 +11,7 @@
 import { stopActiveTurn, TURN_STOPPED_MESSAGE } from "@/lib/agent-runtime/turn-ingest";
 import { closeAbandonedTurn, resolveTurn } from "@/lib/agent-runtime/turn-tail";
 import { getAuthState } from "@/lib/auth/auth-state";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
 import { getSession } from "@/lib/db/sessions";
 
@@ -34,6 +35,8 @@ export async function POST(
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
 	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
 
 	if (stopActiveTurn(id)) {
 		return Response.json({ stopped: true, message: TURN_STOPPED_MESSAGE });

--- a/web-next/src/app/api/sessions/[id]/terminal/redeem/route.ts
+++ b/web-next/src/app/api/sessions/[id]/terminal/redeem/route.ts
@@ -7,6 +7,7 @@
  * WebSocket URL; "mock" tickets (AUTH_BYPASS) just confirm the mode.
  */
 import { getAuthState } from "@/lib/auth/auth-state";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
 import { getSession } from "@/lib/db/sessions";
 import {
@@ -44,6 +45,8 @@ export async function POST(
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
 	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
 
 	const body: unknown = await request.json().catch(() => undefined);
 	const ticket =

--- a/web-next/src/app/api/sessions/[id]/terminal/route.ts
+++ b/web-next/src/app/api/sessions/[id]/terminal/route.ts
@@ -10,6 +10,7 @@
  */
 import { getAuthState } from "@/lib/auth/auth-state";
 import { authBypassEnabled } from "@/lib/auth/config";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
 import { getSession } from "@/lib/db/sessions";
 import {
@@ -39,6 +40,8 @@ export async function POST(
 	if (!session) {
 		return Response.json({ error: "unknown session" }, { status: 404 });
 	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
 
 	if (authBypassEnabled()) {
 		const ticket = await issueTerminalTicket(handle, {

--- a/web-next/src/app/api/sessions/route.test.ts
+++ b/web-next/src/app/api/sessions/route.test.ts
@@ -63,6 +63,7 @@ describe("POST /api/sessions", () => {
 		const row = await getSession(getDatabase(), body.id);
 		expect(row?.model).toBe(DEFAULT_MODEL);
 		expect(row?.repoId).toBeNull();
+		expect(row?.ownerLogin).toBe("fairchild");
 	});
 
 	test("defaults: empty title, the configured default provider", async () => {

--- a/web-next/src/app/api/sessions/route.ts
+++ b/web-next/src/app/api/sessions/route.ts
@@ -71,6 +71,7 @@ export async function POST(request: Request) {
 
 	const session = await createSession(getDatabase(), {
 		id: crypto.randomUUID(),
+		ownerLogin: auth.user.login,
 		title,
 		provider,
 	});

--- a/web-next/src/lib/auth/config.test.ts
+++ b/web-next/src/lib/auth/config.test.ts
@@ -34,7 +34,7 @@ describe("isLoginAllowed", () => {
 	});
 });
 
-describe("authBypassEnabled (double lock)", () => {
+describe("authBypassEnabled (triple lock)", () => {
 	it("requires the explicit env var", () => {
 		expect(authBypassEnabled({})).toBe(false);
 		expect(authBypassEnabled({ AUTH_BYPASS: "0" })).toBe(false);
@@ -46,6 +46,15 @@ describe("authBypassEnabled (double lock)", () => {
 			authBypassEnabled({
 				AUTH_BYPASS: "1",
 				GITHUB_OAUTH_CLIENT_ID: "Iv1.real",
+			}),
+		).toBe(false);
+	});
+
+	it("is inert on Vercel even without OAuth config", () => {
+		expect(
+			authBypassEnabled({
+				AUTH_BYPASS: "1",
+				VERCEL: "1",
 			}),
 		).toBe(false);
 	});

--- a/web-next/src/lib/auth/config.ts
+++ b/web-next/src/lib/auth/config.ts
@@ -39,17 +39,20 @@ export function realAuthConfigured(env: Env = process.env): boolean {
 
 /**
  * Test/dev auth bypass: cookie-driven identity instead of GitHub OAuth, so
- * e2e, evidence, and perf runs work headlessly. Double-locked:
+ * e2e, evidence, and perf runs work headlessly. Triple-locked:
  *
  * 1. `AUTH_BYPASS=1` must be set explicitly (never set it in production).
  * 2. It is inert whenever a real OAuth app is configured — production sets
  *    GITHUB_OAUTH_CLIENT_ID, so even a leaked AUTH_BYPASS=1 cannot open it.
+ * 3. It is inert on Vercel runtime (`VERCEL` is present there), so a deploy
+ *    that accidentally carries AUTH_BYPASS=1 but omits OAuth config still
+ *    refuses the unsigned test cookie.
  *
  * When active, the absence of TEST_AUTH_COOKIE is still "signed out": the
  * unauth redirect and the allowlist rejection stay testable per request.
  */
 export function authBypassEnabled(env: Env = process.env): boolean {
-	return env.AUTH_BYPASS === "1" && !realAuthConfigured(env);
+	return env.AUTH_BYPASS === "1" && !realAuthConfigured(env) && !env.VERCEL;
 }
 
 /**

--- a/web-next/src/lib/auth/session-owner.ts
+++ b/web-next/src/lib/auth/session-owner.ts
@@ -1,0 +1,19 @@
+/*
+ * Per-session ownership guard for mutating/attaching API routes. Sessions
+ * created before owner stamping have a null owner and stay grandfathered; new
+ * rows compare the stamped login to the current allowlisted principal.
+ */
+import type { Session } from "@/lib/db/sessions";
+
+function normalizeLogin(login: string | null | undefined): string {
+	return login?.trim().toLowerCase() ?? "";
+}
+
+export function sessionOwnerScopeResponse(
+	session: Pick<Session, "ownerLogin">,
+	actingLogin: string,
+): Response | undefined {
+	const ownerLogin = normalizeLogin(session.ownerLogin);
+	if (!ownerLogin || ownerLogin === normalizeLogin(actingLogin)) return undefined;
+	return Response.json({ error: "session belongs to another user" }, { status: 403 });
+}

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -37,6 +37,8 @@ export interface SessionsTable {
 	id: string;
 	/** repos.id this session runs against; null for not-yet-bound sessions. */
 	repo_id: string | null;
+	/** GitHub login that created the session; null for legacy grandfathered rows. */
+	owner_login: string | null;
 	title: string;
 	/** Compute provider id — "mock" | "vercel" | "anthropic" | … */
 	provider: string;

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -215,10 +215,32 @@ const terminalTickets: Migration = {
 	},
 };
 
+/**
+ * Adds `sessions.owner_login` — the allowlisted GitHub login that created the
+ * session (#910). Nullable by design: pre-existing rows have no stamped owner
+ * and remain accessible until they are naturally replaced.
+ */
+const sessionOwnerLogin: Migration = {
+	id: "0006_session_owner_login",
+	async up(db) {
+		const info = await sql<{
+			name: string;
+		}>`PRAGMA table_info(sessions)`.execute(db);
+		const hasColumn = info.rows.some((row) => row.name === "owner_login");
+		if (!hasColumn) {
+			await db.schema
+				.alterTable("sessions")
+				.addColumn("owner_login", "text")
+				.execute();
+		}
+	},
+};
+
 export const MIGRATIONS: Migration[] = [
 	baseline,
 	authTables,
 	sessionResumeState,
 	sessionModel,
 	terminalTickets,
+	sessionOwnerLogin,
 ];

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -55,6 +55,7 @@ describe("session store", () => {
 			"0003_session_resume_state",
 			"0004_session_model",
 			"0005_terminal_tickets",
+			"0006_session_owner_login",
 		]);
 	});
 
@@ -63,12 +64,14 @@ describe("session store", () => {
 		const created = await createSession(handle, {
 			id: "s1",
 			repoId: "owner/name",
+			ownerLogin: "FairChild",
 			title: "Fix the bug",
 			provider: "mock",
 		});
 		expect(created).toMatchObject({
 			id: "s1",
 			repoId: "owner/name",
+			ownerLogin: "fairchild",
 			title: "Fix the bug",
 			provider: "mock",
 			status: "active",

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -22,6 +22,8 @@ import { ensureSchema } from "./schema";
 export interface NewSession {
 	id: string;
 	repoId?: string | null;
+	/** Acting GitHub login; omitted only for legacy/test rows. */
+	ownerLogin?: string | null;
 	title?: string;
 	provider: string;
 	status?: string;
@@ -33,6 +35,8 @@ export interface NewSession {
 export interface Session {
 	id: string;
 	repoId: string | null;
+	/** GitHub login that created the session; null for legacy grandfathered rows. */
+	ownerLogin: string | null;
 	title: string;
 	provider: string;
 	status: string;
@@ -55,6 +59,7 @@ function rowToSession(row: SessionsTable): Session {
 	return {
 		id: row.id,
 		repoId: row.repo_id,
+		ownerLogin: row.owner_login,
 		title: row.title,
 		provider: row.provider,
 		status: row.status,
@@ -75,6 +80,7 @@ export async function createSession(
 	const row: SessionsTable = {
 		id: session.id,
 		repo_id: session.repoId ?? null,
+		owner_login: session.ownerLogin?.trim().toLowerCase() || null,
 		title: session.title ?? "",
 		provider: session.provider,
 		status: session.status ?? "active",

--- a/web-next/src/lib/db/start-session.test.ts
+++ b/web-next/src/lib/db/start-session.test.ts
@@ -81,9 +81,10 @@ describe("ensureRepo (default_branch recording)", () => {
 describe("startSession", () => {
 	test("creates the repo on first use and an empty active session on it", async () => {
 		const handle = freshDb();
-		const session = await startSession(handle, "fairchild/workspaces");
+		const session = await startSession(handle, "fairchild/workspaces", "FairChild");
 		expect(session).toMatchObject({
 			repoId: "fairchild/workspaces",
+			ownerLogin: "fairchild",
 			title: "",
 			provider: "mock",
 			status: "active",

--- a/web-next/src/lib/db/start-session.ts
+++ b/web-next/src/lib/db/start-session.ts
@@ -40,6 +40,7 @@ export function defaultComputeProvider(): string {
 export async function startSession(
 	handle: DatabaseHandle,
 	repoFullName: string,
+	ownerLogin?: string | null,
 ): Promise<Session> {
 	const trimmed = repoFullName.trim();
 	if (!isValidRepoFullName(trimmed)) {
@@ -50,6 +51,7 @@ export async function startSession(
 	return createSession(handle, {
 		id: crypto.randomUUID(),
 		repoId: repo.id,
+		ownerLogin,
 		provider: defaultComputeProvider(),
 	});
 }


### PR DESCRIPTION
Closes #910 (milestone W5, Lane B).

Two pre-existing findings from the #752 security review, now closed:

1. **Third lock on the test bypass.** `authBypassEnabled()` additionally
   requires no `VERCEL` env — a production deploy that both carries
   `AUTH_BYPASS=1` and omits OAuth config still refuses the unsigned test
   cookie. Keyed on `VERCEL` rather than NODE_ENV deliberately: the local
   e2e server runs a production build with the bypass on by design.
2. **Per-session owner scoping.** New nullable `sessions.owner_login`
   (migration 0006), stamped from the acting allowlisted login on both
   creation paths, enforced by one shared guard on every mutating/attaching
   route: chat, stop, terminal mint + redeem, DELETE session, sandbox,
   PATCH title/model. Legacy null-owner rows are grandfathered; reads stay
   unscoped (that boundary is #829's scope). This is the prerequisite that
   makes a future second allowlist login (e.g. a bot) safe against
   cross-principal terminal minting.

**What to look at:** nothing visual — behavior is 403 `session belongs to
another user` on foreign-owner mutation; existing single-user flows are
unchanged.

Implementation by codex CLI (gpt-5.5, high) from a coordinator brief; both
mutation checks produced real failures (dropped VERCEL lock → config test
fails; dropped owner check → route 403 test fails). Coordinator review found
no gaps; rebased over #967/#971, full gates re-run green.

## Mergeability

- **Surface:** web-next auth config, sessions schema (+1 nullable column migration), session API routes; no UI.
- **Behavior changed:** bypass inert on Vercel runtime; foreign-owner mutations 403.
- **Non-happy paths:** null owner (legacy rows) allowed; owner comparison case-insensitive matching allowlist normalization; migration idempotent via PRAGMA column check.
- **Residual risk:** GET/stream routes remain unscoped by design until #829; single-principal today, so no behavior change for the owner.

## Evidence

![auth-hardening-tests](https://evidence.cloudcompute.com/workspaces/pr-977/20260708-154132-auth-hardening-tests.png)

Gates on the rebased tree: 449/449 tests, typecheck, lint, clean production build.

