### PR TITLE
chore(skills): correct codex model pin to gpt-5.6-sol

### DIFF
--- a/.claude/skills/codex-execution/SKILL.md
+++ b/.claude/skills/codex-execution/SKILL.md
@@ -24,6 +24,13 @@ codex exec --cd <worktree-path> \
   "$(cat brief.md)" </dev/null
 ```
 
+**Model pin: `gpt-5.6-sol`.** Marketing names and dispatchable ids diverge —
+ChatGPT-account codex rejects bare `gpt-5.6` ("model is not supported when
+using Codex with a ChatGPT account"). On that error, don't guess ids: read the
+CLI's own configured default (`rg '^model' <codex home>/config.toml` — the
+runtime's config is the known-good id), dispatch with that, and update this
+pin in the same arc.
+
 **Foreground-synchronous, stdin closed.** A backgrounded codex hangs on
 "Reading additional input from stdin…" with zero output — this stalled three
 agents in one arc. Run it in the foreground of a background *shell* if you need

--- a/.claude/skills/codex-execution/SKILL.md
+++ b/.claude/skills/codex-execution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-execution
-description: Dispatch codex CLI (gpt-5.6 xhigh) as the implementing agent for a well-specified issue — codex commits locally in a dedicated worktree, the orchestrator reviews, gates, and ships. Use when delegating implementation work to codex ("dispatch to codex", "codex implements"), especially when Claude subagent capacity is constrained. Complements codex-review-loop (codex as reviewer).
+description: Dispatch codex CLI (gpt-5.6-sol xhigh) as the implementing agent for a well-specified issue — codex commits locally in a dedicated worktree, the orchestrator reviews, gates, and ships. Use when delegating implementation work to codex ("dispatch to codex", "codex implements"), especially when Claude subagent capacity is constrained. Complements codex-review-loop (codex as reviewer).
 ---
 
 # Codex as Execution Agent
@@ -19,7 +19,7 @@ git -C <repo> fetch origin main   # ALWAYS — a stale origin/main base costs a
                                   # surprise rebase later (bit twice in W6)
 git -C <repo> worktree add -b codex/<slug> <worktree-path> origin/main
 codex exec --cd <worktree-path> \
-  -c model='"gpt-5.6"' -c model_reasoning_effort='"xhigh"' \
+  -c model='"gpt-5.6-sol"' -c model_reasoning_effort='"xhigh"' \
   --dangerously-bypass-approvals-and-sandbox \
   "$(cat brief.md)" </dev/null
 ```
@@ -64,7 +64,7 @@ non-negotiables:
 ## Orchestrator gating (after codex returns)
 
 1. Read `CODEX_REPORT.md` + the full diff; react with attributed commits
-   (`In response to my (…) review of the codex (gpt-5.6, xhigh) implementation`).
+   (`In response to my (…) review of the codex (gpt-5.6-sol, xhigh) implementation`).
    **Stage explicit paths, never `git add -A`** — a sweep in a worktree
    commits the untracked report (now also gitignored, but the habit matters).
 2. Rebase onto current `origin/main`; **clean stale build state before

--- a/.claude/skills/codex-review-loop/SKILL.md
+++ b/.claude/skills/codex-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-review-loop
-description: Pre-PR review loop — self-reflect, then a directed codex CLI (gpt-5.6 xhigh) review, then react with attributed commits. Use before opening any substantive PR or when asked to "run the review loop" / "codex review this". Skip for metadata/docs-only diffs.
+description: Pre-PR review loop — self-reflect, then a directed codex CLI (gpt-5.6-sol xhigh) review, then react with attributed commits. Use before opening any substantive PR or when asked to "run the review loop" / "codex review this". Skip for metadata/docs-only diffs.
 ---
 
 # Codex Review Loop
@@ -28,7 +28,7 @@ docs-only diffs.
 2. **Codex, directed.**
 
    ```bash
-   codex exec -c model="gpt-5.6" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"
+   codex exec -c model="gpt-5.6-sol" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"
    ```
 
    Give it the diff command, named failure modes, and one falsifiable completeness question —
@@ -52,7 +52,7 @@ docs-only diffs.
    introduced a finding — run `git log <base>..HEAD -- <files>` before acting. Pre-existing
    findings become issues, not scope creep. Declining a finding is valid; say why in the PR.
 
-4. **React with attribution.** Fix commits open with `In response to codex (gpt-5.6, xhigh) ...`;
+4. **React with attribution.** Fix commits open with `In response to codex (gpt-5.6-sol, xhigh) ...`;
    the PR body carries a `## Review loop` section listing each finding and its disposition.
    Never fold review reactions silently into other commits — attribution is how the loop's
    value is measured.

--- a/.claude/skills/codex-review-loop/references/prompt-patterns.md
+++ b/.claude/skills/codex-review-loop/references/prompt-patterns.md
@@ -4,7 +4,7 @@ Directed prompts produce bugs; "review this" produces checklists. Pick the patte
 
 ## Mechanics
 
-- `codex exec -c model="gpt-5.6" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"`
+- `codex exec -c model="gpt-5.6-sol" -c model_reasoning_effort="xhigh" --skip-git-repo-check "<prompt>"`
   — tell the prompt which diff to read (`git diff main...HEAD`, `git show HEAD`); plain `exec`
   doesn't infer it. (`codex exec review --base main` exists but cannot combine with a custom prompt.)
 - 8–12 min typical at xhigh; set Bash timeout ≥ 600s. On timeout the session survives:

--- a/.claude/skills/tile-orchestration/SKILL.md
+++ b/.claude/skills/tile-orchestration/SKILL.md
@@ -80,7 +80,7 @@ gitignored):
 2. Write `.agents/inbox/tile-start`:
    ```bash
    echo "[worker-<issue>] started $(date)" | tee .agents/inbox/worker.log
-   codex exec --cd . -c model='"gpt-5.6"' -c model_reasoning_effort='"high"' \
+   codex exec --cd . -c model='"gpt-5.6-sol"' -c model_reasoning_effort='"high"' \
      --dangerously-bypass-approvals-and-sandbox \
      "$(cat .agents/inbox/brief-<issue>.md)" </dev/null 2>&1 | tee -a .agents/inbox/worker.log
    echo "[worker-<issue>] finished $(date)" | tee -a .agents/inbox/worker.log


### PR DESCRIPTION
Follow-up to #1068: dispatching with `gpt-5.6` fails on this codex CLI (`The 'gpt-5.6' model is not supported when using Codex with a ChatGPT account`). The working 5.6-generation id is `gpt-5.6-sol` — verified by two live dispatches (#1063, #1065 briefs) that were accepted and are running.

## Mergeability

- **Surface**: skill guidance files under `.claude/skills/` only
- **Behavior changed**: codex dispatches use the id that actually resolves
- **Non-happy paths**: a dispatch with a stale or wrong model id fails fast with codex's "model is not supported" 400 before any work starts; the skill now documents that failure signature and the config.toml re-derivation path, so recovery is self-serve rather than an investigation
- **Residual risk**: the pinned id rots again when OpenAI rotates model names; mitigated by the re-derivation note this PR adds to the skill

Evidence: docs-only diff; the live-dispatch acceptance above is the functional proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
