### PR TITLE
feat(web-next): local single-user serving mode — loopback + minted token (#983)

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -34,6 +34,29 @@ coding turn with reasoning, tool calls, a failing→passing test cycle, and a
 diff. Try `/sessions/demo?scenario=adversarial` or `?scenario=long` to stress
 the transcript.
 
+## Run the owner-local production server
+
+```bash
+cd web-next
+pnpm start:local                  # builds if .next/ is missing, serves :3100
+PORT=3183 pnpm start:local
+WEB_NEXT_DATA_DIR=/path/to/spaces-data PORT=3183 pnpm start:local
+```
+
+`start:local` is the first-class `next start` target for the owner's machine.
+It sets `WEB_NEXT_LOCAL_MODE=1`, mints a random local token under
+`WEB_NEXT_DATA_DIR` (default `.data/local-sign-in-token`), prints
+`http://localhost:<port>/sign-in?token=…`, and starts Next bound with
+`-H 127.0.0.1`. Next owns the socket, so the app also refuses requests whose
+Host header is not loopback (`localhost`, `127.0.0.1`, or `::1`).
+
+Local mode is separate from both GitHub OAuth and the test bypass. It exits at
+startup if `AUTH_BYPASS=1` or GitHub OAuth env vars are present. The local
+identity defaults to `fairchild`; set `WEB_NEXT_LOCAL_LOGIN` to change the
+stored session owner. When GitHub App installation credentials are present, the
+repo picker uses the real installation directory; without them it falls back to
+the deterministic fixture repos used by e2e.
+
 ## Quality gates (what CI runs)
 
 ```bash
@@ -44,7 +67,7 @@ pnpm build       # production build — must stay clean (see #780 for the stale-
 pnpm test:e2e    # Playwright; builds + serves on :3100 in auth-bypass mode
 pnpm evidence    # light+dark screenshot walk → output/evidence/
 pnpm perf        # perf harness vs perf/contract.json budgets
-pnpm validate    # env-targetable validation (--env local|prod, --url <origin>)
+pnpm validate    # env-targetable validation (--env local|local-mode|prod, --url <origin>)
 ```
 
 `pnpm evidence` only writes local files — the repo's evidence gate needs

--- a/web-next/docs/deploy.md
+++ b/web-next/docs/deploy.md
@@ -14,6 +14,7 @@ expects in production. Single-user product: GitHub OAuth + a login allowlist.
 | `ALLOWED_LOGINS` | Comma-separated GitHub logins allowed in (case-insensitive), e.g. `fairchild`. Anyone else who authenticates gets the polite refusal page and no data. |
 | `SESSIONS_DATABASE_URL` | libSQL URL — a Turso `libsql://…` URL in production, or a `file:` path. Defaults to `file:.data/sessions.db` (fine for dev, not for serverless). |
 | `SESSIONS_DATABASE_AUTH_TOKEN` | Turso auth token, when `SESSIONS_DATABASE_URL` is a remote URL. |
+| `WEB_NEXT_DATA_DIR` | Local filesystem data directory for defaults. When `SESSIONS_DATABASE_URL` is unset, SQLite lives at `<dir>/sessions.db`; local serving mode also stores its minted token there. Defaults to `.data`. |
 
 The GitHub OAuth app's authorization callback URL is
 `<BETTER_AUTH_URL>/api/auth/callback/github`. Production uses the
@@ -64,6 +65,26 @@ AUTH_BYPASS=1 ALLOWED_LOGINS=<your-github-login> pnpm dev
 
 Then use the "continue as … (test bypass)" button on `/sign-in`. The database
 defaults to `file:.data/sessions.db` (gitignored); no other env is needed.
+
+## Owner-local `next start`
+
+```bash
+pnpm start:local
+PORT=3183 WEB_NEXT_DATA_DIR=/path/to/spaces-data pnpm start:local
+```
+
+`WEB_NEXT_LOCAL_MODE=1` is the single-user local production-serving mode. It is
+not GitHub OAuth and not the test bypass: startup fails if `AUTH_BYPASS=1` or
+GitHub OAuth env vars are present. The wrapper mints a random token with Node
+crypto, persists it under `WEB_NEXT_DATA_DIR` (default
+`.data/local-sign-in-token`), exports it to middleware, and prints a usable
+sign-in URL: `http://localhost:<port>/sign-in?token=…`. Visiting that URL sets
+the local session cookie for `WEB_NEXT_LOCAL_LOGIN` (default `fairchild`).
+
+The wrapper starts Next with `-H 127.0.0.1`; because Next owns the socket, the
+app also hard-fails any local-mode request whose Host header is not loopback.
+Use `pnpm validate --env local-mode` for the posture check: loopback Host
+required, token cookie required, bypass cookie inert, and no OAuth door.
 
 ## Real-runtime credentials (#750+)
 

--- a/web-next/next.config.ts
+++ b/web-next/next.config.ts
@@ -1,5 +1,16 @@
 import type { NextConfig } from "next";
 
+if (process.env.WEB_NEXT_LOCAL_MODE === "1") {
+	if (process.env.AUTH_BYPASS === "1") {
+		throw new Error("WEB_NEXT_LOCAL_MODE cannot be combined with AUTH_BYPASS=1");
+	}
+	if (process.env.GITHUB_OAUTH_CLIENT_ID || process.env.GITHUB_OAUTH_CLIENT_SECRET) {
+		throw new Error(
+			"WEB_NEXT_LOCAL_MODE cannot be combined with GitHub OAuth environment variables",
+		);
+	}
+}
+
 const nextConfig: NextConfig = {
 	// The real (vercel) compute provider talks to the in-sandbox harness bridge
 	// over a WebSocket. Bundling `ws` (and its native `bufferutil`) breaks that

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -8,7 +8,7 @@
 		"start": "next start --port ${E2E_PORT:-3100}",
 		"start:local": "tsx scripts/start-local.ts",
 		"e2e:prepare-db": "AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db node --import tsx scripts/e2e-db.ts",
-		"e2e:server": "node scripts/clean.mjs e2e-data && { test -f .next/BUILD_ID || NODE_ENV=production next build; } && pnpm run e2e:prepare-db && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port ${E2E_PORT:-3100}",
+		"e2e:server": "env GITHUB_WEB_WORKSPACES_APP_ID= GITHUB_APP_PRIVATE_KEY= sh -c 'node scripts/clean.mjs e2e-data && { test -f .next/BUILD_ID || NODE_ENV=production next build; } && pnpm run e2e:prepare-db && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port ${E2E_PORT:-3100}'",
 		"test": "vitest run",
 		"test:e2e": "playwright test",
 		"typecheck": "tsc --noEmit",

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -6,6 +6,7 @@
 		"dev": "next dev --port 3100",
 		"build": "NODE_ENV=production next build",
 		"start": "next start --port ${E2E_PORT:-3100}",
+		"start:local": "tsx scripts/start-local.ts",
 		"e2e:prepare-db": "AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db node --import tsx scripts/e2e-db.ts",
 		"e2e:server": "node scripts/clean.mjs e2e-data && { test -f .next/BUILD_ID || NODE_ENV=production next build; } && pnpm run e2e:prepare-db && AUTH_BYPASS=1 ALLOWED_LOGINS=fairchild SESSIONS_DATABASE_URL=file:.data/e2e.db next start --port ${E2E_PORT:-3100}",
 		"test": "vitest run",

--- a/web-next/scripts/e2e-server-env.test.mjs
+++ b/web-next/scripts/e2e-server-env.test.mjs
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+describe("e2e:server environment", () => {
+	test("clears GitHub App credentials so the repo directory stays fixture-backed", () => {
+		const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+		const script = pkg.scripts["e2e:server"];
+		expect(script).toContain("GITHUB_WEB_WORKSPACES_APP_ID=");
+		expect(script).toContain("GITHUB_APP_PRIVATE_KEY=");
+	});
+});

--- a/web-next/scripts/harness.mjs
+++ b/web-next/scripts/harness.mjs
@@ -5,7 +5,8 @@
  * Node-only, no test framework.
  */
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
@@ -62,6 +63,33 @@ export function bypassServerEnv(dbDirName) {
 	};
 }
 
+/**
+ * Local-mode server env over a fresh WEB_NEXT_DATA_DIR. The token is persisted
+ * where the app expects it and exported for middleware, matching start:local.
+ */
+export function localModeServerEnv(dbDirName) {
+	const dataDir = path.join(WEB_NEXT_ROOT, "output", dbDirName);
+	rmSync(dataDir, { recursive: true, force: true });
+	mkdirSync(dataDir, { recursive: true });
+	const token = randomBytes(32).toString("base64url");
+	writeFileSync(path.join(dataDir, "local-sign-in-token"), `${token}\n`, {
+		mode: 0o600,
+	});
+	return {
+		env: {
+			WEB_NEXT_LOCAL_MODE: "1",
+			WEB_NEXT_LOCAL_TOKEN: token,
+			WEB_NEXT_DATA_DIR: dataDir,
+			WEB_NEXT_LOCAL_LOGIN: HARNESS_LOGIN,
+			AUTH_BYPASS: "",
+			GITHUB_OAUTH_CLIENT_ID: "",
+			GITHUB_OAUTH_CLIENT_SECRET: "",
+		},
+		token,
+		dataDir,
+	};
+}
+
 /** Fails fast when `next build` hasn't produced a servable build. */
 export function assertProductionBuild() {
 	if (!existsSync(path.join(WEB_NEXT_ROOT, ".next", "BUILD_ID"))) {
@@ -90,28 +118,58 @@ async function waitForServer(url, timeoutMs = 60_000) {
  */
 export async function startProductionServer(port = 3100, env = {}) {
 	assertProductionBuild();
+	const args =
+		env.WEB_NEXT_LOCAL_MODE === "1"
+			? ["exec", "next", "start", "-H", "127.0.0.1", "--port", String(port)]
+			: ["exec", "next", "start", "--port", String(port)];
 	const child = spawn(
 		"pnpm",
-		["exec", "next", "start", "--port", String(port)],
+		args,
 		{
 			cwd: WEB_NEXT_ROOT,
 			stdio: ["ignore", "pipe", "pipe"],
 			env: { ...process.env, ...env },
+			detached: true,
 		},
 	);
 	const baseUrl = `http://localhost:${port}`;
 	try {
 		await waitForServer(baseUrl);
 	} catch (error) {
-		child.kill("SIGTERM");
+		try {
+			process.kill(-child.pid, "SIGTERM");
+		} catch {
+			child.kill("SIGTERM");
+		}
 		throw error;
 	}
 	return {
 		baseUrl,
 		stop: () =>
 			new Promise((resolve) => {
-				child.once("exit", resolve);
-				child.kill("SIGTERM");
+				let done = false;
+				const finish = () => {
+					if (done) return;
+					done = true;
+					resolve();
+				};
+				const killTimer = setTimeout(() => {
+					try {
+						process.kill(-child.pid, "SIGKILL");
+					} catch {
+						child.kill("SIGKILL");
+					}
+					finish();
+				}, 5_000);
+				child.once("exit", () => {
+					clearTimeout(killTimer);
+					finish();
+				});
+				try {
+					process.kill(-child.pid, "SIGTERM");
+				} catch {
+					child.kill("SIGTERM");
+				}
 			}),
 	};
 }

--- a/web-next/scripts/start-local.ts
+++ b/web-next/scripts/start-local.ts
@@ -1,0 +1,94 @@
+/*
+ * Owner-local production server entrypoint. It builds when needed, mints the
+ * local sign-in token under WEB_NEXT_DATA_DIR, prints the bearer URL, then
+ * starts Next in WEB_NEXT_LOCAL_MODE with the token exported for middleware.
+ */
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	ensureLocalSignInToken,
+	localSignInUrl,
+	localTokenPath,
+} from "../src/lib/auth/local-token";
+import { assertAuthModeConfig } from "../src/lib/auth/config";
+
+const WEB_NEXT_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+
+function run(command: string, args: string[], env: NodeJS.ProcessEnv): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: WEB_NEXT_ROOT,
+			stdio: "inherit",
+			env,
+		});
+		child.on("exit", (code) => {
+			if (code === 0) resolve();
+			else reject(new Error(`${command} ${args.join(" ")} exited ${code ?? "unknown"}`));
+		});
+		child.on("error", reject);
+	});
+}
+
+function loadDotEnvLocal(): void {
+	const file = path.join(WEB_NEXT_ROOT, ".env.local");
+	if (!existsSync(file)) return;
+	for (const rawLine of readFileSync(file, "utf8").split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) continue;
+		const equals = line.indexOf("=");
+		if (equals <= 0) continue;
+		const key = line.slice(0, equals).trim();
+		if (process.env[key] !== undefined) continue;
+		let value = line.slice(equals + 1).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		process.env[key] = value;
+	}
+}
+
+loadDotEnvLocal();
+
+async function main(): Promise<void> {
+	const port = process.env.PORT ?? process.env.E2E_PORT ?? "3100";
+	const localEnv = {
+		...process.env,
+		WEB_NEXT_LOCAL_MODE: "1",
+	};
+
+	assertAuthModeConfig(localEnv);
+
+	if (!existsSync(path.join(WEB_NEXT_ROOT, ".next", "BUILD_ID"))) {
+		await run("pnpm", ["run", "build"], {
+			...process.env,
+			WEB_NEXT_LOCAL_MODE: "",
+		});
+	}
+
+	const token = ensureLocalSignInToken(localEnv);
+	const serverEnv = {
+		...localEnv,
+		NODE_ENV: "production" as const,
+		WEB_NEXT_LOCAL_TOKEN: token,
+	};
+
+	console.log(`Local sign-in: ${localSignInUrl(port, token)}`);
+	console.log(`Local token: ${localTokenPath(localEnv)}`);
+	console.log("Local mode accepts only localhost, 127.0.0.1, or ::1 Host headers.");
+
+	await run(
+		"pnpm",
+		["exec", "next", "start", "-H", "127.0.0.1", "--port", port],
+		serverEnv,
+	);
+}
+
+void main();

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -10,6 +10,7 @@
 export const DEFAULT_PROD_URL = "https://folio.cloudcompute.com";
 
 export const LOCAL_PORT = 3101;
+export const LOCAL_MODE_PORT = 3102;
 
 /**
  * Resolves what a run targets. `--url <origin>` wins; `--env local` spawns a
@@ -33,6 +34,14 @@ export function resolveTarget(args, env = {}) {
 	if (envName === "local") {
 		return { envName, baseUrl: `http://localhost:${LOCAL_PORT}`, spawnLocal: true };
 	}
+	if (envName === "local-mode") {
+		return {
+			envName,
+			baseUrl: `http://localhost:${LOCAL_MODE_PORT}`,
+			spawnLocal: true,
+			localMode: true,
+		};
+	}
 	if (envName === "prod") {
 		return {
 			envName,
@@ -51,6 +60,7 @@ export function resolveTarget(args, env = {}) {
  * its presence distinguishes the modes from the outside.
  */
 export function detectAuthMode(signInHtml) {
+	if (/local sign-in token|continue locally/i.test(signInHtml)) return "local";
 	return /test bypass/i.test(signInHtml) ? "bypass" : "real";
 }
 
@@ -129,12 +139,34 @@ export function evaluatePosture(mode, probes) {
 				`GET / with forged test-auth-login → ${probes.forgedCookieHome.status}`,
 			),
 		);
-	} else {
+	} else if (mode === "bypass") {
 		checks.push(
 			check(
 				"bypass_cookie_signs_in",
 				probes.forgedCookieHome.status === 200,
 				`GET / with test-auth-login cookie → ${probes.forgedCookieHome.status} (bypass mode)`,
+			),
+		);
+	} else {
+		checks.push(
+			check(
+				"no_github_oauth_button",
+				!/github/i.test(probes.signIn.body ?? ""),
+				"local-mode door must not offer GitHub OAuth",
+			),
+		);
+		checks.push(
+			check(
+				"no_bypass_button",
+				!/test bypass/i.test(probes.signIn.body ?? ""),
+				"local-mode door must not offer the test bypass",
+			),
+		);
+		checks.push(
+			check(
+				"forged_bypass_cookie_inert",
+				isRedirectToSignIn(probes.forgedCookieHome),
+				`GET / with forged test-auth-login → ${probes.forgedCookieHome.status}`,
 			),
 		);
 	}
@@ -189,6 +221,9 @@ export function validationSessionCookieName(baseUrl) {
  */
 export function authedCookie(mode, baseUrl, env) {
 	if (mode === "bypass") return "test-auth-login=fairchild";
+	if (mode === "local" && env.WEB_NEXT_LOCAL_TOKEN) {
+		return `web-next-local-session=${env.WEB_NEXT_LOCAL_TOKEN}`;
+	}
 	if (!env.WEB_NEXT_VALIDATION_SESSION) return null;
 	return `${validationSessionCookieName(baseUrl)}=${env.WEB_NEXT_VALIDATION_SESSION}`;
 }

--- a/web-next/scripts/validate-core.mjs
+++ b/web-next/scripts/validate-core.mjs
@@ -23,14 +23,19 @@ export function resolveTarget(args, env = {}) {
 		const at = args.indexOf(flag);
 		return at >= 0 ? args[at + 1] : undefined;
 	};
+	const envName = get("--env") ?? "local";
 	const url = get("--url");
 	if (url) {
 		if (!/^https?:\/\//.test(url)) {
 			throw new Error(`--url must be an http(s) origin, got: ${url}`);
 		}
-		return { envName: get("--env") ?? "url", baseUrl: url.replace(/\/$/, ""), spawnLocal: false };
+		return {
+			envName: get("--env") ?? "url",
+			baseUrl: url.replace(/\/$/, ""),
+			spawnLocal: false,
+			localMode: envName === "local-mode",
+		};
 	}
-	const envName = get("--env") ?? "local";
 	if (envName === "local") {
 		return { envName, baseUrl: `http://localhost:${LOCAL_PORT}`, spawnLocal: true };
 	}

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -30,6 +30,15 @@ describe("resolveTarget", () => {
 		).toBe("https://x.example");
 	});
 
+	test("--env local-mode spawns the owner-local target", () => {
+		expect(resolveTarget(["--env", "local-mode"])).toMatchObject({
+			envName: "local-mode",
+			baseUrl: "http://localhost:3102",
+			spawnLocal: true,
+			localMode: true,
+		});
+	});
+
 	test("--url wins and never spawns", () => {
 		const t = resolveTarget(["--env", "preview", "--url", "https://pr-1.vercel.app/"]);
 		expect(t).toMatchObject({
@@ -47,6 +56,7 @@ describe("resolveTarget", () => {
 
 test("detectAuthMode reads the door", () => {
 	expect(detectAuthMode("<button>continue as fairchild (test bypass)</button>")).toBe("bypass");
+	expect(detectAuthMode("<input placeholder='local sign-in token' />")).toBe("local");
 	expect(detectAuthMode("<button>Continue with GitHub</button>")).toBe("real");
 });
 
@@ -83,6 +93,16 @@ describe("evaluatePosture", () => {
 			home: redirect,
 			signIn: { status: 200, body: "test bypass" },
 			forgedCookieHome: { status: 200 },
+			api: [{ path: "/api/x", method: "POST", status: 401, body: unauthJson }],
+		});
+		expect(checks.every((c) => c.status === "pass")).toBe(true);
+	});
+
+	test("local mode: no OAuth door, no bypass door, forged bypass cookie inert", () => {
+		const checks = evaluatePosture("local", {
+			home: redirect,
+			signIn: { status: 200, body: "local sign-in token" },
+			forgedCookieHome: redirect,
 			api: [{ path: "/api/x", method: "POST", status: 401, body: unauthJson }],
 		});
 		expect(checks.every((c) => c.status === "pass")).toBe(true);
@@ -147,6 +167,15 @@ test("validationSessionCookieName picks the __Secure- prefix over https, plain o
 	expect(validationSessionCookieName("http://localhost:3101")).toBe(
 		"better-auth.session_token",
 	);
+});
+
+test("authedCookie can authenticate local-mode validation with the minted token", () => {
+	expect(
+		authedCookie("local", "http://localhost:3102", {
+			WEB_NEXT_LOCAL_TOKEN: "local-secret",
+		}),
+	).toBe("web-next-local-session=local-secret");
+	expect(authedCookie("local", "http://localhost:3102", {})).toBeNull();
 });
 
 describe("classifyModelSweepGate (#816)", () => {

--- a/web-next/scripts/validate-core.test.mjs
+++ b/web-next/scripts/validate-core.test.mjs
@@ -48,6 +48,17 @@ describe("resolveTarget", () => {
 		});
 	});
 
+	test("--env local-mode --url keeps local-mode expectations", () => {
+		expect(
+			resolveTarget(["--env", "local-mode", "--url", "http://localhost:3183/"]),
+		).toMatchObject({
+			envName: "local-mode",
+			baseUrl: "http://localhost:3183",
+			spawnLocal: false,
+			localMode: true,
+		});
+	});
+
 	test("rejects a non-origin --url and an env with no stable origin", () => {
 		expect(() => resolveTarget(["--url", "pr-1.vercel.app"])).toThrow(/http/);
 		expect(() => resolveTarget(["--env", "preview"])).toThrow(/--url/);

--- a/web-next/scripts/validate.mjs
+++ b/web-next/scripts/validate.mjs
@@ -186,7 +186,10 @@ async function localModeStage(baseUrl, token) {
 			{
 				id: "loopback_host_required",
 				status: badHost.status === 403 ? "pass" : "fail",
-				detail: `GET /api/repos with Host: spaces.example → ${badHost.status}`,
+				detail:
+					badHost.status === 403
+						? `GET /api/repos with Host: spaces.example → ${badHost.status}`
+						: `target is not in local mode: GET /api/repos with Host: spaces.example → ${badHost.status}`,
 			},
 			{
 				id: "token_required",

--- a/web-next/scripts/validate.mjs
+++ b/web-next/scripts/validate.mjs
@@ -11,6 +11,7 @@
  */
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import http from "node:http";
 import path from "node:path";
 import { MODEL_OPTIONS } from "../src/lib/agent-runtime/models.ts";
 import { realTurnStage } from "./real-turn.mjs";
@@ -25,6 +26,7 @@ import {
 	evaluatePosture,
 	gateStage,
 	isRedirectToSignIn,
+	LOCAL_MODE_PORT,
 	LOCAL_PORT,
 	redactSecrets,
 	renderMarkdownReport,
@@ -32,7 +34,12 @@ import {
 	summarize,
 	validationSessionCookieName,
 } from "./validate-core.mjs";
-import { bypassServerEnv, startProductionServer, WEB_NEXT_ROOT } from "./harness.mjs";
+import {
+	bypassServerEnv,
+	localModeServerEnv,
+	startProductionServer,
+	WEB_NEXT_ROOT,
+} from "./harness.mjs";
 
 const PROBE_TIMEOUT_MS = 15_000;
 
@@ -75,6 +82,45 @@ async function probe(baseUrl, pathname, init = {}) {
 		];
 		return { path: pathname, method, status: 0, body: redactSecrets(String(error), secrets) };
 	}
+}
+
+async function probeWithHostHeader(baseUrl, pathname, host) {
+	const url = new URL(pathname, baseUrl);
+	return new Promise((resolve) => {
+		const req = http.request(
+			{
+				hostname: url.hostname,
+				port: url.port,
+				path: `${url.pathname}${url.search}`,
+				method: "GET",
+				headers: { Host: host },
+				timeout: PROBE_TIMEOUT_MS,
+			},
+			(res) => {
+				let body = "";
+				res.setEncoding("utf8");
+				res.on("data", (chunk) => {
+					body += chunk;
+				});
+				res.on("end", () => {
+					resolve({
+						path: pathname,
+						method: "GET",
+						status: res.statusCode ?? 0,
+						location: res.headers.location,
+						body,
+					});
+				});
+			},
+		);
+		req.on("timeout", () => {
+			req.destroy(new Error("request timed out"));
+		});
+		req.on("error", (error) => {
+			resolve({ path: pathname, method: "GET", status: 0, body: String(error) });
+		});
+		req.end();
+	});
 }
 
 async function reachabilityStage(baseUrl) {
@@ -121,6 +167,43 @@ async function postureStage(baseUrl, signIn) {
 		id: `posture (${mode} auth)`,
 		status: "run",
 		checks: evaluatePosture(mode, { home, signIn, forgedCookieHome, api }),
+	};
+}
+
+async function localModeStage(baseUrl, token) {
+	const [badHost, noCookieApi, bypassCookieHome, tokenCookieHome] = await Promise.all([
+		probeWithHostHeader(baseUrl, "/api/repos", "spaces.example"),
+		probe(baseUrl, "/api/repos"),
+		probe(baseUrl, "/", { headers: { cookie: "test-auth-login=fairchild" } }),
+		probe(baseUrl, "/", {
+			headers: token ? { cookie: `web-next-local-session=${token}` } : {},
+		}),
+	]);
+	return {
+		id: "local-mode posture",
+		status: "run",
+		checks: [
+			{
+				id: "loopback_host_required",
+				status: badHost.status === 403 ? "pass" : "fail",
+				detail: `GET /api/repos with Host: spaces.example → ${badHost.status}`,
+			},
+			{
+				id: "token_required",
+				status: noCookieApi.status === 401 ? "pass" : "fail",
+				detail: `GET /api/repos without cookie → ${noCookieApi.status}`,
+			},
+			{
+				id: "bypass_cookie_inert",
+				status: isRedirectToSignIn(bypassCookieHome) ? "pass" : "fail",
+				detail: `GET / with test-auth-login cookie → ${bypassCookieHome.status}`,
+			},
+			{
+				id: "local_cookie_authenticates",
+				status: tokenCookieHome.status === 200 ? "pass" : "fail",
+				detail: `GET / with local session cookie → ${tokenCookieHome.status}`,
+			},
+		],
 	};
 }
 
@@ -264,8 +347,14 @@ async function main() {
 	const skipRealTurn = args.includes("--skip-real-turn");
 	let server;
 	if (target.spawnLocal) {
-		const { env } = bypassServerEnv("validate-db");
-		server = await startProductionServer(LOCAL_PORT, env);
+		if (target.localMode) {
+			const { env } = await localModeServerEnv("validate-local-mode");
+			server = await startProductionServer(LOCAL_MODE_PORT, env);
+			process.env.WEB_NEXT_LOCAL_TOKEN = env.WEB_NEXT_LOCAL_TOKEN;
+		} else {
+			const { env } = bypassServerEnv("validate-db");
+			server = await startProductionServer(LOCAL_PORT, env);
+		}
 	}
 	try {
 		console.log(`validating ${target.envName}: ${target.baseUrl}\n`);
@@ -280,6 +369,13 @@ async function main() {
 		const mode = detectAuthMode(reach.signIn?.body ?? "");
 		if (reachable) {
 			stages.push(await timed(() => postureStage(target.baseUrl, reach.signIn)));
+			if (target.localMode) {
+				stages.push(
+					await timed(() =>
+						localModeStage(target.baseUrl, process.env.WEB_NEXT_LOCAL_TOKEN),
+					),
+				);
+			}
 			stages.push(await timed(() => authenticatedStage(target.baseUrl, mode, process.env)));
 			stages.push(await timed(() => modelSweepStage(target.baseUrl, process.env)));
 			stages.push(await timed(() => e2eDeployedSafeStage(target, process.env)));

--- a/web-next/src/app/api/repos/route.ts
+++ b/web-next/src/app/api/repos/route.ts
@@ -1,10 +1,9 @@
 /*
  * GET /api/repos?q=<query> — auth-gated feed for the new-session picker's
  * searchable repo list: the GitHub App installation's repos merged with the
- * already-connected ones (see mergeRepoLists), so one-click rows survive
- * even when the directory is empty. `degraded: true` when the App has no
- * credentials configured, so the client can show the quiet unverified note
- * instead of an empty-looking error.
+ * already-connected ones (see mergeRepoLists), so one-click rows survive.
+ * When App credentials are absent, the directory layer returns deterministic
+ * fixtures rather than coupling itself to the active auth mode.
  */
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";

--- a/web-next/src/app/sign-in/actions.ts
+++ b/web-next/src/app/sign-in/actions.ts
@@ -1,17 +1,20 @@
 "use server";
 
 /*
- * Test-bypass sign-in: sets the acting-login cookie and enters the app.
- * Hard-guarded by authBypassEnabled() — with real OAuth configured (or
- * without AUTH_BYPASS=1) this action refuses, so it is inert in production.
+ * Sign-in actions for non-OAuth doors: the test bypass used by e2e/perf, and
+ * owner-local mode's minted bearer token. Both are hard-guarded by their mode
+ * switches so neither action can silently become a production auth path.
  */
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import {
 	authBypassEnabled,
+	LOCAL_AUTH_COOKIE,
+	localModeEnabled,
 	parseAllowedLogins,
 	TEST_AUTH_COOKIE,
 } from "@/lib/auth/config";
+import { localSignInTokenMatches } from "@/lib/auth/local-token";
 
 export async function testSignInAction(): Promise<void> {
 	if (!authBypassEnabled()) {
@@ -20,5 +23,22 @@ export async function testSignInAction(): Promise<void> {
 	const [login] = parseAllowedLogins();
 	if (!login) throw new Error("ALLOWED_LOGINS is empty — nobody to sign in as");
 	(await cookies()).set(TEST_AUTH_COOKIE, login, { path: "/" });
+	redirect("/");
+}
+
+export async function localSignInAction(formData: FormData): Promise<void> {
+	if (!localModeEnabled()) {
+		throw new Error("local sign-in is disabled outside local mode");
+	}
+	const token = String(formData.get("token") ?? "");
+	if (!localSignInTokenMatches(token)) {
+		throw new Error("invalid local sign-in token");
+	}
+	(await cookies()).set(LOCAL_AUTH_COOKIE, token.trim(), {
+		path: "/",
+		httpOnly: true,
+		sameSite: "lax",
+		secure: false,
+	});
 	redirect("/");
 }

--- a/web-next/src/app/sign-in/page.tsx
+++ b/web-next/src/app/sign-in/page.tsx
@@ -1,13 +1,16 @@
 /*
- * The doorway: wordmark, one GitHub button, nothing else. In test-bypass
- * mode a second quiet button signs in as the allowlisted user so e2e,
- * evidence, and local dev work without OAuth. Already signed in → home
- * (the allowlist verdict, if negative, is delivered by the app shell).
+ * The doorway: GitHub OAuth in production, the quiet test bypass in harness
+ * mode, or a local token paste box under WEB_NEXT_LOCAL_MODE. Already signed
+ * in → home (the allowlist verdict, if negative, is delivered by the shell).
  */
 import { redirect } from "next/navigation";
 import { getAuthState } from "@/lib/auth/auth-state";
-import { authBypassEnabled, parseAllowedLogins } from "@/lib/auth/config";
-import { testSignInAction } from "./actions";
+import {
+	authBypassEnabled,
+	localModeEnabled,
+	parseAllowedLogins,
+} from "@/lib/auth/config";
+import { localSignInAction, testSignInAction } from "./actions";
 import { GitHubSignInButton } from "./github-sign-in-button";
 
 export const dynamic = "force-dynamic";
@@ -15,6 +18,7 @@ export const dynamic = "force-dynamic";
 export default async function SignInPage() {
 	const auth = await getAuthState();
 	if (auth.kind !== "unauthenticated") redirect("/");
+	const local = localModeEnabled();
 	const bypass = authBypassEnabled();
 	const [bypassLogin] = bypass ? parseAllowedLogins() : [];
 
@@ -27,7 +31,26 @@ export default async function SignInPage() {
 				</p>
 			</div>
 			<div className="flex flex-col items-center gap-4">
-				<GitHubSignInButton />
+				{local ? (
+					<form action={localSignInAction} className="flex w-full max-w-sm flex-col gap-3">
+						<input
+							name="token"
+							type="password"
+							required
+							autoComplete="off"
+							placeholder="local sign-in token"
+							className="rounded-md border border-line bg-transparent px-3 py-2 font-mono text-[13px] text-ink outline-none transition-colors placeholder:text-hint focus:border-focus-line"
+						/>
+						<button
+							type="submit"
+							className="rounded-md border border-line px-3 py-2 font-mono text-[12px] text-ink transition-colors hover:border-focus-line hover:text-accent"
+						>
+							continue locally
+						</button>
+					</form>
+				) : (
+					<GitHubSignInButton />
+				)}
 				{bypass && bypassLogin && (
 					<form action={testSignInAction}>
 						<button

--- a/web-next/src/lib/auth/auth-state.ts
+++ b/web-next/src/lib/auth/auth-state.ts
@@ -8,7 +8,15 @@
 import { cookies, headers } from "next/headers";
 import { getDatabase } from "../db/client";
 import { ensureSchema } from "../db/schema";
-import { authBypassEnabled, isLoginAllowed, TEST_AUTH_COOKIE } from "./config";
+import {
+	authBypassEnabled,
+	isLoginAllowed,
+	LOCAL_AUTH_COOKIE,
+	localModeEnabled,
+	resolveLocalLogin,
+	TEST_AUTH_COOKIE,
+} from "./config";
+import { localSignInTokenMatches } from "./local-token";
 
 export type AuthState =
 	| { kind: "unauthenticated" }
@@ -22,6 +30,13 @@ function verdict(login: string, name: string): AuthState {
 }
 
 export async function getAuthState(): Promise<AuthState> {
+	if (localModeEnabled()) {
+		const token = (await cookies()).get(LOCAL_AUTH_COOKIE)?.value ?? "";
+		if (!localSignInTokenMatches(token)) return { kind: "unauthenticated" };
+		const login = resolveLocalLogin();
+		return { kind: "authorized", user: { login, name: login } };
+	}
+
 	if (authBypassEnabled()) {
 		const login = (await cookies()).get(TEST_AUTH_COOKIE)?.value ?? "";
 		if (!login) return { kind: "unauthenticated" };

--- a/web-next/src/lib/auth/config.test.ts
+++ b/web-next/src/lib/auth/config.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
 	authBypassEnabled,
+	assertAuthModeConfig,
+	constantTimeEqual,
+	isLoopbackHostHeader,
 	isLoginAllowed,
+	localModeEnabled,
+	localSessionCookieValid,
+	oauthEnvConfigured,
 	parseAllowedLogins,
 	realAuthConfigured,
+	resolveLocalLogin,
 	resolveAuthSecret,
 } from "./config";
 
@@ -58,6 +65,15 @@ describe("authBypassEnabled (triple lock)", () => {
 			}),
 		).toBe(false);
 	});
+
+	it("is inert in local mode", () => {
+		expect(
+			authBypassEnabled({
+				AUTH_BYPASS: "1",
+				WEB_NEXT_LOCAL_MODE: "1",
+			}),
+		).toBe(false);
+	});
 });
 
 describe("resolveAuthSecret", () => {
@@ -80,5 +96,56 @@ describe("realAuthConfigured", () => {
 	it("keys on the OAuth client id", () => {
 		expect(realAuthConfigured({})).toBe(false);
 		expect(realAuthConfigured({ GITHUB_OAUTH_CLIENT_ID: "x" })).toBe(true);
+	});
+});
+
+describe("local mode config", () => {
+	it("resolves explicit local mode and default login", () => {
+		expect(localModeEnabled({ WEB_NEXT_LOCAL_MODE: "1" })).toBe(true);
+		expect(localModeEnabled({ WEB_NEXT_LOCAL_MODE: "0" })).toBe(false);
+		expect(resolveLocalLogin({})).toBe("fairchild");
+		expect(resolveLocalLogin({ WEB_NEXT_LOCAL_LOGIN: " Owner " })).toBe("owner");
+	});
+
+	it("treats any OAuth var as an OAuth configuration conflict", () => {
+		expect(oauthEnvConfigured({})).toBe(false);
+		expect(oauthEnvConfigured({ GITHUB_OAUTH_CLIENT_ID: "id" })).toBe(true);
+		expect(oauthEnvConfigured({ GITHUB_OAUTH_CLIENT_SECRET: "secret" })).toBe(true);
+	});
+
+	it("rejects local-mode conflicts at startup/config time", () => {
+		expect(() =>
+			assertAuthModeConfig({ WEB_NEXT_LOCAL_MODE: "1", AUTH_BYPASS: "1" }),
+		).toThrow(/AUTH_BYPASS/);
+		expect(() =>
+			assertAuthModeConfig({
+				WEB_NEXT_LOCAL_MODE: "1",
+				GITHUB_OAUTH_CLIENT_ID: "id",
+			}),
+		).toThrow(/OAuth/);
+		expect(() => assertAuthModeConfig({ WEB_NEXT_LOCAL_MODE: "1" })).not.toThrow();
+	});
+
+	it("checks local session cookies with the configured token", () => {
+		const env = { WEB_NEXT_LOCAL_MODE: "1", WEB_NEXT_LOCAL_TOKEN: "secret-token" };
+		expect(localSessionCookieValid("secret-token", env)).toBe(true);
+		expect(localSessionCookieValid("wrong", env)).toBe(false);
+		expect(localSessionCookieValid(undefined, env)).toBe(false);
+	});
+
+	it("compares strings without accepting prefixes or length mismatches", () => {
+		expect(constantTimeEqual("abc", "abc")).toBe(true);
+		expect(constantTimeEqual("abc", "abcd")).toBe(false);
+		expect(constantTimeEqual("abc", "xbc")).toBe(false);
+	});
+
+	it("recognizes loopback Host headers only", () => {
+		expect(isLoopbackHostHeader("localhost")).toBe(true);
+		expect(isLoopbackHostHeader("localhost:3100")).toBe(true);
+		expect(isLoopbackHostHeader("127.0.0.1:3100")).toBe(true);
+		expect(isLoopbackHostHeader("[::1]:3100")).toBe(true);
+		expect(isLoopbackHostHeader("spaces.example")).toBe(false);
+		expect(isLoopbackHostHeader("127.0.0.2:3100")).toBe(false);
+		expect(isLoopbackHostHeader(null)).toBe(false);
 	});
 });

--- a/web-next/src/lib/auth/config.test.ts
+++ b/web-next/src/lib/auth/config.test.ts
@@ -5,6 +5,7 @@ import {
 	constantTimeEqual,
 	isLoopbackHostHeader,
 	isLoginAllowed,
+	loopbackHostOrigin,
 	localModeEnabled,
 	localSessionCookieValid,
 	oauthEnvConfigured,
@@ -144,7 +145,13 @@ describe("local mode config", () => {
 		expect(isLoopbackHostHeader("localhost:3100")).toBe(true);
 		expect(isLoopbackHostHeader("127.0.0.1:3100")).toBe(true);
 		expect(isLoopbackHostHeader("[::1]:3100")).toBe(true);
+		expect(loopbackHostOrigin("localhost:3100")).toBe("http://localhost:3100");
+		expect(loopbackHostOrigin("[::1]:3100")).toBe("http://[::1]:3100");
 		expect(isLoopbackHostHeader("spaces.example")).toBe(false);
+		expect(isLoopbackHostHeader("localhost.attacker.test")).toBe(false);
+		expect(isLoopbackHostHeader("localhost:3100:evil")).toBe(false);
+		expect(isLoopbackHostHeader("[::1]:bad")).toBe(false);
+		expect(isLoopbackHostHeader("localhost:")).toBe(false);
 		expect(isLoopbackHostHeader("127.0.0.2:3100")).toBe(false);
 		expect(isLoopbackHostHeader(null)).toBe(false);
 	});

--- a/web-next/src/lib/auth/config.ts
+++ b/web-next/src/lib/auth/config.ts
@@ -14,6 +14,13 @@ type Env = Record<string, string | undefined>;
  */
 export const TEST_AUTH_COOKIE = "test-auth-login";
 
+/**
+ * Cookie carrying the bearer token for owner-local serving mode. This is not
+ * the test bypass: it is minted locally, persisted under the data dir, and only
+ * honored when WEB_NEXT_LOCAL_MODE=1.
+ */
+export const LOCAL_AUTH_COOKIE = "web-next-local-session";
+
 /** GitHub logins allowed in (`ALLOWED_LOGINS`, csv, case-insensitive). */
 export function parseAllowedLogins(env: Env = process.env): Set<string> {
 	return new Set(
@@ -37,6 +44,33 @@ export function realAuthConfigured(env: Env = process.env): boolean {
 	return Boolean(env.GITHUB_OAUTH_CLIENT_ID);
 }
 
+/** Any GitHub OAuth var means the server is trying to use the real OAuth door. */
+export function oauthEnvConfigured(env: Env = process.env): boolean {
+	return Boolean(env.GITHUB_OAUTH_CLIENT_ID || env.GITHUB_OAUTH_CLIENT_SECRET);
+}
+
+/** First-class local serving mode: loopback + locally minted bearer token. */
+export function localModeEnabled(env: Env = process.env): boolean {
+	return env.WEB_NEXT_LOCAL_MODE === "1";
+}
+
+export function resolveLocalLogin(env: Env = process.env): string {
+	const login = env.WEB_NEXT_LOCAL_LOGIN?.trim();
+	return login && login.length > 0 ? login.toLowerCase() : "fairchild";
+}
+
+export function assertAuthModeConfig(env: Env = process.env): void {
+	if (!localModeEnabled(env)) return;
+	if (env.AUTH_BYPASS === "1") {
+		throw new Error("WEB_NEXT_LOCAL_MODE cannot be combined with AUTH_BYPASS=1");
+	}
+	if (oauthEnvConfigured(env)) {
+		throw new Error(
+			"WEB_NEXT_LOCAL_MODE cannot be combined with GitHub OAuth environment variables",
+		);
+	}
+}
+
 /**
  * Test/dev auth bypass: cookie-driven identity instead of GitHub OAuth, so
  * e2e, evidence, and perf runs work headlessly. Triple-locked:
@@ -52,7 +86,50 @@ export function realAuthConfigured(env: Env = process.env): boolean {
  * unauth redirect and the allowlist rejection stay testable per request.
  */
 export function authBypassEnabled(env: Env = process.env): boolean {
-	return env.AUTH_BYPASS === "1" && !realAuthConfigured(env) && !env.VERCEL;
+	return (
+		env.AUTH_BYPASS === "1" &&
+		!localModeEnabled(env) &&
+		!realAuthConfigured(env) &&
+		!env.VERCEL
+	);
+}
+
+const encoder = new TextEncoder();
+
+/**
+ * Edge-safe constant-time string comparison. It keeps the loop count tied to
+ * the longest encoded input and folds the length mismatch into the result, so
+ * callers do not branch early on unequal lengths.
+ */
+export function constantTimeEqual(left: string, right: string): boolean {
+	const a = encoder.encode(left);
+	const b = encoder.encode(right);
+	let diff = a.length ^ b.length;
+	const length = Math.max(a.length, b.length);
+	for (let index = 0; index < length; index += 1) {
+		diff |= (a[index] ?? 0) ^ (b[index] ?? 0);
+	}
+	return diff === 0;
+}
+
+export function localSessionCookieValid(
+	cookieValue: string | null | undefined,
+	env: Env = process.env,
+): boolean {
+	if (!localModeEnabled(env) || !cookieValue || !env.WEB_NEXT_LOCAL_TOKEN) {
+		return false;
+	}
+	return constantTimeEqual(cookieValue, env.WEB_NEXT_LOCAL_TOKEN);
+}
+
+export function isLoopbackHostHeader(hostHeader: string | null): boolean {
+	if (!hostHeader) return false;
+	const host = hostHeader.trim().toLowerCase();
+	if (host === "localhost" || host === "127.0.0.1") return true;
+	if (host.startsWith("[::1]")) return host === "[::1]" || host.startsWith("[::1]:");
+	if (host === "::1") return true;
+	const withoutPort = host.includes(":") ? host.split(":")[0] : host;
+	return withoutPort === "localhost" || withoutPort === "127.0.0.1";
 }
 
 /**

--- a/web-next/src/lib/auth/config.ts
+++ b/web-next/src/lib/auth/config.ts
@@ -122,14 +122,32 @@ export function localSessionCookieValid(
 	return constantTimeEqual(cookieValue, env.WEB_NEXT_LOCAL_TOKEN);
 }
 
-export function isLoopbackHostHeader(hostHeader: string | null): boolean {
-	if (!hostHeader) return false;
+function hostHeaderHasValidPortToken(hostHeader: string): boolean {
+	if (hostHeader.startsWith("[")) {
+		const match = hostHeader.match(/^\[[^\]]+\](?::([0-9]+))?$/);
+		return match !== null;
+	}
+	const parts = hostHeader.split(":");
+	if (parts.length === 1) return true;
+	return parts.length === 2 && /^[0-9]+$/.test(parts[1] ?? "");
+}
+
+export function loopbackHostOrigin(hostHeader: string | null): string | null {
+	if (!hostHeader) return null;
 	const host = hostHeader.trim().toLowerCase();
-	if (host === "localhost" || host === "127.0.0.1") return true;
-	if (host.startsWith("[::1]")) return host === "[::1]" || host.startsWith("[::1]:");
-	if (host === "::1") return true;
-	const withoutPort = host.includes(":") ? host.split(":")[0] : host;
-	return withoutPort === "localhost" || withoutPort === "127.0.0.1";
+	if (!hostHeaderHasValidPortToken(host)) return null;
+	try {
+		const url = new URL(`http://${host}`);
+		if (url.pathname !== "/" || url.search !== "" || url.hash !== "") return null;
+		if (!["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)) return null;
+		return url.origin;
+	} catch {
+		return null;
+	}
+}
+
+export function isLoopbackHostHeader(hostHeader: string | null): boolean {
+	return loopbackHostOrigin(hostHeader) !== null;
 }
 
 /**

--- a/web-next/src/lib/auth/local-token.test.ts
+++ b/web-next/src/lib/auth/local-token.test.ts
@@ -32,6 +32,22 @@ describe("local sign-in token", () => {
 		expect(fs.readFileSync(localTokenPath(testEnv), "utf8").trim()).toBe(first);
 	});
 
+	it("tightens an existing token file to owner-only permissions before reuse", () => {
+		const testEnv = env();
+		const file = localTokenPath(testEnv);
+		fs.writeFileSync(file, "existing-token\n", { mode: 0o644 });
+		expect(ensureLocalSignInToken(testEnv)).toBe("existing-token");
+		expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+	});
+
+	it("refuses to reuse a symlinked token file", () => {
+		const testEnv = env();
+		const target = path.join(testEnv.WEB_NEXT_DATA_DIR, "target-token");
+		fs.writeFileSync(target, "existing-token\n", { mode: 0o600 });
+		fs.symlinkSync(target, localTokenPath(testEnv));
+		expect(() => ensureLocalSignInToken(testEnv)).toThrow(/symlinked local sign-in token/);
+	});
+
 	it("compares the supplied token without accepting wrong values", () => {
 		const testEnv = env();
 		const token = ensureLocalSignInToken(testEnv);

--- a/web-next/src/lib/auth/local-token.test.ts
+++ b/web-next/src/lib/auth/local-token.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	ensureLocalSignInToken,
+	localSignInTokenMatches,
+	localTokenPath,
+} from "./local-token";
+
+const dirs: string[] = [];
+
+function env() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "web-next-local-token-"));
+	dirs.push(dir);
+	return { WEB_NEXT_LOCAL_MODE: "1", WEB_NEXT_DATA_DIR: dir };
+}
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("local sign-in token", () => {
+	it("mints once, persists under WEB_NEXT_DATA_DIR, and reuses the token", () => {
+		const testEnv = env();
+		const first = ensureLocalSignInToken(testEnv);
+		const second = ensureLocalSignInToken(testEnv);
+		expect(first).toBe(second);
+		expect(first).toHaveLength(43);
+		expect(fs.readFileSync(localTokenPath(testEnv), "utf8").trim()).toBe(first);
+	});
+
+	it("compares the supplied token without accepting wrong values", () => {
+		const testEnv = env();
+		const token = ensureLocalSignInToken(testEnv);
+		expect(localSignInTokenMatches(token, testEnv)).toBe(true);
+		expect(localSignInTokenMatches(`${token}x`, testEnv)).toBe(false);
+		expect(localSignInTokenMatches("wrong", testEnv)).toBe(false);
+		expect(localSignInTokenMatches("", testEnv)).toBe(false);
+	});
+
+	it("uses WEB_NEXT_LOCAL_TOKEN when middleware/startup provided it", () => {
+		expect(
+			localSignInTokenMatches("from-env", {
+				WEB_NEXT_LOCAL_MODE: "1",
+				WEB_NEXT_LOCAL_TOKEN: "from-env",
+			}),
+		).toBe(true);
+	});
+});

--- a/web-next/src/lib/auth/local-token.ts
+++ b/web-next/src/lib/auth/local-token.ts
@@ -1,0 +1,55 @@
+/*
+ * Node-only local serving token store. start:local and server actions use this
+ * to mint/read the owner-local bearer token from WEB_NEXT_DATA_DIR; middleware
+ * receives the token through WEB_NEXT_LOCAL_TOKEN because edge code cannot read
+ * the filesystem.
+ */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveWebNextDataDir } from "../local-data-dir";
+import { assertAuthModeConfig, constantTimeEqual } from "./config";
+
+type Env = Record<string, string | undefined>;
+
+export const LOCAL_SIGN_IN_TOKEN_FILE = "local-sign-in-token";
+
+export function localTokenPath(env: Env = process.env): string {
+	return path.join(resolveWebNextDataDir(env), LOCAL_SIGN_IN_TOKEN_FILE);
+}
+
+function mintToken(): string {
+	return crypto.randomBytes(32).toString("base64url");
+}
+
+function normalizeToken(token: string): string {
+	return token.trim();
+}
+
+export function ensureLocalSignInToken(env: Env = process.env): string {
+	assertAuthModeConfig(env);
+	const file = localTokenPath(env);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	if (fs.existsSync(file)) {
+		const existing = normalizeToken(fs.readFileSync(file, "utf8"));
+		if (existing.length > 0) return existing;
+	}
+	const token = mintToken();
+	fs.writeFileSync(file, `${token}\n`, { mode: 0o600 });
+	return token;
+}
+
+export function localSignInTokenMatches(
+	candidate: string | null | undefined,
+	env: Env = process.env,
+): boolean {
+	if (!candidate) return false;
+	const expected = env.WEB_NEXT_LOCAL_TOKEN ?? ensureLocalSignInToken(env);
+	return constantTimeEqual(normalizeToken(candidate), expected);
+}
+
+export function localSignInUrl(port: string | number, token: string): string {
+	const url = new URL(`http://localhost:${port}/sign-in`);
+	url.searchParams.set("token", token);
+	return url.toString();
+}

--- a/web-next/src/lib/auth/local-token.ts
+++ b/web-next/src/lib/auth/local-token.ts
@@ -31,6 +31,13 @@ export function ensureLocalSignInToken(env: Env = process.env): string {
 	const file = localTokenPath(env);
 	fs.mkdirSync(path.dirname(file), { recursive: true });
 	if (fs.existsSync(file)) {
+		const stat = fs.lstatSync(file);
+		if (stat.isSymbolicLink()) {
+			throw new Error(`refusing to reuse symlinked local sign-in token file: ${file}`);
+		}
+		if ((stat.mode & 0o077) !== 0) {
+			fs.chmodSync(file, 0o600);
+		}
 		const existing = normalizeToken(fs.readFileSync(file, "utf8"));
 		if (existing.length > 0) return existing;
 	}

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -14,6 +14,7 @@ import { type Client, createClient } from "@libsql/client";
 import { Kysely } from "kysely";
 import type { ApprovalDecision, ApprovalResolvedBy } from "../agent-runtime/stream-chunk";
 import type { ApprovalPolicy } from "../agent-runtime/approval-policy";
+import { resolveSessionsDatabaseUrl } from "../local-data-dir";
 import { LibsqlDialect } from "./libsql-dialect";
 
 /**
@@ -155,9 +156,7 @@ let singleton: DatabaseHandle | undefined;
 /** The app-wide handle, created once from `SESSIONS_DATABASE_URL`. */
 export function getDatabase(): DatabaseHandle {
 	if (!singleton) {
-		singleton = openDatabase(
-			process.env.SESSIONS_DATABASE_URL ?? "file:.data/sessions.db",
-		);
+		singleton = openDatabase(resolveSessionsDatabaseUrl());
 	}
 	return singleton;
 }

--- a/web-next/src/lib/db/start-session.test.ts
+++ b/web-next/src/lib/db/start-session.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { DEFAULT_MODEL } from "../agent-runtime/models";
 import { type DatabaseHandle, openDatabase } from "./client";
 import { ensureRepo, listRepos } from "./repos";
@@ -115,12 +115,18 @@ describe("startSession", () => {
 		expect(await listSessions(handle)).toHaveLength(0);
 	});
 
-	// The GitHub validation step (see ../github/repo-directory): no App creds
-	// gives deterministic fixtures, so these stay hermetic unit tests.
-	describe("GitHub validation (fixture directory)", () => {
-		test("records the real default_branch from the fixture on first connect", async () => {
-			const handle = freshDb();
-			await startSession(handle, "fairchild/web-next-fixtures");
+		// The GitHub validation step (see ../github/repo-directory): no App creds
+		// plus test bypass gives deterministic fixtures, so these stay hermetic.
+		describe("GitHub validation (fixture directory)", () => {
+			beforeEach(() => {
+				vi.stubEnv("AUTH_BYPASS", "1");
+				vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+				vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+			});
+
+			test("records the real default_branch from the fixture on first connect", async () => {
+				const handle = freshDb();
+				await startSession(handle, "fairchild/web-next-fixtures");
 			const [repo] = await listRepos(handle);
 			expect(repo.defaultBranch).toBe("trunk");
 		});
@@ -140,14 +146,16 @@ describe("startSession", () => {
 			await startSession(handle, "fairchild/web-next-fixtures");
 			const [repo] = await listRepos(handle);
 			expect(repo.defaultBranch).toBe("trunk");
+			});
 		});
-	});
 
-	test("fixture mode is independent of AUTH_BYPASS", async () => {
-		vi.stubEnv("AUTH_BYPASS", "1");
-		const handle = freshDb();
-		await startSession(handle, "fairchild/web-next-fixtures");
-		const [repo] = await listRepos(handle);
+		test("local mode also uses the fixture directory when App creds are absent", async () => {
+			vi.stubEnv("WEB_NEXT_LOCAL_MODE", "1");
+			vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+			vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+			const handle = freshDb();
+			await startSession(handle, "fairchild/web-next-fixtures");
+			const [repo] = await listRepos(handle);
 		expect(repo.defaultBranch).toBe("trunk");
 	});
 });

--- a/web-next/src/lib/db/start-session.test.ts
+++ b/web-next/src/lib/db/start-session.test.ts
@@ -115,11 +115,10 @@ describe("startSession", () => {
 		expect(await listSessions(handle)).toHaveLength(0);
 	});
 
-	// The GitHub validation step (see ../github/repo-directory): bypass mode
+	// The GitHub validation step (see ../github/repo-directory): no App creds
 	// gives deterministic fixtures, so these stay hermetic unit tests.
-	describe("GitHub validation (bypass fixtures)", () => {
+	describe("GitHub validation (fixture directory)", () => {
 		test("records the real default_branch from the fixture on first connect", async () => {
-			vi.stubEnv("AUTH_BYPASS", "1");
 			const handle = freshDb();
 			await startSession(handle, "fairchild/web-next-fixtures");
 			const [repo] = await listRepos(handle);
@@ -127,7 +126,6 @@ describe("startSession", () => {
 		});
 
 		test("rejects a repo the fixture directory doesn't recognize, writing nothing", async () => {
-			vi.stubEnv("AUTH_BYPASS", "1");
 			const handle = freshDb();
 			await expect(
 				startSession(handle, "fairchild/not-a-real-repo"),
@@ -137,7 +135,6 @@ describe("startSession", () => {
 		});
 
 		test("backfills the default_branch onto a repo connected before validation existed", async () => {
-			vi.stubEnv("AUTH_BYPASS", "1");
 			const handle = freshDb();
 			await ensureRepo(handle, "fairchild/web-next-fixtures"); // no branch yet
 			await startSession(handle, "fairchild/web-next-fixtures");
@@ -146,15 +143,12 @@ describe("startSession", () => {
 		});
 	});
 
-	// No AUTH_BYPASS and no App creds in this test run (see vitest.config.ts /
-	// CI): startSession runs in degraded mode here, same as unset env in prod
-	// local dev — freetext is accepted unverified rather than blocked.
-	test("degraded mode (no App creds) accepts any shape-valid repo unverified", async () => {
+	test("fixture mode is independent of AUTH_BYPASS", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
 		const handle = freshDb();
-		const session = await startSession(handle, "anyone/anything");
-		expect(session.repoId).toBe("anyone/anything");
+		await startSession(handle, "fairchild/web-next-fixtures");
 		const [repo] = await listRepos(handle);
-		expect(repo.defaultBranch).toBeNull();
+		expect(repo.defaultBranch).toBe("trunk");
 	});
 });
 

--- a/web-next/src/lib/github/repo-directory.test.ts
+++ b/web-next/src/lib/github/repo-directory.test.ts
@@ -1,7 +1,7 @@
 /*
- * Covers all three repo-directory modes: bypass fixtures (the hermetic e2e
- * seam), degraded (no App creds — never blocks), and configured (real GitHub
- * calls, network mocked here so these stay unit tests).
+ * Covers both repo-directory modes: fixtures when App creds are absent (the
+ * hermetic e2e seam) and configured (real GitHub calls, network mocked here so
+ * these stay unit tests). Auth mode must not decide directory mode.
  */
 import crypto from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -25,9 +25,10 @@ afterEach(() => {
 	vi.unstubAllEnvs();
 });
 
-describe("bypass mode (AUTH_BYPASS=1)", () => {
+describe("fixture mode (no App creds)", () => {
 	it("lists the deterministic fixture repos, alphabetical", async () => {
-		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		await expect(listDirectoryRepos()).resolves.toEqual([
 			{ fullName: "fairchild/dotfiles", defaultBranch: "main", private: false },
 			{
@@ -40,7 +41,8 @@ describe("bypass mode (AUTH_BYPASS=1)", () => {
 	});
 
 	it("validates a fixture repo as ok, case-insensitively", async () => {
-		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		await expect(validateDirectoryRepo("Fairchild/Workspaces")).resolves.toEqual({
 			kind: "ok",
 			fullName: "fairchild/workspaces",
@@ -50,7 +52,8 @@ describe("bypass mode (AUTH_BYPASS=1)", () => {
 	});
 
 	it("resolves a non-fixture repo as not-found without touching the network", async () => {
-		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		const fetchSpy = vi.fn();
 		vi.stubGlobal("fetch", fetchSpy);
 		await expect(
@@ -60,59 +63,19 @@ describe("bypass mode (AUTH_BYPASS=1)", () => {
 	});
 
 	it("is never degraded", () => {
-		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		expect(isDirectoryDegraded()).toBe(false);
 	});
 
-	// The double lock, proven through this seam (not just config.test.ts):
-	// AUTH_BYPASS=1 with real OAuth configured must NOT serve fixtures —
-	// a leaked bypass flag in production falls through to the real path.
-	it("fixtures cannot activate when real OAuth is configured", async () => {
-		vi.stubEnv("AUTH_BYPASS", "1");
-		vi.stubEnv("GITHUB_OAUTH_CLIENT_ID", "Iv1.real");
+	it("falls back to fixtures even when auth is not bypass", async () => {
+		vi.stubEnv("AUTH_BYPASS", "");
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
 		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
-		// Without App creds the fall-through lands in degraded, not fixtures.
-		expect(isDirectoryDegraded()).toBe(true);
-		await expect(listDirectoryRepos()).resolves.toEqual([]);
-		await expect(validateDirectoryRepo("fairchild/workspaces")).resolves.toEqual({
-			kind: "unverified",
+		await expect(listDirectoryRepos()).resolves.toContainEqual({
 			fullName: "fairchild/workspaces",
-		});
-	});
-});
-
-describe("degraded mode (no App creds, no bypass)", () => {
-	it("reports degraded", () => {
-		vi.stubEnv("AUTH_BYPASS", "");
-		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
-		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
-		expect(isDirectoryDegraded()).toBe(true);
-	});
-
-	it("lists no repos rather than throwing", async () => {
-		vi.stubEnv("AUTH_BYPASS", "");
-		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
-		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
-		await expect(listDirectoryRepos()).resolves.toEqual([]);
-	});
-
-	it("validates any shape-valid repo as unverified, not blocking", async () => {
-		vi.stubEnv("AUTH_BYPASS", "");
-		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
-		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
-		await expect(validateDirectoryRepo("anyone/anything")).resolves.toEqual({
-			kind: "unverified",
-			fullName: "anyone/anything",
-		});
-	});
-
-	it("resolveRepo accepts unverified without a default branch", async () => {
-		vi.stubEnv("AUTH_BYPASS", "");
-		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
-		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
-		await expect(resolveRepo("anyone/anything")).resolves.toEqual({
-			defaultBranch: null,
+			defaultBranch: "main",
+			private: false,
 		});
 	});
 });
@@ -227,6 +190,46 @@ describe("configured mode (App creds present, GitHub mocked)", () => {
 		await expect(listDirectoryRepos()).resolves.toEqual([
 			{ fullName: "fairchild/alpha", defaultBranch: "main", private: false },
 			{ fullName: "fairchild/zeta", defaultBranch: "main", private: false },
+		]);
+	});
+
+	it("uses real App credentials even under AUTH_BYPASS", async () => {
+		stubEnv();
+		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/app/installations")) {
+					return Response.json([{ id: 7, account: { login: "fairchild" } }]);
+				}
+				if (url.endsWith("/app/installations/7/access_tokens")) {
+					return Response.json({
+						token: "ghs_dir_token",
+						expires_at: "2026-01-01T00:00:00Z",
+						permissions: {},
+					});
+				}
+				if (url.includes("/installation/repositories")) {
+					return Response.json({
+						repositories: [
+							{
+								full_name: "fairchild/real-from-app",
+								default_branch: "main",
+								private: true,
+							},
+						],
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		await expect(listDirectoryRepos()).resolves.toEqual([
+			{
+				fullName: "fairchild/real-from-app",
+				defaultBranch: "main",
+				private: true,
+			},
 		]);
 	});
 });

--- a/web-next/src/lib/github/repo-directory.test.ts
+++ b/web-next/src/lib/github/repo-directory.test.ts
@@ -1,7 +1,7 @@
 /*
- * Covers both repo-directory modes: fixtures when App creds are absent (the
- * hermetic e2e seam) and configured (real GitHub calls, network mocked here so
- * these stay unit tests). Auth mode must not decide directory mode.
+ * Covers the repo-directory decision matrix: App credentials always use the
+ * real GitHub path, no credentials plus local/bypass use fixtures, and no
+ * credentials plus real OAuth stays degraded.
  */
 import crypto from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -25,8 +25,9 @@ afterEach(() => {
 	vi.unstubAllEnvs();
 });
 
-describe("fixture mode (no App creds)", () => {
+describe("fixture mode (no App creds plus local or bypass auth)", () => {
 	it("lists the deterministic fixture repos, alphabetical", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
 		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		await expect(listDirectoryRepos()).resolves.toEqual([
@@ -41,6 +42,7 @@ describe("fixture mode (no App creds)", () => {
 	});
 
 	it("validates a fixture repo as ok, case-insensitively", async () => {
+		vi.stubEnv("WEB_NEXT_LOCAL_MODE", "1");
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
 		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		await expect(validateDirectoryRepo("Fairchild/Workspaces")).resolves.toEqual({
@@ -52,6 +54,7 @@ describe("fixture mode (no App creds)", () => {
 	});
 
 	it("resolves a non-fixture repo as not-found without touching the network", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
 		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		const fetchSpy = vi.fn();
@@ -63,13 +66,14 @@ describe("fixture mode (no App creds)", () => {
 	});
 
 	it("is never degraded", () => {
+		vi.stubEnv("WEB_NEXT_LOCAL_MODE", "1");
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
 		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		expect(isDirectoryDegraded()).toBe(false);
 	});
 
-	it("falls back to fixtures even when auth is not bypass", async () => {
-		vi.stubEnv("AUTH_BYPASS", "");
+	it("treats empty-string App credentials as absent for e2e fixture mode", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
 		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
 		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
 		await expect(listDirectoryRepos()).resolves.toContainEqual({
@@ -77,6 +81,34 @@ describe("fixture mode (no App creds)", () => {
 			defaultBranch: "main",
 			private: false,
 		});
+	});
+});
+
+describe("degraded mode (no App creds plus real OAuth)", () => {
+	it("lists no repos and accepts freetext as unverified", async () => {
+		vi.stubEnv("AUTH_BYPASS", "");
+		vi.stubEnv("WEB_NEXT_LOCAL_MODE", "");
+		vi.stubEnv("GITHUB_OAUTH_CLIENT_ID", "Iv1.real");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		expect(isDirectoryDegraded()).toBe(true);
+		await expect(listDirectoryRepos()).resolves.toEqual([]);
+		await expect(validateDirectoryRepo("fairchild/workspaces")).resolves.toEqual({
+			kind: "unverified",
+			fullName: "fairchild/workspaces",
+		});
+		await expect(resolveRepo("fairchild/workspaces")).resolves.toEqual({
+			defaultBranch: null,
+		});
+	});
+
+	it("does not let a leaked bypass flag activate fixtures when real OAuth is configured", async () => {
+		vi.stubEnv("AUTH_BYPASS", "1");
+		vi.stubEnv("GITHUB_OAUTH_CLIENT_ID", "Iv1.real");
+		vi.stubEnv("GITHUB_WEB_WORKSPACES_APP_ID", "");
+		vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "");
+		expect(isDirectoryDegraded()).toBe(true);
+		await expect(listDirectoryRepos()).resolves.toEqual([]);
 	});
 });
 
@@ -227,6 +259,46 @@ describe("configured mode (App creds present, GitHub mocked)", () => {
 		await expect(listDirectoryRepos()).resolves.toEqual([
 			{
 				fullName: "fairchild/real-from-app",
+				defaultBranch: "main",
+				private: true,
+			},
+			]);
+	});
+
+	it("uses real App credentials even under local mode", async () => {
+		stubEnv();
+		vi.stubEnv("WEB_NEXT_LOCAL_MODE", "1");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/app/installations")) {
+					return Response.json([{ id: 7, account: { login: "fairchild" } }]);
+				}
+				if (url.endsWith("/app/installations/7/access_tokens")) {
+					return Response.json({
+						token: "ghs_dir_token",
+						expires_at: "2026-01-01T00:00:00Z",
+						permissions: {},
+					});
+				}
+				if (url.includes("/installation/repositories")) {
+					return Response.json({
+						repositories: [
+							{
+								full_name: "fairchild/local-but-real",
+								default_branch: "main",
+								private: true,
+							},
+						],
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		await expect(listDirectoryRepos()).resolves.toEqual([
+			{
+				fullName: "fairchild/local-but-real",
 				defaultBranch: "main",
 				private: true,
 			},

--- a/web-next/src/lib/github/repo-directory.ts
+++ b/web-next/src/lib/github/repo-directory.ts
@@ -1,19 +1,14 @@
 /*
  * GitHub-backed repo directory for the new-session picker: lists the App
  * installation's repositories and validates a freetext `owner/name`, sitting
- * in front of the raw App-auth mechanics in `../diag/github-app`. Three modes,
- * resolved once per call so callers never branch on environment themselves:
+ * in front of the raw App-auth mechanics in `../diag/github-app`. Directory
+ * mode is credential-driven, not auth-driven:
  *
- *  - bypass (`AUTH_BYPASS=1`, no real OAuth configured — see `../auth/config`):
- *    a small deterministic fixture set, so e2e/evidence/perf runs never touch
- *    the real GitHub API.
  *  - configured (App creds present): the real installation-repos + repo-read
  *    endpoints.
- *  - degraded (App creds absent, e.g. local dev without `.env.local`): listing
- *    comes back empty and validation always resolves "unverified" rather than
- *    blocking — freetext still works, just unproven.
+ *  - fixtures (App creds absent): a small deterministic fixture set, so
+ *    e2e/evidence/perf runs stay hermetic and local mode has a visible picker.
  */
-import { authBypassEnabled } from "../auth/config";
 import {
 	type DirectoryRepo,
 	listInstallationRepositories,
@@ -34,9 +29,7 @@ export class RepoUnavailableError extends Error {
 
 export type RepoValidation =
 	| ({ kind: "ok" } & DirectoryRepo)
-	| { kind: "not-found"; fullName: string }
-	/** Degraded mode: no App creds to check against, so we don't block. */
-	| { kind: "unverified"; fullName: string };
+	| { kind: "not-found"; fullName: string };
 
 const FIXTURE_REPOS: DirectoryRepo[] = [
 	{ fullName: "fairchild/workspaces", defaultBranch: "main", private: false },
@@ -54,17 +47,16 @@ function hasAppCredentials(): boolean {
 	);
 }
 
-/** True when the picker has nothing but the freetext escape hatch to offer. */
+/** No degraded mode now: no App creds means deterministic fixtures, not empty. */
 export function isDirectoryDegraded(): boolean {
-	return !authBypassEnabled() && !hasAppCredentials();
+	return false;
 }
 
-/** The installation's repos, alphabetical — empty (not thrown) when degraded. */
+/** The installation's repos, or deterministic fixtures when App creds are absent. */
 export async function listDirectoryRepos(): Promise<DirectoryRepo[]> {
-	if (authBypassEnabled()) {
+	if (!hasAppCredentials()) {
 		return [...FIXTURE_REPOS].sort((a, b) => a.fullName.localeCompare(b.fullName));
 	}
-	if (!hasAppCredentials()) return [];
 	const { token } = await mintDirectoryToken();
 	const repos = await listInstallationRepositories(token);
 	return repos.sort((a, b) => a.fullName.localeCompare(b.fullName));
@@ -74,13 +66,12 @@ export async function listDirectoryRepos(): Promise<DirectoryRepo[]> {
 export async function validateDirectoryRepo(
 	fullName: string,
 ): Promise<RepoValidation> {
-	if (authBypassEnabled()) {
+	if (!hasAppCredentials()) {
 		const fixture = FIXTURE_REPOS.find(
 			(repo) => repo.fullName.toLowerCase() === fullName.toLowerCase(),
 		);
 		return fixture ? { kind: "ok", ...fixture } : { kind: "not-found", fullName };
 	}
-	if (!hasAppCredentials()) return { kind: "unverified", fullName };
 	try {
 		const { token } = await mintInstallationToken(fullName);
 		const repo = await verifyRepoAccess(token, fullName);
@@ -103,7 +94,6 @@ export async function resolveRepo(
 ): Promise<{ defaultBranch: string | null }> {
 	const result = await validateDirectoryRepo(fullName);
 	if (result.kind === "not-found") throw new RepoUnavailableError(fullName);
-	if (result.kind === "unverified") return { defaultBranch: null };
 	return { defaultBranch: result.defaultBranch };
 }
 

--- a/web-next/src/lib/github/repo-directory.ts
+++ b/web-next/src/lib/github/repo-directory.ts
@@ -2,13 +2,17 @@
  * GitHub-backed repo directory for the new-session picker: lists the App
  * installation's repositories and validates a freetext `owner/name`, sitting
  * in front of the raw App-auth mechanics in `../diag/github-app`. Directory
- * mode is credential-driven, not auth-driven:
+ * mode is credential-first, then local/test auth posture:
  *
  *  - configured (App creds present): the real installation-repos + repo-read
  *    endpoints.
- *  - fixtures (App creds absent): a small deterministic fixture set, so
- *    e2e/evidence/perf runs stay hermetic and local mode has a visible picker.
+ *  - fixtures (App creds absent + local mode or test bypass): a small
+ *    deterministic fixture set, so e2e/evidence/perf runs stay hermetic and
+ *    local mode has a visible picker.
+ *  - degraded (App creds absent + real OAuth): listing comes back empty and
+ *    validation resolves "unverified" rather than blocking.
  */
+import { authBypassEnabled, localModeEnabled } from "../auth/config";
 import {
 	type DirectoryRepo,
 	listInstallationRepositories,
@@ -29,7 +33,9 @@ export class RepoUnavailableError extends Error {
 
 export type RepoValidation =
 	| ({ kind: "ok" } & DirectoryRepo)
-	| { kind: "not-found"; fullName: string };
+	| { kind: "not-found"; fullName: string }
+	/** Degraded mode: no App creds to check against, so we don't block. */
+	| { kind: "unverified"; fullName: string };
 
 const FIXTURE_REPOS: DirectoryRepo[] = [
 	{ fullName: "fairchild/workspaces", defaultBranch: "main", private: false },
@@ -47,16 +53,21 @@ function hasAppCredentials(): boolean {
 	);
 }
 
-/** No degraded mode now: no App creds means deterministic fixtures, not empty. */
-export function isDirectoryDegraded(): boolean {
-	return false;
+function shouldUseFixtureDirectory(): boolean {
+	return !hasAppCredentials() && (localModeEnabled() || authBypassEnabled());
 }
 
-/** The installation's repos, or deterministic fixtures when App creds are absent. */
+/** True when the picker has nothing but the freetext escape hatch to offer. */
+export function isDirectoryDegraded(): boolean {
+	return !hasAppCredentials() && !shouldUseFixtureDirectory();
+}
+
+/** The installation's repos, fixtures for hermetic modes, or empty when degraded. */
 export async function listDirectoryRepos(): Promise<DirectoryRepo[]> {
-	if (!hasAppCredentials()) {
+	if (shouldUseFixtureDirectory()) {
 		return [...FIXTURE_REPOS].sort((a, b) => a.fullName.localeCompare(b.fullName));
 	}
+	if (!hasAppCredentials()) return [];
 	const { token } = await mintDirectoryToken();
 	const repos = await listInstallationRepositories(token);
 	return repos.sort((a, b) => a.fullName.localeCompare(b.fullName));
@@ -66,12 +77,13 @@ export async function listDirectoryRepos(): Promise<DirectoryRepo[]> {
 export async function validateDirectoryRepo(
 	fullName: string,
 ): Promise<RepoValidation> {
-	if (!hasAppCredentials()) {
+	if (shouldUseFixtureDirectory()) {
 		const fixture = FIXTURE_REPOS.find(
 			(repo) => repo.fullName.toLowerCase() === fullName.toLowerCase(),
 		);
 		return fixture ? { kind: "ok", ...fixture } : { kind: "not-found", fullName };
 	}
+	if (!hasAppCredentials()) return { kind: "unverified", fullName };
 	try {
 		const { token } = await mintInstallationToken(fullName);
 		const repo = await verifyRepoAccess(token, fullName);
@@ -94,6 +106,7 @@ export async function resolveRepo(
 ): Promise<{ defaultBranch: string | null }> {
 	const result = await validateDirectoryRepo(fullName);
 	if (result.kind === "not-found") throw new RepoUnavailableError(fullName);
+	if (result.kind === "unverified") return { defaultBranch: null };
 	return { defaultBranch: result.defaultBranch };
 }
 

--- a/web-next/src/lib/local-data-dir.test.ts
+++ b/web-next/src/lib/local-data-dir.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionsDatabaseUrl, resolveWebNextDataDir } from "./local-data-dir";
+
+describe("local data dir resolution", () => {
+	it("defaults to .data", () => {
+		expect(resolveWebNextDataDir({})).toBe(".data");
+		expect(resolveSessionsDatabaseUrl({})).toBe("file:.data/sessions.db");
+	});
+
+	it("moves the default SQLite file under WEB_NEXT_DATA_DIR", () => {
+		expect(resolveSessionsDatabaseUrl({ WEB_NEXT_DATA_DIR: "/tmp/spaces-local" })).toBe(
+			"file:/tmp/spaces-local/sessions.db",
+		);
+	});
+
+	it("keeps an explicit database URL authoritative", () => {
+		expect(
+			resolveSessionsDatabaseUrl({
+				WEB_NEXT_DATA_DIR: "/tmp/spaces-local",
+				SESSIONS_DATABASE_URL: "file:/tmp/custom.db",
+			}),
+		).toBe("file:/tmp/custom.db");
+	});
+});

--- a/web-next/src/lib/local-data-dir.ts
+++ b/web-next/src/lib/local-data-dir.ts
@@ -1,0 +1,18 @@
+/*
+ * Shared local storage resolution for single-machine runs. The app keeps the
+ * SQLite default and local-mode sign-in token under one owner-controlled data
+ * directory so a native host can relocate both with WEB_NEXT_DATA_DIR.
+ */
+import path from "node:path";
+
+type Env = Record<string, string | undefined>;
+
+export function resolveWebNextDataDir(env: Env = process.env): string {
+	const configured = env.WEB_NEXT_DATA_DIR?.trim();
+	return configured && configured.length > 0 ? configured : ".data";
+}
+
+export function resolveSessionsDatabaseUrl(env: Env = process.env): string {
+	if (env.SESSIONS_DATABASE_URL) return env.SESSIONS_DATABASE_URL;
+	return `file:${path.join(resolveWebNextDataDir(env), "sessions.db")}`;
+}

--- a/web-next/src/middleware.test.ts
+++ b/web-next/src/middleware.test.ts
@@ -17,6 +17,15 @@ function requestFor(path: string, cookie?: string): NextRequest {
 	});
 }
 
+function localRequestFor(path: string, host = "localhost:3100", cookie?: string): NextRequest {
+	return new NextRequest(`http://localhost:3100${path}`, {
+		headers: {
+			host,
+			...(cookie ? { cookie } : {}),
+		},
+	});
+}
+
 describe("middleware", () => {
 	beforeEach(() => {
 		process.env.AUTH_BYPASS = "1";
@@ -54,5 +63,64 @@ describe("middleware", () => {
 	it("passes /api/auth/* through unauthenticated — already public", async () => {
 		const response = await middleware(requestFor("/api/auth/session"));
 		expect(response.headers.get("x-middleware-next")).toBe("1");
+	});
+});
+
+describe("middleware local mode", () => {
+	beforeEach(() => {
+		process.env.WEB_NEXT_LOCAL_MODE = "1";
+		process.env.WEB_NEXT_LOCAL_TOKEN = "local-secret";
+		delete process.env.AUTH_BYPASS;
+		delete process.env.GITHUB_OAUTH_CLIENT_ID;
+	});
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it("rejects non-loopback Host headers before serving local mode", async () => {
+		const response = await middleware(localRequestFor("/api/repos", "spaces.example"));
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			error: "local mode only accepts localhost or 127.0.0.1 Host headers",
+		});
+	});
+
+	it("sets the local session cookie from a valid /sign-in token query", async () => {
+		const response = await middleware(localRequestFor("/sign-in?token=local-secret"));
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe("http://localhost:3100/");
+		expect(response.headers.get("set-cookie")).toContain(
+			"web-next-local-session=local-secret",
+		);
+	});
+
+	it("does not accept a wrong local token", async () => {
+		const response = await middleware(localRequestFor("/api/repos", "localhost:3100"));
+		expect(response.status).toBe(401);
+		const forged = await middleware(
+			localRequestFor(
+				"/api/repos",
+				"localhost:3100",
+				"web-next-local-session=wrong",
+			),
+		);
+		expect(forged.status).toBe(401);
+	});
+
+	it("lets a valid local session cookie through and ignores the test bypass cookie", async () => {
+		const response = await middleware(
+			localRequestFor(
+				"/api/repos",
+				"localhost:3100",
+				"web-next-local-session=local-secret",
+			),
+		);
+		expect(response.headers.get("x-middleware-next")).toBe("1");
+
+		const bypass = await middleware(
+			localRequestFor("/api/repos", "localhost:3100", "test-auth-login=fairchild"),
+		);
+		expect(bypass.status).toBe(401);
 	});
 });

--- a/web-next/src/middleware.test.ts
+++ b/web-next/src/middleware.test.ts
@@ -17,8 +17,13 @@ function requestFor(path: string, cookie?: string): NextRequest {
 	});
 }
 
-function localRequestFor(path: string, host = "localhost:3100", cookie?: string): NextRequest {
-	return new NextRequest(`http://localhost:3100${path}`, {
+function localRequestFor(
+	path: string,
+	host = "localhost:3100",
+	cookie?: string,
+	origin = "http://localhost:3100",
+): NextRequest {
+	return new NextRequest(`${origin}${path}`, {
 		headers: {
 			host,
 			...(cookie ? { cookie } : {}),
@@ -86,6 +91,17 @@ describe("middleware local mode", () => {
 		});
 	});
 
+	it("rejects malformed loopback-looking Host headers", async () => {
+		for (const host of [
+			"localhost:3100:evil",
+			"[::1]:bad",
+			"localhost.attacker.test",
+		]) {
+			const response = await middleware(localRequestFor("/api/repos", host));
+			expect(response.status).toBe(403);
+		}
+	});
+
 	it("sets the local session cookie from a valid /sign-in token query", async () => {
 		const response = await middleware(localRequestFor("/sign-in?token=local-secret"));
 		expect(response.status).toBe(307);
@@ -93,6 +109,19 @@ describe("middleware local mode", () => {
 		expect(response.headers.get("set-cookie")).toContain(
 			"web-next-local-session=local-secret",
 		);
+	});
+
+	it("redirects local sign-in accepts to the validated Host origin", async () => {
+		const response = await middleware(
+			localRequestFor(
+				"/sign-in?token=local-secret",
+				"localhost:3100",
+				undefined,
+				"http://attacker.test",
+			),
+		);
+		expect(response.status).toBe(307);
+		expect(response.headers.get("location")).toBe("http://localhost:3100/");
 	});
 
 	it("does not accept a wrong local token", async () => {

--- a/web-next/src/middleware.ts
+++ b/web-next/src/middleware.ts
@@ -13,6 +13,10 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
 	authBypassEnabled,
+	isLoopbackHostHeader,
+	LOCAL_AUTH_COOKIE,
+	localModeEnabled,
+	localSessionCookieValid,
 	resolveAuthSecret,
 	TEST_AUTH_COOKIE,
 } from "@/lib/auth/config";
@@ -42,6 +46,13 @@ function unauthorizedJson(): NextResponse {
 	);
 }
 
+function forbiddenLocalHostJson(): NextResponse {
+	return NextResponse.json(
+		{ error: "local mode only accepts localhost or 127.0.0.1 Host headers" },
+		{ status: 403 },
+	);
+}
+
 function redirectToSignIn(request: NextRequest): NextResponse {
 	const signInUrl = new URL("/sign-in", request.url);
 	return NextResponse.redirect(signInUrl);
@@ -59,6 +70,32 @@ function unauthenticatedResponse(request: NextRequest): NextResponse {
 
 export async function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl;
+
+	if (localModeEnabled()) {
+		if (!isLoopbackHostHeader(request.headers.get("host"))) {
+			return isApiPath(pathname)
+				? forbiddenLocalHostJson()
+				: new NextResponse("local mode only accepts loopback Host headers", {
+						status: 403,
+					});
+		}
+		const queryToken = request.nextUrl.searchParams.get("token");
+		if (pathname === "/sign-in" && localSessionCookieValid(queryToken)) {
+			const response = NextResponse.redirect(new URL("/", request.url));
+			response.cookies.set(LOCAL_AUTH_COOKIE, queryToken ?? "", {
+				path: "/",
+				httpOnly: true,
+				sameSite: "lax",
+				secure: false,
+			});
+			return response;
+		}
+		if (isPublic(pathname)) return NextResponse.next();
+		return localSessionCookieValid(request.cookies.get(LOCAL_AUTH_COOKIE)?.value)
+			? NextResponse.next()
+			: unauthenticatedResponse(request);
+	}
+
 	if (isPublic(pathname)) return NextResponse.next();
 
 	// Test bypass (inert in production — see authBypassEnabled): the test

--- a/web-next/src/middleware.ts
+++ b/web-next/src/middleware.ts
@@ -13,8 +13,8 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
 	authBypassEnabled,
-	isLoopbackHostHeader,
 	LOCAL_AUTH_COOKIE,
+	loopbackHostOrigin,
 	localModeEnabled,
 	localSessionCookieValid,
 	resolveAuthSecret,
@@ -72,7 +72,8 @@ export async function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
 	if (localModeEnabled()) {
-		if (!isLoopbackHostHeader(request.headers.get("host"))) {
+		const localOrigin = loopbackHostOrigin(request.headers.get("host"));
+		if (!localOrigin) {
 			return isApiPath(pathname)
 				? forbiddenLocalHostJson()
 				: new NextResponse("local mode only accepts loopback Host headers", {
@@ -81,7 +82,7 @@ export async function middleware(request: NextRequest) {
 		}
 		const queryToken = request.nextUrl.searchParams.get("token");
 		if (pathname === "/sign-in" && localSessionCookieValid(queryToken)) {
-			const response = NextResponse.redirect(new URL("/", request.url));
+			const response = NextResponse.redirect(new URL("/", localOrigin));
 			response.cookies.set(LOCAL_AUTH_COOKIE, queryToken ?? "", {
 				path: "/",
 				httpOnly: true,


### PR DESCRIPTION
## What

Local serving mode (#983, W6): `pnpm start:local` makes `next start` on the owner's machine a first-class target — `WEB_NEXT_LOCAL_MODE=1`, bound to 127.0.0.1, authenticated by a minted 32-byte token (printed as a sign-in URL, persisted 0600 under `WEB_NEXT_DATA_DIR`, constant-time compared) instead of either prod OAuth or the test bypass. This is the serving half of the embedded Claude-Desktop story (#987 consumes it) and the direct answer to both test-drive findings recorded on the issue: no more dead OAuth button, and the repo picker now shows the REAL App-installation directory whenever App creds exist (decoupled from auth mode).

## Security posture

- Strict loopback: Host header parsed via URL construction — hostname ∈ {localhost, 127.0.0.1, [::1]} with a valid numeric port only; redirects built from the validated origin, never `request.url`. Foreign Host ⇒ 403.
- Startup refuses `WEB_NEXT_LOCAL_MODE` combined with `AUTH_BYPASS` or OAuth env (no silent precedence).
- Token file: symlinks refused, permissive modes chmodded to 0600 on reuse.
- **Prod inertness traced by review**: every local branch (middleware, auth config, sign-in, directory) is inert without the env flag; real-OAuth-without-creds keeps its original degraded directory behavior (never fixtures in a real deployment).

## Process

codex (gpt-5.5, high) implemented per codex-execution with the issue's two coordinator findings as binding constraints; directed codex (xhigh) review found 1 blocker + 4 should-fixes — the blocker being hermetic e2e breaking once worktrees inherit real App creds (a direct interaction with #1013's env-linking fix): `e2e:server` now clears App creds explicitly, pinned by test. All five fixed in an attributed hardening commit. Mutation checks: constant-time compare broken → token tests fail; directory re-coupled to auth mode → decoupling test fails; e2e cred-clearing removed → its test fails; Host parse loosened → strict-host tests fail. All restored.

## Verification

- Unit 534 passed; typecheck; lint; clean build; `E2E_PORT=3183 pnpm test:e2e` 47 passed (rebased over #982/#986)
- `pnpm validate --env local-mode`: full posture green (loopback rejection, token-required 401 JSON, bypass inert, OAuth absent) — and the stage now FAILS loudly when a target isn't actually in local mode
- Manual smoke: token URL → 307 + cookie; wrong Host → 403; no cookie → 401 JSON

## Evidence

![local-mode-smoke](https://evidence.cloudcompute.com/workspaces/pr-1017/20260709-002242-local-mode-smoke.png)

Closes #983

## Mergeability

- **Surface:** auth config + middleware local branch, local-token module, data-dir resolution, repo-directory mode matrix, start:local script, validate stage, sign-in page local variant.
- **Behavior changed:** folio/prod — none (flag off; degraded path preserved; review-traced). Bypass dev gains real repo directory when creds are present. e2e stays hermetic by explicit cred-clearing.
- **Non-happy paths:** mode conflicts fail startup; foreign Host 403; missing/expired token 401 JSON; symlinked token file refused.
- **Residual risk:** no Playwright spec for the token sign-in flow (harness is bypass-shaped; covered by middleware/unit tests + validate stage + smoke — recorded gap); e2e cred-clearing asserted by script inspection, not live process env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
