### PR TITLE
web-next: make Folio styles package-owned

### DIFF
--- a/web-next/packages/folio/README.md
+++ b/web-next/packages/folio/README.md
@@ -17,7 +17,32 @@ Import only from the named entry point:
 
 ```tsx
 import { SessionView, type SessionViewData } from "@fairchild/folio";
+import "@fairchild/folio/styles.css";
 ```
+
+The stylesheet compiles utilities from Folio source only and scopes every
+selector to `data-folio-root`. `SessionView` supplies its own surface root;
+`FolioRoot` is available when composing lower-level exports. Multiple instances
+can coexist with host UI without resets or token values escaping the root.
+
+Hosts own font loading and may override the narrow `--folio-*` token seam on an
+ancestor or one instance. For example:
+
+```css
+:root {
+  --folio-font-serif: var(--my-prose-font), Georgia, serif;
+  --folio-accent: #8f4f2a;
+  --folio-dark-accent: #dfa36c;
+}
+```
+
+Full session surfaces default to `--folio-min-height: 100dvh`; embedded hosts
+can set that token to `100%`, a pane height, or `auto` without changing package
+CSS.
+
+Folio currently has no external image or font asset paths: its small interface
+marks are text/inline CSS. The exported sheet therefore contains the complete
+visual dependency graph.
 
 Hosts integrate through `FolioConversationPort`, not through component-specific
 knowledge of their routes or runtimes. The port exposes a durable snapshot,

--- a/web-next/packages/folio/package.json
+++ b/web-next/packages/folio/package.json
@@ -26,6 +26,7 @@
 			"import": "./src/theme-entry.ts",
 			"default": "./src/theme-entry.ts"
 		},
+		"./styles.css": "./src/styles.css",
 		"./testing": {
 			"types": "./src/testing-entry.ts",
 			"import": "./src/testing-entry.ts",
@@ -37,7 +38,9 @@
 		"!src/**/*.test.ts",
 		"!src/**/*.test.tsx"
 	],
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/styles.css"
+	],
 	"folioCompatibility": {
 		"next": ">=15.5.0 <16"
 	},

--- a/web-next/packages/folio/src/conversation-port-component.test.tsx
+++ b/web-next/packages/folio/src/conversation-port-component.test.tsx
@@ -57,5 +57,6 @@ describe("Folio port component integration", () => {
 
 		expect(html).toContain("Port-driven session");
 		expect(html).toContain("Hello from the host port");
+		expect(html).toMatch(/^<div data-folio-root="surface">/);
 	});
 });

--- a/web-next/packages/folio/src/folio-root.tsx
+++ b/web-next/packages/folio/src/folio-root.tsx
@@ -1,0 +1,14 @@
+/* Instance boundary for Folio's scoped visual contract and host token overrides. */
+import type { HTMLAttributes, ReactNode } from "react";
+
+export interface FolioRootProps extends HTMLAttributes<HTMLDivElement> {
+	children: ReactNode;
+}
+
+export function FolioRoot({ children, ...props }: FolioRootProps) {
+	return (
+		<div {...props} data-folio-root="surface">
+			{children}
+		</div>
+	);
+}

--- a/web-next/packages/folio/src/index.ts
+++ b/web-next/packages/folio/src/index.ts
@@ -11,6 +11,7 @@ export {
 	type SessionViewData,
 	type SessionViewProps,
 } from "./session-view";
+export { FolioRoot, type FolioRootProps } from "./folio-root";
 export type { MastheadData } from "./session-masthead";
 export {
 	FolioConversationController,

--- a/web-next/packages/folio/src/session-view.tsx
+++ b/web-next/packages/folio/src/session-view.tsx
@@ -5,6 +5,7 @@
  */
 import { ActivityLine, type ActivityLineProps } from "./activity-line";
 import { ComposeField } from "./compose-field";
+import { FolioRoot } from "./folio-root";
 import { Message, MessageArticle } from "./message";
 import { SessionMasthead, type MastheadData } from "./session-masthead";
 import { StatusLine, type StatusLineData } from "./status-line";
@@ -161,7 +162,7 @@ export function SessionView({
 		!!session.masthead.pullRequestAction ||
 		!!session.masthead.pullRequestError;
 	return (
-		<>
+		<FolioRoot>
 			<SessionMasthead
 				session={session.masthead}
 				onTitleChange={actions?.changeTitle}
@@ -261,6 +262,6 @@ export function SessionView({
 				/>
 				<StatusLine status={session.statusLine} onModelChange={actions?.changeModel} />
 			</footer>
-		</>
+		</FolioRoot>
 	);
 }

--- a/web-next/packages/folio/src/styles-boundary.test.ts
+++ b/web-next/packages/folio/src/styles-boundary.test.ts
@@ -1,0 +1,48 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, test } from "vitest";
+
+const packageRoot = new URL("../", import.meta.url);
+
+describe("Folio style boundary", () => {
+	test("exports its stylesheet as an intentional package side effect", async () => {
+		const manifest = JSON.parse(
+			await readFile(new URL("package.json", packageRoot), "utf8"),
+		) as {
+			exports: Record<string, unknown>;
+			sideEffects: string[];
+		};
+
+		expect(manifest.exports["./styles.css"]).toBe("./src/styles.css");
+		expect(manifest.sideEffects).toContain("./src/styles.css");
+	});
+
+	test("scans package source and scopes visual selectors to Folio roots", async () => {
+		const styles = await readFile(new URL("src/styles.css", packageRoot), "utf8");
+		const beforeScope = styles.slice(0, styles.indexOf("@scope"));
+
+		expect(styles).toContain('@source "./**/*.{ts,tsx}"');
+		expect(styles).toContain("@scope ([data-folio-root])");
+		expect(styles).toContain("@layer folio-base");
+		expect(styles).toContain("--folio-accent");
+		expect(styles).not.toContain("url(");
+		expect(styles).not.toMatch(/@source\s+["']\.\.\//);
+		expect(beforeScope).not.toMatch(/(^|\n)\s*(html|body|:root|\*)\s*[{,]/);
+		expect(
+			styles
+				.match(/@keyframes\s+([\w-]+)/g)
+				?.every((rule) => rule.startsWith("@keyframes folio-")),
+		).toBe(true);
+	});
+
+	test("keeps package-only selectors out of the Workspaces host sheet", async () => {
+		const hostStyles = await readFile(
+			new URL("../../../src/app/globals.css", import.meta.url),
+			"utf8",
+		);
+
+		expect(hostStyles).toContain('@import "tailwindcss" source(none)');
+		expect(hostStyles).toContain('@source "../**/*.{ts,tsx}"');
+		expect(hostStyles).not.toContain(".reasoning-content");
+		expect(hostStyles).not.toContain(".ellipsis-dots");
+	});
+});

--- a/web-next/packages/folio/src/styles.css
+++ b/web-next/packages/folio/src/styles.css
@@ -1,0 +1,338 @@
+/*
+ * Folio's complete visual contract. Utilities, tokens, motion, and component
+ * selectors are generated only for package source and scoped to a Folio root;
+ * hosts keep their own resets, fonts, navigation chrome, and page background.
+ */
+@import "tailwindcss/theme" theme(reference);
+
+@source "./**/*.{ts,tsx}";
+@source not "./**/*.test.{ts,tsx}";
+
+@custom-variant dark (:scope&:where([data-folio-root][data-theme="dark"]), &:where([data-folio-root][data-theme="dark"] *), :scope&:where([data-theme="dark"] [data-folio-root]:not([data-theme])):not(:where([data-folio-root][data-theme="light"])), &:where([data-theme="dark"] [data-folio-root]:not([data-theme]) *):not(:where([data-folio-root][data-theme="light"], [data-folio-root][data-theme="light"] *)));
+
+@theme inline {
+	/* Tailwind primitives used by package components. Inline values keep the
+	   exported sheet independent from a host Tailwind theme. */
+	--spacing: 0.25rem;
+	--breakpoint-sm: 40rem;
+	--breakpoint-md: 48rem;
+	--radius-md: 0.375rem;
+	--radius-lg: 0.5rem;
+	--font-weight-normal: 400;
+	--font-weight-medium: 500;
+	--leading-relaxed: 1.625;
+	--default-transition-duration: 150ms;
+	--default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+
+	--font-serif: var(--folio-resolved-font-serif);
+	--font-mono: var(--folio-resolved-font-mono);
+
+	--color-paper: var(--paper);
+	--color-raised: var(--raised);
+	--color-ink: var(--ink);
+	--color-muted: var(--muted);
+	--color-faint: var(--faint);
+	--color-hint: var(--hint);
+	--color-line: var(--line);
+	--color-line-strong: var(--line-strong);
+	--color-accent: var(--accent);
+	--color-live: var(--live);
+	--color-live-halo: var(--live-halo);
+	--color-add-bg: var(--add-bg);
+	--color-add-ink: var(--add-ink);
+	--color-del-bg: var(--del-bg);
+	--color-del-ink: var(--del-ink);
+	--color-del-strike: var(--del-strike);
+	--color-code-bg: var(--code-bg);
+	--color-sel: var(--sel);
+	--color-user-ink: var(--user-ink);
+	--color-item-ink: var(--item-ink);
+	--color-mast-bg: var(--mast-bg);
+	--color-paper-0: var(--paper-0);
+	--color-hover-bg: var(--hover-bg);
+	--color-selected-bg: var(--selected-bg);
+	--color-scrim: var(--scrim);
+	--color-status-bg: var(--status-bg);
+	--color-focus-line: var(--focus-line);
+	--color-focus-ring: var(--focus-ring);
+	--color-send-ink: var(--send-ink);
+
+	--shadow-card: var(--card-shadow);
+	--shadow-palette: var(--palette-shadow);
+	--shadow-field: var(--field-shadow);
+
+	--text-body: 17.5px;
+	--text-body--line-height: 1.72;
+	--text-compose: 17px;
+	--text-title: 13.5px;
+	--text-tool: 13px;
+	--text-code: 12.5px;
+	--text-code--line-height: 1.75;
+	--text-caption: 12px;
+	--text-masthead: 11.5px;
+	--text-stat: 11px;
+	--text-label: 10.5px;
+
+	--animate-rise: folio-rise 0.55s ease both;
+	--animate-rise-fast: folio-rise 0.3s ease both;
+	--animate-settle: folio-settle 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) both 0.35s;
+	--animate-breathe: folio-breathe 2.2s ease-in-out infinite;
+	--animate-breathe-fast: folio-breathe 1.4s ease-in-out infinite;
+}
+
+/* Public override seam: hosts may set --folio-* variables on an ancestor or
+   one instance. Internal short names never escape the package root. */
+[data-folio-root] {
+	--folio-resolved-font-serif: var(
+		--folio-font-serif,
+		"Iowan Old Style",
+		Georgia,
+		serif
+	);
+	--folio-resolved-font-mono: var(
+		--folio-font-mono,
+		ui-monospace,
+		"SF Mono",
+		monospace
+	);
+	--paper: var(--folio-paper, #f7f4ed);
+	--raised: var(--folio-raised, #fdfbf6);
+	--ink: var(--folio-ink, #26221a);
+	--muted: var(--folio-muted, #6e6757);
+	--faint: var(--folio-faint, #908a7b);
+	--hint: var(--folio-hint, #6d685c);
+	--line: var(--folio-line, #e7e1d2);
+	--line-strong: var(--folio-line-strong, #dcd3bf);
+	--accent: var(--folio-accent, #a15c31);
+	--live: var(--folio-live, #6e9c72);
+	--live-halo: var(--folio-live-halo, rgba(110, 156, 114, 0.14));
+	--add-bg: var(--folio-add-bg, #ecf2e6);
+	--add-ink: var(--folio-add-ink, #3e6b36);
+	--del-bg: var(--folio-del-bg, #f6ebe5);
+	--del-ink: var(--folio-del-ink, #9a4b33);
+	--del-strike: var(--folio-del-strike, rgba(154, 75, 51, 0.35));
+	--code-bg: var(--folio-code-bg, rgba(38, 34, 26, 0.05));
+	--sel: var(--folio-selection, #ebdfc8);
+	--user-ink: var(--folio-user-ink, #3b362b);
+	--item-ink: var(--folio-item-ink, #4a4436);
+	--mast-bg: var(--folio-mast-bg, rgba(247, 244, 237, 0.88));
+	--paper-0: var(--folio-paper-transparent, rgba(247, 244, 237, 0));
+	--hover-bg: var(--folio-hover-bg, #f3eddf);
+	--selected-bg: var(--folio-selected-bg, #f1eada);
+	--scrim: var(--folio-scrim, rgba(56, 49, 36, 0.14));
+	--status-bg: var(--folio-status-bg, #f1ede0);
+	--card-shadow: var(
+		--folio-card-shadow,
+		0 1px 2px rgba(60, 50, 30, 0.05), 0 12px 32px -24px rgba(60, 50, 30, 0.25)
+	);
+	--palette-shadow: var(
+		--folio-palette-shadow,
+		0 40px 90px -24px rgba(48, 40, 24, 0.4), 0 2px 6px rgba(48, 40, 24, 0.08)
+	);
+	--field-shadow: var(
+		--folio-field-shadow,
+		0 1px 2px rgba(60, 50, 30, 0.05), 0 14px 34px -26px rgba(60, 50, 30, 0.35)
+	);
+	--focus-line: var(--folio-focus-line, #c08b60);
+	--focus-ring: var(--folio-focus-ring, rgba(161, 92, 49, 0.09));
+	--send-ink: var(--folio-send-ink, #f7f4ed);
+}
+
+[data-folio-root][data-theme="dark"],
+:where([data-theme="dark"])
+	[data-folio-root]:not([data-theme]):not(
+		:where([data-folio-root][data-theme="light"] [data-folio-root])
+	) {
+	--paper: var(--folio-dark-paper, #161410);
+	--raised: var(--folio-dark-raised, #211e18);
+	--ink: var(--folio-dark-ink, #eae4d6);
+	--muted: var(--folio-dark-muted, #a79e8c);
+	--faint: var(--folio-dark-faint, #837a69);
+	--hint: var(--folio-dark-hint, #8f8778);
+	--line: var(--folio-dark-line, rgba(234, 222, 196, 0.1));
+	--line-strong: var(--folio-dark-line-strong, rgba(234, 222, 196, 0.2));
+	--accent: var(--folio-dark-accent, #d89a62);
+	--live: var(--folio-dark-live, #93bd82);
+	--live-halo: var(--folio-dark-live-halo, rgba(147, 189, 130, 0.12));
+	--add-bg: var(--folio-dark-add-bg, rgba(147, 189, 130, 0.11));
+	--add-ink: var(--folio-dark-add-ink, #a9c896);
+	--del-bg: var(--folio-dark-del-bg, rgba(207, 133, 112, 0.11));
+	--del-ink: var(--folio-dark-del-ink, #ce9480);
+	--del-strike: var(--folio-dark-del-strike, rgba(206, 148, 128, 0.4));
+	--code-bg: var(--folio-dark-code-bg, rgba(234, 222, 196, 0.08));
+	--sel: var(--folio-dark-selection, rgba(216, 154, 98, 0.3));
+	--user-ink: var(--folio-dark-user-ink, #d8d0be);
+	--item-ink: var(--folio-dark-item-ink, #cfc7b5);
+	--mast-bg: var(--folio-dark-mast-bg, rgba(22, 20, 16, 0.86));
+	--paper-0: var(--folio-dark-paper-transparent, rgba(22, 20, 16, 0));
+	--hover-bg: var(--folio-dark-hover-bg, rgba(234, 222, 196, 0.05));
+	--selected-bg: var(--folio-dark-selected-bg, rgba(234, 222, 196, 0.08));
+	--scrim: var(--folio-dark-scrim, rgba(0, 0, 0, 0.5));
+	--status-bg: var(--folio-dark-status-bg, #1b1913);
+	--card-shadow: var(
+		--folio-dark-card-shadow,
+		0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 40px -26px rgba(0, 0, 0, 0.7)
+	);
+	--palette-shadow: var(
+		--folio-dark-palette-shadow,
+		0 40px 90px -24px rgba(0, 0, 0, 0.75), 0 2px 6px rgba(0, 0, 0, 0.3)
+	);
+	--field-shadow: var(
+		--folio-dark-field-shadow,
+		0 1px 2px rgba(0, 0, 0, 0.25), 0 16px 38px -26px rgba(0, 0, 0, 0.7)
+	);
+	--focus-line: var(--folio-dark-focus-line, rgba(216, 154, 98, 0.55));
+	--focus-ring: var(--folio-dark-focus-ring, rgba(216, 154, 98, 0.1));
+	--send-ink: var(--folio-dark-send-ink, #1c160c);
+}
+
+[data-folio-root="inline"] {
+	display: contents;
+}
+
+@layer folio-base {
+	@scope ([data-folio-root]) {
+		:scope[data-folio-root="surface"] {
+			min-height: var(--folio-min-height, 100dvh);
+			background: var(--paper);
+			color: var(--ink);
+			font-family: var(--folio-resolved-font-serif);
+			font-size: 17.5px;
+			line-height: 1.72;
+			font-optical-sizing: auto;
+			-webkit-font-smoothing: antialiased;
+			text-rendering: optimizeLegibility;
+			transition:
+				background-color 0.25s ease,
+				color 0.25s ease;
+		}
+
+		:scope[data-folio-root="surface"][data-theme="dark"],
+		:where([data-theme="dark"])
+			:scope[data-folio-root="surface"]:not([data-theme]):not(
+				:where([data-folio-root][data-theme="light"] [data-folio-root])
+			) {
+			background:
+				radial-gradient(
+					1100px 560px at 76% -6%,
+					rgba(216, 154, 98, 0.05),
+					transparent 62%
+				),
+				var(--paper);
+		}
+
+		::selection {
+			background: var(--sel);
+		}
+
+		button {
+			cursor: pointer;
+		}
+
+		code {
+			border-radius: 4px;
+			background: var(--code-bg);
+			padding: 1px 5px 2px;
+			font-family: var(--folio-resolved-font-mono);
+			font-size: 0.82em;
+		}
+	}
+}
+
+@scope ([data-folio-root]) {
+	@tailwind utilities source(none);
+
+	.reasoning-content[data-state="open"] {
+		animation: folio-reasoning-expand 240ms cubic-bezier(0.2, 0.7, 0.2, 1);
+	}
+
+	.reasoning-content[data-state="closed"] {
+		animation: folio-reasoning-collapse 320ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	.ellipsis-dots::after {
+		content: "…";
+		animation: folio-ellipsis 1.8s steps(4) infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:scope,
+		*,
+		*::before,
+		*::after {
+			animation: none !important;
+			transition: none !important;
+		}
+	}
+}
+
+@keyframes folio-rise {
+	from {
+		opacity: 0;
+		transform: translateY(10px);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+@keyframes folio-settle {
+	from {
+		opacity: 0;
+		transform: translateY(14px) scale(0.99);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+@keyframes folio-breathe {
+	0%,
+	100% {
+		opacity: 0.35;
+		transform: scale(0.85);
+	}
+	50% {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+@keyframes folio-reasoning-expand {
+	from {
+		height: 0;
+		opacity: 0;
+	}
+	to {
+		height: var(--radix-collapsible-content-height);
+		opacity: 1;
+	}
+}
+
+@keyframes folio-reasoning-collapse {
+	from {
+		height: var(--radix-collapsible-content-height);
+		opacity: 1;
+	}
+	to {
+		height: 0;
+		opacity: 0;
+	}
+}
+
+@keyframes folio-ellipsis {
+	0% {
+		content: "";
+	}
+	25% {
+		content: ".";
+	}
+	50% {
+		content: "..";
+	}
+	75% {
+		content: "…";
+	}
+}

--- a/web-next/packages/folio/src/theme-toggle.tsx
+++ b/web-next/packages/folio/src/theme-toggle.tsx
@@ -9,14 +9,16 @@ import { useThemeToggle } from "./use-theme";
 export function ThemeToggle() {
 	const toggleTheme = useThemeToggle();
 	return (
-		<button
-			type="button"
-			onClick={toggleTheme}
-			title="Toggle light / dark"
-			aria-label="Toggle light / dark theme"
-			className="relative ml-4 rounded-md px-1.5 py-1 text-[13px] leading-none text-faint [transition:color_.2s_ease,transform_.35s_ease] after:absolute after:top-1/2 after:left-1/2 after:h-11 after:w-11 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] hover:text-accent dark:rotate-180"
-		>
-			◐
-		</button>
+		<span data-folio-root="inline">
+			<button
+				type="button"
+				onClick={toggleTheme}
+				title="Toggle light / dark"
+				aria-label="Toggle light / dark theme"
+				className="relative ml-4 rounded-md px-1.5 py-1 text-[13px] leading-none text-faint [transition:color_.2s_ease,transform_.35s_ease] after:absolute after:top-1/2 after:left-1/2 after:h-11 after:w-11 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] hover:text-accent dark:rotate-180"
+			>
+				◐
+			</button>
+		</span>
 	);
 }

--- a/web-next/scripts/folio-boundary.test.mjs
+++ b/web-next/scripts/folio-boundary.test.mjs
@@ -18,6 +18,7 @@ const SKIPPED_CONSUMER_DIRECTORIES = new Set([
 const PUBLIC_FOLIO_IMPORTS = new Set([
 	"@fairchild/folio",
 	"@fairchild/folio/format",
+	"@fairchild/folio/styles.css",
 	"@fairchild/folio/theme",
 	"@fairchild/folio/testing",
 ]);
@@ -100,6 +101,7 @@ describe("Folio package boundary", () => {
 				import: "./src/theme-entry.ts",
 				default: "./src/theme-entry.ts",
 			},
+			"./styles.css": "./src/styles.css",
 			"./testing": {
 				types: "./src/testing-entry.ts",
 				import: "./src/testing-entry.ts",

--- a/web-next/src/app/globals.css
+++ b/web-next/src/app/globals.css
@@ -1,17 +1,16 @@
-/*
- * Folio design tokens on Tailwind v4 — the "Refined Folio" system from
- * prototypes/web-session-redesign/refine-folio.html: paper light theme +
- * warm-charcoal dark, Newsreader serif prose, IBM Plex Mono apparatus.
- * Palettes live on :root[data-theme=...]; `@theme inline` maps them to
- * Tailwind tokens so utilities follow the active theme attribute.
- */
-@import "tailwindcss";
+/* Workspaces shell tokens and host-owned base rules. Folio's independently
+   scoped utilities, tokens, and component selectors live in its package CSS. */
+@import "tailwindcss" source(none);
+@source "../**/*.{ts,tsx}";
 
 /* Theme is a data attribute (set pre-paint by themeInitScript), not the
    OS scheme — system preference only feeds the initial resolution. */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 :root {
+	/* Host-owned font loading, passed through Folio's narrow token seam. */
+	--folio-font-serif: var(--font-newsreader, "Iowan Old Style"), Georgia, serif;
+	--folio-font-mono: var(--font-plex-mono, ui-monospace), "SF Mono", monospace;
 	--paper: #f7f4ed;
 	--raised: #fdfbf6;
 	--ink: #26221a;
@@ -242,66 +241,6 @@
 		background: var(--code-bg);
 		padding: 1px 5px 2px;
 		border-radius: 4px;
-	}
-}
-
-@layer components {
-	/* Radix exposes the exact content height, so the thinking block can fold
-	   without deleting a pageful of layout in one frame. This is the one
-	   intentional layout animation in the transcript: it prevents the browser's
-	   max-scroll clamp from producing a much larger viewport jump. */
-	.reasoning-content[data-state="open"] {
-		animation: reasoning-expand 240ms cubic-bezier(0.2, 0.7, 0.2, 1);
-	}
-	.reasoning-content[data-state="closed"] {
-		animation: reasoning-collapse 320ms cubic-bezier(0.4, 0, 0.2, 1);
-	}
-	@keyframes reasoning-expand {
-		from {
-			height: 0;
-			opacity: 0;
-		}
-		to {
-			height: var(--radix-collapsible-content-height);
-			opacity: 1;
-		}
-	}
-	@keyframes reasoning-collapse {
-		from {
-			height: var(--radix-collapsible-content-height);
-			opacity: 1;
-		}
-		to {
-			height: 0;
-			opacity: 0;
-		}
-	}
-	@media (prefers-reduced-motion: reduce) {
-		.reasoning-content[data-state="open"],
-		.reasoning-content[data-state="closed"] {
-			animation: none;
-		}
-	}
-
-	/* Animated trailing dots ('' → . → .. → …); content keyframes can't be
-	   expressed as a Tailwind utility. */
-	.ellipsis-dots::after {
-		content: "…";
-		animation: ellip 1.8s steps(4) infinite;
-	}
-	@keyframes ellip {
-		0% {
-			content: "";
-		}
-		25% {
-			content: ".";
-		}
-		50% {
-			content: "..";
-		}
-		75% {
-			content: "…";
-		}
 	}
 }
 

--- a/web-next/src/app/layout.tsx
+++ b/web-next/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Newsreader } from "next/font/google";
 import { themeInitScript } from "@fairchild/folio/theme";
+import "@fairchild/folio/styles.css";
 import "./globals.css";
 
 const newsreader = Newsreader({

--- a/web-next/tests/e2e/folio-styles.spec.ts
+++ b/web-next/tests/e2e/folio-styles.spec.ts
@@ -1,0 +1,120 @@
+/* Browser contract for Folio's package-owned, instance-scoped stylesheet. */
+import { expect, test } from "@playwright/test";
+
+test("package-only selectors apply inside a Folio root and nowhere else", async ({ page }) => {
+	await page.goto("/sessions/demo");
+	await expect(page.locator('[data-folio-root="surface"]')).toHaveCount(1);
+
+	const animations = await page.evaluate(() => {
+		const root = document.querySelector<HTMLElement>('[data-folio-root="surface"]');
+		if (!root) throw new Error("missing Folio root");
+		const inside = document.createElement("div");
+		inside.className = "reasoning-content";
+		inside.dataset.state = "open";
+		root.append(inside);
+		const outside = inside.cloneNode() as HTMLElement;
+		document.body.append(outside);
+		const result = {
+			inside: getComputedStyle(inside).animationName,
+			outside: getComputedStyle(outside).animationName,
+		};
+		inside.remove();
+		outside.remove();
+		return result;
+	});
+
+	expect(animations.inside).toBe("folio-reasoning-expand");
+	expect(animations.outside).not.toBe("folio-reasoning-expand");
+});
+
+test("host utilities can override Folio's low-priority element defaults", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+
+	const fontSize = await page.evaluate(() => {
+		const root = document.querySelector<HTMLElement>('[data-folio-root="surface"]');
+		if (!root) throw new Error("missing Folio root");
+		const code = document.createElement("code");
+		// text-3xl belongs to the Workspaces host source, not Folio's @source graph.
+		code.className = "text-3xl";
+		root.append(code);
+		const result = getComputedStyle(code).fontSize;
+		code.remove();
+		return result;
+	});
+
+	expect(fontSize).toBe("30px");
+});
+
+test("token overrides stay local to each Folio instance", async ({ page }) => {
+	await page.goto("/sessions/demo");
+
+	const probes = await page.evaluate(() => {
+		const makeProbe = (accent: string) => {
+			const root = document.createElement("div");
+			root.dataset.folioRoot = "surface";
+			root.style.setProperty("--folio-accent", accent);
+			const text = document.createElement("span");
+			text.className = "text-accent text-tool";
+			text.textContent = "probe";
+			root.append(text);
+			document.body.append(root);
+			return { root, text };
+		};
+		const first = makeProbe("rgb(1, 2, 3)");
+		const second = makeProbe("rgb(4, 5, 6)");
+		const outside = document.createElement("span");
+		outside.className = "text-tool";
+		document.body.append(outside);
+		const result = {
+			firstColor: getComputedStyle(first.text).color,
+			secondColor: getComputedStyle(second.text).color,
+			insideSize: getComputedStyle(first.text).fontSize,
+			outsideSize: getComputedStyle(outside).fontSize,
+		};
+		first.root.remove();
+		second.root.remove();
+		outside.remove();
+		return result;
+	});
+
+	expect(probes.firstColor).toBe("rgb(1, 2, 3)");
+	expect(probes.secondColor).toBe("rgb(4, 5, 6)");
+	expect(probes.insideSize).toBe("13px");
+	expect(probes.outsideSize).not.toBe("13px");
+});
+
+test("an explicit instance theme overrides its host and reaches root utilities", async ({
+	page,
+}) => {
+	await page.goto("/sessions/demo");
+
+	const themes = await page.evaluate(() => {
+		document.documentElement.dataset.theme = "dark";
+		const lightRoot = document.createElement("div");
+		lightRoot.dataset.folioRoot = "surface";
+		lightRoot.dataset.theme = "light";
+		const lightText = document.createElement("span");
+		lightText.className = "text-accent";
+		lightRoot.append(lightText);
+		document.body.append(lightRoot);
+
+		const darkRoot = document.createElement("div");
+		darkRoot.dataset.folioRoot = "surface";
+		darkRoot.dataset.theme = "dark";
+		darkRoot.className = "dark:rotate-180";
+		document.body.append(darkRoot);
+
+		const result = {
+			lightAccent: getComputedStyle(lightText).color,
+			darkRootRotation: getComputedStyle(darkRoot).rotate,
+		};
+		lightRoot.remove();
+		darkRoot.remove();
+		return result;
+	});
+
+	expect(themes.lightAccent).toBe("rgb(161, 92, 49)");
+	expect(themes.darkRootRotation).toBe("180deg");
+});


### PR DESCRIPTION
## Summary

- Export Folio's complete visual contract from `@fairchild/folio/styles.css`: package-only Tailwind generation, light/dark tokens, motion, reduced-motion behavior, and component selectors.
- Scope the sheet to explicit `data-folio-root` boundaries, add the public `FolioRoot`, and make `SessionView` plus standalone `ThemeToggle` self-scoping.
- Keep Workspaces resets, navigation chrome, body background, and `next/font` loading host-owned; the host now opts into the stylesheet and passes fonts through the narrow `--folio-*` override seam.
- Prove selector isolation and per-instance token overrides in a real browser, and verify the packed source artifact contains every referenced style with no external or repository-relative asset path.

Closes #1052

## Mergeability

- Surface: web — reusable web-next Folio package styles and the Workspaces consumer import
- User-facing behavior changed: No intentional visual or interaction change; the existing Folio light/dark, responsive, streaming, error, empty, artifact, disabled, and reduced-motion states are preserved
- Non-happy paths considered: stylesheet tree-shaking, missing host fonts, standalone theme toggle, multiple instances, per-instance token overrides, selector leakage, reduced motion, dark mode, mobile overflow, and absent external assets
- Residual risk or follow-up: `@scope` targets the modern browser baseline used by web-next; #1054 will compile the source-first package into the final versioned install artifact and re-inspect its emitted CSS

## Validation

- [ ] `swift build` — not applicable; web-only change
- [ ] `swift test` — not applicable; web-only change
- [x] `cd web-next && pnpm exec tsc --noEmit -p packages/folio/tsconfig.json` — passed
- [x] `cd web-next && pnpm typecheck` — passed
- [x] `cd web-next && pnpm lint` — passed
- [x] `cd web-next && pnpm test` — 66 files / 652 tests passed (host-authorized for the loopback harness)
- [x] `cd web-next && pnpm build` — production build passed; `/sessions/[id]` first-load JS remained 186 kB
- [x] `cd web-next && pnpm exec playwright test tests/e2e/sessions.spec.ts tests/e2e/folio-styles.spec.ts --project=chromium` — 21/21 passed
- [x] `cd web-next && pnpm evidence` — complete light/dark desktop/mobile lifecycle matrix passed
- [x] `cd web-next/packages/folio && pnpm pack --pack-destination /tmp` — stylesheet present; tests absent; no external or repository-relative asset URLs

## Performance

- [x] Performance-sensitive CSS boundary change
- [x] Before and after evidence came from production builds of `origin/main` and this branch on the same host and dependency lock
- [x] The measured delta and interpretation are called out below

Performance evidence:

- Scenario ID: production CSS artifact and `next build` route report
- Before Summary: 42,549 bytes raw / 8,924 bytes gzip CSS; `/sessions/[id]` 186 kB first-load JS
- After Summary: 51,955 bytes raw / 10,252 bytes gzip CSS; `/sessions/[id]` 186 kB first-load JS
- Delta Summary: +9,406 bytes raw / +1,328 bytes gzip CSS, the bounded cost of shipping a self-contained scoped Folio sheet; no JS delta

## Evidence

- [ ] Not a testable change (docs-only, config)
- [x] Test evidence attached
- [x] UI evidence attached from the exact commit under review

Evidence links:

- [Contract, verification, and CSS delta](https://evidence.cloudcompute.com/workspaces/pr-1058/20260712-192810-folio-styles-contract-final.svg)
- [Light session with diff, test output, and compose states](https://evidence.cloudcompute.com/workspaces/pr-1058/20260712-192810-folio-styles-light-final.png)
- [Dark session with the same completed-turn state](https://evidence.cloudcompute.com/workspaces/pr-1058/20260712-192810-folio-styles-dark-final.png)
- [375px mobile diff and sticky compose/status layout](https://evidence.cloudcompute.com/workspaces/pr-1058/20260712-192810-folio-styles-mobile-final.png)

## Review

- Personal reflection completed against issue #1052 and the web mergeability checklist.
- Targeted source-aware Fable review found four actionable issues. All four were accepted and fixed: recursive package source discovery, low-priority base element defaults, explicit light-instance precedence inside dark hosts, and `dark:` utilities matching the `@scope` root itself.
- Added real-browser regressions for selector isolation, host-overrides-base cascade order, per-instance token isolation, explicit theme precedence, and root-level dark utilities. The first root-selector regression failed before the selector correction and then passed, proving the test exercises the actual seam.

## Blockers

- [x] None
- [ ] Blocked on evidence
