### PR TITLE
web-next: consume Folio through its public conversation port

### DIFF
--- a/web-next/docs/decisions/folio-package-boundary.md
+++ b/web-next/docs/decisions/folio-package-boundary.md
@@ -47,8 +47,32 @@ acquires host authority merely because it renders the control.
   primitives are package dependencies.
 - The package is source-first and `private` in this slice. W7's artifact issue
   defines compilation, semver, checksums, and the public-registry decision.
-- Styles remain supplied by the Workspaces host only until #1052 moves tokens,
-  assets, and scoped styles behind package-owned exports.
+- Folio supplies its scoped stylesheet and tokens through the declared
+  `@fairchild/folio/styles.css` export; hosts retain the narrow documented token
+  override seam.
+
+## Workspaces strict-consumer proof
+
+Workspaces crosses the conversation boundary in one application-owned module:
+`src/lib/folio/workspaces-conversation-adapter.ts`.
+
+- The authenticated session page and API routes keep identity and authorization;
+  Folio receives only the already-authorized author's display metadata.
+- `useChat` and the append-only session event log keep streaming, persistence,
+  reload, and resume authority. The live view projects that current state into a
+  `FolioConversationSnapshot` instead of teaching Folio about AI SDK transport.
+- The adapter implements `FolioConversationPort` through the public package
+  export. Its capability checks translate sends, queue cancellation, mutable
+  session settings, approvals, turn stop, sandbox stop, and PR publication into
+  explicit Workspaces callbacks.
+- `FolioConversationController.fromSnapshot()` supports hosts that already own
+  a live projection, avoiding a second state owner or a redundant asynchronous
+  snapshot read. The controller still derives the package's action membrane.
+
+Deleting the Workspaces adapter removes this host integration without removing
+or partially disabling any Folio package module. The package compiles and tests
+under its independent TypeScript configuration, and the boundary test scans
+both production and test imports for package-private paths.
 
 ## Sequence
 

--- a/web-next/packages/folio/README.md
+++ b/web-next/packages/folio/README.md
@@ -62,7 +62,8 @@ await controller.follow(render);
 
 When an established host runtime already owns and projects the current live
 snapshot, seed the controller without a redundant async read, then recreate the
-binding when that host snapshot changes:
+binding when that host snapshot changes. `follow()` begins at the seeded cursor
+without calling `readSnapshot()` again:
 
 ```ts
 const controller = FolioConversationController.fromSnapshot(hostPort, hostSnapshot);
@@ -70,8 +71,16 @@ const controller = FolioConversationController.fromSnapshot(hostPort, hostSnapsh
 
 Only one `follow()` may own a controller at a time. Hosts reconnect by creating
 a controller from their durable snapshot cursor; unknown cursors fail closed
-instead of replaying the conversation from the beginning. Command receipts
-return the host's durable cursor rather than a separate acknowledgement ID.
+with `FolioUnknownCursorError` instead of replaying the conversation from the
+beginning. A command receipt carries the first host cursor known to contain the
+effect. Its cursor is `null` when a host accepted the command but an externally
+owned projection has not observed it yet; callers then await the next snapshot
+instead of assuming the old cursor includes new state.
+
+Send commands carry a unique `requestId` for correlation and optional `retryOf`
+UI provenance. A retry is a new send unless the host explicitly provides
+stronger semantics; hosts may use `requestId` as a deduplication key, but Folio
+does not claim that every transport does so.
 
 `SessionView` receives one `FolioConversationActions` object. Missing callbacks
 are missing capabilities; the component never discovers or constructs host

--- a/web-next/packages/folio/README.md
+++ b/web-next/packages/folio/README.md
@@ -6,8 +6,8 @@ authentication, persistence, transport, agent execution, repositories, and
 publication authority.
 
 The current package is source-first and private while the boundary is proven
-inside Workspaces. Follow-up W7 slices add host ports, package-owned styles,
-the versioned install artifact, and a real external-consumer proof.
+inside Workspaces. It owns its host ports and scoped styles; the remaining W7
+slices create a versioned install artifact and prove a real external consumer.
 
 React 19 and AI SDK 7 are peers. Next 15.5 is the tested Workspaces host and is
 recorded as advisory compatibility metadata rather than a peer because Folio
@@ -58,6 +58,14 @@ import {
 const controller = new FolioConversationController(hostPort satisfies FolioConversationPort);
 await controller.hydrate();
 await controller.follow(render);
+```
+
+When an established host runtime already owns and projects the current live
+snapshot, seed the controller without a redundant async read, then recreate the
+binding when that host snapshot changes:
+
+```ts
+const controller = FolioConversationController.fromSnapshot(hostPort, hostSnapshot);
 ```
 
 Only one `follow()` may own a controller at a time. Hosts reconnect by creating

--- a/web-next/packages/folio/src/compose-field.tsx
+++ b/web-next/packages/folio/src/compose-field.tsx
@@ -119,7 +119,7 @@ export function ComposeField({ agentName, onSend, disabled, onStop }: ComposeFie
 							type="button"
 							title="Stop the turn"
 							aria-label="Stop"
-							onClick={onStop}
+							onClick={() => onStop()}
 							className="flex h-[37px] w-[37px] shrink-0 items-center justify-center rounded-[10px] border border-line-strong text-[11px] leading-none text-muted transition-colors duration-200 hover:border-del-ink hover:text-del-ink"
 						>
 							■

--- a/web-next/packages/folio/src/conversation-controller.test.ts
+++ b/web-next/packages/folio/src/conversation-controller.test.ts
@@ -248,6 +248,27 @@ describe("FolioConversationController", () => {
 		]);
 	});
 
+	test("derives actions from a host-projected snapshot without reading it twice", () => {
+		const projected = snapshot("cursor-projected");
+		const port = new FakeConversationPort(projected);
+		const controller = FolioConversationController.fromSnapshot(port, projected);
+		const actions = createPortBackedConversationActions(
+			controller,
+			() => "request-1",
+			vi.fn(),
+		);
+
+		actions.send?.("Hello");
+
+		expect(controller.snapshot).toBe(projected);
+		expect(port.calls).toEqual([
+			{
+				command: "send",
+				payload: { text: "Hello", idempotencyKey: "request-1" },
+			},
+		]);
+	});
+
 	test("routes a command rejected after an authority change to the host error channel", async () => {
 		const port = new FakeConversationPort(snapshot(), [
 			{

--- a/web-next/packages/folio/src/conversation-controller.test.ts
+++ b/web-next/packages/folio/src/conversation-controller.test.ts
@@ -8,7 +8,10 @@ import type {
 	FolioConversationEvent,
 	FolioConversationSnapshot,
 } from "./conversation-ports";
-import { FolioCapabilityUnavailableError } from "./conversation-ports";
+import {
+	FolioCapabilityUnavailableError,
+	FolioUnknownCursorError,
+} from "./conversation-ports";
 import { FakeConversationPort } from "./fake-conversation-port";
 
 function snapshot(cursor = "cursor-0"): FolioConversationSnapshot {
@@ -167,7 +170,7 @@ describe("FolioConversationController", () => {
 	test("rejects unknown resume cursors instead of replaying duplicates", async () => {
 		const port = new FakeConversationPort(snapshot(), events);
 		const iterator = port.readEvents("unknown-cursor")[Symbol.asyncIterator]();
-		await expect(iterator.next()).rejects.toThrow("unknown conversation cursor");
+		await expect(iterator.next()).rejects.toBeInstanceOf(FolioUnknownCursorError);
 	});
 
 	test("projects a stopped turn as terminal failure state", async () => {
@@ -236,11 +239,11 @@ describe("FolioConversationController", () => {
 		expect(port.calls.filter((call) => call.command !== "readSnapshot")).toEqual([
 			{
 				command: "send",
-				payload: { text: "Hello", idempotencyKey: "request-1" },
+				payload: { text: "Hello", requestId: "request-1" },
 			},
 			{
 				command: "send",
-				payload: { text: "Again", idempotencyKey: "request-2", retryOf: "message-1" },
+				payload: { text: "Again", requestId: "request-2", retryOf: "message-1" },
 			},
 			{ command: "cancelQueuedMessage", payload: "queue-1" },
 			{ command: "updateConversation", payload: { title: "Updated" } },
@@ -264,8 +267,23 @@ describe("FolioConversationController", () => {
 		expect(port.calls).toEqual([
 			{
 				command: "send",
-				payload: { text: "Hello", idempotencyKey: "request-1" },
+				payload: { text: "Hello", requestId: "request-1" },
 			},
+		]);
+	});
+
+	test("follows from a host-projected cursor without re-reading the snapshot", async () => {
+		const projected = snapshot("cursor-projected");
+		const port = new FakeConversationPort(projected, [
+			{ cursor: "cursor-next", type: "complete" },
+		]);
+		const controller = FolioConversationController.fromSnapshot(port, projected);
+
+		const result = await controller.follow();
+
+		expect(result.cursor).toBe("cursor-next");
+		expect(port.calls).toEqual([
+			{ command: "readEvents", payload: "cursor-projected" },
 		]);
 	});
 
@@ -311,10 +329,10 @@ describe("FolioConversationController", () => {
 		);
 	});
 
-	test("fake host records idempotent send and authority requests", async () => {
+	test("fake host records correlated sends and authority requests", async () => {
 		const port = new FakeConversationPort(snapshot());
 		const controller = new FolioConversationController(port);
-		const sendReceipt = await controller.send({ text: "Hello", idempotencyKey: "request-1" });
+		const sendReceipt = await controller.send({ text: "Hello", requestId: "request-1" });
 		await controller.decideApproval("approval-1", "allow");
 		await controller.decideReview("accept", "ship it");
 		await controller.updateConversation({ title: "Updated" });

--- a/web-next/packages/folio/src/conversation-controller.ts
+++ b/web-next/packages/folio/src/conversation-controller.ts
@@ -94,6 +94,21 @@ export class FolioConversationController {
 
 	constructor(readonly port: FolioConversationPort) {}
 
+	/**
+	 * Starts from a snapshot the host already projected. This is the bridge for
+	 * hosts whose established runtime owns live state (for example an SDK hook):
+	 * they can use the same port-backed command membrane without an async blank
+	 * render while `readSnapshot()` repeats data they already have.
+	 */
+	static fromSnapshot(
+		port: FolioConversationPort,
+		snapshot: FolioConversationSnapshot,
+	): FolioConversationController {
+		const controller = new FolioConversationController(port);
+		controller.#snapshot = snapshot;
+		return controller;
+	}
+
 	get snapshot(): FolioConversationSnapshot | null {
 		return this.#snapshot;
 	}

--- a/web-next/packages/folio/src/conversation-controller.ts
+++ b/web-next/packages/folio/src/conversation-controller.ts
@@ -195,7 +195,7 @@ export class FolioFollowInProgressError extends Error {
 
 export function createPortBackedConversationActions(
 	controller: FolioConversationController,
-	idempotencyKey: () => string,
+	requestId: () => string,
 	onCommandError: (error: unknown) => void,
 ): FolioConversationActions {
 	const snapshot = controller.snapshot;
@@ -207,11 +207,11 @@ export function createPortBackedConversationActions(
 	};
 	return {
 		send: capabilities.send
-			? (text) => run(controller.send({ text, idempotencyKey: idempotencyKey() }))
+			? (text) => run(controller.send({ text, requestId: requestId() }))
 			: undefined,
 		retry: capabilities.retry
 			? (messageId, text) =>
-					run(controller.send({ text, idempotencyKey: idempotencyKey(), retryOf: messageId }))
+					run(controller.send({ text, requestId: requestId(), retryOf: messageId }))
 			: undefined,
 		cancelQueuedMessage: capabilities.cancelQueuedMessage
 			? (queueId) => run(controller.cancelQueuedMessage(queueId))

--- a/web-next/packages/folio/src/conversation-ports.ts
+++ b/web-next/packages/folio/src/conversation-ports.ts
@@ -11,6 +11,9 @@ export type FolioConversationCursor = string;
 
 export class FolioCapabilityUnavailableError extends Error {}
 
+/** The host cannot resume from a cursor it did not issue or no longer retains. */
+export class FolioUnknownCursorError extends Error {}
+
 export interface FolioConversationCapabilities {
 	send: boolean;
 	stop: boolean;
@@ -86,19 +89,26 @@ export type FolioConversationEvent =
 	| (EventEnvelope & { type: "complete" });
 
 export interface FolioCommandReceipt {
-	cursor: FolioConversationCursor;
+	/**
+	 * A host cursor known to contain the command's effect. `null` means the host
+	 * accepted the command but its externally owned projection has not observed
+	 * the effect yet; callers must await the next snapshot rather than assuming.
+	 */
+	cursor: FolioConversationCursor | null;
 }
 
 export interface FolioSendRequest {
 	text: string;
-	idempotencyKey: string;
+	/** Unique client correlation id. Hosts may additionally use it for deduplication. */
+	requestId: string;
+	/** UI provenance only; a retry remains a new send unless the host says otherwise. */
 	retryOf?: string;
 }
 
-export interface FolioConversationUpdate {
-	title?: string;
-	model?: string;
-}
+/** One atomic mutable field per command; hosts never expose partial combined updates. */
+export type FolioConversationUpdate =
+	| { title: string; model?: never }
+	| { model: string; title?: never };
 
 export interface FolioConversationPort {
 	readSnapshot(signal?: AbortSignal): Promise<FolioConversationSnapshot>;

--- a/web-next/packages/folio/src/fake-conversation-port.ts
+++ b/web-next/packages/folio/src/fake-conversation-port.ts
@@ -7,7 +7,10 @@ import type {
 	FolioConversationUpdate,
 	FolioSendRequest,
 } from "./conversation-ports";
-import { FolioCapabilityUnavailableError } from "./conversation-ports";
+import {
+	FolioCapabilityUnavailableError,
+	FolioUnknownCursorError,
+} from "./conversation-ports";
 
 export interface FakeConversationCall {
 	command: string;
@@ -49,7 +52,7 @@ export class FakeConversationPort implements FolioConversationPort {
 		this.calls.push({ command: "readEvents", payload: after });
 		const eventIndex = this.events.findIndex((event) => event.cursor === after);
 		if (eventIndex < 0 && after !== this.initialSnapshot.cursor) {
-			throw new Error(`unknown conversation cursor: ${after}`);
+			throw new FolioUnknownCursorError(`unknown conversation cursor: ${after}`);
 		}
 		const startIndex = eventIndex < 0 ? 0 : eventIndex + 1;
 		for (const event of this.events.slice(startIndex)) {
@@ -66,7 +69,10 @@ export class FakeConversationPort implements FolioConversationPort {
 	}
 
 	async send(request: FolioSendRequest): Promise<FolioCommandReceipt> {
-		this.#require(this.#capabilities.send, "send");
+		this.#require(
+			request.retryOf ? this.#capabilities.retry : this.#capabilities.send,
+			request.retryOf ? "retry" : "send",
+		);
 		this.calls.push({ command: "send", payload: request });
 		return this.#receipt();
 	}

--- a/web-next/packages/folio/src/index.ts
+++ b/web-next/packages/folio/src/index.ts
@@ -19,7 +19,10 @@ export {
 	applyConversationEvent,
 	createPortBackedConversationActions,
 } from "./conversation-controller";
-export { FolioCapabilityUnavailableError } from "./conversation-ports";
+export {
+	FolioCapabilityUnavailableError,
+	FolioUnknownCursorError,
+} from "./conversation-ports";
 export type {
 	FolioArtifact,
 	FolioCommandReceipt,

--- a/web-next/packages/folio/src/session-masthead.tsx
+++ b/web-next/packages/folio/src/session-masthead.tsx
@@ -152,7 +152,7 @@ export function SessionMasthead({
 									data-testid="sandbox-stop"
 									title="Stop the sandbox"
 									aria-label="Stop sandbox"
-									onClick={onSandboxStop}
+									onClick={() => onSandboxStop()}
 									className="ml-2 rounded-[5px] border-b border-transparent px-1 py-0.5 leading-none text-hint opacity-0 transition-opacity duration-200 group-hover/sandbox:opacity-100 hover:text-del-ink focus-visible:opacity-100"
 								>
 									stop
@@ -189,7 +189,7 @@ export function SessionMasthead({
 							<button
 								type="button"
 								data-testid="open-session-pr"
-								onClick={onPullRequestAction}
+								onClick={() => onPullRequestAction?.()}
 								disabled={!prAction.enabled || session.pullRequestBusy}
 								title={prAction.enabled ? prButtonLabel : prAction.reason}
 								className="ml-auto rounded-[5px] border-b border-transparent px-1.5 py-0.5 text-muted transition-colors hover:border-accent hover:text-accent disabled:cursor-not-allowed disabled:text-faint disabled:hover:border-transparent"

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -182,18 +182,23 @@ export function LiveSessionView({
 				setModel(previous);
 			}
 		};
-		modelPatchChain.current = modelPatchChain.current.then(() =>
-			fetch(`/api/sessions/${sessionId}`, {
-				method: "PATCH",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ model: nextModel }),
-			})
-				.then((res) => {
-					if (!res.ok) revert();
-				})
-				.catch(revert),
-		);
-		return modelPatchChain.current;
+		const request = modelPatchChain.current.then(async () => {
+			try {
+				const res = await fetch(`/api/sessions/${sessionId}`, {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ model: nextModel }),
+				});
+				if (!res.ok) throw new Error(`model update failed (${res.status})`);
+			} catch (caught) {
+				revert();
+				throw caught;
+			}
+		});
+		// Keep the sequencing chain live after a rejected command while returning
+		// the real request promise to Folio's command error channel.
+		modelPatchChain.current = request.catch(() => undefined);
+		return request;
 	};
 
 	// The persisted title, "" until either the auto-titler or an edit sets one.
@@ -211,50 +216,47 @@ export function LiveSessionView({
 				setTitle(previous);
 			}
 		};
-		titlePatchChain.current = titlePatchChain.current.then(() =>
-			fetch(`/api/sessions/${sessionId}`, {
-				method: "PATCH",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ title: nextTitle }),
-			})
-				.then(async (res) => {
-					if (!res.ok) {
-						revert();
-						return;
-					}
-					// The route cleans the title server-side (trim + whitespace
-					// collapse), which can differ from the raw optimistic text (e.g.
-					// "Fix   the  bug" → "Fix the bug") — reconcile so the display
-					// matches what's actually persisted, unless a newer edit has
-					// already superseded this one.
-					const data = (await res.json().catch(() => null)) as {
-						title?: string;
-					} | null;
-					if (
-						data?.title &&
-						data.title !== nextTitle &&
-						latestTitleRef.current === nextTitle
-					) {
-						latestTitleRef.current = data.title;
-						setTitle(data.title);
-					}
-				})
-				.catch(revert),
-		);
-		return titlePatchChain.current;
+		const request = titlePatchChain.current.then(async () => {
+			try {
+				const res = await fetch(`/api/sessions/${sessionId}`, {
+					method: "PATCH",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ title: nextTitle }),
+				});
+				if (!res.ok) throw new Error(`title update failed (${res.status})`);
+				// The route cleans the title server-side (trim + whitespace
+				// collapse), which can differ from the raw optimistic text (e.g.
+				// "Fix   the  bug" → "Fix the bug") — reconcile so the display
+				// matches what's actually persisted, unless a newer edit has
+				// already superseded this one.
+				const data = (await res.json().catch(() => null)) as {
+					title?: string;
+				} | null;
+				if (
+					data?.title &&
+					data.title !== nextTitle &&
+					latestTitleRef.current === nextTitle
+				) {
+					latestTitleRef.current = data.title;
+					setTitle(data.title);
+				}
+			} catch (caught) {
+				revert();
+				throw caught;
+			}
+		});
+		titlePatchChain.current = request.catch(() => undefined);
+		return request;
 	};
 
-	const pendingSendRequestRef = useRef<FolioSendRequest | null>(null);
 	const transport = useMemo(
 		() =>
 			new DefaultChatTransport<FolioMessage>({
 				api: `/api/sessions/${sessionId}/chat`,
 				// The server owns the transcript (the event log); a send carries the
 				// new text plus Folio's correlation and retry-provenance metadata.
-				prepareSendMessagesRequest: ({ messages }) => ({
-					body: pendingSendRequestRef.current
-						? createWorkspacesChatRequestBody(pendingSendRequestRef.current)
-						: { text: lastUserText(messages) },
+				prepareSendMessagesRequest: ({ messages, body }) => ({
+					body: body ?? { text: lastUserText(messages) },
 				}),
 				// Resume reconnects here — the durable tail route, not the send
 				// endpoint's default `${api}/${chatId}/stream`.
@@ -477,14 +479,10 @@ export function LiveSessionView({
 		// reads the session row this send was composed against.
 		await modelPatchChain.current;
 		if (busy) return queueMessage(request);
-		pendingSendRequestRef.current = request;
-		try {
-			await sendMessage({ text: request.text, metadata: { author } });
-		} finally {
-			if (pendingSendRequestRef.current === request) {
-				pendingSendRequestRef.current = null;
-			}
-		}
+		await sendMessage(
+			{ text: request.text, metadata: { author } },
+			{ body: createWorkspacesChatRequestBody(request) },
+		);
 	};
 
 	const cancelQueuedMessage = useCallback(
@@ -632,7 +630,11 @@ export function LiveSessionView({
 		// Workspaces' durable AI SDK/event-log transport owns resume. This stable
 		// fingerprint changes with every material host projection, so an old
 		// cursor fails closed instead of falsely claiming that new state is current.
-		cursor: createWorkspacesProjectionCursor(sessionId, folioProjection),
+		// It stays lazy because this SDK-owned binding never follows the Folio port;
+		// streaming renders therefore do not serialize the transcript just for UI.
+		get cursor() {
+			return createWorkspacesProjectionCursor(sessionId, folioProjection);
+		},
 		...folioProjection,
 	};
 	const folioConversation = createWorkspacesFolioConversation(folioSnapshot, {

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -49,6 +49,7 @@ import {
 	createPortBackedConversationActions,
 	type ActiveTurnData,
 	type FolioConversationSnapshot,
+	type FolioSendRequest,
 	type QueuedMessageData,
 	SessionView,
 	type SessionViewData,
@@ -56,7 +57,11 @@ import {
 import type { FolioDataParts, FolioMessage } from "@fairchild/folio";
 import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
-import { createWorkspacesFolioConversation } from "@/lib/folio/workspaces-conversation-adapter";
+import {
+	createWorkspacesChatRequestBody,
+	createWorkspacesFolioConversation,
+	createWorkspacesProjectionCursor,
+} from "@/lib/folio/workspaces-conversation-adapter";
 import {
 	applyLiveTurnErrors,
 	isVisibleMessage,
@@ -239,14 +244,17 @@ export function LiveSessionView({
 		return titlePatchChain.current;
 	};
 
+	const pendingSendRequestRef = useRef<FolioSendRequest | null>(null);
 	const transport = useMemo(
 		() =>
 			new DefaultChatTransport<FolioMessage>({
 				api: `/api/sessions/${sessionId}/chat`,
-				// The server owns the transcript (the event log); a send carries
-				// only the new user text.
+				// The server owns the transcript (the event log); a send carries the
+				// new text plus Folio's correlation and retry-provenance metadata.
 				prepareSendMessagesRequest: ({ messages }) => ({
-					body: { text: lastUserText(messages) },
+					body: pendingSendRequestRef.current
+						? createWorkspacesChatRequestBody(pendingSendRequestRef.current)
+						: { text: lastUserText(messages) },
 				}),
 				// Resume reconnects here — the durable tail route, not the send
 				// endpoint's default `${api}/${chatId}/stream`.
@@ -415,12 +423,12 @@ export function LiveSessionView({
 	};
 
 	const queueMessage = useCallback(
-		async (text: string) => {
+		async (request: FolioSendRequest) => {
 			try {
 				const res = await fetch(`/api/sessions/${sessionId}/chat`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ text, queue: true }),
+					body: JSON.stringify(createWorkspacesChatRequestBody(request, true)),
 				});
 				if (res.status !== 202) {
 					await refreshSessionFromServer();
@@ -450,7 +458,7 @@ export function LiveSessionView({
 						...current.filter((message) => message.queueId !== queueId),
 						{
 							queueId,
-							text,
+							text: request.text,
 							queuedAt: new Date().toISOString(),
 							position: data.position ?? current.length + 1,
 						},
@@ -463,13 +471,20 @@ export function LiveSessionView({
 		[sessionId, refreshSessionFromServer],
 	);
 
-	const send = async (text: string) => {
+	const send = async (request: FolioSendRequest) => {
 		setSteps([]);
 		// Await any in-flight model PATCH first, so the turn the server starts
 		// reads the session row this send was composed against.
 		await modelPatchChain.current;
-		if (busy) return queueMessage(text);
-		await sendMessage({ text, metadata: { author } });
+		if (busy) return queueMessage(request);
+		pendingSendRequestRef.current = request;
+		try {
+			await sendMessage({ text: request.text, metadata: { author } });
+		} finally {
+			if (pendingSendRequestRef.current === request) {
+				pendingSendRequestRef.current = null;
+			}
+		}
 	};
 
 	const cancelQueuedMessage = useCallback(
@@ -574,12 +589,10 @@ export function LiveSessionView({
 				deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
 		},
 	};
-	const folioSnapshot: FolioConversationSnapshot = {
-		conversationId: sessionId,
-		// Workspaces' durable AI SDK/event-log transport owns resume. This opaque
-		// projection cursor identifies the current host snapshot at the Folio seam;
-		// the adapter deliberately does not invent a second replay stream.
-		cursor: `workspaces:${sessionId}:${messages.at(-1)?.id ?? "empty"}:${status}:${queueKey}`,
+	const folioProjection: Omit<
+		FolioConversationSnapshot,
+		"conversationId" | "cursor"
+	> = {
 		view: folioView,
 		queuedMessages,
 		capabilities: {
@@ -614,8 +627,16 @@ export function LiveSessionView({
 				: null,
 		failure: error?.message ?? null,
 	};
+	const folioSnapshot: FolioConversationSnapshot = {
+		conversationId: sessionId,
+		// Workspaces' durable AI SDK/event-log transport owns resume. This stable
+		// fingerprint changes with every material host projection, so an old
+		// cursor fails closed instead of falsely claiming that new state is current.
+		cursor: createWorkspacesProjectionCursor(sessionId, folioProjection),
+		...folioProjection,
+	};
 	const folioConversation = createWorkspacesFolioConversation(folioSnapshot, {
-		sendMessage: ({ text }) => send(text),
+		sendMessage: send,
 		cancelQueuedMessage,
 		changeModel: handleModelChange,
 		changeTitle: handleTitleChange,

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -46,7 +46,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApprovalDecision } from "@/lib/agent-runtime/stream-chunk";
 import { modelLabel } from "@/lib/agent-runtime/models";
 import {
+	createPortBackedConversationActions,
 	type ActiveTurnData,
+	type FolioConversationSnapshot,
 	type QueuedMessageData,
 	SessionView,
 	type SessionViewData,
@@ -54,7 +56,7 @@ import {
 import type { FolioDataParts, FolioMessage } from "@fairchild/folio";
 import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
-import { createWorkspacesFolioActions } from "@/lib/folio/workspaces-conversation-adapter";
+import { createWorkspacesFolioConversation } from "@/lib/folio/workspaces-conversation-adapter";
 import {
 	applyLiveTurnErrors,
 	isVisibleMessage,
@@ -186,6 +188,7 @@ export function LiveSessionView({
 				})
 				.catch(revert),
 		);
+		return modelPatchChain.current;
 	};
 
 	// The persisted title, "" until either the auto-titler or an edit sets one.
@@ -233,6 +236,7 @@ export function LiveSessionView({
 				})
 				.catch(revert),
 		);
+		return titlePatchChain.current;
 	};
 
 	const transport = useMemo(
@@ -366,7 +370,7 @@ export function LiveSessionView({
 	// and two honest controls — stop the in-flight turn (the compose's send
 	// affordance while busy), stop the live VM (a quiet masthead action).
 	const { sandbox, stopSandbox } = useSandboxState(sessionId, busy);
-	const stopTurn = () => {
+	const stopTurn = async () => {
 		// On success the UI follows the stream, not this request: the server
 		// closes the turn's log, the tail surfaces the stop as this turn's
 		// failure card ("Turn stopped."), and the hook's status transition
@@ -375,24 +379,22 @@ export function LiveSessionView({
 		// another server instance) must not be a silent click (codex finding,
 		// gpt-5.5 xhigh). The benign 409 right after the turn finished on its
 		// own adds a step nothing renders: the activity line is already gone.
-		void (async () => {
-			try {
-				const res = await fetch(`/api/sessions/${sessionId}/stop`, {
-					method: "POST",
-				});
-				if (!res.ok) {
-					const data = (await res.json().catch(() => null)) as {
-						error?: string;
-					} | null;
-					setSteps((current) => [
-						...current,
-						`Stop unavailable — ${data?.error ?? `HTTP ${res.status}`}`,
-					]);
-				}
-			} catch {
-				setSteps((current) => [...current, "Stop unavailable — network error"]);
+		try {
+			const res = await fetch(`/api/sessions/${sessionId}/stop`, {
+				method: "POST",
+			});
+			if (!res.ok) {
+				const data = (await res.json().catch(() => null)) as {
+					error?: string;
+				} | null;
+				setSteps((current) => [
+					...current,
+					`Stop unavailable — ${data?.error ?? `HTTP ${res.status}`}`,
+				]);
 			}
-		})();
+		} catch {
+			setSteps((current) => [...current, "Stop unavailable — network error"]);
+		}
 	};
 
 	const answerApproval = async (
@@ -461,31 +463,29 @@ export function LiveSessionView({
 		[sessionId, refreshSessionFromServer],
 	);
 
-	const send = (text: string) => {
+	const send = async (text: string) => {
 		setSteps([]);
 		// Await any in-flight model PATCH first, so the turn the server starts
 		// reads the session row this send was composed against.
-		void modelPatchChain.current.then(() => {
-			if (busy) return queueMessage(text);
-			return sendMessage({ text, metadata: { author } });
-		});
+		await modelPatchChain.current;
+		if (busy) return queueMessage(text);
+		await sendMessage({ text, metadata: { author } });
 	};
 
 	const cancelQueuedMessage = useCallback(
-		(queueId: string) => {
+		async (queueId: string) => {
 			const previous = queuedMessagesRef.current;
 			setQueuedMessages((current) =>
 				current.filter((message) => message.queueId !== queueId),
 			);
-			void fetch(`/api/sessions/${sessionId}/queue/${queueId}`, {
-				method: "DELETE",
-			})
-				.then(async (res) => {
-					if (!res.ok) await refreshSessionFromServer();
-				})
-				.catch(() => {
-					setQueuedMessages(previous);
+			try {
+				const res = await fetch(`/api/sessions/${sessionId}/queue/${queueId}`, {
+					method: "DELETE",
 				});
+				if (!res.ok) await refreshSessionFromServer();
+			} catch {
+				setQueuedMessages(previous);
+			}
 		},
 		[sessionId, refreshSessionFromServer],
 	);
@@ -548,51 +548,100 @@ export function LiveSessionView({
 		document.title = displayTitle ? `${displayTitle} — Spaces` : "Spaces";
 	}, [displayTitle]);
 
-	const folioActions = createWorkspacesFolioActions({
-		sendMessage: send,
+	const pullRequestAction = deriveLivePullRequestAction(
+		session.masthead.pullRequestAction,
+		{ hasBranchWork, busy },
+	);
+	const folioView: SessionViewData = {
+		...session,
+		messages: visibleMessages,
+		activeTurn,
+		masthead: {
+			...session.masthead,
+			title: displayTitle,
+			stateLabel: sandboxStateLabel(sandbox),
+			live: sandbox?.state === "live",
+			pullRequest,
+			pullRequestAction,
+			pullRequestBusy,
+			pullRequestError,
+		},
+		statusLine: {
+			...session.statusLine,
+			model,
+			modelLabel: modelLabel(model),
+			contextLabel:
+				deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
+		},
+	};
+	const folioSnapshot: FolioConversationSnapshot = {
+		conversationId: sessionId,
+		// Workspaces' durable AI SDK/event-log transport owns resume. This opaque
+		// projection cursor identifies the current host snapshot at the Folio seam;
+		// the adapter deliberately does not invent a second replay stream.
+		cursor: `workspaces:${sessionId}:${messages.at(-1)?.id ?? "empty"}:${status}:${queueKey}`,
+		view: folioView,
+		queuedMessages,
+		capabilities: {
+			send: true,
+			stop: busy,
+			retry: true,
+			cancelQueuedMessage: true,
+			decideApproval: true,
+			decideReview: false,
+			updateConversation: true,
+		},
+		// Workspaces currently renders artifacts and review receipts as durable
+		// message parts. These top-level seams stay empty until the host exposes
+		// conversation-wide artifact/review authority.
+		artifacts: [],
+		review: null,
+		workspace: sandbox
+			? {
+					id: sessionId,
+					state: sandbox.state,
+					actions: sandbox.state === "live" && !busy ? ["stop"] : [],
+				}
+			: null,
+		publication:
+			pullRequestAction || pullRequest
+				? {
+						id: pullRequest ? String(pullRequest.number) : null,
+						state: pullRequest?.state ?? null,
+						url: pullRequest?.url ?? null,
+						actions: pullRequestAction?.enabled ? ["open"] : [],
+					}
+				: null,
+		failure: error?.message ?? null,
+	};
+	const folioConversation = createWorkspacesFolioConversation(folioSnapshot, {
+		sendMessage: ({ text }) => send(text),
 		cancelQueuedMessage,
 		changeModel: handleModelChange,
 		changeTitle: handleTitleChange,
 		stopTurn: busy ? stopTurn : undefined,
-		stopSandbox:
-			sandbox?.state === "live" && !busy ? () => void stopSandbox() : undefined,
-		openPullRequest,
+		stopSandbox: sandbox?.state === "live" && !busy ? stopSandbox : undefined,
+		openPullRequest: () => openPullRequest(),
 		answerApproval,
 	});
+	const folioActions = createPortBackedConversationActions(
+		folioConversation,
+		() => crypto.randomUUID(),
+		(caught) => {
+			const message = caught instanceof Error ? caught.message : "command failed";
+			setSteps((current) => [...current, `Action unavailable — ${message}`]);
+		},
+	);
 
 	return (
 		<>
 			<TerminalDrawer sessionId={sessionId} />
 			<SessionView
 				turnFollowScopeId={sessionId}
-				session={{
-					...session,
-					messages: visibleMessages,
-					activeTurn,
-					masthead: {
-						...session.masthead,
-						title: displayTitle,
-						stateLabel: sandboxStateLabel(sandbox),
-						live: sandbox?.state === "live",
-						pullRequest,
-						pullRequestAction: deriveLivePullRequestAction(
-							session.masthead.pullRequestAction,
-							{ hasBranchWork, busy },
-						),
-						pullRequestBusy,
-						pullRequestError,
-					},
-					statusLine: {
-						...session.statusLine,
-						model,
-						modelLabel: modelLabel(model),
-						contextLabel:
-							deriveContextLabel(visibleMessages) ?? session.statusLine.contextLabel,
-					},
-				}}
+				session={folioConversation.snapshot!.view}
 				actions={folioActions}
 				retryDisabled={busy}
-				queuedMessages={queuedMessages}
+				queuedMessages={folioConversation.snapshot!.queuedMessages}
 			/>
 		</>
 	);

--- a/web-next/src/app/api/sessions/[id]/chat/route.test.ts
+++ b/web-next/src/app/api/sessions/[id]/chat/route.test.ts
@@ -67,7 +67,11 @@ describe("POST /api/sessions/[id]/chat", () => {
 			queuedAt: "2026-01-01T00:00:00.000Z",
 		});
 
-		const res = await post(id, { text: "steer next" });
+		const res = await post(id, {
+			text: "steer next",
+			requestId: "request-1",
+			retryOf: "message-0",
+		});
 
 		expect(res.status).toBe(202);
 		expect(await res.json()).toEqual({
@@ -91,7 +95,12 @@ describe("POST /api/sessions/[id]/chat", () => {
 			queuedAt: "2026-01-01T00:00:00.000Z",
 		});
 
-		const res = await post(id, { text: "still next", queue: true });
+		const res = await post(id, {
+			text: "still next",
+			requestId: "request-2",
+			retryOf: "message-1",
+			queue: true,
+		});
 
 		expect(res.status).toBe(202);
 		expect(await res.json()).toMatchObject({

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
@@ -1,52 +1,124 @@
+import type { FolioConversationSnapshot } from "@fairchild/folio";
 import { describe, expect, test, vi } from "vitest";
-import { createWorkspacesFolioActions } from "./workspaces-conversation-adapter";
+import {
+	createWorkspacesConversationPort,
+	createWorkspacesFolioConversation,
+	type WorkspacesConversationHost,
+} from "./workspaces-conversation-adapter";
 
-describe("createWorkspacesFolioActions", () => {
-	test("translates Workspaces callbacks into explicit Folio capabilities", async () => {
-		const callbacks = {
-			sendMessage: vi.fn(),
-			cancelQueuedMessage: vi.fn(),
-			changeModel: vi.fn(),
-			changeTitle: vi.fn(),
-			stopTurn: vi.fn(),
-			stopSandbox: vi.fn(),
-			openPullRequest: vi.fn(),
-			answerApproval: vi.fn(async () => undefined),
-		};
-		const actions = createWorkspacesFolioActions(callbacks);
+function snapshot(): FolioConversationSnapshot {
+	return {
+		conversationId: "session-1",
+		cursor: "workspaces:7",
+		view: {
+			masthead: {
+				repo: "fairchild/workspaces",
+				branch: "main",
+				title: "Adapter proof",
+				agentName: "Claude",
+				stateLabel: "sandbox live",
+			},
+			messages: [],
+			statusLine: { model: "model-1" },
+		},
+		queuedMessages: [],
+		capabilities: {
+			send: true,
+			stop: true,
+			retry: true,
+			cancelQueuedMessage: true,
+			decideApproval: true,
+			decideReview: false,
+			updateConversation: true,
+		},
+		artifacts: [],
+		review: null,
+		workspace: { id: "session-1", state: "live", actions: ["stop"] },
+		publication: { id: null, state: null, url: null, actions: ["open"] },
+		failure: null,
+	};
+}
 
-		actions.send?.("hello");
-		actions.retry?.("message-1", "again");
-		actions.cancelQueuedMessage?.("queue-1");
-		actions.changeModel?.("model-2");
-		actions.changeTitle?.("Title");
-		actions.stopTurn?.();
-		actions.stopWorkspace?.();
-		actions.requestPublication?.();
-		await actions.decideApproval?.("approval-1", "allow");
+function host(): WorkspacesConversationHost {
+	return {
+		sendMessage: vi.fn(),
+		cancelQueuedMessage: vi.fn(),
+		changeModel: vi.fn(),
+		changeTitle: vi.fn(),
+		stopTurn: vi.fn(),
+		stopSandbox: vi.fn(),
+		openPullRequest: vi.fn(),
+		answerApproval: vi.fn(async () => undefined),
+	};
+}
 
-		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(1, "hello");
-		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(2, "again");
+describe("Workspaces Folio conversation adapter", () => {
+	test("translates every granted Folio command into host authority", async () => {
+		const callbacks = host();
+		const controller = createWorkspacesFolioConversation(snapshot(), callbacks);
+
+		await controller.send({ text: "hello", idempotencyKey: "send-1" });
+		await controller.send({
+			text: "again",
+			idempotencyKey: "send-2",
+			retryOf: "message-1",
+		});
+		await controller.cancelQueuedMessage("queue-1");
+		await controller.updateConversation({ model: "model-2", title: "Title" });
+		await controller.stop();
+		await controller.requestWorkspaceAction("stop");
+		await controller.requestPublication("open");
+		await controller.decideApproval("approval-1", "allow");
+
+		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(1, {
+			text: "hello",
+			idempotencyKey: "send-1",
+		});
+		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(2, {
+			text: "again",
+			idempotencyKey: "send-2",
+			retryOf: "message-1",
+		});
 		expect(callbacks.cancelQueuedMessage).toHaveBeenCalledWith("queue-1");
 		expect(callbacks.changeModel).toHaveBeenCalledWith("model-2");
 		expect(callbacks.changeTitle).toHaveBeenCalledWith("Title");
 		expect(callbacks.stopTurn).toHaveBeenCalledOnce();
 		expect(callbacks.stopSandbox).toHaveBeenCalledOnce();
-		expect(callbacks.openPullRequest).toHaveBeenCalledOnce();
+		expect(callbacks.openPullRequest).toHaveBeenCalledWith("open");
 		expect(callbacks.answerApproval).toHaveBeenCalledWith("approval-1", "allow");
 	});
 
-	test("does not invent unavailable optional authority", () => {
-		const actions = createWorkspacesFolioActions({
-			sendMessage: vi.fn(),
-			cancelQueuedMessage: vi.fn(),
-			changeModel: vi.fn(),
-			changeTitle: vi.fn(),
-			openPullRequest: vi.fn(),
-			answerApproval: vi.fn(async () => undefined),
-		});
+	test("fails closed when the projected snapshot withholds authority", async () => {
+		const denied = snapshot();
+		denied.capabilities = {
+			...denied.capabilities,
+			stop: false,
+			decideApproval: false,
+		};
+		denied.workspace = { ...denied.workspace!, actions: [] };
+		denied.publication = { ...denied.publication!, actions: [] };
+		const controller = createWorkspacesFolioConversation(denied, host());
 
-		expect(actions.stopTurn).toBeUndefined();
-		expect(actions.stopWorkspace).toBeUndefined();
+		await expect(controller.stop()).rejects.toThrow("stop capability");
+		await expect(controller.requestWorkspaceAction("stop")).rejects.toThrow(
+			"workspace stop capability",
+		);
+		await expect(controller.requestPublication("open")).rejects.toThrow(
+			"publication open capability",
+		);
+		await expect(controller.decideApproval("approval-1", "deny")).rejects.toThrow(
+			"approval decision capability",
+		);
+	});
+
+	test("exposes only the current host projection through the snapshot stream", async () => {
+		const projected = snapshot();
+		const port = createWorkspacesConversationPort(projected, host());
+
+		await expect(port.readSnapshot()).resolves.toBe(projected);
+		const current = port.readEvents(projected.cursor)[Symbol.asyncIterator]();
+		await expect(current.next()).resolves.toEqual({ done: true, value: undefined });
+		const unknown = port.readEvents("stale")[Symbol.asyncIterator]();
+		await expect(unknown.next()).rejects.toThrow("unknown Workspaces conversation cursor");
 	});
 });

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
@@ -1,8 +1,14 @@
-import type { FolioConversationSnapshot } from "@fairchild/folio";
+import {
+	FolioUnknownCursorError,
+	type FolioConversationSnapshot,
+	type FolioConversationUpdate,
+} from "@fairchild/folio";
 import { describe, expect, test, vi } from "vitest";
 import {
+	createWorkspacesChatRequestBody,
 	createWorkspacesConversationPort,
 	createWorkspacesFolioConversation,
+	createWorkspacesProjectionCursor,
 	type WorkspacesConversationHost,
 } from "./workspaces-conversation-adapter";
 
@@ -57,14 +63,15 @@ describe("Workspaces Folio conversation adapter", () => {
 		const callbacks = host();
 		const controller = createWorkspacesFolioConversation(snapshot(), callbacks);
 
-		await controller.send({ text: "hello", idempotencyKey: "send-1" });
-		await controller.send({
+		const sendReceipt = await controller.send({ text: "hello", requestId: "send-1" });
+		const retryReceipt = await controller.send({
 			text: "again",
-			idempotencyKey: "send-2",
+			requestId: "send-2",
 			retryOf: "message-1",
 		});
 		await controller.cancelQueuedMessage("queue-1");
-		await controller.updateConversation({ model: "model-2", title: "Title" });
+		await controller.updateConversation({ model: "model-2" });
+		await controller.updateConversation({ title: "Title" });
 		await controller.stop();
 		await controller.requestWorkspaceAction("stop");
 		await controller.requestPublication("open");
@@ -72,13 +79,15 @@ describe("Workspaces Folio conversation adapter", () => {
 
 		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(1, {
 			text: "hello",
-			idempotencyKey: "send-1",
+			requestId: "send-1",
 		});
 		expect(callbacks.sendMessage).toHaveBeenNthCalledWith(2, {
 			text: "again",
-			idempotencyKey: "send-2",
+			requestId: "send-2",
 			retryOf: "message-1",
 		});
+		expect(sendReceipt.cursor).toBeNull();
+		expect(retryReceipt.cursor).toBeNull();
 		expect(callbacks.cancelQueuedMessage).toHaveBeenCalledWith("queue-1");
 		expect(callbacks.changeModel).toHaveBeenCalledWith("model-2");
 		expect(callbacks.changeTitle).toHaveBeenCalledWith("Title");
@@ -86,6 +95,24 @@ describe("Workspaces Folio conversation adapter", () => {
 		expect(callbacks.stopSandbox).toHaveBeenCalledOnce();
 		expect(callbacks.openPullRequest).toHaveBeenCalledWith("open");
 		expect(callbacks.answerApproval).toHaveBeenCalledWith("approval-1", "allow");
+	});
+
+	test("rejects a combined mutable update instead of partially applying it", async () => {
+		const callbacks = host();
+		const controller = createWorkspacesFolioConversation(snapshot(), callbacks);
+		const invalid = {
+			model: "model-2",
+			title: "Title",
+		} as unknown as FolioConversationUpdate;
+
+		await expect(controller.updateConversation(invalid)).rejects.toThrow(
+			"exactly one field",
+		);
+		await expect(
+			controller.updateConversation({} as unknown as FolioConversationUpdate),
+		).rejects.toThrow("exactly one field");
+		expect(callbacks.changeModel).not.toHaveBeenCalled();
+		expect(callbacks.changeTitle).not.toHaveBeenCalled();
 	});
 
 	test("fails closed when the projected snapshot withholds authority", async () => {
@@ -119,6 +146,86 @@ describe("Workspaces Folio conversation adapter", () => {
 		const current = port.readEvents(projected.cursor)[Symbol.asyncIterator]();
 		await expect(current.next()).resolves.toEqual({ done: true, value: undefined });
 		const unknown = port.readEvents("stale")[Symbol.asyncIterator]();
-		await expect(unknown.next()).rejects.toThrow("unknown Workspaces conversation cursor");
+		await expect(unknown.next()).rejects.toBeInstanceOf(FolioUnknownCursorError);
+	});
+
+	test("fingerprints every material projection change, including same-message streaming", () => {
+		const initial = snapshot();
+		const { conversationId } = initial;
+		const projection: Omit<
+			FolioConversationSnapshot,
+			"conversationId" | "cursor"
+		> = {
+			view: initial.view,
+			queuedMessages: initial.queuedMessages,
+			capabilities: initial.capabilities,
+			artifacts: initial.artifacts,
+			review: initial.review,
+			workspace: initial.workspace,
+			publication: initial.publication,
+			failure: initial.failure,
+		};
+		const baseline = createWorkspacesProjectionCursor(conversationId, projection);
+		const changes: Array<Omit<FolioConversationSnapshot, "conversationId" | "cursor">> = [
+			{
+				...projection,
+				view: {
+					...projection.view,
+					messages: [
+						{ id: "message-1", role: "assistant", parts: [{ type: "text", text: "A" }] },
+					],
+				},
+			},
+			{
+				...projection,
+				view: {
+					...projection.view,
+					masthead: { ...projection.view.masthead, title: "Changed" },
+				},
+			},
+			{
+				...projection,
+				view: {
+					...projection.view,
+					statusLine: { ...projection.view.statusLine, model: "model-2" },
+				},
+			},
+			{ ...projection, workspace: { ...projection.workspace!, state: "parked" } },
+		];
+
+		const cursors = changes.map((change) =>
+			createWorkspacesProjectionCursor(conversationId, change),
+		);
+		expect(new Set([baseline, ...cursors])).toHaveLength(cursors.length + 1);
+	});
+
+	test("preserves public send correlation and retry provenance in Workspaces HTTP bodies", () => {
+		const request = { text: "Again", requestId: "request-2", retryOf: "message-1" };
+
+		expect(createWorkspacesChatRequestBody(request)).toEqual(request);
+		expect(createWorkspacesChatRequestBody(request, true)).toEqual({
+			...request,
+			queue: true,
+		});
+	});
+
+	test("does not report failure when cancellation races after host acceptance", async () => {
+		let accept!: () => void;
+		const accepted = new Promise<void>((resolve) => {
+			accept = resolve;
+		});
+		const callbacks = host();
+		callbacks.sendMessage = vi.fn(() => accepted);
+		const port = createWorkspacesConversationPort(snapshot(), callbacks);
+		const abort = new AbortController();
+
+		const command = port.send(
+			{ text: "Hello", requestId: "request-1" },
+			abort.signal,
+		);
+		abort.abort();
+		accept();
+
+		await expect(command).resolves.toEqual({ cursor: null });
 	});
 });

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.ts
@@ -7,6 +7,7 @@
 import {
 	FolioCapabilityUnavailableError,
 	FolioConversationController,
+	FolioUnknownCursorError,
 	type FolioCommandReceipt,
 	type FolioConversationPort,
 	type FolioConversationSnapshot,
@@ -34,12 +35,42 @@ function unavailable(command: string): never {
 	);
 }
 
-function commandReceipt(snapshot: FolioConversationSnapshot): FolioCommandReceipt {
-	return { cursor: snapshot.cursor };
+function acceptedButUnobservedReceipt(): FolioCommandReceipt {
+	return { cursor: null };
 }
 
 function assertNotAborted(signal?: AbortSignal): void {
 	signal?.throwIfAborted();
+}
+
+function fnv1a(value: string, seed: number): string {
+	let hash = seed >>> 0;
+	for (let index = 0; index < value.length; index += 1) {
+		hash = Math.imul(hash ^ value.charCodeAt(index), 0x01000193);
+	}
+	return (hash >>> 0).toString(36).padStart(7, "0");
+}
+
+/** Stable identity for the complete host projection, not only its last message. */
+export function createWorkspacesProjectionCursor(
+	conversationId: string,
+	projection: unknown,
+): string {
+	const serialized = JSON.stringify(projection);
+	return `workspaces:${conversationId}:${serialized.length}:${fnv1a(serialized, 0x811c9dc5)}${fnv1a(serialized, 0x9e3779b9)}`;
+}
+
+/** The exact Workspaces HTTP payload derived from a public Folio send request. */
+export function createWorkspacesChatRequestBody(
+	request: FolioSendRequest,
+	queue = false,
+): { text: string; requestId: string; retryOf?: string; queue?: true } {
+	return {
+		text: request.text,
+		requestId: request.requestId,
+		...(request.retryOf ? { retryOf: request.retryOf } : {}),
+		...(queue ? { queue: true as const } : {}),
+	};
 }
 
 /**
@@ -52,7 +83,7 @@ export function createWorkspacesConversationPort(
 	snapshot: FolioConversationSnapshot,
 	host: WorkspacesConversationHost,
 ): FolioConversationPort {
-	const receipt = () => commandReceipt(snapshot);
+	const receipt = acceptedButUnobservedReceipt;
 	return {
 		async readSnapshot(signal) {
 			assertNotAborted(signal);
@@ -61,7 +92,9 @@ export function createWorkspacesConversationPort(
 		async *readEvents(after, signal) {
 			assertNotAborted(signal);
 			if (after !== snapshot.cursor) {
-				throw new Error(`unknown Workspaces conversation cursor: ${after}`);
+				throw new FolioUnknownCursorError(
+					`unknown Workspaces conversation cursor: ${after}`,
+				);
 			}
 		},
 		async send(request, signal) {
@@ -71,14 +104,12 @@ export function createWorkspacesConversationPort(
 				: snapshot.capabilities.send;
 			if (!granted) unavailable(request.retryOf ? "retry" : "send");
 			await host.sendMessage(request);
-			assertNotAborted(signal);
 			return receipt();
 		},
 		async stop(signal) {
 			assertNotAborted(signal);
 			if (!snapshot.capabilities.stop || !host.stopTurn) unavailable("stop");
 			await host.stopTurn();
-			assertNotAborted(signal);
 			return receipt();
 		},
 		async cancelQueuedMessage(queueId, signal) {
@@ -87,14 +118,12 @@ export function createWorkspacesConversationPort(
 				unavailable("queued-message cancellation");
 			}
 			await host.cancelQueuedMessage(queueId);
-			assertNotAborted(signal);
 			return receipt();
 		},
 		async decideApproval(requestId, decision, signal) {
 			assertNotAborted(signal);
 			if (!snapshot.capabilities.decideApproval) unavailable("approval decision");
 			await host.answerApproval(requestId, decision);
-			assertNotAborted(signal);
 			return receipt();
 		},
 		async decideReview() {
@@ -105,9 +134,13 @@ export function createWorkspacesConversationPort(
 			if (!snapshot.capabilities.updateConversation) {
 				unavailable("conversation update");
 			}
-			if (update.model !== undefined) await host.changeModel(update.model);
-			if (update.title !== undefined) await host.changeTitle(update.title);
-			assertNotAborted(signal);
+			const changesModel = typeof update.model === "string";
+			const changesTitle = typeof update.title === "string";
+			if (changesModel === changesTitle) {
+				throw new TypeError("Folio conversation updates change exactly one field");
+			}
+			if (changesModel) await host.changeModel(update.model);
+			else await host.changeTitle(update.title);
 			return receipt();
 		},
 		async requestWorkspaceAction(action, signal) {
@@ -117,7 +150,6 @@ export function createWorkspacesConversationPort(
 			}
 			if (action !== "stop") unavailable(`workspace ${action}`);
 			await host.stopSandbox();
-			assertNotAborted(signal);
 			return receipt();
 		},
 		async requestPublication(action, signal) {
@@ -126,7 +158,6 @@ export function createWorkspacesConversationPort(
 				unavailable(`publication ${action}`);
 			}
 			await host.openPullRequest(action);
-			assertNotAborted(signal);
 			return receipt();
 		},
 	};

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.ts
@@ -1,34 +1,142 @@
 /*
- * Workspaces-to-Folio action adapter. It translates host vocabulary into
- * Folio's public capability object without granting the package route, Git,
- * sandbox, persistence, authentication, or publication implementations.
+ * Workspaces' host adapter for Folio's public conversation port. Workspaces
+ * keeps ownership of AI SDK streaming, authenticated routes, persistence,
+ * sandboxes, and publication; this membrane projects their current state and
+ * translates only explicitly granted Folio commands back into host callbacks.
  */
-import type { FolioConversationActions } from "@fairchild/folio";
+import {
+	FolioCapabilityUnavailableError,
+	FolioConversationController,
+	type FolioCommandReceipt,
+	type FolioConversationPort,
+	type FolioConversationSnapshot,
+	type FolioConversationUpdate,
+	type FolioSendRequest,
+} from "@fairchild/folio";
 import type { ApprovalDecision } from "@/lib/agent-runtime/stream-chunk";
 
-export interface WorkspacesConversationCallbacks {
-	sendMessage: (text: string) => void;
-	cancelQueuedMessage: (queueId: string) => void;
-	changeModel: (id: string) => void;
-	changeTitle: (title: string) => void;
-	stopTurn?: () => void;
-	stopSandbox?: () => void;
-	openPullRequest: () => void;
+type HostCommand = void | Promise<void>;
+
+export interface WorkspacesConversationHost {
+	sendMessage: (request: FolioSendRequest) => HostCommand;
+	cancelQueuedMessage: (queueId: string) => HostCommand;
+	changeModel: (id: string) => HostCommand;
+	changeTitle: (title: string) => HostCommand;
+	stopTurn?: () => HostCommand;
+	stopSandbox?: () => HostCommand;
+	openPullRequest: (action: string) => HostCommand;
 	answerApproval: (requestId: string, decision: ApprovalDecision) => Promise<void>;
 }
 
-export function createWorkspacesFolioActions(
-	callbacks: WorkspacesConversationCallbacks,
-): FolioConversationActions {
+function unavailable(command: string): never {
+	throw new FolioCapabilityUnavailableError(
+		`Workspaces does not currently grant the Folio ${command} capability`,
+	);
+}
+
+function commandReceipt(snapshot: FolioConversationSnapshot): FolioCommandReceipt {
+	return { cursor: snapshot.cursor };
+}
+
+function assertNotAborted(signal?: AbortSignal): void {
+	signal?.throwIfAborted();
+}
+
+/**
+ * Adapts the host-owned live snapshot and command implementations to Folio's
+ * public port. `readEvents` is intentionally empty: Workspaces' existing
+ * `useChat` runtime supplies newer projected snapshots on React renders, while
+ * Folio's controller remains the command/capability authority for each one.
+ */
+export function createWorkspacesConversationPort(
+	snapshot: FolioConversationSnapshot,
+	host: WorkspacesConversationHost,
+): FolioConversationPort {
+	const receipt = () => commandReceipt(snapshot);
 	return {
-		send: callbacks.sendMessage,
-		retry: (_messageId, text) => callbacks.sendMessage(text),
-		cancelQueuedMessage: callbacks.cancelQueuedMessage,
-		changeModel: callbacks.changeModel,
-		changeTitle: callbacks.changeTitle,
-		stopTurn: callbacks.stopTurn,
-		stopWorkspace: callbacks.stopSandbox,
-		requestPublication: callbacks.openPullRequest,
-		decideApproval: callbacks.answerApproval,
+		async readSnapshot(signal) {
+			assertNotAborted(signal);
+			return snapshot;
+		},
+		async *readEvents(after, signal) {
+			assertNotAborted(signal);
+			if (after !== snapshot.cursor) {
+				throw new Error(`unknown Workspaces conversation cursor: ${after}`);
+			}
+		},
+		async send(request, signal) {
+			assertNotAborted(signal);
+			const granted = request.retryOf
+				? snapshot.capabilities.retry
+				: snapshot.capabilities.send;
+			if (!granted) unavailable(request.retryOf ? "retry" : "send");
+			await host.sendMessage(request);
+			assertNotAborted(signal);
+			return receipt();
+		},
+		async stop(signal) {
+			assertNotAborted(signal);
+			if (!snapshot.capabilities.stop || !host.stopTurn) unavailable("stop");
+			await host.stopTurn();
+			assertNotAborted(signal);
+			return receipt();
+		},
+		async cancelQueuedMessage(queueId, signal) {
+			assertNotAborted(signal);
+			if (!snapshot.capabilities.cancelQueuedMessage) {
+				unavailable("queued-message cancellation");
+			}
+			await host.cancelQueuedMessage(queueId);
+			assertNotAborted(signal);
+			return receipt();
+		},
+		async decideApproval(requestId, decision, signal) {
+			assertNotAborted(signal);
+			if (!snapshot.capabilities.decideApproval) unavailable("approval decision");
+			await host.answerApproval(requestId, decision);
+			assertNotAborted(signal);
+			return receipt();
+		},
+		async decideReview() {
+			return unavailable("review decision");
+		},
+		async updateConversation(update: FolioConversationUpdate, signal) {
+			assertNotAborted(signal);
+			if (!snapshot.capabilities.updateConversation) {
+				unavailable("conversation update");
+			}
+			if (update.model !== undefined) await host.changeModel(update.model);
+			if (update.title !== undefined) await host.changeTitle(update.title);
+			assertNotAborted(signal);
+			return receipt();
+		},
+		async requestWorkspaceAction(action, signal) {
+			assertNotAborted(signal);
+			if (!snapshot.workspace?.actions.includes(action) || !host.stopSandbox) {
+				unavailable(`workspace ${action}`);
+			}
+			if (action !== "stop") unavailable(`workspace ${action}`);
+			await host.stopSandbox();
+			assertNotAborted(signal);
+			return receipt();
+		},
+		async requestPublication(action, signal) {
+			assertNotAborted(signal);
+			if (!snapshot.publication?.actions.includes(action)) {
+				unavailable(`publication ${action}`);
+			}
+			await host.openPullRequest(action);
+			assertNotAborted(signal);
+			return receipt();
+		},
 	};
+}
+
+/** A fully public-API Folio controller seeded from Workspaces' live projection. */
+export function createWorkspacesFolioConversation(
+	snapshot: FolioConversationSnapshot,
+	host: WorkspacesConversationHost,
+): FolioConversationController {
+	const port = createWorkspacesConversationPort(snapshot, host);
+	return FolioConversationController.fromSnapshot(port, snapshot);
 }


### PR DESCRIPTION
## Summary

- replace Workspaces' direct Folio callback injection with a capability-checked `FolioConversationPort`
- project the established AI SDK/session runtime into a public `FolioConversationSnapshot` without creating a second state owner
- seed the public controller from host-owned live snapshots and derive all Folio UI actions through the package API
- document the strict-consumer ownership membrane and fix zero-argument controls leaking React click events into host verbs

Closes #1053

## Validation

- `pnpm typecheck`
- `pnpm exec tsc --noEmit -p packages/folio/tsconfig.json`
- `pnpm lint`
- `pnpm test` — 66 files, 659 tests
- `pnpm build` — session route remains 188 kB first-load JS
- `pnpm test:e2e` — 57 browser tests across auth, conversation, resume, queue/cancel, approval, publication, terminal, lifecycle, and mobile flows
- Folio boundary tests cover both production and test imports
- exact-head validation: [659 tests + 57 browser flows + 50-shot matrix](https://evidence.cloudcompute.com/workspaces/pr-1059/20260712-203028-folio-port-validation-final.svg)
- representative UI: [light session](https://evidence.cloudcompute.com/workspaces/pr-1059/20260712-203028-folio-session-light-final.png) · [dark session](https://evidence.cloudcompute.com/workspaces/pr-1059/20260712-203028-folio-session-dark-final.png) · [resume complete](https://evidence.cloudcompute.com/workspaces/pr-1059/20260712-203028-folio-resume-complete-final.png) · [375px mobile](https://evidence.cloudcompute.com/workspaces/pr-1059/20260712-203028-folio-mobile-dark-final.png)

## Review

- Self-review: tightened host command settlement, unavailable publication state, abort-after-acceptance semantics, and the latent React click-event leak before review
- Fable review (Claude CLI, targeted diff-only): two passes. Incorporated full-projection cursor identity, nullable observed cursors, correlation-only send semantics, atomic one-field updates, typed unknown-cursor failures, seeded-controller tests, per-call AI SDK request bodies, lazy cursor fingerprinting, and rejecting PATCH failures. The one inspection-only concern—whether the chat route tolerates correlation fields—was confirmed from the route and pinned in direct + queued route tests.
- Final response: every actionable finding was incorporated; Fable explicitly verified the first six as resolved before the final request-handoff/PATCH findings were addressed on head `292a6e29`.

## Mergeability

- Surface: web — Workspaces-to-Folio conversation integration and public package controller
- User-facing behavior changed: No intentional visual or workflow change; strict port authority now underlies the existing Folio chat controls
- Non-happy paths considered: absent capabilities and unknown cursors fail closed; accepted-but-unobserved commands do not claim stale cursors; abort-after-acceptance cannot manufacture a retryable failure; failed PATCHes revert and reject; auth, stop, failure/retry, reload resume, rapid/queued sends, cancellation, approval, unavailable publication, and mobile flows are covered
- Residual risk or follow-up: Folio remains source-first/private until #1054 creates the versioned install artifact; #1055 proves the external consumer
