### PR TITLE
fix(factory): scope contributor write grant and adopt stream-json telemetry

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -440,7 +440,10 @@ def export_head_tree(destination: Path, env: dict[str, str]) -> None:
 
 
 def create_scratch_workspace(env: dict[str, str]) -> ScratchPatchArtifact:
-    temp_root = Path(tempfile.mkdtemp(prefix="contributor-scratch-"))
+    # resolve(): macOS mkdtemp returns symlinked paths (/var -> /private/var);
+    # project trust and path-scoped permission rules must both use the real
+    # path or the runtime's permission matcher never recognizes the scratch.
+    temp_root = Path(tempfile.mkdtemp(prefix="contributor-scratch-")).resolve()
     baseline_dir = temp_root / "baseline"
     scratch_dir = temp_root / "scratch"
     export_head_tree(baseline_dir, env)
@@ -685,6 +688,88 @@ def ensure_claude_project_trust(cwd: Path, env: dict[str, str]) -> None:
     config_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+WRITE_SCOPED_TOOLS = ("Edit", "Write", "MultiEdit")
+
+
+def scoped_tool_rules(tools: str, write_scope: Path | None) -> str:
+    """Permission rules for --allowedTools. With a write scope, the write
+    tools become path-scoped rules (`Tool(//abs/path/**)` — claude-code's
+    absolute-path rule syntax) so the grant is bound to the scratch; read
+    tools stay bare. Proven against the pinned CLI (#1117): in-scope edits
+    land, out-of-scope edits are permission-denied and recorded in
+    stream-json `permission_denials`."""
+    if write_scope is None:
+        return tools
+    pattern = f"//{str(write_scope.resolve()).lstrip('/')}/**"
+    return ",".join(
+        f"{tool}({pattern})" if tool in WRITE_SCOPED_TOOLS else tool
+        for tool in tools.split(",")
+    )
+
+
+@dataclass(frozen=True)
+class StreamRunSummary:
+    result_text: str | None
+    result_subtype: str
+    tool_uses: list[dict[str, Any]]
+    permission_denials: list[dict[str, Any]]
+
+
+def summarize_stream_json(raw_output: str) -> StreamRunSummary:
+    """Fold a `--output-format stream-json` transcript into the final result
+    text plus the telemetry CI needs: every tool attempt and every permission
+    denial. Non-stream output yields result_text=None so callers can fall
+    back to the raw text."""
+    result_text: str | None = None
+    result_subtype = ""
+    tool_uses: list[dict[str, Any]] = []
+    permission_denials: list[dict[str, Any]] = []
+    for line in raw_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "assistant":
+            for block in (event.get("message") or {}).get("content", []):
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tool_uses.append(
+                        {"name": block.get("name"), "input": block.get("input") or {}}
+                    )
+        elif event.get("type") == "result":
+            result_text = str(event.get("result") or "")
+            result_subtype = str(event.get("subtype") or "")
+            denials = event.get("permission_denials")
+            if isinstance(denials, list):
+                permission_denials = [d for d in denials if isinstance(d, dict)]
+    return StreamRunSummary(
+        result_text=result_text,
+        result_subtype=result_subtype,
+        tool_uses=tool_uses,
+        permission_denials=permission_denials,
+    )
+
+
+def emit_stream_telemetry(summary: StreamRunSummary) -> None:
+    if summary.result_subtype:
+        log(f"Model run finished: {summary.result_subtype}")
+    log(f"Tool attempts: {len(summary.tool_uses)}")
+    for use in summary.tool_uses:
+        rendered_input = json.dumps(use.get("input", {}), ensure_ascii=False)[:200]
+        log(f"  tool_use: {use.get('name')} {rendered_input}")
+    if summary.permission_denials:
+        log(f"Permission denials: {len(summary.permission_denials)}")
+        for denial in summary.permission_denials:
+            rendered_input = json.dumps(denial.get("tool_input", {}), ensure_ascii=False)[:200]
+            log(f"  denied: {denial.get('tool_name')} {rendered_input}")
+    else:
+        log("Permission denials: none")
+
+
 def run_claude(
     system_prompt: str | Path,
     task: str,
@@ -695,6 +780,7 @@ def run_claude(
     timeout: int | None = None,
     budget: str = "2.50",
     cwd: Path | None = None,
+    write_scope: Path | None = None,
 ) -> str:
     prompt_text = (
         system_prompt.read_text(encoding="utf-8")
@@ -707,11 +793,18 @@ def run_claude(
     # project trust instead: only the implement scratch (repo HEAD export) is
     # seeded trusted; PR-head review checkouts stay untrusted, so headless
     # Claude skips their settings, hooks, and CLAUDE.md.
+    #
+    # stream-json (+ --verbose, required with --print): tool attempts and
+    # permission_denials land in CI logs on every run; the model's final text
+    # is extracted from the `result` event, preserving the return contract.
     cmd = [
         "npx",
         "--yes",
         CLAUDE_CODE_PACKAGE,
         "--print",
+        "--output-format",
+        "stream-json",
+        "--verbose",
         "--system-prompt",
         prompt_text,
     ]
@@ -722,12 +815,19 @@ def run_claude(
             # use them is a separate gate. In --print mode nothing can answer
             # permission prompts, so without --allowedTools every Edit/Write
             # call is silently denied and execution runs finish with prose
-            # instead of file changes.
-            cmd.extend(["--tools", tools, "--allowedTools", tools])
+            # instead of file changes. The write tools' permission rules are
+            # path-scoped to the scratch when one is given.
+            cmd.extend(["--tools", tools, "--allowedTools", scoped_tool_rules(tools, write_scope)])
         cmd.extend(["--max-budget-usd", budget])
         effective_timeout = timeout or 1200
     cmd.append(task)
-    return run_checked(cmd, timeout=effective_timeout, cwd=cwd or REPO_ROOT, env=env).stdout
+    raw_output = run_checked(cmd, timeout=effective_timeout, cwd=cwd or REPO_ROOT, env=env).stdout
+    summary = summarize_stream_json(raw_output)
+    emit_stream_telemetry(summary)
+    if summary.result_text is None:
+        log("stream-json result event missing; returning raw model output")
+        return raw_output
+    return summary.result_text
 
 
 def contributor_model_cwd(selection_kind: str, env: dict[str, str]) -> Path:
@@ -1397,6 +1497,9 @@ def main() -> int:
             mode=args.mode,
             tools=contributor_tools_for_selection(choice.selection_kind),
             cwd=claude_cwd,
+            write_scope=(
+                scratch_workspace.scratch_dir if scratch_workspace is not None else None
+            ),
         )
         exit_code, validated_json, error_text = validate_output(raw_output, env)
 
@@ -1420,10 +1523,12 @@ def main() -> int:
             log(f"Applying scratch patch with {len(artifact.changed_files)} changed files")
             if not artifact.changed_files:
                 # Downstream routing fails on execution actions without file
-                # changes; surface what the model actually did so CI logs show
-                # tool denials or prose-only runs instead of swallowing them.
-                print("--- Model output (tail) ---", file=sys.stderr)
-                print(raw_output[-4000:], file=sys.stderr)
+                # changes; the per-run stream-json telemetry above already
+                # shows every tool attempt and permission denial.
+                log(
+                    "Scratch has zero changed files; see the stream-json "
+                    "telemetry above for tool attempts and permission denials"
+                )
             enforce_agent_patch_policy(
                 artifact,
                 env,

--- a/scripts/tests/test_run_contributor.py
+++ b/scripts/tests/test_run_contributor.py
@@ -291,6 +291,9 @@ class RunContributorEvidenceTests(unittest.TestCase):
         # them or every linked path becomes a phantom diff the patch refuses.
         self.assertTrue(symlinks)
         self.assertEqual(artifact.changed_files, [])
+        # Trust seeding and path-scoped permission rules both key on the real
+        # path, so the workspace root must come pre-resolved.
+        self.assertEqual(workspace.temp_root, workspace.temp_root.resolve())
 
     def test_scratch_diff_detects_symlink_target_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -372,6 +375,150 @@ class RunContributorEvidenceTests(unittest.TestCase):
             command[command.index("--allowedTools") + 1],
             run_contributor.EXECUTION_TOOLS,
         )
+
+    def test_write_grant_is_scoped_to_the_scratch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scratch = Path(tmpdir).resolve()
+            with mock.patch.object(
+                run_contributor,
+                "run_checked",
+                return_value=mock.Mock(stdout="ok"),
+            ) as run_checked:
+                run_contributor.run_claude(
+                    "system",
+                    "task",
+                    {"HOME": "/tmp", "PATH": "/usr/bin"},
+                    mode="cli",
+                    tools=run_contributor.EXECUTION_TOOLS,
+                    write_scope=scratch,
+                )
+
+        command = run_checked.call_args.args[0]
+        pattern = f"//{str(scratch).lstrip('/')}/**"
+        # Exposure stays bare tool names; the permission rules bind every
+        # write tool to the scratch while read tools stay unscoped.
+        self.assertEqual(command[command.index("--tools") + 1], run_contributor.EXECUTION_TOOLS)
+        self.assertEqual(
+            command[command.index("--allowedTools") + 1],
+            f"Read,Grep,Glob,Edit({pattern}),Write({pattern}),MultiEdit({pattern})",
+        )
+
+    def test_scoped_tool_rules_resolve_symlinked_scratch_paths(self) -> None:
+        # macOS mkdtemp hands out symlinked paths (/var -> /private/var); the
+        # permission matcher compares real paths, so an unresolved pattern
+        # would deny every in-scratch edit.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_dir = Path(tmpdir).resolve() / "real"
+            real_dir.mkdir()
+            alias = Path(tmpdir).resolve() / "alias"
+            alias.symlink_to(real_dir)
+
+            rules = run_contributor.scoped_tool_rules("Read,Edit", alias)
+
+        self.assertEqual(
+            rules,
+            f"Read,Edit(//{str(real_dir).lstrip('/')}/**)",
+        )
+        self.assertEqual(
+            run_contributor.scoped_tool_rules(run_contributor.EXECUTION_TOOLS, None),
+            run_contributor.EXECUTION_TOOLS,
+        )
+
+    def test_run_claude_requests_stream_json_telemetry(self) -> None:
+        for mode in ("cli", "print"):
+            with self.subTest(mode=mode):
+                with mock.patch.object(
+                    run_contributor,
+                    "run_checked",
+                    return_value=mock.Mock(stdout="ok"),
+                ) as run_checked:
+                    run_contributor.run_claude(
+                        "system",
+                        "task",
+                        {"HOME": "/tmp", "PATH": "/usr/bin"},
+                        mode=mode,
+                        tools=run_contributor.EXECUTION_TOOLS,
+                    )
+                command = run_checked.call_args.args[0]
+                self.assertEqual(
+                    command[command.index("--output-format") + 1], "stream-json"
+                )
+                # --print requires --verbose for stream-json output.
+                self.assertIn("--verbose", command)
+
+    def test_run_claude_extracts_result_text_and_logs_denials(self) -> None:
+        stream = "\n".join(
+            [
+                json.dumps({"type": "system", "subtype": "init"}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "name": "Edit",
+                                    "input": {"file_path": "/outside/forbidden.txt"},
+                                }
+                            ]
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "result": "---\naction: propose\n---\nfinal text",
+                        "permission_denials": [
+                            {
+                                "tool_name": "Edit",
+                                "tool_input": {"file_path": "/outside/forbidden.txt"},
+                            }
+                        ],
+                    }
+                ),
+            ]
+        )
+
+        with io.StringIO() as stderr, contextlib.redirect_stderr(stderr):
+            with mock.patch.object(
+                run_contributor,
+                "run_checked",
+                return_value=mock.Mock(stdout=stream),
+            ):
+                output = run_contributor.run_claude(
+                    "system",
+                    "task",
+                    {"HOME": "/tmp", "PATH": "/usr/bin"},
+                    mode="cli",
+                    tools=run_contributor.EXECUTION_TOOLS,
+                )
+            telemetry = stderr.getvalue()
+
+        # Downstream parses the model's final text: the return contract is the
+        # `result` event payload, not the raw stream transcript.
+        self.assertEqual(output, "---\naction: propose\n---\nfinal text")
+        self.assertIn("Tool attempts: 1", telemetry)
+        self.assertIn("tool_use: Edit", telemetry)
+        self.assertIn("Permission denials: 1", telemetry)
+        self.assertIn("denied: Edit", telemetry)
+        self.assertIn("/outside/forbidden.txt", telemetry)
+
+    def test_run_claude_falls_back_to_raw_output_without_result_event(self) -> None:
+        with mock.patch.object(
+            run_contributor,
+            "run_checked",
+            return_value=mock.Mock(stdout="plain prose output"),
+        ):
+            output = run_contributor.run_claude(
+                "system",
+                "task",
+                {"HOME": "/tmp", "PATH": "/usr/bin"},
+                mode="cli",
+                tools=run_contributor.READ_ONLY_MODEL_TOOLS,
+            )
+
+        self.assertEqual(output, "plain prose output")
 
     def test_project_trust_seeding_preserves_existing_config(self) -> None:
         with tempfile.TemporaryDirectory() as home:


### PR DESCRIPTION
## Summary

Two changes to `run_claude` in `.agents/skills/cofounder-contributor/scripts/run-contributor.py`, shipped together because they land in the same function and the headless repro proves them jointly.

**#1117 — write grant scoped to the scratch.** `--allowedTools Edit,Write,MultiEdit` granted writes to any path the process could reach; containment was patch-diff-only. Repro verdict against the pinned 2.1.200: path-scoped permission rules in `--allowedTools` **are supported** in `--print` mode, via the `Tool(//abs/path/**)` absolute-path rule syntax. `run_claude` now takes a `write_scope` and rewrites the write-tool rules to `Edit(//<scratch>/**)`, `Write(...)`, `MultiEdit(...)`; read tools stay bare and `--tools` exposure is unchanged. The scratch root is resolved at creation: macOS `mkdtemp` hands out symlinked paths (`/var` → `/private/var`) and the permission matcher compares real paths — the post-fix run exercises this exact condition (mkdtemp returned `/var/folders/...`, the rule used the resolved `/private/var/...`, and the in-scratch edit still landed).

**#1126 — stream-json telemetry.** Every run now passes `--output-format stream-json --verbose`; `run_claude` folds the stream into per-run stderr telemetry — every tool attempt and every `permission_denials` entry — and returns the model's final text extracted from the `result` event. The return contract downstream (validate-agent-output, action routing) is unchanged, with a raw-output fallback when no result event exists. This subsumes the #1112 zero-changes output-tail echo, which becomes a pointer log line.

## Evidence

[Headless repro + post-fix verification + test suites](https://evidence.cloudcompute.com/workspaces/pr-1134/20260717-200210-scratch-scope-stream-json-repro.txt) — all runs use the pinned CLI, isolated HOME, trust seeded only for the scratch cwd, sanitized env, exact `run_claude` flag set:

- **Part 1 (capability, pre-implementation):** with scoped rules an in-scratch edit lands; an instructed edit outside the scratch is permission-denied (recorded in stream-json `permission_denials`) and the file stays untouched; the unscoped control — the current CI shape — successfully writes outside the scratch, which is the hole this closes.
- **Part 2:** canonical `//path-from-root/**` rule form and a symlinked-cwd probe both pass.
- **Part 3 (post-fix, headline):** the patched `run_claude` imported from `run-contributor.py` and driven end-to-end — in-scratch edit lands, out-of-scratch edit denied, the denial is visible in the telemetry log, and the returned value is the model's final text, not the stream.
- **Part 4:** contributor 67/67, validate-agent-output 3/3, planner 110/110, factory workflows + review suites, pr-readiness 21/21 — green on the rebase including #1130 (which touched the same files).

## Mergeability

- **Surface:** infra — factory contributor runtime (`run_claude` permission rules + output format, scratch creation) + its test suite. No app/web code.
- **User-facing behavior changed:** none for humans; factory implement runs can no longer write outside their scratch workspace, and CI logs show every tool attempt and permission denial on every run.
- **Non-happy paths considered:** review/selector lanes pass no `write_scope`, so read-only grants are unchanged; non-stream or malformed model output falls back to the raw text (legacy contract preserved — also keeps `--mode print` and mocked-output tests working); error result subtypes are logged; telemetry inputs are truncated to 200 chars; the patch-diff containment and privileged-path patch policy remain as the second enforcement layer.
- **Residual risk or follow-up:** Read/Grep/Glob stay unscoped — the model can still read outside the scratch (matches the existing trust model; scoping reads would break repo-context gathering). Bash was never granted. The next factory implement run in production is the live proof of the telemetry lane.

## Review loop

Worker PR under the factory-m3-hands orchestrator, who holds review + merge authority.

Closes #1117
Closes #1126
