### PR TITLE
fix(github): dismiss stale reviews on push — M3 review-lane TOCTOU backstop

### DIFF
--- a/config/github/rulesets/main-merge.json
+++ b/config/github/rulesets/main-merge.json
@@ -27,7 +27,7 @@
           "squash",
           "rebase"
         ],
-        "dismiss_stale_reviews_on_push": false,
+        "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_approving_review_count": 0,


### PR DESCRIPTION
## Summary

- flip `dismiss_stale_reviews_on_push` to `true` in the main-merge ruleset

The M3 review lane posts approvals pinned to the admitted head SHA, with a final head re-check *after* the post — the documented residual (#1097 "Residual risk") is that a push landing in that window leaves an APPROVE anchored to the old SHA, and the stated backstop is branch protection dismissing stale approvals. Verifying that backstop after the M3 merge found it off. One line makes the accepted-risk analysis true.

Tradeoff: any human push to a PR after an approval also re-requires review — for a repo where the owner is the only approver-of-record, that cost is near zero.

Note: after merge, the ruleset change still needs applying to GitHub via the config-as-code sync (same path as PR #835).

## Evidence Status

- [x] Not a testable change

Config-only diff — a single boolean flip in the ruleset JSON. Correctness is validated mechanically by the `drift` check (`scripts/github-settings.py check`), which compares the committed config against the live ruleset. That check is currently red **by design**: it will pass once the live ruleset is updated to match this file (see the merge note below).

## Mergeability

- **Surface:** infra (GitHub ruleset config-as-code)
- **User-facing behavior changed:** pushes to a PR after approval dismiss that approval on main-targeted PRs.
- **Non-happy paths considered:** none new — this narrows an existing window; factory reviews re-fire on `synchronize`, so a dismissed bot approval regenerates on the new head.
- **Residual risk or follow-up:** ruleset must be re-applied from config after merge; owner-side apply step.

## Review loop

One-line config diff — codex review skipped per convention.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Merge note — the `drift` check needs a live ruleset apply first

This PR changes `dismiss_stale_reviews_on_push` false→true in the config file. The required `drift` check compares config against the **live** ruleset and fails while they disagree — which is exactly this PR's premise. Resolution (repo-admin action): run `python3 scripts/github-settings.py apply` to PUT the updated ruleset live, or flip the setting in the GitHub ruleset UI. Once live matches this file, `drift` goes green and auto-merge completes.
