### PR TITLE
web-next: produce a versioned installable Folio artifact

### DIFF
--- a/.github/workflows/web-next-ci.yml
+++ b/.github/workflows/web-next-ci.yml
@@ -48,11 +48,14 @@ jobs:
       - name: Unit tests
         run: pnpm test
 
+      - name: Package Folio and build clean consumer
+        run: pnpm folio:package
+
       - name: Cache Next.js build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: web-next/.next/cache
-          key: nextjs-web-next-${{ runner.os }}-${{ hashFiles('web-next/pnpm-lock.yaml') }}-${{ hashFiles('web-next/src/**') }}
+          key: nextjs-web-next-${{ runner.os }}-${{ hashFiles('web-next/pnpm-lock.yaml') }}-${{ hashFiles('web-next/src/**', 'web-next/packages/folio/**') }}
           restore-keys: |
             nextjs-web-next-${{ runner.os }}-${{ hashFiles('web-next/pnpm-lock.yaml') }}-
 
@@ -94,6 +97,18 @@ jobs:
           name: web-next-evidence
           path: web-next/output/evidence/
           if-no-files-found: ignore
+
+      - name: Upload Folio install artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: folio-package
+          path: |
+            web-next/artifacts/folio/*.tgz
+            web-next/artifacts/folio/manifest.json
+            web-next/artifacts/folio/files.txt
+            web-next/artifacts/folio/clean-fixture.log
+          if-no-files-found: error
 
       - name: Upload perf results
         if: always()

--- a/.github/workflows/web-next-ci.yml
+++ b/.github/workflows/web-next-ci.yml
@@ -49,13 +49,14 @@ jobs:
         run: pnpm test
 
       - name: Package Folio and build clean consumer
+        id: folio_package
         run: pnpm folio:package
 
       - name: Cache Next.js build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: web-next/.next/cache
-          key: nextjs-web-next-${{ runner.os }}-${{ hashFiles('web-next/pnpm-lock.yaml') }}-${{ hashFiles('web-next/src/**', 'web-next/packages/folio/**') }}
+          key: nextjs-web-next-${{ runner.os }}-${{ hashFiles('web-next/pnpm-lock.yaml') }}-${{ hashFiles('web-next/src/**', 'web-next/packages/folio/src/**', 'web-next/packages/folio/package.json', 'web-next/packages/folio/tsup.*.config.ts', 'web-next/scripts/build-folio-css.mjs') }}
           restore-keys: |
             nextjs-web-next-${{ runner.os }}-${{ hashFiles('web-next/pnpm-lock.yaml') }}-
 
@@ -99,7 +100,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Folio install artifact
-        if: always()
+        if: ${{ !cancelled() && steps.folio_package.outcome != 'skipped' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: folio-package

--- a/web-next/.gitignore
+++ b/web-next/.gitignore
@@ -7,6 +7,8 @@ next-env.d.ts
 
 # Test + harness artifacts
 output/
+artifacts/
+packages/folio/dist/
 playwright-report/
 test-results/
 perf/results.json

--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -47,12 +47,12 @@ pnpm folio:package
 ```
 
 `folio:package` is the only supported pack path. It emits ESM, declarations,
-JavaScript/CSS source maps, and standalone compiled CSS; packs the staged tree
-twice and requires matching SHA-256 checksums; enforces the exact file/dependency
-and size contracts; then installs the tarball into a temporary non-workspace
-Next app and production-builds it. Evidence lands in `artifacts/folio/` and is
-uploaded by CI. Semver and the public-registry decision gate are documented in
-`packages/folio/RELEASING.md`.
+JavaScript/CSS source maps, and standalone compiled CSS; independently builds
+and packs two staging trees and requires matching SHA-256 checksums; enforces
+the exact file/dependency and size contracts; then installs the tarball into a
+temporary non-workspace Next app and production-builds it. Evidence lands in
+`artifacts/folio/` and is uploaded by CI. Semver and the public-registry
+decision gate are documented in `packages/folio/RELEASING.md`.
 
 ## Run the owner-local production server
 

--- a/web-next/CONTRIBUTING.md
+++ b/web-next/CONTRIBUTING.md
@@ -35,19 +35,24 @@ the transcript.
 
 ## Folio workspace package
 
-The conversation UI lives in `packages/folio` and the app consumes its named
-`@fairchild/folio` entry point. Package-private source paths are guarded by a
-unit test. The first W7 slice is source-first: Workspaces still supplies the
-global Folio styles while later slices add package-owned styles, host ports,
-and a compiled install artifact.
+The conversation UI lives in `packages/folio` and the app consumes only its
+named `@fairchild/folio` entries. Package-private paths are guarded across
+production and tests. The workspace stays source-first for fast co-development;
+the canonical release candidate is a compiled, versioned tarball with its own
+scoped CSS and host-neutral port.
 
 ```bash
-pnpm --filter @fairchild/folio pack --pack-destination /tmp/folio-pack --json
-pnpm exec vitest run scripts/folio-boundary.test.mjs packages/folio/src/*.test.ts
+pnpm folio:build
+pnpm folio:package
 ```
 
-The pack listing is reviewer evidence: it should contain the package README,
-manifest, and runtime/type source, but no tests or Workspaces application files.
+`folio:package` is the only supported pack path. It emits ESM, declarations,
+JavaScript/CSS source maps, and standalone compiled CSS; packs the staged tree
+twice and requires matching SHA-256 checksums; enforces the exact file/dependency
+and size contracts; then installs the tarball into a temporary non-workspace
+Next app and production-builds it. Evidence lands in `artifacts/folio/` and is
+uploaded by CI. Semver and the public-registry decision gate are documented in
+`packages/folio/RELEASING.md`.
 
 ## Run the owner-local production server
 

--- a/web-next/docs/decisions/folio-package-boundary.md
+++ b/web-next/docs/decisions/folio-package-boundary.md
@@ -41,12 +41,18 @@ acquires host authority merely because it renders the control.
 - Workspaces imports Folio through its declared `@fairchild/folio` exports,
   never package-private source paths. Pure server-safe helpers use the explicit
   `@fairchild/folio/format` entry so component modules cannot enter server graphs;
-  app shells use `@fairchild/folio/theme` so they do not load the conversation
-  graph.
+  app shells use the server-safe `@fairchild/folio/theme`; interactive surfaces
+  use `@fairchild/folio/theme-toggle` so the compiled artifact preserves the
+  React Server Component boundary without loading the conversation graph.
+- Conversation authority uses the server-safe `@fairchild/folio/conversation`
+  entry. The testing entry imports that runtime rather than bundling a second
+  copy, so exported error identities remain stable across entries.
 - React, React DOM, and AI SDK identity are peer contracts; Folio-owned Radix
   primitives are package dependencies.
-- The package is source-first and `private` in this slice. W7's artifact issue
-  defines compilation, semver, checksums, and the public-registry decision.
+- The workspace is source-first; `pnpm folio:package` produces the install
+  surface as a compiled `private` tarball with deterministic checksum/file/size
+  gates and a clean non-workspace consumer build. Public-registry publication
+  remains a separate owner decision after the external-consumer proof.
 - Folio supplies its scoped stylesheet and tokens through the declared
   `@fairchild/folio/styles.css` export; hosts retain the narrow documented token
   override seam.

--- a/web-next/eslint.config.mjs
+++ b/web-next/eslint.config.mjs
@@ -13,8 +13,10 @@ const eslintConfig = [
 	{
 		ignores: [
 			".next/**",
+			"artifacts/**",
 			"node_modules/**",
 			"output/**",
+			"packages/folio/dist/**",
 			"playwright-report/**",
 			"test-results/**",
 			"next-env.d.ts",

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -14,6 +14,8 @@
 		"typecheck": "tsc --noEmit",
 		"lint": "eslint .",
 		"clean": "node scripts/clean.mjs",
+		"folio:build": "pnpm --filter @fairchild/folio build",
+		"folio:package": "node scripts/folio-artifact.mjs",
 		"evidence": "node scripts/evidence.mjs",
 		"evidence:upload": "bash scripts/upload-evidence.sh",
 		"demo:scroll-turn": "playwright test --config=playwright.scroll-turn.config.ts",
@@ -47,7 +49,9 @@
 		"@types/react-dom": "^19",
 		"eslint": "^9.39.4",
 		"eslint-config-next": "^15.5.20",
+		"postcss": "8.5.17",
 		"tailwindcss": "^4.3.2",
+		"tsup": "8.5.1",
 		"tsx": "^4.22.5",
 		"typescript": "^5.7.2",
 		"vitest": "^4.1.9"

--- a/web-next/packages/folio/CHANGELOG.md
+++ b/web-next/packages/folio/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 - 2026-07-12
+
+- First versioned Folio conversation artifact.
+- Document-first session UI, messages, approvals, tool ledger, diffs, receipts,
+  compose, status, themes, and scoped standalone styles.
+- Host-neutral snapshot/event/command port, shared-runtime controller entry, and
+  deterministic fake.
+- Server-safe formatter and theme initialization entries; explicit client theme
+  control entry.
+
+This release candidate is installed from its checked tarball. It is not yet
+published to a public registry.

--- a/web-next/packages/folio/README.md
+++ b/web-next/packages/folio/README.md
@@ -5,13 +5,23 @@ This workspace package owns presentation and typed view data; its host owns
 authentication, persistence, transport, agent execution, repositories, and
 publication authority.
 
-The current package is source-first and private while the boundary is proven
-inside Workspaces. It owns its host ports and scoped styles; the remaining W7
-slices create a versioned install artifact and prove a real external consumer.
+The workspace package is source-first for co-development inside Workspaces. Its
+canonical `0.1.x` install surface is the compiled, private tarball produced by
+`pnpm folio:package`: ESM, declarations, source maps, and standalone scoped CSS.
+The remaining W7 slice proves that artifact in a real external consumer.
 
 React 19 and AI SDK 7 are peers. Next 15.5 is the tested Workspaces host and is
 recorded as advisory compatibility metadata rather than a peer because Folio
 itself imports no Next.js API.
+
+Install a release candidate by its checked tarball rather than copying source:
+
+```bash
+pnpm add ./fairchild-folio-0.1.0.tgz
+```
+
+The artifact stays `private: true` to close accidental registry publication;
+private packages remain installable from a local or Git-hosted tarball.
 
 Import only from the named entry point:
 
@@ -53,7 +63,7 @@ remains with the host:
 import {
   FolioConversationController,
   type FolioConversationPort,
-} from "@fairchild/folio";
+} from "@fairchild/folio/conversation";
 
 const controller = new FolioConversationController(hostPort satisfies FolioConversationPort);
 await controller.hydrate();
@@ -103,11 +113,12 @@ format entry instead of loading the React component barrel:
 import { formatTokenCount } from "@fairchild/folio/format";
 ```
 
-App shells use the narrow theme entry so a home or layout route does not pull
-in the conversation component graph:
+App layouts use the server-safe theme entry; interactive surfaces import the
+explicit client control without collapsing those RSC boundaries:
 
 ```tsx
-import { ThemeToggle, themeInitScript } from "@fairchild/folio/theme";
+import { themeInitScript } from "@fairchild/folio/theme";
+import { ThemeToggle } from "@fairchild/folio/theme-toggle";
 ```
 
 All entries expose an import condition and a default condition so the

--- a/web-next/packages/folio/RELEASING.md
+++ b/web-next/packages/folio/RELEASING.md
@@ -11,11 +11,12 @@ Run the canonical release-candidate command from `web-next/`:
 pnpm folio:package
 ```
 
-It clean-builds the compiled ESM, declarations, JavaScript/CSS source maps, and
-standalone stylesheet; packs the same staging tree twice and requires identical
-SHA-256 checksums; enforces the file and size allowlists; then copies the tarball
-into a temporary project, installs with no workspace link, and runs a
-production Next build. Review artifacts are written under `artifacts/folio/`.
+It independently clean-builds and stages the compiled ESM, declarations,
+JavaScript/CSS source maps, and standalone stylesheet twice; packs both staging
+trees and requires identical SHA-256 checksums; enforces the file and size
+allowlists; then copies the tarball into a temporary project, installs with no
+workspace link, and runs a production Next build. Review artifacts are written
+under `artifacts/folio/`.
 
 The artifact remains `private: true`. Public-registry publication is a separate
 owner decision after the first external-consumer proof (#1055). That gate must

--- a/web-next/packages/folio/RELEASING.md
+++ b/web-next/packages/folio/RELEASING.md
@@ -1,0 +1,28 @@
+# Releasing Folio
+
+Folio follows semantic versioning. Before 1.0, breaking public API or visual
+contract changes increment the minor version; backward-compatible fixes increment
+the patch version. Every version updates `CHANGELOG.md` and the package version
+in the same pull request.
+
+Run the canonical release-candidate command from `web-next/`:
+
+```bash
+pnpm folio:package
+```
+
+It clean-builds the compiled ESM, declarations, JavaScript/CSS source maps, and
+standalone stylesheet; packs the same staging tree twice and requires identical
+SHA-256 checksums; enforces the file and size allowlists; then copies the tarball
+into a temporary project, installs with no workspace link, and runs a
+production Next build. Review artifacts are written under `artifacts/folio/`.
+
+The artifact remains `private: true`. Public-registry publication is a separate
+owner decision after the first external-consumer proof (#1055). That gate must
+decide package scope/ownership, provenance signing, npm trusted publishing, and
+support expectations before removing `private` or adding a publish command.
+
+Compatibility metadata is advisory and lives in `folioCompatibility`. React,
+React DOM, and AI SDK are peer contracts; bundled code must not create duplicate
+runtime identities. Next.js 15.5 is the clean-fixture and Workspaces reference
+host for 0.1.x.

--- a/web-next/packages/folio/package.json
+++ b/web-next/packages/folio/package.json
@@ -21,10 +21,20 @@
 			"import": "./src/format.ts",
 			"default": "./src/format.ts"
 		},
+		"./conversation": {
+			"types": "./src/conversation.ts",
+			"import": "./src/conversation.ts",
+			"default": "./src/conversation.ts"
+		},
 		"./theme": {
 			"types": "./src/theme-entry.ts",
 			"import": "./src/theme-entry.ts",
 			"default": "./src/theme-entry.ts"
+		},
+		"./theme-toggle": {
+			"types": "./src/theme-toggle-entry.ts",
+			"import": "./src/theme-toggle-entry.ts",
+			"default": "./src/theme-toggle-entry.ts"
 		},
 		"./styles.css": "./src/styles.css",
 		"./testing": {
@@ -41,6 +51,9 @@
 	"sideEffects": [
 		"./src/styles.css"
 	],
+	"scripts": {
+		"build": "node ../../scripts/clean.mjs folio-build && tsup --config tsup.client.config.ts && tsup --config tsup.server.config.ts && node ../../scripts/build-folio-css.mjs"
+	},
 	"folioCompatibility": {
 		"next": ">=15.5.0 <16"
 	},
@@ -50,8 +63,8 @@
 		"react-dom": "^19.0.0"
 	},
 	"dependencies": {
-		"@radix-ui/react-collapsible": "^1.1.15",
-		"@radix-ui/react-use-controllable-state": "^1.2.3"
+		"@radix-ui/react-collapsible": "1.1.15",
+		"@radix-ui/react-use-controllable-state": "1.2.3"
 	},
 	"devDependencies": {
 		"vitest": "^4.1.9"

--- a/web-next/packages/folio/src/conversation.ts
+++ b/web-next/packages/folio/src/conversation.ts
@@ -1,0 +1,26 @@
+/** Folio's server-safe conversation port, replay controller, and command membrane. */
+export {
+	FolioConversationController,
+	FolioFollowInProgressError,
+	applyConversationEvent,
+	createPortBackedConversationActions,
+} from "./conversation-controller";
+export {
+	FolioCapabilityUnavailableError,
+	FolioUnknownCursorError,
+} from "./conversation-ports";
+export type {
+	FolioArtifact,
+	FolioCommandReceipt,
+	FolioConversationActions,
+	FolioConversationCapabilities,
+	FolioConversationCursor,
+	FolioConversationEvent,
+	FolioConversationPort,
+	FolioConversationSnapshot,
+	FolioConversationUpdate,
+	FolioPublication,
+	FolioReview,
+	FolioSendRequest,
+	FolioWorkspace,
+} from "./conversation-ports";

--- a/web-next/packages/folio/src/fake-conversation-port.ts
+++ b/web-next/packages/folio/src/fake-conversation-port.ts
@@ -10,7 +10,7 @@ import type {
 import {
 	FolioCapabilityUnavailableError,
 	FolioUnknownCursorError,
-} from "./conversation-ports";
+} from "./conversation.js";
 
 export interface FakeConversationCall {
 	command: string;

--- a/web-next/packages/folio/src/index.ts
+++ b/web-next/packages/folio/src/index.ts
@@ -13,16 +13,6 @@ export {
 } from "./session-view";
 export { FolioRoot, type FolioRootProps } from "./folio-root";
 export type { MastheadData } from "./session-masthead";
-export {
-	FolioConversationController,
-	FolioFollowInProgressError,
-	applyConversationEvent,
-	createPortBackedConversationActions,
-} from "./conversation-controller";
-export {
-	FolioCapabilityUnavailableError,
-	FolioUnknownCursorError,
-} from "./conversation-ports";
 export type {
 	FolioArtifact,
 	FolioCommandReceipt,

--- a/web-next/packages/folio/src/testing-entry.ts
+++ b/web-next/packages/folio/src/testing-entry.ts
@@ -2,5 +2,8 @@
 export {
 	FakeConversationPort,
 } from "./fake-conversation-port";
-export { FolioCapabilityUnavailableError } from "./conversation-ports";
+export {
+	FolioCapabilityUnavailableError,
+	FolioUnknownCursorError,
+} from "./conversation.js";
 export type { FakeConversationCall } from "./fake-conversation-port";

--- a/web-next/packages/folio/src/theme-entry.ts
+++ b/web-next/packages/folio/src/theme-entry.ts
@@ -1,8 +1,7 @@
 /**
- * Folio's narrow theme entry. Hosts can initialize and toggle presentation
- * without pulling the conversation/session component graph into every route.
+ * Folio's server-safe theme entry. Hosts can initialize presentation without
+ * pulling React or the conversation component graph into layouts.
  */
-export { ThemeToggle } from "./theme-toggle";
 export {
 	THEME_STORAGE_KEY,
 	resolveTheme,

--- a/web-next/packages/folio/src/theme-toggle-entry.ts
+++ b/web-next/packages/folio/src/theme-toggle-entry.ts
@@ -1,0 +1,3 @@
+/** Folio's explicit client entry for the interactive theme control. */
+export { ThemeToggle } from "./theme-toggle";
+export type { Theme } from "./theme";

--- a/web-next/packages/folio/tsup.client.config.ts
+++ b/web-next/packages/folio/tsup.client.config.ts
@@ -1,0 +1,19 @@
+/* Builds Folio's React entry points with the client boundary preserved. */
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: {
+		index: "src/index.ts",
+		"theme-toggle": "src/theme-toggle-entry.ts",
+	},
+	format: ["esm"],
+	target: "es2022",
+	platform: "browser",
+	dts: true,
+	sourcemap: true,
+	splitting: false,
+	clean: false,
+	outDir: "dist",
+	banner: { js: '"use client";' },
+	external: ["ai", "react", "react-dom"],
+});

--- a/web-next/packages/folio/tsup.server.config.ts
+++ b/web-next/packages/folio/tsup.server.config.ts
@@ -1,0 +1,26 @@
+/* Builds Folio's server-safe entries without hashed shared declaration chunks. */
+import { defineConfig, type Options } from "tsup";
+
+const shared = {
+	format: ["esm"],
+	target: "es2022",
+	platform: "neutral",
+	dts: true,
+	sourcemap: true,
+	splitting: false,
+	clean: false,
+	outDir: "dist",
+	external: ["./conversation.js", "ai", "react", "react-dom"],
+} satisfies Options;
+
+export default defineConfig(
+	Object.entries({
+		conversation: "src/conversation.ts",
+		format: "src/format.ts",
+		theme: "src/theme-entry.ts",
+		testing: "src/testing-entry.ts",
+	}).map(([name, source]) => ({
+		...shared,
+		entry: { [name]: source },
+	})),
+);

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 7.0.15(zod@4.4.3)
       better-auth:
         specifier: 1.6.20
-        version: 1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)))
+        version: 1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)))
       ghostty-web:
         specifier: ^0.4.0
         version: 0.4.0
@@ -81,9 +81,15 @@ importers:
       eslint-config-next:
         specifier: ^15.5.20
         version: 15.5.20(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      postcss:
+        specifier: 8.5.17
+        version: 8.5.17
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.17)(tsx@4.22.5)(typescript@5.9.3)
       tsx:
         specifier: ^4.22.5
         version: 4.22.5
@@ -92,15 +98,15 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))
+        version: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5))
 
   packages/folio:
     dependencies:
       '@radix-ui/react-collapsible':
-        specifier: ^1.1.15
+        specifier: 1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-controllable-state':
-        specifier: ^1.2.3
+        specifier: 1.2.3
         version: 1.2.3(@types/react@19.2.17)(react@19.2.7)
       ai:
         specifier: ^7.0.15
@@ -276,16 +282,34 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -294,16 +318,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -312,10 +354,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -324,10 +378,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -336,10 +402,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -348,10 +426,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -360,10 +450,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -372,16 +474,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -390,10 +510,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -402,11 +534,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -414,16 +558,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -996,6 +1158,131 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1368,6 +1655,9 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1537,6 +1827,16 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1564,6 +1864,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1574,8 +1878,19 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1698,6 +2013,11 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1881,6 +2201,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -2129,6 +2452,10 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-base64@3.8.0:
     resolution: {integrity: sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==}
 
@@ -2255,6 +2582,17 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2291,8 +2629,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
@@ -2421,9 +2765,16 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
@@ -2439,12 +2790,30 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.17:
+    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2476,6 +2845,10 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2487,6 +2860,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2507,6 +2884,11 @@ packages:
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rou3@0.7.12:
@@ -2589,6 +2971,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -2649,6 +3035,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2675,12 +3066,22 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
@@ -2698,17 +3099,43 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.22.5:
     resolution: {integrity: sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==}
@@ -2739,6 +3166,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3070,79 +3500,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -3590,6 +4098,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
@@ -3666,7 +4249,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.16
+      postcss: 8.5.17
       tailwindcss: 4.3.2
 
   '@tybys/wasm-util@0.10.3':
@@ -3892,6 +4475,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)
+
   '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))':
     dependencies:
       '@vitest/spy': 4.1.9
@@ -3958,6 +4549,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
 
   argparse@2.0.1: {}
 
@@ -4056,7 +4649,7 @@ snapshots:
 
   bare-events@2.9.1: {}
 
-  better-auth@1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))):
+  better-auth@1.6.20(next@15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5))):
     dependencies:
       '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -4079,7 +4672,7 @@ snapshots:
       next: 15.5.20(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5))
+      vitest: 4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -4105,6 +4698,13 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4134,6 +4734,10 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
@@ -4142,7 +4746,13 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4333,6 +4943,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4614,6 +5253,12 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.62.2
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -4870,6 +5515,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  joycon@3.1.1: {}
+
   js-base64@3.8.0: {}
 
   js-tokens@4.0.0: {}
@@ -4980,6 +5627,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5013,7 +5666,20 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.17.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.15: {}
 
@@ -5141,7 +5807,15 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pirates@4.0.7: {}
+
   pkce-challenge@5.0.1: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
 
   playwright-core@1.61.1: {}
 
@@ -5153,13 +5827,21 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.17)(tsx@4.22.5):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.17
+      tsx: 4.22.5
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.16:
+  postcss@8.5.17:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -5188,6 +5870,8 @@ snapshots:
 
   react@19.2.7: {}
 
+  readdirp@4.1.2: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -5209,6 +5893,8 @@ snapshots:
       set-function-name: 2.0.2
 
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -5245,6 +5931,37 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.4
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
 
   rou3@0.7.12: {}
 
@@ -5371,6 +6088,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.7.6: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -5451,6 +6170,16 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.7
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5482,9 +6211,19 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.2.4: {}
 
@@ -5499,9 +6238,13 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tree-kill@1.2.2: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -5511,6 +6254,34 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.17)(tsx@4.22.5)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.17)(tsx@4.22.5)
+      resolve-from: 5.0.0
+      rollup: 4.62.2
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.17
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.22.5:
     dependencies:
@@ -5556,6 +6327,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -5603,11 +6376,25 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.17
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.5
+
   vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.17
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -5616,6 +6403,33 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.5
+
+  vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.9(@types/node@22.20.0)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)):
     dependencies:

--- a/web-next/scripts/build-folio-css.mjs
+++ b/web-next/scripts/build-folio-css.mjs
@@ -1,0 +1,26 @@
+/*
+ * Compiles Folio's Tailwind source contract into a standalone distributable
+ * stylesheet. Consumers receive plain scoped CSS and need no Tailwind tooling.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/postcss";
+import postcss from "postcss";
+
+const WEB_NEXT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const source = path.join(WEB_NEXT, "packages", "folio", "src", "styles.css");
+const output = path.join(WEB_NEXT, "packages", "folio", "dist", "styles.css");
+
+await mkdir(path.dirname(output), { recursive: true });
+const result = await postcss([tailwindcss({ optimize: true })]).process(
+	await readFile(source, "utf8"),
+	{
+		from: source,
+		to: output,
+		map: { inline: false, annotation: true, sourcesContent: true },
+	},
+);
+await writeFile(output, result.css);
+if (result.map) await writeFile(`${output}.map`, result.map.toString());
+console.log(`built ${path.relative(WEB_NEXT, output)} (${Buffer.byteLength(result.css)} bytes)`);

--- a/web-next/scripts/clean-core.mjs
+++ b/web-next/scripts/clean-core.mjs
@@ -16,6 +16,7 @@ export const TARGETS = {
 		".data/sessions-spec.lock",
 	],
 	artifacts: [
+		"artifacts/folio",
 		"output",
 		"playwright-report",
 		"test-results",
@@ -24,6 +25,8 @@ export const TARGETS = {
 		"perf/results-deployed.json",
 		"perf/results-deployed.md",
 	],
+	"folio-build": ["packages/folio/dist"],
+	"folio-artifact": ["artifacts/folio"],
 	deps: ["node_modules"],
 };
 
@@ -31,7 +34,7 @@ export const TARGETS = {
 export const DEFAULT_TARGETS = ["build", "data", "artifacts"];
 
 export const USAGE =
-	"usage: pnpm run clean [build|data|e2e-data|artifacts|deps|all]... [--dry-run]";
+	"usage: pnpm run clean [build|data|e2e-data|artifacts|folio-build|folio-artifact|deps|all]... [--dry-run]";
 
 /**
  * Expands target names into a deduplicated list of web-next-relative paths.

--- a/web-next/scripts/clean-core.test.mjs
+++ b/web-next/scripts/clean-core.test.mjs
@@ -32,6 +32,13 @@ describe("expandTargets", () => {
 		]);
 	});
 
+	test("Folio generated package state has explicit cleanup targets", () => {
+		expect(expandTargets(["folio-build", "folio-artifact"])).toEqual([
+			"packages/folio/dist",
+			"artifacts/folio",
+		]);
+	});
+
 	test("unknown targets are rejected with the valid vocabulary", () => {
 		expect(() => expandTargets(["buld"])).toThrow(/unknown target.*buld.*valid/);
 		expect(() => expandTargets(["hasOwnProperty"])).toThrow(/unknown target/);

--- a/web-next/scripts/folio-artifact-core.mjs
+++ b/web-next/scripts/folio-artifact-core.mjs
@@ -137,6 +137,9 @@ export function validateBuildOutput({
 		if (!/^\s*["']use client["'];/.test(source)) {
 			errors.push(`${name} lost its use client boundary`);
 		}
+		if (/Folio(?:UnknownCursor|CapabilityUnavailable)Error/.test(source)) {
+			errors.push(`${name} bundles conversation runtime identities`);
+		}
 	}
 	for (const [name, sourceMap] of Object.entries(sourceMaps)) {
 		const sources = Array.isArray(sourceMap.sources) ? sourceMap.sources : [];

--- a/web-next/scripts/folio-artifact-core.mjs
+++ b/web-next/scripts/folio-artifact-core.mjs
@@ -1,0 +1,190 @@
+/* Pure manifest, file-list, and size contracts for Folio's install artifact. */
+
+export const MAX_PACKED_BYTES = 120_000;
+
+export const DIST_FILES = [
+	"conversation.d.ts",
+	"conversation.js",
+	"conversation.js.map",
+	"format.d.ts",
+	"format.js",
+	"format.js.map",
+	"index.d.ts",
+	"index.js",
+	"index.js.map",
+	"styles.css",
+	"styles.css.map",
+	"testing.d.ts",
+	"testing.js",
+	"testing.js.map",
+	"theme-toggle.d.ts",
+	"theme-toggle.js",
+	"theme-toggle.js.map",
+	"theme.d.ts",
+	"theme.js",
+	"theme.js.map",
+];
+
+export const PACKED_FILES = [
+	"package/CHANGELOG.md",
+	"package/LICENSE",
+	"package/README.md",
+	...DIST_FILES.map((file) => `package/dist/${file}`),
+	"package/package.json",
+].sort();
+
+export const ARTIFACT_EXPORTS = {
+	".": {
+		types: "./dist/index.d.ts",
+		import: "./dist/index.js",
+		default: "./dist/index.js",
+	},
+	"./format": {
+		types: "./dist/format.d.ts",
+		import: "./dist/format.js",
+		default: "./dist/format.js",
+	},
+	"./conversation": {
+		types: "./dist/conversation.d.ts",
+		import: "./dist/conversation.js",
+		default: "./dist/conversation.js",
+	},
+	"./theme": {
+		types: "./dist/theme.d.ts",
+		import: "./dist/theme.js",
+		default: "./dist/theme.js",
+	},
+	"./theme-toggle": {
+		types: "./dist/theme-toggle.d.ts",
+		import: "./dist/theme-toggle.js",
+		default: "./dist/theme-toggle.js",
+	},
+	"./styles.css": "./dist/styles.css",
+	"./testing": {
+		types: "./dist/testing.d.ts",
+		import: "./dist/testing.js",
+		default: "./dist/testing.js",
+	},
+};
+
+export function createArtifactManifest(source) {
+	return {
+		name: source.name,
+		version: source.version,
+		private: true,
+		type: "module",
+		description: source.description,
+		types: "./dist/index.d.ts",
+		module: "./dist/index.js",
+		license: source.license,
+		repository: source.repository,
+		exports: ARTIFACT_EXPORTS,
+		files: ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
+		sideEffects: ["./dist/styles.css"],
+		folioCompatibility: source.folioCompatibility,
+		peerDependencies: source.peerDependencies,
+		dependencies: source.dependencies,
+	};
+}
+
+export function tarballFilename(name, version) {
+	return `${name.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`;
+}
+
+function packageName(specifier) {
+	if (specifier.startsWith("@")) return specifier.split("/").slice(0, 2).join("/");
+	return specifier.split("/")[0];
+}
+
+export function runtimeImports(javascript) {
+	const specifiers = [
+		...javascript.matchAll(/(?:from\s+|import\s*(?:\(\s*)?)(["'])([^"']+)\1/g),
+	].map((match) => match[2]);
+	return [...new Set(specifiers.filter((value) => !value.startsWith(".")).map(packageName))];
+}
+
+export function validateBuildOutput({
+	manifest,
+	javascript,
+	clientJavascript = {},
+	sourceMaps,
+	css,
+}) {
+	const errors = [];
+	const declared = new Set([
+		...Object.keys(manifest.dependencies ?? {}),
+		...Object.keys(manifest.peerDependencies ?? {}),
+	]);
+	const imports = javascript.flatMap(runtimeImports);
+	const undeclared = [...new Set(imports.filter((name) => !declared.has(name)))].sort();
+	if (undeclared.length > 0) {
+		errors.push(`undeclared runtime imports: ${undeclared.join(", ")}`);
+	}
+	if (/@source|@import\s+["']tailwindcss/.test(css)) {
+		errors.push("compiled stylesheet still requires Tailwind source processing");
+	}
+	const unpackedAssets = [
+		...css.matchAll(/url\(\s*(["']?)([^"')]+)\1\s*\)/g),
+	]
+		.map((match) => match[2].trim())
+		.filter((url) => !url.startsWith("data:") && !url.startsWith("#"));
+	if (unpackedAssets.length > 0) {
+		errors.push(
+			`compiled stylesheet references unpacked assets: ${[...new Set(unpackedAssets)].sort().join(", ")}`,
+		);
+	}
+	for (const [name, source] of Object.entries(clientJavascript)) {
+		if (!/^\s*["']use client["'];/.test(source)) {
+			errors.push(`${name} lost its use client boundary`);
+		}
+	}
+	for (const [name, sourceMap] of Object.entries(sourceMaps)) {
+		const sources = Array.isArray(sourceMap.sources) ? sourceMap.sources : [];
+		if (
+			sources.length === 0 ||
+			!Array.isArray(sourceMap.sourcesContent) ||
+			sourceMap.sourcesContent.length !== sources.length
+		) {
+			errors.push(`${name} lacks complete source-map sourcesContent`);
+		}
+		if (sources.some((source) => pathIsAbsolute(source))) {
+			errors.push(`${name} contains checkout-specific absolute source paths`);
+		}
+	}
+	return errors;
+}
+
+function pathIsAbsolute(value) {
+	return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+export function validatePackedArtifact({
+	manifest,
+	files,
+	packedBytes,
+	firstSha256,
+	secondSha256,
+}) {
+	const errors = [];
+	if (manifest.name !== "@fairchild/folio") errors.push("unexpected package name");
+	if (!/^0\.\d+\.\d+$/.test(manifest.version)) {
+		errors.push("version must be pre-1.0 semantic versioning");
+	}
+	if (manifest.private !== true) errors.push("registry publication gate must stay closed");
+	if (JSON.stringify(manifest.exports) !== JSON.stringify(ARTIFACT_EXPORTS)) {
+		errors.push("artifact exports differ from the public contract");
+	}
+	if (manifest.sideEffects?.length !== 1 || manifest.sideEffects[0] !== "./dist/styles.css") {
+		errors.push("only the compiled stylesheet may be a package side effect");
+	}
+	if (JSON.stringify([...files].sort()) !== JSON.stringify(PACKED_FILES)) {
+		errors.push("tarball file list differs from the intentional allowlist");
+	}
+	if (packedBytes > MAX_PACKED_BYTES) {
+		errors.push(`packed size ${packedBytes} exceeds ${MAX_PACKED_BYTES} byte budget`);
+	}
+	if (firstSha256 !== secondSha256) {
+		errors.push("two packs of the same staged package produced different checksums");
+	}
+	return errors;
+}

--- a/web-next/scripts/folio-artifact-core.test.mjs
+++ b/web-next/scripts/folio-artifact-core.test.mjs
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import sourceManifest from "../packages/folio/package.json";
+import {
+	ARTIFACT_EXPORTS,
+	createArtifactManifest,
+	MAX_PACKED_BYTES,
+	PACKED_FILES,
+	runtimeImports,
+	tarballFilename,
+	validateBuildOutput,
+	validatePackedArtifact,
+} from "./folio-artifact-core.mjs";
+
+describe("Folio artifact contract", () => {
+	test("derives a private compiled manifest without workspace-only metadata", () => {
+		const manifest = createArtifactManifest(sourceManifest);
+
+		expect(manifest).toMatchObject({
+			name: "@fairchild/folio",
+			version: "0.1.0",
+			private: true,
+			types: "./dist/index.d.ts",
+			module: "./dist/index.js",
+			exports: ARTIFACT_EXPORTS,
+			files: ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
+		});
+		expect(manifest).not.toHaveProperty("scripts");
+		expect(manifest).not.toHaveProperty("devDependencies");
+	});
+
+	test("pins the deterministic file allowlist, checksum, and size budget", () => {
+		const manifest = createArtifactManifest(sourceManifest);
+		expect(
+			validatePackedArtifact({
+				manifest,
+				files: PACKED_FILES,
+				packedBytes: MAX_PACKED_BYTES,
+				firstSha256: "same",
+				secondSha256: "same",
+			}),
+		).toEqual([]);
+
+		expect(
+			validatePackedArtifact({
+				manifest,
+				files: [...PACKED_FILES, "package/private.txt"],
+				packedBytes: MAX_PACKED_BYTES + 1,
+				firstSha256: "first",
+				secondSha256: "second",
+			}),
+		).toEqual([
+			"tarball file list differs from the intentional allowlist",
+			`packed size ${MAX_PACKED_BYTES + 1} exceeds ${MAX_PACKED_BYTES} byte budget`,
+			"two packs of the same staged package produced different checksums",
+		]);
+	});
+
+	test("uses the stable scoped-package tarball name", () => {
+		expect(tarballFilename("@fairchild/folio", "0.1.0")).toBe(
+			"fairchild-folio-0.1.0.tgz",
+		);
+	});
+
+	test("detects undeclared imports, uncompiled CSS, unpacked assets, and incomplete maps", () => {
+		const manifest = createArtifactManifest(sourceManifest);
+		expect(runtimeImports('import "react/jsx-runtime"; import x from "@scope/pkg/x";')).toEqual(
+			["react", "@scope/pkg"],
+		);
+		expect(
+			validateBuildOutput({
+				manifest,
+				javascript: ['import "react/jsx-runtime"; import "undeclared-package";'],
+				sourceMaps: {
+					"index.js.map": { sources: ["/checkout/src.ts"], sourcesContent: [] },
+					"missing.js.map": {},
+				},
+				css: '@import "tailwindcss/theme"; @source "./src"; .icon { background: url("./missing.svg"); }',
+			}),
+		).toEqual([
+			"undeclared runtime imports: undeclared-package",
+			"compiled stylesheet still requires Tailwind source processing",
+			"compiled stylesheet references unpacked assets: ./missing.svg",
+			"index.js.map lacks complete source-map sourcesContent",
+			"index.js.map contains checkout-specific absolute source paths",
+			"missing.js.map lacks complete source-map sourcesContent",
+		]);
+	});
+
+	test("rejects client bundles that lose their React boundary directive", () => {
+		const manifest = createArtifactManifest(sourceManifest);
+		expect(
+			validateBuildOutput({
+				manifest,
+				javascript: [],
+				clientJavascript: {
+					"index.js": '"use client";\nexport const ok = true;',
+					"theme-toggle.js": "export const missing = true;",
+				},
+				sourceMaps: {},
+				css: "",
+			}),
+		).toEqual(["theme-toggle.js lost its use client boundary"]);
+	});
+});

--- a/web-next/scripts/folio-artifact-core.test.mjs
+++ b/web-next/scripts/folio-artifact-core.test.mjs
@@ -101,4 +101,19 @@ describe("Folio artifact contract", () => {
 			}),
 		).toEqual(["theme-toggle.js lost its use client boundary"]);
 	});
+
+	test("rejects duplicate conversation runtime identities in client entries", () => {
+		const manifest = createArtifactManifest(sourceManifest);
+		expect(
+			validateBuildOutput({
+				manifest,
+				javascript: [],
+				clientJavascript: {
+					"index.js": '"use client";\nclass FolioUnknownCursorError {}',
+				},
+				sourceMaps: {},
+				css: "",
+			}),
+		).toEqual(["index.js bundles conversation runtime identities"]);
+	});
 });

--- a/web-next/scripts/folio-artifact.mjs
+++ b/web-next/scripts/folio-artifact.mjs
@@ -1,0 +1,261 @@
+/*
+ * Canonical Folio release candidate: clean-build, stage, pack twice, inspect,
+ * checksum, then install and build a standalone Next consumer from /tmp.
+ */
+import { createHash } from "node:crypto";
+import {
+	cp,
+	mkdir,
+	mkdtemp,
+	readFile,
+	realpath,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+	createArtifactManifest,
+	tarballFilename,
+	validateBuildOutput,
+	validatePackedArtifact,
+} from "./folio-artifact-core.mjs";
+
+const exec = promisify(execFile);
+const WEB_NEXT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PACKAGE = path.join(WEB_NEXT, "packages", "folio");
+const ARTIFACTS = path.join(WEB_NEXT, "artifacts", "folio");
+const STAGE = path.join(ARTIFACTS, "stage");
+const RUN_A = path.join(ARTIFACTS, "pack-a");
+const RUN_B = path.join(ARTIFACTS, "pack-b");
+const PNPM = process.env.npm_execpath;
+
+if (!PNPM) throw new Error("run this script through pnpm so npm_execpath is defined");
+
+async function runPnpm(args, options = {}) {
+	const javascriptEntrypoint = /\.[cm]?js$/.test(PNPM);
+	return exec(javascriptEntrypoint ? process.execPath : PNPM, javascriptEntrypoint ? [PNPM, ...args] : args, {
+		cwd: options.cwd ?? WEB_NEXT,
+		env: { ...process.env, ...options.env },
+		maxBuffer: 20 * 1024 * 1024,
+	});
+}
+
+async function sha256(file) {
+	return createHash("sha256").update(await readFile(file)).digest("hex");
+}
+
+async function stagePackage() {
+	await runPnpm(["run", "clean", "folio-artifact"]);
+	await runPnpm(["--filter", "@fairchild/folio", "build"]);
+	await mkdir(STAGE, { recursive: true });
+	await cp(path.join(PACKAGE, "dist"), path.join(STAGE, "dist"), {
+		recursive: true,
+	});
+	for (const file of ["README.md", "LICENSE", "CHANGELOG.md"]) {
+		await cp(path.join(PACKAGE, file), path.join(STAGE, file));
+	}
+	const sourceManifest = JSON.parse(
+		await readFile(path.join(PACKAGE, "package.json"), "utf8"),
+	);
+	const manifest = createArtifactManifest(sourceManifest);
+	const dist = path.join(PACKAGE, "dist");
+	const distFiles = Object.fromEntries(
+		await Promise.all(
+			[
+			"index.js",
+			"conversation.js",
+			"format.js",
+			"theme.js",
+			"theme-toggle.js",
+			"testing.js",
+			].map(async (file) => [file, await readFile(path.join(dist, file), "utf8")]),
+		),
+	);
+	const sourceMaps = Object.fromEntries(
+		await Promise.all(
+			[
+				"index.js.map",
+				"conversation.js.map",
+				"format.js.map",
+				"theme.js.map",
+				"theme-toggle.js.map",
+				"testing.js.map",
+				"styles.css.map",
+			].map(async (file) => [file, JSON.parse(await readFile(path.join(dist, file), "utf8"))]),
+		),
+	);
+	const buildErrors = validateBuildOutput({
+		manifest,
+		javascript: Object.values(distFiles),
+		clientJavascript: {
+			"index.js": distFiles["index.js"],
+			"theme-toggle.js": distFiles["theme-toggle.js"],
+		},
+		sourceMaps,
+		css: await readFile(path.join(dist, "styles.css"), "utf8"),
+	});
+	if (buildErrors.length > 0) throw new Error(buildErrors.join("\n"));
+	await writeFile(path.join(STAGE, "package.json"), `${JSON.stringify(manifest, null, "\t")}\n`);
+	return manifest;
+}
+
+async function packInto(destination) {
+	await mkdir(destination, { recursive: true });
+	await runPnpm(["pack", "--pack-destination", destination], { cwd: STAGE });
+}
+
+async function tarFiles(tarball) {
+	const { stdout } = await exec("tar", ["-tzf", tarball], {
+		maxBuffer: 10 * 1024 * 1024,
+	});
+	return stdout
+		.split("\n")
+		.map((line) => line.trim().replace(/\/$/, ""))
+		.filter(Boolean)
+		.sort();
+}
+
+function fixtureFiles(tarballName) {
+	const testingEntry = "@fairchild/folio" + "/testing";
+	const conversationEntry = "@fairchild/folio" + "/conversation";
+	return {
+		"package.json": `${JSON.stringify(
+			{
+				name: "folio-clean-consumer",
+				version: "0.0.0",
+				private: true,
+				type: "module",
+				scripts: { build: "next build" },
+				dependencies: {
+					"@fairchild/folio": `file:./${tarballName}`,
+					ai: "7.0.15",
+					next: "15.5.20",
+					react: "19.2.7",
+					"react-dom": "19.2.7",
+				},
+				devDependencies: {
+					"@types/node": "22.20.0",
+					"@types/react": "19.2.17",
+					"@types/react-dom": "19.2.3",
+					typescript: "5.9.3",
+				},
+			},
+			null,
+			"\t",
+		)}\n`,
+		"tsconfig.json": `${JSON.stringify(
+			{
+				compilerOptions: {
+					target: "ES2022",
+					lib: ["dom", "dom.iterable", "esnext"],
+					strict: true,
+					noEmit: true,
+					module: "esnext",
+					moduleResolution: "bundler",
+					jsx: "preserve",
+					plugins: [{ name: "next" }],
+				},
+				include: ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+			},
+			null,
+			"\t",
+		)}\n`,
+		"app/layout.tsx": `import type { ReactNode } from "react";\nimport { themeInitScript } from "@fairchild/folio/theme";\nimport "@fairchild/folio/styles.css";\nexport default function Layout({ children }: { children: ReactNode }) {\n  return <html lang="en" data-theme="light"><body><script dangerouslySetInnerHTML={{ __html: themeInitScript }} />{children}</body></html>;\n}\n`,
+		"app/theme-control.tsx": `"use client";\nimport { ThemeToggle } from "@fairchild/folio/theme-toggle";\nexport function ThemeControl() { return <ThemeToggle />; }\n`,
+		"app/page.tsx": `import { SessionView } from "@fairchild/folio";\nimport { ThemeControl } from "./theme-control";\nexport default function Page() {\n  return <><ThemeControl /><SessionView session={{ masthead: { repo: "fixture/repo", branch: "main", title: "Installed Folio", agentName: "Agent", stateLabel: "ready" }, messages: [], statusLine: { model: "fixture" }, empty: { title: "Clean install.", hint: "No workspace source." } }} /></>;\n}\n`,
+		"app/api/format/route.ts": `import { formatTokenCount } from "@fairchild/folio/format";\nexport function GET() { return Response.json({ value: formatTokenCount(1200) }); }\n`,
+		"app/api/testing/route.ts": `import { FolioUnknownCursorError as PublicError } from "${conversationEntry}";\nimport { FakeConversationPort, FolioUnknownCursorError as TestingError } from "${testingEntry}";\nexport function GET() { return Response.json({ fake: typeof FakeConversationPort, sameError: PublicError === TestingError }); }\n`,
+		"contract.ts": `import { type FolioConversationPort } from "@fairchild/folio";\nimport { FakeConversationPort, FolioUnknownCursorError } from "${testingEntry}";\nexport const contract = { FakeConversationPort, FolioUnknownCursorError } satisfies Record<string, unknown>;\nexport type HostPort = FolioConversationPort;\n`,
+	};
+}
+
+async function verifyCleanConsumer(tarball) {
+	const fixture = await mkdtemp(path.join(os.tmpdir(), "folio-clean-consumer-"));
+	try {
+		const fixtureRoot = await realpath(fixture);
+		const localTarball = path.join(fixture, path.basename(tarball));
+		await cp(tarball, localTarball);
+		for (const [relative, contents] of Object.entries(fixtureFiles(path.basename(tarball)))) {
+			const target = path.join(fixture, relative);
+			await mkdir(path.dirname(target), { recursive: true });
+			await writeFile(target, contents);
+		}
+		const install = await runPnpm(["install", "--prefer-offline", "--ignore-workspace"], {
+			cwd: fixture,
+		});
+		const installed = await realpath(path.join(fixture, "node_modules", "@fairchild", "folio"));
+		if (!installed.startsWith(fixtureRoot + path.sep)) {
+			throw new Error(`clean fixture resolved Folio outside itself: ${installed}`);
+		}
+		const identity = await exec(
+			process.execPath,
+			[
+				"--input-type=module",
+				"--eval",
+				`import { FolioUnknownCursorError as PublicError } from "${"@fairchild/folio" + "/conversation"}"; import { FolioUnknownCursorError as TestingError } from "${"@fairchild/folio" + "/testing"}"; if (PublicError !== TestingError) throw new Error("entry identity mismatch");`,
+			],
+			{ cwd: fixture },
+		);
+		const build = await runPnpm(["--ignore-workspace", "run", "build"], {
+			cwd: fixture,
+			env: { NODE_ENV: "production", NEXT_TELEMETRY_DISABLED: "1" },
+		});
+		await writeFile(
+			path.join(ARTIFACTS, "clean-fixture.log"),
+			`INSTALL\n${install.stdout}${install.stderr}\nIDENTITY\n${identity.stdout}${identity.stderr}shared conversation runtime identity verified\nBUILD\n${build.stdout}${build.stderr}`,
+		);
+	} finally {
+		await rm(fixture, { recursive: true, force: true });
+	}
+}
+
+const manifest = await stagePackage();
+const filename = tarballFilename(manifest.name, manifest.version);
+await packInto(RUN_A);
+await packInto(RUN_B);
+const first = path.join(RUN_A, filename);
+const second = path.join(RUN_B, filename);
+const [firstSha256, secondSha256, files, packedStat] = await Promise.all([
+	sha256(first),
+	sha256(second),
+	tarFiles(first),
+	stat(first),
+]);
+const errors = validatePackedArtifact({
+	manifest,
+	files,
+	packedBytes: packedStat.size,
+	firstSha256,
+	secondSha256,
+});
+if (errors.length > 0) throw new Error(errors.join("\n"));
+
+const finalTarball = path.join(ARTIFACTS, filename);
+await cp(first, finalTarball);
+await writeFile(path.join(ARTIFACTS, "files.txt"), `${files.join("\n")}\n`);
+await writeFile(
+	path.join(ARTIFACTS, "manifest.json"),
+	`${JSON.stringify(
+		{
+			name: manifest.name,
+			version: manifest.version,
+			filename,
+			sha256: firstSha256,
+			packedBytes: packedStat.size,
+			files,
+		},
+		null,
+		"\t",
+	)}\n`,
+);
+await verifyCleanConsumer(finalTarball);
+
+console.log(`packed ${path.relative(WEB_NEXT, finalTarball)}`);
+console.log(`sha256 ${firstSha256}`);
+console.log(`${packedStat.size} bytes, ${files.length} intentional files`);
+console.log("clean standalone Next fixture installed without a workspace link and built successfully");

--- a/web-next/scripts/folio-artifact.mjs
+++ b/web-next/scripts/folio-artifact.mjs
@@ -29,7 +29,8 @@ const exec = promisify(execFile);
 const WEB_NEXT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PACKAGE = path.join(WEB_NEXT, "packages", "folio");
 const ARTIFACTS = path.join(WEB_NEXT, "artifacts", "folio");
-const STAGE = path.join(ARTIFACTS, "stage");
+const STAGE_A = path.join(ARTIFACTS, "stage-a");
+const STAGE_B = path.join(ARTIFACTS, "stage-b");
 const RUN_A = path.join(ARTIFACTS, "pack-a");
 const RUN_B = path.join(ARTIFACTS, "pack-b");
 const PNPM = process.env.npm_execpath;
@@ -49,15 +50,14 @@ async function sha256(file) {
 	return createHash("sha256").update(await readFile(file)).digest("hex");
 }
 
-async function stagePackage() {
-	await runPnpm(["run", "clean", "folio-artifact"]);
+async function stagePackage(destination) {
 	await runPnpm(["--filter", "@fairchild/folio", "build"]);
-	await mkdir(STAGE, { recursive: true });
-	await cp(path.join(PACKAGE, "dist"), path.join(STAGE, "dist"), {
+	await mkdir(destination, { recursive: true });
+	await cp(path.join(PACKAGE, "dist"), path.join(destination, "dist"), {
 		recursive: true,
 	});
 	for (const file of ["README.md", "LICENSE", "CHANGELOG.md"]) {
-		await cp(path.join(PACKAGE, file), path.join(STAGE, file));
+		await cp(path.join(PACKAGE, file), path.join(destination, file));
 	}
 	const sourceManifest = JSON.parse(
 		await readFile(path.join(PACKAGE, "package.json"), "utf8"),
@@ -100,13 +100,13 @@ async function stagePackage() {
 		css: await readFile(path.join(dist, "styles.css"), "utf8"),
 	});
 	if (buildErrors.length > 0) throw new Error(buildErrors.join("\n"));
-	await writeFile(path.join(STAGE, "package.json"), `${JSON.stringify(manifest, null, "\t")}\n`);
+	await writeFile(path.join(destination, "package.json"), `${JSON.stringify(manifest, null, "\t")}\n`);
 	return manifest;
 }
 
-async function packInto(destination) {
+async function packInto(source, destination) {
 	await mkdir(destination, { recursive: true });
-	await runPnpm(["pack", "--pack-destination", destination], { cwd: STAGE });
+	await runPnpm(["pack", "--pack-destination", destination], { cwd: source });
 }
 
 async function tarFiles(tarball) {
@@ -176,6 +176,8 @@ function fixtureFiles(tarballName) {
 
 async function verifyCleanConsumer(tarball) {
 	const fixture = await mkdtemp(path.join(os.tmpdir(), "folio-clean-consumer-"));
+	const log = [];
+	let stage = "install";
 	try {
 		const fixtureRoot = await realpath(fixture);
 		const localTarball = path.join(fixture, path.basename(tarball));
@@ -188,10 +190,14 @@ async function verifyCleanConsumer(tarball) {
 		const install = await runPnpm(["install", "--prefer-offline", "--ignore-workspace"], {
 			cwd: fixture,
 		});
+		log.push(`INSTALL\n${install.stdout}${install.stderr}`);
+		stage = "isolation";
 		const installed = await realpath(path.join(fixture, "node_modules", "@fairchild", "folio"));
 		if (!installed.startsWith(fixtureRoot + path.sep)) {
 			throw new Error(`clean fixture resolved Folio outside itself: ${installed}`);
 		}
+		log.push(`ISOLATION\ninstalled package resolved inside ${fixtureRoot}`);
+		stage = "identity";
 		const identity = await exec(
 			process.execPath,
 			[
@@ -201,23 +207,35 @@ async function verifyCleanConsumer(tarball) {
 			],
 			{ cwd: fixture },
 		);
+		log.push(
+			`IDENTITY\n${identity.stdout}${identity.stderr}shared conversation runtime identity verified`,
+		);
+		stage = "build";
 		const build = await runPnpm(["--ignore-workspace", "run", "build"], {
 			cwd: fixture,
 			env: { NODE_ENV: "production", NEXT_TELEMETRY_DISABLED: "1" },
 		});
-		await writeFile(
-			path.join(ARTIFACTS, "clean-fixture.log"),
-			`INSTALL\n${install.stdout}${install.stderr}\nIDENTITY\n${identity.stdout}${identity.stderr}shared conversation runtime identity verified\nBUILD\n${build.stdout}${build.stderr}`,
+		log.push(`BUILD\n${build.stdout}${build.stderr}`);
+		await writeFile(path.join(ARTIFACTS, "clean-fixture.log"), `${log.join("\n")}\n`);
+	} catch (error) {
+		const stdout = typeof error?.stdout === "string" ? error.stdout : "";
+		const stderr = typeof error?.stderr === "string" ? error.stderr : "";
+		log.push(
+			`${stage.toUpperCase()} FAILED\n${stdout}${stderr}${error instanceof Error ? error.stack : String(error)}`,
 		);
+		await writeFile(path.join(ARTIFACTS, "clean-fixture.log"), `${log.join("\n")}\n`);
+		throw error;
 	} finally {
 		await rm(fixture, { recursive: true, force: true });
 	}
 }
 
-const manifest = await stagePackage();
+await runPnpm(["run", "clean", "folio-artifact"]);
+const manifest = await stagePackage(STAGE_A);
 const filename = tarballFilename(manifest.name, manifest.version);
-await packInto(RUN_A);
-await packInto(RUN_B);
+await packInto(STAGE_A, RUN_A);
+await stagePackage(STAGE_B);
+await packInto(STAGE_B, RUN_B);
 const first = path.join(RUN_A, filename);
 const second = path.join(RUN_B, filename);
 const [firstSha256, secondSha256, files, packedStat] = await Promise.all([

--- a/web-next/scripts/folio-boundary.test.mjs
+++ b/web-next/scripts/folio-boundary.test.mjs
@@ -17,9 +17,11 @@ const SKIPPED_CONSUMER_DIRECTORIES = new Set([
 ]);
 const PUBLIC_FOLIO_IMPORTS = new Set([
 	"@fairchild/folio",
+	"@fairchild/folio/conversation",
 	"@fairchild/folio/format",
 	"@fairchild/folio/styles.css",
 	"@fairchild/folio/theme",
+	"@fairchild/folio/theme-toggle",
 	"@fairchild/folio/testing",
 ]);
 const require = createRequire(import.meta.url);
@@ -96,10 +98,20 @@ describe("Folio package boundary", () => {
 				import: "./src/format.ts",
 				default: "./src/format.ts",
 			},
+			"./conversation": {
+				types: "./src/conversation.ts",
+				import: "./src/conversation.ts",
+				default: "./src/conversation.ts",
+			},
 			"./theme": {
 				types: "./src/theme-entry.ts",
 				import: "./src/theme-entry.ts",
 				default: "./src/theme-entry.ts",
+			},
+			"./theme-toggle": {
+				types: "./src/theme-toggle-entry.ts",
+				import: "./src/theme-toggle-entry.ts",
+				default: "./src/theme-toggle-entry.ts",
 			},
 			"./styles.css": "./src/styles.css",
 			"./testing": {

--- a/web-next/src/app/(app)/page.tsx
+++ b/web-next/src/app/(app)/page.tsx
@@ -3,7 +3,7 @@
  * the quiet new-session flow. This is the app's front door — everything on
  * it stays calm: one masthead, one list, one affordance.
  */
-import { ThemeToggle } from "@fairchild/folio/theme";
+import { ThemeToggle } from "@fairchild/folio/theme-toggle";
 import { getDatabase } from "@/lib/db/client";
 import { listSessionFilterOptions, listSessions } from "@/lib/db/sessions";
 import { NewSession } from "./new-session";

--- a/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
+++ b/web-next/src/app/(app)/sessions/[id]/live-session-view.tsx
@@ -46,7 +46,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ApprovalDecision } from "@/lib/agent-runtime/stream-chunk";
 import { modelLabel } from "@/lib/agent-runtime/models";
 import {
-	createPortBackedConversationActions,
 	type ActiveTurnData,
 	type FolioConversationSnapshot,
 	type FolioSendRequest,
@@ -55,6 +54,7 @@ import {
 	type SessionViewData,
 } from "@fairchild/folio";
 import type { FolioDataParts, FolioMessage } from "@fairchild/folio";
+import { createPortBackedConversationActions } from "@fairchild/folio/conversation";
 import { TerminalDrawer } from "@/components/terminal/terminal-drawer";
 import { deriveSessionTitle } from "@/lib/session-title";
 import {

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.test.ts
@@ -1,8 +1,8 @@
-import {
-	FolioUnknownCursorError,
-	type FolioConversationSnapshot,
-	type FolioConversationUpdate,
+import type {
+	FolioConversationSnapshot,
+	FolioConversationUpdate,
 } from "@fairchild/folio";
+import { FolioUnknownCursorError } from "@fairchild/folio/conversation";
 import { describe, expect, test, vi } from "vitest";
 import {
 	createWorkspacesChatRequestBody,

--- a/web-next/src/lib/folio/workspaces-conversation-adapter.ts
+++ b/web-next/src/lib/folio/workspaces-conversation-adapter.ts
@@ -13,7 +13,7 @@ import {
 	type FolioConversationSnapshot,
 	type FolioConversationUpdate,
 	type FolioSendRequest,
-} from "@fairchild/folio";
+} from "@fairchild/folio/conversation";
 import type { ApprovalDecision } from "@/lib/agent-runtime/stream-chunk";
 
 type HostCommand = void | Promise<void>;


### PR DESCRIPTION
## Summary

- compile `@fairchild/folio` 0.1.0 as ESM, bundled declarations, standalone scoped CSS, and complete source maps
- add stable public entries for server-safe conversation authority and theme initialization while preserving client boundaries and cross-entry runtime identity
- add `pnpm folio:package`, which cleans, builds, packs twice, validates the exact manifest/file/dependency/asset/size contracts, and installs the tarball into a non-workspace Next app
- run that artifact contract in CI and retain the tarball, manifest, file listing, and clean-consumer build log
- document semver, compatibility, release-candidate installation, and the explicit public-registry decision gate

Closes #1054

## Validation

- `pnpm folio:package` — 24 intentional files, 81,160 bytes, SHA-256 `d4d86300f0c2182cb85f9e65bf2574391698760efe13dda148d84e744d702c43`; clean standalone Next consumer installed, verified shared runtime identity, and production-built
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec tsc --noEmit -p packages/folio/tsconfig.json`
- `pnpm test` — 67 files / 666 tests
- `pnpm build` — Workspaces production build; `/sessions/[id]` remains 188 kB first load
- `pnpm test:e2e` — 57 passed
- `git -c core.whitespace=trailing-space,space-before-tab diff --check`

## Reflection

The preparatory split matters as much as the pack command. A mixed theme entry would have pulled a client module into server layouts, so theme initialization and the interactive toggle now have separate entries. Likewise, bundling conversation runtime values into both root and testing entries would have broken `instanceof`; one server-safe conversation entry now owns those identities. The build also emits each server declaration entry independently so no hashed shared declaration file leaks into the versioned file contract. A failed treeshake experiment removed `"use client"`; the artifact validator now guards that boundary explicitly. CSS asset references, undeclared runtime imports, incomplete or checkout-specific source maps, accidental files, non-deterministic packing, and size growth all fail closed.

## Fable review

Targeted review was run through the Claude CLI against the published `origin/main...3f8adab7` diff. Fable found no high-severity defect and raised five actionable hardening points; all five are incorporated in `46015ff0`:

- accepted: gate artifact upload on the package step actually running, avoiding a misleading second failure when earlier checks fail
- accepted: persist install/identity/build stdout and stderr before rethrowing a clean-consumer failure
- accepted: hash Folio source/config inputs rather than generated `dist/` in the Next cache key
- accepted: independently build and stage twice before comparing packed checksums, so the determinism claim covers build output as well as `pnpm pack`
- accepted: reject client bundles that contain conversation error runtime identities, guarding against future duplicate-class regressions

## Mergeability

- Surface: web / reusable Folio package, CI, and release-candidate tooling
- User-facing behavior changed: No visual behavior change; consumers gain an installable versioned Folio artifact and explicit public entries
- Non-happy paths considered: lost client directives, duplicate runtime identities, hashed declaration chunks, missing exports/assets, undeclared dependencies, accidental private files, incomplete source maps, non-deterministic tarballs, workspace-link leakage, and size regression
- Residual risk or follow-up: #1055 must prove this exact tarball in MFWiki before any public-registry decision; 0.1.x remains a private tarball release candidate
- Release/ops preconditions: No registry credentials or publication are required; CI must produce and retain the checked 0.1.0 tarball artifact

## Evidence

- [Reviewed-head artifact validation summary](https://evidence.cloudcompute.com/workspaces/pr-1060/20260712-211853-folio-artifact-validation-reviewed.svg)
- CI retains the raw tarball, manifest, exact file list, and clean-consumer log as the `folio-package` workflow artifact.
