### PR TITLE
feat(web-next): validate active compute provider

### DIFF
--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -91,6 +91,20 @@ set by hand. Both report `skipped: validation session expired — re-seed`
 when the session cookie doesn't authenticate, matching the decision doc's
 expiry wording, rather than failing.
 
+To exercise the host provider end to end, use the explicit local-mode lane:
+
+```bash
+WEB_NEXT_COMPUTE_PROVIDER=host \
+WEB_NEXT_HOST_WORKSPACE_ROOT="$HOME/.webnext/workspaces" \
+pnpm validate --env local-mode
+```
+
+This is the only local spawn that runs a real model turn without `--url`. It
+uses the local Claude login, restricts the probe to `Read`, verifies durable
+completion plus a resume handle, deletes the probe session, and leaves ordinary
+`pnpm validate` zero-spend. Pass `--skip-real-turn` to retain only the zero-spend
+local-mode posture and authenticated-flow stages.
+
 ## Cleaning up
 
 ```bash

--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -100,8 +100,9 @@ pnpm validate --env local-mode
 ```
 
 This is the only local spawn that runs a real model turn without `--url`. It
-uses the local Claude login, restricts the probe to `Read`, verifies durable
-completion plus a resume handle, deletes the probe session, and leaves ordinary
+uses the local Claude login, enforces the host provider's read-only tool
+allowlist and proves a `Read`, verifies durable completion plus a resume handle,
+deletes the probe session, and leaves ordinary
 `pnpm validate` zero-spend. Pass `--skip-real-turn` to retain only the zero-spend
 local-mode posture and authenticated-flow stages.
 

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -83,8 +83,11 @@ async function captureSettled(page, url, file) {
 async function scrollToSettled(page, testId) {
 	let detachedError;
 	for (let attempt = 0; attempt < 4; attempt += 1) {
-		const target = page.getByTestId(testId).last();
-		await target.waitFor({ state: "visible", timeout: TURN_TIMEOUT_MS });
+		const target = page.getByTestId(testId);
+		await target.waitFor({
+			state: "visible",
+			timeout: attempt === 0 ? TURN_TIMEOUT_MS : 5_000,
+		});
 		try {
 			await target.scrollIntoViewIfNeeded({ timeout: 5_000 });
 			await page.waitForTimeout(ANIMATION_SETTLE_MS);

--- a/web-next/scripts/evidence.mjs
+++ b/web-next/scripts/evidence.mjs
@@ -75,6 +75,29 @@ async function captureSettled(page, url, file) {
 	await page.screenshot({ path: file });
 }
 
+/**
+ * Scroll to a final-state element without retaining a DOM node across React's
+ * streaming→settled replacement. Playwright locators re-resolve, but the node
+ * can still detach during the scroll action itself; retry only that condition.
+ */
+async function scrollToSettled(page, testId) {
+	let detachedError;
+	for (let attempt = 0; attempt < 4; attempt += 1) {
+		const target = page.getByTestId(testId).last();
+		await target.waitFor({ state: "visible", timeout: TURN_TIMEOUT_MS });
+		try {
+			await target.scrollIntoViewIfNeeded({ timeout: 5_000 });
+			await page.waitForTimeout(ANIMATION_SETTLE_MS);
+			return;
+		} catch (error) {
+			if (!/not attached|detached/i.test(String(error))) throw error;
+			detachedError = error;
+			await page.waitForTimeout(100);
+		}
+	}
+	throw detachedError ?? new Error(`could not scroll to settled ${testId}`);
+}
+
 /** Drives the real new-session flow and captures the empty session it makes. */
 async function captureNewSessionFlow(page, file) {
 	await page.goto("/", { waitUntil: "networkidle" });
@@ -151,14 +174,12 @@ async function captureSessionTurn(page, shot) {
 	await page.getByTestId("tool-row").nth(3).locator("button").first().click();
 	await page.getByTestId("test-output").waitFor();
 	// Scroll to the end of the turn so the diff + receipt are in frame.
-	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
-	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await scrollToSettled(page, "turn-stats");
 	await page.screenshot({ path: shot("session-turn-final") });
 
 	// Reloaded: the persisted transcript served from session_events.
 	await page.reload({ waitUntil: "networkidle" });
-	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
-	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await scrollToSettled(page, "turn-stats");
 	await page.screenshot({ path: shot("session-turn-reloaded") });
 }
 
@@ -214,8 +235,7 @@ async function captureFailedTurn(page, shot) {
 
 	await page.getByRole("button", { name: "Retry" }).click();
 	await page.getByTestId("turn-stats").waitFor({ timeout: TURN_TIMEOUT_MS });
-	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
-	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await scrollToSettled(page, "turn-stats");
 	await page.screenshot({ path: shot("session-turn-failed-retried") });
 }
 
@@ -247,8 +267,7 @@ async function captureErrorSurfaces(page, shot) {
 		await page.getByRole("textbox", { name: "Reply to Claude" }).fill(text);
 		await page.keyboard.press("Enter");
 		await page.getByTestId("turn-failure").waitFor({ timeout: TURN_TIMEOUT_MS });
-		await page.getByTestId("turn-failure").scrollIntoViewIfNeeded();
-		await page.waitForTimeout(ANIMATION_SETTLE_MS);
+		await scrollToSettled(page, "turn-failure");
 		await page.screenshot({ path: shot(name) });
 	}
 }
@@ -297,8 +316,7 @@ async function captureMobile(context, shot) {
 	const rows = page.getByTestId("tool-row");
 	await rows.nth(2).locator("button").first().click();
 	await page.getByTestId("diff-lines").waitFor();
-	await page.getByTestId("turn-stats").scrollIntoViewIfNeeded();
-	await page.waitForTimeout(ANIMATION_SETTLE_MS);
+	await scrollToSettled(page, "turn-stats");
 	await page.screenshot({ path: shot("session-mobile-diff") });
 	await page.close();
 }
@@ -345,8 +363,7 @@ async function captureDisconnectResume(context, shot) {
 
 	// Completed: the resumed turn finished; the receipt proves it caught up.
 	await reopened.getByTestId("turn-stats").waitFor({ timeout: TURN_TIMEOUT_MS });
-	await reopened.getByTestId("turn-stats").scrollIntoViewIfNeeded();
-	await reopened.waitForTimeout(ANIMATION_SETTLE_MS);
+	await scrollToSettled(reopened, "turn-stats");
 	await reopened.screenshot({ path: shot("resume-complete") });
 	await reopened.close();
 }

--- a/web-next/scripts/real-turn-core.mjs
+++ b/web-next/scripts/real-turn-core.mjs
@@ -209,10 +209,15 @@ export function evaluateHostTurnEvents(events, nonce, { deadlineMs } = {}) {
 		/preparing host workspace|starting local claude code/i.test(event.content ?? ""),
 	);
 	const toolUses = assistant.filter((event) => event.kind === "tool_use");
-	const readUsed = toolUses.some((event) => {
+	const toolNames = toolUses.map((event) => {
 		const name = event.metadata?.toolName ?? event.content;
-		return String(name ?? "").toLowerCase() === "read";
+		return String(name ?? "");
 	});
+	const readUsed = toolNames.some((name) => name.toLowerCase() === "read");
+	const allowed = new Set(["read", "ls", "glob", "grep", "todoread"]);
+	const unexpectedTools = toolNames.filter(
+		(name) => !allowed.has(name.toLowerCase()),
+	);
 	const streamed = assistant.filter(
 		(event) =>
 			(event.kind === "text" || event.kind === "reasoning") &&
@@ -231,9 +236,13 @@ export function evaluateHostTurnEvents(events, nonce, { deadlineMs } = {}) {
 			localLifecycle ? "host workspace/Claude lifecycle observed" : "no host lifecycle status event",
 		),
 		check(
-			"read_only_tool_used",
-			readUsed,
-			readUsed ? "Read tool observed" : `no Read tool among ${toolUses.length} tool call(s)`,
+			"read_only_tools",
+			readUsed && unexpectedTools.length === 0,
+			unexpectedTools.length > 0
+				? `unexpected tool(s): ${unexpectedTools.join(", ")}`
+				: readUsed
+					? "Read observed; every tool call is in the host read-only allowlist"
+					: `no Read tool among ${toolUses.length} tool call(s)`,
 		),
 		check(
 			"streamed_output",
@@ -276,10 +285,14 @@ export function classifyTeardown(state, del) {
 	if (del.status === 200 && del.body?.deleted === true) {
 		const sandbox = del.body.sandbox;
 		if (!turnCompleted) {
+			const possibleLeak =
+				provider === "host"
+					? "a local Claude process may still be running"
+					: "an unparked live sandbox may persist until its lifetime cap";
 			return check(
 				"no_leaked_sandbox",
 				false,
-				`session deleted but the turn never closed — an unparked live sandbox may persist until its lifetime cap (disposition: ${sandbox})`,
+				`session deleted but the turn never closed — ${possibleLeak} (disposition: ${sandbox})`,
 			);
 		}
 		const ok =

--- a/web-next/scripts/real-turn-core.mjs
+++ b/web-next/scripts/real-turn-core.mjs
@@ -30,6 +30,15 @@ export function buildProbePrompt(nonce) {
 	].join("\n");
 }
 
+/** Read-only host probe: exercises local Claude + workspace + durable resume. */
+export function buildHostProbePrompt(nonce) {
+	return [
+		"Read package.json from the repository root and report its package name.",
+		`End your answer with exactly: host-turn probe ${nonce}`,
+		"Do not edit files, run commands, commit, push, or open a pull request.",
+	].join("\n");
+}
+
 /**
  * Interprets `/api/diag/preflight` (cheap, no sandbox spin-up) as the stage's
  * runtime-credential gate. Only a failing env-presence check is a *skip* — a
@@ -47,7 +56,9 @@ export function classifyPreflightGate(probe) {
 			reason: "target has no /api/diag/preflight — deployment predates the real runtime",
 		};
 	}
-	if (probe.status === 200) return { ok: true };
+	if (probe.status === 200) {
+		return { ok: true, provider: probe.body?.provider ?? "vercel" };
+	}
 	const checks = Array.isArray(probe.body?.checks) ? probe.body.checks : [];
 	const failing = checks.filter((c) => c.ok === false);
 	const envCheck = failing.find((c) => /env/i.test(String(c.name)));
@@ -190,6 +201,64 @@ export function evaluateRealTurnEvents(events, nonce, { deadlineMs } = {}) {
 	return checks;
 }
 
+/** Host turn contract: local lifecycle, read-only tool use, durable completion. */
+export function evaluateHostTurnEvents(events, nonce, { deadlineMs } = {}) {
+	const assistant = events.filter(isAssistant);
+	const statuses = assistant.filter((event) => event.kind === "status");
+	const localLifecycle = statuses.some((event) =>
+		/preparing host workspace|starting local claude code/i.test(event.content ?? ""),
+	);
+	const toolUses = assistant.filter((event) => event.kind === "tool_use");
+	const readUsed = toolUses.some((event) => {
+		const name = event.metadata?.toolName ?? event.content;
+		return String(name ?? "").toLowerCase() === "read";
+	});
+	const streamed = assistant.filter(
+		(event) =>
+			(event.kind === "text" || event.kind === "reasoning") &&
+			(event.content ?? "").length > 0,
+	);
+	const marker = streamed.some((event) =>
+		(event.content ?? "").includes(`host-turn probe ${nonce}`),
+	);
+	const errors = assistant.filter((event) => event.kind === "error");
+	const done = assistant.find((event) => event.kind === "done");
+	const aborted = done?.metadata?.aborted === true;
+	return [
+		check(
+			"host_lifecycle_started",
+			localLifecycle,
+			localLifecycle ? "host workspace/Claude lifecycle observed" : "no host lifecycle status event",
+		),
+		check(
+			"read_only_tool_used",
+			readUsed,
+			readUsed ? "Read tool observed" : `no Read tool among ${toolUses.length} tool call(s)`,
+		),
+		check(
+			"streamed_output",
+			streamed.length > 0 && marker,
+			`${streamed.length} text/reasoning event(s); marker ${marker ? "observed" : "missing"}`,
+		),
+		check(
+			"no_turn_errors",
+			errors.length === 0,
+			errors.length === 0
+				? "no error events"
+				: `error event(s): ${errors.map((event) => JSON.stringify((event.content ?? "").slice(0, 200))).join("; ")}`,
+		),
+		check(
+			"turn_done",
+			!!done && !aborted,
+			done
+				? aborted
+					? "turn closed as aborted"
+					: `terminal done arrived (durationMs=${done.metadata?.durationMs ?? "?"})`
+				: `no terminal done${deadlineMs ? ` within ${Math.round(deadlineMs / 1000)}s` : ""}`,
+		),
+	];
+}
+
 /**
  * The no-leak verdict from the DELETE response (assertion 6). `state` is what
  * the probe observed: `turnCompleted` (a terminal done landed) and `parked`
@@ -203,7 +272,7 @@ export function evaluateRealTurnEvents(events, nonce, { deadlineMs } = {}) {
  * which is litter and equally a failure.
  */
 export function classifyTeardown(state, del) {
-	const { parked, turnCompleted } = state;
+	const { parked, turnCompleted, provider = "vercel" } = state;
 	if (del.status === 200 && del.body?.deleted === true) {
 		const sandbox = del.body.sandbox;
 		if (!turnCompleted) {
@@ -213,9 +282,12 @@ export function classifyTeardown(state, del) {
 				`session deleted but the turn never closed — an unparked live sandbox may persist until its lifetime cap (disposition: ${sandbox})`,
 			);
 		}
-		const ok = parked
-			? sandbox === "stopped" || sandbox === "expired"
-			: sandbox === "none" || sandbox === "stopped" || sandbox === "expired";
+		const ok =
+			provider === "host"
+				? sandbox === "none"
+				: parked
+					? sandbox === "stopped" || sandbox === "expired"
+					: sandbox === "none" || sandbox === "stopped" || sandbox === "expired";
 		return check(
 			"no_leaked_sandbox",
 			ok,
@@ -250,7 +322,7 @@ const hasDone = (events) =>
  * assertion or client fault can't leak the probe session; the teardown check
  * is appended even on that path so the report shows what happened to it.
  */
-export async function runRealTurnProbe(client, options) {
+async function runProviderTurnProbe(client, options, specification) {
 	const {
 		nonce,
 		defaultModel,
@@ -263,7 +335,7 @@ export async function runRealTurnProbe(client, options) {
 
 	const created = await client.createSession({
 		title: buildProbeTitle(nowIso),
-		provider: "vercel",
+		provider: specification.provider,
 	});
 	const gate = classifyCreateGate(created);
 	if (gate.skip) return { status: "skip", reason: gate.reason };
@@ -296,7 +368,7 @@ export async function runRealTurnProbe(client, options) {
 	let turnCompleted = false;
 	let aborted = false;
 	try {
-		const chat = await client.sendChat(sessionId, buildProbePrompt(nonce));
+		const chat = await client.sendChat(sessionId, specification.prompt(nonce));
 		if (chat.status !== 200) {
 			checks.push(
 				check(
@@ -324,7 +396,20 @@ export async function runRealTurnProbe(client, options) {
 			}
 			await sleep(pollMs);
 		}
-		checks.push(...evaluateRealTurnEvents(events, nonce, { deadlineMs }));
+		checks.push(...specification.evaluate(events, nonce, { deadlineMs }));
+		if (specification.requireResume) {
+			checks.push(
+				check(
+					"resume_handle_persisted",
+					turnCompleted && parked,
+					turnCompleted
+						? parked
+							? "completed host turn retained a durable resume handle"
+							: "completed host turn did not retain a resume handle"
+						: "turn did not complete, so no resume handle could be verified",
+				),
+			);
+		}
 	} catch (error) {
 		// Never rethrow: an escaped client fault would otherwise discard every
 		// accumulated check — including the teardown verdict below — from the
@@ -341,7 +426,34 @@ export async function runRealTurnProbe(client, options) {
 		}
 		// A probe aborted before its turn ever started has no turn to hold
 		// against the teardown — only the delete itself is asserted.
-		checks.push(classifyTeardown({ parked, turnCompleted: turnCompleted || aborted }, del));
+		checks.push(
+			classifyTeardown(
+				{
+					parked,
+					turnCompleted: turnCompleted || aborted,
+					provider: specification.provider,
+				},
+				del,
+			),
+		);
 	}
 	return { status: "run", checks };
+}
+
+export async function runRealTurnProbe(client, options) {
+	return runProviderTurnProbe(client, options, {
+		provider: "vercel",
+		prompt: buildProbePrompt,
+		evaluate: evaluateRealTurnEvents,
+		requireResume: false,
+	});
+}
+
+export async function runHostTurnProbe(client, options) {
+	return runProviderTurnProbe(client, options, {
+		provider: "host",
+		prompt: buildHostProbePrompt,
+		evaluate: evaluateHostTurnEvents,
+		requireResume: true,
+	});
 }

--- a/web-next/scripts/real-turn-core.test.mjs
+++ b/web-next/scripts/real-turn-core.test.mjs
@@ -1,14 +1,17 @@
 import { describe, expect, test } from "vitest";
 import {
 	buildProbePrompt,
+	buildHostProbePrompt,
 	buildProbeTitle,
 	classifyCreateGate,
 	classifyPreflightGate,
 	classifyTeardown,
 	checkDefaultModel,
 	evaluateRealTurnEvents,
+	evaluateHostTurnEvents,
 	PROBE_FILE,
 	runRealTurnProbe,
+	runHostTurnProbe,
 } from "./real-turn-core.mjs";
 
 const NONCE = "abc123deadbeef00";
@@ -86,7 +89,35 @@ describe("classifyPreflightGate", () => {
 	});
 
 	test("200 runs the stage", () => {
-		expect(classifyPreflightGate({ status: 200 })).toEqual({ ok: true });
+		expect(
+			classifyPreflightGate({ status: 200, body: { provider: "host" } }),
+		).toEqual({ ok: true, provider: "host" });
+		expect(classifyPreflightGate({ status: 200 })).toEqual({
+			ok: true,
+			provider: "vercel",
+		});
+	});
+});
+
+describe("host turn contract", () => {
+	test("prompt is read-only and carries a unique response marker", () => {
+		const prompt = buildHostProbePrompt(NONCE);
+		expect(prompt).toMatch(/read package\.json/i);
+		expect(prompt).toContain(NONCE);
+		expect(prompt).toMatch(/do not edit/i);
+	});
+
+	test("healthy host events prove lifecycle, Read use, output, and completion", () => {
+		const checks = evaluateHostTurnEvents([
+			ev("assistant", "status", "Preparing host workspace"),
+			ev("assistant", "status", "Starting local Claude Code"),
+			ev("assistant", "tool_use", "Read", { toolName: "Read" }),
+			ev("assistant", "tool_result", '{"name":"spaces-next"}'),
+			ev("assistant", "text", `spaces-next\nhost-turn probe ${NONCE}`),
+			ev("assistant", "done", "", { durationMs: 123 }),
+		], NONCE);
+
+		expect(checks.every((check) => check.status === "pass")).toBe(true);
 	});
 });
 
@@ -204,6 +235,15 @@ describe("classifyTeardown (leak semantics)", () => {
 		expect(
 			classifyTeardown(done(true), { status: 200, body: { deleted: true, sandbox: "none" } }).status,
 		).toBe("fail");
+	});
+
+	test("a host resume handle names a conversation, not a live sandbox", () => {
+		expect(
+			classifyTeardown(
+				{ parked: true, turnCompleted: true, provider: "host" },
+				{ status: 200, body: { deleted: true, sandbox: "none" } },
+			).status,
+		).toBe("pass");
 	});
 
 	test("a turn that never closed cannot pass, even when the delete succeeds", () => {
@@ -351,5 +391,51 @@ describe("runRealTurnProbe", () => {
 		// An unclosed turn can hide a live unparked sandbox — the leak check
 		// must not read the delete's "none" as proof of cleanliness.
 		expect(result.checks.find((c) => c.id === "no_leaked_sandbox").status).toBe("fail");
+	});
+});
+
+describe("runHostTurnProbe", () => {
+	test("runs a read-only host session and requires a persisted resume handle", async () => {
+		const log = [];
+		const events = [
+			ev("assistant", "status", "Preparing host workspace"),
+			ev("assistant", "status", "Starting local Claude Code"),
+			ev("assistant", "tool_use", "Read", { toolName: "Read" }),
+			ev("assistant", "text", `spaces-next\nhost-turn probe ${NONCE}`),
+			ev("assistant", "done", "", { durationMs: 12 }),
+		];
+		const client = {
+			createSession: async (body) => {
+				log.push(["create", body]);
+				return { status: 201, body: { id: "host-probe", model: "model-default" } };
+			},
+			sendChat: async (_id, prompt) => {
+				log.push(["chat", prompt]);
+				return { status: 200 };
+			},
+			getSession: async () => ({
+				status: 200,
+				body: { session: { parked: true }, events },
+			}),
+			deleteSession: async () => ({
+				status: 200,
+				body: { deleted: true, sandbox: "none" },
+			}),
+		};
+
+		const result = await runHostTurnProbe(client, {
+			nonce: NONCE,
+			defaultModel: "model-default",
+			deadlineMs: 10,
+			pollMs: 1,
+			sleep: () => Promise.resolve(),
+		});
+
+		expect(log[0][1].provider).toBe("host");
+		expect(log[1][1]).toEqual(buildHostProbePrompt(NONCE));
+		expect(result.checks.every((check) => check.status === "pass")).toBe(true);
+		expect(
+			result.checks.find((check) => check.id === "resume_handle_persisted"),
+		).toMatchObject({ status: "pass" });
 	});
 });

--- a/web-next/scripts/real-turn-core.test.mjs
+++ b/web-next/scripts/real-turn-core.test.mjs
@@ -119,6 +119,25 @@ describe("host turn contract", () => {
 
 		expect(checks.every((check) => check.status === "pass")).toBe(true);
 	});
+
+	test("fails unexpected tools, missing marker, errors, and aborted completion", () => {
+		const byId = Object.fromEntries(
+			evaluateHostTurnEvents([
+				ev("assistant", "status", "Starting local Claude Code"),
+				ev("assistant", "tool_use", "Read", { toolName: "Read" }),
+				ev("assistant", "tool_use", "Bash", { toolName: "Bash" }),
+				ev("assistant", "text", "package name is spaces-next"),
+				ev("assistant", "error", "write-capable tool escaped policy"),
+				ev("assistant", "done", "", { aborted: true }),
+			], NONCE).map((check) => [check.id, check]),
+		);
+
+		expect(byId.read_only_tools).toMatchObject({ status: "fail" });
+		expect(byId.read_only_tools.detail).toMatch(/Bash/);
+		expect(byId.streamed_output).toMatchObject({ status: "fail" });
+		expect(byId.no_turn_errors).toMatchObject({ status: "fail" });
+		expect(byId.turn_done).toMatchObject({ status: "fail" });
+	});
 });
 
 describe("classifyCreateGate", () => {
@@ -244,6 +263,21 @@ describe("classifyTeardown (leak semantics)", () => {
 				{ status: 200, body: { deleted: true, sandbox: "none" } },
 			).status,
 		).toBe("pass");
+		expect(
+			classifyTeardown(
+				{ parked: true, turnCompleted: true, provider: "host" },
+				{ status: 200, body: { deleted: true, sandbox: "stopped" } },
+			).status,
+		).toBe("fail");
+	});
+
+	test("an unclosed host turn reports the possible local process leak", () => {
+		const verdict = classifyTeardown(
+			{ parked: false, turnCompleted: false, provider: "host" },
+			{ status: 200, body: { deleted: true, sandbox: "none" } },
+		);
+		expect(verdict).toMatchObject({ status: "fail" });
+		expect(verdict.detail).toMatch(/local Claude process/);
 	});
 
 	test("a turn that never closed cannot pass, even when the delete succeeds", () => {
@@ -437,5 +471,42 @@ describe("runHostTurnProbe", () => {
 		expect(
 			result.checks.find((check) => check.id === "resume_handle_persisted"),
 		).toMatchObject({ status: "pass" });
+	});
+
+	test("fails when a completed host turn does not persist its resume handle", async () => {
+		const events = [
+			ev("assistant", "status", "Starting local Claude Code"),
+			ev("assistant", "tool_use", "Read", { toolName: "Read" }),
+			ev("assistant", "text", `host-turn probe ${NONCE}`),
+			ev("assistant", "done", "", { durationMs: 12 }),
+		];
+		const result = await runHostTurnProbe(
+			{
+				createSession: async () => ({
+					status: 201,
+					body: { id: "host-probe", model: "model-default" },
+				}),
+				sendChat: async () => ({ status: 200 }),
+				getSession: async () => ({
+					status: 200,
+					body: { session: { parked: false }, events },
+				}),
+				deleteSession: async () => ({
+					status: 200,
+					body: { deleted: true, sandbox: "none" },
+				}),
+			},
+			{
+				nonce: NONCE,
+				defaultModel: "model-default",
+				deadlineMs: 10,
+				pollMs: 1,
+				sleep: () => Promise.resolve(),
+			},
+		);
+
+		expect(
+			result.checks.find((check) => check.id === "resume_handle_persisted"),
+		).toMatchObject({ status: "fail" });
 	});
 });

--- a/web-next/scripts/real-turn.mjs
+++ b/web-next/scripts/real-turn.mjs
@@ -153,10 +153,7 @@ export async function realTurnStage(baseUrl, cookie, env, options = {}) {
 				detail: redactSecrets(String(c.detail ?? ""), secretsToRedact(env)),
 			}));
 		}
-		return {
-			id: gate.provider === "host" ? "real host-provider turn (#1014)" : id,
-			...result,
-		};
+		return { id, ...result };
 	} catch (error) {
 		// The probe's own teardown already ran (its `finally`); an escaped error
 		// becomes a failing check rather than crashing the whole run.

--- a/web-next/scripts/real-turn.mjs
+++ b/web-next/scripts/real-turn.mjs
@@ -10,6 +10,7 @@ import crypto from "node:crypto";
 import { DEFAULT_MODEL } from "../src/lib/agent-runtime/models.ts";
 import {
 	classifyPreflightGate,
+	runHostTurnProbe,
 	runRealTurnProbe,
 } from "./real-turn-core.mjs";
 import { redactSecrets } from "./validate-core.mjs";
@@ -131,7 +132,15 @@ export async function realTurnStage(baseUrl, cookie, env, options = {}) {
 	}
 
 	try {
-		const result = await runRealTurnProbe(createRealTurnClient(baseUrl, cookie, env), {
+		if (gate.provider !== "vercel" && gate.provider !== "host") {
+			return {
+				id,
+				status: "skip",
+				reason: `provider ${JSON.stringify(gate.provider)} has no real-turn validation contract`,
+			};
+		}
+		const runProbe = gate.provider === "host" ? runHostTurnProbe : runRealTurnProbe;
+		const result = await runProbe(createRealTurnClient(baseUrl, cookie, env), {
 			nonce: crypto.randomBytes(8).toString("hex"),
 			defaultModel: DEFAULT_MODEL,
 			...options,
@@ -144,7 +153,10 @@ export async function realTurnStage(baseUrl, cookie, env, options = {}) {
 				detail: redactSecrets(String(c.detail ?? ""), secretsToRedact(env)),
 			}));
 		}
-		return { id, ...result };
+		return {
+			id: gate.provider === "host" ? "real host-provider turn (#1014)" : id,
+			...result,
+		};
 	} catch (error) {
 		// The probe's own teardown already ran (its `finally`); an escaped error
 		// becomes a failing check rather than crashing the whole run.

--- a/web-next/scripts/validate.mjs
+++ b/web-next/scripts/validate.mjs
@@ -3,8 +3,8 @@
  * <origin>]` runs the full staged suite — reachability, the auth/security
  * posture checks, authenticated flows (#814), the per-model gateway sweep
  * (#816), deployed-safe e2e (#817), and one real agentic coding turn (#818,
- * deployed targets; `--skip-real-turn` to opt out of the spend) — against a
- * local spawn or a real deployment, and reports pass/fail/skip per check
+ * deployed Vercel targets and local-mode host targets; `--skip-real-turn` to
+ * opt out of the spend) — against a local spawn or a real deployment, and reports pass/fail/skip per check
  * (JSON + a Markdown report under output/validate/, exit 1 on any failure).
  * Stages needing credentials gate themselves and report `skipped: missing
  * <name>` rather than silently passing.
@@ -382,23 +382,30 @@ async function main() {
 			stages.push(await timed(() => authenticatedStage(target.baseUrl, mode, process.env)));
 			stages.push(await timed(() => modelSweepStage(target.baseUrl, process.env)));
 			stages.push(await timed(() => e2eDeployedSafeStage(target, process.env)));
-			// The real turn runs LAST: it is the only stage that spends real money
-			// (one small coding turn) and boots a sandbox, so everything cheaper
-			// gets its verdict in first. Local spawns skip it — the throwaway
-			// bypass server has no deployed runtime posture worth probing, and
-			// `pnpm validate` with no args must never surprise-spend.
+			// The real turn runs LAST: it is the only stage that spends model usage.
+			// Ordinary local spawns still skip so `pnpm validate` never surprise-
+			// spends. An explicitly host-configured local-mode target is the host
+			// provider's sanctioned production-shaped validation lane (#1014).
+			const localHostTarget =
+				target.spawnLocal &&
+				target.localMode &&
+				process.env.WEB_NEXT_COMPUTE_PROVIDER === "host";
 			if (skipRealTurn) {
 				stages.push({ id: REAL_TURN_STAGE_ID, status: "skip", reason: "skipped by flag (--skip-real-turn)" });
-			} else if (target.spawnLocal) {
+			} else if (target.spawnLocal && !localHostTarget) {
 				stages.push({
 					id: REAL_TURN_STAGE_ID,
 					status: "skip",
-					reason: "local spawn — probe a deployed target (or --url a server provisioned with runtime credentials)",
+					reason: "local spawn — use --env local-mode with WEB_NEXT_COMPUTE_PROVIDER=host, or probe a deployed target",
 				});
 			} else {
 				const cookie = authedCookie(mode, target.baseUrl, process.env);
 				if (!cookie) {
-					const gate = gateStage({ WEB_NEXT_VALIDATION_SESSION: process.env.WEB_NEXT_VALIDATION_SESSION });
+					const gate = gateStage(
+						localHostTarget
+							? { WEB_NEXT_LOCAL_TOKEN: process.env.WEB_NEXT_LOCAL_TOKEN }
+							: { WEB_NEXT_VALIDATION_SESSION: process.env.WEB_NEXT_VALIDATION_SESSION },
+					);
 					stages.push({ id: REAL_TURN_STAGE_ID, status: "skip", reason: gate.reason });
 				} else {
 					stages.push(await timed(() => realTurnStage(target.baseUrl, cookie, process.env)));

--- a/web-next/src/app/api/diag/preflight/route.ts
+++ b/web-next/src/app/api/diag/preflight/route.ts
@@ -1,8 +1,8 @@
 /*
- * GET /api/diag/preflight — auth-gated environment health check for the #750
- * real runtime. Default run proves model inference, GitHub App clone
- * credentials, and Vercel access (cheap, no sandbox cost). Add `?sandbox=1` to
- * also spin a live Vercel sandbox that runs bash and clones the repo inside it.
+ * GET /api/diag/preflight — auth-gated, provider-aware runtime health check.
+ * Vercel targets prove model/GitHub/Vercel access; host targets prove local
+ * Claude, git, and the owned workspace root. Add `?sandbox=1` to a Vercel
+ * target to spin a live sandbox that runs bash and clones the repo inside it.
  * Never returns secret values — only status and non-secret metadata. Returns
  * 200 when every check passes/skips, 503 otherwise.
  */

--- a/web-next/src/lib/agent-runtime/sandbox-release.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "vitest";
 import { releaseParkedSandbox, type StoppableSandbox } from "./sandbox-release";
 import { sessionSandboxName } from "./vercel-provider";
 
-const parked = { claudeSessionId: "harness-1", resumeState: "{}" };
+const parked = {
+	claudeSessionId: "harness-1",
+	resumeState: "{}",
+	provider: "vercel",
+};
 
 function sandbox(status: string, stop: () => Promise<unknown> = async () => {}) {
 	return { status, stop } satisfies StoppableSandbox;
@@ -24,10 +28,18 @@ describe("releaseParkedSandbox", () => {
 
 	test("a session that never parked has nothing to release", async () => {
 		expect(
-			await releaseParkedSandbox({ claudeSessionId: null, resumeState: null }),
+			await releaseParkedSandbox({
+				claudeSessionId: null,
+				resumeState: null,
+				provider: "vercel",
+			}),
 		).toEqual({ disposition: "none" });
 		expect(
-			await releaseParkedSandbox({ claudeSessionId: "h", resumeState: null }),
+			await releaseParkedSandbox({
+				claudeSessionId: "h",
+				resumeState: null,
+				provider: "vercel",
+			}),
 		).toEqual({ disposition: "none" });
 	});
 

--- a/web-next/src/lib/agent-runtime/sandbox-release.test.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.test.ts
@@ -9,6 +9,19 @@ function sandbox(status: string, stop: () => Promise<unknown> = async () => {}) 
 }
 
 describe("releaseParkedSandbox", () => {
+	test("a host resume handle is not treated as a Vercel sandbox", async () => {
+		let lookedUp = false;
+		const release = await releaseParkedSandbox(
+			{ ...parked, provider: "host" },
+			async () => {
+				lookedUp = true;
+				return sandbox("running");
+			},
+		);
+		expect(release).toEqual({ disposition: "none" });
+		expect(lookedUp).toBe(false);
+	});
+
 	test("a session that never parked has nothing to release", async () => {
 		expect(
 			await releaseParkedSandbox({ claudeSessionId: null, resumeState: null }),

--- a/web-next/src/lib/agent-runtime/sandbox-release.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.ts
@@ -80,9 +80,13 @@ async function defaultGetSandbox(name: string): Promise<StoppableSandbox> {
  * treats `stop-failed` as a reason not to delete; everything else is clear).
  */
 export async function releaseParkedSandbox(
-	session: Pick<Session, "claudeSessionId" | "resumeState">,
+	session: Pick<Session, "claudeSessionId" | "resumeState"> &
+		Partial<Pick<Session, "provider">>,
 	getSandbox: GetStoppableSandbox = defaultGetSandbox,
 ): Promise<SandboxRelease> {
+	// Host turns exit after each invocation. Their persisted resume handle names
+	// a Claude conversation + working copy, not a live Vercel sandbox.
+	if (session.provider === "host") return { disposition: "none" };
 	if (!session.claudeSessionId || !session.resumeState) {
 		return { disposition: "none" };
 	}

--- a/web-next/src/lib/agent-runtime/sandbox-release.ts
+++ b/web-next/src/lib/agent-runtime/sandbox-release.ts
@@ -80,8 +80,7 @@ async function defaultGetSandbox(name: string): Promise<StoppableSandbox> {
  * treats `stop-failed` as a reason not to delete; everything else is clear).
  */
 export async function releaseParkedSandbox(
-	session: Pick<Session, "claudeSessionId" | "resumeState"> &
-		Partial<Pick<Session, "provider">>,
+	session: Pick<Session, "claudeSessionId" | "resumeState" | "provider">,
 	getSandbox: GetStoppableSandbox = defaultGetSandbox,
 ): Promise<SandboxRelease> {
 	// Host turns exit after each invocation. Their persisted resume handle names

--- a/web-next/src/lib/db/start-session.ts
+++ b/web-next/src/lib/db/start-session.ts
@@ -26,8 +26,10 @@ export function isValidRepoFullName(value: string): boolean {
  * `WEB_NEXT_COMPUTE_PROVIDER=vercel` or `WEB_NEXT_COMPUTE_PROVIDER=host` to
  * route new sessions to a real runtime.
  */
-export function defaultComputeProvider(): string {
-	return process.env.WEB_NEXT_COMPUTE_PROVIDER ?? "mock";
+export function defaultComputeProvider(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	return env.WEB_NEXT_COMPUTE_PROVIDER ?? "mock";
 }
 
 /**

--- a/web-next/src/lib/diag/preflight.test.ts
+++ b/web-next/src/lib/diag/preflight.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { runPreflight } from "./preflight";
+
+const tempRoots: string[] = [];
+
+function tempRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "web-next-preflight-"));
+	tempRoots.push(root);
+	return root;
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+const hostDependencies = {
+	resolveClaude: async () => "/opt/bin/claude",
+	version: async (command: string) =>
+		command === "git" ? "git version 2.50.0" : "2.1.206 (Claude Code)",
+};
+
+describe("provider-aware preflight", () => {
+	test("host gates only Claude, git, and its writable workspace root", async () => {
+		const report = await runPreflight({
+			includeSandbox: true,
+			provider: "host",
+			env: {
+				NODE_ENV: "test",
+				PATH: "/usr/bin:/bin",
+				WEB_NEXT_HOST_WORKSPACE_ROOT: join(tempRoot(), "sessions"),
+				// An inactive provider's stale credential must not fail this report.
+				VERCEL_TOKEN: "expired-token",
+			},
+			hostDependencies,
+		});
+
+		expect(report).toMatchObject({ ok: true, provider: "host" });
+		expect(
+			report.checks
+				.filter((check) => ["env", "llm", "vercel", "github", "sandbox"].includes(check.name))
+				.every((check) => check.ok && check.skipped),
+		).toBe(true);
+		expect(
+			report.checks
+				.filter((check) => check.name.startsWith("host:"))
+				.map((check) => [check.name, check.ok]),
+		).toEqual([
+			["host:claude", true],
+			["host:git", true],
+			["host:workspace", true],
+		]);
+	});
+
+	test("host fails when its workspace root is not configured", async () => {
+		const report = await runPreflight({
+			includeSandbox: false,
+			provider: "host",
+			env: { NODE_ENV: "test", PATH: "/usr/bin:/bin" },
+			hostDependencies,
+		});
+
+		expect(report.ok).toBe(false);
+		expect(report.checks.find((check) => check.name === "host:workspace")).toMatchObject({
+			ok: false,
+			error: "WEB_NEXT_HOST_WORKSPACE_ROOT unset",
+		});
+	});
+
+	test("mock reports that no real-runtime preflight is required", async () => {
+		const report = await runPreflight({
+			includeSandbox: false,
+			provider: "mock",
+			env: { NODE_ENV: "test" },
+		});
+
+		expect(report).toMatchObject({ ok: true, provider: "mock" });
+		expect(report.checks).toEqual([
+			expect.objectContaining({ name: "provider", ok: true, skipped: true }),
+		]);
+	});
+});

--- a/web-next/src/lib/diag/preflight.test.ts
+++ b/web-next/src/lib/diag/preflight.test.ts
@@ -71,16 +71,34 @@ describe("provider-aware preflight", () => {
 		});
 	});
 
-	test("mock reports that no real-runtime preflight is required", async () => {
+	test("mock fails closed because it is not a real runtime", async () => {
 		const report = await runPreflight({
 			includeSandbox: false,
-			provider: "mock",
 			env: { NODE_ENV: "test" },
 		});
 
-		expect(report).toMatchObject({ ok: true, provider: "mock" });
+		expect(report).toMatchObject({ ok: false, provider: "mock" });
 		expect(report.checks).toEqual([
-			expect.objectContaining({ name: "provider", ok: true, skipped: true }),
+			expect.objectContaining({
+				name: "provider",
+				ok: false,
+				error: "mock is not a configured real compute provider",
+			}),
 		]);
+	});
+
+	test("derives the active provider through the runtime's selection function", async () => {
+		const report = await runPreflight({
+			includeSandbox: false,
+			env: {
+				NODE_ENV: "test",
+				PATH: "/usr/bin:/bin",
+				WEB_NEXT_COMPUTE_PROVIDER: "host",
+				WEB_NEXT_HOST_WORKSPACE_ROOT: join(tempRoot(), "sessions"),
+			},
+			hostDependencies,
+		});
+
+		expect(report).toMatchObject({ ok: true, provider: "host" });
 	});
 });

--- a/web-next/src/lib/diag/preflight.ts
+++ b/web-next/src/lib/diag/preflight.ts
@@ -12,6 +12,7 @@ import {
 	curatedClaudeEnv,
 	resolveClaudeBinary,
 } from "@/lib/agent-runtime/host-provider";
+import { defaultComputeProvider } from "@/lib/db/start-session";
 import {
 	generateAppJWT,
 	findInstallationId,
@@ -424,8 +425,8 @@ async function checkSandbox(
 
 export async function runPreflight({
 	includeSandbox,
-	provider = process.env.WEB_NEXT_COMPUTE_PROVIDER ?? "mock",
 	env = process.env,
+	provider = defaultComputeProvider(env),
 	hostDependencies,
 }: {
 	includeSandbox: boolean;
@@ -458,16 +459,16 @@ export async function runPreflight({
 		const checks = [
 			{
 				name: "provider",
-				ok: true,
-				skipped: true,
+				ok: false,
+				error: `${provider} is not a configured real compute provider`,
 				detail: {
 					provider,
-					note: "no real-runtime preflight required for this provider",
+					note: "set WEB_NEXT_COMPUTE_PROVIDER to host or vercel",
 				},
 			},
 		];
 		return {
-			ok: true,
+			ok: false,
 			ranAt: new Date().toISOString(),
 			onVercel: !!env.VERCEL,
 			provider,

--- a/web-next/src/lib/diag/preflight.ts
+++ b/web-next/src/lib/diag/preflight.ts
@@ -1,10 +1,17 @@
 /*
- * Environment preflight: one call that proves every capability a real #750 turn
- * needs — model inference, GitHub App clone credentials, Vercel access, and
- * (opt-in) a live sandbox that runs bash and clones the repo. Each check is
- * isolated so one failure still reports the rest. Secret values are never
- * returned — only presence, status, and non-secret metadata.
+ * Provider-aware environment preflight. Vercel targets prove model, GitHub
+ * App, Vercel, and optional sandbox access; host targets prove the local
+ * Claude binary, git, and a writable owned-workspace root. Inactive-provider
+ * checks remain visible as informational skips, never as false failures.
  */
+import { execFile } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+	curatedClaudeEnv,
+	resolveClaudeBinary,
+} from "@/lib/agent-runtime/host-provider";
 import {
 	generateAppJWT,
 	findInstallationId,
@@ -26,15 +33,28 @@ export interface PreflightReport {
 	ok: boolean;
 	ranAt: string;
 	onVercel: boolean;
+	provider: string;
 	cloneRepo: string;
 	checks: CheckResult[];
 	tookMs: number;
 }
 
 /** Repo the GitHub + sandbox-clone checks target. */
-const CLONE_REPO = process.env.PREFLIGHT_CLONE_REPO ?? "fairchild/workspaces";
+function cloneRepo(env: NodeJS.ProcessEnv): string {
+	return env.PREFLIGHT_CLONE_REPO ?? "fairchild/workspaces";
+}
 
 type CheckBody = Omit<CheckResult, "name" | "latencyMs">;
+
+type VersionProbe = (
+	command: string,
+	env: NodeJS.ProcessEnv,
+) => Promise<string>;
+
+interface HostPreflightDependencies {
+	resolveClaude?: typeof resolveClaudeBinary;
+	version?: VersionProbe;
+}
 
 async function timed(
 	name: string,
@@ -42,7 +62,8 @@ async function timed(
 ): Promise<CheckResult> {
 	const started = Date.now();
 	try {
-		return { name, latencyMs: Date.now() - started, ...(await fn()) };
+		const result = await fn();
+		return { name, latencyMs: Date.now() - started, ...result };
 	} catch (e) {
 		return {
 			name,
@@ -58,7 +79,7 @@ function redact(s: string): string {
 	return s.replace(/x-access-token:[^@\s]*@/g, "x-access-token:***@");
 }
 
-function checkEnv(): CheckResult {
+function checkEnv(env: NodeJS.ProcessEnv): CheckResult {
 	const all = [
 		"AI_GATEWAY_API_KEY",
 		"ANTHROPIC_API_KEY",
@@ -69,20 +90,17 @@ function checkEnv(): CheckResult {
 		"GITHUB_WEB_WORKSPACES_APP_ID",
 		"GITHUB_APP_PRIVATE_KEY",
 	];
-	const present = all.filter((v) => !!process.env[v]);
-	const missing = all.filter((v) => !process.env[v]);
+	const present = all.filter((v) => !!env[v]);
+	const missing = all.filter((v) => !env[v]);
 	const hasModel = !!(
-		process.env.AI_GATEWAY_API_KEY || process.env.ANTHROPIC_API_KEY
+		env.AI_GATEWAY_API_KEY || env.ANTHROPIC_API_KEY
 	);
 	const hasVercel = !!(
-		process.env.VERCEL_OIDC_TOKEN ||
-		(process.env.VERCEL_TOKEN &&
-			process.env.VERCEL_TEAM_ID &&
-			process.env.VERCEL_PROJECT_ID)
+		env.VERCEL_OIDC_TOKEN ||
+		(env.VERCEL_TOKEN && env.VERCEL_TEAM_ID && env.VERCEL_PROJECT_ID)
 	);
 	const hasGithub = !!(
-		process.env.GITHUB_WEB_WORKSPACES_APP_ID &&
-		process.env.GITHUB_APP_PRIVATE_KEY
+		env.GITHUB_WEB_WORKSPACES_APP_ID && env.GITHUB_APP_PRIVATE_KEY
 	);
 	return {
 		name: "env",
@@ -91,8 +109,85 @@ function checkEnv(): CheckResult {
 	};
 }
 
-async function checkLlm(): Promise<CheckBody> {
-	const gateway = process.env.AI_GATEWAY_API_KEY;
+function informational(name: string, activeProvider: string): CheckResult {
+	return {
+		name,
+		ok: true,
+		skipped: true,
+		detail: {
+			informational: true,
+			reason: `inactive for ${activeProvider} compute provider`,
+		},
+	};
+}
+
+function defaultVersionProbe(
+	command: string,
+	env: NodeJS.ProcessEnv,
+): Promise<string> {
+	return new Promise((resolveProbe, rejectProbe) => {
+		execFile(
+			command,
+			["--version"],
+			{
+				encoding: "utf8",
+				env,
+				timeout: 10_000,
+			},
+			(error, stdout) => {
+				if (error) rejectProbe(error);
+				else resolveProbe(stdout.trim());
+			},
+		);
+	});
+}
+
+/** Host-provider readiness without exposing credentials or touching user repos. */
+export async function checkHostProvider(
+	env: NodeJS.ProcessEnv = process.env,
+	dependencies: HostPreflightDependencies = {},
+): Promise<CheckResult[]> {
+	const resolveBinary = dependencies.resolveClaude ?? resolveClaudeBinary;
+	const version = dependencies.version ?? defaultVersionProbe;
+	const claude = await timed("host:claude", async () => {
+		const binary = await resolveBinary(env);
+		if (typeof binary !== "string") {
+			return { ok: false, error: binary.message };
+		}
+		return {
+			ok: true,
+			detail: {
+				binary,
+				version: await version(binary, curatedClaudeEnv(env)),
+			},
+		};
+	});
+	const git = await timed("host:git", async () => ({
+		ok: true,
+		detail: {
+			version: await version("git", curatedClaudeEnv(env)),
+		},
+	}));
+	const workspace = await timed("host:workspace", async () => {
+		const configured = env.WEB_NEXT_HOST_WORKSPACE_ROOT?.trim();
+		if (!configured) {
+			return {
+				ok: false,
+				error: "WEB_NEXT_HOST_WORKSPACE_ROOT unset",
+			};
+		}
+		const root = resolve(configured);
+		await mkdir(root, { recursive: true });
+		await access(root, constants.R_OK | constants.W_OK | constants.X_OK);
+		const probe = await mkdtemp(join(root, ".preflight-"));
+		await rm(probe, { recursive: true, force: true });
+		return { ok: true, detail: { root, writable: true } };
+	});
+	return [claude, git, workspace];
+}
+
+async function checkLlm(env: NodeJS.ProcessEnv): Promise<CheckBody> {
+	const gateway = env.AI_GATEWAY_API_KEY;
 	if (gateway) {
 		const res = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
 			method: "POST",
@@ -117,7 +212,7 @@ async function checkLlm(): Promise<CheckBody> {
 			},
 		};
 	}
-	const anthropic = process.env.ANTHROPIC_API_KEY;
+	const anthropic = env.ANTHROPIC_API_KEY;
 	if (anthropic) {
 		const res = await fetch("https://api.anthropic.com/v1/messages", {
 			method: "POST",
@@ -146,12 +241,12 @@ async function checkLlm(): Promise<CheckBody> {
 	return { ok: false, error: "no model credential (AI_GATEWAY_API_KEY or ANTHROPIC_API_KEY)" };
 }
 
-async function checkVercel(): Promise<CheckBody> {
-	const token = process.env.VERCEL_TOKEN;
-	const teamId = process.env.VERCEL_TEAM_ID;
-	const projectId = process.env.VERCEL_PROJECT_ID;
+async function checkVercel(env: NodeJS.ProcessEnv): Promise<CheckBody> {
+	const token = env.VERCEL_TOKEN;
+	const teamId = env.VERCEL_TEAM_ID;
+	const projectId = env.VERCEL_PROJECT_ID;
 	if (!token) {
-		if (process.env.VERCEL_OIDC_TOKEN) {
+		if (env.VERCEL_OIDC_TOKEN) {
 			return {
 				ok: true,
 				skipped: true,
@@ -192,10 +287,13 @@ async function checkVercel(): Promise<CheckBody> {
 }
 
 /** Mint + verify the GitHub App token, returning it (out of band) for the clone check. */
-async function mintGithub(): Promise<{ result: CheckResult; token?: string }> {
+async function mintGithub(
+	env: NodeJS.ProcessEnv,
+	repo: string,
+): Promise<{ result: CheckResult; token?: string }> {
 	const started = Date.now();
-	const appId = process.env.GITHUB_WEB_WORKSPACES_APP_ID;
-	const pk = process.env.GITHUB_APP_PRIVATE_KEY;
+	const appId = env.GITHUB_WEB_WORKSPACES_APP_ID;
+	const pk = env.GITHUB_APP_PRIVATE_KEY;
 	if (!appId || !pk) {
 		return {
 			result: {
@@ -208,9 +306,9 @@ async function mintGithub(): Promise<{ result: CheckResult; token?: string }> {
 	}
 	try {
 		const jwt = generateAppJWT(appId, pk);
-		const installationId = await findInstallationId(jwt, CLONE_REPO);
+		const installationId = await findInstallationId(jwt, repo);
 		const tok = await getInstallationToken(jwt, installationId);
-		const repo = await verifyRepoAccess(tok.token, CLONE_REPO);
+		const accessibleRepo = await verifyRepoAccess(tok.token, repo);
 		return {
 			token: tok.token,
 			result: {
@@ -218,9 +316,9 @@ async function mintGithub(): Promise<{ result: CheckResult; token?: string }> {
 				ok: true,
 				latencyMs: Date.now() - started,
 				detail: {
-					repo: repo.fullName,
-					defaultBranch: repo.defaultBranch,
-					private: repo.private,
+					repo: accessibleRepo.fullName,
+					defaultBranch: accessibleRepo.defaultBranch,
+					private: accessibleRepo.private,
 					installationId,
 					tokenExpiresAt: tok.expiresAt,
 					permissions: tok.permissions,
@@ -240,7 +338,11 @@ async function mintGithub(): Promise<{ result: CheckResult; token?: string }> {
 }
 
 /** Opt-in: create a live sandbox, run bash, and clone the repo inside it. */
-async function checkSandbox(cloneToken?: string): Promise<CheckResult> {
+async function checkSandbox(
+	cloneToken: string | undefined,
+	env: NodeJS.ProcessEnv,
+	repo: string,
+): Promise<CheckResult> {
 	const started = Date.now();
 	const detail: Record<string, unknown> = {};
 	let sandbox: Awaited<ReturnType<typeof import("@vercel/sandbox").Sandbox.create>> | undefined;
@@ -256,9 +358,9 @@ async function checkSandbox(cloneToken?: string): Promise<CheckResult> {
 			};
 		}
 		sandbox = await mod.Sandbox.create({
-			token: process.env.VERCEL_TOKEN,
-			teamId: process.env.VERCEL_TEAM_ID,
-			projectId: process.env.VERCEL_PROJECT_ID,
+			token: env.VERCEL_TOKEN,
+			teamId: env.VERCEL_TEAM_ID,
+			projectId: env.VERCEL_PROJECT_ID,
 			runtime: "node22",
 			resources: { vcpus: 2 },
 			timeout: 5 * 60 * 1000,
@@ -275,7 +377,7 @@ async function checkSandbox(cloneToken?: string): Promise<CheckResult> {
 		};
 
 		if (cloneToken) {
-			const url = `https://x-access-token:${cloneToken}@github.com/${CLONE_REPO}.git`;
+			const url = `https://x-access-token:${cloneToken}@github.com/${repo}.git`;
 			const clone = await sandbox.runCommand({
 				cmd: "git",
 				args: ["clone", "--depth", "1", url, "/tmp/preflight-repo"],
@@ -322,22 +424,71 @@ async function checkSandbox(cloneToken?: string): Promise<CheckResult> {
 
 export async function runPreflight({
 	includeSandbox,
+	provider = process.env.WEB_NEXT_COMPUTE_PROVIDER ?? "mock",
+	env = process.env,
+	hostDependencies,
 }: {
 	includeSandbox: boolean;
+	provider?: string;
+	env?: NodeJS.ProcessEnv;
+	hostDependencies?: HostPreflightDependencies;
 }): Promise<PreflightReport> {
 	const started = Date.now();
+	const repo = cloneRepo(env);
+	if (provider === "host") {
+		const checks = [
+			informational("env", provider),
+			informational("llm", provider),
+			informational("vercel", provider),
+			informational("github", provider),
+			...(await checkHostProvider(env, hostDependencies)),
+		];
+		if (includeSandbox) checks.push(informational("sandbox", provider));
+		return {
+			ok: checks.every((check) => check.ok || check.skipped),
+			ranAt: new Date().toISOString(),
+			onVercel: !!env.VERCEL,
+			provider,
+			cloneRepo: repo,
+			checks,
+			tookMs: Date.now() - started,
+		};
+	}
+	if (provider !== "vercel") {
+		const checks = [
+			{
+				name: "provider",
+				ok: true,
+				skipped: true,
+				detail: {
+					provider,
+					note: "no real-runtime preflight required for this provider",
+				},
+			},
+		];
+		return {
+			ok: true,
+			ranAt: new Date().toISOString(),
+			onVercel: !!env.VERCEL,
+			provider,
+			cloneRepo: repo,
+			checks,
+			tookMs: Date.now() - started,
+		};
+	}
 	const [llm, vercel, gh] = await Promise.all([
-		timed("llm", checkLlm),
-		timed("vercel", checkVercel),
-		mintGithub(),
+		timed("llm", () => checkLlm(env)),
+		timed("vercel", () => checkVercel(env)),
+		mintGithub(env, repo),
 	]);
-	const checks: CheckResult[] = [checkEnv(), llm, vercel, gh.result];
-	if (includeSandbox) checks.push(await checkSandbox(gh.token));
+	const checks: CheckResult[] = [checkEnv(env), llm, vercel, gh.result];
+	if (includeSandbox) checks.push(await checkSandbox(gh.token, env, repo));
 	return {
 		ok: checks.every((c) => c.ok || c.skipped),
 		ranAt: new Date().toISOString(),
-		onVercel: !!process.env.VERCEL,
-		cloneRepo: CLONE_REPO,
+		onVercel: !!env.VERCEL,
+		provider,
+		cloneRepo: repo,
 		checks,
 		tookMs: Date.now() - started,
 	};


### PR DESCRIPTION
## What

- make `/api/diag/preflight` declare the active compute provider and gate only that provider’s required capabilities
- prove host readiness through the local Claude version, git version, and an actual writable-directory probe under `WEB_NEXT_HOST_WORKSPACE_ROOT`
- retain inactive Vercel/model/GitHub/sandbox checks as explicit informational skips on host targets
- add a sanctioned `pnpm validate --env local-mode` host lane that runs one real read-only turn and requires durable completion plus a resume handle
- keep host conversation handles out of the Vercel sandbox-release path when deleting sessions
- share turn-probe orchestration while preserving provider-specific assertions and teardown semantics

## Why

A host-configured server failed validation on an expired `VERCEL_TOKEN`, even though the host provider neither uses nor needs Vercel. The existing real-turn probe also required write tools and sandbox lifecycle evidence, so it could not honestly validate the read-only host provider.

## Verification

- `pnpm test` — 61 files, 631 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` — production build passed
- `EVIDENCE_PORT=3198 pnpm evidence` — full light+dark screenshot matrix passed with strict locator semantics
- `WEB_NEXT_COMPUTE_PROVIDER=host WEB_NEXT_HOST_WORKSPACE_ROOT=/tmp/web-next-host-validate-workspaces pnpm validate --env local-mode`
  - reachability 1/1
  - local auth posture 8/8
  - local-mode posture 4/4
  - authenticated flows 2/2
  - real provider turn 10/10, including actual `Read`, an all-read-only tool trace, durable `done`, resume handle, and deletion with no sandbox lookup
- port 3102 had no listener after validation cleanup

One full-suite run immediately after the long production build hit two pre-existing timing limits in `host-provider.test.ts`; that file passed 13/13 in isolation, and the subsequent full suite passed 627/627. CI remains the independent timing signal.

## Evidence Status

![Provider-aware host validation after two Fable reviews](https://evidence.cloudcompute.com/workspaces/pr-1014/20260711-212215-provider-aware-host-validation-final.svg)

## Review status

Personal reflection completed. Targeted read-only Claude/Fable review requested changes for fail-open mock preflight, incomplete read-only assertions, and optional provider identity in sandbox release; all were accepted and fixed in `763dd280`. Stage identity, negative-path coverage, and host-specific teardown wording were also tightened. A second narrow Fable pass on the CI evidence-locator fix found no blocker and recommended merge; its strict-locator and shorter-retry suggestions were accepted in `d887e5dc`. Full attributed reactions are recorded in PR comments.

The repository-referenced `codex-review-loop` skill is absent in this checkout, and external Codex review was not authorized by the host policy; the approved Fable review was therefore the external review surface.

## Mergeability

- Surface: web-next diagnostics, validation tooling, and host session teardown
- User-facing behavior changed: Host targets now receive relevant readiness diagnostics and have a first-class real-turn validation lane; invalid inactive Vercel credentials no longer fail host validation.
- Non-happy paths considered: missing/non-executable Claude, missing git, unset or unwritable workspace root, stale inactive credentials, unsupported provider, failed/aborted turn, missing resume handle, deletion after a parked host turn, Vercel sandbox stop failure, and local authentication failure
- Residual risk or follow-up: Host validation depends on the machine’s local Claude login and network access. The per-session clone remains under the configured owned root after probe-session deletion; ownership hardening, retention, and registered-checkout policy are tracked in #1044–#1046. Current-head readiness, CodeQL, lint, typecheck, 631 unit tests, build, E2E, light/dark evidence, and performance gates passed.

Closes #1014
