### PR TITLE
fix(factory): claim survives App-token agent-assignment restriction

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/lifecycle-health-check.py
+++ b/.agents/skills/cofounder-contributor/scripts/lifecycle-health-check.py
@@ -163,14 +163,18 @@ def check_review_pr_consistency(issues: list[dict[str, Any]], prs_by_issue: dict
 
 
 def check_claim_assignment_consistency(issues: list[dict[str, Any]]) -> dict[str, Any]:
+    # App installation tokens cannot assign agent accounts, so assignment is
+    # best-effort visibility; the claim-marker comment is the canonical record.
     problems = []
     for issue in issues:
         n = issue["number"]
         labels = label_names(issue)
+        if "claimed" not in labels:
+            continue
         bots = bot_assignees(issue)
-
-        if "claimed" in labels and not bots:
-            problems.append({"number": n, "problem": "claimed but no bot assignee"})
+        comments = issue.get("comments", {}).get("nodes", [])
+        if not bots and latest_claim(n, comments) is None:
+            problems.append({"number": n, "problem": "claimed but no bot assignee or claim comment"})
     return {"name": "claim_assignment_consistency", "pass": len(problems) == 0, "issues": problems}
 
 

--- a/docs/development/agent-factory-v2-overview.html
+++ b/docs/development/agent-factory-v2-overview.html
@@ -346,13 +346,13 @@
     <tr><td>review TOCTOU</td><td>the pinned-commit approval posts before the final head re-check; a mid-window push can leave an APPROVE anchored to the old SHA</td><td>branch protection dismisses stale reviews; the run fails visibly</td></tr>
     <tr><td>self-hosted gather</td><td>the evidence job builds model-authored code on <code>lume-macos</code> runners</td><td>zero secrets or credentials on that job — exfil-resistant; host persistence rests on runner ephemerality</td></tr>
     <tr><td>semantic evidence trust</td><td>tests are authored by the same model whose change they verify</td><td>counterpart review + owner merge; binding guarantees provenance, not meaning</td></tr>
-    <tr><td>first live run</td><td>App assignment and the contributor runtime are integration-proven only by a real dispatch</td><td>supervised first run (§07)</td></tr>
+    <tr><td>first live run</td><td>the contributor runtime is integration-proven only by a real dispatch (run 1 proved the gates and found that App tokens cannot assign agent accounts — assignment is now best-effort visibility; the claim comment is the record)</td><td>supervised first run (§07)</td></tr>
   </table>
 </section>
 
 <section id="s7">
   <h2><span class="sn">§07 · Operations</span>Operating the factory</h2>
-  <p>To turn the hands on: set <code>FACTORY_IMPLEMENT_ENABLED</code> and <code>FACTORY_REVIEW_ENABLED</code> alongside the existing master switch, optionally tune the two daily caps, then run one supervised pass — label a trivial, non-privileged issue <code>ready</code> yourself and watch the whole chain (claim comment, assignment, PR, evidence, counterpart review) before trusting the label path unattended.</p>
+  <p>To turn the hands on: set <code>FACTORY_IMPLEMENT_ENABLED</code> and <code>FACTORY_REVIEW_ENABLED</code> alongside the existing master switch, optionally tune the two daily caps, then run one supervised pass — label a trivial, non-privileged issue <code>ready</code> yourself and watch the whole chain (claim comment, claimed label, PR, evidence, counterpart review) before trusting the label path unattended.</p>
   <p>Observability lives in three places: the pinned Factory Digest issue (label-state funnel, run budgets, ready-but-unclaimed ageing, per-stage activity), the telemetry branch <code>factory/ops-data</code> the monitor writes, and the workflow runs themselves — every dispatch names its issue in the run title. When something looks wrong, the kill switches stop the factory in one variable flip, and the janitor's next pass repairs label drift.</p>
 </section>
 

--- a/scripts/factory-implement.py
+++ b/scripts/factory-implement.py
@@ -177,6 +177,20 @@ class GitHubClient:
     def update_issue(self, number: int, payload: dict[str, Any]) -> None:
         self.request("PATCH", f"/repos/{self.repository}/issues/{number}", payload)
 
+    def add_assignees(self, number: int, assignees: list[str]) -> None:
+        self.request(
+            "POST",
+            f"/repos/{self.repository}/issues/{number}/assignees",
+            {"assignees": assignees},
+        )
+
+    def remove_assignees(self, number: int, assignees: list[str]) -> None:
+        self.request(
+            "DELETE",
+            f"/repos/{self.repository}/issues/{number}/assignees",
+            {"assignees": assignees},
+        )
+
     def comment(self, number: int, body: str) -> None:
         self.request(
             "POST",
@@ -253,28 +267,36 @@ def evaluate_claim(
     return ClaimDecision("claim", "issue is eligible for unattended implementation")
 
 
-def claim_payload(issue: dict[str, Any], assignee: str) -> dict[str, Any]:
+def claim_payload(issue: dict[str, Any]) -> dict[str, Any]:
     labels = sorted((label_names(issue) - {"ready", "claimed"}) | {"claimed"})
-    assignees = {
-        str(assignee.get("login", ""))
-        for assignee in issue.get("assignees", []) or []
-        if isinstance(assignee, dict) and assignee.get("login")
-    }
-    assignees.add(assignee)
-    return {"labels": labels, "assignees": sorted(assignees)}
+    return {"labels": labels}
 
 
-def rollback_payload(issue: dict[str, Any], assignee: str) -> dict[str, Any]:
+def rollback_payload(issue: dict[str, Any]) -> dict[str, Any]:
     labels = sorted((label_names(issue) - {"claimed", "ready"}) | {"ready"})
-    claim_assignee = assignee.casefold()
-    assignees = sorted(
-        str(assignee.get("login"))
-        for assignee in issue.get("assignees", []) or []
-        if isinstance(assignee, dict)
-        and assignee.get("login")
-        and str(assignee["login"]).casefold() != claim_assignee
-    )
-    return {"labels": labels, "assignees": assignees}
+    return {"labels": labels}
+
+
+def sync_claim_assignee(
+    client: GitHubClient,
+    issue_number: int,
+    assignee: str,
+    *,
+    add: bool,
+) -> None:
+    # Best-effort visibility only: GitHub rejects agent-account assignment from
+    # App installation tokens, and claim state lives in the label + bot comment.
+    try:
+        if add:
+            client.add_assignees(issue_number, [assignee])
+        else:
+            client.remove_assignees(issue_number, [assignee])
+    except FactoryImplementError as error:
+        verb = "assignment" if add else "unassignment"
+        print(
+            f"Factory implement {verb} of {assignee} on #{issue_number} skipped: {error}",
+            file=sys.stderr,
+        )
 
 
 def comment_once(
@@ -500,7 +522,8 @@ def claim(
         return
 
     client.comment(issue_number, claim_comment(issue, run_url))
-    client.update_issue(issue_number, claim_payload(issue, assignee))
+    client.update_issue(issue_number, claim_payload(issue))
+    sync_claim_assignee(client, issue_number, assignee, add=True)
     write_output("matched", "true")
 
 
@@ -542,7 +565,8 @@ def rollback(
     if latest_factory_claim_run(client.comments(issue_number), assignee) != run_url:
         print(f"Factory implement rollback for #{issue_number}: claim belongs to another run")
         return
-    client.update_issue(issue_number, rollback_payload(issue, assignee))
+    client.update_issue(issue_number, rollback_payload(issue))
+    sync_claim_assignee(client, issue_number, assignee, add=False)
     comment_once(
         client,
         issue_number,

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -29,6 +29,10 @@ def load_module(name: str, path: Path):
 
 
 factory_implement = load_module("factory_implement", IMPLEMENT_SCRIPT)
+lifecycle_health = load_module(
+    "lifecycle_health_check",
+    REPO_ROOT / ".agents" / "skills" / "cofounder-contributor" / "scripts" / "lifecycle-health-check.py",
+)
 
 
 class FactoryImplementTests(unittest.TestCase):
@@ -232,24 +236,111 @@ class FactoryImplementTests(unittest.TestCase):
     def test_claim_and_rollback_payloads_preserve_unrelated_state(self) -> None:
         issue = self.issue(labels=("agent", "task", "ready", "quality"))
 
-        claim = factory_implement.claim_payload(issue, "april-clearwater[bot]")
+        claim = factory_implement.claim_payload(issue)
         self.assertEqual(claim["labels"], ["agent", "claimed", "quality", "task"])
-        self.assertEqual(
-            claim["assignees"],
-            ["april-clearwater[bot]", "fairchild"],
-        )
+        self.assertNotIn("assignees", claim)
 
         claimed_issue = {
             **issue,
             "labels": [{"name": name} for name in claim["labels"]],
-            "assignees": [{"login": login} for login in claim["assignees"]],
         }
-        rollback = factory_implement.rollback_payload(
-            claimed_issue,
+        rollback = factory_implement.rollback_payload(claimed_issue)
+        self.assertEqual(rollback["labels"], ["agent", "quality", "ready", "task"])
+        self.assertNotIn("assignees", rollback)
+
+    def test_claim_survives_unsupported_agent_assignment(self) -> None:
+        client = mock.Mock()
+        client.issue.return_value = self.issue()
+        client.timeline.return_value = [
+            {
+                "event": "labeled",
+                "label": {"name": "ready"},
+                "actor": {"login": "fairchild"},
+            }
+        ]
+        client.claimed_issues.return_value = []
+        client.add_assignees.side_effect = factory_implement.FactoryImplementError(
+            "GitHub API POST /assignees failed with HTTP 403: "
+            "Assigning agents is not supported with GitHub App installation tokens."
+        )
+        actions_client = mock.Mock()
+        actions_client.workflow_runs_on.return_value = []
+        outputs: list[str] = []
+
+        with mock.patch.object(
+            factory_implement, "write_output", lambda name, value: outputs.append(f"{name}={value}")
+        ):
+            factory_implement.claim(
+                client,
+                actions_client,
+                42,
+                "https://example.test/runs/7",
+                "april-clearwater[bot]",
+                "fairchild",
+                "fairchild",
+                "true",
+                "true",
+                6,
+                "7",
+                1,
+            )
+
+        client.update_issue.assert_called_once_with(42, {"labels": mock.ANY})
+        client.add_assignees.assert_called_once_with(42, ["april-clearwater[bot]"])
+        self.assertIn("matched=true", outputs)
+
+    def test_health_check_accepts_claim_comment_without_assignee(self) -> None:
+        marker = factory_implement.claim_comment(
+            {**self.issue(), "title": "Fix it"},
+            "https://example.test/runs/7",
+        )
+
+        def health_issue(*, assignees=(), comments=()):
+            return {
+                "number": 42,
+                "labels": {"nodes": [{"name": name} for name in ("agent", "task", "claimed")]},
+                "assignees": {"nodes": [{"login": login} for login in assignees]},
+                "comments": {"nodes": [{"body": body, "createdAt": "2026-07-15T00:00:00Z"} for body in comments]},
+            }
+
+        assigned = lifecycle_health.check_claim_assignment_consistency(
+            [health_issue(assignees=["april-clearwater[bot]"])]
+        )
+        commented = lifecycle_health.check_claim_assignment_consistency(
+            [health_issue(comments=[marker])]
+        )
+        orphaned = lifecycle_health.check_claim_assignment_consistency(
+            [health_issue()]
+        )
+
+        self.assertTrue(assigned["pass"])
+        self.assertTrue(commented["pass"])
+        self.assertFalse(orphaned["pass"])
+
+    def test_rollback_removes_assignee_best_effort(self) -> None:
+        claim_body = factory_implement.claim_comment(
+            self.issue(labels=("agent", "task", "claimed")),
+            "https://example.test/runs/7",
+        )
+        client = mock.Mock()
+        client.issue.return_value = self.issue(labels=("agent", "task", "claimed"))
+        client.comments.return_value = [
+            {"body": claim_body, "user": {"login": "april-clearwater[bot]"}}
+        ]
+        client.remove_assignees.side_effect = factory_implement.FactoryImplementError(
+            "GitHub API DELETE /assignees failed with HTTP 403"
+        )
+
+        factory_implement.rollback(
+            client,
+            42,
+            "https://example.test/runs/7",
             "april-clearwater[bot]",
         )
-        self.assertEqual(rollback["labels"], ["agent", "quality", "ready", "task"])
-        self.assertEqual(rollback["assignees"], ["fairchild"])
+
+        client.update_issue.assert_called_once_with(42, {"labels": mock.ANY})
+        client.remove_assignees.assert_called_once_with(42, ["april-clearwater[bot]"])
+        client.comment.assert_called_once()
 
     def test_claim_comment_binds_runtime_identity_branch_and_run(self) -> None:
         issue = {**self.issue(), "title": "Fix a subtle bug"}


### PR DESCRIPTION
## Summary

- claim and rollback mutate labels only; the bot assignee becomes best-effort visibility (`add_assignees`/`remove_assignees`, tolerated failure with a stderr log)
- the lifecycle health checker accepts a bot-authored claim comment in place of an assignee, so successful factory claims stop reading as unhealthy
- the overview page's first-run residual and supervised-chain wording reflect what run 1 actually proved

The first live Factory dispatch ([issue #1103, run 29388121714](https://github.com/fairchild/workspaces/actions/runs/29388121714)) passed every gate — actor verification, admission, budget — then failed on the claim PATCH: GitHub rejects agent-account assignment from App installation tokens (HTTP 403). Assignment was always visibility, not state; the canonical claim record is the `claimed` label plus the bot-authored claim comment, which rollback already verifies. This makes that explicit and keeps the nicety where a token class allows it.

## Evidence

Focused suites green post-change: factory workflows 12/12 (new: claim survives assignment 403; rollback unassign best-effort; health-check contract for claim-comment-without-assignee), contributor policy 52/52, actionlint clean. [Test log](https://evidence.cloudcompute.com/workspaces/pr-1104/20260715-042238-claim-fix-tests.txt)

## Mergeability

- **Surface:** infra — Agent Factory claim/rollback scripts, lifecycle health checker, overview doc
- **User-facing behavior changed:** factory claims succeed without an issue assignee; claim attribution is the claim comment + `claimed` label.
- **Non-happy paths considered:** assignment/unassignment failures of any class never fail claim or rollback (visibility only); labels-PATCH failure still fails the run and rollback still no-ops safely; health check still errors on claimed issues with neither assignee nor claim comment.
- **Residual risk or follow-up:** proof run 2 on issue #1103 after merge is the live confirmation; if GitHub later permits App-token agent assignment, the best-effort call starts succeeding with no change needed.

## Review loop

Directed codex review (gpt-5.6-sol, xhigh): request-changes with one P2 — the lifecycle health checker's `claimed ⇒ bot assignee` invariant conflicted with the new reality, and the overview page named assignment in the success chain; both addressed in this diff with a contract test. Rollback trust, failure orderings, error-swallowing scope, and DELETE-with-body semantics all confirmed sound.
