### PR TITLE
fix(web-next): adaptive sandbox idle-stop with settled-turn guard

### DIFF
--- a/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.test.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { sandboxStateLabel } from "./use-sandbox-state";
+
+describe("sandboxStateLabel", () => {
+	test("renders stopped as a calm resumable resting state", () => {
+		expect(sandboxStateLabel({ state: "parked", detail: "stopped" })).toBe(
+			"sandbox stopped; resumes next message",
+		);
+	});
+
+	test("keeps transitional parked states distinct from stopped", () => {
+		expect(sandboxStateLabel({ state: "parked", detail: "snapshotting" })).toBe(
+			"sandbox parking",
+		);
+	});
+});

--- a/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-sandbox-state.ts
@@ -110,6 +110,11 @@ export function useSandboxState(sessionId: string, turnInFlight: boolean) {
 export function sandboxStateLabel(sandbox: SandboxState | null): string {
 	if (!sandbox) return "";
 	if (sandbox.state === "live") return "sandbox live";
-	if (sandbox.state === "parked") return "sandbox parked";
+	if (sandbox.state === "parked") {
+		if (sandbox.detail === "stopped") {
+			return "sandbox stopped; resumes next message";
+		}
+		return "sandbox parking";
+	}
 	return "no sandbox";
 }

--- a/web-next/src/app/api/sessions/[id]/sandbox/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/sandbox/route.test.ts
@@ -1,0 +1,119 @@
+/*
+ * /api/sessions/[id]/sandbox — the state poller is also the adaptive idle
+ * sweeper, so these tests keep the sweep tied to the durable session_events
+ * log instead of any process-local active-turn registry.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Sandbox } from "@vercel/sandbox";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { ADAPTIVE_IDLE_STOP_MS } from "@/lib/agent-runtime/sandbox-state";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import {
+	appendEvents,
+	createSession,
+	updateSession,
+	type AppendEvent,
+} from "@/lib/db/sessions";
+
+vi.mock("@/lib/auth/auth-state", () => ({
+	getAuthState: vi.fn(),
+}));
+
+vi.mock("@vercel/sandbox", () => ({
+	Sandbox: { get: vi.fn() },
+}));
+
+const dir = mkdtempSync(join(tmpdir(), "web-next-sandbox-route-"));
+process.env.SESSIONS_DATABASE_URL = `file:${join(dir, "test.db")}`;
+
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const AUTHORIZED = {
+	kind: "authorized" as const,
+	user: { login: "fairchild", name: "Fairchild" },
+};
+
+const NOW = new Date("2026-07-08T17:00:00.000Z");
+
+beforeEach(() => {
+	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+	vi.mocked(Sandbox.get).mockReset();
+});
+
+let seq = 0;
+
+async function get(id: string) {
+	const { GET } = await import("./route");
+	return GET(new Request(`http://test/api/sessions/${id}/sandbox`), {
+		params: Promise.resolve({ id }),
+	});
+}
+
+async function sessionPastIdleWindow(events: readonly AppendEvent[]): Promise<string> {
+	const id = `sandbox-s-${++seq}`;
+	await createSession(getDatabase(), {
+		id,
+		provider: "vercel",
+		ownerLogin: "fairchild",
+	});
+	await updateSession(getDatabase(), id, {
+		claudeSessionId: "harness-1",
+		resumeState: '{"parked":true}',
+	});
+	await appendEvents(getDatabase(), id, events);
+	await getDatabase()
+		.db.updateTable("sessions")
+		.set({
+			last_activity_at: new Date(
+				NOW.getTime() - ADAPTIVE_IDLE_STOP_MS - 1_000,
+			).toISOString(),
+		})
+		.where("id", "=", id)
+		.execute();
+	return id;
+}
+
+function liveSandbox() {
+	return {
+		name: "wm-harness-1",
+		status: "running",
+		stop: vi.fn(async () => ({})),
+	};
+}
+
+describe("GET /api/sessions/[id]/sandbox", () => {
+	test("does not idle-stop a live sandbox while the current turn is unsettled in the durable log", async () => {
+		const sandbox = liveSandbox();
+		vi.mocked(Sandbox.get).mockResolvedValue(sandbox as never);
+		const id = await sessionPastIdleWindow([
+			{ role: "user", chunk: { type: "text", content: "run the long build" } },
+			{ role: "assistant", chunk: { type: "tool_use", content: "pnpm build" } },
+		]);
+
+		const res = await get(id);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ state: "live" });
+		expect(sandbox.stop).not.toHaveBeenCalled();
+	});
+
+	test("idle-stops a live sandbox past the window after the current turn settled", async () => {
+		const sandbox = liveSandbox();
+		vi.mocked(Sandbox.get).mockResolvedValue(sandbox as never);
+		const id = await sessionPastIdleWindow([
+			{ role: "user", chunk: { type: "text", content: "run the build" } },
+			{ role: "assistant", chunk: { type: "done", content: "" } },
+		]);
+
+		const res = await get(id);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ state: "parked", detail: "stopped" });
+		expect(sandbox.stop).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web-next/src/app/api/sessions/[id]/sandbox/route.ts
+++ b/web-next/src/app/api/sessions/[id]/sandbox/route.ts
@@ -1,10 +1,11 @@
 /*
  * The session's sandbox lifecycle surface (#753). GET reports the sandbox's
  * real state (live / parked / none — checked against the platform, never
- * inferred); DELETE stops a live VM and reports the state that's actually
- * left. Auth-gated same as the chat route; both verbs are safe to repeat —
- * a re-GET re-checks, a re-DELETE of an already-parked sandbox is a no-op
- * that returns the honest current state.
+ * inferred) and sweeps parked live VMs after the adaptive idle window; DELETE
+ * stops a live VM and reports the state that's actually left. Auth-gated same
+ * as the chat route; both verbs are safe to repeat — a re-GET re-checks, a
+ * re-DELETE of an already-parked sandbox is a no-op that returns the honest
+ * current state.
  */
 import {
 	resolveSandboxState,

--- a/web-next/src/app/api/sessions/[id]/sandbox/route.ts
+++ b/web-next/src/app/api/sessions/[id]/sandbox/route.ts
@@ -1,14 +1,15 @@
 /*
  * The session's sandbox lifecycle surface (#753). GET reports the sandbox's
  * real state (live / parked / none — checked against the platform, never
- * inferred) and sweeps parked live VMs after the adaptive idle window; DELETE
- * stops a live VM and reports the state that's actually left. Auth-gated same
- * as the chat route; both verbs are safe to repeat — a re-GET re-checks, a
- * re-DELETE of an already-parked sandbox is a no-op that returns the honest
- * current state.
+ * inferred) and sweeps parked live VMs after the adaptive idle window only
+ * when the durable log says the current turn settled; DELETE stops a live VM
+ * and reports the state that's actually left. Auth-gated same as the chat
+ * route; both verbs are safe to repeat — a re-GET re-checks, a re-DELETE of an
+ * already-parked sandbox is a no-op that returns the honest current state.
  */
 import {
 	resolveSandboxState,
+	readCurrentTurnSettled,
 	stopSessionSandbox,
 } from "@/lib/agent-runtime/sandbox-state";
 import { getAuthState } from "@/lib/auth/auth-state";
@@ -48,7 +49,13 @@ export async function GET(
 	const { id } = await params;
 	const gated = await gate(id);
 	if (gated.response) return gated.response;
-	return Response.json(await resolveSandboxState(gated.session));
+	const currentTurnSettled = await readCurrentTurnSettled(
+		getDatabase(),
+		gated.session.id,
+	);
+	return Response.json(
+		await resolveSandboxState(gated.session, undefined, { currentTurnSettled }),
+	);
 }
 
 export async function DELETE(

--- a/web-next/src/lib/agent-runtime/sandbox-state.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-state.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, test, vi } from "vitest";
 import {
+	ADAPTIVE_IDLE_STOP_MS,
 	type LifecycleSandbox,
 	resolveSandboxState,
 	stopSessionSandbox,
@@ -17,6 +18,7 @@ const PARKED_SESSION = {
 	claudeSessionId: "harness-1",
 	resumeState: '{"parked":true}',
 };
+const NOW = new Date("2026-07-08T17:00:00.000Z");
 
 function sandboxWith(status: string): LifecycleSandbox & { stop: ReturnType<typeof vi.fn> } {
 	return {
@@ -55,6 +57,64 @@ describe("resolveSandboxState", () => {
 			sandboxWith(status),
 		);
 		expect(state).toEqual({ state: "live" });
+	});
+
+	test("a live sandbox inside the adaptive idle window stays warm", async () => {
+		const sandbox = sandboxWith("running");
+		const state = await resolveSandboxState(
+			{
+				...PARKED_SESSION,
+				lastActivityAt: new Date(
+					NOW.getTime() - ADAPTIVE_IDLE_STOP_MS + 1_000,
+				).toISOString(),
+			},
+			async () => sandbox,
+			{ now: NOW },
+		);
+
+		expect(sandbox.stop).not.toHaveBeenCalled();
+		expect(state).toEqual({ state: "live" });
+	});
+
+	test("a live sandbox past the adaptive idle window is stopped and reported parked", async () => {
+		const sandbox = sandboxWith("running");
+		const state = await resolveSandboxState(
+			{
+				...PARKED_SESSION,
+				lastActivityAt: new Date(
+					NOW.getTime() - ADAPTIVE_IDLE_STOP_MS - 1_000,
+				).toISOString(),
+			},
+			async () => sandbox,
+			{ now: NOW },
+		);
+
+		expect(sandbox.stop).toHaveBeenCalledTimes(1);
+		expect(state).toEqual({ state: "parked", detail: "stopped" });
+	});
+
+	test("adaptive idle-stop failures leave the sandbox live and do not throw", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const sandbox = sandboxWith("running");
+		sandbox.stop.mockRejectedValueOnce(new Error("api timeout"));
+
+		const state = await resolveSandboxState(
+			{
+				...PARKED_SESSION,
+				lastActivityAt: new Date(
+					NOW.getTime() - ADAPTIVE_IDLE_STOP_MS - 1_000,
+				).toISOString(),
+			},
+			async () => sandbox,
+			{ now: NOW },
+		);
+
+		expect(sandbox.stop).toHaveBeenCalledTimes(1);
+		expect(state).toEqual({ state: "live" });
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("adaptive idle-stop failed"),
+		);
+		warn.mockRestore();
 	});
 
 	test.each(["stopping", "stopped", "snapshotting"])(

--- a/web-next/src/lib/agent-runtime/sandbox-state.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-state.test.ts
@@ -8,10 +8,12 @@
 import { describe, expect, test, vi } from "vitest";
 import {
 	ADAPTIVE_IDLE_STOP_MS,
+	isCurrentTurnSettled,
 	type LifecycleSandbox,
 	resolveSandboxState,
 	stopSessionSandbox,
 } from "./sandbox-state";
+import type { StreamChunk } from "./stream-chunk";
 import { sessionSandboxName } from "./vercel-provider";
 
 const PARKED_SESSION = {
@@ -26,6 +28,14 @@ function sandboxWith(status: string): LifecycleSandbox & { stop: ReturnType<type
 		status,
 		stop: vi.fn(async () => ({})),
 	};
+}
+
+function event(
+	seq: number,
+	role: "user" | "assistant",
+	chunk: StreamChunk,
+): { seq: number; role: "user" | "assistant"; chunk: StreamChunk } {
+	return { seq, role, chunk };
 }
 
 describe("resolveSandboxState", () => {
@@ -78,6 +88,10 @@ describe("resolveSandboxState", () => {
 
 	test("a live sandbox past the adaptive idle window is stopped and reported parked", async () => {
 		const sandbox = sandboxWith("running");
+		const currentTurnSettled = isCurrentTurnSettled([
+			event(1, "user", { type: "text", content: "build it" }),
+			event(2, "assistant", { type: "done", content: "" }),
+		]);
 		const state = await resolveSandboxState(
 			{
 				...PARKED_SESSION,
@@ -86,11 +100,37 @@ describe("resolveSandboxState", () => {
 				).toISOString(),
 			},
 			async () => sandbox,
-			{ now: NOW },
+			{ now: NOW, currentTurnSettled },
 		);
 
 		expect(sandbox.stop).toHaveBeenCalledTimes(1);
 		expect(state).toEqual({ state: "parked", detail: "stopped" });
+	});
+
+	test("a live sandbox past the adaptive idle window stays live while the current turn is unsettled", async () => {
+		const sandbox = sandboxWith("running");
+		const currentTurnSettled = isCurrentTurnSettled([
+			event(1, "user", { type: "text", content: "run the long build" }),
+			event(2, "assistant", {
+				type: "tool_use",
+				content: "pnpm build",
+			}),
+		]);
+
+		const state = await resolveSandboxState(
+			{
+				...PARKED_SESSION,
+				lastActivityAt: new Date(
+					NOW.getTime() - ADAPTIVE_IDLE_STOP_MS - 1_000,
+				).toISOString(),
+			},
+			async () => sandbox,
+			{ now: NOW, currentTurnSettled },
+		);
+
+		expect(currentTurnSettled).toBe(false);
+		expect(sandbox.stop).not.toHaveBeenCalled();
+		expect(state).toEqual({ state: "live" });
 	});
 
 	test("adaptive idle-stop failures leave the sandbox live and do not throw", async () => {
@@ -106,7 +146,7 @@ describe("resolveSandboxState", () => {
 				).toISOString(),
 			},
 			async () => sandbox,
-			{ now: NOW },
+			{ now: NOW, currentTurnSettled: true },
 		);
 
 		expect(sandbox.stop).toHaveBeenCalledTimes(1);

--- a/web-next/src/lib/agent-runtime/sandbox-state.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-state.ts
@@ -1,11 +1,12 @@
 /*
  * The session's sandbox lifecycle, truthfully (#753): resolve the parked
  * Vercel sandbox's real status into the three states the masthead surfaces
- * (live / parked / none), and stop a live one on request. Point-in-time
- * facts checked against the platform, never inferred from what the UI hopes
- * is true — the same honesty contract as the terminal drawer's
- * `resolveLiveSandbox` (#752), with which this shares the name derivation
- * and the "a stale/absent handle reads as none, calmly" behavior.
+ * (live / parked / none), stop a live one on request, and opportunistically
+ * stop warm parked VMs after a short idle window. Point-in-time facts are
+ * checked against the platform, never inferred from what the UI hopes is true
+ * — the same honesty contract as the terminal drawer's `resolveLiveSandbox`
+ * (#752), with which this shares the name derivation and the "a stale/absent
+ * handle reads as none, calmly" behavior.
  *
  * Why stop is the only control: the Vercel sandbox API has no pause/freeze —
  * `Sandbox.stop()` ends the VM (optionally snapshotting), and resumption
@@ -14,6 +15,13 @@
  */
 import { sessionSandboxName } from "./vercel-provider";
 import type { Session } from "../db/sessions";
+
+/**
+ * Adaptive idle-stop window for parked live VMs (#970). Five minutes keeps
+ * quick follow-up turns warm while cutting the old 30-minute idle billing
+ * window by roughly 6x when the session page is open and refreshing state.
+ */
+export const ADAPTIVE_IDLE_STOP_MS = 5 * 60 * 1000;
 
 /** The slice of @vercel/sandbox's Sandbox the lifecycle path touches. */
 export interface LifecycleSandbox {
@@ -37,6 +45,11 @@ export type SandboxState =
 	| { state: "parked"; detail: string }
 	| { state: "none"; detail: string };
 
+export interface ResolveSandboxStateOptions {
+	now?: Date;
+	idleStopAfterMs?: number;
+}
+
 const LIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
 const PARKED_STATUSES: ReadonlySet<string> = new Set([
 	"stopping",
@@ -59,8 +72,10 @@ async function defaultGetSandbox(name: string): Promise<LifecycleSandbox> {
 
 /** The session's sandbox state, checked against the platform right now. */
 export async function resolveSandboxState(
-	session: Pick<Session, "claudeSessionId" | "resumeState">,
+	session: Pick<Session, "claudeSessionId" | "resumeState"> &
+		Partial<Pick<Session, "lastActivityAt">>,
 	getSandbox: GetLifecycleSandbox = defaultGetSandbox,
+	options: ResolveSandboxStateOptions = {},
 ): Promise<SandboxState> {
 	if (!session.claudeSessionId || !session.resumeState) {
 		return { state: "none", detail: "no turn has started a sandbox yet" };
@@ -71,11 +86,41 @@ export async function resolveSandboxState(
 	} catch {
 		return { state: "none", detail: "the session's sandbox has expired" };
 	}
-	if (LIVE_STATUSES.has(sandbox.status)) return { state: "live" };
+	if (LIVE_STATUSES.has(sandbox.status)) {
+		if (shouldStopForIdle(session, options)) {
+			try {
+				await sandbox.stop();
+				return { state: "parked", detail: "stopped" };
+			} catch (error) {
+				console.warn(
+					`[sandbox-state] adaptive idle-stop failed for ${sandbox.name}: ${errorMessage(error)}`,
+				);
+			}
+		}
+		return { state: "live" };
+	}
 	if (PARKED_STATUSES.has(sandbox.status)) {
 		return { state: "parked", detail: sandbox.status };
 	}
 	return { state: "none", detail: `the session's sandbox is ${sandbox.status}` };
+}
+
+function shouldStopForIdle(
+	session: Partial<Pick<Session, "lastActivityAt">>,
+	options: ResolveSandboxStateOptions,
+): boolean {
+	if (!session.lastActivityAt) return false;
+	const lastActivityMs = Date.parse(session.lastActivityAt);
+	if (!Number.isFinite(lastActivityMs)) return false;
+	const idleStopAfterMs = options.idleStopAfterMs ?? ADAPTIVE_IDLE_STOP_MS;
+	if (idleStopAfterMs <= 0) return true;
+	const nowMs = (options.now ?? new Date()).getTime();
+	return nowMs - lastActivityMs >= idleStopAfterMs;
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	return String(error);
 }
 
 /**

--- a/web-next/src/lib/agent-runtime/sandbox-state.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-state.ts
@@ -14,7 +14,9 @@
  * pause button would be a fake; stop is real, so stop is what ships.
  */
 import { sessionSandboxName } from "./vercel-provider";
-import type { Session } from "../db/sessions";
+import type { DatabaseHandle } from "../db/client";
+import { readEvents, type Session } from "../db/sessions";
+import type { ProjectedEvent } from "../transcript/project-events";
 
 /**
  * Adaptive idle-stop window for parked live VMs (#970). Five minutes keeps
@@ -48,6 +50,7 @@ export type SandboxState =
 export interface ResolveSandboxStateOptions {
 	now?: Date;
 	idleStopAfterMs?: number;
+	currentTurnSettled?: boolean;
 }
 
 const LIVE_STATUSES: ReadonlySet<string> = new Set(["running", "pending"]);
@@ -109,6 +112,7 @@ function shouldStopForIdle(
 	session: Partial<Pick<Session, "lastActivityAt">>,
 	options: ResolveSandboxStateOptions,
 ): boolean {
+	if (options.currentTurnSettled !== true) return false;
 	if (!session.lastActivityAt) return false;
 	const lastActivityMs = Date.parse(session.lastActivityAt);
 	if (!Number.isFinite(lastActivityMs)) return false;
@@ -116,6 +120,41 @@ function shouldStopForIdle(
 	if (idleStopAfterMs <= 0) return true;
 	const nowMs = (options.now ?? new Date()).getTime();
 	return nowMs - lastActivityMs >= idleStopAfterMs;
+}
+
+/**
+ * Idle-stop invariant (#970): never stop a sandbox while the current turn is
+ * unsettled. The durable `session_events` log is the authority because the
+ * polling state GET may land on a different Vercel instance than the detached
+ * ingest loop. A turn is settled only when assistant events after the last
+ * user event contain the terminal `done` chunk that turn-ingest also appends
+ * for error/abort paths.
+ *
+ * If a runner crashes and never appends `done`, this deliberately leaves the
+ * sandbox live until the platform's SANDBOX_TIMEOUT_MS cap (30 minutes).
+ */
+export function isCurrentTurnSettled(
+	events: readonly Pick<ProjectedEvent, "seq" | "role" | "chunk">[],
+): boolean {
+	let lastUserSeq = 0;
+	for (const event of events) {
+		if (event.role === "user") lastUserSeq = event.seq;
+	}
+	if (lastUserSeq === 0) return true;
+	return events.some(
+		(event) =>
+			event.seq > lastUserSeq &&
+			event.role === "assistant" &&
+			event.chunk.type === "done",
+	);
+}
+
+/** Reads the durable log and classifies whether the session's current turn settled. */
+export async function readCurrentTurnSettled(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<boolean> {
+	return isCurrentTurnSettled(await readEvents(handle, sessionId));
 }
 
 function errorMessage(error: unknown): string {

--- a/web-next/src/lib/agent-runtime/vercel-provider.ts
+++ b/web-next/src/lib/agent-runtime/vercel-provider.ts
@@ -9,11 +9,12 @@
  * open a PR against it. The turn is driven by the user's actual message.
  *
  * Sessions are durable: after each turn the harness session is `detach()`-ed
- * (parked with the sandbox left running) and its resume payload persisted; the
- * next turn reconnects that warm session so the conversation and working copy
- * continue. Reconnect is bounded by the sandbox lifetime — once it expires the
- * turn falls back to a fresh clone. Heavy deps load lazily so the seam stays
- * light for the mock path; sessions opt in via sessions.provider = "vercel".
+ * and its resume payload persisted; the next turn reconnects that warm session
+ * so the conversation and working copy continue. The lifecycle state endpoint
+ * may stop an idle parked VM after a short warm window (#970); once the harness
+ * session is unresumable, the turn falls back to a fresh clone plus replayed
+ * context. Heavy deps load lazily so the seam stays light for the mock path;
+ * sessions opt in via sessions.provider = "vercel".
  */
 import type { HarnessAgentSandboxConfig } from "@ai-sdk/harness/agent";
 import { mintInstallationToken } from "../diag/github-app";
@@ -47,9 +48,8 @@ const BRIDGE_PORT = 4000;
  */
 export const TERMINAL_PORT = 7681;
 /**
- * Max sandbox lifetime. Also the resume window: a parked (detached) session
- * reconnects only while its sandbox is still alive, so this bounds how long a
- * conversation can idle between turns before the next turn re-clones fresh.
+ * Max sandbox lifetime. Adaptive idle-stop normally cuts parked VMs off much
+ * sooner, but this remains the platform backstop if no sweeper observes them.
  */
 const SANDBOX_TIMEOUT_MS = 30 * 60 * 1000;
 /** The persistent per-session working copy: name under the sandbox default cwd. */
@@ -1015,10 +1015,9 @@ export function parseGitDiff(raw: string): FileDiff[] {
 }
 
 /**
- * Detaches the session (parks it with the sandbox left running) under the id
- * that names its sandbox, and returns the handle to persist for the next turn —
- * or null when parking fails, so the caller tears the session down and clears
- * any stored handle.
+ * Detaches the session under the id that names its sandbox, and returns the
+ * handle to persist for the next turn — or null when parking fails, so the
+ * caller tears the session down and clears any stored handle.
  */
 async function parkSession(
 	session: { detach: () => Promise<unknown> },


### PR DESCRIPTION
Closes #970.

Parked sandboxes were idling against the full 30-minute `SANDBOX_TIMEOUT_MS`, burning ~$0.08 of Provisioned Memory per park window at 4 vCPU/8 GB even at zero CPU. This ships **adaptive idle-stop**: a parked-but-live VM is stopped once the session has been idle ≥ 5 minutes, guarded so it can never fire under a running turn.

## Why not stop-on-park

The originally preferred policy (stop immediately in the turn tail) was live-probed first and rejected on evidence:

- Filesystem snapshot/resume works: `sandbox.stop()` returned in ~6.5 s (snapshot captured), raw SDK resume to a working `runCommand` in **4.9 s**, marker file intact.
- But a detached **harness session does not survive an explicit stop**: harness resume hung and was aborted after ~121 s; no continuation turn ran.

So the turn tail stays detach-only (warm VM for quick follow-ups) and the sweep happens after the idle window. Probe methodology and measurements are in the worker's report; the probe script ran against real Vercel creds and cleaned up after itself.

## What changed

- `sandbox-state.ts`: `ADAPTIVE_IDLE_STOP_MS = 5 min`; `resolveSandboxState` opportunistically stops a live parked sandbox when the session is idle past the window. Stop failures log and leave the honest `live` state.
- **Mid-turn guard** (coordinator review finding): `last_activity_at` bumps per streamed chunk, but a single long tool call is chunk-silent — and the client polls this route every 10 s during turns, so an unguarded sweep would kill the sandbox under a live harness turn. The sweep now requires `isCurrentTurnSettled` derived from the durable `session_events` log (a terminal `done` after the last user event — appended on completion, stream-end, and error/abort paths alike). Fail-safe default: no settled verdict, no stop. A hard-crashed turn that never settles is capped by the sandbox's own 30-minute timeout.
- `GET /api/sessions/[id]/sandbox` computes the settled verdict and acts as the sweeper; DELETE unchanged.
- Masthead copy: stopped state reads "sandbox stopped; resumes next message" — stopped is the healthy resting state, and the UI says so calmly.

## Mergeability

- **Surface**: web-next sandbox lifecycle — `sandbox-state.ts`, the sandbox state route, masthead label copy. Turn tail behavior unchanged (still detach-only).
- **Behavior changed**: sessions idle ≥ 5 minutes with the page open get their VM stopped (~$0.01 vs ~$0.08 per park window); next message resumes via the existing fresh-fallback + context replay (#969).
- **Non-happy paths**: sweep never fires while a turn is unsettled (long chunk-silent tool calls covered); stop failure leaves honest `live` state and logs; missing/invalid `lastActivityAt` disables the sweep; crashed turns fall through to the platform timeout.
- **Residual risk**: browser-closed (fire-and-forget) sessions are never polled, so they still ride the full 30-minute window — status quo, filed as #999 (cron sweeper reusing the same guarded path). The 5-minute window is a judgment call balancing warm follow-up turns against burn.

## Verification

- `pnpm test`: **42 files, 471 passed** (new: idle-stop behavior, settled-turn guard incl. unsettled `tool_use` staying live, stopped-state copy, route sweeping)
- `pnpm typecheck` / `pnpm lint` / `pnpm build`: all pass
- Mutation checks (worker): removed the sweeper `stop()` → idle-stop tests fail; removed the settled guard → mid-turn test fails; both restored, green.
- Live probe on real infra (see above).

Evidence: ![cost-policy-tests](https://evidence.cloudcompute.com/workspaces/pr-1001/20260708-180216-cost-policy-tests.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
