### PR TITLE
fix(ghosttykit): guard repair sweep against polluted zig cache

### DIFF
--- a/docs/development/libghostty-integration.md
+++ b/docs/development/libghostty-integration.md
@@ -260,6 +260,32 @@ The script passes `-Demit-macos-app=false` because Workspaces only needs
 `GhosttyKit.xcframework`; building Ghostty's full app bundle adds an unrelated
 `xcodebuild` step that can fail after the xcframework has already been produced.
 
+### Shared Zig cache pollution (wrong platform / minimum macOS)
+
+The per-commit Zig cache (`~/.cache/workspacemanager/zig-cache/<commit>/`) is
+shared by every build of the pinned Ghostty commit on the host. When the
+emitted archive lacks `ghostty_init` (a recurring quirk of cached xcframework
+emits), the script's repair sweep rebuilds `libghostty-fat.a` from every thin
+`.a` in that cache — so anything another build wrote there ends up candidate
+material. A universal/iOS xcframework build sharing the cache leaves thin
+arm64 archives for other platforms and macOS objects pinned to the host's own
+OS version. Objects for the wrong platform are a **fatal ld error** when the
+app links (`building for 'macOS', but linking in object file ... built for
+'iOS-simulator'`); objects with a too-new minimum macOS link with warnings but
+can't ship at the app's 14.0 deployment target. This is exactly how the
+v0.23.0 release build failed — and the fatal ld line never made it into the CI
+log, only the minos warnings did.
+
+The sweep therefore filters objects by platform and minimum-macOS (in
+addition to host arch), and `assert_macos_deployment_target` fails the build
+loudly if the final archive still contains an object for another platform or
+a minimum macOS above the app's deployment target. The remedy for a polluted
+cache is a purge via the named entrypoint:
+
+```bash
+./scripts/build-ghosttykit.sh --purge-cache
+```
+
 ## Upgrade Procedure (when bumping Ghostty)
 
 1. Edit `GHOSTTY_COMMIT` in `scripts/build-ghosttykit.sh`.

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -585,6 +585,11 @@ main() {
   resolve_zig_runner
 
   if [[ "$purge_cache" == "1" ]]; then
+    # Only ever delete the script-managed per-commit location. A user-managed
+    # GHOSTTY_ZIG_CACHE_DIR could point anywhere; refuse rather than rm -rf it.
+    if [[ -n "${GHOSTTY_ZIG_CACHE_DIR:-}" ]]; then
+      die "--purge-cache refuses to delete a user-managed GHOSTTY_ZIG_CACHE_DIR; clean it yourself or unset it"
+    fi
     echo "Purging Zig cache for pinned commit: $ZIG_CACHE_DIR"
     rm -rf "$ZIG_CACHE_DIR"
   fi

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -16,7 +16,13 @@ set -euo pipefail
 #   lands so `swift build` and Xcode open/build work reliably.
 #
 # Usage:
-#   ./scripts/build-ghosttykit.sh
+#   ./scripts/build-ghosttykit.sh [--purge-cache]
+#
+# Flags:
+#   --purge-cache     Delete the per-commit Zig cache before building. The
+#                     remedy when the shared cache has been polluted by a
+#                     build for another platform or macOS version (see
+#                     assert_macos_deployment_target below).
 #
 # Optional environment variables:
 #   GHOSTTY_DIR       Existing Ghostty checkout (must already be at pinned commit).
@@ -42,6 +48,9 @@ ZIG_VERSION="0.15.2"
 ARM64_HOMEBREW_PREFIX="/opt/homebrew"
 HOMEBREW_ZIG_BIN="$ARM64_HOMEBREW_PREFIX/opt/zig@0.15/bin/zig"
 GHOSTTY_ARCH_DIAGNOSTICS="${GHOSTTY_ARCH_DIAGNOSTICS:-1}"
+# The app's minimum macOS (Package.swift `.macOS(.v14)`). Objects built for a
+# newer minimum, or for another platform entirely, cannot link into the app.
+MACOS_DEPLOYMENT_TARGET="14.0"
 
 GHOSTTY_REPO_URL="https://github.com/ghostty-org/ghostty.git"
 CACHE_DIR="${GHOSTTY_CACHE_DIR:-$HOME/.cache/workspacemanager}"
@@ -231,6 +240,29 @@ archive_exports_ghostty_api() {
   nm -gU "$archive" 2>/dev/null | grep ' _ghostty_init$' >/dev/null
 }
 
+# Prints "<platform> <minos>" for a Mach-O object — "macos 13.0",
+# "other 17.0", or "none -" when it carries no version load command
+# (platform-agnostic, e.g. raw assembly). otool prints LC_BUILD_VERSION
+# platforms numerically (1 = macOS) or symbolically depending on version;
+# older objects use LC_VERSION_MIN_MACOSX instead.
+object_platform_minos() {
+  local object="$1"
+  otool -l "$object" 2>/dev/null | awk '
+    $1 == "cmd" { curcmd = $2 }
+    curcmd == "LC_BUILD_VERSION" && $1 == "platform" && platform == "" { platform = $2 }
+    curcmd == "LC_BUILD_VERSION" && $1 == "minos" && out == "" {
+      out = ((platform == "1" || platform == "MACOS") ? "macos " : "other ") $2
+    }
+    curcmd == "LC_VERSION_MIN_MACOSX" && $1 == "version" && out == "" { out = "macos " $2 }
+    END { print (out == "" ? "none -" : out) }
+  '
+}
+
+# True when dotted-decimal version $1 <= $2.
+version_lte() {
+  [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" == "$2" ]]
+}
+
 find_ghostty_archives() {
   local cache_root="$ZIG_CACHE_DIR/local/o"
   local candidate
@@ -290,12 +322,30 @@ repair_ghostty_archive_if_needed() {
   # or drop an object based on its filename rather than its actual
   # architecture), and `-w` requires a whole-word match so "arm64" doesn't
   # also match "arm64e".
-  local host_arch object
+  #
+  # Arch alone is not enough: a universal/iOS xcframework build sharing this
+  # cache leaves thin arm64 archives for other platforms (iOS-simulator
+  # objects are a fatal ld error when linking the macOS app) and macOS
+  # objects with the host's own minimum version (unlinkable at the app's
+  # deployment target). Drop those too; platform-agnostic objects with no
+  # version load command are kept.
+  local host_arch object platform_minos
   host_arch="$(uname -m)"
   while IFS= read -r object; do
     if ! file -b "$object" 2>/dev/null | grep -qw "$host_arch"; then
       rm -f "$object"
+      continue
     fi
+    platform_minos="$(object_platform_minos "$object")"
+    case "$platform_minos" in
+      "none -") ;;
+      macos\ *)
+        if ! version_lte "${platform_minos#macos }" "$MACOS_DEPLOYMENT_TARGET"; then
+          rm -f "$object"
+        fi
+        ;;
+      *) rm -f "$object" ;;
+    esac
   done < <(find "$tmp_dir/objects" -type f -name "*.o")
 
   if ! find "$tmp_dir/objects" -type f -name "*.o" -print -quit | grep -q .; then
@@ -354,6 +404,51 @@ assert_host_arch_slice() {
   if ! plutil -p "$info_plist" 2>/dev/null | grep -q "\"$host_arch\""; then
     die "xcframework Info.plist does not declare a slice supporting host arch $host_arch: $info_plist"
   fi
+}
+
+# A poisoned Zig cache can hand the repair sweep objects for the wrong
+# platform or a newer minimum macOS than the app's deployment target. ld
+# rejects wrong-platform objects outright — and CI swallowed exactly that
+# error once (the v0.23.0 release: an iOS-simulator targets.o swept in from a
+# universal build sharing the cache). Fail here, at GhosttyKit build time,
+# with the remedy in hand.
+assert_macos_deployment_target() {
+  local framework_dir="$1"
+
+  local archive violations
+  while IFS= read -r archive; do
+    violations="$(otool -l "$archive" 2>/dev/null | awk -v max="$MACOS_DEPLOYMENT_TARGET" '
+      function vgt(a, b,   n, m, i, x, y, av, bv) {
+        n = split(a, av, "."); m = split(b, bv, ".")
+        for (i = 1; i <= (n > m ? n : m); i++) {
+          x = (i <= n) ? av[i] + 0 : 0
+          y = (i <= m) ? bv[i] + 0 : 0
+          if (x != y) return x > y
+        }
+        return 0
+      }
+      function flush() {
+        if (member == "") return
+        if (platform != "" && platform != "1" && platform != "MACOS")
+          printf "  %s: platform %s (not macOS)\n", member, platform
+        else if (minos != "" && vgt(minos, max))
+          printf "  %s: minimum macOS %s > %s\n", member, minos, max
+      }
+      /\):$/ { flush(); member = $0; sub(/:$/, "", member); platform = ""; minos = ""; curcmd = "" }
+      $1 == "cmd" { curcmd = $2 }
+      curcmd == "LC_BUILD_VERSION" && $1 == "platform" && platform == "" { platform = $2 }
+      curcmd == "LC_BUILD_VERSION" && $1 == "minos" && minos == "" { minos = $2 }
+      curcmd == "LC_VERSION_MIN_MACOSX" && $1 == "version" && minos == "" { platform = "1"; minos = $2 }
+      END { flush() }
+    ')"
+    if [[ -n "$violations" ]]; then
+      die "GhosttyKit archive has objects unusable at the app deployment target (macOS $MACOS_DEPLOYMENT_TARGET):
+$violations
+The shared Zig cache is likely polluted by a build for another platform or
+macOS version (e.g. a universal/iOS xcframework build). Purge and rebuild:
+  ./scripts/build-ghosttykit.sh --purge-cache"
+    fi
+  done < <(find "$framework_dir" -type f -name "libghostty-fat.a" 2>/dev/null)
 }
 
 log_arch_diagnostics() {
@@ -476,10 +571,23 @@ install_xcframework() {
 }
 
 main() {
+  local arg purge_cache=0
+  for arg in "$@"; do
+    case "$arg" in
+      --purge-cache) purge_cache=1 ;;
+      *) die "unknown argument: $arg (supported: --purge-cache)" ;;
+    esac
+  done
+
   require_cmd git
   require_cmd xcrun
   require_msgfmt
   resolve_zig_runner
+
+  if [[ "$purge_cache" == "1" ]]; then
+    echo "Purging Zig cache for pinned commit: $ZIG_CACHE_DIR"
+    rm -rf "$ZIG_CACHE_DIR"
+  fi
 
   resolve_ghostty_dir
   ensure_ghostty_checkout
@@ -496,6 +604,7 @@ main() {
   postprocess_xcframework "$OUT_DIR/GhosttyKit.xcframework"
   log_arch_diagnostics "$OUT_DIR/GhosttyKit.xcframework"
   assert_host_arch_slice "$OUT_DIR/GhosttyKit.xcframework"
+  assert_macos_deployment_target "$OUT_DIR/GhosttyKit.xcframework"
   echo "Built GhosttyKit.xcframework -> $OUT_DIR/GhosttyKit.xcframework"
 }
 

--- a/scripts/build-ghosttykit.sh
+++ b/scripts/build-ghosttykit.sh
@@ -244,17 +244,27 @@ archive_exports_ghostty_api() {
 # "other 17.0", or "none -" when it carries no version load command
 # (platform-agnostic, e.g. raw assembly). otool prints LC_BUILD_VERSION
 # platforms numerically (1 = macOS) or symbolically depending on version;
-# older objects use LC_VERSION_MIN_MACOSX instead.
+# older objects use LC_VERSION_MIN_MACOSX (or _IPHONEOS/_TVOS/_WATCHOS)
+# instead. All version commands are scanned: a zippered object (macOS +
+# Catalyst) counts as macOS with the macOS command's minos, whichever order
+# the commands appear in. otool failing on a member must not kill the build
+# under pipefail, hence the `|| true`.
 object_platform_minos() {
   local object="$1"
-  otool -l "$object" 2>/dev/null | awk '
+  { otool -l "$object" 2>/dev/null || true; } | awk '
     $1 == "cmd" { curcmd = $2 }
-    curcmd == "LC_BUILD_VERSION" && $1 == "platform" && platform == "" { platform = $2 }
-    curcmd == "LC_BUILD_VERSION" && $1 == "minos" && out == "" {
-      out = ((platform == "1" || platform == "MACOS") ? "macos " : "other ") $2
+    curcmd == "LC_BUILD_VERSION" && $1 == "platform" { platform = $2; seen = 1 }
+    curcmd == "LC_BUILD_VERSION" && $1 == "minos" {
+      if (platform == "1" || platform == "MACOS") mac_minos = $2
+      else if (other == "") other = $2
     }
-    curcmd == "LC_VERSION_MIN_MACOSX" && $1 == "version" && out == "" { out = "macos " $2 }
-    END { print (out == "" ? "none -" : out) }
+    curcmd == "LC_VERSION_MIN_MACOSX" && $1 == "version" { mac_minos = $2; seen = 1 }
+    curcmd ~ /^LC_VERSION_MIN_/ && curcmd != "LC_VERSION_MIN_MACOSX" { seen = 1; if ($1 == "version" && other == "") other = $2 }
+    END {
+      if (mac_minos != "") print "macos " mac_minos
+      else if (seen) print "other " (other == "" ? "-" : other)
+      else print "none -"
+    }
   '
 }
 
@@ -330,7 +340,9 @@ repair_ghostty_archive_if_needed() {
   # deployment target). Drop those too; platform-agnostic objects with no
   # version load command are kept.
   local host_arch object platform_minos
+  local drops_file="$tmp_dir/dropped-names"
   host_arch="$(uname -m)"
+  : > "$drops_file"
   while IFS= read -r object; do
     if ! file -b "$object" 2>/dev/null | grep -qw "$host_arch"; then
       rm -f "$object"
@@ -341,12 +353,28 @@ repair_ghostty_archive_if_needed() {
       "none -") ;;
       macos\ *)
         if ! version_lte "${platform_minos#macos }" "$MACOS_DEPLOYMENT_TARGET"; then
+          basename "$object" >> "$drops_file"
           rm -f "$object"
         fi
         ;;
-      *) rm -f "$object" ;;
+      *)
+        basename "$object" >> "$drops_file"
+        rm -f "$object"
+        ;;
     esac
   done < <(find "$tmp_dir/objects" -type f -name "*.o")
+
+  # A platform/minos drop is only safe while another copy of that object
+  # survives (the native build that just populated the cache provides one).
+  # If the sweep removed every copy of a member, the archive would silently
+  # lose symbols and fail at app link time — die here instead.
+  local dropped_name
+  while IFS= read -r dropped_name; do
+    if ! find "$tmp_dir/objects" -type f -name "$dropped_name" -print -quit | grep -q .; then
+      die "repair sweep dropped every copy of $dropped_name (wrong platform or minimum macOS above $MACOS_DEPLOYMENT_TARGET); the Zig cache has no usable copy. Purge and rebuild: ./scripts/build-ghosttykit.sh --purge-cache"
+    fi
+  done < <(sort -u "$drops_file")
+  rm -f "$drops_file"
 
   if ! find "$tmp_dir/objects" -type f -name "*.o" -print -quit | grep -q .; then
     die "no $host_arch objects found in the Zig cache to repair the GhosttyKit archive"
@@ -417,7 +445,7 @@ assert_macos_deployment_target() {
 
   local archive violations
   while IFS= read -r archive; do
-    violations="$(otool -l "$archive" 2>/dev/null | awk -v max="$MACOS_DEPLOYMENT_TARGET" '
+    violations="$({ otool -l "$archive" 2>/dev/null || true; } | awk -v max="$MACOS_DEPLOYMENT_TARGET" '
       function vgt(a, b,   n, m, i, x, y, av, bv) {
         n = split(a, av, "."); m = split(b, bv, ".")
         for (i = 1; i <= (n > m ? n : m); i++) {
@@ -429,16 +457,26 @@ assert_macos_deployment_target() {
       }
       function flush() {
         if (member == "") return
-        if (platform != "" && platform != "1" && platform != "MACOS")
-          printf "  %s: platform %s (not macOS)\n", member, platform
-        else if (minos != "" && vgt(minos, max))
-          printf "  %s: minimum macOS %s > %s\n", member, minos, max
+        if (mac_minos != "") {
+          if (vgt(mac_minos, max))
+            printf "  %s: minimum macOS %s > %s\n", member, mac_minos, max
+        } else if (seen)
+          printf "  %s: platform %s (not macOS)\n", member, (plat_desc == "" ? "unknown" : plat_desc)
       }
-      /\):$/ { flush(); member = $0; sub(/:$/, "", member); platform = ""; minos = ""; curcmd = "" }
+      /^[^ \t].*\):$/ { flush(); member = $0; sub(/:$/, "", member); mac_minos = ""; seen = 0; plat_desc = ""; platform = ""; curcmd = "" }
       $1 == "cmd" { curcmd = $2 }
-      curcmd == "LC_BUILD_VERSION" && $1 == "platform" && platform == "" { platform = $2 }
-      curcmd == "LC_BUILD_VERSION" && $1 == "minos" && minos == "" { minos = $2 }
-      curcmd == "LC_VERSION_MIN_MACOSX" && $1 == "version" && minos == "" { platform = "1"; minos = $2 }
+      curcmd == "LC_BUILD_VERSION" && $1 == "platform" {
+        platform = $2; seen = 1
+        if (platform != "1" && platform != "MACOS" && plat_desc == "") plat_desc = platform
+      }
+      curcmd == "LC_BUILD_VERSION" && $1 == "minos" {
+        if (platform == "1" || platform == "MACOS") mac_minos = $2
+      }
+      curcmd == "LC_VERSION_MIN_MACOSX" && $1 == "version" { mac_minos = $2; seen = 1 }
+      curcmd ~ /^LC_VERSION_MIN_/ && curcmd != "LC_VERSION_MIN_MACOSX" {
+        seen = 1
+        if (plat_desc == "") plat_desc = curcmd
+      }
       END { flush() }
     ')"
     if [[ -n "$violations" ]]; then


### PR DESCRIPTION
# fix(ghosttykit): guard repair sweep against polluted zig cache

## Summary

The v0.23.0 release build ([run 29139329947](https://github.com/fairchild/workspaces/actions/runs/29139329947)) failed at link on the signing host, and the CI log swallowed the fatal line. Reproduced locally in the runner workdir:

```
ld: building for 'macOS', but linking in object file (libghostty-fat.a[264](targets.o)) built for 'iOS-simulator'
clang: error: linker command failed with exit code 1
```

**Root cause:** `build-ghosttykit.sh`'s repair sweep (`repair_ghostty_archive_if_needed`, the #939/#962 arc) rebuilds `libghostty-fat.a` from every thin `.a` in the shared per-commit zig cache, filtering objects by **CPU arch only**. On 2026-07-07 a universal/iOS Ghostty build shared that cache, leaving thin **arm64 iOS-simulator** archives (e.g. `libhighway.a` → `targets.o`, platform 7, minos 17.0 — passes an arch-only filter, fatal to `ld`) and macOS zlib objects at the **host's own minimum OS** (26.4.1 > the app's 14.0 deployment target). The sweep produced a 97 MB frankenarchive with 420 iOS-simulator objects; a known-good build is 30 MB. The sweep's existing fat-archive skip anticipated universal-mode cache sharing, but universal builds also emit thin per-platform archives, which slipped through.

The pollution predates Jul 7: the Jul 4 dev framework already carries duplicate members with mixed minos (13.0 + 26.4.1 copies of each zlib object) — it links only because the symbol table resolves to the 13.0 copies. Jul 7's iOS objects made it fatal.

## Changes

- **Sweep filter**: objects for another platform, or with minimum macOS above the app deployment target (`Package.swift` `.macOS(.v14)`), are dropped — mirroring the existing arch filter. Platform-agnostic objects (no version load command) are kept.
- **`assert_macos_deployment_target`**: post-build assertion over every member of the final archive (one `otool -l` pass; handles `LC_BUILD_VERSION` and legacy `LC_VERSION_MIN_MACOSX`). A poisoned cache now fails the GhosttyKit build loudly with the remedy, instead of a swallowed `ld` error at app link time.
- **`--purge-cache`**: named entrypoint for clearing the per-commit zig cache (no ad-hoc `rm -rf`); refuses to delete a user-managed `GHOSTTY_ZIG_CACHE_DIR`.
- Doc subsection in `docs/development/libghostty-integration.md`.

## Verification

- New assertion run against the **poisoned** runner framework: dies listing 420 `platform 7 (not macOS)` objects + 15 zlib `minimum macOS 26.4.1 > 14.0` members.
- Run against a **clean** framework: passes silently.
- `object_platform_minos` spot-checked against real objects: iOS-sim `targets.o` → `other 17.0`; good `zutil.o` → `macos 13.0`; legacy/none paths covered.
- `sort -V` confirmed supported by macOS BSD sort (`2.3-Apple`).
- End-to-end on the signing host: `./scripts/build-ghosttykit.sh --purge-cache` (cold rebuild) → assertion passes → `swift build -c release` links clean. (Evidence links below.)

![ghosttykit-cache-hygiene-verification](https://evidence.cloudcompute.com/workspaces/pr-1049/20260711-213952-ghosttykit-cache-hygiene-verification.png)

Also required en route (host state, not part of this diff): Xcode 26 ships without the Metal toolchain — the purge forced a fresh shader compile, fixed by `xcodebuild -downloadComponent MetalToolchain` (17F109). The old cache's `Ghostty.metallib` had been masking that since the Xcode upgrade.

## Release recovery

The v0.23.0 tag is fine — the failure was host cache state. With the host cache purged (done as part of verification), re-running `release.yml` on the existing tag should pass even with the tag's pre-fix script, since a clean cache contains only good objects. This PR prevents recurrence and makes any future pollution fail loudly at framework-build time.

## Review loop

- Reflection finding (fixed pre-review): `--purge-cache` would `rm -rf` a user-set `GHOSTTY_ZIG_CACHE_DIR` — now refuses.
- Codex (gpt-5.5, xhigh) directed review — 4 findings:
  1. **Fixed** — legacy `LC_VERSION_MIN_IPHONEOS`/TVOS/WATCHOS objects classified as platform-agnostic ("none") and kept by the sweep / missed by the assert. Now classified `other` (verified against a generated `arm64-apple-ios10.0` object).
  2. **Fixed** — sweep could silently drop the cache's only copy of a member, moving the failure to app link as undefined symbols. Now dies when a platform/minos drop removes the last copy of a member name.
  3. **Fixed** — zippered (macOS + Catalyst) objects were judged by their first build-version command only. Parser now scans all commands and prefers the macOS one.
  4. **Declined** — also refusing `--purge-cache` under `GHOSTTY_CACHE_DIR`: that env var is the documented script cache root, and the purge stays bounded to its `zig-cache/<commit>` subtree. `GHOSTTY_ZIG_CACHE_DIR` (arbitrary path) is refused.
  - From directed answers, also applied: `otool` wrapped to degrade soft under `pipefail`; member-header detection anchored to column 1. `sort -V` confirmed on Apple sort (2.3-Apple).

## Mergeability

- **Surface:** `scripts/build-ghosttykit.sh` (repair sweep filter, post-build assertion, `--purge-cache` flag) + `docs/development/libghostty-integration.md`. No app code.
- **Behavior changed:** GhosttyKit builds from a polluted zig cache now fail loudly at framework-build time (previously: silent frankenarchive, swallowed ld failure at app link). Clean-cache builds unchanged.
- **Non-happy paths:** wrong-platform / too-new-minos objects → filtered in sweep, asserted on final archive with purge remedy; user-managed `GHOSTTY_ZIG_CACHE_DIR` + `--purge-cache` → refuses; objects with no version load command → kept (platform-agnostic).
- **Residual risk:** if the cache's only copy of a needed object is too-new, the sweep drops it and the miss surfaces as undefined symbols at app link (can't happen when the sweep runs right after a native build populated the cache, which is the only path that triggers it). Assertion parses `otool -l` text — a future otool format change would surface as a false failure, not a silent pass.
