### PR TITLE
feat(web-next): session list search, filters, and keyboard resume (#986)

### DIFF
--- a/CODEX_REPORT.md
+++ b/CODEX_REPORT.md
@@ -1,0 +1,39 @@
+# Issue #986 report
+
+## What changed
+
+- Made the `web-next` sessions home searchable and filterable while preserving the calm Folio front door: one masthead, one list, and a quiet filter strip.
+- Added DB-backed search across session titles and the projected first user message, with repo and persisted-state filters.
+- Added keyboard resume ergonomics:
+  - `/` focuses session search when focus is not already in an input/select/textarea/contenteditable element.
+  - Arrow keys move a visible selected row.
+  - Enter opens the selected session.
+  - The search input itself supports ArrowUp/ArrowDown/Enter for the intended keyboard path after `/`.
+- Kept row metadata cheap: the home list still comes from one sessions/repo list query, with no per-row event reads.
+
+## Shape and schema
+
+- Added migration `0007_session_first_user_message`.
+- Added nullable `sessions.first_user_message`, backfilled from the first user text event via `session_events` and maintained during `appendEvents` / `appendEventsIfTurnOpen`.
+- Used the actual persisted session statuses in this tree: `active`, `idle`, `archived`. I did not invent `running` / `parked` / `failed` / `done` state values because the session row schema does not store them.
+- Updated `docs/schema.md` for the new column and also documented the already-existing `owner_login` column that was missing from the table.
+
+## Verification
+
+- `npx pnpm@10 install` passed.
+- `pnpm test` passed: 40 files, 466 tests.
+- `pnpm typecheck` passed after the final restore.
+- `pnpm lint` passed.
+- `pnpm build` passed. It emitted the existing Better Auth / `jose` Edge Runtime warning for `CompressionStream` / `DecompressionStream`.
+- `E2E_PORT=3186 pnpm test:e2e` final run passed: 44 tests.
+
+## Mutation check
+
+- Temporarily changed the title search predicate from `like` to `not like`.
+- Confirmed `pnpm test src/lib/db/sessions.test.ts` failed in `listSessions searches titles and projected first user messages, filters, and keeps last activity order`.
+- Restored the predicate and reran `pnpm test src/lib/db/sessions.test.ts`: 17 tests passed.
+
+## Deviations
+
+- The first full E2E run had one transient mobile helper timeout while creating a session. The failure occurred before any #986 assertion; the captured state showed the new-session server action pending. A rerun of the relevant subset passed, and the final full `E2E_PORT=3186 pnpm test:e2e` passed all 44 tests.
+- No GitHub issue, push, or PR action was performed.

--- a/web-next/docs/schema.md
+++ b/web-next/docs/schema.md
@@ -42,7 +42,9 @@ that log, never stored here.
 |---|---|---|
 | `id` | text PK | Session id. |
 | `repo_id` | text? | `repos.id` this session runs against; null until bound. |
+| `owner_login` | text? | GitHub login that created the session; null for legacy grandfathered rows (migration `0006_session_owner_login`). |
 | `title` | text | Display title; `""` until named. Auto-titled from the first user message's first line at turn-start (`titleSessionIfEmpty`, `src/lib/agent-runtime/turn-ingest.ts`, #823) via a `WHERE title = ''` conditional update — idempotent, and skipped when that line has no usable text (session stays untitled for a later turn). User edits go through `PATCH /api/sessions/[id]` (`updateSession`, unconditional) and are never overwritten by the auto-titler once set. Derivation rules (cleaning, length cap) live in `src/lib/session-title.ts`, shared by both paths. |
+| `first_user_message` | text? | First user-authored text chunk, projected from `session_events` by migration `0007_session_first_user_message` and maintained by `appendEvents`. Used for cheap sessions-home search without per-row event-log reads. |
 | `provider` | text | Compute provider id — `mock` \| `vercel` \| `anthropic` \| … |
 | `status` | text | Lifecycle — `active` \| `idle` \| `archived` (owned by #749/#750). |
 | `claude_session_id` | text? | Harness/Claude session id for resume; null until a real turn parks one. |

--- a/web-next/src/app/(app)/page.tsx
+++ b/web-next/src/app/(app)/page.tsx
@@ -3,53 +3,33 @@
  * the quiet new-session flow. This is the app's front door — everything on
  * it stays calm: one masthead, one list, one affordance.
  */
-import Link from "next/link";
 import { ThemeToggle } from "@/components/folio/theme-toggle";
 import { getDatabase } from "@/lib/db/client";
-import { listSessions, type SessionListItem } from "@/lib/db/sessions";
-import { formatRelativeTime } from "@/lib/relative-time";
+import { listSessionFilterOptions, listSessions } from "@/lib/db/sessions";
 import { NewSession } from "./new-session";
+import { SessionsHomeList } from "./sessions-home-list";
 import { SignOutButton } from "./sign-out-button";
 
-function SessionRow({ session, index }: { session: SessionListItem; index: number }) {
-	return (
-		<li
-			className="animate-rise border-b border-line"
-			style={index < 6 ? { animationDelay: `${0.03 + index * 0.05}s` } : undefined}
-		>
-			<Link
-				href={`/sessions/${session.id}`}
-				className="group block px-2.5 py-[16px]"
-			>
-				{session.title ? (
-					<span className="font-serif text-body text-ink transition-colors group-hover:text-accent">
-						{session.title}
-					</span>
-				) : (
-					<span className="font-serif text-body text-hint italic transition-colors group-hover:text-accent">
-						Untitled session
-					</span>
-				)}
-				<span className="mt-1 flex items-baseline gap-[9px] font-mono text-caption text-muted">
-					{session.repoFullName ?? "no repository"}
-					<span className="text-faint">·</span>
-					{formatRelativeTime(session.lastActivityAt)}
-					{session.status !== "active" && (
-						<>
-							<span className="text-faint">·</span>
-							<span className="text-hint">{session.status}</span>
-						</>
-					)}
-				</span>
-			</Link>
-		</li>
-	);
+interface SessionsHomeProps {
+	searchParams?: Promise<{
+		q?: string;
+		repo?: string;
+		status?: string;
+	}>;
 }
 
-export default async function SessionsHome() {
+export default async function SessionsHome({ searchParams }: SessionsHomeProps) {
 	const handle = getDatabase();
-	const sessions = await listSessions(handle);
+	const params = (await searchParams) ?? {};
+	const query = params.q?.trim() ?? "";
+	const repoId = params.repo ?? "";
+	const status = params.status ?? "";
+	const [sessions, filters] = await Promise.all([
+		listSessions(handle, { query, repoId, status }),
+		listSessionFilterOptions(handle),
+	]);
 	const isEmpty = sessions.length === 0;
+	const hasFilters = query || repoId || status;
 
 	return (
 		<>
@@ -62,7 +42,7 @@ export default async function SessionsHome() {
 				</span>
 			</header>
 			<main className="mx-auto max-w-[680px] px-5 pt-[72px] pb-16">
-				{isEmpty ? (
+				{isEmpty && !hasFilters ? (
 					<div className="animate-rise flex flex-col items-center pt-[14vh]">
 						<p className="font-serif text-body text-muted italic">
 							No sessions yet.
@@ -79,15 +59,13 @@ export default async function SessionsHome() {
 						<h1 className="mb-2 px-2.5 font-mono text-label font-medium tracking-[.16em] text-hint uppercase">
 							Sessions
 						</h1>
-						<ul>
-							{sessions.map((session, index) => (
-								<SessionRow key={session.id} session={session} index={index} />
-							))}
-						</ul>
-						{/* The list ends in a quiet invitation, not a persistent button. */}
-						<div className="mt-4 px-2.5">
-							<NewSession />
-						</div>
+						<SessionsHomeList
+							sessions={sessions}
+							filters={filters}
+							initialQuery={query}
+							initialRepoId={repoId}
+							initialStatus={status}
+						/>
 					</>
 				)}
 			</main>

--- a/web-next/src/app/(app)/page.tsx
+++ b/web-next/src/app/(app)/page.tsx
@@ -11,19 +11,20 @@ import { SessionsHomeList } from "./sessions-home-list";
 import { SignOutButton } from "./sign-out-button";
 
 interface SessionsHomeProps {
-	searchParams?: Promise<{
-		q?: string;
-		repo?: string;
-		status?: string;
-	}>;
+	searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+/** Next hands repeated params (`?q=a&q=b`) through as arrays; take the first. */
+function firstParam(value: string | string[] | undefined): string {
+	return (Array.isArray(value) ? value[0] : value) ?? "";
 }
 
 export default async function SessionsHome({ searchParams }: SessionsHomeProps) {
 	const handle = getDatabase();
 	const params = (await searchParams) ?? {};
-	const query = params.q?.trim() ?? "";
-	const repoId = params.repo ?? "";
-	const status = params.status ?? "";
+	const query = firstParam(params.q).trim();
+	const repoId = firstParam(params.repo);
+	const status = firstParam(params.status);
 	const [sessions, filters] = await Promise.all([
 		listSessions(handle, { query, repoId, status }),
 		listSessionFilterOptions(handle),

--- a/web-next/src/app/(app)/sessions-home-list.tsx
+++ b/web-next/src/app/(app)/sessions-home-list.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+/*
+ * Keyboard-first sessions-home list: a quiet filter strip plus visible row
+ * selection. The server owns the data query; this component only reflects
+ * controls into URL params and opens the selected session.
+ */
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+	type KeyboardEvent,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import type {
+	SessionListFilterOptions,
+	SessionListItem,
+} from "@/lib/db/sessions";
+import { formatRelativeTime } from "@/lib/relative-time";
+import { NewSession } from "./new-session";
+
+interface SessionsHomeListProps {
+	sessions: SessionListItem[];
+	filters: SessionListFilterOptions;
+	initialQuery: string;
+	initialRepoId: string;
+	initialStatus: string;
+}
+
+function isTextInput(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	const tag = target.tagName.toLowerCase();
+	return (
+		tag === "input" ||
+		tag === "textarea" ||
+		tag === "select" ||
+		target.isContentEditable
+	);
+}
+
+function SessionRow({
+	session,
+	index,
+	selected,
+	onSelect,
+}: {
+	session: SessionListItem;
+	index: number;
+	selected: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<li
+			className="animate-rise border-b border-line"
+			style={index < 6 ? { animationDelay: `${0.03 + index * 0.05}s` } : undefined}
+		>
+			<Link
+				href={`/sessions/${session.id}`}
+				aria-current={selected ? "page" : undefined}
+				data-selected={selected ? "true" : undefined}
+				onMouseEnter={onSelect}
+				className="group block rounded-md px-2.5 py-[16px] outline-none transition-colors hover:bg-hover-bg focus-visible:bg-selected-bg data-[selected=true]:bg-selected-bg"
+			>
+				{session.title ? (
+					<span className="font-serif text-body text-ink transition-colors group-hover:text-accent group-focus-visible:text-accent">
+						{session.title}
+					</span>
+				) : (
+					<span className="font-serif text-body text-hint italic transition-colors group-hover:text-accent group-focus-visible:text-accent">
+						Untitled session
+					</span>
+				)}
+				<span className="mt-1 flex flex-wrap items-baseline gap-[9px] font-mono text-caption text-muted">
+					{session.repoFullName ?? "no repository"}
+					<span className="text-faint">·</span>
+					{formatRelativeTime(session.lastActivityAt)}
+					{session.status !== "active" && (
+						<>
+							<span className="text-faint">·</span>
+							<span className="text-hint">{session.status}</span>
+						</>
+					)}
+				</span>
+			</Link>
+		</li>
+	);
+}
+
+export function SessionsHomeList({
+	sessions,
+	filters,
+	initialQuery,
+	initialRepoId,
+	initialStatus,
+}: SessionsHomeListProps) {
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const searchRef = useRef<HTMLInputElement>(null);
+	const [query, setQuery] = useState(initialQuery);
+	const [selectedIndex, setSelectedIndex] = useState(sessions.length > 0 ? 0 : -1);
+
+	useEffect(() => setQuery(initialQuery), [initialQuery]);
+	useEffect(() => {
+		setSelectedIndex((current) => {
+			if (sessions.length === 0) return -1;
+			if (current < 0) return 0;
+			return Math.min(current, sessions.length - 1);
+		});
+	}, [sessions.length]);
+
+	const replaceParams = useCallback(
+		(next: { q?: string; repo?: string; status?: string }) => {
+			const params = new URLSearchParams(searchParams);
+			for (const [key, value] of Object.entries(next)) {
+				if (value) params.set(key, value);
+				else params.delete(key);
+			}
+			const suffix = params.toString();
+			router.replace(suffix ? `${pathname}?${suffix}` : pathname, { scroll: false });
+		},
+		[pathname, router, searchParams],
+	);
+
+	useEffect(() => {
+		const handle = window.setTimeout(() => {
+			if (query !== initialQuery) replaceParams({ q: query.trim() });
+		}, 120);
+		return () => window.clearTimeout(handle);
+	}, [initialQuery, query, replaceParams]);
+
+	const openSelected = useCallback(() => {
+		const selected = sessions[selectedIndex];
+		if (selected) router.push(`/sessions/${selected.id}`);
+	}, [router, selectedIndex, sessions]);
+
+	useEffect(() => {
+		const onKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (isTextInput(event.target)) return;
+			if (event.key === "/") {
+				event.preventDefault();
+				searchRef.current?.focus();
+				searchRef.current?.select();
+				return;
+			}
+			if (event.key === "ArrowDown" && sessions.length > 0) {
+				event.preventDefault();
+				setSelectedIndex((current) => Math.min(current + 1, sessions.length - 1));
+				return;
+			}
+			if (event.key === "ArrowUp" && sessions.length > 0) {
+				event.preventDefault();
+				setSelectedIndex((current) => Math.max(current - 1, 0));
+				return;
+			}
+			if (event.key === "Enter") {
+				openSelected();
+			}
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [openSelected, sessions.length]);
+
+	const resultLabel = useMemo(() => {
+		if (sessions.length === 1) return "1 session";
+		return `${sessions.length} sessions`;
+	}, [sessions.length]);
+
+	function onSearchKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+		if (event.key === "ArrowDown" && sessions.length > 0) {
+			event.preventDefault();
+			setSelectedIndex((current) => Math.min(current + 1, sessions.length - 1));
+		}
+		if (event.key === "ArrowUp" && sessions.length > 0) {
+			event.preventDefault();
+			setSelectedIndex((current) => Math.max(current - 1, 0));
+		}
+		if (event.key === "Enter") {
+			event.preventDefault();
+			openSelected();
+		}
+	}
+
+	return (
+		<>
+			<div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-2 px-2.5 font-mono text-caption text-hint">
+				<label className="flex min-w-[210px] flex-1 items-center gap-2 border-b border-line py-1 transition-colors focus-within:border-focus-line">
+					<span aria-hidden className="text-faint">
+						/
+					</span>
+					<input
+						ref={searchRef}
+						type="search"
+						value={query}
+						onChange={(event) => setQuery(event.target.value)}
+						onKeyDown={onSearchKeyDown}
+						aria-label="Search sessions"
+						placeholder="search sessions"
+						spellCheck={false}
+						className="min-w-0 flex-1 bg-transparent font-mono text-caption text-ink outline-none placeholder:text-hint"
+					/>
+				</label>
+				<select
+					aria-label="Filter by repository"
+					value={initialRepoId}
+					onChange={(event) => replaceParams({ repo: event.target.value })}
+					className="max-w-[210px] bg-transparent font-mono text-caption text-hint outline-none hover:text-accent focus:text-accent"
+				>
+					<option value="">all repos</option>
+					{filters.repos.map((repo) => (
+						<option key={repo.value} value={repo.value}>
+							{repo.label} ({repo.count})
+						</option>
+					))}
+				</select>
+				<select
+					aria-label="Filter by state"
+					value={initialStatus}
+					onChange={(event) => replaceParams({ status: event.target.value })}
+					className="bg-transparent font-mono text-caption text-hint outline-none hover:text-accent focus:text-accent"
+				>
+					<option value="">all states</option>
+					{filters.statuses.map((status) => (
+						<option key={status.value} value={status.value}>
+							{status.label} ({status.count})
+						</option>
+					))}
+				</select>
+				<span className="ml-auto text-faint">{resultLabel}</span>
+			</div>
+			{sessions.length > 0 ? (
+				<ul>
+					{sessions.map((session, index) => (
+						<SessionRow
+							key={session.id}
+							session={session}
+							index={index}
+							selected={index === selectedIndex}
+							onSelect={() => setSelectedIndex(index)}
+						/>
+					))}
+				</ul>
+			) : (
+				<p className="px-2.5 py-10 font-serif text-body text-muted italic">
+					No matching sessions.
+				</p>
+			)}
+			{/* The list ends in a quiet invitation, not a persistent button. */}
+			<div className="mt-4 px-2.5">
+				<NewSession />
+			</div>
+		</>
+	);
+}

--- a/web-next/src/app/(app)/sessions-home-list.tsx
+++ b/web-next/src/app/(app)/sessions-home-list.tsx
@@ -6,7 +6,7 @@
  * controls into URL params and opens the selected session.
  */
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
 	type KeyboardEvent,
 	useCallback,
@@ -103,7 +103,6 @@ export function SessionsHomeList({
 }: SessionsHomeListProps) {
 	const router = useRouter();
 	const pathname = usePathname();
-	const searchParams = useSearchParams();
 	const searchRef = useRef<HTMLInputElement>(null);
 	const [query, setQuery] = useState(initialQuery);
 	const [selectedIndex, setSelectedIndex] = useState(sessions.length > 0 ? 0 : -1);
@@ -124,17 +123,26 @@ export function SessionsHomeList({
 
 	const replaceParams = useCallback(
 		(next: { q?: string; repo?: string; status?: string }) => {
-			const params = new URLSearchParams(searchParams);
-			// Local query state rides along on every change, so a filter picked
+			// Built from the server-passed values + local state, NOT
+			// useSearchParams: reading search params from a client component
+			// opts the page out of static server paint (CSR bailout), which
+			// showed up as a 2x route_home LCP regression in the perf floor.
+			// Local query rides along on every change, so a filter picked
 			// before the search debounce fires can't drop the pending text.
-			for (const [key, value] of Object.entries({ q: query.trim(), ...next })) {
+			const params = new URLSearchParams();
+			const merged = {
+				q: query.trim(),
+				repo: initialRepoId,
+				status: initialStatus,
+				...next,
+			};
+			for (const [key, value] of Object.entries(merged)) {
 				if (value) params.set(key, value);
-				else params.delete(key);
 			}
 			const suffix = params.toString();
 			router.replace(suffix ? `${pathname}?${suffix}` : pathname, { scroll: false });
 		},
-		[pathname, query, router, searchParams],
+		[initialRepoId, initialStatus, pathname, query, router],
 	);
 
 	useEffect(() => {

--- a/web-next/src/app/(app)/sessions-home-list.tsx
+++ b/web-next/src/app/(app)/sessions-home-list.tsx
@@ -41,6 +41,12 @@ function isTextInput(target: EventTarget | null): boolean {
 	);
 }
 
+/** Enter must stay with a focused control (button, link, …), not open a row. */
+function isInteractive(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	return target.closest("a, button, [role='button'], summary") !== null;
+}
+
 function SessionRow({
 	session,
 	index,
@@ -59,7 +65,6 @@ function SessionRow({
 		>
 			<Link
 				href={`/sessions/${session.id}`}
-				aria-current={selected ? "page" : undefined}
 				data-selected={selected ? "true" : undefined}
 				onMouseEnter={onSelect}
 				className="group block rounded-md px-2.5 py-[16px] outline-none transition-colors hover:bg-hover-bg focus-visible:bg-selected-bg data-[selected=true]:bg-selected-bg"
@@ -103,7 +108,12 @@ export function SessionsHomeList({
 	const [query, setQuery] = useState(initialQuery);
 	const [selectedIndex, setSelectedIndex] = useState(sessions.length > 0 ? 0 : -1);
 
-	useEffect(() => setQuery(initialQuery), [initialQuery]);
+	// Sync from the URL only while the user isn't mid-keystroke: an older
+	// debounced replace's RSC payload must not clobber newer typed input.
+	useEffect(() => {
+		if (document.activeElement === searchRef.current) return;
+		setQuery(initialQuery);
+	}, [initialQuery]);
 	useEffect(() => {
 		setSelectedIndex((current) => {
 			if (sessions.length === 0) return -1;
@@ -115,14 +125,16 @@ export function SessionsHomeList({
 	const replaceParams = useCallback(
 		(next: { q?: string; repo?: string; status?: string }) => {
 			const params = new URLSearchParams(searchParams);
-			for (const [key, value] of Object.entries(next)) {
+			// Local query state rides along on every change, so a filter picked
+			// before the search debounce fires can't drop the pending text.
+			for (const [key, value] of Object.entries({ q: query.trim(), ...next })) {
 				if (value) params.set(key, value);
 				else params.delete(key);
 			}
 			const suffix = params.toString();
 			router.replace(suffix ? `${pathname}?${suffix}` : pathname, { scroll: false });
 		},
-		[pathname, router, searchParams],
+		[pathname, query, router, searchParams],
 	);
 
 	useEffect(() => {
@@ -156,7 +168,7 @@ export function SessionsHomeList({
 				setSelectedIndex((current) => Math.max(current - 1, 0));
 				return;
 			}
-			if (event.key === "Enter") {
+			if (event.key === "Enter" && !isInteractive(event.target)) {
 				openSelected();
 			}
 		};

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -40,6 +40,8 @@ export interface SessionsTable {
 	/** GitHub login that created the session; null for legacy grandfathered rows. */
 	owner_login: string | null;
 	title: string;
+	/** First user-authored text chunk, projected for cheap sessions-home search. */
+	first_user_message: string | null;
 	/** Compute provider id — "mock" | "vercel" | "anthropic" | … */
 	provider: string;
 	/** Lifecycle state — "active" | "idle" | "archived" (owned by #749/#750). */

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -236,6 +236,42 @@ const sessionOwnerLogin: Migration = {
 	},
 };
 
+/**
+ * Adds `sessions.first_user_message` — the first user text chunk projected out
+ * of the append-only log so sessions-home search can stay one list query
+ * instead of probing `session_events` per row.
+ */
+const sessionFirstUserMessage: Migration = {
+	id: "0007_session_first_user_message",
+	async up(db) {
+		const info = await sql<{
+			name: string;
+		}>`PRAGMA table_info(sessions)`.execute(db);
+		const hasColumn = info.rows.some((row) => row.name === "first_user_message");
+		if (!hasColumn) {
+			await db.schema
+				.alterTable("sessions")
+				.addColumn("first_user_message", "text")
+				.execute();
+		}
+		await sql`
+			UPDATE sessions
+			SET first_user_message = (
+				SELECT json_extract(session_events.payload, '$.content')
+				FROM session_events
+				WHERE session_events.session_id = sessions.id
+					AND session_events.role = 'user'
+					AND session_events.kind = 'text'
+					AND json_extract(session_events.payload, '$.content') IS NOT NULL
+					AND trim(json_extract(session_events.payload, '$.content')) <> ''
+				ORDER BY session_events.seq ASC
+				LIMIT 1
+			)
+			WHERE first_user_message IS NULL
+		`.execute(db);
+	},
+};
+
 export const MIGRATIONS: Migration[] = [
 	baseline,
 	authTables,
@@ -243,4 +279,5 @@ export const MIGRATIONS: Migration[] = [
 	sessionModel,
 	terminalTickets,
 	sessionOwnerLogin,
+	sessionFirstUserMessage,
 ];

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -11,11 +11,14 @@ import {
 	createSession,
 	deleteSession,
 	getSession,
+	listSessionFilterOptions,
+	listSessions,
 	readEvents,
 	readTranscript,
 	titleSessionIfEmpty,
 	updateSession,
 } from "./sessions";
+import { ensureSchema } from "./schema";
 
 // A throwaway on-disk libSQL DB per test — isolated, and (unlike a bare
 // `:memory:` client) it survives the reconnect the driver makes across a
@@ -56,6 +59,7 @@ describe("session store", () => {
 			"0004_session_model",
 			"0005_terminal_tickets",
 			"0006_session_owner_login",
+			"0007_session_first_user_message",
 		]);
 	});
 
@@ -77,6 +81,7 @@ describe("session store", () => {
 			status: "active",
 		});
 		expect(created.resumeState).toBeNull();
+		expect(created.firstUserMessage).toBeNull();
 		expect(await getSession(handle, "s1")).toEqual(created);
 		expect(await getSession(handle, "missing")).toBeUndefined();
 	});
@@ -184,10 +189,147 @@ describe("session store", () => {
 		expect(events.map((e) => e.seq)).toEqual([1, 2, 3]);
 		expect(events.map((e) => e.role)).toEqual(["user", "assistant", "assistant"]);
 		expect(events[0].chunk).toEqual({ type: "text", content: "hi" });
+		expect((await getSession(handle, "s1"))?.firstUserMessage).toBe("hi");
 
 		// Resume cursor: only events after seq 1.
 		const tail = await readEvents(handle, "s1", 1);
 		expect(tail.map((e) => e.seq)).toEqual([2, 3]);
+	});
+
+	test("keeps the projected first user message stable after later user turns", async () => {
+		const handle = freshDb();
+		await createSession(handle, { id: "s1", provider: "mock" });
+		await appendEvents(handle, "s1", [
+			evt("assistant", { type: "status", content: "ready" }),
+			evt("user", { type: "text", content: "First request" }),
+		]);
+		await appendEvents(handle, "s1", [
+			evt("user", { type: "text", content: "Second request" }),
+		]);
+
+		expect((await getSession(handle, "s1"))?.firstUserMessage).toBe(
+			"First request",
+		);
+	});
+
+	test("listSessions searches titles and projected first user messages, filters, and keeps last activity order", async () => {
+		const handle = freshDb();
+		await ensureSchema(handle);
+		await handle.db
+			.insertInto("repos")
+			.values([
+				{
+					id: "repo-a",
+					full_name: "fairchild/workspaces",
+					default_branch: "main",
+					created_at: "2026-01-01T00:00:00.000Z",
+				},
+				{
+					id: "repo-b",
+					full_name: "fairchild/services",
+					default_branch: "main",
+					created_at: "2026-01-01T00:00:00.000Z",
+				},
+			])
+			.execute();
+		await createSession(handle, {
+			id: "old-title",
+			repoId: "repo-a",
+			title: "Fix launch crash",
+			provider: "mock",
+			status: "archived",
+		});
+		await createSession(handle, {
+			id: "middle-message",
+			repoId: "repo-b",
+			title: "Untitled",
+			provider: "mock",
+			status: "idle",
+		});
+		await createSession(handle, {
+			id: "new-title",
+			repoId: "repo-a",
+			title: "Keyboard resume polish",
+			provider: "mock",
+			status: "active",
+		});
+		await appendEvents(handle, "old-title", [
+			evt("user", { type: "text", content: "Unrelated first message" }),
+		]);
+		await appendEvents(handle, "middle-message", [
+			evt("user", { type: "text", content: "Search the session body" }),
+		]);
+		await appendEvents(handle, "new-title", [
+			evt("user", { type: "text", content: "Resume ergonomics" }),
+		]);
+		await handle.db
+			.updateTable("sessions")
+			.set({ last_activity_at: "2026-01-01T00:00:00.000Z" })
+			.where("id", "=", "old-title")
+			.execute();
+		await handle.db
+			.updateTable("sessions")
+			.set({ last_activity_at: "2026-01-01T00:01:00.000Z" })
+			.where("id", "=", "middle-message")
+			.execute();
+		await handle.db
+			.updateTable("sessions")
+			.set({ last_activity_at: "2026-01-01T00:02:00.000Z" })
+			.where("id", "=", "new-title")
+			.execute();
+
+		expect((await listSessions(handle, { query: "body" })).map((s) => s.id)).toEqual([
+			"middle-message",
+		]);
+		expect((await listSessions(handle, { query: "keyboard" })).map((s) => s.id)).toEqual([
+			"new-title",
+		]);
+		expect(
+			(await listSessions(handle, { repoId: "repo-a", status: "active" })).map(
+				(s) => s.id,
+			),
+		).toEqual(["new-title"]);
+		expect((await listSessions(handle)).map((s) => s.id)).toEqual([
+			"new-title",
+			"middle-message",
+			"old-title",
+		]);
+	});
+
+	test("listSessionFilterOptions returns cheap repo and status facets", async () => {
+		const handle = freshDb();
+		await ensureSchema(handle);
+		await handle.db
+			.insertInto("repos")
+			.values({
+				id: "repo-a",
+				full_name: "fairchild/workspaces",
+				default_branch: "main",
+				created_at: "2026-01-01T00:00:00.000Z",
+			})
+			.execute();
+		await createSession(handle, {
+			id: "s1",
+			repoId: "repo-a",
+			provider: "mock",
+			status: "active",
+		});
+		await createSession(handle, {
+			id: "s2",
+			provider: "mock",
+			status: "idle",
+		});
+
+		expect(await listSessionFilterOptions(handle)).toEqual({
+			repos: [
+				{ value: "__none", label: "no repository", count: 1 },
+				{ value: "repo-a", label: "fairchild/workspaces", count: 1 },
+			],
+			statuses: [
+				{ value: "active", label: "active", count: 1 },
+				{ value: "idle", label: "idle", count: 1 },
+			],
+		});
 	});
 
 	test("keeps per-session seq independent across sessions", async () => {

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -296,6 +296,26 @@ describe("session store", () => {
 		]);
 	});
 
+	test("listSessions treats LIKE wildcards in the query as literals", async () => {
+		const handle = freshDb();
+		await ensureSchema(handle);
+		await createSession(handle, {
+			id: "percent",
+			title: "Migration 50% done",
+			provider: "mock",
+		});
+		await createSession(handle, {
+			id: "plain",
+			title: "Migration 50x done",
+			provider: "mock",
+		});
+		// An unescaped `50%` would match both titles; a literal match is one.
+		expect((await listSessions(handle, { query: "50%" })).map((s) => s.id)).toEqual([
+			"percent",
+		]);
+		expect(await listSessions(handle, { query: "_igration" })).toEqual([]);
+	});
+
 	test("listSessionFilterOptions returns cheap repo and status facets", async () => {
 		const handle = freshDb();
 		await ensureSchema(handle);

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -9,6 +9,7 @@
  * the raw log as the source of truth lets projection improve across adapter
  * versions and keeps #749's ingest a dumb append.
  */
+import { sql } from "kysely";
 import { DEFAULT_MODEL } from "../agent-runtime/models";
 import type { StreamChunk } from "../agent-runtime/stream-chunk";
 import type {
@@ -18,6 +19,10 @@ import type {
 import { projectSessionEvents } from "../transcript/project-events";
 import type { DatabaseHandle, SessionsTable } from "./client";
 import { ensureSchema } from "./schema";
+
+const SESSION_STATUSES = ["active", "idle", "archived"] as const;
+
+export type SessionStatus = (typeof SESSION_STATUSES)[number];
 
 export interface NewSession {
 	id: string;
@@ -38,6 +43,7 @@ export interface Session {
 	/** GitHub login that created the session; null for legacy grandfathered rows. */
 	ownerLogin: string | null;
 	title: string;
+	firstUserMessage: string | null;
 	provider: string;
 	status: string;
 	claudeSessionId: string | null;
@@ -61,6 +67,7 @@ function rowToSession(row: SessionsTable): Session {
 		repoId: row.repo_id,
 		ownerLogin: row.owner_login,
 		title: row.title,
+		firstUserMessage: row.first_user_message,
 		provider: row.provider,
 		status: row.status,
 		claudeSessionId: row.claude_session_id,
@@ -82,6 +89,7 @@ export async function createSession(
 		repo_id: session.repoId ?? null,
 		owner_login: session.ownerLogin?.trim().toLowerCase() || null,
 		title: session.title ?? "",
+		first_user_message: null,
 		provider: session.provider,
 		status: session.status ?? "active",
 		claude_session_id: session.claudeSessionId ?? null,
@@ -184,27 +192,107 @@ export interface SessionListItem extends Session {
 	repoFullName: string | null;
 }
 
+export interface SessionListFilters {
+	query?: string;
+	repoId?: string;
+	status?: string;
+	limit?: number;
+}
+
 /**
  * Sessions for the home screen, most recently active first (served by the
  * `idx_sessions_last_activity` index).
  */
 export async function listSessions(
 	handle: DatabaseHandle,
-	limit = 100,
+	filtersOrLimit: SessionListFilters | number = {},
 ): Promise<SessionListItem[]> {
 	await ensureSchema(handle);
-	const rows = await handle.db
+	const filters =
+		typeof filtersOrLimit === "number" ? { limit: filtersOrLimit } : filtersOrLimit;
+	const query = filters.query?.trim();
+	const likeQuery = query ? `%${query}%` : undefined;
+	let builder = handle.db
 		.selectFrom("sessions")
 		.leftJoin("repos", "repos.id", "sessions.repo_id")
 		.selectAll("sessions")
-		.select("repos.full_name as repo_full_name")
+		.select("repos.full_name as repo_full_name");
+
+	if (likeQuery) {
+		builder = builder.where((eb) =>
+			eb.or([
+				eb("sessions.title", "like", likeQuery),
+				eb("sessions.first_user_message", "like", likeQuery),
+			]),
+		);
+	}
+	if (filters.repoId) {
+		builder =
+			filters.repoId === "__none"
+				? builder.where("sessions.repo_id", "is", null)
+				: builder.where("sessions.repo_id", "=", filters.repoId);
+	}
+	if (filters.status && SESSION_STATUSES.includes(filters.status as SessionStatus)) {
+		builder = builder.where("sessions.status", "=", filters.status);
+	}
+
+	const rows = await builder
 		.orderBy("sessions.last_activity_at", "desc")
-		.limit(limit)
+		.limit(filters.limit ?? 100)
 		.execute();
 	return rows.map((row) => ({
 		...rowToSession(row),
 		repoFullName: row.repo_full_name,
 	}));
+}
+
+export interface SessionListFilterOption {
+	value: string;
+	label: string;
+	count: number;
+}
+
+export interface SessionListFilterOptions {
+	repos: SessionListFilterOption[];
+	statuses: SessionListFilterOption[];
+}
+
+/** Distinct repo/state facets for the sessions-home filters. */
+export async function listSessionFilterOptions(
+	handle: DatabaseHandle,
+): Promise<SessionListFilterOptions> {
+	await ensureSchema(handle);
+	const [repoRows, statusRows] = await Promise.all([
+		handle.db
+			.selectFrom("sessions")
+			.leftJoin("repos", "repos.id", "sessions.repo_id")
+			.select(({ fn }) => [
+				"sessions.repo_id as repo_id",
+				"repos.full_name as repo_full_name",
+				fn.countAll<number>().as("count"),
+			])
+			.groupBy(["sessions.repo_id", "repos.full_name"])
+			.orderBy("repos.full_name", "asc")
+			.execute(),
+		handle.db
+			.selectFrom("sessions")
+			.select(({ fn }) => ["status", fn.countAll<number>().as("count")])
+			.groupBy("status")
+			.orderBy("status", "asc")
+			.execute(),
+	]);
+	return {
+		repos: repoRows.map((row) => ({
+			value: row.repo_id ?? "__none",
+			label: row.repo_full_name ?? "no repository",
+			count: Number(row.count),
+		})),
+		statuses: statusRows.map((row) => ({
+			value: row.status,
+			label: row.status,
+			count: Number(row.count),
+		})),
+	};
 }
 
 export async function getSession(
@@ -262,6 +350,15 @@ export async function appendEvents(
 			.set({ last_activity_at: now })
 			.where("id", "=", sessionId)
 			.execute();
+		const firstUserMessage = firstUserMessageFrom(events);
+		if (firstUserMessage) {
+			await trx
+				.updateTable("sessions")
+				.set({ first_user_message: firstUserMessage })
+				.where("id", "=", sessionId)
+				.where(sql<boolean>`first_user_message is null`)
+				.execute();
+		}
 		return seq;
 	});
 }
@@ -336,8 +433,26 @@ async function appendIfOpenOnce(
 			.set({ last_activity_at: now })
 			.where("id", "=", sessionId)
 			.execute();
+		const firstUserMessage = firstUserMessageFrom(events);
+		if (firstUserMessage) {
+			await trx
+				.updateTable("sessions")
+				.set({ first_user_message: firstUserMessage })
+				.where("id", "=", sessionId)
+				.where(sql<boolean>`first_user_message is null`)
+				.execute();
+		}
 		return true;
 	});
+}
+
+function firstUserMessageFrom(events: readonly AppendEvent[]): string | null {
+	for (const event of events) {
+		if (event.role !== "user" || event.chunk.type !== "text") continue;
+		const content = event.chunk.content.trim();
+		if (content) return content;
+	}
+	return null;
 }
 
 async function currentMaxSeq(

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -211,7 +211,10 @@ export async function listSessions(
 	const filters =
 		typeof filtersOrLimit === "number" ? { limit: filtersOrLimit } : filtersOrLimit;
 	const query = filters.query?.trim();
-	const likeQuery = query ? `%${query}%` : undefined;
+	// Literal % and _ in a search must not act as LIKE wildcards.
+	const likeQuery = query
+		? `%${query.replace(/[\\%_]/g, (c) => `\\${c}`)}%`
+		: undefined;
 	let builder = handle.db
 		.selectFrom("sessions")
 		.leftJoin("repos", "repos.id", "sessions.repo_id")
@@ -221,8 +224,8 @@ export async function listSessions(
 	if (likeQuery) {
 		builder = builder.where((eb) =>
 			eb.or([
-				eb("sessions.title", "like", likeQuery),
-				eb("sessions.first_user_message", "like", likeQuery),
+				sql<boolean>`sessions.title like ${likeQuery} escape '\\'`,
+				sql<boolean>`sessions.first_user_message like ${likeQuery} escape '\\'`,
 			]),
 		);
 	}

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -295,6 +295,26 @@ test("the derived title shows on home and is inline-editable from the masthead, 
 	await expect(page).toHaveURL(SESSION_URL);
 });
 
+test("home search narrows the list and keyboard resume opens the selected session (#986)", async ({
+	page,
+}) => {
+	await page.goto("/");
+	const sessionLinks = page.locator("main ul li a");
+	await expect(sessionLinks).toHaveCount(2);
+
+	await page.keyboard.press("/");
+	const search = page.getByRole("searchbox", { name: "Search sessions" });
+	await expect(search).toBeFocused();
+	await search.type("failing session");
+
+	await expect(sessionLinks).toHaveCount(1);
+	await expect(sessionLinks.first()).toContainText("Renamed by hand");
+
+	await search.press("ArrowDown");
+	await search.press("Enter");
+	await expect(page).toHaveURL(turnSessionUrl);
+});
+
 test("a reload renders the same turn from the persisted event log", async ({
 	page,
 }) => {


### PR DESCRIPTION
## What

The sessions home becomes a daily-driver workspace (#986, W6): search across titles and first user messages, repo/status filters, activity-recency order, and a keyboard path (`/` focuses search, arrows move a visible selection, Enter opens) — while keeping the calm front door (one masthead, one list, a quiet filter strip).

Data stays one query: a new `sessions.first_user_message` column (migration `0007`, idempotent, backfilled from the event log, maintained only-when-null on append) so search never scans `session_events`.

## Process

Implemented by codex (gpt-5.5, medium) in a dedicated worktree per `codex-execution`; orchestrator review + directed codex (gpt-5.5, xhigh) review followed. The review pass found five should-fixes — Enter double-fire on focused controls, a debounce/RSC race dropping keystrokes, filters dropping pending search text, unescaped LIKE wildcards, and array-typed `searchParams` crashing the home — all fixed in the attributed reaction commit with a wildcard regression test. Mutation checks: search predicate inverted → tests fail → restored (codex); documented in the commit trail.

## Verification

- Unit 467 passed (incl. new search/filter/wildcard tests), typecheck, lint, clean production build
- `E2E_PORT=3186 pnpm test:e2e`: 44 passed on the rebased tree (incl. new search + keyboard specs, reload determinism)

## Evidence

The changed surface (sessions home, light+dark):

### home-empty-dark
![home-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180336-home-empty-dark.png)
### home-empty-light
![home-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180337-home-empty-light.png)
### home-populated-dark
![home-populated-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180339-home-populated-dark.png)
### home-populated-light
![home-populated-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180340-home-populated-light.png)

<details><summary>Full 50-shot evidence walk (light+dark, all surfaces)</summary>

### compose-disabled-dark
![compose-disabled-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180331-compose-disabled-dark.png)

### compose-disabled-light
![compose-disabled-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180332-compose-disabled-light.png)

### compose-empty-dark
![compose-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180332-compose-empty-dark.png)

### compose-empty-light
![compose-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180333-compose-empty-light.png)

### compose-multiline-dark
![compose-multiline-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180334-compose-multiline-dark.png)

### compose-multiline-light
![compose-multiline-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180335-compose-multiline-light.png)

### home-empty-dark
![home-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180336-home-empty-dark.png)

### home-empty-light
![home-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180337-home-empty-light.png)

### home-populated-dark
![home-populated-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180339-home-populated-dark.png)

### home-populated-light
![home-populated-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180340-home-populated-light.png)

### prototype-folio-dark
![prototype-folio-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180340-prototype-folio-dark.png)

### prototype-folio-light
![prototype-folio-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180341-prototype-folio-light.png)

### resume-catchup-dark
![resume-catchup-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180343-resume-catchup-dark.png)

### resume-catchup-light
![resume-catchup-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180344-resume-catchup-light.png)

### resume-complete-dark
![resume-complete-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180346-resume-complete-dark.png)

### resume-complete-light
![resume-complete-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180347-resume-complete-light.png)

### resume-midturn-dark
![resume-midturn-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180348-resume-midturn-dark.png)

### resume-midturn-light
![resume-midturn-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180350-resume-midturn-light.png)

### session-empty-dark
![session-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180351-session-empty-dark.png)

### session-empty-light
![session-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180352-session-empty-light.png)

### session-error-provisioning-dark
![session-error-provisioning-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180353-session-error-provisioning-dark.png)

### session-error-provisioning-light
![session-error-provisioning-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180354-session-error-provisioning-light.png)

### session-error-sandbox-died-dark
![session-error-sandbox-died-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180355-session-error-sandbox-died-dark.png)

### session-error-sandbox-died-light
![session-error-sandbox-died-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180356-session-error-sandbox-died-light.png)

### session-error-stream-dark
![session-error-stream-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180356-session-error-stream-dark.png)

### session-error-stream-light
![session-error-stream-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180357-session-error-stream-light.png)

### session-mobile-diff-dark
![session-mobile-diff-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180357-session-mobile-diff-dark.png)

### session-mobile-diff-light
![session-mobile-diff-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180358-session-mobile-diff-light.png)

### session-mobile-turn-dark
![session-mobile-turn-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180359-session-mobile-turn-dark.png)

### session-mobile-turn-light
![session-mobile-turn-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180359-session-mobile-turn-light.png)

### session-terminal-drawer-dark
![session-terminal-drawer-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180400-session-terminal-drawer-dark.png)

### session-terminal-drawer-light
![session-terminal-drawer-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180401-session-terminal-drawer-light.png)

### session-turn-failed-dark
![session-turn-failed-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180401-session-turn-failed-dark.png)

### session-turn-failed-light
![session-turn-failed-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180402-session-turn-failed-light.png)

### session-turn-failed-retried-dark
![session-turn-failed-retried-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180402-session-turn-failed-retried-dark.png)

### session-turn-failed-retried-light
![session-turn-failed-retried-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180403-session-turn-failed-retried-light.png)

### session-turn-final-dark
![session-turn-final-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180404-session-turn-final-dark.png)

### session-turn-final-light
![session-turn-final-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180404-session-turn-final-light.png)

### session-turn-midstream-dark
![session-turn-midstream-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180405-session-turn-midstream-dark.png)

### session-turn-midstream-light
![session-turn-midstream-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180406-session-turn-midstream-light.png)

### session-turn-reloaded-dark
![session-turn-reloaded-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180406-session-turn-reloaded-dark.png)

### session-turn-reloaded-light
![session-turn-reloaded-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180407-session-turn-reloaded-light.png)

### session-turn-stopped-dark
![session-turn-stopped-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180408-session-turn-stopped-dark.png)

### session-turn-stopped-light
![session-turn-stopped-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180408-session-turn-stopped-light.png)

### session-turn-stopping-dark
![session-turn-stopping-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180409-session-turn-stopping-dark.png)

### session-turn-stopping-light
![session-turn-stopping-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180409-session-turn-stopping-light.png)

### session-turn-streaming-dark
![session-turn-streaming-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180410-session-turn-streaming-dark.png)

### session-turn-streaming-light
![session-turn-streaming-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180411-session-turn-streaming-light.png)

### sessions-demo-dark
![sessions-demo-dark](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180411-sessions-demo-dark.png)

### sessions-demo-light
![sessions-demo-light](https://evidence.cloudcompute.com/workspaces/pr-1002/20260708-180412-sessions-demo-light.png)


</details>

Closes #986

## Mergeability

- **Surface:** web-next sessions home (server page + one new client list component), `lib/db/sessions` list queries, one additive migration. No provider/runtime changes.
- **Behavior changed:** home list gains search/filter/keyboard; default view unchanged (same order, same rows) when no params set.
- **Non-happy paths:** repeated `?q=` params coerce (no crash); LIKE wildcards match literally; keyboard handler yields to text inputs and focused controls; empty-result state renders the existing empty view.
- **Residual risk:** `first_user_message` backfill runs once on existing DBs — idempotent and null-guarded; sessions created before a first user message stay searchable by title only until one arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
