### PR TITLE
feat(automation): bounded surface/read for created workspaces (#990)

### DIFF
--- a/Sources/WorkspaceManager/Surface/SurfaceStore.swift
+++ b/Sources/WorkspaceManager/Surface/SurfaceStore.swift
@@ -315,6 +315,10 @@ final class SurfaceStore {
         terminalSurface(forSession: sessionID)?.surfaceView
     }
 
+    func terminalPlainText(for sessionID: UUID) -> String? {
+        terminalSurface(forSession: sessionID)?.surfaceView.readPlainScreenText()
+    }
+
     /// The display title for `session`'s terminal, falling back to its directory name before the
     /// surface mounts. Mirrors the legacy `HostTerminalSurfaceStore.displayTitle(for:)`.
     func displayTitle(for session: HostTerminalSession) -> String {

--- a/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
+++ b/Sources/WorkspaceManager/Terminal/GhosttySurfaceView.swift
@@ -454,6 +454,34 @@ final class GhosttySurfaceView: NSView, RetirementClosableSurface {
         _ = performBindingAction("scroll_to_row:\(row)", surface: surface)
     }
 
+    func readPlainScreenText() -> String? {
+        guard let surface else { return nil }
+        var text = ghostty_text_s()
+        let selection = ghostty_selection_s(
+            top_left: ghostty_point_s(
+                tag: GHOSTTY_POINT_SCREEN,
+                coord: GHOSTTY_POINT_COORD_TOP_LEFT,
+                x: 0,
+                y: 0
+            ),
+            bottom_right: ghostty_point_s(
+                tag: GHOSTTY_POINT_SCREEN,
+                coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
+                x: 0,
+                y: 0
+            ),
+            rectangle: false
+        )
+        guard ghostty_surface_read_text(surface, selection, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let pointer = text.text else { return "" }
+        let bytes = UnsafeBufferPointer(
+            start: UnsafeRawPointer(pointer).assumingMemoryBound(to: UInt8.self),
+            count: Int(text.text_len)
+        )
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
     // MARK: - Drag and drop
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -13,6 +13,7 @@ final class AutomationController: AutomationControlling {
     private var windows: @MainActor () -> [AutomationWindowDescriptor]
     private var windowSnapshot: @MainActor (String) async -> WindowSnapshotOutcome
     private var workspaceInventory: @MainActor () -> AutomationWorkspaceInventory
+    private var surfaceTextReader: @MainActor (TileTreeStore, UUID) -> String?
     /// The gesture-verb layer — the single place workspace mutation verbs enter
     /// the real UI path. `nil` when no window is attached, which is exactly the `unsupported`
     /// condition: a mutation verb cannot run without a live window, and never falls back.
@@ -30,6 +31,9 @@ final class AutomationController: AutomationControlling {
         workspaceInventory: @escaping @MainActor () -> AutomationWorkspaceInventory = {
             AutomationWorkspaceInventory()
         },
+        surfaceTextReader: @escaping @MainActor (TileTreeStore, UUID) -> String? = { store, surfaceID in
+            store.surfaceStore.terminalPlainText(for: surfaceID)
+        },
         gestureVerbs: AutomationGestureVerbs? = nil,
         isInputWriteEnabled: @escaping @MainActor () -> Bool = {
             ExperimentalFeatures.isEnabled(.automationInputWrite)
@@ -44,6 +48,7 @@ final class AutomationController: AutomationControlling {
         self.windows = windows
         self.windowSnapshot = windowSnapshot
         self.workspaceInventory = workspaceInventory
+        self.surfaceTextReader = surfaceTextReader
         self.gestureVerbs = gestureVerbs
         self.isInputWriteEnabled = isInputWriteEnabled
     }
@@ -57,6 +62,7 @@ final class AutomationController: AutomationControlling {
         windows: (@MainActor () -> [AutomationWindowDescriptor])? = nil,
         windowSnapshot: (@MainActor (String) async -> WindowSnapshotOutcome)? = nil,
         workspaceInventory: (@MainActor () -> AutomationWorkspaceInventory)? = nil,
+        surfaceTextReader: (@MainActor (TileTreeStore, UUID) -> String?)? = nil,
         gestureVerbs: AutomationGestureVerbs? = nil
     ) {
         self.tileTreeStore = tileTreeStore
@@ -77,6 +83,9 @@ final class AutomationController: AutomationControlling {
         }
         if let workspaceInventory {
             self.workspaceInventory = workspaceInventory
+        }
+        if let surfaceTextReader {
+            self.surfaceTextReader = surfaceTextReader
         }
     }
 
@@ -220,6 +229,12 @@ final class AutomationController: AutomationControlling {
         let capabilities = entry.capabilities
         switch await gestureVerbs.createWorkspace(command) {
         case .completed(let effect):
+            if effect.attachedTerminal, let attachedSurfaceID = effect.attachedSurfaceID {
+                handleRegistry.recordWorkspaceCreation(
+                    operatorHandle: entry.handle,
+                    hostSessionID: attachedSurfaceID
+                )
+            }
             return AutomationWorkspaceCreateResult(
                 repoID: repoIDText,
                 workspaceID: effect.workspaceID,
@@ -265,6 +280,48 @@ final class AutomationController: AutomationControlling {
             from: outcome,
             windowID: windowID,
             capabilities: entry.capabilities
+        )
+    }
+
+    func automationReadSurface(
+        for handle: String,
+        request: AutomationSurfaceReadRequest
+    ) throws -> AutomationSurfaceReadResult {
+        let entry = try resolveOperator(handle, requiring: .surfaceRead)
+        guard let surfaceID = UUID(uuidString: request.surfaceID) else {
+            throw AutomationServiceError(.invalidRequest, "surfaceID must be a UUID.")
+        }
+        guard handleRegistry.operatorHandle(entry.handle, createdHostSessionID: surfaceID) else {
+            throw AutomationServiceError(
+                .capabilityDenied,
+                "This operator handle did not create the requested terminal surface this launch."
+            )
+        }
+        guard let tileTreeStore else {
+            throw AutomationServiceError(
+                .unsupported, "No WorkSpaces window is currently attached to the Automation API.")
+        }
+        guard tileTreeStore.primarySessionID(containing: surfaceID) != nil else {
+            throw AutomationServiceError(.staleHandle, "The requested terminal surface is no longer live.")
+        }
+        guard let fullText = surfaceTextReader(tileTreeStore, surfaceID) else {
+            throw AutomationServiceError(.staleHandle, "The requested terminal surface is not ready to read.")
+        }
+
+        let lineLimit = min(request.lines, AutomationAPI.surfaceReadMaxLines)
+        let bounded = Self.boundedSurfaceReadText(
+            fullText,
+            maxLines: lineLimit,
+            maxUTF8Bytes: AutomationAPI.surfaceReadMaxUTF8Bytes
+        )
+        return AutomationSurfaceReadResult(
+            surfaceID: surfaceID.uuidString,
+            requestedLines: request.lines,
+            lines: lineLimit,
+            returnedLines: Self.lineCount(in: bounded),
+            byteCount: bounded.utf8.count,
+            text: bounded,
+            system: AutomationSystemDescriptor(capabilities: entry.capabilities)
         )
     }
 
@@ -560,6 +617,52 @@ final class AutomationController: AutomationControlling {
             isVisible: isVisible,
             capabilities: capabilities
         )
+    }
+
+    private static func boundedSurfaceReadText(
+        _ text: String,
+        maxLines: Int,
+        maxUTF8Bytes: Int
+    ) -> String {
+        guard maxLines > 0, maxUTF8Bytes > 0, !text.isEmpty else { return "" }
+        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")
+        var lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let hadTrailingNewline = lines.last == ""
+        if hadTrailingNewline {
+            lines.removeLast()
+        }
+
+        var selected = Array(lines.suffix(maxLines))
+        while !selected.isEmpty {
+            let candidate = selected.joined(separator: "\n") + (hadTrailingNewline ? "\n" : "")
+            if candidate.utf8.count <= maxUTF8Bytes {
+                return candidate
+            }
+            if selected.count == 1 {
+                return utf8SafeSuffix(candidate, maxBytes: maxUTF8Bytes)
+            }
+            selected.removeFirst()
+        }
+        return ""
+    }
+
+    private static func utf8SafeSuffix(_ text: String, maxBytes: Int) -> String {
+        guard text.utf8.count > maxBytes else { return text }
+        let suffix = text.utf8.suffix(maxBytes)
+        guard var start = suffix.indices.first else { return "" }
+        while start < suffix.endIndex, (suffix[start] & 0b1100_0000) == 0b1000_0000 {
+            start = suffix.index(after: start)
+        }
+        return String(decoding: suffix[start..<suffix.endIndex], as: UTF8.self)
+    }
+
+    private static func lineCount(in text: String) -> Int {
+        guard !text.isEmpty else { return 0 }
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false).count
+        if text.hasSuffix("\n") {
+            lines -= 1
+        }
+        return max(lines, 0)
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -25,7 +25,7 @@ public enum AutomationAPI {
     /// Operator handles still never carry tile mutation or `input.write`.
     public static let operatorCapabilities = [
         AutomationCapability.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect,
-        .workspaceCreate,
+        .workspaceCreate, .surfaceRead,
     ]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
@@ -46,6 +46,13 @@ public enum AutomationAPI {
     /// no width bound — the snapshot is the window at its true composited resolution, since
     /// full-fidelity evidence is the whole point of the operator capture lane.
     public static let windowSnapshotMaxRawBytes = 64 * 1_024 * 1_024
+
+    /// Bounds for `POST /v1/surface/read` (`surface.read`, operator scope). Requests asking for
+    /// more than `surfaceReadMaxLines` are clamped, not rejected. Returned text is also clamped to
+    /// `surfaceReadMaxUTF8Bytes` without splitting a UTF-8 scalar; if a single terminal line exceeds
+    /// the cap, the returned line is the UTF-8-safe suffix of that line.
+    public static let surfaceReadMaxLines = 500
+    public static let surfaceReadMaxUTF8Bytes = 256 * 1_024
 }
 
 public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equatable {
@@ -61,6 +68,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case workspaceRead = "workspace.read"
     case workspaceSelect = "workspace.select"
     case workspaceCreate = "workspace.create"
+    case surfaceRead = "surface.read"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -697,6 +705,50 @@ public struct AutomationWorkspaceCreateResult: Codable, Sendable, Equatable {
     }
 }
 
+public struct AutomationSurfaceReadRequest: Codable, Sendable, Equatable {
+    public let surfaceID: String
+    public let lines: Int
+
+    public init(surfaceID: String, lines: Int) {
+        self.surfaceID = surfaceID
+        self.lines = lines
+    }
+}
+
+/// Plain-text read-back for an operator-created terminal surface (`surface.read`). `text` is the
+/// bounded, style-free terminal dump suffix. `requestedLines` is the caller's original request;
+/// `lines` is the effective line cap after clamping to `AutomationAPI.surfaceReadMaxLines`;
+/// `returnedLines` and `byteCount` describe the bounded payload actually returned.
+public struct AutomationSurfaceReadResult: Codable, Sendable, Equatable {
+    public let surfaceID: String
+    public let requestedLines: Int
+    public let lines: Int
+    public let returnedLines: Int
+    public let byteCount: Int
+    public let text: String
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        surfaceID: String,
+        requestedLines: Int,
+        lines: Int,
+        returnedLines: Int,
+        byteCount: Int,
+        text: String,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.surfaceID = surfaceID
+        self.requestedLines = requestedLines
+        self.lines = lines
+        self.returnedLines = returnedLines
+        self.byteCount = byteCount
+        self.text = text
+        self.system = system
+    }
+}
+
 public struct AutomationMutationResult: Codable, Sendable, Equatable {
     public let changed: Bool
     public let focusedSurfaceID: String?
@@ -880,6 +932,10 @@ public protocol AutomationControlling: AnyObject, Sendable {
         for handle: String,
         windowID: String
     ) async throws -> AutomationWindowSnapshotResult
+    func automationReadSurface(
+        for handle: String,
+        request: AutomationSurfaceReadRequest
+    ) throws -> AutomationSurfaceReadResult
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult
     func automationWebSurfaceSnapshot(
         for handle: String,

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAuditLogger.swift
@@ -12,6 +12,9 @@ public actor AutomationAuditLogger {
         public let allowed: Bool
         public let errorCode: AutomationErrorCode?
         public let metadata: [String: String]?
+        public let surfaceID: String?
+        public let requestedLines: Int?
+        public let returnedLines: Int?
 
         public init(
             timestamp: String,
@@ -21,7 +24,10 @@ public actor AutomationAuditLogger {
             operatorHandle: Bool = false,
             allowed: Bool,
             errorCode: AutomationErrorCode?,
-            metadata: [String: String]? = nil
+            metadata: [String: String]? = nil,
+            surfaceID: String? = nil,
+            requestedLines: Int? = nil,
+            returnedLines: Int? = nil
         ) {
             self.timestamp = timestamp
             self.method = method
@@ -31,6 +37,9 @@ public actor AutomationAuditLogger {
             self.allowed = allowed
             self.errorCode = errorCode
             self.metadata = metadata
+            self.surfaceID = surfaceID
+            self.requestedLines = requestedLines
+            self.returnedLines = returnedLines
         }
     }
 
@@ -62,6 +71,11 @@ public actor AutomationAuditLogger {
         operatorHandle: Bool = false
     ) {
         let summary = (try? AutomationJSON.decoder.decode(AuditEnvelopeSummary.self, from: responseBody))
+        let surfaceRead = surfaceReadAuditMetadata(
+            path: path,
+            requestBody: requestBody,
+            responseBody: responseBody
+        )
         let event = Event(
             timestamp: timestampFormatter.string(from: Date()),
             method: method,
@@ -70,7 +84,10 @@ public actor AutomationAuditLogger {
             operatorHandle: operatorHandle,
             allowed: summary?.ok == true,
             errorCode: summary?.error?.code,
-            metadata: Self.routeMetadata(method: method, path: path, body: requestBody)
+            metadata: Self.routeMetadata(method: method, path: path, body: requestBody),
+            surfaceID: surfaceRead?.surfaceID,
+            requestedLines: surfaceRead?.requestedLines,
+            returnedLines: surfaceRead?.returnedLines
         )
         guard let data = try? encoder.encode(event) else { return }
 
@@ -108,9 +125,34 @@ public actor AutomationAuditLogger {
         }
         return metadata.isEmpty ? nil : metadata
     }
+
+    private nonisolated func surfaceReadAuditMetadata(
+        path: String,
+        requestBody: Data,
+        responseBody: Data
+    ) -> SurfaceReadAuditMetadata? {
+        guard path == "/v1/surface/read" else { return nil }
+        let request = try? AutomationJSON.decoder.decode(AutomationSurfaceReadRequest.self, from: requestBody)
+        let response =
+            try? AutomationJSON.decoder.decode(
+                AutomationResponseEnvelope<AutomationSurfaceReadResult>.self,
+                from: responseBody
+            )
+        return SurfaceReadAuditMetadata(
+            surfaceID: response?.result?.surfaceID ?? request?.surfaceID,
+            requestedLines: response?.result?.requestedLines ?? request?.lines,
+            returnedLines: response?.result?.returnedLines
+        )
+    }
 }
 
 private struct AuditEnvelopeSummary: Decodable {
     let ok: Bool
     let error: AutomationErrorResponse?
+}
+
+private struct SurfaceReadAuditMetadata: Sendable, Equatable {
+    let surfaceID: String?
+    let requestedLines: Int?
+    let returnedLines: Int?
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -92,6 +92,10 @@ enum AutomationHTTPRouter {
             let create = try decodeWorkspaceCreate(from: request.body)
             return try await controller.automationCreateWorkspace(for: handle, request: create)
 
+        case ("POST", "/v1/surface/read"):
+            let read = try decodeSurfaceRead(from: request.body)
+            return try await controller.automationReadSurface(for: handle, request: read)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -136,6 +140,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/select.")
         case (_, "/v1/workspace/create"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/create.")
+        case (_, "/v1/surface/read"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/surface/read.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -313,6 +319,28 @@ enum AutomationHTTPRouter {
         return request
     }
 
+    private static func decodeSurfaceRead(from body: Data) throws -> AutomationSurfaceReadRequest {
+        guard !body.isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request body is required.")
+        }
+        let request: AutomationSurfaceReadRequest
+        do {
+            request = try AutomationJSON.decoder.decode(AutomationSurfaceReadRequest.self, from: body)
+        } catch {
+            throw AutomationServiceError(
+                .invalidRequest,
+                "Request body must be JSON with string 'surfaceID' and positive integer 'lines'."
+            )
+        }
+        guard !request.surfaceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AutomationServiceError(.invalidRequest, "Request 'surfaceID' must be a non-empty string.")
+        }
+        guard request.lines > 0 else {
+            throw AutomationServiceError(.invalidRequest, "Request 'lines' must be greater than zero.")
+        }
+        return request
+    }
+
     private static func rejectCallerSuppliedTargetIDs(in body: Data, allowEmptyBody: Bool) throws {
         guard !body.isEmpty else {
             if allowEmptyBody { return }
@@ -409,6 +437,7 @@ extension AutomationWorkspacesResult: CodableSendableEquatable {}
 extension AutomationWorkspaceSelectResult: CodableSendableEquatable {}
 extension AutomationWorkspaceCreateResult: CodableSendableEquatable {}
 extension AutomationWindowSnapshotResult: CodableSendableEquatable {}
+extension AutomationSurfaceReadResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}
 extension AutomationWebSurfaceSnapshotResult: CodableSendableEquatable {}
 extension AutomationMutationResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHandleRegistry.swift
@@ -41,6 +41,7 @@ public final class AutomationHandleRegistry {
 
     private var handleByHostSessionID: [UUID: String] = [:]
     private var entriesByHandle: [String: Entry] = [:]
+    private var createdHostSessionIDsByOperatorHandle: [String: Set<UUID>] = [:]
     private let makeHandle: () -> String
 
     public init(makeHandle: @escaping () -> String = { UUID().uuidString.lowercased() }) {
@@ -107,14 +108,28 @@ public final class AutomationHandleRegistry {
         handleByHostSessionID[hostSessionID]
     }
 
+    public func recordWorkspaceCreation(operatorHandle: String, hostSessionID: UUID) {
+        guard entriesByHandle[operatorHandle]?.isOperator == true else { return }
+        createdHostSessionIDsByOperatorHandle[operatorHandle, default: []].insert(hostSessionID)
+    }
+
+    public func operatorHandle(_ handle: String, createdHostSessionID hostSessionID: UUID) -> Bool {
+        createdHostSessionIDsByOperatorHandle[handle]?.contains(hostSessionID) == true
+    }
+
     public func remove(hostSessionID: UUID) {
         guard let handle = handleByHostSessionID.removeValue(forKey: hostSessionID) else { return }
         entriesByHandle.removeValue(forKey: handle)
+        createdHostSessionIDsByOperatorHandle.removeValue(forKey: handle)
+        for operatorHandle in Array(createdHostSessionIDsByOperatorHandle.keys) {
+            createdHostSessionIDsByOperatorHandle[operatorHandle]?.remove(hostSessionID)
+        }
     }
 
     public func removeAll() {
         handleByHostSessionID.removeAll()
         entriesByHandle.removeAll()
+        createdHostSessionIDsByOperatorHandle.removeAll()
     }
 
     private func makeUniqueHandle() -> String {

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -511,7 +511,7 @@ struct AutomationControllerTests {
         #expect(result.windows == [descriptor])
         #expect(
             result.system.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
             ])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
@@ -605,7 +605,7 @@ struct AutomationControllerTests {
         #expect(result.workspaces.first?.backend == "lume")
         #expect(
             result.system.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
             ])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
@@ -679,7 +679,7 @@ struct AutomationControllerTests {
         #expect(Data(base64Encoded: result.data) == png)
         #expect(
             result.system.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
             ])
         #expect(requestedWindowIDs == ["42"])
     }

--- a/Tests/WorkspaceManagerAppTests/AutomationCreateVerbTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationCreateVerbTests.swift
@@ -318,4 +318,136 @@ struct AutomationCreateVerbTests {
         #expect(activeSessionID != staleSession.id)
         #expect(store.sessions.first(where: { $0.id == activeSessionID })?.directoryPath == workspacePath)
     }
+
+    @Test("surface.read is limited to surfaces created by the same operator handle")
+    func surfaceReadRequiresSameOperatorCreationAttribution() async throws {
+        let store = TileTreeStore()
+        let repoID = UUID()
+        let workspaceID = UUID()
+        let otherSession = store.activateSession(
+            key: .repoPath("/tmp/repo"),
+            directory: URL(fileURLWithPath: "/tmp/repo")
+        ).session
+        var createdSurfaceID: UUID?
+        var reads: [UUID] = []
+
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            resolveRepo: { [repoID] in
+                $0 == repoID
+                    ? AutomationGestureVerbs.RepoTarget(repoID: repoID, name: "repo", path: "/tmp/repo")
+                    : nil
+            },
+            performCreation: { _, command in
+                let session = store.activateSession(
+                    key: .hostPath("/tmp/repo/workspaces/\(command.name)"),
+                    directory: URL(fileURLWithPath: "/tmp/repo/workspaces/\(command.name)")
+                ).session
+                createdSurfaceID = session.id
+                return .completed(
+                    AutomationWorkspaceCreateEffect(
+                        repoID: repoID,
+                        workspaceID: workspaceID,
+                        workspaceName: command.name,
+                        workspacePath: session.directoryPath,
+                        selectedWorkspaceID: workspaceID,
+                        attachedSurfaceID: session.id,
+                        attachedTerminal: true
+                    )
+                )
+            }
+        )
+        let registry = AutomationHandleRegistry(makeHandle: { UUID().uuidString })
+        let operatorEntry = registry.registerOperator(appScopeID: "workspaces.local")
+        let otherOperator = registry.registerOperator(appScopeID: "workspaces.local")
+        let tile = registry.upsert(
+            hostSessionID: otherSession.id,
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "workspaces.local"
+        )
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            surfaceTextReader: { _, surfaceID in
+                reads.append(surfaceID)
+                return "one\ntwo\nthree"
+            },
+            gestureVerbs: verbs
+        )
+
+        _ = try await controller.automationCreateWorkspace(
+            for: operatorEntry.handle,
+            request: AutomationWorkspaceCreateRequest(repoID: repoID.uuidString, name: "created")
+        )
+        let surfaceID = try #require(createdSurfaceID)
+
+        let result = try controller.automationReadSurface(
+            for: operatorEntry.handle,
+            request: AutomationSurfaceReadRequest(surfaceID: surfaceID.uuidString, lines: 2)
+        )
+        #expect(result.text == "two\nthree")
+        #expect(result.returnedLines == 2)
+        #expect(reads == [surfaceID])
+
+        await expectFailure(.capabilityDenied) {
+            try controller.automationReadSurface(
+                for: otherOperator.handle,
+                request: AutomationSurfaceReadRequest(surfaceID: surfaceID.uuidString, lines: 2)
+            )
+        }
+        await expectFailure(.capabilityDenied) {
+            try controller.automationReadSurface(
+                for: operatorEntry.handle,
+                request: AutomationSurfaceReadRequest(surfaceID: otherSession.id.uuidString, lines: 2)
+            )
+        }
+        await expectFailure(.capabilityDenied) {
+            try controller.automationReadSurface(
+                for: tile.handle,
+                request: AutomationSurfaceReadRequest(surfaceID: surfaceID.uuidString, lines: 2)
+            )
+        }
+        #expect(reads == [surfaceID])
+    }
+
+    @Test("surface.read clamps over-cap line requests and byte output")
+    func surfaceReadClampsLinesAndBytes() throws {
+        let store = TileTreeStore()
+        let session = store.activateSession(
+            key: .repoPath("/tmp/repo"),
+            directory: URL(fileURLWithPath: "/tmp/repo")
+        ).session
+        let registry = AutomationHandleRegistry()
+        let operatorEntry = registry.registerOperator(appScopeID: "workspaces.local")
+        registry.recordWorkspaceCreation(operatorHandle: operatorEntry.handle, hostSessionID: session.id)
+        let longLines = (0..<600).map { index in
+            "\(index)-" + String(repeating: "x", count: 1024)
+        }.joined(separator: "\n")
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: store,
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            surfaceTextReader: { _, _ in longLines }
+        )
+
+        let result = try controller.automationReadSurface(
+            for: operatorEntry.handle,
+            request: AutomationSurfaceReadRequest(surfaceID: session.id.uuidString, lines: 10_000)
+        )
+
+        #expect(result.requestedLines == 10_000)
+        #expect(result.lines == AutomationAPI.surfaceReadMaxLines)
+        #expect(result.returnedLines <= AutomationAPI.surfaceReadMaxLines)
+        #expect(result.byteCount <= AutomationAPI.surfaceReadMaxUTF8Bytes)
+        #expect(result.text.contains("599-"))
+    }
 }

--- a/Tests/WorkspaceManagerAppTests/WorkspacesAppIntentsTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspacesAppIntentsTests.swift
@@ -108,6 +108,13 @@ private final class FakeWorkspacesAppIntentController: AutomationControlling {
         throw AutomationServiceError(.unsupported, "Not used by App Intents.")
     }
 
+    func automationReadSurface(
+        for handle: String,
+        request: AutomationSurfaceReadRequest
+    ) throws -> AutomationSurfaceReadResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
     func automationWebSurfaces(for handle: String) throws -> AutomationWebSurfacesResult {
         throw AutomationServiceError(.unsupported, "Not used by App Intents.")
     }

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -219,6 +219,7 @@ private final class FakeAutomationController: AutomationControlling {
     }
 
     var windowSnapshotCalls: [String] = []
+    var surfaceReadCalls: [AutomationSurfaceReadRequest] = []
 
     func automationWindowSnapshot(
         for handle: String,
@@ -239,6 +240,28 @@ private final class FakeAutomationController: AutomationControlling {
             height: 1,
             byteCount: 4,
             data: "AQID"
+        )
+    }
+
+    func automationReadSurface(
+        for handle: String,
+        request: AutomationSurfaceReadRequest
+    ) throws -> AutomationSurfaceReadResult {
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(.capabilityDenied, "The automation handle does not include surface.read.")
+        }
+        surfaceReadCalls.append(request)
+        let effectiveLines = min(request.lines, AutomationAPI.surfaceReadMaxLines)
+        return AutomationSurfaceReadResult(
+            surfaceID: request.surfaceID,
+            requestedLines: request.lines,
+            lines: effectiveLines,
+            returnedLines: 2,
+            byteCount: 11,
+            text: "hello\nworld"
         )
     }
 
@@ -850,7 +873,9 @@ struct AutomationAPITests {
         #expect(entry.isOperator)
         #expect(entry.tileID == nil)
         #expect(
-            entry.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate])
+            entry.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+            ])
         // Operator mutation capabilities are reviewed gesture verbs; an operator handle still never
         // carries tile mutation or input.write.
         #expect(!entry.capabilities.contains(.tileClose))
@@ -887,7 +912,7 @@ struct AutomationAPITests {
         #expect(okEnvelope.result?.windows.first?.windowID == "42")
         #expect(
             okEnvelope.result?.system.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
             ])
         #expect(controller.windowCalls == ["operator"])
 
@@ -969,7 +994,7 @@ struct AutomationAPITests {
         #expect(okEnvelope.result?.workspaces.first?.isSelected == true)
         #expect(
             okEnvelope.result?.system.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
             ])
         #expect(controller.workspaceCalls == ["operator"])
 
@@ -1418,6 +1443,90 @@ struct AutomationAPITests {
         #expect(controller.windowSnapshotCalls == ["42"])
     }
 
+    @Test("POST /v1/surface/read routes operator-created read requests and clamps line count")
+    @MainActor
+    func routerSurfaceRead() async throws {
+        let controller = FakeAutomationController()
+        let surfaceID = "99999999-9999-9999-9999-999999999999"
+        let body = try JSONSerialization.data(
+            withJSONObject: ["surfaceID": surfaceID, "lines": 10_000],
+            options: [.sortedKeys]
+        )
+
+        let ok = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/surface/read",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: body
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationSurfaceReadResult>.self,
+            from: ok.body
+        )
+
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.surfaceID == surfaceID)
+        #expect(okEnvelope.result?.requestedLines == 10_000)
+        #expect(okEnvelope.result?.lines == AutomationAPI.surfaceReadMaxLines)
+        #expect(okEnvelope.result?.text == "hello\nworld")
+        #expect(controller.surfaceReadCalls == [AutomationSurfaceReadRequest(surfaceID: surfaceID, lines: 10_000)])
+
+        let denied = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/surface/read",
+                headers: [AutomationAPI.handleHeader: "live"],
+                body: body
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: denied.body
+        )
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        let badLines = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/surface/read",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data("{\"surfaceID\":\"\(surfaceID)\",\"lines\":0}".utf8)
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let badLinesEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: badLines.body
+        )
+        #expect(badLines.status == 400)
+        #expect(badLinesEnvelope.error?.code == .invalidRequest)
+
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/surface/read",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self,
+            from: wrongMethod.body
+        )
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
     @Test("Operator credential round-trips through the store and is written user-only (0600)")
     func operatorCredentialStoreRoundTrip() throws {
         let url = FileManager.default.temporaryDirectory
@@ -1430,7 +1539,9 @@ struct AutomationAPITests {
         let loaded = AutomationOperatorCredentialStore.load(from: url)
         #expect(loaded == credential)
         #expect(
-            loaded?.capabilities == [.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate])
+            loaded?.capabilities == [
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+            ])
 
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
@@ -1461,7 +1572,7 @@ struct AutomationAPITests {
         #expect(AutomationOperatorCredentialStore.load(from: url) == mintedCredential)
         #expect(
             registry.resolve(mintedCredential.handle)?.capabilities == [
-                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate,
+                .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
             ]
         )
         #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)
@@ -1561,6 +1672,51 @@ struct AutomationAPITests {
         #expect(createEvent.metadata?["workspaceCreate.select"] == "provided")
         #expect(createEvent.metadata?["workspaceCreate.fromRef"] == "provided")
         #expect(!String(describing: createEvent.metadata).contains("origin/main"))
+    }
+
+    @Test("Audit log records surface.read metadata without terminal text")
+    func auditLogSurfaceReadMetadataIsContentFree() async throws {
+        let auditURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wm-surface-read-audit-\(UUID().uuidString.prefix(8)).jsonl")
+        defer { try? FileManager.default.removeItem(at: auditURL) }
+        let logger = AutomationAuditLogger(auditURL: auditURL)
+        let surfaceID = "99999999-9999-9999-9999-999999999999"
+        let requestBody = try AutomationJSON.encoder.encode(
+            AutomationSurfaceReadRequest(surfaceID: surfaceID, lines: 10_000)
+        )
+        let responseBody = try AutomationJSON.encoder.encode(
+            AutomationResponseEnvelope(
+                result: AutomationSurfaceReadResult(
+                    surfaceID: surfaceID,
+                    requestedLines: 10_000,
+                    lines: AutomationAPI.surfaceReadMaxLines,
+                    returnedLines: 2,
+                    byteCount: 11,
+                    text: "secret\ntext"
+                )
+            )
+        )
+
+        await logger.record(
+            method: "POST",
+            path: "/v1/surface/read",
+            headers: [AutomationAPI.handleHeader: "op"],
+            requestBody: requestBody,
+            responseBody: responseBody,
+            operatorHandle: true
+        )
+
+        let contents = try String(contentsOf: auditURL, encoding: .utf8)
+        #expect(!contents.contains("secret"))
+        let event = try AutomationJSON.decoder.decode(
+            AutomationAuditLogger.Event.self,
+            from: Data(try #require(contents.split(separator: "\n").first).utf8)
+        )
+        #expect(event.surfaceID == surfaceID)
+        #expect(event.requestedLines == 10_000)
+        #expect(event.returnedLines == 2)
+        #expect(event.allowed)
+        #expect(event.errorCode == nil)
     }
 
     @Test("CLI formatter emits result JSON and surfaces envelope errors")

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -193,6 +193,29 @@ the experiment was off, or after it is turned off, fail with
 `capability_denied` — restart WorkSpaces and open a fresh tile after toggling
 it. The audit log records the route and outcome, never the written text.
 
+## Read Created Workspace Terminal Text
+
+`surface/read` is operator-scoped, not tile-scoped. It is for automation that
+creates a workspace through `workspace.create` and then needs a bounded text
+read-back from that newly attached terminal. It does not grant access to
+arbitrary human-owned terminal tiles.
+
+The route body names the `attachedSurfaceID` returned by `workspace.create`:
+
+```json
+{ "surfaceID": "…", "lines": 200 }
+```
+
+Rules:
+
+- Only the same operator handle that created the workspace terminal in this app
+  launch can read it. Other operator handles, tile handles, and unattributed
+  surface IDs fail `capability_denied`.
+- Returned text is plain terminal text, with no ANSI styling.
+- `lines` is clamped to 500; the payload is capped at 256 KiB UTF-8.
+- The audit log records route metadata, surface ID, requested lines, returned
+  lines, and allow/deny outcome, never the terminal text.
+
 ## Shell Alias Ideas
 
 These examples are intentionally small. They stay inside the V1 scope and do
@@ -254,6 +277,7 @@ V1 is intentionally narrow:
 - close the caller tile through normal app behavior
 - write into the caller's own PTY (experimental, double-gated — see
   [Automation Input Write Decision](./decisions/automation-input-write.md))
+- read bounded plain text from operator-created workspace terminals
 
 V1 does not support browser mutation, opening URLs, tab metadata changes,
 writing into other tiles, resize/equalize, or global control across

--- a/docs/decisions/automation-surface-read.md
+++ b/docs/decisions/automation-surface-read.md
@@ -1,0 +1,57 @@
+# Automation Surface Read Decision
+
+## Status
+
+Accepted as a creation-scoped operator capability.
+
+## Context
+
+Automation already exposes structure (`context.read`, `surfaces.read`,
+`workspace.read`) and pixels (`window.snapshot`, web-surface snapshots), but not
+terminal text. Reading terminal content is a larger grant than capturing the app's
+own window: it can expose the human owner's private terminal scrollback. The
+route therefore needs its own authority boundary instead of silently inheriting
+operator scope.
+
+GhosttyKit at the pinned commit exposes a real plain-text extraction API:
+`ghostty_surface_read_text(surface, ghostty_selection_s, ghostty_text_s*)`, with
+`ghostty_surface_free_text` for ownership cleanup. The app's bridge uses that API
+over the whole screen/scrollback selection; no OCR or screenshot workaround is
+involved.
+
+## Decision
+
+Add `POST /v1/surface/read` guarded by `surface.read`, granted only to operator
+handles. A request may read only a terminal surface whose `attachedSurfaceID`
+came from a completed `workspace.create` call made by the same operator handle in
+the same app launch.
+
+- `AutomationHandleRegistry` records `operatorHandle -> created hostSessionID`
+  attribution when `workspace.create` completes with an attached terminal.
+- Reads from another operator handle, a tile handle, or an unattributed surface
+  fail `capability_denied`.
+- The route returns plain text only, clamped to 500 requested lines and 256 KiB
+  UTF-8. Over-cap line requests are clamped, not rejected.
+- Audit records the route, surface id, requested/returned line counts, and
+  allow/deny result. It never records the terminal text.
+
+## Rejected Alternatives
+
+### Blanket Operator Read
+
+Rejected. Operator scope is useful for same-user evidence and app orchestration,
+but terminal text read-back is qualitatively different from listing windows or
+capturing app-owned pixels. It would let automation read arbitrary human-owned
+terminal tiles, which is too broad for this route.
+
+### Experiment-Gated All-Surface Read
+
+Rejected for this pass because narrow creation attribution was straightforward:
+`workspace.create` already reports the attached terminal surface, and the handle
+registry already owns per-launch operator bookkeeping.
+
+### OCR Or Pixel Parsing
+
+Rejected. GhosttyKit exposes a real text API at the pinned commit. If that API
+disappears in a future pin, this route should fail closed or be redesigned, not
+fall back to OCR.

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -66,7 +66,9 @@ WorkSpaces terminal tile. See
   against the fresh registry (`stale_handle`).
 - **Capture, read, and operator mutations.** The operator capability set is
   `window.read` (list windows), `window.snapshot` (composited PNG of a listed
-  window), and `workspace.read` (list repos and workspaces), plus
+  window), `workspace.read` (list repos and workspaces), and `surface.read`
+  (bounded terminal text read-back for surfaces this same operator handle
+  created through `workspace.create` this launch), plus
   `workspace.select` and `workspace.create`, reviewed exceptions that drive real
   UI gestures rather than data-layer writes
   (see [Verb contract](#verb-contract-verbs--clicks)). Operator handles still
@@ -94,6 +96,9 @@ WorkSpaces terminal tile. See
 - Input injection is caller-scoped only and double-gated behind the
   `Automation Input Write` experiment; see
   [Automation Input Write Decision](../decisions/automation-input-write.md).
+- Terminal text read-back is creation-scoped to the operator handle that created
+  the workspace terminal via `workspace.create` in this launch; see
+  [Automation Surface Read Decision](../decisions/automation-surface-read.md).
 
 ## Verb contract: verbs = clicks
 
@@ -191,6 +196,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `GET /v1/workspaces` | **Operator scope.** Returns the app's tracked repos and workspaces with stable SwiftData model ids, names, and enough state to target: per workspace, its `status`, `isArchived`, `backend`, and whether it `isSelected`; per repo, whether it `isSelected`. Read-only — mutation verbs use these stable targets. Requires `workspace.read`; a tile handle lacks it and fails `capability_denied`. See [Workspace list](#workspace-list). |
 | `POST /v1/workspace/select` | **Operator scope, mutation.** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
 | `POST /v1/workspace/create` | **Operator scope, mutation.** Creates a workspace in the repo named by `repoID` (from `workspace.read`) by driving the sidebar's real create helper. Body is `{"repoID":"…","name":"…","providerID":"local","guestOS":null,"select":true,"fromRef":"origin/main"}`; `providerID` defaults to `local`, `select` defaults to `true`, and `fromRef` is omitted by default. Returns `completed` with the created workspace and, when selected, the attached terminal, or `confirmation_required` with provider setup confirmation details. Requires `workspace.create`; tile handles fail `capability_denied`. See [Workspace create](#workspace-create). |
+| `POST /v1/surface/read` | **Operator scope, content read.** Reads plain text from a terminal surface created by the same operator handle through `workspace.create` this launch. Body is `{"surfaceID":"…","lines":200}` where `surfaceID` is the `attachedSurfaceID` from that create result. Requests above 500 lines are clamped; output is capped at 256 KiB UTF-8. Requires `surface.read`; tile handles and non-created/unattributed surfaces fail `capability_denied`. See [Surface read](#surface-read). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -224,6 +230,7 @@ handle.
 | `workspace.read` | `GET /v1/workspaces` (list the app's repos and workspaces); granted only to operator handles under the Automation Operator Scope experiment, never to tile handles |
 | `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); granted only to operator handles, never to tile handles |
 | `workspace.create` | `POST /v1/workspace/create` (drive the real sidebar create helper for a repo); granted only to operator handles, never to tile handles — distinct from `workspace.read` and `workspace.select` so the read/write split stays legible |
+| `surface.read` | `POST /v1/surface/read` (bounded plain-text terminal read-back for surfaces created by the same operator handle through `workspace.create` this launch); granted only to operator handles, never to tile handles |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -327,7 +334,7 @@ mutation rides this route.
   "system": {
     "capabilities": [
       "window.read", "window.snapshot", "workspace.read",
-      "workspace.select", "workspace.create"
+      "workspace.select", "workspace.create", "surface.read"
     ]
   }
 }
@@ -438,6 +445,46 @@ user must confirm:
 - **Operator mutation.** Requires `workspace.create`, distinct from
   `workspace.read` and `workspace.select`. A tile handle lacks it and fails
   `capability_denied`.
+
+## Surface read
+
+`POST /v1/surface/read` (operator scope, `surface.read`) returns bounded plain
+text from a terminal surface created by the same operator handle through
+`workspace.create` during this app launch:
+
+```json
+{ "surfaceID": "…", "lines": 200 }
+```
+
+The success envelope carries the text plus the effective bounds:
+
+```json
+{
+  "surfaceID": "…",
+  "requestedLines": 10000,
+  "lines": 500,
+  "returnedLines": 200,
+  "byteCount": 8192,
+  "text": "plain terminal text\n",
+  "system": { "capabilities": [ … ] }
+}
+```
+
+- **Creation-scoped authority.** The only readable terminal surfaces are those
+  whose `attachedSurfaceID` came from a completed `workspace.create` call made by
+  the same operator handle in the same launch. This is not a blanket grant to
+  read the human owner's arbitrary terminal tiles. A different operator handle, a
+  tile handle, or an unattributed surface fails `capability_denied`.
+- **Ghostty text API.** The app reads GhosttyKit's plain terminal text through
+  `ghostty_surface_read_text` over the whole screen/scrollback selection. No OCR
+  or screenshot path is used.
+- **Bounds.** `lines` must be greater than zero. Values over 500 are clamped to
+  500, not rejected. The returned UTF-8 payload is capped at 256 KiB; if the line
+  suffix still exceeds that, older lines are dropped first, and a single over-cap
+  line is UTF-8-safely truncated from the front.
+- **Content-free audit.** `automation-audit.jsonl` records the route, surface id,
+  requested line count, returned line count, allow/deny outcome, and error code.
+  It never records the terminal text.
 
 ## Workspace select
 


### PR DESCRIPTION
## Summary

Adds `POST /v1/surface/read` — a bounded, plain-text read of a terminal surface's scrollback, the first Automation API route that exposes terminal *content*. Feasibility was a real open question (the issue explicitly allowed for "implement nothing, this is a hard wall" as a valid outcome) — it turned out feasible: `ghostty_surface_read_text` is a real, already-used-elsewhere GhosttyKit C API (the vendored macOS `SurfaceView_AppKit.swift` already calls it for cached screen/visible-content reads), so this reuses an established pattern rather than inventing new libghostty surface area.

**Authority model** (the design half of this issue, written down per the issue's requirement): creation-scoped, not blanket operator access. `AutomationHandleRegistry` now records which operator handle created a workspace terminal via `workspace.create`; `surface/read` succeeds only for the surface's own creator. A different operator handle, a tile handle, or an unattributed surface fails `capability_denied`. Full rationale in `docs/decisions/automation-surface-read.md` (new).

Bounds: 500 lines / 256 KiB, clamped (not rejected) when a request exceeds them; truncation is UTF-8-scalar-boundary-safe (never splits a multi-byte character). Audit records route/surfaceID/line-counts/outcome — never surface text.

Codex (gpt-5.5, high) implemented this in a dedicated worktree; `CODEX_REPORT.md` (untracked) has the full investigation trail.

## Review loop

- **Reflect**: read the full diff personally, cross-checked `readPlainScreenText()`'s use of `ghostty_surface_read_text`/`ghostty_selection_s`/`GHOSTTY_POINT_SCREEN` byte-for-byte against the existing precedent in the vendored `ghostty/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift` — matches exactly, not a speculative guess at the C API's contract. Traced `boundedSurfaceReadText`/`utf8SafeSuffix` by hand for the continuation-byte-boundary case (walks backward skipping `0b10xxxxxx` continuation bytes — correct). Verified the `ghostty_text_s` buffer is decoded into a Swift `String` *before* `ghostty_surface_free_text` runs in the `defer` (no use-after-free). Checked the cross-issue interaction with #989 (`select:false` workspace creation): confirmed `effect.attachedTerminal`/`attachedSurfaceID` are still populated correctly on that path (via `attachWorkspaceSessionWithoutSelection`), so creation-attribution recording isn't silently skipped for surfaces created without selection.
- **Codex directed review**: could not run. The account-wide codex usage quota was exhausted mid-review (four parallel implementation workers + review calls in the same window) — `ERROR: You've hit your usage limit ... try again at 1:44 PM`. Documented as a real limitation in the tile-orchestration skill README rather than silently skipped.
- No findings to adjudicate (none surfaced from the manual pass). One known test-depth gap, disclosed by the implementer: no live PTY echo round-trip test — the app's test harness doesn't currently construct a headless-injectable Ghostty PTY surface, so coverage relies on the controller's injected text-reader plus compile-time integration against the real GhosttyKit API. Noted as residual risk below, not hidden.

## Gates (rebased onto current origin/main before this run)

- `swift build`: PASS
- `swift test --filter Automation`: PASS (102 tests, 10 suites)
- Full `swift test`: PASS (1279 tests, 193 suites) — one unrelated test (`AutomationOperatorProvisioner` write-failure test, untouched by this diff) flaked once under heavy concurrent build load and passed clean on retry; confirmed not touched by this change.
- `mise run lint`: PASS

## Mergeability

- Surface: desktop — Automation API (new `surface.read` capability + route), `GhosttySurfaceView` (new read-only text extraction), `AutomationHandleRegistry` (creation attribution)
- User-facing behavior changed: No existing behavior changed; new opt-in route only reachable via operator scope for self-created surfaces
- Non-happy paths considered: unauthorized read (different operator, tile handle, unattributed surface) → `capability_denied`; stale/torn-down surface → `stale_handle`; over-cap request → clamped, not errored; empty surface → empty string, not an error
- Residual risk or follow-up: no live PTY content round-trip test (see above) — the compile-time integration against the real, precedented GhosttyKit API is the mitigating factor; worth a follow-up if the app ever gains a headless-PTY test harness

🤖 Generated with a codex (gpt-5.5) implementation worker, orchestrated by Claude Code (Sonnet 5)

## Evidence

![gates](https://evidence.cloudcompute.com/workspaces/pr-1006/20260708-183701-gates.png)

(Full-suite pass confirmed separately, not pictured; the one flaky unrelated test is documented above.)
