### PR TITLE
fix(factory): responder-lane coexistence + code-span-safe mention detection

### DIFF
--- a/.agents/scripts/mention_detection.py
+++ b/.agents/scripts/mention_detection.py
@@ -1,0 +1,115 @@
+"""Single source of truth for agent @-slug mention detection across responder lanes.
+
+Mention triage (scripts/agent-triage-request.py) dispatches on these slugs, and the
+Factory comment responder (scripts/factory-responder-payload.py) stands down when one
+is present, so both lanes must read a comment identically. Fenced code blocks and
+inline code spans are stripped before matching: a slug quoted in backticks neither
+fires triage nor suppresses the responder.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+SUPPORTED_AGENTS = ("april-clearwater", "plat", "peter", "claude")
+MENTION_PATTERNS = {
+    agent: re.compile(
+        rf"(?<![A-Za-z0-9_-])@{re.escape(agent)}(?![A-Za-z0-9_-])", re.IGNORECASE
+    )
+    for agent in SUPPORTED_AGENTS
+}
+
+_FENCE_LINE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+
+
+def _strip_fenced_blocks(text: str) -> str:
+    """Drop fenced code blocks the way GitHub renders them.
+
+    A closing fence uses the same character and at least the opening run length,
+    with nothing but whitespace after it. An unterminated fence swallows the rest
+    of the text, matching rendered output. A backtick run followed by more
+    backticks on the same line is an inline span, not a fence (CommonMark forbids
+    backticks in a backtick fence's info string).
+    """
+    kept: list[str] = []
+    fence_char = ""
+    fence_len = 0
+    for line in text.splitlines():
+        match = _FENCE_LINE_RE.match(line)
+        remainder = line[match.end() :] if match else ""
+        if fence_len:
+            closes = (
+                match is not None
+                and match.group(1)[0] == fence_char
+                and len(match.group(1)) >= fence_len
+                and not remainder.strip()
+            )
+            if closes:
+                fence_char, fence_len = "", 0
+            continue
+        opens = match is not None and not (
+            match.group(1)[0] == "`" and "`" in remainder
+        )
+        if opens:
+            fence_char, fence_len = match.group(1)[0], len(match.group(1))
+        else:
+            kept.append(line)
+    return "\n".join(kept)
+
+
+def _strip_inline_code_spans(text: str) -> str:
+    """Drop inline code spans: a backtick run closed by an equal-length run.
+
+    Longer or shorter runs do not close a span, and spans do not cross blank
+    lines, so a stray unmatched backtick stays literal and cannot hide mentions
+    in later paragraphs. A linear scan, not a regex, so backtick floods in
+    untrusted comment bodies cannot trigger pathological backtracking.
+    """
+    pieces: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        run_start = text.find("`", index)
+        if run_start == -1:
+            pieces.append(text[index:])
+            break
+        pieces.append(text[index:run_start])
+        run_end = run_start
+        while run_end < length and text[run_end] == "`":
+            run_end += 1
+        run_len = run_end - run_start
+        closer = "`" * run_len
+        paragraph_end = text.find("\n\n", run_end)
+        limit = length if paragraph_end == -1 else paragraph_end
+        search = run_end
+        close_at = -1
+        while search < limit:
+            found = text.find(closer, search, limit)
+            if found == -1:
+                break
+            found_end = found
+            while found_end < length and text[found_end] == "`":
+                found_end += 1
+            if found_end - found == run_len:
+                close_at = found
+                break
+            search = found_end
+        if close_at == -1:
+            pieces.append(closer)
+            index = run_end
+        else:
+            pieces.append(" ")
+            index = close_at + run_len
+    return "".join(pieces)
+
+
+def strip_code_sections(text: str) -> str:
+    return _strip_inline_code_spans(_strip_fenced_blocks(text or ""))
+
+
+def find_agent_mentions(
+    text: str, candidates: Sequence[str] = SUPPORTED_AGENTS
+) -> list[str]:
+    stripped = strip_code_sections(text)
+    return [agent for agent in candidates if MENTION_PATTERNS[agent].search(stripped)]

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -13,8 +13,10 @@ on:
       - ".github/workflows/factory-*.yml"
       - "scripts/factory-implement.py"
       - "scripts/factory-review.py"
+      - "scripts/factory-responder-payload.py"
       - "scripts/tests/test_factory_workflows.py"
       - "scripts/tests/test_factory_review.py"
+      - "scripts/tests/test_factory_comment_responder.py"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
@@ -36,8 +38,10 @@ on:
       - ".github/workflows/factory-*.yml"
       - "scripts/factory-implement.py"
       - "scripts/factory-review.py"
+      - "scripts/factory-responder-payload.py"
       - "scripts/tests/test_factory_workflows.py"
       - "scripts/tests/test_factory_review.py"
+      - "scripts/tests/test_factory_comment_responder.py"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
@@ -88,6 +92,7 @@ jobs:
         run: |
           uv run --script scripts/tests/test_factory_workflows.py
           uv run --script scripts/tests/test_factory_review.py
+          uv run --script scripts/tests/test_factory_comment_responder.py
 
       - name: Run Fable orchestrator tests
         run: uv run --script scripts/tests/test_fable_orchestrator.py

--- a/scripts/agent-triage-request.py
+++ b/scripts/agent-triage-request.py
@@ -26,18 +26,18 @@ SHARED_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".agents" / "scripts"
 if str(SHARED_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SHARED_SCRIPTS_DIR))
 
+from mention_detection import (  # noqa: E402
+    MENTION_PATTERNS,
+    SUPPORTED_AGENTS,
+    find_agent_mentions,
+)
 from prompt_context import normalize_trust_level  # noqa: E402
 
 APPROVAL_LABEL = "safe-to-run-agent"
 PRIVILEGED_PATCH_LABEL = "privileged-agent-patch"
 TRIAGE_COMMENT_AUTHOR = "github-actions[bot]"
 TRIAGE_MARKER_RE = re.compile(r"<!-- agent-triage-request:v1:([A-Za-z0-9_\-=]+) -->")
-SUPPORTED_AGENTS = ("april-clearwater", "plat", "peter", "claude")
 ISSUE_BODY_AGENTS = ("claude",)
-MENTION_PATTERNS = {
-    agent: re.compile(rf"(?<![A-Za-z0-9_-])@{re.escape(agent)}(?![A-Za-z0-9_-])", re.IGNORECASE)
-    for agent in SUPPORTED_AGENTS
-}
 UNSAFE_SUMMARY_PATTERNS = (
     re.compile(r"\bignore (all|every|previous|prior)\b", re.IGNORECASE),
     re.compile(r"\bsystem override\b", re.IGNORECASE),
@@ -155,7 +155,7 @@ def find_requested_agents(context: EventContext) -> list[str]:
         candidates = ISSUE_BODY_AGENTS
     else:
         candidates = SUPPORTED_AGENTS
-    return [agent for agent in candidates if MENTION_PATTERNS[agent].search(context.source_text or "")]
+    return find_agent_mentions(context.source_text or "", candidates)
 
 
 def build_request_payload(context: EventContext, repo_owner: str, requested_agent: str) -> dict[str, Any]:

--- a/scripts/factory-responder-payload.py
+++ b/scripts/factory-responder-payload.py
@@ -7,6 +7,8 @@
 
 GitHub content, model output, and the final post body cross steps through files.
 The model never receives a GitHub token, target selector, or write capability.
+Owner comments carrying an agent dispatch slug are left to mention triage
+(scripts/agent-triage-request.py) so one owner mention gets one bot response.
 """
 
 from __future__ import annotations
@@ -22,6 +24,12 @@ from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
+
+SHARED_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".agents" / "scripts"
+if str(SHARED_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SHARED_SCRIPTS_DIR))
+
+from mention_detection import find_agent_mentions  # noqa: E402
 
 
 RESPONSE_MARKER = "<!-- factory-responder -->"
@@ -405,6 +413,17 @@ def prepare(output_path: Path, prompt_file: Path) -> int:
         append_output(output_path, "matched", False)
         append_output(output_path, "already_replied", False)
         print("owner comment has its own trailing responder marker; no response")
+        return 0
+
+    dispatch_mentions = find_agent_mentions(context.body)
+    if dispatch_mentions:
+        append_output(output_path, "matched", False)
+        append_output(output_path, "already_replied", False)
+        slugs = ", ".join(f"@{slug}" for slug in dispatch_mentions)
+        print(
+            f"owner comment carries an agent dispatch mention ({slugs}); "
+            "standing down in favor of mention triage"
+        )
         return 0
 
     repo = require_env("GITHUB_REPOSITORY")

--- a/scripts/tests/test_agent_triage.py
+++ b/scripts/tests/test_agent_triage.py
@@ -38,6 +38,9 @@ def load_fixture(name: str) -> dict:
     return json.loads((FIXTURES_DIR / name).read_text(encoding="utf-8"))
 
 
+mention_detection = load_module(
+    "mention_detection", REPO_ROOT / ".agents" / "scripts" / "mention_detection.py"
+)
 triage = load_module("agent_triage_request", REPO_ROOT / "scripts" / "agent-triage-request.py")
 
 
@@ -205,6 +208,83 @@ class AgentTriageTests(unittest.TestCase):
             }
         )
         self.assertEqual(triage.find_requested_agents(short_context), [])
+
+    def test_mention_detection_strips_code_spans_and_fences_before_matching(self) -> None:
+        cases = [
+            ("bare mention fires", "@april-clearwater please review", ["april-clearwater"]),
+            ("backticked slug is quoting", "the run quoted `@april-clearwater` here", []),
+            ("double-backtick span with inner backtick", "``quoting `@april-clearwater` inside``", []),
+            ("fenced block", "```\n@april-clearwater\n```\ndone", []),
+            ("fenced block with info string", "```text\n@april-clearwater\n```", []),
+            ("tilde fence", "~~~\n@april-clearwater\n~~~", []),
+            ("unterminated fence swallows the rest", "evidence:\n```\n@april-clearwater ran", []),
+            (
+                "shorter fence markers stay inside a longer fence",
+                "````\n```\n@april-clearwater\n```\n````\n@claude go",
+                ["claude"],
+            ),
+            (
+                "closing fence must be at least opening length",
+                "````\n@april-clearwater\n```\nstill code\n````\nafter",
+                [],
+            ),
+            (
+                "fence line with trailing text does not close",
+                "```\n@april-clearwater\n``` not-a-close\nstill code",
+                [],
+            ),
+            (
+                "inline triple-backtick one-liner is a span, not a fence",
+                "```@april-clearwater``` quoted, and more prose after",
+                [],
+            ),
+            (
+                "mixed bare and backticked fires on the bare one",
+                "@claude please check the run that quoted `@april-clearwater`",
+                ["claude"],
+            ),
+            ("bare mention before a fence still fires", "@peter look:\n```\n@claude\n```", ["peter"]),
+            (
+                "lone backtick does not hide later paragraphs",
+                "odd ` backtick\n\n@claude please review",
+                ["claude"],
+            ),
+            ("unmatched backtick in the same paragraph keeps the mention", "` @claude please review", ["claude"]),
+            (
+                "CRLF bodies from the GitHub API still strip fences",
+                "quote:\r\n```\r\n@april-clearwater\r\n```\r\ndone",
+                [],
+            ),
+            ("empty text matches nothing", "", []),
+        ]
+        for name, text, expected in cases:
+            with self.subTest(name):
+                self.assertEqual(mention_detection.find_agent_mentions(text), expected)
+
+    def test_find_requested_agents_ignores_slug_quoted_in_code(self) -> None:
+        context = triage.EventContext(
+            event_name="issue_comment",
+            action="created",
+            target_type="issue",
+            target_number=1110,
+            source_type="issue_comment",
+            source_id="issue_comment:1",
+            source_url="https://github.com/fairchild/workspaces/issues/1110#issuecomment-1",
+            author_login="fairchild",
+            author_association="OWNER",
+            source_text="Evidence: the triage run matched `@april-clearwater` in this comment.",
+            requested_at="2026-07-17T16:00:00Z",
+        )
+
+        self.assertEqual(triage.find_requested_agents(context), [])
+
+        bare_context = triage.EventContext(
+            **{
+                **context.__dict__,
+                "source_text": "@april-clearwater please rerun the smoke",
+            }
+        )
+        self.assertEqual(triage.find_requested_agents(bare_context), ["april-clearwater"])
 
     def test_april_clearwater_mention_requires_exact_slug_boundary(self) -> None:
         context = triage.EventContext(

--- a/scripts/tests/test_factory_comment_responder.py
+++ b/scripts/tests/test_factory_comment_responder.py
@@ -217,6 +217,88 @@ class FactoryCommentResponderTests(unittest.TestCase):
         self.assertGreaterEqual(prompt.count("[truncated to 16384 UTF-8 bytes]"), 3)
         self.assertNotIn(payload.response_marker(4242), prompt)
 
+    def run_prepare_with_body(self, body: str):
+        event = {
+            "comment": {
+                "id": 4242,
+                "user": {"login": "fairchild", "type": "User"},
+                "body": body,
+            },
+            "issue": {"number": 1089},
+        }
+        target = {
+            "title": "Responder",
+            "body": "Target body",
+            "html_url": "https://github.com/fairchild/workspaces/issues/1089",
+            "labels": [{"name": "agent"}],
+            "comments": 0,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            event_path = root / "event.json"
+            output_path = root / "output.txt"
+            prompt_path = root / "prompt.txt"
+            event_path.write_text(json.dumps(event), encoding="utf-8")
+            env = {
+                "GITHUB_EVENT_NAME": "issue_comment",
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_REPOSITORY": "fairchild/workspaces",
+                "GITHUB_REPOSITORY_OWNER": "fairchild",
+                "GITHUB_API_URL": "https://api.github.com",
+                "GH_TOKEN": "not-a-real-token",
+            }
+            with (
+                mock.patch.dict(os.environ, env, clear=True),
+                mock.patch.object(
+                    payload, "github_get", side_effect=[target, []]
+                ) as github_get,
+            ):
+                result = payload.prepare(output_path, prompt_path)
+            outputs = dict(
+                line.split("=", 1)
+                for line in output_path.read_text(encoding="utf-8").splitlines()
+            )
+            prompt_exists = prompt_path.exists()
+        return result, outputs, prompt_exists, github_get
+
+    def test_responder_defers_to_mention_triage_without_touching_the_target(
+        self,
+    ) -> None:
+        result, outputs, prompt_exists, github_get = self.run_prepare_with_body(
+            "@april-clearwater please rerun the desktop smoke"
+        )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(outputs["matched"], "false")
+        self.assertEqual(outputs["already_replied"], "false")
+        self.assertFalse(prompt_exists)
+        github_get.assert_not_called()
+
+    def test_responder_deference_truth_table_uses_code_stripped_detection(
+        self,
+    ) -> None:
+        cases = [
+            ("dispatch mention stands down", "@april-clearwater please rerun the smoke", False),
+            ("plain owner comment replies", "Please also update the state label.", True),
+            ("backticked slug does not suppress", "Evidence quoted `@april-clearwater` in the log.", True),
+            (
+                "fenced slug does not suppress",
+                "The run log said:\n```\n@april-clearwater fired here\n```\nThoughts?",
+                True,
+            ),
+            (
+                "bare mention next to a backticked one stands down",
+                "@claude please review the run that quoted `@april-clearwater`",
+                False,
+            ),
+        ]
+        for name, body, expect_reply in cases:
+            with self.subTest(name):
+                result, outputs, prompt_exists, _ = self.run_prepare_with_body(body)
+                self.assertEqual(result, 0)
+                self.assertEqual(outputs["matched"], str(expect_reply).lower())
+                self.assertEqual(prompt_exists, expect_reply)
+
     def test_prepare_hardwires_comment_and_target_ids_and_detects_duplicate(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

Two owner-approved refinements from the 2026-07-17 factory dogfood (#1110), coupled by a shared-detection refactor:

**#1123 — Lane B defers to Lane A.** Both responder lanes fired on a single owner mention: mention triage (`agent-mention.yml` → `agent-triage-request.py`) posted a pending-approval marker while the comment responder (`factory-comment-responder.yml` → `factory-responder-payload.py`) posted a contextual reply. The responder's `prepare` gate now checks the owner comment against the same dispatch-slug detection triage uses and stands down with a logged reason (`matched=false`, "standing down in favor of mention triage") when one is present. Plain owner comments with no dispatch mention still get replies. One mention, one bot response; both lanes keep their jobs.

**#1124 — code spans no longer fire triage.** The live incident: an evidence comment quoting an agent slug in backticks fired the triage lane on #1110. Detection now strips fenced code blocks and inline code spans before slug matching. Bare mentions still fire.

**Shared detection, not two regexes.** The slug set, word-boundary patterns, and code-stripping moved to `.agents/scripts/mention_detection.py` (the existing shared-module home Lane A already imports from). Both lanes call `find_agent_mentions()`, so a quoted slug neither fires Lane A nor suppresses Lane B, and the two readings cannot drift.

Detection semantics (matching how GitHub renders):
- Closing fences need the same fence character at greater-or-equal run length with nothing after; an unterminated fence swallows the rest of the comment; a backtick run with more backticks later on the line is an inline span, not a fence.
- Inline spans close only on an equal-length backtick run and never cross blank lines, so a stray backtick stays literal and cannot hide mentions in later paragraphs. The scan is linear — no regex backtracking on untrusted backtick floods.
- CRLF bodies from the GitHub API are normalized before matching.

Also: `ci-agents.yml` now runs `test_factory_comment_responder.py` — the responder suite previously ran in no workflow.

## Testing

- Responder truth table extended 14 → 16 tests: dispatch mention → skip (with no target API call), plain comment → reply, backticked slug → reply (no suppress), fenced slug → reply, mixed bare+backticked → skip.
- Triage suite 8 → 10 tests, including a 17-case table for the stripping semantics: bare/backticked/fenced, tilde fences, nested and unterminated fences, short-closing-fence, fence line with trailing text, inline triple-backtick one-liner, lone/unmatched backticks, CRLF, empty.
- Full ci-agents parity run locally: all suites green (see evidence).
- **Deploy note:** both scripts run from the default branch on comment triggers, so this behavior takes effect only after merge. The `agent-mention.yml` YAML-level `contains()` prefilter is untouched (no trigger/permission changes): a quoted slug still starts a triage run, which now exits `matched=false` without posting.

## Evidence

- [Verbose test run: both suites + ci-agents parity](https://evidence.cloudcompute.com/workspaces/pr-1129/20260717-195351-responder-lane-coexistence-tests.txt)

## Mergeability

- **Surface:** infra — responder-lane gating scripts (`agent-triage-request.py`, `factory-responder-payload.py`), new shared `.agents/scripts/mention_detection.py`, their test suites, ci-agents test wiring. No workflow triggers, permissions, or tokens changed.
- **User-facing behavior changed:** an owner dispatch mention on a factory-managed target now yields exactly one bot response (the triage marker); quoting a slug in backticks or fences no longer fires triage and no longer suppresses the contextual reply.
- **Non-happy paths considered:** unterminated/nested fences and unequal backtick runs resolve the way GitHub renders them; over-stripping is bounded by the blank-line span barrier so stray backticks can't hide real mentions; linear scan avoids pathological regex backtracking on adversarial bodies; deference also applies to the responder's manual `workflow_dispatch` path (a manual run on a mention-bearing comment would duplicate the triage response); bot authors and marker-bearing comments keep their existing gates.
- **Residual risk or follow-up:** blockquoted (`> `) dispatch mentions still fire triage — pre-existing, out of #1124's approved scope, and consistent across both lanes; the YAML prefilter still spends a no-op workflow run on quoted slugs.

## Review loop

Worker PR under the factory-m3-hands orchestrator, who holds review + merge authority. The factory review lane will also auto-review.

Closes #1123
Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
