### PR TITLE
test(web-next): filmed hero-flow demo spec — real turn to draft PR

### DIFF
--- a/web-next/playwright.hero.config.ts
+++ b/web-next/playwright.hero.config.ts
@@ -1,0 +1,28 @@
+/*
+ * Playwright config for the video-recorded hero-flow demo (tests/demo/).
+ * Unlike the hermetic e2e suite, this expects an already-running server on
+ * HERO_DEMO_PORT (default 3200) wired to the REAL vercel compute provider —
+ * the run costs sandbox + model money and opens a real draft PR on GitHub.
+ * Video is always on; artifacts land under output/hero-demo/.
+ */
+import { defineConfig, devices } from "@playwright/test";
+import { E2E_LOGIN, signedInAs } from "./playwright.config";
+
+const PORT = Number(process.env.HERO_DEMO_PORT ?? 3200);
+
+export default defineConfig({
+	testDir: "./tests/demo",
+	timeout: 25 * 60_000,
+	retries: 0,
+	workers: 1,
+	reporter: [["list"]],
+	outputDir: "output/hero-demo/test-results",
+	use: {
+		...devices["Desktop Chrome"],
+		viewport: { width: 1280, height: 720 },
+		baseURL: `http://localhost:${PORT}`,
+		storageState: signedInAs(E2E_LOGIN),
+		video: { mode: "on", size: { width: 1280, height: 720 } },
+		trace: "off",
+	},
+});

--- a/web-next/tests/demo/hero-flow.spec.ts
+++ b/web-next/tests/demo/hero-flow.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * The hero flow, filmed: home → new session on a real repo → a real
+ * vercel-sandbox agent turn → end-of-turn checkpoint → "Open PR" → the
+ * draft-PR masthead line. Runs only via playwright.hero.config.ts against
+ * a server on the real vercel provider; never part of the hermetic suite.
+ */
+import { expect, test } from "@playwright/test";
+
+const REPO = process.env.HERO_DEMO_REPO ?? "fairchild/workspaces";
+const TURN_TIMEOUT = 15 * 60_000;
+
+const PROMPT =
+	"Create a new file demos/web-next-hero-flow.md containing a short note " +
+	"(3-4 lines) saying this file was created by a live web-next hero-flow " +
+	"demo: a Playwright-driven browser session created this agent session, " +
+	"sent this message, and opened the pull request you are reading. " +
+	"Do not change anything else.";
+
+test("hero flow: new session → real agent turn → draft PR", async ({ page }) => {
+	await page.goto("/");
+	await page.waitForTimeout(1500);
+
+	const picker = page.getByTestId("new-session-picker");
+	if (!(await picker.isVisible())) {
+		await page.getByRole("button", { name: "+ new session" }).click();
+	}
+	const repoInput = page.getByRole("textbox", { name: "Repository (owner/name)" });
+	await repoInput.pressSequentially(REPO, { delay: 40 });
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(/\/sessions\/[0-9a-f-]{36}$/);
+
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await compose.click();
+	await compose.pressSequentially(PROMPT, { delay: 6 });
+	await page.waitForTimeout(500);
+	await page.getByRole("button", { name: "Send" }).click();
+
+	// The real turn: sandbox provisioning, clone, the agent's edit, and the
+	// end-of-turn checkpoint commit + push.
+	await expect(page.getByTestId("turn-stats")).toBeVisible({
+		timeout: TURN_TIMEOUT,
+	});
+	await page.waitForTimeout(2500);
+
+	// has_branch_work is server-rendered into the masthead action; reload
+	// until the checkpoint has landed and the affordance arms.
+	const openPr = page.getByTestId("open-session-pr");
+	await expect(async () => {
+		await page.reload();
+		await expect(openPr).toBeEnabled({ timeout: 5_000 });
+	}).toPass({ timeout: 3 * 60_000, intervals: [5_000] });
+	await page.waitForTimeout(1500);
+	await openPr.click();
+
+	const prLine = page.getByTestId("session-pr-line");
+	await expect(prLine).toContainText(/PR #\d+/, { timeout: 5 * 60_000 });
+	const href = await prLine.getByRole("link").first().getAttribute("href");
+	console.log(`HERO_DEMO_PR_URL=${href}`);
+	await page.waitForTimeout(5000);
+});


### PR DESCRIPTION
## Summary

Adds the video-recorded hero-flow demo as a keeper: `web-next/playwright.hero.config.ts` (video always on, `tests/demo/`, port 3200, storage-state reuse from the main config) plus one spec that drives the full daily-driver loop against the **real** vercel provider — new session on a real repo → live agent turn → end-of-turn checkpoint → **Open PR** → draft PR on GitHub.

It costs sandbox + model money and opens a real PR, so it never runs in the hermetic suite: the main e2e config's `testDir` is `tests/e2e/` and vitest's include globs don't reach `tests/demo/`. Run it explicitly with a server wired to real credentials:

```bash
pnpm exec playwright test --config playwright.hero.config.ts
```

This is a first installment on the live-flow validation debt noted in #1014 (PR-from-session's real flow had no automated exercise).

## Evidence

Filmed run (1 passed, 55s; produced and then closed real draft PR #1024, branch deleted):

![hero-flow-demo](https://evidence.cloudcompute.com/workspaces/pr-1024/20260709-024027-hero-flow-demo.gif)

- [Demo PR #1024 — opened by the filmed session, closed as the final step](https://github.com/fairchild/workspaces/pull/1024)
- Gates (bare): `pnpm typecheck` 0, `pnpm lint` 0

## Mergeability

- **Surface**: web-next test tooling only — one new Playwright config + one spec under `tests/demo/`; no app code, no CI wiring.
- **Behavior changed**: none at runtime; adds an explicitly-invoked demo/validation lane.
- **Non-happy paths**: spec reload-polls for the checkpoint (`toPass` over 3m) and bounds the real turn at 15m; a failed run leaves only a session row in the throwaway demo DB and possibly an unclicked PR affordance — nothing on GitHub until the Open PR click succeeds.
- **Residual risk**: selector drift against future masthead/composer changes — surfaced only when the demo lane is run; acceptable for an explicitly-invoked spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)