### PR TITLE
feat(automation): workspace.create options — select:false, fromRef (#989)

### DIFF
--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -194,6 +194,13 @@ final class AutomationController: AutomationControlling {
         guard !providerID.isEmpty else {
             throw AutomationServiceError(.invalidRequest, "providerID must be non-empty when provided.")
         }
+        let fromRef: String?
+        switch WorkspaceCreationRefValidator.normalize(request.fromRef) {
+        case .success(let normalized):
+            fromRef = normalized
+        case .failure(let error):
+            throw AutomationServiceError(.invalidRequest, error.message)
+        }
 
         guard let gestureVerbs else {
             throw AutomationServiceError(
@@ -206,7 +213,9 @@ final class AutomationController: AutomationControlling {
             repoID: repoID,
             name: name,
             providerID: providerID,
-            guestOS: request.guestOS
+            guestOS: request.guestOS,
+            shouldSelect: request.select ?? true,
+            fromRef: fromRef
         )
         let capabilities = entry.capabilities
         switch await gestureVerbs.createWorkspace(command) {

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -1540,6 +1540,20 @@ struct ContentView: View {
     }
 
     @MainActor
+    private func attachWorkspaceSessionWithoutSelection(_ workspace: Workspace) -> UUID? {
+        guard workspace.status == .active else { return nil }
+        guard workspace.backend == .local else { return nil }
+
+        let workspaceDirectory = workspace.workspaceURL.standardizedFileURL.resolvingSymlinksInPath()
+        let session = tileTreeStore.ensureSession(
+            key: .hostPath(workspaceDirectory.path),
+            directory: workspaceDirectory
+        ).session
+        _ = tileTreeStore.terminalSurfaceView(for: session)
+        return session.id
+    }
+
+    @MainActor
     private func handleWorkspaceSelection(_ workspace: Workspace) {
         handleWorkspaceSelection(workspace, preferredDirectory: nil)
     }
@@ -2149,10 +2163,22 @@ struct ContentView: View {
                 guard case .completed(let effect) = outcome else {
                     return outcome
                 }
+                var attachedSurfaceID: UUID?
+                var attached = false
+                if !command.shouldSelect,
+                    let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == effect.workspaceID })
+                {
+                    attachedSurfaceID = attachWorkspaceSessionWithoutSelection(workspace)
+                    attached = attachedSurfaceID != nil
+                }
                 let selectedID = currentSelectedWorkspace?.id
                 let activeSessionID = tileTreeStore.activeSessionID
-                let attached = selectedID == effect.workspaceID && activeSessionID != nil
-                if desktopUISmokeAutomation.usesAPICreateDriver,
+                if command.shouldSelect {
+                    attached = selectedID == effect.workspaceID && activeSessionID != nil
+                    attachedSurfaceID = attached ? activeSessionID : nil
+                }
+                if command.shouldSelect,
+                    desktopUISmokeAutomation.usesAPICreateDriver,
                     desktopUISmokeAutomation.usesAPISelectDriver,
                     let repo = repos.first(where: { $0.id == effect.repoID }),
                     let workspace = repos.flatMap(\.workspaces).first(where: { $0.id == effect.workspaceID })
@@ -2174,7 +2200,7 @@ struct ContentView: View {
                         workspaceName: effect.workspaceName,
                         workspacePath: effect.workspacePath,
                         selectedWorkspaceID: selectedID,
-                        attachedSurfaceID: attached ? activeSessionID : nil,
+                        attachedSurfaceID: attachedSurfaceID,
                         attachedTerminal: attached
                     )
                 )

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -868,7 +868,9 @@ struct SidebarView: View {
             name: command.name,
             nameSource: .manual,
             providerID: command.providerID,
-            guestOS: command.guestOS
+            guestOS: command.guestOS,
+            shouldSelect: command.shouldSelect,
+            fromRef: command.fromRef
         )
 
         switch result {
@@ -881,7 +883,7 @@ struct SidebarView: View {
                     workspaceID: workspace.id,
                     workspaceName: workspace.name,
                     workspacePath: workspace.path,
-                    selectedWorkspaceID: workspace.id,
+                    selectedWorkspaceID: command.shouldSelect ? workspace.id : selectedWorkspace?.id,
                     attachedSurfaceID: nil,
                     attachedTerminal: false
                 )
@@ -917,7 +919,9 @@ struct SidebarView: View {
         name: String,
         nameSource: WorkspaceNameSource,
         providerID: String,
-        guestOS: WorkspaceGuestOS? = nil
+        guestOS: WorkspaceGuestOS? = nil,
+        shouldSelect: Bool = true,
+        fromRef: String? = nil
     ) async -> SidebarWorkspaceCreationResult {
         guard let provider = workspaceProviderRegistry.provider(for: providerID) else {
             let message = "Workspace provider '\(providerID)' is not registered."
@@ -937,7 +941,9 @@ struct SidebarView: View {
                     name: name,
                     nameSource: nameSource,
                     providerID: providerID,
-                    guestOS: guestOS
+                    guestOS: guestOS,
+                    shouldSelect: shouldSelect,
+                    fromRef: fromRef
                 )
             } perform: {
                 createdWorkspace = await createWorkspaceAfterSetup(
@@ -945,7 +951,9 @@ struct SidebarView: View {
                     name: name,
                     nameSource: nameSource,
                     providerID: providerID,
-                    guestOS: guestOS
+                    guestOS: guestOS,
+                    shouldSelect: shouldSelect,
+                    fromRef: fromRef
                 )
             }
             if intercepted {
@@ -982,7 +990,9 @@ struct SidebarView: View {
         name: String,
         nameSource: WorkspaceNameSource,
         providerID: String,
-        guestOS: WorkspaceGuestOS? = nil
+        guestOS: WorkspaceGuestOS? = nil,
+        shouldSelect: Bool = true,
+        fromRef: String? = nil
     ) async -> Workspace? {
         let repoID = repo.id
         guard !isCreatingWorkspace(for: repoID) else { return nil }
@@ -1018,6 +1028,7 @@ struct SidebarView: View {
                 nameSource: nameSource,
                 providerID: providerID,
                 guestOS: guestOS,
+                fromRef: fromRef,
                 progress: { phase in
                     creationLog.debug("createWorkspaceAfterSetup: progress phase=\(phase)")
                     await MainActor.run {
@@ -1032,7 +1043,9 @@ struct SidebarView: View {
             creationLog.info("createWorkspaceAfterSetup: workspace created, updating selection")
             workspaceCreationStatusByRepoID.removeValue(forKey: repoID)
             onWorkspaceCreated()
-            selectedWorkspace = workspace
+            if shouldSelect {
+                selectedWorkspace = workspace
+            }
             await hostLumeSmokeAutomation.noteWorkspaceActive(
                 HostLumeSmokeWorkspaceRecord(workspace: workspace)
             )

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarWorkspaceController.swift
@@ -93,6 +93,7 @@ struct SidebarWorkspaceController {
         nameSource: WorkspaceNameSource = .manual,
         providerID: String,
         guestOS: WorkspaceGuestOS? = nil,
+        fromRef: String? = nil,
         progress: WorkspaceProviderProgressHandler? = nil,
         onPersisted: (@MainActor @Sendable (HostLumeSmokeWorkspaceRecord) async -> Void)? = nil
     ) async throws -> Workspace {
@@ -117,7 +118,8 @@ struct SidebarWorkspaceController {
             repoLocalURL: repo.localURL,
             repoRemoteURL: repo.remoteURL,
             workspaceName: reservation.resolvedName,
-            guestOS: guestOS
+            guestOS: guestOS,
+            fromRef: fromRef
         )
 
         do {

--- a/Sources/WorkspaceManager/Views/MainWindow/TileTreeStore.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/TileTreeStore.swift
@@ -240,6 +240,24 @@ final class TileTreeStore: ObservableObject {
     }
 
     @discardableResult
+    func ensureSession(
+        key: HostTerminalSessionKey,
+        directory: URL,
+        customCommand: String? = nil,
+        initialCommand: String? = nil
+    ) -> HostTerminalSessionActivationResult {
+        let result = coordinator.ensureSession(
+            key: key,
+            directory: directory,
+            customCommand: customCommand,
+            initialCommand: initialCommand
+        )
+        _ = renderTileID(for: result.session.id)
+        publishSnapshot()
+        return result
+    }
+
+    @discardableResult
     func activateExistingSession(sessionID: UUID) -> Bool {
         guard coordinator.activate(sessionID: sessionID) != nil else { return false }
         publishSnapshot()

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -571,17 +571,23 @@ public struct AutomationWorkspaceCreateRequest: Codable, Sendable, Equatable {
     public let name: String
     public let providerID: String?
     public let guestOS: WorkspaceGuestOS?
+    public let select: Bool?
+    public let fromRef: String?
 
     public init(
         repoID: String,
         name: String,
         providerID: String? = nil,
-        guestOS: WorkspaceGuestOS? = nil
+        guestOS: WorkspaceGuestOS? = nil,
+        select: Bool? = nil,
+        fromRef: String? = nil
     ) {
         self.repoID = repoID
         self.name = name
         self.providerID = providerID
         self.guestOS = guestOS
+        self.select = select
+        self.fromRef = fromRef
     }
 }
 
@@ -590,23 +596,30 @@ public struct AutomationWorkspaceCreateCommand: Sendable, Equatable {
     public let name: String
     public let providerID: String
     public let guestOS: WorkspaceGuestOS?
+    public let shouldSelect: Bool
+    public let fromRef: String?
 
     public init(
         repoID: UUID,
         name: String,
         providerID: String,
-        guestOS: WorkspaceGuestOS? = nil
+        guestOS: WorkspaceGuestOS? = nil,
+        shouldSelect: Bool = true,
+        fromRef: String? = nil
     ) {
         self.repoID = repoID
         self.name = name
         self.providerID = providerID
         self.guestOS = guestOS
+        self.shouldSelect = shouldSelect
+        self.fromRef = fromRef
     }
 }
 
-/// What driving the real workspace-create gesture produced. A completed create must report the
-/// created workspace, the selected workspace, and the attached terminal surface so callers can prove
-/// the next input will land in the newly created PTY.
+/// What driving the real workspace-create gesture produced. When `shouldSelect` is true, a completed
+/// create reports the selected workspace and attached terminal surface so callers can prove the next
+/// input will land in the newly created PTY. With `shouldSelect` false, creation still runs through
+/// the sidebar helper but intentionally preserves the current selection and active surface.
 public struct AutomationWorkspaceCreateEffect: Sendable, Equatable {
     public let repoID: UUID
     public let workspaceID: UUID

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
@@ -11,6 +11,7 @@ public actor AutomationAuditLogger {
         public let operatorHandle: Bool
         public let allowed: Bool
         public let errorCode: AutomationErrorCode?
+        public let metadata: [String: String]?
 
         public init(
             timestamp: String,
@@ -19,7 +20,8 @@ public actor AutomationAuditLogger {
             handlePresent: Bool,
             operatorHandle: Bool = false,
             allowed: Bool,
-            errorCode: AutomationErrorCode?
+            errorCode: AutomationErrorCode?,
+            metadata: [String: String]? = nil
         ) {
             self.timestamp = timestamp
             self.method = method
@@ -28,6 +30,7 @@ public actor AutomationAuditLogger {
             self.operatorHandle = operatorHandle
             self.allowed = allowed
             self.errorCode = errorCode
+            self.metadata = metadata
         }
     }
 
@@ -54,6 +57,7 @@ public actor AutomationAuditLogger {
         method: String,
         path: String,
         headers: [String: String],
+        requestBody: Data = Data(),
         responseBody: Data,
         operatorHandle: Bool = false
     ) {
@@ -65,7 +69,8 @@ public actor AutomationAuditLogger {
             handlePresent: headers[AutomationAPI.handleHeader]?.isEmpty == false,
             operatorHandle: operatorHandle,
             allowed: summary?.ok == true,
-            errorCode: summary?.error?.code
+            errorCode: summary?.error?.code,
+            metadata: Self.routeMetadata(method: method, path: path, body: requestBody)
         )
         guard let data = try? encoder.encode(event) else { return }
 
@@ -85,6 +90,23 @@ public actor AutomationAuditLogger {
         } catch {
             NSLog("[AutomationAudit] append failed: %@", "\(error)")
         }
+    }
+
+    private nonisolated static func routeMetadata(method: String, path: String, body: Data) -> [String: String]? {
+        guard method.uppercased() == "POST", path == "/v1/workspace/create", !body.isEmpty,
+            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+        else {
+            return nil
+        }
+
+        var metadata: [String: String] = [:]
+        if object.keys.contains("select") {
+            metadata["workspaceCreate.select"] = "provided"
+        }
+        if object.keys.contains("fromRef") {
+            metadata["workspaceCreate.fromRef"] = "provided"
+        }
+        return metadata.isEmpty ? nil : metadata
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -265,7 +265,7 @@ enum AutomationHTTPRouter {
         } catch {
             throw AutomationServiceError(
                 .invalidRequest,
-                "Request body must be JSON with string 'repoID', string 'name', optional string 'providerID', and optional 'guestOS'."
+                "Request body must be JSON with string 'repoID', string 'name', optional string 'providerID', optional 'guestOS', optional boolean 'select', and optional string 'fromRef'."
             )
         }
         guard !request.repoID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -278,6 +278,14 @@ enum AutomationHTTPRouter {
             providerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             throw AutomationServiceError(.invalidRequest, "Request 'providerID' must be non-empty when provided.")
+        }
+        if let fromRef = request.fromRef {
+            switch WorkspaceCreationRefValidator.normalize(fromRef) {
+            case .success:
+                break
+            case .failure(let error):
+                throw AutomationServiceError(.invalidRequest, error.message)
+            }
         }
         return request
     }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
@@ -187,6 +187,7 @@ public actor AutomationListener {
             method: request.method,
             path: request.path,
             headers: request.headers,
+            requestBody: request.body,
             responseBody: result.body,
             operatorHandle: operatorHandle
         )

--- a/Sources/WorkspaceManagerCore/Services/GitService.swift
+++ b/Sources/WorkspaceManagerCore/Services/GitService.swift
@@ -69,16 +69,25 @@ public actor GitService: GitServiceProtocol {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    public func fetchAll(at path: URL) async throws {
+        _ = try await runGit(["fetch", "--all", "--prune"], at: path)
+    }
+
     public func createBranch(_ name: String, at path: URL) async throws {
         _ = try await runGit(["checkout", "-b", name], at: path)
     }
 
-    public func createWorktree(branchName: String, at destination: URL, from source: URL) async throws {
+    public func createWorktree(
+        branchName: String,
+        at destination: URL,
+        from source: URL,
+        startPoint: String? = nil
+    ) async throws {
         if try await localBranchExists(branchName, at: source) {
             throw GitError.branchAlreadyExists(name: branchName)
         }
 
-        let args = ["worktree", "add", "-b", branchName, destination.path, "HEAD"]
+        let args = ["worktree", "add", "-b", branchName, destination.path, startPoint ?? "HEAD"]
         let result = try await runGitResult(args, at: source)
         guard result.success else {
             try? await deleteLocalBranchIfExists(branchName, at: source)

--- a/Sources/WorkspaceManagerCore/Services/HostTerminalSessionCoordinator.swift
+++ b/Sources/WorkspaceManagerCore/Services/HostTerminalSessionCoordinator.swift
@@ -253,6 +253,49 @@ public struct HostTerminalSessionCoordinator: Sendable {
     }
 
     @discardableResult
+    public mutating func ensureSession(
+        key: HostTerminalSessionKey,
+        directory: URL,
+        customCommand: String? = nil,
+        initialCommand: String? = nil
+    ) -> HostTerminalSessionActivationResult {
+        let normalizedDirectory = HostTerminalSession.normalize(directory)
+        let normalizedPath = normalizedDirectory.path
+        let normalizedKey = key.normalized()
+
+        if let activeScopeSession = activeSessionIDByScopeKey[normalizedKey].flatMap(session(withID:)) {
+            return HostTerminalSessionActivationResult(session: activeScopeSession, created: false)
+        }
+
+        if let existing = sessions.first(where: { $0.key == normalizedKey }) {
+            activeSessionIDByScopeKey[normalizedKey] = existing.id
+            return HostTerminalSessionActivationResult(session: existing, created: false)
+        }
+
+        if shouldReuseByDirectoryPath(for: normalizedKey),
+            let existing = sessions.first(where: {
+                shouldReuseByDirectoryPath(for: $0.key) && $0.directoryPath == normalizedPath
+            })
+        {
+            activeSessionIDByScopeKey[normalizedKey] = existing.id
+            return HostTerminalSessionActivationResult(session: existing, created: false)
+        }
+
+        let session = HostTerminalSession(
+            key: normalizedKey,
+            directory: normalizedDirectory,
+            customCommand: customCommand,
+            initialCommand: initialCommand
+        )
+        sessions.append(session)
+        activeSessionIDByScopeKey[normalizedKey] = session.id
+        if activeSessionID == nil {
+            setActiveSessionID(session.id)
+        }
+        return HostTerminalSessionActivationResult(session: session, created: true)
+    }
+
+    @discardableResult
     public mutating func activate(sessionID: UUID) -> HostTerminalSession? {
         guard let session = session(withID: sessionID) else { return nil }
         setActiveSessionID(session.id)

--- a/Sources/WorkspaceManagerCore/Services/LocalWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LocalWorkspaceProvider.swift
@@ -39,6 +39,7 @@ public struct LocalWorkspaceProvider: WorkspaceProviderProtocol {
             repoName: request.repoName,
             repoLocalURL: request.repoLocalURL,
             name: request.workspaceName,
+            fromRef: request.fromRef,
             progress: { phase in
                 await progress?(Self.progressMessage(for: phase))
             }

--- a/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
+++ b/Sources/WorkspaceManagerCore/Services/LumeWorkspaceProvider.swift
@@ -129,6 +129,7 @@ public actor LumeWorkspaceProvider: WorkspaceProviderProtocol {
                 repoName: request.repoName,
                 repoLocalURL: request.repoLocalURL,
                 name: request.workspaceName,
+                fromRef: request.fromRef,
                 progress: { phase in
                     await progress?(LocalWorkspaceProvider.progressMessage(for: phase))
                 }

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -86,8 +86,14 @@ public protocol GitServiceProtocol: Sendable {
     func getStatus(at path: URL) async throws -> [FileChange]
     func getRemoteURL(at path: URL) async throws -> String?
     func getCurrentBranch(at path: URL) async throws -> String?
+    func fetchAll(at path: URL) async throws
     func createBranch(_ name: String, at path: URL) async throws
-    func createWorktree(branchName: String, at destination: URL, from source: URL) async throws
+    func createWorktree(
+        branchName: String,
+        at destination: URL,
+        from source: URL,
+        startPoint: String?
+    ) async throws
     func checkoutBranch(_ name: String, at path: URL) async throws
     func getFileTree(at path: URL, maxDepth: Int) async throws -> FileNode
     func diff(file: String, at path: URL) async throws -> UnifiedDiff
@@ -99,6 +105,12 @@ public protocol GitServiceProtocol: Sendable {
 }
 
 extension GitServiceProtocol {
+    public func fetchAll(at path: URL) async throws {}
+
+    public func createWorktree(branchName: String, at destination: URL, from source: URL) async throws {
+        try await createWorktree(branchName: branchName, at: destination, from: source, startPoint: nil)
+    }
+
     public func getFileTree(at path: URL) async throws -> FileNode {
         try await getFileTree(at: path, maxDepth: 4)
     }
@@ -110,6 +122,7 @@ public protocol WorkspaceServiceProtocol: Sendable {
         repoName: String,
         repoLocalURL: URL,
         name: String,
+        fromRef: String?,
         progress: WorkspaceCreationProgressHandler?
     ) async throws -> NewWorkspaceInfo
     @discardableResult
@@ -132,7 +145,23 @@ extension WorkspaceServiceProtocol {
             repoName: repoName,
             repoLocalURL: repoLocalURL,
             name: name,
+            fromRef: nil,
             progress: nil
+        )
+    }
+
+    public func createWorkspace(
+        repoName: String,
+        repoLocalURL: URL,
+        name: String,
+        progress: WorkspaceCreationProgressHandler?
+    ) async throws -> NewWorkspaceInfo {
+        try await createWorkspace(
+            repoName: repoName,
+            repoLocalURL: repoLocalURL,
+            name: name,
+            fromRef: nil,
+            progress: progress
         )
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceMaterializer.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceMaterializer.swift
@@ -19,7 +19,8 @@ protocol WorkspaceMaterializer: Sendable {
     func materializeWorkspace(
         named sanitizedName: String,
         at destination: URL,
-        from sourceRepository: URL
+        from sourceRepository: URL,
+        fromRef: String?
     ) async throws -> MaterializedWorkspace
 
     func removeWorkspace(at workspaceURL: URL) async throws
@@ -45,13 +46,18 @@ struct GitWorktreeWorkspaceMaterializer: WorkspaceMaterializer {
     func materializeWorkspace(
         named sanitizedName: String,
         at destination: URL,
-        from sourceRepository: URL
+        from sourceRepository: URL,
+        fromRef: String? = nil
     ) async throws -> MaterializedWorkspace {
         let branchName = "workspace/\(sanitizedName)"
+        if fromRef != nil {
+            try await gitService.fetchAll(at: sourceRepository)
+        }
         try await gitService.createWorktree(
             branchName: branchName,
             at: destination,
-            from: sourceRepository
+            from: sourceRepository,
+            startPoint: fromRef
         )
 
         let currentBranch = try? await gitService.getCurrentBranch(at: destination)
@@ -73,8 +79,13 @@ struct GitCloneWorkspaceMaterializer: WorkspaceMaterializer {
     func materializeWorkspace(
         named sanitizedName: String,
         at destination: URL,
-        from sourceRepository: URL
+        from sourceRepository: URL,
+        fromRef: String? = nil
     ) async throws -> MaterializedWorkspace {
+        if fromRef != nil {
+            try await gitService.fetchAll(at: sourceRepository)
+        }
+
         let cloneArguments = [
             "clone",
             "--local",
@@ -95,6 +106,19 @@ struct GitCloneWorkspaceMaterializer: WorkspaceMaterializer {
 
         let branchName = "workspace/\(sanitizedName)"
         try await gitService.createBranch(branchName, at: destination)
+        if let fromRef {
+            let checkoutArguments = ["reset", "--hard", fromRef]
+            let checkoutResult = try await ProcessRunner.run(
+                executable: "/usr/bin/git",
+                arguments: checkoutArguments,
+                currentDirectory: destination,
+                timeout: 30
+            )
+            guard checkoutResult.success else {
+                let reason = checkoutResult.stderr.isEmpty ? "Unknown error" : checkoutResult.stderr
+                throw GitError.commandFailed(args: checkoutArguments, stderr: reason)
+            }
+        }
         let currentBranch = try? await gitService.getCurrentBranch(at: destination)
 
         return MaterializedWorkspace(gitBranch: currentBranch ?? branchName)

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceProviders.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceProviders.swift
@@ -113,19 +113,22 @@ public struct WorkspaceProviderCreationRequest: Sendable {
     public let repoRemoteURL: String?
     public let workspaceName: String
     public let guestOS: WorkspaceGuestOS?
+    public let fromRef: String?
 
     public init(
         repoName: String,
         repoLocalURL: URL,
         repoRemoteURL: String?,
         workspaceName: String,
-        guestOS: WorkspaceGuestOS? = nil
+        guestOS: WorkspaceGuestOS? = nil,
+        fromRef: String? = nil
     ) {
         self.repoName = repoName
         self.repoLocalURL = repoLocalURL
         self.repoRemoteURL = repoRemoteURL
         self.workspaceName = workspaceName
         self.guestOS = guestOS
+        self.fromRef = fromRef
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WorkspaceService.swift
@@ -22,6 +22,63 @@ private let defaultCleanupFailureReporter: @Sendable (WorkspaceCleanupFailure) -
     )
 }
 
+public struct WorkspaceCreationRefValidationError: Error, Sendable, Equatable {
+    public let message: String
+}
+
+public enum WorkspaceCreationRefValidator {
+    public static func normalize(_ rawValue: String?) -> Result<String?, WorkspaceCreationRefValidationError> {
+        guard let rawValue else { return .success(nil) }
+        let ref = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !ref.isEmpty else {
+            return .failure(WorkspaceCreationRefValidationError(message: "fromRef must be non-empty when provided."))
+        }
+        guard ref == rawValue else {
+            return .failure(
+                WorkspaceCreationRefValidationError(
+                    message: "fromRef must not contain leading or trailing whitespace."))
+        }
+        guard isPlausibleRefName(ref) else {
+            return .failure(WorkspaceCreationRefValidationError(message: "fromRef must be a plausible git ref name."))
+        }
+        return .success(ref)
+    }
+
+    public static func normalizedValue(_ rawValue: String?) throws -> String? {
+        switch normalize(rawValue) {
+        case .success(let ref):
+            return ref
+        case .failure(let error):
+            throw WorkspaceError.invalidRef(error.message)
+        }
+    }
+
+    private static func isPlausibleRefName(_ ref: String) -> Bool {
+        if ref == "@" || ref.hasPrefix("-") || ref.hasPrefix("/") || ref.hasSuffix("/")
+            || ref.hasSuffix(".")
+        {
+            return false
+        }
+
+        let forbiddenScalars = CharacterSet.whitespacesAndNewlines.union(.controlCharacters)
+        if ref.rangeOfCharacter(from: forbiddenScalars) != nil { return false }
+
+        let forbiddenFragments = [
+            "..", "//", "@{", "\\", "~", "^", ":", "?", "*", "[", "]",
+            ";", "&", "|", "$", "`", "\"", "'", "<", ">", "(", ")",
+        ]
+        if forbiddenFragments.contains(where: ref.contains) { return false }
+
+        return ref.split(separator: "/", omittingEmptySubsequences: false).allSatisfy { component in
+            !component.isEmpty
+                && component != "."
+                && component != ".."
+                && !component.hasPrefix(".")
+                && !component.hasSuffix(".lock")
+        }
+    }
+}
+
 public actor WorkspaceService: WorkspaceServiceProtocol {
     public static let shared = WorkspaceService()
 
@@ -84,12 +141,14 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
         repoName: String,
         repoLocalURL: URL,
         name: String,
+        fromRef: String? = nil,
         progress: WorkspaceCreationProgressHandler? = nil
     ) async throws -> NewWorkspaceInfo {
         let sanitizedName = Self.sanitizeWorkspaceNameComponent(name)
         guard Self.isValidWorkspaceNameComponent(sanitizedName) else {
             throw WorkspaceError.invalidName(name: name)
         }
+        let normalizedFromRef = try WorkspaceCreationRefValidator.normalizedValue(fromRef)
 
         let repoDir = workspacesRoot.appendingPathComponent(repoName, isDirectory: true)
         let workspaceDir = repoDir.appendingPathComponent(sanitizedName, isDirectory: true)
@@ -119,7 +178,8 @@ public actor WorkspaceService: WorkspaceServiceProtocol {
             materializedWorkspace = try await materializer.materializeWorkspace(
                 named: sanitizedName,
                 at: workspaceDir,
-                from: repoLocalURL
+                from: repoLocalURL,
+                fromRef: normalizedFromRef
             )
         } catch {
             await cleanupMaterializedWorkspace(at: workspaceDir, context: "materialization failure")
@@ -413,6 +473,7 @@ public enum WorkspaceError: LocalizedError {
     case notAGitRepo
     case alreadyExists(name: String)
     case invalidName(name: String)
+    case invalidRef(String)
     case materializationFailed(operation: String, reason: String)
     case deletionFailed(reason: String)
 
@@ -424,6 +485,8 @@ public enum WorkspaceError: LocalizedError {
             return "A workspace named '\(name)' already exists"
         case .invalidName(let name):
             return "Workspace name '\(name)' is not valid"
+        case .invalidRef(let message):
+            return message
         case .materializationFailed(let operation, let reason):
             return "Failed to \(operation): \(reason)"
         case .deletionFailed(let reason):

--- a/Tests/WorkspaceManagerAppTests/AutomationCreateVerbTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationCreateVerbTests.swift
@@ -62,7 +62,9 @@ struct AutomationCreateVerbTests {
                     : nil
             },
             performCreation: { _, command in
-                .completed(
+                #expect(command.shouldSelect)
+                #expect(command.fromRef == nil)
+                return .completed(
                     AutomationWorkspaceCreateEffect(
                         repoID: repoID,
                         workspaceID: workspaceID,
@@ -89,6 +91,73 @@ struct AutomationCreateVerbTests {
         #expect(result.attachedSurfaceID == surfaceID.uuidString)
         #expect(result.selectedWorkspaceID == workspaceID)
         #expect(result.system.capabilities.contains(.workspaceCreate))
+    }
+
+    @Test("select false creates without changing the active surface")
+    func selectFalsePreservesActiveSurface() async throws {
+        let store = TileTreeStore()
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let staleSession = store.activateSession(
+            key: .repoPath("/tmp/repo"),
+            directory: URL(fileURLWithPath: "/tmp/repo")
+        ).session
+        var observedCommand: AutomationWorkspaceCreateCommand?
+
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in
+                $0 == repoID
+                    ? AutomationGestureVerbs.RepoTarget(repoID: repoID, name: "repo", path: "/tmp/repo")
+                    : nil
+            },
+            performCreation: { _, command in
+                observedCommand = command
+                return .completed(
+                    AutomationWorkspaceCreateEffect(
+                        repoID: repoID,
+                        workspaceID: workspaceID,
+                        workspaceName: command.name,
+                        workspacePath: "/tmp/repo/\(command.name)",
+                        selectedWorkspaceID: nil,
+                        attachedSurfaceID: nil,
+                        attachedTerminal: false
+                    )
+                )
+            }
+        )
+        let registry = AutomationHandleRegistry(makeHandle: { UUID().uuidString })
+        let entry = registry.registerOperator(appScopeID: "workspaces.local")
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            gestureVerbs: verbs
+        )
+
+        let result = try await controller.automationCreateWorkspace(
+            for: entry.handle,
+            request: AutomationWorkspaceCreateRequest(
+                repoID: repoID.uuidString,
+                name: "created",
+                select: false,
+                fromRef: "origin/main"
+            )
+        )
+
+        #expect(observedCommand?.shouldSelect == false)
+        #expect(observedCommand?.fromRef == "origin/main")
+        #expect(result.outcome == .completed)
+        #expect(result.workspaceID == workspaceID)
+        #expect(result.selectedWorkspaceID == nil)
+        #expect(!result.attachedTerminal)
+        #expect(result.attachedSurfaceID == nil)
+        #expect(store.activeSessionID == staleSession.id)
     }
 
     @Test("a tile handle lacks workspace.create and is denied")

--- a/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
+++ b/Tests/WorkspaceManagerAppTests/SidebarWorkspaceControllerBehaviorTests.swift
@@ -978,6 +978,7 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         let repoName: String
         let repoLocalURL: URL
         let name: String
+        let fromRef: String?
     }
 
     var workspacesRootValue = URL(fileURLWithPath: "/tmp/workspaces")
@@ -998,11 +999,12 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         repoName: String,
         repoLocalURL: URL,
         name: String,
+        fromRef: String?,
         progress: WorkspaceCreationProgressHandler?
     ) async throws -> NewWorkspaceInfo {
         await MainActor.run {
             createWorkspaceCalls.append(
-                CreateWorkspaceCall(repoName: repoName, repoLocalURL: repoLocalURL, name: name)
+                CreateWorkspaceCall(repoName: repoName, repoLocalURL: repoLocalURL, name: name, fromRef: fromRef)
             )
         }
         await createWorkspaceDelay()

--- a/Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspaceCreationRaceTests.swift
@@ -169,6 +169,7 @@ private final class MockWorkspaceService: WorkspaceServiceProtocol, @unchecked S
         repoName: String,
         repoLocalURL: URL,
         name: String,
+        fromRef: String?,
         progress: WorkspaceCreationProgressHandler?
     ) async throws -> NewWorkspaceInfo {
         await createWorkspaceDelay()

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -1207,6 +1207,29 @@ struct AutomationAPITests {
         #expect(okEnvelope.result?.system.capabilities.contains(.workspaceCreate) == true)
         #expect(controller.createCalls == [AutomationWorkspaceCreateRequest(repoID: validRepoID, name: "created")])
 
+        let withOptions = await post(
+            "operator",
+            body: try AutomationJSON.encoder.encode(
+                AutomationWorkspaceCreateRequest(
+                    repoID: validRepoID,
+                    name: "from-ref",
+                    select: false,
+                    fromRef: "origin/main"
+                )
+            )
+        )
+        #expect(withOptions.status == 200)
+        #expect(
+            controller.createCalls == [
+                AutomationWorkspaceCreateRequest(repoID: validRepoID, name: "created"),
+                AutomationWorkspaceCreateRequest(
+                    repoID: validRepoID,
+                    name: "from-ref",
+                    select: false,
+                    fromRef: "origin/main"
+                ),
+            ])
+
         let confirmation = await post(
             "operator",
             body: try body(repoID: FakeAutomationController.createConfirmationRepoID, name: "needs-lume")
@@ -1242,6 +1265,20 @@ struct AutomationAPITests {
 
         let empty = await post("operator", body: Data())
         #expect(empty.status == 400)
+        let badRef = await post(
+            "operator",
+            body: try AutomationJSON.encoder.encode(
+                AutomationWorkspaceCreateRequest(
+                    repoID: validRepoID,
+                    name: "bad-ref",
+                    fromRef: "origin/main; rm -rf /"
+                )
+            )
+        )
+        let badRefEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: badRef.body)
+        #expect(badRef.status == 400)
+        #expect(badRefEnvelope.error?.code == .invalidRequest)
         let wrongMethod = await AutomationHTTPRouter.route(
             HTTPRequest(
                 method: "GET", path: "/v1/workspace/create",
@@ -1494,10 +1531,25 @@ struct AutomationAPITests {
             responseBody: okBody,
             operatorHandle: false
         )
+        await logger.record(
+            method: "POST",
+            path: "/v1/workspace/create",
+            headers: [AutomationAPI.handleHeader: "op"],
+            requestBody: try AutomationJSON.encoder.encode(
+                AutomationWorkspaceCreateRequest(
+                    repoID: UUID().uuidString,
+                    name: "created",
+                    select: false,
+                    fromRef: "origin/main"
+                )
+            ),
+            responseBody: okBody,
+            operatorHandle: true
+        )
 
         let contents = try String(contentsOf: auditURL, encoding: .utf8)
         let lines = contents.split(separator: "\n").map(String.init)
-        #expect(lines.count == 2)
+        #expect(lines.count == 3)
         let events = try lines.map { line in
             try AutomationJSON.decoder.decode(AutomationAuditLogger.Event.self, from: Data(line.utf8))
         }
@@ -1505,6 +1557,10 @@ struct AutomationAPITests {
         #expect(windowsEvent.operatorHandle)
         let contextEvent = try #require(events.first { $0.path == "/v1/context" })
         #expect(!contextEvent.operatorHandle)
+        let createEvent = try #require(events.first { $0.path == "/v1/workspace/create" })
+        #expect(createEvent.metadata?["workspaceCreate.select"] == "provided")
+        #expect(createEvent.metadata?["workspaceCreate.fromRef"] == "provided")
+        #expect(!String(describing: createEvent.metadata).contains("origin/main"))
     }
 
     @Test("CLI formatter emits result JSON and surfaces envelope errors")

--- a/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
+++ b/Tests/WorkspaceManagerTests/Helpers/MockGitService.swift
@@ -14,7 +14,8 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     // MARK: - Call Tracking
 
     var createBranchCalls: [(name: String, path: URL)] = []
-    var createWorktreeCalls: [(branchName: String, destination: URL, source: URL)] = []
+    var createWorktreeCalls: [(branchName: String, destination: URL, source: URL, startPoint: String?)] = []
+    var fetchAllCalls: [URL] = []
     var getCurrentBranchCalls: [URL] = []
 
     // MARK: - Configurable Returns
@@ -25,6 +26,7 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
     var fileTreeResult: FileNode = FileNode(name: "root", path: "", isDirectory: true, children: [])
     var createBranchError: Error? = nil
     var createWorktreeError: Error? = nil
+    var fetchAllError: Error? = nil
 
     // MARK: - Protocol Conformance
 
@@ -41,6 +43,13 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
         return currentBranchResult
     }
 
+    func fetchAll(at path: URL) async throws {
+        fetchAllCalls.append(path)
+        if let error = fetchAllError {
+            throw error
+        }
+    }
+
     func createBranch(_ name: String, at path: URL) async throws {
         createBranchCalls.append((name: name, path: path))
         if let error = createBranchError {
@@ -48,8 +57,19 @@ final class MockGitService: GitServiceProtocol, @unchecked Sendable {
         }
     }
 
-    func createWorktree(branchName: String, at destination: URL, from source: URL) async throws {
-        createWorktreeCalls.append((branchName: branchName, destination: destination, source: source))
+    func createWorktree(
+        branchName: String,
+        at destination: URL,
+        from source: URL,
+        startPoint: String?
+    ) async throws {
+        createWorktreeCalls.append(
+            (
+                branchName: branchName,
+                destination: destination,
+                source: source,
+                startPoint: startPoint
+            ))
         if let error = createWorktreeError {
             throw error
         }

--- a/Tests/WorkspaceManagerTests/HostTerminalSessionCoordinatorTests.swift
+++ b/Tests/WorkspaceManagerTests/HostTerminalSessionCoordinatorTests.swift
@@ -33,6 +33,27 @@ struct HostTerminalSessionCoordinatorTests {
         #expect(coordinator.activeSessionID == first.session.id)
     }
 
+    @Test("Ensures a session without changing the active session")
+    func ensureSessionDoesNotActivateWhenAnotherSessionIsActive() {
+        var coordinator = HostTerminalSessionCoordinator()
+        let repoURL = URL(fileURLWithPath: "/tmp/repo-a")
+        let workspaceURL = URL(fileURLWithPath: "/tmp/workspaces/repo-a/feature")
+
+        let active = coordinator.activate(
+            key: .repoPath(repoURL.path),
+            directory: repoURL
+        ).session
+        let ensured = coordinator.ensureSession(
+            key: .hostPath(workspaceURL.path),
+            directory: workspaceURL
+        )
+
+        #expect(ensured.created)
+        #expect(coordinator.sessions.count == 2)
+        #expect(coordinator.activeSessionID == active.id)
+        #expect(coordinator.activeSessionIDByScopeKey[.hostPath(workspaceURL.path).normalized()] == ensured.session.id)
+    }
+
     @Test("Reuses existing session by canonical path when key differs")
     func reusesByCanonicalPath() {
         var coordinator = HostTerminalSessionCoordinator()

--- a/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WorkspaceServiceTests.swift
@@ -46,7 +46,7 @@ struct WorkspaceServiceTests {
     }
 
     final class RecordingWorkspaceMaterializer: WorkspaceMaterializer, @unchecked Sendable {
-        var materializeCalls: [(sanitizedName: String, destination: URL, source: URL)] = []
+        var materializeCalls: [(sanitizedName: String, destination: URL, source: URL, fromRef: String?)] = []
         var removeCalls: [URL] = []
         var materializeError: Error?
         var removeError: Error?
@@ -60,9 +60,16 @@ struct WorkspaceServiceTests {
         func materializeWorkspace(
             named sanitizedName: String,
             at destination: URL,
-            from sourceRepository: URL
+            from sourceRepository: URL,
+            fromRef: String?
         ) async throws -> MaterializedWorkspace {
-            materializeCalls.append((sanitizedName: sanitizedName, destination: destination, source: sourceRepository))
+            materializeCalls.append(
+                (
+                    sanitizedName: sanitizedName,
+                    destination: destination,
+                    source: sourceRepository,
+                    fromRef: fromRef
+                ))
             if createsDestination {
                 try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
             }
@@ -351,6 +358,51 @@ struct WorkspaceServiceTests {
         #expect(mockGit.createWorktreeCalls[0].branchName == "workspace/my-feature")
         #expect(mockGit.createWorktreeCalls[0].destination == workspaceDir)
         #expect(mockGit.createWorktreeCalls[0].source == repoDir)
+        #expect(mockGit.createWorktreeCalls[0].startPoint == nil)
+        #expect(mockGit.fetchAllCalls.isEmpty)
+    }
+
+    @Test("default materializer fetches and branches from requested ref")
+    func defaultMaterializerUsesRequestedRef() async throws {
+        let mockGit = MockGitService()
+        let service = WorkspaceService(gitService: mockGit)
+        let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        _ = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "my-feature",
+            fromRef: "origin/main"
+        )
+
+        #expect(mockGit.fetchAllCalls == [repoDir])
+        #expect(mockGit.createWorktreeCalls.count == 1)
+        #expect(mockGit.createWorktreeCalls[0].startPoint == "origin/main")
+    }
+
+    @Test("createWorkspace rejects unsafe fromRef values before git")
+    func createWorkspaceRejectsUnsafeFromRef() async throws {
+        let mockGit = MockGitService()
+        let service = WorkspaceService(gitService: mockGit)
+        let (testRoot, repoDir, wsRoot) = try makeWorkspaceFixture()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        await #expect(throws: WorkspaceError.self) {
+            _ = try await service.createWorkspace(
+                repoName: "test-repo",
+                repoLocalURL: repoDir,
+                name: "my-feature",
+                fromRef: "origin/main; rm -rf /"
+            )
+        }
+
+        #expect(mockGit.fetchAllCalls.isEmpty)
+        #expect(mockGit.createWorktreeCalls.isEmpty)
     }
 
     @Test("sequential race fan-out keeps earlier workspaces when a later one fails")
@@ -578,6 +630,55 @@ struct WorkspaceServiceTests {
 
         let worktreeList = try runGit(["worktree", "list", "--porcelain"], at: repoDir)
         #expect(self.worktreeList(worktreeList, contains: info.path))
+    }
+
+    @Test("createWorkspace with fromRef materializes from fetched origin ref")
+    func createWorkspaceMaterializesFromFetchedRef() async throws {
+        let service = WorkspaceService()
+        let testRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+        let seedDir = testRoot.appendingPathComponent("seed", isDirectory: true)
+        let remoteDir = testRoot.appendingPathComponent("origin.git", isDirectory: true)
+        let repoDir = testRoot.appendingPathComponent("repos/test-repo", isDirectory: true)
+        let wsRoot = testRoot.appendingPathComponent("workspaces", isDirectory: true)
+        try FileManager.default.createDirectory(at: seedDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: wsRoot, withIntermediateDirectories: true)
+
+        _ = try runGit(["init", "-b", "main"], at: seedDir)
+        _ = try runGit(["config", "user.email", "test@example.com"], at: seedDir)
+        _ = try runGit(["config", "user.name", "Test User"], at: seedDir)
+        try "stale\n".write(to: seedDir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        _ = try runGit(["add", "-A"], at: seedDir)
+        _ = try runGit(["commit", "-m", "initial"], at: seedDir)
+        _ = try runGit(["init", "--bare", remoteDir.path], at: testRoot)
+        _ = try runGit(["remote", "add", "origin", remoteDir.path], at: seedDir)
+        _ = try runGit(["push", "-u", "origin", "main"], at: seedDir)
+        _ = try runGit(["clone", remoteDir.path, repoDir.path], at: testRoot)
+        let staleHead = try runGit(["rev-parse", "HEAD"], at: repoDir)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        try "fresh\n".write(to: seedDir.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        _ = try runGit(["add", "-A"], at: seedDir)
+        _ = try runGit(["commit", "-m", "fresh"], at: seedDir)
+        _ = try runGit(["push", "origin", "main"], at: seedDir)
+        let fetchedHead = try runGit(["rev-parse", "HEAD"], at: seedDir)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(fetchedHead != staleHead)
+
+        let originalRoot = setWorkspacesRoot(wsRoot)
+        defer { restoreWorkspacesRoot(originalRoot) }
+
+        let info = try await service.createWorkspace(
+            repoName: "test-repo",
+            repoLocalURL: repoDir,
+            name: "fresh-ref",
+            fromRef: "origin/main"
+        )
+
+        let workspaceHead = try runGit(["rev-parse", "HEAD"], at: info.path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(workspaceHead == fetchedHead)
+        #expect(workspaceHead != staleHead)
     }
 
     @Test("createWorkspace can materialize with repository copy adapter")

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -26,6 +26,12 @@ For development launches, you can force the feature on for that process:
 WORKSPACES_AUTOMATION_API=1 ./scripts/launch-dev.sh --no-build
 ```
 
+Trusted operator launches can also enable operator-scope workspace verbs:
+
+```bash
+WORKSPACES_AUTOMATION_API=1 WORKSPACES_AUTOMATION_OPERATOR=1 ./scripts/launch-dev.sh --no-build --no-activate
+```
+
 Terminal processes receive automation environment only when their surface is
 created. If you turn the experiment on or off, restart WorkSpaces and create a
 fresh terminal tile before testing.
@@ -81,6 +87,42 @@ workspaces surface list --json
 
 Each entry reports a stable surface ID, surface kind, title, working directory,
 visibility, active state, and whether it is the caller.
+
+## Create A Workspace (Operator Scope)
+
+`workspace.create` drives the app's real sidebar create helper. It requires an
+operator handle, not a tile handle.
+
+The default body preserves the original behavior exactly: branch from the base
+repo clone's local `HEAD`, create the workspace, select it, and attach/activate
+its terminal.
+
+```json
+{ "repoID": "...", "name": "feature-a", "providerID": "local", "guestOS": null }
+```
+
+Two optional fields are available:
+
+- `select`: boolean, default `true`. Set `false` to create the workspace without
+  changing the owner's current sidebar selection or focus.
+- `fromRef`: string, omitted by default. Set values such as `"origin/main"` to
+  fetch before creation and branch the workspace from that fetched ref instead
+  of stale local `HEAD`.
+
+```json
+{
+  "repoID": "...",
+  "name": "feature-a",
+  "providerID": "local",
+  "select": false,
+  "fromRef": "origin/main"
+}
+```
+
+`fromRef` must be a plausible git ref name; empty, whitespace-padded,
+option-like, or shell-metacharacter-shaped values fail `invalid_request`. The
+route does not support `startCommand`; that option is intentionally blocked by
+the open libghostty issue tracked as #889.
 
 ## Focus A Neighboring Tile
 

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -190,7 +190,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `POST /v1/window/snapshot` | **Operator scope.** Returns a composited PNG of the app window named by the body's `windowID` (a `window.read` id). The capture includes the full window — sidebar chrome *and* the GhosttyKit terminal surface — and works with the app backgrounded (no activation). Requires `window.snapshot`; own-window only, so an id the app does not own fails `invalid_request`. See [Window snapshot](#window-snapshot). |
 | `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — mutation verbs use these stable targets. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
 | `POST /v1/workspace/select` | **Operator scope, mutation.** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
-| `POST /v1/workspace/create` | **Operator scope, mutation.** Creates a workspace in the repo named by `repoID` (from `workspace.read`) by driving the sidebar's real create helper. Body is `{"repoID":"…","name":"…","providerID":"local","guestOS":null}`; `providerID` defaults to `local`. Returns `completed` with the created workspace and attached terminal, or `confirmation_required` with provider setup confirmation details. Requires `workspace.create`; tile handles fail `capability_denied`. See [Workspace create](#workspace-create). |
+| `POST /v1/workspace/create` | **Operator scope, mutation.** Creates a workspace in the repo named by `repoID` (from `workspace.read`) by driving the sidebar's real create helper. Body is `{"repoID":"…","name":"…","providerID":"local","guestOS":null,"select":true,"fromRef":"origin/main"}`; `providerID` defaults to `local`, `select` defaults to `true`, and `fromRef` is omitted by default. Returns `completed` with the created workspace and, when selected, the attached terminal, or `confirmation_required` with provider setup confirmation details. Requires `workspace.create`; tile handles fail `capability_denied`. See [Workspace create](#workspace-create). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -351,14 +351,29 @@ mutation rides this route.
 workspace by driving the sidebar create helper used by the New Workspace sheet
 and desktop UI smoke driver. The body names a repo from `workspace.read`; `name`
 is the workspace name; `providerID` defaults to `local`; `guestOS` is optional
-and used by providers that support guest OS variants:
+and used by providers that support guest OS variants; `select` is optional and
+defaults to `true`; `fromRef` is optional and, when present, is fetched before
+the workspace branch is created:
 
 ```json
-{ "repoID": "…", "name": "feature-a", "providerID": "local", "guestOS": null }
+{
+  "repoID": "…",
+  "name": "feature-a",
+  "providerID": "local",
+  "guestOS": null,
+  "select": false,
+  "fromRef": "origin/main"
+}
 ```
 
-The success envelope reports the structured gesture outcome and, on completion,
-the selected and attached workspace terminal:
+Omitting `select` and `fromRef` preserves the previous behavior exactly:
+creation branches from the source repo's local `HEAD`, selects the created
+workspace, and attaches/activates its terminal through the normal selection
+binding.
+
+The success envelope reports the structured gesture outcome and, when the
+workspace is selected on completion, the selected and attached workspace
+terminal:
 
 ```json
 {
@@ -401,10 +416,21 @@ user must confirm:
 - **Same path as the UI.** The verb enters the sidebar create helper, not
   `WorkspaceService` or SwiftData directly. On completion, the helper selects the
   created workspace through the same binding the UI uses, which attaches and
-  activates the workspace terminal.
+  activates the workspace terminal. If `select` is `false`, the helper skips only
+  that final selection write so the owner's current sidebar selection and focus
+  stay untouched.
+- **Ref freshness.** If `fromRef` is present, WorkSpaces validates it as a
+  plausible git ref name, fetches before creating the worktree, and creates the
+  workspace branch from that fetched ref. Empty, whitespace-padded, option-like,
+  or shell-metacharacter-shaped values fail `invalid_request`. Omitted `fromRef`
+  keeps the previous local-`HEAD` behavior.
 - **Wrong-PTY guard.** `attachedSurfaceID` is the active terminal session after
-  create. A following caller-scoped input write targets that PTY, not the repo
-  terminal or a previously selected workspace.
+  create when `select` is true. A following caller-scoped input write targets
+  that PTY, not the repo terminal or a previously selected workspace. With
+  `select: false`, the response reflects the pre-existing selection/active
+  surface instead of claiming the new workspace owns focus.
+- **No start command.** `workspace.create` does not accept `startCommand`; that
+  option is intentionally blocked pending the libghostty issue tracked by #889.
 - **Structured outcome.** `outcome` is `completed` or `confirmation_required`.
   A live-window-less app fails `unsupported` (never a data-layer fallback), an
   unknown/non-UUID `repoID` fails `invalid_request`, and unknown providers fail


### PR DESCRIPTION
## Summary

Adds the first two of #989's three requested `workspace.create` options (the third, `startCommand`, is explicitly blocked by open issue #889 — a libghostty bug — and is NOT implemented here, per the issue's own sequencing guidance):

- **`select: false`** — creates the workspace and attaches a terminal session for it exactly as today, but skips only the final selection write, so a human's current sidebar selection/focus is left untouched. Decomposes the real create gesture (`SidebarView.createWorkspaceAfterSetup`'s final `selectedWorkspace = workspace` becomes conditional; a new `ContentView.attachWorkspaceSessionWithoutSelection` creates/attaches the terminal via the same `TileTreeStore` session machinery without touching selection) — no parallel SwiftData-only write path.
- **`fromRef`** — fetches the given ref before branching, so `workspace.create` no longer silently branches from a stale local `HEAD`. Validated by a new `WorkspaceCreationRefValidator` (denylist of shell/git-metacharacter shapes, all git invocations use argument arrays, never shell-interpolated).

Omitting both fields preserves today's behavior byte-for-byte (verified: existing golden/envelope tests pass unmodified).

Codex (gpt-5.5, high) implemented this in a dedicated worktree; `CODEX_REPORT.md` (untracked) has the full before/after trail.

## Review loop

- **Reflect**: read the full diff personally — `GitService`/`Protocols.swift` changes are additive protocol-extension defaults preserving every existing call site; `fromRef` never reaches a shell (argument-array git invocation throughout, plus the validator's denylist for defense in depth); audit metadata records option *presence* only (`workspaceCreate.select`/`workspaceCreate.fromRef` = `"provided"`), never the ref value or select flag itself, matching the issue's privacy requirement. Confirmed the `select:false` path still sets `attachedTerminal`/`attachedSurfaceID` correctly (verified this doesn't silently break #990's creation-attribution recording, which depends on `attachedTerminal` being true).
- **Codex directed review**: could not run. The account-wide codex usage quota was exhausted partway through this review pass (four parallel implementation workers + review calls in the same window) — `ERROR: You've hit your usage limit ... try again at 1:44 PM`. This is a real, documented limitation, not a skipped step; see the tile-orchestration skill README for the concurrency writeup. No automated second-opinion pass ran for this PR; the reflect pass above is the only review this diff got beyond the implementer's own gates.
- No findings to adjudicate (none surfaced from the manual pass).

## Gates (rebased onto current origin/main before this run)

- `swift build`: PASS
- `swift test --filter 'WorkspaceService|AutomationCreateVerb|AutomationAPI|HostTerminalSessionCoordinator'`: PASS (100 tests)
- Full `swift test` (given the shared-protocol blast radius — `GitServiceProtocol`, `WorkspaceServiceProtocol`, `WorkspaceMaterializer`): PASS (1280 tests, 193 suites)
- `mise run lint`: PASS

## Mergeability

- Surface: desktop — Automation API (`workspace.create` verb), `WorkspaceService`/`GitService`/materializer layer, sidebar create-gesture decomposition
- User-facing behavior changed: No for the default path (verified byte-identical via existing tests); new opt-in behavior for callers that pass `select:false` and/or `fromRef`
- Non-happy paths considered: invalid/empty/malformed `fromRef` → `invalid_request`; `select:false` when the workspace-attach step itself fails → no session, `attachedTerminal:false`; omitted fields → unchanged behavior
- Residual risk or follow-up: `startCommand` remains unimplemented pending #889; live verification against a running dev app instance was intentionally skipped because one was already running (shared automation socket/credential path) — coverage relies on the Swift Testing suite instead, noted explicitly in `CODEX_REPORT.md`

🤖 Generated with a codex (gpt-5.5) implementation worker, orchestrated by Claude Code (Sonnet 5)

## Evidence

![gates](https://evidence.cloudcompute.com/workspaces/pr-1005/20260708-183551-gates.png)

(`swift test` filtered suite (100 tests) + `mise run lint` clean; full-suite run (1280 tests) confirmed separately, not pictured.)
