### PR TITLE
fix(factory): echo stdout when a checked command fails

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/_helpers.py
+++ b/.agents/skills/cofounder-contributor/scripts/_helpers.py
@@ -64,9 +64,14 @@ def run_checked(
         sys.exit(1)
     if result.returncode != 0:
         command = " ".join(cmd)
-        print(f"error: command failed: {command}", file=sys.stderr)
+        print(f"error: command failed (exit {result.returncode}): {command}", file=sys.stderr)
         if result.stderr.strip():
-            print(result.stderr.strip(), file=sys.stderr)
+            print("--- stderr ---", file=sys.stderr)
+            print(result.stderr.strip()[:8000], file=sys.stderr)
+        if result.stdout.strip():
+            # Print-mode CLIs (claude --print) report errors on stdout.
+            print("--- stdout ---", file=sys.stderr)
+            print(result.stdout.strip()[:8000], file=sys.stderr)
         sys.exit(result.returncode or 1)
     return result
 


### PR DESCRIPTION
## Summary

- `run_checked`'s failure echo now includes stdout as well as stderr (both truncated to 8k) and the exit code

Proof run 3 ([run 29390100817](https://github.com/fairchild/workspaces/actions/runs/29390100817)) failed inside `claude --print` after ~6s with an empty stderr — and the harness discards stdout, which is where print-mode CLIs report their errors. Two real fixes came out of runs 1–2 (App-token assignment, project trust); run 3's cause is unknowable from the logs as captured, so per the repo's own lesson this ships the probe instead of a third guess. Run 4 reads the actual error.

## Evidence

[Contributor policy suite 53/53 post-change](https://evidence.cloudcompute.com/workspaces/pr-1106/20260715-050711-probe-tests.txt) (diagnostic-only path; no behavior change on success paths).

## Mergeability

- **Surface:** infra — contributor runtime shared helper
- **User-facing behavior changed:** none on success; failed subprocess runs now log their stdout.
- **Non-happy paths considered:** output truncated at 8k per stream to keep CI logs bounded; secrets don't transit stdout/stderr of these commands by construction (tokens live in env, and GitHub Actions masks registered secrets in logs regardless).
- **Residual risk or follow-up:** run 4 on issue #1103 reads the diagnostic; revert-or-keep decision on the probe after root cause (keep — this blind spot already cost a cycle).

## Review loop

Diagnostic-only diff of nine lines; codex review skipped per convention for mechanical changes.
