### PR TITLE
docs(web-next): embedded-native contract for #987 — spawn, readiness, token, deep-links

### DIFF
--- a/web-next/docs/decisions/embedded-native-contract.md
+++ b/web-next/docs/decisions/embedded-native-contract.md
@@ -1,0 +1,82 @@
+# Contract: native embedding of local-mode web-next (#987)
+
+- Status: **Proposed** (2026-07-09; acceptance = owner merge)
+- Parent decision: `host-compute-daily-driver.md` — this file makes its
+  "boundary crossing via contract, not reach-in" concrete.
+- Parties: the workspaces native app (consumer, `Sources/`) and web-next
+  (provider, `web-next/`). Neither side imports from or writes into the other;
+  everything below travels over process spawn, the filesystem token file, and
+  loopback HTTP.
+
+## 1. Spawn
+
+The app launches web-next by running **`pnpm run start:local`** with:
+
+- `cwd` = the web-next root, an app setting (Milestone 1 demo default:
+  `~/code/workspaces/web-next`; packaging web-next into the app bundle is out
+  of scope here).
+- Env, set by the app: `PORT` (app-chosen loopback port, default **3140** —
+  clear of dev 3100 and hero 3200) and `WEB_NEXT_DATA_DIR` (an app-managed
+  directory, e.g. `~/Library/Application Support/WorkspaceManager/web-next/`).
+- Everything else — provider credentials, DB location under the data dir —
+  is web-next's own business: `start:local` loads `web-next/.env.local`
+  itself. The app never reads or writes `.env.local` or the SQLite files.
+
+Lifecycle is app-owned. `start:local` runs `next start` as a child without
+signal forwarding, so the app spawns the entrypoint **in its own process
+group and terminates the group** (SIGTERM, then SIGKILL after a grace
+period) on quit or restart. Crash/restart policy is the app's choice; the
+server holds no state that makes restarts unsafe (sessions live in the
+SQLite DB under the data dir).
+
+## 2. Readiness and auth handoff
+
+- **Readiness**: the app polls `GET http://127.0.0.1:<port>/api/healthz`
+  until it answers `200` with `{ "ok": true, "localMode": true }`. The
+  endpoint is unauthenticated and constant — it reveals nothing beyond
+  liveness. (Until healthz ships, any HTTP response on the port may be
+  treated as "up"; healthz is the contract.)
+- **Token**: after readiness, the app reads the minted bearer token from
+  `<WEB_NEXT_DATA_DIR>/local-sign-in-token` (created `0600` by
+  `src/lib/auth/local-token.ts`). The app holds it in memory only.
+- **Sign-in**: the app navigates its WKWebView to
+  `http://127.0.0.1:<port>/sign-in?token=<token>&redirect=<path>`.
+  Middleware validates the token (constant-time), sets the httpOnly local
+  session cookie, and 302s to `redirect` — which must be a relative path
+  (`/…`, not `//…`, no scheme); anything else falls back to `/`.
+
+## 3. Deep-link surface
+
+One URL creates work; everything else is ordinary navigation.
+
+- **`GET /new?repo=<owner>/<name>[&title=<text>]`** (authenticated):
+  validates the repo the same way the UI's create-session action does,
+  creates a session bound to it using the server's default compute provider,
+  and 302s to `/sessions/<id>`. Validation failures return a readable
+  4xx page, not a 500.
+- **`POST /api/sessions`** additionally accepts an optional
+  `repo: "<owner>/<name>"`, resolving it identically. Omitted → today's
+  repo-less behavior.
+- **Reserved for Milestone 2**: `path=<absolute working-copy path>` on both
+  surfaces, binding a host-provider session to an app-managed
+  workspace/worktree. Until implemented it is rejected with `400` and an
+  explicit "not yet supported" message — never silently ignored.
+- Existing per-session URLs (`/sessions/<id>`) are the app's re-entry points;
+  the app may persist and deep-link to them freely.
+
+## 4. Security invariants
+
+- Serving stays loopback-bound by construction (`-H 127.0.0.1` plus the
+  middleware Host-header check). The contract adds no listener and no new
+  unauthenticated surface beyond `healthz`.
+- The WKWebView allowlists navigation to `127.0.0.1:<port>` /
+  `localhost:<port>`; external links open in the default browser.
+- The token appears only in the initial sign-in navigation within the app's
+  own webview; it is never logged, never placed in a persisted URL.
+
+## 5. Milestone 1 scope notes
+
+Milestone 1 (usable embedded demo, real draft PR out) runs the **vercel
+provider** end to end: `/new?repo=…` → agent turn → the existing Open PR
+affordance. The host provider's write/PR lane and `path=` binding are
+Milestone 2 and change nothing above except un-reserving `path=`.

--- a/web-next/docs/decisions/host-compute-daily-driver.md
+++ b/web-next/docs/decisions/host-compute-daily-driver.md
@@ -71,6 +71,8 @@ Owner direction, recorded here as policy: **web-next work stays in
 - The **one sanctioned boundary crossing** is #987, and it crosses via a
   contract, not reach-in: the native app spawns the `start:local` entrypoint,
   passes a loopback port + minted token, and talks localhost HTTP/deep-links.
+  The concrete interface (spawn env, readiness, token handoff, deep-links) is
+  specified in `embedded-native-contract.md`.
   Native code never imports from or writes into `web-next/`; web-next never
   imports from `Sources/`. Native work lands in separate PRs on the desktop
   lane.


### PR DESCRIPTION
## Summary

C0 of the #987 embedded arc (Milestone 1, vercel-provider-first per owner direction): the concrete interface contract between the native app and local-mode web-next. Both implementation lanes (web-next session API slice, native server-supervisor slice) are being built against this document.

- New: `web-next/docs/decisions/embedded-native-contract.md` — spawn contract (`pnpm run start:local`, PORT/WEB_NEXT_DATA_DIR, app-owned process group), readiness (`/api/healthz`), token handoff (data-dir token file → `/sign-in?token&redirect`), deep-link surface (`GET /new?repo=…`, `POST /api/sessions` repo param, reserved `path=` for Milestone 2), security invariants.
- One-line pointer added to `host-compute-daily-driver.md` § Containment.

Part of #987

## Evidence

- Docs-only diff (two markdown files); no runtime surface.
- CI: [all checks green](https://github.com/fairchild/workspaces/actions/runs/28996267978) (docs-only: analyzers pass, build/evidence gates skipped by design per #1023)

Gate note: docs-only tier — full diff read by orchestrator (author), CI green on 196f84a8. Flipping ready and merging under delegated authority.

## Mergeability

- Surface: docs — web-next decision records (`web-next/docs/decisions/`)
- User-facing behavior changed: No — documentation only; the endpoints it specifies land in the W1/N1 implementation PRs.
- Non-happy paths considered: The contract itself specifies them (invalid redirect falls back to /, reserved path= rejected 400, process-group kill for the non-forwarding entrypoint); as a diff, the only risk is stale docs if implementation diverges — the implementing PRs are gated against this file.
- Residual risk or follow-up: Contract marked Proposed; acceptance = owner merge. Milestone 2 (host provider write/PR, path= binding) will amend § 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋