### PR TITLE
feat(web-next): mid-turn steering — durable message queue (#984)

### DIFF
--- a/web-next/docs/schema.md
+++ b/web-next/docs/schema.md
@@ -109,19 +109,20 @@ transcript events: the running turn's ingest loop stays the only writer to
 `session_events`, and the queued text is appended there only when the row is
 claimed for dispatch as the next turn.
 
-Migration: `0009_queued_messages`.
+Migration: `0009_queued_messages`, `0010_queued_message_dispatch_order`.
 
 | Column | Type | Meaning |
 |---|---|---|
+| `id` | integer | Monotonic insertion order; the dispatcher's strict FIFO key. |
 | `session_id` | text | Owning session. |
 | `queue_id` | text | Stable id used by the client to cancel/reconcile the row. |
 | `text` | text | User text to dispatch next. |
-| `queued_at` | text | ISO-8601 enqueue time; oldest active row dispatches first. |
+| `queued_at` | text | ISO-8601 enqueue time for display/debugging. |
 | `dispatched_at` | text? | Set when claimed for `startTurn`; null while pending. |
 | `canceled_at` | text? | Set when canceled before dispatch. |
 
-Primary key `(session_id, queue_id)`. Index
-`(session_id, queued_at)` serves the oldest-first queue read.
+Primary key `id`; unique `(session_id, queue_id)`. Index
+`(session_id, id)` serves the oldest-first queue read.
 
 ### Better Auth tables (`user`, `session`, `account`, `verification`)
 

--- a/web-next/docs/schema.md
+++ b/web-next/docs/schema.md
@@ -50,7 +50,7 @@ that log, never stored here.
 | `claude_session_id` | text? | Harness/Claude session id for resume; null until a real turn parks one. |
 | `resume_state` | text? | JSON harness resume payload from the last turn's `detach()` (migration `0003_session_resume_state`); null until a real turn parks, cleared when the parked sandbox expires. Session-row state, deliberately not in the event log. |
 | `model` | text | Claude model id this session's turns run on (migration `0004_session_model`, #824); NOT NULL, defaulting to `DEFAULT_MODEL` (`src/lib/agent-runtime/models.ts` — the single source of truth for the selectable set). Threaded into `TurnRequest.model` on every turn; changed via the status line's picker (`PATCH /api/sessions/[id]`). |
-| `approval_policy` | text | Tool approval posture for provider turns (migration `0007_turn_approvals`, #982): `auto` (default), `ask-writes`, or `ask-all`. Providers use `src/lib/agent-runtime/approval-policy.ts` to classify tool names; the mock approval scenario opens a real broker request regardless of this default so the round trip is testable without credentials. |
+| `approval_policy` | text | Tool approval posture for provider turns (migration `0008_turn_approvals`, #982): `auto` (default), `ask-writes`, or `ask-all`. Providers use `src/lib/agent-runtime/approval-policy.ts` to classify tool names; the mock approval scenario opens a real broker request regardless of this default so the round trip is testable without credentials. |
 | `created_at` | text | ISO-8601. |
 | `last_activity_at` | text | ISO-8601; bumped on every event append. |
 
@@ -85,6 +85,8 @@ approval requests and resolutions as provider-native `StreamChunk`s in
 `session_events`; this side table is the mutable answer surface providers await
 and answer routes update. The answer endpoint never appends to `session_events`.
 
+Migration: `0008_turn_approvals`.
+
 | Column | Type | Meaning |
 |---|---|---|
 | `session_id` | text | Owning session. |
@@ -99,6 +101,27 @@ and answer routes update. The answer endpoint never appends to `session_events`.
 
 Primary key `(session_id, request_id)`. Index
 `idx_turn_approvals_pending_expiry` covers per-session pending/expiry checks.
+
+### `queued_messages`
+
+Durable mid-turn steering queue (#984). Rows here are pending user text, not
+transcript events: the running turn's ingest loop stays the only writer to
+`session_events`, and the queued text is appended there only when the row is
+claimed for dispatch as the next turn.
+
+Migration: `0009_queued_messages`.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `session_id` | text | Owning session. |
+| `queue_id` | text | Stable id used by the client to cancel/reconcile the row. |
+| `text` | text | User text to dispatch next. |
+| `queued_at` | text | ISO-8601 enqueue time; oldest active row dispatches first. |
+| `dispatched_at` | text? | Set when claimed for `startTurn`; null while pending. |
+| `canceled_at` | text? | Set when canceled before dispatch. |
+
+Primary key `(session_id, queue_id)`. Index
+`(session_id, queued_at)` serves the oldest-first queue read.
 
 ### Better Auth tables (`user`, `session`, `account`, `verification`)
 

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -42,11 +42,12 @@
  */
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApprovalDecision } from "@/lib/agent-runtime/stream-chunk";
 import { modelLabel } from "@/lib/agent-runtime/models";
 import {
 	type ActiveTurnData,
+	type QueuedMessageData,
 	SessionView,
 	type SessionViewData,
 } from "@/components/folio/session-view";
@@ -64,6 +65,12 @@ import { sandboxStateLabel, useSandboxState } from "./use-sandbox-state";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
 const TOKEN_THROTTLE_MS = 50;
+
+interface SessionSnapshot {
+	turn?: { status: "none" | "running" | "done" | "stale"; fromSeq: number | null };
+	messages?: FolioMessage[];
+	queuedMessages?: QueuedMessageData[];
+}
 
 function lastUserText(messages: FolioMessage[]): string {
 	const last = [...messages].reverse().find((m) => m.role === "user");
@@ -90,6 +97,7 @@ export function LiveSessionView({
 	session,
 	author,
 	initialMessages,
+	initialQueuedMessages = [],
 	resume = false,
 }: {
 	sessionId: string;
@@ -98,11 +106,20 @@ export function LiveSessionView({
 	author: string;
 	/** The persisted transcript, projected server-side from session_events. */
 	initialMessages: FolioMessage[];
+	/** Durable mid-turn user messages that have not dispatched yet. */
+	initialQueuedMessages?: QueuedMessageData[];
 	/** When a turn is in flight on mount, reconnect to its tail and catch up. */
 	resume?: boolean;
 }) {
 	// Transient provider statuses of the in-flight turn, oldest first.
 	const [steps, setSteps] = useState<string[]>([]);
+	const [queuedMessages, setQueuedMessages] = useState<QueuedMessageData[]>(
+		initialQueuedMessages,
+	);
+	const queuedMessagesRef = useRef(queuedMessages);
+	useEffect(() => {
+		queuedMessagesRef.current = queuedMessages;
+	}, [queuedMessages]);
 
 	// The selected model: seeded from the server-resolved session, updated
 	// optimistically on change (reverted if its PATCH fails while it is still
@@ -205,7 +222,14 @@ export function LiveSessionView({
 		[sessionId],
 	);
 
-	const { messages, sendMessage, status, error } = useChat<FolioMessage>({
+	const {
+		messages,
+		setMessages,
+		sendMessage,
+		resumeStream,
+		status,
+		error,
+	} = useChat<FolioMessage>({
 		id: sessionId,
 		transport,
 		messages: initialMessages,
@@ -222,6 +246,39 @@ export function LiveSessionView({
 	});
 
 	const busy = status === "submitted" || status === "streaming";
+	const hasSeenBusyRef = useRef(false);
+	useEffect(() => {
+		if (busy) hasSeenBusyRef.current = true;
+	}, [busy]);
+	const refreshInFlightRef = useRef(false);
+	const refreshSessionFromServer = useCallback(async () => {
+		if (refreshInFlightRef.current) return;
+		refreshInFlightRef.current = true;
+		try {
+			const res = await fetch(`/api/sessions/${sessionId}`);
+			if (!res.ok) return;
+			const data = (await res.json()) as SessionSnapshot;
+			if (data.messages) setMessages(data.messages);
+			setQueuedMessages(data.queuedMessages ?? []);
+			if (data.turn?.status === "running" || data.turn?.status === "stale") {
+				void resumeStream();
+			}
+		} finally {
+			refreshInFlightRef.current = false;
+		}
+	}, [sessionId, setMessages, resumeStream]);
+	const queueKey = queuedMessages.map((message) => message.queueId).join("|");
+	const lastQueueKickRef = useRef("");
+	useEffect(() => {
+		if (resume && !hasSeenBusyRef.current) return;
+		if (busy || queueKey.length === 0) {
+			if (queueKey.length === 0) lastQueueKickRef.current = "";
+			return;
+		}
+		if (lastQueueKickRef.current === queueKey) return;
+		lastQueueKickRef.current = queueKey;
+		void refreshSessionFromServer();
+	}, [busy, queueKey, refreshSessionFromServer, resume]);
 
 	// The sandbox lifecycle surface (#753): a verified state in the masthead,
 	// and two honest controls — stop the in-flight turn (the compose's send
@@ -273,14 +330,83 @@ export function LiveSessionView({
 		}
 	};
 
+	const queueMessage = useCallback(
+		async (text: string) => {
+			try {
+				const res = await fetch(`/api/sessions/${sessionId}/chat`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ text, queue: true }),
+				});
+				if (res.status !== 202) {
+					await refreshSessionFromServer();
+					if (!res.ok) {
+						const data = (await res.json().catch(() => null)) as {
+							error?: string;
+						} | null;
+						setSteps((current) => [
+							...current,
+							`Queue unavailable — ${data?.error ?? `HTTP ${res.status}`}`,
+						]);
+					}
+					return;
+				}
+				const data = (await res.json()) as {
+					queued?: boolean;
+					queueId?: string;
+					position?: number;
+				};
+				if (!data.queued || !data.queueId) {
+					await refreshSessionFromServer();
+					return;
+				}
+				const queueId = data.queueId;
+				setQueuedMessages((current) =>
+					[
+						...current.filter((message) => message.queueId !== queueId),
+						{
+							queueId,
+							text,
+							queuedAt: new Date().toISOString(),
+							position: data.position ?? current.length + 1,
+						},
+					].sort((a, b) => a.position - b.position),
+				);
+			} catch {
+				setSteps((current) => [...current, "Queue unavailable — network error"]);
+			}
+		},
+		[sessionId, refreshSessionFromServer],
+	);
+
 	const send = (text: string) => {
 		setSteps([]);
 		// Await any in-flight model PATCH first, so the turn the server starts
 		// reads the session row this send was composed against.
-		void modelPatchChain.current.then(() =>
-			sendMessage({ text, metadata: { author } }),
-		);
+		void modelPatchChain.current.then(() => {
+			if (busy) return queueMessage(text);
+			return sendMessage({ text, metadata: { author } });
+		});
 	};
+
+	const cancelQueuedMessage = useCallback(
+		(queueId: string) => {
+			const previous = queuedMessagesRef.current;
+			setQueuedMessages((current) =>
+				current.filter((message) => message.queueId !== queueId),
+			);
+			void fetch(`/api/sessions/${sessionId}/queue/${queueId}`, {
+				method: "DELETE",
+			})
+				.then(async (res) => {
+					if (!res.ok) await refreshSessionFromServer();
+				})
+				.catch(() => {
+					setQueuedMessages(previous);
+				});
+		},
+		[sessionId, refreshSessionFromServer],
+	);
 
 	// A live failure (#808): the trailing assistant message useChat pushed at
 	// the turn's `start` never gets `metadata.error` from the stream itself
@@ -356,7 +482,9 @@ export function LiveSessionView({
 					},
 				}}
 				onSend={send}
-				composeDisabled={busy}
+				retryDisabled={busy}
+				queuedMessages={queuedMessages}
+				onCancelQueuedMessage={cancelQueuedMessage}
 				onModelChange={handleModelChange}
 				onTitleChange={handleTitleChange}
 				onStopTurn={busy ? stopTurn : undefined}

--- a/web-next/src/app/(app)/sessions/[id]/page.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/page.tsx
@@ -18,6 +18,7 @@ import { resolveTurn } from "@/lib/agent-runtime/turn-tail";
 import type { FolioMessage } from "@/components/folio/types";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
+import { listQueuedMessages } from "@/lib/db/queued-messages";
 import { getRepo } from "@/lib/db/repos";
 import { getSession, readTranscript } from "@/lib/db/sessions";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
@@ -61,6 +62,7 @@ export default async function SessionPage({
 	// Assistant messages carry their metadata (author, turn stats) from the
 	// projection; user messages get the signed-in user's name here.
 	const transcript = (await readTranscript(handle, id)) as FolioMessage[];
+	const queuedMessages = await listQueuedMessages(handle, id);
 	const initialMessages = transcript
 		.filter((message) => !(resume && message.id === activeMessageId))
 		.map((message) =>
@@ -75,6 +77,12 @@ export default async function SessionPage({
 			author={author}
 			resume={resume}
 			initialMessages={initialMessages}
+			initialQueuedMessages={queuedMessages.map((message) => ({
+				queueId: message.queueId,
+				text: message.text,
+				queuedAt: message.queuedAt,
+				position: message.position,
+			}))}
 			session={{
 				masthead: {
 					repo: repoName,

--- a/web-next/src/app/api/sessions/[id]/chat/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/chat/route.test.ts
@@ -1,0 +1,109 @@
+/*
+ * POST /api/sessions/[id]/chat — route response semantics around turn start
+ * vs durable queueing. The runtime/store tests cover the queue's persistence
+ * and dispatch behavior; this file keeps the HTTP contract focused.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { queueSessionTurn, runSessionTurn } from "@/lib/agent-runtime/run-turn";
+import { getDatabase } from "@/lib/db/client";
+import { createSession } from "@/lib/db/sessions";
+
+vi.mock("@/lib/auth/auth-state", () => ({
+	getAuthState: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-runtime/run-turn", () => ({
+	runSessionTurn: vi.fn(),
+	queueSessionTurn: vi.fn(),
+}));
+
+const dir = mkdtempSync(join(tmpdir(), "web-next-chat-route-"));
+process.env.SESSIONS_DATABASE_URL = `file:${join(dir, "test.db")}`;
+
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const AUTHORIZED = {
+	kind: "authorized" as const,
+	user: { login: "fairchild", name: "Fairchild" },
+};
+
+beforeEach(() => {
+	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+	vi.mocked(runSessionTurn).mockReset();
+	vi.mocked(queueSessionTurn).mockReset();
+});
+
+let seq = 0;
+async function freshSession(): Promise<string> {
+	const id = `chat-${++seq}`;
+	await createSession(getDatabase(), { id, ownerLogin: "fairchild", provider: "mock" });
+	return id;
+}
+
+async function post(id: string, body: unknown) {
+	const { POST } = await import("./route");
+	return POST(
+		new Request(`http://test/api/sessions/${id}/chat`, {
+			method: "POST",
+			body: JSON.stringify(body),
+		}),
+		{ params: Promise.resolve({ id }) },
+	);
+}
+
+describe("POST /api/sessions/[id]/chat", () => {
+	test("returns 202 JSON when the turn starter queues a mid-turn send", async () => {
+		const id = await freshSession();
+		vi.mocked(runSessionTurn).mockResolvedValue({
+			kind: "queued",
+			queueId: "q-1",
+			position: 1,
+			queuedAt: "2026-01-01T00:00:00.000Z",
+		});
+
+		const res = await post(id, { text: "steer next" });
+
+		expect(res.status).toBe(202);
+		expect(await res.json()).toEqual({
+			queued: true,
+			queueId: "q-1",
+			position: 1,
+		});
+		expect(runSessionTurn).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ id }),
+			"steer next",
+		);
+	});
+
+	test("queue=true forces the durable queue path for busy clients", async () => {
+		const id = await freshSession();
+		vi.mocked(queueSessionTurn).mockResolvedValue({
+			kind: "queued",
+			queueId: "q-forced",
+			position: 2,
+			queuedAt: "2026-01-01T00:00:00.000Z",
+		});
+
+		const res = await post(id, { text: "still next", queue: true });
+
+		expect(res.status).toBe(202);
+		expect(await res.json()).toMatchObject({
+			queued: true,
+			queueId: "q-forced",
+			position: 2,
+		});
+		expect(queueSessionTurn).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ id }),
+			"still next",
+		);
+		expect(runSessionTurn).not.toHaveBeenCalled();
+	});
+});

--- a/web-next/src/app/api/sessions/[id]/chat/route.ts
+++ b/web-next/src/app/api/sessions/[id]/chat/route.ts
@@ -3,15 +3,17 @@
  * (same allowlist verdict as the pages; middleware freshness is not enough
  * for a data-writing route), then delegates to runSessionTurn: the user event
  * and the provider's chunks land in session_events while the adapted
- * UIMessage stream flows back to useChat.
+ * UIMessage stream flows back to useChat. Mid-turn sends are queued durably
+ * and return 202; their user event is appended only when the row dispatches as
+ * the next turn.
  */
 import { createUIMessageStreamResponse } from "ai";
 import { after } from "next/server";
 import { getAuthState } from "@/lib/auth/auth-state";
 import {
 	ApprovalPolicyUnsupportedError,
+	queueSessionTurn,
 	runSessionTurn,
-	TurnConflictError,
 } from "@/lib/agent-runtime/run-turn";
 import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
@@ -48,25 +50,35 @@ export async function POST(
 		typeof body === "object" && body !== null && "text" in body
 			? String((body as { text: unknown }).text).trim()
 			: "";
+	const queueOnly =
+		typeof body === "object" &&
+		body !== null &&
+		"queue" in body &&
+		(body as { queue: unknown }).queue === true;
 	if (text.length === 0) {
 		return Response.json({ error: "text is required" }, { status: 400 });
 	}
 
 	let turn;
 	try {
-		turn = await runSessionTurn(handle, session, text);
+		turn = queueOnly
+			? await queueSessionTurn(handle, session, text)
+			: await runSessionTurn(handle, session, text);
 	} catch (error) {
-		// Structured errors, not unhandled 500s: a concurrent send is a 409 the
-		// client can retry after the turn; a session naming an unregistered
-		// provider is a 500 with the reason.
-		if (error instanceof TurnConflictError) {
-			return Response.json({ error: error.message }, { status: 409 });
-		}
+		// Structured errors, not unhandled 500s: unsupported approval policy is
+		// a client-fixable session/provider mismatch. Active-turn sends no
+		// longer throw here; they enqueue and return 202.
 		if (error instanceof ApprovalPolicyUnsupportedError) {
 			return Response.json({ error: error.message }, { status: 409 });
 		}
 		const message = error instanceof Error ? error.message : "failed to start the turn";
 		return Response.json({ error: message }, { status: 500 });
+	}
+	if (turn.kind === "queued") {
+		return Response.json(
+			{ queued: true, queueId: turn.queueId, position: turn.position },
+			{ status: 202 },
+		);
 	}
 	// The ingest loop already runs eagerly (the stream below tails it live).
 	// after() keeps a serverless invocation alive until the turn settles — the

--- a/web-next/src/app/api/sessions/[id]/queue/[queueId]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/queue/[queueId]/route.test.ts
@@ -1,0 +1,83 @@
+/*
+ * DELETE /api/sessions/[id]/queue/[queueId] — canceling durable steering rows
+ * before dispatch, while refusing rows already claimed by the turn runtime.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { getAuthState } from "@/lib/auth/auth-state";
+import { getDatabase } from "@/lib/db/client";
+import {
+	claimNextQueuedMessage,
+	enqueueMessage,
+	listQueuedMessages,
+} from "@/lib/db/queued-messages";
+import { createSession } from "@/lib/db/sessions";
+
+vi.mock("@/lib/auth/auth-state", () => ({
+	getAuthState: vi.fn(),
+}));
+
+const dir = mkdtempSync(join(tmpdir(), "web-next-queue-route-"));
+process.env.SESSIONS_DATABASE_URL = `file:${join(dir, "test.db")}`;
+
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const AUTHORIZED = {
+	kind: "authorized" as const,
+	user: { login: "fairchild", name: "Fairchild" },
+};
+
+beforeEach(() => {
+	vi.mocked(getAuthState).mockResolvedValue(AUTHORIZED);
+});
+
+let seq = 0;
+async function freshSession(): Promise<string> {
+	const id = `queue-${++seq}`;
+	await createSession(getDatabase(), { id, ownerLogin: "fairchild", provider: "mock" });
+	return id;
+}
+
+async function del(id: string, queueId: string) {
+	const { DELETE } = await import("./route");
+	return DELETE(
+		new Request(`http://test/api/sessions/${id}/queue/${queueId}`, {
+			method: "DELETE",
+		}),
+		{ params: Promise.resolve({ id, queueId }) },
+	);
+}
+
+describe("DELETE /api/sessions/[id]/queue/[queueId]", () => {
+	test("cancels an undispatched queued message", async () => {
+		const id = await freshSession();
+		const queued = await enqueueMessage(getDatabase(), id, "not anymore");
+
+		const res = await del(id, queued.queueId);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ canceled: true, queueId: queued.queueId });
+		expect(await listQueuedMessages(getDatabase(), id)).toEqual([]);
+	});
+
+	test("returns 409 once the queued message has dispatched", async () => {
+		const id = await freshSession();
+		const queued = await enqueueMessage(getDatabase(), id, "too late");
+		await claimNextQueuedMessage(getDatabase(), id);
+
+		const res = await del(id, queued.queueId);
+
+		expect(res.status).toBe(409);
+		expect((await res.json()).error).toMatch(/already dispatched/);
+	});
+
+	test("returns 404 for an unknown queue id", async () => {
+		const id = await freshSession();
+		const res = await del(id, "missing");
+		expect(res.status).toBe(404);
+	});
+});

--- a/web-next/src/app/api/sessions/[id]/queue/[queueId]/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/queue/[queueId]/route.test.ts
@@ -9,7 +9,7 @@ import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { getDatabase } from "@/lib/db/client";
 import {
-	claimNextQueuedMessage,
+	claimAndStartQueuedTurn,
 	enqueueMessage,
 	listQueuedMessages,
 } from "@/lib/db/queued-messages";
@@ -67,7 +67,7 @@ describe("DELETE /api/sessions/[id]/queue/[queueId]", () => {
 	test("returns 409 once the queued message has dispatched", async () => {
 		const id = await freshSession();
 		const queued = await enqueueMessage(getDatabase(), id, "too late");
-		await claimNextQueuedMessage(getDatabase(), id);
+		await claimAndStartQueuedTurn(getDatabase(), id);
 
 		const res = await del(id, queued.queueId);
 

--- a/web-next/src/app/api/sessions/[id]/queue/[queueId]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/queue/[queueId]/route.ts
@@ -1,0 +1,46 @@
+/*
+ * DELETE /api/sessions/[id]/queue/[queueId] — cancel a durable mid-turn
+ * steering message before it dispatches. Dispatched rows are immutable because
+ * their text has already entered session_events as a normal user turn.
+ */
+import { getAuthState } from "@/lib/auth/auth-state";
+import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
+import { getDatabase } from "@/lib/db/client";
+import { cancelQueuedMessage } from "@/lib/db/queued-messages";
+import { getSession } from "@/lib/db/sessions";
+
+export const runtime = "nodejs";
+
+export async function DELETE(
+	_request: Request,
+	{ params }: { params: Promise<{ id: string; queueId: string }> },
+) {
+	const auth = await getAuthState();
+	if (auth.kind !== "authorized") {
+		return Response.json(
+			{ error: "not signed in as the allowed user" },
+			{ status: auth.kind === "unauthenticated" ? 401 : 403 },
+		);
+	}
+
+	const { id, queueId } = await params;
+	const handle = getDatabase();
+	const session = await getSession(handle, id);
+	if (!session) {
+		return Response.json({ error: "unknown session" }, { status: 404 });
+	}
+	const ownerScope = sessionOwnerScopeResponse(session, auth.user.login);
+	if (ownerScope) return ownerScope;
+
+	const result = await cancelQueuedMessage(handle, id, queueId);
+	if (result === "canceled") {
+		return Response.json({ canceled: true, queueId });
+	}
+	if (result === "dispatched") {
+		return Response.json(
+			{ error: "queued message has already dispatched" },
+			{ status: 409 },
+		);
+	}
+	return Response.json({ error: "queued message not found" }, { status: 404 });
+}

--- a/web-next/src/app/api/sessions/[id]/route.ts
+++ b/web-next/src/app/api/sessions/[id]/route.ts
@@ -9,19 +9,24 @@
  * the session, so the only pointer to a still-billing machine is never lost.
  * Every method carries the same auth gate as the chat route.
  */
+import { after } from "next/server";
+import { dispatchQueuedTurnIfIdle } from "@/lib/agent-runtime/run-turn";
 import { isSelectableModel } from "@/lib/agent-runtime/models";
 import { releaseParkedSandbox } from "@/lib/agent-runtime/sandbox-release";
 import { resolveTurn } from "@/lib/agent-runtime/turn-tail";
 import { getAuthState } from "@/lib/auth/auth-state";
 import { sessionOwnerScopeResponse } from "@/lib/auth/session-owner";
 import { getDatabase } from "@/lib/db/client";
+import { listQueuedMessages } from "@/lib/db/queued-messages";
 import {
 	deleteSession,
 	getSession,
 	readEvents,
+	readTranscript,
 	updateSession,
 } from "@/lib/db/sessions";
 import { cleanTitleText, MAX_TITLE_LENGTH } from "@/lib/session-title";
+import type { FolioMessage } from "@/components/folio/types";
 
 export const runtime = "nodejs";
 
@@ -52,7 +57,27 @@ export async function GET(
 			{ status: 400 },
 		);
 	}
+	const dispatched = await dispatchQueuedTurnIfIdle(handle, session);
+	if (dispatched) {
+		try {
+			after(() => dispatched.ingest);
+		} catch {
+			// Outside a request scope in tests — the ingest is already running.
+		}
+	}
 	const events = await readEvents(handle, id, sinceSeq);
+	const turn = await resolveTurn(handle, id);
+	const activeMessageId = turn.fromSeq !== null ? `${id}:${turn.fromSeq}` : null;
+	const resume = turn.status === "running" || turn.status === "stale";
+	const transcript = (await readTranscript(handle, id)) as FolioMessage[];
+	const messages = transcript
+		.filter((message) => !(resume && message.id === activeMessageId))
+		.map((message) =>
+			message.role === "user"
+				? { ...message, metadata: { author: auth.user.name, ...message.metadata } }
+				: message,
+		);
+	const queuedMessages = await listQueuedMessages(handle, id);
 	return Response.json({
 		session: {
 			id: session.id,
@@ -66,6 +91,14 @@ export async function GET(
 			createdAt: session.createdAt,
 			lastActivityAt: session.lastActivityAt,
 		},
+		turn,
+		messages,
+		queuedMessages: queuedMessages.map((message) => ({
+			queueId: message.queueId,
+			text: message.text,
+			queuedAt: message.queuedAt,
+			position: message.position,
+		})),
 		events: events.map((event) => ({
 			seq: event.seq,
 			role: event.role,

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -25,11 +25,10 @@ export interface ComposeFieldProps {
 	/** Names the reply target for assistive tech ("Reply to Claude"). */
 	agentName: string;
 	onSend?: (text: string) => void;
-	/** While true, submits are held and the draft kept (turn in flight). */
+	/** Hard-disable for contexts that cannot accept text at all. */
 	disabled?: boolean;
-	/** Stops the in-flight turn (#753). While `disabled` (a turn is running)
-	 * the send affordance becomes this stop — same footprint, honest verb —
-	 * rather than a dead button beside new chrome. */
+	/** Stops the in-flight turn (#753). Mid-turn steering keeps Send live, so
+	 * Stop sits beside it instead of replacing it. */
 	onStop?: () => void;
 }
 
@@ -113,28 +112,29 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 					// the field instead of growing the field (and the page) forever.
 					className="my-[7px] max-h-[168px] min-w-0 flex-1 resize-none overflow-y-auto border-none bg-transparent font-serif text-compose text-ink outline-none"
 				/>
-				{disabled && onStop ? (
-					<button
-						type="button"
-						title="Stop the turn"
-						aria-label="Stop"
-						onClick={onStop}
-						className="relative z-[1] flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[11px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
-					>
-						■
-					</button>
-				) : (
+				<div className="relative z-[1] flex shrink-0 items-center gap-2">
+					{onStop && (
+						<button
+							type="button"
+							title="Stop the turn"
+							aria-label="Stop"
+							onClick={onStop}
+							className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[11px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
+						>
+							■
+						</button>
+					)}
 					<button
 						type="button"
 						title="Send"
 						aria-label="Send"
 						disabled={disabled}
 						onClick={submit}
-						className="relative z-[1] flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent disabled:opacity-40 disabled:group-focus-within:border-line-strong disabled:group-focus-within:bg-transparent disabled:group-focus-within:text-muted disabled:hover:border-line-strong disabled:hover:text-muted"
+						className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[15px] leading-none text-muted transition-colors duration-200 group-focus-within:border-accent group-focus-within:bg-accent group-focus-within:text-send-ink hover:border-accent hover:text-accent disabled:opacity-40 disabled:group-focus-within:border-line-strong disabled:group-focus-within:bg-transparent disabled:group-focus-within:text-muted disabled:hover:border-line-strong disabled:hover:text-muted"
 					>
 						↑
 					</button>
-				)}
+				</div>
 			</div>
 		</div>
 	);

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -33,6 +33,13 @@ export interface SessionViewData {
 	empty?: EmptyTranscriptNote;
 }
 
+export interface QueuedMessageData {
+	queueId: string;
+	text: string;
+	queuedAt: string;
+	position: number;
+}
+
 /** Entry stagger for the first few messages, matching the prototype. */
 function riseDelay(index: number): number {
 	return index < 4 ? 0.03 + index * 0.07 : 0;
@@ -81,20 +88,71 @@ function withoutMessagePresence(message: FolioMessage): FolioMessage {
 	};
 }
 
+function QueuedMessages({
+	messages,
+	onCancel,
+}: {
+	messages: QueuedMessageData[];
+	onCancel?: (queueId: string) => void;
+}) {
+	if (messages.length === 0) return null;
+	return (
+		<div
+			aria-label="Queued messages"
+			className="mx-auto flex max-w-[680px] flex-col gap-2 px-5 pb-2"
+		>
+			{messages.map((message) => (
+				<div
+					key={message.queueId}
+					data-testid="queued-message"
+					className="flex items-start gap-3 rounded-[13px] border border-dashed border-line-strong bg-raised/95 px-4 py-3 shadow-field"
+				>
+					<div className="min-w-0 flex-1">
+						<div className="mb-1 flex items-center gap-2 font-mono text-[10px] font-medium tracking-[.14em] text-hint uppercase">
+							<span>queued</span>
+							<span aria-hidden>#{message.position}</span>
+						</div>
+						<p className="font-serif text-[15px] leading-[1.45] text-user-ink">
+							{message.text}
+						</p>
+					</div>
+					{onCancel && (
+						<button
+							type="button"
+							aria-label={`Cancel queued message ${message.position}`}
+							title="Cancel queued message"
+							onClick={() => onCancel(message.queueId)}
+							className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-line text-[15px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
+						>
+							×
+						</button>
+					)}
+				</div>
+			))}
+		</div>
+	);
+}
+
 export interface SessionViewProps {
 	session: SessionViewData;
 	/** Compose submit handler (client wrappers wire this; fixtures omit it). */
 	onSend?: (text: string) => void;
-	/** Holds sends (keeping the draft) while a turn is streaming. */
+	/** Hard-disables compose when this surface cannot accept text. */
 	composeDisabled?: boolean;
+	/** Holds retry actions while a turn is streaming; new compose sends queue. */
+	retryDisabled?: boolean;
+	/** User messages waiting for the current turn to settle (#984). */
+	queuedMessages?: QueuedMessageData[];
+	/** Cancels an undispatched queued message. */
+	onCancelQueuedMessage?: (queueId: string) => void;
 	/** Model picker handler (client wrappers wire this; fixtures omit it, which
 	 * leaves the status line's model as static text — see status-line.tsx). */
 	onModelChange?: (id: string) => void;
 	/** Inline title-edit handler (client wrappers wire this; fixtures omit it,
 	 * which leaves the masthead title as static text — see session-masthead.tsx). */
 	onTitleChange?: (title: string) => void;
-	/** Stops the in-flight turn (#753); the compose's send affordance becomes
-	 * the stop while a turn runs. Fixtures omit it. */
+	/** Stops the in-flight turn (#753); compose keeps Send live for queued
+	 * steering while this quiet control sits beside it. Fixtures omit it. */
 	onStopTurn?: () => void;
 	/** Stops the session's live sandbox (#753); a quiet masthead action beside
 	 * the state label. Fixtures omit it. */
@@ -109,6 +167,9 @@ export function SessionView({
 	session,
 	onSend,
 	composeDisabled,
+	retryDisabled,
+	queuedMessages = [],
+	onCancelQueuedMessage,
 	onModelChange,
 	onTitleChange,
 	onStopTurn,
@@ -174,7 +235,7 @@ export function SessionView({
 												? () => onSend(retryText)
 												: undefined
 										}
-										retryDisabled={composeDisabled}
+										retryDisabled={retryDisabled}
 										onApprovalDecision={onApprovalDecision}
 									/>
 								))}
@@ -196,6 +257,10 @@ export function SessionView({
 				})()}
 			</main>
 			<footer className="sticky bottom-0 z-[15]">
+				<QueuedMessages
+					messages={queuedMessages}
+					onCancel={onCancelQueuedMessage}
+				/>
 				<ComposeField
 					agentName={session.masthead.agentName}
 					onSend={onSend}

--- a/web-next/src/lib/agent-runtime/run-turn.test.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.test.ts
@@ -11,12 +11,23 @@ import {
 	type Session,
 	updateSession,
 } from "../db/sessions";
+import {
+	cancelQueuedMessage,
+	enqueueMessage,
+	listQueuedMessages,
+} from "../db/queued-messages";
 import type { ComputeProvider, TurnRequest } from "./provider";
 import {
 	ApprovalPolicyUnsupportedError,
+	dispatchQueuedTurnIfIdle,
 	runSessionTurn,
-	TurnConflictError,
+	type SessionTurn,
+	type SessionTurnResult,
 } from "./run-turn";
+import {
+	MOCK_PROVISION_ERROR_TRIGGER,
+	MOCK_TURN_ERROR_TRIGGER,
+} from "./mock-provider";
 import type { StreamChunk } from "./stream-chunk";
 
 // Same throwaway on-disk DB pattern as sessions.test.ts.
@@ -71,11 +82,16 @@ async function drain(stream: ReadableStream<unknown>): Promise<unknown[]> {
 	}
 }
 
+function started(result: SessionTurnResult): SessionTurn {
+	expect(result.kind).toBe("started");
+	return result as SessionTurn;
+}
+
 describe("runSessionTurn", () => {
 	test("persists the user event immediately, before the turn is ingested", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);
-		const turn = await runSessionTurn(handle, session, "fix it", stubProvider());
+		const turn = started(await runSessionTurn(handle, session, "fix it", stubProvider()));
 
 		// The user event exists as soon as runSessionTurn returns — detached
 		// ingest of the assistant reply runs independently.
@@ -94,7 +110,7 @@ describe("runSessionTurn", () => {
 		const session = await makeSession(handle);
 		// Drop the stream on the floor — the turn must still complete because
 		// ingest is independent of any reader.
-		const turn = await runSessionTurn(handle, session, "fix it", stubProvider());
+		const turn = started(await runSessionTurn(handle, session, "fix it", stubProvider()));
 		await turn.stream.cancel();
 		await turn.ingest;
 
@@ -111,7 +127,7 @@ describe("runSessionTurn", () => {
 	test("the live stream tails the log with ids matching its projection", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);
-		const turn = await runSessionTurn(handle, session, "fix it", stubProvider());
+		const turn = started(await runSessionTurn(handle, session, "fix it", stubProvider()));
 		const chunks = (await drain(turn.stream)) as {
 			type: string;
 			messageId?: string;
@@ -129,7 +145,7 @@ describe("runSessionTurn", () => {
 	test("the finished stream carries the derived turn receipt", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);
-		const turn = await runSessionTurn(handle, session, "fix it", stubProvider());
+		const turn = started(await runSessionTurn(handle, session, "fix it", stubProvider()));
 		const chunks = (await drain(turn.stream)) as {
 			type: string;
 			messageMetadata?: { author?: string; turnStats?: { toolCount: number } };
@@ -183,7 +199,7 @@ describe("runSessionTurn", () => {
 				yield { type: "done", content: "" } as StreamChunk;
 			},
 		};
-		const turn = await runSessionTurn(handle, fresh, "again", capturing);
+		const turn = started(await runSessionTurn(handle, fresh, "again", capturing));
 		await drain(turn.stream);
 		await turn.ingest;
 
@@ -209,7 +225,7 @@ describe("runSessionTurn", () => {
 				yield { type: "done", content: "" } as StreamChunk;
 			},
 		};
-		const turn = await runSessionTurn(handle, session, "go", capturing);
+		const turn = started(await runSessionTurn(handle, session, "go", capturing));
 		await drain(turn.stream);
 		await turn.ingest;
 
@@ -230,7 +246,7 @@ describe("runSessionTurn", () => {
 				},
 			},
 		]);
-		const turn = await runSessionTurn(handle, session, "go", parking);
+		const turn = started(await runSessionTurn(handle, session, "go", parking));
 		await drain(turn.stream);
 		await turn.ingest;
 
@@ -256,7 +272,7 @@ describe("runSessionTurn", () => {
 		const clearing = stubProvider([
 			{ type: "done", content: "", metadata: { resume: null } },
 		]);
-		const turn = await runSessionTurn(handle, session, "go", clearing);
+		const turn = started(await runSessionTurn(handle, session, "go", clearing));
 		await drain(turn.stream);
 		await turn.ingest;
 
@@ -265,9 +281,12 @@ describe("runSessionTurn", () => {
 		expect(after?.resumeState).toBeNull();
 	});
 
-	test("a send while a turn is running is a structured conflict, not interleaved (#811)", async () => {
+	test("a send while a turn is running queues without touching session_events (#984)", async () => {
 		const handle = freshDb();
-		const session = await makeSession(handle);
+		const session = await createSession(handle, {
+			id: "queue-conflict",
+			provider: "mock",
+		});
 		// A provider that stays open until the test releases it.
 		let release!: () => void;
 		const gate = new Promise<void>((r) => (release = r));
@@ -280,28 +299,121 @@ describe("runSessionTurn", () => {
 			},
 		};
 
-		const first = await runSessionTurn(handle, session, "one", slow);
-		await expect(
-			runSessionTurn(handle, session, "two", stubProvider()),
-		).rejects.toBeInstanceOf(TurnConflictError);
-		// The rejected send persisted nothing — the live turn's seq range is intact.
-		const during = await readEvents(handle, "s1");
+		const first = started(await runSessionTurn(handle, session, "one", slow));
+		const queuedText = `two ${MOCK_TURN_ERROR_TRIGGER}`;
+		const queued = await runSessionTurn(handle, session, queuedText, stubProvider());
+		expect(queued).toMatchObject({ kind: "queued", position: 1 });
+		// The queued send persisted nothing to session_events while the live
+		// turn's seq range is still open.
+		const during = await readEvents(handle, session.id);
 		expect(during.filter((e) => e.role === "user")).toHaveLength(1);
 
 		release();
 		await first.ingest;
-		// With the turn closed, the session accepts the next send.
-		const second = await runSessionTurn(handle, session, "two", stubProvider());
-		await second.ingest;
-		expect(
-			(await readEvents(handle, "s1")).filter((e) => e.role === "user"),
-		).toHaveLength(2);
+		// The queued row dispatched as the next normal user turn after the first
+		// turn closed.
+		const after = await readEvents(handle, session.id);
+		expect(after.filter((e) => e.role === "user").map((e) => e.chunk.content)).toEqual([
+			"one",
+			queuedText,
+		]);
+	});
+
+	test("queued turns dispatch oldest-first after the running turn settles (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-order",
+			provider: "mock",
+		});
+		let release!: () => void;
+		const gate = new Promise<void>((r) => (release = r));
+		const slow: ComputeProvider = {
+			id: "slow",
+			runTurn: async function* () {
+				yield { type: "text", content: "working " } as StreamChunk;
+				await gate;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+
+		const first = started(await runSessionTurn(handle, session, "one", slow));
+		const secondText = `two ${MOCK_TURN_ERROR_TRIGGER}`;
+		const thirdText = `three ${MOCK_PROVISION_ERROR_TRIGGER}`;
+		await runSessionTurn(handle, session, secondText, stubProvider());
+		await runSessionTurn(handle, session, thirdText, stubProvider());
+		expect((await listQueuedMessages(handle, session.id)).map((m) => m.text)).toEqual([
+			secondText,
+			thirdText,
+		]);
+
+		release();
+		await first.ingest;
+		const users = (await readEvents(handle, session.id))
+			.filter((event) => event.role === "user")
+			.map((event) => event.chunk.content);
+		expect(users).toEqual(["one", secondText, thirdText]);
+		expect(await listQueuedMessages(handle, session.id)).toEqual([]);
+	});
+
+	test("canceling an undispatched queued turn prevents dispatch (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-cancel",
+			provider: "mock",
+		});
+		let release!: () => void;
+		const gate = new Promise<void>((r) => (release = r));
+		const slow: ComputeProvider = {
+			id: "slow",
+			runTurn: async function* () {
+				yield { type: "text", content: "working " } as StreamChunk;
+				await gate;
+				yield { type: "done", content: "" } as StreamChunk;
+			},
+		};
+
+		const first = started(await runSessionTurn(handle, session, "one", slow));
+		const queued = await runSessionTurn(handle, session, "two", stubProvider());
+		expect(queued.kind).toBe("queued");
+		if (queued.kind !== "queued") throw new Error("expected queued result");
+
+		await expect(cancelQueuedMessage(handle, session.id, queued.queueId)).resolves.toBe(
+			"canceled",
+		);
+		release();
+		await first.ingest;
+		const users = (await readEvents(handle, session.id))
+			.filter((event) => event.role === "user")
+			.map((event) => event.chunk.content);
+		expect(users).toEqual(["one"]);
+	});
+
+	test("dispatched queued turns cannot be canceled, and idle fallback starts them (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-fallback",
+			provider: "mock",
+		});
+		const queuedText = `handoff turn ${MOCK_TURN_ERROR_TRIGGER}`;
+		const queued = await enqueueMessage(handle, session.id, queuedText);
+
+		const fallback = await dispatchQueuedTurnIfIdle(handle, session);
+		expect(fallback?.kind).toBe("started");
+		await expect(cancelQueuedMessage(handle, session.id, queued.queueId)).resolves.toBe(
+			"dispatched",
+		);
+		await fallback?.ingest;
+
+		const users = (await readEvents(handle, session.id))
+			.filter((event) => event.role === "user")
+			.map((event) => event.chunk.content);
+		expect(users).toEqual([queuedText]);
 	});
 
 	test("titles the session from the first turn's message, before the tab could close (#823)", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);
-		const turn = await runSessionTurn(handle, session, "  Fix   the   login   bug  ", stubProvider());
+		const turn = started(await runSessionTurn(handle, session, "  Fix   the   login   bug  ", stubProvider()));
 		// The title is set as soon as runSessionTurn returns — synchronously with
 		// the durable user-event append, not waiting on the detached ingest.
 		expect((await getSession(handle, "s1"))?.title).toBe("Fix the login bug");
@@ -311,11 +423,11 @@ describe("runSessionTurn", () => {
 	test("a second turn never overwrites the title from the first (#823)", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);
-		const first = await runSessionTurn(handle, session, "Fix the login bug", stubProvider());
+		const first = started(await runSessionTurn(handle, session, "Fix the login bug", stubProvider()));
 		await first.ingest;
 
 		const resessioned = (await getSession(handle, "s1")) as Session;
-		const second = await runSessionTurn(handle, resessioned, "Now add a test", stubProvider());
+		const second = started(await runSessionTurn(handle, resessioned, "Now add a test", stubProvider()));
 		await second.ingest;
 
 		expect((await getSession(handle, "s1"))?.title).toBe("Fix the login bug");
@@ -324,12 +436,12 @@ describe("runSessionTurn", () => {
 	test("an empty first message leaves the session untitled for a later turn to name (#823)", async () => {
 		const handle = freshDb();
 		const session = await makeSession(handle);
-		const first = await runSessionTurn(handle, session, "   ", stubProvider());
+		const first = started(await runSessionTurn(handle, session, "   ", stubProvider()));
 		await first.ingest;
 		expect((await getSession(handle, "s1"))?.title).toBe("");
 
 		const resessioned = (await getSession(handle, "s1")) as Session;
-		const second = await runSessionTurn(handle, resessioned, "Fix the real bug", stubProvider());
+		const second = started(await runSessionTurn(handle, resessioned, "Fix the real bug", stubProvider()));
 		await second.ingest;
 		expect((await getSession(handle, "s1"))?.title).toBe("Fix the real bug");
 	});
@@ -340,7 +452,7 @@ describe("runSessionTurn", () => {
 		await updateSession(handle, "s1", { title: "My own title" });
 		const resessioned = (await getSession(handle, "s1")) as Session;
 
-		const turn = await runSessionTurn(handle, resessioned, "Fix the login bug", stubProvider());
+		const turn = started(await runSessionTurn(handle, resessioned, "Fix the login bug", stubProvider()));
 		await turn.ingest;
 		expect((await getSession(handle, "s1"))?.title).toBe("My own title");
 	});
@@ -359,7 +471,7 @@ describe("runSessionTurn", () => {
 			args: [old],
 		});
 
-		const turn = await runSessionTurn(handle, session, "new", stubProvider());
+		const turn = started(await runSessionTurn(handle, session, "new", stubProvider()));
 		await turn.ingest;
 		const events = await readEvents(handle, "s1");
 		// The old run gained error+done BEFORE the new user event — every

--- a/web-next/src/lib/agent-runtime/run-turn.test.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { type DatabaseHandle, openDatabase } from "../db/client";
 import {
 	appendEvents,
@@ -24,6 +24,7 @@ import {
 	type SessionTurn,
 	type SessionTurnResult,
 } from "./run-turn";
+import { startNextQueuedTurn } from "./turn-ingest";
 import {
 	MOCK_PROVISION_ERROR_TRIGGER,
 	MOCK_TURN_ERROR_TRIGGER,
@@ -41,6 +42,7 @@ function freshDb(): DatabaseHandle {
 }
 
 afterEach(async () => {
+	vi.useRealTimers();
 	await open?.db.destroy();
 	open = undefined;
 	if (dir) rmSync(dir, { recursive: true, force: true });
@@ -80,6 +82,25 @@ async function drain(stream: ReadableStream<unknown>): Promise<unknown[]> {
 		if (done) return out;
 		out.push(value);
 	}
+}
+
+async function waitForUserContents(
+	handle: DatabaseHandle,
+	sessionId: string,
+	count: number,
+): Promise<string[]> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		const events = await readEvents(handle, sessionId);
+		const users = events
+			.filter((event) => event.role === "user")
+			.map((event) => event.chunk.content);
+		const doneCount = events.filter(
+			(event) => event.role === "assistant" && event.chunk.type === "done",
+		).length;
+		if (users.length >= count && doneCount >= count) return users;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(`timed out waiting for ${count} user events`);
 }
 
 function started(result: SessionTurnResult): SessionTurn {
@@ -312,8 +333,7 @@ describe("runSessionTurn", () => {
 		await first.ingest;
 		// The queued row dispatched as the next normal user turn after the first
 		// turn closed.
-		const after = await readEvents(handle, session.id);
-		expect(after.filter((e) => e.role === "user").map((e) => e.chunk.content)).toEqual([
+		await expect(waitForUserContents(handle, session.id, 2)).resolves.toEqual([
 			"one",
 			queuedText,
 		]);
@@ -348,11 +368,102 @@ describe("runSessionTurn", () => {
 
 		release();
 		await first.ingest;
+		const users = await waitForUserContents(handle, session.id, 3);
+		expect(users).toEqual(["one", secondText, thirdText]);
+		expect(await listQueuedMessages(handle, session.id)).toEqual([]);
+	});
+
+	test("concurrent continuation and GET sweep dispatch exactly one queued turn first (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-concurrent",
+			provider: "mock",
+		});
+		const firstText = `first ${MOCK_TURN_ERROR_TRIGGER}`;
+		const secondText = `second ${MOCK_PROVISION_ERROR_TRIGGER}`;
+		await enqueueMessage(handle, session.id, firstText);
+		await enqueueMessage(handle, session.id, secondText);
+
+		const [continued, swept] = await Promise.all([
+			startNextQueuedTurn(handle, session.id),
+			dispatchQueuedTurnIfIdle(handle, session),
+		]);
+
+		const startedTurns = [continued, swept].filter(
+			(turn): turn is NonNullable<typeof turn> => turn !== null,
+		);
+		expect(startedTurns).toHaveLength(1);
+		await startedTurns[0].ingest;
+		const users = await waitForUserContents(handle, session.id, 2);
+		expect(users).toEqual([firstText, secondText]);
+	});
+
+	test("a direct POST behind a pending queue row enqueues instead of jumping ahead (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-direct-behind-pending",
+			provider: "mock",
+		});
+		const firstText = "already queued";
+		const directText = "new direct post";
+		await enqueueMessage(handle, session.id, firstText);
+
+		const result = await runSessionTurn(handle, session, directText, stubProvider());
+
+		expect(result).toMatchObject({ kind: "queued", position: 2 });
+		expect((await readEvents(handle, session.id)).filter((e) => e.role === "user")).toEqual(
+			[],
+		);
+		expect((await listQueuedMessages(handle, session.id)).map((m) => m.text)).toEqual([
+			firstText,
+			directText,
+		]);
+	});
+
+	test("a post-claim start failure leaves queued text visible in session_events (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-stranded-claim",
+			provider: "nope",
+		});
+		const queuedText = "dispatch me once";
+		await enqueueMessage(handle, session.id, queuedText);
+
+		await expect(dispatchQueuedTurnIfIdle(handle, session)).rejects.toThrow(
+			"Unknown compute provider: nope",
+		);
+
+		expect(await listQueuedMessages(handle, session.id)).toEqual([]);
 		const users = (await readEvents(handle, session.id))
 			.filter((event) => event.role === "user")
 			.map((event) => event.chunk.content);
-		expect(users).toEqual(["one", secondText, thirdText]);
-		expect(await listQueuedMessages(handle, session.id)).toEqual([]);
+		expect(users).toEqual([queuedText]);
+	});
+
+	test("same-millisecond queued messages dispatch in insertion order (#984)", async () => {
+		const handle = freshDb();
+		const session = await createSession(handle, {
+			id: "queue-fifo-tie",
+			provider: "mock",
+		});
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+		const firstText = `same-ms first ${MOCK_TURN_ERROR_TRIGGER}`;
+		const secondText = `same-ms second ${MOCK_PROVISION_ERROR_TRIGGER}`;
+		const first = await enqueueMessage(handle, session.id, firstText);
+		const second = await enqueueMessage(handle, session.id, secondText);
+		vi.useRealTimers();
+
+		expect(first.queuedAt).toBe(second.queuedAt);
+		expect((await listQueuedMessages(handle, session.id)).map((m) => m.text)).toEqual([
+			firstText,
+			secondText,
+		]);
+		const turn = await dispatchQueuedTurnIfIdle(handle, session);
+		expect(turn?.kind).toBe("started");
+		await turn?.ingest;
+		const users = await waitForUserContents(handle, session.id, 2);
+		expect(users).toEqual([firstText, secondText]);
 	});
 
 	test("canceling an undispatched queued turn prevents dispatch (#984)", async () => {

--- a/web-next/src/lib/agent-runtime/run-turn.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.ts
@@ -10,11 +10,18 @@
  */
 import type { UIMessageChunk } from "ai";
 import type { DatabaseHandle } from "../db/client";
-import { enqueueMessage, type QueuedMessage } from "../db/queued-messages";
+import {
+	appendImmediateTurnOrQueue,
+	enqueueMessage,
+	type QueuedMessage,
+} from "../db/queued-messages";
 import type { Session } from "../db/sessions";
 import type { ComputeProvider } from "./provider";
 import { getProvider } from "./provider";
-import { startNextQueuedTurn, startTurn } from "./turn-ingest";
+import {
+	startNextQueuedTurn,
+	startTurnFromAppendedUserEvent,
+} from "./turn-ingest";
 import { closeAbandonedTurn, resolveTurn, tailStream } from "./turn-tail";
 
 export interface SessionTurn {
@@ -55,10 +62,10 @@ export type SessionTurnResult = SessionTurn | QueuedSessionTurn;
  * One turn at a time: a send against a session whose current turn is still
  * running (in-process, or fresh in the log per resolveTurn) is durably queued
  * instead of interleaving a second provider's chunks into the live turn's seq
- * range. The queued text does not touch session_events until the active turn's
- * ingest writes its terminal done and claims the row for the next startTurn.
- * Two truly simultaneous first sends can still race the check — full
- * serialization would need a DB reservation and is out of scope; see #811.
+ * range. The queued text does not touch session_events until an atomic
+ * claim-and-append transaction dispatches it as the next turn. If the log is
+ * idle but pending queue rows exist, this send also queues behind them; FIFO
+ * queue order is more important than making the newest POST special.
  */
 export async function runSessionTurn(
 	handle: DatabaseHandle,
@@ -74,7 +81,15 @@ export async function runSessionTurn(
 	if (current.status === "stale" && current.fromSeq !== null) {
 		await closeAbandonedTurn(handle, session.id, current.fromSeq);
 	}
-	const { fromSeq, ingest } = await startTurn(handle, session, userText, provider);
+	const start = await appendImmediateTurnOrQueue(handle, session.id, userText);
+	if (start.kind === "queued") return queuedTurnResponse(start.queued);
+	const { fromSeq, ingest } = await startTurnFromAppendedUserEvent(
+		handle,
+		session,
+		userText,
+		start.userSeq,
+		provider,
+	);
 	return { kind: "started", fromSeq, ingest, stream: tailStream(handle, session.id, fromSeq) };
 }
 

--- a/web-next/src/lib/agent-runtime/run-turn.ts
+++ b/web-next/src/lib/agent-runtime/run-turn.ts
@@ -10,13 +10,15 @@
  */
 import type { UIMessageChunk } from "ai";
 import type { DatabaseHandle } from "../db/client";
+import { enqueueMessage, type QueuedMessage } from "../db/queued-messages";
 import type { Session } from "../db/sessions";
 import type { ComputeProvider } from "./provider";
 import { getProvider } from "./provider";
-import { startTurn } from "./turn-ingest";
+import { startNextQueuedTurn, startTurn } from "./turn-ingest";
 import { closeAbandonedTurn, resolveTurn, tailStream } from "./turn-tail";
 
 export interface SessionTurn {
+	kind: "started";
 	/** First assistant seq — the assistant message id is `${sessionId}:${fromSeq}`. */
 	fromSeq: number;
 	/** The live tail of the turn, for the POST response. */
@@ -26,12 +28,11 @@ export interface SessionTurn {
 	ingest: Promise<void>;
 }
 
-/** A send while the session's current turn is still running (route → 409). */
-export class TurnConflictError extends Error {
-	constructor(sessionId: string) {
-		super(`a turn is already running on session ${sessionId}`);
-		this.name = "TurnConflictError";
-	}
+export interface QueuedSessionTurn {
+	kind: "queued";
+	queueId: string;
+	position: number;
+	queuedAt: string;
 }
 
 /** A non-auto approval policy on a provider that can't enforce it (route → 409). */
@@ -44,27 +45,84 @@ export class ApprovalPolicyUnsupportedError extends Error {
 	}
 }
 
+export type SessionTurnResult = SessionTurn | QueuedSessionTurn;
+
 /**
  * Appends the user's message, launches the detached turn, and returns a tail
  * over its log plus the ingest promise. The provider is resolved eagerly so an
  * unknown provider rejects before anything is persisted.
  *
  * One turn at a time: a send against a session whose current turn is still
- * running (in-process, or fresh in the log per resolveTurn) throws
- * TurnConflictError instead of interleaving a second provider's chunks into
- * the live turn's seq range. The client's send-gating makes this the rare
- * path, but the API is directly callable, so the log defends itself. (Two
- * truly simultaneous first sends can still race the check — full
- * serialization would need a DB reservation and is out of scope; see #811.)
+ * running (in-process, or fresh in the log per resolveTurn) is durably queued
+ * instead of interleaving a second provider's chunks into the live turn's seq
+ * range. The queued text does not touch session_events until the active turn's
+ * ingest writes its terminal done and claims the row for the next startTurn.
+ * Two truly simultaneous first sends can still race the check — full
+ * serialization would need a DB reservation and is out of scope; see #811.
  */
 export async function runSessionTurn(
 	handle: DatabaseHandle,
 	session: Session,
 	userText: string,
 	provider: ComputeProvider = getProvider(session.provider),
-): Promise<SessionTurn> {
-	// Refuse, don't silently bypass: an ask-* session must never run on a
-	// provider that would execute tools without consulting the broker.
+): Promise<SessionTurnResult> {
+	assertApprovalPolicySupported(session, provider);
+	const current = await resolveTurn(handle, session.id);
+	if (current.status === "running") return queueSessionTurn(handle, session, userText);
+	// A stale predecessor (runner died before its `done`) is closed durably
+	// before the new turn opens, so every assistant run in the log terminates.
+	if (current.status === "stale" && current.fromSeq !== null) {
+		await closeAbandonedTurn(handle, session.id, current.fromSeq);
+	}
+	const { fromSeq, ingest } = await startTurn(handle, session, userText, provider);
+	return { kind: "started", fromSeq, ingest, stream: tailStream(handle, session.id, fromSeq) };
+}
+
+export async function queueSessionTurn(
+	handle: DatabaseHandle,
+	session: Session,
+	userText: string,
+	provider: ComputeProvider = getProvider(session.provider),
+): Promise<QueuedSessionTurn> {
+	assertApprovalPolicySupported(session, provider);
+	const queued = await enqueueMessage(handle, session.id, userText);
+	return queuedTurnResponse(queued);
+}
+
+export async function dispatchQueuedTurnIfIdle(
+	handle: DatabaseHandle,
+	session: Session,
+): Promise<SessionTurn | null> {
+	const current = await resolveTurn(handle, session.id);
+	if (current.status === "running") return null;
+	if (current.status === "stale" && current.fromSeq !== null) {
+		await closeAbandonedTurn(handle, session.id, current.fromSeq);
+	}
+	const started = await startNextQueuedTurn(handle, session.id);
+	if (!started) return null;
+	return {
+		kind: "started",
+		fromSeq: started.fromSeq,
+		ingest: started.ingest,
+		stream: tailStream(handle, session.id, started.fromSeq),
+	};
+}
+
+function queuedTurnResponse(queued: QueuedMessage): QueuedSessionTurn {
+	return {
+		kind: "queued",
+		queueId: queued.queueId,
+		position: queued.position,
+		queuedAt: queued.queuedAt,
+	};
+}
+
+function assertApprovalPolicySupported(
+	session: Session,
+	provider: ComputeProvider,
+): void {
+	// Refuse, don't silently bypass: an ask-* session must never run or queue
+	// against a provider that would execute tools without consulting the broker.
 	if (session.approvalPolicy !== "auto" && !provider.supportsApprovals) {
 		throw new ApprovalPolicyUnsupportedError(
 			session.id,
@@ -72,13 +130,4 @@ export async function runSessionTurn(
 			session.approvalPolicy,
 		);
 	}
-	const current = await resolveTurn(handle, session.id);
-	if (current.status === "running") throw new TurnConflictError(session.id);
-	// A stale predecessor (runner died before its `done`) is closed durably
-	// before the new turn opens, so every assistant run in the log terminates.
-	if (current.status === "stale" && current.fromSeq !== null) {
-		await closeAbandonedTurn(handle, session.id, current.fromSeq);
-	}
-	const { fromSeq, ingest } = await startTurn(handle, session, userText, provider);
-	return { fromSeq, ingest, stream: tailStream(handle, session.id, fromSeq) };
 }

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -23,6 +23,10 @@
  */
 import { EventEmitter } from "node:events";
 import type { DatabaseHandle } from "../db/client";
+import {
+	claimNextQueuedMessage,
+	releaseClaimedQueuedMessage,
+} from "../db/queued-messages";
 import { getRepo } from "../db/repos";
 import {
 	appendEvents,
@@ -175,7 +179,7 @@ export async function startTurn(
 		resume,
 		priorContext,
 	).then(
-		(outcome) => {
+		async (outcome) => {
 			// Deregister once this turn settles — but only if a newer turn hasn't
 			// already taken the slot (guards a fast resend replacing the entry).
 			if (activeTurns.get(session.id)?.fromSeq === fromSeq) {
@@ -196,6 +200,15 @@ export async function startTurn(
 					error,
 				);
 			}
+			try {
+				const next = await startNextQueuedTurn(handle, session.id);
+				if (next) await next.ingest;
+			} catch (error) {
+				console.error(
+					`[turn-ingest] queued turn continuation failed for ${session.id}`,
+					error,
+				);
+			}
 		},
 		(error) => {
 			if (activeTurns.get(session.id)?.fromSeq === fromSeq) {
@@ -206,6 +219,32 @@ export async function startTurn(
 	);
 	activeTurns.set(session.id, { fromSeq, startedAt, controller });
 	return { fromSeq, ingest };
+}
+
+/**
+ * Claims and starts the next queued user message for a session. This is the
+ * post-terminal continuation path: the claimed row is marked dispatched before
+ * startTurn appends its normal user event, preventing duplicate dispatch across
+ * processes while preserving session_events as a single-writer log.
+ */
+export async function startNextQueuedTurn(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<StartedTurn | null> {
+	if (activeTurns.has(sessionId)) return null;
+	const queued = await claimNextQueuedMessage(handle, sessionId);
+	if (!queued) return null;
+	const session = await getSession(handle, sessionId);
+	if (!session) {
+		await releaseClaimedQueuedMessage(handle, queued);
+		return null;
+	}
+	try {
+		return await startTurn(handle, session, queued.text);
+	} catch (error) {
+		await releaseClaimedQueuedMessage(handle, queued);
+		throw error;
+	}
 }
 
 async function emitTurnCompletionNotification(

--- a/web-next/src/lib/agent-runtime/turn-ingest.ts
+++ b/web-next/src/lib/agent-runtime/turn-ingest.ts
@@ -9,10 +9,14 @@
  * The loop runs eagerly (fire-and-forget) so the POST response can tail it live;
  * the route additionally hands the ingest promise to next/server `after()` so a
  * serverless invocation is kept alive until the turn settles (a no-op on a
- * long-running node server). In-process state — an `activeTurns` map for
- * liveness and an EventEmitter bus for wakeups — lets same-process tail readers
- * follow without polling; the DB remains the durable source of truth, so a
- * cross-instance reader falls back to polling it.
+ * long-running node server). When a settled turn finds queued work, it starts
+ * the successor and then resolves without awaiting that successor's ingest; on
+ * serverless, later queued turns rely on the GET sweep/client pickup if the
+ * platform freezes the detached successor after the current `after()` window.
+ * In-process state — an `activeTurns` map for liveness and an EventEmitter bus
+ * for wakeups — lets same-process tail readers follow without polling; the DB
+ * remains the durable source of truth, so a cross-instance reader falls back to
+ * polling it.
  *
  * This is the seam #750 replaces with a sandbox-side detached runner: the
  * contract is exactly "append the turn's chunks to the log under (sessionId,
@@ -23,10 +27,7 @@
  */
 import { EventEmitter } from "node:events";
 import type { DatabaseHandle } from "../db/client";
-import {
-	claimNextQueuedMessage,
-	releaseClaimedQueuedMessage,
-} from "../db/queued-messages";
+import { claimAndStartQueuedTurn } from "../db/queued-messages";
 import { getRepo } from "../db/repos";
 import {
 	appendEvents,
@@ -142,6 +143,32 @@ export async function startTurn(
 	const userSeq = await appendEvents(handle, session.id, [
 		{ role: "user", chunk: { type: "text", content: userText } },
 	]);
+	return startTurnFromAppendedUserEvent(
+		handle,
+		session,
+		userText,
+		userSeq,
+		provider,
+		repo,
+	);
+}
+
+/**
+ * Starts a detached provider turn from a user event that has already been
+ * appended. Queue dispatch uses this after its atomic claim+append transaction:
+ * the provider launches only after the transaction commits, from the exact seq
+ * the transaction returned.
+ */
+export async function startTurnFromAppendedUserEvent(
+	handle: DatabaseHandle,
+	session: Session,
+	userText: string,
+	userSeq: number,
+	provider: ComputeProvider = getProvider(session.provider),
+	resolvedRepo?: TurnRepo | null,
+): Promise<StartedTurn> {
+	const repo =
+		resolvedRepo === undefined ? await resolveTurnRepo(handle, session) : resolvedRepo;
 	// Auto-title (#823): runs on every turn, not just conditionally "the
 	// first" — `titleSessionIfEmpty`'s atomic `WHERE title = ''` is what
 	// actually enforces "only once", so a first message that derives no
@@ -202,7 +229,14 @@ export async function startTurn(
 			}
 			try {
 				const next = await startNextQueuedTurn(handle, session.id);
-				if (next) await next.ingest;
+				if (next) {
+					void next.ingest.catch((error) => {
+						console.error(
+							`[turn-ingest] queued turn ingest failed for ${session.id}`,
+							error,
+						);
+					});
+				}
 			} catch (error) {
 				console.error(
 					`[turn-ingest] queued turn continuation failed for ${session.id}`,
@@ -232,19 +266,16 @@ export async function startNextQueuedTurn(
 	sessionId: string,
 ): Promise<StartedTurn | null> {
 	if (activeTurns.has(sessionId)) return null;
-	const queued = await claimNextQueuedMessage(handle, sessionId);
-	if (!queued) return null;
+	const claimed = await claimAndStartQueuedTurn(handle, sessionId);
+	if (!claimed) return null;
 	const session = await getSession(handle, sessionId);
-	if (!session) {
-		await releaseClaimedQueuedMessage(handle, queued);
-		return null;
-	}
-	try {
-		return await startTurn(handle, session, queued.text);
-	} catch (error) {
-		await releaseClaimedQueuedMessage(handle, queued);
-		throw error;
-	}
+	if (!session) return null;
+	return startTurnFromAppendedUserEvent(
+		handle,
+		session,
+		claimed.queued.text,
+		claimed.userSeq,
+	);
 }
 
 async function emitTurnCompletionNotification(

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -85,6 +85,24 @@ export interface SessionEventsTable {
 }
 
 /**
+ * Durable mid-turn steering queue (#984). Rows live outside session_events so
+ * the in-flight turn's ingest loop remains the only writer to the transcript;
+ * a queued row becomes a normal user event only when it is claimed for the next
+ * turn.
+ */
+export interface QueuedMessagesTable {
+	session_id: string;
+	/** Stable client-facing id for canceling or reconciling this queued send. */
+	queue_id: string;
+	text: string;
+	queued_at: string;
+	/** Set just before the queued row is dispatched through startTurn. */
+	dispatched_at: string | null;
+	/** Set when the user cancels a not-yet-dispatched row. */
+	canceled_at: string | null;
+}
+
+/**
  * Single-use, short-TTL terminal access tickets (#752): issued by the
  * authenticated mint route and redeemed exactly once, binding a login +
  * session to one sandbox attach. Only the SHA-256 of the ticket is stored;
@@ -127,6 +145,7 @@ export interface Database {
 	repos: ReposTable;
 	sessions: SessionsTable;
 	session_events: SessionEventsTable;
+	queued_messages: QueuedMessagesTable;
 	terminal_tickets: TerminalTicketsTable;
 	turn_approvals: TurnApprovalsTable;
 }

--- a/web-next/src/lib/db/client.ts
+++ b/web-next/src/lib/db/client.ts
@@ -11,7 +11,7 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { type Client, createClient } from "@libsql/client";
-import { Kysely } from "kysely";
+import { type Generated, Kysely } from "kysely";
 import type { ApprovalDecision, ApprovalResolvedBy } from "../agent-runtime/stream-chunk";
 import type { ApprovalPolicy } from "../agent-runtime/approval-policy";
 import { resolveSessionsDatabaseUrl } from "../local-data-dir";
@@ -91,6 +91,8 @@ export interface SessionEventsTable {
  * turn.
  */
 export interface QueuedMessagesTable {
+	/** Monotonic insertion order for strict FIFO dispatch. */
+	id: Generated<number>;
 	session_id: string;
 	/** Stable client-facing id for canceling or reconciling this queued send. */
 	queue_id: string;

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -346,6 +346,71 @@ const queuedMessages: Migration = {
 	},
 };
 
+/**
+ * Adds a monotonic queue insertion key. `queued_at` can tie for two sends in
+ * the same millisecond; `id` is the durable FIFO order the dispatcher uses.
+ */
+const queuedMessageDispatchOrder: Migration = {
+	id: "0010_queued_message_dispatch_order",
+	async up(db) {
+		const info = await sql<{
+			name: string;
+		}>`PRAGMA table_info(queued_messages)`.execute(db);
+		const hasId = info.rows.some((row) => row.name === "id");
+		if (!hasId) {
+			await db.transaction().execute(async (trx) => {
+				await sql`
+					CREATE TABLE queued_messages_next (
+						id INTEGER PRIMARY KEY AUTOINCREMENT,
+						session_id TEXT NOT NULL,
+						queue_id TEXT NOT NULL,
+						text TEXT NOT NULL,
+						queued_at TEXT NOT NULL,
+						dispatched_at TEXT,
+						canceled_at TEXT,
+						UNIQUE(session_id, queue_id)
+					)
+				`.execute(trx);
+				await sql`
+					INSERT INTO queued_messages_next (
+						session_id,
+						queue_id,
+						text,
+						queued_at,
+						dispatched_at,
+						canceled_at
+					)
+					SELECT
+						session_id,
+						queue_id,
+						text,
+						queued_at,
+						dispatched_at,
+						canceled_at
+					FROM queued_messages
+					ORDER BY queued_at ASC, queue_id ASC
+				`.execute(trx);
+				await sql`DROP TABLE queued_messages`.execute(trx);
+				await sql`ALTER TABLE queued_messages_next RENAME TO queued_messages`.execute(
+					trx,
+				);
+			});
+		}
+		await db.schema
+			.createIndex("idx_queued_messages_session_order")
+			.ifNotExists()
+			.on("queued_messages")
+			.columns(["session_id", "id"])
+			.execute();
+		await db.schema
+			.createIndex("idx_queued_messages_session_queue_id")
+			.ifNotExists()
+			.on("queued_messages")
+			.columns(["session_id", "queue_id"])
+			.execute();
+	},
+};
+
 export const MIGRATIONS: Migration[] = [
 	baseline,
 	authTables,
@@ -356,4 +421,5 @@ export const MIGRATIONS: Migration[] = [
 	sessionFirstUserMessage,
 	turnApprovals,
 	queuedMessages,
+	queuedMessageDispatchOrder,
 ];

--- a/web-next/src/lib/db/migrations.ts
+++ b/web-next/src/lib/db/migrations.ts
@@ -318,6 +318,34 @@ const turnApprovals: Migration = {
 	},
 };
 
+/**
+ * Adds `queued_messages` (#984): durable mid-turn steering text that must not
+ * enter `session_events` until the running turn has closed and the row is
+ * claimed for dispatch as the next turn.
+ */
+const queuedMessages: Migration = {
+	id: "0009_queued_messages",
+	async up(db) {
+		await db.schema
+			.createTable("queued_messages")
+			.ifNotExists()
+			.addColumn("session_id", "text", (c) => c.notNull())
+			.addColumn("queue_id", "text", (c) => c.notNull())
+			.addColumn("text", "text", (c) => c.notNull())
+			.addColumn("queued_at", "text", (c) => c.notNull())
+			.addColumn("dispatched_at", "text")
+			.addColumn("canceled_at", "text")
+			.addPrimaryKeyConstraint("queued_messages_pk", ["session_id", "queue_id"])
+			.execute();
+		await db.schema
+			.createIndex("idx_queued_messages_session_queued_at")
+			.ifNotExists()
+			.on("queued_messages")
+			.columns(["session_id", "queued_at"])
+			.execute();
+	},
+};
+
 export const MIGRATIONS: Migration[] = [
 	baseline,
 	authTables,
@@ -327,4 +355,5 @@ export const MIGRATIONS: Migration[] = [
 	sessionOwnerLogin,
 	sessionFirstUserMessage,
 	turnApprovals,
+	queuedMessages,
 ];

--- a/web-next/src/lib/db/queued-messages.ts
+++ b/web-next/src/lib/db/queued-messages.ts
@@ -1,0 +1,208 @@
+/*
+ * Durable steering queue for mid-turn sends. Queued rows are intentionally not
+ * transcript events: the ingest loop remains the single writer to
+ * session_events, and claiming a row is the moment it becomes the next turn's
+ * normal user event through startTurn.
+ */
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type { DatabaseHandle, QueuedMessagesTable } from "./client";
+import { ensureSchema } from "./schema";
+
+export interface QueuedMessage {
+	sessionId: string;
+	queueId: string;
+	text: string;
+	queuedAt: string;
+	dispatchedAt: string | null;
+	canceledAt: string | null;
+	position: number;
+}
+
+export type CancelQueuedMessageResult = "canceled" | "not_found" | "dispatched";
+
+const queueBus = new EventEmitter();
+queueBus.setMaxListeners(0);
+
+function isSqliteBusy(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const code = "code" in error ? error.code : undefined;
+	return error.message.includes("SQLITE_BUSY") || code === "SQLITE_BUSY";
+}
+
+async function sleep(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withBusyRetry<T>(operation: () => Promise<T>): Promise<T> {
+	let lastError: unknown;
+	for (let attempt = 0; attempt < 6; attempt += 1) {
+		try {
+			return await operation();
+		} catch (error) {
+			if (!isSqliteBusy(error)) throw error;
+			lastError = error;
+			await sleep(25 * 2 ** attempt);
+		}
+	}
+	throw lastError;
+}
+
+export function notifyQueueChanged(sessionId: string): void {
+	queueBus.emit(sessionId);
+}
+
+export function subscribeQueueChanged(
+	sessionId: string,
+	onChange: () => void,
+): () => void {
+	queueBus.on(sessionId, onChange);
+	return () => queueBus.off(sessionId, onChange);
+}
+
+function rowToQueuedMessage(
+	row: QueuedMessagesTable,
+	position: number,
+): QueuedMessage {
+	return {
+		sessionId: row.session_id,
+		queueId: row.queue_id,
+		text: row.text,
+		queuedAt: row.queued_at,
+		dispatchedAt: row.dispatched_at,
+		canceledAt: row.canceled_at,
+		position,
+	};
+}
+
+export async function enqueueMessage(
+	handle: DatabaseHandle,
+	sessionId: string,
+	text: string,
+): Promise<QueuedMessage> {
+	await ensureSchema(handle);
+	const row: QueuedMessagesTable = {
+		session_id: sessionId,
+		queue_id: randomUUID(),
+		text,
+		queued_at: new Date().toISOString(),
+		dispatched_at: null,
+		canceled_at: null,
+	};
+	await withBusyRetry(() =>
+		handle.db.insertInto("queued_messages").values(row).execute(),
+	);
+	const active = await listQueuedMessages(handle, sessionId);
+	notifyQueueChanged(sessionId);
+	return (
+		active.find((message) => message.queueId === row.queue_id) ??
+		rowToQueuedMessage(row, active.length)
+	);
+}
+
+export async function listQueuedMessages(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<QueuedMessage[]> {
+	await ensureSchema(handle);
+	const rows = await withBusyRetry(() =>
+		handle.db
+			.selectFrom("queued_messages")
+			.selectAll()
+			.where("session_id", "=", sessionId)
+			.where("dispatched_at", "is", null)
+			.where("canceled_at", "is", null)
+			.orderBy("queued_at", "asc")
+			.orderBy("queue_id", "asc")
+			.execute(),
+	);
+	return rows.map((row, index) => rowToQueuedMessage(row, index + 1));
+}
+
+export async function claimNextQueuedMessage(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<QueuedMessage | null> {
+	await ensureSchema(handle);
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		const row = await withBusyRetry(() =>
+			handle.db
+				.selectFrom("queued_messages")
+				.selectAll()
+				.where("session_id", "=", sessionId)
+				.where("dispatched_at", "is", null)
+				.where("canceled_at", "is", null)
+				.orderBy("queued_at", "asc")
+				.orderBy("queue_id", "asc")
+				.limit(1)
+				.executeTakeFirst(),
+		);
+		if (!row) return null;
+
+		const dispatchedAt = new Date().toISOString();
+		const result = await withBusyRetry(() =>
+			handle.db
+				.updateTable("queued_messages")
+				.set({ dispatched_at: dispatchedAt })
+				.where("session_id", "=", sessionId)
+				.where("queue_id", "=", row.queue_id)
+				.where("dispatched_at", "is", null)
+				.where("canceled_at", "is", null)
+				.execute(),
+		);
+		if (Number(result[0]?.numUpdatedRows ?? 0) === 0) continue;
+		notifyQueueChanged(sessionId);
+		return rowToQueuedMessage({ ...row, dispatched_at: dispatchedAt }, 1);
+	}
+	return null;
+}
+
+export async function releaseClaimedQueuedMessage(
+	handle: DatabaseHandle,
+	message: Pick<QueuedMessage, "sessionId" | "queueId">,
+): Promise<void> {
+	await ensureSchema(handle);
+	await withBusyRetry(() =>
+		handle.db
+			.updateTable("queued_messages")
+			.set({ dispatched_at: null })
+			.where("session_id", "=", message.sessionId)
+			.where("queue_id", "=", message.queueId)
+			.where("canceled_at", "is", null)
+			.execute(),
+	);
+	notifyQueueChanged(message.sessionId);
+}
+
+export async function cancelQueuedMessage(
+	handle: DatabaseHandle,
+	sessionId: string,
+	queueId: string,
+): Promise<CancelQueuedMessageResult> {
+	await ensureSchema(handle);
+	const canceledAt = new Date().toISOString();
+	const result = await withBusyRetry(() =>
+		handle.db
+			.updateTable("queued_messages")
+			.set({ canceled_at: canceledAt })
+			.where("session_id", "=", sessionId)
+			.where("queue_id", "=", queueId)
+			.where("dispatched_at", "is", null)
+			.where("canceled_at", "is", null)
+			.execute(),
+	);
+	if (Number(result[0]?.numUpdatedRows ?? 0) > 0) {
+		notifyQueueChanged(sessionId);
+		return "canceled";
+	}
+	const row = await withBusyRetry(() =>
+		handle.db
+			.selectFrom("queued_messages")
+			.select(["dispatched_at", "canceled_at"])
+			.where("session_id", "=", sessionId)
+			.where("queue_id", "=", queueId)
+			.executeTakeFirst(),
+	);
+	if (!row || row.canceled_at) return "not_found";
+	return row.dispatched_at ? "dispatched" : "not_found";
+}

--- a/web-next/src/lib/db/queued-messages.ts
+++ b/web-next/src/lib/db/queued-messages.ts
@@ -1,12 +1,13 @@
 /*
  * Durable steering queue for mid-turn sends. Queued rows are intentionally not
- * transcript events: the ingest loop remains the single writer to
- * session_events, and claiming a row is the moment it becomes the next turn's
- * normal user event through startTurn.
+ * transcript events while pending. Dispatch atomically marks the oldest row
+ * claimed and appends its normal user event to session_events, so there is no
+ * observable claimed-but-missing-from-the-log window.
  */
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import type { DatabaseHandle, QueuedMessagesTable } from "./client";
+import { sql, type Insertable, type Selectable, type Transaction } from "kysely";
+import type { Database, DatabaseHandle, QueuedMessagesTable } from "./client";
 import { ensureSchema } from "./schema";
 
 export interface QueuedMessage {
@@ -20,6 +21,27 @@ export interface QueuedMessage {
 }
 
 export type CancelQueuedMessageResult = "canceled" | "not_found" | "dispatched";
+
+type QueuedMessageRow = Selectable<QueuedMessagesTable>;
+
+export interface ClaimedQueuedTurn {
+	queued: QueuedMessage;
+	/** Seq of the user event appended in the same transaction as the claim. */
+	userSeq: number;
+	/** First assistant seq for the detached ingest/tail. */
+	fromSeq: number;
+}
+
+export type ImmediateTurnStart =
+	| {
+			kind: "started";
+			userSeq: number;
+			fromSeq: number;
+	  }
+	| {
+			kind: "queued";
+			queued: QueuedMessage;
+	  };
 
 const queueBus = new EventEmitter();
 queueBus.setMaxListeners(0);
@@ -48,6 +70,14 @@ async function withBusyRetry<T>(operation: () => Promise<T>): Promise<T> {
 	throw lastError;
 }
 
+let queueStartChain: Promise<unknown> = Promise.resolve();
+
+async function withSerializedQueueStart<T>(operation: () => Promise<T>): Promise<T> {
+	const run = queueStartChain.then(() => withBusyRetry(operation));
+	queueStartChain = run.catch(() => {});
+	return run;
+}
+
 export function notifyQueueChanged(sessionId: string): void {
 	queueBus.emit(sessionId);
 }
@@ -61,7 +91,7 @@ export function subscribeQueueChanged(
 }
 
 function rowToQueuedMessage(
-	row: QueuedMessagesTable,
+	row: QueuedMessageRow,
 	position: number,
 ): QueuedMessage {
 	return {
@@ -81,7 +111,7 @@ export async function enqueueMessage(
 	text: string,
 ): Promise<QueuedMessage> {
 	await ensureSchema(handle);
-	const row: QueuedMessagesTable = {
+	const row: Insertable<QueuedMessagesTable> = {
 		session_id: sessionId,
 		queue_id: randomUUID(),
 		text,
@@ -94,10 +124,9 @@ export async function enqueueMessage(
 	);
 	const active = await listQueuedMessages(handle, sessionId);
 	notifyQueueChanged(sessionId);
-	return (
-		active.find((message) => message.queueId === row.queue_id) ??
-		rowToQueuedMessage(row, active.length)
-	);
+	const inserted = active.find((message) => message.queueId === row.queue_id);
+	if (!inserted) throw new Error("queued message insert was not readable");
+	return inserted;
 }
 
 export async function listQueuedMessages(
@@ -112,66 +141,111 @@ export async function listQueuedMessages(
 			.where("session_id", "=", sessionId)
 			.where("dispatched_at", "is", null)
 			.where("canceled_at", "is", null)
-			.orderBy("queued_at", "asc")
-			.orderBy("queue_id", "asc")
+			.orderBy("id", "asc")
 			.execute(),
 	);
 	return rows.map((row, index) => rowToQueuedMessage(row, index + 1));
 }
 
-export async function claimNextQueuedMessage(
+/**
+ * Opens a direct POST turn when the session log and queue are both idle;
+ * otherwise enqueues the new text behind whatever is already running/pending.
+ *
+ * This is the direct-send half of the #984 serialization boundary. The
+ * running-turn check, pending-queue check, and either user-event append or
+ * queue insert share one transaction, so a queued continuation cannot race a
+ * direct POST into reordering the session.
+ */
+export async function appendImmediateTurnOrQueue(
 	handle: DatabaseHandle,
 	sessionId: string,
-): Promise<QueuedMessage | null> {
+	text: string,
+): Promise<ImmediateTurnStart> {
 	await ensureSchema(handle);
-	for (let attempt = 0; attempt < 3; attempt += 1) {
-		const row = await withBusyRetry(() =>
-			handle.db
+	const result = await withSerializedQueueStart(() =>
+		handle.db.transaction().execute(async (trx) => {
+			const hasOpen = await hasOpenTurn(trx, sessionId);
+			const pendingCount = await countPendingMessages(trx, sessionId);
+			if (hasOpen || pendingCount > 0) {
+				const queued = await insertQueuedMessageInTransaction(
+					trx,
+					sessionId,
+					text,
+					pendingCount + 1,
+				);
+				return { kind: "queued" as const, queued };
+			}
+			const now = new Date().toISOString();
+			const userSeq = await appendUserTextEventInTransaction(
+				trx,
+				sessionId,
+				text,
+				now,
+			);
+			return { kind: "started" as const, userSeq, fromSeq: userSeq + 1 };
+		}),
+	);
+	if (result.kind === "queued") notifyQueueChanged(sessionId);
+	return result;
+}
+
+/**
+ * Atomically claims the oldest pending row and appends its user event.
+ * Returning a result means the queue row is dispatched and visible in
+ * session_events; returning null means no row was claimable because the session
+ * had an open turn or an empty queue.
+ */
+export async function claimAndStartQueuedTurn(
+	handle: DatabaseHandle,
+	sessionId: string,
+): Promise<ClaimedQueuedTurn | null> {
+	await ensureSchema(handle);
+	const claimed = await withSerializedQueueStart(() =>
+		handle.db.transaction().execute(async (trx) => {
+			const session = await trx
+				.selectFrom("sessions")
+				.select("id")
+				.where("id", "=", sessionId)
+				.executeTakeFirst();
+			if (!session) return null;
+			if (await hasOpenTurn(trx, sessionId)) return null;
+			const row = await trx
 				.selectFrom("queued_messages")
 				.selectAll()
 				.where("session_id", "=", sessionId)
 				.where("dispatched_at", "is", null)
 				.where("canceled_at", "is", null)
-				.orderBy("queued_at", "asc")
-				.orderBy("queue_id", "asc")
+				.orderBy("id", "asc")
 				.limit(1)
-				.executeTakeFirst(),
-		);
-		if (!row) return null;
+				.executeTakeFirst();
+			if (!row) return null;
 
-		const dispatchedAt = new Date().toISOString();
-		const result = await withBusyRetry(() =>
-			handle.db
+			const dispatchedAt = new Date().toISOString();
+			const updated = await trx
 				.updateTable("queued_messages")
 				.set({ dispatched_at: dispatchedAt })
+				.where("id", "=", row.id)
 				.where("session_id", "=", sessionId)
-				.where("queue_id", "=", row.queue_id)
 				.where("dispatched_at", "is", null)
 				.where("canceled_at", "is", null)
-				.execute(),
-		);
-		if (Number(result[0]?.numUpdatedRows ?? 0) === 0) continue;
-		notifyQueueChanged(sessionId);
-		return rowToQueuedMessage({ ...row, dispatched_at: dispatchedAt }, 1);
-	}
-	return null;
-}
+				.execute();
+			if (Number(updated[0]?.numUpdatedRows ?? 0) === 0) return null;
 
-export async function releaseClaimedQueuedMessage(
-	handle: DatabaseHandle,
-	message: Pick<QueuedMessage, "sessionId" | "queueId">,
-): Promise<void> {
-	await ensureSchema(handle);
-	await withBusyRetry(() =>
-		handle.db
-			.updateTable("queued_messages")
-			.set({ dispatched_at: null })
-			.where("session_id", "=", message.sessionId)
-			.where("queue_id", "=", message.queueId)
-			.where("canceled_at", "is", null)
-			.execute(),
+			const userSeq = await appendUserTextEventInTransaction(
+				trx,
+				sessionId,
+				row.text,
+				dispatchedAt,
+			);
+			return {
+				queued: rowToQueuedMessage({ ...row, dispatched_at: dispatchedAt }, 1),
+				userSeq,
+				fromSeq: userSeq + 1,
+			};
+		}),
 	);
-	notifyQueueChanged(message.sessionId);
+	if (claimed) notifyQueueChanged(sessionId);
+	return claimed;
 }
 
 export async function cancelQueuedMessage(
@@ -205,4 +279,108 @@ export async function cancelQueuedMessage(
 	);
 	if (!row || row.canceled_at) return "not_found";
 	return row.dispatched_at ? "dispatched" : "not_found";
+}
+
+async function hasOpenTurn(
+	trx: Transaction<Database>,
+	sessionId: string,
+): Promise<boolean> {
+	const lastUser = await trx
+		.selectFrom("session_events")
+		.select("seq")
+		.where("session_id", "=", sessionId)
+		.where("role", "=", "user")
+		.orderBy("seq", "desc")
+		.limit(1)
+		.executeTakeFirst();
+	if (!lastUser) return false;
+	const done = await trx
+		.selectFrom("session_events")
+		.select("seq")
+		.where("session_id", "=", sessionId)
+		.where("seq", ">=", lastUser.seq + 1)
+		.where("role", "=", "assistant")
+		.where("kind", "=", "done")
+		.limit(1)
+		.executeTakeFirst();
+	return !done;
+}
+
+async function countPendingMessages(
+	trx: Transaction<Database>,
+	sessionId: string,
+): Promise<number> {
+	const count = await trx
+		.selectFrom("queued_messages")
+		.select(({ fn }) => fn.countAll().as("count"))
+		.where("session_id", "=", sessionId)
+		.where("dispatched_at", "is", null)
+		.where("canceled_at", "is", null)
+		.executeTakeFirst();
+	return Number(count?.count ?? 0);
+}
+
+async function insertQueuedMessageInTransaction(
+	trx: Transaction<Database>,
+	sessionId: string,
+	text: string,
+	position: number,
+): Promise<QueuedMessage> {
+	const row: Insertable<QueuedMessagesTable> = {
+		session_id: sessionId,
+		queue_id: randomUUID(),
+		text,
+		queued_at: new Date().toISOString(),
+		dispatched_at: null,
+		canceled_at: null,
+	};
+	await trx.insertInto("queued_messages").values(row).execute();
+	const inserted = await trx
+		.selectFrom("queued_messages")
+		.selectAll()
+		.where("session_id", "=", sessionId)
+		.where("queue_id", "=", row.queue_id)
+		.executeTakeFirst();
+	if (!inserted) throw new Error("queued message insert was not readable");
+	return rowToQueuedMessage(inserted, position);
+}
+
+async function appendUserTextEventInTransaction(
+	trx: Transaction<Database>,
+	sessionId: string,
+	text: string,
+	now: string,
+): Promise<number> {
+	const max = await trx
+		.selectFrom("session_events")
+		.select(({ fn }) => fn.max("seq").as("maxSeq"))
+		.where("session_id", "=", sessionId)
+		.executeTakeFirst();
+	const seq = Number(max?.maxSeq ?? 0) + 1;
+	await trx
+		.insertInto("session_events")
+		.values({
+			session_id: sessionId,
+			seq,
+			role: "user",
+			kind: "text",
+			payload: JSON.stringify({ type: "text", content: text }),
+			created_at: now,
+		})
+		.execute();
+	await trx
+		.updateTable("sessions")
+		.set({ last_activity_at: now })
+		.where("id", "=", sessionId)
+		.execute();
+	const firstUserMessage = text.trim();
+	if (firstUserMessage) {
+		await trx
+			.updateTable("sessions")
+			.set({ first_user_message: firstUserMessage })
+			.where("id", "=", sessionId)
+			.where(sql<boolean>`first_user_message is null`)
+			.execute();
+	}
+	return seq;
 }

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -62,6 +62,7 @@ describe("session store", () => {
 			"0007_session_first_user_message",
 			"0008_turn_approvals",
 			"0009_queued_messages",
+			"0010_queued_message_dispatch_order",
 		]);
 	});
 

--- a/web-next/src/lib/db/sessions.test.ts
+++ b/web-next/src/lib/db/sessions.test.ts
@@ -61,6 +61,7 @@ describe("session store", () => {
 			"0006_session_owner_login",
 			"0007_session_first_user_message",
 			"0008_turn_approvals",
+			"0009_queued_messages",
 		]);
 	});
 

--- a/web-next/src/lib/db/sessions.ts
+++ b/web-next/src/lib/db/sessions.ts
@@ -191,6 +191,7 @@ export async function deleteSession(
 	await ensureSchema(handle);
 	return handle.db.transaction().execute(async (trx) => {
 		await trx.deleteFrom("session_events").where("session_id", "=", id).execute();
+		await trx.deleteFrom("queued_messages").where("session_id", "=", id).execute();
 		await trx.deleteFrom("terminal_tickets").where("session_id", "=", id).execute();
 		await trx.deleteFrom("turn_approvals").where("session_id", "=", id).execute();
 		const result = await trx.deleteFrom("sessions").where("id", "=", id).execute();

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -200,14 +200,14 @@ test("sending a message streams a mock coding turn into the Folio transcript", a
 	await compose.fill("Fix the failing session test");
 	await page.keyboard.press("Enter");
 
-	// The user message lands at once; compose clears and holds while busy —
-	// the send affordance becomes the stop control for the in-flight turn (#753).
+	// The user message lands at once; compose clears while busy. Send remains
+	// live for mid-turn steering (#984), with Stop beside it (#753).
 	await expect(page.locator('[data-message-role="user"]')).toContainText(
 		"Fix the failing session test",
 	);
 	await expect(page.getByTestId("empty-transcript")).toHaveCount(0);
 	await expect(compose).toHaveValue("");
-	await expect(page.getByRole("button", { name: "Send" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
 	await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
 
 	// The activity line breathes while the provider provisions.
@@ -386,6 +386,66 @@ test("a turn survives a mid-stream reload and resumes to completion", async ({
 	await expect(page.getByTestId("tool-row")).toHaveCount(8);
 	// Nothing is in flight once the resumed turn completes.
 	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+});
+
+test("sending during a running turn queues, then auto-dispatches as the next turn (#984)", async ({
+	page,
+}) => {
+	await createSessionForRepo(page);
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await compose.fill("First steering turn");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("activity-line")).toBeVisible();
+
+	await compose.fill("Queue this next");
+	await page.keyboard.press("Enter");
+
+	const queued = page.getByTestId("queued-message");
+	await expect(queued).toContainText("queued");
+	await expect(queued).toContainText("Queue this next");
+	await expect(compose).toHaveValue("");
+	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
+	await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+	await expect(queued).toHaveCount(0, { timeout: TURN_TIMEOUT });
+	const userMessages = page.locator('[data-message-role="user"]');
+	await expect(userMessages).toHaveCount(2, { timeout: TURN_TIMEOUT });
+	await expect(userMessages.nth(0)).toContainText("First steering turn");
+	await expect(userMessages.nth(1)).toContainText("Queue this next");
+	await expect(page.getByTestId("turn-stats")).toHaveCount(2, {
+		timeout: TURN_TIMEOUT * 2,
+	});
+	await expect(page.getByTestId("activity-line")).toHaveCount(0);
+});
+
+test("reload preserves queued bubbles and cancel removes an undispatched row (#984)", async ({
+	page,
+}) => {
+	await createSessionForRepo(page);
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await compose.fill("Turn with reloadable queue");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("activity-line")).toBeVisible();
+
+	await compose.fill("Cancel me after reload");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("queued-message")).toContainText(
+		"Cancel me after reload",
+	);
+
+	await page.reload();
+	const queued = page.getByTestId("queued-message");
+	await expect(queued).toContainText("Cancel me after reload");
+	await queued.getByRole("button", { name: /Cancel queued message/ }).click();
+	await expect(page.getByTestId("queued-message")).toHaveCount(0);
+
+	await expect(page.getByTestId("turn-stats")).toHaveCount(1, {
+		timeout: TURN_TIMEOUT,
+	});
+	await expect(page.locator('[data-message-role="user"]')).toHaveCount(1);
+	await expect(page.locator('[data-message-role="user"]')).not.toContainText(
+		"Cancel me after reload",
+	);
 });
 
 test("closing the tab mid-turn does not kill it — a fresh tab catches up", async ({


### PR DESCRIPTION
## What

Mid-turn steering (#984, W6): compose stays live while a turn runs. A message sent mid-turn queues durably (`queued_messages`, migration `0009`), renders as a quiet pending bubble with a cancel control, and dispatches as the next turn the moment the running one completes — the biggest feel gap vs. daily-driver Claude Code, closed.

The concurrency spine, post-review: **claim-and-append is one DB transaction** — verify the log is idle, claim the oldest row, append its user event, all atomically — so there is no observable state where a message is claimed but has no turn, and no window where two dispatchers (ingest continuation, session-GET sweep, direct POST) can start concurrent turns. Direct sends behind a pending queue enqueue instead of jumping the line. FIFO rides an autoincrement key, not timestamps. `session_events` stays single-writer throughout. The `after()` continuation holds only the current turn (bounded); serverless recovery for later rows is the GET sweep + client pickup, documented in the seam.

## Process

codex (gpt-5.5, xhigh) implemented; the rebase over the merged #982/#986 (8 conflicted files, migration renumbered to 0009) was resolved by codex under explicit semantic-merge rules (approval guard fires before queueing; both UI surfaces coexist). Directed codex (xhigh) concurrency review found 2 blockers (row-atomic-but-not-session-atomic dispatch; unbounded after() chain with a stranded-claim window) + 1 should-fix (FIFO timestamp ties) — all fixed in an attributed hardening commit. Mutation checks: split the atomic claim+append → stranded-row test fails; drop the queue-order check on direct POST → ordering test fails; direct session_events write from enqueue → SQLITE_BUSY single-writer violation; LIFO claim → order test fails. All restored. Review explicitly cleared: cancel-vs-dispatch races, approval-pending interaction (queue drains after the turn settles, no wedge).

## Verification

- Unit 546 passed; typecheck; lint; clean build
- `E2E_PORT=3184 pnpm test:e2e`: 49 passed — queue → bubble → auto-dispatch → both turns in transcript; reload mid-queue; cancel

## Evidence

![steering-queued](https://evidence.cloudcompute.com/workspaces/pr-1018/20260709-005550-steering-queued.png)
![steering-dispatched](https://evidence.cloudcompute.com/workspaces/pr-1018/20260709-005550-steering-dispatched.png)

Closes #984

## Mergeability

- **Surface:** queued_messages table + db module, run-turn/turn-ingest dispatch seam, chat route (409→202 for running turns), queue cancel route, session GET sweep, compose/session-view queued bubbles.
- **Behavior changed:** send-while-running queues (202) instead of erroring (409); compose no longer disables mid-turn. Single-message sessions behave identically.
- **Non-happy paths:** cancel races dispatch safely (dispatched rows 409 on cancel); process death mid-dispatch leaves rows pending or fully dispatched, never invisible; ask-policy guard fires before any queue interaction.
- **Residual risk:** queue UI updates ride session refresh/reconnect rather than a live subscription (recorded; calm-bar acceptable); multi-instance dispatch serialization relies on the log-idle transaction check — same discipline as the rest of the durable-turn layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
