### PR TITLE
fix(app): size embedded web-next readiness for cold first-run build (#987 M1.1)

### DIFF
--- a/Sources/WorkspaceManager/Web/EmbeddedWebNextDetailView.swift
+++ b/Sources/WorkspaceManager/Web/EmbeddedWebNextDetailView.swift
@@ -64,13 +64,16 @@ final class EmbeddedWebNextModel: ObservableObject {
     }
 
     /// Poll until the server leaves `.starting`, so an activation that raced an
-    /// in-flight launch resolves on the real outcome. Bounded well past the
-    /// service's own readiness timeout as a backstop against a wedged launch.
+    /// in-flight launch resolves on the real outcome. This is only a backstop
+    /// against a wedged launch that never transitions; it must stay comfortably
+    /// past the service's own `readinessTimeout` (currently 180s, sized for a
+    /// cold first-run build) so the UI never gives up on a launch the service
+    /// still considers healthy-in-progress.
     private func awaitTerminalState() async -> WebNextServerState {
         var state = await server.state
         var elapsed: TimeInterval = 0
         let pollInterval: TimeInterval = 0.15
-        let maxWait: TimeInterval = 45
+        let maxWait: TimeInterval = 210
         while case .starting = state, elapsed < maxWait, !Task.isCancelled {
             try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
             elapsed += pollInterval
@@ -158,9 +161,13 @@ struct EmbeddedWebNextStatusView: View {
                     .controlSize(.large)
                 Text("Starting web-next…")
                     .font(.headline)
-                Text("Launching the local server and signing you in.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                Text(
+                    "Launching the local server and signing you in. The first run builds web-next and can take a minute."
+                )
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 420)
             case .failed(let reason):
                 Image(systemName: "exclamationmark.triangle")
                     .font(.largeTitle)

--- a/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
+++ b/Sources/WorkspaceManagerCore/Services/WebNextServerService.swift
@@ -63,6 +63,12 @@ public struct WebNextServerConfiguration: Sendable {
     /// Where per-launch server logs (captured child stdout/stderr) are written.
     public var logDirectory: URL
     public var launchCommand: WebNextLaunchCommand
+    /// How long to wait for `/api/healthz` after spawn before declaring failure.
+    /// Sized for a cold first run: `start:local` builds web-next when
+    /// `.next/BUILD_ID` is absent, which takes one to two minutes. A generous
+    /// budget is safe because a process that dies mid-build is detected
+    /// independently and fails fast (see `start()`); this only bounds the
+    /// alive-but-not-yet-serving window, which is precisely the build.
     public var readinessTimeout: TimeInterval
     public var readinessPollInterval: TimeInterval
     /// How long termination waits after SIGTERM before escalating to SIGKILL.
@@ -78,7 +84,7 @@ public struct WebNextServerConfiguration: Sendable {
         dataDir: URL? = nil,
         logDirectory: URL? = nil,
         launchCommand: WebNextLaunchCommand = .default,
-        readinessTimeout: TimeInterval = 30,
+        readinessTimeout: TimeInterval = 180,
         readinessPollInterval: TimeInterval = 0.5,
         terminationGracePeriod: TimeInterval = 5,
         watchdogInterval: TimeInterval = 5,
@@ -155,7 +161,11 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
     // MARK: Lifecycle
 
     /// Spawn the server and wait until `/api/healthz` reports healthy or the
-    /// readiness timeout elapses. Returns immediately when already starting or ready.
+    /// readiness timeout elapses. Returns immediately when already starting or
+    /// ready. Cancelling the caller does not abort the launch: the server is a
+    /// process-wide resource whose bring-up is owned by the actor, so a cancelled
+    /// activation leaves it coming up (and available on reopen) rather than
+    /// killing a build in flight.
     public func start() async {
         switch state {
         case .starting, .ready:
@@ -179,6 +189,23 @@ public actor WebNextServerService: WebNextServerServiceProtocol {
         }
         processID = pid
 
+        // Own the readiness poll as an unstructured task so it runs in a fresh,
+        // non-cancelled context. If the triggering caller is cancelled mid-launch
+        // (e.g. the user closes the pane during a cold build), an inline poll would
+        // busy-spin and its health probes would auto-cancel — never observing
+        // readiness and forcing a spurious timeout-kill of a live build. The
+        // launch's lifetime is owned by the actor + generation, not the caller;
+        // `await launch.value` keeps start()'s "blocks until terminal" contract.
+        let launch = Task { await self.awaitReadiness(pid: pid, launchGeneration: launchGeneration) }
+        await launch.value
+    }
+
+    /// Poll `/api/healthz` until it reports healthy, the process exits, or the
+    /// readiness timeout elapses — then transition state. Runs as an unstructured
+    /// task (see `start()`) so caller cancellation cannot poison the launch;
+    /// generation guards drop the outcome if a newer `start()`/`stop()`
+    /// superseded it.
+    private func awaitReadiness(pid: pid_t, launchGeneration: UInt64) async {
         let deadline = Date().addingTimeInterval(configuration.readinessTimeout)
         while Date() < deadline {
             guard generation == launchGeneration else { return }

--- a/Tests/WorkspaceManagerAppTests/EmbeddedWebNextStatusRenderTests.swift
+++ b/Tests/WorkspaceManagerAppTests/EmbeddedWebNextStatusRenderTests.swift
@@ -19,7 +19,7 @@ struct EmbeddedWebNextStatusRenderTests {
         try render(
             EmbeddedWebNextStatusView(
                 state: .failed(
-                    "Timed out after 30s waiting for web-next health on port 3140."
+                    "Timed out after 180s waiting for web-next health on port 3140."
                 )
             ),
             named: "embedded-webnext-failed.png"

--- a/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
+++ b/Tests/WorkspaceManagerTests/WebNextServerServiceTests.swift
@@ -207,6 +207,38 @@ struct WebNextServerServiceTests {
         #expect(died, "spawned process should be terminated after readiness timeout")
     }
 
+    @Test("a cancelled activation does not abort the launch — the server still becomes ready")
+    func callerCancellationDoesNotPoisonLaunch() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cleanup() }
+        // Delay the healthz listener a beat so cancellation lands while the
+        // service is mid-readiness, not after it is already healthy.
+        let script = """
+            sleep 0.4
+            \(fixture.healthzServerScript)
+            """
+        let service = WebNextServerService(
+            configuration: fixture.configuration(script: script, readinessTimeout: 20))
+
+        // Trigger start() from a task we cancel almost immediately — mirroring the
+        // user closing the embedded pane during a cold build. If the readiness poll
+        // were bound to the caller's task it would busy-spin, auto-cancel every
+        // health probe, and time out into a process-killing .failed; the launch must
+        // instead run to ready in its own context.
+        let starter = Task { await service.start() }
+        try? await Task.sleep(nanoseconds: 50_000_000)  // 50ms: inside the readiness loop
+        starter.cancel()
+
+        let ready = await waitUntil(timeout: 10) {
+            if case .ready = await service.state { return true }
+            return false
+        }
+        #expect(ready, "caller cancellation must not prevent the server from reaching .ready")
+
+        await service.stop()
+        #expect(await service.state == .idle)
+    }
+
     @Test("early process exit transitions to failed before the timeout")
     func earlyExitFails() async throws {
         let fixture = try Fixture()


### PR DESCRIPTION
## Summary

The embedded web-next surface spawns `pnpm start:local`, which **builds web-next on the first run** (`.next/BUILD_ID` absent) — one to two minutes — before it serves anything. The readiness timeout was **30s**, so the very first launch on a fresh checkout timed out and SIGKILLed the build mid-flight, showing "Couldn't start web-next"; retrying killed the restarted build again. It only surfaces on a cold run across the `start:local` × service boundary, so no unit test or review caught it — it was found in the #987 reflection.

- **`readinessTimeout` 30s → 180s.** Safe because a process that dies mid-build is detected independently and fails *fast* (`processHasExited` → immediate `.failed`); the timeout only bounds the *alive-but-not-yet-serving* window, which is precisely the build.
- **UI backstop `awaitTerminalState.maxWait` 45s → 210s.** This value was set "well past the service's readiness timeout" back when that was 30s; it must stay above `readinessTimeout` or the view would give up before the service. The two are now documented as coupled.
- **Status-pane copy** tells the user the first run builds web-next and can take a minute.

## Review loop

Directed codex (gpt-5.5, xhigh) review of this diff. One finding, **fixed in the same commit** (the timeout bump is only *safe* with it, so they are one atomic change — a `=180`-only intermediate would ship the amplified bug):

- **Cancelled activation poisoned the launch.** The readiness poll ran inline in the SwiftUI activation task and swallowed cancellation. Closing the pane during the cold build cancelled that task → every `Task.sleep` returned instantly (busy-spin) and every `serverIsHealthy()` probe auto-cancelled → readiness was *never* observed → guaranteed timeout-kill of a live build. Pre-existing (the swallow predates this diff), but the 6×-longer window amplified it from a 30s annoyance to a guaranteed kill. **Fix:** the poll now runs in an actor-owned **unstructured** task (fresh, non-cancelled context); `await launch.value` preserves `start()`'s blocks-until-terminal contract. A regression test proves a cancelled activation still reaches `.ready` — it **fails at 10.1s on the old inline poll and passes at 0.6s with the fix** (mutation-checked).

Codex also confirmed `maxWait` is the *only* fast-readiness gate coupled to the old 30s (watchdog starts only after `.ready`; termination budget and tests are independent), and that `210 > 180` has adequate margin.

## Evidence

Rendered headless (ImageRenderer / qlmanage) — no app launch, no server required.

- **Starting pane, new first-run copy:** ![starting-pane](https://evidence.cloudcompute.com/workspaces/pr-1035/20260710-092100-starting-pane.png)
- **Failed pane, 180s message:** ![failed-pane](https://evidence.cloudcompute.com/workspaces/pr-1035/20260710-092100-failed-pane-180s.png)
- **Test results + mutation check** (regression test fails at 10.1s without the fix, passes at 0.6s with it): ![test-results](https://evidence.cloudcompute.com/workspaces/pr-1035/20260710-092101-test-results.png)

## Mergeability

- **Surface:** macOS app — `WebNextServerService` readiness supervision + `EmbeddedWebNextDetailView` status pane. No web-next, schema, or infra changes.
- **Behavior changed:** cold first-run launch now waits up to 180s (was 30s) so the build completes instead of being killed; a cancelled activation no longer kills a live build; the starting pane explains the first-run build.
- **Non-happy paths:** process death mid-build → fast `.failed` (unchanged); genuine hang → `.failed` at 180s with Retry; caller cancellation → server keeps coming up, available on reopen; `stop()`/second-activation races → generation-guarded (unchanged, covered).
- **Residual risk:** a contended machine whose cold build exceeds 180s still fails (Retry available; no "keep waiting" path — deferred). Bundling web-next into the app bundle and build-progress streaming remain Milestone-2 items.

Surfaced by the #987 reflection as the M1.1 cold-first-run gap.

Made with [Orca](https://github.com/stablyai/orca) 🐋