### PR TITLE
fix(factory): pre-approve exposed tools so headless edits land

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -715,7 +715,12 @@ def run_claude(
     effective_timeout = timeout or CLAUDE_TIMEOUT
     if mode == "cli":
         if tools:
-            cmd.extend(["--tools", tools])
+            # --tools only restricts which tools are AVAILABLE; permission to
+            # use them is a separate gate. In --print mode nothing can answer
+            # permission prompts, so without --allowedTools every Edit/Write
+            # call is silently denied and execution runs finish with prose
+            # instead of file changes.
+            cmd.extend(["--tools", tools, "--allowedTools", tools])
         cmd.extend(["--max-budget-usd", budget])
         effective_timeout = timeout or 1200
     cmd.append(task)
@@ -1410,6 +1415,12 @@ def main() -> int:
         if scratch_workspace is not None and not args.dry_run:
             artifact = build_scratch_patch_artifact(scratch_workspace, env)
             log(f"Applying scratch patch with {len(artifact.changed_files)} changed files")
+            if not artifact.changed_files:
+                # Downstream routing fails on execution actions without file
+                # changes; surface what the model actually did so CI logs show
+                # tool denials or prose-only runs instead of swallowing them.
+                print("--- Model output (tail) ---", file=sys.stderr)
+                print(raw_output[-4000:], file=sys.stderr)
             enforce_agent_patch_policy(
                 artifact,
                 env,

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -19,6 +19,7 @@ import json
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -190,7 +191,9 @@ class RunContributorEvidenceTests(unittest.TestCase):
                             "<!-- contributor:issue=42;status=claimed;"
                             "agent=april-clearwater;branch=codex/april-clearwater-issue-42-fix-it -->"
                         ),
-                        "createdAt": "2026-07-14T12:00:00Z",
+                        # A fixed date goes stale once STALE_CLAIM_HOURS passes
+                        # in real time; the fixture must stay a fresh claim.
+                        "createdAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                         "author": {"login": "april-clearwater[bot]"},
                         "authorAssociation": "NONE",
                     }
@@ -340,6 +343,34 @@ class RunContributorEvidenceTests(unittest.TestCase):
         self.assertNotIn("--bare", command)
         self.assertEqual(run_checked.call_args.kwargs["cwd"], Path("/tmp/model-workspace"))
         self.assertFalse(trust_file_written)
+
+    def test_cli_mode_pre_approves_every_exposed_tool(self) -> None:
+        with mock.patch.object(
+            run_contributor,
+            "run_checked",
+            return_value=mock.Mock(stdout="ok"),
+        ) as run_checked:
+            run_contributor.run_claude(
+                "system",
+                "task",
+                {"HOME": "/tmp", "PATH": "/usr/bin"},
+                mode="cli",
+                tools=run_contributor.EXECUTION_TOOLS,
+            )
+
+        command = run_checked.call_args.args[0]
+        # --tools only controls which tools are available; --allowedTools is
+        # the permission allowlist. Headless --print runs cannot answer
+        # permission prompts, so every exposed tool must be pre-approved or
+        # Edit/Write calls are silently denied and execution runs produce
+        # zero file changes.
+        self.assertIn("--tools", command)
+        self.assertEqual(command[command.index("--tools") + 1], run_contributor.EXECUTION_TOOLS)
+        self.assertIn("--allowedTools", command)
+        self.assertEqual(
+            command[command.index("--allowedTools") + 1],
+            run_contributor.EXECUTION_TOOLS,
+        )
 
     def test_project_trust_seeding_preserves_existing_config(self) -> None:
         with tempfile.TemporaryDirectory() as home:


### PR DESCRIPTION
## Summary

Root-causes the priority-1 implement-lane failure ([run 29591081206](https://github.com/fairchild/workspaces/actions/runs/29591081206), issue #1109): `execute_issue selected for #1109 but no file changes were made`.

`run_claude` exposed the write tools with `--tools Read,Grep,Glob,Edit,Write,MultiEdit`, but in claude-code `--tools` only controls which tools are **available** — permission to use them is a separate gate (`--allowedTools`). In `--print` mode nothing can answer permission prompts, so every `Edit`/`Write` call was silently denied. A local repro with the exact CI flag set proves the mechanism: the model *attempted* the edit and the permission system refused it — the stream-json result carries two `permission_denials` entries for `Edit` — after which the model finished with prose and the run failed downstream with zero changed files.

Two changes to `run-contributor.py`:

- `run_claude` now passes `--allowedTools` with the same list it exposes via `--tools`. No new capability: the permission grant covers exactly the tools already made available (never Bash), inside the isolated scratch workspace.
- Observability: when the scratch patch has **zero changed files** (the path that fails downstream as `execution_state: no file changes`), the model output tail is printed to stderr — CI logs now show what the model actually did instead of swallowing it (the #1106 echo only fires on nonzero exit; this path exits 0).

Plus one test-fixture repair in `scripts/tests/test_run_contributor.py`: the claim fixture's hardcoded `createdAt: 2026-07-14` crossed `STALE_CLAIM_HOURS` and made `test_factory_claim_keeps_selected_issue_approved_for_current_agent` fail on any checkout after 2026-07-16 (fails on clean `main` today). The fixture now uses a relative timestamp; without this the ci-agents gate on this PR would be red for a pre-existing reason.

## Evidence

[Repro A/B + post-fix verification + test suites](https://evidence.cloudcompute.com/workspaces/pr-1112/20260717-154157-allowed-tools-repro.txt) — harness mirrors `run_claude` exactly (pinned `@anthropic-ai/claude-code@2.1.200`, isolated HOME, seeded project trust, sanitized env):

- **A (current CI flags):** exit 0, README unchanged, model output: "I don't have permission to write to README.md"
- **A (stream-json):** `permission_denials: [{tool_name: "Edit", ...} x2]` — edit attempted, denied
- **B (+ `--allowedTools`):** exit 0, README changed, marker present
- **Post-fix:** patched `run_claude` imported from `run-contributor.py`, driven end-to-end — edit lands
- Contributor suite 56/56 (was 55 + 1 pre-existing time-bomb failure), validate-agent-output 3/3, factory workflows + review suites OK

## Mergeability

- **Surface:** infra — factory contributor runtime (`run_claude` invocation, no-file-changes observability) + its test suite
- **User-facing behavior changed:** implement-lane runs can now actually edit files headlessly; failed runs log the model output tail instead of nothing.
- **Non-happy paths considered:** read-only lanes (selector, review) get `--allowedTools Read,Grep,Glob` — no write grant; the allowlist never includes Bash; scratch isolation and the privileged-path patch policy are unchanged, so a model writing outside the scratch still produces no patch entries; output tail is capped at 4000 chars.
- **Residual risk or follow-up:** `--allowedTools` grants Edit/Write for any path the process can reach (not scoped to the scratch cwd) — same trust model as before, but worth noting; the next factory-implement run on #1109 is the production proof.

## Review loop

Worker PR under the factory-m3-hands coordinator, who holds review + merge authority. Root cause is mechanically proven by the repro (tool denial recorded in stream-json), fix locked by a flag-shape regression test.
