### PR TITLE
feat(web-next): replay conversation context on fresh fallback turns

### DIFF
--- a/web-next/src/lib/agent-runtime/provider.ts
+++ b/web-next/src/lib/agent-runtime/provider.ts
@@ -37,6 +37,12 @@ export interface TurnRequest {
 	/** Prior parked session to resume, or null/undefined for a fresh turn. */
 	resume?: SessionResumeHandle | null;
 	/**
+	 * Compact replay of prior session dialogue for providers that must boot a
+	 * fresh model conversation after their warm resume path fails. Omitted on a
+	 * genuine first turn.
+	 */
+	priorContext?: string | null;
+	/**
 	 * The session's selected Claude model id (see `./models.ts`). Providers
 	 * that drive a real model (vercel) thread it into the harness; providers
 	 * that don't (mock) record it for testability but otherwise ignore it.

--- a/web-next/src/lib/agent-runtime/turn-ingest.test.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.test.ts
@@ -10,9 +10,14 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { type DatabaseHandle, openDatabase } from "../db/client";
 import { ensureRepo } from "../db/repos";
-import { createSession, getSession, readEvents } from "../db/sessions";
+import {
+	appendEvents,
+	createSession,
+	getSession,
+	readEvents,
+} from "../db/sessions";
 import { notifyTurnCompleted } from "../notify/turn-notification";
-import type { ComputeProvider } from "./provider";
+import type { ComputeProvider, TurnRequest } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 import { startTurn, stopActiveTurn } from "./turn-ingest";
 
@@ -130,6 +135,86 @@ describe("startTurn — auto-title failure isolation", () => {
 			fullName: "fairchild/web-next-fixtures",
 			defaultBranch: "trunk",
 		});
+	});
+});
+
+describe("startTurn — prior context threading", () => {
+	test("passes a compact replay when the session already has prior turns", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "context-session",
+			provider: "mock",
+		});
+		await appendEvents(handle, "context-session", [
+			{ role: "user", chunk: { type: "text", content: "Find the flaky test" } },
+			{ role: "assistant", chunk: { type: "status", content: "Starting sandbox" } },
+			{ role: "assistant", chunk: { type: "text", content: "I found it. " } },
+			{
+				role: "assistant",
+				chunk: {
+					type: "tool_use",
+					content: "Read",
+					metadata: { toolUseId: "t-1", toolName: "Read" },
+				},
+			},
+			{
+				role: "assistant",
+				chunk: {
+					type: "tool_result",
+					content: "file contents",
+					metadata: { toolUseId: "t-1" },
+				},
+			},
+			{ role: "assistant", chunk: { type: "text", content: "The guard is missing." } },
+			{ role: "assistant", chunk: { type: "done", content: "" } },
+		]);
+		let seenRequest: TurnRequest | undefined;
+		const provider: ComputeProvider = {
+			id: "capture",
+			runTurn: async function* (request) {
+				seenRequest = request;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+
+		const started = await startTurn(
+			handle,
+			session,
+			"Now add the regression test",
+			provider,
+		);
+		await started.ingest;
+
+		expect(seenRequest?.priorContext).toBe(
+			[
+				"User: Find the flaky test",
+				"Assistant: I found it. The guard is missing.",
+			].join("\n\n"),
+		);
+		expect(seenRequest?.priorContext).not.toContain("Now add");
+		expect(seenRequest?.priorContext).not.toContain("Starting sandbox");
+		expect(seenRequest?.priorContext).not.toContain("file contents");
+	});
+
+	test("omits priorContext on a genuine first turn", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "first-turn-session",
+			provider: "mock",
+		});
+		let seenRequest: TurnRequest | undefined;
+		const provider: ComputeProvider = {
+			id: "capture",
+			runTurn: async function* (request) {
+				seenRequest = request;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+
+		const started = await startTurn(handle, session, "Start fresh", provider);
+		await started.ingest;
+
+		expect(Object.hasOwn(seenRequest ?? {}, "priorContext")).toBe(false);
 	});
 });
 

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -27,6 +27,7 @@ import { getRepo } from "../db/repos";
 import {
 	appendEvents,
 	getSession,
+	readEvents,
 	type Session,
 	titleSessionIfEmpty,
 	updateSession,
@@ -36,11 +37,13 @@ import {
 	type TurnNotificationOutcome,
 } from "../notify/turn-notification";
 import { deriveSessionTitle } from "../session-title";
+import { projectReplayContext } from "../transcript/replay-context";
 import {
 	type ComputeProvider,
 	getProvider,
 	type SessionResumeHandle,
 	type TurnRepo,
+	type TurnRequest,
 } from "./provider";
 import type { StreamChunk } from "./stream-chunk";
 
@@ -152,9 +155,25 @@ export async function startTurn(
 		console.error(`[turn-ingest] auto-title write failed for ${session.id}`, error);
 	}
 	const fromSeq = userSeq + 1;
+	const resume = resumeHandle(session);
+	const priorContext = await replayContextForTurn(
+		handle,
+		session.id,
+		userSeq,
+		resume,
+	);
 	const controller = new AbortController();
 	const startedAt = Date.now();
-	const ingest = ingestTurn(handle, session, userText, provider, controller.signal, repo).then(
+	const ingest = ingestTurn(
+		handle,
+		session,
+		userText,
+		provider,
+		controller.signal,
+		repo,
+		resume,
+		priorContext,
+	).then(
 		(outcome) => {
 			// Deregister once this turn settles — but only if a newer turn hasn't
 			// already taken the slot (guards a fast resend replacing the entry).
@@ -223,6 +242,26 @@ async function resolveTurnRepo(
 	return { fullName: repo.fullName, defaultBranch: repo.defaultBranch };
 }
 
+async function replayContextForTurn(
+	handle: DatabaseHandle,
+	sessionId: string,
+	currentUserSeq: number,
+	resume: SessionResumeHandle | null,
+): Promise<string | null> {
+	if (!resume && currentUserSeq <= 1) return null;
+	try {
+		const events = await readEvents(handle, sessionId);
+		const priorEvents = events.filter((event) => event.seq < currentUserSeq);
+		return projectReplayContext(priorEvents);
+	} catch (error) {
+		console.error(
+			`[turn-ingest] prior context replay failed for ${sessionId}`,
+			error,
+		);
+		return null;
+	}
+}
+
 /** The abort-race verdict: the source yielded (or finished), or the stop won. */
 type NextOrAborted<T> = { aborted: true } | { aborted: false; result: IteratorResult<T> };
 
@@ -275,6 +314,8 @@ async function ingestTurn(
 	provider: ComputeProvider,
 	signal: AbortSignal,
 	repo: TurnRepo | null,
+	resume: SessionResumeHandle | null,
+	priorContext: string | null,
 ): Promise<TurnNotificationOutcome> {
 	let closed = false;
 	// An `error` chunk anywhere in the stream marks the turn failed for the
@@ -283,14 +324,16 @@ async function ingestTurn(
 	// not whether the stream terminated cleanly.
 	let sawError = false;
 	try {
+		const request: TurnRequest = {
+			sessionId: session.id,
+			userMessage: userText,
+			repo,
+			resume,
+			model: session.model,
+		};
+		if (priorContext) request.priorContext = priorContext;
 		const iterator = provider
-			.runTurn({
-				sessionId: session.id,
-				userMessage: userText,
-				repo,
-				resume: resumeHandle(session),
-				model: session.model,
-			})
+			.runTurn(request)
 			[Symbol.asyncIterator]();
 		while (true) {
 			const verdict = await nextOrAborted(iterator, signal);

--- a/web-next/src/lib/agent-runtime/vercel-provider.test.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { projectReplayContext } from "../transcript/replay-context";
 import {
 	buildPrompt,
 	buildSessionSetupScript,
@@ -162,6 +163,67 @@ describe("repo targeting", () => {
 			type: "done",
 			metadata: { aborted: true },
 		});
+	});
+});
+
+describe("buildPrompt", () => {
+	const repo = {
+		fullName: "fairchild/web-next-fixtures",
+		defaultBranch: "trunk",
+	};
+
+	test("frames projected prior context on a fresh fallback with history", () => {
+		const priorContext = projectReplayContext([
+			{ seq: 1, role: "user", chunk: { type: "text", content: "Fix resume" } },
+			{
+				seq: 2,
+				role: "assistant",
+				chunk: { type: "text", content: "I restored the branch." },
+			},
+			{ seq: 3, role: "assistant", chunk: { type: "done", content: "" } },
+		]);
+
+		const prompt = buildPrompt(
+			"Now add the replay test",
+			"abcdef123456",
+			true,
+			repo,
+			priorContext,
+		);
+
+		expect(prompt).toContain(
+			"The conversation so far (the sandbox restarted; your working copy was restored from the session branch):",
+		);
+		expect(prompt).toContain("User: Fix resume");
+		expect(prompt).toContain("Assistant: I restored the branch.");
+		expect(prompt.indexOf("User: Fix resume")).toBeLessThan(
+			prompt.indexOf("The user's request:"),
+		);
+		expect(prompt).toContain("The user's request:\nNow add the replay test");
+	});
+
+	test("keeps the first-turn prompt byte-identical when no prior context exists", () => {
+		const prompt = buildPrompt("Fix the failing test", "abcdef123456", true, repo);
+
+		expect(buildPrompt("Fix the failing test", "abcdef123456", true, repo, null)).toBe(
+			prompt,
+		);
+		expect(
+			buildPrompt("Fix the failing test", "abcdef123456", true, repo, " \n\t "),
+		).toBe(prompt);
+		expect(prompt).not.toContain("The conversation so far");
+	});
+
+	test("ignores priorContext on a successful warm resume", () => {
+		expect(
+			buildPrompt(
+				"Continue from the live harness session",
+				"abcdef123456",
+				false,
+				repo,
+				"User: old\n\nAssistant: context",
+			),
+		).toBe("Continue from the live harness session");
 	});
 });
 

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -326,7 +326,8 @@ export async function* mapFullStream(
  * the persistent workspace clone. A fresh session gets a one-time preamble
  * establishing where the working copy lives and how to open a PR; a resumed
  * session already carries that context in its harness conversation, so it
- * receives the user's message alone.
+ * receives the user's message alone. If a warm resume failed but the durable
+ * log has history, the fresh prompt also replays compact prior dialogue.
  */
 function baseBranchLabel(repo: TurnRepo): string {
 	return repo.defaultBranch
@@ -343,6 +344,7 @@ export function buildPrompt(
 	sessionId: string,
 	firstTurn: boolean,
 	repo: TurnRepo,
+	priorContext?: string | null,
 ): string {
 	if (!firstTurn) return userMessage;
 	const branch = sessionBranch(sessionId);
@@ -351,6 +353,23 @@ export function buildPrompt(
 	const baseAssignment = repo.defaultBranch
 		? `BASE_BRANCH=${shellQuote(base)}`
 		: `BASE_BRANCH="${base}"`;
+	const replay = priorContext?.trim();
+	if (replay) {
+		return [
+			`You are working inside a persistent clone of the GitHub repository ${repo.fullName}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`, created from ${baseLabel}. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
+			``,
+			`Working notes:`,
+			`- Relative paths and git commands resolve against the repo (you are inside it) — edit and \`git status\`/\`git diff\` normally.`,
+			`- To open or update a pull request: commit, \`git push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token against base ${baseLabel}, e.g. \`${baseAssignment}; curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${repo.fullName}/pulls -d "{\\"title\\":\\"…\\",\\"head\\":\\"${branch}\\",\\"base\\":\\"$BASE_BRANCH\\",\\"body\\":\\"…\\"}"\`. Report the \`html_url\`.`,
+			`- Only open a PR when the request calls for one; otherwise just do the work and summarize it.`,
+			``,
+			`The conversation so far (the sandbox restarted; your working copy was restored from the session branch):`,
+			replay,
+			``,
+			`The user's request:`,
+			userMessage,
+		].join("\n");
+	}
 	return [
 		`You are working inside a persistent clone of the GitHub repository ${repo.fullName}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`, created from ${baseLabel}. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
 		``,
@@ -624,6 +643,8 @@ export const vercelProvider: ComputeProvider = {
 		// buildPrompt then sends the user's message alone.
 		let session: Awaited<ReturnType<typeof agent.createSession>> | undefined;
 		let resumed = false;
+		const replayContext = request.priorContext?.trim();
+		let replayStatusEmitted = false;
 		if (request.resume) {
 			yield { type: "status", content: "Resuming session" };
 			try {
@@ -639,9 +660,23 @@ export const vercelProvider: ComputeProvider = {
 					type: "status",
 					content: "Previous sandbox expired — starting fresh",
 				};
+				if (replayContext) {
+					yield {
+						type: "status",
+						content: "Restored conversation context from the session log",
+					};
+					replayStatusEmitted = true;
+				}
 			}
 		}
 		if (!session) {
+			if (replayContext && !replayStatusEmitted) {
+				yield {
+					type: "status",
+					content: "Restored conversation context from the session log",
+				};
+				replayStatusEmitted = true;
+			}
 			yield { type: "status", content: "Booting Claude Code in sandbox" };
 			sandboxSessionId = request.sessionId;
 			try {
@@ -660,7 +695,13 @@ export const vercelProvider: ComputeProvider = {
 		try {
 			const result = await agent.stream({
 				session,
-				prompt: buildPrompt(request.userMessage, request.sessionId, !resumed, repo),
+				prompt: buildPrompt(
+					request.userMessage,
+					request.sessionId,
+					!resumed,
+					repo,
+					!resumed ? replayContext : null,
+				),
 			});
 			let doneChunk: StreamChunk | undefined;
 			// Tracks every real toolCallId this turn so the synthetic Diff rows

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -354,33 +354,23 @@ export function buildPrompt(
 		? `BASE_BRANCH=${shellQuote(base)}`
 		: `BASE_BRANCH="${base}"`;
 	const replay = priorContext?.trim();
-	if (replay) {
-		return [
-			`You are working inside a persistent clone of the GitHub repository ${repo.fullName}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`, created from ${baseLabel}. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
-			``,
-			`Working notes:`,
-			`- Relative paths and git commands resolve against the repo (you are inside it) — edit and \`git status\`/\`git diff\` normally.`,
-			`- To open or update a pull request: commit, \`git push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token against base ${baseLabel}, e.g. \`${baseAssignment}; curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${repo.fullName}/pulls -d "{\\"title\\":\\"…\\",\\"head\\":\\"${branch}\\",\\"base\\":\\"$BASE_BRANCH\\",\\"body\\":\\"…\\"}"\`. Report the \`html_url\`.`,
-			`- Only open a PR when the request calls for one; otherwise just do the work and summarize it.`,
-			``,
-			`The conversation so far (the sandbox restarted; your working copy was restored from the session branch):`,
-			replay,
-			``,
-			`The user's request:`,
-			userMessage,
-		].join("\n");
-	}
-	return [
+	const lines = [
 		`You are working inside a persistent clone of the GitHub repository ${repo.fullName}. The current directory (${WORKSPACE_DIR}) is the repo root, checked out on branch \`${branch}\`, created from ${baseLabel}. This workspace and our conversation persist across turns — later messages continue in the same working copy.`,
 		``,
 		`Working notes:`,
 		`- Relative paths and git commands resolve against the repo (you are inside it) — edit and \`git status\`/\`git diff\` normally.`,
 		`- To open or update a pull request: commit, \`git push -u origin HEAD\`, then call the GitHub API with the token in /tmp/gh_token against base ${baseLabel}, e.g. \`${baseAssignment}; curl -sS -X POST -H "Authorization: Bearer $(cat /tmp/gh_token)" -H "Accept: application/vnd.github+json" https://api.github.com/repos/${repo.fullName}/pulls -d "{\\"title\\":\\"…\\",\\"head\\":\\"${branch}\\",\\"base\\":\\"$BASE_BRANCH\\",\\"body\\":\\"…\\"}"\`. Report the \`html_url\`.`,
 		`- Only open a PR when the request calls for one; otherwise just do the work and summarize it.`,
-		``,
-		`The user's request:`,
-		userMessage,
-	].join("\n");
+	];
+	if (replay) {
+		lines.push(
+			``,
+			`The conversation so far (the sandbox restarted; your working copy was restored from the session branch):`,
+			replay,
+		);
+	}
+	lines.push(``, `The user's request:`, userMessage);
+	return lines.join("\n");
 }
 
 /**

--- a/web-next/src/lib/transcript/replay-context.test.ts
+++ b/web-next/src/lib/transcript/replay-context.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import type { ProjectedEvent } from "./project-events";
+import {
+	projectReplayContext,
+	REPLAY_CONTEXT_TRUNCATED_MARKER,
+} from "./replay-context";
+
+function u(seq: number, content: string): ProjectedEvent {
+	return { seq, role: "user", chunk: { type: "text", content } };
+}
+
+function a(
+	seq: number,
+	type: ProjectedEvent["chunk"]["type"],
+	content: string,
+	metadata?: Record<string, unknown>,
+): ProjectedEvent {
+	return { seq, role: "assistant", chunk: { type, content, metadata } };
+}
+
+describe("projectReplayContext", () => {
+	test("returns null for an empty session log", () => {
+		expect(projectReplayContext([])).toBeNull();
+	});
+
+	test("replays user messages and assistant text while eliding operational chunks", () => {
+		const replay = projectReplayContext([
+			u(1, "Fix the failed resume"),
+			a(2, "status", "Starting sandbox"),
+			a(3, "reasoning", "I should inspect the provider."),
+			a(4, "text", "I found the missing guard. "),
+			a(5, "tool_use", "Read", {
+				toolUseId: "t-1",
+				toolName: "Read",
+			}),
+			a(6, "tool_result", "source text", { toolUseId: "t-1" }),
+			a(7, "text", "The fix is in."),
+			a(8, "error", "ignored failure text"),
+			a(9, "done", ""),
+		]);
+
+		expect(replay).toBe(
+			[
+				"User: Fix the failed resume",
+				"Assistant: I found the missing guard. The fix is in.",
+			].join("\n\n"),
+		);
+		expect(replay).not.toContain("Starting sandbox");
+		expect(replay).not.toContain("I should inspect");
+		expect(replay).not.toContain("source text");
+		expect(replay).not.toContain("ignored failure");
+	});
+
+	test("orders events by seq before formatting the dialogue", () => {
+		const replay = projectReplayContext([
+			a(3, "done", ""),
+			a(2, "text", "Hello."),
+			u(1, "Hi"),
+		]);
+
+		expect(replay).toBe("User: Hi\n\nAssistant: Hello.");
+	});
+
+	test("truncates oldest dialogue first and stays within the character cap", () => {
+		const replay = projectReplayContext(
+			[
+				u(1, "old request that should fall away"),
+				a(2, "text", "old answer that should fall away"),
+				a(3, "done", ""),
+				u(4, "new request with important details"),
+				a(5, "text", "new answer with the useful plan"),
+				a(6, "done", ""),
+			],
+			120,
+		);
+
+		expect(replay).not.toBeNull();
+		expect(replay?.length).toBeLessThanOrEqual(120);
+		expect(replay?.startsWith(REPLAY_CONTEXT_TRUNCATED_MARKER)).toBe(true);
+		expect(replay).toContain("new request with important details");
+		expect(replay).toContain("new answer with the useful plan");
+		expect(replay).not.toContain("old request");
+		expect(replay).not.toContain("old answer");
+	});
+
+	test("clips an oversized newest message instead of exceeding the cap", () => {
+		const replay = projectReplayContext(
+			[u(1, "x".repeat(200))],
+			80,
+		);
+
+		expect(replay).not.toBeNull();
+		expect(replay?.length).toBeLessThanOrEqual(80);
+		expect(replay?.startsWith(REPLAY_CONTEXT_TRUNCATED_MARKER)).toBe(true);
+		expect(replay).toContain("User:");
+	});
+});

--- a/web-next/src/lib/transcript/replay-context.ts
+++ b/web-next/src/lib/transcript/replay-context.ts
@@ -1,0 +1,111 @@
+/*
+ * Pure projection for model replay after a sandbox resume falls back fresh.
+ * The UI transcript keeps rich parts; this produces only the compact dialogue
+ * a model needs to recover conversational context from the durable event log.
+ */
+import type { ProjectedEvent, SessionEventRole } from "./project-events";
+
+// Roughly 8k chars keeps the replay under a few thousand tokens in normal
+// English while leaving most of the model window for the fresh turn itself.
+export const REPLAY_CONTEXT_MAX_CHARS = 8_000;
+export const REPLAY_CONTEXT_TRUNCATED_MARKER =
+	"[earlier conversation truncated]";
+
+interface ReplayLine {
+	role: Extract<SessionEventRole, "user" | "assistant">;
+	text: string;
+}
+
+/**
+ * Projects stored events into a readable User/Assistant dialogue. Only user
+ * text and assistant answer text are replayed; reasoning, tool calls/results,
+ * status, and errors are omitted because they are either private reasoning,
+ * operational noise, or already visible in the restored working copy.
+ */
+export function projectReplayContext(
+	events: readonly ProjectedEvent[],
+	maxChars = REPLAY_CONTEXT_MAX_CHARS,
+): string | null {
+	const lines = replayLines(events);
+	if (lines.length === 0) return null;
+	const rendered = lines
+		.map((line) => `${speaker(line.role)}: ${line.text.trim()}`)
+		.filter((line) => !line.endsWith(": "))
+		.join("\n\n");
+	if (!rendered) return null;
+	return capReplayContext(rendered, maxChars);
+}
+
+function replayLines(events: readonly ProjectedEvent[]): ReplayLine[] {
+	const ordered = [...events].sort((a, b) => a.seq - b.seq);
+	const lines: ReplayLine[] = [];
+	let current: ReplayLine | undefined;
+
+	function flush(): void {
+		if (!current) return;
+		const text = current.text.trim();
+		if (text) lines.push({ ...current, text });
+		current = undefined;
+	}
+
+	function append(role: ReplayLine["role"], text: string): void {
+		if (current?.role !== role) flush();
+		if (!current) current = { role, text: "" };
+		current.text += text;
+	}
+
+	for (const event of ordered) {
+		if (event.role === "user") {
+			append("user", event.chunk.content);
+			continue;
+		}
+		if (event.chunk.type === "text") {
+			append("assistant", event.chunk.content);
+			continue;
+		}
+		if (event.chunk.type === "done") flush();
+	}
+	flush();
+
+	return lines;
+}
+
+function speaker(role: ReplayLine["role"]): "User" | "Assistant" {
+	return role === "user" ? "User" : "Assistant";
+}
+
+function capReplayContext(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	const prefix = `${REPLAY_CONTEXT_TRUNCATED_MARKER}\n\n`;
+	if (maxChars <= prefix.length) {
+		return REPLAY_CONTEXT_TRUNCATED_MARKER.slice(0, Math.max(0, maxChars));
+	}
+
+	const budget = maxChars - prefix.length;
+	const paragraphs = text.split("\n\n");
+	const kept: string[] = [];
+	let used = 0;
+	for (let index = paragraphs.length - 1; index >= 0; index -= 1) {
+		const paragraph = paragraphs[index];
+		const separatorLength = kept.length === 0 ? 0 : 2;
+		const nextLength = used + separatorLength + paragraph.length;
+		if (nextLength <= budget) {
+			kept.unshift(paragraph);
+			used = nextLength;
+			continue;
+		}
+		if (kept.length === 0) kept.unshift(clipParagraphTail(paragraph, budget));
+		break;
+	}
+
+	return `${prefix}${kept.join("\n\n")}`.slice(0, maxChars);
+}
+
+function clipParagraphTail(paragraph: string, budget: number): string {
+	const labelEnd = paragraph.indexOf(": ");
+	if (labelEnd < 0) return paragraph.slice(-budget);
+	const label = paragraph.slice(0, labelEnd + 2);
+	const contentBudget = budget - label.length;
+	if (contentBudget <= 0) return paragraph.slice(-budget);
+	return `${label}${paragraph.slice(-contentBudget)}`;
+}


### PR DESCRIPTION
Closes #969.

When a Vercel sandbox warm resume fails and the provider boots fresh, the model previously lost the entire conversation — the working copy came back from the session branch but the dialogue didn't. This projects a compact User/Assistant replay from the durable `session_events` log and threads it into the fresh-fallback prompt, so continuity survives sandbox expiry.

## What changed

- `src/lib/transcript/replay-context.ts` — pure projection: user text + assistant `text` chunks only (reasoning, tool calls/results, status, errors elided); capped at 8,000 chars, truncating oldest-first with an explicit `[earlier conversation truncated]` marker.
- `TurnRequest.priorContext` (optional) threaded through `startTurn` → provider. Computed only when the session has history (`resume` handle present or prior user turns); genuine first turns omit the field entirely.
- Vercel provider: fresh-fallback prompt gains a "conversation so far" section; a calm status chunk ("Restored conversation context from the session log") tells the user what happened. Successful warm resumes ignore `priorContext` — the harness conversation already has the context.
- Coordinator reaction commit: collapsed the duplicated prompt preamble into one template with an optional replay section (output bytes unchanged, tests prove it).

## Mergeability

- **Surface**: web-next agent runtime — turn ingest, Vercel provider prompt construction, new transcript projection module. No UI component changes; one new status message flows through the existing status chunk path.
- **Behavior changed**: fresh-fallback turns after failed warm resume now carry replayed dialogue + a status line; first turns and warm resumes are byte-identical to before (tested).
- **Non-happy paths**: replay projection failure is caught and logged, turn proceeds without context; empty/whitespace history projects to null (no replay section); oversized history truncates oldest-first with a visible marker; dangling repoId still throws per #967 behavior.
- **Residual risk**: 8k-char cap is a judgment call — very long sessions replay only the tail; mitigated by the truncation marker telling the model context is partial, and the restored working copy carrying the actual state.

## Verification

- `pnpm test`: **40 files, 463 passed** (includes 47 targeted tests across replay projection, ingest threading, prompt framing)
- `pnpm typecheck`, `pnpm lint`, `pnpm build`: all pass
- Mutation check (worker): `projectReplayContext` forced to `null` → 6 expected failures → restored, green.

Evidence: ![context-replay-tests](https://evidence.cloudcompute.com/workspaces/pr-997/20260708-170741-context-replay-tests.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
