### PR TITLE
fix(setup): link per-app env files into worktrees, not just root

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -160,7 +160,9 @@ link_env_from_main() {
   git_dir="$(git rev-parse --git-dir 2>/dev/null)" || return 0
   [[ "$git_common" != "$git_dir" ]] || return 0  # not a worktree
 
-  for envfile in .env .env.local; do
+  # Root env files plus each app's local env: a worktree without
+  # web-next/.env.local silently falls back to bypass-only auth.
+  for envfile in .env .env.local web-next/.env.local web/.env.local; do
     if [[ -L "$REPO_ROOT/$envfile" && ! -e "$REPO_ROOT/$envfile" ]]; then
       echo "=> Replacing broken $envfile symlink"
       rm "$REPO_ROOT/$envfile"


### PR DESCRIPTION
## What

`scripts/setup`'s `link_env_from_main` only linked root `.env`/`.env.local` into worktrees — `web-next/.env.local` (real GitHub OAuth for local sign-in) and `web/.env.local` never arrived, so a fresh worktree silently fell back to bypass-only auth. Found when the owner couldn't sign in with real credentials on a host-provider test drive served from a codex worktree.

One-line-of-substance change: the env-file loop now covers `web-next/.env.local` and `web/.env.local` through the same source-discovery chain (Conductor sibling → `~/code/<repo>` → other worktrees).

## Verification

`bash -n` clean; live run in a fresh worktree:

```
=> Symlinking .env from /Users/fairchild/code/workspaces
=> Symlinking web-next/.env.local from /Users/fairchild/code/workspaces/web-next
=> Symlinking web/.env.local from /Users/fairchild/code/workspaces/web
```

## Mergeability

- **Surface:** `scripts/setup` env-linking loop only.
- **Behavior changed:** worktree setup now provisions per-app env symlinks; no-ops when files already exist (same guards as before).
- **Non-happy paths:** missing source → silently skipped (unchanged); broken symlink → replaced (unchanged, now also for per-app paths).
- **Residual risk:** none beyond existing symlink semantics; secrets stay out of git (paths remain gitignored).

Evidence: verification transcript above (script tooling; no runtime surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification

Test passed live in a fresh worktree (`~/.worktrees/workspaces/hero-demo`, 2026-07-08): the unpatched setup linked only root `.env`, leaving `web-next/.env.local` missing (server booted bypass-only with no runtime creds — the exact failure this fixes); with this PR's script, `--env-only` linked both `web-next/.env.local` and `web/.env.local` from `~/code/workspaces`:

```
=> Symlinking web-next/.env.local from /Users/fairchild/code/workspaces/web-next
=> Symlinking web/.env.local from /Users/fairchild/code/workspaces/web
```

## Mergeability

- **Surface**: `scripts/setup` env-link loop only.
- **Behavior changed**: worktree setup now also links `web-next/.env.local` and `web/.env.local` when the canonical checkout has them; root files unchanged.
- **Non-happy paths**: missing source files are skipped silently (same as before); broken symlinks are replaced, real files never overwritten.
- **Residual risk**: none beyond an extra symlink per app dir; script is idempotent.

<!-- readiness: retrigger after verification appended -->
