### PR TITLE
fix(web-next): prevent stale harness server reuse

### DIFF
--- a/web-next/perf/run.mjs
+++ b/web-next/perf/run.mjs
@@ -18,6 +18,7 @@ import path from "node:path";
 import { gzipSync } from "node:zlib";
 import {
 	bypassServerEnv,
+	closeHarnessResources,
 	connectSeedClient,
 	launchChromium,
 	startProductionServer,
@@ -465,66 +466,70 @@ async function runLocalSuite() {
 	let failed = false;
 
 	const { env, databaseUrl } = bypassServerEnv("perf-db");
-	const server = await startProductionServer(PORT, env);
-	// Seed the fixed rows the scenarios navigate to: one repo, one empty
-	// session at a stable id, and one fresh session per turn-scenario run.
-	const db = await connectSeedClient(server.baseUrl, databaseUrl);
-	const now = new Date().toISOString();
-	await db.execute({
-		sql: "INSERT INTO repos (id, full_name, default_branch, created_at) VALUES (?, ?, 'main', ?)",
-		args: ["fairchild/workspaces", "fairchild/workspaces", now],
-	});
-	const seedSession = (id) =>
-		db.execute({
-			sql: `INSERT INTO sessions
+	let server;
+	let db;
+	let browser;
+	try {
+		server = await startProductionServer(PORT, env);
+		// Seed the fixed rows the scenarios navigate to: one repo, one empty
+		// session at a stable id, and one fresh session per turn-scenario run.
+		db = await connectSeedClient(server.baseUrl, databaseUrl);
+		const now = new Date().toISOString();
+		await db.execute({
+			sql: "INSERT INTO repos (id, full_name, default_branch, created_at) VALUES (?, ?, 'main', ?)",
+			args: ["fairchild/workspaces", "fairchild/workspaces", now],
+		});
+		const seedSession = (id) =>
+			db.execute({
+				sql: `INSERT INTO sessions
 				(id, repo_id, title, provider, status, claude_session_id, created_at, last_activity_at)
 				VALUES (?, 'fairchild/workspaces', '', 'mock', 'active', NULL, ?, ?)`,
-			args: [id, now, now],
-		});
-	// A ~100-event assistant turn with no `done`, backdated so it reads as
-	// stale (an interrupted turn). seq 1 is the user prompt; seq 2..N are
-	// assistant text deltas, the last carrying the caught-up marker.
-	const seedInterruptedTurn = async (db, id) => {
-		const old = new Date(Date.now() - 60_000).toISOString();
-		const event = (seq, role, chunk) =>
-			db.execute({
-				sql: `INSERT INTO session_events (session_id, seq, role, kind, payload, created_at)
-					VALUES (?, ?, ?, ?, ?, ?)`,
-				args: [id, seq, role, chunk.type, JSON.stringify(chunk), old],
+				args: [id, now, now],
 			});
-		await event(1, "user", { type: "text", content: "Resume a long turn" });
-		for (let seq = 2; seq < RESUME_EVENT_COUNT; seq++) {
-			await event(seq, "assistant", { type: "text", content: `token${seq} ` });
+		// A ~100-event assistant turn with no `done`, backdated so it reads as
+		// stale (an interrupted turn). seq 1 is the user prompt; seq 2..N are
+		// assistant text deltas, the last carrying the caught-up marker.
+		const seedInterruptedTurn = async (db, id) => {
+			const old = new Date(Date.now() - 60_000).toISOString();
+			const event = (seq, role, chunk) =>
+				db.execute({
+					sql: `INSERT INTO session_events (session_id, seq, role, kind, payload, created_at)
+					VALUES (?, ?, ?, ?, ?, ?)`,
+					args: [id, seq, role, chunk.type, JSON.stringify(chunk), old],
+				});
+			await event(1, "user", { type: "text", content: "Resume a long turn" });
+			for (let seq = 2; seq < RESUME_EVENT_COUNT; seq++) {
+				await event(seq, "assistant", { type: "text", content: `token${seq} ` });
+			}
+			await event(RESUME_EVENT_COUNT, "assistant", {
+				type: "text",
+				content: RESUME_MARKER,
+			});
+		};
+		await seedSession("perf-empty");
+		const runsOf = (id) =>
+			contract.scenarios.find((scenario) => scenario.id === id)?.runs ?? 0;
+		for (let i = 0; i < runsOf("ttft_mock"); i++) {
+			await seedSession(`perf-turn-${i}`);
 		}
-		await event(RESUME_EVENT_COUNT, "assistant", {
-			type: "text",
-			content: RESUME_MARKER,
-		});
-	};
-	await seedSession("perf-empty");
-	const runsOf = (id) =>
-		contract.scenarios.find((scenario) => scenario.id === id)?.runs ?? 0;
-	for (let i = 0; i < runsOf("ttft_mock"); i++) {
-		await seedSession(`perf-turn-${i}`);
-	}
-	for (let i = 0; i < runsOf("streaming_cadence"); i++) {
-		await seedSession(`perf-cadence-${i}`);
-	}
-	for (let i = 0; i < runsOf("terminal_drawer_interactive"); i++) {
-		await seedSession(`perf-drawer-${i}`);
-	}
-	// resume_latency_100: one interrupted turn per run. Each is a ~100-event
-	// assistant turn with NO `done` and a backdated clock, so resolveTurn reads
-	// it as stale and the client resumes it on load.
-	for (let i = 0; i < runsOf("resume_latency_100"); i++) {
-		const id = `${RESUME_SESSION_PREFIX}${i}`;
-		await seedSession(id);
-		await seedInterruptedTurn(db, id);
-	}
-	db.close();
+		for (let i = 0; i < runsOf("streaming_cadence"); i++) {
+			await seedSession(`perf-cadence-${i}`);
+		}
+		for (let i = 0; i < runsOf("terminal_drawer_interactive"); i++) {
+			await seedSession(`perf-drawer-${i}`);
+		}
+		// resume_latency_100: one interrupted turn per run. Each is a ~100-event
+		// assistant turn with NO `done` and a backdated clock, so resolveTurn reads
+		// it as stale and the client resumes it on load.
+		for (let i = 0; i < runsOf("resume_latency_100"); i++) {
+			const id = `${RESUME_SESSION_PREFIX}${i}`;
+			await seedSession(id);
+			await seedInterruptedTurn(db, id);
+		}
+		db.close();
+		db = undefined;
 
-	const browser = await launchChromium();
-	try {
+		browser = await launchChromium();
 		for (const scenario of contract.scenarios) {
 			if (scenario.status === "pending") {
 				results.scenarios.push({
@@ -559,8 +564,7 @@ async function runLocalSuite() {
 			results.scenarios.push({ id: scenario.id, status: "measured", metrics });
 		}
 	} finally {
-		await browser.close();
-		await server.stop();
+		await closeHarnessResources({ browser, database: db, server });
 	}
 
 	const markdown = toMarkdown(results);

--- a/web-next/perf/run.mjs
+++ b/web-next/perf/run.mjs
@@ -469,6 +469,7 @@ async function runLocalSuite() {
 	let server;
 	let db;
 	let browser;
+	let primaryError;
 	try {
 		server = await startProductionServer(PORT, env);
 		// Seed the fixed rows the scenarios navigate to: one repo, one empty
@@ -563,8 +564,16 @@ async function runLocalSuite() {
 			}
 			results.scenarios.push({ id: scenario.id, status: "measured", metrics });
 		}
+	} catch (error) {
+		primaryError = error;
+		throw error;
 	} finally {
-		await closeHarnessResources({ browser, database: db, server });
+		try {
+			await closeHarnessResources({ browser, database: db, server });
+		} catch (cleanupError) {
+			if (!primaryError) throw cleanupError;
+			console.error("Harness cleanup also failed after the primary error:", cleanupError);
+		}
 	}
 
 	const markdown = toMarkdown(results);

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -18,6 +18,7 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 import {
 	bypassServerEnv,
+	closeHarnessResources,
 	connectSeedClient,
 	launchChromium,
 	startProductionServer,
@@ -408,10 +409,13 @@ async function capturePrototype(page, theme, file) {
 async function main() {
 	mkdirSync(OUTPUT_DIR, { recursive: true });
 	const { env, databaseUrl } = bypassServerEnv("evidence-db");
-	const server = await startProductionServer(PORT, env);
-	const db = await connectSeedClient(server.baseUrl, databaseUrl);
-	const browser = await launchChromium();
+	let server;
+	let db;
+	let browser;
 	try {
+		server = await startProductionServer(PORT, env);
+		db = await connectSeedClient(server.baseUrl, databaseUrl);
+		browser = await launchChromium();
 		for (const colorScheme of ["light", "dark"]) {
 			// colorScheme emulation drives the app theme (system preference is
 			// the default resolution); the prototype is forced via its hash.
@@ -448,9 +452,7 @@ async function main() {
 			);
 		}
 	} finally {
-		await browser.close();
-		await server.stop();
-		db.close();
+		await closeHarnessResources({ browser, database: db, server });
 	}
 	console.log(`evidence written to ${OUTPUT_DIR}`);
 }

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -412,6 +412,7 @@ async function main() {
 	let server;
 	let db;
 	let browser;
+	let primaryError;
 	try {
 		server = await startProductionServer(PORT, env);
 		db = await connectSeedClient(server.baseUrl, databaseUrl);
@@ -451,8 +452,16 @@ async function main() {
 				`captured home (empty+populated) + session (empty, streaming, final, reloaded) + compose (empty, multiline, disabled) + terminal drawer + failed turn (failure, retried) + error surfaces (provisioning, sandbox-died, stream) + stop control (stopping, stopped) + mobile 375px (turn, diff) + disconnect→resume (midturn, catchup, complete) + sessions-demo + prototype (${colorScheme})`,
 			);
 		}
+	} catch (error) {
+		primaryError = error;
+		throw error;
 	} finally {
-		await closeHarnessResources({ browser, database: db, server });
+		try {
+			await closeHarnessResources({ browser, database: db, server });
+		} catch (cleanupError) {
+			if (!primaryError) throw cleanupError;
+			console.error("Harness cleanup also failed after the primary error:", cleanupError);
+		}
 	}
 	console.log(`evidence written to ${OUTPUT_DIR}`);
 }

--- a/web-next/scripts/harness.mjs
+++ b/web-next/scripts/harness.mjs
@@ -113,7 +113,7 @@ async function waitForServer(url, timeoutMs = 60_000) {
 }
 
 function hostHasListener(port, host) {
-	return new Promise((resolve, reject) => {
+	return new Promise((resolve) => {
 		const socket = connect({ port, host });
 		let settled = false;
 		const finish = (value) => {
@@ -124,17 +124,9 @@ function hostHasListener(port, host) {
 		};
 		socket.setTimeout(500, () => finish(false));
 		socket.once("connect", () => finish(true));
-		socket.once("error", (error) => {
-			if (["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH", "EAFNOSUPPORT"].includes(error.code)) {
-				finish(false);
-				return;
-			}
-			if (!settled) {
-				settled = true;
-				socket.destroy();
-				reject(error);
-			}
-		});
+		// Any connection error means this address did not accept a connection.
+		// In particular, IPv6-less runners may report EADDRNOTAVAIL for ::1.
+		socket.once("error", () => finish(false));
 	});
 }
 
@@ -278,16 +270,12 @@ export async function startProductionServer(port = 3100, env = {}) {
 		terminateChildProcessGroup(child, "SIGTERM");
 		throw error;
 	}
-	let stopped = false;
+	let stopPromise;
 	return {
 		baseUrl,
-		stop: () =>
-			new Promise((resolve) => {
-				if (stopped) {
-					resolve();
-					return;
-				}
-				stopped = true;
+		stop: () => {
+			if (stopPromise) return stopPromise;
+			stopPromise = new Promise((resolve) => {
 				unregisterExitCleanup();
 				let done = false;
 				const finish = () => {
@@ -310,7 +298,9 @@ export async function startProductionServer(port = 3100, env = {}) {
 					return;
 				}
 				terminateChildProcessGroup(child, "SIGTERM");
-			}),
+			});
+			return stopPromise;
+		},
 	};
 }
 

--- a/web-next/scripts/harness.mjs
+++ b/web-next/scripts/harness.mjs
@@ -4,9 +4,10 @@
  * launch Chromium (honoring the remote-sandbox executable override).
  * Node-only, no test framework.
  */
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { connect } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
@@ -111,6 +112,141 @@ async function waitForServer(url, timeoutMs = 60_000) {
 	throw new Error(`Server at ${url} not ready within ${timeoutMs}ms`);
 }
 
+function hostHasListener(port, host) {
+	return new Promise((resolve, reject) => {
+		const socket = connect({ port, host });
+		let settled = false;
+		const finish = (value) => {
+			if (settled) return;
+			settled = true;
+			socket.destroy();
+			resolve(value);
+		};
+		socket.setTimeout(500, () => finish(false));
+		socket.once("connect", () => finish(true));
+		socket.once("error", (error) => {
+			if (["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH", "EAFNOSUPPORT"].includes(error.code)) {
+				finish(false);
+				return;
+			}
+			if (!settled) {
+				settled = true;
+				socket.destroy();
+				reject(error);
+			}
+		});
+	});
+}
+
+async function loopbackHasListener(port) {
+	const results = await Promise.all([
+		hostHasListener(port, "127.0.0.1"),
+		hostHasListener(port, "::1"),
+	]);
+	return results.some(Boolean);
+}
+
+function describePortOwner(port) {
+	try {
+		const output = execFileSync(
+			"lsof",
+			["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+		);
+		let pid;
+		let command;
+		for (const line of output.split("\n")) {
+			if (!pid && line.startsWith("p")) pid = line.slice(1);
+			if (!command && line.startsWith("c")) command = line.slice(1);
+			if (pid && command) break;
+		}
+		if (!pid && !command) return "";
+		return ` (${[pid && `PID ${pid}`, command].filter(Boolean).join(", ")})`;
+	} catch {
+		return "";
+	}
+}
+
+/** Refuse to let a stale server satisfy readiness for a newly spawned child. */
+export async function assertPortAvailable(
+	port,
+	{ probe = loopbackHasListener, describeOwner = describePortOwner } = {},
+) {
+	if (await probe(port)) {
+		throw new Error(
+			`Harness port ${port} is already listening${describeOwner(port)}; stop that process or choose another EVIDENCE_PORT/PERF_PORT.`,
+		);
+	}
+}
+
+function terminateChildProcessGroup(child, signal = "SIGTERM") {
+	if (!child || child.exitCode != null || child.signalCode != null) return;
+	try {
+		process.kill(-child.pid, signal);
+	} catch {
+		try {
+			child.kill(signal);
+		} catch {
+			// Best effort during process teardown: the child may already be gone.
+		}
+	}
+}
+
+/** Keep detached `next start` descendants tied to the harness parent lifetime. */
+export function registerParentExitCleanup(
+	child,
+	{
+		parent = process,
+		terminate = terminateChildProcessGroup,
+		resignal = (signal) => process.kill(process.pid, signal),
+	} = {},
+) {
+	let registered = true;
+	const onExit = () => terminate(child, "SIGTERM");
+	const signalHandlers = new Map(
+		["SIGINT", "SIGTERM"].map((signal) => [
+			signal,
+			() => {
+				unregister();
+				terminate(child, "SIGTERM");
+				resignal(signal);
+			},
+		]),
+	);
+	parent.once("exit", onExit);
+	for (const [signal, handler] of signalHandlers) parent.once(signal, handler);
+	function unregister() {
+		if (!registered) return;
+		registered = false;
+		parent.off("exit", onExit);
+		for (const [signal, handler] of signalHandlers) parent.off(signal, handler);
+	}
+	return unregister;
+}
+
+/** Close every acquired harness resource even when an earlier close fails. */
+export async function closeHarnessResources({ browser, database, server }) {
+	const errors = [];
+	try {
+		await browser?.close();
+	} catch (error) {
+		errors.push(error);
+	}
+	try {
+		database?.close();
+	} catch (error) {
+		errors.push(error);
+	}
+	try {
+		await server?.stop();
+	} catch (error) {
+		errors.push(error);
+	}
+	if (errors.length > 0) {
+		throw new AggregateError(errors, "Failed to close every harness resource");
+	}
+}
+
 /**
  * Starts `next start` on the given port (with optional extra env) and
  * resolves once it serves 200s. Returns { baseUrl, stop } — always call
@@ -118,6 +254,7 @@ async function waitForServer(url, timeoutMs = 60_000) {
  */
 export async function startProductionServer(port = 3100, env = {}) {
 	assertProductionBuild();
+	await assertPortAvailable(port);
 	const args =
 		env.WEB_NEXT_LOCAL_MODE === "1"
 			? ["exec", "next", "start", "-H", "127.0.0.1", "--port", String(port)]
@@ -132,21 +269,26 @@ export async function startProductionServer(port = 3100, env = {}) {
 			detached: true,
 		},
 	);
+	const unregisterExitCleanup = registerParentExitCleanup(child);
 	const baseUrl = `http://localhost:${port}`;
 	try {
 		await waitForServer(baseUrl);
 	} catch (error) {
-		try {
-			process.kill(-child.pid, "SIGTERM");
-		} catch {
-			child.kill("SIGTERM");
-		}
+		unregisterExitCleanup();
+		terminateChildProcessGroup(child, "SIGTERM");
 		throw error;
 	}
+	let stopped = false;
 	return {
 		baseUrl,
 		stop: () =>
 			new Promise((resolve) => {
+				if (stopped) {
+					resolve();
+					return;
+				}
+				stopped = true;
+				unregisterExitCleanup();
 				let done = false;
 				const finish = () => {
 					if (done) return;
@@ -154,22 +296,20 @@ export async function startProductionServer(port = 3100, env = {}) {
 					resolve();
 				};
 				const killTimer = setTimeout(() => {
-					try {
-						process.kill(-child.pid, "SIGKILL");
-					} catch {
-						child.kill("SIGKILL");
-					}
+					terminateChildProcessGroup(child, "SIGKILL");
 					finish();
 				}, 5_000);
+				killTimer.unref();
 				child.once("exit", () => {
 					clearTimeout(killTimer);
 					finish();
 				});
-				try {
-					process.kill(-child.pid, "SIGTERM");
-				} catch {
-					child.kill("SIGTERM");
+				if (child.exitCode != null || child.signalCode != null) {
+					clearTimeout(killTimer);
+					finish();
+					return;
 				}
+				terminateChildProcessGroup(child, "SIGTERM");
 			}),
 	};
 }

--- a/web-next/scripts/harness.test.mjs
+++ b/web-next/scripts/harness.test.mjs
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { createServer } from "node:net";
 import { describe, expect, test, vi } from "vitest";
 import {
 	assertPortAvailable,
@@ -23,6 +24,25 @@ describe("production harness lifecycle", () => {
 		const probe = vi.fn().mockResolvedValue(false);
 
 		await expect(assertPortAvailable(3188, { probe })).resolves.toBeUndefined();
+	});
+
+	test("detects a real IPv4 loopback listener", async () => {
+		const listener = createServer();
+		await new Promise((resolve, reject) => {
+			listener.once("error", reject);
+			listener.listen(0, "127.0.0.1", resolve);
+		});
+		try {
+			const address = listener.address();
+			expect(address).not.toBeNull();
+			await expect(
+				assertPortAvailable(address.port, { describeOwner: () => "" }),
+			).rejects.toThrow(/already listening/i);
+		} finally {
+			await new Promise((resolve, reject) =>
+				listener.close((error) => (error ? reject(error) : resolve())),
+			);
+		}
 	});
 
 	test("terminates the child on parent exit and unregisters after normal cleanup", () => {

--- a/web-next/scripts/harness.test.mjs
+++ b/web-next/scripts/harness.test.mjs
@@ -1,0 +1,77 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, test, vi } from "vitest";
+import {
+	assertPortAvailable,
+	closeHarnessResources,
+	registerParentExitCleanup,
+} from "./harness.mjs";
+
+describe("production harness lifecycle", () => {
+	test("refuses an occupied port before a stale server can satisfy readiness", async () => {
+		const port = 3187;
+		const probe = vi.fn().mockResolvedValue(true);
+
+		await expect(
+			assertPortAvailable(port, { probe, describeOwner: () => " (PID 123, node)" }),
+		).rejects.toThrow(
+			new RegExp(`port ${port}.*already`, "i"),
+		);
+		expect(probe).toHaveBeenCalledWith(port);
+	});
+
+	test("allows a port with no loopback listener", async () => {
+		const probe = vi.fn().mockResolvedValue(false);
+
+		await expect(assertPortAvailable(3188, { probe })).resolves.toBeUndefined();
+	});
+
+	test("terminates the child on parent exit and unregisters after normal cleanup", () => {
+		const parent = new EventEmitter();
+		const child = { pid: 42 };
+		const terminate = vi.fn();
+		const unregister = registerParentExitCleanup(child, { parent, terminate });
+
+		parent.emit("exit");
+		expect(terminate).toHaveBeenCalledOnce();
+		expect(terminate).toHaveBeenCalledWith(child, "SIGTERM");
+
+		unregister();
+		parent.emit("exit");
+		expect(terminate).toHaveBeenCalledOnce();
+	});
+
+	test("cleans up and re-raises termination signals after removing its handlers", () => {
+		const parent = new EventEmitter();
+		const child = { pid: 42 };
+		const terminate = vi.fn();
+		const resignal = vi.fn();
+		registerParentExitCleanup(child, { parent, terminate, resignal });
+
+		parent.emit("SIGTERM");
+
+		expect(terminate).toHaveBeenCalledWith(child, "SIGTERM");
+		expect(resignal).toHaveBeenCalledWith("SIGTERM");
+		expect(parent.listenerCount("exit")).toBe(0);
+		expect(parent.listenerCount("SIGINT")).toBe(0);
+		expect(parent.listenerCount("SIGTERM")).toBe(0);
+	});
+
+	test("attempts every cleanup when an earlier resource close fails", async () => {
+		const browser = {
+			close: vi.fn().mockRejectedValue(new Error("browser close failed")),
+		};
+		const database = {
+			close: vi.fn(() => {
+				throw new Error("database close failed");
+			}),
+		};
+		const server = { stop: vi.fn().mockResolvedValue(undefined) };
+
+		await expect(
+			closeHarnessResources({ browser, database, server }),
+		).rejects.toThrow(AggregateError);
+		expect(browser.close).toHaveBeenCalledOnce();
+		expect(database.close).toHaveBeenCalledOnce();
+		expect(server.stop).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## What

- refuse an occupied evidence/performance harness port before spawning `next start`, with best-effort PID and process diagnostics
- tie detached production-server process groups to parent exit and termination signals
- make shutdown idempotent and exhaust browser, database, and server cleanup after partial initialization
- add focused regression coverage for stale-server, signal, and cleanup-failure paths

## Diagnosis

The evidence and performance scripts acquired the production server, seed database, and browser before entering their cleanup scope. A failure during database warm-up or browser launch could therefore leave detached `next start` descendants alive. The existing readiness check could then accept that stale server during a later run.

A real two-server smoke test also caught that a bind-only availability check was insufficient on this platform, so the final preflight probes active IPv4 and IPv6 loopback listeners and uses `lsof` only for optional owner diagnostics.

## Verification

- `pnpm test` — 60 files, 619 tests passed, including a real bound-loopback-socket regression
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` — production build passed
- real two-server smoke — second harness refused the occupied port and no listener remained after owner cleanup

## Evidence Status

![Harness lifecycle verification after Fable review](https://evidence.cloudcompute.com/workspaces/pr-1004/20260711-200551-harness-lifecycle-fable-reviewed.svg)

## Review status

Personal reflection completed. A targeted read-only Claude/Fable review requested changes for IPv6-less hosts and primary-error masking; both were accepted and fixed in `c9fd82bd`. Its request for production-shaped coverage was also accepted with a real bound-socket test. The SIGTERM-only abnormal-exit path and unavoidable preflight/spawn race remain documented residual risks. Full attributed reactions are recorded in a PR comment.

The repository-referenced `codex-review-loop` skill is absent in this checkout, and external Codex review was not authorized by the host policy; the approved Fable review was therefore the external review surface.

## Mergeability

- Surface: `web-next` evidence and performance harness lifecycle
- User-facing behavior changed: Harness runs now refuse occupied ports and reliably clean up detached server processes and partially acquired resources.
- Non-happy paths considered: occupied stale server, partial initialization, parent exit, SIGINT/SIGTERM, already-exited child, repeated stop calls, cleanup failures, and unavailable `lsof` diagnostics
- Residual risk or follow-up: abnormal parent signal/exit handling can only attempt synchronous SIGTERM, and there remains an unavoidable narrow race between the preflight probe and child bind. Both are mitigated by fail-closed occupied-port detection on the next run. Current-head readiness, CodeQL, lint, typecheck, unit, build, E2E, screenshot evidence, and performance gates passed.

Closes #1004
