### PR TITLE
feat(core): WebNextServerService — supervise local-mode web-next (#987 N1)

### DIFF
--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -185,6 +185,15 @@ public protocol EventStreamServiceProtocol: Sendable {
     var lastDisconnectReason: StreamDisconnectReason { get async }
 }
 
+/// Supervision surface for the embedded local-mode web-next server. Views and
+/// tests inject this instead of the concrete actor.
+public protocol WebNextServerServiceProtocol: Sendable {
+    var state: WebNextServerState { get async }
+    func start() async
+    func stop() async
+    func signInURL(redirect: String?) async -> URL?
+}
+
 public protocol GitHubDeviceAuthProtocol: Sendable {
     func requestDeviceCode(scope: String) async throws -> DeviceCodeResponse
     func pollForToken(deviceCode: String, interval: Int) async throws -> GitHubAuthToken

--- a/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
@@ -1,0 +1,354 @@
+//
+//  WebNextServerService.swift
+//  WorkspaceManagerCore
+//
+//  Spawns and supervises the local-mode web-next server (`pnpm run start:local`)
+//  in its own process group, polls the port for readiness, and builds
+//  token-bearing sign-in URLs for the embedded web UI. The entrypoint does not
+//  forward signals to its `next start` child, so shutdown terminates the whole
+//  process group (SIGTERM → bounded grace → SIGKILL).
+//
+
+import Foundation
+
+// MARK: - State
+
+public enum WebNextServerState: Sendable, Equatable {
+    case idle
+    case starting
+    case ready(signInBaseURL: URL)
+    case failed(reason: String)
+
+    public var label: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .starting:
+            return "Starting"
+        case .ready:
+            return "Ready"
+        case .failed:
+            return "Failed"
+        }
+    }
+}
+
+// MARK: - Configuration
+
+/// The command that launches the server, injectable so tests can substitute a
+/// stub script and never require pnpm or a web-next checkout.
+public struct WebNextLaunchCommand: Sendable, Equatable {
+    public var executablePath: String
+    public var arguments: [String]
+
+    public init(executablePath: String, arguments: [String]) {
+        self.executablePath = executablePath
+        self.arguments = arguments
+    }
+
+    public static let `default` = WebNextLaunchCommand(
+        executablePath: "/usr/bin/env",
+        arguments: ["pnpm", "run", "start:local"]
+    )
+}
+
+public struct WebNextServerConfiguration: Sendable {
+    /// Checkout containing the web-next app; the launch command's working directory.
+    public var webNextRoot: URL
+    public var port: Int
+    /// App-managed directory passed as `WEB_NEXT_DATA_DIR`; the server creates
+    /// `local-sign-in-token` (0600) inside it once ready.
+    public var dataDir: URL
+    /// Where per-launch server logs (captured child stdout/stderr) are written.
+    public var logDirectory: URL
+    public var launchCommand: WebNextLaunchCommand
+    public var readinessTimeout: TimeInterval
+    public var readinessPollInterval: TimeInterval
+    /// How long `stop()` waits after SIGTERM before escalating to SIGKILL.
+    public var terminationGracePeriod: TimeInterval
+
+    public init(
+        webNextRoot: URL,
+        port: Int = 3140,
+        dataDir: URL? = nil,
+        logDirectory: URL? = nil,
+        launchCommand: WebNextLaunchCommand = .default,
+        readinessTimeout: TimeInterval = 30,
+        readinessPollInterval: TimeInterval = 0.5,
+        terminationGracePeriod: TimeInterval = 5
+    ) {
+        let resolvedDataDir = dataDir ?? Self.defaultDataDirectory()
+        self.webNextRoot = webNextRoot
+        self.port = port
+        self.dataDir = resolvedDataDir
+        self.logDirectory = logDirectory ?? resolvedDataDir.appendingPathComponent("logs", isDirectory: true)
+        self.launchCommand = launchCommand
+        self.readinessTimeout = readinessTimeout
+        self.readinessPollInterval = readinessPollInterval
+        self.terminationGracePeriod = terminationGracePeriod
+    }
+
+    public static func defaultDataDirectory(fileManager: FileManager = .default) -> URL {
+        let appSupport =
+            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return
+            appSupport
+            .appendingPathComponent("WorkspaceManager", isDirectory: true)
+            .appendingPathComponent("web-next", isDirectory: true)
+    }
+}
+
+// MARK: - Service
+
+public actor WebNextServerService: WebNextServerServiceProtocol {
+    public private(set) var state: WebNextServerState = .idle
+    /// Log file for the current (or most recent) launch, for the UI slice to surface.
+    public private(set) var logFileURL: URL?
+
+    private let configuration: WebNextServerConfiguration
+    private let urlSession: URLSession
+    private let fileManager: FileManager
+    private var processID: pid_t?
+    /// Bumped by every `start()`/`stop()`; in-flight readiness polls compare
+    /// against it so a superseded launch never overwrites current state.
+    private var generation: UInt64 = 0
+
+    private static let signInTokenFilename = "local-sign-in-token"
+
+    public init(
+        configuration: WebNextServerConfiguration,
+        urlSession: URLSession = .shared,
+        fileManager: FileManager = .default
+    ) {
+        self.configuration = configuration
+        self.urlSession = urlSession
+        self.fileManager = fileManager
+    }
+
+    public var baseURL: URL {
+        URL(string: "http://127.0.0.1:\(configuration.port)")!
+    }
+
+    // MARK: Lifecycle
+
+    /// Spawn the server and wait until it answers on the port or the readiness
+    /// timeout elapses. Returns immediately when already starting or ready.
+    public func start() async {
+        switch state {
+        case .starting, .ready:
+            return
+        case .idle, .failed:
+            break
+        }
+
+        generation &+= 1
+        let launchGeneration = generation
+        state = .starting
+
+        let pid: pid_t
+        do {
+            try prepareDirectories()
+            pid = try spawnServer()
+        } catch {
+            state = .failed(reason: "Failed to launch web-next server: \(error.localizedDescription)")
+            return
+        }
+        processID = pid
+
+        let deadline = Date().addingTimeInterval(configuration.readinessTimeout)
+        while Date() < deadline {
+            guard generation == launchGeneration else { return }
+
+            if processHasExited(pid) {
+                processID = nil
+                state = .failed(
+                    reason: "web-next server exited before becoming ready; see \(logFileURL?.path ?? "logs")"
+                )
+                return
+            }
+
+            if await serverAnswersHTTP() {
+                guard generation == launchGeneration else { return }
+                state = .ready(signInBaseURL: baseURL)
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: UInt64(configuration.readinessPollInterval * 1_000_000_000))
+        }
+
+        guard generation == launchGeneration else { return }
+        await terminateProcessGroup(pid)
+        processID = nil
+        state = .failed(
+            reason:
+                "Timed out after \(Int(configuration.readinessTimeout))s waiting for web-next on port \(configuration.port)."
+        )
+    }
+
+    /// Terminate the whole process group: SIGTERM, bounded grace, SIGKILL.
+    /// Idempotent — safe to call in any state, including mid-start.
+    public func stop() async {
+        generation &+= 1
+        let pid = processID
+        processID = nil
+        if let pid {
+            await terminateProcessGroup(pid)
+        }
+        state = .idle
+    }
+
+    // MARK: Sign-in
+
+    /// Sign-in URL carrying the server-minted bearer token, or nil while the
+    /// server is not ready or the token file has not been written yet. The
+    /// token stays in the returned URL only — it is never logged.
+    public func signInURL(redirect: String?) -> URL? {
+        guard case .ready(let signInBaseURL) = state else { return nil }
+        let tokenFileURL = configuration.dataDir.appendingPathComponent(Self.signInTokenFilename)
+        guard let rawToken = try? String(contentsOf: tokenFileURL, encoding: .utf8) else { return nil }
+        let token = rawToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { return nil }
+
+        var components = URLComponents(
+            url: signInBaseURL.appendingPathComponent("sign-in"),
+            resolvingAgainstBaseURL: false
+        )
+        var queryItems = [URLQueryItem(name: "token", value: token)]
+        if let redirect {
+            queryItems.append(URLQueryItem(name: "redirect", value: redirect))
+        }
+        components?.queryItems = queryItems
+        return components?.url
+    }
+
+    // MARK: Spawning
+
+    private func prepareDirectories() throws {
+        try fileManager.createDirectory(at: configuration.dataDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: configuration.logDirectory, withIntermediateDirectories: true)
+    }
+
+    private func spawnServer() throws -> pid_t {
+        let logURL = makeLogFileURL()
+        logFileURL = logURL
+
+        let logFD = open(logURL.path, O_WRONLY | O_CREAT | O_APPEND, 0o644)
+        guard logFD >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(logFD) }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PORT"] = String(configuration.port)
+        environment["WEB_NEXT_DATA_DIR"] = configuration.dataDir.path
+
+        return try Self.spawnInNewProcessGroup(
+            executablePath: configuration.launchCommand.executablePath,
+            arguments: configuration.launchCommand.arguments,
+            environment: environment,
+            workingDirectory: configuration.webNextRoot.path,
+            outputFD: logFD
+        )
+    }
+
+    private func makeLogFileURL() -> URL {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        let stamp = formatter.string(from: Date())
+        return configuration.logDirectory.appendingPathComponent("web-next-server-\(stamp).log")
+    }
+
+    /// posix_spawn with `POSIX_SPAWN_SETPGROUP` so the child leads a fresh
+    /// process group (pgid == pid). Foundation's `Process` cannot express this,
+    /// and without it a group signal cannot reach the entrypoint's `next start`
+    /// child. stdout/stderr are redirected to `outputFD`; stdin to /dev/null.
+    private static func spawnInNewProcessGroup(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        workingDirectory: String,
+        outputFD: Int32
+    ) throws -> pid_t {
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
+        posix_spawn_file_actions_adddup2(&fileActions, outputFD, 1)
+        posix_spawn_file_actions_adddup2(&fileActions, outputFD, 2)
+        posix_spawn_file_actions_addchdir_np(&fileActions, workingDirectory)
+
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
+        posix_spawnattr_setpgroup(&attributes, 0)
+
+        var argv: [UnsafeMutablePointer<CChar>?] = ([executablePath] + arguments).map { strdup($0) }
+        argv.append(nil)
+        defer { for pointer in argv { free(pointer) } }
+
+        var envp: [UnsafeMutablePointer<CChar>?] = environment.map { strdup("\($0.key)=\($0.value)") }
+        envp.append(nil)
+        defer { for pointer in envp { free(pointer) } }
+
+        var pid: pid_t = 0
+        let status = posix_spawn(&pid, executablePath, &fileActions, &attributes, argv, envp)
+        guard status == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: status) ?? .EIO)
+        }
+        return pid
+    }
+
+    // MARK: Supervision
+
+    /// True once the child has exited (reaping it as a side effect). ECHILD —
+    /// already reaped by an earlier check — also counts as exited.
+    private func processHasExited(_ pid: pid_t) -> Bool {
+        var status: Int32 = 0
+        let result = waitpid(pid, &status, WNOHANG)
+        if result == pid { return true }
+        return result == -1 && errno == ECHILD
+    }
+
+    private func terminateProcessGroup(_ pid: pid_t) async {
+        kill(-pid, SIGTERM)
+
+        let deadline = Date().addingTimeInterval(configuration.terminationGracePeriod)
+        while Date() < deadline {
+            if processHasExited(pid) { return }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        kill(-pid, SIGKILL)
+        for _ in 0..<40 where !processHasExited(pid) {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    // MARK: Readiness
+
+    /// Any HTTP response on the port means the server is up — connection
+    /// refused means it is still starting. When `/api/healthz` answers 200
+    /// with a JSON `ok` field (the endpoint ships in a parallel PR), that
+    /// field is authoritative.
+    private func serverAnswersHTTP() async -> Bool {
+        var request = URLRequest(url: baseURL.appendingPathComponent("api/healthz"))
+        request.timeoutInterval = 2
+
+        do {
+            let (data, response) = try await urlSession.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return true }
+            if httpResponse.statusCode == 200,
+                let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let ok = object["ok"] as? Bool
+            {
+                return ok
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
@@ -3,10 +3,11 @@
 //  WorkspaceManagerCore
 //
 //  Spawns and supervises the local-mode web-next server (`pnpm run start:local`)
-//  in its own process group, polls the port for readiness, and builds
-//  token-bearing sign-in URLs for the embedded web UI. The entrypoint does not
-//  forward signals to its `next start` child, so shutdown terminates the whole
-//  process group (SIGTERM → bounded grace → SIGKILL).
+//  in its own process group, requires a healthy `/api/healthz` for readiness,
+//  watches the server after it becomes ready, and builds token-bearing sign-in
+//  URLs for the embedded web UI. The entrypoint does not forward signals to its
+//  `next start` child, so shutdown terminates the whole process group
+//  (SIGTERM → bounded grace → SIGKILL until the group is empty).
 //
 
 import Foundation
@@ -64,8 +65,12 @@ public struct WebNextServerConfiguration: Sendable {
     public var launchCommand: WebNextLaunchCommand
     public var readinessTimeout: TimeInterval
     public var readinessPollInterval: TimeInterval
-    /// How long `stop()` waits after SIGTERM before escalating to SIGKILL.
+    /// How long termination waits after SIGTERM before escalating to SIGKILL.
     public var terminationGracePeriod: TimeInterval
+    /// How often the post-ready watchdog checks process liveness and health.
+    public var watchdogInterval: TimeInterval
+    /// Consecutive failed health checks before the watchdog declares the server dead.
+    public var watchdogFailureThreshold: Int
 
     public init(
         webNextRoot: URL,
@@ -75,7 +80,9 @@ public struct WebNextServerConfiguration: Sendable {
         launchCommand: WebNextLaunchCommand = .default,
         readinessTimeout: TimeInterval = 30,
         readinessPollInterval: TimeInterval = 0.5,
-        terminationGracePeriod: TimeInterval = 5
+        terminationGracePeriod: TimeInterval = 5,
+        watchdogInterval: TimeInterval = 5,
+        watchdogFailureThreshold: Int = 3
     ) {
         let resolvedDataDir = dataDir ?? Self.defaultDataDirectory()
         self.webNextRoot = webNextRoot
@@ -86,6 +93,8 @@ public struct WebNextServerConfiguration: Sendable {
         self.readinessTimeout = readinessTimeout
         self.readinessPollInterval = readinessPollInterval
         self.terminationGracePeriod = terminationGracePeriod
+        self.watchdogInterval = watchdogInterval
+        self.watchdogFailureThreshold = watchdogFailureThreshold
     }
 
     public static func defaultDataDirectory(fileManager: FileManager = .default) -> URL {
@@ -110,11 +119,22 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     private let urlSession: URLSession
     private let fileManager: FileManager
     private var processID: pid_t?
-    /// Bumped by every `start()`/`stop()`; in-flight readiness polls compare
-    /// against it so a superseded launch never overwrites current state.
+    /// Bumped by every `start()`/`stop()`; in-flight readiness polls and the
+    /// watchdog compare against it so a superseded launch never overwrites
+    /// current state or another launch's process handle.
     private var generation: UInt64 = 0
+    private var watchdogTask: Task<Void, Never>?
 
     private static let signInTokenFilename = "local-sign-in-token"
+
+    /// Query-value encoding for the sign-in URL. `URLQueryItem` leaves `+`
+    /// literal, which servers commonly decode as a space — encode it (and the
+    /// query structure characters) so redirect paths round-trip exactly.
+    private static let queryValueAllowedCharacters: CharacterSet = {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "+&=")
+        return allowed
+    }()
 
     public init(
         configuration: WebNextServerConfiguration,
@@ -132,8 +152,8 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
 
     // MARK: Lifecycle
 
-    /// Spawn the server and wait until it answers on the port or the readiness
-    /// timeout elapses. Returns immediately when already starting or ready.
+    /// Spawn the server and wait until `/api/healthz` reports healthy or the
+    /// readiness timeout elapses. Returns immediately when already starting or ready.
     public func start() async {
         switch state {
         case .starting, .ready:
@@ -144,6 +164,7 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
 
         generation &+= 1
         let launchGeneration = generation
+        cancelWatchdog()
         state = .starting
 
         let pid: pid_t
@@ -161,16 +182,21 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
             guard generation == launchGeneration else { return }
 
             if processHasExited(pid) {
-                processID = nil
+                // The leader may have left group members behind (e.g. a child
+                // holding the port) — clean up the whole group before failing.
+                await terminateProcessGroup(pid)
+                guard generation == launchGeneration else { return }
+                if processID == pid { processID = nil }
                 state = .failed(
                     reason: "web-next server exited before becoming ready; see \(logFileURL?.path ?? "logs")"
                 )
                 return
             }
 
-            if await serverAnswersHTTP() {
+            if await serverIsHealthy() {
                 guard generation == launchGeneration else { return }
                 state = .ready(signInBaseURL: baseURL)
+                startWatchdog(pid: pid, launchGeneration: launchGeneration)
                 return
             }
 
@@ -179,10 +205,11 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
 
         guard generation == launchGeneration else { return }
         await terminateProcessGroup(pid)
-        processID = nil
+        guard generation == launchGeneration else { return }
+        if processID == pid { processID = nil }
         state = .failed(
             reason:
-                "Timed out after \(Int(configuration.readinessTimeout))s waiting for web-next on port \(configuration.port)."
+                "Timed out after \(Int(configuration.readinessTimeout))s waiting for web-next health on port \(configuration.port)."
         )
     }
 
@@ -190,6 +217,7 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     /// Idempotent — safe to call in any state, including mid-start.
     public func stop() async {
         generation &+= 1
+        cancelWatchdog()
         let pid = processID
         processID = nil
         if let pid {
@@ -214,12 +242,16 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
             url: signInBaseURL.appendingPathComponent("sign-in"),
             resolvingAgainstBaseURL: false
         )
-        var queryItems = [URLQueryItem(name: "token", value: token)]
+        var query = "token=\(Self.encodeQueryValue(token))"
         if let redirect {
-            queryItems.append(URLQueryItem(name: "redirect", value: redirect))
+            query += "&redirect=\(Self.encodeQueryValue(redirect))"
         }
-        components?.queryItems = queryItems
+        components?.percentEncodedQuery = query
         return components?.url
+    }
+
+    private static func encodeQueryValue(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: queryValueAllowedCharacters) ?? value
     }
 
     // MARK: Spawning
@@ -282,7 +314,20 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
         var attributes: posix_spawnattr_t?
         posix_spawnattr_init(&attributes)
         defer { posix_spawnattr_destroy(&attributes) }
-        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP))
+        // SETSIGDEF/SETSIGMASK reset the child's signal state: ignored
+        // dispositions (SIG_IGN survives exec) and masked signals would
+        // otherwise leak from the parent and make the server deaf to the
+        // SIGTERM this supervisor relies on for graceful shutdown.
+        var defaultSignals = sigset_t()
+        sigfillset(&defaultSignals)
+        posix_spawnattr_setsigdefault(&attributes, &defaultSignals)
+        var emptySignalMask = sigset_t()
+        sigemptyset(&emptySignalMask)
+        posix_spawnattr_setsigmask(&attributes, &emptySignalMask)
+        posix_spawnattr_setflags(
+            &attributes,
+            Int16(POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK)
+        )
         posix_spawnattr_setpgroup(&attributes, 0)
 
         var argv: [UnsafeMutablePointer<CChar>?] = ([executablePath] + arguments).map { strdup($0) }
@@ -303,8 +348,9 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
 
     // MARK: Supervision
 
-    /// True once the child has exited (reaping it as a side effect). ECHILD —
-    /// already reaped by an earlier check — also counts as exited.
+    /// True once the leader has exited (reaping it as a side effect). ECHILD —
+    /// already reaped by an earlier check — also counts as exited. Says nothing
+    /// about other group members; use `processGroupIsEmpty` for that.
     private func processHasExited(_ pid: pid_t) -> Bool {
         var status: Int32 = 0
         let result = waitpid(pid, &status, WNOHANG)
@@ -312,41 +358,108 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
         return result == -1 && errno == ECHILD
     }
 
+    /// True when no member of the child's process group remains. Reaps the
+    /// leader first so a zombie leader doesn't count as a live member, then
+    /// probes the group with signal 0 (ESRCH = empty).
+    private func processGroupIsEmpty(_ pid: pid_t) -> Bool {
+        var status: Int32 = 0
+        _ = waitpid(pid, &status, WNOHANG)
+        if kill(-pid, 0) == 0 { return false }
+        return errno == ESRCH
+    }
+
+    /// SIGTERM the group, wait for the *group* — not just the leader — to be
+    /// empty within the grace period, then SIGKILL the group. The leader dying
+    /// while a member (e.g. `next start` ignoring SIGTERM) survives must still
+    /// escalate.
     private func terminateProcessGroup(_ pid: pid_t) async {
         kill(-pid, SIGTERM)
 
         let deadline = Date().addingTimeInterval(configuration.terminationGracePeriod)
         while Date() < deadline {
-            if processHasExited(pid) { return }
+            if processGroupIsEmpty(pid) { return }
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
 
         kill(-pid, SIGKILL)
-        for _ in 0..<40 where !processHasExited(pid) {
+        for _ in 0..<40 where !processGroupIsEmpty(pid) {
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
     }
 
+    // MARK: Watchdog
+
+    /// Post-ready supervision: without it, a server that dies after one
+    /// successful health check would stay `.ready` forever and `signInURL()`
+    /// would keep vending URLs for a dead server.
+    private func startWatchdog(pid: pid_t, launchGeneration: UInt64) {
+        cancelWatchdog()
+        watchdogTask = Task { [weak self] in
+            await self?.runWatchdog(pid: pid, launchGeneration: launchGeneration)
+        }
+    }
+
+    private func cancelWatchdog() {
+        watchdogTask?.cancel()
+        watchdogTask = nil
+    }
+
+    private func runWatchdog(pid: pid_t, launchGeneration: UInt64) async {
+        var consecutiveHealthFailures = 0
+        while !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: UInt64(configuration.watchdogInterval * 1_000_000_000))
+            guard generation == launchGeneration, !Task.isCancelled else { return }
+
+            if processHasExited(pid) {
+                await failFromWatchdog(
+                    pid: pid,
+                    launchGeneration: launchGeneration,
+                    reason: "web-next server exited after becoming ready; see \(logFileURL?.path ?? "logs")"
+                )
+                return
+            }
+
+            if await serverIsHealthy() {
+                consecutiveHealthFailures = 0
+            } else {
+                consecutiveHealthFailures += 1
+                if consecutiveHealthFailures >= configuration.watchdogFailureThreshold {
+                    await failFromWatchdog(
+                        pid: pid,
+                        launchGeneration: launchGeneration,
+                        reason: "web-next server stopped answering on port \(configuration.port)."
+                    )
+                    return
+                }
+            }
+        }
+    }
+
+    private func failFromWatchdog(pid: pid_t, launchGeneration: UInt64, reason: String) async {
+        await terminateProcessGroup(pid)
+        guard generation == launchGeneration else { return }
+        if processID == pid { processID = nil }
+        state = .failed(reason: reason)
+    }
+
     // MARK: Readiness
 
-    /// Any HTTP response on the port means the server is up — connection
-    /// refused means it is still starting. When `/api/healthz` answers 200
-    /// with a JSON `ok` field (the endpoint ships in a parallel PR), that
-    /// field is authoritative.
-    private func serverAnswersHTTP() async -> Bool {
+    /// Strict readiness per embedded-native-contract.md § 2: `.ready` requires
+    /// `GET /api/healthz` to answer 200 with JSON `ok == true`. Any other HTTP
+    /// response — including a stale or foreign listener on the port — is not
+    /// ready; connection refused means still starting.
+    private func serverIsHealthy() async -> Bool {
         var request = URLRequest(url: baseURL.appendingPathComponent("api/healthz"))
         request.timeoutInterval = 2
 
         do {
             let (data, response) = try await urlSession.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return true }
-            if httpResponse.statusCode == 200,
+            guard let httpResponse = response as? HTTPURLResponse,
+                httpResponse.statusCode == 200,
                 let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                 let ok = object["ok"] as? Bool
-            {
-                return ok
-            }
-            return true
+            else { return false }
+            return ok
         } catch {
             return false
         }

--- a/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
@@ -1,0 +1,262 @@
+//
+//  WebNextServerServiceTests.swift
+//  WorkspaceManagerTests
+//
+//  Behavior tests for the local-mode web-next supervisor: state transitions,
+//  process-group termination, and sign-in URL construction — all against stub
+//  shell commands so no test needs pnpm or a web-next checkout.
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("WebNextServerService")
+struct WebNextServerServiceTests {
+    // MARK: - Fixture
+
+    private struct Fixture {
+        let root: URL
+        let dataDir: URL
+        let port: Int
+
+        init() throws {
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("webnext-server-tests-\(UUID().uuidString)", isDirectory: true)
+            dataDir = root.appendingPathComponent("data", isDirectory: true)
+            try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+            port = try Self.findFreePort()
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        func configuration(
+            script: String,
+            readinessTimeout: TimeInterval = 20,
+            readinessPollInterval: TimeInterval = 0.1,
+            terminationGracePeriod: TimeInterval = 3
+        ) -> WebNextServerConfiguration {
+            WebNextServerConfiguration(
+                webNextRoot: root,
+                port: port,
+                dataDir: dataDir,
+                logDirectory: root.appendingPathComponent("logs", isDirectory: true),
+                launchCommand: WebNextLaunchCommand(executablePath: "/bin/sh", arguments: ["-c", script]),
+                readinessTimeout: readinessTimeout,
+                readinessPollInterval: readinessPollInterval,
+                terminationGracePeriod: terminationGracePeriod
+            )
+        }
+
+        /// Stub server: records env/cwd the service injected, then answers HTTP
+        /// on the configured port (any HTTP response counts as ready).
+        var httpServerScript: String {
+            """
+            echo "$PORT" > "$WEB_NEXT_DATA_DIR/observed-port"
+            pwd > "$WEB_NEXT_DATA_DIR/observed-cwd"
+            exec python3 -m http.server "$PORT" --bind 127.0.0.1
+            """
+        }
+
+        private static func findFreePort() throws -> Int {
+            let sock = socket(AF_INET, SOCK_STREAM, 0)
+            guard sock >= 0 else { throw POSIXError(.EIO) }
+            defer { close(sock) }
+
+            var address = sockaddr_in()
+            address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            address.sin_family = sa_family_t(AF_INET)
+            address.sin_port = 0
+            address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+            let bound = withUnsafeMutablePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    bind(sock, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            guard bound == 0 else { throw POSIXError(.EADDRINUSE) }
+
+            var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let named = withUnsafeMutablePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    getsockname(sock, $0, &length)
+                }
+            }
+            guard named == 0 else { throw POSIXError(.EIO) }
+            return Int(UInt16(bigEndian: address.sin_port))
+        }
+    }
+
+    private func processIsAlive(_ pid: pid_t) -> Bool {
+        kill(pid, 0) == 0
+    }
+
+    private func readPID(at url: URL) -> pid_t? {
+        guard let raw = try? String(contentsOf: url, encoding: .utf8),
+            let value = Int32(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return value
+    }
+
+    // MARK: - Readiness
+
+    @Test("start reaches ready once the port answers HTTP, with PORT/WEB_NEXT_DATA_DIR/cwd injected")
+    func startBecomesReady() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let service = WebNextServerService(configuration: fixture.configuration(script: fixture.httpServerScript))
+
+        await service.start()
+        defer { Task { await service.stop() } }
+
+        let expectedBaseURL = URL(string: "http://127.0.0.1:\(fixture.port)")!
+        #expect(await service.state == .ready(signInBaseURL: expectedBaseURL))
+
+        let observedPort = try String(
+            contentsOf: fixture.dataDir.appendingPathComponent("observed-port"), encoding: .utf8)
+        #expect(observedPort.trimmingCharacters(in: .whitespacesAndNewlines) == String(fixture.port))
+
+        let observedCwd = try String(
+            contentsOf: fixture.dataDir.appendingPathComponent("observed-cwd"), encoding: .utf8)
+        #expect(
+            URL(fileURLWithPath: observedCwd.trimmingCharacters(in: .whitespacesAndNewlines))
+                .resolvingSymlinksInPath().path == fixture.root.resolvingSymlinksInPath().path
+        )
+
+        await service.stop()
+    }
+
+    @Test("readiness timeout transitions to failed and kills the spawned process")
+    func readinessTimeoutFails() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let script = """
+            echo $$ > "$WEB_NEXT_DATA_DIR/server.pid"
+            exec sleep 300
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, readinessTimeout: 1.5))
+
+        await service.start()
+
+        guard case .failed(let reason) = await service.state else {
+            Issue.record("expected .failed, got \(await service.state)")
+            return
+        }
+        #expect(reason.contains("Timed out"))
+
+        let serverPID = try #require(readPID(at: fixture.dataDir.appendingPathComponent("server.pid")))
+        let died = await waitUntil { !self.processIsAlive(serverPID) }
+        #expect(died, "spawned process should be terminated after readiness timeout")
+    }
+
+    @Test("early process exit transitions to failed before the timeout")
+    func earlyExitFails() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: "exit 1", readinessTimeout: 30))
+
+        let startedAt = Date()
+        await service.start()
+
+        guard case .failed(let reason) = await service.state else {
+            Issue.record("expected .failed, got \(await service.state)")
+            return
+        }
+        #expect(reason.contains("exited before becoming ready"))
+        #expect(Date().timeIntervalSince(startedAt) < 10, "early exit should fail fast, not wait out the timeout")
+    }
+
+    // MARK: - Stop
+
+    @Test("stop terminates the entire process group, including grandchildren")
+    func stopKillsProcessGroup() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let script = """
+            sleep 300 &
+            echo $! > "$WEB_NEXT_DATA_DIR/child.pid"
+            \(fixture.httpServerScript)
+            """
+        let service = WebNextServerService(configuration: fixture.configuration(script: script))
+
+        await service.start()
+        guard case .ready = await service.state else {
+            Issue.record("expected .ready, got \(await service.state)")
+            return
+        }
+        let childPID = try #require(readPID(at: fixture.dataDir.appendingPathComponent("child.pid")))
+        #expect(processIsAlive(childPID))
+
+        await service.stop()
+
+        let childDied = await waitUntil { !self.processIsAlive(childPID) }
+        #expect(childDied, "grandchild should die with the process group")
+        #expect(await service.state == .idle)
+
+        await service.stop()
+        #expect(await service.state == .idle, "stop is idempotent")
+    }
+
+    // MARK: - Sign-in URL
+
+    @Test("signInURL builds token + redirect URL from the token file, and the token never reaches logs")
+    func signInURLFromTokenFile() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let service = WebNextServerService(configuration: fixture.configuration(script: fixture.httpServerScript))
+
+        await service.start()
+        defer { Task { await service.stop() } }
+
+        let token = "tok-\(UUID().uuidString)"
+        try "\(token)\n".write(
+            to: fixture.dataDir.appendingPathComponent("local-sign-in-token"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let url = try #require(await service.signInURL(redirect: "/w/demo"))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.host == "127.0.0.1")
+        #expect(components.port == fixture.port)
+        #expect(components.path == "/sign-in")
+        #expect(
+            components.queryItems == [
+                URLQueryItem(name: "token", value: token),
+                URLQueryItem(name: "redirect", value: "/w/demo"),
+            ]
+        )
+
+        let bare = try #require(await service.signInURL(redirect: nil))
+        let bareComponents = try #require(URLComponents(url: bare, resolvingAgainstBaseURL: false))
+        #expect(bareComponents.queryItems == [URLQueryItem(name: "token", value: token)])
+
+        let logURL = try #require(await service.logFileURL)
+        let logContents = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        #expect(!logContents.contains(token), "token must never appear in server logs")
+
+        await service.stop()
+    }
+
+    @Test("signInURL is nil while not ready")
+    func signInURLNilWhenNotReady() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let service = WebNextServerService(configuration: fixture.configuration(script: "exit 0"))
+
+        #expect(await service.signInURL(redirect: "/w/demo") == nil)
+
+        try "tok-unreachable\n".write(
+            to: fixture.dataDir.appendingPathComponent("local-sign-in-token"),
+            atomically: true,
+            encoding: .utf8
+        )
+        #expect(await service.signInURL(redirect: nil) == nil, "token on disk alone must not produce a URL")
+    }
+}

--- a/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
@@ -3,8 +3,9 @@
 //  WorkspaceManagerTests
 //
 //  Behavior tests for the local-mode web-next supervisor: state transitions,
-//  process-group termination, and sign-in URL construction — all against stub
-//  shell commands so no test needs pnpm or a web-next checkout.
+//  strict healthz readiness, process-group termination, post-ready watchdog,
+//  and sign-in URL construction — all against stub shell commands so no test
+//  needs pnpm or a web-next checkout.
 //
 
 import Darwin
@@ -28,6 +29,8 @@ struct WebNextServerServiceTests {
             dataDir = root.appendingPathComponent("data", isDirectory: true)
             try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
             port = try Self.findFreePort()
+            try Self.healthzServerSource.write(
+                to: root.appendingPathComponent("healthz-server.py"), atomically: true, encoding: .utf8)
         }
 
         func cleanup() {
@@ -38,7 +41,9 @@ struct WebNextServerServiceTests {
             script: String,
             readinessTimeout: TimeInterval = 20,
             readinessPollInterval: TimeInterval = 0.1,
-            terminationGracePeriod: TimeInterval = 3
+            terminationGracePeriod: TimeInterval = 1,
+            watchdogInterval: TimeInterval = 5,
+            watchdogFailureThreshold: Int = 3
         ) -> WebNextServerConfiguration {
             WebNextServerConfiguration(
                 webNextRoot: root,
@@ -48,19 +53,46 @@ struct WebNextServerServiceTests {
                 launchCommand: WebNextLaunchCommand(executablePath: "/bin/sh", arguments: ["-c", script]),
                 readinessTimeout: readinessTimeout,
                 readinessPollInterval: readinessPollInterval,
-                terminationGracePeriod: terminationGracePeriod
+                terminationGracePeriod: terminationGracePeriod,
+                watchdogInterval: watchdogInterval,
+                watchdogFailureThreshold: watchdogFailureThreshold
             )
         }
 
-        /// Stub server: records env/cwd the service injected, then answers HTTP
-        /// on the configured port (any HTTP response counts as ready).
-        var httpServerScript: String {
+        /// Stub server: records env/cwd the service injected, then answers
+        /// `/api/healthz` with `200 {"ok": true}` on the configured port.
+        var healthzServerScript: String {
             """
             echo "$PORT" > "$WEB_NEXT_DATA_DIR/observed-port"
             pwd > "$WEB_NEXT_DATA_DIR/observed-cwd"
-            exec python3 -m http.server "$PORT" --bind 127.0.0.1
+            exec python3 "\(root.path)/healthz-server.py"
             """
         }
+
+        /// Minimal healthz endpoint matching embedded-native-contract.md § 2;
+        /// every other path answers 404 so tests exercise the strict check.
+        private static let healthzServerSource = """
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+            import os
+
+            class Handler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    if self.path.startswith("/api/healthz"):
+                        body = b'{"ok": true}'
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("Content-Length", str(len(body)))
+                        self.end_headers()
+                        self.wfile.write(body)
+                    else:
+                        self.send_response(404)
+                        self.end_headers()
+
+                def log_message(self, *args):
+                    pass
+
+            HTTPServer(("127.0.0.1", int(os.environ["PORT"])), Handler).serve_forever()
+            """
 
         private static func findFreePort() throws -> Int {
             let sock = socket(AF_INET, SOCK_STREAM, 0)
@@ -104,11 +136,11 @@ struct WebNextServerServiceTests {
 
     // MARK: - Readiness
 
-    @Test("start reaches ready once the port answers HTTP, with PORT/WEB_NEXT_DATA_DIR/cwd injected")
+    @Test("start reaches ready on healthz ok, with PORT/WEB_NEXT_DATA_DIR/cwd injected")
     func startBecomesReady() async throws {
         let fixture = try Fixture()
         defer { fixture.cleanup() }
-        let service = WebNextServerService(configuration: fixture.configuration(script: fixture.httpServerScript))
+        let service = WebNextServerService(configuration: fixture.configuration(script: fixture.healthzServerScript))
 
         await service.start()
         defer { Task { await service.stop() } }
@@ -128,6 +160,27 @@ struct WebNextServerServiceTests {
         )
 
         await service.stop()
+    }
+
+    @Test("an HTTP listener without healthz never becomes ready — stale/foreign ports are rejected")
+    func readinessRejectsNonHealthzListener() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        // python http.server answers every path (404 for /api/healthz) — an HTTP
+        // response, but not a healthy web-next. Must time out, not go ready.
+        let script = """
+            exec python3 -m http.server "$PORT" --bind 127.0.0.1
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, readinessTimeout: 2.5))
+
+        await service.start()
+
+        guard case .failed(let reason) = await service.state else {
+            Issue.record("expected .failed, got \(await service.state)")
+            return
+        }
+        #expect(reason.contains("Timed out"))
     }
 
     @Test("readiness timeout transitions to failed and kills the spawned process")
@@ -172,6 +225,31 @@ struct WebNextServerServiceTests {
         #expect(Date().timeIntervalSince(startedAt) < 10, "early exit should fail fast, not wait out the timeout")
     }
 
+    @Test("pre-ready leader exit still kills surviving group members")
+    func earlyExitKillsSurvivingChildren() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let script = """
+            sleep 300 &
+            echo $! > "$WEB_NEXT_DATA_DIR/child.pid"
+            exit 0
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, readinessTimeout: 30))
+
+        await service.start()
+
+        guard case .failed(let reason) = await service.state else {
+            Issue.record("expected .failed, got \(await service.state)")
+            return
+        }
+        #expect(reason.contains("exited before becoming ready"))
+
+        let childPID = try #require(readPID(at: fixture.dataDir.appendingPathComponent("child.pid")))
+        let childDied = await waitUntil { !self.processIsAlive(childPID) }
+        #expect(childDied, "a child left behind by an exited leader must not survive the failure transition")
+    }
+
     // MARK: - Stop
 
     @Test("stop terminates the entire process group, including grandchildren")
@@ -181,7 +259,7 @@ struct WebNextServerServiceTests {
         let script = """
             sleep 300 &
             echo $! > "$WEB_NEXT_DATA_DIR/child.pid"
-            \(fixture.httpServerScript)
+            \(fixture.healthzServerScript)
             """
         let service = WebNextServerService(configuration: fixture.configuration(script: script))
 
@@ -203,13 +281,78 @@ struct WebNextServerServiceTests {
         #expect(await service.state == .idle, "stop is idempotent")
     }
 
+    @Test("stop escalates to SIGKILL when the leader dies but a member ignores SIGTERM")
+    func stopEscalatesToSIGKILLForTermIgnoringMember() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        // The child writes an "armed" marker only after installing SIG_IGN, so
+        // the test cannot race SIGTERM against handler installation.
+        let script = """
+            python3 -c 'import os, signal, time
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            open(os.environ["WEB_NEXT_DATA_DIR"] + "/term-ignorer-armed", "w").write("1")
+            time.sleep(300)' &
+            echo $! > "$WEB_NEXT_DATA_DIR/child.pid"
+            \(fixture.healthzServerScript)
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, terminationGracePeriod: 0.5))
+
+        await service.start()
+        guard case .ready = await service.state else {
+            Issue.record("expected .ready, got \(await service.state)")
+            return
+        }
+        let armedURL = fixture.dataDir.appendingPathComponent("term-ignorer-armed")
+        let armed = await waitUntil(timeout: 5) { FileManager.default.fileExists(atPath: armedURL.path) }
+        #expect(armed, "the SIGTERM-ignoring child must be armed before stop() is exercised")
+        let childPID = try #require(readPID(at: fixture.dataDir.appendingPathComponent("child.pid")))
+        #expect(processIsAlive(childPID))
+
+        await service.stop()
+
+        let childDied = await waitUntil(timeout: 5) { !self.processIsAlive(childPID) }
+        #expect(childDied, "a SIGTERM-ignoring group member must be SIGKILLed even after the leader exits")
+        #expect(await service.state == .idle)
+    }
+
+    // MARK: - Watchdog
+
+    @Test("watchdog fails the state when the server dies after becoming ready")
+    func watchdogDetectsServerDeath() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let script = """
+            echo $$ > "$WEB_NEXT_DATA_DIR/server.pid"
+            \(fixture.healthzServerScript)
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, watchdogInterval: 0.15))
+
+        await service.start()
+        guard case .ready = await service.state else {
+            Issue.record("expected .ready, got \(await service.state)")
+            return
+        }
+
+        let serverPID = try #require(readPID(at: fixture.dataDir.appendingPathComponent("server.pid")))
+        kill(serverPID, SIGKILL)
+
+        let failed = await waitUntil(timeout: 5) {
+            if case .failed = await service.state { return true }
+            return false
+        }
+        #expect(failed, "watchdog should transition to .failed after the server dies")
+        #expect(await service.signInURL(redirect: nil) == nil, "no sign-in URLs for a dead server")
+    }
+
     // MARK: - Sign-in URL
 
     @Test("signInURL builds token + redirect URL from the token file, and the token never reaches logs")
     func signInURLFromTokenFile() async throws {
         let fixture = try Fixture()
         defer { fixture.cleanup() }
-        let service = WebNextServerService(configuration: fixture.configuration(script: fixture.httpServerScript))
+        let service = WebNextServerService(configuration: fixture.configuration(script: fixture.healthzServerScript))
 
         await service.start()
         defer { Task { await service.stop() } }
@@ -236,6 +379,14 @@ struct WebNextServerServiceTests {
         let bare = try #require(await service.signInURL(redirect: nil))
         let bareComponents = try #require(URLComponents(url: bare, resolvingAgainstBaseURL: false))
         #expect(bareComponents.queryItems == [URLQueryItem(name: "token", value: token)])
+
+        let plussed = try #require(await service.signInURL(redirect: "/search?q=a+b"))
+        #expect(plussed.absoluteString.contains("%2B"), "a literal + must be percent-encoded in the query")
+        let plussedComponents = try #require(URLComponents(url: plussed, resolvingAgainstBaseURL: false))
+        #expect(
+            plussedComponents.queryItems?.last == URLQueryItem(name: "redirect", value: "/search?q=a+b"),
+            "a literal + in the redirect must survive the round-trip, not decay to a space"
+        )
 
         let logURL = try #require(await service.logFileURL)
         let logContents = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""


### PR DESCRIPTION
First native slice (N1) of the embedded-native arc: a `WorkspaceManagerCore` actor that supervises the local-mode web-next server, per the contract in PR #1028 (`web-next/docs/decisions/embedded-native-contract.md`). Service only — no UI; the embedded WKWebView surface is the next slice.

Part of #987

## What it does

- `WebNextServerService` (actor) with `idle / starting / ready(signInBaseURL) / failed(reason)` states, modeled on `LumeRuntimeService`'s supervision approach but much smaller.
- `start()` spawns the configured launch command (default `pnpm run start:local`, cwd = configurable web-next root) via `posix_spawn` with `POSIX_SPAWN_SETPGROUP` — the entrypoint does not forward signals to its `next start` child, so the child must lead a fresh process group. The child's signal state is reset (`SETSIGDEF` + `SETSIGMASK`) so inherited ignored dispositions can't make the server deaf to the supervisor's SIGTERM. Env: `PORT` (default 3140) + `WEB_NEXT_DATA_DIR`; child stdout/stderr go to a per-launch log file under the data dir.
- Readiness is strict healthz per the contract § 2: `.ready` requires `GET /api/healthz` → 200 with JSON `ok == true` (endpoint ships in #1030, same milestone). A stale or foreign HTTP listener on the port never becomes ready; connection refused = still starting; early child exit fails fast and cleans up the group.
- `stop()` terminates the whole group and waits for the *group* to be empty — SIGTERM → bounded grace → SIGKILL — so a member that outlives the leader (e.g. `next start` ignoring SIGTERM) still dies. Idempotent, including mid-start (generation counter keeps a superseded launch from overwriting state or another launch's process handle).
- After `.ready`, a generation-guarded watchdog polls process liveness + healthz (default every 5s); process exit or 3 consecutive health failures terminates the group and transitions to `.failed`, so `signInURL()` never vends URLs for a dead server.
- `signInURL(redirect:)` reads the server-minted `local-sign-in-token` from the data dir and builds `http://127.0.0.1:<port>/sign-in?token=<t>&redirect=<path>` with strict percent-encoding (`+`/`&`/`=` encoded so redirects round-trip exactly); nil while not ready. The token stays in memory — never logged, never in error strings.
- `WebNextServerServiceProtocol` added to `Protocols.swift` for DI, mirroring `GitServiceProtocol`/`WorkspaceServiceProtocol`.
- Launch command is injectable, so tests run against `/bin/sh` stubs — no pnpm, no web-next checkout.

## Verification

- `swift build` clean; `swift test`: **1302 tests in 195 suites passed** (10 in the `WebNextServerService` suite); `mise run lint` (swift-format --strict) clean.
- Behaviors covered: ready transition via strict healthz with env/cwd injection asserted from inside the child; a non-healthz HTTP listener never becomes ready; readiness timeout → `.failed` + process killed; early exit → fail fast; pre-ready leader exit still kills surviving group members; `stop()` kills the entire group (backgrounded grandchild asserted dead); SIGKILL escalation when a member ignores SIGTERM after the leader dies (child arms its SIG_IGN handler deterministically before the test stops); watchdog fails the state when the server dies post-ready; sign-in URL construction with/without redirect + `+` round-trip; nil while not ready even with a token on disk; token absent from the captured server log.
- **Mutation checks**: (1) initial PR — removed `POSIX_SPAWN_SETPGROUP`: two group-kill tests failed, reverted. (2) review fixes — restored the leader-exit early-return in `terminateProcessGroup` (the exact blocker-2 regression): `stop escalates to SIGKILL when the leader dies but a member ignores SIGTERM` failed as expected, reverted, suite green.

## Review loop

Directed codex review (gpt-5.5, xhigh) returned 3 blockers, 2 majors, 1 minor — all accepted and fixed in a86a0549:

1. **Blocker — timeout path missing generation re-check after terminate await:** fixed — re-checks `generation` after the await; clears `processID` only if it still holds this launch's pid.
2. **Blocker — termination treated leader exit as group death:** fixed — grace/SIGKILL loops now probe group emptiness via `kill(-pid, 0)` (with leader reap), so a surviving member still gets SIGKILL.
3. **Blocker — pre-ready leader exit orphaned the group:** fixed — the early-exit failure path runs group-aware termination before transitioning to `.failed`.
4. **Major — readiness accepted any HTTP response:** fixed — strict healthz (200 + JSON `ok == true`, contract § 2); stale/foreign listeners are rejected, covered by a dedicated test.
5. **Minor — `+` left literal in query values:** fixed — query values percent-encode `+`/`&`/`=`; round-trip covered by test.
6. **Major — no post-ready supervision:** fixed — generation-guarded watchdog (interval + failure threshold configurable) terminates the group and fails the state on process exit or repeated health failures.

Found while verifying the fixes: ignored signal dispositions leak through `posix_spawn`/exec (SIG_IGN survives exec), which had been masking SIGTERM delivery in the test harness — the spawn now resets the child's signal state (`POSIX_SPAWN_SETSIGDEF` + `SETSIGMASK`), which also protects the production server if the app ever ignores SIGTERM.

## Evidence

![webnext-server-service](https://evidence.cloudcompute.com/workspaces/pr-1029/20260709-053932-webnext-server-service.png)

Review-fix run (a86a0549):

![webnext-server-service-review-fixes](https://evidence.cloudcompute.com/workspaces/pr-1029/20260709-060524-webnext-server-service-review-fixes.png)

- CI: [build-and-test + analyzers green](https://github.com/fairchild/workspaces/pull/1029/checks) on a86a0549

## Mergeability

- Surface: desktop — new `WorkspaceManagerCore` service (`WebNextServerService.swift`) plus a protocol addition in `Protocols.swift`; nothing wired into the app or UI yet.
- User-facing behavior changed: No — no call sites exist yet; the WKWebView slice consumes this next.
- Non-happy paths considered: launch failure (bad executable/cwd) → `.failed` with reason; child exits before answering → fail fast, group cleaned up; readiness timeout → group killed so no orphaned server holds the port; stale/foreign listener on the port → never ready (strict healthz); `stop()` mid-start, superseding `start()`, and double-`stop()` are safe via a generation counter; SIGKILL escalation covers members that outlive the leader or ignore SIGTERM; post-ready server death is detected by the watchdog; missing/empty token file → `signInURL` returns nil rather than a broken URL.
- Residual risk or follow-up: strict healthz means the service reports failed-not-ready against a pre-#1030 web-next checkout (truthful — that ordering dependency resolves when #1030 merges in this milestone). Default launch command resolves `pnpm` via `/usr/bin/env`, and an app-launched process may have a minimal PATH — the UI slice that wires this up should decide PATH plumbing (login-shell wrapper or explicit path setting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Gate note (orchestrator): full diff read; independent `swift test` re-run on the fix commit (1302 tests, 195 suites); directed codex (gpt-5.5, xhigh) review → 6 findings all fixed in a86a0549 with attributed commit; mutation check re-verified. Merging under delegated authority.