### PR TITLE
fix(retro): finish hero-flow follow-ups

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,6 +123,9 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
+      - name: Test evidence worker
+        if: matrix.worker == 'cloudflare-evidence-store'
+        run: npm ci && npm test
       - name: Deploy to preview env
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/development/evidence.md
+++ b/docs/development/evidence.md
@@ -13,8 +13,9 @@ Evidence is a merge gate for all PRs. Upload test results or screenshots before 
 # Capture the live desktop screenshot + upload in one step
 ./scripts/evidence.sh --pr <number> --name <slug>
 
-# Upload an existing file
+# Upload an existing image or video file
 ./scripts/evidence.sh --pr <number> --name <slug> --file /tmp/screenshot.png
+./scripts/evidence.sh --pr <number> --name <slug> --file /tmp/flow.webm
 
 # Via mise
 mise run evidence -- --pr <number> --name <slug>
@@ -132,7 +133,11 @@ gh secret set EVIDENCE_UPLOAD_TOKEN --repo fairchild/workspaces --body "$TOKEN"
 
 ### `scripts/upload-evidence.py`
 
-Lower-level upload client. Accepts png, jpg, gif, webp, svg. Called internally by `evidence.sh`.
+Lower-level upload client. Accepts `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`,
+`webm`, and `mp4`, with a 50 MiB per-file limit enforced by both the client and
+the evidence-store Worker. Called internally by `evidence.sh`. Images produce
+inline-image Markdown; videos produce a normal click-to-play link because
+GitHub does not render uploaded video URLs inline in PR bodies.
 
 ```bash
 uv run scripts/upload-evidence.py <file> --repo workspaces --pr <number> --name <slug>
@@ -177,6 +182,6 @@ Three layers, from gentlest to strongest:
 
 ## Architecture
 
-Screenshots flow through: `evidence.sh` → `upload-evidence.py` (PUT with bearer token) → Cloudflare Worker (`infra/cloudflare-evidence-store/`) → R2 bucket (`evidence-screenshots`) → public URL at `https://evidence.cloudcompute.com/`.
+Evidence files flow through: `evidence.sh` → `upload-evidence.py` (PUT with bearer token) → Cloudflare Worker (`infra/cloudflare-evidence-store/`) → R2 bucket (`evidence-screenshots`) → public URL at `https://evidence.cloudcompute.com/`.
 
 For infrastructure details (Worker deployment, R2 bucket config, runner setup), see [lume-runner-setup.md § Evidence store](lume-runner-setup.md#evidence-store-r2).

--- a/docs/development/evidence.md
+++ b/docs/development/evidence.md
@@ -135,9 +135,12 @@ gh secret set EVIDENCE_UPLOAD_TOKEN --repo fairchild/workspaces --body "$TOKEN"
 
 Lower-level upload client. Accepts `png`, `jpg`, `jpeg`, `gif`, `webp`, `svg`,
 `webm`, and `mp4`, with a 50 MiB per-file limit enforced by both the client and
-the evidence-store Worker. Called internally by `evidence.sh`. Images produce
-inline-image Markdown; videos produce a normal click-to-play link because
-GitHub does not render uploaded video URLs inline in PR bodies.
+the evidence-store Worker. Uploads carry a fixed `Content-Length`; the Worker
+rejects chunked or malformed-length requests so accepted files can stream
+directly into R2 without consuming the Worker's memory budget. Called internally
+by `evidence.sh`. Images produce inline-image Markdown; videos produce a normal
+click-to-play link because GitHub does not render uploaded video URLs inline in
+PR bodies.
 
 ```bash
 uv run scripts/upload-evidence.py <file> --repo workspaces --pr <number> --name <slug>

--- a/infra/cloudflare-evidence-store/package-lock.json
+++ b/infra/cloudflare-evidence-store/package-lock.json
@@ -7,6 +7,7 @@
       "name": "evidence-store",
       "devDependencies": {
         "@cloudflare/workers-types": "^4",
+        "tsx": "^4.22.5",
         "wrangler": "^4"
       }
     },
@@ -1382,6 +1383,509 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/undici": {
       "version": "7.24.4",

--- a/infra/cloudflare-evidence-store/package.json
+++ b/infra/cloudflare-evidence-store/package.json
@@ -1,9 +1,11 @@
 {
   "name": "evidence-store",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "test": "node --test src/*.test.mjs"
   },
   "devDependencies": {
     "wrangler": "^4",

--- a/infra/cloudflare-evidence-store/package.json
+++ b/infra/cloudflare-evidence-store/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test src/*.test.mjs"
+    "test": "tsx --test src/*.test.mjs"
   },
   "devDependencies": {
     "wrangler": "^4",
-    "@cloudflare/workers-types": "^4"
+    "@cloudflare/workers-types": "^4",
+    "tsx": "^4.22.5"
   }
 }

--- a/infra/cloudflare-evidence-store/src/index.test.mjs
+++ b/infra/cloudflare-evidence-store/src/index.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import worker, { MAX_UPLOAD_BYTES, readBodyWithinLimit } from "./index.ts";
+import worker, { MAX_UPLOAD_BYTES } from "./index.ts";
 
 function env(overrides = {}) {
 	return {
@@ -22,7 +22,10 @@ test("stores webm and mp4 uploads with their browser video MIME types", async ()
 		const response = await worker.fetch(
 			new Request(`https://evidence.example/workspaces/pr-1027/demo.${extension}`, {
 				method: "PUT",
-				headers: { Authorization: "Bearer test-token" },
+				headers: {
+					Authorization: "Bearer test-token",
+					"Content-Length": "3",
+				},
 				body: new Uint8Array([1, 2, 3]),
 			}),
 			env({
@@ -64,16 +67,61 @@ test("rejects uploads declared over the cap before touching R2", async () => {
 	assert.equal(await response.text(), "upload exceeds the 50 MiB limit");
 });
 
-test("bounds the actual stream when Content-Length is absent or undersized", async () => {
-	const exact = await readBodyWithinLimit(
-		new Response(new Uint8Array([1, 2, 3])).body,
-		3,
-	);
-	assert.deepEqual([...new Uint8Array(exact)], [1, 2, 3]);
+test("requires a valid fixed upload length before reading or storing", async () => {
+	for (const [contentLength, expectedStatus] of [
+		[null, 411],
+		["not-a-number", 400],
+		["-1", 400],
+	]) {
+		let putCalled = false;
+		const headers = { Authorization: "Bearer test-token" };
+		if (contentLength !== null) headers["Content-Length"] = contentLength;
+		const response = await worker.fetch(
+			new Request("https://evidence.example/workspaces/pr-1027/video.webm", {
+				method: "PUT",
+				headers,
+				body: new Uint8Array([1]),
+			}),
+			env({
+				EVIDENCE_BUCKET: {
+					put: async () => {
+						putCalled = true;
+					},
+				},
+			}),
+		);
+		assert.equal(response.status, expectedStatus);
+		assert.equal(putCalled, false);
+	}
+});
 
-	const oversized = await readBodyWithinLimit(
-		new Response(new Uint8Array([1, 2, 3, 4])).body,
-		3,
+test("streams an exact-limit upload to R2 without buffering it", async () => {
+	const request = new Request(
+		"https://evidence.example/workspaces/pr-1027/exact.webm",
+		{
+			method: "PUT",
+			headers: {
+				Authorization: "Bearer test-token",
+				"Content-Length": String(MAX_UPLOAD_BYTES),
+			},
+			// The Worker trusts Cloudflare HTTP framing for the declared length;
+			// this small synthetic body lets the test observe allocation shape.
+			body: new Uint8Array([1]),
+		},
 	);
-	assert.equal(oversized, null);
+	const originalBody = request.body;
+	let storedBody;
+	const response = await worker.fetch(
+		request,
+		env({
+			EVIDENCE_BUCKET: {
+				put: async (_key, body) => {
+					storedBody = body;
+				},
+			},
+		}),
+	);
+
+	assert.equal(response.status, 201);
+	assert.equal(storedBody, originalBody);
 });

--- a/infra/cloudflare-evidence-store/src/index.test.mjs
+++ b/infra/cloudflare-evidence-store/src/index.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import worker, { MAX_UPLOAD_BYTES } from "./index.ts";
+
+function env(overrides = {}) {
+	return {
+		EVIDENCE_UPLOAD_TOKEN: "test-token",
+		EVIDENCE_BUCKET: {
+			put: async () => undefined,
+			get: async () => null,
+		},
+		...overrides,
+	};
+}
+
+test("stores webm and mp4 uploads with their browser video MIME types", async () => {
+	for (const [extension, contentType] of [
+		["webm", "video/webm"],
+		["mp4", "video/mp4"],
+	]) {
+		let storedContentType = "";
+		const response = await worker.fetch(
+			new Request(`https://evidence.example/workspaces/pr-1027/demo.${extension}`, {
+				method: "PUT",
+				headers: { Authorization: "Bearer test-token" },
+				body: new Uint8Array([1, 2, 3]),
+			}),
+			env({
+				EVIDENCE_BUCKET: {
+					put: async (_key, _body, options) => {
+						storedContentType = options?.httpMetadata?.contentType ?? "";
+					},
+				},
+			}),
+		);
+
+		assert.equal(response.status, 201);
+		assert.equal(storedContentType, contentType);
+	}
+});
+
+test("rejects uploads declared over the cap before touching R2", async () => {
+	let putCalled = false;
+	const response = await worker.fetch(
+		new Request("https://evidence.example/workspaces/pr-1027/too-large.webm", {
+			method: "PUT",
+			headers: {
+				Authorization: "Bearer test-token",
+				"Content-Length": String(MAX_UPLOAD_BYTES + 1),
+			},
+			body: new Uint8Array([1]),
+		}),
+		env({
+			EVIDENCE_BUCKET: {
+				put: async () => {
+					putCalled = true;
+				},
+			},
+		}),
+	);
+
+	assert.equal(response.status, 413);
+	assert.equal(putCalled, false);
+	assert.equal(await response.text(), "upload exceeds the 50 MiB limit");
+});

--- a/infra/cloudflare-evidence-store/src/index.test.mjs
+++ b/infra/cloudflare-evidence-store/src/index.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import worker, { MAX_UPLOAD_BYTES } from "./index.ts";
+import worker, { MAX_UPLOAD_BYTES, readBodyWithinLimit } from "./index.ts";
 
 function env(overrides = {}) {
 	return {
@@ -62,4 +62,18 @@ test("rejects uploads declared over the cap before touching R2", async () => {
 	assert.equal(response.status, 413);
 	assert.equal(putCalled, false);
 	assert.equal(await response.text(), "upload exceeds the 50 MiB limit");
+});
+
+test("bounds the actual stream when Content-Length is absent or undersized", async () => {
+	const exact = await readBodyWithinLimit(
+		new Response(new Uint8Array([1, 2, 3])).body,
+		3,
+	);
+	assert.deepEqual([...new Uint8Array(exact)], [1, 2, 3]);
+
+	const oversized = await readBodyWithinLimit(
+		new Response(new Uint8Array([1, 2, 3, 4])).body,
+		3,
+	);
+	assert.equal(oversized, null);
 });

--- a/infra/cloudflare-evidence-store/src/index.ts
+++ b/infra/cloudflare-evidence-store/src/index.ts
@@ -5,6 +5,8 @@ interface Env {
 
 const encoder = new TextEncoder();
 
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
 function timingSafeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
   const aBytes = encoder.encode(a);
@@ -25,6 +27,8 @@ const CONTENT_TYPES: Record<string, string> = {
   svg: "image/svg+xml",
   txt: "text/plain",
   json: "application/json",
+  webm: "video/webm",
+  mp4: "video/mp4",
 };
 
 function contentTypeFromPath(path: string): string {
@@ -62,9 +66,17 @@ export default {
         return new Response("unauthorized", { status: 401 });
       }
 
+      const declaredLength = Number(request.headers.get("Content-Length"));
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_BYTES) {
+        return new Response("upload exceeds the 50 MiB limit", { status: 413 });
+      }
+
       const contentType =
         request.headers.get("Content-Type") ?? contentTypeFromPath(path);
       const body = await request.arrayBuffer();
+      if (body.byteLength > MAX_UPLOAD_BYTES) {
+        return new Response("upload exceeds the 50 MiB limit", { status: 413 });
+      }
 
       await env.EVIDENCE_BUCKET.put(path, body, {
         httpMetadata: { contentType },

--- a/infra/cloudflare-evidence-store/src/index.ts
+++ b/infra/cloudflare-evidence-store/src/index.ts
@@ -36,6 +36,34 @@ function contentTypeFromPath(path: string): string {
   return CONTENT_TYPES[ext] ?? "application/octet-stream";
 }
 
+export async function readBodyWithinLimit(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes = MAX_UPLOAD_BYTES,
+): Promise<ArrayBuffer | null> {
+  if (!body) return new ArrayBuffer(0);
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (total + value.byteLength > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+    total += value.byteLength;
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged.buffer;
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -73,8 +101,8 @@ export default {
 
       const contentType =
         request.headers.get("Content-Type") ?? contentTypeFromPath(path);
-      const body = await request.arrayBuffer();
-      if (body.byteLength > MAX_UPLOAD_BYTES) {
+      const body = await readBodyWithinLimit(request.body);
+      if (!body) {
         return new Response("upload exceeds the 50 MiB limit", { status: 413 });
       }
 

--- a/infra/cloudflare-evidence-store/src/index.ts
+++ b/infra/cloudflare-evidence-store/src/index.ts
@@ -36,32 +36,22 @@ function contentTypeFromPath(path: string): string {
   return CONTENT_TYPES[ext] ?? "application/octet-stream";
 }
 
-export async function readBodyWithinLimit(
-  body: ReadableStream<Uint8Array> | null,
-  maxBytes = MAX_UPLOAD_BYTES,
-): Promise<ArrayBuffer | null> {
-  if (!body) return new ArrayBuffer(0);
-  const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (total + value.byteLength > maxBytes) {
-      await reader.cancel().catch(() => undefined);
-      return null;
-    }
-    chunks.push(value);
-    total += value.byteLength;
+function declaredUploadLength(request: Request): number | Response {
+  const raw = request.headers.get("Content-Length");
+  if (raw === null) {
+    return new Response("Content-Length is required", { status: 411 });
   }
-
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
+  if (!/^\d+$/.test(raw)) {
+    return new Response("invalid Content-Length", { status: 400 });
   }
-  return merged.buffer;
+  const length = Number(raw);
+  if (!Number.isSafeInteger(length)) {
+    return new Response("invalid Content-Length", { status: 400 });
+  }
+  if (length > MAX_UPLOAD_BYTES) {
+    return new Response("upload exceeds the 50 MiB limit", { status: 413 });
+  }
+  return length;
 }
 
 export default {
@@ -94,19 +84,16 @@ export default {
         return new Response("unauthorized", { status: 401 });
       }
 
-      const declaredLength = Number(request.headers.get("Content-Length"));
-      if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_BYTES) {
-        return new Response("upload exceeds the 50 MiB limit", { status: 413 });
+      const declaredLength = declaredUploadLength(request);
+      if (declaredLength instanceof Response) return declaredLength;
+      if (declaredLength > 0 && !request.body) {
+        return new Response("request body is required", { status: 400 });
       }
 
       const contentType =
         request.headers.get("Content-Type") ?? contentTypeFromPath(path);
-      const body = await readBodyWithinLimit(request.body);
-      if (!body) {
-        return new Response("upload exceeds the 50 MiB limit", { status: 413 });
-      }
 
-      await env.EVIDENCE_BUCKET.put(path, body, {
+      await env.EVIDENCE_BUCKET.put(path, request.body, {
         httpMetadata: { contentType },
       });
 

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -13,7 +13,7 @@
 #   # no activation, no focus steal.
 #   ./scripts/evidence.sh --pr 253 --fixture phase-1-release
 #
-# Outputs markdown-ready image link to stdout.
+# Outputs the uploaded URL to stdout and markdown-ready evidence to stderr.
 # ==========================================================================
 
 set -euo pipefail
@@ -201,7 +201,11 @@ echo "" >&2
 echo "Uploaded: $URL" >&2
 echo "" >&2
 echo "Markdown:" >&2
-echo "![${NAME}](${URL})" >&2
+FILE_EXT="${FILE##*.}"
+case "$FILE_EXT" in
+  [Ww][Ee][Bb][Mm]|[Mm][Pp]4) echo "[${NAME}](${URL})" >&2 ;;
+  *) echo "![${NAME}](${URL})" >&2 ;;
+esac
 echo "" >&2
 
 # Print just the URL to stdout for piping

--- a/scripts/tests/test_upload_evidence.py
+++ b/scripts/tests/test_upload_evidence.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Evidence upload contract tests.
+
+Intent: protect video MIME handling and the local upload-size guard without
+network access, secrets, UI access, or live evidence-store mutations.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "upload-evidence.py"
+SPEC = importlib.util.spec_from_file_location("upload_evidence", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+upload_evidence = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(upload_evidence)
+
+
+class FakeResponse:
+    status = 201
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class UploadEvidenceTests(unittest.TestCase):
+    def run_main(self, file: Path) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        argv = [
+            str(SCRIPT_PATH),
+            str(file),
+            "--repo",
+            "workspaces",
+            "--pr",
+            "1027",
+            "--base-url",
+            "https://evidence.example",
+        ]
+        with (
+            patch.object(sys, "argv", argv),
+            patch.dict(os.environ, {"EVIDENCE_UPLOAD_TOKEN": "test-token"}),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            result = upload_evidence.main()
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    def test_webm_and_mp4_upload_with_browser_video_content_types(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            for extension, expected in (
+                ("webm", "video/webm"),
+                ("mp4", "video/mp4"),
+            ):
+                with self.subTest(extension=extension):
+                    video = Path(tmp) / f"hero-flow.{extension}"
+                    video.write_bytes(b"video-evidence")
+                    with patch.object(
+                        upload_evidence, "urlopen", return_value=FakeResponse()
+                    ) as urlopen:
+                        result, stdout, stderr = self.run_main(video)
+
+                    self.assertEqual(result, 0, stderr)
+                    request = urlopen.call_args.args[0]
+                    self.assertEqual(request.get_header("Content-type"), expected)
+                    self.assertIn(f"hero-flow.{extension}", stdout)
+
+    def test_rejects_files_over_the_upload_cap_before_reading_or_network(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            video = Path(tmp) / "too-large.webm"
+            with video.open("wb") as handle:
+                handle.truncate(upload_evidence.MAX_UPLOAD_BYTES + 1)
+
+            with patch.object(upload_evidence, "urlopen") as urlopen:
+                result, _stdout, stderr = self.run_main(video)
+
+            self.assertEqual(result, 1)
+            self.assertIn("exceeds the 50 MiB upload limit", stderr)
+            urlopen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_upload_evidence.py
+++ b/scripts/tests/test_upload_evidence.py
@@ -95,6 +95,22 @@ class UploadEvidenceTests(unittest.TestCase):
             self.assertIn("exceeds the 50 MiB upload limit", stderr)
             urlopen.assert_not_called()
 
+    def test_rechecks_the_bytes_when_a_recording_grows_after_stat(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            video = Path(tmp) / "still-recording.webm"
+            video.write_bytes(b"123")
+
+            with (
+                patch.object(upload_evidence, "MAX_UPLOAD_BYTES", 4),
+                patch.object(Path, "read_bytes", return_value=b"12345"),
+                patch.object(upload_evidence, "urlopen") as urlopen,
+            ):
+                result, _stdout, stderr = self.run_main(video)
+
+            self.assertEqual(result, 1)
+            self.assertIn("file grew to 5 bytes", stderr)
+            urlopen.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_upload_evidence.py
+++ b/scripts/tests/test_upload_evidence.py
@@ -80,6 +80,7 @@ class UploadEvidenceTests(unittest.TestCase):
                     self.assertEqual(result, 0, stderr)
                     request = urlopen.call_args.args[0]
                     self.assertEqual(request.get_header("Content-type"), expected)
+                    self.assertEqual(request.get_header("Content-length"), "14")
                     self.assertIn(f"hero-flow.{extension}", stdout)
 
     def test_rejects_files_over_the_upload_cap_before_reading_or_network(self) -> None:

--- a/scripts/upload-evidence.py
+++ b/scripts/upload-evidence.py
@@ -73,6 +73,12 @@ def main() -> int:
 
     content_type = CONTENT_TYPES.get(ext, "application/octet-stream")
     data = filepath.read_bytes()
+    if len(data) > MAX_UPLOAD_BYTES:
+        print(
+            f"error: file grew to {len(data)} bytes and exceeds the 50 MiB upload limit",
+            file=sys.stderr,
+        )
+        return 1
 
     url = f"{base_url.rstrip('/')}/{key}"
     req = Request(url, data=data, method="PUT")

--- a/scripts/upload-evidence.py
+++ b/scripts/upload-evidence.py
@@ -83,6 +83,7 @@ def main() -> int:
     url = f"{base_url.rstrip('/')}/{key}"
     req = Request(url, data=data, method="PUT")
     req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Length", str(len(data)))
     req.add_header("Content-Type", content_type)
     req.add_header("User-Agent", "upload-evidence/1.0")
 

--- a/scripts/upload-evidence.py
+++ b/scripts/upload-evidence.py
@@ -16,7 +16,8 @@ from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp", "svg"}
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp", "svg", "webm", "mp4"}
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 DEFAULT_BASE_URL = "https://evidence.cloudcompute.com"
 
 CONTENT_TYPES = {
@@ -26,6 +27,8 @@ CONTENT_TYPES = {
     "gif": "image/gif",
     "webp": "image/webp",
     "svg": "image/svg+xml",
+    "webm": "video/webm",
+    "mp4": "video/mp4",
 }
 
 
@@ -53,6 +56,14 @@ def main() -> int:
     ext = filepath.suffix.lstrip(".").lower()
     if ext not in ALLOWED_EXTENSIONS:
         print(f"error: unsupported file type: .{ext} (allowed: {', '.join(sorted(ALLOWED_EXTENSIONS))})", file=sys.stderr)
+        return 1
+
+    size = filepath.stat().st_size
+    if size > MAX_UPLOAD_BYTES:
+        print(
+            f"error: file is {size} bytes and exceeds the 50 MiB upload limit",
+            file=sys.stderr,
+        )
         return 1
 
     now = datetime.now(timezone.utc)

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -66,6 +66,7 @@ import {
 	shouldRefreshSessionAfterTurn,
 } from "./pull-request-action";
 import { sandboxStateLabel, useSandboxState } from "./use-sandbox-state";
+import { fetchSessionSnapshotWithRetry } from "./session-refresh";
 import { useTurnFollow } from "./use-turn-follow";
 
 /** Streamed tokens paint at most this often — batched, never per-chunk. */
@@ -293,9 +294,10 @@ export function LiveSessionView({
 		try {
 			do {
 				refreshQueuedRef.current = false;
-				const res = await fetch(`/api/sessions/${sessionId}`);
-				if (!res.ok) continue;
-				const data = (await res.json()) as SessionSnapshot;
+				const data = await fetchSessionSnapshotWithRetry<SessionSnapshot>(
+					`/api/sessions/${sessionId}`,
+				);
+				if (!data) continue;
 				if (data.session) {
 					setHasBranchWork(data.session.hasBranchWork === true);
 					setPullRequest(data.session.pullRequest ?? null);

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -61,6 +61,10 @@ import {
 	recordLiveTurnError,
 } from "@/lib/transcript/live-turn-error";
 import { deriveContextLabel } from "@/lib/transcript/turn-stats";
+import {
+	deriveLivePullRequestAction,
+	shouldRefreshSessionAfterTurn,
+} from "./pull-request-action";
 import { sandboxStateLabel, useSandboxState } from "./use-sandbox-state";
 import { useTurnFollow } from "./use-turn-follow";
 
@@ -276,26 +280,45 @@ export function LiveSessionView({
 		if (busy) hasSeenBusyRef.current = true;
 	}, [busy]);
 	const refreshInFlightRef = useRef(false);
+	const refreshQueuedRef = useRef(false);
 	const refreshSessionFromServer = useCallback(async () => {
-		if (refreshInFlightRef.current) return;
+		if (refreshInFlightRef.current) {
+			// A completion edge must not disappear behind an older snapshot fetch.
+			// Coalesce concurrent callers into one follow-up read after the current
+			// request settles so the newest durable checkpoint state wins.
+			refreshQueuedRef.current = true;
+			return;
+		}
 		refreshInFlightRef.current = true;
 		try {
-			const res = await fetch(`/api/sessions/${sessionId}`);
-			if (!res.ok) return;
-			const data = (await res.json()) as SessionSnapshot;
-			if (data.session) {
-				setHasBranchWork(data.session.hasBranchWork === true);
-				setPullRequest(data.session.pullRequest ?? null);
-			}
-			if (data.messages) setMessages(data.messages);
-			setQueuedMessages(data.queuedMessages ?? []);
-			if (data.turn?.status === "running" || data.turn?.status === "stale") {
-				void resumeStream();
-			}
+			do {
+				refreshQueuedRef.current = false;
+				const res = await fetch(`/api/sessions/${sessionId}`);
+				if (!res.ok) continue;
+				const data = (await res.json()) as SessionSnapshot;
+				if (data.session) {
+					setHasBranchWork(data.session.hasBranchWork === true);
+					setPullRequest(data.session.pullRequest ?? null);
+				}
+				if (data.messages) setMessages(data.messages);
+				setQueuedMessages(data.queuedMessages ?? []);
+				if (data.turn?.status === "running" || data.turn?.status === "stale") {
+					void resumeStream();
+				}
+			} while (refreshQueuedRef.current);
 		} finally {
 			refreshInFlightRef.current = false;
 		}
 	}, [sessionId, setMessages, resumeStream]);
+	const previousBusyRef = useRef(busy);
+	useEffect(() => {
+		const shouldRefresh = shouldRefreshSessionAfterTurn(
+			previousBusyRef.current,
+			busy,
+		);
+		previousBusyRef.current = busy;
+		if (shouldRefresh) void refreshSessionFromServer();
+	}, [busy, refreshSessionFromServer]);
 	const queueKey = queuedMessages.map((message) => message.queueId).join("|");
 	const lastQueueKickRef = useRef("");
 	useEffect(() => {
@@ -537,20 +560,10 @@ export function LiveSessionView({
 						stateLabel: sandboxStateLabel(sandbox),
 						live: sandbox?.state === "live",
 						pullRequest,
-						pullRequestAction: session.masthead.pullRequestAction
-							? {
-									...session.masthead.pullRequestAction,
-									enabled:
-										session.masthead.pullRequestAction.enabled &&
-										hasBranchWork &&
-										!busy,
-									reason: busy
-										? "wait for turn"
-										: hasBranchWork
-											? session.masthead.pullRequestAction.reason
-											: "no checkpoints ready",
-								}
-							: null,
+						pullRequestAction: deriveLivePullRequestAction(
+							session.masthead.pullRequestAction,
+							{ hasBranchWork, busy },
+						),
 						pullRequestBusy,
 						pullRequestError,
 					},

--- a/web-next/src/app/(app)/sessions/[id]/pull-request-action.test.ts
+++ b/web-next/src/app/(app)/sessions/[id]/pull-request-action.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import {
+	deriveLivePullRequestAction,
+	shouldRefreshSessionAfterTurn,
+} from "./pull-request-action";
+
+const staleDisabledAction = {
+	head: "spaces/session-123",
+	base: "main",
+	enabled: false,
+	reason: "no checkpoints ready",
+};
+
+describe("deriveLivePullRequestAction", () => {
+	test("arms a page-load-disabled action when live branch work arrives", () => {
+		expect(
+			deriveLivePullRequestAction(staleDisabledAction, {
+				hasBranchWork: true,
+				busy: false,
+			}),
+		).toEqual({
+			head: "spaces/session-123",
+			base: "main",
+			enabled: true,
+			reason: undefined,
+		});
+	});
+
+	test("keeps the action disabled while a turn is busy", () => {
+		expect(
+			deriveLivePullRequestAction(staleDisabledAction, {
+				hasBranchWork: true,
+				busy: true,
+			}),
+		).toMatchObject({ enabled: false, reason: "wait for turn" });
+	});
+
+	test("keeps the action disabled when no checkpoint exists", () => {
+		expect(
+			deriveLivePullRequestAction(staleDisabledAction, {
+				hasBranchWork: false,
+				busy: false,
+			}),
+		).toMatchObject({ enabled: false, reason: "no checkpoints ready" });
+	});
+
+	test("does not invent an action for providers without PR support", () => {
+		expect(
+			deriveLivePullRequestAction(null, {
+				hasBranchWork: true,
+				busy: false,
+			}),
+		).toBeNull();
+	});
+});
+
+describe("shouldRefreshSessionAfterTurn", () => {
+	test("refreshes only on the busy to idle edge", () => {
+		expect(shouldRefreshSessionAfterTurn(true, false)).toBe(true);
+		expect(shouldRefreshSessionAfterTurn(false, false)).toBe(false);
+		expect(shouldRefreshSessionAfterTurn(false, true)).toBe(false);
+		expect(shouldRefreshSessionAfterTurn(true, true)).toBe(false);
+	});
+});

--- a/web-next/src/app/(app)/sessions/[id]/pull-request-action.ts
+++ b/web-next/src/app/(app)/sessions/[id]/pull-request-action.ts
@@ -1,0 +1,32 @@
+/*
+ * Live PR-action state for a session. The server-rendered action establishes
+ * provider capability and branch identity; live turn state owns whether the
+ * action is currently eligible, so a completed checkpoint can arm it without
+ * a page reload.
+ */
+import type { MastheadData } from "@/components/folio/session-masthead";
+
+type PullRequestAction = NonNullable<MastheadData["pullRequestAction"]>;
+
+export function deriveLivePullRequestAction(
+	action: PullRequestAction | null | undefined,
+	state: { hasBranchWork: boolean; busy: boolean },
+): PullRequestAction | null {
+	if (!action) return null;
+	return {
+		...action,
+		enabled: state.hasBranchWork && !state.busy,
+		reason: state.busy
+			? "wait for turn"
+			: state.hasBranchWork
+				? undefined
+				: "no checkpoints ready",
+	};
+}
+
+export function shouldRefreshSessionAfterTurn(
+	wasBusy: boolean,
+	isBusy: boolean,
+): boolean {
+	return wasBusy && !isBusy;
+}

--- a/web-next/src/app/(app)/sessions/[id]/session-refresh.test.ts
+++ b/web-next/src/app/(app)/sessions/[id]/session-refresh.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from "vitest";
+import { fetchSessionSnapshotWithRetry } from "./session-refresh";
+
+describe("fetchSessionSnapshotWithRetry", () => {
+	test("retries a transient non-OK completion snapshot", async () => {
+		const fetcher = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+			.mockResolvedValueOnce(
+				Response.json({ session: { hasBranchWork: true } }),
+			);
+		const sleep = vi.fn(async () => undefined);
+
+		const snapshot = await fetchSessionSnapshotWithRetry<{
+			session: { hasBranchWork: boolean };
+		}>("/api/sessions/session-123", { fetcher, sleep });
+
+		expect(snapshot).toEqual({ session: { hasBranchWork: true } });
+		expect(fetcher).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledWith(250);
+	});
+
+	test("retries rejected fetches but remains bounded", async () => {
+		const fetcher = vi.fn<typeof fetch>().mockRejectedValue(new Error("offline"));
+		const sleep = vi.fn(async () => undefined);
+
+		await expect(
+			fetchSessionSnapshotWithRetry("/api/sessions/session-123", {
+				attempts: 3,
+				fetcher,
+				sleep,
+			}),
+		).resolves.toBeNull();
+		expect(fetcher).toHaveBeenCalledTimes(3);
+		expect(sleep).toHaveBeenNthCalledWith(1, 250);
+		expect(sleep).toHaveBeenNthCalledWith(2, 500);
+	});
+});

--- a/web-next/src/app/(app)/sessions/[id]/session-refresh.ts
+++ b/web-next/src/app/(app)/sessions/[id]/session-refresh.ts
@@ -1,0 +1,39 @@
+/*
+ * Bounded session-snapshot reconciliation for live turn transitions. A turn
+ * can finish while one request or one server instance is transiently failing;
+ * retrying the durable read keeps page state convergent without an unbounded
+ * poller or a second source of truth in the stream protocol.
+ */
+
+const DEFAULT_ATTEMPTS = 3;
+const RETRY_BASE_MS = 250;
+
+export async function fetchSessionSnapshotWithRetry<T>(
+	url: string,
+	options: {
+		attempts?: number;
+		fetcher?: typeof fetch;
+		sleep?: (milliseconds: number) => Promise<void>;
+	} = {},
+): Promise<T | null> {
+	const attempts = Math.max(1, options.attempts ?? DEFAULT_ATTEMPTS);
+	const fetcher = options.fetcher ?? fetch;
+	const sleep =
+		options.sleep ??
+		((milliseconds: number) =>
+			new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
+		try {
+			const response = await fetcher(url);
+			if (response.ok) return (await response.json()) as T;
+		} catch {
+			// A rejected fetch and an invalid JSON response are both transient from
+			// this reconciliation seam; retry below, then leave current UI intact.
+		}
+		if (attempt + 1 < attempts) {
+			await sleep(RETRY_BASE_MS * 2 ** attempt);
+		}
+	}
+	return null;
+}

--- a/web-next/tests/demo/hero-flow.spec.ts
+++ b/web-next/tests/demo/hero-flow.spec.ts
@@ -42,13 +42,10 @@ test("hero flow: new session → real agent turn → draft PR", async ({ page })
 	});
 	await page.waitForTimeout(2500);
 
-	// has_branch_work is server-rendered into the masthead action; reload
-	// until the checkpoint has landed and the affordance arms.
+	// The completed turn refreshes its durable session snapshot and arms the
+	// affordance in place — no page reload or transcript discontinuity.
 	const openPr = page.getByTestId("open-session-pr");
-	await expect(async () => {
-		await page.reload();
-		await expect(openPr).toBeEnabled({ timeout: 5_000 });
-	}).toPass({ timeout: 3 * 60_000, intervals: [5_000] });
+	await expect(openPr).toBeEnabled({ timeout: 3 * 60_000 });
 	await page.waitForTimeout(1500);
 	await openPr.click();
 


### PR DESCRIPTION
## Summary

The hero-flow demo exposed two gaps in the path it was meant to prove: a completed checkpoint left **Open PR** disabled until reload, and its Playwright video had to be degraded to GIF before the evidence store would accept it.

This PR makes the live session reconcile its durable snapshot when a turn becomes idle, with bounded retry and capability/eligibility kept separate so the existing button arms in place. It also accepts `webm`/`mp4` evidence up to 50 MiB, sends a fixed length from the client, and streams accepted request bodies directly into R2 so the Worker does not buffer large recordings.

Closes #1026
Closes #1027

## Mergeability

- Surface: web session UI; evidence upload script and Cloudflare Worker; preview-worker CD gate
- User-facing behavior changed: Open PR arms after checkpoint completion without a page reload; WebM/MP4 recordings upload as click-to-play evidence links
- Non-happy paths considered: unsupported providers remain actionless; busy/no-checkpoint states remain disabled; transient session reads retry three times; growing files, missing/malformed/oversized lengths, exact-limit streams, MIME metadata, and rejected R2 writes are covered
- Release/ops preconditions: the evidence Worker deploys through the existing preview → health check → production promotion path; no new secrets or operator steps
- Residual risk or follow-up: the completion reconciliation uses the existing full session snapshot route, so its normal-path GET is O(transcript history); a sustained outage beyond the bounded retry window still needs a later reconciliation trigger or reload

## Validation

- [ ] `swift build` — not applicable
- [ ] `swift test` — not applicable
- [x] Other checks run:
  - `cd web-next && pnpm typecheck`
  - `cd web-next && pnpm lint`
  - `cd web-next && pnpm test` — 59 files / 613 tests
  - `E2E_PORT=3199 WEB_NEXT_COMPUTE_PROVIDER=mock pnpm exec playwright test tests/e2e/sessions.spec.ts --project=chromium` — 17 passed
  - `HERO_DEMO_PORT=3202 pnpm exec playwright test --config playwright.hero.config.ts tests/demo/hero-flow.spec.ts` — real provider, 1 passed in 53.5s, temporary PR #1040 closed
  - `cd infra/cloudflare-evidence-store && npm ci && npm test` — 4 passed
  - Worker TypeScript `--noEmit`, uploader tests (3 passed), `bash -n scripts/evidence.sh`, and `git diff --check`

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `config/performance/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [x] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a
- Before Summary: n/a
- After Summary: n/a
- Delta Summary: one existing session-snapshot GET now runs after each busy → idle transition; no render-path or bundle dependency was added

Performance comparison notes:

- Exact commands used: typecheck, lint, unit, isolated sessions E2E, and the real-provider hero flow listed above
- Workload / environment context: the session route returns the full transcript, so long-history cost remains the named residual risk

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [x] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Final real-provider hero flow — Open PR arms without reload](https://evidence.cloudcompute.com/workspaces/pr-1026/20260711-043137-final-hero-flow-no-reload.webm)
- ![Final validation summary](https://evidence.cloudcompute.com/workspaces/pr-1026/20260711-043137-final-rebased-validation.png)

## Review loop

The configured external `codex exec` path was blocked by the execution security gate even after owner approval, so the directed review ran in an isolated internal Codex context against the same staged diff. It found and drove five fixes: preserve freshly merged #1036 during rebase, retry transient completion reads, close the uploader stat/read race, gate Worker tests in CD with a Node-portable runner, and remove exact-limit Worker double-buffering in favor of fixed-length R2 streaming.

Two separately attributed reaction commits carry those changes. The post-reaction review found the buffering issue; the final narrow pass over the streaming design returned **APPROVE / no findings**.

## Blockers

- [x] None
- [ ] Blocked on evidence

Made with [Orca](https://github.com/stablyai/orca) 🐋
