### PR TITLE
feat(factory): add safety rails and dispatch observability

### DIFF
--- a/.github/workflows/factory-monitor.yml
+++ b/.github/workflows/factory-monitor.yml
@@ -192,6 +192,7 @@ jobs:
         shell: bash
         env:
           DRY_RUN: ${{ inputs.dry_run || false }}
+          FACTORY_IMPLEMENT_DAILY_CAP: ${{ vars.FACTORY_IMPLEMENT_DAILY_CAP || '6' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/docs/development/agent-factory-v2-plan.md
+++ b/docs/development/agent-factory-v2-plan.md
@@ -107,6 +107,16 @@ New in v2:
 4. Triage's write powers are labels and comments only; implementation starts only from a label event.
 5. The future auto-merge class requires a deliberate main-merge ruleset change (`config/github/`) — flagged now so it is a designed decision, not an expedient hack.
 
+The code-writing stages use the following operating switches. Scheduled and event-driven dispatch requires both the global master and the stage switch; `workflow_dispatch` remains an explicit operator break-glass path and is always logged. `FACTORY_IMPLEMENT_DAILY_CAP` defaults to 6 UTC-day workflow runs: the claim gate counts `factory-implement.yml` runs through the Actions API, leaves over-budget issues `ready`, and reports the skip in the Digest.
+
+| Stage | Global switch | Stage switch | Off behavior |
+| --- | --- | --- | --- |
+| Implement | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_IMPLEMENT_ENABLED` | No automatic issue-label or Monitor recovery dispatch reaches the contributor runtime |
+| Review | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_REVIEW_ENABLED` | No automatic PR review signal reaches a counterpart reviewer |
+| Responder | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_RESPONDER_ENABLED` | No automatic owner-comment reply is generated or posted |
+
+Attribution is a runtime invariant: autonomous PR creation applies exactly one `author:<agent>` label, while autonomous reviews and comments begin with the acting persona or carry the responder's mechanical anti-loop marker. Shared GitHub account authorship is never treated as sufficient attribution.
+
 ## Instruments and dials
 
 The Monitor computes weekly, into dashboard + Digest:

--- a/docs/development/agent-factory-v2-plan.md
+++ b/docs/development/agent-factory-v2-plan.md
@@ -107,11 +107,11 @@ New in v2:
 4. Triage's write powers are labels and comments only; implementation starts only from a label event.
 5. The future auto-merge class requires a deliberate main-merge ruleset change (`config/github/`) — flagged now so it is a designed decision, not an expedient hack.
 
-The code-writing stages use the following operating switches. Scheduled and event-driven dispatch requires both the global master and the stage switch; `workflow_dispatch` remains an explicit operator break-glass path and is always logged. `FACTORY_IMPLEMENT_DAILY_CAP` defaults to 6 UTC-day workflow runs: the claim gate counts `factory-implement.yml` runs through the Actions API, leaves over-budget issues `ready`, and reports the skip in the Digest.
+The code-writing stages use the following operating switches. Scheduled, event-driven, and manual implementation dispatch requires both the global master and the stage switch; implementation `workflow_dispatch` is owner-only but does not bypass either switch. `FACTORY_IMPLEMENT_DAILY_CAP` defaults to 6 UTC-day workflow attempts: the claim gate counts only repository-owner-authorized `factory-implement.yml` runs through the Actions API, leaves over-budget issues `ready`, and reports the skip in the Digest.
 
 | Stage | Global switch | Stage switch | Off behavior |
 | --- | --- | --- | --- |
-| Implement | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_IMPLEMENT_ENABLED` | No automatic issue-label or Monitor recovery dispatch reaches the contributor runtime |
+| Implement | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_IMPLEMENT_ENABLED` | No issue-label or manual dispatch reaches the contributor runtime; the Monitor does not bypass the release gate |
 | Review | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_REVIEW_ENABLED` | No automatic PR review signal reaches a counterpart reviewer |
 | Responder | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_RESPONDER_ENABLED` | No automatic owner-comment reply is generated or posted |
 

--- a/docs/development/agent-factory-v2-plan.md
+++ b/docs/development/agent-factory-v2-plan.md
@@ -107,13 +107,13 @@ New in v2:
 4. Triage's write powers are labels and comments only; implementation starts only from a label event.
 5. The future auto-merge class requires a deliberate main-merge ruleset change (`config/github/`) — flagged now so it is a designed decision, not an expedient hack.
 
-The code-writing stages use the following operating switches. Scheduled, event-driven, and manual implementation dispatch requires both the global master and the stage switch; implementation `workflow_dispatch` is owner-only but does not bypass either switch. `FACTORY_IMPLEMENT_DAILY_CAP` defaults to 6 UTC-day workflow attempts: the claim gate counts only repository-owner-authorized `factory-implement.yml` runs through the Actions API, leaves over-budget issues `ready`, and reports the skip in the Digest.
+The code-writing stages use the following operating switches. Scheduled, event-driven, and manual implementation dispatch requires both the global master and the stage switch; implementation `workflow_dispatch` is owner-only but does not bypass either switch. `FACTORY_IMPLEMENT_DAILY_CAP` defaults to 6 UTC-day workflow attempts: the claim gate counts only repository-owner-authorized `factory-implement.yml` runs through the Actions API, leaves over-budget issues `ready`, and reports the skip in the Digest. `FACTORY_REVIEW_DAILY_CAP` defaults to 12 UTC-day executor attempts, including reruns; the default-branch admit job counts `factory-review-execute.yml` through the Actions API and fails closed before counterpart routing.
 
-| Stage | Global switch | Stage switch | Off behavior |
-| --- | --- | --- | --- |
-| Implement | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_IMPLEMENT_ENABLED` | No issue-label or manual dispatch reaches the contributor runtime; the Monitor does not bypass the release gate |
-| Review | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_REVIEW_ENABLED` | No automatic PR review signal reaches a counterpart reviewer |
-| Responder | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_RESPONDER_ENABLED` | No automatic owner-comment reply is generated or posted |
+| Stage | Global switch | Stage switch | Daily attempt cap | Off behavior |
+| --- | --- | --- | --- | --- |
+| Implement | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_IMPLEMENT_ENABLED` | `FACTORY_IMPLEMENT_DAILY_CAP` (6) | No issue-label or manual dispatch reaches the contributor runtime; the Monitor does not bypass the release gate |
+| Review | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_REVIEW_ENABLED` | `FACTORY_REVIEW_DAILY_CAP` (12) | No automatic PR review signal reaches a counterpart reviewer |
+| Responder | `AGENT_AUTOMATIONS_ENABLED` | `FACTORY_RESPONDER_ENABLED` | Not yet defined | No automatic owner-comment reply is generated or posted |
 
 Attribution is a runtime invariant: autonomous PR creation applies exactly one `author:<agent>` label, while autonomous reviews and comments begin with the acting persona or carry the responder's mechanical anti-loop marker. Shared GitHub account authorship is never treated as sufficient attribution.
 

--- a/scripts/factory-digest.py
+++ b/scripts/factory-digest.py
@@ -203,18 +203,25 @@ def count_successful_steps(
     return count
 
 
-def is_factory_implement_dispatch(run: dict[str, Any]) -> bool:
-    return (
+def is_factory_implement_dispatch(
+    run: dict[str, Any],
+    repository_owner: str,
+) -> bool:
+    actor = str((run.get("actor") or {}).get("login") or "")
+    return actor.casefold() == repository_owner.casefold() and (
         str(run.get("event", "")) == "workflow_dispatch"
         or str(run.get("display_title", "")).startswith("Factory Implement ready #")
     )
 
 
-def count_factory_implement_runs(runs: list[dict[str, Any]]) -> int:
+def count_factory_implement_runs(
+    runs: list[dict[str, Any]],
+    repository_owner: str,
+) -> int:
     return sum(
         max(1, int(run.get("run_attempt") or 1))
         for run in runs
-        if is_factory_implement_dispatch(run)
+        if is_factory_implement_dispatch(run, repository_owner)
     )
 
 
@@ -237,6 +244,7 @@ def fetch_factory_activity(
     current_time: datetime,
     implement_daily_cap: int,
 ) -> FactoryActivity:
+    repository_owner, _repository_name = split_repo_slug(repo_slug)
     day = current_time.astimezone(UTC).date().isoformat()
     implement_runs = fetch_workflow_runs(
         repo_slug,
@@ -259,7 +267,10 @@ def fetch_factory_activity(
     )
 
     return FactoryActivity(
-        implement_runs=count_factory_implement_runs(implement_runs),
+        implement_runs=count_factory_implement_runs(
+            implement_runs,
+            repository_owner,
+        ),
         review_verdicts=count_successful_steps(
             repo_slug,
             token,

--- a/scripts/factory-digest.py
+++ b/scripts/factory-digest.py
@@ -147,37 +147,46 @@ def fetch_run_jobs(
     token: str,
     run_id: int,
 ) -> list[dict[str, Any]]:
-    url = (
-        f"{GITHUB_API_URL}/repos/{repo_slug}/actions/runs/{run_id}/jobs"
-        "?filter=all&per_page=100"
-    )
-    request = urllib.request.Request(
-        url,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "User-Agent": "workspaces-factory-digest",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        detail = error.read().decode("utf-8", errors="replace")
-        raise FactoryDigestError(
-            f"GitHub jobs request for run {run_id} failed with HTTP "
-            f"{error.code}: {detail}"
-        ) from error
-    except urllib.error.URLError as error:
-        raise FactoryDigestError(
-            f"GitHub jobs request for run {run_id} failed: {error.reason}"
-        ) from error
-    except json.JSONDecodeError as error:
-        raise FactoryDigestError(
-            f"GitHub jobs request for run {run_id} returned invalid JSON"
-        ) from error
-    return [dict(job) for job in payload.get("jobs") or []]
+    jobs: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        query = urllib.parse.urlencode(
+            {"filter": "all", "per_page": 100, "page": page}
+        )
+        url = (
+            f"{GITHUB_API_URL}/repos/{repo_slug}/actions/runs/{run_id}/jobs?{query}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "workspaces-factory-digest",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise FactoryDigestError(
+                f"GitHub jobs request for run {run_id} failed with HTTP "
+                f"{error.code}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise FactoryDigestError(
+                f"GitHub jobs request for run {run_id} failed: {error.reason}"
+            ) from error
+        except json.JSONDecodeError as error:
+            raise FactoryDigestError(
+                f"GitHub jobs request for run {run_id} returned invalid JSON"
+            ) from error
+        batch = list(payload.get("jobs") or [])
+        jobs.extend(dict(job) for job in batch)
+        if len(batch) < 100:
+            return jobs
+        page += 1
 
 
 def count_successful_steps(
@@ -614,16 +623,15 @@ def render_digest(
         lines = [line for _, line in sorted(release_lines, key=lambda item: item[0])]
         sections.append("## Awaiting your release\n\n" + "\n".join(lines))
     if ready_issues:
-        count = len(ready_issues)
-        noun = "issue" if count == 1 else "issues"
-        line = f"{count} {noun} ready for claim"
-        if count <= 3:
-            itemized = ", ".join(
-                render_item_reference(issue)
-                for issue in sorted(ready_issues, key=lambda item: int(item["number"]))
+        lines = [
+            f"- no activity {age_days(str(issue['updatedAt']), current_time)}d "
+            f"{render_item_reference(issue)}: ready for claim"
+            for issue in sorted(
+                ready_issues,
+                key=lambda item: parse_datetime(str(item["updatedAt"])),
             )
-            line += f": {itemized}"
-        sections.append(line)
+        ]
+        sections.append("## Ready but unclaimed\n\n" + "\n".join(lines))
     if anomalies:
         numbers = ", ".join(f"#{number}" for number in sorted(anomalies))
         sections.append(f"State anomalies: {numbers} — janitor")

--- a/scripts/factory-digest.py
+++ b/scripts/factory-digest.py
@@ -149,7 +149,7 @@ def fetch_run_jobs(
 ) -> list[dict[str, Any]]:
     url = (
         f"{GITHUB_API_URL}/repos/{repo_slug}/actions/runs/{run_id}/jobs"
-        "?filter=latest&per_page=100"
+        "?filter=all&per_page=100"
     )
     request = urllib.request.Request(
         url,
@@ -210,6 +210,14 @@ def is_factory_implement_dispatch(run: dict[str, Any]) -> bool:
     )
 
 
+def count_factory_implement_runs(runs: list[dict[str, Any]]) -> int:
+    return sum(
+        max(1, int(run.get("run_attempt") or 1))
+        for run in runs
+        if is_factory_implement_dispatch(run)
+    )
+
+
 def parse_daily_implement_cap(value: str | None) -> int:
     raw = (value or str(DEFAULT_DAILY_IMPLEMENT_CAP)).strip()
     try:
@@ -251,7 +259,7 @@ def fetch_factory_activity(
     )
 
     return FactoryActivity(
-        implement_runs=sum(1 for run in implement_runs if is_factory_implement_dispatch(run)),
+        implement_runs=count_factory_implement_runs(implement_runs),
         review_verdicts=count_successful_steps(
             repo_slug,
             token,

--- a/scripts/factory-digest.py
+++ b/scripts/factory-digest.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -28,6 +29,8 @@ DIGEST_TITLE = "Factory Digest"
 DIGEST_MARKER = "<!-- factory-digest:v1 -->"
 FACTORY_LABEL_COLOR = "BFD4F2"
 FACTORY_LABEL_DESCRIPTION = "Agent Factory observability and operations"
+DEFAULT_DAILY_IMPLEMENT_CAP = 6
+GITHUB_API_URL = "https://api.github.com"
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 MAX_TITLE_LENGTH = 80
 
@@ -49,6 +52,14 @@ class DigestInputs:
     repo: RepoInfo
     issues: list[dict[str, Any]]
     pulls: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class FactoryActivity:
+    implement_runs: int = 0
+    review_verdicts: int = 0
+    responder_replies: int = 0
+    implement_daily_cap: int = DEFAULT_DAILY_IMPLEMENT_CAP
 
 
 def graphql(token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
@@ -78,6 +89,183 @@ def graphql(token: str, query: str, variables: dict[str, Any]) -> dict[str, Any]
         messages = "; ".join(str(item.get("message", item)) for item in payload["errors"])
         raise FactoryDigestError(f"GitHub GraphQL error: {messages}")
     return payload
+
+
+def fetch_workflow_runs(
+    repo_slug: str,
+    token: str,
+    workflow: str,
+    day: str,
+    *,
+    missing_ok: bool = False,
+) -> list[dict[str, Any]]:
+    runs: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        query = urllib.parse.urlencode({"created": day, "per_page": 100, "page": page})
+        url = (
+            f"{GITHUB_API_URL}/repos/{repo_slug}/actions/workflows/"
+            f"{urllib.parse.quote(workflow, safe='')}/runs?{query}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "workspaces-factory-digest",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            if missing_ok and error.code == 404:
+                return []
+            detail = error.read().decode("utf-8", errors="replace")
+            raise FactoryDigestError(
+                f"GitHub workflow runs request for {workflow} failed with HTTP "
+                f"{error.code}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise FactoryDigestError(
+                f"GitHub workflow runs request for {workflow} failed: {error.reason}"
+            ) from error
+        except json.JSONDecodeError as error:
+            raise FactoryDigestError(
+                f"GitHub workflow runs request for {workflow} returned invalid JSON"
+            ) from error
+        batch = list(payload.get("workflow_runs") or [])
+        runs.extend(dict(run) for run in batch)
+        if len(batch) < 100:
+            return runs
+        page += 1
+
+
+def fetch_run_jobs(
+    repo_slug: str,
+    token: str,
+    run_id: int,
+) -> list[dict[str, Any]]:
+    url = (
+        f"{GITHUB_API_URL}/repos/{repo_slug}/actions/runs/{run_id}/jobs"
+        "?filter=latest&per_page=100"
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "workspaces-factory-digest",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise FactoryDigestError(
+            f"GitHub jobs request for run {run_id} failed with HTTP "
+            f"{error.code}: {detail}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise FactoryDigestError(
+            f"GitHub jobs request for run {run_id} failed: {error.reason}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise FactoryDigestError(
+            f"GitHub jobs request for run {run_id} returned invalid JSON"
+        ) from error
+    return [dict(job) for job in payload.get("jobs") or []]
+
+
+def count_successful_steps(
+    repo_slug: str,
+    token: str,
+    runs: list[dict[str, Any]],
+    step_names: set[str],
+) -> int:
+    count = 0
+    for run in runs:
+        if str(run.get("status", "")).casefold() != "completed":
+            continue
+        run_id = int(run["id"])
+        jobs = fetch_run_jobs(repo_slug, token, run_id)
+        if any(
+            str(step.get("name", "")) in step_names
+            and str(step.get("conclusion", "")).casefold() == "success"
+            for job in jobs
+            for step in job.get("steps") or []
+            if isinstance(step, dict)
+        ):
+            count += 1
+    return count
+
+
+def is_factory_implement_dispatch(run: dict[str, Any]) -> bool:
+    return (
+        str(run.get("event", "")) == "workflow_dispatch"
+        or str(run.get("display_title", "")).startswith("Factory Implement ready #")
+    )
+
+
+def parse_daily_implement_cap(value: str | None) -> int:
+    raw = (value or str(DEFAULT_DAILY_IMPLEMENT_CAP)).strip()
+    try:
+        cap = int(raw)
+    except ValueError as error:
+        raise FactoryDigestError(
+            f"FACTORY_IMPLEMENT_DAILY_CAP must be a positive integer, got {raw!r}"
+        ) from error
+    if cap <= 0:
+        raise FactoryDigestError("FACTORY_IMPLEMENT_DAILY_CAP must be a positive integer")
+    return cap
+
+
+def fetch_factory_activity(
+    repo_slug: str,
+    token: str,
+    current_time: datetime,
+    implement_daily_cap: int,
+) -> FactoryActivity:
+    day = current_time.astimezone(UTC).date().isoformat()
+    implement_runs = fetch_workflow_runs(
+        repo_slug,
+        token,
+        "factory-implement.yml",
+        day,
+    )
+    review_runs = fetch_workflow_runs(
+        repo_slug,
+        token,
+        "factory-review-execute.yml",
+        day,
+    )
+    responder_runs = fetch_workflow_runs(
+        repo_slug,
+        token,
+        "factory-comment-responder.yml",
+        day,
+        missing_ok=True,
+    )
+
+    return FactoryActivity(
+        implement_runs=sum(1 for run in implement_runs if is_factory_implement_dispatch(run)),
+        review_verdicts=count_successful_steps(
+            repo_slug,
+            token,
+            review_runs,
+            {"Run April counterpart review", "Run Plat counterpart review"},
+        ),
+        responder_replies=count_successful_steps(
+            repo_slug,
+            token,
+            responder_runs,
+            {"Post reply to gated target"},
+        ),
+        implement_daily_cap=implement_daily_cap,
+    )
 
 
 def split_repo_slug(slug: str) -> tuple[str, str]:
@@ -238,6 +426,20 @@ def render_stats(summary: dict[str, Any]) -> str:
     return f"Stats: {rendered} · generated {summary['generated_at']}"
 
 
+def render_factory_activity(activity: FactoryActivity) -> str:
+    cap_note = ""
+    if activity.implement_runs > activity.implement_daily_cap:
+        cap_note = " (cap exceeded; dispatches skipped)"
+    elif activity.implement_runs == activity.implement_daily_cap:
+        cap_note = " (cap reached; further dispatches skipped)"
+    return (
+        "Factory activity: "
+        f"implement runs today {activity.implement_runs}/{activity.implement_daily_cap}"
+        f"{cap_note} · review verdicts {activity.review_verdicts} · "
+        f"responder replies {activity.responder_replies}"
+    )
+
+
 def body_has_digest_marker(body: Any) -> bool:
     return str(body or "").lstrip().startswith(DIGEST_MARKER)
 
@@ -284,6 +486,7 @@ def render_digest(
     issues: list[dict[str, Any]],
     pulls: list[dict[str, Any]],
     summary: dict[str, Any],
+    activity: FactoryActivity | None = None,
 ) -> str:
     digest_issue = select_digest_issue(issues)
     digest_issue_number = int(digest_issue["number"]) if digest_issue is not None else None
@@ -416,6 +619,7 @@ def render_digest(
 
     if not sections:
         sections.append("No open gates. The factory is idle.")
+    sections.append(render_factory_activity(activity or FactoryActivity()))
     sections.append(render_stats(summary))
     return "\n\n".join([DIGEST_MARKER, *sections])
 
@@ -537,7 +741,13 @@ def main() -> int:
     if not token:
         raise FactoryDigestError("GH_TOKEN is required for live GitHub access")
     inputs = fetch_live_inputs(repo_slug, token)
-    markdown = render_digest(inputs.issues, inputs.pulls, summary)
+    activity = fetch_factory_activity(
+        repo_slug,
+        token,
+        parse_datetime(str(summary["generated_at"])),
+        parse_daily_implement_cap(os.environ.get("FACTORY_IMPLEMENT_DAILY_CAP")),
+    )
+    markdown = render_digest(inputs.issues, inputs.pulls, summary, activity)
     if args.dry_run:
         print(markdown)
         return 0

--- a/scripts/tests/test_factory_digest.py
+++ b/scripts/tests/test_factory_digest.py
@@ -123,6 +123,24 @@ class FactoryDigestTests(unittest.TestCase):
                 }
             )
         )
+        self.assertEqual(
+            factory_digest.count_factory_implement_runs(
+                [
+                    {
+                        "event": "issues",
+                        "display_title": "Factory Implement ready #42",
+                        "run_attempt": 2,
+                    },
+                    {"event": "workflow_dispatch", "run_attempt": 1},
+                    {
+                        "event": "issues",
+                        "display_title": "Factory Implement claimed #42",
+                        "run_attempt": 5,
+                    },
+                ]
+            ),
+            3,
+        )
 
     def test_render_digest_orders_mergeable_linked_prs_first(self) -> None:
         summary = {

--- a/scripts/tests/test_factory_digest.py
+++ b/scripts/tests/test_factory_digest.py
@@ -107,12 +107,19 @@ class FactoryDigestTests(unittest.TestCase):
                 {
                     "event": "issues",
                     "display_title": "Factory Implement ready #42",
-                }
+                    "actor": {"login": "fairchild"},
+                },
+                "fairchild",
             )
         )
         self.assertTrue(
             factory_digest.is_factory_implement_dispatch(
-                {"event": "workflow_dispatch", "display_title": "manual"}
+                {
+                    "event": "workflow_dispatch",
+                    "display_title": "manual",
+                    "actor": {"login": "fairchild"},
+                },
+                "fairchild",
             )
         )
         self.assertFalse(
@@ -120,7 +127,19 @@ class FactoryDigestTests(unittest.TestCase):
                 {
                     "event": "issues",
                     "display_title": "Factory Implement claimed #42",
-                }
+                    "actor": {"login": "fairchild"},
+                },
+                "fairchild",
+            )
+        )
+        self.assertFalse(
+            factory_digest.is_factory_implement_dispatch(
+                {
+                    "event": "workflow_dispatch",
+                    "display_title": "manual",
+                    "actor": {"login": "april-clearwater[bot]"},
+                },
+                "fairchild",
             )
         )
         self.assertEqual(
@@ -130,14 +149,26 @@ class FactoryDigestTests(unittest.TestCase):
                         "event": "issues",
                         "display_title": "Factory Implement ready #42",
                         "run_attempt": 2,
+                        "actor": {"login": "fairchild"},
                     },
-                    {"event": "workflow_dispatch", "run_attempt": 1},
+                    {
+                        "event": "workflow_dispatch",
+                        "run_attempt": 1,
+                        "actor": {"login": "fairchild"},
+                    },
+                    {
+                        "event": "workflow_dispatch",
+                        "run_attempt": 9,
+                        "actor": {"login": "april-clearwater[bot]"},
+                    },
                     {
                         "event": "issues",
                         "display_title": "Factory Implement claimed #42",
                         "run_attempt": 5,
+                        "actor": {"login": "fairchild"},
                     },
-                ]
+                ],
+                "fairchild",
             ),
             3,
         )

--- a/scripts/tests/test_factory_digest.py
+++ b/scripts/tests/test_factory_digest.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import os
 import subprocess
 import sys
@@ -100,6 +101,24 @@ class FactoryDigestTests(unittest.TestCase):
 
         self.assertEqual(count, 1)
         self.assertEqual(fetch_jobs.call_count, 2)
+
+    def test_fetch_run_jobs_paginates_all_attempt_jobs(self) -> None:
+        responses = []
+        for payload in (
+            {"jobs": [{"id": number} for number in range(100)]},
+            {"jobs": [{"id": 100}]},
+        ):
+            response = mock.MagicMock()
+            response.__enter__.return_value.read.return_value = json.dumps(payload).encode()
+            responses.append(response)
+
+        with mock.patch("urllib.request.urlopen", side_effect=responses) as urlopen:
+            jobs = factory_digest.fetch_run_jobs("fairchild/workspaces", "token", 42)
+
+        self.assertEqual([job["id"] for job in jobs], list(range(101)))
+        requested_urls = [call.args[0].full_url for call in urlopen.call_args_list]
+        self.assertIn("page=1", requested_urls[0])
+        self.assertIn("page=2", requested_urls[1])
 
     def test_implement_activity_ignores_unrelated_label_event_runs(self) -> None:
         self.assertTrue(
@@ -328,8 +347,9 @@ class FactoryDigestTests(unittest.TestCase):
             markdown,
         )
         self.assertIn(
-            "1 issue ready for claim: "
-            "[#11](https://example.test/issues/11) `Available task`",
+            "## Ready but unclaimed\n\n"
+            "- no activity 3d [#11](https://example.test/issues/11) "
+            "`Available task`: ready for claim",
             markdown,
         )
         self.assertIn(
@@ -472,7 +492,7 @@ class FactoryDigestTests(unittest.TestCase):
                 self.assertNotIn("State anomalies", markdown)
                 self.assertIn("No open gates. The factory is idle.", markdown)
 
-    def test_render_digest_does_not_itemize_more_than_three_ready_issues(self) -> None:
+    def test_render_digest_itemizes_age_for_every_ready_unclaimed_issue(self) -> None:
         summary = {
             "generated_at": "2026-07-12T13:30:00Z",
             "funnel": {},
@@ -492,8 +512,13 @@ class FactoryDigestTests(unittest.TestCase):
 
         markdown = factory_digest.render_digest(issues, [], summary)
 
-        self.assertIn("4 issues ready for claim", markdown)
-        self.assertNotIn("#40", markdown)
+        self.assertIn("## Ready but unclaimed", markdown)
+        for number in range(40, 44):
+            self.assertIn(
+                f"- no activity 0d [#{number}](https://example.test/issues/{number}) "
+                f"`Ready {number}`: ready for claim",
+                markdown,
+            )
 
     def test_cli_renders_basic_fixture_without_network_access(self) -> None:
         result = subprocess.run(

--- a/scripts/tests/test_factory_digest.py
+++ b/scripts/tests/test_factory_digest.py
@@ -42,6 +42,88 @@ factory_digest = load_module("factory_digest", SCRIPT_PATH)
 class FactoryDigestTests(unittest.TestCase):
     maxDiff = None
 
+    def test_render_digest_reports_factory_activity_and_cap_skip(self) -> None:
+        summary = {
+            "generated_at": "2026-07-14T13:30:00Z",
+            "funnel": {},
+            "breaches": [],
+        }
+        activity = factory_digest.FactoryActivity(
+            implement_runs=7,
+            review_verdicts=3,
+            responder_replies=2,
+            implement_daily_cap=6,
+        )
+
+        markdown = factory_digest.render_digest([], [], summary, activity)
+
+        self.assertIn(
+            "Factory activity: implement runs today 7/6 "
+            "(cap exceeded; dispatches skipped) · review verdicts 3 · responder replies 2",
+            markdown,
+        )
+
+    def test_count_successful_steps_counts_only_completed_target_steps(self) -> None:
+        runs = [
+            {"id": 1, "status": "completed"},
+            {"id": 2, "status": "completed"},
+            {"id": 3, "status": "in_progress"},
+        ]
+        jobs = {
+            1: [
+                {
+                    "steps": [
+                        {"name": "Post reply to gated target", "conclusion": "success"}
+                    ]
+                }
+            ],
+            2: [
+                {
+                    "steps": [
+                        {"name": "Post reply to gated target", "conclusion": "skipped"}
+                    ]
+                }
+            ],
+        }
+
+        with mock.patch.object(
+            factory_digest,
+            "fetch_run_jobs",
+            side_effect=lambda _repo, _token, run_id: jobs[run_id],
+        ) as fetch_jobs:
+            count = factory_digest.count_successful_steps(
+                "fairchild/workspaces",
+                "token",
+                runs,
+                {"Post reply to gated target"},
+            )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(fetch_jobs.call_count, 2)
+
+    def test_implement_activity_ignores_unrelated_label_event_runs(self) -> None:
+        self.assertTrue(
+            factory_digest.is_factory_implement_dispatch(
+                {
+                    "event": "issues",
+                    "display_title": "Factory Implement ready #42",
+                }
+            )
+        )
+        self.assertTrue(
+            factory_digest.is_factory_implement_dispatch(
+                {"event": "workflow_dispatch", "display_title": "manual"}
+            )
+        )
+        self.assertFalse(
+            factory_digest.is_factory_implement_dispatch(
+                {
+                    "event": "issues",
+                    "display_title": "Factory Implement claimed #42",
+                }
+            )
+        )
+
     def test_render_digest_orders_mergeable_linked_prs_first(self) -> None:
         summary = {
             "generated_at": "2026-07-12T13:30:00Z",
@@ -409,6 +491,8 @@ class FactoryDigestTests(unittest.TestCase):
             result.stdout,
             "<!-- factory-digest:v1 -->\n\n"
             "No open gates. The factory is idle.\n\n"
+            "Factory activity: implement runs today 0/6 · review verdicts 0 · "
+            "responder replies 0\n\n"
             "Stats: ideas 0 · approved 0 · planned 0 · active 0 · merged 0 · stalled 0 "
             "· generated 2026-07-12T13:30:00Z\n",
         )
@@ -818,16 +902,24 @@ class FactoryDigestTests(unittest.TestCase):
             with mock.patch.object(factory_digest, "fetch_live_inputs", return_value=inputs):
                 with mock.patch.object(
                     factory_digest,
-                    "publish_digest",
-                    side_effect=AssertionError("publish_digest called"),
+                    "fetch_factory_activity",
+                    return_value=factory_digest.FactoryActivity(),
                 ):
-                    with mock.patch.dict(
-                        os.environ,
-                        {"GITHUB_REPOSITORY": "fairchild/workspaces", "GH_TOKEN": "read-token"},
-                        clear=True,
+                    with mock.patch.object(
+                        factory_digest,
+                        "publish_digest",
+                        side_effect=AssertionError("publish_digest called"),
                     ):
-                        with mock.patch("sys.stdout", stdout):
-                            result = factory_digest.main()
+                        with mock.patch.dict(
+                            os.environ,
+                            {
+                                "GITHUB_REPOSITORY": "fairchild/workspaces",
+                                "GH_TOKEN": "read-token",
+                            },
+                            clear=True,
+                        ):
+                            with mock.patch("sys.stdout", stdout):
+                                result = factory_digest.main()
 
         self.assertEqual(result, 0)
         self.assertIn("No open gates. The factory is idle.", stdout.getvalue())
@@ -854,19 +946,24 @@ class FactoryDigestTests(unittest.TestCase):
             ) as fetch:
                 with mock.patch.object(
                     factory_digest,
-                    "publish_digest",
-                    return_value={"url": "https://example.test/issues/1"},
-                ) as publish:
-                    with mock.patch.dict(
-                        os.environ,
-                        {
-                            "GITHUB_REPOSITORY": "fairchild/workspaces",
-                            "GH_TOKEN": "actions-token",
-                        },
-                        clear=True,
-                    ):
-                        with mock.patch("sys.stdout", io.StringIO()):
-                            result = factory_digest.main()
+                    "fetch_factory_activity",
+                    return_value=factory_digest.FactoryActivity(),
+                ):
+                    with mock.patch.object(
+                        factory_digest,
+                        "publish_digest",
+                        return_value={"url": "https://example.test/issues/1"},
+                    ) as publish:
+                        with mock.patch.dict(
+                            os.environ,
+                            {
+                                "GITHUB_REPOSITORY": "fairchild/workspaces",
+                                "GH_TOKEN": "actions-token",
+                            },
+                            clear=True,
+                        ):
+                            with mock.patch("sys.stdout", io.StringIO()):
+                                result = factory_digest.main()
 
         self.assertEqual(result, 0)
         fetch.assert_called_once_with("fairchild/workspaces", "actions-token")


### PR DESCRIPTION
## Summary

- Documents the Factory implementation, review, and responder kill switches, including owner-only implementation dispatch that remains gated by both switches.
- Reports the UTC-day implementation attempt cap established in #1096, including reruns and repository-owner actor filtering, without duplicating its enforcement in this slice.
- Adds morning-digest activity counts for implementation runs, successful counterpart-review actions, and successful responder posts, with visible reached/exceeded cap states.
- Documents #1097's 12-attempt review cap and surfaces every ready-but-unclaimed issue with age so a displaced event is visible to the owner.
- Stacked on `codex/m3-evidence-integration`; required merge order is #1096, #1097, #1098, then this PR.

Closes #1093

## Evidence

![Factory safety gates](https://evidence.cloudcompute.com/workspaces/pr-1099/20260714-112617-factory-safety-gates.png)

Bare `actionlint` and YAML parsing passed for the stacked Factory workflows. Nine focused UV-script suites passed 175 tests, and the stacked diff passed `git diff --check` at `db4f70b3`.

## Review loop

- Accepted the actor-authentication and kill-switch findings: #1096 now makes the claim step the authenticated chokepoint, requires owner actors on labeled and manual entry, rechecks both switches at execution, and removes Monitor re-fire through `workflow_dispatch`.
- Sunk cap enforcement into #1096 so replay protection exists before this slice lands. This slice only adds observability, counts rerun attempts, and ignores runs whose actor is not the repository owner.
- Rebased without retaining duplicate implementation-workflow or claim-script metering changes; the evidence slice remains the sole immediate parent.
- The responder workflow is intentionally delivered by parallel PR #1095; the digest tolerates its workflow endpoint being absent until that slice lands, then counts successful `Post reply to gated target` steps without implementing responder behavior here.
- Job telemetry now reads all attempts so a successful prior review or responder action is not erased by a later rerun.
- Second-pass delta review at `db4f70b3` closed R4-R5 and the plan-doc part of A1: job fetching paginates beyond 100 entries per run, the switch table records `FACTORY_REVIEW_DAILY_CAP` (default 12), and ready-but-unclaimed issues are itemized with inactivity age after removal of the unsafe Monitor re-fire lane.

## Mergeability

- Surface: Agent Factory workflows, monitor telemetry, operating documentation, and focused script contracts.
- Behavior changed: Owner-authorized implementation and counterpart-review execution are daily-capped below this slice; the Factory Digest reports same-day activity plus aged ready-but-unclaimed work.
- Non-happy paths: Invalid caps fail closed, disabled switches block manual and event entry, privileged and WIP skips stay attributed, cap excess leaves issues ready, reruns consume budget, untrusted-actor implementation runs are not charged, job pagination preserves late-attempt telemetry, and missing parallel responder machinery remains observable as zero until PR #1095 lands.
- Residual risk: Counts depend on GitHub Actions workflow and job-step API shape; issue `updatedAt` is the available inactivity proxy rather than the exact ready-label timestamp, and responder activity remains zero until the separately owned responder PR lands.
