### PR TITLE
docs(agents): add orca-agents skill for opt-in Orca fan-out

### DIFF
--- a/.agents/skills/orca-agents/SKILL.md
+++ b/.agents/skills/orca-agents/SKILL.md
@@ -6,12 +6,7 @@ description: >
   them work live in the Orca UI and take over/type into any session himself.
   Layers on top of the global orca-cli and orchestration skills, which own the
   full CLI mechanics — this skill only adds what's specific to this repo.
-  STRICTLY OPT-IN: only use when Michael explicitly names Orca in the current
-  turn ("use orca", "fan out with orca", "open an orca worktree/session").
-  Never reach for this on a bare "spin up some agents" / "parallelize this" —
-  that stays on the Agent tool per subagent-delegation. Do not self-trigger
-  from the global skills' broader phrase matches (e.g. "spawn codex in a
-  worktree") unless Michael said Orca too.
+disable-model-invocation: true
 ---
 
 # orca-agents: Orca fan-out conventions for this repo

--- a/.agents/skills/orca-agents/SKILL.md
+++ b/.agents/skills/orca-agents/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: orca-agents
+description: >
+  Repo-specific conventions for fanning out sub-agent sessions (codex, claude)
+  through the Orca desktop app in fairchild/workspaces, so Michael can watch
+  them work live in the Orca UI and take over/type into any session himself.
+  Layers on top of the global orca-cli and orchestration skills, which own the
+  full CLI mechanics — this skill only adds what's specific to this repo.
+  STRICTLY OPT-IN: only use when Michael explicitly names Orca in the current
+  turn ("use orca", "fan out with orca", "open an orca worktree/session").
+  Never reach for this on a bare "spin up some agents" / "parallelize this" —
+  that stays on the Agent tool per subagent-delegation. Do not self-trigger
+  from the global skills' broader phrase matches (e.g. "spawn codex in a
+  worktree") unless Michael said Orca too.
+---
+
+# orca-agents: Orca fan-out conventions for this repo
+
+The global `orca-cli` and `orchestration` skills already document every flag —
+read those for mechanics. This file only covers what's specific to
+`fairchild/workspaces` and to Michael's stated preference: Orca is opt-in,
+never the silent default.
+
+## The gate
+
+Default fan-out in this repo is the `Agent` tool (`subagent-delegation`
+skill). Only route through Orca when Michael says so in-turn. If unsure
+whether he meant "parallel Claude subagents" or "parallel Orca worktrees",
+ask — don't guess toward Orca.
+
+## Why Orca here, when it applies
+
+Each Orca worktree runs the agent in a real PTY inside its own git worktree,
+visible as a tab in the Orca app the moment it's created — Michael can watch
+it stream and click in to type without any handoff protocol. That's the
+whole point: visibility + takeover that a backgrounded `Agent` tool call
+can't give him. It's real, billable, on-disk state (a new worktree + branch
+under `~/orca/workspaces/workspaces/<name>`, a live agent process) — confirm
+scope (how many agents, doing what) before creating more than one or two.
+
+## Repo facts
+
+- Selector: `--repo name:workspaces` (canonical remote
+  `github.com/fairchild/workspaces`; confirm with `orca repo list --json` if
+  it ever stops resolving — repos can be re-registered under a new id).
+- Base branch: `origin/main`.
+- Verified working `--agent` ids on this machine: `codex`, `claude`. The full
+  registry Orca supports is in
+  [references/verified-agent-ids.md](references/verified-agent-ids.md) — most
+  of those ids won't have a binary installed here and will fail fast
+  (`invalid_argument`) before any worktree is created.
+- Fresh worktrees lack `Frameworks/GhosttyKit.xcframework` — a Swift build in
+  a new Orca worktree needs it rsynced from the main checkout first (see
+  `docs/development/libghostty-integration.md`). Put that step in the prompt
+  if the fanned-out agent will run `swift build`/`swift test`.
+- `--setup skip` skips the repo's setup hook (`bash ./scripts/setup --fast`)
+  — fine for a short-lived probe, not for an agent that needs a working dev
+  environment. Use `--setup run` (or the default `inherit`) when the agent
+  needs to actually build/test.
+
+## Fan out
+
+```bash
+orca worktree create --repo name:workspaces --name <slug> \
+  --agent codex --prompt "<task brief>" \
+  --base-branch origin/main --setup run --activate --json
+```
+
+The brief must carry the same contract every execution agent gets in this
+repo (see `subagent-delegation` and `codex-execution`): issue claim protocol
+from `CLAUDE.md`, draft-PR-only (never self-merge), evidence before PR,
+`codex-review-loop` before opening a substantive PR. Orca doesn't know any of
+this — it's just the terminal, the brief is what teaches the agent the repo's
+rules.
+
+## Watch and take over
+
+```bash
+orca worktree ps --limit 20
+orca terminal list --worktree name:<slug> --json
+orca terminal read --terminal <handle> --json
+orca terminal switch --terminal <handle>     # foregrounds it in the Orca app for Michael to type into directly
+orca terminal send --terminal <handle> --text "..." --enter   # or type into it headlessly
+```
+
+`terminal switch` is the "take over" move Michael asked for — it's a real
+terminal, so once it's foregrounded he just types like normal. No CLI needed
+after that unless he wants to hand control back to an automated flow.
+
+## Clean up
+
+```bash
+orca worktree rm --worktree name:<slug> --force --json
+```
+
+Skips the repo's archive hook by default (a `warning` field on the response
+says so); pass `--run-hooks` to run it. Confirm the work already shipped or
+Michael's actually done with it before removing — this deletes the checkout
+and its branch.

--- a/.agents/skills/orca-agents/references/verified-agent-ids.md
+++ b/.agents/skills/orca-agents/references/verified-agent-ids.md
@@ -1,0 +1,57 @@
+# Orca's known `--agent <id>` registry
+
+No public docs enumerate valid `--agent` values for `orca worktree create`
+or `orca terminal create --command`; the CLI's error on a bad id
+(`invalid_argument: Unknown TUI agent "<id>"`) doesn't list alternatives
+either. This table was extracted directly from Orca.app's bundled config
+(ground truth, not inferred) on 2026-07-08:
+
+```bash
+cat "/Applications/Orca.app/Contents/Resources/app.asar.unpacked/out/shared/tui-agent-config.js"
+```
+
+Re-run that if a command with `--agent` fails unexpectedly after an Orca
+update — this list can drift.
+
+| id | launch cmd | prompt injection |
+|----|-----------|-------------------|
+| `claude` | `claude` | argv `--prefill` |
+| `claude-agent-teams` | `orca claude-teams` | stdin-after-start |
+| `openclaude` | `openclaude` | argv `--prefill` |
+| `codex` | `codex` | argv |
+| `autohand` | `autohand` | stdin-after-start |
+| `ante` | `ante` | stdin-after-start |
+| `opencode` | `opencode` | flag-prompt |
+| `mimo-code` | `mimo` | flag-prompt |
+| `pi` | `pi` | argv (env `ORCA_PI_PREFILL` overlay) |
+| `omp` | `omp` | argv (env `ORCA_OMP_PREFILL`) |
+| `gemini` | `gemini` | flag-prompt-interactive |
+| `antigravity` | `agy` | flag-prompt-interactive |
+| `aider` | `aider` | stdin-after-start |
+| `goose` | `goose` | stdin-after-start |
+| `amp` | `amp` | stdin-after-start |
+| `kilo` | `kilo` | stdin-after-start |
+| `kiro` | `kiro-cli chat --tui` | stdin-after-start |
+| `crush` | `crush` | stdin-after-start |
+| `aug` | `auggie` | stdin-after-start |
+| `cline` | `cline` | stdin-after-start |
+| `codebuff` | `codebuff` | stdin-after-start |
+| `command-code` | `command-code --trust` | argv |
+| `continue` | `cn` | stdin-after-start |
+| `cursor` | `cursor-agent` | argv |
+| `droid` | `droid` | argv |
+| `kimi` | `kimi` | stdin-after-start |
+| `mistral-vibe` | `vibe` | stdin-after-start |
+| `qwen-code` | `qwen` | stdin-after-start |
+| `rovo` | `rovo` | stdin-after-start |
+| `hermes` | `hermes --tui` | stdin-after-start |
+| `openclaw` | `openclaw` | stdin-after-start |
+| `copilot` | `copilot` | flag-interactive |
+| `grok` | `grok` | stdin-after-start |
+| `devin` | `devin` | stdin-after-start |
+
+Only `codex` and `claude` are confirmed installed and used in this
+environment. The rest are Orca's supported registry, not necessarily on this
+machine's `PATH` — passing one of them will fail at agent-launch time even
+though the worktree itself was created successfully, so check `terminal read`
+after `--agent` with an unfamiliar id.

--- a/.claude/skills/orca-agents
+++ b/.claude/skills/orca-agents
@@ -1,0 +1,1 @@
+../../.agents/skills/orca-agents


### PR DESCRIPTION
## Summary

- Adds `orca-agents`, a project-local skill for fanning out visible, interactive sub-agent sessions via the Orca desktop app, layered on the existing global orca-cli/orchestration skills. Marked `disable-model-invocation: true` so it's only ever invoked explicitly, never auto-selected.

## Mergeability

- Surface: docs
- User-facing behavior changed: None
- Non-happy paths considered: None — skill file is inert prose; nothing executes it, and `disable-model-invocation: true` blocks automatic selection by the model.
- Residual risk or follow-up: None

## Validation

- [x] Not a testable change (docs-only, config)

## Evidence

- [x] Not a testable change (docs-only, config)

## Blockers

- [x] None