### PR TITLE
feat(web-next): quiet sign-out from the sessions masthead (#871)

### DIFF
--- a/web-next/src/app/(app)/page.tsx
+++ b/web-next/src/app/(app)/page.tsx
@@ -9,6 +9,7 @@ import { getDatabase } from "@/lib/db/client";
 import { listSessions, type SessionListItem } from "@/lib/db/sessions";
 import { formatRelativeTime } from "@/lib/relative-time";
 import { NewSession } from "./new-session";
+import { SignOutButton } from "./sign-out-button";
 
 function SessionRow({ session, index }: { session: SessionListItem; index: number }) {
 	return (
@@ -54,8 +55,9 @@ export default async function SessionsHome() {
 		<>
 			<header className="sticky top-0 z-20 flex h-[52px] items-center justify-between border-b border-line bg-mast-bg px-8 backdrop-blur-[10px] backdrop-saturate-[1.1]">
 				<span className="font-serif text-[17px] text-ink italic">Spaces</span>
-				<span className="flex items-center font-mono text-masthead tracking-[.02em] text-muted">
+				<span className="flex items-center gap-3 font-mono text-masthead tracking-[.02em] text-muted">
 					sessions
+					<SignOutButton variant="masthead" />
 					<ThemeToggle />
 				</span>
 			</header>

--- a/web-next/src/app/(app)/sign-out-button.tsx
+++ b/web-next/src/app/(app)/sign-out-button.tsx
@@ -8,7 +8,19 @@
 import { signOut } from "@/lib/auth/auth-client";
 import { TEST_AUTH_COOKIE } from "@/lib/auth/config";
 
-export function SignOutButton() {
+type SignOutButtonVariant = "page" | "masthead";
+
+const variantClassName: Record<SignOutButtonVariant, string> = {
+	page: "mt-3 font-mono text-[13px] text-hint underline decoration-line-strong underline-offset-4 transition-colors hover:text-accent",
+	masthead:
+		"font-mono text-masthead tracking-[.02em] text-hint transition-colors hover:text-accent focus-visible:text-accent",
+};
+
+export function SignOutButton({
+	variant = "page",
+}: {
+	variant?: SignOutButtonVariant;
+}) {
 	const handleSignOut = async () => {
 		document.cookie = `${TEST_AUTH_COOKIE}=; path=/; max-age=0`;
 		await signOut().catch(() => {
@@ -21,7 +33,7 @@ export function SignOutButton() {
 		<button
 			type="button"
 			onClick={handleSignOut}
-			className="mt-3 font-mono text-[13px] text-hint underline decoration-line-strong underline-offset-4 transition-colors hover:text-accent"
+			className={variantClassName[variant]}
 		>
 			sign out
 		</button>

--- a/web-next/tests/e2e/auth.spec.ts
+++ b/web-next/tests/e2e/auth.spec.ts
@@ -118,3 +118,25 @@ test("a signed-in user visiting sign-in is sent home", async ({ page }) => {
 	await page.goto("/sign-in");
 	await expect(page).toHaveURL("/");
 });
+
+test("a signed-in user can sign out from the sessions masthead and sign in again", async ({
+	page,
+}) => {
+	await page.goto("/");
+	const signOut = page.getByRole("button", { name: "sign out" });
+	await expect(signOut).toBeVisible();
+
+	await page.keyboard.press("Tab");
+	await expect(signOut).toBeFocused();
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL("/sign-in");
+
+	await page.goto("/");
+	await expect(page).toHaveURL("/sign-in");
+
+	await page
+		.getByRole("button", { name: `continue as ${E2E_LOGIN} (test bypass)` })
+		.click();
+	await expect(page).toHaveURL("/");
+	await expect(page.getByRole("banner").getByText("Spaces")).toBeVisible();
+});


### PR DESCRIPTION
Closes #871 (milestone W5, Lane B).

An authenticated, allowlisted user finally has a way out: the sessions
home masthead's right-side cluster gains a low-emphasis `sign out` next to
the `sessions` label and theme toggle. It reuses the access-denied page's
existing `SignOutButton` (clears both identities — Better Auth session and
test-bypass cookie — then lands on `/sign-in`) via a `masthead` variant, so
there is exactly one sign-out path in the codebase.

**What to look at:** the sessions home masthead — `sessions · sign out · ◐`
— quiet text weight (`text-hint`, accent on hover/focus-visible), a real
button, keyboard-reachable per the #805 standard. Then sign back in and
confirm the round trip.

Implementation by codex CLI (gpt-5.5, medium) from a coordinator brief.
Codex's mutation check hid the control, watched the new e2e spec fail at
`getByRole('button', { name: 'sign out' })`, and restored — catching the
stale-.next trap itself and using the sanctioned clean script (#780 lesson).
Coordinator review found no gaps; rebased over #967/#971, gates re-run green
(447/447, typecheck, lint, clean build; e2e rides CI).

## Mergeability

- **Surface:** sessions home masthead + SignOutButton variant + one e2e spec; no runtime, schema, or API changes.
- **Behavior changed:** a sign-out affordance exists on the sessions home; access-denied page rendering unchanged (default variant).
- **Non-happy paths:** signOut() failure in bypass mode is swallowed (no Better Auth session to revoke) and navigation still lands on /sign-in; keyboard focus ring via focus-visible.
- **Residual risk:** none beyond visual taste — the owner can veto placement from the screenshots.

## Evidence

![signout-masthead-dark](https://evidence.cloudcompute.com/workspaces/pr-978/20260708-154258-signout-masthead-dark.png)
![signout-masthead-light](https://evidence.cloudcompute.com/workspaces/pr-978/20260708-154258-signout-masthead-light.png)

