### PR TITLE
feat(skills): tile-orchestration — coordinate codex workers in WorkSpaces tiles

### DIFF
--- a/.claude/skills/tile-orchestration/README.md
+++ b/.claude/skills/tile-orchestration/README.md
@@ -1,0 +1,31 @@
+# tile-orchestration — maintenance notes
+
+This skill documents the W5-era surface (2026-07-08), including its
+workarounds. Several are load-bearing only until tracked machinery lands.
+**When any issue below closes, update SKILL.md in the same PR** — each row
+names exactly what changes. Provenance for all of it:
+`docs/retros/2026-07-08-automation-dogfood-w5.md`.
+
+| Issue | What lands | Skill change when it does |
+|---|---|---|
+| #973 | Tiles receive `WORKSPACES_AUTOMATION_SOCKET`/`_HANDLE` again | Bootstrap hook gates on the handle env instead of cwd; workers can self-report via `workspaces automation context`; `input.write` becomes usable inside tiles |
+| #989 | `workspace.create` options: `select:false`, `fromRef`, `startCommand` | Delete the "flips the owner's selection" warning (pass `select:false`); delete Preflight step 3 (pass `fromRef:"origin/main"`); **retire the rc-hook bootstrap entirely** (`startCommand` seeds the tile at creation — the inbox/tile-start dance and `references/bootstrap-hook.zsh` reduce to the re-tasking path only, or go away with #838) |
+| #990 | Bounded text read-back of own-created tiles | Replace the `tee`-to-`worker.log` monitoring contract with `surface/read`; the finished-marker watcher can poll the API instead of a file |
+| #991 | `workspace.archive` verb | Replace the Teardown section's "tell the owner" with an archive call at lane close |
+| #992 | Health reports pid/launchedAt/experiments/protocolVersion | Simplify Preflight step 1 (no `ps` cross-check; version skew self-diagnoses) |
+| #995 | Reference documents windowID string type + snapshot `data` key | Drop the inline warnings in the Monitor section (the reference becomes sufficient) |
+| #889 | libghostty per-surface command/initial_input fix | Prerequisite for #989's `startCommand`; no direct skill text, but unblocks the row above |
+| #838 | Child-handle authority model (cross-tile write to created surfaces) | If built, interactive worker steering (mid-run input) becomes possible; add a "steer a worker" section |
+
+Also worth folding in when they happen:
+
+- **A coordinator-durability pattern** — two session interruptions in W5
+  killed background CI watchers; the durable-signals sweep (worker logs,
+  `gh pr list`) is documented in Monitor, but a checkpoint file the
+  coordinator maintains would make resumes mechanical.
+- **Evidence-walk reliability (#976)** — web-next side; until fixed, the
+  skill's gate step inherits the targeted-Playwright fallback for UI
+  evidence in fresh worktrees.
+- **Worker model/effort table** — W5 used xhigh for provider-seam work,
+  high for design-lite features, medium for small UI; if the next arc
+  confirms the mapping, promote it from judgment to guidance in SKILL.md.

--- a/.claude/skills/tile-orchestration/SKILL.md
+++ b/.claude/skills/tile-orchestration/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: tile-orchestration
+description: Coordinate implementation workers (codex CLI or similar) inside WorkSpaces terminal tiles via the Automation API operator scope — spawn workspaces, bootstrap workers hands-free, monitor via logs + window snapshots, re-task idle tiles, and ship through the normal gate/merge flow. Use when dispatching multi-worker milestone execution with the WorkSpaces app as the visible fleet surface ("run workers in tiles", "tile orchestration", "dogfood the automation API"). Complements codex-execution (the per-worker contract); this skill is the fleet layer around it.
+---
+
+# Tile Orchestration
+
+Workers run *inside* WorkSpaces tiles — visible in the owner's sidebar, one
+tile per issue — while the coordinator stays *outside* (operator scope was
+designed for exactly this; a coordinator inside a tile dies with every app
+restart). Proven on the W5 arc (2026-07-08): five codex workers, six issues
+shipped; findings in `docs/retros/2026-07-08-automation-dogfood-w5.md`.
+Division of labor: this skill spawns/monitors/re-tasks; the brief contract,
+gating, and merge flow are `codex-execution` unchanged.
+
+## Preflight (once per session)
+
+1. **App + experiments.** The app must run with Automation API + Operator
+   Scope on (Settings → Experimental Features, then restart — experiments
+   are read at launch). Verify with the **bundled** CLI — the Homebrew one
+   is version-skewed against dev builds:
+   `"<app>/Contents/Helpers/workspaces" automation health --json`.
+   Confirm exactly one app instance (`ps aux | rg WorkspaceManager`) — a
+   stale twin answers convincingly (see retro finding 5; #992 fixes this).
+2. **Operator credential.** An opt-in launch writes
+   `automation-operator.json` (0600) next to `automation.sock` under
+   `~/Library/Application Support/com.cloudcompute.workspaces/`. Its absence
+   means operator scope is off → toggle + restart.
+3. **Fast-forward the base repo.** `workspace.create` branches from the base
+   clone's LOCAL HEAD. Skip this and workers start in the past (cost a full
+   rebase pass in W5): `git -C <repo.path> fetch origin main && git -C
+   <repo.path> merge --ff-only origin/main`. Repo paths come from
+   `GET /v1/workspaces`. (#989's `fromRef` retires this step.)
+4. **Bootstrap hook present.** Tiles currently get NO automation env (#973),
+   so identification is by cwd. `~/.zshrc.local` needs the hook in
+   [references/bootstrap-hook.zsh](references/bootstrap-hook.zsh) —
+   interactive-only guard, consume-before-source, `TMOUT=5` idle watcher.
+
+## Spawn a worker
+
+Use [scripts/ws-op.py](scripts/ws-op.py) for operator calls:
+
+```bash
+python3 scripts/ws-op.py POST /v1/workspace/create \
+  '{"repoID":"<from GET /v1/workspaces>","name":"codex-<issue>-<slug>","providerID":"local"}'
+```
+
+Returns `workspacePath` + attached tile. **Warning:** each spawn currently
+flips the owner's sidebar selection (verbs=clicks; #989's `select:false`
+fixes it) — batch spawns and tell the owner, or spawn while they're away.
+
+Then stage the work (paths relative to `workspacePath`; `.agents/inbox/` is
+gitignored):
+
+1. Write the brief per `codex-execution`'s template to
+   `.agents/inbox/brief-<issue>.md`. Name the branch the app created
+   (`workspace/<workspace-name>`) in the brief's "you are on branch" line.
+2. Write `.agents/inbox/tile-start`:
+   ```bash
+   echo "[worker-<issue>] started $(date)" | tee .agents/inbox/worker.log
+   codex exec --cd . -c model='"gpt-5.5"' -c model_reasoning_effort='"xhigh"' \
+     --dangerously-bypass-approvals-and-sandbox \
+     "$(cat .agents/inbox/brief-<issue>.md)" </dev/null 2>&1 | tee -a .agents/inbox/worker.log
+   echo "[worker-<issue>] finished $(date)" | tee -a .agents/inbox/worker.log
+   ```
+   `</dev/null` is load-bearing (codex hangs on open stdin). The idle
+   watcher picks the file up within ~5 s; confirm via
+   `head -1 <workspacePath>/.agents/inbox/worker.log`.
+
+## Monitor
+
+- **Text is ground truth**: the `tee`'d `worker.log` plus a background
+  watcher on the finished marker —
+  `until rg -q "\[worker-<issue>\] finished" <log>; do sleep 45; done`.
+  (#990 makes read-back first-class.)
+- **Pixels are for aesthetics and coarse liveness**: `GET /v1/windows` →
+  `POST /v1/window/snapshot` `{"windowID":"<id-as-STRING>"}` → PNG base64
+  in the response's `data` field. Full composited fidelity, backgrounded,
+  no focus steal — good enough to sign off UI placement from.
+- Durable state (logs, git, PR state) survives coordinator interruptions;
+  after a session drop, sweep worker logs + `gh pr list` before resuming.
+
+## Re-task an idle tile
+
+When codex exits, the tile shell returns to its prompt and the watcher
+resumes: drop a new `tile-start` (+ brief) into the same inbox. This is how
+follow-up passes (rebases, review reactions) run without new tiles. Never
+drop a `tile-start` while the worker is mid-run — the interactive guard
+protects against codex's own subshells eating it, but the *timing* guard is
+you (check for the finished marker first).
+
+## Gate and ship
+
+Exactly `codex-execution` from here: read `CODEX_REPORT.md` + full diff,
+react with attributed commits, rebase onto `origin/main`, clean stale build
+state, re-run every gate with visible pass/fail output (don't trust
+`cmd | tail` exit codes — pipes swallow failures), evidence, PR labeled
+`author:codex`, merge per the arc's authority contract. Serialize merges
+within a lane; re-verify a worker's branch base (`git log origin/main..`)
+before review — stale bases look like huge diffs.
+
+## Teardown
+
+No archive verb yet (#991): stale workspaces accumulate in the owner's
+sidebar; tell them what to archive, or leave live worker tiles as the
+fleet view.

--- a/.claude/skills/tile-orchestration/SKILL.md
+++ b/.claude/skills/tile-orchestration/SKILL.md
@@ -38,10 +38,10 @@ gating, and merge flow are `codex-execution` unchanged.
 
 ## Spawn a worker
 
-Use [scripts/ws-op.py](scripts/ws-op.py) for operator calls:
+Use [scripts/ws-op.py](scripts/ws-op.py) (single-file uv script) for operator calls:
 
 ```bash
-python3 scripts/ws-op.py POST /v1/workspace/create \
+uv run --script scripts/ws-op.py POST /v1/workspace/create \
   '{"repoID":"<from GET /v1/workspaces>","name":"codex-<issue>-<slug>","providerID":"local"}'
 ```
 

--- a/.claude/skills/tile-orchestration/references/bootstrap-hook.zsh
+++ b/.claude/skills/tile-orchestration/references/bootstrap-hook.zsh
@@ -1,0 +1,23 @@
+# WorkSpaces tile agent bootstrap — goes in ~/.zshrc.local (the dotfiles'
+# per-machine override). Interactive WorkSpaces-tile shells run
+# .agents/inbox/tile-start when it appears; the file is moved away before
+# sourcing so it can never run twice; the TMOUT watcher lets a coordinator
+# drop work into an idle tile within ~5s (also the re-tasking path).
+#
+# Guards, each load-bearing (see the W5 dogfood retro):
+# - [[ -o interactive ]]: codex's own `zsh -lc` subshells source rc files
+#   and would consume a re-task file mid-run without it.
+# - cwd fallback: tiles currently receive no automation env (#973); the
+#   handle check is kept for when that fixes. Scope the path to the app's
+#   workspace dir so ordinary shells never run inbox files.
+if [[ -o interactive ]] && [[ -n "$WORKSPACES_AUTOMATION_HANDLE" || "$PWD" == "$HOME/workspaces/workspaces/"* ]]; then
+  _ws_tile_start() {
+    if [[ -f .agents/inbox/tile-start ]]; then
+      local f="/tmp/ws-tile-start-$$"
+      command mv .agents/inbox/tile-start "$f" && source "$f"
+    fi
+  }
+  _ws_tile_start
+  TMOUT=5
+  TRAPALRM() { _ws_tile_start }
+fi

--- a/.claude/skills/tile-orchestration/scripts/ws-op.py
+++ b/.claude/skills/tile-orchestration/scripts/ws-op.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 """Operator-scope helper for the WorkSpaces Automation API.
 
 Reads the per-launch operator credential the app mints
 (automation-operator.json, 0600, next to automation.sock) and issues one
 request over the unix socket with the handle header. Usage:
 
-    ws-op.py GET  /v1/workspaces
-    ws-op.py POST /v1/workspace/create '{"repoID":"…","name":"…","providerID":"local"}'
-    ws-op.py POST /v1/window/snapshot '{"windowID":"12345"}' --png out.png
+    uv run --script ws-op.py GET  /v1/workspaces
+    uv run --script ws-op.py POST /v1/workspace/create '{"repoID":"…","name":"…","providerID":"local"}'
+    uv run --script ws-op.py POST /v1/window/snapshot '{"windowID":"12345"}' --png out.png
 
 The snapshot payload's PNG is base64 under `data`; `--png` decodes it to a
 file and prints the remaining metadata. windowID must be a JSON string (#995).

--- a/.claude/skills/tile-orchestration/scripts/ws-op.py
+++ b/.claude/skills/tile-orchestration/scripts/ws-op.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Operator-scope helper for the WorkSpaces Automation API.
+
+Reads the per-launch operator credential the app mints
+(automation-operator.json, 0600, next to automation.sock) and issues one
+request over the unix socket with the handle header. Usage:
+
+    ws-op.py GET  /v1/workspaces
+    ws-op.py POST /v1/workspace/create '{"repoID":"…","name":"…","providerID":"local"}'
+    ws-op.py POST /v1/window/snapshot '{"windowID":"12345"}' --png out.png
+
+The snapshot payload's PNG is base64 under `data`; `--png` decodes it to a
+file and prints the remaining metadata. windowID must be a JSON string (#995).
+"""
+
+import argparse
+import base64
+import json
+import pathlib
+import subprocess
+import sys
+
+CRED = (
+    pathlib.Path.home()
+    / "Library/Application Support/com.cloudcompute.workspaces/automation-operator.json"
+)
+
+
+def call(method: str, route: str, body: dict | None = None) -> dict:
+    cred = json.loads(CRED.read_text())
+    cmd = [
+        "curl", "-s", "--unix-socket", cred["socketPath"], "-X", method,
+        "-H", "x-workspaces-automation-handle: " + cred["handle"],
+        "http://localhost" + route,
+    ]
+    if body is not None:
+        cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(body)]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return json.loads(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("method", choices=["GET", "POST"])
+    ap.add_argument("route")
+    ap.add_argument("body", nargs="?", default=None)
+    ap.add_argument("--png", help="decode result.data to this file (snapshots)")
+    args = ap.parse_args()
+
+    if not CRED.exists():
+        print("no operator credential — enable Operator Scope and restart the app", file=sys.stderr)
+        return 1
+    body = json.loads(args.body) if args.body else None
+    result = call(args.method, args.route, body)
+    if args.png and result.get("ok") and "data" in result.get("result", {}):
+        payload = result["result"]
+        pathlib.Path(args.png).write_bytes(base64.b64decode(payload.pop("data")))
+        payload["png"] = args.png
+    print(json.dumps(result, indent=1))
+    return 0 if result.get("ok") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The skill distilled from today's W5 dogfood session (retro: `docs/retros/2026-07-08-automation-dogfood-w5.md`, merged in #979): how a coordinator outside the app spawns codex workers into WorkSpaces tiles via operator scope, bootstraps them hands-free (inbox + idle-watcher pattern), monitors with text logs as ground truth and window snapshots for aesthetics, re-tasks idle tiles, and ships through the codex-execution gate flow.

Structure per the skills-use-references convention: SKILL.md is the operating procedure; `scripts/ws-op.py` is the operator-call helper used all session; `references/bootstrap-hook.zsh` is the annotated hook. **README.md is the maintenance contract** — a table mapping every documented workaround to the tracked issue that retires it (#973 env injection, #989 create options, #990 read-back, #991 archive, #992 health, #995 doc corrections, #838/#889 upstream), so whoever lands those updates the skill in the same PR.

Docs/skill-only; codex review loop skipped per policy.

## Mergeability

- **Surface:** new .claude/skills/tile-orchestration/ (SKILL.md, README.md, script, reference); no app or web code.
- **Behavior changed:** none at runtime; adds a discoverable skill.
- **Non-happy paths:** ws-op.py exits non-zero without an operator credential or on a non-ok envelope.
- **Residual risk:** skill text can drift as the wishlist lands — that's exactly what README.md's table is for.

## Evidence

![ws-op-selfcheck](https://evidence.cloudcompute.com/workspaces/pr-996/20260708-164909-ws-op-selfcheck.png)

The helper script exercised live against the running app (operator scope): workspace list (45 repos, 13 workspaces) and window list. The readiness gate earned its keep here — pushing for evidence surfaced that the committed script had never been run as committed (`dict | None` annotations fail on system python 3.9); it is now a PEP 723 uv script per house convention.
