### PR TITLE
feat(web-next): end-of-turn checkpoint commit+push — sandbox death never loses work (#968)

### DIFF
--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -3,18 +3,42 @@ import {
 	buildPrompt,
 	buildSessionSetupScript,
 	canonicalToolName,
+	checkpointSessionBranch,
 	createHarness,
 	errorText,
 	mapFullStream,
 	parseGitDiff,
 	resolveTargetRepo,
+	runTurnTail,
 	toolResultContent,
 	uniqueDiffToolCallId,
 	vercelProvider,
+	WORKSPACE_DIR,
 } from "./vercel-provider";
 import type { StreamChunk } from "./stream-chunk";
+import type { RunnableSandbox } from "./vercel-provider";
 
 type Part = { type: string; [k: string]: unknown };
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+function runResult(
+	stdout = "",
+	exitCode = 0,
+	stderr = "",
+): RunResult {
+	return { exitCode, stdout, stderr };
+}
+
+class RecordingSandbox implements RunnableSandbox {
+	readonly calls: string[] = [];
+
+	constructor(private readonly respond: (command: string) => RunResult) {}
+
+	async run({ command }: { command: string }): Promise<RunResult> {
+		this.calls.push(command);
+		return this.respond(command);
+	}
+}
 
 async function collect(parts: Part[]): Promise<StreamChunk[]> {
 	async function* source(): AsyncIterable<Part> {
@@ -23,6 +47,33 @@ async function collect(parts: Part[]): Promise<StreamChunk[]> {
 	const out: StreamChunk[] = [];
 	for await (const chunk of mapFullStream(source(), 0)) out.push(chunk);
 	return out;
+}
+
+async function collectTail(
+	sandbox: RunnableSandbox,
+	events: string[],
+): Promise<{ chunks: StreamChunk[]; detached: boolean }> {
+	const chunks: StreamChunk[] = [];
+	const tail = runTurnTail({
+		sandbox,
+		branch: "agent/session-abcdef12",
+		seenToolCallIds: new Set(),
+		doneChunk: { type: "done", content: "", metadata: { tokenCount: 7 } },
+		session: {
+			detach: async () => {
+				events.push("detach");
+				return { parked: true };
+			},
+		},
+		sandboxSessionId: "sandbox-1",
+		debug: false,
+	});
+
+	for (;;) {
+		const next = await tail.next();
+		if (next.done) return { chunks, detached: next.value };
+		chunks.push(next.value);
+	}
 }
 
 describe("repo targeting", () => {
@@ -254,6 +305,217 @@ describe("createHarness", () => {
 
 		createHarness(fakeCreateClaudeCode, undefined);
 		expect(calls[0]).not.toHaveProperty("model");
+	});
+});
+
+describe("buildSessionSetupScript", () => {
+	test("checks out an existing remote session branch on a fresh clone (#968)", () => {
+		const script = buildSessionSetupScript("abcdef1234567890", {
+			fullName: "fairchild/web-next-fixtures",
+			defaultBranch: "trunk",
+		});
+
+		expect(script).toContain(
+			`git clone --depth 50 --branch "$DEFAULT_BRANCH" https://github.com/fairchild/web-next-fixtures.git ${WORKSPACE_DIR}`,
+		);
+		expect(script).toContain(
+			`git -C ${WORKSPACE_DIR} ls-remote --exit-code --heads origin 'agent/session-abcdef12'`,
+		);
+		expect(script).toContain(
+			`git -C ${WORKSPACE_DIR} fetch --depth 50 origin 'refs/heads/agent/session-abcdef12:refs/remotes/origin/agent/session-abcdef12'`,
+		);
+		expect(script).toContain(
+			`git -C ${WORKSPACE_DIR} checkout 'agent/session-abcdef12'`,
+		);
+		expect(script).toContain(
+			`git -C ${WORKSPACE_DIR} checkout -b 'agent/session-abcdef12'`,
+		);
+		expect(script).not.toContain("fairchild/workspaces.git");
+	});
+});
+
+describe("checkpointSessionBranch", () => {
+	test("skips add, commit, and push when tree and remote branch are already clean", async () => {
+		const events: string[] = [];
+		const sandbox = new RecordingSandbox((command) => {
+			if (command.includes("status --porcelain")) {
+				events.push("status");
+				return runResult("");
+			}
+			if (command.includes("ls-remote --exit-code")) {
+				events.push("ls-remote");
+				return runResult("");
+			}
+			if (command.includes("fetch --depth 50")) {
+				events.push("fetch");
+				return runResult("");
+			}
+			if (command.includes("rev-list --count")) {
+				events.push("ahead");
+				return runResult("0\n");
+			}
+			throw new Error(`unexpected command: ${command}`);
+		});
+
+		const status = await checkpointSessionBranch(
+			sandbox,
+			"agent/session-abcdef12",
+		);
+
+		expect(status).toBeUndefined();
+		expect(events).toEqual(["status", "ls-remote", "fetch", "ahead"]);
+		expect(sandbox.calls.some((c) => c.includes(" add -A"))).toBe(false);
+		expect(sandbox.calls.some((c) => c.includes(" commit -m "))).toBe(false);
+		expect(sandbox.calls.some((c) => c.includes(" push -u origin "))).toBe(false);
+	});
+});
+
+describe("runTurnTail", () => {
+	test("emits Diff rows, then pushes a checkpoint, then parks", async () => {
+		const events: string[] = [];
+		const sandbox = new RecordingSandbox((command) => {
+			if (command.includes("add -N .") && command.includes(" diff")) {
+				events.push("diff");
+				return runResult(
+					[
+						"diff --git a/web-next/src/demo.ts b/web-next/src/demo.ts",
+						"--- a/web-next/src/demo.ts",
+						"+++ b/web-next/src/demo.ts",
+						"@@ -1 +1 @@",
+						"-old",
+						"+new",
+					].join("\n"),
+				);
+			}
+			if (command.includes("status --porcelain")) {
+				events.push("status");
+				return runResult(" M web-next/src/demo.ts\n");
+			}
+			if (command.includes(" add -A")) {
+				events.push("add");
+				return runResult("");
+			}
+			if (command.includes("diff --cached --quiet")) {
+				events.push("staged");
+				return runResult("dirty");
+			}
+			if (command.includes(" commit -m ")) {
+				events.push("commit");
+				return runResult("[agent/session-abcdef12 1234567] checkpoint\n");
+			}
+			if (command.includes("ls-remote --exit-code")) {
+				events.push("ls-remote");
+				return runResult("");
+			}
+			if (command.includes("fetch --depth 50")) {
+				events.push("fetch");
+				return runResult("");
+			}
+			if (command.includes("rev-list --count")) {
+				events.push("ahead");
+				return runResult("1\n");
+			}
+			if (command.includes(" push -u origin ")) {
+				events.push("push");
+				expect(command).toContain("push -u origin 'agent/session-abcdef12'");
+				return runResult("branch pushed\n");
+			}
+			throw new Error(`unexpected command: ${command}`);
+		});
+
+		const { chunks, detached } = await collectTail(sandbox, events);
+
+		expect(detached).toBe(true);
+		expect(events).toEqual([
+			"diff",
+			"status",
+			"add",
+			"staged",
+			"commit",
+			"ls-remote",
+			"fetch",
+			"ahead",
+			"push",
+			"detach",
+		]);
+		expect(chunks.map((c) => c.type)).toEqual([
+			"tool_use",
+			"tool_result",
+			"status",
+			"done",
+		]);
+		expect(chunks[2]).toMatchObject({
+			type: "status",
+			content: "Pushed checkpoint to agent/session-abcdef12",
+		});
+		expect(chunks.at(-1)?.metadata).toMatchObject({
+			tokenCount: 7,
+			resume: {
+				harnessSessionId: "sandbox-1",
+				resumeState: JSON.stringify({ parked: true }),
+			},
+		});
+	});
+
+	test("push failure yields a calm status and still parks the turn", async () => {
+		const events: string[] = [];
+		const sandbox = new RecordingSandbox((command) => {
+			if (command.includes("add -N .") && command.includes(" diff")) {
+				events.push("diff");
+				return runResult("");
+			}
+			if (command.includes("status --porcelain")) {
+				events.push("status");
+				return runResult(" M web-next/src/demo.ts\n");
+			}
+			if (command.includes(" add -A")) {
+				events.push("add");
+				return runResult("");
+			}
+			if (command.includes("diff --cached --quiet")) {
+				events.push("staged");
+				return runResult("dirty");
+			}
+			if (command.includes(" commit -m ")) {
+				events.push("commit");
+				return runResult("[agent/session-abcdef12 1234567] checkpoint\n");
+			}
+			if (command.includes("ls-remote --exit-code")) {
+				events.push("ls-remote");
+				return runResult("", 2);
+			}
+			if (command.includes("rev-list --count")) {
+				events.push("ahead");
+				return runResult("1\n");
+			}
+			if (command.includes(" push -u origin ")) {
+				events.push("push");
+				return runResult("", 1, "remote rejected checkpoint");
+			}
+			throw new Error(`unexpected command: ${command}`);
+		});
+
+		const { chunks, detached } = await collectTail(sandbox, events);
+
+		expect(detached).toBe(true);
+		expect(events).toEqual([
+			"diff",
+			"status",
+			"add",
+			"staged",
+			"commit",
+			"ls-remote",
+			"ahead",
+			"push",
+			"detach",
+		]);
+		expect(chunks.map((c) => c.type)).toEqual(["status", "done"]);
+		expect(chunks[0]).toMatchObject({
+			type: "status",
+			content:
+				"Checkpoint push failed: checkpoint push failed (exit 1): remote rejected checkpoint",
+		});
+		expect(chunks.some((c) => c.type === "error")).toBe(false);
 	});
 });
 

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -109,8 +109,12 @@ export function resolveTargetRepo(
 }
 
 /** A stable per-session branch the agent commits and opens its PR from. */
-function sessionBranch(sessionId: string): string {
+export function sessionBranch(sessionId: string): string {
 	return `agent/session-${sessionId.slice(0, 8)}`;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 /**
@@ -126,6 +130,12 @@ export function buildSessionSetupScript(
 	repo: TurnRepo,
 ): string {
 	const branch = sessionBranch(sessionId);
+	const branchArg = shellQuote(branch);
+	const repoUrl = `https://github.com/${repo.fullName}.git`;
+	const remoteRefspec = shellQuote(
+		`refs/heads/${branch}:refs/remotes/origin/${branch}`,
+	);
+	const remoteBranchArg = shellQuote(`origin/${branch}`);
 	return [
 		"set -e",
 		"umask 077",
@@ -136,11 +146,16 @@ export function buildSessionSetupScript(
 		'printf "%s" "$GH_TOKEN" > /tmp/gh_token',
 		`if [ ! -d ${WORKSPACE_DIR}/.git ]; then`,
 		`  if [ -n "$DEFAULT_BRANCH" ]; then`,
-		`    git clone --depth 50 --branch "$DEFAULT_BRANCH" https://github.com/${repo.fullName}.git ${WORKSPACE_DIR}`,
+		`    git clone --depth 50 --branch "$DEFAULT_BRANCH" ${repoUrl} ${WORKSPACE_DIR}`,
 		"  else",
-		`    git clone --depth 50 https://github.com/${repo.fullName}.git ${WORKSPACE_DIR}`,
+		`    git clone --depth 50 ${repoUrl} ${WORKSPACE_DIR}`,
 		"  fi",
-		`  git -C ${WORKSPACE_DIR} checkout -b ${branch}`,
+		`  if git -C ${WORKSPACE_DIR} ls-remote --exit-code --heads origin ${branchArg} >/dev/null 2>&1; then`,
+		`    git -C ${WORKSPACE_DIR} fetch --depth 50 origin ${remoteRefspec}`,
+		`    git -C ${WORKSPACE_DIR} checkout ${branchArg} 2>/dev/null || git -C ${WORKSPACE_DIR} checkout -b ${branchArg} --track ${remoteBranchArg}`,
+		"  else",
+		`    git -C ${WORKSPACE_DIR} checkout -b ${branchArg}`,
+		"  fi",
 		"fi",
 		`if [ -z "$DEFAULT_BRANCH" ]; then`,
 		`  DEFAULT_BRANCH="$(git -C ${WORKSPACE_DIR} symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##' || true)"`,
@@ -321,10 +336,6 @@ function baseBranchLabel(repo: TurnRepo): string {
 
 function promptCurlBase(repo: TurnRepo): string {
 	return repo.defaultBranch ?? "$(cat /tmp/default_branch)";
-}
-
-function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 export function buildPrompt(
@@ -669,44 +680,23 @@ export const vercelProvider: ComputeProvider = {
 				if (typeof id === "string") seenToolCallIds.add(id);
 				yield chunk;
 			}
-			// Synthesize one Diff ledger row per changed file from the working tree
-			// (the Edit/Write results carry no patch; the real diff lives in git).
-			// Emitted as a tool_use + tool_result pair — the Folio adapter merges
-			// metadata.diff into that same call's own output (#790: a diff's home
-			// is its own expandable ledger row, never a separate floating card),
-			// and the AI SDK only keeps a tool result that has a matching opened
-			// call. This is a per-file summary, not per Edit invocation — git diff
-			// can't attribute hunks back to individual tool calls when a file is
-			// edited more than once in a turn, so multiple edits to one file land
-			// as a single Diff row rather than each Edit call carrying its own.
-			for (const diff of await changedFileDiffs(sandbox)) {
-				const toolUseId = uniqueDiffToolCallId(diff.file, seenToolCallIds);
-				seenToolCallIds.add(toolUseId);
-				yield {
-					type: "tool_use",
-					content: "Diff",
-					metadata: {
-						toolUseId,
-						toolName: "Diff",
-						input: { file_path: diff.file },
-					},
-				};
-				yield {
-					type: "tool_result",
-					content: "",
-					metadata: { toolUseId, output: "", diff },
-				};
+			const tail = runTurnTail({
+				sandbox,
+				branch: sessionBranch(request.sessionId),
+				seenToolCallIds,
+				doneChunk,
+				session,
+				sandboxSessionId,
+				debug: debugHarness,
+			});
+			for (;;) {
+				const next = await tail.next();
+				if (next.done) {
+					detached = next.value;
+					break;
+				}
+				yield next.value;
 			}
-			// Park the session so the next turn reconnects it; carry the resume
-			// payload out on the done chunk for the ingest loop to persist. If
-			// parking fails, `resume: null` clears the stale handle and the session
-			// is torn down below.
-			const resume = await parkSession(session, sandboxSessionId, debugHarness);
-			detached = resume !== null;
-			yield {
-				...(doneChunk ?? { type: "done", content: "" }),
-				metadata: { ...doneChunk?.metadata, resume },
-			};
 		} finally {
 			if (!detached) await session.destroy().catch(() => {});
 		}
@@ -739,7 +729,7 @@ export function uniqueDiffToolCallId(file: string, seen: ReadonlySet<string>): s
 }
 
 /** A sandbox session that can run shell commands (the onSession surface). */
-interface RunnableSandbox {
+export interface RunnableSandbox {
 	run: (opts: {
 		command: string;
 	}) => PromiseLike<{ exitCode: number; stdout: string; stderr: string }>;
@@ -772,6 +762,190 @@ async function changedFileDiffs(sandbox: RunnableSandbox | undefined): Promise<F
 	} catch {
 		return [];
 	}
+}
+
+const CHECKPOINT_COMMIT_MESSAGE = "wip(session): checkpoint after turn";
+const CHECKPOINT_ERROR_CAP = 240;
+
+function commandFailure(
+	label: string,
+	res: { exitCode: number; stdout: string; stderr: string },
+): Error {
+	const detail = [res.stderr.trim(), res.stdout.trim()].filter(Boolean).join("\n");
+	return new Error(
+		`${label} failed (exit ${res.exitCode})${detail ? `: ${detail}` : ""}`,
+	);
+}
+
+async function runRequired(
+	sandbox: RunnableSandbox,
+	label: string,
+	command: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const res = await sandbox.run({ command });
+	if (res.exitCode !== 0) throw commandFailure(label, res);
+	return res;
+}
+
+function capCheckpointError(value: unknown): string {
+	const text = errorText(value).replace(/\s+/g, " ").trim() || "unknown error";
+	if (text.length <= CHECKPOINT_ERROR_CAP) return text;
+	return `${text.slice(0, CHECKPOINT_ERROR_CAP - 3)}...`;
+}
+
+async function unpushedCommitCount(
+	sandbox: RunnableSandbox,
+	branch: string,
+): Promise<number> {
+	const branchArg = shellQuote(branch);
+	const remoteRef = `refs/remotes/origin/${branch}`;
+	const remoteExists = await sandbox.run({
+		command: `git -C ${WORKSPACE_DIR} ls-remote --exit-code --heads origin ${branchArg} >/dev/null`,
+	});
+	let baseRef: string;
+	if (remoteExists.exitCode === 0) {
+		await runRequired(
+			sandbox,
+			"checkpoint fetch",
+			`git -C ${WORKSPACE_DIR} fetch --depth 50 origin ${shellQuote(`refs/heads/${branch}:refs/remotes/origin/${branch}`)}`,
+		);
+		baseRef = remoteRef;
+	} else if (remoteExists.exitCode === 2) {
+		baseRef = "origin/HEAD";
+	} else {
+		throw commandFailure("checkpoint remote branch check", remoteExists);
+	}
+
+	const ahead = await runRequired(
+		sandbox,
+		"checkpoint ahead check",
+		`git -C ${WORKSPACE_DIR} rev-list --count ${shellQuote(`${baseRef}..HEAD`)}`,
+	);
+	const count = Number.parseInt(ahead.stdout.trim(), 10);
+	if (!Number.isFinite(count)) {
+		throw new Error(`checkpoint ahead check returned ${JSON.stringify(ahead.stdout)}`);
+	}
+	return count;
+}
+
+/**
+ * Best-effort end-of-turn preservation. It records dirty work as a WIP commit
+ * and pushes the session branch when local commits are ahead of the remote.
+ * Failures become calm status chunks; they never fail the agent turn.
+ */
+export async function checkpointSessionBranch(
+	sandbox: RunnableSandbox | undefined,
+	branch: string,
+): Promise<string | undefined> {
+	if (!sandbox) return undefined;
+	try {
+		const status = await runRequired(
+			sandbox,
+			"checkpoint status",
+			`git -C ${WORKSPACE_DIR} status --porcelain=v1`,
+		);
+		const hasTreeChanges = status.stdout.trim().length > 0;
+		if (hasTreeChanges) {
+			await runRequired(
+				sandbox,
+				"checkpoint add",
+				`git -C ${WORKSPACE_DIR} add -A`,
+			);
+			const staged = await runRequired(
+				sandbox,
+				"checkpoint staged check",
+				[
+					"set +e",
+					`git -C ${WORKSPACE_DIR} diff --cached --quiet`,
+					"code=$?",
+					"set -e",
+					'if [ "$code" -eq 0 ]; then printf clean; elif [ "$code" -eq 1 ]; then printf dirty; else exit "$code"; fi',
+				].join("; "),
+			);
+			if (staged.stdout.trim() === "dirty") {
+				await runRequired(
+					sandbox,
+					"checkpoint commit",
+					`git -C ${WORKSPACE_DIR} commit -m ${shellQuote(CHECKPOINT_COMMIT_MESSAGE)}`,
+				);
+			}
+		}
+
+		const ahead = await unpushedCommitCount(sandbox, branch);
+		if (ahead <= 0) return undefined;
+
+		await runRequired(
+			sandbox,
+			"checkpoint push",
+			`git -C ${WORKSPACE_DIR} push -u origin ${shellQuote(branch)}`,
+		);
+		return `Pushed checkpoint to ${branch}`;
+	} catch (error) {
+		return `Checkpoint push failed: ${capCheckpointError(error)}`;
+	}
+}
+
+export interface TurnTailOptions {
+	sandbox: RunnableSandbox | undefined;
+	branch: string;
+	seenToolCallIds: Set<string>;
+	doneChunk: StreamChunk | undefined;
+	session: { detach: () => Promise<unknown> };
+	sandboxSessionId: string;
+	debug: boolean;
+}
+
+export async function* runTurnTail({
+	sandbox,
+	branch,
+	seenToolCallIds,
+	doneChunk,
+	session,
+	sandboxSessionId,
+	debug,
+}: TurnTailOptions): AsyncGenerator<StreamChunk, boolean, void> {
+	// Synthesize one Diff ledger row per changed file from the working tree
+	// (the Edit/Write results carry no patch; the real diff lives in git).
+	// Emitted as a tool_use + tool_result pair — the Folio adapter merges
+	// metadata.diff into that same call's own output (#790: a diff's home
+	// is its own expandable ledger row, never a separate floating card),
+	// and the AI SDK only keeps a tool result that has a matching opened
+	// call. This is a per-file summary, not per Edit invocation — git diff
+	// can't attribute hunks back to individual tool calls when a file is
+	// edited more than once in a turn, so multiple edits to one file land
+	// as a single Diff row rather than each Edit call carrying its own.
+	for (const diff of await changedFileDiffs(sandbox)) {
+		const toolUseId = uniqueDiffToolCallId(diff.file, seenToolCallIds);
+		seenToolCallIds.add(toolUseId);
+		yield {
+			type: "tool_use",
+			content: "Diff",
+			metadata: {
+				toolUseId,
+				toolName: "Diff",
+				input: { file_path: diff.file },
+			},
+		};
+		yield {
+			type: "tool_result",
+			content: "",
+			metadata: { toolUseId, output: "", diff },
+		};
+	}
+
+	const checkpointStatus = await checkpointSessionBranch(sandbox, branch);
+	if (checkpointStatus) yield { type: "status", content: checkpointStatus };
+
+	// Park the session so the next turn reconnects it; carry the resume
+	// payload out on the done chunk for the ingest loop to persist. If
+	// parking fails, `resume: null` clears the stale handle and the session
+	// is torn down by the caller.
+	const resume = await parkSession(session, sandboxSessionId, debug);
+	yield {
+		...(doneChunk ?? { type: "done", content: "" }),
+		metadata: { ...doneChunk?.metadata, resume },
+	};
+	return resume !== null;
 }
 
 /** Splits a multi-file unified diff into per-file diffs. */


### PR DESCRIPTION
Closes #968 (milestone W5, Lane A — the continuity keystone).

The 30-minute sandbox lifetime stops being a cliff: after every turn that
changed anything, the provider checkpoints the session branch —
`git status --porcelain` → `add -A` + `wip(session): checkpoint after turn`
when dirty → push when ahead of the remote — and a fresh-fallback sandbox
now checks out the existing session branch from the remote instead of
restarting from the default branch. Work survives sandbox death by
construction.

**What to look at:** run a real turn that edits files (vercel provider), let
the sandbox expire (30 min), send a follow-up — the fresh sandbox resumes on
the pushed session branch with the prior work present. In the transcript,
the end-of-turn status line reads "Pushed checkpoint to <branch>" (or a calm
"Checkpoint push failed: …" that never fails the turn).

Ordering guarantees (briefed and verified by tests): Diff-row synthesis →
checkpoint → park, so the diffs shown match what pushed, and a successful
turn preserves work before the sandbox detaches. Template identity and
`SANDBOX_TIMEOUT_MS` untouched — the cost policy is #970.

Implementation by codex CLI (gpt-5.5, xhigh) from a coordinator brief. Its
first pass was cut from a stale local main (pre-#967); a re-tasked rebase
pass composed both behaviors (per-repo clone + session-branch checkout) with
conflicts documented in its report. Mutation check: removed the push while
returning success → tail-ordering tests failed → restored.

## Mergeability

- **Surface:** web-next vercel provider only (setup script + turn tail + tests); no schema, no API routes, no UI.
- **Behavior changed:** turns checkpoint-commit and push the session branch; fresh fallbacks resume an existing remote session branch.
- **Non-happy paths:** push/commit failure → calm status chunk, turn still parks; clean tree + up-to-date remote → no-op; error text capped at 240 chars; all checkpoint git args shell-quoted.
- **Residual risk:** checkpoint commits accumulate on `agent/session-*` branches — #820's PR-surface design decides squash-vs-keep; stale-branch cleanup noted there.

## Evidence

![checkpoint-tail-tests](https://evidence.cloudcompute.com/workspaces/pr-980/20260708-160127-checkpoint-tail-tests.png)

Gates on the rebased tree: 453/453 tests, typecheck, lint, clean production build.

