### PR TITLE
chore(factory): fixture sweep, persona prune, ops lessons docs

### DIFF
--- a/.agents/skills/cofounder-contributor/references/april-clearwater.md
+++ b/.agents/skills/cofounder-contributor/references/april-clearwater.md
@@ -21,7 +21,7 @@ Work through this list in order. If an item applies, do it.
 2. **Open PRs** — If there's a PR you do not own that needs review, review it. The PR diff is included inline in the "Open PRs" context under each PR's `"diff"` field when it is safe to use — use it directly for code review. If the PR instead has `diffOmittedReason`, do not review it during scheduled/background work; only review it when a trusted human explicitly directs that PR. Give substantive code review focused on your domain (UI, UX, app behavior, SwiftUI/AppKit patterns).
 
 3. **Execution-approved work** — After review work is clear, move implementation forward. Use the execution sections in your context.
-   - **Continue your own open PR first** — if you already have an open PR, check review feedback and keep it moving toward merge readiness. If the PR already exists for the linked issue, check out that PR branch before editing and use `advance_pr` rather than starting over from the issue.
+   - **Continue your own open PR first** — if you already have an open PR, check review feedback and keep it moving toward merge readiness. If the PR already exists for the linked issue, use `advance_pr` rather than starting over from the issue; the runtime checks out that PR branch for you.
    - **Continue your own claimed issue next** — if you claimed an issue earlier but never opened the PR, keep moving that same branch.
    - **Check your GitHub assignments** — issues assigned to you are your responsibility. Advance assigned issues before claiming new ones.
    - **Otherwise claim the highest-priority ready issue** — only pick issues listed as execution-approved and ready in your context. Work one issue per PR and use `execute_issue` only when no PR exists yet.
@@ -67,7 +67,7 @@ Choose ONE action based on your priority assessment:
 
 Use this when the linked issue already has your PR and you are pushing it toward merge readiness after review.
 
-- Check out the existing PR branch before editing.
+- The runtime checks out the existing PR branch; edit files in the workspace.
 - Read the latest external review and the execution context carefully.
 - Use the numbered requested-evidence items from context.
 - Do not write `## Evidence Status` manually. The runtime renders it from your frontmatter.
@@ -102,8 +102,7 @@ evidence_blocked:
 
 Use this only when the issue does not already have your PR. If you choose this action, you must have already edited the code during this run.
 
-- If the issue already has your open PR, check out that PR branch before editing.
-- Otherwise create or switch to a branch named `codex/april-clearwater-issue-<number>-<slug>` before editing.
+- The runtime handles all git operations — it checks out your open PR branch when one exists, or creates the working branch otherwise. Edit files in the workspace.
 - Do not add `evidence_complete`, `evidence_blocked`, or `evidence_pending_ci` fields. The runtime owns Evidence Status and downstream evidence collection.
 - Do not claim you ran tests, captured screenshots, or uploaded proof unless that fact appears in trusted runtime context.
 - Keep `## Validation` limited to honest, high-level notes about what should be validated or what the downstream evidence workflow will gather.
@@ -132,7 +131,7 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 
 ### Review a PR
 
-Lead with your decision, then explain. Use `gh pr view <number>` and `gh issue view <linked-issue>` to compare the issue's `requested_evidence` against the PR's `## Evidence Status` section before deciding. Use GitHub suggestion blocks for small fixes. For larger changes, open a PR against the author's branch.
+Lead with your decision, then explain. Compare the issue's `requested_evidence` items against the PR's `## Evidence Status` section — both are provided in your context — before deciding. Use GitHub suggestion blocks for small fixes. For larger changes, describe the needed change concretely in your review.
 
 Review rules:
 - If any requested evidence item is missing from `## Evidence Status`, verdict must be `request_changes`.
@@ -161,7 +160,7 @@ For small fixes, use GitHub code suggestions:
 corrected code here
 ` ```
 
-For significant changes, note that you'll open a PR against their branch.
+For significant changes, describe the change concretely enough for the author to implement it.
 ```
 
 ### Recommend closing a stale discussion

--- a/.agents/skills/cofounder-contributor/references/plat-ironwood.md
+++ b/.agents/skills/cofounder-contributor/references/plat-ironwood.md
@@ -21,7 +21,7 @@ Work through this list in order. If an item applies, do it.
 2. **Open PRs** — If there's a PR you do not own that needs review, review it. The PR diff is included inline in the "Open PRs" context under each PR's `"diff"` field when it is safe to use — use it directly for code review. If the PR instead has `diffOmittedReason`, do not review it during scheduled/background work; only review it when a trusted human explicitly directs that PR. Give substantive code review focused on your domain (CI, infra, testing, release pipeline, agent workflows, notifications).
 
 3. **Execution-approved work** — After review work is clear, move implementation forward. Use the execution sections in your context.
-   - **Continue your own open PR first** — if you already have an open PR, check review feedback and keep it moving toward merge readiness. If the PR already exists for the linked issue, check out that PR branch before editing and use `advance_pr` rather than starting over from the issue.
+   - **Continue your own open PR first** — if you already have an open PR, check review feedback and keep it moving toward merge readiness. If the PR already exists for the linked issue, use `advance_pr` rather than starting over from the issue; the runtime checks out that PR branch for you.
    - **Continue your own claimed issue next** — if you claimed an issue earlier but never opened the PR, keep moving that same branch.
    - **Check your GitHub assignments** — issues assigned to you are your responsibility. Advance assigned issues before claiming new ones.
    - **Otherwise claim the highest-priority ready issue** — only pick issues listed as execution-approved and ready in your context. Work one issue per PR and use `execute_issue` only when no PR exists yet.
@@ -67,7 +67,7 @@ Choose ONE action based on your priority assessment:
 
 Use this when the linked issue already has your PR and you are pushing it toward merge readiness after review.
 
-- Check out the existing PR branch before editing.
+- The runtime checks out the existing PR branch; edit files in the workspace.
 - Read the latest external review and the execution context carefully.
 - Use the numbered requested-evidence items from context.
 - Do not write `## Evidence Status` manually. The runtime renders it from your frontmatter.
@@ -102,8 +102,7 @@ evidence_blocked:
 
 Use this only when the issue does not already have your PR. If you choose this action, you must have already edited the code during this run.
 
-- If the issue already has your open PR, check out that PR branch before editing.
-- Otherwise create or switch to a branch named `codex/plat-ironwood-issue-<number>-<slug>` before editing.
+- The runtime handles all git operations — it checks out your open PR branch when one exists, or creates the working branch otherwise. Edit files in the workspace.
 - Do not add `evidence_complete`, `evidence_blocked`, or `evidence_pending_ci` fields. The runtime owns Evidence Status and downstream evidence collection.
 - Do not claim you ran tests, captured screenshots, or uploaded proof unless that fact appears in trusted runtime context.
 - Keep `## Validation` limited to honest, high-level notes about what should be validated or what the downstream evidence workflow will gather.
@@ -132,7 +131,7 @@ commit_message: "Fix environment status color semantics in NewWorkspaceSheet"
 
 ### Review a PR
 
-Lead with your decision, then explain. Use `gh pr view <number>` and `gh issue view <linked-issue>` to compare the issue's `requested_evidence` against the PR's `## Evidence Status` section before deciding. Use GitHub suggestion blocks for small fixes. For larger changes, open a PR against the author's branch.
+Lead with your decision, then explain. Compare the issue's `requested_evidence` items against the PR's `## Evidence Status` section — both are provided in your context — before deciding. Use GitHub suggestion blocks for small fixes. For larger changes, describe the needed change concretely in your review.
 
 Review rules:
 - If any requested evidence item is missing from `## Evidence Status`, verdict must be `request_changes`.
@@ -161,7 +160,7 @@ For small fixes, use GitHub code suggestions:
 corrected code here
 ` ```
 
-For significant changes, note that you'll open a PR against their branch.
+For significant changes, describe the change concretely enough for the author to implement it.
 ```
 
 ### Recommend closing a stale discussion

--- a/docs/development/agent-factory-v2-overview.html
+++ b/docs/development/agent-factory-v2-overview.html
@@ -354,6 +354,7 @@
   <h2><span class="sn">§07 · Operations</span>Operating the factory</h2>
   <p>To turn the hands on: set <code>FACTORY_IMPLEMENT_ENABLED</code> and <code>FACTORY_REVIEW_ENABLED</code> alongside the existing master switch, optionally tune the two daily caps, then run one supervised pass — label a trivial, non-privileged issue <code>ready</code> yourself and watch the whole chain (claim comment, claimed label, PR, evidence, counterpart review) before trusting the label path unattended.</p>
   <p>Observability lives in three places: the pinned Factory Digest issue (label-state funnel, run budgets, ready-but-unclaimed ageing, per-stage activity), the telemetry branch <code>factory/ops-data</code> the monitor writes, and the workflow runs themselves — every dispatch names its issue in the run title. When something looks wrong, the kill switches stop the factory in one variable flip, and the janitor's next pass repairs label drift.</p>
+  <p>Owner-side close-out procedures learned in live operation — superseding a stale counterpart verdict by re-dispatch, pre-flighting label-triggered workflows against the default branch, attesting blocked evidence in the PR body — are catalogued in the plan's <a href="agent-factory-v2-plan.md">operational lessons</a>.</p>
 </section>
 
 <section id="s8">

--- a/docs/development/agent-factory-v2-plan.md
+++ b/docs/development/agent-factory-v2-plan.md
@@ -153,6 +153,14 @@ The Factory never builds itself autonomously: M1–M4 are Interactive Lane work,
 - **Third-reviewer quorum** — which change classes reach reviewer-agreement rates that justify delegation, and how fast.
 - **Feedback loop closure** — surfacing "your feedback shipped" back through the product once `status='resolved'` write-back exists.
 
+## Operational lessons
+
+Close-out procedures learned in live operation (2026-07-17 dogfood). These are owner-side runbook entries, not design changes.
+
+1. **A stale CHANGES_REQUESTED is superseded by re-dispatch, not dismissal.** A counterpart verdict anchors to the state it reviewed; a fix that only edits the PR body (evidence attestation, Mergeability fields) fires no event that would prompt a re-review, so the verdict sits stale. The remedy is `gh workflow run factory-review.yml -f pr_number=<N>` — the counterpart re-reviews and supersedes its own verdict, keeping the reviewer-agreement record intact. Dismissing the review through the owner API is the anti-pattern (and is blocked): it erases the reviewer's verdict instead of letting the reviewer replace it.
+2. **Comment- and label-triggered workflows execute from the default branch.** `issue_comment`, label events, and `workflow_dispatch` all run the workflow definition on `main`, not the one in your checkout. Pre-flight a workflow change against what `main` currently contains; triggering the event from a feature branch exercises the old definition, and the new one only takes effect at merge.
+3. **The evidence-status body block is the owner's attestation surface.** When evidence items sit `[blocked]` and the owner has verified them out of band, the close-out is: edit the item statuses in the PR's `## Evidence Status` block, strip the `blocked` label, and re-dispatch the review (lesson 1). On the counterpart's superseding approval, the runtime applies `mergeable` to the PR and its source issue — no manual label flip needed beyond removing `blocked`.
+
 ## References
 
 - Live-state audit, infra deep-dive, feedback-feature map: session artifacts, 2026-07-12 (summarized in "Why v1 stalled").


### PR DESCRIPTION
## Summary

Mechanical cleanup set from the 2026-07-17 factory dogfood (tracking #1110). Three issues, one PR:

**#1118 — time-bomb fixture sweep (no-op; closed by audit comment).** Swept `scripts/tests/`, `Tests/WorkspaceManagerTests/`, `Tests/WorkspaceManagerAppTests/`, and the `web/`/`web-next/` test dirs for hardcoded timestamps whose meaning depends on wall-clock now — the class that broke clean main when a claim fixture's fixed `createdAt` crossed `STALE_CLAIM_HOURS=24`. Since main is green today, a live bomb must be a future-dated literal asserted fresh, or a fixture date flowing into production code that reads the wall clock internally; the sweep traced every date-literal test file to how its "now" enters. Result: every fixture pairs fixed dates with an injected/fixed clock (or the timestamps are decode-only passthrough) — no live offenders beyond the one already fixed in PR #1112. `scripts/tests/test_run_contributor.py` (owned by another worker this sweep) was audited read-only: clean, nothing to hand over. Full method + per-file trace in the evidence log.

**#1127 — prune impossible instructions from April's persona.** `april-clearwater.md` told the model to check out PR branches, create/switch branches (`codex/april-clearwater-issue-<n>-<slug>`), and run `gh pr view`/`gh issue view` — but the contributor runtime caps its tools at `Read,Grep,Glob,Edit,Write,MultiEdit` (no Bash), does the branching itself (`run-contributor.py`), and provides PR/issue state in context. Five instructions replaced with what actually happens: the model edits files in the workspace; the runtime handles git; comparisons use the provided context. Impossible-action pruning only — no restyling. Scope extension per coordinator direction: same class, both personas — `plat-ironwood.md` carried the identical five instructions and gets the identical prune (see the Mergeability flag). `test_run_contributor.py` (56/56) and `test_run_planner.py` (110/110, includes persona-name extraction from both files) pass after both edits.

**#1128 — encode the operational lessons.** New `## Operational lessons` runbook section in `docs/development/agent-factory-v2-plan.md`: (a) stale CHANGES_REQUESTED after a body-only fix → re-dispatch `factory-review.yml` with the PR number so the counterpart supersedes its own verdict (owner API dismissal is the blocked anti-pattern); (b) comment/label-triggered workflows execute the default-branch definition — pre-flight against `main`, not your checkout; (c) the evidence-status body block is the owner's attestation surface — edit statuses, strip `blocked`, re-dispatch, and the runtime applies `mergeable` to PR + source issue on the superseding approval. One pointer sentence added to the overview HTML's existing §07 Operations section (no restructure).

## Evidence

- [Sweep method + per-file trace + test runs](https://evidence.cloudcompute.com/workspaces/pr-1132/20260717-200039-time-bomb-sweep-audit-v2.txt) (v2: verification section covers the both-personas prune; [v1](https://evidence.cloudcompute.com/workspaces/pr-1132/20260717-195753-time-bomb-sweep-audit.txt))
- Diff-evidence for the persona prune and docs changes (docs/persona surface, no runtime behavior)

## Mergeability

- **Surface:** docs + agent persona prompts (`docs/development/agent-factory-v2-plan.md`, `agent-factory-v2-overview.html`, `.agents/skills/cofounder-contributor/references/april-clearwater.md` + `plat-ironwood.md`); no product or runtime code
- **User-facing behavior changed:** none — persona text steers future factory implement/review runs; docs are owner-facing runbook material
- **Non-happy paths considered:** persona-name extraction (`test_run_planner.py`) and the contributor suite still pass against both edited files; the `plat-ironwood.md` flag from the first push is resolved — same defect class, pruned identically in the same PR per coordinator direction; HTML pointer is additive inside the existing §07 section
- **Residual risk or follow-up:** the ops-lessons section describes today's close-out mechanics; if the M4 revision loop (#1125) ships, lesson 1 becomes the interim procedure it references

Closes #1127
Closes #1128

## Review loop

Worker PR under the factory-m3-hands coordinator, who holds review + merge authority. The factory review lane will also auto-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
