### PR TITLE
fix(web-next): mobile status-line gutter + 44px touch targets (#809)

### DIFF
--- a/CODEX_REPORT.md
+++ b/CODEX_REPORT.md
@@ -1,0 +1,39 @@
+# CODEX Report: issue #809 mobile polish
+
+## Changes
+
+- `web-next/src/components/folio/status-line.tsx`
+  - Changed the status-line inner row from `px-0.5` to `px-5` so its phone-width gutter matches the compose gutter directly above it.
+  - Reworked the dismissed handle from a 9px button into a 44px (`h-11 w-11`) transparent button with the original 9px dot centered inside. The dot keeps the same visual size and hover behavior.
+  - Added a centered 44px `::after` hit area to the status-line dismiss `✕` button, preserving the existing visible padding/layout.
+- `web-next/src/components/folio/theme-toggle.tsx`
+  - Added a centered 44px `::after` hit area to the theme toggle, preserving the visible `◐` mark and existing spacing.
+- `web-next/tests/e2e/mobile.spec.ts`
+  - Added a 375px mobile spec that asserts the status row gutter computes to `20px`, the theme toggle and status dismiss pseudo hit areas are at least 44px, and the dismissed handle's real box is at least 44px.
+
+## Verification
+
+- `npx pnpm@10 install` passed.
+- `pnpm test` passed: 40 files, 463 tests.
+- `pnpm typecheck` passed.
+- `pnpm lint` passed.
+- `pnpm build` passed. Next emitted existing Edge Runtime warnings from `jose`/`better-auth` during the first build, but exited 0.
+- `E2E_PORT=3109 pnpm test:e2e` passed: 44 tests.
+- After mutation/restore, final fixed rebuild passed: `pnpm build`.
+- Final focused fixed confirmation passed: `pnpm exec playwright test tests/e2e/mobile.spec.ts -g "mobile status chrome" --project=lifecycle --workers=1 --no-deps`.
+
+## Mutation Check
+
+- Temporarily changed the status row gutter back to `px-0.5`.
+- Rebuilt the production output so Playwright would serve the mutated source: `pnpm build`.
+- Ran `pnpm exec playwright test tests/e2e/mobile.spec.ts -g "mobile status chrome" --project=lifecycle --workers=1 --no-deps`.
+- Expected failure occurred in the new mobile spec:
+  - `Expected: "20px"`
+  - `Received: "2px"`
+- Restored `px-5`, rebuilt, and reran the focused mobile spec successfully.
+
+## Deviations
+
+- No screenshots captured, per orchestrator instruction.
+- No GitHub issue/PR actions performed.
+- No files outside `web-next/` were modified except this required untracked `CODEX_REPORT.md`.

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -119,7 +119,7 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 						title="Stop the turn"
 						aria-label="Stop"
 						onClick={onStop}
-						className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[11px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
+						className="relative z-[1] flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[11px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
 					>
 						■
 					</button>
@@ -130,7 +130,7 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 						aria-label="Send"
 						disabled={disabled}
 						onClick={submit}
-						className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent disabled:opacity-40 disabled:group-focus-within:border-line-strong disabled:group-focus-within:bg-transparent disabled:group-focus-within:text-muted disabled:hover:border-line-strong disabled:hover:text-muted"
+						className="relative z-[1] flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent disabled:opacity-40 disabled:group-focus-within:border-line-strong disabled:group-focus-within:bg-transparent disabled:group-focus-within:text-muted disabled:hover:border-line-strong disabled:hover:text-muted"
 					>
 						↑
 					</button>

--- a/web-next/src/components/folio/status-line.tsx
+++ b/web-next/src/components/folio/status-line.tsx
@@ -49,8 +49,10 @@ export function StatusLine({
 				title="Show status line"
 				aria-label="Show status line"
 				onClick={() => setDismissed(false)}
-				className="absolute right-[18px] bottom-[13px] h-[9px] w-[9px] rounded-full bg-faint opacity-40 transition-[opacity,transform,background-color] duration-200 hover:scale-[1.35] hover:bg-accent hover:opacity-100"
-			/>
+				className="group absolute right-[0.5px] bottom-[-4.5px] flex h-11 w-11 items-center justify-center"
+			>
+				<span className="h-[9px] w-[9px] rounded-full bg-faint opacity-40 transition-[opacity,transform,background-color] duration-200 group-hover:scale-[1.35] group-hover:bg-accent group-hover:opacity-100" />
+			</button>
 		);
 	}
 
@@ -61,7 +63,7 @@ export function StatusLine({
 			data-testid="status-line"
 			className="h-[30px] border-t border-line bg-status-bg font-mono text-stat tracking-[.03em] text-hint"
 		>
-			<div className="mx-auto flex h-full max-w-[680px] items-center px-0.5">
+			<div className="mx-auto flex h-full max-w-[680px] items-center px-5">
 				<span className="font-medium text-muted before:mr-2 before:inline-block before:h-[5px] before:w-[5px] before:rounded-full before:bg-accent before:align-[2px] before:opacity-75 before:content-['']">
 					{picker ? (
 						<select
@@ -93,7 +95,7 @@ export function StatusLine({
 					title="Hide status line"
 					aria-label="Hide status line"
 					onClick={() => setDismissed(true)}
-					className="ml-auto rounded-[5px] px-1.5 py-1 text-stat leading-none text-faint opacity-70 transition-[opacity,color] duration-200 hover:text-ink hover:opacity-100"
+					className="relative ml-auto rounded-[5px] px-1.5 py-1 text-stat leading-none text-faint opacity-70 transition-[opacity,color] duration-200 after:absolute after:top-1/2 after:left-1/2 after:h-11 after:w-11 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] hover:text-ink hover:opacity-100"
 				>
 					✕
 				</button>

--- a/web-next/src/components/folio/theme-toggle.tsx
+++ b/web-next/src/components/folio/theme-toggle.tsx
@@ -14,7 +14,7 @@ export function ThemeToggle() {
 			onClick={toggleTheme}
 			title="Toggle light / dark"
 			aria-label="Toggle light / dark theme"
-			className="ml-4 rounded-md px-1.5 py-1 text-[13px] leading-none text-faint [transition:color_.2s_ease,transform_.35s_ease] hover:text-accent dark:rotate-180"
+			className="relative ml-4 rounded-md px-1.5 py-1 text-[13px] leading-none text-faint [transition:color_.2s_ease,transform_.35s_ease] after:absolute after:top-1/2 after:left-1/2 after:h-11 after:w-11 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] hover:text-accent dark:rotate-180"
 		>
 			◐
 		</button>

--- a/web-next/tests/e2e/mobile.spec.ts
+++ b/web-next/tests/e2e/mobile.spec.ts
@@ -6,7 +6,7 @@
  * scroll at the page level. Wide content scrolls inside its own panel,
  * never by dragging the page sideways.
  */
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 test.use({ viewport: { width: 375, height: 812 } });
 
@@ -27,6 +27,18 @@ async function expectNoHorizontalScroll(page: Page, where: string): Promise<void
 	expect(await horizontalOverflow(page), `horizontal overflow ${where}`).toBe(0);
 }
 
+async function expectAfterHitArea(locator: Locator, name: string): Promise<void> {
+	const size = await locator.evaluate((element) => {
+		const style = getComputedStyle(element, "::after");
+		return {
+			height: Number.parseFloat(style.height),
+			width: Number.parseFloat(style.width),
+		};
+	});
+	expect(size.width, `${name} hit-area width`).toBeGreaterThanOrEqual(44);
+	expect(size.height, `${name} hit-area height`).toBeGreaterThanOrEqual(44);
+}
+
 async function createSession(page: Page): Promise<void> {
 	await page.goto("/");
 	const picker = page.getByTestId("new-session-picker");
@@ -39,6 +51,35 @@ async function createSession(page: Page): Promise<void> {
 	await page.keyboard.press("Enter");
 	await expect(page).toHaveURL(/\/sessions\/[0-9a-f-]{36}$/);
 }
+
+test("mobile status chrome keeps compose gutter and 44px hit areas", async ({
+	page,
+}) => {
+	await createSession(page);
+
+	const statusLine = page.getByTestId("status-line");
+	const rowPadding = await statusLine.evaluate((element) => {
+		const row = element.firstElementChild;
+		if (!(row instanceof HTMLElement)) return null;
+		return getComputedStyle(row).paddingLeft;
+	});
+	expect(rowPadding, "status row left gutter").toBe("20px");
+
+	await expectAfterHitArea(
+		page.getByRole("button", { name: "Toggle light / dark theme" }),
+		"theme toggle",
+	);
+
+	const hideStatus = statusLine.getByRole("button", { name: "Hide status line" });
+	await expectAfterHitArea(hideStatus, "status dismiss");
+
+	await hideStatus.click();
+	const handle = page.getByTestId("status-line-handle");
+	const handleBox = await handle.boundingBox();
+	expect(handleBox, "status handle box").not.toBeNull();
+	expect(handleBox?.width, "status handle width").toBeGreaterThanOrEqual(44);
+	expect(handleBox?.height, "status handle height").toBeGreaterThanOrEqual(44);
+});
 
 test("transcript + compose hold up at 375px through a full turn, with no horizontal scroll", async ({
 	page,

--- a/web-next/tests/e2e/mobile.spec.ts
+++ b/web-next/tests/e2e/mobile.spec.ts
@@ -79,6 +79,42 @@ test("mobile status chrome keeps compose gutter and 44px hit areas", async ({
 	expect(handleBox, "status handle box").not.toBeNull();
 	expect(handleBox?.width, "status handle width").toBeGreaterThanOrEqual(44);
 	expect(handleBox?.height, "status handle height").toBeGreaterThanOrEqual(44);
+
+	// Hit-test the real stacking, not just declared geometry: the handle's
+	// invisible halo overlaps the send button's lower-right corner, and live
+	// controls must win those pixels while the halo keeps the dead strip.
+	const hitAt = (x: number, y: number) =>
+		page.evaluate(
+			([px, py]) => {
+				const el = document.elementFromPoint(px, py);
+				const target = el?.closest("button, a");
+				return (
+					target?.getAttribute("data-testid") ??
+					target?.getAttribute("aria-label") ??
+					null
+				);
+			},
+			[x, y],
+		);
+	const sendBox = await page
+		.getByRole("button", { name: "Send" })
+		.boundingBox();
+	expect(sendBox, "send button box").not.toBeNull();
+	if (sendBox && handleBox) {
+		const corner = await hitAt(
+			sendBox.x + sendBox.width - 2,
+			sendBox.y + sendBox.height - 2,
+		);
+		expect(corner, "send button owns its own corner").toBe("Send");
+		const halo = await hitAt(
+			handleBox.x + handleBox.width - 4,
+			handleBox.y + handleBox.height / 2,
+		);
+		expect(halo, "handle owns the dead strip").toBe("status-line-handle");
+	}
+	// The dot itself still reopens the status line.
+	await handle.click();
+	await expect(statusLine).toBeVisible();
 });
 
 test("transcript + compose hold up at 375px through a full turn, with no horizontal scroll", async ({

--- a/web-next/tests/e2e/mobile.spec.ts
+++ b/web-next/tests/e2e/mobile.spec.ts
@@ -101,11 +101,14 @@ test("mobile status chrome keeps compose gutter and 44px hit areas", async ({
 		.boundingBox();
 	expect(sendBox, "send button box").not.toBeNull();
 	if (sendBox && handleBox) {
+		// Inside the halo/send overlap but clear of the button's 10px corner
+		// radius — hit-testing honors border-radius, so true corner-arc pixels
+		// belong to no button.
 		const corner = await hitAt(
-			sendBox.x + sendBox.width - 2,
+			sendBox.x + sendBox.width - 12,
 			sendBox.y + sendBox.height - 2,
 		);
-		expect(corner, "send button owns its own corner").toBe("Send");
+		expect(corner, "send button owns its overlapped edge").toBe("Send");
 		const halo = await hitAt(
 			handleBox.x + handleBox.width - 4,
 			handleBox.y + handleBox.height / 2,


### PR DESCRIPTION
## What

The two verified mobile-width fixes from the first-release review (#809, W6): the status row now shares the compose gutter (`px-5`, was 2px from the screen edge), and the three sub-44px controls — dismissed-state handle, theme toggle, status ✕ — get ~44px hit areas with pixel-identical visual marks (centered container for the handle; transparent `::after` halos for the other two).

## Process

Implemented by codex (gpt-5.5, medium) per `codex-execution`; orchestrator review + directed codex (gpt-5.5, xhigh) review. The review found a real **blocker**: the handle's invisible 44px button (rendered after compose in the same sticky footer) stole taps from the send/stop button's lower-right corner. Fixed by stacking live controls above the halo (`relative z-[1]` on send/stop) — dead space goes to the handle, live pixels stay with controls. The follow-up test failure was diagnosed by DOM probe, not guesswork: the assertion point sat inside the send button's 10px corner radius, where hit-testing correctly falls through; the point moved clear of the arc.

Mutation checks: gutter reverted → spec fails on 2px vs 20px (codex); z-fix removed → hit-test fails with the original stolen-corner scenario (orchestrator). Both restored.

## Verification

- Unit 463, typecheck, lint, clean build; `E2E_PORT=3109 pnpm test:e2e` 44 passed on the final tree
- New mobile spec asserts computed gutter, hit-area geometry, and **real stacking** via `elementFromPoint` (send owns its overlapped edge; handle owns the dead strip; dot still reopens the status line)

## Evidence

The changed surface (375px mobile, light+dark):

### session-mobile-diff-dark
![session-mobile-diff-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213502-session-mobile-diff-dark.png)
### session-mobile-diff-light
![session-mobile-diff-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213503-session-mobile-diff-light.png)
### session-mobile-turn-dark
![session-mobile-turn-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213504-session-mobile-turn-dark.png)
### session-mobile-turn-light
![session-mobile-turn-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213505-session-mobile-turn-light.png)

<details><summary>Full 50-shot evidence walk (light+dark, all surfaces)</summary>

### compose-disabled-dark
![compose-disabled-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213448-compose-disabled-dark.png)

### compose-disabled-light
![compose-disabled-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213449-compose-disabled-light.png)

### compose-empty-dark
![compose-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213449-compose-empty-dark.png)

### compose-empty-light
![compose-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213450-compose-empty-light.png)

### compose-multiline-dark
![compose-multiline-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213450-compose-multiline-dark.png)

### compose-multiline-light
![compose-multiline-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213451-compose-multiline-light.png)

### home-empty-dark
![home-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213451-home-empty-dark.png)

### home-empty-light
![home-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213452-home-empty-light.png)

### home-populated-dark
![home-populated-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213453-home-populated-dark.png)

### home-populated-light
![home-populated-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213453-home-populated-light.png)

### prototype-folio-dark
![prototype-folio-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213454-prototype-folio-dark.png)

### prototype-folio-light
![prototype-folio-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213454-prototype-folio-light.png)

### resume-catchup-dark
![resume-catchup-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213455-resume-catchup-dark.png)

### resume-catchup-light
![resume-catchup-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213455-resume-catchup-light.png)

### resume-complete-dark
![resume-complete-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213456-resume-complete-dark.png)

### resume-complete-light
![resume-complete-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213456-resume-complete-light.png)

### resume-midturn-dark
![resume-midturn-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213457-resume-midturn-dark.png)

### resume-midturn-light
![resume-midturn-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213457-resume-midturn-light.png)

### session-empty-dark
![session-empty-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213458-session-empty-dark.png)

### session-empty-light
![session-empty-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213458-session-empty-light.png)

### session-error-provisioning-dark
![session-error-provisioning-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213459-session-error-provisioning-dark.png)

### session-error-provisioning-light
![session-error-provisioning-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213459-session-error-provisioning-light.png)

### session-error-sandbox-died-dark
![session-error-sandbox-died-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213500-session-error-sandbox-died-dark.png)

### session-error-sandbox-died-light
![session-error-sandbox-died-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213501-session-error-sandbox-died-light.png)

### session-error-stream-dark
![session-error-stream-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213501-session-error-stream-dark.png)

### session-error-stream-light
![session-error-stream-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213502-session-error-stream-light.png)

### session-mobile-diff-dark
![session-mobile-diff-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213502-session-mobile-diff-dark.png)

### session-mobile-diff-light
![session-mobile-diff-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213503-session-mobile-diff-light.png)

### session-mobile-turn-dark
![session-mobile-turn-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213504-session-mobile-turn-dark.png)

### session-mobile-turn-light
![session-mobile-turn-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213505-session-mobile-turn-light.png)

### session-terminal-drawer-dark
![session-terminal-drawer-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213509-session-terminal-drawer-dark.png)

### session-terminal-drawer-light
![session-terminal-drawer-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213510-session-terminal-drawer-light.png)

### session-turn-failed-dark
![session-turn-failed-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213511-session-turn-failed-dark.png)

### session-turn-failed-light
![session-turn-failed-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213512-session-turn-failed-light.png)

### session-turn-failed-retried-dark
![session-turn-failed-retried-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213512-session-turn-failed-retried-dark.png)

### session-turn-failed-retried-light
![session-turn-failed-retried-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213513-session-turn-failed-retried-light.png)

### session-turn-final-dark
![session-turn-final-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213514-session-turn-final-dark.png)

### session-turn-final-light
![session-turn-final-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213514-session-turn-final-light.png)

### session-turn-midstream-dark
![session-turn-midstream-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213515-session-turn-midstream-dark.png)

### session-turn-midstream-light
![session-turn-midstream-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213515-session-turn-midstream-light.png)

### session-turn-reloaded-dark
![session-turn-reloaded-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213516-session-turn-reloaded-dark.png)

### session-turn-reloaded-light
![session-turn-reloaded-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213517-session-turn-reloaded-light.png)

### session-turn-stopped-dark
![session-turn-stopped-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213517-session-turn-stopped-dark.png)

### session-turn-stopped-light
![session-turn-stopped-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213518-session-turn-stopped-light.png)

### session-turn-stopping-dark
![session-turn-stopping-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213518-session-turn-stopping-dark.png)

### session-turn-stopping-light
![session-turn-stopping-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213519-session-turn-stopping-light.png)

### session-turn-streaming-dark
![session-turn-streaming-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213519-session-turn-streaming-dark.png)

### session-turn-streaming-light
![session-turn-streaming-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213520-session-turn-streaming-light.png)

### sessions-demo-dark
![sessions-demo-dark](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213520-sessions-demo-dark.png)

### sessions-demo-light
![sessions-demo-light](https://evidence.cloudcompute.com/workspaces/pr-1010/20260708-213521-sessions-demo-light.png)


</details>

Closes #809

## Mergeability

- **Surface:** three Folio components (status-line, theme-toggle, compose-field send/stop classnames) + the mobile e2e spec. No logic, data, or runtime changes.
- **Behavior changed:** touch targets and gutter only; desktop visuals pixel-identical (halos are transparent; z-index has no paint effect).
- **Non-happy paths:** corner-radius pixels fall through by design (true of every rounded button); halo/live-control overlap is hit-tested in CI both ways.
- **Residual risk:** the theme toggle's halo extends ~10px into masthead whitespace — clicks in that dead zone now toggle theme instead of doing nothing; no adjacent control is within reach (review-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
