### PR TITLE
fix(factory): terminal label hygiene + admission-stage comment voice

### DIFF
--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -12,11 +12,14 @@ on:
       - "scripts/tests/test_validate_agent_output.py"
       - ".github/workflows/factory-*.yml"
       - "scripts/factory-implement.py"
+      - "scripts/factory-janitor.py"
       - "scripts/factory-review.py"
       - "scripts/factory-responder-payload.py"
       - "scripts/tests/test_factory_workflows.py"
+      - "scripts/tests/test_factory_janitor.py"
       - "scripts/tests/test_factory_review.py"
       - "scripts/tests/test_factory_comment_responder.py"
+      - "fixtures/factory-janitor/**"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
@@ -37,11 +40,14 @@ on:
       - "scripts/tests/test_validate_agent_output.py"
       - ".github/workflows/factory-*.yml"
       - "scripts/factory-implement.py"
+      - "scripts/factory-janitor.py"
       - "scripts/factory-review.py"
       - "scripts/factory-responder-payload.py"
       - "scripts/tests/test_factory_workflows.py"
+      - "scripts/tests/test_factory_janitor.py"
       - "scripts/tests/test_factory_review.py"
       - "scripts/tests/test_factory_comment_responder.py"
+      - "fixtures/factory-janitor/**"
       - "scripts/fable-orchestrator.py"
       - "scripts/tests/test_fable_orchestrator.py"
       - "scripts/carl-community.py"
@@ -91,6 +97,7 @@ jobs:
       - name: Run Factory workflow policy tests
         run: |
           uv run --script scripts/tests/test_factory_workflows.py
+          uv run --script scripts/tests/test_factory_janitor.py
           uv run --script scripts/tests/test_factory_review.py
           uv run --script scripts/tests/test_factory_comment_responder.py
 

--- a/fixtures/factory-janitor/basic/state.json
+++ b/fixtures/factory-janitor/basic/state.json
@@ -469,5 +469,39 @@
       "mergedAt": null,
       "closingIssuesReferences": [{"number": 118}]
     }
+  ],
+  "closedIssues": [
+    {
+      "id": "I_120",
+      "number": 120,
+      "title": "Closed issue retains claimed and mergeable",
+      "state": "CLOSED",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_task", "name": "task"},
+        {"id": "L_claimed", "name": "claimed"},
+        {"id": "L_mergeable", "name": "mergeable"}
+      ]
+    },
+    {
+      "id": "I_121",
+      "number": 121,
+      "title": "Closed issue retains ready outside the agent lane",
+      "state": "CLOSED",
+      "labels": [
+        {"id": "L_human", "name": "human"},
+        {"id": "L_ready", "name": "ready"}
+      ]
+    },
+    {
+      "id": "I_122",
+      "number": 122,
+      "title": "Closed issue without lifecycle labels",
+      "state": "CLOSED",
+      "labels": [
+        {"id": "L_agent", "name": "agent"},
+        {"id": "L_dogfood", "name": "dogfood"}
+      ]
+    }
   ]
 }

--- a/scripts/factory-implement.py
+++ b/scripts/factory-implement.py
@@ -49,12 +49,25 @@ PRIVILEGED_PATCH_LABEL = "privileged-agent-patch"
 API_ATTEMPTS = 3
 API_BACKOFF_SECONDS = 1.0
 APRIL_ATTRIBUTION = "*April Clearwater, Application Lead*\n\n"
-PRIVILEGED_COMMENT = APRIL_ATTRIBUTION + (
-    "Factory implementation skipped: this issue indicates privileged-path scope "
-    "and requires the orchestrator lane."
+
+# Negative admission outcomes split on whether a retry can ever succeed.
+# Terminal declines strip `ready` so the release cannot refire a run the
+# factory will always refuse; transient deferrals keep `ready` because the
+# blocking condition (WIP capacity, daily budget) clears on its own and the
+# Owner's release stays valid. Admission only ever removes `ready` — applying
+# it remains Owner-only, matching the janitor's release-gate invariant.
+TERMINAL_DECLINES = frozenset({"privileged"})
+TRANSIENT_DEFERRALS = frozenset({"wip", "budget"})
+
+# Admission comments speak as the pipeline stage, not as a contributor
+# persona: no contributor ran, so persona attribution would misattribute.
+PRIVILEGED_COMMENT = (
+    "Factory admission: declined — this issue indicates privileged-path scope "
+    "and requires the orchestrator lane. Removing `ready`; the factory cannot "
+    "take this issue."
 )
-WIP_COMMENT = APRIL_ATTRIBUTION + (
-    f"Factory implementation is waiting: the {FACTORY_WIP_CAP}-issue factory WIP "
+WIP_COMMENT = (
+    f"Factory admission: deferred — the {FACTORY_WIP_CAP}-issue factory WIP "
     "cap is full; leaving this issue ready."
 )
 BUDGET_COMMENT_MARKER = "<!-- factory-implement-budget-skip -->"
@@ -277,6 +290,10 @@ def rollback_payload(issue: dict[str, Any]) -> dict[str, Any]:
     return {"labels": labels}
 
 
+def decline_payload(issue: dict[str, Any]) -> dict[str, Any]:
+    return {"labels": sorted(label_names(issue) - {"ready"})}
+
+
 def sync_claim_assignee(
     client: GitHubClient,
     issue_number: int,
@@ -319,8 +336,7 @@ def budget_skip_comment(daily_run_count: int, daily_cap: int) -> str:
     return (
         BUDGET_COMMENT_MARKER
         + "\n"
-        + APRIL_ATTRIBUTION
-        + "Factory implementation skipped: "
+        + "Factory admission: deferred — "
         + f"{daily_run_count} implementation runs have started today, above the "
         + f"configured daily cap of {daily_cap}; leaving this issue ready. "
         + "The workflow log records the skip."
@@ -504,19 +520,20 @@ def claim(
     write_output("matched", "false")
     write_output("issue_scope_digest", issue_scope_digest(issue))
     write_output("verified_actor", verified_actor)
-    if decision.action == "privileged":
+    if decision.action in TERMINAL_DECLINES:
         comment_once(client, issue_number, PRIVILEGED_COMMENT)
+        client.update_issue(issue_number, decline_payload(issue))
         return
-    if decision.action == "wip":
-        comment_once(client, issue_number, WIP_COMMENT)
-        return
-    if decision.action == "budget":
-        comment_once(
-            client,
-            issue_number,
-            budget_skip_comment(daily_run_count, daily_cap),
-            dedupe_key=BUDGET_COMMENT_MARKER,
-        )
+    if decision.action in TRANSIENT_DEFERRALS:
+        if decision.action == "wip":
+            comment_once(client, issue_number, WIP_COMMENT)
+        else:
+            comment_once(
+                client,
+                issue_number,
+                budget_skip_comment(daily_run_count, daily_cap),
+                dedupe_key=BUDGET_COMMENT_MARKER,
+            )
         return
     if decision.action == "skip":
         return

--- a/scripts/factory-janitor.py
+++ b/scripts/factory-janitor.py
@@ -5,8 +5,9 @@
 # ///
 """Reconcile Agent Factory issue lifecycle state during the daily monitor.
 
-The janitor derives expected labels from issue, claim, and pull-request state.
-It is dry-run by default; only an explicit ``--apply`` mutates GitHub.
+The janitor derives expected labels from issue, claim, and pull-request state,
+and strips stale lifecycle labels from closed issues. It is dry-run by
+default; only an explicit ``--apply`` mutates GitHub.
 """
 
 from __future__ import annotations
@@ -32,6 +33,11 @@ MUTATION_ATTEMPTS = 3
 MUTATION_BACKOFF_SECONDS = 1.0
 MANAGED_STATES = frozenset({"ready", "claimed", "review"})
 STATE_PRIORITY = ("review", "claimed", "ready")
+# Lifecycle labels describe open work; on a closed issue every one of them —
+# the managed trio plus the additive `mergeable` review signal — is stale.
+# The janitor only removes these from closed issues; applying `ready` remains
+# Owner-only, so the release-gate invariant is untouched.
+CLOSED_LIFECYCLE_LABELS = STATE_PRIORITY + ("mergeable",)
 DIGEST_MARKER = "<!-- " + "-".join(("factory", "digest:v1")) + " -->"
 JANITOR_MARKER_PREFIX = "factory-janitor"
 CLAIM_MARKER_RE = re.compile(
@@ -84,6 +90,27 @@ query FactoryJanitorIssues($owner: String!, $name: String!, $after: String) {
 """
 
 
+CLOSED_ISSUES_QUERY = """
+query FactoryJanitorClosedIssues($owner: String!, $name: String!, $label: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: 100
+      after: $after
+      states: CLOSED
+      labels: [$label]
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id number title state
+        labels(first: 50) { nodes { id name } }
+      }
+    }
+  }
+}
+"""
+
+
 PULLS_QUERY = """
 query FactoryJanitorPulls($owner: String!, $name: String!, $after: String) {
   repository(owner: $owner, name: $name) {
@@ -129,6 +156,7 @@ class JanitorInputs:
     repo: RepoInfo
     issues: list[dict[str, Any]]
     pulls: list[dict[str, Any]]
+    closed_issues: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -294,10 +322,37 @@ def fetch_live_inputs(repo_slug: str, token: str) -> JanitorInputs:
             break
         cursor = connection["pageInfo"]["endCursor"]
 
+    closed_issues: list[dict[str, Any]] = []
+    seen_closed: set[int] = set()
+    for label_name in CLOSED_LIFECYCLE_LABELS:
+        cursor = None
+        while True:
+            payload = graphql(
+                token,
+                CLOSED_ISSUES_QUERY,
+                {**common_variables, "label": label_name, "after": cursor},
+            )
+            repository = payload.get("data", {}).get("repository")
+            if repository is None:
+                raise FactoryJanitorError(f"repository {repo_slug} was not found")
+            connection = repository["issues"]
+            for node in connection["nodes"]:
+                number = int(node["number"])
+                if number in seen_closed:
+                    continue
+                seen_closed.add(number)
+                closed_issues.append(
+                    {**node, "labels": list(node.get("labels", {}).get("nodes", []))}
+                )
+            if not connection["pageInfo"]["hasNextPage"]:
+                break
+            cursor = connection["pageInfo"]["endCursor"]
+
     return JanitorInputs(
         repo=RepoInfo(owner, name, repository_id, label_ids),
         issues=issues,
         pulls=pulls,
+        closed_issues=closed_issues,
     )
 
 
@@ -351,6 +406,7 @@ def load_fixture_inputs(fixtures_dir: Path) -> tuple[JanitorInputs, datetime]:
         ),
         issues=list(payload["issues"]),
         pulls=list(payload["pulls"]),
+        closed_issues=list(payload.get("closedIssues", [])),
     )
     return inputs, parse_datetime(str(payload["now"]))
 
@@ -555,6 +611,29 @@ def _transition(
     )
 
 
+def closed_lifecycle_transition(issue: dict[str, Any]) -> Transition | None:
+    if str(issue.get("state", "")).upper() != "CLOSED":
+        return None
+    label_ids = {
+        str(label["name"]): str(label["id"])
+        for label in issue.get("labels", []) or []
+        if label.get("name") in CLOSED_LIFECYCLE_LABELS and label.get("id")
+    }
+    if not label_ids:
+        return None
+    return Transition(
+        issue_id=str(issue["id"]),
+        issue_number=int(issue["number"]),
+        title=str(issue.get("title", "")),
+        current_states=tuple(
+            state for state in CLOSED_LIFECYCLE_LABELS if state in label_ids
+        ),
+        desired_state=None,
+        reason="issue is closed",
+        current_label_ids=label_ids,
+    )
+
+
 def _newest_pull(pulls: list[dict[str, Any]]) -> dict[str, Any]:
     return max(
         pulls,
@@ -706,6 +785,11 @@ def build_plan(inputs: JanitorInputs, *, now: datetime) -> ReconciliationPlan:
 
         reason = f"keep highest-priority lifecycle state {desired_state}"
         transition = _transition(issue, desired_state, reason)
+        if transition is not None:
+            transitions.append(transition)
+
+    for issue in sorted(inputs.closed_issues, key=lambda item: int(item["number"])):
+        transition = closed_lifecycle_transition(issue)
         if transition is not None:
             transitions.append(transition)
 

--- a/scripts/tests/test_factory_janitor.py
+++ b/scripts/tests/test_factory_janitor.py
@@ -159,7 +159,7 @@ class FactoryJanitorTests(unittest.TestCase):
     ) -> None:
         issue = copy.deepcopy(self.issue(104))
         del issue["comments"][-1]["createdAt"]
-        inputs = replace(self.inputs, issues=[issue], pulls=[])
+        inputs = replace(self.inputs, issues=[issue], pulls=[], closed_issues=[])
 
         plan = factory_janitor.build_plan(inputs, now=self.now)
 
@@ -244,15 +244,19 @@ class FactoryJanitorTests(unittest.TestCase):
 
     def test_second_plan_after_state_repairs_is_idempotent(self) -> None:
         replay = copy.deepcopy(self.inputs)
-        by_number = {int(issue["number"]): issue for issue in replay.issues}
+        by_number = {
+            int(issue["number"]): issue
+            for issue in replay.issues + replay.closed_issues
+        }
         for transition in self.plan.transitions:
             issue = by_number[transition.issue_number]
+            removed = set(transition.current_label_ids) - {transition.desired_state}
             issue["labels"] = [
-                label
-                for label in issue["labels"]
-                if label["name"] not in factory_janitor.MANAGED_STATES
+                label for label in issue["labels"] if label["name"] not in removed
             ]
-            if transition.desired_state is not None:
+            if transition.desired_state is not None and transition.desired_state not in {
+                label["name"] for label in issue["labels"]
+            }:
                 issue["labels"].append(
                     {
                         "id": replay.repo.label_ids[transition.desired_state],
@@ -260,11 +264,12 @@ class FactoryJanitorTests(unittest.TestCase):
                     }
                 )
             removed_ids = {assignee_id for assignee_id, _ in transition.assignees}
-            issue["assignees"] = [
-                assignee
-                for assignee in issue["assignees"]
-                if assignee["id"] not in removed_ids
-            ]
+            if removed_ids:
+                issue["assignees"] = [
+                    assignee
+                    for assignee in issue["assignees"]
+                    if assignee["id"] not in removed_ids
+                ]
             if transition.comment:
                 issue["comments"].append(
                     {
@@ -281,6 +286,89 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertEqual(
             [anomaly.issue_number for anomaly in second_plan.anomalies],
             [110, 113, 119],
+        )
+
+    def test_closed_issues_shed_lifecycle_labels_without_comment(self) -> None:
+        stale = self.transitions[120]
+        human_lane = self.transitions[121]
+
+        self.assertEqual(stale.current_states, ("claimed", "mergeable"))
+        self.assertIsNone(stale.desired_state)
+        self.assertEqual(stale.reason, "issue is closed")
+        self.assertIsNone(stale.comment)
+        self.assertEqual(stale.assignees, ())
+        self.assertEqual(human_lane.current_states, ("ready",))
+        self.assertIsNone(human_lane.desired_state)
+
+    def test_closed_issue_without_lifecycle_labels_is_untouched(self) -> None:
+        self.assertNotIn(122, self.handled_numbers())
+
+    def test_closed_cleanup_rejects_open_issue_defensively(self) -> None:
+        open_issue = copy.deepcopy(self.issue(101))
+
+        self.assertIn("claimed", factory_janitor.label_names(open_issue))
+        self.assertIsNone(factory_janitor.closed_lifecycle_transition(open_issue))
+
+    def test_closed_issue_mutations_only_remove_labels(self) -> None:
+        operations = factory_janitor._mutations_for_transition(
+            self.transitions[120], self.inputs.repo.label_ids
+        )
+
+        self.assertEqual([operation.name for operation in operations], ["remove-labels"])
+        self.assertEqual(
+            operations[0].variables["input"]["labelIds"],
+            ["L_claimed", "L_mergeable"],
+        )
+
+    def test_live_fetch_dedupes_closed_issues_across_label_queries(self) -> None:
+        closed_node = {
+            "id": "I_900",
+            "number": 900,
+            "title": "Closed with claimed and mergeable",
+            "state": "CLOSED",
+            "labels": {
+                "nodes": [
+                    {"id": "L_claimed", "name": "claimed"},
+                    {"id": "L_mergeable", "name": "mergeable"},
+                ]
+            },
+        }
+        page = {"pageInfo": {"hasNextPage": False, "endCursor": None}}
+        queried_labels: list[str] = []
+
+        def fake_graphql(_token, query, variables):
+            if "FactoryJanitorIssues" in query:
+                repository = {
+                    "id": "R_1",
+                    "readyLabel": {"id": "L_ready", "name": "ready"},
+                    "claimedLabel": {"id": "L_claimed", "name": "claimed"},
+                    "reviewLabel": {"id": "L_review", "name": "review"},
+                    "issues": {**page, "nodes": []},
+                }
+            elif "FactoryJanitorPulls" in query:
+                repository = {"pullRequests": {**page, "nodes": []}}
+            else:
+                queried_labels.append(variables["label"])
+                nodes = (
+                    [closed_node]
+                    if variables["label"] in {"claimed", "mergeable"}
+                    else []
+                )
+                repository = {"issues": {**page, "nodes": nodes}}
+            return {"data": {"repository": repository}}
+
+        with mock.patch.object(factory_janitor, "graphql", side_effect=fake_graphql):
+            inputs = factory_janitor.fetch_live_inputs("fairchild/workspaces", "token")
+
+        self.assertEqual(
+            queried_labels, list(factory_janitor.CLOSED_LIFECYCLE_LABELS)
+        )
+        self.assertEqual(
+            [issue["number"] for issue in inputs.closed_issues], [900]
+        )
+        self.assertEqual(
+            [label["name"] for label in inputs.closed_issues[0]["labels"]],
+            ["claimed", "mergeable"],
         )
 
     def test_mutations_are_ordered_labels_unassign_then_comment(self) -> None:
@@ -391,9 +479,13 @@ class FactoryJanitorTests(unittest.TestCase):
         self.assertIn("[transition] #102: ready -> review", result.stdout)
         self.assertIn("[transition] #103: review -> ready", result.stdout)
         self.assertIn("[transition] #117: review -> none", result.stdout)
+        self.assertIn(
+            "[transition] #120: claimed+mergeable -> none (issue is closed)",
+            result.stdout,
+        )
         self.assertIn("[anomaly] #110: multiple open PRs", result.stdout)
         self.assertIn(
-            "Dry run: 9 transition(s), 3 anomalies; no writes.", result.stdout
+            "Dry run: 11 transition(s), 3 anomalies; no writes.", result.stdout
         )
         self.assertNotRegex(result.stdout, r"\[transition\].*: none ->")
         self.assertNotIn("[applied]", result.stdout)

--- a/scripts/tests/test_factory_workflows.py
+++ b/scripts/tests/test_factory_workflows.py
@@ -255,6 +255,126 @@ class FactoryImplementTests(unittest.TestCase):
         self.assertEqual(rollback["labels"], ["agent", "quality", "ready", "task"])
         self.assertNotIn("assignees", rollback)
 
+        decline = factory_implement.decline_payload(issue)
+        self.assertEqual(decline["labels"], ["agent", "quality", "task"])
+        self.assertNotIn("assignees", decline)
+
+    def test_negative_outcomes_partition_terminal_and_transient(self) -> None:
+        self.assertEqual(
+            factory_implement.TERMINAL_DECLINES | factory_implement.TRANSIENT_DEFERRALS,
+            {"privileged", "wip", "budget"},
+        )
+        self.assertEqual(
+            factory_implement.TERMINAL_DECLINES & factory_implement.TRANSIENT_DEFERRALS,
+            frozenset(),
+        )
+
+    def claim_client(self, issue) -> mock.Mock:
+        client = mock.Mock()
+        client.issue.return_value = issue
+        client.timeline.return_value = [
+            {
+                "event": "labeled",
+                "label": {"name": "ready"},
+                "actor": {"login": "fairchild"},
+            }
+        ]
+        client.claimed_issues.return_value = []
+        client.comments.return_value = []
+        return client
+
+    def run_claim(self, client, actions_client, *, daily_cap: int = 6) -> list[str]:
+        outputs: list[str] = []
+        with mock.patch.object(
+            factory_implement,
+            "write_output",
+            lambda name, value: outputs.append(f"{name}={value}"),
+        ):
+            factory_implement.claim(
+                client,
+                actions_client,
+                42,
+                "https://example.test/runs/7",
+                "april-clearwater[bot]",
+                "fairchild",
+                "fairchild",
+                "true",
+                "true",
+                daily_cap,
+                "7",
+                1,
+            )
+        return outputs
+
+    def test_privileged_decline_is_terminal_and_withdraws_ready(self) -> None:
+        client = self.claim_client(
+            self.issue(
+                body="Change `.github/workflows/ci.yml`",
+                labels=("agent", "task", "ready", "quality"),
+            )
+        )
+        actions_client = mock.Mock()
+        actions_client.workflow_runs_on.return_value = []
+
+        outputs = self.run_claim(client, actions_client)
+
+        client.comment.assert_called_once_with(
+            42, factory_implement.PRIVILEGED_COMMENT
+        )
+        client.update_issue.assert_called_once_with(
+            42, {"labels": ["agent", "quality", "task"]}
+        )
+        client.add_assignees.assert_not_called()
+        self.assertIn("matched=false", outputs)
+        self.assertNotIn("matched=true", outputs)
+
+    def test_transient_deferrals_leave_ready_for_retry(self) -> None:
+        wip_client = self.claim_client(self.issue())
+        wip_client.claimed_issues.return_value = [{"number": 1}, {"number": 2}]
+        idle_actions = mock.Mock()
+        idle_actions.workflow_runs_on.return_value = []
+
+        self.run_claim(wip_client, idle_actions)
+
+        wip_client.comment.assert_called_once_with(42, factory_implement.WIP_COMMENT)
+        wip_client.update_issue.assert_not_called()
+
+        budget_client = self.claim_client(self.issue())
+        busy_actions = mock.Mock()
+        busy_actions.workflow_runs_on.return_value = [
+            {
+                "id": run_id,
+                "event": "workflow_dispatch",
+                "run_attempt": 1,
+                "actor": {"login": "fairchild"},
+            }
+            for run_id in range(100, 107)
+        ]
+
+        self.run_claim(budget_client, busy_actions)
+
+        budget_client.comment.assert_called_once()
+        self.assertIn(
+            "leaving this issue ready", budget_client.comment.call_args.args[1]
+        )
+        budget_client.update_issue.assert_not_called()
+
+    def test_admission_comments_speak_as_the_stage_not_a_persona(self) -> None:
+        budget = factory_implement.budget_skip_comment(7, 6)
+
+        for body in (
+            factory_implement.PRIVILEGED_COMMENT,
+            factory_implement.WIP_COMMENT,
+            budget,
+        ):
+            with self.subTest(body=body):
+                self.assertNotIn("April Clearwater", body)
+                self.assertIn("Factory admission:", body)
+        self.assertTrue(
+            factory_implement.PRIVILEGED_COMMENT.startswith("Factory admission:")
+        )
+        self.assertTrue(factory_implement.WIP_COMMENT.startswith("Factory admission:"))
+
     def test_claim_survives_unsupported_agent_assignment(self) -> None:
         client = mock.Mock()
         client.issue.return_value = self.issue()


### PR DESCRIPTION
## Summary

Two claim/label-surface refinements from the 2026-07-17 factory dogfood (tracking #1110).

**#1121 — terminal label hygiene.** Negative admission outcomes in `scripts/factory-implement.py` now split on whether a retry can ever succeed, encoded as `TERMINAL_DECLINES` / `TRANSIENT_DEFERRALS`:

- **Privileged-scope declines are terminal** — the path policy will classify the issue the same way every time, so admission withdraws the Owner's release (`decline_payload` strips `ready`; removal only — applying `ready` stays Owner-only, matching the janitor's release-gate invariant). Previously the issue kept `ready`, so a re-add refired the whole run just to re-decline, with `comment_once` deduping only the comment.
- **WIP-cap and budget skips are transient** — the blocking condition (factory WIP capacity, daily run budget) clears on its own and the release stays valid, so `ready` stays for retry. Their comments already say "leaving this issue ready"; now the code distinction matches the wording.

The janitor (`scripts/factory-janitor.py`, the M1 label-state-machine lane) gains a **closed-issue sweep**: closed issues shed stale lifecycle labels (`ready`/`claimed`/`review`/`mergeable`) via per-label `states: CLOSED` GraphQL queries, remove-only mutations, and no comments. The Owner release gate stays total: the sweep never applies a label, `closed_lifecycle_transition` defensively rejects non-CLOSED issues, and `validate_plan`'s none→* prohibition is untouched. Dry-run/apply semantics unchanged; the fixture pack gains an optional `closedIssues` input (absent key ⇒ empty, backwards compatible). The janitor test suite now runs in `ci-agents` (it previously ran nowhere in CI).

**#1122 — admission-skip comment voice.** The privileged/WIP/budget skip comments posted under April's persona (`*April Clearwater, Application Lead*`) though no contributor ran (live example: [#1111 comment](https://github.com/fairchild/workspaces/issues/1111#issuecomment-5004881969)). All three pre-run admission comments now speak as the stage — `Factory admission: declined/deferred — ...` — same posting mechanics and token, wording only. The claim comment and rollback comment keep April attribution: in both, the contributor identity is real (claim binds the branch/run; rollback follows an actual run).

## Evidence

- [Test suites: factory workflows 16/16, janitor 29/29, review 8/8](https://evidence.cloudcompute.com/workspaces/pr-1131/20260717-195731-factory-label-hygiene-tests.txt)
- [Live janitor dry-run on fairchild/workspaces](https://evidence.cloudcompute.com/workspaces/pr-1131/20260717-195738-janitor-live-dry-run.txt) — 93 closed-issue transitions planned, 0 anomalies, no writes; includes the cited #1109/#1032/#934 (`claimed+mergeable -> none (issue is closed)`)

## Mergeability

- **Surface:** infra — factory admission CLI (`factory-implement.py`), lifecycle janitor (`factory-janitor.py`) + fixture pack + test suites, `ci-agents` workflow wiring.
- **User-facing behavior changed:** privileged declines now remove `ready` (a stale release can no longer refire a guaranteed-refusal run); the daily janitor apply will one-time sweep ~93 closed issues' lifecycle labels, then stay quiet; admission skip comments read as pipeline-stage voice.
- **Non-happy paths considered:** decline comment posts before the label mutation, so a failed mutation reruns safely (comment dedupes, strip retries); re-released privileged issues re-decline idempotently; closed-query pagination dedupes issues appearing under multiple lifecycle labels; fixture packs without `closedIssues` load unchanged; `--fixtures-dir --apply` still rejected; per-issue mutation failures still collect and fail the run without blocking other issues.
- **Residual risk or follow-up:** the first janitor apply performs ~93 remove-label mutations (bounded by retry/backoff; removals are idempotent); the transient-deferral retry still depends on the Owner re-adding `ready` or a dispatch — this PR makes retry *valid*, not automatic; rollback's April-voiced comment left as is (a run did execute there) — flag if the stage voice should extend to it.

## Review loop

W2 worker PR under the factory-m3-hands orchestrator, who holds review and merge authority. The factory review lane will auto-review; orchestrator handles close-out.

Closes #1121
Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
