### PR TITLE
fix(factory): pin and restrict planner lane model invocation

### DIFF
--- a/.agents/scripts/test_run_planner.py
+++ b/.agents/scripts/test_run_planner.py
@@ -614,7 +614,7 @@ class RunPlannerTests(unittest.TestCase):
         self.assertEqual(payload[1]["trust_level"], "owner")
         self.assertEqual(payload[2]["trust_level"], "public")
 
-    def test_run_planner_claude_invocation_uses_static_system_prompt_without_tools(self) -> None:
+    def test_run_planner_claude_invocation_uses_static_system_prompt_and_read_only_tools(self) -> None:
         fixture = load_fixture("planner-prompt-injection.json")
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
         with (
@@ -624,11 +624,35 @@ class RunPlannerTests(unittest.TestCase):
             run_planner.run_claude(fixture["discussion"], CATALOG, {}, mode="cli")
         cmd = run_checked.call_args.kwargs["cmd"] if "cmd" in run_checked.call_args.kwargs else run_checked.call_args.args[0]
         self.assertNotIn("--append-system-prompt", cmd)
-        self.assertNotIn("--tools", cmd)
         self.assertNotIn("--permission-mode", cmd)
+        # Read-only spec drafting: exposure (--tools) and permission
+        # (--allowedTools) are separate gates and must carry the same list.
+        self.assertEqual(cmd[cmd.index("--tools") + 1], run_planner.PLANNER_TOOLS)
+        self.assertEqual(cmd[cmd.index("--allowedTools") + 1], run_planner.PLANNER_TOOLS)
+        self.assertNotIn("Edit", run_planner.PLANNER_TOOLS)
+        self.assertNotIn("Write", run_planner.PLANNER_TOOLS)
+        self.assertNotIn("Bash", run_planner.PLANNER_TOOLS)
         self.assertIn("Trust policy:", cmd[-1])
         self.assertIn("PROMPT INJECTION", cmd[-1])
         self.assertNotIn("PROMPT INJECTION", cmd[cmd.index("--system-prompt") + 1])
+
+    def test_run_planner_claude_cli_package_is_version_pinned(self) -> None:
+        # The planner fetches the CLI with GH_TOKEN in the environment, so it
+        # must never resolve `@latest`. Same guard as the contributor lane.
+        fixture = load_fixture("planner-prompt-injection.json")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
+        with (
+            mock.patch.object(run_planner, "repo_owner_name", return_value=("fairchild", "workspaces")),
+            mock.patch.object(run_planner, "run_checked", return_value=completed) as run_checked,
+        ):
+            run_planner.run_claude(fixture["discussion"], CATALOG, {}, mode="cli")
+        cmd = run_checked.call_args.args[0]
+        self.assertNotIn("@anthropic-ai/claude-code", cmd)
+        self.assertIn(run_planner.CLAUDE_CODE_PACKAGE, cmd)
+        package = run_planner.CLAUDE_CODE_PACKAGE
+        self.assertTrue(package.startswith("@anthropic-ai/claude-code@"))
+        self.assertRegex(package.rsplit("@", 1)[1], r"^\d+\.\d+\.\d+")
+        self.assertEqual(package, run_contributor.CLAUDE_CODE_PACKAGE)
 
 
 class RunContributorTests(unittest.TestCase):

--- a/.agents/skills/peter-planner/scripts/run-planner.py
+++ b/.agents/skills/peter-planner/scripts/run-planner.py
@@ -40,6 +40,21 @@ PLANNER_TASK_CLI = (
 )
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
+# Pin the Claude Code CLI to an exact version so a compromised `@latest` release
+# can't run in the planner job (GH_TOKEN is in the environment). Shares the
+# contributor lane's bump var so one env/repo-var moves both lanes together.
+CLAUDE_CODE_VERSION = os.environ.get(
+    "CONTRIBUTOR_CLAUDE_CODE_VERSION", "2.1.200"
+).strip() or "2.1.200"
+CLAUDE_CODE_PACKAGE = f"@anthropic-ai/claude-code@{CLAUDE_CODE_VERSION}"
+
+# The planner drafts issue specs and is asked to reference relevant source
+# files, so it gets read-only repo access — never Edit/Write/Bash. --tools
+# only controls exposure; --allowedTools is the separate permission gate, and
+# headless --print runs cannot answer permission prompts, so both must carry
+# the same list or every tool call is silently denied.
+PLANNER_TOOLS = "Read,Grep,Glob"
+
 # Timeouts (seconds) — every external call must declare its budget
 GITHUB_API_TIMEOUT = 30
 CLAUDE_TIMEOUT = 300
@@ -861,10 +876,14 @@ def run_claude(
     cmd = [
         "npx",
         "--yes",
-        "@anthropic-ai/claude-code",
+        CLAUDE_CODE_PACKAGE,
         "--print",
         "--system-prompt",
         PROMPT_FILE.read_text(encoding="utf-8"),
+        "--tools",
+        PLANNER_TOOLS,
+        "--allowedTools",
+        PLANNER_TOOLS,
     ]
     timeout = CLAUDE_TIMEOUT
     if mode == "cli":


### PR DESCRIPTION
## Summary

The planner lane (`run_claude` in `.agents/skills/peter-planner/scripts/run-planner.py`) invoked unpinned `@anthropic-ai/claude-code` — `npx --yes` resolves `@latest` on every run — with `GH_TOKEN` in the environment and no tool restriction. The contributor lane already pins 2.1.200 and caps tools (#1112); this matches it.

- Pins the CLI to `@anthropic-ai/claude-code@2.1.200` through the same bump var the contributor lane reads (`CONTRIBUTOR_CLAUDE_CODE_VERSION`), so one env/repo-var moves both lanes together. A new test asserts the two lanes' package specs stay equal.
- Restricts tools to `Read,Grep,Glob`: the planner drafts issue specs and its prompt asks it to reference relevant source files, so it gets read-only repo access — never Edit/Write/Bash. `--allowedTools` carries the same list per the #1112 lesson: `--tools` is exposure, `--allowedTools` is the separate permission gate, and headless `--print` runs cannot answer permission prompts.

Note: issue #1116 names `cofounder-contributor/scripts/run-planner.py`; the planner actually lives in the peter-planner skill (`.agents/skills/peter-planner/scripts/run-planner.py`, with `.agents/scripts/run-planner.py` as a compatibility shim onto it).

## Evidence

[Live planner-lane smoke + test suites](https://evidence.cloudcompute.com/workspaces/pr-1133/20260717-200210-planner-pin-tools-smoke.txt) — the patched `run_claude` imported from `run-planner.py` and driven against the real pinned CLI with the repo's prompt-injection fixture (isolated HOME, untrusted cwd matching the production runner posture): returncode 0, valid multi-document plan produced, planner validator accepts it, and the model resists the fixture's public-comment injection. Suites on the rebase: planner 111/111, contributor 62/62, validate-agent-output 3/3, frontmatter 23/23.

## Mergeability

- **Surface:** infra — factory planner runtime (model invocation flags) + planner test suite. No app/web code.
- **User-facing behavior changed:** none for humans; planner runs now fetch a pinned CLI and expose only read tools.
- **Non-happy paths considered:** untrusted-cwd runners (the workspace-trust stderr warning is non-fatal, and the plan contract does not depend on tool access — the discussion payload is inline); an empty/whitespace `CONTRIBUTOR_CLAUDE_CODE_VERSION` falls back to the pinned default; `--mode print` gets the same restriction as `cli`.
- **Residual risk or follow-up:** `GH_TOKEN` remains in the planner process env (the script needs it for its own `gh` calls); narrowing the model subprocess env the way the contributor's `sanitized_claude_env` does would be the next step and is out of scope here.

## Review loop

Worker PR under the factory-m3-hands orchestrator, who holds review + merge authority.

Closes #1116
