### PR TITLE
docs(factory): Agent Factory v2 plan, ADRs, and glossary (M0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ New standalone Python utilities are single-file UV scripts: `#!/usr/bin/env -S u
 | Web local dev (mise tasks, auth bypass) | web/docs/local-dev.md | - |
 | Web architecture | web/docs/architecture.md | - |
 | PR reviewer agent | docs/pr-review/pr-reviewer.md | - |
+| Agent Factory (autonomous pipeline) plan + glossary | docs/development/agent-factory-v2-plan.md, docs/agents/CONTEXT.md | docs/development/agent-team.md (superseded architecture) |
 | Roadmap/planning | backlog/ROADMAP.md | - |
 | Deferred work items | backlog/*.md | - |
 | Prototypes | prototypes/README.md | - |

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,16 @@
+# Context Map
+
+## Contexts
+
+- [WorkSpaces Native App](./CONTEXT.md) — the product domain: repositories, workspaces, terminal sessions, surfaces
+- [Agent Factory](./docs/agents/CONTEXT.md) — the development-process domain: the autonomous loop that triages, prepares, implements, and ships work on this repo
+
+## Relationships
+
+- **Factory → Product**: the Factory's work items are changes to the WorkSpaces product; issue titles and specs use the product context's language
+- **Product → Factory**: Feedback submitted through the product (feedback-store) is an inlet of Factory work
+- The web/chat "Spaces" context is flagged in the product glossary but has no `CONTEXT.md` yet
+
+## Ambiguities
+
+- "Agent" belongs to both contexts with different meanings: in the product context it is an AI assistant a user drives inside a Terminal Session; in the Factory context it is an autonomous worker in the development loop. Qualify when crossing contexts.

--- a/docs/agents/CONTEXT.md
+++ b/docs/agents/CONTEXT.md
@@ -1,0 +1,86 @@
+# Agent Factory
+
+The development-process context: the language of the autonomous loop that advances this repo between the Owner's interactive sessions. Distinct from the product domain in the root `CONTEXT.md`.
+
+## Language
+
+**Factory**:
+The autonomous development system — agents plus the GitHub state machine they run on — that advances the repo between the Owner's interactive sessions.
+_Avoid_: automation, agent team (the personas, not the system), pipeline (a Factory has one)
+
+**Owner**:
+The single human authority the Factory gates on.
+_Avoid_: user (product-context term), maintainer (a broader GitHub permission class)
+
+**Gate**:
+A point where the Factory waits on the Owner, expressed as exactly one of: a label flip, a PR review, or a merge.
+_Avoid_: approval keyword, reaction gate, sign-off
+
+**Interactive Lane**:
+Development done live in the Owner's own working sessions, outside the Factory.
+_Avoid_: fast lane, manual work
+
+**Inlet**:
+A source of inbound Factory work: product feedback, Owner steering, or signals the Factory raises itself.
+_Avoid_: queue, backlog source
+
+**Steering**:
+Owner-originated intent entering the Factory asynchronously through an Inlet, rather than through a live session.
+_Avoid_: command, request, directive
+
+**Digest**:
+The single rolling surface where the Factory presents its open Gates to the Owner, each answerable in one gesture.
+_Avoid_: dashboard (the committed telemetry artifact behind it), notification feed
+
+**Stage**:
+One event-fired step of the Factory's pipeline: Triage, Spec, Implement, Review, Verify, or Monitor.
+_Avoid_: phase (roadmap term), agent (an identity may run several stages)
+
+**Spec**:
+The reviewable pair of artifacts — product behavior invariants plus technical plan — that a spec-only PR carries; merging that PR is the Gate that releases implementation.
+_Avoid_: plan, design doc, RFC
+
+**Monitor**:
+The Stage that observes the Factory itself: writes the Digest and dashboard, ages and escalates Gates, reconciles expected-vs-actual state, and raises issues from CI signals.
+_Avoid_: observer (retired persona framing), ops report
+
+**Persona**:
+A named, role-bound Factory identity — a GitHub App credential, a perspective lens, an `author:` label, and a long-term memory — that acts only when an event routes work to it.
+_Avoid_: bot, scheduled agent, character
+
+**Memory Block**:
+One fact a Persona keeps: a markdown file with YAML frontmatter (short slug name, freshness metadata) in that Persona's own memory directory.
+_Avoid_: note, log entry (that's the Journal)
+
+**Journal**:
+A Persona's append-only observation stream, written directly after non-PR work; raw material for consolidation, never consumed as instructions.
+_Avoid_: memory (unconsolidated), diary
+
+**Profile**:
+A Persona's short machine-readable self-description — strengths, known areas, calibration — that Triage reads when routing implementer vs reviewer.
+_Avoid_: persona prompt (the lens), bio
+
+**Dreaming**:
+A periodic or triggered consolidation pass in which a Persona curates its Memory Blocks from its Journal and history — compacting, refreshing, and retiring stale blocks.
+_Avoid_: garbage collection, compaction (mechanical framings)
+
+## Relationships
+
+- The **Factory** advances work only through state transitions on issues, labels, and PRs; comment keywords and reactions are never control signals.
+- Every human decision in the **Factory** is a **Gate**; anything else runs without the **Owner**.
+- The **Factory** and the **Interactive Lane** ship into the same repo and the same label state machine.
+- The **Owner** steers the **Factory** through the same **Inlet** as product feedback; **Steering** and feedback differ in trust level, not in path.
+- The **Digest** renders open **Gates**; a committed telemetry artifact backs it.
+- A **Persona** writes its own **Memory Blocks** and **Profile** only inside reviewed PRs; the counterpart Persona reviews every self-modification. The **Journal** is the only direct-write memory surface, and it is append-only.
+- **Dreaming** consolidates **Journal** entries into **Memory Blocks**; consolidation lands through the same reviewed-PR path.
+
+## Example dialogue
+
+> **Dev:** "The planner used to wait for the Owner to reply 'plan it' on a thread — is that a **Gate**?"
+> **Domain expert:** "No. A **Gate** is only a label flip, a PR review, or a merge. Keyword parsing is the failure mode Gates replaced."
+
+## Flagged ambiguities
+
+- "Gate" vs the "gate label" category in `docs/agents/triage-labels.md`: a **Gate** is the human decision point; gate labels (`safe-to-run-agent`, `needs-human`, `privileged-agent-patch`) are one mechanism that implements certain Gates.
+- "Agent team" named the personas (April, Plat, Peter, Oliver); **Factory** names the whole system. Resolved: Personas survive as role-bound identities — April and Plat as the implement/review pair (each reviews the other's work), Peter as triage and spec author, Oliver as the deterministic Monitor's name. No Persona is ever scheduled to "find something to do."
+- "Heartbeat" is resolved: the Monitor's daily pulse is the Factory's only heartbeat; work moves by label events, and an idle Factory does nothing. Avoid using "heartbeat" to mean scheduled contributor wake-ups — that model is retired.

--- a/docs/decisions/factory-event-driven-stages.md
+++ b/docs/decisions/factory-event-driven-stages.md
@@ -1,0 +1,32 @@
+---
+status: decided
+date: 2026-07-12
+decision: factory-event-driven-stages
+related:
+  - docs/development/agent-factory-v2-plan.md
+  - docs/decisions/factory-label-control-plane.md
+  - docs/agents/CONTEXT.md
+---
+
+# Event-fired Stages replace scheduled persona wake-ups
+
+## Decision
+
+**The Factory pipeline is six Stages — Triage, Spec, Implement, Review, Verify, Monitor — each fired by a label event, never by a schedule that asks an agent to find something to do. Only two crons survive: the Monitor's daily pulse (Digest, Gate aging, state reconciliation) and a feedback poll. An idle Factory does nothing.**
+
+Two mechanics inside this:
+
+1. **Spec-merge is the release gate.** Large/ambiguous work gets a `spec` label; the Spec stage opens a spec-only PR (`specs/<slug>/PRODUCT.md` + `TECH.md`); merging that PR applies `ready` to the linked issue via a merge hook. One gesture reviews the direction and releases implementation. `blocked` on the issue defers implementation after an accepted spec.
+2. **Personas are rebound to roles, never scheduled.** April/Plat form the implement/review pair (whichever implements, the other reviews — satisfying GitHub's author≠approver rule); Peter runs Triage and Spec; Oliver names the deterministic Monitor. The wake-up/selector runtime is retired.
+
+## Why
+
+v1's contributor runtime allowed exactly one action per wake-up, chosen by strict priority where reviewing always outranked claiming work — and in a repo whose Interactive Lane generates PRs constantly, something reviewable always existed. Proposing a new idea was the terminal fallback when idle; stale-thread cleanup was unreachable dead code. Result: April authored 2 PRs ever, Plat 0, against 106 reviews; two personas structurally biased toward accumulating conversation and barred from finishing.
+
+Scheduled "find work" agents also generate supply without demand — new proposals queued into an approval funnel that didn't scale. Event-fired stages invert this: pace comes from Inlets (feedback, Steering, operational signals) feeding Triage, so throughput tracks real demand.
+
+The spec-merge gate collapses v1's two sequential human gestures (keyword reply, then 👍) into one action on the Owner's proven surface: he merges PRs in a median of 18 minutes and visits Discussions never. A separate second gesture is the exact failure mode that starved v1.
+
+## Trade-off accepted
+
+Pure event-driven systems stall invisibly when a trigger misfires — v1's planner failed silently on its one genuine trigger. Mitigation is structural: the Monitor's daily reconciliation pass re-derives expected-vs-actual state and re-fires anything stuck (`sync-execution-state.py`'s logic survives as this janitor duty). The persona fiction also carries a seduction cost — v1's most designed artifact was the team narrative, which fossilized while unglamorous machinery worked. The guard: a Persona exists only when an event routes work to it.

--- a/docs/decisions/factory-label-control-plane.md
+++ b/docs/decisions/factory-label-control-plane.md
@@ -1,0 +1,27 @@
+---
+status: decided
+date: 2026-07-12
+decision: factory-label-control-plane
+related:
+  - docs/development/agent-factory-v2-plan.md
+  - docs/agents/CONTEXT.md
+  - docs/agents/triage-labels.md
+---
+
+# Labels and PRs are the Factory's only control plane
+
+## Decision
+
+**All Factory state lives in the GitHub-native state machine the repo already owns — issue labels (lane/state/gate axes per `docs/agents/triage-labels.md`), issue assignment, and PR review state. Every agent is a stateless skill fired by a state transition. Every human Gate is exactly one of: a label flip, a PR review, or a merge. No gate or trigger ever parses comment keywords or scrapes reactions.**
+
+This kills, deliberately: the `plan it`/`approved` keyword trigger for planning; the 👍-on-summary-comment execution gate; Discussions as a decision surface; and the `[idea]` → `[idea][endorsed]` title-tag lifecycle (replaced by the existing `idea` label). GitHub Discussions are demoted to a single pinned Digest thread the Monitor rewrites; agent deliberation that should change outcomes must terminate in an agent flipping a label or editing an issue.
+
+## Why
+
+The 2026-07-12 audit showed v1 failed at conversion, not execution. Execution: 141 agent-lane PRs merged in 60 days, 18-minute median time-to-merge. Conversion: the planner's keyword trigger fired genuinely once ever (2026-03-22) and failed silently that time; Discussions went fully silent on June 9; 22 of 25 open discussions were idle >14 days; zero `[idea]` discussions converted in 60 days.
+
+The Owner's revealed preference is the design's ground truth: PR review requests get processed in minutes; Discussions never. Keyword parsing and reaction scraping also fail invisibly — an edited comment, a login mismatch, or a workflow failure leaves no trace that a decision was made but not consumed. Label events are durable, replayable, and reconcilable.
+
+## Trade-off accepted
+
+The conversational "team room" — agents visibly deliberating, the Owner participating in threads — was part of the original intent and is lost as a control surface. The audit ruled on its actual value: it was write-only theater. Legibility is rebuilt deliberately as an observability surface (Digest + dashboard) rather than preserved as the control plane. Multi-agent deliberation remains possible as an experiment, but never on the critical path of a decision.

--- a/docs/decisions/factory-persona-memory.md
+++ b/docs/decisions/factory-persona-memory.md
@@ -1,0 +1,33 @@
+---
+status: decided
+date: 2026-07-12
+decision: factory-persona-memory
+related:
+  - docs/development/agent-factory-v2-plan.md
+  - docs/decisions/factory-event-driven-stages.md
+  - docs/agents/CONTEXT.md
+---
+
+# Personas manage their own memory through peer-reviewed PRs
+
+## Decision
+
+**Each Persona owns a versioned, public memory at `.agents/memory/<persona>/`: a `PROFILE.md` (short machine-readable self-description that Triage reads when routing implementer vs reviewer), a `MEMORY.md` index over Memory Blocks (one fact per markdown file, YAML frontmatter carrying a short slug and freshness metadata), and an append-only `journal/`.**
+
+Write paths are asymmetric by design:
+
+- **Memory Blocks and Profile change only inside the Persona's normal PRs**, where the counterpart Persona reviews them — every self-modification is peer-reviewed for free.
+- **The Journal is the only direct-write surface**: append-only observations committed after non-PR work (triage runs, reviews). Journals are never consumed as instructions; consolidation of journal → Memory Blocks ("Dreaming", periodic or triggered) lands through the reviewed-PR path.
+- `.agents/memory/<own-persona>/**` is carved out of the privileged-path patch guard; a CI check enforces that each GitHub App identity only touches its own directory. Everything else under `.agents/` remains privileged.
+
+Specialization is emergent, not configured: Profiles are seeded from the existing persona lenses (April: application/UX; Plat: platform/CI) and diverge from real history. Persona divergence over months is an explicit research goal — journals are rich, and periodic self-retrospectives are a designed Dreaming output.
+
+## Why
+
+v1 had zero cross-run memory: each wake-up re-derived "what I did" from GitHub, capped at three threads. Agents could not build judgment, notice repetition, or specialize. Memory is also the safest first form of self-modification — additive, reviewable, low blast radius — and a prerequisite for routing-by-strength rather than routing-by-rule.
+
+The threat model drove the write-path asymmetry: memory is agent-written text fed back into trusted context later. A Persona processes untrusted public content (issues, feedback); an unreviewed write channel into files that shape future privileged prompts would let injected instructions launder themselves into persistent trust. Routing all behavior-shaping writes through counterpart-reviewed PRs closes that channel at zero ceremony cost, since implementation PRs are peer-reviewed anyway.
+
+## Trade-off accepted
+
+Freshness vs safety: PR-carried memory lags (a lesson learned mid-task lands when the PR does), and non-PR stages would otherwise have no memory at all — hence the append-only Journal side channel, which trades a small unreviewed surface (observations, quarantined as data) for continuous capture. Public memory on a public repo is deliberate: auditable specialization, at the cost of the Personas having no private state.

--- a/docs/development/agent-factory-v2-plan.md
+++ b/docs/development/agent-factory-v2-plan.md
@@ -1,0 +1,150 @@
+---
+status: approved
+date: 2026-07-12
+supersedes: docs/development/agent-team.md (architecture; file to be rewritten in M1)
+related:
+  - docs/agents/CONTEXT.md
+  - docs/decisions/factory-label-control-plane.md
+  - docs/decisions/factory-event-driven-stages.md
+  - docs/decisions/factory-persona-memory.md
+---
+
+# Agent Factory v2
+
+The Factory is the autonomous development system that advances this repo between the Owner's interactive sessions. This plan replaces the v1 "Agent Team" architecture (scheduled persona wake-ups coordinating through GitHub Discussions) with an event-driven, label-fired pipeline. Language is canonical in [docs/agents/CONTEXT.md](../agents/CONTEXT.md); decisions were made in a grilled design session on 2026-07-12 against a live-state audit, an infrastructure deep-dive, and Warp's published software-factory work.
+
+## Purpose
+
+Twofold, in priority order:
+
+1. **Learning lab.** Push the state of the art in agent-run development; the telemetry, persona divergence, and dial-turning history are deliverables in their own right, carried into the Owner's other work.
+2. **Steady metabolism.** Advance the product through the weekday lulls between the Owner's spiky engagement, growing toward a self-sustaining — eventually perhaps commercial — product.
+
+v2's role is **background metabolism with a growth path to a second engine**. The Factory does not originate feature ideas in v2; origination earns its way back through the autonomy gradient. Work enters through Inlets that carry real demand: product feedback, Owner Steering, and the Factory's own operational signals (CI failures, monitor findings).
+
+## Why v1 stalled (audit, 2026-07-12)
+
+v1 failed at **conversion, not execution**:
+
+- Execution was fast and reliable: 141 agent-lane PRs merged in 60 days at an 18-minute median; agent workflow success >85%.
+- Every conversion gate fanned into the Owner on a surface he stopped visiting. Idea→plan required an exact keyword comment (Peter's last successful run: April 11; its one genuine "plan it" trigger failed silently). Plan→execute required a 👍 on a specific comment. Discussions went fully silent June 9; 22 of 25 open discussions sat idle >14 days; zero `[idea]` discussions converted in 60 days.
+- The contributor runtime was structurally biased against finishing: one action per wake-up, review-always-wins priority, propose-new-idea as the terminal fallback, `recommend_close` unreachable dead code, no cross-run memory, claims expiring silently. April authored 2 PRs ever; Plat 0 — against 106 reviews between them.
+- Observability was broken by construction: Oliver computed a weekly ops report and discarded it (read-only token, no commit step). `docs/ops/` froze on 2026-03-12.
+
+Model capability was at most secondary: agents did what the pipeline permitted. The architecture made proposing cheap and finishing impossible. Better models in the same pipeline would have stalled identically.
+
+## Decisions
+
+| # | Decision |
+|---|---|
+| D1 | **Role**: background metabolism, growth path to second engine; no agent-originated feature ideas in v2 |
+| D2 | **Control plane**: issue labels + PR state only; a Gate is exactly a label flip, a PR review, or a merge; comment keywords and reactions are never control signals |
+| D3 | **Interface**: one pinned Digest discussion + committed dashboard; PR-shaped gates; the product's feedback box is the Owner's Steering inlet; WorkSpaces-app Attention integration later |
+| D4 | **Pipeline**: six event-fired Stages; the Monitor's daily pulse is the only heartbeat; an idle Factory does nothing |
+| D5 | **Personas**: rebound to roles — April/Plat as implement/review pair (counterpart always reviews), Peter as triage + spec author, Oliver as the deterministic Monitor's name; no Persona is ever scheduled to find work |
+| D6 | **Memory**: per-Persona Memory Blocks + Profile, self-managed, peer-reviewed via PRs; append-only Journal as the only direct-write surface; Dreaming later |
+| D7 | **Feedback inlet**: poll cron → triage; Owner Steering flows gateless; non-owner publication is Owner-gated in v1, widened later |
+| D8 | **Autonomy gradient**: explicit gate map, measured instruments, pre-defined auto-merge class (disabled); Owner intends to delegate merges as reviewer-agreement evidence accumulates; privileged paths stay Owner-merged forever |
+| D9 | **Safety**: v1 posture carries over plus five deltas (memory carve-out, per-stage + global kill switches, spend caps, label-only triage powers, ruleset note) |
+| D10 | **Cleanup**: close all 25 discussions; batch re-triage the 52 agent issues via one disposition table; retire v1 machinery in one PR wave; fossil ideas are not auto-converted |
+| D11 | **Rollout**: M0–M6 below; the Factory never builds itself autonomously — its own code ships only through Owner-merged PRs |
+
+## The pipeline
+
+| Stage | Persona | Trigger | Does | Builds on |
+|---|---|---|---|---|
+| Triage | Peter | issue opened; feedback poll cron | understand/reproduce; route small+clear → `ready`, large/ambiguous → `spec`, unclear → `needs-info`, someday → `idea`; sanitize + dedup feedback | new |
+| Spec | Peter | `spec` applied | write `specs/<slug>/PRODUCT.md` + `TECH.md`; open spec-only PR | new; Warp's spec-skill shape |
+| Implement | April or Plat | `ready` applied | claim → branch → implement → evidence → PR (`Closes #N`) | evidence lane (`_evidence.yml`, `evidence.sh`) reused as-is |
+| Review | the counterpart | agent PR opened | review against mergeability standard; apply `mergeable` | the one organically working v1 behavior |
+| Verify | — | PR gate | tests, screenshots, smoke lanes | exists; ahead of reference designs |
+| Monitor | Oliver (deterministic) | daily cron; CI events | Digest + dashboard, Gate aging/escalation, state reconciliation, CI-failure issues, feedback status write-back | replaces v1 Oliver, with a write path |
+
+**Spec gate mechanics**: merging the spec PR is the approval — a merge hook applies `ready` to the linked issue. Review-with-comments is steering; closing the PR is a veto. `blocked` on the issue is the escape hatch to accept a spec but defer implementation. PRODUCT.md carries numbered testable behavior invariants; TECH.md maps tests 1:1 to those invariants and includes a parallelization assessment.
+
+**Reconciliation**: pure event-driven systems stall invisibly when a trigger misfires (v1's Peter failure). The Monitor's daily pass re-derives expected-vs-actual state and re-fires anything stuck — `sync-execution-state.py`'s logic survives here as the janitor duty.
+
+## Gate map and trust tiers (v1 settings)
+
+| Decision | Setting |
+|---|---|
+| Publish non-owner feedback as issue | **Gated** (Digest tap) |
+| Publish Owner Steering | Gateless |
+| Release small+clear Owner-sourced work | Gateless (triage applies `ready`) |
+| Release small+clear external work | Gated (`ready` flip) |
+| Release large/ambiguous work | Gated (spec PR merge) |
+| Merge any implementation PR | Gated — Owner is sole merge authority |
+| Persona memory/profile changes | Peer-reviewed in PRs |
+
+Composed property: **no public input reaches code execution without passing through an Owner gesture.** Public GitHub issues opened directly follow the same tiers as feedback: triage may label and ask, but `ready` on externally-sourced work is the Owner's to flip.
+
+The trust ladder is meant to be climbed. The Owner is a temporary merge gate, not a permanent one; delegation advances on reviewer-agreement evidence (below), with large spec'd work and privileged paths staying Owner-gated indefinitely.
+
+## Personas and memory
+
+- **Identity** = GitHub App credential + perspective lens + `author:` label + long-term memory. The three existing minimal-scope Apps carry over. Author labels are applied by machinery, not aspiration (v1 applied zero).
+- **Routing**: Peter reads both Profiles at triage and assigns the implementer; the counterpart automatically becomes reviewer — the author≠approver requirement falls out of the pairing. Profiles are seeded from the existing persona prompts (April: application/UX; Plat: platform/CI) and diverge from real history.
+- **Memory layout**: `.agents/memory/<persona>/` — `PROFILE.md` (short, machine-readable; what triage reads), `MEMORY.md` index + Memory Blocks (one fact per markdown file, YAML frontmatter with slug + freshness metadata), `journal/` (append-only observations, direct-committed after non-PR work, never consumed as instructions).
+- **Write path**: memory and profile changes ride inside the Persona's normal PRs, so the counterpart reviews every self-modification. Journal → Memory Block consolidation ("Dreaming", periodic or triggered) also lands through reviewed PRs. This is the safety boundary against untrusted content laundering itself into future privileged prompts.
+- **Enforcement**: `.agents/memory/<own-persona>/**` is carved out of the privileged-path guard; a CI check verifies each App identity only touches its own directory.
+
+## The Owner interface
+
+- **Digest**: one pinned GitHub Discussion — the only live discussion — rewritten daily by the Monitor. Gates sorted by age, each line answerable in one tap (link to the PR, the label flip, the pending feedback). Optimized for GitHub mobile in a 5-minute daily touch.
+- **Dashboard**: committed `docs/ops/dashboard.md` + snapshot JSON — the durable, queryable telemetry behind the Digest, and later the API the WorkSpaces app's Attention integration consumes.
+- **Steering**: the product's own feedback box (`kind=idea`) or a directly-opened issue; both flow through triage identically. Owner submissions are recognized by `submitter_login` and flow gateless per the gate map.
+- **Escalation**: aging Gates rise in the Digest; the Monitor escalates rather than repeating itself verbatim (v1's Fable thread nagged identically 6 of 7 days into the void).
+
+## Safety posture
+
+Carried over from v1 unchanged: three minimal-scope GitHub Apps; env-var sanitization (tokens never reach model context); all GitHub text framed as untrusted data; fork-PR diff exclusion; privileged-path patch guard (`.github/`, `.agents/` outside memory, auth/token/sandbox, release/signing — Owner-merged forever); two-phase mention triage (`safe-to-run-agent` label gate, server-side permission verification) retained as the persona-summoning path; pinned CLI versions.
+
+New in v2:
+
+1. Memory carve-out with per-App directory ownership CI check (above).
+2. **Kill switches: per-stage variables (`FACTORY_TRIAGE_ENABLED`, `FACTORY_IMPLEMENT_ENABLED`, …) *and* the global master (`AGENT_AUTOMATIONS_ENABLED`)** — both required to be on for a stage to run.
+3. Spend caps as config: per-run token/time budget per stage, daily Factory-wide cap, enforced in the runner, reported in the Digest.
+4. Triage's write powers are labels and comments only; implementation starts only from a label event.
+5. The future auto-merge class requires a deliberate main-merge ruleset change (`config/github/`) — flagged now so it is a designed decision, not an expedient hack.
+
+## Instruments and dials
+
+The Monitor computes weekly, into dashboard + Digest:
+
+- shipped changes; **touches-per-shipped-change**; median time-in-gate per gate type
+- % of shipped work fully autonomous up to PR review
+- **reviewer-agreement rate**: Owner merge decision vs reviewing Persona's verdict (and reviewer-vs-reviewer once a third reviewer exists) — the evidence that justifies merge delegation
+- token spend per shipped change; spend vs caps
+
+Dials are reviewed monthly against the dashboard. First pre-defined widening (defined now, **disabled**): auto-merge for PRs where all hold — mechanical change class (docs, deps, test-only, config-as-code) · implementer ≠ reviewer and reviewer approved · CI green · evidence attached · no privileged paths.
+
+## Cleanup wave (part of M1)
+
+- **Discussions**: close all 25 with a short disposition comment linking this plan. The Fable daily-recommendation thread retires — its function is the Digest. One new pinned Digest discussion becomes the only live thread. Fossil `[idea]` threads are not auto-converted; anything still alive re-enters via Steering.
+- **Issues**: one interactive-lane batch re-triage of the 52 `agent` issues — shipped-detection first (`rg` acceptance criteria against the tree; the tracker lags the code), then a single disposition table (close-as-shipped / close-as-stale / relabel / `idea`) approved by the Owner in one sitting.
+- **Machinery**: one PR wave deletes the cron-contributor workflows (`agent-april.yml`, `agent-plat.yml` schedules + selector runtime), Peter's keyword trigger, and the wake-up model; `sync-execution-state.py` donates its logic to the Monitor; `docs/development/agent-team.md` is rewritten as the Factory doc. Kept: `_evidence.yml`, App identities, mention flow, evidence lane, label vocabulary.
+
+## Milestones
+
+- **M0 — Decisions on paper** *(this session)*: this plan, three ADRs, glossary (`CONTEXT-MAP.md`, `docs/agents/CONTEXT.md`), doc-nav row. Done when the PR merges.
+- **M1 — Eyes + broom**: Monitor v1 (daily Digest posted, dashboard committed by workflow — write path proven, Gate aging, reconciliation janitor) + the cleanup wave. Done when: a Digest exists and updates daily; `docs/ops/` shows a current timestamp; open discussions = 1; the disposition table has been approved and applied; v1 crons are deleted.
+- **M2 — Front door**: Triage stage on issue-opened + feedback-poll cron; worker `status='new'` service endpoint; trust tiers enforced; feedback status write-back. Done when: an Owner feedback submission flows gateless to a `ready` issue with no human touch; a non-owner submission waits in the Digest.
+- **M3 — Hands**: Implement + Review stages on small `ready` work; Profile-based routing; memory v1 (journal, blocks, PR-carried updates, ownership CI check). Done when: the first Factory-authored PR merges carrying machinery-applied `author:` labels, counterpart review, evidence, and a memory diff.
+- **M4 — Spec gate**: `spec` label, spec-only PRs, merge→`ready` hook. Done when one large item flows steering → spec PR → merge → `ready` → implementation PR.
+- **M5 — Instruments and dials**: full metric suite live; monthly dial-review ritual; auto-merge class formally specified, disabled.
+- **M6+ — Earned autonomy** (sequenced later, by evidence): third agent reviewer (codex; `codex-review-loop` machinery exists) → reviewer-quorum auto-approve on mechanical classes; Dreaming; app-integrated Digest via Attention; skill-optimization outer loop **with explicit exit criteria** (the named failure mode of graderless loops is token-burning local-maxima chasing); integration branches for large work; feedback-publication widening.
+
+The Factory never builds itself autonomously: M1–M4 are Interactive Lane work, and even at M6 the Factory's own code changes only through fully-gated PRs the Owner merges.
+
+## Experiment register (observe, don't design yet)
+
+- **Persona divergence** — a first-class research goal: rich journals, periodic published self-retrospectives (a Dreaming output), routing history as data. What does months of accumulated, peer-reviewed memory do to two initially-similar agents?
+- **Integration-branch approach** for large spec'd work — deliberately unresolved; observe where big PRs strain the single-PR flow and let the mechanism emerge.
+- **Third-reviewer quorum** — which change classes reach reviewer-agreement rates that justify delegation, and how fast.
+- **Feedback loop closure** — surfacing "your feedback shipped" back through the product once `status='resolved'` write-back exists.
+
+## References
+
+- Live-state audit, infra deep-dive, feedback-feature map: session artifacts, 2026-07-12 (summarized in "Why v1 stalled").
+- Warp: [the automatic triage skill](https://www.warp.dev/blog/how-to-build-a-cloud-software-factory-the-automatic-triage-skill) · [three skills for spec-driven development](https://www.warp.dev/blog/three-skills-for-spec-driven-development) · [skill optimization loop](https://www.warp.dev/blog/building-a-skill-optimization-loop) · [demo repo](https://github.com/warpdotdev-demos/cloud-factory-demo) · [common-skills](https://github.com/warpdotdev/common-skills)
+- Factory.ai: [Factory 2.0](https://factory.ai/news/software-factory) · [Signals](https://factory.ai/news/factory-signals)


### PR DESCRIPTION
## Summary

M0 of the Agent Factory redesign — decisions on paper. Supersedes the v1 "Agent Team" architecture (scheduled persona wake-ups + Discussions control flow) with an event-driven, label-fired pipeline. Product of a grilled design session (2026-07-12) run against a live GitHub state audit, an infrastructure deep-dive, the feedback-feature map, and Warp's published software-factory series.

**What's in the diff:**
- `docs/development/agent-factory-v2-plan.md` — the plan: diagnosis of why v1 stalled (conversion, not execution), 11 decisions, pipeline, gate map + trust tiers, persona memory architecture, safety deltas, autonomy instruments, cleanup wave, milestones M0–M6
- `docs/decisions/factory-label-control-plane.md` — labels/PRs as the only control plane; Gates = label flip / PR review / merge; no keyword or reaction parsing
- `docs/decisions/factory-event-driven-stages.md` — six event-fired Stages, monitor-only heartbeat, spec-PR-merge as release gate, persona rebinding
- `docs/decisions/factory-persona-memory.md` — self-managed persona memory via peer-reviewed PRs, append-only journal, `.agents/memory/` carve-out
- `CONTEXT-MAP.md` + `docs/agents/CONTEXT.md` — the Factory bounded context and glossary (Factory, Gate, Inlet, Steering, Digest, Stage, Spec, Persona, Memory Block, Journal, Profile, Dreaming)
- `AGENTS.md` — doc-nav row pointing at the plan and glossary

**Key v1 audit facts encoded in the plan:** 141 agent-lane PRs merged in 60d at 18-min median vs zero `[idea]` discussions converted; Peter's keyword trigger fired genuinely once and failed silently; Oliver's ops report discarded weekly since March (no write path); April 2 PRs ever / Plat 0 vs 106 reviews.

## Evidence

Docs-only diff — no runtime surface. Verified: all file paths referenced in the plan, ADRs, and doc-nav row exist in the tree; decision frontmatter matches the `docs/decisions/` house format. Codex review skipped per repo convention for docs-only diffs.

## Mergeability

- **Surface**: documentation only (`docs/`, `AGENTS.md` nav table, new root `CONTEXT-MAP.md`)
- **Behavior changed**: none at runtime; establishes the approved design baseline that M1+ implementation PRs will cite
- **Non-happy paths**: n/a (no code); the plan itself documents failure modes of the design it replaces
- **Residual risk**: plan/reality drift if M1+ diverges from this doc — mitigated by ADR discipline (contradictions must supersede, not silently override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)