### PR TITLE
web-next: define host-neutral Folio conversation ports

### DIFF
--- a/web-next/packages/folio/README.md
+++ b/web-next/packages/folio/README.md
@@ -19,6 +19,41 @@ Import only from the named entry point:
 import { SessionView, type SessionViewData } from "@fairchild/folio";
 ```
 
+Hosts integrate through `FolioConversationPort`, not through component-specific
+knowledge of their routes or runtimes. The port exposes a durable snapshot,
+opaque resume cursor, ordered host-neutral events, and commands whose authority
+remains with the host:
+
+```ts
+import {
+  FolioConversationController,
+  type FolioConversationPort,
+} from "@fairchild/folio";
+
+const controller = new FolioConversationController(hostPort satisfies FolioConversationPort);
+await controller.hydrate();
+await controller.follow(render);
+```
+
+Only one `follow()` may own a controller at a time. Hosts reconnect by creating
+a controller from their durable snapshot cursor; unknown cursors fail closed
+instead of replaying the conversation from the beginning. Command receipts
+return the host's durable cursor rather than a separate acknowledgement ID.
+
+`SessionView` receives one `FolioConversationActions` object. Missing callbacks
+are missing capabilities; the component never discovers or constructs host
+authority itself. A hydrated controller can derive that action membrane with
+`createPortBackedConversationActions`, which requires a host error callback for
+command failures. Derive it again after a capabilities, workspace, or
+publication event so the UI reflects the latest host authority; the error
+callback still closes the race if authority changes between render and click.
+Tests and external adapters can use the deterministic fake without putting test
+code in production imports:
+
+```ts
+import { FakeConversationPort } from "@fairchild/folio/testing";
+```
+
 Server code that only needs the pure token formatter uses the side-effect-free
 format entry instead of loading the React component barrel:
 

--- a/web-next/packages/folio/package.json
+++ b/web-next/packages/folio/package.json
@@ -25,6 +25,11 @@
 			"types": "./src/theme-entry.ts",
 			"import": "./src/theme-entry.ts",
 			"default": "./src/theme-entry.ts"
+		},
+		"./testing": {
+			"types": "./src/testing-entry.ts",
+			"import": "./src/testing-entry.ts",
+			"default": "./src/testing-entry.ts"
 		}
 	},
 	"files": [

--- a/web-next/packages/folio/src/conversation-controller.test.ts
+++ b/web-next/packages/folio/src/conversation-controller.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+	FolioConversationController,
+	FolioFollowInProgressError,
+	createPortBackedConversationActions,
+} from "./conversation-controller";
+import type {
+	FolioConversationEvent,
+	FolioConversationSnapshot,
+} from "./conversation-ports";
+import { FolioCapabilityUnavailableError } from "./conversation-ports";
+import { FakeConversationPort } from "./fake-conversation-port";
+
+function snapshot(cursor = "cursor-0"): FolioConversationSnapshot {
+	return {
+		conversationId: "conversation-1",
+		cursor,
+		view: {
+			masthead: {
+				repo: "example/repo",
+				branch: null,
+				title: "Example",
+				agentName: "Agent",
+				stateLabel: "",
+			},
+			messages: [],
+			statusLine: { model: "model-1" },
+		},
+		queuedMessages: [],
+		capabilities: {
+			send: true,
+			stop: true,
+			retry: true,
+			cancelQueuedMessage: true,
+			decideApproval: true,
+			decideReview: true,
+			updateConversation: true,
+		},
+		artifacts: [],
+		review: null,
+		workspace: { id: "workspace-1", state: "attached", actions: ["recover"] },
+		publication: { id: null, state: null, url: null, actions: ["publish"] },
+		failure: null,
+	};
+}
+
+const userMessage = {
+	id: "message-1",
+	role: "user" as const,
+	metadata: { author: "You" },
+	parts: [{ type: "text" as const, text: "Hello" }],
+};
+
+const events: FolioConversationEvent[] = [
+	{ cursor: "cursor-1", type: "message-upsert", message: userMessage },
+	{
+		cursor: "cursor-2",
+		type: "active-turn",
+		activeTurn: { agentName: "Agent", action: "Working", details: [] },
+	},
+	{
+		cursor: "cursor-3",
+		type: "artifact",
+		artifact: { id: "artifact-1", kind: "diff", label: "Change" },
+	},
+	{
+		cursor: "cursor-4",
+		type: "review",
+		review: {
+			id: "review-1",
+			summary: "Ready",
+			changedFiles: ["example.txt"],
+			state: "pending",
+		},
+	},
+	{
+		cursor: "cursor-5",
+		type: "workspace",
+		workspace: { id: "workspace-1", state: "attached", actions: [] },
+	},
+	{
+		cursor: "cursor-6",
+		type: "publication",
+		publication: { id: "pr-1", state: "open", url: "https://example.test/1", actions: [] },
+	},
+	{ cursor: "cursor-7", type: "complete" },
+];
+
+class BlockingConversationPort extends FakeConversationPort {
+	readonly started: Promise<void>;
+	#markStarted!: () => void;
+	#release!: () => void;
+	readonly released: Promise<void>;
+
+	constructor(initial: FolioConversationSnapshot) {
+		super(initial);
+		this.started = new Promise((resolve) => {
+			this.#markStarted = resolve;
+		});
+		this.released = new Promise((resolve) => {
+			this.#release = resolve;
+		});
+	}
+
+	release(): void {
+		this.#release();
+	}
+
+	override async *readEvents(
+		after: string,
+		signal?: AbortSignal,
+	): AsyncIterable<FolioConversationEvent> {
+		this.#markStarted();
+		await this.released;
+		yield* super.readEvents(after, signal);
+	}
+}
+
+describe("FolioConversationController", () => {
+	test("replays ordered host events into host-neutral view state", async () => {
+		const controller = new FolioConversationController(
+			new FakeConversationPort(snapshot(), events),
+		);
+
+		const result = await controller.follow();
+
+		expect(result.cursor).toBe("cursor-7");
+		expect(result.view.messages).toEqual([userMessage]);
+		expect(result.view.activeTurn).toBeUndefined();
+		expect(result.artifacts).toHaveLength(1);
+		expect(result.review?.summary).toBe("Ready");
+		expect(result.workspace?.state).toBe("attached");
+		expect(result.publication?.state).toBe("open");
+	});
+
+	test("preserves the durable cursor across disconnect and resumes without duplicates", async () => {
+		const disconnected = new FolioConversationController(
+			new FakeConversationPort(snapshot(), events, "cursor-2"),
+		);
+		await expect(disconnected.follow()).rejects.toThrow("deterministic disconnect");
+		expect(disconnected.snapshot?.cursor).toBe("cursor-2");
+
+		const resumedSnapshot = {
+			...disconnected.snapshot!,
+			cursor: "cursor-2",
+		};
+		const resumed = new FolioConversationController(
+			new FakeConversationPort(resumedSnapshot, events),
+		);
+		const result = await resumed.follow();
+
+		expect(result.cursor).toBe("cursor-7");
+		expect(result.view.messages).toHaveLength(1);
+	});
+
+	test("rejects a concurrent follower instead of interleaving snapshots", async () => {
+		const port = new BlockingConversationPort(snapshot());
+		const controller = new FolioConversationController(port);
+		const first = controller.follow();
+		await port.started;
+
+		await expect(controller.follow()).rejects.toBeInstanceOf(FolioFollowInProgressError);
+		port.release();
+		await first;
+	});
+
+	test("rejects unknown resume cursors instead of replaying duplicates", async () => {
+		const port = new FakeConversationPort(snapshot(), events);
+		const iterator = port.readEvents("unknown-cursor")[Symbol.asyncIterator]();
+		await expect(iterator.next()).rejects.toThrow("unknown conversation cursor");
+	});
+
+	test("projects a stopped turn as terminal failure state", async () => {
+		const controller = new FolioConversationController(
+			new FakeConversationPort(snapshot(), [
+				events[1],
+				{ cursor: "cursor-3", type: "failure", message: "Turn stopped" },
+				{ cursor: "cursor-4", type: "complete" },
+			]),
+		);
+
+		const result = await controller.follow();
+		expect(result.failure).toBe("Turn stopped");
+		expect(result.view.activeTurn).toBeUndefined();
+	});
+
+	test("clears a prior failure when a retry becomes active", async () => {
+		const failed = snapshot("cursor-3");
+		failed.failure = "Turn stopped";
+		const controller = new FolioConversationController(
+			new FakeConversationPort(failed, [
+				{
+					cursor: "cursor-4",
+					type: "active-turn",
+					activeTurn: { agentName: "Agent", action: "Retrying", details: [] },
+				},
+				{ cursor: "cursor-5", type: "complete" },
+			]),
+		);
+
+		const result = await controller.follow();
+		expect(result.failure).toBeNull();
+		expect(result.view.activeTurn).toBeUndefined();
+	});
+
+	test("capability events become the fake host's command authority", async () => {
+		const nextCapabilities = { ...snapshot().capabilities, stop: false };
+		const port = new FakeConversationPort(snapshot(), [
+			{ cursor: "cursor-1", type: "capabilities", capabilities: nextCapabilities },
+		]);
+		const controller = new FolioConversationController(port);
+		await controller.follow();
+
+		await expect(controller.stop()).rejects.toBeInstanceOf(
+			FolioCapabilityUnavailableError,
+		);
+	});
+
+	test("derives a total UI action membrane from a hydrated port", async () => {
+		const port = new FakeConversationPort(snapshot());
+		const controller = new FolioConversationController(port);
+		await controller.hydrate();
+		let key = 0;
+		const actions = createPortBackedConversationActions(
+			controller,
+			() => `request-${++key}`,
+			vi.fn(),
+		);
+
+		actions.send?.("Hello");
+		actions.retry?.("message-1", "Again");
+		actions.cancelQueuedMessage?.("queue-1");
+		actions.changeTitle?.("Updated");
+		actions.requestPublication?.();
+
+		expect(port.calls.filter((call) => call.command !== "readSnapshot")).toEqual([
+			{
+				command: "send",
+				payload: { text: "Hello", idempotencyKey: "request-1" },
+			},
+			{
+				command: "send",
+				payload: { text: "Again", idempotencyKey: "request-2", retryOf: "message-1" },
+			},
+			{ command: "cancelQueuedMessage", payload: "queue-1" },
+			{ command: "updateConversation", payload: { title: "Updated" } },
+			{ command: "requestPublication", payload: "publish" },
+		]);
+	});
+
+	test("routes a command rejected after an authority change to the host error channel", async () => {
+		const port = new FakeConversationPort(snapshot(), [
+			{
+				cursor: "cursor-1",
+				type: "capabilities",
+				capabilities: { ...snapshot().capabilities, stop: false },
+			},
+		]);
+		const controller = new FolioConversationController(port);
+		await controller.hydrate();
+		const onCommandError = vi.fn();
+		const actions = createPortBackedConversationActions(
+			controller,
+			() => "request-1",
+			onCommandError,
+		);
+		await controller.follow();
+
+		actions.stopTurn?.();
+
+		await vi.waitFor(() =>
+			expect(onCommandError).toHaveBeenCalledWith(
+				expect.any(FolioCapabilityUnavailableError),
+			),
+		);
+	});
+
+	test("fake host denies commands that durable capabilities do not grant", async () => {
+		const denied = snapshot();
+		denied.capabilities = {
+			...denied.capabilities,
+			stop: false,
+		};
+		denied.workspace = { id: "workspace-1", state: "failed", actions: [] };
+		const port = new FakeConversationPort(denied);
+
+		await expect(port.stop()).rejects.toBeInstanceOf(FolioCapabilityUnavailableError);
+		await expect(port.requestWorkspaceAction("recover")).rejects.toBeInstanceOf(
+			FolioCapabilityUnavailableError,
+		);
+	});
+
+	test("fake host records idempotent send and authority requests", async () => {
+		const port = new FakeConversationPort(snapshot());
+		const controller = new FolioConversationController(port);
+		const sendReceipt = await controller.send({ text: "Hello", idempotencyKey: "request-1" });
+		await controller.decideApproval("approval-1", "allow");
+		await controller.decideReview("accept", "ship it");
+		await controller.updateConversation({ title: "Updated" });
+		await controller.requestWorkspaceAction("recover");
+		await controller.requestPublication("publish");
+
+		expect(sendReceipt.cursor).toBe("cursor-0");
+
+		expect(port.calls.map((call) => call.command)).toEqual([
+			"send",
+			"decideApproval",
+			"decideReview",
+			"updateConversation",
+			"requestWorkspaceAction",
+			"requestPublication",
+		]);
+	});
+});

--- a/web-next/packages/folio/src/conversation-controller.ts
+++ b/web-next/packages/folio/src/conversation-controller.ts
@@ -1,0 +1,223 @@
+/* Pure replay state machine over the host-neutral Folio conversation port. */
+import type {
+	FolioCommandReceipt,
+	FolioConversationActions,
+	FolioConversationEvent,
+	FolioConversationPort,
+	FolioConversationSnapshot,
+	FolioConversationUpdate,
+	FolioSendRequest,
+} from "./conversation-ports";
+import type { ApprovalDecision } from "./types";
+
+function upsertById<T extends { id: string }>(items: readonly T[], item: T): T[] {
+	const index = items.findIndex((candidate) => candidate.id === item.id);
+	if (index < 0) return [...items, item];
+	return items.map((candidate, candidateIndex) =>
+		candidateIndex === index ? item : candidate,
+	);
+}
+
+export function applyConversationEvent(
+	snapshot: FolioConversationSnapshot,
+	event: FolioConversationEvent,
+): FolioConversationSnapshot {
+	const next = { ...snapshot, cursor: event.cursor };
+	switch (event.type) {
+		case "message-upsert":
+			return {
+				...next,
+				view: {
+					...snapshot.view,
+					messages: upsertById(snapshot.view.messages, event.message),
+				},
+			};
+		case "active-turn":
+			return {
+				...next,
+				failure: event.activeTurn ? null : snapshot.failure,
+				view: {
+					...snapshot.view,
+					activeTurn: event.activeTurn ?? undefined,
+				},
+			};
+		case "queued-messages":
+			return { ...next, queuedMessages: event.messages };
+		case "conversation-updated":
+			return {
+				...next,
+				view: {
+					...snapshot.view,
+					masthead: {
+						...snapshot.view.masthead,
+						title: event.title ?? snapshot.view.masthead.title,
+					},
+					statusLine: {
+						...snapshot.view.statusLine,
+						model: event.model ?? snapshot.view.statusLine.model,
+						modelLabel: event.modelLabel ?? snapshot.view.statusLine.modelLabel,
+					},
+				},
+			};
+		case "capabilities":
+			return { ...next, capabilities: event.capabilities };
+		case "status":
+			return { ...next, view: { ...snapshot.view, statusLine: event.status } };
+		case "artifact":
+			return { ...next, artifacts: upsertById(snapshot.artifacts, event.artifact) };
+		case "review":
+			return { ...next, review: event.review };
+		case "workspace":
+			return { ...next, workspace: event.workspace };
+		case "publication":
+			return { ...next, publication: event.publication };
+		case "failure":
+			return {
+				...next,
+				failure: event.message,
+				view: {
+					...snapshot.view,
+					activeTurn: undefined,
+				},
+			};
+		case "complete":
+			return {
+				...next,
+				view: { ...snapshot.view, activeTurn: undefined },
+			};
+	}
+}
+
+export class FolioConversationController {
+	#snapshot: FolioConversationSnapshot | null = null;
+	#following = false;
+
+	constructor(readonly port: FolioConversationPort) {}
+
+	get snapshot(): FolioConversationSnapshot | null {
+		return this.#snapshot;
+	}
+
+	async hydrate(signal?: AbortSignal): Promise<FolioConversationSnapshot> {
+		this.#snapshot = await this.port.readSnapshot(signal);
+		return this.#snapshot;
+	}
+
+	async follow(
+		onChange?: (snapshot: FolioConversationSnapshot) => void,
+		signal?: AbortSignal,
+	): Promise<FolioConversationSnapshot> {
+		if (this.#following) throw new FolioFollowInProgressError();
+		this.#following = true;
+		try {
+			let current = this.#snapshot ?? (await this.hydrate(signal));
+			for await (const event of this.port.readEvents(current.cursor, signal)) {
+				current = applyConversationEvent(current, event);
+				this.#snapshot = current;
+				onChange?.(current);
+			}
+			return current;
+		} finally {
+			this.#following = false;
+		}
+	}
+
+	send(request: FolioSendRequest, signal?: AbortSignal): Promise<FolioCommandReceipt> {
+		return this.port.send(request, signal);
+	}
+
+	stop(signal?: AbortSignal): Promise<FolioCommandReceipt> {
+		return this.port.stop(signal);
+	}
+
+	cancelQueuedMessage(queueId: string, signal?: AbortSignal): Promise<FolioCommandReceipt> {
+		return this.port.cancelQueuedMessage(queueId, signal);
+	}
+
+	decideApproval(
+		requestId: string,
+		decision: ApprovalDecision,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt> {
+		return this.port.decideApproval(requestId, decision, signal);
+	}
+
+	decideReview(
+		decision: "accept" | "reject",
+		note?: string,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt> {
+		return this.port.decideReview(decision, note, signal);
+	}
+
+	updateConversation(
+		update: FolioConversationUpdate,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt> {
+		return this.port.updateConversation(update, signal);
+	}
+
+	requestWorkspaceAction(
+		action: string,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt> {
+		return this.port.requestWorkspaceAction(action, signal);
+	}
+
+	requestPublication(
+		action: string,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt> {
+		return this.port.requestPublication(action, signal);
+	}
+}
+
+export class FolioFollowInProgressError extends Error {
+	constructor() {
+		super("conversation follow is already in progress");
+	}
+}
+
+export function createPortBackedConversationActions(
+	controller: FolioConversationController,
+	idempotencyKey: () => string,
+	onCommandError: (error: unknown) => void,
+): FolioConversationActions {
+	const snapshot = controller.snapshot;
+	if (!snapshot) throw new Error("conversation controller must hydrate before creating actions");
+	const { capabilities, workspace, publication } = snapshot;
+	const publicationAction = publication?.actions[0];
+	const run = (command: Promise<FolioCommandReceipt>): void => {
+		void command.catch(onCommandError);
+	};
+	return {
+		send: capabilities.send
+			? (text) => run(controller.send({ text, idempotencyKey: idempotencyKey() }))
+			: undefined,
+		retry: capabilities.retry
+			? (messageId, text) =>
+					run(controller.send({ text, idempotencyKey: idempotencyKey(), retryOf: messageId }))
+			: undefined,
+		cancelQueuedMessage: capabilities.cancelQueuedMessage
+			? (queueId) => run(controller.cancelQueuedMessage(queueId))
+			: undefined,
+		changeModel: capabilities.updateConversation
+			? (model) => run(controller.updateConversation({ model }))
+			: undefined,
+		changeTitle: capabilities.updateConversation
+			? (title) => run(controller.updateConversation({ title }))
+			: undefined,
+		stopTurn: capabilities.stop ? () => run(controller.stop()) : undefined,
+		stopWorkspace: workspace?.actions.includes("stop")
+			? () => run(controller.requestWorkspaceAction("stop"))
+			: undefined,
+		requestPublication: publicationAction
+			? (action = publicationAction) => run(controller.requestPublication(action))
+			: undefined,
+		decideApproval: capabilities.decideApproval
+			? async (requestId, decision) => {
+					await controller.decideApproval(requestId, decision);
+				}
+			: undefined,
+	};
+}

--- a/web-next/packages/folio/src/conversation-port-component.test.tsx
+++ b/web-next/packages/folio/src/conversation-port-component.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { FolioConversationController } from "./conversation-controller";
+import type { FolioConversationSnapshot } from "./conversation-ports";
+import { FakeConversationPort } from "./fake-conversation-port";
+import { SessionView } from "./session-view";
+
+describe("Folio port component integration", () => {
+	test("renders a snapshot replayed through the deterministic fake host", async () => {
+		const snapshot: FolioConversationSnapshot = {
+			conversationId: "conversation-1",
+			cursor: "cursor-0",
+			view: {
+				masthead: {
+					repo: "example/repo",
+					branch: null,
+					title: "Port-driven session",
+					agentName: "Agent",
+					stateLabel: "ready",
+				},
+				messages: [],
+				statusLine: { model: "model-1" },
+			},
+			queuedMessages: [],
+			capabilities: {
+				send: false,
+				stop: false,
+				retry: false,
+				cancelQueuedMessage: false,
+				decideApproval: false,
+				decideReview: false,
+				updateConversation: false,
+			},
+			artifacts: [],
+			review: null,
+			workspace: null,
+			publication: null,
+			failure: null,
+		};
+		const controller = new FolioConversationController(
+			new FakeConversationPort(snapshot, [
+				{
+					cursor: "cursor-1",
+					type: "message-upsert",
+					message: {
+						id: "message-1",
+						role: "user",
+						metadata: { author: "You" },
+						parts: [{ type: "text", text: "Hello from the host port" }],
+					},
+				},
+			]),
+		);
+
+		const result = await controller.follow();
+		const html = renderToStaticMarkup(<SessionView session={result.view} />);
+
+		expect(html).toContain("Port-driven session");
+		expect(html).toContain("Hello from the host port");
+	});
+});

--- a/web-next/packages/folio/src/conversation-ports.ts
+++ b/web-next/packages/folio/src/conversation-ports.ts
@@ -1,0 +1,150 @@
+/*
+ * Host-neutral conversation authority for Folio. Hosts own persistence,
+ * transport, compute, workspaces, and publication; Folio consumes snapshots,
+ * ordered events, and explicitly available commands through this membrane.
+ */
+import type { ActiveTurnData, QueuedMessageData, SessionViewData } from "./session-view";
+import type { ApprovalDecision } from "./types";
+
+/** Opaque durable resume token; hosts persist it across reload and restart. */
+export type FolioConversationCursor = string;
+
+export class FolioCapabilityUnavailableError extends Error {}
+
+export interface FolioConversationCapabilities {
+	send: boolean;
+	stop: boolean;
+	retry: boolean;
+	cancelQueuedMessage: boolean;
+	decideApproval: boolean;
+	decideReview: boolean;
+	updateConversation: boolean;
+}
+
+export interface FolioArtifact {
+	id: string;
+	kind: "diff" | "file" | "report" | "link";
+	label: string;
+	url?: string;
+}
+
+export interface FolioReview {
+	id: string;
+	summary: string;
+	changedFiles: readonly string[];
+	state: "pending" | "accepted" | "rejected";
+}
+
+export interface FolioWorkspace {
+	id: string;
+	label?: string;
+	state: string;
+	actions: readonly string[];
+}
+
+export interface FolioPublication {
+	id: string | null;
+	state: string | null;
+	url: string | null;
+	actions: readonly string[];
+}
+
+export interface FolioConversationSnapshot {
+	conversationId: string;
+	cursor: FolioConversationCursor;
+	view: SessionViewData;
+	queuedMessages: QueuedMessageData[];
+	capabilities: FolioConversationCapabilities;
+	artifacts: FolioArtifact[];
+	review: FolioReview | null;
+	workspace: FolioWorkspace | null;
+	publication: FolioPublication | null;
+	failure: string | null;
+}
+
+interface EventEnvelope {
+	cursor: FolioConversationCursor;
+}
+
+export type FolioConversationEvent =
+	| (EventEnvelope & { type: "message-upsert"; message: SessionViewData["messages"][number] })
+	| (EventEnvelope & { type: "active-turn"; activeTurn: ActiveTurnData | null })
+	| (EventEnvelope & { type: "queued-messages"; messages: QueuedMessageData[] })
+	| (EventEnvelope & {
+			type: "conversation-updated";
+			title?: string;
+			model?: string;
+			modelLabel?: string;
+	  })
+	| (EventEnvelope & { type: "capabilities"; capabilities: FolioConversationCapabilities })
+	| (EventEnvelope & { type: "status"; status: SessionViewData["statusLine"] })
+	| (EventEnvelope & { type: "artifact"; artifact: FolioArtifact })
+	| (EventEnvelope & { type: "review"; review: FolioReview | null })
+	| (EventEnvelope & { type: "workspace"; workspace: FolioWorkspace | null })
+	| (EventEnvelope & { type: "publication"; publication: FolioPublication | null })
+	| (EventEnvelope & { type: "failure"; message: string })
+	| (EventEnvelope & { type: "complete" });
+
+export interface FolioCommandReceipt {
+	cursor: FolioConversationCursor;
+}
+
+export interface FolioSendRequest {
+	text: string;
+	idempotencyKey: string;
+	retryOf?: string;
+}
+
+export interface FolioConversationUpdate {
+	title?: string;
+	model?: string;
+}
+
+export interface FolioConversationPort {
+	readSnapshot(signal?: AbortSignal): Promise<FolioConversationSnapshot>;
+	readEvents(
+		after: FolioConversationCursor,
+		signal?: AbortSignal,
+	): AsyncIterable<FolioConversationEvent>;
+	send(request: FolioSendRequest, signal?: AbortSignal): Promise<FolioCommandReceipt>;
+	stop(signal?: AbortSignal): Promise<FolioCommandReceipt>;
+	cancelQueuedMessage(queueId: string, signal?: AbortSignal): Promise<FolioCommandReceipt>;
+	decideApproval(
+		requestId: string,
+		decision: ApprovalDecision,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt>;
+	decideReview(
+		decision: "accept" | "reject",
+		note?: string,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt>;
+	updateConversation(
+		update: FolioConversationUpdate,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt>;
+	requestWorkspaceAction(
+		action: string,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt>;
+	requestPublication(
+		action: string,
+		signal?: AbortSignal,
+	): Promise<FolioCommandReceipt>;
+}
+
+/** UI-level dependency injection. An absent callback is an absent capability. */
+export interface FolioConversationActions {
+	send?: (text: string) => void;
+	retry?: (messageId: string, text: string) => void;
+	cancelQueuedMessage?: (queueId: string) => void;
+	changeModel?: (id: string) => void;
+	changeTitle?: (title: string) => void;
+	stopTurn?: () => void;
+	stopWorkspace?: () => void;
+	requestPublication?: (action?: string) => void;
+	decideApproval?: (
+		requestId: string,
+		decision: ApprovalDecision,
+	) => Promise<void>;
+}

--- a/web-next/packages/folio/src/fake-conversation-port.ts
+++ b/web-next/packages/folio/src/fake-conversation-port.ts
@@ -1,0 +1,135 @@
+/* Deterministic host adapter for Folio contract and state-machine tests. */
+import type {
+	FolioCommandReceipt,
+	FolioConversationEvent,
+	FolioConversationPort,
+	FolioConversationSnapshot,
+	FolioConversationUpdate,
+	FolioSendRequest,
+} from "./conversation-ports";
+import { FolioCapabilityUnavailableError } from "./conversation-ports";
+
+export interface FakeConversationCall {
+	command: string;
+	payload?: unknown;
+}
+
+export class FakeConversationPort implements FolioConversationPort {
+	readonly calls: FakeConversationCall[] = [];
+	#capabilities: FolioConversationSnapshot["capabilities"];
+	#workspace: FolioConversationSnapshot["workspace"];
+	#publication: FolioConversationSnapshot["publication"];
+	#cursor: FolioConversationSnapshot["cursor"];
+
+	constructor(
+		readonly initialSnapshot: FolioConversationSnapshot,
+		readonly events: readonly FolioConversationEvent[] = [],
+		readonly disconnectAfterCursor?: string,
+	) {
+		const cursors = events.map((event) => event.cursor);
+		if (new Set(cursors).size !== cursors.length) {
+			throw new Error("fake conversation cursors must be unique");
+		}
+		this.#capabilities = initialSnapshot.capabilities;
+		this.#workspace = initialSnapshot.workspace;
+		this.#publication = initialSnapshot.publication;
+		this.#cursor = initialSnapshot.cursor;
+	}
+
+	async readSnapshot(signal?: AbortSignal): Promise<FolioConversationSnapshot> {
+		signal?.throwIfAborted();
+		this.calls.push({ command: "readSnapshot" });
+		return this.initialSnapshot;
+	}
+
+	async *readEvents(
+		after: string,
+		signal?: AbortSignal,
+	): AsyncIterable<FolioConversationEvent> {
+		this.calls.push({ command: "readEvents", payload: after });
+		const eventIndex = this.events.findIndex((event) => event.cursor === after);
+		if (eventIndex < 0 && after !== this.initialSnapshot.cursor) {
+			throw new Error(`unknown conversation cursor: ${after}`);
+		}
+		const startIndex = eventIndex < 0 ? 0 : eventIndex + 1;
+		for (const event of this.events.slice(startIndex)) {
+			signal?.throwIfAborted();
+			this.#cursor = event.cursor;
+			if (event.type === "capabilities") this.#capabilities = event.capabilities;
+			if (event.type === "workspace") this.#workspace = event.workspace;
+			if (event.type === "publication") this.#publication = event.publication;
+			yield event;
+			if (event.cursor === this.disconnectAfterCursor) {
+				throw new Error("deterministic disconnect");
+			}
+		}
+	}
+
+	async send(request: FolioSendRequest): Promise<FolioCommandReceipt> {
+		this.#require(this.#capabilities.send, "send");
+		this.calls.push({ command: "send", payload: request });
+		return this.#receipt();
+	}
+
+	async stop(): Promise<FolioCommandReceipt> {
+		this.#require(this.#capabilities.stop, "stop");
+		this.calls.push({ command: "stop" });
+		return this.#receipt();
+	}
+
+	async cancelQueuedMessage(queueId: string): Promise<FolioCommandReceipt> {
+		this.#require(
+			this.#capabilities.cancelQueuedMessage,
+			"cancelQueuedMessage",
+		);
+		this.calls.push({ command: "cancelQueuedMessage", payload: queueId });
+		return this.#receipt();
+	}
+
+	async decideApproval(
+		requestId: string,
+		decision: "allow" | "deny",
+	): Promise<FolioCommandReceipt> {
+		this.#require(this.#capabilities.decideApproval, "decideApproval");
+		this.calls.push({ command: "decideApproval", payload: { requestId, decision } });
+		return this.#receipt();
+	}
+
+	async decideReview(decision: "accept" | "reject", note?: string): Promise<FolioCommandReceipt> {
+		this.#require(this.#capabilities.decideReview, "decideReview");
+		this.calls.push({ command: "decideReview", payload: { decision, note } });
+		return this.#receipt();
+	}
+
+	async updateConversation(update: FolioConversationUpdate): Promise<FolioCommandReceipt> {
+		this.#require(this.#capabilities.updateConversation, "updateConversation");
+		this.calls.push({ command: "updateConversation", payload: update });
+		return this.#receipt();
+	}
+
+	async requestWorkspaceAction(action: string): Promise<FolioCommandReceipt> {
+		this.#require(
+			this.#workspace?.actions.includes(action) === true,
+			"requestWorkspaceAction",
+		);
+		this.calls.push({ command: "requestWorkspaceAction", payload: action });
+		return this.#receipt();
+	}
+
+	async requestPublication(action: string): Promise<FolioCommandReceipt> {
+		this.#require(
+			this.#publication?.actions.includes(action) === true,
+			"requestPublication",
+		);
+		this.calls.push({ command: "requestPublication", payload: action });
+		return this.#receipt();
+	}
+
+	#receipt(): FolioCommandReceipt {
+		return { cursor: this.#cursor };
+	}
+
+	#require(available: boolean, command: string): void {
+		if (!available) throw new FolioCapabilityUnavailableError(`${command} is unavailable`);
+	}
+}

--- a/web-next/packages/folio/src/index.ts
+++ b/web-next/packages/folio/src/index.ts
@@ -12,6 +12,28 @@ export {
 	type SessionViewProps,
 } from "./session-view";
 export type { MastheadData } from "./session-masthead";
+export {
+	FolioConversationController,
+	FolioFollowInProgressError,
+	applyConversationEvent,
+	createPortBackedConversationActions,
+} from "./conversation-controller";
+export { FolioCapabilityUnavailableError } from "./conversation-ports";
+export type {
+	FolioArtifact,
+	FolioCommandReceipt,
+	FolioConversationActions,
+	FolioConversationCapabilities,
+	FolioConversationCursor,
+	FolioConversationEvent,
+	FolioConversationPort,
+	FolioConversationSnapshot,
+	FolioConversationUpdate,
+	FolioPublication,
+	FolioReview,
+	FolioSendRequest,
+	FolioWorkspace,
+} from "./conversation-ports";
 export type {
 	ApprovalDecision,
 	ApprovalPartData,

--- a/web-next/packages/folio/src/session-view.tsx
+++ b/web-next/packages/folio/src/session-view.tsx
@@ -8,7 +8,8 @@ import { ComposeField } from "./compose-field";
 import { Message, MessageArticle } from "./message";
 import { SessionMasthead, type MastheadData } from "./session-masthead";
 import { StatusLine, type StatusLineData } from "./status-line";
-import type { ApprovalDecision, FolioMessage } from "./types";
+import type { FolioConversationActions } from "./conversation-ports";
+import type { FolioMessage } from "./types";
 
 /** The live turn: always focal, labeled but unstamped while it works. */
 export interface ActiveTurnData extends ActivityLineProps {
@@ -136,50 +137,23 @@ export interface SessionViewProps {
 	session: SessionViewData;
 	/** Scopes live-turn follow DOM lookups when this is a real session surface. */
 	turnFollowScopeId?: string;
-	/** Compose submit handler (client wrappers wire this; fixtures omit it). */
-	onSend?: (text: string) => void;
+	/** Host authority injected as one capability object; fixtures omit it. */
+	actions?: FolioConversationActions;
 	/** Hard-disables compose when this surface cannot accept text. */
 	composeDisabled?: boolean;
 	/** Holds retry actions while a turn is streaming; new compose sends queue. */
 	retryDisabled?: boolean;
 	/** User messages waiting for the current turn to settle (#984). */
 	queuedMessages?: QueuedMessageData[];
-	/** Cancels an undispatched queued message. */
-	onCancelQueuedMessage?: (queueId: string) => void;
-	/** Model picker handler (client wrappers wire this; fixtures omit it, which
-	 * leaves the status line's model as static text — see status-line.tsx). */
-	onModelChange?: (id: string) => void;
-	/** Inline title-edit handler (client wrappers wire this; fixtures omit it,
-	 * which leaves the masthead title as static text — see session-masthead.tsx). */
-	onTitleChange?: (title: string) => void;
-	/** Stops the in-flight turn (#753); compose keeps Send live for queued
-	 * steering while this quiet control sits beside it. Fixtures omit it. */
-	onStopTurn?: () => void;
-	/** Stops the session's live sandbox (#753); a quiet masthead action beside
-	 * the state label. Fixtures omit it. */
-	onSandboxStop?: () => void;
-	/** Opens or updates the session PR (#820). Fixtures omit it. */
-	onPullRequestAction?: () => void;
-	onApprovalDecision?: (
-		requestId: string,
-		decision: ApprovalDecision,
-	) => Promise<void>;
 }
 
 export function SessionView({
 	session,
 	turnFollowScopeId,
-	onSend,
+	actions,
 	composeDisabled,
 	retryDisabled,
 	queuedMessages = [],
-	onCancelQueuedMessage,
-	onModelChange,
-	onTitleChange,
-	onStopTurn,
-	onSandboxStop,
-	onPullRequestAction,
-	onApprovalDecision,
 }: SessionViewProps) {
 	const isEmpty = session.messages.length === 0 && !session.activeTurn;
 	const hasMastheadSubline =
@@ -190,9 +164,9 @@ export function SessionView({
 		<>
 			<SessionMasthead
 				session={session.masthead}
-				onTitleChange={onTitleChange}
-				onSandboxStop={onSandboxStop}
-				onPullRequestAction={onPullRequestAction}
+				onTitleChange={actions?.changeTitle}
+				onSandboxStop={actions?.stopWorkspace}
+				onPullRequestAction={actions?.requestPublication}
 			/>
 			{/* break-words inherits into the prose, so an unbroken token (a long
 			    path, a URL) wraps instead of forcing 375px pages sideways (#753);
@@ -246,12 +220,12 @@ export function SessionView({
 										openToolCallIds={session.openToolCallIds}
 										animationDelay={riseDelay(orderIndex.get(message.id) ?? 0)}
 										onRetry={
-											message.metadata?.error && onSend && retryText
-												? () => onSend(retryText)
+											message.metadata?.error && actions?.retry && retryText
+												? () => actions.retry?.(message.id, retryText)
 												: undefined
 										}
 										retryDisabled={retryDisabled}
-										onApprovalDecision={onApprovalDecision}
+										onApprovalDecision={actions?.decideApproval}
 									/>
 								))}
 								{recent && session.activeTurn && (
@@ -277,15 +251,15 @@ export function SessionView({
 			>
 				<QueuedMessages
 					messages={queuedMessages}
-					onCancel={onCancelQueuedMessage}
+					onCancel={actions?.cancelQueuedMessage}
 				/>
 				<ComposeField
 					agentName={session.masthead.agentName}
-					onSend={onSend}
+					onSend={actions?.send}
 					disabled={composeDisabled}
-					onStop={onStopTurn}
+					onStop={actions?.stopTurn}
 				/>
-				<StatusLine status={session.statusLine} onModelChange={onModelChange} />
+				<StatusLine status={session.statusLine} onModelChange={actions?.changeModel} />
 			</footer>
 		</>
 	);

--- a/web-next/packages/folio/src/testing-entry.ts
+++ b/web-next/packages/folio/src/testing-entry.ts
@@ -1,0 +1,6 @@
+/** Deterministic test host for consumers of the Folio port contract. */
+export {
+	FakeConversationPort,
+} from "./fake-conversation-port";
+export { FolioCapabilityUnavailableError } from "./conversation-ports";
+export type { FakeConversationCall } from "./fake-conversation-port";

--- a/web-next/scripts/folio-boundary.test.mjs
+++ b/web-next/scripts/folio-boundary.test.mjs
@@ -19,6 +19,7 @@ const PUBLIC_FOLIO_IMPORTS = new Set([
 	"@fairchild/folio",
 	"@fairchild/folio/format",
 	"@fairchild/folio/theme",
+	"@fairchild/folio/testing",
 ]);
 const require = createRequire(import.meta.url);
 
@@ -58,6 +59,11 @@ describe("Folio package boundary", () => {
 				expect(specifier, file).not.toContain("packages/folio/src");
 				if (specifier.startsWith("@fairchild/folio")) {
 					expect(PUBLIC_FOLIO_IMPORTS, file).toContain(specifier);
+					if (specifier === "@fairchild/folio/testing") {
+						expect(file, "testing entry imported by production source").toMatch(
+						/\.test\.[cm]?[jt]sx?$/,
+					);
+					}
 				}
 			}
 		}
@@ -93,6 +99,11 @@ describe("Folio package boundary", () => {
 				types: "./src/theme-entry.ts",
 				import: "./src/theme-entry.ts",
 				default: "./src/theme-entry.ts",
+			},
+			"./testing": {
+				types: "./src/testing-entry.ts",
+				import: "./src/testing-entry.ts",
+				default: "./src/testing-entry.ts",
 			},
 		});
 		expect(manifest.files).toEqual([

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -54,6 +54,7 @@ import {
 import type { FolioDataParts, FolioMessage } from "@fairchild/folio";
 import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
+import { createWorkspacesFolioActions } from "@/lib/folio/workspaces-conversation-adapter";
 import {
 	applyLiveTurnErrors,
 	isVisibleMessage,
@@ -547,6 +548,18 @@ export function LiveSessionView({
 		document.title = displayTitle ? `${displayTitle} — Spaces` : "Spaces";
 	}, [displayTitle]);
 
+	const folioActions = createWorkspacesFolioActions({
+		sendMessage: send,
+		cancelQueuedMessage,
+		changeModel: handleModelChange,
+		changeTitle: handleTitleChange,
+		stopTurn: busy ? stopTurn : undefined,
+		stopSandbox:
+			sandbox?.state === "live" && !busy ? () => void stopSandbox() : undefined,
+		openPullRequest,
+		answerApproval,
+	});
+
 	return (
 		<>
 			<TerminalDrawer sessionId={sessionId} />
@@ -577,18 +590,9 @@ export function LiveSessionView({
 							deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
 					},
 				}}
-				onSend={send}
+				actions={folioActions}
 				retryDisabled={busy}
 				queuedMessages={queuedMessages}
-				onCancelQueuedMessage={cancelQueuedMessage}
-				onModelChange={handleModelChange}
-				onTitleChange={handleTitleChange}
-				onStopTurn={busy ? stopTurn : undefined}
-				onSandboxStop={
-					sandbox?.state === "live" && !busy ? () => void stopSandbox() : undefined
-				}
-				onPullRequestAction={openPullRequest}
-				onApprovalDecision={answerApproval}
 			/>
 		</>
 	);

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from "vitest";
+import { createWorkspacesFolioActions } from "./workspaces-conversation-adapter";
+
+describe("createWorkspacesFolioActions", () => {
+	test("translates Workspaces callbacks into explicit Folio capabilities", async () => {
+		const callbacks = {
+			sendMessage: vi.fn(),
+			cancelQueuedMessage: vi.fn(),
+			changeModel: vi.fn(),
+			changeTitle: vi.fn(),
+			stopTurn: vi.fn(),
+			stopSandbox: vi.fn(),
+			openPullRequest: vi.fn(),
+			answerApproval: vi.fn(async () => undefined),
+		};
+		const actions = createWorkspacesFolioActions(callbacks);
+
+		actions.send?.("hello");
+		actions.retry?.("message-1", "again");
+		actions.cancelQueuedMessage?.("queue-1");
+		actions.changeModel?.("model-2");
+		actions.changeTitle?.("Title");
+		actions.stopTurn?.();
+		actions.stopWorkspace?.();
+		actions.requestPublication?.();
+		await actions.decideApproval?.("approval-1", "allow");
+
+		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(1, "hello");
+		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(2, "again");
+		expect(callbacks.cancelQueuedMessage).toHaveBeenCalledWith("queue-1");
+		expect(callbacks.changeModel).toHaveBeenCalledWith("model-2");
+		expect(callbacks.changeTitle).toHaveBeenCalledWith("Title");
+		expect(callbacks.stopTurn).toHaveBeenCalledOnce();
+		expect(callbacks.stopSandbox).toHaveBeenCalledOnce();
+		expect(callbacks.openPullRequest).toHaveBeenCalledOnce();
+		expect(callbacks.answerApproval).toHaveBeenCalledWith("approval-1", "allow");
+	});
+
+	test("does not invent unavailable optional authority", () => {
+		const actions = createWorkspacesFolioActions({
+			sendMessage: vi.fn(),
+			cancelQueuedMessage: vi.fn(),
+			changeModel: vi.fn(),
+			changeTitle: vi.fn(),
+			openPullRequest: vi.fn(),
+			answerApproval: vi.fn(async () => undefined),
+		});
+
+		expect(actions.stopTurn).toBeUndefined();
+		expect(actions.stopWorkspace).toBeUndefined();
+	});
+});

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.ts
@@ -1,0 +1,34 @@
+/*
+ * Workspaces-to-Folio action adapter. It translates host vocabulary into
+ * Folio's public capability object without granting the package route, Git,
+ * sandbox, persistence, authentication, or publication implementations.
+ */
+import type { FolioConversationActions } from "@fairchild/folio";
+import type { ApprovalDecision } from "@/lib/agent-runtime/stream-chunk";
+
+export interface WorkspacesConversationCallbacks {
+	sendMessage: (text: string) => void;
+	cancelQueuedMessage: (queueId: string) => void;
+	changeModel: (id: string) => void;
+	changeTitle: (title: string) => void;
+	stopTurn?: () => void;
+	stopSandbox?: () => void;
+	openPullRequest: () => void;
+	answerApproval: (requestId: string, decision: ApprovalDecision) => Promise<void>;
+}
+
+export function createWorkspacesFolioActions(
+	callbacks: WorkspacesConversationCallbacks,
+): FolioConversationActions {
+	return {
+		send: callbacks.sendMessage,
+		retry: (_messageId, text) => callbacks.sendMessage(text),
+		cancelQueuedMessage: callbacks.cancelQueuedMessage,
+		changeModel: callbacks.changeModel,
+		changeTitle: callbacks.changeTitle,
+		stopTurn: callbacks.stopTurn,
+		stopWorkspace: callbacks.stopSandbox,
+		requestPublication: callbacks.openPullRequest,
+		decideApproval: callbacks.answerApproval,
+	};
+}


### PR DESCRIPTION
## Summary

- Define the public `FolioConversationPort` snapshot, opaque-cursor event, capability, artifact/review, workspace/publication, and command contracts.
- Add a pure replay/controller layer plus a deterministic `@fairchild/folio/testing` fake that covers disconnect/resume, terminal failures, cancellation, artifacts, reviews, and capability denial.
- Replace `SessionView`'s scattered host callbacks with one injected `FolioConversationActions` authority object.
- Add the Workspaces adapter over the current proven AI SDK runtime; no route, persistence, compute, sandbox, Git, authentication, or publication implementation moves into Folio.

Closes #1051

## Mergeability

- Surface: web — web-next Folio package contract and Workspaces session adapter
- User-facing behavior changed: No; the existing Folio session experience and AI SDK transport remain unchanged
- Non-happy paths considered: disconnect/resume from the last durable cursor, duplicate message replay, failure/cancellation terminal state, unavailable stop/workspace/publication/review authority, absent optional UI callbacks, and test-only adapter imports leaking into production
- Residual risk or follow-up: #1052 moves styles/assets, #1053 makes Workspaces a strict full-port consumer, and #1054 produces the compiled artifact; this PR intentionally leaves Workspaces' proven AI SDK controller in place

## Validation

- [ ] `swift build` — not applicable; web-only change
- [ ] `swift test` — not applicable; web-only change
- [x] `cd web-next && pnpm exec tsc --noEmit -p packages/folio/tsconfig.json` — independent package contract passed
- [x] `cd web-next && pnpm typecheck` — passed
- [x] `cd web-next && pnpm lint` — passed
- [x] `cd web-next && pnpm test` — 65 files / 649 tests passed (host-authorized for the loopback harness)
- [x] `cd web-next && pnpm build` — Next 15.5 production build passed; `/sessions/[id]` first-load JS 186 kB
- [x] `cd web-next && pnpm exec playwright test tests/e2e/sessions.spec.ts --project=chromium` — 17/17 passed: send/stream, reload, resume, queue/cancel, disconnect, failure/retry, title/model, and approval flows
- [x] Focused port/controller/adapter/boundary suite — 4 files / 36 tests passed

## Performance

- [x] Not a performance-sensitive change
- [ ] Used canonical scenario(s) from `web-next/perf/contract.json`
- [ ] Before and after evidence came from a like-for-like workload and environment
- [ ] Any meaningful delta, missing metric, target crossing, or non-comparable context is called out below

Performance evidence:

- Scenario ID: n/a — typed authority-boundary refactor with no rendering or runtime algorithm change
- Before Summary: n/a
- After Summary: production build passed; session first-load JS remained below the existing 200 kB budget at 186 kB
- Delta Summary: not measured because the change is not performance-sensitive

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached (Playwright report, test output, or equivalent)
- [ ] UI evidence attached (screenshot or recording from the exact commit under review)

Evidence links:

- [Exact-commit contract, build, and session E2E evidence](https://evidence.cloudcompute.com/workspaces/pr-1057/20260712-181511-folio-conversation-ports-final.svg)

No screenshot is attached because this PR intentionally changes no rendered behavior; the real browser session suite is the relevant evidence.

## Review

- Personal reflection completed against the issue acceptance criteria and mergeability standard.
- Source-aware Fable review found eight actionable contract issues; all eight were accepted and addressed: concurrent-follow serialization, one authoritative capability source, total port-to-action mapping, retry identity, fail-closed unknown cursors, retry failure clearing, public capability errors, and meaningful cursor-only command receipts.
- A bounded Fable follow-up on those fixes exhausted its $2 review cap without returning output. The final tree then passed the full exact-head unit, build, and browser gates above; no review finding was left unaddressed.

## Blockers

- [x] None
- [ ] Blocked on evidence
