### PR TITLE
ci(cd): fail fast when Vercel protection-bypass is not honored

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -164,18 +164,28 @@ jobs:
             echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is not set — validators would measure the Vercel SSO login page, not the app. Set the repo secret to the project's Protection-Bypass-for-Automation value (Vercel → spaces-web → Settings → Deployment Protection)."
             exit 1
           fi
-          read -r STATUS REDIRECT < <(
-            curl -sS -o /dev/null -w '%{http_code} %{redirect_url}' \
-              -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
-              "$PREVIEW_URL/"
-          )
-          echo "preview probe: status=$STATUS redirect=${REDIRECT:-<none>}"
+          # Capture curl's exit explicitly: `curl -w` emits no trailing newline,
+          # so `read` would return non-zero at EOF and, under `set -e`, abort the
+          # job before the case ever runs (a false failure on every probe). A
+          # herestring re-adds the newline; the network-failure branch is its own.
+          set +e
+          PROBE=$(curl -sS -o /dev/null -w '%{http_code} %{redirect_url}' \
+            -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+            "$PREVIEW_URL/")
+          CURL_EXIT=$?
+          set -e
+          read -r STATUS REDIRECT <<< "$PROBE"
+          echo "preview probe: status=${STATUS:-<none>} redirect=${REDIRECT:-<none>} curl_exit=$CURL_EXIT"
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            echo "::error::curl failed (exit $CURL_EXIT) probing $PREVIEW_URL/ — could not reach the preview deployment."
+            exit 1
+          fi
           case "$STATUS" in
             2*)
               echo "Protection-bypass honored — validators will see the app."
               ;;
             *)
-              if printf '%s' "$REDIRECT" | grep -qiE 'vercel\.com/(sso-api|login)'; then
+              if printf '%s' "$REDIRECT" | grep -qiE '^https://[^/]*vercel\.com/(sso-api|login)([/?#]|$)'; then
                 echo "::error::Deployment-protection bypass NOT honored: $PREVIEW_URL/ redirected to Vercel SSO ($REDIRECT). The repo secret VERCEL_AUTOMATION_BYPASS_SECRET does not match the project's Protection-Bypass-for-Automation secret, or that feature is disabled. Fix: Vercel → spaces-web → Settings → Deployment Protection → enable + copy the automation bypass secret, then 'gh secret set VERCEL_AUTOMATION_BYPASS_SECRET --repo fairchild/workspaces'."
               else
                 echo "::error::Unexpected status $STATUS probing $PREVIEW_URL/ with the bypass header (redirect=${REDIRECT:-<none>}); expected 2xx."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -143,8 +143,49 @@ jobs:
           echo "::error::Health check failed after 3 attempts against ${{ matrix.health_url }}"
           exit 1
 
-  playwright-validate:
+  bypass-preflight:
+    # Fail fast and loud when Vercel deployment-protection bypass is not honored.
+    # A stale/mismatched VERCEL_AUTOMATION_BYPASS_SECRET otherwise lets the
+    # validators measure Vercel's SSO login page instead of the app — surfacing
+    # as a bogus ~12-minute Lighthouse "perf regression" rather than the real
+    # cause. This probes the app root with the bypass header and requires a 2xx;
+    # an SSO redirect is a hard fail with the exact remedy. lighthouse and
+    # playwright-validate gate on it so the expensive work never runs blind.
     needs: preview-web
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe preview with protection-bypass header
+        env:
+          PREVIEW_URL: ${{ needs.preview-web.outputs.preview_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is not set — validators would measure the Vercel SSO login page, not the app. Set the repo secret to the project's Protection-Bypass-for-Automation value (Vercel → spaces-web → Settings → Deployment Protection)."
+            exit 1
+          fi
+          read -r STATUS REDIRECT < <(
+            curl -sS -o /dev/null -w '%{http_code} %{redirect_url}' \
+              -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" \
+              "$PREVIEW_URL/"
+          )
+          echo "preview probe: status=$STATUS redirect=${REDIRECT:-<none>}"
+          case "$STATUS" in
+            2*)
+              echo "Protection-bypass honored — validators will see the app."
+              ;;
+            *)
+              if printf '%s' "$REDIRECT" | grep -qiE 'vercel\.com/(sso-api|login)'; then
+                echo "::error::Deployment-protection bypass NOT honored: $PREVIEW_URL/ redirected to Vercel SSO ($REDIRECT). The repo secret VERCEL_AUTOMATION_BYPASS_SECRET does not match the project's Protection-Bypass-for-Automation secret, or that feature is disabled. Fix: Vercel → spaces-web → Settings → Deployment Protection → enable + copy the automation bypass secret, then 'gh secret set VERCEL_AUTOMATION_BYPASS_SECRET --repo fairchild/workspaces'."
+              else
+                echo "::error::Unexpected status $STATUS probing $PREVIEW_URL/ with the bypass header (redirect=${REDIRECT:-<none>}); expected 2xx."
+              fi
+              exit 1
+              ;;
+          esac
+
+  playwright-validate:
+    needs: [preview-web, bypass-preflight]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -195,7 +236,7 @@ jobs:
           path: web/findings.md
 
   lighthouse:
-    needs: preview-web
+    needs: [preview-web, bypass-preflight]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
# ci(cd): fail fast when Vercel protection-bypass is not honored

## Summary

For weeks every `cd.yml` run failed at `lighthouse` + `playwright-validate`, and it read as a performance regression (the tracked task was "perf 0.63 / TBT 685 — rebaseline?"). It wasn't. A stale/mismatched `VERCEL_AUTOMATION_BYPASS_SECRET` meant the `x-vercel-protection-bypass` header wasn't honored, so both gates measured/asserted against **Vercel's SSO login page** (`vercel.com/sso-api`) instead of the app — Lighthouse was scoring the login SPA (perf 0.55, TBT 1905ms), and the failing-URL column literally showed `vercel.com/login`. Re-syncing the secret turned the whole pipeline green with **no real perf work** (the app meets the budget once actually measured).

This adds a guard so that failure mode can never again masquerade as a perf regression.

## Change

A `bypass-preflight` job probes the preview root with the bypass header and **hard-fails in seconds** with the exact remedy when:
- the deployment redirects to Vercel SSO (`vercel.com/sso-api|login`) — the bypass isn't honored, or
- `VERCEL_AUTOMATION_BYPASS_SECRET` is unset.

`lighthouse` and `playwright-validate` now `needs: [preview-web, bypass-preflight]`, so the expensive validation never runs blind against the login wall. `promote` (`if: success()`) skips when the validators skip. Previously the bypass warmup was `curl … || true`, which swallowed the 401 and let ~12 minutes of Lighthouse run against the wrong page.

## Testing

Preflight logic verified against the **real failing preview URL** plus controls:

![preflight-verification](https://evidence.cloudcompute.com/workspaces/pr-1072/20260713-060228-cd-bypass-preflight-verification.png)

- Live preview URL + wrong secret → `302 → vercel.com/sso-api` → detected → fail (the exact weeks-long failure mode, now caught in seconds)
- Secret unset → fail with remedy
- `2xx` → pass
- YAML validated; gating confirmed (`promote: if: success()` skips when validators skip).

## Review loop

Directed codex review (gpt-5.5, xhigh) of the workflow diff:

- **HIGH — fixed.** The first draft used `read -r STATUS REDIRECT < <(curl -w …)`. `curl -w` emits no trailing newline, so `read` returns non-zero at EOF and, under `set -e`, the job aborts **before** the `case` — failing every probe including a correct 2xx. (My local test missed it: the harness function didn't inherit `set -e`.) Fixed by capturing curl's exit explicitly, parsing via a herestring, and adding a dedicated network-failure branch. Re-verified under real `set -euo pipefail`.
- **Nit — applied.** Anchored the SSO grep to `^https://[^/]*vercel\\.com/(sso-api|login)([/?#]|$)` so a redirect whose query merely contains the string can't false-match.
- **Directed answers confirmed:** no false-negative pass exists; `promote` (`if: success()`) does not run when validators skip; `fail-notify-*` correctly do not misfire on a `skipped` result; `preview-web` still outputs `preview_url` unchanged.
- **Accepted by design:** a stale-bypass failure now surfaces as the preflight job's own labeled `::error::` rather than a findings-artifact notification. That's the intended behavior — the error is self-describing with the remedy; adding a separate notification channel would be scope creep.

## Mergeability

- **Surface:** `.github/workflows/cd.yml` — one new `bypass-preflight` job + two `needs:` edits on the existing validators. No app code, no changes to validator internals or promote/prod jobs.
- **Behavior changed:** a non-honored deployment-protection bypass (stale secret / disabled feature / unset secret) now fails the pipeline fast with a labeled, actionable error instead of running ~12 min of Lighthouse against the SSO login page and reporting a bogus perf score. Happy path (bypass honored → 2xx) is unchanged.
- **Non-happy paths:** SSO redirect → specific remedy error; unset secret → specific error; any other non-2xx on `/` → generic "unexpected status" failure (fails loud rather than proceeding blind); network/curl failure → `000`/empty → generic failure branch (no false pass).
- **Residual risk:** low — the probe is read-only and pre-gates existing jobs; worst case a genuinely-2xx-but-odd deployment is briefly held, which is safer than promoting an unvalidated one. Secret is only used in a request header, never echoed (only status + redirect URL are logged).
