### PR TITLE
feat(factory): review-time live CI verification and diff evidence completion

### DIFF
--- a/.agents/skills/cofounder-contributor/scripts/evidence.py
+++ b/.agents/skills/cofounder-contributor/scripts/evidence.py
@@ -595,7 +595,14 @@ def review_evidence_gate_error(verdict: str, accounting: dict[str, object], erro
             "requested evidence is still blocked and review must stay in request_changes; "
             f"blocked: {preview}"
         )
-    pending_ci_items = accounting.get("pending_ci_items", [])
+    # Pending `diff` items do not block approve: the approving review IS the
+    # verification act, and the review lane writes the completion (bound to
+    # the review URL and head SHA) immediately after the approval lands.
+    pending_ci_items = [
+        item
+        for item in accounting.get("pending_ci_items", [])
+        if _evidence_item_kind(str(item)) != "diff"
+    ]
     if pending_ci_items:
         preview = "; ".join(str(item) for item in pending_ci_items[:3])
         return (

--- a/.agents/skills/cofounder-contributor/scripts/execution.py
+++ b/.agents/skills/cofounder-contributor/scripts/execution.py
@@ -42,14 +42,19 @@ from _helpers import (
     short_persona_name,
 )
 from evidence import (
+    _ci_check_name,
+    _evidence_item_kind,
+    _extract_evidence_metadata,
     _extract_test_commands,
     _has_unautomatable_evidence,
     _needs_macos_evidence,
     _needs_screenshot_evidence,
     classify_evidence_errors,
+    latest_completed_check_run,
     render_execution_summary_body,
     review_evidence_gate_error,
     synthesize_initial_execution_evidence,
+    update_evidence_entries,
     validate_evidence_accounting,
     validate_requested_test_commands,
 )
@@ -529,6 +534,153 @@ def _update_mergeable_label(pr_number: int, verdict: str, env: dict[str, str]) -
         cwd=REPO_ROOT,
         env=env,
     )
+
+
+def _pr_body_and_head(pr_number: int, env: dict[str, str]) -> tuple[str, str]:
+    pr = json.loads(
+        run_checked(
+            ["gh", "pr", "view", str(pr_number), "--json", "body,headRefOid"],
+            timeout=GITHUB_API_TIMEOUT,
+            cwd=REPO_ROOT,
+            env=env,
+        ).stdout
+    )
+    return str(pr.get("body") or ""), str(pr.get("headRefOid") or "")
+
+
+def _pr_evidence_entries(body: str) -> list[dict[str, object]]:
+    metadata = _extract_evidence_metadata(body)
+    entries = metadata.get("entries") if isinstance(metadata, dict) else None
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _live_ci_evidence_gate_error(pr_number: int, env: dict[str, str]) -> str | None:
+    """The PR body is untrusted at review time: before an approve counts,
+    every named-check evidence entry is re-verified against the live
+    check-run state on the current head, never the recorded conclusion."""
+    body, head_sha = _pr_body_and_head(pr_number, env)
+    expected = env.get("FACTORY_EXPECTED_PR_HEAD_SHA", "").strip()
+    if expected and not hmac.compare_digest(head_sha, expected):
+        return "PR head changed during Factory review"
+    if not head_sha:
+        return "PR head could not be resolved for live CI verification"
+    for entry in _pr_evidence_entries(body):
+        item = str(entry.get("item", "")).strip()
+        if _evidence_item_kind(item) != "ci":
+            continue
+        check_name = _ci_check_name(item)
+        if check_name is None:
+            return f"ci evidence entry has no extractable check name: {item!r}"
+        run = latest_completed_check_run(check_name, head_sha, env)
+        conclusion = str(run.get("conclusion", "") or "").strip() if isinstance(run, dict) else ""
+        if conclusion != "success":
+            return (
+                f"named check `{check_name}` is not green on head {head_sha[:12]} "
+                f"(live conclusion: {conclusion or 'none'})"
+            )
+    return None
+
+
+def _latest_approving_review(
+    pr_number: int,
+    head_sha: str,
+    env: dict[str, str],
+) -> dict[str, object] | None:
+    """Most recent APPROVED review bound to exactly this head, or None."""
+    owner, name = repo_owner_name(env)
+    raw = run_optional(
+        ["gh", "api", f"repos/{owner}/{name}/pulls/{pr_number}/reviews"],
+        timeout=GITHUB_API_TIMEOUT,
+        cwd=REPO_ROOT,
+        env=env,
+        default="",
+    )
+    try:
+        reviews = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(reviews, list):
+        return None
+    approved = [
+        review
+        for review in reviews
+        if isinstance(review, dict)
+        and review.get("state") == "APPROVED"
+        and str(review.get("commit_id", "")) == head_sha
+    ]
+    if not approved:
+        return None
+    return max(approved, key=lambda review: str(review.get("submitted_at", "")))
+
+
+def _edit_pr_body(pr_number: int, body: str, env: dict[str, str]) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".md", delete=False) as handle:
+        handle.write(body)
+        body_file = handle.name
+    try:
+        run_checked(
+            ["gh", "pr", "edit", str(pr_number), "--body-file", body_file],
+            timeout=GITHUB_API_TIMEOUT,
+            cwd=REPO_ROOT,
+            env=env,
+        )
+    finally:
+        try:
+            os.unlink(body_file)
+        except OSError:
+            pass
+
+
+def _complete_diff_evidence_after_approval(pr_number: int, env: dict[str, str]) -> None:
+    """The approving review is the verification act for diff-kind evidence:
+    bind the completion to the review URL and the exact reviewed head.
+
+    Best-effort by design — if anything here fails, the entries stay
+    pending-ci and the readiness gate stays red (fail-closed)."""
+    body, head_sha = _pr_body_and_head(pr_number, env)
+    if not head_sha:
+        return
+    pending_diff = [
+        entry
+        for entry in _pr_evidence_entries(body)
+        if _evidence_item_kind(str(entry.get("item", "")).strip()) == "diff"
+        and str(entry.get("status", "")).strip() == "pending-ci"
+    ]
+    if not pending_diff:
+        return
+    review = _latest_approving_review(pr_number, head_sha, env)
+    if review is None:
+        log(
+            f"PR #{pr_number}: no approving review bound to head {head_sha[:12]}; "
+            "leaving diff evidence pending"
+        )
+        return
+    review_url = str(review.get("html_url", "") or "").strip()
+    link = f" — {review_url}" if review_url else ""
+    updates: dict[int, dict[str, object]] = {}
+    for entry in pending_diff:
+        try:
+            index = int(entry["index"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        updates[index] = {
+            "status": "complete",
+            "detail": f"diff-verified by the counterpart approving review on head {head_sha[:12]}{link}",
+            "kind": "diff",
+            "verified_head_sha": head_sha,
+            "proof_url": review_url,
+        }
+    if not updates:
+        return
+    new_body = update_evidence_entries(body, updates)
+    if new_body == body:
+        return
+    if not _factory_expected_pr_head_is_current(pr_number, env):
+        return
+    _edit_pr_body(pr_number, new_body, env)
+    log(f"PR #{pr_number}: completed {len(updates)} diff evidence entries from the approving review")
 
 
 def _factory_expected_pr_head_is_current(pr_number: int, env: dict[str, str]) -> bool:
@@ -1057,6 +1209,15 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                     categories = [c["category"] for c in classify_evidence_errors(review_state["evidence_errors"])]
                     log(json.dumps({"error_class": "evidence_gate", "categories": categories, "pr": pr_number, "verdict": verdict}))
                     return 1
+            if verdict in ("approve", "approve_with_followups"):
+                live_gate_error = _mod._live_ci_evidence_gate_error(pr_number, env)
+                if live_gate_error is not None:
+                    print(
+                        f"error: PR #{pr_number} cannot be approved: {live_gate_error}",
+                        file=sys.stderr,
+                    )
+                    log(json.dumps({"error_class": "evidence_gate", "categories": ["ci_live_verification"], "pr": pr_number, "verdict": verdict}))
+                    return 1
             review_flag = {
                 "approve": "--approve",
                 "approve_with_followups": "--approve",
@@ -1110,6 +1271,8 @@ def route_action(validated_json: str, dry_run: bool, env: dict[str, str]) -> int
                     _dismiss_own_blocking_reviews(pr_number, bot, env)
             if not _factory_expected_pr_head_is_current(pr_number, env):
                 return 1
+            if review_flag == "--approve":
+                _mod._complete_diff_evidence_after_approval(pr_number, env)
             _mod._update_mergeable_label(int(data["pr_number"]), verdict, env)
             return 0
         if action == "execute_issue":

--- a/.agents/skills/cofounder-contributor/scripts/run-contributor.py
+++ b/.agents/skills/cofounder-contributor/scripts/run-contributor.py
@@ -213,7 +213,13 @@ from triage import (  # noqa: E402, F401
 from execution import (  # noqa: E402, F401
     APP_BOT_GIT_IDENTITIES,
     _changed_surface_files,
+    _complete_diff_evidence_after_approval,
+    _edit_pr_body,
+    _latest_approving_review,
+    _live_ci_evidence_gate_error,
     _mergeability_surface,
+    _pr_body_and_head,
+    _pr_evidence_entries,
     _update_mergeable_label,
     _write_github_outputs,
     app_bot_git_identity,

--- a/.github/workflows/ci-agents.yml
+++ b/.github/workflows/ci-agents.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/factory-evidence-verify.py"
       - "scripts/tests/test_factory_evidence_kinds.py"
       - "scripts/tests/test_factory_evidence_verify.py"
+      - "scripts/tests/test_factory_evidence_review.py"
       - "scripts/factory-responder-payload.py"
       - "scripts/tests/test_factory_workflows.py"
       - "scripts/tests/test_factory_janitor.py"
@@ -48,6 +49,7 @@ on:
       - "scripts/factory-evidence-verify.py"
       - "scripts/tests/test_factory_evidence_kinds.py"
       - "scripts/tests/test_factory_evidence_verify.py"
+      - "scripts/tests/test_factory_evidence_review.py"
       - "scripts/factory-responder-payload.py"
       - "scripts/tests/test_factory_workflows.py"
       - "scripts/tests/test_factory_janitor.py"
@@ -110,6 +112,7 @@ jobs:
         run: |
           uv run --script scripts/tests/test_factory_evidence_kinds.py
           uv run --script scripts/tests/test_factory_evidence_verify.py
+          uv run --script scripts/tests/test_factory_evidence_review.py
           uv run --script scripts/tests/test_factory_comment_responder.py
 
       - name: Run Fable orchestrator tests

--- a/.github/workflows/factory-evidence-verify.yml
+++ b/.github/workflows/factory-evidence-verify.yml
@@ -28,10 +28,11 @@ concurrency:
 
 jobs:
   verify:
+    # Kill switches gate every entry path, manual dispatch included
+    # (M3 hardening norm: no factory lane runs while switched off).
     if: >-
-      (github.event_name == 'workflow_dispatch' ||
-      (vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
-      vars.FACTORY_EVIDENCE_VERIFY_ENABLED == 'true')) &&
+      vars.AGENT_AUTOMATIONS_ENABLED == 'true' &&
+      vars.FACTORY_EVIDENCE_VERIFY_ENABLED == 'true' &&
       (github.event_name != 'check_suite' ||
       github.event.check_suite.pull_requests[0] != null)
     runs-on: ubuntu-latest

--- a/scripts/tests/test_factory_evidence_review.py
+++ b/scripts/tests/test_factory_evidence_review.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Policy tests for review-time evidence handling (#1120 step 3).
+
+Intent: pending diff items alone don't block approve (the approving review is
+the verification act, completed immediately after with review URL + head SHA),
+while the PR body stays untrusted — every named-check entry is re-verified
+live against the current head before an approve counts.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".agents" / "skills" / "cofounder-contributor" / "scripts" / "run-contributor.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Registered as "run_contributor" so route_action's `_mod` indirection sees
+# the same module these tests patch.
+run_contributor = load_module("run_contributor", SCRIPT_PATH)
+execution = sys.modules["execution"]
+
+HEAD = "c" * 40
+OTHER_HEAD = "d" * 40
+CI_ITEM = "CI: `Web CI` green on the PR head"
+DIFF_ITEM = "Diff: dot-only segments rejected, readable from the diff alone"
+
+
+def body_with_entries(entries: list[dict[str, object]]) -> str:
+    payload = json.dumps({"entries": entries}, indent=2, ensure_ascii=False)
+    lines = "\n".join(
+        f"- [{entry['status']}] {entry['item']} -- {entry['detail']}" for entry in entries
+    )
+    return (
+        "*Persona*\n\n## Summary\n- change\n\n"
+        f"<!-- evidence-status:v1\n{payload}\n-->\n\n"
+        f"## Evidence Status\n{lines}\n\n"
+        "## Validation\n- blocked on evidence: pending\n\n"
+        "Closes #99\n\n<!-- contributor:issue=99;agent=test -->"
+    )
+
+
+def accounting(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "blocked_items": [],
+        "pending_ci_items": [],
+        "missing_items": [],
+        "complete_items": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class ApproveGateDiffExemptionTests(unittest.TestCase):
+    def test_pending_diff_items_alone_do_not_block_approve(self) -> None:
+        self.assertIsNone(
+            run_contributor.review_evidence_gate_error(
+                "approve", accounting(pending_ci_items=[DIFF_ITEM]), []
+            )
+        )
+
+    def test_pending_non_diff_items_still_block_approve(self) -> None:
+        error = run_contributor.review_evidence_gate_error(
+            "approve", accounting(pending_ci_items=[CI_ITEM, DIFF_ITEM]), []
+        )
+        self.assertIsNotNone(error)
+        self.assertIn(CI_ITEM, error)
+        self.assertNotIn(DIFF_ITEM, error)
+
+    def test_blocked_diff_items_still_block_approve(self) -> None:
+        error = run_contributor.review_evidence_gate_error(
+            "approve", accounting(blocked_items=[DIFF_ITEM]), []
+        )
+        self.assertIsNotNone(error)
+        self.assertIn("blocked", error)
+
+    def test_request_changes_never_gates(self) -> None:
+        self.assertIsNone(
+            run_contributor.review_evidence_gate_error(
+                "request_changes", accounting(pending_ci_items=[CI_ITEM]), ["boom"]
+            )
+        )
+
+
+class LiveCiVerificationTests(unittest.TestCase):
+    def gate(self, body: str, *, run: object, env: dict[str, str] | None = None) -> str | None:
+        with (
+            mock.patch.object(execution, "_pr_body_and_head", return_value=(body, HEAD)),
+            mock.patch.object(execution, "latest_completed_check_run", return_value=run),
+        ):
+            return execution._live_ci_evidence_gate_error(42, env or {})
+
+    def test_green_live_check_passes(self) -> None:
+        body = body_with_entries(
+            [{"index": 1, "item": CI_ITEM, "status": "complete", "detail": "green earlier"}]
+        )
+        self.assertIsNone(self.gate(body, run={"conclusion": "success"}))
+
+    def test_recorded_complete_is_not_trusted_when_live_check_is_red(self) -> None:
+        body = body_with_entries(
+            [{"index": 1, "item": CI_ITEM, "status": "complete", "detail": "claims green"}]
+        )
+        error = self.gate(body, run={"conclusion": "failure"})
+        self.assertIsNotNone(error)
+        self.assertIn("`Web CI`", error)
+        self.assertIn("live conclusion: failure", error)
+
+    def test_missing_live_run_blocks_approve(self) -> None:
+        body = body_with_entries(
+            [{"index": 1, "item": CI_ITEM, "status": "complete", "detail": "claims green"}]
+        )
+        error = self.gate(body, run=None)
+        self.assertIsNotNone(error)
+        self.assertIn("live conclusion: none", error)
+
+    def test_expected_head_mismatch_blocks_approve(self) -> None:
+        body = body_with_entries(
+            [{"index": 1, "item": CI_ITEM, "status": "complete", "detail": "green"}]
+        )
+        error = self.gate(
+            body,
+            run={"conclusion": "success"},
+            env={"FACTORY_EXPECTED_PR_HEAD_SHA": OTHER_HEAD},
+        )
+        self.assertEqual(error, "PR head changed during Factory review")
+
+    def test_bodies_without_ci_entries_pass(self) -> None:
+        body = body_with_entries(
+            [{"index": 1, "item": DIFF_ITEM, "status": "pending-ci", "detail": "d"}]
+        )
+        self.assertIsNone(self.gate(body, run=None))
+        self.assertIsNone(self.gate("plain body without metadata", run=None))
+
+
+class ApprovingReviewBindingTests(unittest.TestCase):
+    def reviews(self, payload: object) -> object:
+        env = {"GITHUB_REPOSITORY": "acme/widgets"}
+        with mock.patch.object(execution, "run_optional", return_value=json.dumps(payload)):
+            return execution._latest_approving_review(42, HEAD, env)
+
+    def test_only_head_bound_approvals_qualify(self) -> None:
+        self.assertIsNone(
+            self.reviews(
+                [{"state": "APPROVED", "commit_id": OTHER_HEAD, "submitted_at": "2026-07-17T00:00:00Z"}]
+            )
+        )
+        self.assertIsNone(
+            self.reviews(
+                [{"state": "CHANGES_REQUESTED", "commit_id": HEAD, "submitted_at": "2026-07-17T00:00:00Z"}]
+            )
+        )
+
+    def test_latest_head_bound_approval_wins(self) -> None:
+        review = self.reviews(
+            [
+                {
+                    "state": "APPROVED",
+                    "commit_id": HEAD,
+                    "submitted_at": "2026-07-17T00:00:00Z",
+                    "html_url": "https://example.invalid/review/1",
+                },
+                {
+                    "state": "APPROVED",
+                    "commit_id": HEAD,
+                    "submitted_at": "2026-07-17T01:00:00Z",
+                    "html_url": "https://example.invalid/review/2",
+                },
+            ]
+        )
+        self.assertEqual(review["html_url"], "https://example.invalid/review/2")
+
+
+class DiffCompletionWriteTests(unittest.TestCase):
+    maxDiff = None
+
+    BODY = None
+
+    def setUp(self) -> None:
+        self.body = body_with_entries(
+            [
+                {
+                    "index": 1,
+                    "item": CI_ITEM,
+                    "status": "complete",
+                    "detail": "green",
+                    "verified_head_sha": HEAD,
+                },
+                {"index": 2, "item": DIFF_ITEM, "status": "pending-ci", "detail": "awaiting review"},
+            ]
+        )
+        self.review = {
+            "state": "APPROVED",
+            "commit_id": HEAD,
+            "submitted_at": "2026-07-17T01:00:00Z",
+            "html_url": "https://example.invalid/review/2",
+        }
+
+    def test_approval_completes_pending_diff_entries_with_proof(self) -> None:
+        written: dict[str, str] = {}
+
+        with (
+            mock.patch.object(execution, "_pr_body_and_head", return_value=(self.body, HEAD)),
+            mock.patch.object(execution, "_latest_approving_review", return_value=self.review),
+            mock.patch.object(execution, "_factory_expected_pr_head_is_current", return_value=True),
+            mock.patch.object(
+                execution,
+                "_edit_pr_body",
+                side_effect=lambda pr, body, env: written.__setitem__("body", body),
+            ),
+        ):
+            execution._complete_diff_evidence_after_approval(42, {})
+
+        self.assertIn(f"- [complete] {DIFF_ITEM}", written["body"])
+        self.assertIn("diff-verified by the counterpart approving review", written["body"])
+        self.assertIn("https://example.invalid/review/2", written["body"])
+        self.assertIn(f'"verified_head_sha": "{HEAD}"', written["body"])
+        self.assertIn(f"- [complete] {CI_ITEM}", written["body"])
+
+    def test_no_head_bound_approval_leaves_entries_pending(self) -> None:
+        with (
+            mock.patch.object(execution, "_pr_body_and_head", return_value=(self.body, HEAD)),
+            mock.patch.object(execution, "_latest_approving_review", return_value=None),
+            mock.patch.object(execution, "_edit_pr_body") as edit,
+        ):
+            execution._complete_diff_evidence_after_approval(42, {})
+        edit.assert_not_called()
+
+    def test_head_movement_before_write_skips_the_write(self) -> None:
+        with (
+            mock.patch.object(execution, "_pr_body_and_head", return_value=(self.body, HEAD)),
+            mock.patch.object(execution, "_latest_approving_review", return_value=self.review),
+            mock.patch.object(execution, "_factory_expected_pr_head_is_current", return_value=False),
+            mock.patch.object(execution, "_edit_pr_body") as edit,
+        ):
+            execution._complete_diff_evidence_after_approval(42, {})
+        edit.assert_not_called()
+
+    def test_bodies_without_pending_diff_entries_do_nothing(self) -> None:
+        body = body_with_entries(
+            [{"index": 1, "item": CI_ITEM, "status": "complete", "detail": "green"}]
+        )
+        with (
+            mock.patch.object(execution, "_pr_body_and_head", return_value=(body, HEAD)),
+            mock.patch.object(execution, "_latest_approving_review") as lookup,
+            mock.patch.object(execution, "_edit_pr_body") as edit,
+        ):
+            execution._complete_diff_evidence_after_approval(42, {})
+        lookup.assert_not_called()
+        edit.assert_not_called()
+
+
+class ReviewActionWiringTests(unittest.TestCase):
+    def action_json(self) -> str:
+        return json.dumps(
+            {
+                "action": "review_pr",
+                "pr_number": 42,
+                "body": "review body",
+                "persona": "Reviewer Persona",
+                "verdict": "approve",
+            }
+        )
+
+    def test_live_gate_failure_stops_the_approve_before_posting(self) -> None:
+        with (
+            mock.patch.object(run_contributor, "find_pr_review_state", return_value=None),
+            mock.patch.object(
+                run_contributor,
+                "_live_ci_evidence_gate_error",
+                return_value="named check `Web CI` is not green",
+            ),
+            mock.patch.object(run_contributor, "run_checked") as run_checked,
+            mock.patch.object(execution, "_factory_expected_pr_head_is_current", return_value=True),
+        ):
+            result = run_contributor.route_action(self.action_json(), dry_run=False, env={})
+
+        self.assertEqual(result, 1)
+        run_checked.assert_not_called()
+
+    def test_successful_approve_posts_review_then_completes_diff_evidence(self) -> None:
+        calls: list[str] = []
+
+        with (
+            mock.patch.object(run_contributor, "find_pr_review_state", return_value=None),
+            mock.patch.object(run_contributor, "_live_ci_evidence_gate_error", return_value=None),
+            mock.patch.object(
+                run_contributor,
+                "run_checked",
+                side_effect=lambda cmd, **kwargs: calls.append("review-post"),
+            ),
+            mock.patch.object(execution, "_factory_expected_pr_head_is_current", return_value=True),
+            mock.patch.object(execution, "detect_bot_login", return_value=""),
+            mock.patch.object(
+                run_contributor,
+                "_complete_diff_evidence_after_approval",
+                side_effect=lambda pr, env: calls.append("diff-complete"),
+            ),
+            mock.patch.object(
+                run_contributor,
+                "_update_mergeable_label",
+                side_effect=lambda pr, verdict, env: calls.append("mergeable-label"),
+            ),
+        ):
+            result = run_contributor.route_action(self.action_json(), dry_run=False, env={})
+
+        self.assertEqual(result, 0)
+        self.assertEqual(calls, ["review-post", "diff-complete", "mergeable-label"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_factory_evidence_verify.py
+++ b/scripts/tests/test_factory_evidence_verify.py
@@ -293,6 +293,9 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("types: [completed]", workflow)
         self.assertIn("vars.AGENT_AUTOMATIONS_ENABLED == 'true'", workflow)
         self.assertIn("vars.FACTORY_EVIDENCE_VERIFY_ENABLED == 'true'", workflow)
+        # M3 hardening norm: manual dispatch respects kill switches on every
+        # factory entry — no event path may bypass the vars gates.
+        self.assertNotIn("github.event_name == 'workflow_dispatch' ||", workflow)
         self.assertIn("github.event.check_suite.pull_requests[0] != null", workflow)
         self.assertIn("runs-on: ubuntu-latest", workflow)
         self.assertIn("ref: main", workflow)


### PR DESCRIPTION
## Summary

Step 3 of the approved #1120 design — the diff-completion half. #1136 (steps 1+2) merged; this is rebased onto it and ready.

**Also carries one QC follow-up that crossed with #1136's auto-merge**: the verifier workflow's job condition let `workflow_dispatch` bypass both kill switches, contradicting the M3 hardening norm (manual dispatch respects kill switches on every factory entry). `AGENT_AUTOMATIONS_ENABLED` and `FACTORY_EVIDENCE_VERIFY_ENABLED` now gate every event path; the check_suite PR-association filter is unchanged; the workflow contract test locks the norm (asserts no dispatch bypass). Distinct commit, flagged for orchestrator review since it widens this PR beyond step 3.

- **Diff approve-gate exemption** (`evidence.py`): pending `diff`-kind items no longer block approve in `review_evidence_gate_error`. The deadlock this resolves: the review that would verify a diff item was itself blocked by the item's pendingness. `blocked` items and pending non-diff items still hard-block approve.
- **Review-time live CI verification** (`execution.py`): before any approve counts, `_live_ci_evidence_gate_error` re-verifies every named-check entry against live check-run state on the current head (`FACTORY_EXPECTED_PR_HEAD_SHA`-bound). The PR body is never trusted at review time — an entry claiming `complete` with a red live check refuses the approve.
- **Completion write**: after the approving review lands and the head re-check passes, `_complete_diff_evidence_after_approval` flips pending diff entries to `complete`, bound to the review URL and the exact reviewed head (`commit_id == head`, latest such APPROVED review), via the structured-entry updater from #1136. Best-effort by design: any failure leaves entries pending and the readiness gate red.
- Ordering in the review action: live gate → post review → dismiss stale blocking reviews → head re-check → diff completion → mergeable label. Locked by a wiring test asserting the sequence.

## Evidence

- Post-rebase test suites + actionlint (current head): [v2 log](https://evidence.cloudcompute.com/workspaces/pr-1137/20260717-202108-evidence-review-completion-v2.txt); pre-rebase run: [v1 log](https://evidence.cloudcompute.com/workspaces/pr-1137/20260717-201758-evidence-review-completion-1120.txt)
- New suite: `test_factory_evidence_review.py` 17/17 (gate exemption, live-verification distrust of the body, head-bound review selection, completion write, route wiring; registered in ci-agents.yml).
- Untouched-behavior proof: `test_run_contributor.py` 62/62, `test_factory_evidence_kinds.py` 17/17, `test_factory_evidence_verify.py` 12/12, `test_factory_workflows.py` 12/12, `test_factory_review.py` 8/8, `test_factory_comment_responder.py` 16/16, `test_validate_agent_output.py` 3/3.

## Mergeability

- Surface: infra — factory review lane (`.agents/skills/cofounder-contributor/scripts/evidence.py` approve gate, `execution.py` review action + live verification + completion write, `run-contributor.py` re-exports), ci-agents registration, one new test suite; plus the verifier workflow's kill-switch condition (`factory-evidence-verify.yml`) and its contract test
- User-facing behavior changed: No end-user surface. Factory PRs whose only outstanding evidence is diff-verifiable can now be approved, and the approval itself completes the evidence; approvals of PRs with red or missing named checks are refused even if the body claims green.
- Non-happy paths considered: no APPROVED review bound to the current head → entries stay pending (no write); head moves before the completion write → skipped; expected-head mismatch at live-gate time → approve refused; ci entry with no extractable check name → approve refused; bodies without structured metadata → live gate passes them to the existing accounting gate, completion write is a no-op; completion-write failure leaves readiness red rather than merging on an unverified claim.
- Residual risk or follow-up: the counterpart persona becomes the attestor for diff items a human never explicitly confirms — auditable via the review URL + SHA recorded in each completed entry, and the owner's merge authority is unchanged; `_latest_approving_review` reads one page of reviews (factory PRs have few; a 30+-review PR could miss the latest, failing toward pending); the deferred owner slash-command (step 4) remains the escape hatch for body-block surgery on `other`-kind items.

Closes #1120

Worker PR under the factory-m3-hands orchestrator, who holds review and merge authority.
