### PR TITLE
feat(automation): workspace.archive verb + health server metadata (#991, #992)

### DIFF
--- a/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
+++ b/Sources/WorkspaceManager/App/AutomationIntegrationLifecycle.swift
@@ -194,7 +194,13 @@ final class AutomationIntegrationLifecycle: ObservableObject {
             bundleIdentifier: bundleID,
             controller: controller,
             auditLogger: auditLogger,
-            isEnabled: { ExperimentalFeatures.isEnabled(.automationAPI) }
+            isEnabled: { ExperimentalFeatures.isEnabled(.automationAPI) },
+            makeHealthServer: { launchedAt in
+                AutomationServerDescriptor.current(
+                    launchedAt: launchedAt,
+                    experiments: Self.activeAutomationExperimentKeys()
+                )
+            }
         )
 
         let startTask = Task<String, Error> {
@@ -307,6 +313,16 @@ final class AutomationIntegrationLifecycle: ObservableObject {
                 }
             )
         }
+    }
+
+    private nonisolated static func activeAutomationExperimentKeys() -> [String] {
+        [
+            ExperimentalFeature.automationAPI,
+            .automationOperator,
+            .automationInputWrite,
+        ]
+        .filter { ExperimentalFeatures.isEnabled($0) }
+        .map(\.rawValue)
     }
 
     /// Resolves a snapshot request against the caller's live source records and the surface

--- a/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/AutomationController.swift
@@ -267,6 +267,50 @@ final class AutomationController: AutomationControlling {
         }
     }
 
+    func automationArchiveWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceArchiveResult {
+        let entry = try resolveOperator(handle, requiring: .workspaceArchive)
+        guard let uuid = UUID(uuidString: workspaceID) else {
+            throw AutomationServiceError(.invalidRequest, "workspaceID must be a UUID.")
+        }
+
+        guard let gestureVerbs else {
+            throw AutomationServiceError(
+                .unsupported,
+                "No WorkSpaces window is attached; workspace.archive requires a live window."
+            )
+        }
+
+        let capabilities = entry.capabilities
+        switch await gestureVerbs.archiveWorkspace(uuid) {
+        case .completed(let effect):
+            return AutomationWorkspaceArchiveResult(
+                workspaceID: workspaceID,
+                outcome: .completed,
+                changed: true,
+                archivedWorkspaceID: effect.workspaceID,
+                selectedWorkspaceID: effect.selectedWorkspaceID,
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        case .confirmationRequired(let confirmation):
+            return AutomationWorkspaceArchiveResult(
+                workspaceID: workspaceID,
+                outcome: .confirmationRequired,
+                changed: false,
+                confirmation: confirmation,
+                message: confirmation.message,
+                system: AutomationSystemDescriptor(capabilities: capabilities)
+            )
+        case .unsupported(let message):
+            throw AutomationServiceError(.unsupported, message)
+        case .notFound:
+            throw AutomationServiceError(
+                .invalidRequest, "No workspace with id \(workspaceID) is tracked by the app.")
+        }
+    }
+
     func automationWindowSnapshot(
         for handle: String,
         windowID: String

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -2204,6 +2204,34 @@ struct ContentView: View {
                         attachedTerminal: attached
                     )
                 )
+            },
+            performArchive: { target in
+                guard
+                    let workspace = repos.flatMap(\.workspaces).first(where: {
+                        $0.id == target.workspaceID
+                    })
+                else {
+                    return .notFound
+                }
+                let controller = SidebarWorkspaceController(
+                    modelContext: modelContext,
+                    workspaceService: workspaceService,
+                    workspaceProviderRegistry: workspaceProviderRegistry,
+                    retireTerminalSessions: { key in
+                        try await retireTerminalSessions(inScope: key)
+                    }
+                )
+                do {
+                    try await controller.archive(workspace)
+                    return .completed(
+                        AutomationWorkspaceArchiveEffect(
+                            workspaceID: workspace.id,
+                            selectedWorkspaceID: currentSelectedWorkspace?.id
+                        )
+                    )
+                } catch {
+                    return .unsupported("Failed to archive workspace: \(error.localizedDescription)")
+                }
             }
         )
     }

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -981,9 +981,11 @@ private final class CLIApp {
             return try runWorkspaceSelect(arguments: Array(arguments.dropFirst()))
         case "create":
             return try runWorkspaceCreate(arguments: Array(arguments.dropFirst()))
+        case "archive":
+            return try runWorkspaceArchive(arguments: Array(arguments.dropFirst()))
         default:
             throw CLIError(
-                "Usage: workspaces workspace list [--json] | workspace select <id> [--json] | workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json]"
+                "Usage: workspaces workspace list [--json] | workspace select <id> [--json] | workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json] | workspace archive <id> [--json]"
             )
         }
     }
@@ -1171,6 +1173,51 @@ private final class CLIApp {
             } else {
                 print("Selected \(result.workspaceID) — no terminal attached.")
             }
+        case .confirmationRequired:
+            print("Confirmation required: \(result.message ?? "the app needs confirmation to proceed.")")
+        }
+        return 0
+    }
+
+    /// `workspaces workspace archive <id> [--json]` — an operator mutation verb. Drives the
+    /// running app's real sidebar archive gesture, so the row leaves the active list exactly as it
+    /// would from the sidebar menu. `<id>` is a stable workspace id from `workspace list`.
+    private func runWorkspaceArchive(arguments: [String]) throws -> Int32 {
+        let usage = "workspaces workspace archive <id> [--json]"
+        var json = false
+        var workspaceID: String?
+        for argument in arguments {
+            switch argument {
+            case "--json":
+                json = true
+            default:
+                guard workspaceID == nil else { throw CLIError("Usage: \(usage)") }
+                workspaceID = argument
+            }
+        }
+        guard let workspaceID, !workspaceID.isEmpty else {
+            throw CLIError("Usage: \(usage)")
+        }
+
+        let credential = try loadOperatorCredential()
+        let body = try JSONSerialization.data(withJSONObject: ["workspaceID": workspaceID])
+        let result = try operatorRequest(
+            AutomationWorkspaceArchiveResult.self,
+            credential: credential,
+            method: "POST",
+            path: "/v1/workspace/archive",
+            body: body
+        )
+
+        if json {
+            print(try AutomationCLIResultPrinter.resultJSON(result))
+            return 0
+        }
+
+        switch result.outcome {
+        case .completed:
+            let selected = result.selectedWorkspaceID?.uuidString ?? "-"
+            print("Archived \(result.workspaceID) — selected workspace \(selected).")
         case .confirmationRequired:
             print("Confirmation required: \(result.message ?? "the app needs confirmation to proceed.")")
         }
@@ -1748,6 +1795,7 @@ private func printHelp() {
           workspaces workspace list [--json]
           workspaces workspace select <workspace-id> [--json]
           workspaces workspace create <repo-id> <name> [--provider <id>] [--guest-os <linux|macos>] [--json]
+          workspaces workspace archive <workspace-id> [--json]
           workspaces help
 
         Launch behavior:

--- a/Sources/WorkspaceManagerCLI/main.swift
+++ b/Sources/WorkspaceManagerCLI/main.swift
@@ -704,15 +704,11 @@ private final class CLIApp {
 
         switch subcommand {
         case "health":
-            let result: AutomationHealthResult = try performAutomationRequest(
-                method: "GET",
-                path: "/v1/health",
-                requiresHandle: false
-            )
+            let result = try performAutomationHealthRequest()
             if arguments.dropFirst().contains("--json") {
                 print(try AutomationCLIResultPrinter.resultJSON(result))
             } else {
-                print(result.status.uppercased())
+                print(Self.healthLine(result))
             }
             return 0
 
@@ -1280,6 +1276,45 @@ private final class CLIApp {
                 "automation request failed: \(error.response.code.rawValue): \(error.response.message)"
             )
         }
+    }
+
+    private func performAutomationHealthRequest() throws -> AutomationHealthResult {
+        let response = try automationClient().request(
+            method: "GET",
+            path: "/v1/health",
+            handle: nil,
+            body: Data()
+        )
+        do {
+            return try AutomationCLIResultPrinter.decodeHealthEnvelope(
+                from: response,
+                bundledCLIPath: Self.bundledCLIPath()
+            )
+        } catch let error as AutomationCLIResponseError {
+            throw CLIError(error.localizedDescription)
+        } catch let error as AutomationServiceError {
+            throw CLIError(
+                "automation request failed: \(error.response.code.rawValue): \(error.response.message)"
+            )
+        }
+    }
+
+    private static func healthLine(_ result: AutomationHealthResult) -> String {
+        guard let server = result.server else {
+            return result.status.uppercased()
+        }
+        let experiments = server.experiments.isEmpty ? "-" : server.experiments.joined(separator: ",")
+        return "\(result.status.uppercased()) pid=\(server.pid) launchedAt=\(server.launchedAt) "
+            + "protocol=\(server.protocolVersion) experiments=\(experiments)"
+    }
+
+    private static func bundledCLIPath() -> String {
+        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appBundleIdentifier) {
+            return appURL.appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent("workspaces", isDirectory: false).path
+        }
+        return Bundle.main.executablePath ?? "workspaces"
     }
 
     private func automationClient() throws -> AutomationSocketClient {

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -25,7 +25,7 @@ public enum AutomationAPI {
     /// Operator handles still never carry tile mutation or `input.write`.
     public static let operatorCapabilities = [
         AutomationCapability.windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect,
-        .workspaceCreate, .surfaceRead,
+        .workspaceCreate, .surfaceRead, .workspaceArchive,
     ]
 
     public static let inputWriteMaxUTF8Bytes = 32_768
@@ -69,6 +69,7 @@ public enum AutomationCapability: String, Codable, Sendable, CaseIterable, Equat
     case workspaceSelect = "workspace.select"
     case workspaceCreate = "workspace.create"
     case surfaceRead = "surface.read"
+    case workspaceArchive = "workspace.archive"
 }
 
 public enum AutomationSurfaceKind: String, Codable, Sendable, Equatable {
@@ -599,6 +600,14 @@ public struct AutomationWorkspaceCreateRequest: Codable, Sendable, Equatable {
     }
 }
 
+public struct AutomationWorkspaceArchiveRequest: Codable, Sendable, Equatable {
+    public let workspaceID: String
+
+    public init(workspaceID: String) {
+        self.workspaceID = workspaceID
+    }
+}
+
 public struct AutomationWorkspaceCreateCommand: Sendable, Equatable {
     public let repoID: UUID
     public let name: String
@@ -653,6 +662,18 @@ public struct AutomationWorkspaceCreateEffect: Sendable, Equatable {
         self.selectedWorkspaceID = selectedWorkspaceID
         self.attachedSurfaceID = attachedSurfaceID
         self.attachedTerminal = attachedTerminal
+    }
+}
+
+/// What driving the real workspace-archive gesture produced. `selectedWorkspaceID` is read after
+/// the gesture so callers can observe the same selection fallback a sidebar archive click produced.
+public struct AutomationWorkspaceArchiveEffect: Sendable, Equatable {
+    public let workspaceID: UUID
+    public let selectedWorkspaceID: UUID?
+
+    public init(workspaceID: UUID, selectedWorkspaceID: UUID?) {
+        self.workspaceID = workspaceID
+        self.selectedWorkspaceID = selectedWorkspaceID
     }
 }
 
@@ -745,6 +766,43 @@ public struct AutomationSurfaceReadResult: Codable, Sendable, Equatable {
         self.returnedLines = returnedLines
         self.byteCount = byteCount
         self.text = text
+        self.system = system
+    }
+}
+
+/// Response for `POST /v1/workspace/archive` (`workspace.archive`, operator scope). On completion
+/// the result mirrors the sidebar archive gesture: the workspace moves into the archived state and
+/// `selectedWorkspaceID` reports the selection state the click path left behind. If the path reaches
+/// modal UI, the success envelope reports `confirmation_required` with a structured payload.
+public struct AutomationWorkspaceArchiveResult: Codable, Sendable, Equatable {
+    public let workspaceID: String
+    public let outcome: AutomationGestureOutcomeKind
+    public let changed: Bool
+    public let archivedWorkspaceID: UUID?
+    public let selectedWorkspaceID: UUID?
+    public let confirmation: AutomationConfirmationRequirement?
+    public let message: String?
+    public let system: AutomationSystemDescriptor
+
+    public init(
+        workspaceID: String,
+        outcome: AutomationGestureOutcomeKind,
+        changed: Bool,
+        archivedWorkspaceID: UUID? = nil,
+        selectedWorkspaceID: UUID? = nil,
+        confirmation: AutomationConfirmationRequirement? = nil,
+        message: String? = nil,
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(
+            capabilities: AutomationAPI.operatorCapabilities
+        )
+    ) {
+        self.workspaceID = workspaceID
+        self.outcome = outcome
+        self.changed = changed
+        self.archivedWorkspaceID = archivedWorkspaceID
+        self.selectedWorkspaceID = selectedWorkspaceID
+        self.confirmation = confirmation
+        self.message = message
         self.system = system
     }
 }
@@ -928,6 +986,10 @@ public protocol AutomationControlling: AnyObject, Sendable {
         for handle: String,
         request: AutomationWorkspaceCreateRequest
     ) async throws -> AutomationWorkspaceCreateResult
+    func automationArchiveWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceArchiveResult
     func automationWindowSnapshot(
         for handle: String,
         windowID: String

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationAPI.swift
@@ -104,10 +104,73 @@ public struct AutomationSystemDescriptor: Codable, Sendable, Equatable {
 public struct AutomationHealthResult: Codable, Sendable, Equatable {
     public let status: String
     public let system: AutomationSystemDescriptor
+    public let server: AutomationServerDescriptor?
 
-    public init(status: String = "ok", system: AutomationSystemDescriptor = AutomationSystemDescriptor()) {
+    public init(
+        status: String = "ok",
+        system: AutomationSystemDescriptor = AutomationSystemDescriptor(),
+        server: AutomationServerDescriptor? = nil
+    ) {
         self.status = status
         self.system = system
+        self.server = server
+    }
+}
+
+public struct AutomationServerDescriptor: Codable, Sendable, Equatable {
+    public let pid: Int32
+    public let launchedAt: String
+    public let appVersion: String
+    public let build: String
+    public let experiments: [String]
+    public let protocolVersion: Int
+
+    public init(
+        pid: Int32,
+        launchedAt: String,
+        appVersion: String,
+        build: String,
+        experiments: [String],
+        protocolVersion: Int = AutomationAPI.version
+    ) {
+        self.pid = pid
+        self.launchedAt = launchedAt
+        self.appVersion = appVersion
+        self.build = build
+        self.experiments = experiments
+        self.protocolVersion = protocolVersion
+    }
+
+    public static func current(
+        launchedAt: Date,
+        experiments: [String],
+        bundle: Bundle = .main,
+        processInfo: ProcessInfo = .processInfo
+    ) -> AutomationServerDescriptor {
+        let appVersion =
+            bundle.infoDictionary?["CFBundleShortVersionString"] as? String
+            ?? bundle.infoDictionary?["CFBundleVersion"] as? String
+            ?? "dev"
+        return AutomationServerDescriptor(
+            pid: processInfo.processIdentifier,
+            launchedAt: Self.iso8601String(from: launchedAt),
+            appVersion: appVersion,
+            build: Self.buildConfiguration,
+            experiments: experiments.sorted(),
+            protocolVersion: AutomationAPI.version
+        )
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private static var buildConfiguration: String {
+        #if DEBUG
+            "debug"
+        #else
+            "release"
+        #endif
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationCLIFormatting.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+public enum AutomationCLIResponseError: Error, Equatable, LocalizedError {
+    case protocolVersionMismatch(cliVersion: Int, appVersion: Int, bundledCLIPath: String)
+    case undecodableResponse(rawBody: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .protocolVersionMismatch(let cliVersion, let appVersion, let bundledCLIPath):
+            return "CLI v\(cliVersion) vs app v\(appVersion) — use the bundled CLI at \(bundledCLIPath)"
+        case .undecodableResponse(let rawBody):
+            return "Could not parse automation health response. Raw response:\n\(rawBody)"
+        }
+    }
+}
+
 public enum AutomationCLIResultPrinter {
     public static func resultJSON<Result: Encodable>(_ result: Result) throws -> String {
         let data = try AutomationJSON.prettyEncoder.encode(result)
@@ -18,5 +32,42 @@ public enum AutomationCLIResultPrinter {
             envelope.error
             ?? AutomationErrorResponse(code: .internalError, message: "Automation response did not include an error.")
         throw AutomationServiceError(response: error)
+    }
+
+    public static func decodeHealthEnvelope(
+        from response: AutomationSocketClient.Response,
+        bundledCLIPath: String
+    ) throws -> AutomationHealthResult {
+        if let protocolVersion = healthProtocolVersion(in: response.body),
+            protocolVersion != AutomationAPI.version
+        {
+            throw AutomationCLIResponseError.protocolVersionMismatch(
+                cliVersion: AutomationAPI.version,
+                appVersion: protocolVersion,
+                bundledCLIPath: bundledCLIPath
+            )
+        }
+        do {
+            return try decodeEnvelope(AutomationHealthResult.self, from: response)
+        } catch let error as AutomationServiceError {
+            throw error
+        } catch {
+            throw AutomationCLIResponseError.undecodableResponse(rawBody: rawBody(response.body))
+        }
+    }
+
+    private static func healthProtocolVersion(in body: Data) -> Int? {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+            let result = object["result"] as? [String: Any],
+            let server = result["server"] as? [String: Any]
+        else {
+            return nil
+        }
+        return server["protocolVersion"] as? Int
+    }
+
+    private static func rawBody(_ body: Data) -> String {
+        String(data: body, encoding: .utf8) ?? body.base64EncodedString()
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationGestureVerbs.swift
@@ -47,6 +47,18 @@ public enum AutomationWorkspaceCreateOutcome: Sendable, Equatable {
     case invalidRequest(String)
 }
 
+public enum AutomationWorkspaceArchiveOutcome: Sendable, Equatable {
+    /// The archive gesture ran through the real UI path and persisted the archive state.
+    case completed(AutomationWorkspaceArchiveEffect)
+    /// The gesture reached a modal or setup confirmation. The caller gets the confirmation details
+    /// as data instead of waiting on UI it cannot answer.
+    case confirmationRequired(AutomationConfirmationRequirement)
+    /// The verb cannot run in the current context, most often because no live window/sidebar is bound.
+    case unsupported(String)
+    /// The workspace id resolves to nothing the app tracks. Mapped to `invalid_request` at the wire.
+    case notFound
+}
+
 @MainActor
 public final class AutomationGestureVerbs {
     /// The minimum a verb needs to target and describe a workspace, projected out of the live
@@ -92,6 +104,8 @@ public final class AutomationGestureVerbs {
     /// Drive the real sidebar create gesture for `command` and report what the UI did.
     private let performCreation:
         (@MainActor (RepoTarget, AutomationWorkspaceCreateCommand) async -> AutomationWorkspaceCreateOutcome)?
+    /// Drive the real sidebar archive gesture for `target` and report what the UI did.
+    private let performArchive: (@MainActor (WorkspaceTarget) async -> AutomationWorkspaceArchiveOutcome)?
 
     public init(
         resolveWorkspace: @escaping @MainActor (UUID) -> WorkspaceTarget?,
@@ -99,12 +113,14 @@ public final class AutomationGestureVerbs {
         resolveRepo: (@MainActor (UUID) -> RepoTarget?)? = nil,
         performCreation: (
             @MainActor (RepoTarget, AutomationWorkspaceCreateCommand) async -> AutomationWorkspaceCreateOutcome
-        )? = nil
+        )? = nil,
+        performArchive: (@MainActor (WorkspaceTarget) async -> AutomationWorkspaceArchiveOutcome)? = nil
     ) {
         self.resolveWorkspace = resolveWorkspace
         self.performSelection = performSelection
         self.resolveRepo = resolveRepo
         self.performCreation = performCreation
+        self.performArchive = performArchive
     }
 
     /// `workspace.select`: enter the same selection path a sidebar click takes. Resolves the id, then
@@ -132,5 +148,18 @@ public final class AutomationGestureVerbs {
             return .notFound
         }
         return await performCreation(target, command)
+    }
+
+    /// `workspace.archive`: enter the same sidebar archive action the row menu uses. Resolves the
+    /// workspace id, then drives only the supplied gesture closure. A missing archive closure means
+    /// the live window did not install an archive path, so the verb fails closed.
+    public func archiveWorkspace(_ workspaceID: UUID) async -> AutomationWorkspaceArchiveOutcome {
+        guard let performArchive else {
+            return .unsupported("No WorkSpaces sidebar is attached; workspace.archive requires a live window.")
+        }
+        guard let target = resolveWorkspace(workspaceID) else {
+            return .notFound
+        }
+        return await performArchive(target)
     }
 }

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -10,10 +10,16 @@ enum AutomationHTTPRouter {
         _ request: HTTPRequest,
         controller: any AutomationControlling,
         enabled: Bool,
+        healthServer: AutomationServerDescriptor? = nil,
         encoder: JSONEncoder = AutomationJSON.encoder
     ) async -> AutomationHTTPResult {
         do {
-            let result = try await routeResult(request, controller: controller, enabled: enabled)
+            let result = try await routeResult(
+                request,
+                controller: controller,
+                enabled: enabled,
+                healthServer: healthServer
+            )
             return try success(result, encoder: encoder)
         } catch let error as AutomationServiceError {
             return failure(error.response, status: httpStatus(for: error.response.code), encoder: encoder)
@@ -29,12 +35,13 @@ enum AutomationHTTPRouter {
     private static func routeResult(
         _ request: HTTPRequest,
         controller: any AutomationControlling,
-        enabled: Bool
+        enabled: Bool,
+        healthServer: AutomationServerDescriptor?
     ) async throws -> any CodableSendableEquatable {
         let method = request.method.uppercased()
         switch (method, request.path) {
         case ("GET", "/v1/health"):
-            return AutomationHealthResult()
+            return AutomationHealthResult(server: healthServer)
 
         case (_, "/v1/health"):
             throw AutomationServiceError(.methodNotAllowed, "Use GET /v1/health.")

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationHTTPRouter.swift
@@ -96,6 +96,10 @@ enum AutomationHTTPRouter {
             let read = try decodeSurfaceRead(from: request.body)
             return try await controller.automationReadSurface(for: handle, request: read)
 
+        case ("POST", "/v1/workspace/archive"):
+            let workspaceID = try decodeWorkspaceID(from: request.body)
+            return try await controller.automationArchiveWorkspace(for: handle, workspaceID: workspaceID)
+
         case ("POST", "/v1/tile/focus"):
             let direction = try decodeDirection(
                 AutomationTileFocusDirection.self,
@@ -142,6 +146,8 @@ enum AutomationHTTPRouter {
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/create.")
         case (_, "/v1/surface/read"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/surface/read.")
+        case (_, "/v1/workspace/archive"):
+            throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/workspace/archive.")
         case (_, "/v1/tile/focus"):
             throw AutomationServiceError(.methodNotAllowed, "Use POST /v1/tile/focus.")
         case (_, "/v1/tile/split"):
@@ -436,6 +442,7 @@ extension AutomationWindowsResult: CodableSendableEquatable {}
 extension AutomationWorkspacesResult: CodableSendableEquatable {}
 extension AutomationWorkspaceSelectResult: CodableSendableEquatable {}
 extension AutomationWorkspaceCreateResult: CodableSendableEquatable {}
+extension AutomationWorkspaceArchiveResult: CodableSendableEquatable {}
 extension AutomationWindowSnapshotResult: CodableSendableEquatable {}
 extension AutomationSurfaceReadResult: CodableSendableEquatable {}
 extension AutomationWebSurfacesResult: CodableSendableEquatable {}

--- a/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
+++ b/Sources/WorkspaceManagerCore/Services/Automation/AutomationListener.swift
@@ -19,11 +19,13 @@ public actor AutomationListener {
     private let lockURL: URL
     private let controller: any AutomationControlling
     private let isEnabled: @Sendable () -> Bool
+    private let makeHealthServer: @Sendable (Date) -> AutomationServerDescriptor
     private let auditLogger: AutomationAuditLogger?
     private let logger: @Sendable (String) -> Void
     private var listener: NWListener?
     private var lockFileDescriptor: Int32?
     private var statistics = Statistics()
+    private var healthServer: AutomationServerDescriptor?
 
     public init(
         bundleIdentifier: String,
@@ -31,11 +33,15 @@ public actor AutomationListener {
         socketURLOverride: URL? = nil,
         auditLogger: AutomationAuditLogger? = nil,
         isEnabled: @escaping @Sendable () -> Bool = { true },
+        makeHealthServer: @escaping @Sendable (Date) -> AutomationServerDescriptor = {
+            AutomationServerDescriptor.current(launchedAt: $0, experiments: [])
+        },
         logger: @escaping @Sendable (String) -> Void = { NSLog("[AutomationListener] %@", $0) }
     ) {
         self.controller = controller
         self.auditLogger = auditLogger
         self.isEnabled = isEnabled
+        self.makeHealthServer = makeHealthServer
         self.logger = logger
         if let socketURLOverride {
             self.socketURL = socketURLOverride
@@ -92,6 +98,7 @@ public actor AutomationListener {
         }
         listener.start(queue: .global(qos: .userInitiated))
         self.listener = listener
+        self.healthServer = makeHealthServer(Date())
         hardenSocketFileIfPresent()
         logger("listener started at \(socketURL.path)")
     }
@@ -100,6 +107,7 @@ public actor AutomationListener {
         let hadListener = listener != nil
         listener?.cancel()
         listener = nil
+        healthServer = nil
         if hadListener {
             try? FileManager.default.removeItem(at: socketURL)
             logger("listener stopped; socket file removed at \(socketURL.path)")
@@ -164,7 +172,8 @@ public actor AutomationListener {
         let result = await AutomationHTTPRouter.route(
             request,
             controller: controller,
-            enabled: isEnabled()
+            enabled: isEnabled(),
+            healthServer: healthServer
         )
         statistics.requestCount += 1
         if result.status == 404 {

--- a/Tests/WorkspaceManagerAppTests/AutomationArchiveVerbTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationArchiveVerbTests.swift
@@ -1,0 +1,175 @@
+//
+//  AutomationArchiveVerbTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Exercises the real AutomationController.automationArchiveWorkspace against a real handle registry:
+//  operator-scope capability enforcement, completed/unsupported/invalid_request outcome mapping, and
+//  the selected-workspace fallback reported after the real archive gesture runs.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManager
+@testable import WorkspaceManagerCore
+
+@MainActor
+@Suite("AutomationController workspace.archive")
+struct AutomationArchiveVerbTests {
+    private func expectFailure(
+        _ code: AutomationErrorCode,
+        _ body: () async throws -> some Any
+    ) async {
+        do {
+            _ = try await body()
+            Issue.record("Expected \(code.rawValue) but the call succeeded.")
+        } catch let error as AutomationServiceError {
+            #expect(error.response.code == code)
+        } catch {
+            Issue.record("Expected AutomationServiceError but got \(error).")
+        }
+    }
+
+    private func operatorController(
+        gestureVerbs: AutomationGestureVerbs?
+    ) -> (AutomationController, registry: AutomationHandleRegistry, operatorHandle: String) {
+        let registry = AutomationHandleRegistry(makeHandle: { UUID().uuidString })
+        let entry = registry.registerOperator(appScopeID: "workspaces.local")
+        let controller = AutomationController(
+            handleRegistry: registry,
+            tileTreeStore: TileTreeStore(),
+            focusTerminal: { _ in },
+            requestCloseTerminal: { _ in },
+            gestureVerbs: gestureVerbs
+        )
+        return (controller, registry, entry.handle)
+    }
+
+    @Test("operator handle with a live archive layer completes and reports selected fallback")
+    func operatorCompletes() async throws {
+        let id = UUID()
+        let selected = UUID()
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { [id] in
+                $0 == id
+                    ? AutomationGestureVerbs.WorkspaceTarget(workspaceID: id, name: "ws", isArchived: false)
+                    : nil
+            },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            performArchive: { target in
+                .completed(
+                    AutomationWorkspaceArchiveEffect(
+                        workspaceID: target.workspaceID,
+                        selectedWorkspaceID: selected))
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        let result = try await controller.automationArchiveWorkspace(
+            for: handle, workspaceID: id.uuidString)
+
+        #expect(result.outcome == .completed)
+        #expect(result.changed)
+        #expect(result.archivedWorkspaceID == id)
+        #expect(result.selectedWorkspaceID == selected)
+        #expect(result.system.capabilities.contains(.workspaceArchive))
+    }
+
+    @Test("a tile handle lacks workspace.archive and is denied")
+    func tileHandleDenied() async throws {
+        let (controller, registry, _) = operatorController(gestureVerbs: nil)
+        let tile = registry.upsert(
+            hostSessionID: UUID(),
+            tileID: nil,
+            surfaceKind: .terminal,
+            windowScopeID: "window",
+            appScopeID: "workspaces.local"
+        )
+
+        await expectFailure(.capabilityDenied) {
+            try await controller.automationArchiveWorkspace(
+                for: tile.handle, workspaceID: UUID().uuidString)
+        }
+    }
+
+    @Test("no live gesture layer is unsupported")
+    func noWindowUnsupported() async throws {
+        let (controller, _, handle) = operatorController(gestureVerbs: nil)
+
+        await expectFailure(.unsupported) {
+            try await controller.automationArchiveWorkspace(
+                for: handle, workspaceID: UUID().uuidString)
+        }
+    }
+
+    @Test("detaching the gesture layer makes archive unsupported")
+    func detachedGestureLayerIsUnsupported() async throws {
+        var drove = false
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: {
+                AutomationGestureVerbs.WorkspaceTarget(workspaceID: $0, name: "ws", isArchived: false)
+            },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            performArchive: { target in
+                drove = true
+                return .completed(
+                    AutomationWorkspaceArchiveEffect(workspaceID: target.workspaceID, selectedWorkspaceID: nil))
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        controller.detachGestureVerbs()
+
+        await expectFailure(.unsupported) {
+            try await controller.automationArchiveWorkspace(
+                for: handle, workspaceID: UUID().uuidString)
+        }
+        #expect(!drove)
+    }
+
+    @Test("a non-UUID id is invalid_request")
+    func badUUIDInvalid() async throws {
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            performArchive: { _ in .unsupported("should not run") }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        await expectFailure(.invalidRequest) {
+            try await controller.automationArchiveWorkspace(for: handle, workspaceID: "not-a-uuid")
+        }
+    }
+
+    @Test("a well-shaped but unknown id is invalid_request and never drives the gesture")
+    func unknownIDInvalid() async throws {
+        var performed = false
+        let verbs = AutomationGestureVerbs(
+            resolveWorkspace: { _ in nil },
+            performSelection: { _ in
+                AutomationWorkspaceSelectEffect(
+                    selectedWorkspaceID: nil, attachedSurfaceID: nil, attachedTerminal: false)
+            },
+            performArchive: { _ in
+                performed = true
+                return .unsupported("should not run")
+            }
+        )
+        let (controller, _, handle) = operatorController(gestureVerbs: verbs)
+
+        await expectFailure(.invalidRequest) {
+            try await controller.automationArchiveWorkspace(
+                for: handle, workspaceID: UUID().uuidString)
+        }
+        #expect(!performed)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AutomationControllerTests.swift
@@ -512,6 +512,7 @@ struct AutomationControllerTests {
         #expect(
             result.system.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
@@ -606,6 +607,7 @@ struct AutomationControllerTests {
         #expect(
             result.system.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
         #expect(controller.automationHandleIsOperator(operatorEntry.handle))
     }
@@ -680,6 +682,7 @@ struct AutomationControllerTests {
         #expect(
             result.system.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
         #expect(requestedWindowIDs == ["42"])
     }

--- a/Tests/WorkspaceManagerAppTests/WorkspacesAppIntentsTests.swift
+++ b/Tests/WorkspaceManagerAppTests/WorkspacesAppIntentsTests.swift
@@ -101,6 +101,13 @@ private final class FakeWorkspacesAppIntentController: AutomationControlling {
             )
     }
 
+    func automationArchiveWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceArchiveResult {
+        throw AutomationServiceError(.unsupported, "Not used by App Intents.")
+    }
+
     func automationWindowSnapshot(
         for handle: String,
         windowID: String

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -440,10 +440,19 @@ struct AutomationAPITests {
     @MainActor
     func routerHealthAndDisabled() async throws {
         let controller = FakeAutomationController()
+        let server = AutomationServerDescriptor(
+            pid: 7301,
+            launchedAt: "2026-07-08T08:35:44Z",
+            appVersion: "1.2.3",
+            build: "debug",
+            experiments: ["automationAPI", "automationInputWrite", "automationOperator"],
+            protocolVersion: AutomationAPI.version
+        )
         let health = await AutomationHTTPRouter.route(
             HTTPRequest(method: "GET", path: "/v1/health", headers: [:], body: Data()),
             controller: controller,
-            enabled: false
+            enabled: false,
+            healthServer: server
         )
         let healthEnvelope = try AutomationJSON.decoder.decode(
             AutomationResponseEnvelope<AutomationHealthResult>.self,
@@ -451,6 +460,8 @@ struct AutomationAPITests {
         )
         #expect(health.status == 200)
         #expect(healthEnvelope.ok)
+        #expect(healthEnvelope.result?.server == server)
+        #expect(healthEnvelope.result?.server?.protocolVersion == AutomationAPI.version)
 
         let context = await AutomationHTTPRouter.route(
             HTTPRequest(
@@ -1912,6 +1923,53 @@ struct AutomationAPITests {
         } catch let error as AutomationServiceError {
             #expect(error.response.code == .staleHandle)
         }
+
+        let health = AutomationHealthResult(
+            server: AutomationServerDescriptor(
+                pid: 7301,
+                launchedAt: "2026-07-08T08:35:44Z",
+                appVersion: "1.2.3",
+                build: "debug",
+                experiments: ["automationAPI"],
+                protocolVersion: AutomationAPI.version
+            )
+        )
+        let healthResponse = AutomationSocketClient.Response(
+            statusCode: 200,
+            body: try AutomationJSON.encoder.encode(AutomationResponseEnvelope(result: health))
+        )
+        #expect(
+            try AutomationCLIResultPrinter.decodeHealthEnvelope(
+                from: healthResponse,
+                bundledCLIPath: "/Applications/WorkSpaces.app/Contents/MacOS/workspaces"
+            ) == health)
+
+        let skewed = Data(
+            #"{"ok":true,"result":{"server":{"protocolVersion":2}},"v":1}"#.utf8
+        )
+        do {
+            _ = try AutomationCLIResultPrinter.decodeHealthEnvelope(
+                from: AutomationSocketClient.Response(statusCode: 200, body: skewed),
+                bundledCLIPath: "/Applications/WorkSpaces.app/Contents/MacOS/workspaces"
+            )
+            Issue.record("Expected protocol version mismatch")
+        } catch let error as AutomationCLIResponseError {
+            #expect(
+                error.localizedDescription
+                    == "CLI v1 vs app v2 — use the bundled CLI at /Applications/WorkSpaces.app/Contents/MacOS/workspaces"
+            )
+        }
+
+        let raw = #"{"ok":true,"result":{"status":123}}"#
+        do {
+            _ = try AutomationCLIResultPrinter.decodeHealthEnvelope(
+                from: AutomationSocketClient.Response(statusCode: 200, body: Data(raw.utf8)),
+                bundledCLIPath: "/Applications/WorkSpaces.app/Contents/MacOS/workspaces"
+            )
+            Issue.record("Expected raw-body decode fallback")
+        } catch let error as AutomationCLIResponseError {
+            #expect(error.localizedDescription.contains(raw))
+        }
     }
 
     @Test("A second listener fails instead of becoming a dormant handle issuer")
@@ -1972,6 +2030,8 @@ struct AutomationListenerTests {
         #expect(response.statusCode == 200)
         #expect(envelope.ok)
         #expect(envelope.result?.status == "ok")
+        #expect(envelope.result?.server?.pid == ProcessInfo.processInfo.processIdentifier)
+        #expect(envelope.result?.server?.protocolVersion == AutomationAPI.version)
         await listener.stop()
     }
 }

--- a/Tests/WorkspaceManagerTests/AutomationAPITests.swift
+++ b/Tests/WorkspaceManagerTests/AutomationAPITests.swift
@@ -79,6 +79,9 @@ private final class FakeAutomationController: AutomationControlling {
     }
 
     var workspaceCalls: [String] = []
+    var archivedWorkspaceIDs: Set<String> = []
+    static let inventoryRepoID = "55555555-5555-5555-5555-555555555555"
+    static let inventoryWorkspaceID = "66666666-6666-6666-6666-666666666666"
 
     func automationWorkspaces(for handle: String) throws -> AutomationWorkspacesResult {
         // Only an operator handle carries workspace.read; a tile handle ("live") fails closed, and an
@@ -90,10 +93,12 @@ private final class FakeAutomationController: AutomationControlling {
             throw AutomationServiceError(.capabilityDenied, "The automation handle does not include workspace.read.")
         }
         workspaceCalls.append(handle)
+        let workspaceID = Self.inventoryWorkspaceID
+        let archived = archivedWorkspaceIDs.contains(workspaceID)
         return AutomationWorkspacesResult(
             repos: [
                 AutomationRepoDescriptor(
-                    repoID: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+                    repoID: UUID(uuidString: Self.inventoryRepoID)!,
                     name: "workspaces",
                     path: "/Users/test/workspaces",
                     isSelected: true
@@ -101,13 +106,13 @@ private final class FakeAutomationController: AutomationControlling {
             ],
             workspaces: [
                 AutomationWorkspaceDescriptor(
-                    workspaceID: UUID(uuidString: "66666666-6666-6666-6666-666666666666")!,
-                    repoID: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+                    workspaceID: UUID(uuidString: workspaceID)!,
+                    repoID: UUID(uuidString: Self.inventoryRepoID)!,
                     name: "feature-a",
                     path: "/Users/test/workspaces/feature-a",
                     branch: "feature-a",
-                    status: "active",
-                    isArchived: false,
+                    status: archived ? "archived" : "active",
+                    isArchived: archived,
                     backend: "local",
                     isSelected: true
                 )
@@ -117,6 +122,7 @@ private final class FakeAutomationController: AutomationControlling {
 
     var selectCalls: [String] = []
     var createCalls: [AutomationWorkspaceCreateRequest] = []
+    var archiveCalls: [String] = []
 
     /// Named ids the fake maps to each projected outcome, so router tests can drive the wire mapping
     /// without a live app. A well-shaped-but-unknown id and a non-UUID id both project to
@@ -129,6 +135,9 @@ private final class FakeAutomationController: AutomationControlling {
     static let createConfirmationRepoID = "55555555-5555-5555-5555-555555555555"
     static let createWorkspaceID = "88888888-8888-8888-8888-888888888888"
     static let createAttachedSurfaceID = "99999999-9999-9999-9999-999999999999"
+    static let archiveUnknownID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    static let archiveNoWindowID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    static let archiveSelectedWorkspaceID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
 
     func automationSelectWorkspace(
         for handle: String,
@@ -215,6 +224,39 @@ private final class FakeAutomationController: AutomationControlling {
             selectedWorkspaceID: UUID(uuidString: Self.createWorkspaceID),
             attachedTerminal: true,
             attachedSurfaceID: Self.createAttachedSurfaceID
+        )
+    }
+
+    func automationArchiveWorkspace(
+        for handle: String,
+        workspaceID: String
+    ) async throws -> AutomationWorkspaceArchiveResult {
+        guard handle == "operator" else {
+            guard handle == "live" else {
+                throw AutomationServiceError(.staleHandle, "stale")
+            }
+            throw AutomationServiceError(
+                .capabilityDenied, "The automation handle does not include workspace.archive.")
+        }
+        guard UUID(uuidString: workspaceID) != nil else {
+            throw AutomationServiceError(.invalidRequest, "workspaceID must be a UUID.")
+        }
+        if workspaceID == Self.archiveUnknownID {
+            throw AutomationServiceError(
+                .invalidRequest, "No workspace with id \(workspaceID) is tracked by the app.")
+        }
+        if workspaceID == Self.archiveNoWindowID {
+            throw AutomationServiceError(
+                .unsupported, "No WorkSpaces window is attached; workspace.archive requires a live window.")
+        }
+        archiveCalls.append(workspaceID)
+        archivedWorkspaceIDs.insert(workspaceID)
+        return AutomationWorkspaceArchiveResult(
+            workspaceID: workspaceID,
+            outcome: .completed,
+            changed: true,
+            archivedWorkspaceID: UUID(uuidString: workspaceID),
+            selectedWorkspaceID: UUID(uuidString: Self.archiveSelectedWorkspaceID)
         )
     }
 
@@ -875,6 +917,7 @@ struct AutomationAPITests {
         #expect(
             entry.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
         // Operator mutation capabilities are reviewed gesture verbs; an operator handle still never
         // carries tile mutation or input.write.
@@ -913,6 +956,7 @@ struct AutomationAPITests {
         #expect(
             okEnvelope.result?.system.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
         #expect(controller.windowCalls == ["operator"])
 
@@ -995,6 +1039,7 @@ struct AutomationAPITests {
         #expect(
             okEnvelope.result?.system.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
         #expect(controller.workspaceCalls == ["operator"])
 
@@ -1342,6 +1387,119 @@ struct AutomationAPITests {
         #expect(json.contains("\"providerID\":\"lume\""))
     }
 
+    @Test("POST /v1/workspace/archive projects the gesture outcome and enforces the capability")
+    @MainActor
+    func routerWorkspaceArchive() async throws {
+        let controller = FakeAutomationController()
+        let validID = FakeAutomationController.inventoryWorkspaceID
+
+        func post(_ handle: String?, body: Data) async -> AutomationHTTPResult {
+            var headers: [String: String] = [:]
+            if let handle { headers[AutomationAPI.handleHeader] = handle }
+            return await AutomationHTTPRouter.route(
+                HTTPRequest(method: "POST", path: "/v1/workspace/archive", headers: headers, body: body),
+                controller: controller,
+                enabled: true
+            )
+        }
+
+        func body(_ id: String) -> Data {
+            Data("{\"workspaceID\":\"\(id)\"}".utf8)
+        }
+
+        let ok = await post("operator", body: body(validID))
+        let okEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWorkspaceArchiveResult>.self, from: ok.body)
+        #expect(ok.status == 200)
+        #expect(okEnvelope.result?.outcome == .completed)
+        #expect(okEnvelope.result?.changed == true)
+        #expect(okEnvelope.result?.archivedWorkspaceID?.uuidString == validID)
+        let expectedSelectedWorkspaceID = UUID(uuidString: FakeAutomationController.archiveSelectedWorkspaceID)
+        #expect(okEnvelope.result?.selectedWorkspaceID == expectedSelectedWorkspaceID)
+        #expect(okEnvelope.result?.system.capabilities.contains(.workspaceArchive) == true)
+        #expect(controller.archiveCalls == [validID])
+
+        let listed = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET",
+                path: "/v1/workspaces",
+                headers: [AutomationAPI.handleHeader: "operator"],
+                body: Data()
+            ),
+            controller: controller,
+            enabled: true
+        )
+        let listedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationWorkspacesResult>.self, from: listed.body)
+        #expect(listed.status == 200)
+        #expect(listedEnvelope.result?.workspaces.first?.workspaceID.uuidString == validID)
+        #expect(listedEnvelope.result?.workspaces.first?.isArchived == true)
+        #expect(listedEnvelope.result?.workspaces.first?.status == "archived")
+
+        let denied = await post("live", body: body(validID))
+        let deniedEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: denied.body)
+        #expect(denied.status == 403)
+        #expect(deniedEnvelope.error?.code == .capabilityDenied)
+
+        let stale = await post("ghost", body: body(validID))
+        #expect(stale.status == 401)
+        let missing = await post(nil, body: body(validID))
+        let missingEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: missing.body)
+        #expect(missing.status == 401)
+        #expect(missingEnvelope.error?.code == .missingHandle)
+
+        let unknown = await post("operator", body: body(FakeAutomationController.archiveUnknownID))
+        #expect(unknown.status == 400)
+        let badUUID = await post("operator", body: body("not-a-uuid"))
+        let badUUIDEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: badUUID.body)
+        #expect(badUUID.status == 400)
+        #expect(badUUIDEnvelope.error?.code == .invalidRequest)
+
+        let noWindow = await post("operator", body: body(FakeAutomationController.archiveNoWindowID))
+        let noWindowEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: noWindow.body)
+        #expect(noWindow.status == 409)
+        #expect(noWindowEnvelope.error?.code == .unsupported)
+
+        let empty = await post("operator", body: Data())
+        #expect(empty.status == 400)
+        let wrongMethod = await AutomationHTTPRouter.route(
+            HTTPRequest(
+                method: "GET", path: "/v1/workspace/archive",
+                headers: [AutomationAPI.handleHeader: "operator"], body: Data()),
+            controller: controller,
+            enabled: true
+        )
+        let wrongMethodEnvelope = try AutomationJSON.decoder.decode(
+            AutomationResponseEnvelope<AutomationEmptyResult>.self, from: wrongMethod.body)
+        #expect(wrongMethod.status == 405)
+        #expect(wrongMethodEnvelope.error?.code == .methodNotAllowed)
+    }
+
+    @Test("workspace-archive result encodes the structured confirmation payload")
+    func workspaceArchiveResultEncoding() throws {
+        let confirmation = AutomationWorkspaceArchiveResult(
+            workspaceID: "ws",
+            outcome: .confirmationRequired,
+            changed: false,
+            confirmation: AutomationConfirmationRequirement(
+                action: "workspace.archive",
+                title: "Archive Workspace",
+                message: "Archive workspace?",
+                primaryButtonTitle: "Archive"
+            ),
+            message: "Archive workspace?"
+        )
+        let data = try AutomationJSON.encoder.encode(AutomationResponseEnvelope(result: confirmation))
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("\"outcome\":\"confirmation_required\""))
+        #expect(json.contains("\"confirmation\""))
+        #expect(json.contains("\"action\":\"workspace.archive\""))
+    }
+
     @Test("POST /v1/window/snapshot captures for an operator handle and fails closed otherwise")
     @MainActor
     func routerWindowSnapshot() async throws {
@@ -1541,6 +1699,7 @@ struct AutomationAPITests {
         #expect(
             loaded?.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ])
 
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
@@ -1573,6 +1732,7 @@ struct AutomationAPITests {
         #expect(
             registry.resolve(mintedCredential.handle)?.capabilities == [
                 .windowRead, .windowSnapshot, .workspaceRead, .workspaceSelect, .workspaceCreate, .surfaceRead,
+                .workspaceArchive,
             ]
         )
         #expect(registry.resolve(mintedCredential.handle)?.isOperator == true)

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -216,6 +216,24 @@ Rules:
 - The audit log records route metadata, surface ID, requested lines, returned
   lines, and allow/deny outcome, never the terminal text.
 
+## Operator Workspace Commands
+
+Operator commands use the per-launch operator credential minted by an app
+started with Automation Operator Scope enabled. They work from any same-user
+shell, not just inside a WorkSpaces terminal tile:
+
+```bash
+WORKSPACES_AUTOMATION_API=1 WORKSPACES_AUTOMATION_OPERATOR=1 ./scripts/launch-dev.sh --no-build
+workspaces workspace list
+workspaces workspace create <repo-id> feature-a
+workspaces workspace select <workspace-id>
+workspaces workspace archive <workspace-id>
+```
+
+`workspace archive` drives the same sidebar archive action as the row menu. On
+success, the workspace leaves the active list and `workspace list --json`
+reports it with `isArchived: true`.
+
 ## Shell Alias Ideas
 
 These examples are intentionally small. They stay inside the V1 scope and do
@@ -275,6 +293,8 @@ V1 is intentionally narrow:
 - focus a neighboring tile
 - split from a primary tile
 - close the caller tile through normal app behavior
+- operator workspace list/create/select/archive verbs when Automation Operator
+  Scope is enabled
 - write into the caller's own PTY (experimental, double-gated — see
   [Automation Input Write Decision](./decisions/automation-input-write.md))
 - read bounded plain text from operator-created workspace terminals

--- a/docs/automation-api.md
+++ b/docs/automation-api.md
@@ -48,7 +48,10 @@ echo "$WORKSPACES_AUTOMATION_HANDLE"
 Both values should be present. The handle is an opaque capability. Do not copy
 it into another terminal, save it in dotfiles, or treat it as a tile ID.
 
-`workspaces automation health` checks only that a local listener is reachable:
+`workspaces automation health` checks only that a local listener is reachable.
+When the running app supports health metadata, plain output also includes the
+listener pid, listener start time, protocol version, and active automation
+experiments; `--json` includes the same values under `server`.
 
 ```bash
 workspaces automation health

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -183,7 +183,25 @@ Every route returns a versioned JSON envelope:
 ## Routes
 
 `GET /v1/health` is the only unauthenticated route. It reports listener
-liveness only and does not prove that a terminal handle is valid.
+liveness plus server metadata (`pid`, listener `launchedAt`, `appVersion`,
+`build`, active automation experiment keys, and `protocolVersion`) so callers
+can distinguish coexisting app instances. It does not prove that a terminal
+handle is valid.
+
+```json
+{
+  "status": "ok",
+  "server": {
+    "pid": 7301,
+    "launchedAt": "2026-07-08T08:35:44Z",
+    "appVersion": "dev",
+    "build": "debug",
+    "experiments": ["automationAPI", "automationInputWrite", "automationOperator"],
+    "protocolVersion": 1
+  },
+  "system": { "capabilities": [ … ] }
+}
+```
 
 Scoped routes require `x-workspaces-automation-handle`:
 

--- a/docs/development/automation-api.md
+++ b/docs/development/automation-api.md
@@ -197,6 +197,7 @@ Scoped routes require `x-workspaces-automation-handle`:
 | `POST /v1/workspace/select` | **Operator scope, mutation.** Selects the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the *same* selection gesture a sidebar click takes — the binding whose setter attaches the terminal and requests focus. Returns a structured gesture outcome (`completed`/`confirmation_required`); a live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.select`. This is the verbs-=-clicks exemplar — see [Verb contract](#verb-contract-verbs--clicks) and [Workspace select](#workspace-select). |
 | `POST /v1/workspace/create` | **Operator scope, mutation.** Creates a workspace in the repo named by `repoID` (from `workspace.read`) by driving the sidebar's real create helper. Body is `{"repoID":"…","name":"…","providerID":"local","guestOS":null,"select":true,"fromRef":"origin/main"}`; `providerID` defaults to `local`, `select` defaults to `true`, and `fromRef` is omitted by default. Returns `completed` with the created workspace and, when selected, the attached terminal, or `confirmation_required` with provider setup confirmation details. Requires `workspace.create`; tile handles fail `capability_denied`. See [Workspace create](#workspace-create). |
 | `POST /v1/surface/read` | **Operator scope, content read.** Reads plain text from a terminal surface created by the same operator handle through `workspace.create` this launch. Body is `{"surfaceID":"…","lines":200}` where `surfaceID` is the `attachedSurfaceID` from that create result. Requests above 500 lines are clamped; output is capped at 256 KiB UTF-8. Requires `surface.read`; tile handles and non-created/unattributed surfaces fail `capability_denied`. See [Surface read](#surface-read). |
+| `POST /v1/workspace/archive` | **Operator scope, mutation.** Archives the workspace named by the body's `workspaceID` (a `workspace.read` id) by driving the same sidebar archive action as the row menu. Returns `completed` with the archived workspace id and post-gesture selection state, or `confirmation_required` if the UI path ever reaches a modal. A live-window-less app fails `unsupported`, an unknown/non-UUID id fails `invalid_request`. Requires `workspace.archive`; tile handles fail `capability_denied`. See [Workspace archive](#workspace-archive). |
 | `GET /v1/web-surfaces` | Returns the app's WorkSpaces-owned web surfaces (global, repo, or workspace scoped) with stable source id, display name, configured URL, and — only when a `WKWebView` is live — the live URL, title, and loading state. Read-only. |
 | `GET /v1/web-surfaces/{id}/snapshot` | Returns a bounded PNG of the live web surface with stable source id `{id}`. Read-only pixels of an already-visible surface (`browser.read`). Fails closed when no `WKWebView` is live — never instantiates a hidden view. See [Web-surface snapshot bounds](#web-surface-snapshot-bounds). |
 | `POST /v1/tile/focus` | Focuses `left`, `right`, `up`, `down`, `next`, or `previous` relative to the caller tile. |
@@ -231,6 +232,7 @@ handle.
 | `workspace.select` | `POST /v1/workspace/select` (drive the real selection gesture for a workspace); granted only to operator handles, never to tile handles |
 | `workspace.create` | `POST /v1/workspace/create` (drive the real sidebar create helper for a repo); granted only to operator handles, never to tile handles — distinct from `workspace.read` and `workspace.select` so the read/write split stays legible |
 | `surface.read` | `POST /v1/surface/read` (bounded plain-text terminal read-back for surfaces created by the same operator handle through `workspace.create` this launch); granted only to operator handles, never to tile handles |
+| `workspace.archive` | `POST /v1/workspace/archive` (drive the real sidebar archive action for a workspace); granted only to operator handles, never to tile handles |
 | `tile.focus` | `POST /v1/tile/focus` |
 | `tile.split` | `POST /v1/tile/split` |
 | `tile.close` | `POST /v1/tile/close` |
@@ -334,7 +336,7 @@ mutation rides this route.
   "system": {
     "capabilities": [
       "window.read", "window.snapshot", "workspace.read",
-      "workspace.select", "workspace.create", "surface.read"
+      "workspace.select", "workspace.create", "surface.read", "workspace.archive"
     ]
   }
 }
@@ -520,6 +522,52 @@ did:
   `workspace.read`. A tile handle lacks it and fails `capability_denied`. The call is operator-tagged in
   `automation-audit.jsonl` like every operator route.
 
+## Workspace archive
+
+`POST /v1/workspace/archive` (operator scope, `workspace.archive`) archives a
+workspace by driving the same sidebar archive action exposed from the workspace
+row menu. The body names the target by a `workspaceID` obtained from
+`workspace.read`:
+
+```json
+{ "workspaceID": "…" }
+```
+
+The success envelope reports the structured gesture outcome and the selection
+state left behind by the real archive gesture:
+
+```json
+{
+  "workspaceID": "…",
+  "outcome": "completed",
+  "changed": true,
+  "archivedWorkspaceID": "…",
+  "selectedWorkspaceID": "…",
+  "system": { "capabilities": [ … ] }
+}
+```
+
+After completion, `GET /v1/workspaces` reports the same workspace with
+`isArchived: true` and status `archived`; the row leaves the active workspace
+list exactly as it does after using the sidebar. If the archived workspace was
+selected, the API does not invent a separate fallback — `selectedWorkspaceID`
+is whatever the sidebar gesture left selected.
+
+- **Same path as the UI.** The verb enters `SidebarWorkspaceController.archive`
+  through the window-bound gesture layer, not `WorkspaceService` or SwiftData
+  directly.
+- **Structured outcome.** `outcome` is `completed` or
+  `confirmation_required`. The archive action has no confirmation dialog today,
+  but if the UI path gains one the route returns the same structured
+  confirmation payload shape as `workspace.create`.
+- **Failure mapping.** A live-window-less app fails `unsupported` (never a
+  data-layer fallback), and an unknown or non-UUID `workspaceID` fails
+  `invalid_request`.
+- **Operator mutation.** Requires `workspace.archive`, distinct from
+  `workspace.read`, `workspace.select`, and `workspace.create`. A tile handle
+  lacks it and fails `capability_denied`. The call is operator-tagged in
+  `automation-audit.jsonl` like every operator route.
+
 ## Error Codes
 
 | Code | Meaning |
@@ -579,6 +627,8 @@ workspaces workspace select <id> --json              # same, as the raw result e
 workspaces workspace create <repo-id> feature-a      # create local workspace through the UI path
 workspaces workspace create <repo-id> feature-a --json
 workspaces workspace create <repo-id> feature-a --provider lume --guest-os macos
+workspaces workspace archive <id>                   # archive through the sidebar action path
+workspaces workspace archive <id> --json
 ```
 
 `workspace list` reads the running app's repos and workspaces (`workspace.read`),


### PR DESCRIPTION
## Summary

Two paired issues, landed as two separate commits (`feat(automation): add workspace archive verb (#991)` and `feat(automation): report health server metadata (#992)`):

**#991 — `workspace.archive`**: `POST /v1/workspace/archive` drives the same real sidebar archive action a row-menu click takes (`SidebarWorkspaceController.archive(_:)` — retires terminal sessions, then the workspace/provider archive path), not a parallel SwiftData write. `selectedWorkspaceID` in the response is read *after* the gesture completes, so callers observe whatever selection fallback the real archive path produced rather than an invented one. Failure mapping mirrors `workspace/select`: unknown/non-UUID id → `invalid_request`, tile handle → `capability_denied`, no live window → `unsupported`.

**#992 — richer `automation health`**: `GET /v1/health` gains a `server` block (`pid`, `launchedAt`, `appVersion`, `build`, active `experiments`, `protocolVersion`). `launchedAt` and the descriptor are captured once when the automation listener actually starts (`AutomationListener.start()`), not recomputed per request — so it genuinely disambiguates two coexisting app instances rather than reporting call-time noise. The CLI now prints a clear `CLI vX vs app vY — use the bundled CLI at <path>` message on protocol-version skew (checked *before* attempting a full decode) and falls back to printing the raw response body on any other decode failure, instead of a bare JSON-decode error.

Codex (gpt-5.5, high) implemented both in a dedicated worktree; `CODEX_REPORT.md` (untracked) has the full trail.

## Review loop

- **Reflect**: read the full diff personally. Verified `healthServer` is captured exactly once in `AutomationListener.start()` and reused for every subsequent health call (not reconstructed per-request, which would defeat the point of disambiguating instances). Verified the CLI's protocol-version check runs before attempting envelope decode, so a version-skewed CLI gets the intended message rather than falling through to the generic undecodable-response path. Verified the archive gesture reads `selectedWorkspaceID` after `controller.archive(workspace)` completes, so it reflects the real fallback rather than a guessed one.
- **Codex directed review**: could not run for this PR — the account-wide codex usage quota was exhausted by the time review reached this pair (four parallel implementation workers + review calls on #989/#990 in the same window) — `ERROR: You've hit your usage limit ... try again at 1:44 PM`. Documented as a real limitation in the tile-orchestration skill README rather than silently skipped; the reflect pass above is the only review this diff got beyond the implementer's own gates and my own reading.
- No findings to adjudicate.

## Gates (rebased onto current origin/main before this run)

- `swift build`: PASS
- `swift test --filter Automation`: PASS (106 tests, 11 suites)
- Full `swift test`: PASS (1283 tests, 194 suites)
- `mise run lint`: PASS

## Mergeability

- Surface: desktop — Automation API (new `workspace.archive` verb + `automation health` server metadata), `WorkspaceManagerCLI` (health rendering + decode fallback)
- User-facing behavior changed: No for existing routes/fields (additive only); new `workspace.archive` route and new `server` health block are new surface
- Non-happy paths considered: archiving an unknown/non-existent workspace → `invalid_request`; archiving from a tile handle → `capability_denied`; no live window → `unsupported`; CLI hitting a version-skewed app → explicit skew message instead of a decode crash; CLI hitting a genuinely malformed body → raw-body fallback instead of a bare error
- Residual risk or follow-up: live CLI/curl verification against a running dev instance was intentionally skipped because one was already running (shared automation socket/credential path) — coverage relies on the Swift Testing suite instead, noted explicitly in `CODEX_REPORT.md`

🤖 Generated with a codex (gpt-5.5) implementation worker, orchestrated by Claude Code (Sonnet 5)

## Evidence

![gates](https://evidence.cloudcompute.com/workspaces/pr-1007/20260708-183813-gates.png)

(Full-suite pass confirmed separately, not pictured.)
