### PR TITLE
docs(mergeability): visual changes require visual evidence

### DIFF
--- a/docs/development/mergeability-standard.md
+++ b/docs/development/mergeability-standard.md
@@ -13,6 +13,7 @@ Work is mergeable when it is correct, coherent with the product, reviewable, ver
 - Cover the non-happy paths a reviewer would expect: empty, loading, error, permissions, timing, focus, and recovery states.
 - Preserve clear service contracts, observable failure modes, useful logs or diagnostics, and explicit production assumptions.
 - Match tests and evidence to the risk and blast radius. For docs-only changes, `git diff --check` plus a clear note is usually enough.
+- Visual changes ship visual evidence: before/after screenshots (or after-only when the before state is gone or irrelevant) for any user-visible UI change, captured via the fixture lane, the capture-only handshake, or a VM lane. Narrative-only claims do not clear the gate; if capture is genuinely blocked, mark `blocked:evidence` with the reason.
 - State what changed, how it was verified, and what residual risk or follow-up remains.
 - If evidence is blocked, say so explicitly before merge and explain what approval or environment is needed.
 - Use machine-readable blocker labels when a PR is not merge-ready: `blocked:ci`, `blocked:secrets`, `blocked:evidence`, or `blocked:review`.


### PR DESCRIPTION
Owner directive from the #1086 review cycle, where April's evidence gate and the owner independently landed on the same rule: **user-visible UI changes ship visual evidence** — before/after screenshots, or after-only when the before state is gone — via the fixture lane, capture-only handshake, or a VM lane. Deferral is an explicit `blocked:evidence` state, not a PR-body caveat.

Companion issue (filed separately) covers the factory-grade capture lane: Xcode Cloud UI-test screenshots preferred, tart-ui VM lane as the pragmatic interim.

## Evidence

Docs-only diff; `git diff --check` clean per the standard's own docs-only rule.

## Mergeability

- **Surface**: `docs/development/mergeability-standard.md` (one rule line)
- **Behavior changed**: reviewers (agent and human) can now cite a written rule when requesting visual evidence
- **Non-happy paths**: genuinely blocked capture is an explicit labeled state rather than silent deferral
- **Residual risk**: prose-level enforcement until the readiness check learns to demand it for visual surfaces — noted in the companion issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)