### PR TITLE
fix(factory): preserve scratch symlinks; guard .claude/ paths

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/patch_policy.py
+++ b/.agents/skills/cofounder-contributor/scripts/patch_policy.py
@@ -21,6 +21,7 @@ from release_policy import RELEASE_PATHS  # noqa: E402
 SENSITIVE_PATH_PREFIXES = (
     ".github/",
     ".agents/",
+    ".claude/",
 )
 SENSITIVE_RELEASE_SCRIPT_PATHS = RELEASE_PATHS | {
     "scripts/signing-config.sh.template",

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -454,11 +454,28 @@ def create_scratch_workspace(env: dict[str, str]) -> ScratchPatchArtifact:
 
 
 def _tree_files(root: Path) -> dict[str, Path]:
+    # Symlinks are entries in their own right: is_file() alone would follow
+    # them (hiding target-path changes) and drop links to dirs entirely.
     files: dict[str, Path] = {}
     for path in root.rglob("*"):
-        if path.is_file():
+        if path.is_symlink() or path.is_file():
             files[path.relative_to(root).as_posix()] = path
     return files
+
+
+def _tree_entries_identical(baseline_path: Path, scratch_path: Path) -> bool:
+    baseline_is_link = baseline_path.is_symlink()
+    scratch_is_link = scratch_path.is_symlink()
+    if baseline_is_link or scratch_is_link:
+        return (
+            baseline_is_link == scratch_is_link
+            and os.readlink(baseline_path) == os.readlink(scratch_path)
+        )
+    return (
+        baseline_path.stat().st_mode == scratch_path.stat().st_mode
+        and hashlib.sha256(baseline_path.read_bytes()).digest()
+        == hashlib.sha256(scratch_path.read_bytes()).digest()
+    )
 
 
 def _run_binary_diff(cmd: list[str], *, cwd: Path, env: dict[str, str]) -> str:
@@ -514,10 +531,7 @@ def build_scratch_patch_artifact(
             patch_chunks.append(chunk)
             continue
         assert baseline_path is not None and scratch_path is not None
-        if (
-            baseline_path.stat().st_mode == scratch_path.stat().st_mode
-            and hashlib.sha256(baseline_path.read_bytes()).digest() == hashlib.sha256(scratch_path.read_bytes()).digest()
-        ):
+        if _tree_entries_identical(baseline_path, scratch_path):
             continue
         chunk = _run_binary_diff(
             [

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -441,7 +441,9 @@ def create_scratch_workspace(env: dict[str, str]) -> ScratchPatchArtifact:
     baseline_dir = temp_root / "baseline"
     scratch_dir = temp_root / "scratch"
     export_head_tree(baseline_dir, env)
-    shutil.copytree(baseline_dir, scratch_dir)
+    # symlinks=True keeps repo symlinks as symlinks; following them turns
+    # every linked path into a phantom mode-change diff that git apply refuses.
+    shutil.copytree(baseline_dir, scratch_dir, symlinks=True)
     return ScratchPatchArtifact(
         temp_root=temp_root,
         baseline_dir=baseline_dir,

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -89,6 +89,11 @@ class FactoryImplementTests(unittest.TestCase):
             )
         )
 
+        self.assertFalse(
+            factory_implement.privileged_scope(
+                self.issue(body="Change `myclaude/config.json`")
+            )
+        )
         self.assertFalse(factory_implement.privileged_scope(self.issue()))
 
     def test_claim_requires_open_released_non_privileged_issue_and_capacity(self) -> None:

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -56,6 +56,8 @@ class FactoryImplementTests(unittest.TestCase):
         privileged = (
             ".github/workflows/ci.yml",
             ".agents/memory/april/PROFILE.md",
+            ".claude/settings.json",
+            ".claude/skills/chat-sdk/SKILL.md",
             "Auth.swift",
             "scripts/notarize.sh",
             "scripts/generate-sparkle-appcast.sh",

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -274,6 +274,46 @@ class RunContributorEvidenceTests(unittest.TestCase):
         self.assertIn(["gh", "pr", "edit", "77", "--add-label", "mergeable"], commands)
         self.assertFalse(any(command[:3] == ["gh", "issue", "edit"] for command in commands))
 
+    def test_scratch_workspace_preserves_symlinks_and_yields_empty_diff(self) -> None:
+        env = dict(run_contributor.os.environ)
+        workspace = run_contributor.create_scratch_workspace(env)
+        try:
+            symlinks = [p for p in workspace.scratch_dir.rglob("*") if p.is_symlink()]
+            artifact = run_contributor.build_scratch_patch_artifact(workspace, env)
+        finally:
+            run_contributor.shutil.rmtree(workspace.temp_root, ignore_errors=True)
+
+        # The repo contains symlinks (e.g. CLAUDE.md); the scratch must mirror
+        # them or every linked path becomes a phantom diff the patch refuses.
+        self.assertTrue(symlinks)
+        self.assertEqual(artifact.changed_files, [])
+
+    def test_scratch_diff_detects_symlink_target_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline"
+            scratch = root / "scratch"
+            for tree, target in ((baseline, "AGENTS.md"), (scratch, "README.md")):
+                tree.mkdir()
+                (tree / "AGENTS.md").write_text("agents\n")
+                (tree / "README.md").write_text("agents\n")
+                (tree / "CLAUDE.md").symlink_to(target)
+            workspace = run_contributor.ScratchPatchArtifact(
+                temp_root=root,
+                baseline_dir=baseline,
+                scratch_dir=scratch,
+                changed_files=[],
+                patch_text="",
+            )
+
+            artifact = run_contributor.build_scratch_patch_artifact(
+                workspace, dict(run_contributor.os.environ)
+            )
+
+        # Both link targets hold identical bytes, so a comparison that follows
+        # symlinks would call this unchanged; the target path itself moved.
+        self.assertEqual(artifact.changed_files, ["CLAUDE.md"])
+
     def test_review_workspace_stays_untrusted_and_oauth_compatible(self) -> None:
         with (
             tempfile.TemporaryDirectory() as home,


### PR DESCRIPTION
## Summary

- `create_scratch_workspace` copies the baseline with `symlinks=True`, so the scratch mirrors repo symlinks instead of materializing them — an untouched scratch now diffs to zero changed files (regression test runs against the real repo, which contains symlinks like `CLAUDE.md`)
- `.claude/` added to `SENSITIVE_PATH_PREFIXES` — runtime settings, permissions, and skills are privileged-path scope, with contract-test coverage

Proof run 5 ([run 29391726824](https://github.com/fairchild/workspaces/actions/runs/29391726824)) was the first to reach the model: auth held, April implemented the README change, output validated — then `git apply --check` refused the patch because the scratch's followed-symlink copies produced 19 phantom mode-change diffs ("affected file is beyond a symbolic link"). The phantom paths doubled as a live probe of the patch guard, which passed `.claude/*` files it should treat as privileged — hence the second change.

## Evidence

[Contributor 53/53 + factory workflows 12/12](https://evidence.cloudcompute.com/workspaces/pr-1108/20260715-053913-symlink-fix-tests.txt) — includes the new zero-diff scratch integration test and the `.claude/` policy cases.

## Evidence Status

- [complete] contributor policy suite (55/55) + factory workflows (12/12) — includes the zero-diff scratch integration test, the symlink-target-change test, and the .claude/ positive+negative policy cases — uploaded via scripts/evidence.sh: https://evidence.cloudcompute.com/workspaces/pr-1108/20260715-061757-symlink-fix-tests-v2.txt

## Mergeability

- **Surface:** infra — contributor scratch workspace + privileged-path policy
- **User-facing behavior changed:** factory patches apply cleanly on repos with symlinks; model patches touching `.claude/` are blocked to the orchestrator lane.
- **Non-happy paths considered:** a model editing *through* an internal symlink modifies the target inside the scratch and diffs normally; broken/external symlinks are preserved as links, never followed; admission scanning inherits the new prefix automatically (shared module).
- **Residual risk or follow-up:** proof run 6 on issue #1103 is the last daily-budget slot (6/6) — if it fails, the next attempt waits for the UTC rollover or an owner cap bump.

## Review loop (updated)

Counterpart review round 1 (April, request-changes): evidence format + a pipeline-provenance claim April withdrew on the record after correction. Round 2 (April, request-changes): caught that the claimed zero-diff regression test did not exist in the tree (a stale-base insertion had silently no-op'd) and identified the read-side symlink gap in the diff comparison. Both addressed: the tests now exist (55/55, verifiable in the diff), the comparison is symlink-aware via readlink, and the negative prefix case is covered. Original loop note below.

## Review loop

Two-line production diff, both changes locked by tests; the guard addition tightens policy (fail-closed direction). Codex CLI has been wedging this session; shipped on the evidence trail per the established pattern.
