### PR TITLE
fix(web-next): naturally follow active turns

### DIFF
--- a/web-next/package.json
+++ b/web-next/package.json
@@ -16,6 +16,7 @@
 		"clean": "node scripts/clean.mjs",
 		"evidence": "node scripts/evidence.mjs",
 		"evidence:upload": "bash scripts/upload-evidence.sh",
+		"demo:scroll-turn": "playwright test --config=playwright.scroll-turn.config.ts",
 		"perf": "node perf/run.mjs",
 		"validate": "tsx scripts/validate.mjs"
 	},

--- a/web-next/playwright.scroll-turn.config.ts
+++ b/web-next/playwright.scroll-turn.config.ts
@@ -1,0 +1,33 @@
+/*
+ * Playwright config for the filmed #1015 turn-scroll proof. It starts the
+ * hermetic mock-provider app on an isolated port, records one 1280x720 video,
+ * and keeps the artifact separate from the normal E2E suite.
+ */
+import { defineConfig, devices } from "@playwright/test";
+import { E2E_LOGIN, signedInAs } from "./playwright.config";
+
+const PORT = Number(process.env.SCROLL_TURN_PORT ?? 3218);
+
+export default defineConfig({
+	testDir: "./tests/demo",
+	testMatch: /scroll-turn\.spec\.ts/,
+	timeout: 60_000,
+	retries: 0,
+	workers: 1,
+	reporter: [["list"]],
+	outputDir: "output/scroll-turn/test-results",
+	use: {
+		...devices["Desktop Chrome"],
+		viewport: { width: 1280, height: 720 },
+		baseURL: `http://localhost:${PORT}`,
+		storageState: signedInAs(E2E_LOGIN),
+		video: { mode: "on", size: { width: 1280, height: 720 } },
+		trace: "off",
+	},
+	webServer: {
+		command: `WEB_NEXT_COMPUTE_PROVIDER=mock E2E_PORT=${PORT} pnpm run e2e:server`,
+		url: `http://localhost:${PORT}`,
+		reuseExistingServer: false,
+		timeout: 180_000,
+	},
+});

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/lib/transcript/live-turn-error";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
 import { sandboxStateLabel, useSandboxState } from "./use-sandbox-state";
+import { useTurnFollow } from "./use-turn-follow";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
 const TOKEN_THROTTLE_MS = 50;
@@ -98,6 +99,14 @@ function firstUserText(messages: FolioMessage[]): string {
 			.map((part) => part.text)
 			.join("") ?? ""
 	);
+}
+
+function latestUserMessageId(messages: readonly FolioMessage[]): string | null {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (message.role === "user") return message.id;
+	}
+	return null;
 }
 
 export function LiveSessionView({
@@ -476,6 +485,13 @@ export function LiveSessionView({
 	// article stands in for an in-progress, contentless reply.
 	const visibleMessages = displayMessages.filter(isVisibleMessage);
 
+	const latestVisibleUserMessageId = latestUserMessageId(visibleMessages);
+	useTurnFollow({
+		active: busy,
+		scopeId: sessionId,
+		userMessageId: latestVisibleUserMessageId,
+	});
+
 	// The standalone activity article covers the gap before the streamed
 	// reply renders content (provisioning statuses); once parts land, the
 	// growing message itself — running ledger rows, prose — is the live
@@ -510,6 +526,7 @@ export function LiveSessionView({
 		<>
 			<TerminalDrawer sessionId={sessionId} />
 			<SessionView
+				turnFollowScopeId={sessionId}
 				session={{
 					...session,
 					messages: visibleMessages,

--- a/web-next/src/app/(app)/sessions/[id]/use-turn-follow.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-turn-follow.ts
@@ -22,12 +22,14 @@ export function useTurnFollow({
 	scopeId: string;
 	userMessageId: string | null;
 }) {
-	const followedUserMessageIdRef = useRef<string | null>(null);
+	// Ownership survives the active → complete render so the final layout can
+	// settle. User takeover clears it, which prevents completion from yanking
+	// the reader back to the tail.
+	const followOwnerIdRef = useRef<string | null>(null);
 
 	useEffect(() => {
 		if (!userMessageId) return;
-		const finishingFollow =
-			!active && followedUserMessageIdRef.current === userMessageId;
+		const finishingFollow = !active && followOwnerIdRef.current === userMessageId;
 		if (!active && !finishingFollow) return;
 
 		const scope = `[data-turn-follow-scope="${CSS.escape(scopeId)}"]`;
@@ -41,6 +43,8 @@ export function useTurnFollow({
 
 		const scrollRoot = document.documentElement;
 		const previousOverflowAnchor = scrollRoot.style.overflowAnchor;
+		// Native anchoring and our animator otherwise add their corrections,
+		// producing a visible jump when streamed content changes height.
 		if (active) scrollRoot.style.overflowAnchor = "none";
 
 		let measureFrame = 0;
@@ -92,6 +96,8 @@ export function useTurnFollow({
 				0,
 				document.documentElement.scrollHeight - window.innerHeight,
 			);
+			// Never chase small layout contractions backwards; the browser can
+			// clamp at the document tail while follow remains visually monotonic.
 			targetScrollY = Math.max(
 				targetScrollY,
 				Math.min(window.scrollY + overflow, maxScrollY),
@@ -115,7 +121,7 @@ export function useTurnFollow({
 		};
 		const pauseFollowing = () => {
 			followPaused = true;
-			followedUserMessageIdRef.current = null;
+			followOwnerIdRef.current = null;
 			stopFollowing();
 		};
 		const handleScroll = () => {
@@ -128,7 +134,7 @@ export function useTurnFollow({
 			);
 			if (distanceFromTail > FOLLOW_RESUME_THRESHOLD_PX) return;
 			followPaused = false;
-			followedUserMessageIdRef.current = userMessageId;
+			followOwnerIdRef.current = userMessageId;
 			targetScrollY = window.scrollY;
 			lastAnimationAt = 0;
 			follow();
@@ -161,12 +167,12 @@ export function useTurnFollow({
 		};
 
 		if (finishingFollow) {
-			followedUserMessageIdRef.current = null;
+			followOwnerIdRef.current = null;
 			follow();
 			return stopFollowing;
 		}
 
-		followedUserMessageIdRef.current = userMessageId;
+		followOwnerIdRef.current = userMessageId;
 		const observer = new ResizeObserver(follow);
 		observer.observe(turn);
 		observer.observe(compose);

--- a/web-next/src/app/(app)/sessions/[id]/use-turn-follow.ts
+++ b/web-next/src/app/(app)/sessions/[id]/use-turn-follow.ts
@@ -1,0 +1,194 @@
+"use client";
+
+/*
+ * Natural tail-following for a live session turn. One retargetable animator
+ * tracks streamed layout growth, yields immediately to upward user scrolling,
+ * and rearms when the reader returns to the document tail.
+ */
+import { useEffect, useRef } from "react";
+
+const FOLLOW_GAP_PX = 16;
+const FOLLOW_SETTLE_PX = 0.5;
+const FOLLOW_MAX_STEP_PX = 24;
+const FOLLOW_RESUME_THRESHOLD_PX = 48;
+const FOLLOW_TIME_CONSTANT_MS = 120;
+
+export function useTurnFollow({
+	active,
+	scopeId,
+	userMessageId,
+}: {
+	active: boolean;
+	scopeId: string;
+	userMessageId: string | null;
+}) {
+	const followedUserMessageIdRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!userMessageId) return;
+		const finishingFollow =
+			!active && followedUserMessageIdRef.current === userMessageId;
+		if (!active && !finishingFollow) return;
+
+		const scope = `[data-turn-follow-scope="${CSS.escape(scopeId)}"]`;
+		const turn = document.querySelector<HTMLElement>(
+			`${scope} section[data-turn="recent"]`,
+		);
+		const compose = document.querySelector<HTMLElement>(
+			`${scope} [data-compose-boundary]`,
+		);
+		if (!turn || !compose) return;
+
+		const scrollRoot = document.documentElement;
+		const previousOverflowAnchor = scrollRoot.style.overflowAnchor;
+		if (active) scrollRoot.style.overflowAnchor = "none";
+
+		let measureFrame = 0;
+		let animationFrame = 0;
+		let lastAnimationAt = 0;
+		let targetScrollY = window.scrollY;
+		let followPaused = false;
+		let lastTouchY: number | null = null;
+		const reduceMotion = window.matchMedia(
+			"(prefers-reduced-motion: reduce)",
+		).matches;
+
+		const animate = (at: number) => {
+			animationFrame = 0;
+			if (followPaused) return;
+			const currentScrollY = window.scrollY;
+			const remaining = targetScrollY - currentScrollY;
+			if (remaining <= FOLLOW_SETTLE_PX) {
+				if (remaining > 0)
+					window.scrollTo({ top: targetScrollY, behavior: "auto" });
+				lastAnimationAt = 0;
+				return;
+			}
+
+			const elapsed = lastAnimationAt
+				? Math.min(at - lastAnimationAt, 64)
+				: 1_000 / 60;
+			lastAnimationAt = at;
+			const easedStep =
+				remaining * (1 - Math.exp(-elapsed / FOLLOW_TIME_CONSTANT_MS));
+			const step = Math.min(
+				remaining,
+				FOLLOW_MAX_STEP_PX,
+				Math.max(FOLLOW_SETTLE_PX, easedStep),
+			);
+			window.scrollTo({ top: currentScrollY + step, behavior: "auto" });
+			animationFrame = window.requestAnimationFrame(animate);
+		};
+
+		const updateTarget = () => {
+			measureFrame = 0;
+			if (followPaused) return;
+			const overflow =
+				turn.getBoundingClientRect().bottom -
+				(compose.getBoundingClientRect().top - FOLLOW_GAP_PX);
+			if (overflow <= 0) return;
+
+			const maxScrollY = Math.max(
+				0,
+				document.documentElement.scrollHeight - window.innerHeight,
+			);
+			targetScrollY = Math.max(
+				targetScrollY,
+				Math.min(window.scrollY + overflow, maxScrollY),
+			);
+			if (reduceMotion) {
+				window.scrollTo({ top: targetScrollY, behavior: "auto" });
+				return;
+			}
+			if (!animationFrame) animationFrame = window.requestAnimationFrame(animate);
+		};
+
+		const follow = () => {
+			if (!followPaused && !measureFrame)
+				measureFrame = window.requestAnimationFrame(updateTarget);
+		};
+		const stopFollowing = () => {
+			window.cancelAnimationFrame(measureFrame);
+			window.cancelAnimationFrame(animationFrame);
+			measureFrame = 0;
+			animationFrame = 0;
+		};
+		const pauseFollowing = () => {
+			followPaused = true;
+			followedUserMessageIdRef.current = null;
+			stopFollowing();
+		};
+		const handleScroll = () => {
+			if (!followPaused) return;
+			const distanceFromTail = Math.max(
+				0,
+				document.documentElement.scrollHeight -
+					window.innerHeight -
+					window.scrollY,
+			);
+			if (distanceFromTail > FOLLOW_RESUME_THRESHOLD_PX) return;
+			followPaused = false;
+			followedUserMessageIdRef.current = userMessageId;
+			targetScrollY = window.scrollY;
+			lastAnimationAt = 0;
+			follow();
+		};
+		const handleWheel = (event: WheelEvent) => {
+			if (event.deltaY < 0) pauseFollowing();
+		};
+		const handleTouchStart = (event: TouchEvent) => {
+			lastTouchY = event.touches[0]?.clientY ?? null;
+		};
+		const handleTouchMove = (event: TouchEvent) => {
+			const touchY = event.touches[0]?.clientY;
+			if (touchY === undefined) return;
+			if (lastTouchY !== null && touchY > lastTouchY + 4) pauseFollowing();
+			lastTouchY = touchY;
+		};
+		const handleTouchEnd = () => {
+			lastTouchY = null;
+		};
+		const handleKeyDown = (event: KeyboardEvent) => {
+			const target = event.target as HTMLElement | null;
+			if (target?.matches("input, textarea, [contenteditable='true']")) return;
+			if (
+				event.key === "ArrowUp" ||
+				event.key === "PageUp" ||
+				event.key === "Home" ||
+				(event.key === " " && event.shiftKey)
+			)
+				pauseFollowing();
+		};
+
+		if (finishingFollow) {
+			followedUserMessageIdRef.current = null;
+			follow();
+			return stopFollowing;
+		}
+
+		followedUserMessageIdRef.current = userMessageId;
+		const observer = new ResizeObserver(follow);
+		observer.observe(turn);
+		observer.observe(compose);
+		window.addEventListener("resize", follow);
+		window.addEventListener("scroll", handleScroll, { passive: true });
+		window.addEventListener("wheel", handleWheel, { passive: true });
+		window.addEventListener("touchstart", handleTouchStart, { passive: true });
+		window.addEventListener("touchmove", handleTouchMove, { passive: true });
+		window.addEventListener("touchend", handleTouchEnd, { passive: true });
+		window.addEventListener("keydown", handleKeyDown);
+		follow();
+		return () => {
+			observer.disconnect();
+			window.removeEventListener("resize", follow);
+			window.removeEventListener("scroll", handleScroll);
+			window.removeEventListener("wheel", handleWheel);
+			window.removeEventListener("touchstart", handleTouchStart);
+			window.removeEventListener("touchmove", handleTouchMove);
+			window.removeEventListener("touchend", handleTouchEnd);
+			window.removeEventListener("keydown", handleKeyDown);
+			stopFollowing();
+			scrollRoot.style.overflowAnchor = previousOverflowAnchor;
+		};
+	}, [active, scopeId, userMessageId]);
+}

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -246,6 +246,43 @@
 }
 
 @layer components {
+	/* Radix exposes the exact content height, so the thinking block can fold
+	   without deleting a pageful of layout in one frame. This is the one
+	   intentional layout animation in the transcript: it prevents the browser's
+	   max-scroll clamp from producing a much larger viewport jump. */
+	.reasoning-content[data-state="open"] {
+		animation: reasoning-expand 240ms cubic-bezier(0.2, 0.7, 0.2, 1);
+	}
+	.reasoning-content[data-state="closed"] {
+		animation: reasoning-collapse 320ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+	@keyframes reasoning-expand {
+		from {
+			height: 0;
+			opacity: 0;
+		}
+		to {
+			height: var(--radix-collapsible-content-height);
+			opacity: 1;
+		}
+	}
+	@keyframes reasoning-collapse {
+		from {
+			height: var(--radix-collapsible-content-height);
+			opacity: 1;
+		}
+		to {
+			height: 0;
+			opacity: 0;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.reasoning-content[data-state="open"],
+		.reasoning-content[data-state="closed"] {
+			animation: none;
+		}
+	}
+
 	/* Animated trailing dots ('' → . → .. → …); content keyframes can't be
 	   expressed as a Tailwind utility. */
 	.ellipsis-dots::after {

--- a/web-next/src/components/folio/compose-field.tsx
+++ b/web-next/src/components/folio/compose-field.tsx
@@ -83,6 +83,7 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 	return (
 		<div className="bg-[linear-gradient(to_top,var(--paper)_66%,var(--paper-0))] px-5 pt-11 pb-5">
 			<div
+				data-compose-boundary
 				className="group mx-auto flex min-h-[54px] max-w-[680px] cursor-text items-end gap-[13px] rounded-[13px] border border-line-strong bg-raised py-2 pr-2 pl-[19px] shadow-field transition-[border-color,box-shadow] duration-200 hover:border-focus-line focus-within:border-focus-line focus-within:shadow-[0_0_0_3px_var(--focus-ring),var(--field-shadow)]"
 				onClick={(event) => {
 					if (!(event.target as HTMLElement).closest("button"))

--- a/web-next/src/components/folio/reasoning.tsx
+++ b/web-next/src/components/folio/reasoning.tsx
@@ -187,7 +187,7 @@ export const ReasoningContent = memo(function ReasoningContent({
 	return (
 		<Collapsible.Content
 			data-testid="reasoning-content"
-			className={`overflow-hidden ${className ?? ""}`}
+			className={`reasoning-content overflow-hidden ${className ?? ""}`}
 			{...props}
 		>
 			<div className="animate-rise-fast mt-2.5 mb-1 border-l border-line pl-4 text-[16px] leading-[1.65] text-muted [&_code]:text-[.8em] [&_p+p]:mt-3">

--- a/web-next/src/components/folio/session-view.tsx
+++ b/web-next/src/components/folio/session-view.tsx
@@ -135,6 +135,8 @@ function QueuedMessages({
 
 export interface SessionViewProps {
 	session: SessionViewData;
+	/** Scopes live-turn follow DOM lookups when this is a real session surface. */
+	turnFollowScopeId?: string;
 	/** Compose submit handler (client wrappers wire this; fixtures omit it). */
 	onSend?: (text: string) => void;
 	/** Hard-disables compose when this surface cannot accept text. */
@@ -167,6 +169,7 @@ export interface SessionViewProps {
 
 export function SessionView({
 	session,
+	turnFollowScopeId,
 	onSend,
 	composeDisabled,
 	retryDisabled,
@@ -196,6 +199,7 @@ export function SessionView({
 			    path, a URL) wraps instead of forcing 375px pages sideways (#753);
 			    pre/diff bodies keep their own inner overflow-x scrolling. */}
 			<main
+				data-turn-follow-scope={turnFollowScopeId}
 				className={`mx-auto max-w-[680px] px-4 pb-6 break-words sm:px-5 ${
 					hasMastheadSubline ? "pt-[104px]" : "pt-[76px]"
 				}`}
@@ -268,7 +272,10 @@ export function SessionView({
 					});
 				})()}
 			</main>
-			<footer className="sticky bottom-0 z-[15]">
+			<footer
+				data-turn-follow-scope={turnFollowScopeId}
+				className="sticky bottom-0 z-[15]"
+			>
 				<QueuedMessages
 					messages={queuedMessages}
 					onCancel={onCancelQueuedMessage}

--- a/web-next/tests/demo/scroll-turn.spec.ts
+++ b/web-next/tests/demo/scroll-turn.spec.ts
@@ -100,17 +100,12 @@ test("a directly sent follow-up naturally follows its growing bottom", async ({
 	await expect(recentTurn).toContainText(
 		"Keep this active turn above the composer while it grows",
 	);
-	await expectActiveTurnAboveComposer(page);
-
-	// Each milestone grows the same live turn. Its lower edge must keep moving
-	// up with the output instead of disappearing behind the sticky composer.
-	await expect(page.getByTestId("reasoning")).toHaveCount(2, {
-		timeout: TURN_TIMEOUT,
-	});
-	await expectActiveTurnAboveComposer(page);
-	await expect(page.getByTestId("tool-row")).toHaveCount(5, {
-		timeout: TURN_TIMEOUT,
-	});
+	const initialTurnHeight = (await recentTurn.boundingBox())?.height ?? 0;
+	await expect
+		.poll(async () => (await recentTurn.boundingBox())?.height ?? 0, {
+			timeout: TURN_TIMEOUT,
+		})
+		.toBeGreaterThan(initialTurnHeight + 160);
 	await expectActiveTurnAboveComposer(page);
 	await expect(page.getByTestId("turn-stats")).toHaveCount(2, {
 		timeout: TURN_TIMEOUT,
@@ -125,14 +120,25 @@ test("a directly sent follow-up naturally follows its growing bottom", async ({
 		.map((sample, index) => Math.abs(sample.y - samples[index].y));
 	const maxFrameDelta = Math.max(0, ...frameDeltas);
 	const movingFrames = frameDeltas.filter((delta) => delta > 0.5).length;
+	const scrollTravel =
+		Math.max(...samples.map(({ y }) => y)) -
+		Math.min(...samples.map(({ y }) => y));
 	await testInfo.attach("scroll-trace", {
 		body: JSON.stringify(
-			{ sampleCount: samples.length, maxFrameDelta, movingFrames, samples },
+			{
+				sampleCount: samples.length,
+				maxFrameDelta,
+				movingFrames,
+				scrollTravel,
+				samples,
+			},
 			null,
 			2,
 		),
 		contentType: "application/json",
 	});
+	expect(scrollTravel).toBeGreaterThan(400);
+	expect(movingFrames).toBeGreaterThan(10);
 	expect(maxFrameDelta).toBeLessThanOrEqual(MAX_NATURAL_FRAME_DELTA_PX);
 });
 
@@ -151,11 +157,16 @@ test("manual upward scrolling pauses follow while the turn keeps growing", async
 
 	await compose.fill("Keep streaming while I inspect older output");
 	await page.keyboard.press("Enter");
-	await expect(page.getByTestId("tool-row")).toHaveCount(5, {
-		timeout: TURN_TIMEOUT,
-	});
+	const recentTurn = page.locator('section[data-turn="recent"]');
+	await expect(recentTurn).toContainText(
+		"Keep streaming while I inspect older output",
+	);
+	await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+	await expect
+		.poll(() => page.evaluate(() => window.scrollY))
+		.toBeGreaterThan(150);
 	const followedScrollY = await page.evaluate(() => window.scrollY);
-	expect(followedScrollY).toBeGreaterThan(400);
+	const turnHeightBeforePause = (await recentTurn.boundingBox())?.height ?? 0;
 
 	await page.mouse.move(100, 180);
 	await page.mouse.wheel(0, -500);
@@ -165,15 +176,16 @@ test("manual upward scrolling pauses follow while the turn keeps growing", async
 
 	// More streamed layout lands after the user takes the wheel. Follow must
 	// stay suspended instead of pulling the viewport back to the active tail.
-	await expect(page.getByTestId("tool-row")).toHaveCount(6, {
-		timeout: TURN_TIMEOUT,
-	});
-	await page.waitForTimeout(500);
+	await expect
+		.poll(async () => (await recentTurn.boundingBox())?.height ?? 0, {
+			timeout: TURN_TIMEOUT,
+		})
+		.toBeGreaterThan(turnHeightBeforePause + 60);
 	const afterGrowthScrollY = await page.evaluate(() => window.scrollY);
 	expect(Math.abs(afterGrowthScrollY - pausedScrollY)).toBeLessThanOrEqual(8);
 
-	// Returning to the document tail opts back into follow. Deterministic turn
-	// growth then exercises the same ResizeObserver path without provider timing.
+	// Returning to the document tail opts back into follow. As more visible
+	// output lands, the viewport should move with it again.
 	for (let step = 0; step < 4; step += 1) {
 		await page.mouse.wheel(0, 1_000);
 		await page.waitForTimeout(50);
@@ -188,12 +200,16 @@ test("manual upward scrolling pauses follow while the turn keeps growing", async
 			),
 		)
 		.toBeLessThanOrEqual(8);
-	const recentTurn = page.locator('section[data-turn="recent"]');
-	await recentTurn.evaluate((turn) => {
-		const growth = document.createElement("div");
-		growth.setAttribute("aria-hidden", "true");
-		growth.style.height = "240px";
-		turn.append(growth);
-	});
+	await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+	const resumedScrollY = await page.evaluate(() => window.scrollY);
+	const turnHeightAtResume = (await recentTurn.boundingBox())?.height ?? 0;
+	await expect
+		.poll(async () => (await recentTurn.boundingBox())?.height ?? 0, {
+			timeout: TURN_TIMEOUT,
+		})
+		.toBeGreaterThan(turnHeightAtResume + 40);
+	await expect
+		.poll(() => page.evaluate(() => window.scrollY))
+		.toBeGreaterThan(resumedScrollY + 20);
 	await expectActiveTurnAboveComposer(page);
 });

--- a/web-next/tests/demo/scroll-turn.spec.ts
+++ b/web-next/tests/demo/scroll-turn.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Filmed proof for #1015: after a completed turn creates real scrollback, a
+ * directly sent follow-up keeps its growing lower edge above the composer.
+ */
+import { expect, type Page, test } from "@playwright/test";
+
+const TURN_TIMEOUT = 20_000;
+const MAX_NATURAL_FRAME_DELTA_PX = 26;
+
+interface ScrollSample {
+	at: number;
+	y: number;
+}
+
+async function startScrollTrace(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		const trace = { frame: 0, samples: [] as ScrollSample[] };
+		const sample = (at: number) => {
+			trace.samples.push({ at, y: window.scrollY });
+			trace.frame = window.requestAnimationFrame(sample);
+		};
+		trace.frame = window.requestAnimationFrame(sample);
+		(
+			window as typeof window & {
+				__scrollFollowTrace?: typeof trace;
+			}
+		).__scrollFollowTrace = trace;
+	});
+}
+
+async function stopScrollTrace(page: Page): Promise<ScrollSample[]> {
+	return await page.evaluate(() => {
+		const trace = (
+			window as typeof window & {
+				__scrollFollowTrace?: { frame: number; samples: ScrollSample[] };
+			}
+		).__scrollFollowTrace;
+		if (!trace) return [];
+		window.cancelAnimationFrame(trace.frame);
+		return trace.samples;
+	});
+}
+
+async function expectActiveTurnAboveComposer(page: Page): Promise<void> {
+	const recentTurn = page.locator('section[data-turn="recent"]');
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+	await expect
+		.poll(async () => {
+			const [turnBox, composeBox] = await Promise.all([
+				recentTurn.boundingBox(),
+				compose.boundingBox(),
+			]);
+			if (!turnBox || !composeBox) return Number.POSITIVE_INFINITY;
+			return turnBox.y + turnBox.height - composeBox.y;
+		})
+		.toBeLessThanOrEqual(-8);
+}
+
+async function createSession(page: Page): Promise<void> {
+	await page.goto("/");
+	const picker = page.getByTestId("new-session-picker");
+	if (!(await picker.isVisible())) {
+		await page.getByRole("button", { name: "+ new session" }).click();
+	}
+	await page
+		.getByRole("textbox", { name: "Repository (owner/name)" })
+		.fill("fairchild/workspaces");
+	await page.keyboard.press("Enter");
+	await expect(page).toHaveURL(/\/sessions\/[0-9a-f-]{36}$/);
+}
+
+test("a directly sent follow-up naturally follows its growing bottom", async ({
+	page,
+}, testInfo) => {
+	await createSession(page);
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+
+	await compose.fill("Build enough scrollback for the auto-scroll demo");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("turn-stats")).toHaveCount(1, {
+		timeout: TURN_TIMEOUT,
+	});
+	await page.waitForTimeout(1_000);
+
+	// Recreate the real reading state: the owner has moved back into old
+	// scrollback, while the sticky compose remains available at the bottom.
+	await page.evaluate(() => window.scrollTo(0, 0));
+	await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+	await page.waitForTimeout(1_000);
+
+	await compose.pressSequentially(
+		"Keep this active turn above the composer while it grows",
+		{ delay: 24 },
+	);
+	await page.waitForTimeout(500);
+	await startScrollTrace(page);
+	await page.getByRole("button", { name: "Send" }).click();
+
+	const recentTurn = page.locator('section[data-turn="recent"]');
+	await expect(recentTurn).toContainText(
+		"Keep this active turn above the composer while it grows",
+	);
+	await expectActiveTurnAboveComposer(page);
+
+	// Each milestone grows the same live turn. Its lower edge must keep moving
+	// up with the output instead of disappearing behind the sticky composer.
+	await expect(page.getByTestId("reasoning")).toHaveCount(2, {
+		timeout: TURN_TIMEOUT,
+	});
+	await expectActiveTurnAboveComposer(page);
+	await expect(page.getByTestId("tool-row")).toHaveCount(5, {
+		timeout: TURN_TIMEOUT,
+	});
+	await expectActiveTurnAboveComposer(page);
+	await expect(page.getByTestId("turn-stats")).toHaveCount(2, {
+		timeout: TURN_TIMEOUT,
+	});
+	await expectActiveTurnAboveComposer(page);
+
+	// Keep the final proven position visible in the recorded artifact.
+	await page.waitForTimeout(1_500);
+	const samples = await stopScrollTrace(page);
+	const frameDeltas = samples
+		.slice(1)
+		.map((sample, index) => Math.abs(sample.y - samples[index].y));
+	const maxFrameDelta = Math.max(0, ...frameDeltas);
+	const movingFrames = frameDeltas.filter((delta) => delta > 0.5).length;
+	await testInfo.attach("scroll-trace", {
+		body: JSON.stringify(
+			{ sampleCount: samples.length, maxFrameDelta, movingFrames, samples },
+			null,
+			2,
+		),
+		contentType: "application/json",
+	});
+	expect(maxFrameDelta).toBeLessThanOrEqual(MAX_NATURAL_FRAME_DELTA_PX);
+});
+
+test("manual upward scrolling pauses follow while the turn keeps growing", async ({
+	page,
+}) => {
+	await createSession(page);
+	const compose = page.getByRole("textbox", { name: "Reply to Claude" });
+
+	await compose.fill("Build scrollback before testing manual pause");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("turn-stats")).toHaveCount(1, {
+		timeout: TURN_TIMEOUT,
+	});
+	await page.waitForTimeout(1_000);
+
+	await compose.fill("Keep streaming while I inspect older output");
+	await page.keyboard.press("Enter");
+	await expect(page.getByTestId("tool-row")).toHaveCount(5, {
+		timeout: TURN_TIMEOUT,
+	});
+	const followedScrollY = await page.evaluate(() => window.scrollY);
+	expect(followedScrollY).toBeGreaterThan(400);
+
+	await page.mouse.move(100, 180);
+	await page.mouse.wheel(0, -500);
+	await page.waitForTimeout(80);
+	const pausedScrollY = await page.evaluate(() => window.scrollY);
+	expect(pausedScrollY).toBeLessThan(followedScrollY - 100);
+
+	// More streamed layout lands after the user takes the wheel. Follow must
+	// stay suspended instead of pulling the viewport back to the active tail.
+	await expect(page.getByTestId("tool-row")).toHaveCount(6, {
+		timeout: TURN_TIMEOUT,
+	});
+	await page.waitForTimeout(500);
+	const afterGrowthScrollY = await page.evaluate(() => window.scrollY);
+	expect(Math.abs(afterGrowthScrollY - pausedScrollY)).toBeLessThanOrEqual(8);
+
+	// Returning to the document tail opts back into follow. Deterministic turn
+	// growth then exercises the same ResizeObserver path without provider timing.
+	for (let step = 0; step < 4; step += 1) {
+		await page.mouse.wheel(0, 1_000);
+		await page.waitForTimeout(50);
+	}
+	await expect
+		.poll(() =>
+			page.evaluate(
+				() =>
+					document.documentElement.scrollHeight -
+					window.innerHeight -
+					window.scrollY,
+			),
+		)
+		.toBeLessThanOrEqual(8);
+	const recentTurn = page.locator('section[data-turn="recent"]');
+	await recentTurn.evaluate((turn) => {
+		const growth = document.createElement("div");
+		growth.setAttribute("aria-hidden", "true");
+		growth.style.height = "240px";
+		turn.append(growth);
+	});
+	await expectActiveTurnAboveComposer(page);
+});

--- a/web-next/tests/e2e/sessions.spec.ts
+++ b/web-next/tests/e2e/sessions.spec.ts
@@ -407,11 +407,27 @@ test("sending during a running turn queues, then auto-dispatches as the next tur
 	await expect(page.getByRole("button", { name: "Send" })).toBeEnabled();
 	await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
 
+	// User may be reading earlier scrollback when the queued turn dispatches;
+	// terminal follow should keep the growing next turn above the composer (#1015).
+	await page.evaluate(() => window.scrollTo(0, 0));
+
 	await expect(queued).toHaveCount(0, { timeout: TURN_TIMEOUT });
 	const userMessages = page.locator('[data-message-role="user"]');
 	await expect(userMessages).toHaveCount(2, { timeout: TURN_TIMEOUT });
 	await expect(userMessages.nth(0)).toContainText("First steering turn");
 	await expect(userMessages.nth(1)).toContainText("Queue this next");
+	const recentTurn = page.locator('section[data-turn="recent"]');
+	await expect(recentTurn).toContainText("Queue this next");
+	await expect
+		.poll(async () => {
+			const [turnBox, composeBox] = await Promise.all([
+				recentTurn.boundingBox(),
+				compose.boundingBox(),
+			]);
+			if (!turnBox || !composeBox) return Number.POSITIVE_INFINITY;
+			return turnBox.y + turnBox.height - composeBox.y;
+		})
+		.toBeLessThanOrEqual(-8);
 	await expect(page.getByTestId("turn-stats")).toHaveCount(2, {
 		timeout: TURN_TIMEOUT * 2,
 	});


### PR DESCRIPTION
## Summary

- continuously follows the growing bottom of a newly sent or auto-dispatched turn, maintaining a 16px composer gap
- yields immediately to upward wheel, touch, or keyboard navigation and rearms when the reader returns to the document tail
- smooths reasoning collapse, honors reduced motion, and adds filmed Playwright coverage for natural follow plus manual pause/resume

Closes #1015

## Mergeability

- Surface: web — web-next live session transcript and sticky composer
- User-facing behavior changed: New active turns naturally follow their streamed lower edge above the composer instead of disappearing beneath it or snapping the viewport.
- Non-happy paths considered: Upward wheel/touch/keyboard intent pauses follow; returning to the tail resumes it; queued next turns use the same behavior; reduced-motion users receive immediate correction; reasoning collapse is height-animated to avoid max-scroll clamp jumps.
- Release/ops preconditions: None.
- Residual risk or follow-up: Motion feel can vary with display refresh rate; a 24px frame cap, time-based easing, and the recorded frame-delta assertion constrain that variation.

## Validation

- [ ] `swift build`
- [ ] `swift test`
- [x] Other checks run:
  - `cd web-next && pnpm test` — 56 files, 601 tests passed
  - `cd web-next && pnpm lint`
  - `cd web-next && pnpm typecheck`
  - `cd web-next && pnpm build`
  - `cd web-next && pnpm demo:scroll-turn` — 2 filmed scenarios passed
  - `WEB_NEXT_COMPUTE_PROVIDER=mock E2E_PORT=3219 pnpm exec playwright test tests/e2e/sessions.spec.ts --project chromium --grep "sending during a running turn"` — passed
  - `git diff origin/main...HEAD --check`

## Review loop

- Self-reflection: No actionable findings; scope is isolated to live-turn follow ownership, reasoning collapse motion, and behavior-level coverage.
- Directed Codex review: External invocation was rejected at the repository-data boundary, so no independent Codex findings are claimed. The same directed checklist was applied locally to lifecycle cleanup, input takeover, reduced motion, DOM scoping, and test reliability.

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: n/a

Performance comparison notes:

- Exact commands used: n/a
- Workload / environment context: n/a

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- Natural continuous follow — frame movement capped at 24px; Playwright assertion permits at most 26px:
  ![natural-turn-follow](https://evidence.cloudcompute.com/workspaces/pr-1034/20260710-063429-natural-turn-follow.gif)
- Manual upward-scroll pause and tail-resume:
  ![manual-pause-resume](https://evidence.cloudcompute.com/workspaces/pr-1034/20260710-063508-manual-pause-resume.gif)

## Blockers

- [x] None
- [ ] Blocked on evidence
