### PR TITLE
feat(factory): reconciliation janitor — the monitor repairs state daily

### DIFF
--- a/.github/workflows/factory-monitor.yml
+++ b/.github/workflows/factory-monitor.yml
@@ -174,6 +174,20 @@ jobs:
           git commit -m "chore(factory): update monitor telemetry"
           git push origin HEAD:factory/ops-data
 
+      - name: Reconcile Factory issue state
+        shell: bash
+        env:
+          DRY_RUN: ${{ inputs.dry_run || false }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ARGS=(--apply)
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS=(--dry-run)
+          fi
+
+          uv run --script "$GITHUB_WORKSPACE/source/scripts/factory-janitor.py" "${ARGS[@]}"
+
       - name: Update Factory Digest
         shell: bash
         env:

--- a/fixtures/factory-janitor/basic/state.json
+++ b/fixtures/factory-janitor/basic/state.json
@@ -47,7 +47,13 @@
       ],
       "assignees": [],
       "comments": [],
-      "timelineItems": []
+      "timelineItems": [
+        {
+          "__typename": "LabeledEvent",
+          "createdAt": "2026-07-12T10:00:00Z",
+          "label": {"name": "ready"}
+        }
+      ]
     },
     {
       "id": "I_103",
@@ -62,7 +68,13 @@
       ],
       "assignees": [],
       "comments": [],
-      "timelineItems": []
+      "timelineItems": [
+        {
+          "__typename": "LabeledEvent",
+          "createdAt": "2026-07-12T10:00:00Z",
+          "label": {"name": "ready"}
+        }
+      ]
     },
     {
       "id": "I_104",
@@ -75,7 +87,10 @@
         {"id": "L_task", "name": "task"},
         {"id": "L_claimed", "name": "claimed"}
       ],
-      "assignees": [{"id": "U_april", "login": "april-clearwater[bot]"}],
+      "assignees": [
+        {"id": "U_april", "login": "april-clearwater[bot]"},
+        {"id": "U_human", "login": "fairchild"}
+      ],
       "comments": [
         {
           "body": "Claimed.\n\n<!-- contributor:issue=104;status=claimed;agent=april;branch=agent/april-104 -->",
@@ -84,7 +99,13 @@
           "author": {"login": "april-clearwater[bot]"}
         }
       ],
-      "timelineItems": []
+      "timelineItems": [
+        {
+          "__typename": "LabeledEvent",
+          "createdAt": "2026-07-11T23:00:00Z",
+          "label": {"name": "ready"}
+        }
+      ]
     },
     {
       "id": "I_105",
@@ -141,6 +162,7 @@
       "body": "",
       "state": "OPEN",
       "labels": [
+        {"id": "L_agent", "name": "agent"},
         {"id": "L_human", "name": "human"},
         {"id": "L_task", "name": "task"},
         {"id": "L_ready", "name": "ready"},
@@ -204,7 +226,7 @@
     {
       "id": "I_112",
       "number": 112,
-      "title": "Recent assignee event wins",
+      "title": "Claim label wins over comment and assignment",
       "body": "",
       "state": "OPEN",
       "labels": [
@@ -213,7 +235,14 @@
         {"id": "L_claimed", "name": "claimed"}
       ],
       "assignees": [{"id": "U_plat", "login": "plat-ironwood[bot]"}],
-      "comments": [],
+      "comments": [
+        {
+          "body": "Claimed.\n\n<!-- contributor:issue=112;status=claimed;agent=plat;branch=agent/plat-112 -->",
+          "createdAt": "2026-07-13T08:00:00Z",
+          "authorAssociation": "NONE",
+          "author": {"login": "plat-ironwood[bot]"}
+        }
+      ],
       "timelineItems": [
         {
           "__typename": "LabeledEvent",
@@ -273,14 +302,87 @@
       "assignees": [],
       "comments": [],
       "timelineItems": []
+    },
+    {
+      "id": "I_116",
+      "number": 116,
+      "title": "Ignore draft and raw-body pull requests",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_ready", "name": "ready"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_117",
+      "number": 117,
+      "title": "Demote review without a known pull request",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_review", "name": "review"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_118",
+      "number": 118,
+      "title": "Demote closed pull request without prior release",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_review", "name": "review"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_119",
+      "number": 119,
+      "title": "Malformed chosen claim timestamp",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [{"id": "U_plat", "login": "plat-ironwood[bot]"}],
+      "comments": [
+        {
+          "body": "Claimed.\n\n<!-- contributor:issue=119;status=claimed;agent=plat;branch=agent/plat-119 -->",
+          "createdAt": "2026-07-10T08:00:00Z",
+          "authorAssociation": "NONE",
+          "author": {"login": "plat-ironwood[bot]"}
+        }
+      ],
+      "timelineItems": [
+        {
+          "__typename": "LabeledEvent",
+          "createdAt": "not-a-timestamp",
+          "label": {"name": "claimed"}
+        }
+      ]
     }
   ],
   "pulls": [
     {
       "number": 201,
-      "body": "Implementation",
       "url": "https://example.test/pulls/201",
       "state": "OPEN",
+      "isDraft": false,
       "updatedAt": "2026-07-13T10:00:00Z",
       "closedAt": null,
       "mergedAt": null,
@@ -288,19 +390,29 @@
     },
     {
       "number": 202,
-      "body": "Attempt that did not land.\n\nCloses #103",
       "url": "https://example.test/pulls/202",
       "state": "CLOSED",
+      "isDraft": false,
       "updatedAt": "2026-07-13T09:00:00Z",
       "closedAt": "2026-07-13T09:00:00Z",
       "mergedAt": null,
-      "closingIssuesReferences": []
+      "closingIssuesReferences": [{"number": 103}]
+    },
+    {
+      "number": 205,
+      "url": "https://example.test/pulls/205",
+      "state": "OPEN",
+      "isDraft": false,
+      "updatedAt": "2026-07-13T09:30:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": [{"number": 105}]
     },
     {
       "number": 210,
-      "body": "First contender",
       "url": "https://example.test/pulls/210",
       "state": "OPEN",
+      "isDraft": false,
       "updatedAt": "2026-07-13T11:00:00Z",
       "closedAt": null,
       "mergedAt": null,
@@ -308,23 +420,54 @@
     },
     {
       "number": 211,
-      "body": "Second contender\n\nFixes #110",
       "url": "https://example.test/pulls/211",
       "state": "OPEN",
+      "isDraft": false,
       "updatedAt": "2026-07-13T12:00:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": [{"number": 110}]
+    },
+    {
+      "number": 215,
+      "url": "https://example.test/pulls/215",
+      "state": "OPEN",
+      "isDraft": false,
+      "updatedAt": "2026-07-13T12:30:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": [{"number": 115}]
+    },
+    {
+      "number": 216,
+      "url": "https://example.test/pulls/216",
+      "state": "OPEN",
+      "isDraft": true,
+      "updatedAt": "2026-07-13T12:45:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": [{"number": 116}]
+    },
+    {
+      "number": 217,
+      "body": "Closes #116",
+      "url": "https://example.test/pulls/217",
+      "state": "OPEN",
+      "isDraft": false,
+      "updatedAt": "2026-07-13T12:50:00Z",
       "closedAt": null,
       "mergedAt": null,
       "closingIssuesReferences": []
     },
     {
-      "number": 215,
-      "body": "Closes #115",
-      "url": "https://example.test/pulls/215",
-      "state": "OPEN",
-      "updatedAt": "2026-07-13T12:30:00Z",
-      "closedAt": null,
+      "number": 218,
+      "url": "https://example.test/pulls/218",
+      "state": "CLOSED",
+      "isDraft": false,
+      "updatedAt": "2026-07-13T13:00:00Z",
+      "closedAt": "2026-07-13T13:00:00Z",
       "mergedAt": null,
-      "closingIssuesReferences": []
+      "closingIssuesReferences": [{"number": 118}]
     }
   ]
 }

--- a/fixtures/factory-janitor/basic/state.json
+++ b/fixtures/factory-janitor/basic/state.json
@@ -1,0 +1,330 @@
+{
+  "now": "2026-07-13T13:30:00Z",
+  "repo": {
+    "owner": "fairchild",
+    "name": "workspaces",
+    "id": "R_fixture",
+    "labelIds": {
+      "ready": "L_ready",
+      "claimed": "L_claimed",
+      "review": "L_review"
+    }
+  },
+  "issues": [
+    {
+      "id": "I_101",
+      "number": 101,
+      "title": "Repair claimed and ready",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [
+        {
+          "body": "Claimed.\n\n<!-- contributor:issue=101;status=claimed;agent=april;branch=agent/april-101 -->",
+          "createdAt": "2026-07-13T01:30:00Z",
+          "authorAssociation": "OWNER",
+          "author": {"login": "fairchild"}
+        }
+      ],
+      "timelineItems": []
+    },
+    {
+      "id": "I_102",
+      "number": 102,
+      "title": "Promote open pull request",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_ready", "name": "ready"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_103",
+      "number": 103,
+      "title": "Demote closed pull request",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_review", "name": "review"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_104",
+      "number": 104,
+      "title": "Expire stale comment claim",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [{"id": "U_april", "login": "april-clearwater[bot]"}],
+      "comments": [
+        {
+          "body": "Claimed.\n\n<!-- contributor:issue=104;status=claimed;agent=april;branch=agent/april-104 -->",
+          "createdAt": "2026-07-12T00:00:00Z",
+          "authorAssociation": "NONE",
+          "author": {"login": "april-clearwater[bot]"}
+        }
+      ],
+      "timelineItems": []
+    },
+    {
+      "id": "I_105",
+      "number": 105,
+      "title": "Restore missing lifecycle state",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_106",
+      "number": 106,
+      "title": "Digest identity exclusion",
+      "body": "Owner surface",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_factory", "name": "factory"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_107",
+      "number": 107,
+      "title": "Factory label exclusion",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_factory", "name": "factory"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_108",
+      "number": 108,
+      "title": "Human lane exclusion",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_human", "name": "human"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_109",
+      "number": 109,
+      "title": "Non-task exclusion",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_110",
+      "number": 110,
+      "title": "Multiple pull request anomaly",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_review", "name": "review"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_111",
+      "number": 111,
+      "title": "Expire stale label-event claim",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [{"id": "U_plat", "login": "plat-ironwood[bot]"}],
+      "comments": [],
+      "timelineItems": [
+        {
+          "__typename": "LabeledEvent",
+          "createdAt": "2026-07-11T08:00:00Z",
+          "label": {"name": "claimed"}
+        }
+      ]
+    },
+    {
+      "id": "I_112",
+      "number": 112,
+      "title": "Recent assignee event wins",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [{"id": "U_plat", "login": "plat-ironwood[bot]"}],
+      "comments": [],
+      "timelineItems": [
+        {
+          "__typename": "LabeledEvent",
+          "createdAt": "2026-07-10T08:00:00Z",
+          "label": {"name": "claimed"}
+        },
+        {
+          "__typename": "AssignedEvent",
+          "createdAt": "2026-07-13T08:00:00Z"
+        }
+      ]
+    },
+    {
+      "id": "I_113",
+      "number": 113,
+      "title": "Missing claim timestamp anomaly",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_114",
+      "number": 114,
+      "title": "Closed issue exclusion",
+      "body": "",
+      "state": "CLOSED",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    },
+    {
+      "id": "I_115",
+      "number": 115,
+      "title": "Review is highest priority",
+      "body": "",
+      "state": "OPEN",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_ready", "name": "ready"},
+        {"id": "L_claimed", "name": "claimed"},
+        {"id": "L_review", "name": "review"}
+      ],
+      "assignees": [],
+      "comments": [],
+      "timelineItems": []
+    }
+  ],
+  "pulls": [
+    {
+      "number": 201,
+      "body": "Implementation",
+      "url": "https://example.test/pulls/201",
+      "state": "OPEN",
+      "updatedAt": "2026-07-13T10:00:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": [{"number": 102}]
+    },
+    {
+      "number": 202,
+      "body": "Attempt that did not land.\n\nCloses #103",
+      "url": "https://example.test/pulls/202",
+      "state": "CLOSED",
+      "updatedAt": "2026-07-13T09:00:00Z",
+      "closedAt": "2026-07-13T09:00:00Z",
+      "mergedAt": null,
+      "closingIssuesReferences": []
+    },
+    {
+      "number": 210,
+      "body": "First contender",
+      "url": "https://example.test/pulls/210",
+      "state": "OPEN",
+      "updatedAt": "2026-07-13T11:00:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": [{"number": 110}]
+    },
+    {
+      "number": 211,
+      "body": "Second contender\n\nFixes #110",
+      "url": "https://example.test/pulls/211",
+      "state": "OPEN",
+      "updatedAt": "2026-07-13T12:00:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": []
+    },
+    {
+      "number": 215,
+      "body": "Closes #115",
+      "url": "https://example.test/pulls/215",
+      "state": "OPEN",
+      "updatedAt": "2026-07-13T12:30:00Z",
+      "closedAt": null,
+      "mergedAt": null,
+      "closingIssuesReferences": []
+    }
+  ]
+}

--- a/fixtures/factory-janitor/basic/state.json
+++ b/fixtures/factory-janitor/basic/state.json
@@ -89,7 +89,7 @@
     {
       "id": "I_105",
       "number": 105,
-      "title": "Restore missing lifecycle state",
+      "title": "Await Owner release",
       "body": "",
       "state": "OPEN",
       "labels": [

--- a/scripts/factory-janitor.py
+++ b/scripts/factory-janitor.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
@@ -27,15 +28,15 @@ from typing import Any
 FIXTURE_REQUIRED_FILES = ("state.json",)
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 STALE_CLAIM_HOURS = 24
+MUTATION_ATTEMPTS = 3
+MUTATION_BACKOFF_SECONDS = 1.0
 MANAGED_STATES = frozenset({"ready", "claimed", "review"})
 STATE_PRIORITY = ("review", "claimed", "ready")
 DIGEST_MARKER = "<!-- " + "-".join(("factory", "digest:v1")) + " -->"
+JANITOR_MARKER_PREFIX = "factory-janitor"
 CLAIM_MARKER_RE = re.compile(
     r"<!-- contributor:issue=(?P<number>\d+);status=(?P<status>[a-z_]+);"
     r"agent=(?P<agent>[a-z0-9-]+);branch=(?P<branch>[^>\n]+) -->"
-)
-CLOSING_REFERENCE_RE = re.compile(
-    r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
 TRUSTED_AUTHOR_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 TRUSTED_AUTOMATION_LOGINS = {
@@ -67,14 +68,13 @@ query FactoryJanitorIssues($owner: String!, $name: String!, $after: String) {
             author { login }
           }
         }
-        timelineItems(last: 100, itemTypes: [LABELED_EVENT, ASSIGNED_EVENT]) {
+        timelineItems(last: 100, itemTypes: [LABELED_EVENT]) {
           nodes {
             __typename
             ... on LabeledEvent {
               createdAt
               label { name }
             }
-            ... on AssignedEvent { createdAt }
           }
         }
       }
@@ -95,7 +95,7 @@ query FactoryJanitorPulls($owner: String!, $name: String!, $after: String) {
     ) {
       pageInfo { hasNextPage endCursor }
       nodes {
-        number body url state updatedAt closedAt mergedAt
+        number url state isDraft updatedAt closedAt mergedAt
         closingIssuesReferences(first: 50) { nodes { number } }
       }
     }
@@ -106,6 +106,14 @@ query FactoryJanitorPulls($owner: String!, $name: String!, $after: String) {
 
 class FactoryJanitorError(RuntimeError):
     """Raised when reconciliation cannot be planned or applied safely."""
+
+
+class GitHubRequestError(FactoryJanitorError):
+    """A classified GitHub failure, optionally safe to retry."""
+
+    def __init__(self, message: str, *, transient: bool = False):
+        super().__init__(message)
+        self.transient = transient
 
 
 @dataclass(frozen=True)
@@ -129,11 +137,19 @@ class Transition:
     issue_number: int
     title: str
     current_states: tuple[str, ...]
-    desired_state: str
+    desired_state: str | None
     reason: str
     current_label_ids: dict[str, str]
     assignees: tuple[tuple[str, str], ...] = ()
+    preserved_assignees: tuple[str, ...] = ()
     comment: str | None = None
+
+
+@dataclass(frozen=True)
+class MutationOperation:
+    name: str
+    query: str
+    variables: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -166,20 +182,46 @@ def graphql(token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")
-        raise FactoryJanitorError(
-            f"GitHub GraphQL HTTP {error.code}: {detail}"
+        headers = error.headers or {}
+        rate_limited = error.code == 429 or (
+            error.code == 403
+            and (
+                headers.get("X-RateLimit-Remaining") == "0"
+                or "rate limit" in detail.casefold()
+            )
+        )
+        raise GitHubRequestError(
+            f"GitHub GraphQL HTTP {error.code}: {detail}",
+            transient=rate_limited or 500 <= error.code < 600,
         ) from error
     except urllib.error.URLError as error:
-        raise FactoryJanitorError(
-            f"GitHub GraphQL request failed: {error.reason}"
+        raise GitHubRequestError(
+            f"GitHub GraphQL request failed: {error.reason}", transient=True
         ) from error
     except json.JSONDecodeError as error:
-        raise FactoryJanitorError("GitHub GraphQL returned invalid JSON") from error
+        raise GitHubRequestError(
+            "GitHub GraphQL returned invalid JSON", transient=True
+        ) from error
     if payload.get("errors"):
         messages = "; ".join(
             str(item.get("message", item)) for item in payload["errors"]
         )
-        raise FactoryJanitorError(f"GitHub GraphQL error: {messages}")
+        classifications = " ".join(
+            str(item.get("type", "")) for item in payload["errors"]
+        ).casefold()
+        transient = "rate_limited" in classifications or any(
+            phrase in messages.casefold()
+            for phrase in (
+                "rate limit",
+                "service unavailable",
+                "something went wrong",
+                "timed out",
+                "timeout",
+            )
+        )
+        raise GitHubRequestError(
+            f"GitHub GraphQL error: {messages}", transient=transient
+        )
     return payload
 
 
@@ -355,7 +397,11 @@ def is_managed_issue(issue: dict[str, Any]) -> bool:
     labels = label_names(issue)
     if str(issue.get("state", "")).upper() != "OPEN":
         return False
-    if "factory" in labels or body_has_digest_marker(issue.get("body")):
+    if (
+        "human" in labels
+        or "factory" in labels
+        or body_has_digest_marker(issue.get("body"))
+    ):
         return False
     return {"agent", "task"}.issubset(labels)
 
@@ -372,60 +418,61 @@ def trusted_comment_author(comment: dict[str, Any]) -> bool:
 
 def claim_timestamp(issue: dict[str, Any]) -> tuple[datetime, str] | None:
     issue_number = int(issue["number"])
-    candidates: list[tuple[datetime, str]] = []
-    for comment in issue.get("comments", []) or []:
-        if not isinstance(comment, dict) or not trusted_comment_author(comment):
-            continue
-        match = CLAIM_MARKER_RE.search(str(comment.get("body", "")))
-        if match is None or int(match.group("number")) != issue_number:
-            continue
-        try:
-            candidates.append(
-                (parse_datetime(str(comment["createdAt"])), "claim comment")
-            )
-        except (FactoryJanitorError, KeyError):
-            continue
-
-    for event in issue.get("timelineItems", []) or []:
-        if not isinstance(event, dict) or event.get("__typename") != "AssignedEvent":
-            continue
-        try:
-            candidates.append(
-                (parse_datetime(str(event["createdAt"])), "assignee event")
-            )
-        except (FactoryJanitorError, KeyError):
-            continue
-
-    if candidates:
-        return max(candidates, key=lambda item: item[0])
-
-    label_events: list[tuple[datetime, str]] = []
+    label_events: list[dict[str, Any]] = []
     for event in issue.get("timelineItems", []) or []:
         if not isinstance(event, dict) or event.get("__typename") != "LabeledEvent":
             continue
         label = event.get("label") or {}
         if not isinstance(label, dict) or label.get("name") != "claimed":
             continue
+        label_events.append(event)
+
+    if label_events:
+        event = label_events[-1]
         try:
-            label_events.append(
-                (parse_datetime(str(event["createdAt"])), "claimed label event")
-            )
-        except (FactoryJanitorError, KeyError):
+            return parse_datetime(str(event["createdAt"])), "claimed label event"
+        except (FactoryJanitorError, KeyError) as error:
+            raise FactoryJanitorError(
+                "latest claimed label event has malformed or missing timestamp"
+            ) from error
+
+    claim_comments: list[dict[str, Any]] = []
+    for comment in issue.get("comments", []) or []:
+        if not isinstance(comment, dict) or not trusted_comment_author(comment):
             continue
-    return max(label_events, key=lambda item: item[0]) if label_events else None
+        match = CLAIM_MARKER_RE.search(str(comment.get("body", "")))
+        if match is None or int(match.group("number")) != issue_number:
+            continue
+        claim_comments.append(comment)
+
+    if claim_comments:
+        comment = claim_comments[-1]
+        try:
+            return parse_datetime(str(comment["createdAt"])), "claim comment"
+        except (FactoryJanitorError, KeyError) as error:
+            raise FactoryJanitorError(
+                "latest claim comment has malformed or missing timestamp"
+            ) from error
+
+    return None
+
+
+def has_labeled_event(issue: dict[str, Any], label_name: str) -> bool:
+    return any(
+        isinstance(event, dict)
+        and event.get("__typename") == "LabeledEvent"
+        and isinstance(event.get("label"), dict)
+        and event["label"].get("name") == label_name
+        for event in issue.get("timelineItems", []) or []
+    )
 
 
 def referenced_issue_numbers(pull: dict[str, Any]) -> set[int]:
-    numbers = {
+    return {
         int(reference["number"])
         for reference in pull.get("closingIssuesReferences", []) or []
         if reference.get("number") is not None
     }
-    numbers.update(
-        int(match.group("number"))
-        for match in CLOSING_REFERENCE_RE.finditer(str(pull.get("body", "")))
-    )
-    return numbers
 
 
 def pulls_by_issue(
@@ -440,6 +487,8 @@ def pulls_by_issue(
     merged_pulls: dict[int, list[dict[str, Any]]] = {}
     buckets = {"OPEN": open_pulls, "CLOSED": closed_pulls, "MERGED": merged_pulls}
     for pull in pulls:
+        if bool(pull.get("isDraft")):
+            continue
         bucket = buckets.get(str(pull.get("state", "")).upper())
         if bucket is None:
             continue
@@ -450,22 +499,48 @@ def pulls_by_issue(
 
 def _transition(
     issue: dict[str, Any],
-    desired_state: str,
+    desired_state: str | None,
     reason: str,
     *,
     unassign: bool = False,
     comment: str | None = None,
+    comment_key: str | None = None,
 ) -> Transition | None:
     states = current_states(issue)
-    if states == (desired_state,):
+    if (desired_state is None and not states) or states == (desired_state,):
         return None
-    if comment is not None and "\n" in comment:
-        raise FactoryJanitorError("janitor comments must be exactly one line")
     assignees = tuple(
         (str(assignee["id"]), str(assignee["login"]))
         for assignee in issue.get("assignees", []) or []
-        if unassign and assignee.get("id") and assignee.get("login")
+        if unassign
+        and assignee.get("id")
+        and assignee.get("login")
+        and str(assignee["login"]).casefold().endswith("[bot]")
     )
+    preserved_assignees = tuple(
+        str(assignee["login"])
+        for assignee in issue.get("assignees", []) or []
+        if unassign
+        and assignee.get("login")
+        and not str(assignee["login"]).casefold().endswith("[bot]")
+    )
+    marked_comment = None
+    if comment is not None:
+        if comment_key is None:
+            raise FactoryJanitorError("janitor comment requires a transition key")
+        if preserved_assignees:
+            rendered = ", ".join(f"@{login}" for login in preserved_assignees)
+            comment = f"{comment} Human assignees left in place: {rendered}."
+        marker = f"<!-- {JANITOR_MARKER_PREFIX} transition={comment_key} -->"
+        if not any(
+            isinstance(existing, dict)
+            and trusted_comment_author(existing)
+            and marker in str(existing.get("body", ""))
+            for existing in issue.get("comments", []) or []
+        ):
+            marked_comment = f"{comment} {marker}"
+    if marked_comment is not None and "\n" in marked_comment:
+        raise FactoryJanitorError("janitor comments must be exactly one line")
     return Transition(
         issue_id=str(issue["id"]),
         issue_number=int(issue["number"]),
@@ -475,7 +550,8 @@ def _transition(
         reason=reason,
         current_label_ids=current_label_ids(issue),
         assignees=assignees,
-        comment=comment,
+        preserved_assignees=preserved_assignees,
+        comment=marked_comment,
     )
 
 
@@ -498,6 +574,12 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
             continue
         number = int(issue["number"])
         states = current_states(issue)
+
+        # The Owner release gate is total. Nothing downstream may infer lifecycle
+        # state for an issue that the Owner has not released into a managed lane.
+        if not states:
+            continue
+
         issue_open_pulls = open_pulls.get(number, [])
         issue_closed_pulls = closed_pulls.get(number, [])
         issue_merged_pulls = merged_pulls.get(number, [])
@@ -529,7 +611,7 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
                     number, f"open issue has merged closing PR reference: {rendered}"
                 )
             )
-            if len(states) > 1:
+            if "review" not in states and len(states) > 1:
                 transition = _transition(
                     issue,
                     states[0],
@@ -537,42 +619,55 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
                 )
                 if transition is not None:
                     transitions.append(transition)
-            continue
+            if "review" not in states:
+                continue
 
         if "review" in states:
+            desired_state = "ready" if has_labeled_event(issue, "ready") else None
+            desired_name = desired_state or "awaiting-release"
             if issue_closed_pulls:
                 pull = _newest_pull(issue_closed_pulls)
                 pull_number = int(pull["number"])
+                outcome = (
+                    "restored ready"
+                    if desired_state == "ready"
+                    else "returned to awaiting release"
+                )
                 comment = (
-                    "Factory janitor restored ready because "
-                    f"PR #{pull_number} closed without merging."
+                    f"Factory janitor {outcome} because PR #{pull_number} "
+                    "closed without merging."
                 )
                 transition = _transition(
                     issue,
-                    "ready",
+                    desired_state,
                     f"PR #{pull_number} closed without merging",
                     comment=comment,
+                    comment_key=f"review-pr-{pull_number}-to-{desired_name}",
                 )
-                if transition is not None:
-                    transitions.append(transition)
             else:
-                anomalies.append(Anomaly(number, "review has no known referencing PR"))
-                if len(states) > 1:
-                    transition = _transition(
-                        issue,
-                        "review",
-                        "keep highest-priority lifecycle state review",
-                    )
-                    if transition is not None:
-                        transitions.append(transition)
-            continue
-
-        if not states:
+                outcome = (
+                    "restored ready"
+                    if desired_state == "ready"
+                    else "returned to awaiting release"
+                )
+                transition = _transition(
+                    issue,
+                    desired_state,
+                    "review has no open PR",
+                    comment=f"Factory janitor {outcome} because review has no open PR.",
+                    comment_key=f"review-no-open-pr-to-{desired_name}",
+                )
+            if transition is not None:
+                transitions.append(transition)
             continue
 
         desired_state = states[0]
         if desired_state == "claimed":
-            claim = claim_timestamp(issue)
+            try:
+                claim = claim_timestamp(issue)
+            except FactoryJanitorError as error:
+                anomalies.append(Anomaly(number, str(error)))
+                continue
             if claim is None:
                 anomalies.append(
                     Anomaly(number, "claimed state has no derivable claim timestamp")
@@ -582,16 +677,28 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
                 age = now - claimed_at
                 if age >= timedelta(hours=STALE_CLAIM_HOURS):
                     age_hours = age.total_seconds() / 3600
+                    release_state = (
+                        "ready" if has_labeled_event(issue, "ready") else None
+                    )
+                    desired_name = release_state or "awaiting-release"
+                    outcome = (
+                        "restored ready"
+                        if release_state == "ready"
+                        else "returned to awaiting release"
+                    )
                     comment = (
-                        "Factory janitor restored ready because the claim expired after "
-                        "24 hours without an open PR."
+                        f"Factory janitor {outcome} because the claim expired after "
+                        f"{STALE_CLAIM_HOURS} hours without an open PR."
                     )
                     transition = _transition(
                         issue,
-                        "ready",
+                        release_state,
                         f"claim is stale at {age_hours:.1f}h ({source})",
                         unassign=True,
                         comment=comment,
+                        comment_key=(
+                            f"stale-claim-{claimed_at.isoformat()}-to-{desired_name}"
+                        ),
                     )
                     if transition is not None:
                         transitions.append(transition)
@@ -609,6 +716,24 @@ def _format_states(states: tuple[str, ...]) -> str:
     return "+".join(states) if states else "none"
 
 
+def _format_desired_state(state: str | None) -> str:
+    return state or "none"
+
+
+def validate_plan(plan: ReconciliationPlan) -> None:
+    violations = [
+        transition for transition in plan.transitions if not transition.current_states
+    ]
+    if violations:
+        rendered = ", ".join(
+            f"#{transition.issue_number} none->{_format_desired_state(transition.desired_state)}"
+            for transition in violations
+        )
+        raise FactoryJanitorError(
+            f"Owner release gate forbids every none->* transition: {rendered}"
+        )
+
+
 def _format_anomaly_count(count: int) -> str:
     noun = "anomaly" if count == 1 else "anomalies"
     return f"{count} {noun}"
@@ -621,22 +746,25 @@ def print_plan(plan: ReconciliationPlan) -> None:
             extras.append(
                 "unassign=" + ",".join(login for _, login in transition.assignees)
             )
+        if transition.preserved_assignees:
+            extras.append("preserve=" + ",".join(transition.preserved_assignees))
         if transition.comment:
             extras.append(f"comment={json.dumps(transition.comment)}")
         suffix = f"; {'; '.join(extras)}" if extras else ""
         print(
             f"[transition] #{transition.issue_number}: "
-            f"{_format_states(transition.current_states)} -> {transition.desired_state} "
+            f"{_format_states(transition.current_states)} -> "
+            f"{_format_desired_state(transition.desired_state)} "
             f"({transition.reason}){suffix}"
         )
     for anomaly in plan.anomalies:
         print(f"[anomaly] #{anomaly.issue_number}: {anomaly.detail}")
 
 
-def _mutation_for_transition(
+def _mutations_for_transition(
     transition: Transition,
     label_ids: dict[str, str],
-) -> tuple[str, dict[str, Any]]:
+) -> tuple[MutationOperation, ...]:
     missing_current_ids = [
         state
         for state in transition.current_states
@@ -648,23 +776,32 @@ def _mutation_for_transition(
         raise FactoryJanitorError(
             f"issue #{transition.issue_number} is missing label IDs for: {rendered}"
         )
-    desired_label_id = label_ids.get(transition.desired_state)
-    if desired_label_id is None:
-        raise FactoryJanitorError(
-            f"required label {transition.desired_state!r} does not exist"
+    operations: list[MutationOperation] = []
+    mutation_id_prefix = f"factory-janitor-{transition.issue_number}"
+    if (
+        transition.desired_state is not None
+        and transition.desired_state not in transition.current_states
+    ):
+        desired_label_id = label_ids.get(transition.desired_state)
+        if desired_label_id is None:
+            raise FactoryJanitorError(
+                f"required label {transition.desired_state!r} does not exist"
+            )
+        operations.append(
+            MutationOperation(
+                "add-label",
+                """mutation FactoryJanitorAddLabel($input: AddLabelsToLabelableInput!) {
+  result: addLabelsToLabelable(input: $input) { clientMutationId }
+}""",
+                {
+                    "input": {
+                        "labelableId": transition.issue_id,
+                        "labelIds": [desired_label_id],
+                        "clientMutationId": f"{mutation_id_prefix}-add-label",
+                    }
+                },
+            )
         )
-    variable_definitions: list[str] = []
-    fields: list[str] = []
-    variables: dict[str, Any] = {}
-    if transition.desired_state not in transition.current_states:
-        variable_definitions.append("$addInput: AddLabelsToLabelableInput!")
-        fields.append(
-            "addState: addLabelsToLabelable(input: $addInput) { clientMutationId }"
-        )
-        variables["addInput"] = {
-            "labelableId": transition.issue_id,
-            "labelIds": [desired_label_id],
-        }
 
     remove_ids = [
         label_id
@@ -672,56 +809,101 @@ def _mutation_for_transition(
         if state != transition.desired_state
     ]
     if remove_ids:
-        variable_definitions.append("$removeInput: RemoveLabelsFromLabelableInput!")
-        fields.append(
-            "removeStates: removeLabelsFromLabelable(input: $removeInput) { clientMutationId }"
+        operations.append(
+            MutationOperation(
+                "remove-labels",
+                """mutation FactoryJanitorRemoveLabels($input: RemoveLabelsFromLabelableInput!) {
+  result: removeLabelsFromLabelable(input: $input) { clientMutationId }
+}""",
+                {
+                    "input": {
+                        "labelableId": transition.issue_id,
+                        "labelIds": sorted(remove_ids),
+                        "clientMutationId": f"{mutation_id_prefix}-remove-labels",
+                    }
+                },
+            )
         )
-        variables["removeInput"] = {
-            "labelableId": transition.issue_id,
-            "labelIds": sorted(remove_ids),
-        }
 
     if transition.assignees:
-        variable_definitions.append(
-            "$unassignInput: RemoveAssigneesFromAssignableInput!"
+        operations.append(
+            MutationOperation(
+                "unassign-bots",
+                """mutation FactoryJanitorUnassign($input: RemoveAssigneesFromAssignableInput!) {
+  result: removeAssigneesFromAssignable(input: $input) { clientMutationId }
+}""",
+                {
+                    "input": {
+                        "assignableId": transition.issue_id,
+                        "assigneeIds": sorted(
+                            assignee_id for assignee_id, _ in transition.assignees
+                        ),
+                        "clientMutationId": f"{mutation_id_prefix}-unassign-bots",
+                    }
+                },
+            )
         )
-        fields.append(
-            "unassign: removeAssigneesFromAssignable(input: $unassignInput) { clientMutationId }"
-        )
-        variables["unassignInput"] = {
-            "assignableId": transition.issue_id,
-            "assigneeIds": sorted(
-                assignee_id for assignee_id, _ in transition.assignees
-            ),
-        }
 
     if transition.comment:
-        variable_definitions.append("$commentInput: AddCommentInput!")
-        fields.append("comment: addComment(input: $commentInput) { clientMutationId }")
-        variables["commentInput"] = {
-            "subjectId": transition.issue_id,
-            "body": transition.comment,
-        }
+        operations.append(
+            MutationOperation(
+                "comment",
+                """mutation FactoryJanitorComment($input: AddCommentInput!) {
+  result: addComment(input: $input) { clientMutationId }
+}""",
+                {
+                    "input": {
+                        "subjectId": transition.issue_id,
+                        "body": transition.comment,
+                        "clientMutationId": f"{mutation_id_prefix}-comment",
+                    }
+                },
+            )
+        )
 
-    if not fields:
+    if not operations:
         raise FactoryJanitorError(
             f"issue #{transition.issue_number} transition has no mutation operations"
         )
-    query = (
-        "mutation FactoryJanitorApply("
-        + ", ".join(variable_definitions)
-        + ") {\n  "
-        + "\n  ".join(fields)
-        + "\n}"
-    )
-    return query, variables
+    return tuple(operations)
+
+
+def _apply_mutation_with_retry(token: str, operation: MutationOperation) -> None:
+    for attempt in range(1, MUTATION_ATTEMPTS + 1):
+        try:
+            graphql(token, operation.query, operation.variables)
+            return
+        except GitHubRequestError as error:
+            if not error.transient or attempt == MUTATION_ATTEMPTS:
+                raise
+            delay = MUTATION_BACKOFF_SECONDS * (2 ** (attempt - 1))
+            print(
+                f"[retry] {operation.name}: transient failure; "
+                f"attempt {attempt + 1}/{MUTATION_ATTEMPTS} in {delay:.1f}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
 
 
 def apply_plan(plan: ReconciliationPlan, inputs: JanitorInputs, token: str) -> None:
+    failures: list[tuple[int, str]] = []
     for transition in plan.transitions:
-        query, variables = _mutation_for_transition(transition, inputs.repo.label_ids)
-        graphql(token, query, variables)
-        print(f"[applied] #{transition.issue_number}: {transition.desired_state}")
+        try:
+            operations = _mutations_for_transition(transition, inputs.repo.label_ids)
+            for operation in operations:
+                _apply_mutation_with_retry(token, operation)
+        except FactoryJanitorError as error:
+            failures.append((transition.issue_number, str(error)))
+            print(f"[failed] #{transition.issue_number}: {error}", file=sys.stderr)
+            continue
+        print(
+            f"[applied] #{transition.issue_number}: "
+            f"{_format_desired_state(transition.desired_state)}"
+        )
+
+    if failures:
+        rendered = "; ".join(f"#{number}: {detail}" for number, detail in failures)
+        raise FactoryJanitorError(f"persistent per-issue failures: {rendered}")
 
 
 def main() -> int:
@@ -736,6 +918,7 @@ def main() -> int:
         now = datetime.now(UTC)
 
     plan = build_plan(inputs, now=now)
+    validate_plan(plan)
     print_plan(plan)
     if args.apply:
         apply_plan(plan, inputs, token)

--- a/scripts/factory-janitor.py
+++ b/scripts/factory-janitor.py
@@ -567,7 +567,10 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
                         transitions.append(transition)
             continue
 
-        desired_state = states[0] if states else "ready"
+        if not states:
+            continue
+
+        desired_state = states[0]
         if desired_state == "claimed":
             claim = claim_timestamp(issue)
             if claim is None:
@@ -594,11 +597,7 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
                         transitions.append(transition)
                     continue
 
-        reason = (
-            "add missing lifecycle state"
-            if not states
-            else f"keep highest-priority lifecycle state {desired_state}"
-        )
+        reason = f"keep highest-priority lifecycle state {desired_state}"
         transition = _transition(issue, desired_state, reason)
         if transition is not None:
             transitions.append(transition)

--- a/scripts/factory-janitor.py
+++ b/scripts/factory-janitor.py
@@ -1,0 +1,760 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Reconcile Agent Factory issue lifecycle state during the daily monitor.
+
+The janitor derives expected labels from issue, claim, and pull-request state.
+It is dry-run by default; only an explicit ``--apply`` mutates GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+FIXTURE_REQUIRED_FILES = ("state.json",)
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+STALE_CLAIM_HOURS = 24
+MANAGED_STATES = frozenset({"ready", "claimed", "review"})
+STATE_PRIORITY = ("review", "claimed", "ready")
+DIGEST_MARKER = "<!-- " + "-".join(("factory", "digest:v1")) + " -->"
+CLAIM_MARKER_RE = re.compile(
+    r"<!-- contributor:issue=(?P<number>\d+);status=(?P<status>[a-z_]+);"
+    r"agent=(?P<agent>[a-z0-9-]+);branch=(?P<branch>[^>\n]+) -->"
+)
+CLOSING_REFERENCE_RE = re.compile(
+    r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
+)
+TRUSTED_AUTHOR_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+TRUSTED_AUTOMATION_LOGINS = {
+    "april-clearwater[bot]",
+    "claude[bot]",
+    "github-actions[bot]",
+    "plat-ironwood[bot]",
+    "workspace-agents",
+    "workspace-agents[bot]",
+}
+
+
+ISSUES_QUERY = """
+query FactoryJanitorIssues($owner: String!, $name: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    id
+    readyLabel: label(name: "ready") { id name }
+    claimedLabel: label(name: "claimed") { id name }
+    reviewLabel: label(name: "review") { id name }
+    issues(first: 100, after: $after, states: OPEN, orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id number title body url state
+        labels(first: 50) { nodes { id name } }
+        assignees(first: 50) { nodes { id login } }
+        comments(last: 100) {
+          nodes {
+            body createdAt authorAssociation
+            author { login }
+          }
+        }
+        timelineItems(last: 100, itemTypes: [LABELED_EVENT, ASSIGNED_EVENT]) {
+          nodes {
+            __typename
+            ... on LabeledEvent {
+              createdAt
+              label { name }
+            }
+            ... on AssignedEvent { createdAt }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+PULLS_QUERY = """
+query FactoryJanitorPulls($owner: String!, $name: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(
+      first: 100
+      after: $after
+      states: [OPEN, CLOSED, MERGED]
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number body url state updatedAt closedAt mergedAt
+        closingIssuesReferences(first: 50) { nodes { number } }
+      }
+    }
+  }
+}
+"""
+
+
+class FactoryJanitorError(RuntimeError):
+    """Raised when reconciliation cannot be planned or applied safely."""
+
+
+@dataclass(frozen=True)
+class RepoInfo:
+    owner: str
+    name: str
+    repository_id: str
+    label_ids: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class JanitorInputs:
+    repo: RepoInfo
+    issues: list[dict[str, Any]]
+    pulls: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class Transition:
+    issue_id: str
+    issue_number: int
+    title: str
+    current_states: tuple[str, ...]
+    desired_state: str
+    reason: str
+    current_label_ids: dict[str, str]
+    assignees: tuple[tuple[str, str], ...] = ()
+    comment: str | None = None
+
+
+@dataclass(frozen=True)
+class Anomaly:
+    issue_number: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class ReconciliationPlan:
+    transitions: tuple[Transition, ...]
+    anomalies: tuple[Anomaly, ...]
+
+
+def graphql(token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    request = urllib.request.Request(
+        GITHUB_GRAPHQL_URL,
+        data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "workspaces-factory-janitor",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise FactoryJanitorError(
+            f"GitHub GraphQL HTTP {error.code}: {detail}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise FactoryJanitorError(
+            f"GitHub GraphQL request failed: {error.reason}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise FactoryJanitorError("GitHub GraphQL returned invalid JSON") from error
+    if payload.get("errors"):
+        messages = "; ".join(
+            str(item.get("message", item)) for item in payload["errors"]
+        )
+        raise FactoryJanitorError(f"GitHub GraphQL error: {messages}")
+    return payload
+
+
+def split_repo_slug(slug: str) -> tuple[str, str]:
+    parts = slug.strip().split("/", 1)
+    if len(parts) != 2 or not all(parts):
+        raise FactoryJanitorError("GITHUB_REPOSITORY must be set to owner/name")
+    return parts[0], parts[1]
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise FactoryJanitorError(f"required environment variable {name} is not set")
+    return value
+
+
+def _flatten_issue(node: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **node,
+        "labels": list(node.get("labels", {}).get("nodes", [])),
+        "assignees": list(node.get("assignees", {}).get("nodes", [])),
+        "comments": list(node.get("comments", {}).get("nodes", [])),
+        "timelineItems": list(node.get("timelineItems", {}).get("nodes", [])),
+    }
+
+
+def _flatten_pull(node: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **node,
+        "closingIssuesReferences": list(
+            node.get("closingIssuesReferences", {}).get("nodes", [])
+        ),
+    }
+
+
+def fetch_live_inputs(repo_slug: str, token: str) -> JanitorInputs:
+    owner, name = split_repo_slug(repo_slug)
+    common_variables: dict[str, Any] = {"owner": owner, "name": name}
+    issues: list[dict[str, Any]] = []
+    label_ids: dict[str, str] = {}
+    repository_id = ""
+    cursor: str | None = None
+    while True:
+        payload = graphql(token, ISSUES_QUERY, {**common_variables, "after": cursor})
+        repository = payload.get("data", {}).get("repository")
+        if repository is None:
+            raise FactoryJanitorError(f"repository {repo_slug} was not found")
+        repository_id = str(repository["id"])
+        for state in STATE_PRIORITY:
+            label = repository.get(f"{state}Label")
+            if label is not None:
+                label_ids[state] = str(label["id"])
+        connection = repository["issues"]
+        issues.extend(_flatten_issue(node) for node in connection["nodes"])
+        if not connection["pageInfo"]["hasNextPage"]:
+            break
+        cursor = connection["pageInfo"]["endCursor"]
+
+    pulls: list[dict[str, Any]] = []
+    cursor = None
+    while True:
+        payload = graphql(token, PULLS_QUERY, {**common_variables, "after": cursor})
+        repository = payload.get("data", {}).get("repository")
+        if repository is None:
+            raise FactoryJanitorError(f"repository {repo_slug} was not found")
+        connection = repository["pullRequests"]
+        pulls.extend(_flatten_pull(node) for node in connection["nodes"])
+        if not connection["pageInfo"]["hasNextPage"]:
+            break
+        cursor = connection["pageInfo"]["endCursor"]
+
+    return JanitorInputs(
+        repo=RepoInfo(owner, name, repository_id, label_ids),
+        issues=issues,
+        pulls=pulls,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="plan only (the default)")
+    mode.add_argument(
+        "--apply", action="store_true", help="apply planned GitHub mutations"
+    )
+    parser.add_argument(
+        "--fixtures-dir",
+        type=Path,
+        help="read checked-in state instead of querying GitHub",
+    )
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.fixtures_dir is not None and args.apply:
+        raise FactoryJanitorError("--fixtures-dir cannot be combined with --apply")
+
+
+def load_json_file(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise FactoryJanitorError(f"missing required file: {path}") from error
+    except json.JSONDecodeError as error:
+        raise FactoryJanitorError(f"invalid JSON in {path}: {error}") from error
+
+
+def load_fixture_inputs(fixtures_dir: Path) -> tuple[JanitorInputs, datetime]:
+    if not fixtures_dir.is_dir():
+        raise FactoryJanitorError(f"fixture pack not found: {fixtures_dir}")
+    missing = [
+        name for name in FIXTURE_REQUIRED_FILES if not (fixtures_dir / name).is_file()
+    ]
+    if missing:
+        raise FactoryJanitorError(
+            f"fixture pack {fixtures_dir} is missing required files: {', '.join(missing)}"
+        )
+    payload = load_json_file(fixtures_dir / "state.json")
+    repo = payload["repo"]
+    inputs = JanitorInputs(
+        repo=RepoInfo(
+            owner=str(repo["owner"]),
+            name=str(repo["name"]),
+            repository_id=str(repo["id"]),
+            label_ids={str(key): str(value) for key, value in repo["labelIds"].items()},
+        ),
+        issues=list(payload["issues"]),
+        pulls=list(payload["pulls"]),
+    )
+    return inputs, parse_datetime(str(payload["now"]))
+
+
+def parse_datetime(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise FactoryJanitorError(f"invalid timestamp {value!r}") from error
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def label_names(issue: dict[str, Any]) -> set[str]:
+    return {
+        str(label.get("name", "")).strip()
+        for label in issue.get("labels", []) or []
+        if str(label.get("name", "")).strip()
+    }
+
+
+def current_label_ids(issue: dict[str, Any]) -> dict[str, str]:
+    return {
+        str(label["name"]): str(label["id"])
+        for label in issue.get("labels", []) or []
+        if label.get("name") in MANAGED_STATES and label.get("id")
+    }
+
+
+def current_states(issue: dict[str, Any]) -> tuple[str, ...]:
+    labels = label_names(issue)
+    return tuple(state for state in STATE_PRIORITY if state in labels)
+
+
+def body_has_digest_marker(body: Any) -> bool:
+    return str(body or "").lstrip().startswith(DIGEST_MARKER)
+
+
+def is_managed_issue(issue: dict[str, Any]) -> bool:
+    labels = label_names(issue)
+    if str(issue.get("state", "")).upper() != "OPEN":
+        return False
+    if "factory" in labels or body_has_digest_marker(issue.get("body")):
+        return False
+    return {"agent", "task"}.issubset(labels)
+
+
+def trusted_comment_author(comment: dict[str, Any]) -> bool:
+    if str(comment.get("authorAssociation", "")).upper() in TRUSTED_AUTHOR_ASSOCIATIONS:
+        return True
+    author = comment.get("author") or {}
+    login = str(author.get("login", "")).casefold() if isinstance(author, dict) else ""
+    return bool(
+        login and login in {item.casefold() for item in TRUSTED_AUTOMATION_LOGINS}
+    )
+
+
+def claim_timestamp(issue: dict[str, Any]) -> tuple[datetime, str] | None:
+    issue_number = int(issue["number"])
+    candidates: list[tuple[datetime, str]] = []
+    for comment in issue.get("comments", []) or []:
+        if not isinstance(comment, dict) or not trusted_comment_author(comment):
+            continue
+        match = CLAIM_MARKER_RE.search(str(comment.get("body", "")))
+        if match is None or int(match.group("number")) != issue_number:
+            continue
+        try:
+            candidates.append(
+                (parse_datetime(str(comment["createdAt"])), "claim comment")
+            )
+        except (FactoryJanitorError, KeyError):
+            continue
+
+    for event in issue.get("timelineItems", []) or []:
+        if not isinstance(event, dict) or event.get("__typename") != "AssignedEvent":
+            continue
+        try:
+            candidates.append(
+                (parse_datetime(str(event["createdAt"])), "assignee event")
+            )
+        except (FactoryJanitorError, KeyError):
+            continue
+
+    if candidates:
+        return max(candidates, key=lambda item: item[0])
+
+    label_events: list[tuple[datetime, str]] = []
+    for event in issue.get("timelineItems", []) or []:
+        if not isinstance(event, dict) or event.get("__typename") != "LabeledEvent":
+            continue
+        label = event.get("label") or {}
+        if not isinstance(label, dict) or label.get("name") != "claimed":
+            continue
+        try:
+            label_events.append(
+                (parse_datetime(str(event["createdAt"])), "claimed label event")
+            )
+        except (FactoryJanitorError, KeyError):
+            continue
+    return max(label_events, key=lambda item: item[0]) if label_events else None
+
+
+def referenced_issue_numbers(pull: dict[str, Any]) -> set[int]:
+    numbers = {
+        int(reference["number"])
+        for reference in pull.get("closingIssuesReferences", []) or []
+        if reference.get("number") is not None
+    }
+    numbers.update(
+        int(match.group("number"))
+        for match in CLOSING_REFERENCE_RE.finditer(str(pull.get("body", "")))
+    )
+    return numbers
+
+
+def pulls_by_issue(
+    pulls: list[dict[str, Any]],
+) -> tuple[
+    dict[int, list[dict[str, Any]]],
+    dict[int, list[dict[str, Any]]],
+    dict[int, list[dict[str, Any]]],
+]:
+    open_pulls: dict[int, list[dict[str, Any]]] = {}
+    closed_pulls: dict[int, list[dict[str, Any]]] = {}
+    merged_pulls: dict[int, list[dict[str, Any]]] = {}
+    buckets = {"OPEN": open_pulls, "CLOSED": closed_pulls, "MERGED": merged_pulls}
+    for pull in pulls:
+        bucket = buckets.get(str(pull.get("state", "")).upper())
+        if bucket is None:
+            continue
+        for issue_number in referenced_issue_numbers(pull):
+            bucket.setdefault(issue_number, []).append(pull)
+    return open_pulls, closed_pulls, merged_pulls
+
+
+def _transition(
+    issue: dict[str, Any],
+    desired_state: str,
+    reason: str,
+    *,
+    unassign: bool = False,
+    comment: str | None = None,
+) -> Transition | None:
+    states = current_states(issue)
+    if states == (desired_state,):
+        return None
+    if comment is not None and "\n" in comment:
+        raise FactoryJanitorError("janitor comments must be exactly one line")
+    assignees = tuple(
+        (str(assignee["id"]), str(assignee["login"]))
+        for assignee in issue.get("assignees", []) or []
+        if unassign and assignee.get("id") and assignee.get("login")
+    )
+    return Transition(
+        issue_id=str(issue["id"]),
+        issue_number=int(issue["number"]),
+        title=str(issue.get("title", "")),
+        current_states=states,
+        desired_state=desired_state,
+        reason=reason,
+        current_label_ids=current_label_ids(issue),
+        assignees=assignees,
+        comment=comment,
+    )
+
+
+def _newest_pull(pulls: list[dict[str, Any]]) -> dict[str, Any]:
+    return max(
+        pulls,
+        key=lambda pull: str(
+            pull.get("closedAt") or pull.get("mergedAt") or pull.get("updatedAt") or ""
+        ),
+    )
+
+
+def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
+    transitions: list[Transition] = []
+    anomalies: list[Anomaly] = []
+    open_pulls, closed_pulls, merged_pulls = pulls_by_issue(inputs.pulls)
+
+    for issue in sorted(inputs.issues, key=lambda item: int(item["number"])):
+        if not is_managed_issue(issue):
+            continue
+        number = int(issue["number"])
+        states = current_states(issue)
+        issue_open_pulls = open_pulls.get(number, [])
+        issue_closed_pulls = closed_pulls.get(number, [])
+        issue_merged_pulls = merged_pulls.get(number, [])
+
+        if issue_open_pulls:
+            pull_numbers = sorted(int(pull["number"]) for pull in issue_open_pulls)
+            if len(pull_numbers) > 1:
+                rendered = ", ".join(f"#{pull_number}" for pull_number in pull_numbers)
+                anomalies.append(
+                    Anomaly(
+                        number, f"multiple open PRs reference the issue: {rendered}"
+                    )
+                )
+            reason = (
+                f"open PR #{pull_numbers[0]} references the issue"
+                if len(pull_numbers) == 1
+                else "open PRs reference the issue"
+            )
+            transition = _transition(issue, "review", reason)
+            if transition is not None:
+                transitions.append(transition)
+            continue
+
+        if issue_merged_pulls:
+            pull_numbers = sorted(int(pull["number"]) for pull in issue_merged_pulls)
+            rendered = ", ".join(f"#{pull_number}" for pull_number in pull_numbers)
+            anomalies.append(
+                Anomaly(
+                    number, f"open issue has merged closing PR reference: {rendered}"
+                )
+            )
+            if len(states) > 1:
+                transition = _transition(
+                    issue,
+                    states[0],
+                    f"keep highest-priority lifecycle state {states[0]}",
+                )
+                if transition is not None:
+                    transitions.append(transition)
+            continue
+
+        if "review" in states:
+            if issue_closed_pulls:
+                pull = _newest_pull(issue_closed_pulls)
+                pull_number = int(pull["number"])
+                comment = (
+                    "Factory janitor restored ready because "
+                    f"PR #{pull_number} closed without merging."
+                )
+                transition = _transition(
+                    issue,
+                    "ready",
+                    f"PR #{pull_number} closed without merging",
+                    comment=comment,
+                )
+                if transition is not None:
+                    transitions.append(transition)
+            else:
+                anomalies.append(Anomaly(number, "review has no known referencing PR"))
+                if len(states) > 1:
+                    transition = _transition(
+                        issue,
+                        "review",
+                        "keep highest-priority lifecycle state review",
+                    )
+                    if transition is not None:
+                        transitions.append(transition)
+            continue
+
+        desired_state = states[0] if states else "ready"
+        if desired_state == "claimed":
+            claim = claim_timestamp(issue)
+            if claim is None:
+                anomalies.append(
+                    Anomaly(number, "claimed state has no derivable claim timestamp")
+                )
+            else:
+                claimed_at, source = claim
+                age = now - claimed_at
+                if age >= timedelta(hours=STALE_CLAIM_HOURS):
+                    age_hours = age.total_seconds() / 3600
+                    comment = (
+                        "Factory janitor restored ready because the claim expired after "
+                        "24 hours without an open PR."
+                    )
+                    transition = _transition(
+                        issue,
+                        "ready",
+                        f"claim is stale at {age_hours:.1f}h ({source})",
+                        unassign=True,
+                        comment=comment,
+                    )
+                    if transition is not None:
+                        transitions.append(transition)
+                    continue
+
+        reason = (
+            "add missing lifecycle state"
+            if not states
+            else f"keep highest-priority lifecycle state {desired_state}"
+        )
+        transition = _transition(issue, desired_state, reason)
+        if transition is not None:
+            transitions.append(transition)
+
+    return ReconciliationPlan(tuple(transitions), tuple(anomalies))
+
+
+def _format_states(states: tuple[str, ...]) -> str:
+    return "+".join(states) if states else "none"
+
+
+def _format_anomaly_count(count: int) -> str:
+    noun = "anomaly" if count == 1 else "anomalies"
+    return f"{count} {noun}"
+
+
+def print_plan(plan: ReconciliationPlan) -> None:
+    for transition in plan.transitions:
+        extras: list[str] = []
+        if transition.assignees:
+            extras.append(
+                "unassign=" + ",".join(login for _, login in transition.assignees)
+            )
+        if transition.comment:
+            extras.append(f"comment={json.dumps(transition.comment)}")
+        suffix = f"; {'; '.join(extras)}" if extras else ""
+        print(
+            f"[transition] #{transition.issue_number}: "
+            f"{_format_states(transition.current_states)} -> {transition.desired_state} "
+            f"({transition.reason}){suffix}"
+        )
+    for anomaly in plan.anomalies:
+        print(f"[anomaly] #{anomaly.issue_number}: {anomaly.detail}")
+
+
+def _mutation_for_transition(
+    transition: Transition,
+    label_ids: dict[str, str],
+) -> tuple[str, dict[str, Any]]:
+    missing_current_ids = [
+        state
+        for state in transition.current_states
+        if state != transition.desired_state
+        and state not in transition.current_label_ids
+    ]
+    if missing_current_ids:
+        rendered = ", ".join(missing_current_ids)
+        raise FactoryJanitorError(
+            f"issue #{transition.issue_number} is missing label IDs for: {rendered}"
+        )
+    desired_label_id = label_ids.get(transition.desired_state)
+    if desired_label_id is None:
+        raise FactoryJanitorError(
+            f"required label {transition.desired_state!r} does not exist"
+        )
+    variable_definitions: list[str] = []
+    fields: list[str] = []
+    variables: dict[str, Any] = {}
+    if transition.desired_state not in transition.current_states:
+        variable_definitions.append("$addInput: AddLabelsToLabelableInput!")
+        fields.append(
+            "addState: addLabelsToLabelable(input: $addInput) { clientMutationId }"
+        )
+        variables["addInput"] = {
+            "labelableId": transition.issue_id,
+            "labelIds": [desired_label_id],
+        }
+
+    remove_ids = [
+        label_id
+        for state, label_id in transition.current_label_ids.items()
+        if state != transition.desired_state
+    ]
+    if remove_ids:
+        variable_definitions.append("$removeInput: RemoveLabelsFromLabelableInput!")
+        fields.append(
+            "removeStates: removeLabelsFromLabelable(input: $removeInput) { clientMutationId }"
+        )
+        variables["removeInput"] = {
+            "labelableId": transition.issue_id,
+            "labelIds": sorted(remove_ids),
+        }
+
+    if transition.assignees:
+        variable_definitions.append(
+            "$unassignInput: RemoveAssigneesFromAssignableInput!"
+        )
+        fields.append(
+            "unassign: removeAssigneesFromAssignable(input: $unassignInput) { clientMutationId }"
+        )
+        variables["unassignInput"] = {
+            "assignableId": transition.issue_id,
+            "assigneeIds": sorted(
+                assignee_id for assignee_id, _ in transition.assignees
+            ),
+        }
+
+    if transition.comment:
+        variable_definitions.append("$commentInput: AddCommentInput!")
+        fields.append("comment: addComment(input: $commentInput) { clientMutationId }")
+        variables["commentInput"] = {
+            "subjectId": transition.issue_id,
+            "body": transition.comment,
+        }
+
+    if not fields:
+        raise FactoryJanitorError(
+            f"issue #{transition.issue_number} transition has no mutation operations"
+        )
+    query = (
+        "mutation FactoryJanitorApply("
+        + ", ".join(variable_definitions)
+        + ") {\n  "
+        + "\n  ".join(fields)
+        + "\n}"
+    )
+    return query, variables
+
+
+def apply_plan(plan: ReconciliationPlan, inputs: JanitorInputs, token: str) -> None:
+    for transition in plan.transitions:
+        query, variables = _mutation_for_transition(transition, inputs.repo.label_ids)
+        graphql(token, query, variables)
+        print(f"[applied] #{transition.issue_number}: {transition.desired_state}")
+
+
+def main() -> int:
+    args = parse_args()
+    validate_args(args)
+    if args.fixtures_dir is not None:
+        inputs, now = load_fixture_inputs(args.fixtures_dir)
+        token = ""
+    else:
+        token = require_env("GH_TOKEN")
+        inputs = fetch_live_inputs(require_env("GITHUB_REPOSITORY"), token)
+        now = datetime.now(UTC)
+
+    plan = build_plan(inputs, now=now)
+    print_plan(plan)
+    if args.apply:
+        apply_plan(plan, inputs, token)
+        print(
+            f"Applied {len(plan.transitions)} transition(s); "
+            f"reported {_format_anomaly_count(len(plan.anomalies))}."
+        )
+    else:
+        print(
+            f"Dry run: {len(plan.transitions)} transition(s), "
+            f"{_format_anomaly_count(len(plan.anomalies))}; no writes."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except FactoryJanitorError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/tests/test_factory_janitor.py
+++ b/scripts/tests/test_factory_janitor.py
@@ -13,11 +13,14 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import json
 import os
 import subprocess
 import sys
 import unittest
+from dataclasses import replace
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -47,6 +50,14 @@ class FactoryJanitorTests(unittest.TestCase):
             transition.issue_number: transition for transition in self.plan.transitions
         }
 
+    def issue(self, number: int):
+        return next(issue for issue in self.inputs.issues if issue["number"] == number)
+
+    def handled_numbers(self) -> set[int]:
+        return set(self.transitions) | {
+            anomaly.issue_number for anomaly in self.plan.anomalies
+        }
+
     def test_multi_label_repair_keeps_highest_priority_state(self) -> None:
         claimed = self.transitions[101]
         review = self.transitions[115]
@@ -56,25 +67,50 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertEqual(review.current_states, ("review", "claimed", "ready"))
         self.assertEqual(review.desired_state, "review")
 
-    def test_open_pull_request_promotes_issue_to_review(self) -> None:
+    def test_open_pull_request_promotes_released_issue_to_review(self) -> None:
         transition = self.transitions[102]
 
         self.assertEqual(transition.current_states, ("ready",))
         self.assertEqual(transition.desired_state, "review")
         self.assertEqual(transition.reason, "open PR #201 references the issue")
 
-    def test_closed_unmerged_pull_request_demotes_review_and_comments(self) -> None:
+    def test_owner_gate_blocks_unlabeled_issue_even_with_open_pull_request(
+        self,
+    ) -> None:
+        issue = self.issue(105)
+
+        self.assertEqual(factory_janitor.current_states(issue), ())
+        self.assertNotIn(105, self.handled_numbers())
+
+    def test_closed_pull_restores_ready_only_with_prior_ready_event(self) -> None:
         transition = self.transitions[103]
 
         self.assertEqual(transition.current_states, ("review",))
         self.assertEqual(transition.desired_state, "ready")
-        self.assertEqual(
-            transition.comment,
+        self.assertIn(
             "Factory janitor restored ready because PR #202 closed without merging.",
+            transition.comment or "",
         )
+        self.assertIn("<!-- factory-janitor transition=", transition.comment or "")
         self.assertNotIn("\n", transition.comment or "")
 
-    def test_stale_claim_expires_unassigns_and_comments(self) -> None:
+    def test_closed_pull_without_prior_ready_returns_to_owner_gate(self) -> None:
+        transition = self.transitions[118]
+
+        self.assertIsNone(transition.desired_state)
+        self.assertIn("returned to awaiting release", transition.comment or "")
+        self.assertNotIn("restored ready", transition.comment or "")
+
+    def test_review_without_any_known_pull_demotes_to_owner_gate(self) -> None:
+        transition = self.transitions[117]
+
+        self.assertIsNone(transition.desired_state)
+        self.assertEqual(transition.reason, "review has no open PR")
+        self.assertIn("returned to awaiting release", transition.comment or "")
+
+    def test_stale_claim_uses_comment_fallback_and_preserves_human_assignee(
+        self,
+    ) -> None:
         transition = self.transitions[104]
 
         self.assertEqual(transition.desired_state, "ready")
@@ -83,42 +119,67 @@ class FactoryJanitorTests(unittest.TestCase):
             transition.assignees,
             (("U_april", "april-clearwater[bot]"),),
         )
-        self.assertEqual(
-            transition.comment,
-            "Factory janitor restored ready because the claim expired after "
-            "24 hours without an open PR.",
+        self.assertEqual(transition.preserved_assignees, ("fairchild",))
+        self.assertIn("restored ready", transition.comment or "")
+        self.assertIn(
+            "Human assignees left in place: @fairchild.", transition.comment or ""
         )
+        self.assertIn("<!-- factory-janitor transition=", transition.comment or "")
 
-    def test_claim_age_falls_back_to_label_event(self) -> None:
+    def test_stale_claim_without_prior_ready_returns_to_owner_gate(self) -> None:
         transition = self.transitions[111]
 
-        self.assertEqual(transition.desired_state, "ready")
+        self.assertIsNone(transition.desired_state)
         self.assertIn("claimed label event", transition.reason)
+        self.assertIn("returned to awaiting release", transition.comment or "")
+        self.assertNotIn("restored ready", transition.comment or "")
 
-    def test_recent_assignee_event_prevents_stale_expiry(self) -> None:
-        issue = next(issue for issue in self.inputs.issues if issue["number"] == 112)
+    def test_claim_age_prefers_label_event_and_ignores_assignment_event(self) -> None:
+        issue = self.issue(112)
 
         timestamp, source = factory_janitor.claim_timestamp(issue)
 
-        self.assertEqual(timestamp.isoformat(), "2026-07-13T08:00:00+00:00")
-        self.assertEqual(source, "assignee event")
-        self.assertNotIn(112, self.transitions)
+        self.assertEqual(timestamp.isoformat(), "2026-07-10T08:00:00+00:00")
+        self.assertEqual(source, "claimed label event")
+        self.assertIn(112, self.transitions)
 
-    def test_unlabeled_agent_task_issue_awaits_owner_release(self) -> None:
-        issue = next(issue for issue in self.inputs.issues if issue["number"] == 105)
-        handled_numbers = set(self.transitions) | {
-            anomaly.issue_number for anomaly in self.plan.anomalies
+    def test_malformed_chosen_claim_source_is_anomaly_without_transition(self) -> None:
+        anomalies = {
+            anomaly.issue_number: anomaly.detail for anomaly in self.plan.anomalies
         }
 
-        self.assertEqual(factory_janitor.current_states(issue), ())
-        self.assertNotIn(105, handled_numbers)
+        self.assertEqual(
+            anomalies[119],
+            "latest claimed label event has malformed or missing timestamp",
+        )
+        self.assertNotIn(119, self.transitions)
 
-    def test_digest_factory_human_and_out_of_scope_issues_are_untouched(self) -> None:
-        handled_numbers = set(self.transitions) | {
-            anomaly.issue_number for anomaly in self.plan.anomalies
-        }
+    def test_missing_chosen_comment_timestamp_is_anomaly_without_transition(
+        self,
+    ) -> None:
+        issue = copy.deepcopy(self.issue(104))
+        del issue["comments"][-1]["createdAt"]
+        inputs = replace(self.inputs, issues=[issue], pulls=[])
 
-        self.assertTrue({106, 107, 108, 109, 114}.isdisjoint(handled_numbers))
+        plan = factory_janitor.build_plan(inputs, now=self.now)
+
+        self.assertEqual(plan.transitions, ())
+        self.assertEqual(
+            plan.anomalies[0].detail,
+            "latest claim comment has malformed or missing timestamp",
+        )
+
+    def test_human_label_excludes_agent_task_drift_unconditionally(self) -> None:
+        issue = self.issue(108)
+
+        self.assertTrue(
+            {"human", "agent", "task"}.issubset(factory_janitor.label_names(issue))
+        )
+        self.assertFalse(factory_janitor.is_managed_issue(issue))
+        self.assertNotIn(108, self.handled_numbers())
+
+    def test_digest_factory_closed_and_out_of_scope_issues_are_untouched(self) -> None:
+        self.assertTrue({106, 107, 109, 114}.isdisjoint(self.handled_numbers()))
 
     def test_leading_digest_marker_excludes_issue_without_factory_label(self) -> None:
         issue = {
@@ -136,6 +197,16 @@ class FactoryJanitorTests(unittest.TestCase):
 
         self.assertFalse(factory_janitor.is_managed_issue(issue))
 
+    def test_pull_detection_ignores_drafts_and_raw_body_keywords(self) -> None:
+        self.assertNotIn(116, self.handled_numbers())
+        raw_body_pull = next(
+            pull for pull in self.inputs.pulls if pull["number"] == 217
+        )
+
+        self.assertEqual(factory_janitor.referenced_issue_numbers(raw_body_pull), set())
+        self.assertIn("isDraft", factory_janitor.PULLS_QUERY)
+        self.assertNotIn("number body url", factory_janitor.PULLS_QUERY)
+
     def test_ambiguous_states_are_reported_without_blocking_other_repairs(self) -> None:
         anomalies = {
             anomaly.issue_number: anomaly.detail for anomaly in self.plan.anomalies
@@ -152,7 +223,26 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertNotIn(110, self.transitions)
         self.assertNotIn(113, self.transitions)
 
-    def test_second_plan_after_transitions_is_idempotent(self) -> None:
+    def test_existing_marker_for_same_transition_skips_duplicate_comment(self) -> None:
+        replay = copy.deepcopy(self.inputs)
+        issue = next(item for item in replay.issues if item["number"] == 104)
+        issue["comments"].append(
+            {
+                "body": self.transitions[104].comment,
+                "createdAt": "2026-07-13T13:00:00Z",
+                "authorAssociation": "NONE",
+                "author": {"login": "github-actions[bot]"},
+            }
+        )
+
+        rerun = factory_janitor.build_plan(replay, now=self.now)
+        transition = next(
+            item for item in rerun.transitions if item.issue_number == 104
+        )
+
+        self.assertIsNone(transition.comment)
+
+    def test_second_plan_after_state_repairs_is_idempotent(self) -> None:
         replay = copy.deepcopy(self.inputs)
         by_number = {int(issue["number"]): issue for issue in replay.issues}
         for transition in self.plan.transitions:
@@ -162,36 +252,122 @@ class FactoryJanitorTests(unittest.TestCase):
                 for label in issue["labels"]
                 if label["name"] not in factory_janitor.MANAGED_STATES
             ]
-            issue["labels"].append(
-                {
-                    "id": replay.repo.label_ids[transition.desired_state],
-                    "name": transition.desired_state,
-                }
-            )
-            if transition.assignees:
-                issue["assignees"] = []
+            if transition.desired_state is not None:
+                issue["labels"].append(
+                    {
+                        "id": replay.repo.label_ids[transition.desired_state],
+                        "name": transition.desired_state,
+                    }
+                )
+            removed_ids = {assignee_id for assignee_id, _ in transition.assignees}
+            issue["assignees"] = [
+                assignee
+                for assignee in issue["assignees"]
+                if assignee["id"] not in removed_ids
+            ]
+            if transition.comment:
+                issue["comments"].append(
+                    {
+                        "body": transition.comment,
+                        "createdAt": self.now.isoformat(),
+                        "authorAssociation": "NONE",
+                        "author": {"login": "github-actions[bot]"},
+                    }
+                )
 
         second_plan = factory_janitor.build_plan(replay, now=self.now)
 
         self.assertEqual(second_plan.transitions, ())
         self.assertEqual(
             [anomaly.issue_number for anomaly in second_plan.anomalies],
-            [110, 113],
+            [110, 113, 119],
         )
 
-    def test_apply_mutation_contains_labels_unassignment_and_comment(self) -> None:
-        query, variables = factory_janitor._mutation_for_transition(
-            self.transitions[104],
-            self.inputs.repo.label_ids,
+    def test_mutations_are_ordered_labels_unassign_then_comment(self) -> None:
+        operations = factory_janitor._mutations_for_transition(
+            self.transitions[104], self.inputs.repo.label_ids
         )
 
-        self.assertIn("addLabelsToLabelable", query)
-        self.assertIn("removeLabelsFromLabelable", query)
-        self.assertIn("removeAssigneesFromAssignable", query)
-        self.assertIn("addComment", query)
-        self.assertEqual(variables["addInput"]["labelIds"], ["L_ready"])
-        self.assertEqual(variables["removeInput"]["labelIds"], ["L_claimed"])
-        self.assertEqual(variables["unassignInput"]["assigneeIds"], ["U_april"])
+        self.assertEqual(
+            [operation.name for operation in operations],
+            ["add-label", "remove-labels", "unassign-bots", "comment"],
+        )
+        self.assertEqual(operations[0].variables["input"]["labelIds"], ["L_ready"])
+        self.assertEqual(operations[1].variables["input"]["labelIds"], ["L_claimed"])
+        self.assertEqual(operations[2].variables["input"]["assigneeIds"], ["U_april"])
+        self.assertIn(
+            "<!-- factory-janitor transition=",
+            operations[3].variables["input"]["body"],
+        )
+
+    def test_apply_retries_transient_failure_stops_issue_and_continues(self) -> None:
+        calls: list[str] = []
+
+        def fake_graphql(_token, _query, variables):
+            mutation_id = variables["input"]["clientMutationId"]
+            calls.append(mutation_id)
+            if mutation_id.endswith("104-remove-labels"):
+                raise factory_janitor.GitHubRequestError(
+                    "temporary outage", transient=True
+                )
+            return {"data": {}}
+
+        plan = factory_janitor.ReconciliationPlan(
+            (self.transitions[104], self.transitions[102]), ()
+        )
+        with (
+            mock.patch.object(factory_janitor, "graphql", side_effect=fake_graphql),
+            mock.patch.object(factory_janitor.time, "sleep") as sleep,
+            self.assertRaisesRegex(
+                factory_janitor.FactoryJanitorError,
+                r"persistent per-issue failures: #104: temporary outage",
+            ),
+        ):
+            factory_janitor.apply_plan(plan, self.inputs, "token")
+
+        self.assertEqual(
+            calls,
+            [
+                "factory-janitor-104-add-label",
+                "factory-janitor-104-remove-labels",
+                "factory-janitor-104-remove-labels",
+                "factory-janitor-104-remove-labels",
+                "factory-janitor-102-add-label",
+                "factory-janitor-102-remove-labels",
+            ],
+        )
+        self.assertEqual([item.args[0] for item in sleep.call_args_list], [1.0, 2.0])
+        self.assertFalse(any("104-unassign" in item for item in calls))
+        self.assertFalse(any("104-comment" in item for item in calls))
+
+    def test_graphql_partial_data_with_errors_is_failure(self) -> None:
+        response = mock.MagicMock()
+        response.read.return_value = json.dumps(
+            {"data": {"partial": True}, "errors": [{"message": "field failed"}]}
+        ).encode("utf-8")
+        response.__enter__.return_value = response
+
+        with (
+            mock.patch.object(
+                factory_janitor.urllib.request, "urlopen", return_value=response
+            ),
+            self.assertRaisesRegex(
+                factory_janitor.GitHubRequestError,
+                "GitHub GraphQL error: field failed",
+            ),
+        ):
+            factory_janitor.graphql("token", "query { viewer { login } }", {})
+
+    def test_cli_plan_validation_forbids_every_none_to_transition(self) -> None:
+        invalid = replace(self.transitions[102], current_states=())
+
+        with self.assertRaisesRegex(
+            factory_janitor.FactoryJanitorError,
+            r"Owner release gate forbids every none->\* transition",
+        ):
+            factory_janitor.validate_plan(
+                factory_janitor.ReconciliationPlan((invalid,), ())
+            )
 
     def test_fixture_cli_defaults_to_dry_run_and_reports_zero_writes(self) -> None:
         env = os.environ.copy()
@@ -214,11 +390,12 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("[transition] #102: ready -> review", result.stdout)
         self.assertIn("[transition] #103: review -> ready", result.stdout)
+        self.assertIn("[transition] #117: review -> none", result.stdout)
         self.assertIn("[anomaly] #110: multiple open PRs", result.stdout)
         self.assertIn(
-            "Dry run: 6 transition(s), 2 anomalies; no writes.", result.stdout
+            "Dry run: 9 transition(s), 3 anomalies; no writes.", result.stdout
         )
-        self.assertNotIn("none -> ready", result.stdout)
+        self.assertNotRegex(result.stdout, r"\[transition\].*: none ->")
         self.assertNotIn("[applied]", result.stdout)
 
     def test_fixture_mode_rejects_apply(self) -> None:

--- a/scripts/tests/test_factory_janitor.py
+++ b/scripts/tests/test_factory_janitor.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Fixture tests for the Factory lifecycle reconciliation janitor.
+
+Intent: protect every mechanical transition and exclusion while proving the
+default CLI path is deterministic and incapable of fixture-backed writes.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "factory-janitor.py"
+FIXTURES_DIR = REPO_ROOT / "fixtures" / "factory-janitor" / "basic"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+factory_janitor = load_module("factory_janitor", SCRIPT_PATH)
+
+
+class FactoryJanitorTests(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.inputs, self.now = factory_janitor.load_fixture_inputs(FIXTURES_DIR)
+        self.plan = factory_janitor.build_plan(self.inputs, now=self.now)
+        self.transitions = {
+            transition.issue_number: transition for transition in self.plan.transitions
+        }
+
+    def test_multi_label_repair_keeps_highest_priority_state(self) -> None:
+        claimed = self.transitions[101]
+        review = self.transitions[115]
+
+        self.assertEqual(claimed.current_states, ("claimed", "ready"))
+        self.assertEqual(claimed.desired_state, "claimed")
+        self.assertEqual(review.current_states, ("review", "claimed", "ready"))
+        self.assertEqual(review.desired_state, "review")
+
+    def test_open_pull_request_promotes_issue_to_review(self) -> None:
+        transition = self.transitions[102]
+
+        self.assertEqual(transition.current_states, ("ready",))
+        self.assertEqual(transition.desired_state, "review")
+        self.assertEqual(transition.reason, "open PR #201 references the issue")
+
+    def test_closed_unmerged_pull_request_demotes_review_and_comments(self) -> None:
+        transition = self.transitions[103]
+
+        self.assertEqual(transition.current_states, ("review",))
+        self.assertEqual(transition.desired_state, "ready")
+        self.assertEqual(
+            transition.comment,
+            "Factory janitor restored ready because PR #202 closed without merging.",
+        )
+        self.assertNotIn("\n", transition.comment or "")
+
+    def test_stale_claim_expires_unassigns_and_comments(self) -> None:
+        transition = self.transitions[104]
+
+        self.assertEqual(transition.desired_state, "ready")
+        self.assertIn("37.5h (claim comment)", transition.reason)
+        self.assertEqual(
+            transition.assignees,
+            (("U_april", "april-clearwater[bot]"),),
+        )
+        self.assertEqual(
+            transition.comment,
+            "Factory janitor restored ready because the claim expired after "
+            "24 hours without an open PR.",
+        )
+
+    def test_claim_age_falls_back_to_label_event(self) -> None:
+        transition = self.transitions[111]
+
+        self.assertEqual(transition.desired_state, "ready")
+        self.assertIn("claimed label event", transition.reason)
+
+    def test_recent_assignee_event_prevents_stale_expiry(self) -> None:
+        issue = next(issue for issue in self.inputs.issues if issue["number"] == 112)
+
+        timestamp, source = factory_janitor.claim_timestamp(issue)
+
+        self.assertEqual(timestamp.isoformat(), "2026-07-13T08:00:00+00:00")
+        self.assertEqual(source, "assignee event")
+        self.assertNotIn(112, self.transitions)
+
+    def test_digest_factory_human_and_out_of_scope_issues_are_untouched(self) -> None:
+        handled_numbers = set(self.transitions) | {
+            anomaly.issue_number for anomaly in self.plan.anomalies
+        }
+
+        self.assertTrue({106, 107, 108, 109, 114}.isdisjoint(handled_numbers))
+
+    def test_leading_digest_marker_excludes_issue_without_factory_label(self) -> None:
+        issue = {
+            "id": "I_digest",
+            "number": 999,
+            "body": f" \n{factory_janitor.DIGEST_MARKER}\nOwner surface",
+            "state": "OPEN",
+            "labels": [
+                {"id": "L_agent", "name": "agent"},
+                {"id": "L_task", "name": "task"},
+                {"id": "L_ready", "name": "ready"},
+                {"id": "L_claimed", "name": "claimed"},
+            ],
+        }
+
+        self.assertFalse(factory_janitor.is_managed_issue(issue))
+
+    def test_ambiguous_states_are_reported_without_blocking_other_repairs(self) -> None:
+        anomalies = {
+            anomaly.issue_number: anomaly.detail for anomaly in self.plan.anomalies
+        }
+
+        self.assertEqual(
+            anomalies[110],
+            "multiple open PRs reference the issue: #210, #211",
+        )
+        self.assertEqual(
+            anomalies[113],
+            "claimed state has no derivable claim timestamp",
+        )
+        self.assertNotIn(110, self.transitions)
+        self.assertNotIn(113, self.transitions)
+
+    def test_second_plan_after_transitions_is_idempotent(self) -> None:
+        replay = copy.deepcopy(self.inputs)
+        by_number = {int(issue["number"]): issue for issue in replay.issues}
+        for transition in self.plan.transitions:
+            issue = by_number[transition.issue_number]
+            issue["labels"] = [
+                label
+                for label in issue["labels"]
+                if label["name"] not in factory_janitor.MANAGED_STATES
+            ]
+            issue["labels"].append(
+                {
+                    "id": replay.repo.label_ids[transition.desired_state],
+                    "name": transition.desired_state,
+                }
+            )
+            if transition.assignees:
+                issue["assignees"] = []
+
+        second_plan = factory_janitor.build_plan(replay, now=self.now)
+
+        self.assertEqual(second_plan.transitions, ())
+        self.assertEqual(
+            [anomaly.issue_number for anomaly in second_plan.anomalies],
+            [110, 113],
+        )
+
+    def test_apply_mutation_contains_labels_unassignment_and_comment(self) -> None:
+        query, variables = factory_janitor._mutation_for_transition(
+            self.transitions[104],
+            self.inputs.repo.label_ids,
+        )
+
+        self.assertIn("addLabelsToLabelable", query)
+        self.assertIn("removeLabelsFromLabelable", query)
+        self.assertIn("removeAssigneesFromAssignable", query)
+        self.assertIn("addComment", query)
+        self.assertEqual(variables["addInput"]["labelIds"], ["L_ready"])
+        self.assertEqual(variables["removeInput"]["labelIds"], ["L_claimed"])
+        self.assertEqual(variables["unassignInput"]["assigneeIds"], ["U_april"])
+
+    def test_fixture_cli_defaults_to_dry_run_and_reports_zero_writes(self) -> None:
+        env = os.environ.copy()
+        env.pop("GH_TOKEN", None)
+        env.pop("GITHUB_REPOSITORY", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--fixtures-dir",
+                str(FIXTURES_DIR),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("[transition] #102: ready -> review", result.stdout)
+        self.assertIn("[transition] #103: review -> ready", result.stdout)
+        self.assertIn("[anomaly] #110: multiple open PRs", result.stdout)
+        self.assertIn(
+            "Dry run: 7 transition(s), 2 anomalies; no writes.", result.stdout
+        )
+        self.assertNotIn("[applied]", result.stdout)
+
+    def test_fixture_mode_rejects_apply(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--fixtures-dir",
+                str(FIXTURES_DIR),
+                "--apply",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("--fixtures-dir cannot be combined with --apply", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_factory_janitor.py
+++ b/scripts/tests/test_factory_janitor.py
@@ -104,6 +104,15 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertEqual(source, "assignee event")
         self.assertNotIn(112, self.transitions)
 
+    def test_unlabeled_agent_task_issue_awaits_owner_release(self) -> None:
+        issue = next(issue for issue in self.inputs.issues if issue["number"] == 105)
+        handled_numbers = set(self.transitions) | {
+            anomaly.issue_number for anomaly in self.plan.anomalies
+        }
+
+        self.assertEqual(factory_janitor.current_states(issue), ())
+        self.assertNotIn(105, handled_numbers)
+
     def test_digest_factory_human_and_out_of_scope_issues_are_untouched(self) -> None:
         handled_numbers = set(self.transitions) | {
             anomaly.issue_number for anomaly in self.plan.anomalies
@@ -207,8 +216,9 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertIn("[transition] #103: review -> ready", result.stdout)
         self.assertIn("[anomaly] #110: multiple open PRs", result.stdout)
         self.assertIn(
-            "Dry run: 7 transition(s), 2 anomalies; no writes.", result.stdout
+            "Dry run: 6 transition(s), 2 anomalies; no writes.", result.stdout
         )
+        self.assertNotIn("none -> ready", result.stdout)
         self.assertNotIn("[applied]", result.stdout)
 
     def test_fixture_mode_rejects_apply(self) -> None:


### PR DESCRIPTION
Closes #1064. The last machinery slice of Agent Factory v2 M1 (plan: docs/development/agent-factory-v2-plan.md).

## Summary

`scripts/factory-janitor.py` runs in `factory-monitor.yml` daily, after telemetry and **before** the digest step (the digest renders post-repair state). It enforces lifecycle invariants on open `agent`+`task` issues — nothing has policed labels since the v1 crons were deleted:

- **At most one** of `ready`/`claimed`/`review` (repair priority `review > claimed > ready`; contradictions it can't repair go to anomalies, not silent fixes).
- **The Owner-gate invariant is total**: an unlabeled issue receives no transition of any kind, even with an open PR referencing it — only you (or the future triage stage) apply `ready`.
- `review` requires a non-draft open PR (via GitHub's own `closingIssuesReferences` — no body-regex); orphaned `review` demotes.
- Stale claims (>24h by the latest `claimed` label event; claim comments only as fallback; malformed timestamps → anomaly) expire — bot assignees removed, human assignees never touched.
- `ready` is only ever *restored* with timeline evidence it was previously granted; otherwise the issue returns to awaiting-release.
- Apply-mode: labels → unassign → comment last, marker-deduped comments, retry/backoff, per-issue failure isolation with non-zero exit. Dry-run default; the workflow passes `--apply` on scheduled runs.

## The loop

codex (gpt-5.6-sol, xhigh) implemented; its own live dry-run exposed a **brief error by the orchestrator** (the spec said "exactly one" lifecycle label, implying 20 unlabeled issues should be auto-promoted to `ready` — flipping the Owner's release gate; corrected to "at most one"). The directed review then found 1 blocker + 7 majors — the blocker chained `none → review → ready`, laundering unreleased work past the gate in two hops; also wrong-cycle claim ages, non-idempotent comments, draft/code-block PR false-positives, `human`-label non-exclusion, and human-assignee removal. All eight addressed in an attributed hardening commit (tests 14 → 24). Final live read-only dry run against the freshly-groomed tracker: **0 transitions, 0 anomalies** — the janitor independently confirms the #1066 disposition labels are consistent.

## Evidence

![janitor-gates](https://evidence.cloudcompute.com/workspaces/pr-1078/20260713-104927-janitor-gates.png)

## Post-merge verification plan (orchestrator-run)

Live dry-run via workflow_dispatch (dry_run=true), then a wet scheduled-equivalent run; second wet run must be idempotent (zero transitions).

## Mergeability

- **Surface**: `scripts/factory-janitor.py` + tests + fixtures (new), one step in `factory-monitor.yml`
- **Behavior changed**: lifecycle invariants are enforced daily instead of never
- **Non-happy paths**: unlabeled issues untouchable; anomalies reported not force-fixed; per-issue failure isolation; marker-deduped comments; draft PRs ignored; humans never unassigned
- **Residual risk**: apply-mode mutations unexercised until the post-merge wet run (read paths live-verified; all GraphQL shapes introspected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
