### PR TITLE
test(automation): harden tile env injection diagnostics (#973)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/TileTreeStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TileTreeStore.swift
@@ -962,7 +962,17 @@ final class TileTreeStore: ObservableObject {
     }
 
     func automationEnvironment(for session: HostTerminalSession) -> AutomationTerminalEnvironment? {
-        guard let automationHandleRegistry, let automationSocketPath else { return nil }
+        guard let automationHandleRegistry, let automationSocketPath else {
+            if ExperimentalFeatures.isEnabled(.automationAPI) {
+                NSLog(
+                    "[TileTreeStore] automation environment unavailable for session %@ while Automation API is enabled (handleRegistry=%@ socketPath=%@)",
+                    session.id.uuidString,
+                    automationHandleRegistry == nil ? "nil" : "configured",
+                    automationSocketPath == nil ? "nil" : "configured"
+                )
+            }
+            return nil
+        }
         let entry = automationHandleRegistry.upsert(
             hostSessionID: session.id,
             tileID: automationTileID(for: session.id),

--- a/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
+++ b/Tests/WorkspaceManagerAppTests/GhosttyTerminalConfigTests.swift
@@ -247,6 +247,23 @@ struct GhosttyTerminalConfigTests {
         #expect(config.environmentVariables["WORKSPACES_HOST_SESSION_ID"] == hostSessionID.uuidString)
     }
 
+    @Test("Automation context is omitted when no automation environment is provided")
+    func omitsAutomationContextWhenUnavailable() {
+        let config = GhosttyTerminalConfig(
+            workingDirectory: URL(fileURLWithPath: "/tmp/repo-a"),
+            environment: [
+                "SHELL": "/bin/zsh",
+                "PATH": "/usr/bin:/bin",
+            ],
+            terminalMultiplexingMode: .ghosttyManagedSplits,
+            isTmuxAvailableOverride: true,
+            automationEnvironment: nil
+        )
+
+        #expect(config.environmentVariables[AutomationAPI.socketEnvironmentKey] == nil)
+        #expect(config.environmentVariables[AutomationAPI.handleEnvironmentKey] == nil)
+    }
+
     @Test("custom command config preserves explicit command without hook environment")
     func customCommandConfigPreservesExplicitCommandWithoutHookEnvironment() {
         let config = GhosttyTerminalConfig(customCommand: "/usr/local/bin/lume ssh vm-123")

--- a/Tests/WorkspaceManagerAppTests/TileTreeStoreTests.swift
+++ b/Tests/WorkspaceManagerAppTests/TileTreeStoreTests.swift
@@ -90,6 +90,56 @@ struct TileTreeStoreTests {
         #expect(store.tabTitleOverride(for: session.id) == nil)
     }
 
+    @Test("Automation environment remains nil before automation is configured")
+    func automationEnvironmentIsNilBeforeConfigure() {
+        let store = TileTreeStore()
+        let session = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+
+        #expect(store.automationEnvironment(for: session) == nil)
+    }
+
+    @Test("Automation environment is minted for multiple sessions after one configuration")
+    func automationEnvironmentIsMintedForMultipleSessionsAfterOneConfiguration() throws {
+        let store = TileTreeStore()
+        let socketPath = "/tmp/workspaces-automation.sock"
+        var nextHandle = 0
+        let registry = AutomationHandleRegistry {
+            nextHandle += 1
+            return "handle-\(nextHandle)"
+        }
+        store.configureAutomation(handleRegistry: registry, socketPath: socketPath)
+
+        let first = store.activateSession(
+            key: .defaultHome,
+            directory: URL(fileURLWithPath: "/Users/test")
+        ).session
+        let second = try #require(store.createTab())
+        let third = store.activateSession(
+            key: .repoPath("/Users/test/code/repo"),
+            directory: URL(fileURLWithPath: "/Users/test/code/repo")
+        ).session
+
+        let firstEnvironment = try #require(store.automationEnvironment(for: first))
+        let secondEnvironment = try #require(store.automationEnvironment(for: second))
+        let thirdEnvironment = try #require(store.automationEnvironment(for: third))
+        let environments = [firstEnvironment, secondEnvironment, thirdEnvironment]
+        let sessions = [first, second, third]
+
+        #expect(environments.allSatisfy { $0.socketPath == socketPath })
+        #expect(Set(environments.map(\.handle)).count == environments.count)
+        #expect(environments.map(\.handle) == ["handle-1", "handle-2", "handle-3"])
+
+        for (environment, session) in zip(environments, sessions) {
+            let entry = try #require(registry.resolve(environment.handle))
+            #expect(entry.hostSessionID == session.id)
+            #expect(entry.tileID?.rawValue.uuidString == store.automationTileIDString(for: session.id))
+            #expect(entry.surfaceKind == .terminal)
+        }
+    }
+
     @Test("Surface title changes publish host terminal state updates")
     func surfaceTitleChangesPublishHostTerminalStateUpdates() {
         let store = TileTreeStore()


### PR DESCRIPTION
## Summary

Re-scopes #973 after live investigation: the originally-reported bug (fresh tiles missing `WORKSPACES_AUTOMATION_SOCKET`/`_HANDLE`) is **not currently reproducible** — verified live against a running dev instance with zero code changes in between (see the issue comment thread for the beacon-log evidence). The working theory is that it was an artifact of the duplicate-app-instance confusion (finding 5 of `docs/retros/2026-07-08-automation-dogfood-w5.md`), not a persistent per-surface or libghostty (#889) bug — `GhosttyTerminalConfig`'s env injection is unconditional and correct once `TileTreeStore.configureAutomation(...)` has run once.

Rather than guess at a fix for a bug that isn't reproducing, this PR:
- Adds a targeted `NSLog` diagnostic in `TileTreeStore.automationEnvironment(for:)` so a future recurrence is instantly diagnosable (names the session id and which of registry/socketPath is nil), instead of requiring another ad-hoc beacon-log hack.
- Adds Swift Testing regression coverage proving multiple sequential terminal sessions all receive automation env after one `configureAutomation(...)` call — the specific "first surface works, later ones don't" shape the original issue worried about — plus the existing nil/disabled-path coverage.

Codex (gpt-5.5, high) implemented this in a dedicated worktree; full investigation trail in `CODEX_REPORT.md` (not committed, pasted below for reviewers).

## Review loop

- **Reflect**: small additive diagnostic-only change; no lifecycle/teardown risk — the new log only fires on the already-nil path, gated on the feature flag, and the environment-provider closure is only invoked once per surface from `SurfaceStore`'s get-or-create path (not per-frame), so no log-spam risk.
- **Codex (gpt-5.5, xhigh) directed review**: asked about log-spam risk given call-site cardinality, whether the test's `AutomationHandleRegistry(makeHandle:)` usage matches the real initializer, vacuous assertions, and whether the diagnostic carries enough information to actually diagnose a future recurrence. No runtime/test correctness issues found; confirmed the registry initializer usage is real (not hallucinated) and the log-spam concern is unfounded given call-site cardinality.
- **One finding, declined**: codex flagged `git diff --check` reporting "indent with spaces" on every added line. Verified this is not a real gate — `git diff --check` is not run in CI (only referenced for docs-only diffs per `docs/development/mergeability-standard.md`), and this repo's `core.whitespace = indent-with-non-tab` setting is a tab/space heuristic irrelevant to this space-indented Swift codebase. `mise run lint` (`swift-format lint --strict`, the actual enforced Swift formatting gate) passes clean. No action taken.

## Gates (rebased onto current origin/main before this run)

- `swift build`: PASS
- `swift test --filter TileTreeStoreTests`: PASS (34 tests)
- `swift test --filter GhosttyTerminalConfigTests`: PASS (15 tests)
- `mise run lint`: PASS

## Mergeability

- Surface: desktop — `TileTreeStore` automation-environment wiring (diagnostics + tests only, no behavior change on the happy path)
- User-facing behavior changed: No — this adds a log line (visible only in Console/stdout when automation is enabled and the environment is unexpectedly unavailable) and test coverage; no change to any code path a user or operator would observe under working conditions
- Non-happy paths considered: the pre-configuration nil path stays intentional and is now explicitly tested; the diagnostic explicitly avoids firing on the expected-disabled path
- Residual risk or follow-up: none identified for this diff. #973 stays open on the tracker with the live non-repro finding recorded; if the underlying race (window/session created before `AutomationIntegrationLifecycle.configure` resolves) is ever hit again, the new log makes it immediately diagnosable. #889 (libghostty) is untouched and unrelated per this investigation.

🤖 Generated with a codex (gpt-5.5) implementation worker, orchestrated by Claude Code (Sonnet 5)

## Evidence

![gates](https://evidence.cloudcompute.com/workspaces/pr-1000/20260708-175951-gates.png)

(Full gate transcript rendered above: `swift build`, `swift test --filter TileTreeStoreTests` (34/34), `swift test --filter GhosttyTerminalConfigTests` (15/15), `mise run lint` clean, and the declined `git diff --check` finding for the record.)
