### PR TITLE
feat(app): embedded web-next surface + shortcut + New Web Session (#987 N2)

### DIFF
--- a/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
+++ b/Sources/WorkspaceManager/App/AppChromeShortcuts.swift
@@ -29,6 +29,7 @@ enum AppChromeShortcut: CaseIterable {
     case settings
     case workspaceSwitcher
     case commandRunner
+    case openEmbeddedWebNext
 
     private var definition: AppChromeShortcutDefinition {
         switch self {
@@ -60,6 +61,12 @@ enum AppChromeShortcut: CaseIterable {
         case .commandRunner:
             return AppChromeShortcutDefinition(
                 keyString: "p",
+                modifiers: [.command, .shift],
+                defaultRoute: .appChrome
+            )
+        case .openEmbeddedWebNext:
+            return AppChromeShortcutDefinition(
+                keyString: "a",
                 modifiers: [.command, .shift],
                 defaultRoute: .appChrome
             )
@@ -114,6 +121,7 @@ enum AppChromeShortcut: CaseIterable {
         case .settings: return "Settings"
         case .workspaceSwitcher: return "Switch Session"
         case .commandRunner: return "Run Command"
+        case .openEmbeddedWebNext: return "Open Web Session"
         }
     }
 

--- a/Sources/WorkspaceManager/App/AppRuntimeDependencies.swift
+++ b/Sources/WorkspaceManager/App/AppRuntimeDependencies.swift
@@ -11,10 +11,15 @@ import WorkspaceManagerCore
 struct AppRuntimeDependencies {
     let lumeRuntimeService: any LumeRuntimeServiceProtocol
     let workspaceProviderRegistry: WorkspaceProviderRegistry
+    /// Supervisor for the embedded local-mode web-next server. Constructed here
+    /// but not started — activation of the embedded surface starts it lazily.
+    let webNextServerService: any WebNextServerServiceProtocol
 
     static func resolved(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> AppRuntimeDependencies {
+        let webNextServerService = makeWebNextServerService()
+
         if UIFixtureLumeEnvironment.isEnabled(environment: environment) {
             let runtimeService = UIFixtureLumeRuntimeService()
             return AppRuntimeDependencies(
@@ -25,7 +30,8 @@ struct AppRuntimeDependencies {
                         UIFixtureDaytonaWorkspaceProvider(),
                         UIFixtureLumeWorkspaceProvider(runtimeService: runtimeService),
                     ]
-                )
+                ),
+                webNextServerService: webNextServerService
             )
         }
 
@@ -60,7 +66,18 @@ struct AppRuntimeDependencies {
                         LumeWorkspaceProvider(runtimeService: runtimeService)
                     },
                 ]
-            )
+            ),
+            webNextServerService: webNextServerService
         )
+    }
+
+    /// Build (not start) the embedded web-next supervisor from resolved settings
+    /// and register it for clean shutdown on app termination.
+    private static func makeWebNextServerService() -> any WebNextServerServiceProtocol {
+        let service = WebNextServerService(
+            configuration: WebNextServerSettings.resolvedConfiguration()
+        )
+        WebNextServerLifecycle.shared.register(service)
+        return service
     }
 }

--- a/Sources/WorkspaceManager/App/WebNextServerSettings.swift
+++ b/Sources/WorkspaceManager/App/WebNextServerSettings.swift
@@ -54,10 +54,10 @@ final class WebNextServerLifecycle: @unchecked Sendable {
     }
 
     /// Best-effort synchronous shutdown for `applicationWillTerminate`. Blocks up
-    /// to `timeout` (covering the service's own SIGTERM grace before SIGKILL) so
-    /// the child group is gone before the process exits; returns early if no
-    /// server was ever started.
-    func stopBlocking(timeout: TimeInterval = 6) {
+    /// to `timeout` — kept under the OS's ~5s terminate budget — while the
+    /// service runs its compressed-grace `stopForTermination`, so the child group
+    /// is gone before the process exits; returns early if no server was started.
+    func stopBlocking(timeout: TimeInterval = 4) {
         lock.lock()
         let service = self.service
         lock.unlock()
@@ -65,7 +65,7 @@ final class WebNextServerLifecycle: @unchecked Sendable {
 
         let semaphore = DispatchSemaphore(value: 0)
         Task.detached {
-            await service.stop()
+            await service.stopForTermination()
             semaphore.signal()
         }
         _ = semaphore.wait(timeout: .now() + timeout)

--- a/Sources/WorkspaceManager/App/WebNextServerSettings.swift
+++ b/Sources/WorkspaceManager/App/WebNextServerSettings.swift
@@ -1,0 +1,73 @@
+//
+//  WebNextServerSettings.swift
+//  WorkspaceManager
+//
+//  Resolves the embedded web-next server's launch configuration from user
+//  settings (with the Milestone-1 demo defaults) and holds the live service so
+//  app termination can shut the server's process group down cleanly. The server
+//  is started lazily on first activation of the embedded surface, so nothing
+//  here spawns a process — it only decides where and how one would launch.
+//
+
+import Foundation
+import WorkspaceManagerCore
+
+enum WebNextServerSettings {
+    /// UserDefaults key for the web-next checkout the server launches from.
+    static let rootStorageKey = "webNextServerRoot"
+
+    /// Milestone-1 demo default: the sibling CLAUDE.md/AGENTS.md checkout. Packaging
+    /// web-next into the app bundle is deferred (Milestone-2 follow-up).
+    static let defaultRoot = "~/code/workspaces/web-next"
+
+    /// Loopback port, clear of dev (3100) and hero (3200) per the contract.
+    static let port = 3140
+
+    static func resolvedConfiguration(
+        defaults: UserDefaults = .standard
+    ) -> WebNextServerConfiguration {
+        let configured = defaults.string(forKey: rootStorageKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let root = (configured?.isEmpty == false ? configured! : defaultRoot)
+        let expanded = (root as NSString).expandingTildeInPath
+        return WebNextServerConfiguration(
+            webNextRoot: URL(fileURLWithPath: expanded),
+            port: port
+        )
+    }
+}
+
+/// Process-wide handle to the live embedded web-next server so the AppKit
+/// termination hook — which cannot reach the SwiftUI service graph — can stop
+/// the server's process group before the app exits. Without this, quitting
+/// while the server runs would orphan a `next start` child holding the port.
+final class WebNextServerLifecycle: @unchecked Sendable {
+    static let shared = WebNextServerLifecycle()
+
+    private let lock = NSLock()
+    private var service: (any WebNextServerServiceProtocol)?
+
+    func register(_ service: any WebNextServerServiceProtocol) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.service = service
+    }
+
+    /// Best-effort synchronous shutdown for `applicationWillTerminate`. Blocks up
+    /// to `timeout` (covering the service's own SIGTERM grace before SIGKILL) so
+    /// the child group is gone before the process exits; returns early if no
+    /// server was ever started.
+    func stopBlocking(timeout: TimeInterval = 6) {
+        lock.lock()
+        let service = self.service
+        lock.unlock()
+        guard let service else { return }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached {
+            await service.stop()
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + timeout)
+    }
+}

--- a/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
+++ b/Sources/WorkspaceManager/App/WorkspaceManagerApp.swift
@@ -83,6 +83,7 @@ struct WorkspaceManagerApp: App {
                 \.workspaceProviderRegistry,
                 appRuntimeDependencies.workspaceProviderRegistry
             )
+            .environment(\.webNextServerService, appRuntimeDependencies.webNextServerService)
             .environmentObject(modelStoreStatusController)
             .environmentObject(agentSessionRegistry)
             .environmentObject(lastCommandStatusRegistry)
@@ -240,6 +241,17 @@ struct WorkspaceManagerApp: App {
             SidebarCommands()
 
             CommandMenu("Selection") {
+                Button("Open Web Session") {
+                    appCommandState.perform(.openEmbeddedWebNext)
+                }
+                .keyboardShortcut(
+                    AppChromeShortcut.openEmbeddedWebNext.keyEquivalent,
+                    modifiers: AppChromeShortcut.openEmbeddedWebNext.eventModifiers
+                )
+                .disabled(!appCommandState.mainWindowAvailability.canOpenEmbeddedWebNext)
+
+                Divider()
+
                 Button("Open in Browser") {
                     appCommandState.perform(.openInBrowser)
                 }
@@ -612,6 +624,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return false
     }
 
+    func applicationWillTerminate(_ notification: Notification) {
+        // Tear down the embedded web-next server's process group so quitting
+        // never orphans a `next start` child holding the loopback port. No-op
+        // when the surface was never activated.
+        WebNextServerLifecycle.shared.stopBlocking()
+    }
+
     func application(_ application: NSApplication, shouldSaveSecureApplicationState coder: NSCoder) -> Bool {
         !disablesStateRestoration
     }
@@ -688,6 +707,12 @@ private struct FeedbackServiceKey: EnvironmentKey {
     static let defaultValue: any FeedbackServiceProtocol = FeedbackService.shared
 }
 
+private struct WebNextServerServiceKey: EnvironmentKey {
+    static let defaultValue: any WebNextServerServiceProtocol = WebNextServerService(
+        configuration: WebNextServerSettings.resolvedConfiguration()
+    )
+}
+
 extension EnvironmentValues {
     var gitService: any GitServiceProtocol {
         get { self[GitServiceKey.self] }
@@ -743,6 +768,11 @@ extension EnvironmentValues {
         get { self[FeedbackServiceKey.self] }
         set { self[FeedbackServiceKey.self] = newValue }
     }
+
+    var webNextServerService: any WebNextServerServiceProtocol {
+        get { self[WebNextServerServiceKey.self] }
+        set { self[WebNextServerServiceKey.self] = newValue }
+    }
 }
 
 struct MainWindowFocusedActions {
@@ -764,6 +794,7 @@ struct MainWindowFocusedActions {
     var openSessionSwitcher: Action? = nil
     var openCommandRunner: Action? = nil
     var sendFeedback: Action? = nil
+    var openEmbeddedWebNext: Action? = nil
 
     @MainActor static let empty = MainWindowFocusedActions()
 }
@@ -785,6 +816,7 @@ struct MainWindowCommandAvailability: Equatable {
     let canOpenSessionSwitcher: Bool
     let canOpenCommandRunner: Bool
     let canSendFeedback: Bool
+    let canOpenEmbeddedWebNext: Bool
 
     static let empty = MainWindowCommandAvailability(
         canToggleSidebar: false,
@@ -802,7 +834,8 @@ struct MainWindowCommandAvailability: Equatable {
         canCopyPath: false,
         canOpenSessionSwitcher: false,
         canOpenCommandRunner: false,
-        canSendFeedback: false
+        canSendFeedback: false,
+        canOpenEmbeddedWebNext: false
     )
 }
 
@@ -823,6 +856,7 @@ enum MainWindowCommand {
     case openSessionSwitcher
     case openCommandRunner
     case sendFeedback
+    case openEmbeddedWebNext
 }
 
 @MainActor
@@ -935,6 +969,8 @@ final class AppCommandState: ObservableObject {
             mainWindowActions.openCommandRunner?()
         case .sendFeedback:
             mainWindowActions.sendFeedback?()
+        case .openEmbeddedWebNext:
+            mainWindowActions.openEmbeddedWebNext?()
         }
     }
 }

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -28,6 +28,18 @@ enum PendingCodePreviewNavigation: Equatable {
     case close
 }
 
+/// One activation of the embedded web-next surface. `redirect` is the relative
+/// path to land on after sign-in (`nil` = the app's default `/`); the unique
+/// `id` keys the detail view so a fresh activation always re-navigates.
+struct EmbeddedWebNextActivation: Equatable, Identifiable {
+    let id = UUID()
+    let redirect: String?
+
+    static func == (lhs: EmbeddedWebNextActivation, rhs: EmbeddedWebNextActivation) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
 struct ContentView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.localStateStore) private var localStateStore
@@ -51,6 +63,7 @@ struct ContentView: View {
     private var minimalToolbarEnabled: Bool
     @Environment(\.externalEditorService) private var externalEditorService
     @Environment(\.lumeRuntimeService) private var lumeRuntimeService
+    @Environment(\.webNextServerService) private var webNextServerService
     @EnvironmentObject private var modelStoreStatusController: ModelStoreStatusController
     @Environment(\.workspaceService) private var workspaceService
     @Environment(\.workspaceProviderRegistry) private var workspaceProviderRegistry
@@ -63,6 +76,10 @@ struct ContentView: View {
     @State private var repoForNewWorkspaceFromLanding: Repo?
     @State private var isPreparingLandingNewWorkspaceSheet = false
     @State private var webSourceCreationTarget: WebSourceCreationTarget?
+    /// Non-nil while the embedded web-next surface is shown; takes precedence over
+    /// the SwiftData selection in `detailContent`. Cleared whenever a repo /
+    /// workspace / web source is selected (see `applyNavigationDestination`).
+    @State private var embeddedWebNext: EmbeddedWebNextActivation?
     @State private var workspaceEnvironmentSheetState = WorkspaceEnvironmentSheetState.empty
     @State private var didScheduleInitialWorkspaceStatusSync = false
     @State private var didPrewarmPerfTerminalSurfaces = false
@@ -472,7 +489,8 @@ struct ContentView: View {
             copyPath: copyPathFocusedAction,
             openSessionSwitcher: presentSessionSwitcher,
             openCommandRunner: { viewState.isShowingThemeOverlay = true },
-            sendFeedback: { isShowingFeedbackSheet = true }
+            sendFeedback: { isShowingFeedbackSheet = true },
+            openEmbeddedWebNext: { openEmbeddedWebNext(redirect: nil) }
         )
     }
 
@@ -493,7 +511,8 @@ struct ContentView: View {
             canCopyPath: copyPathFocusedAction != nil,
             canOpenSessionSwitcher: true,
             canOpenCommandRunner: true,
-            canSendFeedback: true
+            canSendFeedback: true,
+            canOpenEmbeddedWebNext: true
         )
     }
 
@@ -556,7 +575,14 @@ struct ContentView: View {
 
     @ViewBuilder
     private var detailContent: some View {
-        if let selectedWebSource = currentSelectedWebSource {
+        if let activation = embeddedWebNext {
+            EmbeddedWebNextDetailView(
+                server: webNextServerService,
+                redirect: activation.redirect,
+                onClose: { embeddedWebNext = nil }
+            )
+            .id(activation.id)
+        } else if let selectedWebSource = currentSelectedWebSource {
             WebSourceDetailView(
                 source: selectedWebSource,
                 tileID: webDetailTileID,
@@ -627,6 +653,8 @@ struct ContentView: View {
                 onRequestWebSourceCreation: { target in
                     webSourceCreationTarget = target
                 },
+                webNextSessionSlug: { GitHubRepoSlug(remoteURL: $0.remoteURL) },
+                onOpenWebNextSession: openWebNextSession,
                 onWorkspaceCreated: handleWorkspaceCreated,
                 retireTerminalSessions: { key in
                     try await retireTerminalSessions(inScope: key)
@@ -1204,11 +1232,32 @@ struct ContentView: View {
         }
     }
 
+    /// Show the embedded web-next surface. `redirect` is the post-sign-in path
+    /// (`nil` for a plain open). Re-activating with the same redirect is a no-op
+    /// so a repeated shortcut press doesn't re-mount and re-navigate the pane.
+    @MainActor
+    private func openEmbeddedWebNext(redirect: String?) {
+        if let existing = embeddedWebNext, existing.redirect == redirect { return }
+        embeddedWebNext = EmbeddedWebNextActivation(redirect: redirect)
+    }
+
+    /// Open a repo-bound New Web Session. No-ops when the repo's remote can't be
+    /// resolved to `owner/name` (the sidebar entry is disabled in that case, so
+    /// this guard only defends against a stale invocation).
+    @MainActor
+    private func openWebNextSession(for repo: Repo) {
+        guard let slug = GitHubRepoSlug(remoteURL: repo.remoteURL) else { return }
+        openEmbeddedWebNext(redirect: EmbeddedWebNextDeepLink.newSessionRedirect(repo: slug))
+    }
+
     @MainActor
     private func applyNavigationDestination(
         _ destination: MainWindowNavigationDestination,
         persistSurface: Bool = true
     ) {
+        // Selecting any sidebar surface dismisses the embedded web-next pane so
+        // the two selection kinds stay mutually exclusive.
+        if embeddedWebNext != nil { embeddedWebNext = nil }
         let transition = navigationStateController.transition(to: destination)
         navigationStateController.apply(transition, to: &viewState)
         if persistSurface {

--- a/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/ContentView.swift
@@ -38,6 +38,21 @@ struct EmbeddedWebNextActivation: Equatable, Identifiable {
     static func == (lhs: EmbeddedWebNextActivation, rhs: EmbeddedWebNextActivation) -> Bool {
         lhs.id == rhs.id
     }
+
+    /// Resolve the next activation. `forceFresh` (an explicit New Web Session)
+    /// always yields a new activation — even for a repo already open — because
+    /// the current pane may have navigated on to `/sessions/<id>` while its
+    /// redirect still reads `/new?repo=…`. The plain shortcut is not force-fresh,
+    /// so re-opening an already-shown surface with the same redirect is a no-op
+    /// (`nil`) rather than a jarring re-mount.
+    static func next(
+        current: EmbeddedWebNextActivation?,
+        redirect: String?,
+        forceFresh: Bool
+    ) -> EmbeddedWebNextActivation? {
+        if !forceFresh, let current, current.redirect == redirect { return nil }
+        return EmbeddedWebNextActivation(redirect: redirect)
+    }
 }
 
 struct ContentView: View {
@@ -1236,18 +1251,29 @@ struct ContentView: View {
     /// (`nil` for a plain open). Re-activating with the same redirect is a no-op
     /// so a repeated shortcut press doesn't re-mount and re-navigate the pane.
     @MainActor
-    private func openEmbeddedWebNext(redirect: String?) {
-        if let existing = embeddedWebNext, existing.redirect == redirect { return }
-        embeddedWebNext = EmbeddedWebNextActivation(redirect: redirect)
+    private func openEmbeddedWebNext(redirect: String?, forceFresh: Bool = false) {
+        guard
+            let next = EmbeddedWebNextActivation.next(
+                current: embeddedWebNext,
+                redirect: redirect,
+                forceFresh: forceFresh
+            )
+        else { return }
+        embeddedWebNext = next
     }
 
-    /// Open a repo-bound New Web Session. No-ops when the repo's remote can't be
+    /// Open a repo-bound New Web Session. Always forces a fresh activation so a
+    /// second New Web Session for the same repo still opens (the prior pane may
+    /// have moved on to `/sessions/<id>`). No-ops when the repo's remote can't be
     /// resolved to `owner/name` (the sidebar entry is disabled in that case, so
     /// this guard only defends against a stale invocation).
     @MainActor
     private func openWebNextSession(for repo: Repo) {
         guard let slug = GitHubRepoSlug(remoteURL: repo.remoteURL) else { return }
-        openEmbeddedWebNext(redirect: EmbeddedWebNextDeepLink.newSessionRedirect(repo: slug))
+        openEmbeddedWebNext(
+            redirect: EmbeddedWebNextDeepLink.newSessionRedirect(repo: slug),
+            forceFresh: true
+        )
     }
 
     @MainActor

--- a/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
+++ b/Sources/WorkspaceManager/Views/MainWindow/SidebarView.swift
@@ -63,6 +63,11 @@ struct SidebarView: View {
     let onRepoTerminalSelected: (Repo) -> Void
     let onWebSourceSelected: (WebSource) -> Void
     let onRequestWebSourceCreation: (WebSourceCreationTarget) -> Void
+    /// Resolves a repo's GitHub `owner/name` for the "New Web Session" deep link,
+    /// or nil when the remote can't be parsed (the entry is then disabled).
+    let webNextSessionSlug: (Repo) -> GitHubRepoSlug?
+    /// Opens the embedded web-next surface with a repo-bound new-session deep link.
+    let onOpenWebNextSession: (Repo) -> Void
     let onWorkspaceCreated: () -> Void
     let retireTerminalSessions: @MainActor (HostTerminalSessionKey) async throws -> Void
     let workspaceProviderSetupCoordinator: WorkspaceProviderSetupCoordinator
@@ -523,6 +528,11 @@ struct SidebarView: View {
                 onRequestWebSourceCreation(.repo(repo))
             }
 
+            Button("New Web Session") {
+                onOpenWebNextSession(repo)
+            }
+            .disabled(webNextSessionSlug(repo) == nil)
+
             Divider()
 
             Button("Reveal in Finder") {
@@ -621,6 +631,13 @@ struct SidebarView: View {
                 localWorkspaceActions(workspace)
             } else {
                 providerWorkspaceActions(workspace)
+            }
+
+            if let repo = workspace.sourceRepo {
+                Button("New Web Session") {
+                    onOpenWebNextSession(repo)
+                }
+                .disabled(webNextSessionSlug(repo) == nil)
             }
 
             Divider()

--- a/Sources/WorkspaceManager/Web/EmbeddedWebNextDetailView.swift
+++ b/Sources/WorkspaceManager/Web/EmbeddedWebNextDetailView.swift
@@ -41,11 +41,13 @@ final class EmbeddedWebNextModel: ObservableObject {
 
     func activate(redirect: String?) async {
         phase = .connecting
-        // `start()` returns once the server is ready, has failed, or timed out;
-        // it is a no-op when already ready, so re-activation is cheap.
+        // `start()` returns immediately when a launch is already in flight
+        // (state `.starting`), so a second activation racing the first must not
+        // sample state once and conclude failure — wait for the launch to reach
+        // a terminal `.ready`/`.failed` transition.
         await server.start()
 
-        switch await server.state {
+        switch await awaitTerminalState() {
         case .ready:
             if let url = await server.signInURL(redirect: redirect) {
                 phase = .ready(url)
@@ -59,6 +61,22 @@ final class EmbeddedWebNextModel: ObservableObject {
         case .idle, .starting:
             phase = .failed("web-next did not reach a ready state.")
         }
+    }
+
+    /// Poll until the server leaves `.starting`, so an activation that raced an
+    /// in-flight launch resolves on the real outcome. Bounded well past the
+    /// service's own readiness timeout as a backstop against a wedged launch.
+    private func awaitTerminalState() async -> WebNextServerState {
+        var state = await server.state
+        var elapsed: TimeInterval = 0
+        let pollInterval: TimeInterval = 0.15
+        let maxWait: TimeInterval = 45
+        while case .starting = state, elapsed < maxWait, !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            elapsed += pollInterval
+            state = await server.state
+        }
+        return state
     }
 }
 
@@ -163,24 +181,26 @@ struct EmbeddedWebNextStatusView: View {
     }
 }
 
-/// WKWebView bound to the loopback web-next origin. The navigation policy allows
-/// only `127.0.0.1` / `localhost` (port is not part of host matching); anything
-/// else is treated as an external link and opened in the default browser.
-private struct EmbeddedWebNextWebView: NSViewRepresentable {
+/// WKWebView bound to the loopback web-next origin, pinned to both host
+/// (`127.0.0.1` / `localhost`) AND the server port so the token-bearing session
+/// cookie can't leak to another local service; anything else is treated as an
+/// external link and opened in the default browser. The webview uses a
+/// non-persistent data store so the session cookie dies with the pane rather
+/// than surviving across app runs on disk.
+struct EmbeddedWebNextWebView: NSViewRepresentable {
     let signInURL: URL
 
     func makeCoordinator() -> WebNavigationPolicy {
         WebNavigationPolicy(
             allowedHost: "127.0.0.1",
             additionalAllowedDomains: ["localhost"],
-            allowsSubdomains: false
+            allowsSubdomains: false,
+            allowedPort: signInURL.port
         )
     }
 
     func makeNSView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .default()
-        let webView = WKWebView(frame: .zero, configuration: configuration)
+        let webView = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
         webView.allowsBackForwardNavigationGestures = true
         webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: signInURL))
@@ -188,4 +208,12 @@ private struct EmbeddedWebNextWebView: NSViewRepresentable {
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {}
+
+    /// Ephemeral, in-memory configuration: the bearer session cookie must not
+    /// persist to disk across runs.
+    static func makeConfiguration() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        return configuration
+    }
 }

--- a/Sources/WorkspaceManager/Web/EmbeddedWebNextDetailView.swift
+++ b/Sources/WorkspaceManager/Web/EmbeddedWebNextDetailView.swift
@@ -1,0 +1,191 @@
+//
+//  EmbeddedWebNextDetailView.swift
+//  WorkspaceManager
+//
+//  The in-app pane for the embedded local-mode web-next experience. On
+//  activation it lazily starts the `WebNextServerService`, shows a status pane
+//  while the server comes up (or fails), then mounts a WKWebView navigated to
+//  the token-bearing sign-in URL (redirecting to `/` for a plain open, or to
+//  `/new?repo=<owner>/<name>` for a repo-bound New Web Session). Navigation is
+//  locked to the loopback origin; external links open in the default browser.
+//
+//  This deliberately does not reuse `WebSurfaceStore`, which is keyed to a
+//  persisted `WebSource`: the sign-in URL carries a bearer token that must never
+//  land in a persisted model, so the surface stays ephemeral and view-local.
+//
+
+import AppKit
+import SwiftUI
+import WebKit
+import WorkspaceManagerCore
+
+/// Drives one activation of the embedded surface: start the server, resolve the
+/// signed-in URL, and expose a coarse phase the view renders. Recreated per
+/// activation (the detail view is `.id`-keyed), so a New Web Session always
+/// re-navigates rather than reusing a stale page.
+@MainActor
+final class EmbeddedWebNextModel: ObservableObject {
+    enum Phase: Equatable {
+        case connecting
+        case ready(URL)
+        case failed(String)
+    }
+
+    @Published private(set) var phase: Phase = .connecting
+
+    private let server: any WebNextServerServiceProtocol
+
+    init(server: any WebNextServerServiceProtocol) {
+        self.server = server
+    }
+
+    func activate(redirect: String?) async {
+        phase = .connecting
+        // `start()` returns once the server is ready, has failed, or timed out;
+        // it is a no-op when already ready, so re-activation is cheap.
+        await server.start()
+
+        switch await server.state {
+        case .ready:
+            if let url = await server.signInURL(redirect: redirect) {
+                phase = .ready(url)
+            } else {
+                phase = .failed(
+                    "web-next is running but the sign-in token is not available yet. Try again in a moment."
+                )
+            }
+        case .failed(let reason):
+            phase = .failed(reason)
+        case .idle, .starting:
+            phase = .failed("web-next did not reach a ready state.")
+        }
+    }
+}
+
+struct EmbeddedWebNextDetailView: View {
+    let redirect: String?
+    let onClose: () -> Void
+
+    @StateObject private var model: EmbeddedWebNextModel
+
+    init(
+        server: any WebNextServerServiceProtocol,
+        redirect: String?,
+        onClose: @escaping () -> Void
+    ) {
+        self.redirect = redirect
+        self.onClose = onClose
+        _model = StateObject(wrappedValue: EmbeddedWebNextModel(server: server))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .task(id: redirect) {
+            await model.activate(redirect: redirect)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "globe")
+                .foregroundStyle(.secondary)
+            Text("Web Session")
+                .font(.headline)
+            Spacer(minLength: 0)
+            Button("Close", action: onClose)
+                .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .connecting:
+            EmbeddedWebNextStatusView(state: .connecting)
+        case .failed(let reason):
+            EmbeddedWebNextStatusView(
+                state: .failed(reason),
+                onRetry: { Task { await model.activate(redirect: redirect) } }
+            )
+        case .ready(let signInURL):
+            EmbeddedWebNextWebView(signInURL: signInURL)
+        }
+    }
+}
+
+/// The non-webview states of the embedded surface (server starting or failed).
+/// Standalone so it renders headless (ImageRenderer) for PR evidence without a
+/// running server, and so the detail view stays a thin state switch.
+struct EmbeddedWebNextStatusView: View {
+    enum State: Equatable {
+        case connecting
+        case failed(String)
+    }
+
+    let state: State
+    var onRetry: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 14) {
+            switch state {
+            case .connecting:
+                ProgressView()
+                    .controlSize(.large)
+                Text("Starting web-next…")
+                    .font(.headline)
+                Text("Launching the local server and signing you in.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            case .failed(let reason):
+                Image(systemName: "exclamationmark.triangle")
+                    .font(.largeTitle)
+                    .foregroundStyle(.orange)
+                Text("Couldn't start web-next")
+                    .font(.headline)
+                Text(reason)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 420)
+                Button("Retry") { onRetry?() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+}
+
+/// WKWebView bound to the loopback web-next origin. The navigation policy allows
+/// only `127.0.0.1` / `localhost` (port is not part of host matching); anything
+/// else is treated as an external link and opened in the default browser.
+private struct EmbeddedWebNextWebView: NSViewRepresentable {
+    let signInURL: URL
+
+    func makeCoordinator() -> WebNavigationPolicy {
+        WebNavigationPolicy(
+            allowedHost: "127.0.0.1",
+            additionalAllowedDomains: ["localhost"],
+            allowsSubdomains: false
+        )
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .default()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsBackForwardNavigationGestures = true
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: signInURL))
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {}
+}

--- a/Sources/WorkspaceManager/Web/WebNavigationPolicy.swift
+++ b/Sources/WorkspaceManager/Web/WebNavigationPolicy.swift
@@ -16,6 +16,12 @@ final class WebNavigationPolicy: NSObject, WKNavigationDelegate {
     let additionalAllowedDomains: [String]
     private(set) var activeAllowedHost: String
     let allowsSubdomains: Bool
+    /// When set, navigation must match this port as well as an allowed host.
+    /// Cookies aren't port-scoped, so a host-only allowlist would let a
+    /// token-bearing loopback surface send its session cookie to any other local
+    /// service; pinning the port closes that. `nil` keeps host-only matching for
+    /// callers that don't need it.
+    let allowedPort: Int?
     private let openURL: (URL) -> Void
     var onBlockedNavigation: ((URL) -> Void)?
 
@@ -23,6 +29,7 @@ final class WebNavigationPolicy: NSObject, WKNavigationDelegate {
         allowedHost: String,
         additionalAllowedDomains: [String] = [],
         allowsSubdomains: Bool = true,
+        allowedPort: Int? = nil,
         openURL: @escaping (URL) -> Void = { url in
             NSWorkspace.shared.open(url)
         },
@@ -33,6 +40,7 @@ final class WebNavigationPolicy: NSObject, WKNavigationDelegate {
         self.additionalAllowedDomains = additionalAllowedDomains.map { $0.lowercased() }
         self.activeAllowedHost = normalizedAllowedHost
         self.allowsSubdomains = allowsSubdomains
+        self.allowedPort = allowedPort
         self.openURL = openURL
         self.onBlockedNavigation = onBlockedNavigation
     }
@@ -105,6 +113,13 @@ final class WebNavigationPolicy: NSObject, WKNavigationDelegate {
             return false
         }
 
+        // Port gate (applies to primary host and additional domains alike): a
+        // token-bearing surface must not navigate to a different port on an
+        // otherwise-allowed host.
+        if let allowedPort, url.port != allowedPort {
+            return false
+        }
+
         if WebSourceValidation.host(
             host,
             isAllowedFor: activeAllowedHost,
@@ -124,6 +139,10 @@ final class WebNavigationPolicy: NSObject, WKNavigationDelegate {
         targetFrameIsMainFrame: Bool?
     ) -> Bool {
         guard targetFrameIsMainFrame != false else { return false }
+        // Never adopt across the pinned port, even for an already-allowed host.
+        if let allowedPort, candidateURL.port != allowedPort {
+            return false
+        }
         guard let candidateHost = candidateURL.host?.lowercased(), !candidateHost.isEmpty else {
             return false
         }

--- a/Sources/WorkspaceManagerCore/Models/GitHubRepoSlug.swift
+++ b/Sources/WorkspaceManagerCore/Models/GitHubRepoSlug.swift
@@ -1,0 +1,92 @@
+//
+//  GitHubRepoSlug.swift
+//  WorkspaceManagerCore
+//
+//  Parses `owner/name` out of a git remote URL and builds the embedded
+//  web-next create-session deep link (`/new?repo=<owner>/<name>`) from it. Kept
+//  provider-agnostic and pure so the sidebar can decide whether a "New Web
+//  Session" entry is reachable, and so URL construction is unit-testable without
+//  a running server.
+//
+
+import Foundation
+
+/// A GitHub repository identity in `owner/name` form, parsed from a git remote.
+public struct GitHubRepoSlug: Equatable, Sendable {
+    public let owner: String
+    public let name: String
+
+    /// `owner/name`, the value the deep-link `repo=` parameter expects.
+    public var path: String { "\(owner)/\(name)" }
+
+    public init(owner: String, name: String) {
+        self.owner = owner
+        self.name = name
+    }
+
+    /// Parse a slug from a git remote URL. Handles the three forms that reach
+    /// this app: `https://github.com/owner/name(.git)`,
+    /// `git@github.com:owner/name(.git)` (scp-like), and
+    /// `ssh://git@github.com/owner/name(.git)`. Returns nil for anything without
+    /// a resolvable two-segment path (a repo the deep link cannot bind to).
+    public init?(remoteURL: String?) {
+        guard var working = remoteURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !working.isEmpty
+        else { return nil }
+
+        // Drop the scheme (`https://`, `ssh://`) if present.
+        if let schemeRange = working.range(of: "://") {
+            working = String(working[schemeRange.upperBound...])
+        }
+        // Drop any `user@` credential prefix.
+        if let atIndex = working.firstIndex(of: "@") {
+            working = String(working[working.index(after: atIndex)...])
+        }
+
+        let pathPortion: String
+        if let colonIndex = working.firstIndex(of: ":") {
+            // Either `host:port/path` or scp-style `host:owner/name`.
+            let rest = String(working[working.index(after: colonIndex)...])
+            if let slashIndex = rest.firstIndex(of: "/"),
+                !rest[..<slashIndex].isEmpty,
+                rest[..<slashIndex].allSatisfy(\.isNumber)
+            {
+                pathPortion = String(rest[rest.index(after: slashIndex)...])
+            } else {
+                pathPortion = rest
+            }
+        } else if let slashIndex = working.firstIndex(of: "/") {
+            pathPortion = String(working[working.index(after: slashIndex)...])
+        } else {
+            return nil
+        }
+
+        var trimmed = pathPortion.trimmingCharacters(in: .whitespaces)
+        while trimmed.hasSuffix("/") { trimmed.removeLast() }
+        if trimmed.hasSuffix(".git") { trimmed.removeLast(4) }
+
+        let segments = trimmed.split(separator: "/", omittingEmptySubsequences: true)
+        guard segments.count >= 2 else { return nil }
+
+        let owner = String(segments[segments.count - 2])
+        let name = String(segments[segments.count - 1])
+        guard !owner.isEmpty, !name.isEmpty,
+            !owner.contains(where: \.isWhitespace),
+            !name.contains(where: \.isWhitespace)
+        else { return nil }
+
+        self.owner = owner
+        self.name = name
+    }
+}
+
+/// Relative deep-link paths for the embedded web-next surface, per
+/// `web-next/docs/decisions/embedded-native-contract.md` § 3. These become the
+/// `redirect` value handed to `WebNextServerServiceProtocol.signInURL(redirect:)`,
+/// which the sign-in middleware validates as a relative path and 302s to.
+public enum EmbeddedWebNextDeepLink {
+    /// Create-session redirect binding the new session to `slug`.
+    public static func newSessionRedirect(repo slug: GitHubRepoSlug) -> String {
+        "/new?repo=\(slug.path)"
+    }
+}

--- a/Sources/WorkspaceManagerCore/Models/GitHubRepoSlug.swift
+++ b/Sources/WorkspaceManagerCore/Models/GitHubRepoSlug.swift
@@ -70,13 +70,23 @@ public struct GitHubRepoSlug: Equatable, Sendable {
 
         let owner = String(segments[segments.count - 2])
         let name = String(segments[segments.count - 1])
-        guard !owner.isEmpty, !name.isEmpty,
-            !owner.contains(where: \.isWhitespace),
-            !name.contains(where: \.isWhitespace)
-        else { return nil }
+        guard Self.isValidSegment(owner), Self.isValidSegment(name) else { return nil }
 
         self.owner = owner
         self.name = name
+    }
+
+    /// GitHub's real owner/name charset. Rejecting anything outside it — plus the
+    /// dot-only `.`/`..` segments GitHub disallows — keeps a crafted remote from
+    /// injecting a second query parameter into the deep link (`repo&title=…`) or
+    /// path-traversing when interpolated into a GitHub API URL.
+    static func isValidSegment(_ segment: String) -> Bool {
+        guard !segment.isEmpty, segment != ".", segment != ".." else { return false }
+        return segment.allSatisfy { character in
+            character.isASCII
+                && (character.isLetter || character.isNumber || character == "." || character == "-"
+                    || character == "_")
+        }
     }
 }
 

--- a/Sources/WorkspaceManagerCore/Services/Protocols.swift
+++ b/Sources/WorkspaceManagerCore/Services/Protocols.swift
@@ -191,6 +191,8 @@ public protocol WebNextServerServiceProtocol: Sendable {
     var state: WebNextServerState { get async }
     func start() async
     func stop() async
+    /// Shutdown under the OS app-termination budget (compressed SIGTERM grace).
+    func stopForTermination() async
     func signInURL(redirect: String?) async -> URL?
 }
 

--- a/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
@@ -124,6 +124,8 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     /// current state or another launch's process handle.
     private var generation: UInt64 = 0
     private var watchdogTask: Task<Void, Never>?
+    /// Pumps captured child stdout/stderr through token redaction onto disk.
+    private var logReaderTask: Task<Void, Never>?
 
     private static let signInTokenFilename = "local-sign-in-token"
 
@@ -216,12 +218,25 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     /// Terminate the whole process group: SIGTERM, bounded grace, SIGKILL.
     /// Idempotent — safe to call in any state, including mid-start.
     public func stop() async {
+        await stopInternal(gracePeriod: configuration.terminationGracePeriod)
+    }
+
+    /// Shutdown variant for the app-termination hook, which runs inside the OS's
+    /// ~5s terminate budget. Uses a compressed SIGTERM grace so the full
+    /// SIGTERM → grace → SIGKILL → reap path completes well under that budget;
+    /// the default `stop()` grace would risk the app being killed mid-cleanup,
+    /// orphaning the child the hook exists to reap.
+    public func stopForTermination() async {
+        await stopInternal(gracePeriod: min(configuration.terminationGracePeriod, 1.5))
+    }
+
+    private func stopInternal(gracePeriod: TimeInterval) async {
         generation &+= 1
         cancelWatchdog()
         let pid = processID
         processID = nil
         if let pid {
-            await terminateProcessGroup(pid)
+            await terminateProcessGroup(pid, gracePeriod: gracePeriod)
         }
         state = .idle
     }
@@ -269,18 +284,99 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
         guard logFD >= 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
-        defer { close(logFD) }
+
+        // The child writes to the pipe, not straight to the log file, so a
+        // reader can redact bearer tokens (`start:local` prints the sign-in URL,
+        // token and all) before they land on disk.
+        var pipeFDs: [Int32] = [0, 0]
+        guard pipe(&pipeFDs) == 0 else {
+            close(logFD)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let readEnd = pipeFDs[0]
+        let writeEnd = pipeFDs[1]
 
         var environment = ProcessInfo.processInfo.environment
         environment["PORT"] = String(configuration.port)
         environment["WEB_NEXT_DATA_DIR"] = configuration.dataDir.path
 
-        return try Self.spawnInNewProcessGroup(
-            executablePath: configuration.launchCommand.executablePath,
-            arguments: configuration.launchCommand.arguments,
-            environment: environment,
-            workingDirectory: configuration.webNextRoot.path,
-            outputFD: logFD
+        let pid: pid_t
+        do {
+            pid = try Self.spawnInNewProcessGroup(
+                executablePath: configuration.launchCommand.executablePath,
+                arguments: configuration.launchCommand.arguments,
+                environment: environment,
+                workingDirectory: configuration.webNextRoot.path,
+                outputFD: writeEnd
+            )
+        } catch {
+            close(readEnd)
+            close(writeEnd)
+            close(logFD)
+            throw error
+        }
+
+        // Only the child writes; drop the parent's write end so the reader sees
+        // EOF once the child group exits. The reader owns `readEnd` and `logFD`.
+        close(writeEnd)
+        startLogRedactionReader(readEnd: readEnd, logFD: logFD)
+        return pid
+    }
+
+    /// Streams `readEnd` to `logFD`, redacting any `token=<value>` occurrence
+    /// line by line. Ends at EOF (child group gone); the detached task never
+    /// touches actor state, so it needs no isolation.
+    private func startLogRedactionReader(readEnd: Int32, logFD: Int32) {
+        logReaderTask?.cancel()
+        logReaderTask = Task.detached(priority: .utility) {
+            Self.pumpRedactedLog(readEnd: readEnd, logFD: logFD)
+        }
+    }
+
+    private nonisolated static func pumpRedactedLog(readEnd: Int32, logFD: Int32) {
+        defer {
+            close(readEnd)
+            close(logFD)
+        }
+        var pending: [UInt8] = []
+        var chunk = [UInt8](repeating: 0, count: 8192)
+        while true {
+            let count = read(readEnd, &chunk, chunk.count)
+            if count <= 0 { break }
+            pending.append(contentsOf: chunk[0..<count])
+            while let newline = pending.firstIndex(of: 0x0A) {
+                writeRedactedLine(Array(pending[0...newline]), to: logFD)
+                pending.removeSubrange(0...newline)
+            }
+        }
+        if !pending.isEmpty {
+            writeRedactedLine(pending, to: logFD)
+        }
+    }
+
+    private nonisolated static func writeRedactedLine(_ line: [UInt8], to logFD: Int32) {
+        var bytes = Array(redactSignInToken(in: String(decoding: line, as: UTF8.self)).utf8)
+        var offset = 0
+        while offset < bytes.count {
+            let written = bytes[offset...].withUnsafeBytes { buffer in
+                write(logFD, buffer.baseAddress, buffer.count)
+            }
+            if written <= 0 { break }
+            offset += written
+        }
+    }
+
+    /// Replace any `token=<value>` with `token=<redacted>` so a captured
+    /// `Local sign-in: …?token=<bearer>` line never persists the secret.
+    nonisolated static func redactSignInToken(in text: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: "token=[^\\s&\"']+") else {
+            return text
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.stringByReplacingMatches(
+            in: text,
+            range: range,
+            withTemplate: "token=<redacted>"
         )
     }
 
@@ -372,10 +468,10 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     /// empty within the grace period, then SIGKILL the group. The leader dying
     /// while a member (e.g. `next start` ignoring SIGTERM) survives must still
     /// escalate.
-    private func terminateProcessGroup(_ pid: pid_t) async {
+    private func terminateProcessGroup(_ pid: pid_t, gracePeriod: TimeInterval? = nil) async {
         kill(-pid, SIGTERM)
 
-        let deadline = Date().addingTimeInterval(configuration.terminationGracePeriod)
+        let deadline = Date().addingTimeInterval(gracePeriod ?? configuration.terminationGracePeriod)
         while Date() < deadline {
             if processGroupIsEmpty(pid) { return }
             try? await Task.sleep(nanoseconds: 50_000_000)
@@ -445,9 +541,12 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     // MARK: Readiness
 
     /// Strict readiness per embedded-native-contract.md § 2: `.ready` requires
-    /// `GET /api/healthz` to answer 200 with JSON `ok == true`. Any other HTTP
-    /// response — including a stale or foreign listener on the port — is not
-    /// ready; connection refused means still starting.
+    /// `GET /api/healthz` to answer 200 with JSON `ok == true` AND
+    /// `localMode == true`. Requiring `localMode` keeps a foreign or
+    /// non-local-mode server that merely answers `{ok:true}` on the port from
+    /// satisfying readiness (the WKWebView would otherwise send its session
+    /// cookie to it). Any other HTTP response is not ready; connection refused
+    /// means still starting.
     private func serverIsHealthy() async -> Bool {
         var request = URLRequest(url: baseURL.appendingPathComponent("api/healthz"))
         request.timeoutInterval = 2
@@ -457,9 +556,10 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
             guard let httpResponse = response as? HTTPURLResponse,
                 httpResponse.statusCode == 200,
                 let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                let ok = object["ok"] as? Bool
+                object["ok"] as? Bool == true,
+                object["localMode"] as? Bool == true
             else { return false }
-            return ok
+            return true
         } catch {
             return false
         }

--- a/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
+++ b/Tests/WorkspaceManagerAppTests/AppCommandStateTests.swift
@@ -128,7 +128,8 @@ struct AppCommandStateTests {
             canCopyPath: false,
             canOpenSessionSwitcher: true,
             canOpenCommandRunner: true,
-            canSendFeedback: true
+            canSendFeedback: true,
+            canOpenEmbeddedWebNext: true
         )
 
         state.setMainWindowActions(

--- a/Tests/WorkspaceManagerAppTests/EmbeddedWebNextStatusRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/EmbeddedWebNextStatusRenderTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("EmbeddedWebNextStatusView render")
+struct EmbeddedWebNextStatusRenderTests {
+    /// Renders the embedded surface's non-webview states to non-empty images
+    /// (a layout smoke) and, when `WORKSPACES_EVIDENCE_DIR` is set, writes PNGs
+    /// there for PR evidence without launching the app or a real server.
+    @Test("Starting and failed panes render to non-empty images")
+    func rendersStatusPanes() throws {
+        try render(
+            EmbeddedWebNextStatusView(state: .connecting),
+            named: "embedded-webnext-starting.png"
+        )
+        try render(
+            EmbeddedWebNextStatusView(
+                state: .failed(
+                    "Timed out after 30s waiting for web-next health on port 3140."
+                )
+            ),
+            named: "embedded-webnext-failed.png"
+        )
+    }
+
+    private func render(_ view: some View, named name: String) throws {
+        let content =
+            VStack(spacing: 0) {
+                embeddedHeader
+                Divider()
+                view
+            }
+            .frame(width: 720, height: 460)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .environment(\.colorScheme, .light)
+
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 2
+        let image = try #require(renderer.nsImage)
+        #expect(image.size.width > 0)
+        #expect(image.size.height > 0)
+
+        guard let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let tiff = image.tiffRepresentation,
+            let bitmap = NSBitmapImageRep(data: tiff),
+            let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            return
+        }
+        try png.write(to: URL(fileURLWithPath: dir).appendingPathComponent(name))
+    }
+
+    private var embeddedHeader: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "globe")
+                .foregroundStyle(.secondary)
+            Text("Web Session")
+                .font(.headline)
+            Spacer(minLength: 0)
+            Text("Close")
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+}

--- a/Tests/WorkspaceManagerAppTests/EmbeddedWebNextTests.swift
+++ b/Tests/WorkspaceManagerAppTests/EmbeddedWebNextTests.swift
@@ -9,19 +9,41 @@
 
 import Foundation
 import Testing
+import WebKit
 import WorkspaceManagerCore
 
 @testable import WorkspaceManager
 
+/// Controllable stub so the model's startup-race handling can be tested without
+/// a real server: `start()` is a no-op (the test drives `state` directly),
+/// mirroring the real actor returning immediately while already `.starting`.
+private actor StubWebNextServer: WebNextServerServiceProtocol {
+    private var currentState: WebNextServerState
+
+    init(state: WebNextServerState) { currentState = state }
+
+    var state: WebNextServerState { currentState }
+    func transition(to next: WebNextServerState) { currentState = next }
+
+    func start() async {}
+    func stop() async { currentState = .idle }
+    func stopForTermination() async { currentState = .idle }
+    func signInURL(redirect: String?) async -> URL? {
+        URL(string: "http://127.0.0.1:3140/sign-in?token=stub")
+    }
+}
+
 @MainActor
 @Suite("EmbeddedWebNext")
 struct EmbeddedWebNextTests {
-    /// Mirrors the policy the embedded surface installs: loopback-only, exact host.
+    /// Mirrors the policy the embedded surface installs: loopback host pinned to
+    /// the server port.
     private func loopbackPolicy() -> WebNavigationPolicy {
         WebNavigationPolicy(
             allowedHost: "127.0.0.1",
             additionalAllowedDomains: ["localhost"],
-            allowsSubdomains: false
+            allowsSubdomains: false,
+            allowedPort: 3140
         )
     }
 
@@ -40,6 +62,57 @@ struct EmbeddedWebNextTests {
         #expect(!policy.shouldAllow(url: URL(string: "http://127.0.0.1.evil.com/")!))
         #expect(!policy.shouldAllow(url: URL(string: "http://example.com:3140/")!))
         #expect(!policy.shouldAllow(url: URL(string: "file:///etc/passwd")!))
+    }
+
+    @Test("Loopback policy rejects other ports on the same host (cookie scoping)")
+    func crossPortRejected() {
+        let policy = loopbackPolicy()
+        #expect(!policy.shouldAllow(url: URL(string: "http://127.0.0.1:3141/sessions/1")!))
+        #expect(!policy.shouldAllow(url: URL(string: "http://127.0.0.1:9999/")!))
+        #expect(!policy.shouldAllow(url: URL(string: "http://localhost:3141/")!))
+        // The configured port on either loopback host still passes.
+        #expect(policy.shouldAllow(url: URL(string: "http://127.0.0.1:3140/")!))
+        #expect(policy.shouldAllow(url: URL(string: "http://localhost:3140/")!))
+    }
+
+    @Test("Embedded webview configuration is non-persistent (ephemeral cookie)")
+    func webviewNonPersistent() {
+        let configuration = EmbeddedWebNextWebView.makeConfiguration()
+        #expect(configuration.websiteDataStore.isPersistent == false)
+    }
+
+    @Test("New Web Session forces a fresh activation even for the same repo")
+    func forceFreshActivation() throws {
+        let redirect = "/new?repo=fairchild/workspaces"
+        let first = try #require(
+            EmbeddedWebNextActivation.next(current: nil, redirect: redirect, forceFresh: true))
+        let second = try #require(
+            EmbeddedWebNextActivation.next(current: first, redirect: redirect, forceFresh: true))
+        #expect(first.id != second.id, "each New Web Session must be a distinct activation")
+
+        // The plain shortcut re-opening the same surface is a no-op.
+        #expect(
+            EmbeddedWebNextActivation.next(current: first, redirect: redirect, forceFresh: false) == nil)
+        // A different redirect always opens.
+        #expect(
+            EmbeddedWebNextActivation.next(current: first, redirect: "/", forceFresh: false) != nil)
+    }
+
+    @Test("Activation racing an in-flight launch resolves on ready, not a spurious failure")
+    func activationAwaitsReady() async {
+        let base = URL(string: "http://127.0.0.1:3140")!
+        let stub = StubWebNextServer(state: .starting)
+        let model = EmbeddedWebNextModel(server: stub)
+
+        async let activation: Void = model.activate(redirect: "/new?repo=a/b")
+        // The in-flight launch reaches ready shortly after the second activation.
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        await stub.transition(to: .ready(signInBaseURL: base))
+        await activation
+
+        #expect(
+            model.phase == .ready(URL(string: "http://127.0.0.1:3140/sign-in?token=stub")!),
+            "must await the real .ready, not sample .starting once and fail")
     }
 
     @Test("New Web Session deep link resolves from a workspace's owning repo")

--- a/Tests/WorkspaceManagerAppTests/EmbeddedWebNextTests.swift
+++ b/Tests/WorkspaceManagerAppTests/EmbeddedWebNextTests.swift
@@ -1,0 +1,75 @@
+//
+//  EmbeddedWebNextTests.swift
+//  WorkspaceManagerAppTests
+//
+//  Behavior for the embedded web-next surface: the loopback navigation
+//  allowlist and the repo-bound New Web Session deep link resolved from a
+//  workspace's owning repo.
+//
+
+import Foundation
+import Testing
+import WorkspaceManagerCore
+
+@testable import WorkspaceManager
+
+@MainActor
+@Suite("EmbeddedWebNext")
+struct EmbeddedWebNextTests {
+    /// Mirrors the policy the embedded surface installs: loopback-only, exact host.
+    private func loopbackPolicy() -> WebNavigationPolicy {
+        WebNavigationPolicy(
+            allowedHost: "127.0.0.1",
+            additionalAllowedDomains: ["localhost"],
+            allowsSubdomains: false
+        )
+    }
+
+    @Test("Loopback policy allows 127.0.0.1 and localhost on the server port")
+    func loopbackAllowed() {
+        let policy = loopbackPolicy()
+        #expect(policy.shouldAllow(url: URL(string: "http://127.0.0.1:3140/sign-in?token=abc")!))
+        #expect(policy.shouldAllow(url: URL(string: "http://localhost:3140/sessions/1")!))
+        #expect(policy.shouldAllow(url: URL(string: "http://127.0.0.1:3140/new?repo=a/b")!))
+    }
+
+    @Test("Loopback policy rejects non-loopback hosts")
+    func nonLoopbackRejected() {
+        let policy = loopbackPolicy()
+        #expect(!policy.shouldAllow(url: URL(string: "https://github.com/login")!))
+        #expect(!policy.shouldAllow(url: URL(string: "http://127.0.0.1.evil.com/")!))
+        #expect(!policy.shouldAllow(url: URL(string: "http://example.com:3140/")!))
+        #expect(!policy.shouldAllow(url: URL(string: "file:///etc/passwd")!))
+    }
+
+    @Test("New Web Session deep link resolves from a workspace's owning repo")
+    func deepLinkFromWorkspace() {
+        let repo = Repo(
+            name: "workspaces",
+            localPath: URL(fileURLWithPath: "/tmp/workspaces"),
+            remoteURL: "git@github.com:fairchild/workspaces.git"
+        )
+        let workspace = Workspace(
+            name: "feature-a",
+            path: URL(fileURLWithPath: "/tmp/workspaces/wt/feature-a"),
+            sourceRepo: repo
+        )
+
+        let slug = GitHubRepoSlug(remoteURL: workspace.sourceRepo?.remoteURL)
+        #expect(slug == GitHubRepoSlug(owner: "fairchild", name: "workspaces"))
+        #expect(
+            EmbeddedWebNextDeepLink.newSessionRedirect(repo: slug!)
+                == "/new?repo=fairchild/workspaces"
+        )
+    }
+
+    @Test("New Web Session is unavailable when the repo has no resolvable remote")
+    func deepLinkUnavailableWithoutRemote() {
+        let repo = Repo(
+            name: "local-only",
+            localPath: URL(fileURLWithPath: "/tmp/local-only"),
+            remoteURL: nil
+        )
+        #expect(GitHubRepoSlug(remoteURL: repo.remoteURL) == nil)
+    }
+}

--- a/Tests/WorkspaceManagerTests/GitHubRepoSlugTests.swift
+++ b/Tests/WorkspaceManagerTests/GitHubRepoSlugTests.swift
@@ -52,6 +52,27 @@ struct GitHubRepoSlugTests {
         #expect(GitHubRepoSlug(remoteURL: "not-a-url") == nil)
     }
 
+    @Test("Rejects segments outside GitHub's charset (query/fragment injection)")
+    func rejectsInjectionChars() {
+        // A crafted remote whose name would inject a second query param once the
+        // deep link is decoded, or carries URL-significant characters.
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/acme/repo&title=pwn.git") == nil)
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/acme/a?b.git") == nil)
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/acme/a#b.git") == nil)
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/acme/a b.git") == nil)
+    }
+
+    @Test("Rejects dot-only path-traversal segments")
+    func rejectsTraversal() {
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/acme/...git") == nil)  // name ".."
+        #expect(GitHubRepoSlug(remoteURL: "git@github.com:../workspaces.git") == nil)  // owner ".."
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/./workspaces") == nil)  // owner "."
+        // A legitimate dotted repo name must still resolve.
+        #expect(
+            GitHubRepoSlug(remoteURL: "https://github.com/acme/my.tool.git")
+                == GitHubRepoSlug(owner: "acme", name: "my.tool"))
+    }
+
     @Test("Builds the create-session redirect path")
     func buildsRedirect() {
         let slug = GitHubRepoSlug(owner: "fairchild", name: "workspaces")

--- a/Tests/WorkspaceManagerTests/GitHubRepoSlugTests.swift
+++ b/Tests/WorkspaceManagerTests/GitHubRepoSlugTests.swift
@@ -1,0 +1,60 @@
+//
+//  GitHubRepoSlugTests.swift
+//  WorkspaceManagerTests
+//
+//  Parsing of `owner/name` from the git remote forms this app sees, and the
+//  create-session deep-link path built from a slug.
+//
+
+import Foundation
+import Testing
+
+@testable import WorkspaceManagerCore
+
+@Suite("GitHubRepoSlug")
+struct GitHubRepoSlugTests {
+    @Test("Parses HTTPS remotes with and without the .git suffix")
+    func parsesHTTPS() {
+        #expect(
+            GitHubRepoSlug(remoteURL: "https://github.com/fairchild/workspaces.git")
+                == GitHubRepoSlug(owner: "fairchild", name: "workspaces"))
+        #expect(
+            GitHubRepoSlug(remoteURL: "https://github.com/fairchild/workspaces")
+                == GitHubRepoSlug(owner: "fairchild", name: "workspaces"))
+        #expect(
+            GitHubRepoSlug(remoteURL: "https://github.com/fairchild/workspaces/")
+                == GitHubRepoSlug(owner: "fairchild", name: "workspaces"))
+    }
+
+    @Test("Parses scp-style and ssh remotes")
+    func parsesSSH() {
+        #expect(
+            GitHubRepoSlug(remoteURL: "git@github.com:fairchild/workspaces.git")
+                == GitHubRepoSlug(owner: "fairchild", name: "workspaces"))
+        #expect(
+            GitHubRepoSlug(remoteURL: "ssh://git@github.com/fairchild/workspaces.git")
+                == GitHubRepoSlug(owner: "fairchild", name: "workspaces"))
+    }
+
+    @Test("Preserves dotted repo names")
+    func preservesDottedName() {
+        #expect(
+            GitHubRepoSlug(remoteURL: "https://github.com/acme/my.tool.git")
+                == GitHubRepoSlug(owner: "acme", name: "my.tool"))
+    }
+
+    @Test("Returns nil for unresolvable remotes")
+    func returnsNilForUnresolvable() {
+        #expect(GitHubRepoSlug(remoteURL: nil) == nil)
+        #expect(GitHubRepoSlug(remoteURL: "") == nil)
+        #expect(GitHubRepoSlug(remoteURL: "   ") == nil)
+        #expect(GitHubRepoSlug(remoteURL: "https://github.com/owneronly") == nil)
+        #expect(GitHubRepoSlug(remoteURL: "not-a-url") == nil)
+    }
+
+    @Test("Builds the create-session redirect path")
+    func buildsRedirect() {
+        let slug = GitHubRepoSlug(owner: "fairchild", name: "workspaces")
+        #expect(EmbeddedWebNextDeepLink.newSessionRedirect(repo: slug) == "/new?repo=fairchild/workspaces")
+    }
+}

--- a/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
@@ -78,7 +78,7 @@ struct WebNextServerServiceTests {
             class Handler(BaseHTTPRequestHandler):
                 def do_GET(self):
                     if self.path.startswith("/api/healthz"):
-                        body = b'{"ok": true}'
+                        body = os.environ.get("HEALTHZ_BODY", '{"ok": true, "localMode": true}').encode()
                         self.send_response(200)
                         self.send_header("Content-Type", "application/json")
                         self.send_header("Content-Length", str(len(body)))
@@ -393,6 +393,115 @@ struct WebNextServerServiceTests {
         #expect(!logContents.contains(token), "token must never appear in server logs")
 
         await service.stop()
+    }
+
+    @Test("readiness rejects healthz without localMode true")
+    func readinessRequiresLocalMode() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let script = """
+            export HEALTHZ_BODY='{"ok": true, "localMode": false}'
+            \(fixture.healthzServerScript)
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(
+                script: script, readinessTimeout: 2, readinessPollInterval: 0.1))
+
+        await service.start()
+        defer { Task { await service.stop() } }
+
+        guard case .failed = await service.state else {
+            Issue.record("localMode:false must not satisfy readiness, got \(await service.state)")
+            return
+        }
+    }
+
+    // MARK: - Log redaction
+
+    @Test("redactSignInToken masks token values, keeps surrounding text")
+    func redactsTokenValue() {
+        let line = "Local sign-in: http://127.0.0.1:3140/sign-in?token=abc.DEF-123&redirect=/"
+        let out = WebNextServerService.redactSignInToken(in: line)
+        #expect(out == "Local sign-in: http://127.0.0.1:3140/sign-in?token=<redacted>&redirect=/")
+        #expect(!out.contains("abc.DEF-123"))
+        #expect(WebNextServerService.redactSignInToken(in: "no tokens here") == "no tokens here")
+    }
+
+    @Test("captured server logs redact bearer tokens before they reach disk")
+    func serverLogsRedactToken() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let secret = "SECRET-\(UUID().uuidString)"
+        let script = """
+            echo "Local sign-in: http://127.0.0.1:$PORT/sign-in?token=\(secret)&redirect=/"
+            \(fixture.healthzServerScript)
+            """
+        let service = WebNextServerService(configuration: fixture.configuration(script: script))
+
+        await service.start()
+        defer { Task { await service.stop() } }
+        guard case .ready = await service.state else {
+            Issue.record("expected .ready, got \(await service.state)")
+            return
+        }
+
+        let logURL = try #require(await service.logFileURL)
+        let redacted = await waitUntil(timeout: 5) {
+            let contents = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+            return contents.contains("token=<redacted>") && !contents.contains(secret)
+        }
+        #expect(redacted, "log must show token=<redacted> and never the raw secret")
+
+        // When capturing evidence, emit the real on-disk log so the PR can show
+        // the redacted line (never the secret) as proof.
+        if let dir = ProcessInfo.processInfo.environment["WORKSPACES_EVIDENCE_DIR"],
+            let contents = try? String(contentsOf: logURL, encoding: .utf8)
+        {
+            try? contents.write(
+                to: URL(fileURLWithPath: dir).appendingPathComponent("redacted-server-log.txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+    }
+
+    // MARK: - Termination budget
+
+    @Test("stopForTermination finishes under the OS terminate budget and still SIGKILLs")
+    func stopForTerminationBudget() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        let script = """
+            python3 -c 'import os, signal, time
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            open(os.environ["WEB_NEXT_DATA_DIR"] + "/term-ignorer-armed", "w").write("1")
+            time.sleep(300)' &
+            echo $! > "$WEB_NEXT_DATA_DIR/child.pid"
+            \(fixture.healthzServerScript)
+            """
+        // A full 5s grace here; stopForTermination must compress it under budget.
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, terminationGracePeriod: 5))
+
+        await service.start()
+        guard case .ready = await service.state else {
+            Issue.record("expected .ready, got \(await service.state)")
+            return
+        }
+        let armedURL = fixture.dataDir.appendingPathComponent("term-ignorer-armed")
+        let armed = await waitUntil(timeout: 5) { FileManager.default.fileExists(atPath: armedURL.path) }
+        #expect(armed, "the SIGTERM-ignoring child must be armed before termination")
+        let childPID = try #require(readPID(at: fixture.dataDir.appendingPathComponent("child.pid")))
+        #expect(processIsAlive(childPID))
+
+        let started = Date()
+        await service.stopForTermination()
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(elapsed < 4, "terminate path must finish under the OS budget, took \(elapsed)s")
+
+        let childDied = await waitUntil(timeout: 5) { !self.processIsAlive(childPID) }
+        #expect(childDied, "a SIGTERM-ignoring member must still be SIGKILLed")
+        #expect(await service.state == .idle)
     }
 
     @Test("signInURL is nil while not ready")


### PR DESCRIPTION
## Summary

Makes the embedded local-mode web-next experience clickable from inside the WorkSpaces app — the native surface, shortcut, and repo-bound entry that the web-next side (turns, Open PR) already backs via the vercel provider.

- **Embedded surface.** A new `detailContent` branch mounts a `WKWebView` navigated to `WebNextServerService.signInURL(redirect:)` once the server is `.ready`. While it comes up it shows a "Starting web-next…" pane; on failure a readable error pane with **Retry**. Navigation is locked to the loopback origin (`127.0.0.1` / `localhost` — port is not part of host matching); external links open in the default browser via the existing blocked-navigation path.
- **Shortcut.** `Cmd+Shift+A` "Open Web Session" (also in the Selection menu) opens the surface with `redirect=/`. Verified free against the existing `AppChromeShortcut` catalog and not a common Ghostty passthrough chord; `defaultRoute: .appChrome`.
- **New Web Session.** Repo and workspace context-menu entries deep-link to `/new?repo=<owner>/<name>`, resolved from the repo's git remote. Disabled when the remote can't be parsed to `owner/name`, so no broken deep link is ever sent.
- **Lifecycle.** The server is constructed but **not** started at launch — it starts lazily on first activation of the surface (config: `webNextRoot` from a setting defaulting to `~/code/workspaces/web-next`, port `3140`, data dir under Application Support). Its process group is stopped on app termination so quitting never orphans a `next start` child holding the port.
- The sign-in token stays in memory and appears only in the initial in-app sign-in navigation — never logged, never persisted in a `WebSource`. That's why this surface is a dedicated view rather than reusing `WebSurfaceStore` (which is keyed to a persisted `WebSource`).

Governed by `web-next/docs/decisions/embedded-native-contract.md`. This PR is native/desktop-only; it does not touch `web-next/`.

`Closes #987` — this slice closes **Milestone 1** (usable embedded demo, real draft PR out via the vercel provider). **Milestone 2** — the host provider's write/PR lane and `path=<absolute working-copy>` binding — remains; it un-reserves `path=` and changes nothing above.

## Demo dependency (follow-up)

The demo requires a local `web-next` checkout at the configured root (`~/code/workspaces/web-next`) to actually serve. That's the M1 demo setup, not bundled — **bundling web-next into the app is a Milestone-2 follow-up**.

## Evidence

Headless `ImageRenderer` renders of the embedded surface's status panes (no app launch, no focus steal — `EmbeddedWebNextStatusRenderTests`):

![Failed status pane — error message with Retry](https://evidence.cloudcompute.com/workspaces/pr-1031/20260709-065542-webnext-embedded-failed.png)

![Starting status pane (spinner is live-only; ImageRenderer shows a placeholder glyph)](https://evidence.cloudcompute.com/workspaces/pr-1031/20260709-065552-webnext-embedded-starting.png)

Redacted server log — the captured child stdout that once leaked the bearer token now writes `token=<redacted>` to disk (raw secret absent):

![Redacted server log showing token=redacted](https://evidence.cloudcompute.com/workspaces/pr-1031/20260709-071950-webnext-embedded-surface-review-fixes-redacted-log.png)

**Exercised live:** unit/behavior suite (loopback allowlist accept/reject incl. cross-port rejection, `owner/name` parsing across https/scp/ssh plus charset/traversal rejection, deep-link redirect from a workspace fixture, New-Web-Session disabled when the remote is unresolvable, non-persistent webview config, force-fresh activation, model startup-race → `.ready`, healthz `localMode` gate, on-disk log redaction, `stopForTermination` budget < 4s + SIGKILL escalation), the full `swift test` suite (**1322 tests**), `swift build`, and `mise run lint` — all green. Mutation checks: (a) forcing `WebSourceValidation.host` to accept every host fails the loopback-rejection test; (b) disabling the port gate fails the cross-port rejection test — both reverted.

**Not exercised live (blocked, honest):** the end-to-end server round-trip (real server `.ready` → signed-in webview → Open PR) was **not** driven. The web-next checkout in this environment has no `.next` production build and this checkout lacks an `api/healthz` route, so `start:local` can't reach the contract's readiness gate in-harness; and a shared-desktop session with another agent's app running made a focus-stealing in-app shortcut drive inappropriate (`launch-dev` would `pkill -x` the other app). The status/error panes shown above are the real rendered SwiftUI; the `.ready` WKWebView branch is covered by the allowlist tests, not a live render.

- CI: [build-and-test + analyzers green](https://github.com/fairchild/workspaces/pull/1031/checks) on 0085cbfe

## Review loop

Directed codex (gpt-5.5, xhigh) review of #1031 returned 2 blockers + 7 majors; all 9 accepted and fixed in `0085cbfe`.

| # | Severity | Finding | Disposition |
|---|----------|---------|-------------|
| 1 | Blocker | Bearer token persisted in the captured server log (`start:local` prints the sign-in URL) | Fixed — child stdout/stderr streams through a line-redacting reader → `token=<redacted>` before disk |
| 2 | Blocker | Host-only allowlist let the token-bearing webview navigate cross-port (cookies aren't port-scoped → session cookie leak) | Fixed — `WebNavigationPolicy` gains an `allowedPort` pin; embedded surface pins host **and** 3140 |
| 3 | Major | Persistent `WKWebsiteDataStore` kept the session cookie on disk across runs | Fixed — `.nonPersistent()` store for the ephemeral surface |
| 4 & 5 | Major | `GitHubRepoSlug` accepted URL-significant / path-traversal chars (query injection, `..`) | Fixed — validate against `[A-Za-z0-9._-]`, reject `.`/`..`. Companion web-next hardening tracked in **#1032** (defense-in-depth on `/new`; not touched here — containment) |
| 6 | Major | `stopBlocking` 6s budget could exceed the OS ~5s terminate window → orphaned child | Fixed — `stopForTermination()` with compressed 1.5s grace; whole path < 4s |
| 7 | Major | Activation racing an in-flight launch sampled state once → spurious `.failed` | Fixed — model awaits the real `.ready`/`.failed` transition |
| 8 | Major | Second New Web Session for the same repo hit the no-op guard → nothing happened | Fixed — New Web Session forces a fresh activation; plain shortcut keeps the guard |
| 9 | Major | Readiness ignored `localMode`, so a foreign `{ok:true}` server satisfied it | Fixed — require `localMode == true` (compounds with #2) |

Each fix ships a behavior test (see Exercised live). Findings 1 and 9 live in `WebNextServerService.swift` (N1) but N2 makes them exploitable; fixed here as native files.

## Mergeability

- **Surface:** desktop app — a new embedded web-next WKWebView detail pane, a `Cmd+Shift+A` app-chrome shortcut, and repo/workspace "New Web Session" sidebar entries. No `web-next/` changes.
- **User-facing behavior changed:** Yes. A new "Web Session" pane opens from the keyboard shortcut, the Selection menu, or the sidebar context menus, auto-signing into the local web-next server; the pane shows starting/failure status and closes back to the prior selection.
- **Non-happy paths considered:** Server slow or failing to start renders an explicit error pane with Retry rather than a blank webview; an activation racing an in-flight launch awaits the real outcome instead of failing spuriously; a repo with an unresolvable, injection-bearing, or traversal (`..`) remote disables the New Web Session entry instead of sending a broken/crafted deep link; navigation to any non-loopback host **or a different port on loopback** is blocked and opened externally; the bearer token is never persisted or logged (redacted in the captured log; ephemeral non-persistent cookie store); readiness requires `localMode:true`; app termination tears down the server process group under a compressed budget so the port isn't orphaned.
- **Residual risk or follow-up:** The live server round-trip is unproven in-harness (see Evidence) — needs a built local web-next with the `healthz`/`localMode` route to demo end to end. `web-next` is not bundled (Milestone-2). Web-next-side `/new` charset hardening is defense-in-depth follow-up **#1032** (the embedded vector is closed here). `webNextRoot` has no Settings UI yet (defaults to the demo path; overridable via the `webNextServerRoot` UserDefaults key). The `.starting` spinner does not rasterize under ImageRenderer (live-only), so its evidence image shows a placeholder glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Gate note (orchestrator): full diff read; independent `swift build`/`swift test` re-run on the fix commit (1322 tests, 198 suites); directed codex (gpt-5.5, xhigh) adversarial review → 2 blockers + 7 majors, all fixed in 0085cbfe with attributed commit + the requested cross-port mutation check; companion web-next hardening filed as #1032. Live re-verification against the real rebuilt server: healthz returns `{"ok":true,"localMode":true}`, so the hardened readiness gate (now requiring localMode) passes end to end; token sign-in + deep-link redirect + open-redirect neutralization all confirmed live. First build-and-test run failed on two pre-existing ProcessRunner timing-assertion flakes (elapsed<10s on an overloaded runner; unrelated to this diff, green locally) — re-run passed. Merging under delegated authority; closes #987 Milestone 1.