### PR TITLE
fix(factory): Discussion has no state field — use closed boolean

### DIFF
--- a/scripts/factory-digest.py
+++ b/scripts/factory-digest.py
@@ -101,7 +101,7 @@ query FactoryDigestDiscussions($owner: String!, $name: String!, $after: String) 
     discussionCategories(first: 25) { nodes { id name } }
     discussions(first: 100, after: $after, states: [OPEN, CLOSED]) {
       pageInfo { hasNextPage endCursor }
-      nodes { id number title body url state createdAt }
+      nodes { id number title body url closed createdAt }
     }
   }
 }
@@ -460,7 +460,7 @@ def publish_digest(
                 f"#{selected['number']} and leaving {others} untouched",
                 file=sys.stderr,
             )
-        if str(selected.get("state", "OPEN")).upper() == "CLOSED":
+        if bool(selected.get("closed")):
             reopen_mutation = """
 mutation ReopenFactoryDigest($input: ReopenDiscussionInput!) {
   reopenDiscussion(input: $input) {

--- a/scripts/tests/test_factory_digest.py
+++ b/scripts/tests/test_factory_digest.py
@@ -345,7 +345,7 @@ class FactoryDigestTests(unittest.TestCase):
                 "title": "Renamed by the owner",
                 "body": "intro\n<!-- factory-digest:v1 -->\nold digest",
                 "url": "https://example.test/discussions/99",
-                "state": "OPEN",
+                "closed": False,
                 "createdAt": "2026-07-01T00:00:00Z",
             }
         ]
@@ -388,7 +388,7 @@ class FactoryDigestTests(unittest.TestCase):
             "title": "Old title",
             "body": "<!-- factory-digest:v1 -->\n\nold",
             "url": "https://example.test/discussions/98",
-            "state": "CLOSED",
+            "closed": True,
             "createdAt": "2026-07-01T00:00:00Z",
         }
         operations: list[str] = []
@@ -465,7 +465,7 @@ class FactoryDigestTests(unittest.TestCase):
             "title": "Factory Digest",
             "body": "owner-authored discussion",
             "url": "https://example.test/discussions/90",
-            "state": "OPEN",
+            "closed": False,
             "createdAt": "2026-06-01T00:00:00Z",
         }
         discussions: list[dict[str, object]] = [unmarked]
@@ -481,7 +481,7 @@ class FactoryDigestTests(unittest.TestCase):
                     "title": "Factory Digest",
                     "body": variables["input"]["body"],
                     "url": "https://example.test/discussions/100",
-                    "state": "OPEN",
+                    "closed": False,
                     "createdAt": "2026-07-01T00:00:00Z",
                 }
                 discussions.append(discussion)
@@ -639,7 +639,7 @@ class FactoryDigestTests(unittest.TestCase):
                                             else "unmarked"
                                         ),
                                         "url": "https://example.test/discussions/1",
-                                        "state": "OPEN" if cursor is None else "CLOSED",
+                                        "closed": False if cursor is None else True,
                                         "createdAt": "2026-07-01T00:00:00Z",
                                     }
                                 ],
@@ -705,7 +705,7 @@ class FactoryDigestTests(unittest.TestCase):
         ]
         self.assertTrue(discussion_queries)
         self.assertIn("states: [OPEN, CLOSED]", discussion_queries[0])
-        self.assertEqual(inputs.discussions[1]["state"], "CLOSED")
+        self.assertTrue(inputs.discussions[1]["closed"])
         self.assertIn(factory_digest.DIGEST_MARKER, inputs.discussions[1]["body"])
         self.assertEqual(inputs.issues[0]["labels"], [{"name": "ready"}])
         self.assertEqual(inputs.pulls[0]["closingIssuesReferences"], [{"number": 10}])


### PR DESCRIPTION
First live run of the merged digest step (#1071) failed: `GitHub GraphQL error: Field 'state' doesn't exist on type 'Discussion'`. The marker-discovery query selected `state` on Discussion nodes — valid on Issue/PullRequest, absent on Discussion, which exposes `closed: Boolean`. Fixture-backed tests structurally cannot catch schema drift; the live dispatch (the post-merge verification plan in #1071) did, on its first run.

Changes: query selects `closed`, the reopen path checks the boolean, test discussion fixtures converted (`"state": "OPEN"/"CLOSED"` → `"closed": False/True`). Verified against the live API: the exact node selection parses, and `ReopenDiscussionInput` exists.

## Evidence

![digest-schema-fix-gates](https://evidence.cloudcompute.com/workspaces/pr-1073/20260713-071650-digest-schema-fix-gates.png)

20/20 tests green; live-schema validation of both query shapes run pre-push (node selection returns data, reopen input type resolves).

## Mergeability

- **Surface**: `scripts/factory-digest.py` + its tests
- **Behavior changed**: digest discovery works against the real GraphQL schema instead of failing on first live contact
- **Non-happy paths**: reopen path now keys off `closed` boolean; multiple-marker and unmarked-title protections unchanged
- **Residual risk**: remaining live unknowns (createDiscussion category, updateDiscussion token capability) are exactly what the next two monitor dispatches verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
