### PR TITLE
feat(factory): route agent PRs to counterpart review

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/execution.py
+++ b/.agents/skills/cofounder-contributor/scripts/execution.py
@@ -315,7 +315,7 @@ def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -
     current_linked_issue, _ = extract_pr_issue_reference(pr_body)
     expected_linked_issue_text = env.get("FACTORY_EXPECTED_LINKED_ISSUE", "").strip()
     expected_linked_issue = int(expected_linked_issue_text) if expected_linked_issue_text else None
-    linked_issue = expected_linked_issue or current_linked_issue
+    linked_issue = expected_linked_issue
     if expected_linked_issue is not None and current_linked_issue != expected_linked_issue:
         print(
             f"error: PR #{pr_number} linked issue changed during Factory review",
@@ -352,20 +352,26 @@ def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -
                 )
         return
 
-    if linked_issue is None:
-        return
     ensure_label_exists(
         env,
         AGENT_MERGEABLE_LABEL,
         AGENT_MERGEABLE_LABEL_COLOR,
         AGENT_MERGEABLE_LABEL_DESCRIPTION,
     )
-    run_checked(
-        ["gh", "issue", "edit", str(linked_issue), "--add-label", AGENT_MERGEABLE_LABEL],
-        timeout=GITHUB_API_TIMEOUT,
-        cwd=REPO_ROOT,
-        env=env,
-    )
+    if linked_issue is not None:
+        run_checked(
+            [
+                "gh",
+                "issue",
+                "edit",
+                str(linked_issue),
+                "--add-label",
+                AGENT_MERGEABLE_LABEL,
+            ],
+            timeout=GITHUB_API_TIMEOUT,
+            cwd=REPO_ROOT,
+            env=env,
+        )
     run_checked(
         ["gh", "pr", "edit", str(pr_number), "--add-label", AGENT_MERGEABLE_LABEL],
         timeout=GITHUB_API_TIMEOUT,

--- a/.agents/skills/cofounder-contributor/scripts/execution.py
+++ b/.agents/skills/cofounder-contributor/scripts/execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import json
 import os
 import subprocess
@@ -297,45 +298,99 @@ def ensure_issue_claimed(
 def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -> None:
     if verdict not in ("approve", "approve_with_followups", "request_changes"):
         return
-    pr_body = run_optional(
-        ["gh", "pr", "view", str(pr_number), "--json", "body", "--jq", ".body"],
+    pr_data = json.loads(
+        run_checked(
+            ["gh", "pr", "view", str(pr_number), "--json", "body,labels"],
+            timeout=GITHUB_API_TIMEOUT,
+            cwd=REPO_ROOT,
+            env=env,
+        ).stdout
+    )
+    pr_body = str(pr_data.get("body") or "")
+    pr_labels = {
+        str(label.get("name") or "")
+        for label in pr_data.get("labels", [])
+        if isinstance(label, dict)
+    }
+    current_linked_issue, _ = extract_pr_issue_reference(pr_body)
+    expected_linked_issue_text = env.get("FACTORY_EXPECTED_LINKED_ISSUE", "").strip()
+    expected_linked_issue = int(expected_linked_issue_text) if expected_linked_issue_text else None
+    linked_issue = expected_linked_issue or current_linked_issue
+    if expected_linked_issue is not None and current_linked_issue != expected_linked_issue:
+        print(
+            f"error: PR #{pr_number} linked issue changed during Factory review",
+            file=sys.stderr,
+        )
+        return
+
+    if verdict == "request_changes":
+        if AGENT_MERGEABLE_LABEL in pr_labels:
+            run_checked(
+                ["gh", "pr", "edit", str(pr_number), "--remove-label", AGENT_MERGEABLE_LABEL],
+                timeout=GITHUB_API_TIMEOUT,
+                cwd=REPO_ROOT,
+                env=env,
+            )
+        if linked_issue is not None:
+            issue_labels = json.loads(
+                run_checked(
+                    ["gh", "issue", "view", str(linked_issue), "--json", "labels"],
+                    timeout=GITHUB_API_TIMEOUT,
+                    cwd=REPO_ROOT,
+                    env=env,
+                ).stdout
+            ).get("labels", [])
+            if any(
+                isinstance(label, dict) and label.get("name") == AGENT_MERGEABLE_LABEL
+                for label in issue_labels
+            ):
+                run_checked(
+                    ["gh", "issue", "edit", str(linked_issue), "--remove-label", AGENT_MERGEABLE_LABEL],
+                    timeout=GITHUB_API_TIMEOUT,
+                    cwd=REPO_ROOT,
+                    env=env,
+                )
+        return
+
+    if linked_issue is None:
+        return
+    ensure_label_exists(
+        env,
+        AGENT_MERGEABLE_LABEL,
+        AGENT_MERGEABLE_LABEL_COLOR,
+        AGENT_MERGEABLE_LABEL_DESCRIPTION,
+    )
+    run_checked(
+        ["gh", "issue", "edit", str(linked_issue), "--add-label", AGENT_MERGEABLE_LABEL],
         timeout=GITHUB_API_TIMEOUT,
         cwd=REPO_ROOT,
         env=env,
-        default="",
     )
-    linked_issue, _ = extract_pr_issue_reference(pr_body)
-    if linked_issue is None:
-        return
-    if verdict in ("approve", "approve_with_followups"):
-        ensure_label_exists(env, AGENT_MERGEABLE_LABEL, AGENT_MERGEABLE_LABEL_COLOR, AGENT_MERGEABLE_LABEL_DESCRIPTION)
-        run_checked(
-            ["gh", "pr", "edit", str(pr_number), "--add-label", AGENT_MERGEABLE_LABEL],
-            timeout=GITHUB_API_TIMEOUT,
-            cwd=REPO_ROOT,
-            env=env,
-        )
-        run_checked(
-            ["gh", "issue", "edit", str(linked_issue), "--add-label", AGENT_MERGEABLE_LABEL],
-            timeout=GITHUB_API_TIMEOUT,
-            cwd=REPO_ROOT,
-            env=env,
-        )
-    else:
-        run_optional(
-            ["gh", "pr", "edit", str(pr_number), "--remove-label", AGENT_MERGEABLE_LABEL],
-            timeout=GITHUB_API_TIMEOUT,
-            cwd=REPO_ROOT,
-            env=env,
-            default="",
-        )
-        run_optional(
-            ["gh", "issue", "edit", str(linked_issue), "--remove-label", AGENT_MERGEABLE_LABEL],
-            timeout=GITHUB_API_TIMEOUT,
-            cwd=REPO_ROOT,
-            env=env,
-            default="",
-        )
+    run_checked(
+        ["gh", "pr", "edit", str(pr_number), "--add-label", AGENT_MERGEABLE_LABEL],
+        timeout=GITHUB_API_TIMEOUT,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
+def _factory_expected_pr_head_is_current(pr_number: int, env: dict[str, str]) -> bool:
+    expected = env.get("FACTORY_EXPECTED_PR_HEAD_SHA", "").strip()
+    if not expected:
+        return True
+    current = run_checked(
+        ["gh", "pr", "view", str(pr_number), "--json", "headRefOid", "--jq", ".headRefOid"],
+        timeout=GITHUB_API_TIMEOUT,
+        cwd=REPO_ROOT,
+        env=env,
+    ).stdout.strip()
+    if hmac.compare_digest(current, expected):
+        return True
+    print(
+        f"error: PR #{pr_number} head changed during Factory review",
+        file=sys.stderr,
+    )
+    return False
 
 
 def _write_github_outputs(
@@ -702,6 +757,8 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
         if action == "review_pr":
             verdict = str(data.get("verdict", "")).lower()
             pr_number = int(data["pr_number"])
+            if not _factory_expected_pr_head_is_current(pr_number, env):
+                return 1
             review_state = _mod.find_pr_review_state(pr_number, env)
             if review_state is not None:
                 evidence_gate_error = review_evidence_gate_error(
@@ -731,16 +788,45 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                 "--body-file",
                 body_file,
             ]
-            _mod.run_checked(
-                review_cmd,
-                timeout=GITHUB_API_TIMEOUT,
-                cwd=REPO_ROOT,
-                env=env,
-            )
+            expected_head = env.get("FACTORY_EXPECTED_PR_HEAD_SHA", "").strip()
+            if expected_head:
+                owner, name = repo_owner_name(env)
+                review_event = {
+                    "approve": "APPROVE",
+                    "approve_with_followups": "APPROVE",
+                    "request_changes": "REQUEST_CHANGES",
+                }.get(verdict, "COMMENT")
+                _mod.run_checked(
+                    [
+                        "gh",
+                        "api",
+                        f"repos/{owner}/{name}/pulls/{pr_number}/reviews",
+                        "--method",
+                        "POST",
+                        "--field",
+                        f"body=@{body_file}",
+                        "--field",
+                        f"commit_id={expected_head}",
+                        "--field",
+                        f"event={review_event}",
+                    ],
+                    timeout=GITHUB_API_TIMEOUT,
+                    cwd=REPO_ROOT,
+                    env=env,
+                )
+            else:
+                _mod.run_checked(
+                    review_cmd,
+                    timeout=GITHUB_API_TIMEOUT,
+                    cwd=REPO_ROOT,
+                    env=env,
+                )
             if review_flag == "--approve":
                 bot = detect_bot_login(env)
                 if bot:
                     _dismiss_own_blocking_reviews(pr_number, bot, env)
+            if not _factory_expected_pr_head_is_current(pr_number, env):
+                return 1
             _mod._update_mergeable_label(int(data["pr_number"]), verdict, env)
             return 0
         if action == "execute_issue":

--- a/.agents/skills/cofounder-contributor/scripts/execution.py
+++ b/.agents/skills/cofounder-contributor/scripts/execution.py
@@ -310,12 +310,25 @@ def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -
     if verdict in ("approve", "approve_with_followups"):
         ensure_label_exists(env, AGENT_MERGEABLE_LABEL, AGENT_MERGEABLE_LABEL_COLOR, AGENT_MERGEABLE_LABEL_DESCRIPTION)
         run_checked(
+            ["gh", "pr", "edit", str(pr_number), "--add-label", AGENT_MERGEABLE_LABEL],
+            timeout=GITHUB_API_TIMEOUT,
+            cwd=REPO_ROOT,
+            env=env,
+        )
+        run_checked(
             ["gh", "issue", "edit", str(linked_issue), "--add-label", AGENT_MERGEABLE_LABEL],
             timeout=GITHUB_API_TIMEOUT,
             cwd=REPO_ROOT,
             env=env,
         )
     else:
+        run_optional(
+            ["gh", "pr", "edit", str(pr_number), "--remove-label", AGENT_MERGEABLE_LABEL],
+            timeout=GITHUB_API_TIMEOUT,
+            cwd=REPO_ROOT,
+            env=env,
+            default="",
+        )
         run_optional(
             ["gh", "issue", "edit", str(linked_issue), "--remove-label", AGENT_MERGEABLE_LABEL],
             timeout=GITHUB_API_TIMEOUT,

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -670,6 +670,7 @@ def run_claude(
         "--yes",
         CLAUDE_CODE_PACKAGE,
         "--print",
+        "--bare",
         "--system-prompt",
         prompt_text,
     ]

--- a/.agents/skills/cofounder-contributor/scripts/validate-agent-output.py
+++ b/.agents/skills/cofounder-contributor/scripts/validate-agent-output.py
@@ -39,7 +39,7 @@ REQUIRED_FIELDS: dict[str, list[str]] = {
     "propose": ["title", "body", "persona"],
     "comment": ["discussion_number", "body", "persona"],
     "recommend_close": ["discussion_number", "body", "persona"],
-    "review_pr": ["pr_number", "body", "persona"],
+    "review_pr": ["pr_number", "body", "persona", "verdict"],
     "execute_issue": ["issue_number", "pr_title", "commit_message", "body", "persona"],
     "advance_pr": ["pr_number", "issue_number", "pr_title", "commit_message", "body", "persona"],
     "plan": ["discussion_number", "issues"],
@@ -215,6 +215,14 @@ def validate_data(data: dict[str, Any]) -> dict[str, Any]:
             pr_number = data.get("pr_number")
             if not isinstance(pr_number, int) or pr_number <= 0:
                 raise ValidationError("field 'pr_number' must be a positive integer")
+
+    if action == "review_pr":
+        verdict = require_non_empty_string(data.get("verdict"), "verdict").casefold()
+        if verdict not in {"approve", "approve_with_followups", "request_changes"}:
+            raise ValidationError(
+                "field 'verdict' must be approve, approve_with_followups, or request_changes"
+            )
+        data["verdict"] = verdict
 
     return data
 

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -9,6 +9,12 @@ on:
       - "scripts/agent-triage-request.py"
       - "scripts/tests/test_agent_triage.py"
       - "scripts/tests/test_run_contributor.py"
+      - "scripts/tests/test_validate_agent_output.py"
+      - ".github/workflows/factory-*.yml"
+      - "scripts/factory-implement.py"
+      - "scripts/factory-review.py"
+      - "scripts/tests/test_factory_workflows.py"
+      - "scripts/tests/test_factory_review.py"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
@@ -26,6 +32,12 @@ on:
       - "scripts/agent-triage-request.py"
       - "scripts/tests/test_agent_triage.py"
       - "scripts/tests/test_run_contributor.py"
+      - "scripts/tests/test_validate_agent_output.py"
+      - ".github/workflows/factory-*.yml"
+      - "scripts/factory-implement.py"
+      - "scripts/factory-review.py"
+      - "scripts/tests/test_factory_workflows.py"
+      - "scripts/tests/test_factory_review.py"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
@@ -68,6 +80,14 @@ jobs:
 
       - name: Run contributor runner policy tests
         run: uv run --script scripts/tests/test_run_contributor.py
+
+      - name: Run contributor output validation tests
+        run: uv run --script scripts/tests/test_validate_agent_output.py
+
+      - name: Run Factory workflow policy tests
+        run: |
+          uv run --script scripts/tests/test_factory_workflows.py
+          uv run --script scripts/tests/test_factory_review.py
 
       - name: Run Fable orchestrator tests
         run: uv run --script scripts/tests/test_fable_orchestrator.py

--- a/.github/workflows/factory-review-execute.yml
+++ b/.github/workflows/factory-review-execute.yml
@@ -1,0 +1,227 @@
+# Executes counterpart review only from trusted default-branch workflow code.
+# Every artifact and current PR field is revalidated before reviewer secrets load.
+
+name: Factory Review Executor
+
+on:
+  workflow_run:
+    workflows: [Factory Review]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  admit:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'workflow_dispatch' ||
+      (vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
+      vars.FACTORY_REVIEW_ENABLED == 'true'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      force_review: ${{ steps.context.outputs.force_review }}
+      matched: ${{ steps.admit.outputs.matched }}
+      pr_number: ${{ steps.admit.outputs.pr_number }}
+      reviewer: ${{ steps.admit.outputs.reviewer }}
+      head_sha: ${{ steps.admit.outputs.head_sha }}
+      linked_issue: ${{ steps.admit.outputs.linked_issue }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          path: source
+          persist-credentials: false
+      - name: Download untrusted review context
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: factory-review-context
+          path: context
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Resolve trusted review context
+        id: context
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="$(jq -er '.pr_number | select(type == "number")' context/factory-review-context.json)"
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          FORCE_REVIEW=false
+          if [ "$RUN_EVENT" = "workflow_dispatch" ]; then
+            if [ "$RUN_ACTOR" != "$REPOSITORY_OWNER" ]; then
+              echo "Only the repository owner may manually re-request Factory review." >&2
+              exit 1
+            fi
+            FORCE_REVIEW=true
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "force_review=$FORCE_REVIEW" >> "$GITHUB_OUTPUT"
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Admit counterpart review
+        id: admit
+        working-directory: source
+        env:
+          FORCE_REVIEW: ${{ steps.context.outputs.force_review }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          ARGS=(--pr "$PR_NUMBER")
+          if [ "$FORCE_REVIEW" = "true" ]; then
+            ARGS+=(--force)
+          fi
+          uv run --script scripts/factory-review.py "${ARGS[@]}"
+
+  april:
+    needs: admit
+    if: needs.admit.outputs.matched == 'true' && needs.admit.outputs.reviewer == 'april'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: factory-review-april-${{ needs.admit.outputs.pr_number }}-${{ needs.admit.outputs.head_sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate April app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.APRIL_APP_ID }}
+          private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 50
+          path: source
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Revalidate serialized April review
+        id: preflight
+        working-directory: source
+        env:
+          FORCE_REVIEW: ${{ needs.admit.outputs.force_review }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ARGS=(--pr "${{ needs.admit.outputs.pr_number }}")
+          ARGS+=(--expected-head "${{ needs.admit.outputs.head_sha }}")
+          ARGS+=(--expected-reviewer april)
+          if [ "$FORCE_REVIEW" = "true" ]; then
+            ARGS+=(--force)
+          fi
+          uv run --script scripts/factory-review.py "${ARGS[@]}"
+      - name: Checkout admitted pull request head
+        if: steps.preflight.outputs.matched == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.admit.outputs.head_sha }}
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Remove PR-controlled execution configuration
+        if: steps.preflight.outputs.matched == 'true'
+        run: |
+          find model-workspace -type l -delete
+          rm -f model-workspace/.npmrc
+      - name: Run April counterpart review
+        if: steps.preflight.outputs.matched == 'true'
+        working-directory: source
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
+          FACTORY_EXPECTED_LINKED_ISSUE: ${{ needs.admit.outputs.linked_issue }}
+          FACTORY_EXPECTED_PR_HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
+          GH_APP_SLUG: april-clearwater
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          MESSAGE="@${REPOSITORY_OWNER} mentioned you in PR #${PR_NUMBER}"
+          uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
+            --prompt-file .agents/skills/cofounder-contributor/references/april-clearwater.md \
+            --mode cli \
+            --message "$MESSAGE"
+
+  plat:
+    needs: admit
+    if: needs.admit.outputs.matched == 'true' && needs.admit.outputs.reviewer == 'plat'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: factory-review-plat-${{ needs.admit.outputs.pr_number }}-${{ needs.admit.outputs.head_sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate Plat app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
+          private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 50
+          path: source
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Revalidate serialized Plat review
+        id: preflight
+        working-directory: source
+        env:
+          FORCE_REVIEW: ${{ needs.admit.outputs.force_review }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          ARGS=(--pr "${{ needs.admit.outputs.pr_number }}")
+          ARGS+=(--expected-head "${{ needs.admit.outputs.head_sha }}")
+          ARGS+=(--expected-reviewer plat)
+          if [ "$FORCE_REVIEW" = "true" ]; then
+            ARGS+=(--force)
+          fi
+          uv run --script scripts/factory-review.py "${ARGS[@]}"
+      - name: Checkout admitted pull request head
+        if: steps.preflight.outputs.matched == 'true'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ needs.admit.outputs.head_sha }}
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Remove PR-controlled execution configuration
+        if: steps.preflight.outputs.matched == 'true'
+        run: |
+          find model-workspace -type l -delete
+          rm -f model-workspace/.npmrc
+      - name: Run Plat counterpart review
+        if: steps.preflight.outputs.matched == 'true'
+        working-directory: source
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
+          FACTORY_EXPECTED_LINKED_ISSUE: ${{ needs.admit.outputs.linked_issue }}
+          FACTORY_EXPECTED_PR_HEAD_SHA: ${{ needs.admit.outputs.head_sha }}
+          GH_APP_SLUG: workspace-agents
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          MESSAGE="@${REPOSITORY_OWNER} mentioned you in PR #${PR_NUMBER}"
+          uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
+            --prompt-file .agents/skills/cofounder-contributor/references/plat-ironwood.md \
+            --mode cli \
+            --message "$MESSAGE"

--- a/.github/workflows/factory-review-execute.yml
+++ b/.github/workflows/factory-review-execute.yml
@@ -65,6 +65,12 @@ jobs:
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "force_review=$FORCE_REVIEW" >> "$GITHUB_OUTPUT"
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Enforce review daily cap
+        working-directory: source
+        env:
+          FACTORY_REVIEW_DAILY_CAP: ${{ vars.FACTORY_REVIEW_DAILY_CAP || '12' }}
+          GH_TOKEN: ${{ github.token }}
+        run: uv run --script scripts/factory-review.py --authorize
       - name: Admit counterpart review
         id: admit
         working-directory: source

--- a/.github/workflows/factory-review.yml
+++ b/.github/workflows/factory-review.yml
@@ -1,11 +1,11 @@
-# Routes agent-authored pull requests to a counterpart App for substantive review.
-# Automatic runs deduplicate by reviewer and head SHA; manual dispatch is a re-request.
+# Emits a secret-free signal when an agent-authored pull request needs review.
+# The default-branch-controlled Factory Review Executor owns privileged execution.
 
 name: Factory Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -15,145 +15,26 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
-  admit:
+  signal:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
       vars.FACTORY_REVIEW_ENABLED == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      matched: ${{ steps.admit.outputs.matched }}
-      pr_number: ${{ steps.admit.outputs.pr_number }}
-      reviewer: ${{ steps.admit.outputs.reviewer }}
-      head_sha: ${{ steps.admit.outputs.head_sha }}
+    timeout-minutes: 2
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          fetch-depth: 1
-          path: source
-          persist-credentials: false
-      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
-      - name: Admit counterpart review
-        id: admit
+      - name: Write untrusted review context
         env:
-          FORCE_REVIEW: ${{ github.event_name == 'workflow_dispatch' }}
-          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-        shell: bash
         run: |
           set -euo pipefail
-          if [ ! -f source/scripts/factory-review.py ]; then
-            echo "Factory review machinery is not present on the trusted base yet; skipping bootstrap PR."
-            echo "matched=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          ARGS=(--pr "$PR_NUMBER")
-          if [ "$FORCE_REVIEW" = "true" ]; then
-            ARGS+=(--force)
-          fi
-          uv run --script source/scripts/factory-review.py "${ARGS[@]}"
-
-  april:
-    needs: admit
-    if: needs.admit.outputs.matched == 'true' && needs.admit.outputs.reviewer == 'april'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    concurrency:
-      group: factory-review-april-${{ needs.admit.outputs.pr_number }}-${{ needs.admit.outputs.head_sha }}
-      cancel-in-progress: false
-    steps:
-      - name: Generate April app token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          printf '{"pr_number":%s}\n' "$PR_NUMBER" > "$RUNNER_TEMP/factory-review-context.json"
+      - name: Upload review context
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          app-id: ${{ secrets.APRIL_APP_ID }}
-          private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
-          permission-contents: read
-          permission-issues: write
-          permission-pull-requests: write
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          fetch-depth: 50
-          path: source
-          persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Checkout pull request workspace
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: refs/pull/${{ needs.admit.outputs.pr_number }}/head
-          fetch-depth: 1
-          path: model-workspace
-          persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
-      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
-      - name: Run April counterpart review
-        working-directory: source
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
-          GH_APP_SLUG: april-clearwater
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-        run: |
-          MESSAGE="@${REPOSITORY_OWNER} mentioned you in PR #${PR_NUMBER}"
-          uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
-            --prompt-file .agents/skills/cofounder-contributor/references/april-clearwater.md \
-            --mode cli \
-            --message "$MESSAGE"
-
-  plat:
-    needs: admit
-    if: needs.admit.outputs.matched == 'true' && needs.admit.outputs.reviewer == 'plat'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    concurrency:
-      group: factory-review-plat-${{ needs.admit.outputs.pr_number }}-${{ needs.admit.outputs.head_sha }}
-      cancel-in-progress: false
-    steps:
-      - name: Generate Plat app token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
-        with:
-          app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
-          private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}
-          permission-contents: read
-          permission-issues: write
-          permission-pull-requests: write
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          fetch-depth: 50
-          path: source
-          persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
-      - name: Checkout pull request workspace
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: refs/pull/${{ needs.admit.outputs.pr_number }}/head
-          fetch-depth: 1
-          path: model-workspace
-          persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
-      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
-      - name: Run Plat counterpart review
-        working-directory: source
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
-          GH_APP_SLUG: workspace-agents
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
-        run: |
-          MESSAGE="@${REPOSITORY_OWNER} mentioned you in PR #${PR_NUMBER}"
-          uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
-            --prompt-file .agents/skills/cofounder-contributor/references/plat-ironwood.md \
-            --mode cli \
-            --message "$MESSAGE"
+          name: factory-review-context
+          path: ${{ runner.temp }}/factory-review-context.json
+          retention-days: 1

--- a/.github/workflows/factory-review.yml
+++ b/.github/workflows/factory-review.yml
@@ -1,0 +1,159 @@
+# Routes agent-authored pull requests to a counterpart App for substantive review.
+# Automatic runs deduplicate by reviewer and head SHA; manual dispatch is a re-request.
+
+name: Factory Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Agent-authored pull request to review"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  admit:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
+      vars.FACTORY_REVIEW_ENABLED == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matched: ${{ steps.admit.outputs.matched }}
+      pr_number: ${{ steps.admit.outputs.pr_number }}
+      reviewer: ${{ steps.admit.outputs.reviewer }}
+      head_sha: ${{ steps.admit.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 1
+          path: source
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Admit counterpart review
+        id: admit
+        env:
+          FORCE_REVIEW: ${{ github.event_name == 'workflow_dispatch' }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f source/scripts/factory-review.py ]; then
+            echo "Factory review machinery is not present on the trusted base yet; skipping bootstrap PR."
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ARGS=(--pr "$PR_NUMBER")
+          if [ "$FORCE_REVIEW" = "true" ]; then
+            ARGS+=(--force)
+          fi
+          uv run --script source/scripts/factory-review.py "${ARGS[@]}"
+
+  april:
+    needs: admit
+    if: needs.admit.outputs.matched == 'true' && needs.admit.outputs.reviewer == 'april'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: factory-review-april-${{ needs.admit.outputs.pr_number }}-${{ needs.admit.outputs.head_sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate April app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.APRIL_APP_ID }}
+          private-key: ${{ secrets.APRIL_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 50
+          path: source
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Checkout pull request workspace
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: refs/pull/${{ needs.admit.outputs.pr_number }}/head
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Run April counterpart review
+        working-directory: source
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
+          GH_APP_SLUG: april-clearwater
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          MESSAGE="@${REPOSITORY_OWNER} mentioned you in PR #${PR_NUMBER}"
+          uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
+            --prompt-file .agents/skills/cofounder-contributor/references/april-clearwater.md \
+            --mode cli \
+            --message "$MESSAGE"
+
+  plat:
+    needs: admit
+    if: needs.admit.outputs.matched == 'true' && needs.admit.outputs.reviewer == 'plat'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: factory-review-plat-${{ needs.admit.outputs.pr_number }}-${{ needs.admit.outputs.head_sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Generate Plat app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.WORKSPACE_AGENTS_APP_ID }}
+          private-key: ${{ secrets.WORKSPACE_AGENTS_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 50
+          path: source
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Checkout pull request workspace
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: refs/pull/${{ needs.admit.outputs.pr_number }}/head
+          fetch-depth: 1
+          path: model-workspace
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+      - name: Run Plat counterpart review
+        working-directory: source
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CONTRIBUTOR_MODEL_CWD: ${{ github.workspace }}/model-workspace
+          GH_APP_SLUG: workspace-agents
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.admit.outputs.pr_number }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          MESSAGE="@${REPOSITORY_OWNER} mentioned you in PR #${PR_NUMBER}"
+          uv run .agents/skills/cofounder-contributor/scripts/run-contributor.py \
+            --prompt-file .agents/skills/cofounder-contributor/references/plat-ironwood.md \
+            --mode cli \
+            --message "$MESSAGE"

--- a/scripts/factory-review.py
+++ b/scripts/factory-review.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -22,6 +23,7 @@ AUTHOR_REVIEWERS = {
     "author:plat": "april",
 }
 APPLICATION_DEFAULT_AUTHORS = {
+    "author:claude-code",
     "author:codex",
     "author:fable-orchestrator",
 }
@@ -30,6 +32,9 @@ REVIEWER_BOTS = {
     "plat": "workspace-agents[bot]",
 }
 PLATFORM_PREFIXES = (".github/", "infra/")
+CLOSING_REFERENCE_RE = re.compile(
+    r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
+)
 
 
 class FactoryReviewError(RuntimeError):
@@ -137,6 +142,11 @@ def reviewed_head(
     )
 
 
+def linked_issue_number(pull_request: dict[str, Any]) -> int | None:
+    match = CLOSING_REFERENCE_RE.search(str(pull_request.get("body") or ""))
+    return int(match.group("number")) if match else None
+
+
 def evaluate_review(
     pull_request: dict[str, Any],
     files: list[dict[str, Any]],
@@ -154,6 +164,9 @@ def evaluate_review(
     reviewer = counterpart_reviewer(author, files)
     if reviewer is None:
         return ReviewDecision("skip", f"author label {author} has no counterpart route")
+    pull_request_author = str((pull_request.get("user") or {}).get("login") or "").casefold()
+    if pull_request_author == REVIEWER_BOTS[reviewer].casefold():
+        return ReviewDecision("skip", f"{reviewer} cannot review its own pull request")
     head_sha = str((pull_request.get("head") or {}).get("sha") or "")
     if not head_sha:
         return ReviewDecision("skip", "pull request has no head SHA")
@@ -175,6 +188,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pr", type=int, required=True)
     parser.add_argument("--force", action="store_true")
+    parser.add_argument("--expected-head", default="")
+    parser.add_argument("--expected-reviewer", choices=sorted(REVIEWER_BOTS))
     return parser.parse_args()
 
 
@@ -197,11 +212,20 @@ def main() -> int:
     reviews = client.pull_request_reviews(args.pr)
     decision = evaluate_review(pull_request, files, reviews, force=args.force)
     head_sha = str((pull_request.get("head") or {}).get("sha") or "")
+    if args.expected_head and args.expected_head != head_sha:
+        decision = ReviewDecision("skip", "pull request head changed after admission")
+    if (
+        args.expected_reviewer
+        and decision.action == "review"
+        and args.expected_reviewer != decision.reviewer
+    ):
+        decision = ReviewDecision("skip", "counterpart route changed after admission")
     print(f"Factory review decision for #{args.pr}: {decision.action} ({decision.reason})")
     write_output("matched", "true" if decision.action == "review" else "false")
     write_output("pr_number", str(args.pr))
     write_output("reviewer", decision.reviewer)
     write_output("head_sha", head_sha)
+    write_output("linked_issue", str(linked_issue_number(pull_request) or ""))
     return 0
 
 

--- a/scripts/factory-review.py
+++ b/scripts/factory-review.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Admit agent-authored pull requests to the Factory counterpart-review lane."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+AUTHOR_REVIEWERS = {
+    "author:april": "plat",
+    "author:plat": "april",
+}
+APPLICATION_DEFAULT_AUTHORS = {
+    "author:codex",
+    "author:fable-orchestrator",
+}
+REVIEWER_BOTS = {
+    "april": "april-clearwater[bot]",
+    "plat": "workspace-agents[bot]",
+}
+PLATFORM_PREFIXES = (".github/", "infra/")
+
+
+class FactoryReviewError(RuntimeError):
+    """Raised when review admission cannot be evaluated safely."""
+
+
+class GitHubClient:
+    def __init__(self, repository: str, token: str, api_url: str = "https://api.github.com"):
+        self.repository = repository
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+
+    def request(self, path: str) -> Any:
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": "workspaces-factory-review",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise FactoryReviewError(
+                f"GitHub API GET {path} failed with HTTP {error.code}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise FactoryReviewError(f"GitHub API GET {path} failed: {error.reason}") from error
+        return json.loads(body) if body else None
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        return dict(self.request(f"/repos/{self.repository}/pulls/{number}"))
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        return self._paginated(f"/repos/{self.repository}/pulls/{number}/files")
+
+    def pull_request_reviews(self, number: int) -> list[dict[str, Any]]:
+        return self._paginated(f"/repos/{self.repository}/pulls/{number}/reviews")
+
+    def _paginated(self, path: str) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            separator = "&" if "?" in path else "?"
+            batch = list(self.request(f"{path}{separator}per_page=100&page={page}"))
+            items.extend(dict(item) for item in batch)
+            if len(batch) < 100:
+                return items
+            page += 1
+
+
+@dataclass(frozen=True)
+class ReviewDecision:
+    action: str
+    reason: str
+    reviewer: str = ""
+
+
+def label_names(pull_request: dict[str, Any]) -> set[str]:
+    return {
+        str(label.get("name", ""))
+        for label in pull_request.get("labels", []) or []
+        if isinstance(label, dict) and label.get("name")
+    }
+
+
+def author_label(pull_request: dict[str, Any]) -> str | None:
+    labels = sorted(label for label in label_names(pull_request) if label.startswith("author:"))
+    if len(labels) != 1:
+        return None
+    return labels[0]
+
+
+def mostly_platform_files(files: list[dict[str, Any]]) -> bool:
+    paths = [str(item.get("filename") or "") for item in files]
+    if not paths:
+        return False
+    platform_count = sum(path.startswith(PLATFORM_PREFIXES) for path in paths)
+    return platform_count > len(paths) / 2
+
+
+def counterpart_reviewer(author: str, files: list[dict[str, Any]]) -> str | None:
+    if author in AUTHOR_REVIEWERS:
+        return AUTHOR_REVIEWERS[author]
+    if author in APPLICATION_DEFAULT_AUTHORS:
+        return "plat" if mostly_platform_files(files) else "april"
+    return None
+
+
+def reviewed_head(
+    reviews: list[dict[str, Any]],
+    *,
+    reviewer: str,
+    head_sha: str,
+) -> bool:
+    expected_login = REVIEWER_BOTS[reviewer].casefold()
+    return any(
+        str((review.get("user") or {}).get("login") or "").casefold() == expected_login
+        and str(review.get("commit_id") or "") == head_sha
+        for review in reviews
+    )
+
+
+def evaluate_review(
+    pull_request: dict[str, Any],
+    files: list[dict[str, Any]],
+    reviews: list[dict[str, Any]],
+    *,
+    force: bool,
+) -> ReviewDecision:
+    if str(pull_request.get("state") or "").casefold() != "open":
+        return ReviewDecision("skip", "pull request is not open")
+    if bool(pull_request.get("draft")):
+        return ReviewDecision("skip", "pull request is a draft")
+    author = author_label(pull_request)
+    if author is None:
+        return ReviewDecision("skip", "pull request does not carry exactly one author label")
+    reviewer = counterpart_reviewer(author, files)
+    if reviewer is None:
+        return ReviewDecision("skip", f"author label {author} has no counterpart route")
+    head_sha = str((pull_request.get("head") or {}).get("sha") or "")
+    if not head_sha:
+        return ReviewDecision("skip", "pull request has no head SHA")
+    if not force and reviewed_head(reviews, reviewer=reviewer, head_sha=head_sha):
+        return ReviewDecision("skip", f"{reviewer} already reviewed head {head_sha}")
+    return ReviewDecision("review", f"route {author} to {reviewer}", reviewer)
+
+
+def write_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT", "")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+    else:
+        print(f"{name}={value}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args()
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise FactoryReviewError(f"{name} is required")
+    return value
+
+
+def main() -> int:
+    args = parse_args()
+    client = GitHubClient(
+        require_env("GITHUB_REPOSITORY"),
+        require_env("GH_TOKEN"),
+        os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+    )
+    pull_request = client.pull_request(args.pr)
+    files = client.pull_request_files(args.pr)
+    reviews = client.pull_request_reviews(args.pr)
+    decision = evaluate_review(pull_request, files, reviews, force=args.force)
+    head_sha = str((pull_request.get("head") or {}).get("sha") or "")
+    print(f"Factory review decision for #{args.pr}: {decision.action} ({decision.reason})")
+    write_output("matched", "true" if decision.action == "review" else "false")
+    write_output("pr_number", str(args.pr))
+    write_output("reviewer", decision.reviewer)
+    write_output("head_sha", head_sha)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except FactoryReviewError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/factory-review.py
+++ b/scripts/factory-review.py
@@ -13,8 +13,10 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 
@@ -32,6 +34,7 @@ REVIEWER_BOTS = {
     "plat": "workspace-agents[bot]",
 }
 PLATFORM_PREFIXES = (".github/", "infra/")
+DEFAULT_DAILY_REVIEW_CAP = 12
 CLOSING_REFERENCE_RE = re.compile(
     r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(?P<number>\d+)\b"
 )
@@ -77,6 +80,24 @@ class GitHubClient:
 
     def pull_request_reviews(self, number: int) -> list[dict[str, Any]]:
         return self._paginated(f"/repos/{self.repository}/pulls/{number}/reviews")
+
+    def workflow_runs_on(self, workflow: str, day: str) -> list[dict[str, Any]]:
+        runs: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            query = urllib.parse.urlencode(
+                {"created": day, "per_page": 100, "page": page}
+            )
+            payload = dict(
+                self.request(
+                    f"/repos/{self.repository}/actions/workflows/{workflow}/runs?{query}"
+                )
+            )
+            batch = list(payload.get("workflow_runs") or [])
+            runs.extend(dict(run) for run in batch)
+            if len(batch) < 100:
+                return runs
+            page += 1
 
     def _paginated(self, path: str) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []
@@ -147,6 +168,57 @@ def linked_issue_number(pull_request: dict[str, Any]) -> int | None:
     return int(match.group("number")) if match else None
 
 
+def parse_daily_cap(value: str | None) -> int:
+    raw = (value or str(DEFAULT_DAILY_REVIEW_CAP)).strip()
+    try:
+        cap = int(raw)
+    except ValueError as error:
+        raise FactoryReviewError(
+            f"FACTORY_REVIEW_DAILY_CAP must be a positive integer, got {raw!r}"
+        ) from error
+    if cap <= 0:
+        raise FactoryReviewError("FACTORY_REVIEW_DAILY_CAP must be a positive integer")
+    return cap
+
+
+def count_daily_runs(
+    runs: list[dict[str, Any]],
+    current_run_id: str,
+    current_run_attempt: int = 1,
+) -> int:
+    attempts_by_run = {
+        str(run["id"]): max(1, int(run.get("run_attempt") or 1))
+        for run in runs
+        if isinstance(run, dict) and run.get("id") is not None
+    }
+    if current_run_id:
+        attempts_by_run[current_run_id] = max(
+            attempts_by_run.get(current_run_id, 0),
+            current_run_attempt,
+        )
+    return sum(attempts_by_run.values())
+
+
+def authorize_execution(
+    client: GitHubClient,
+    daily_cap: int,
+    current_run_id: str,
+    current_run_attempt: int,
+) -> None:
+    day = datetime.now(UTC).date().isoformat()
+    daily_run_count = count_daily_runs(
+        client.workflow_runs_on("factory-review-execute.yml", day),
+        current_run_id,
+        current_run_attempt,
+    )
+    print(f"Factory review execution budget: {daily_run_count}/{daily_cap}")
+    if daily_run_count > daily_cap:
+        raise FactoryReviewError(
+            f"daily review cap of {daily_cap} is exceeded "
+            f"({daily_run_count} run attempts)"
+        )
+
+
 def evaluate_review(
     pull_request: dict[str, Any],
     files: list[dict[str, Any]],
@@ -186,7 +258,9 @@ def write_output(name: str, value: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--pr", type=int, required=True)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pr", type=int)
+    target.add_argument("--authorize", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--expected-head", default="")
     parser.add_argument("--expected-reviewer", choices=sorted(REVIEWER_BOTS))
@@ -207,6 +281,16 @@ def main() -> int:
         require_env("GH_TOKEN"),
         os.environ.get("GITHUB_API_URL", "https://api.github.com"),
     )
+    if args.authorize:
+        authorize_execution(
+            client,
+            parse_daily_cap(os.environ.get("FACTORY_REVIEW_DAILY_CAP")),
+            require_env("GITHUB_RUN_ID"),
+            int(require_env("GITHUB_RUN_ATTEMPT")),
+        )
+        return 0
+
+    assert args.pr is not None
     pull_request = client.pull_request(args.pr)
     files = client.pull_request_files(args.pr)
     reviews = client.pull_request_reviews(args.pr)

--- a/scripts/tests/test_factory_review.py
+++ b/scripts/tests/test_factory_review.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Contract tests for Agent Factory counterpart-review admission."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "factory-review.py"
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "factory-review.yml"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+factory_review = load_module("factory_review", SCRIPT_PATH)
+
+
+class FactoryReviewTests(unittest.TestCase):
+    def pull_request(
+        self,
+        *,
+        label: str = "author:codex",
+        draft: bool = False,
+        head_sha: str = "abc123",
+    ):
+        return {
+            "state": "open",
+            "draft": draft,
+            "labels": [{"name": label}],
+            "head": {"sha": head_sha},
+        }
+
+    def test_fixed_persona_pairs_route_to_counterpart(self) -> None:
+        files = [{"filename": "Sources/Feature.swift"}]
+        self.assertEqual(factory_review.counterpart_reviewer("author:april", files), "plat")
+        self.assertEqual(factory_review.counterpart_reviewer("author:plat", files), "april")
+
+    def test_generalist_authors_route_by_file_majority(self) -> None:
+        application_files = [
+            {"filename": "Sources/Feature.swift"},
+            {"filename": "Tests/FeatureTests.swift"},
+            {"filename": ".github/workflows/ci.yml"},
+        ]
+        platform_files = [
+            {"filename": ".github/workflows/ci.yml"},
+            {"filename": "infra/worker/index.ts"},
+            {"filename": "scripts/helper.py"},
+        ]
+
+        for label in ("author:codex", "author:fable-orchestrator"):
+            with self.subTest(label=label):
+                self.assertEqual(
+                    factory_review.counterpart_reviewer(label, application_files),
+                    "april",
+                )
+                self.assertEqual(
+                    factory_review.counterpart_reviewer(label, platform_files),
+                    "plat",
+                )
+
+    def test_automatic_review_deduplicates_reviewer_and_head_sha(self) -> None:
+        reviews = [
+            {
+                "user": {"login": "april-clearwater[bot]"},
+                "commit_id": "abc123",
+                "state": "APPROVED",
+            }
+        ]
+        pull_request = self.pull_request()
+        files = [{"filename": "Sources/Feature.swift"}]
+
+        automatic = factory_review.evaluate_review(
+            pull_request,
+            files,
+            reviews,
+            force=False,
+        )
+        requested = factory_review.evaluate_review(
+            pull_request,
+            files,
+            reviews,
+            force=True,
+        )
+
+        self.assertEqual(automatic.action, "skip")
+        self.assertEqual(requested.action, "review")
+        self.assertEqual(requested.reviewer, "april")
+
+    def test_human_or_draft_pull_request_does_not_enter_review_lane(self) -> None:
+        files = [{"filename": "Sources/Feature.swift"}]
+        human = self.pull_request(label="quality")
+        draft = self.pull_request(draft=True)
+
+        self.assertEqual(
+            factory_review.evaluate_review(human, files, [], force=False).action,
+            "skip",
+        )
+        self.assertEqual(
+            factory_review.evaluate_review(draft, files, [], force=False).action,
+            "skip",
+        )
+
+    def test_workflow_uses_isolated_apps_kill_switches_and_no_review_trigger(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("types: [opened, ready_for_review]", workflow)
+        self.assertNotIn("pull_request_review:", workflow)
+        self.assertIn("vars.AGENT_AUTOMATIONS_ENABLED == 'true'", workflow)
+        self.assertIn("vars.FACTORY_REVIEW_ENABLED == 'true'", workflow)
+        self.assertIn("secrets.APRIL_APP_ID", workflow)
+        self.assertIn("secrets.APRIL_PRIVATE_KEY", workflow)
+        self.assertIn("secrets.WORKSPACE_AGENTS_APP_ID", workflow)
+        self.assertIn("secrets.WORKSPACE_AGENTS_PRIVATE_KEY", workflow)
+        self.assertIn("GH_APP_SLUG: april-clearwater", workflow)
+        self.assertIn("GH_APP_SLUG: workspace-agents", workflow)
+        self.assertIn("mentioned you in PR #${PR_NUMBER}", workflow)
+        self.assertIn("github.event.pull_request.base.sha || github.sha", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_factory_review.py
+++ b/scripts/tests/test_factory_review.py
@@ -11,6 +11,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -125,6 +126,32 @@ class FactoryReviewTests(unittest.TestCase):
         self.assertEqual(requested.action, "review")
         self.assertEqual(requested.reviewer, "april")
 
+    def test_daily_review_budget_counts_reruns_and_fails_closed(self) -> None:
+        runs = [
+            {"id": 100, "run_attempt": 2},
+            {"id": 101, "run_attempt": 1},
+        ]
+        self.assertEqual(factory_review.count_daily_runs(runs, "101"), 3)
+        self.assertEqual(factory_review.count_daily_runs(runs, "102", 3), 6)
+
+        client = mock.Mock()
+        client.workflow_runs_on.return_value = runs
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "4 run attempts"):
+            factory_review.authorize_execution(client, 3, "102", 1)
+        with self.assertRaisesRegex(factory_review.FactoryReviewError, "positive integer"):
+            factory_review.parse_daily_cap("0")
+
+        api_client = factory_review.GitHubClient("fairchild/workspaces", "token")
+        with mock.patch.object(
+            api_client,
+            "request",
+            return_value={"workflow_runs": runs},
+        ):
+            self.assertEqual(
+                api_client.workflow_runs_on("factory-review-execute.yml", "2026-07-14"),
+                runs,
+            )
+
     def test_human_or_draft_pull_request_does_not_enter_review_lane(self) -> None:
         files = [{"filename": "Sources/Feature.swift"}]
         human = self.pull_request(label="quality")
@@ -159,6 +186,8 @@ class FactoryReviewTests(unittest.TestCase):
         self.assertIn("ref: ${{ needs.admit.outputs.head_sha }}", executor)
         self.assertIn("--expected-head", executor)
         self.assertIn("FACTORY_EXPECTED_PR_HEAD_SHA", executor)
+        self.assertIn("FACTORY_REVIEW_DAILY_CAP", executor)
+        self.assertIn("factory-review.py --authorize", executor)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_factory_review.py
+++ b/scripts/tests/test_factory_review.py
@@ -16,6 +16,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "factory-review.py"
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "factory-review.yml"
+EXECUTOR_PATH = REPO_ROOT / ".github" / "workflows" / "factory-review-execute.yml"
 
 
 def load_module(name: str, path: Path):
@@ -62,7 +63,7 @@ class FactoryReviewTests(unittest.TestCase):
             {"filename": "scripts/helper.py"},
         ]
 
-        for label in ("author:codex", "author:fable-orchestrator"):
+        for label in ("author:claude-code", "author:codex", "author:fable-orchestrator"):
             with self.subTest(label=label):
                 self.assertEqual(
                     factory_review.counterpart_reviewer(label, application_files),
@@ -72,6 +73,29 @@ class FactoryReviewTests(unittest.TestCase):
                     factory_review.counterpart_reviewer(label, platform_files),
                     "plat",
                 )
+
+    def test_app_cannot_review_its_own_mislabeled_pull_request(self) -> None:
+        pull_request = {
+            **self.pull_request(label="author:codex"),
+            "user": {"login": "april-clearwater[bot]"},
+        }
+
+        decision = factory_review.evaluate_review(
+            pull_request,
+            [{"filename": "Sources/Feature.swift"}],
+            [],
+            force=False,
+        )
+
+        self.assertEqual(decision.action, "skip")
+        self.assertIn("cannot review its own", decision.reason)
+
+    def test_linked_issue_is_derived_from_closing_reference(self) -> None:
+        self.assertEqual(
+            factory_review.linked_issue_number({"body": "Summary\n\nCloses #1091"}),
+            1091,
+        )
+        self.assertIsNone(factory_review.linked_issue_number({"body": "Related to #1091"}))
 
     def test_automatic_review_deduplicates_reviewer_and_head_sha(self) -> None:
         reviews = [
@@ -117,19 +141,24 @@ class FactoryReviewTests(unittest.TestCase):
 
     def test_workflow_uses_isolated_apps_kill_switches_and_no_review_trigger(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        executor = EXECUTOR_PATH.read_text(encoding="utf-8")
 
-        self.assertIn("types: [opened, ready_for_review]", workflow)
+        self.assertIn("types: [opened, ready_for_review, synchronize]", workflow)
         self.assertNotIn("pull_request_review:", workflow)
         self.assertIn("vars.AGENT_AUTOMATIONS_ENABLED == 'true'", workflow)
         self.assertIn("vars.FACTORY_REVIEW_ENABLED == 'true'", workflow)
-        self.assertIn("secrets.APRIL_APP_ID", workflow)
-        self.assertIn("secrets.APRIL_PRIVATE_KEY", workflow)
-        self.assertIn("secrets.WORKSPACE_AGENTS_APP_ID", workflow)
-        self.assertIn("secrets.WORKSPACE_AGENTS_PRIVATE_KEY", workflow)
-        self.assertIn("GH_APP_SLUG: april-clearwater", workflow)
-        self.assertIn("GH_APP_SLUG: workspace-agents", workflow)
-        self.assertIn("mentioned you in PR #${PR_NUMBER}", workflow)
-        self.assertIn("github.event.pull_request.base.sha || github.sha", workflow)
+        self.assertNotIn("secrets.", workflow)
+        self.assertIn("workflow_run:", executor)
+        self.assertIn("secrets.APRIL_APP_ID", executor)
+        self.assertIn("secrets.APRIL_PRIVATE_KEY", executor)
+        self.assertIn("secrets.WORKSPACE_AGENTS_APP_ID", executor)
+        self.assertIn("secrets.WORKSPACE_AGENTS_PRIVATE_KEY", executor)
+        self.assertIn("GH_APP_SLUG: april-clearwater", executor)
+        self.assertIn("GH_APP_SLUG: workspace-agents", executor)
+        self.assertIn("mentioned you in PR #${PR_NUMBER}", executor)
+        self.assertIn("ref: ${{ needs.admit.outputs.head_sha }}", executor)
+        self.assertIn("--expected-head", executor)
+        self.assertIn("FACTORY_EXPECTED_PR_HEAD_SHA", executor)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -231,19 +231,51 @@ class RunContributorEvidenceTests(unittest.TestCase):
         execution = sys.modules["execution"]
         commands: list[list[str]] = []
 
+        def fake_run_checked(command, **_kwargs):
+            commands.append(command)
+            if command[:4] == ["gh", "pr", "view", "77"]:
+                return mock.Mock(
+                    stdout=json.dumps(
+                        {
+                            "body": "Closes #42",
+                            "labels": [{"name": "author:codex"}],
+                        }
+                    )
+                )
+            return mock.Mock(stdout="")
+
         with (
-            mock.patch.object(execution, "run_optional", return_value="Closes #42"),
             mock.patch.object(execution, "ensure_label_exists"),
             mock.patch.object(
                 execution,
                 "run_checked",
-                side_effect=lambda command, **_kwargs: commands.append(command),
+                side_effect=fake_run_checked,
             ),
         ):
             run_contributor._update_mergeable_label(77, "approve", {"GH_TOKEN": "token"})
 
         self.assertIn(["gh", "pr", "edit", "77", "--add-label", "mergeable"], commands)
         self.assertIn(["gh", "issue", "edit", "42", "--add-label", "mergeable"], commands)
+
+    def test_claude_runs_bare_in_untrusted_review_workspace(self) -> None:
+        with mock.patch.object(
+            run_contributor,
+            "run_checked",
+            return_value=mock.Mock(stdout="review"),
+        ) as run_checked:
+            output = run_contributor.run_claude(
+                "system",
+                "task",
+                {"PATH": "/usr/bin", "CLAUDE_CODE_OAUTH_TOKEN": "token"},
+                mode="cli",
+                tools=run_contributor.READ_ONLY_MODEL_TOOLS,
+                cwd=Path("/tmp/model-workspace"),
+            )
+
+        command = run_checked.call_args.args[0]
+        self.assertEqual(output, "review")
+        self.assertIn("--bare", command)
+        self.assertEqual(run_checked.call_args.kwargs["cwd"], Path("/tmp/model-workspace"))
 
     def test_reconcile_pending_ci_evidence_includes_uploaded_screenshot_links(self) -> None:
         body = "\n".join(

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -227,7 +227,7 @@ class RunContributorEvidenceTests(unittest.TestCase):
             "author:plat",
         )
 
-    def test_approved_review_labels_pull_request_and_linked_issue_mergeable(self) -> None:
+    def test_approved_review_uses_only_admitted_linked_issue(self) -> None:
         execution = sys.modules["execution"]
         commands: list[list[str]] = []
 
@@ -252,10 +252,27 @@ class RunContributorEvidenceTests(unittest.TestCase):
                 side_effect=fake_run_checked,
             ),
         ):
-            run_contributor._update_mergeable_label(77, "approve", {"GH_TOKEN": "token"})
+            run_contributor._update_mergeable_label(
+                77,
+                "approve",
+                {
+                    "GH_TOKEN": "token",
+                    "FACTORY_EXPECTED_LINKED_ISSUE": "42",
+                },
+            )
 
         self.assertIn(["gh", "pr", "edit", "77", "--add-label", "mergeable"], commands)
         self.assertIn(["gh", "issue", "edit", "42", "--add-label", "mergeable"], commands)
+
+        commands.clear()
+        with (
+            mock.patch.object(execution, "ensure_label_exists"),
+            mock.patch.object(execution, "run_checked", side_effect=fake_run_checked),
+        ):
+            run_contributor._update_mergeable_label(77, "approve", {"GH_TOKEN": "token"})
+
+        self.assertIn(["gh", "pr", "edit", "77", "--add-label", "mergeable"], commands)
+        self.assertFalse(any(command[:3] == ["gh", "issue", "edit"] for command in commands))
 
     def test_claude_runs_bare_in_untrusted_review_workspace(self) -> None:
         with mock.patch.object(

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -227,6 +227,24 @@ class RunContributorEvidenceTests(unittest.TestCase):
             "author:plat",
         )
 
+    def test_approved_review_labels_pull_request_and_linked_issue_mergeable(self) -> None:
+        execution = sys.modules["execution"]
+        commands: list[list[str]] = []
+
+        with (
+            mock.patch.object(execution, "run_optional", return_value="Closes #42"),
+            mock.patch.object(execution, "ensure_label_exists"),
+            mock.patch.object(
+                execution,
+                "run_checked",
+                side_effect=lambda command, **_kwargs: commands.append(command),
+            ),
+        ):
+            run_contributor._update_mergeable_label(77, "approve", {"GH_TOKEN": "token"})
+
+        self.assertIn(["gh", "pr", "edit", "77", "--add-label", "mergeable"], commands)
+        self.assertIn(["gh", "issue", "edit", "42", "--add-label", "mergeable"], commands)
+
     def test_reconcile_pending_ci_evidence_includes_uploaded_screenshot_links(self) -> None:
         body = "\n".join(
             [

--- a/scripts/tests/test_validate_agent_output.py
+++ b/scripts/tests/test_validate_agent_output.py
@@ -61,6 +61,9 @@ Looks safe.
         self.assertEqual(data["pr_number"], 571)
         self.assertIn("Looks safe.", data["body"])
 
+        validated = validate_agent_output.validate_data(data)
+        self.assertEqual(validated["verdict"], "approve_with_followups")
+
     def test_extract_structured_accepts_frontmatter_inside_yaml_fence(self) -> None:
         raw = """Analysis before final output.
 
@@ -80,6 +83,18 @@ verdict: approve
 
         self.assertEqual(data["action"], "review_pr")
         self.assertEqual(data["verdict"], "approve")
+
+    def test_review_verdict_rejects_non_decisions(self) -> None:
+        with self.assertRaisesRegex(validate_agent_output.ValidationError, "verdict"):
+            validate_agent_output.validate_data(
+                {
+                    "action": "review_pr",
+                    "persona": "April Clearwater, Application Lead",
+                    "pr_number": 571,
+                    "verdict": "comment",
+                    "body": "Looks mostly fine.",
+                }
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- route agent-authored pull requests to the April/Plat counterpart through a secret-free `pull_request` signal and a default-branch-controlled executor
- bind admission, checkout, review submission, and additive `mergeable` labels to one head SHA and linked issue
- deduplicate automatic reviews inside the serialized reviewer job, cap executor attempts at 12 per UTC day by default, and preserve owner-only manual re-requests

Closes #1091

## Stack

Stacked on #1096 because this slice reuses the contributor-runtime and Factory workflow contracts introduced there. Required merge order: #1096, then this PR.

## Evidence

![factory-review-gates](https://evidence.cloudcompute.com/workspaces/pr-1097/20260714-102842-factory-review-gates.png)

Rebased hardening gates: bare `actionlint`, YAML parsing, 116 focused UV-script tests, and whitespace validation all passed at `d639c9d7`; the uploaded image records the original slice gate run.

## Mergeability

- **Surface:** infra - Agent Factory review workflows and contributor review runtime
- **User-facing behavior changed:** Agent-authored PRs receive an automatic substantive review from a different App identity; approving reviews add `mergeable` to the PR and linked issue.
- **Non-happy paths considered:** Disabled automation, daily-cap exhaustion and reruns, drafts and human PRs, multiple or unknown author labels, App self-review, changed routing, duplicate events, head changes during review, absent admitted issue links, blocked evidence, request changes, manual re-requests, and PR-controlled configuration are covered.
- **Residual risk or follow-up:** The pinned-commit review posts before the second head recheck, so a mid-window push can leave an approval anchored to the old SHA; branch protection must dismiss stale reviews. The first post-merge agent PR remains the live App review proof, and `author:carl` is intentionally outside the M3 routes.

## Deviations from issue sketch

- Added `synchronize` so a new head receives one fresh counterpart review instead of retaining an additive signal from an older head.
- Split privileged execution into `factory-review-execute.yml` behind `workflow_run`; keeping App private keys in a PR-controlled `pull_request` workflow would expose them to same-repository branch code.

## Review loop

Directed Codex review used `gpt-5.6-sol` at `xhigh` reasoning.

- Fixed the secret boundary by making `factory-review.yml` a secret-free signal and loading reviewer credentials only in a default-branch-controlled `workflow_run` executor.
- Fixed PR-controlled runtime configuration by deleting checkout symlinks and root npm configuration, and invoking Claude Code with `--bare`.
- Fixed mutable-head approval by pinning checkout and REST review submission to the admitted SHA and rechecking immediately before and after review submission.
- Fixed App self-routing by comparing the PR author login with the selected reviewer bot.
- Added the live `author:claude-code` generalist route; retained the fixed M3 scope for Carl.
- Fixed duplicate-event races with a second admission check inside the per-reviewer/head concurrency group.
- Made request-changes label removal fail visibly and bound label mutation to the admitted linked issue.
- Wired Factory and contributor-output policy tests into CI.

Orchestrator hardening propagated through the rebased stack at `2351289f`:

- The implementation stage below this slice now admits only owner-authenticated releases, verifies the latest `ready` timeline actor in its claim chokepoint, and passes that verified actor into the contributor envelope.
- The contributor guard used by counterpart review now derives release-sensitive paths from shared `scripts/release_policy.py`, including the full release validator set, entitlements, signing/keychain/entitlement names, and issue-title paths.
- Implementation kill-switch, rerun-budget, rollback-author, partial-claim, replay, and conflicting-lifecycle fixes are inherited from #1096 without duplicating review-stage policy.
- The existing manual review re-request remains owner-validated in the default-branch executor before reviewer credentials load.

Second-pass delta review at `d639c9d7` closed A1-A4:

- The default-branch executor now fails closed above `FACTORY_REVIEW_DAILY_CAP` (default 12), counting all same-day executor run attempts and reruns through the Actions API before counterpart admission.
- Verdict-time issue labeling now uses only the issue captured at admission; when admission found no closing reference, PR labeling may proceed but issue labeling is skipped even if the body changes later.
- Accepted the narrow approval TOCTOU described under Residual risk: the review remains pinned to the admitted commit, and branch protection owns stale-review dismissal if the head moves in the final post window.
- Verified `--bare` in pinned Claude Code 2.1.200; it skips hooks, plugins, keychain access, and `CLAUDE.md`, and is the untrusted-workspace isolation mechanism used by this lane.
